### PR TITLE
feat: add Portuguese localization and manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full-size tap target.
 
 ### Added
+- **Portuguese is now available across Lotti and its Manual.** The app follows
+  Portuguese system locales, and the published Manual now has a Portuguese
+  route with matching localized screenshots. Settings → Advanced → Language
+  can also select Portuguese explicitly.
 - **Romanian Manual and language-aware links are now available.** Lotti opens
   the published Manual in English, German, French, Czech, or Romanian based on
   your system language, and Settings → Advanced → Language lets you choose one

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LOTTI_VERSION := $(shell yq '.version' pubspec.yaml |  tr -d '"')
 THRESH ?= 1000
 LOTTI_DOCS_DIR ?= $(abspath ../lotti-docs)
 MANUAL_VERSION ?= development
-MANUAL_LOCALES ?= en de fr es cs ro
+MANUAL_LOCALES ?= en de fr es cs ro pt
 MANUAL_CAPTURE_DIR ?= $(LOTTI_DOCS_DIR)/manual/.staging/$(MANUAL_VERSION)
 MANUAL_MEDIA_DIR ?= $(LOTTI_DOCS_DIR)/manual/screenshots
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Contributions are welcome — but with deliberate boundaries. Please read this b
 ### What's very welcome
 
 - 🐛 **Issues and bug reports** — the best place to start. Tell us what broke and how to reproduce it.
-- 🌍 **Translations** — new languages, corrections, improvements to existing locales (currently English, German, Spanish, French, Romanian, Czech). AI‑assisted translations are fine **provided you contribute from a real‑name, established GitHub profile** (not a recently created throwaway).
+- 🌍 **Translations** — new languages, corrections, improvements to existing locales (currently English, German, Spanish, French, Portuguese, Romanian, Czech). AI‑assisted translations are fine **provided you contribute from a real‑name, established GitHub profile** (not a recently created throwaway).
 - 💡 **Discussion of new features** — open an issue, describe what you'd like to have and why, and let's agree on the shape before any code is written.
 - 🐍 **Local image generation service** — a reliable, local Python‑based image‑gen service (following the same architecture as our local Voxtral integration) is a **specifically wanted contribution**. If you have experience in this area and want to take it on, please open an issue first so we can align on the integration shape.
 

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -22,9 +22,10 @@ make manual_serve
 ```
 
 The local English root is `/manual/development/`; German, French, Spanish,
-Czech, and Romanian are available at `/manual/development/de/`,
+Czech, Romanian, and Portuguese are available at `/manual/development/de/`,
 `/manual/development/fr/`, `/manual/development/es/`,
-`/manual/development/cs/`, and `/manual/development/ro/`. The navbar selector
+`/manual/development/cs/`, `/manual/development/ro/`, and
+`/manual/development/pt/`. The navbar selector
 preserves the current page, and a browser using one of those languages that
 visits the unqualified manual root is redirected to that language unless the
 reader has explicitly chosen a language before.
@@ -86,7 +87,8 @@ make manual_screenshots
 ```
 
 That command captures all registered English, German, French, Spanish, Czech,
-and Romanian mobile/desktop and light/dark PNG inputs into an ignored staging
+Romanian, and Portuguese mobile/desktop and light/dark PNG inputs into an
+ignored staging
 directory,
 converts them to canonical WebP paths, and writes a checksum/dimension manifest under
 `../lotti-docs/manual/screenshots/development/`.
@@ -114,8 +116,8 @@ English media keeps the established
 `development/<case>/<viewport>-<theme>.webp` path. Localized media lives at
 `development/<locale>/<case>/<viewport>-<theme>.webp`. Visible deterministic
 demo copy that does not come from the app ARB files must use
-`manualScreenshotText(en: …, de: …, fr: …, es: …, cs: …, ro: …)` so all six
-catalogs show the
+`manualScreenshotText(en: …, de: …, fr: …, es: …, cs: …, ro: …, pt: …)` so all
+seven catalogs show the
 same scenario in the selected language.
 
 Add a screenshot by extending `metadata/screenshot-cases.json`, reusing or

--- a/docs-site/docs/reference/advanced-settings.mdx
+++ b/docs-site/docs/reference/advanced-settings.mdx
@@ -22,11 +22,11 @@ values are used in both layouts.
 ## Choose the Manual language
 
 Open **Language** to decide which published Manual the app opens. **Follow
-system** is the default and chooses the English, German, French, Czech, or
-Romanian Manual from your device language. Select **English**, **German**,
-**French**, **Czech**, or **Romanian** to persist a different choice. The Manual
-entry at the bottom of Settings and **Help → Manual** on macOS both use this
-setting.
+system** is the default and chooses the English, German, French, Czech,
+Romanian, or Portuguese Manual from your device language. Select **English**,
+**German**, **French**, **Czech**, **Romanian**, or **Portuguese** to persist a
+different choice. The Manual entry at the bottom of Settings and **Help →
+Manual** on macOS both use this setting.
 
 ## Control capabilities with Config Flags
 

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -45,7 +45,7 @@ const config: Config = {
   },
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'de', 'fr', 'es', 'cs', 'ro'],
+    locales: ['en', 'de', 'fr', 'es', 'cs', 'ro', 'pt'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -70,6 +70,10 @@ const config: Config = {
       ro: {
         label: 'Română',
         htmlLang: 'ro-RO',
+      },
+      pt: {
+        label: 'Português',
+        htmlLang: 'pt-BR',
       },
     },
   },
@@ -115,7 +119,7 @@ const config: Config = {
         docsRouteBasePath: '/',
         // lunr-languages has no Czech stemmer. Czech pages are still indexed
         // and searchable by exact tokens; the other locales keep stemming.
-        language: ['en', 'de', 'fr', 'es', 'ro'],
+        language: ['en', 'de', 'fr', 'es', 'ro', 'pt'],
       },
     ],
   ],

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
@@ -23,10 +23,11 @@ uložené hodnoty.
 
 Otevři **Jazyk** a rozhodni, kterou vydanou příručku má Lotti otevřít.
 **Používat jazyk systému** je výchozí volba a podle jazyka zařízení otevírá
-anglickou, německou, francouzskou, českou nebo rumunskou příručku. Výběrem
-**Angličtina**, **Němčina**, **Francouzština**, **Čeština** nebo **Rumunština**
-trvale uložíš jinou volbu. Položka **Příručka** na konci Nastavení i **Nápověda
-→ Příručka** v macOS používají toto nastavení.
+anglickou, německou, francouzskou, českou, rumunskou nebo portugalskou
+příručku. Výběrem **Angličtina**, **Němčina**, **Francouzština**, **Čeština**,
+**Rumunština** nebo **Portugalština** trvale uložíš jinou volbu. Položka
+**Příručka** na konci Nastavení i **Nápověda → Příručka** v macOS používají toto
+nastavení.
 
 ## Řiď schopnosti pomocí přepínačů
 

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
@@ -22,11 +22,12 @@ Seite einzeln. Bedienelemente und gespeicherte Werte sind identisch.
 
 Öffne **Sprache**, um festzulegen, welches veröffentlichte Handbuch Lotti
 öffnet. **Systemsprache verwenden** ist die Voreinstellung und öffnet anhand
-der Gerätesprache das englische, deutsche, französische, tschechische oder
-rumänische Handbuch. Wähle **Englisch**, **Deutsch**, **Französisch**,
-**Tschechisch** oder **Rumänisch**, um eine andere Auswahl dauerhaft zu
-speichern. Der Eintrag **Handbuch** am Ende der Einstellungen und **Hilfe →
-Handbuch** unter macOS verwenden beide diese Einstellung.
+der Gerätesprache das englische, deutsche, französische, tschechische,
+rumänische oder portugiesische Handbuch. Wähle **Englisch**, **Deutsch**,
+**Französisch**, **Tschechisch**, **Rumänisch** oder **Portugiesisch**, um eine
+andere Auswahl dauerhaft zu speichern. Der Eintrag **Handbuch** am Ende der
+Einstellungen und **Hilfe → Handbuch** unter macOS verwenden beide diese
+Einstellung.
 
 ## Fähigkeiten mit Funktionsschaltern steuern
 

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
@@ -24,10 +24,10 @@ mêmes contrôles et valeurs enregistrées sont utilisés dans les deux présent
 
 Ouvre **Langue** pour choisir quel manuel publié Lotti ouvre. **Suivre le
 système** est le réglage par défaut et ouvre le manuel anglais, allemand,
-français, tchèque ou roumain selon la langue de ton appareil. Choisis
-**Anglais**, **Allemand**, **Français**, **Tchèque** ou **Roumain** pour
-conserver un autre choix. L’entrée **Manuel** en bas des Réglages et **Aide →
-Manuel** sur macOS utilisent toutes deux ce réglage.
+français, tchèque, roumain ou portugais selon la langue de ton appareil.
+Choisis **Anglais**, **Allemand**, **Français**, **Tchèque**, **Roumain** ou
+**Portugais** pour conserver un autre choix. L’entrée **Manuel** en bas des
+Réglages et **Aide → Manuel** sur macOS utilisent toutes deux ce réglage.
 
 ## Contrôler les fonctionnalités avec les flags
 

--- a/docs-site/i18n/pt/code.json
+++ b/docs-site/i18n/pt/code.json
@@ -1,0 +1,44 @@
+{
+  "manual.screenshot.allScreenshots": {
+    "message": "Todas as capturas de tela",
+    "description": "Label for the global screenshot viewport preference"
+  },
+  "manual.screenshot.close": {"message": "Fechar"},
+  "manual.screenshot.desktop": {"message": "Computador"},
+  "manual.screenshot.desktopView": {"message": "Visualização para computador"},
+  "manual.screenshot.expand": {"message": "Ampliar"},
+  "manual.screenshot.expandedViewer": {"message": "Visualização ampliada da captura de tela"},
+  "manual.screenshot.fullscreen": {"message": "Tela cheia"},
+  "manual.screenshot.layoutLabel": {"message": "Layout das capturas de tela para todas as imagens"},
+  "manual.screenshot.mobile": {"message": "Celular"},
+  "manual.screenshot.mobileView": {"message": "Visualização para celular"},
+  "manual.screenshot.openViewer": {"message": "Abrir visualizador de capturas de tela"},
+  "manual.screenshot.screenshot": {"message": "Captura de tela"},
+  "manual.translationNotice.disclosure": {
+    "message": "Esta tradução foi gerada automaticamente e ainda não foi revisada."
+  },
+  "manual.translationNotice.invitation": {
+    "message": "Correções e melhorias são muito bem-vindas por meio de uma"
+  },
+  "manual.translationNotice.issue": {"message": "issue no GitHub"},
+  "manual.translationNotice.or": {"message": "ou de um"},
+  "manual.translationNotice.pullRequest": {"message": "pull request"},
+  "manual.translationNotice.title": {
+    "message": "Tradução automática — suas sugestões são bem-vindas"
+  },
+  "manual.version.development": {"message": "Desenvolvimento"},
+  "theme.colorToggle.ariaLabel.mode.system": {"message": "modo do sistema"},
+  "theme.docs.sidebar.navAriaLabel": {"message": "Navegação lateral da documentação"},
+  "theme.IconExternalLink.ariaLabel": {"message": "(abre em uma nova aba)"},
+  "theme.NavBar.navAriaLabel": {"message": "Navegação principal"},
+  "theme.SearchBar.label": {"message": "Pesquisar"},
+  "theme.SearchBar.noResultsText": {"message": "Nenhum resultado"},
+  "theme.SearchBar.searchInContext": {"message": "Ver todos os resultados em “{context}”"},
+  "theme.SearchBar.seeAllOutsideContext": {"message": "Ver todos os resultados fora de “{context}”"},
+  "theme.SearchBar.seeAll": {"message": "Ver todos os resultados"},
+  "theme.SearchPage.existingResultsTitle": {"message": "Resultados da pesquisa por “{query}”"},
+  "theme.SearchPage.emptyResultsTitle": {"message": "Pesquisar na documentação"},
+  "theme.SearchPage.documentsFound.plurals": {"message": "Um documento encontrado|{count} documentos encontrados"},
+  "theme.SearchPage.noResultsText": {"message": "Nenhum resultado encontrado"},
+  "theme.SearchPage.searchContext.everywhere": {"message": "Em todo lugar"}
+}

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current.json
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "Atual",
+    "description": "The label for version current"
+  },
+  "sidebar.manualSidebar.category.Start here": {
+    "message": "Comece aqui",
+    "description": "The label for category 'Start here' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Plan & capture": {
+    "message": "Planeje e registre",
+    "description": "The label for category 'Plan & capture' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Organize & reflect": {
+    "message": "Organize e reflita",
+    "description": "The label for category 'Organize & reflect' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.AI & automation": {
+    "message": "IA e automação",
+    "description": "The label for category 'AI & automation' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Sync & data": {
+    "message": "Sincronização e dados",
+    "description": "The label for category 'Sync & data' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Reference": {
+    "message": "Referência",
+    "description": "The label for category 'Reference' in sidebar 'manualSidebar'"
+  }
+}

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agent-blueprints.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agent-blueprints.mdx
@@ -1,0 +1,119 @@
+---
+title: Projete modelos e almas de agentes
+description: Defina as responsabilidades reutilizáveis do agente, separe a personalidade das instruções e melhore ambas por meio de revisões individuais versionadas.
+---
+
+# Crie modelos e almas de agentes
+
+Um **modelo de agente** define uma responsabilidade reutilizável: o tipo de agente,
+seu perfil de inferência, diretivas operacionais, formato de relatório e opcionais
+personalidade. Uma **alma** mantém a voz reutilizável, os limites do tom, o coaching
+estilo e política anti-bajulação. Manter esses conceitos separados permite
+a personalidade melhora consistentemente em vários modelos sem copiar
+instruções entre eles.
+
+## Revise o catálogo de modelos
+
+Abra **Configurações → Agentes → Modelos de agente**. O catálogo mostra o modelo
+tipo, identidade do modelo, versão ativa e se uma revisão precisa de atenção.
+
+<ManualScreenshot
+  caseId="agents/templates"
+  alt="Modelos de agente Lotti para segurança de habitat orbital, planejamento do dia do Projeto Waddle, monitoramento do fornecimento de sardinha e treinamento em diplomacia de peixes"
+  caption="Cada modelo do Projeto Waddle tem uma responsabilidade restrita e uma versão visível, em vez de um agente multifuncional com um prompt irrevisável."
+/>
+
+Os tipos integrados atendem a diferentes escopos:
+
+- **Agente de Tarefas** trabalha em uma tarefa e em suas evidências vinculadas.
+- **Agente diurno** planeja e revisa um dia.
+- **Agente de Projeto** acompanha um projeto ao longo do tempo.
+- **Agente de Eventos** segue um espaço de trabalho de eventos.
+- **Template Improver** oferece suporte ao processo de revisão individual de versão.
+
+## Edite um modelo
+
+Selecione um modelo para editar sua configuração atual. Escolha um padrão
+perfil de inferência com as ferramentas e modalidades que a responsabilidade exige,
+então, opcionalmente, atribua uma alma.
+
+<ManualScreenshot
+  caseId="agents/template-editor"
+  alt="Editor de modelo Orbital Habitat Sentinel usando Project Waddle Command e Admiral Pebble com segurança de habitat e diretivas de relatório"
+  caption="A diretriz operacional da sentinela descreve o que inspecionar; Admiral Pebble contribui com o estilo de comunicação e desafio."
+/>
+
+Use os dois campos de diretiva deliberadamente:
+
+- **Diretriz Geral** define a responsabilidade, os limites e a decisão
+  regras.
+- **Diretiva de Relatórios** define o que um relatório útil salvo deve conter.
+
+Salvar um modelo editado cria uma nova versão. A história existente permanece
+disponível para auditoria e reversão; evite esconder responsabilidades não relacionadas em
+uma longa directiva apenas para reduzir o número de modelos.
+
+## Execute um modelo individualmente
+
+O modelo de quadros de página **1 em 1** propôs alterações em relação ao despertar real
+atividade, feedback, desempenho e sessões anteriores. Uma sessão pendente é uma
+proposta, não uma reescrita automática.
+
+<ManualScreenshot
+  caseId="agents/template-review"
+  alt="Orbital Habitat Sentinel individualmente mostrando uma proposta sobre como trazer à tona a decisão de lançamento e métricas de desempenho recentes"
+  caption="A proposta de exemplo responde a uma falha concreta: a conclusão de segurança estava correta, mas a decisão de avançar/não avançar foi enterrada sob trivialidades sobre peixes."
+/>
+
+Inicie a conversa, inspecione as evidências e aprove apenas as alterações
+que melhoram a responsabilidade. O resultado aprovado passa a ser mais um
+registro de modelo versionado.
+
+## Mantenha a personalidade reutilizável com almas
+
+Abra o **Souls** para ver as personalidades que os modelos podem compartilhar. Uma alma é
+não é outro prompt de tarefa; controla como um agente se comunica, treina e
+empurra de volta.
+
+<ManualScreenshot
+  caseId="agents/souls"
+  alt="Catálogo de almas Lotti contendo Almirante Pebble, Dr. Flipper e Capitão Sardina"
+  caption="O Projeto Waddle separa um diretor de vôo calmo, um cientista curioso e um coordenador de carga prático dos empregos que os utilizam."
+/>
+
+O editor soul mantém quatro preocupações explícitas:
+
+<ManualScreenshot
+  caseId="agents/soul-editor"
+  alt="Editor de soul Admiral Pebble com voz, limites de tom, estilo de treinamento e política anti-bajulação"
+  caption="O Almirante Pebble pode permanecer caloroso e decisivo enquanto desafia as suposições otimistas de lançamento com evidências."
+/>
+
+- **Diretiva de Voz** descreve a voz e a comunicação reconhecíveis
+  prioridades.
+- **Tom Bounds** indica o que a voz deve evitar.
+- **Estilo de Coaching** descreve como ajuda alguém a tomar uma decisão.
+- **Política Anti-Bajulação** explica quando e como deve discordar.
+
+Use limites comportamentais concretos. “Seja útil” é difícil de revisar; “desafio
+suposições otimistas de lançamento e cite a observação que mudou seu
+conclusão” pode ser verificada em relação à saída real.
+
+## Evolua uma alma compartilhada com cuidado
+
+Uma alma **1 a 1** obtém feedback de cada modelo que usa essa personalidade.
+Isso torna a mudança poderosa: aprová-la pode melhorar vários agentes, mas um
+mudanças ruins também podem afetar todos eles.
+
+<ManualScreenshot
+  caseId="agents/soul-review"
+  alt="O almirante Pebble se reúne individualmente com uma proposta, um modelo de compartilhamento e histórico de sessão completo"
+  caption="A contagem de compartilhamentos e o histórico de sessões tornam o raio da explosão visível antes que as alterações de personalidade sejam aprovadas."
+/>
+
+Leia a contagem de compartilhamentos, o resumo do feedback proposto e a recapitulação anterior antes
+iniciando uma revisão de personalidade. Se o feedback se aplicar apenas a uma responsabilidade,
+mude esse modelo em vez de ensinar à alma compartilhada uma regra específica para uma tarefa.
+
+Volte para [Executar e monitorar agentes](./agents.mdx) para inspecionar as instâncias e
+ciclos de despertar produzidos a partir desses projetos.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agent-blueprints.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agent-blueprints.mdx
@@ -6,10 +6,10 @@ description: Defina as responsabilidades reutilizáveis do agente, separe a pers
 # Crie modelos e almas de agentes
 
 Um **modelo de agente** define uma responsabilidade reutilizável: o tipo de agente,
-seu perfil de inferência, diretivas operacionais, formato de relatório e opcionais
-personalidade. Uma **alma** mantém a voz reutilizável, os limites do tom, o coaching
-estilo e política anti-bajulação. Manter esses conceitos separados permite
-a personalidade melhora consistentemente em vários modelos sem copiar
+seu perfil de inferência, diretivas operacionais, formato de relatório e personalidade
+opcional. Uma **alma** reúne a voz reutilizável, os limites de tom, o estilo de
+coaching e a política anti-bajulação. Manter esses conceitos separados permite que
+uma personalidade melhore de forma consistente em vários modelos sem copiar
 instruções entre eles.
 
 ## Revise o catálogo de modelos
@@ -55,8 +55,8 @@ uma longa directiva apenas para reduzir o número de modelos.
 
 ## Execute um modelo individualmente
 
-O modelo de quadros de página **1 em 1** propôs alterações em relação ao despertar real
-atividade, feedback, desempenho e sessões anteriores. Uma sessão pendente é uma
+A página de conversa individual **1 a 1** do modelo propõe alterações com base na atividade
+real de ativação, no feedback, no desempenho e nas sessões anteriores. Uma sessão pendente é uma
 proposta, não uma reescrita automática.
 
 <ManualScreenshot
@@ -78,7 +78,7 @@ empurra de volta.
 <ManualScreenshot
   caseId="agents/souls"
   alt="Catálogo de almas Lotti contendo Almirante Pebble, Dr. Flipper e Capitão Sardina"
-  caption="O Projeto Waddle separa um diretor de vôo calmo, um cientista curioso e um coordenador de carga prático dos empregos que os utilizam."
+  caption="O Projeto Waddle separa um diretor de voo calmo, um cientista curioso e um coordenador de carga prático das tarefas que os utilizam."
 />
 
 O editor soul mantém quatro preocupações explícitas:

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agents.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agents.mdx
@@ -32,7 +32,7 @@ fonte.
 
 Use esta página para responder a três perguntas diferentes:
 
-- **Quando os agentes correram?** Leia o gráfico de vigília de 24 horas.
+- **Quando os agentes foram executados?** Leia o gráfico de atividade de 24 horas.
 - **Quanta inferência eles usaram?** Compare os gráficos diários e por modelo.
 - **Qual responsabilidade o motivou?** Revise o detalhamento do modelo/fonte.
 
@@ -49,7 +49,7 @@ quando diversas responsabilidades compartilham uma voz e um estilo de decisão.
 <ManualScreenshot
   caseId="agents/instances"
   alt="Instâncias do agente Lotti agrupadas pelo Almirante Pebble, Dr. Flipper, Capitão Sardina e uma sessão de evolução"
-  caption="O Inspetor de Focas Habitat, o Planejador do Projeto Waddle e o Coordenador de Carga de Sardinha permanecem instâncias separadas, mesmo quando compartilham recursos no nível do sistema."
+  caption="O Inspetor de Vedações do Habitat, o Planejador do Projeto Waddle e o Coordenador de Carga de Sardinha permanecem instâncias separadas, mesmo quando compartilham recursos no nível do sistema."
 />
 
 Selecione uma instância para inspecionar seus componentes internos. A guia **Estatísticas** mostra o modelo
@@ -76,9 +76,9 @@ modelo para agentes futuros não requer a destruição de instâncias não relac
 
 ## Entenda os ciclos de despertar
 
-Abra **Wake Cycles** para ver o trabalho que está em execução agora e o trabalho a ser concluído mais tarde. Um
-**Pendente** despertar foi solicitado pelo agente. Um velório **Programado** foi feito por
-o sistema ou planejador. Cada linha mantém visível a tarefa, o projeto ou o dia vinculado
+Abra **Ciclos de ativação** para ver o trabalho que está em execução agora e o trabalho a ser concluído mais tarde. Um
+despertar **Pendente** foi solicitado pelo agente. Um despertar **Programado** foi agendado pelo
+sistema ou planejador. Cada linha mantém visível a tarefa, o projeto ou o dia vinculado
 ao lado do agente responsável e uma contagem regressiva ao vivo.
 
 <ManualScreenshot

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agents.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/agents.mdx
@@ -1,0 +1,95 @@
+---
+title: Executar e monitorar agentes
+description: Monitore a atividade do agente, inspecione instâncias em execução e controle ciclos de ativação agendados sem perder a trilha de auditoria.
+---
+
+# Executar e monitorar agentes
+
+Os agentes permitem que Lotti carregue uma responsabilidade definida em vários ciclos de ativação.
+Cada instância em execução vem de um modelo de agente, usa uma configuração de inferência,
+e mantém seu próprio estado, relatórios, observações e histórico de atividades. Abrir
+**Configurações → Agentes** para ver o sistema como um todo.
+
+Relatórios do agente, observações e despertares na fila descrevem o trabalho do agente
+estado; eles não reescrevem silenciosamente o diário de bordo pessoal. Quando um agente de tarefa
+deseja alterar os dados da tarefa, Lotti apresenta uma proposta para sua revisão. Veja
+[Revise as alterações propostas](../organize-and-reflect/tasks.mdx#revise-as-alterações-propostas)
+para os controles de aprovação por tarefa e seu título inicial e idioma restritos
+exceções.
+
+## Leia a atividade do agente antes de alterá-la
+
+A página **Estatísticas** combina atividade de ativação e uso de token. O primeiro gráfico
+mostra quando os agentes acordaram durante as últimas 24 horas. A seção diária compara
+hoje com o mesmo horário dos últimos dias e, em seguida, divide o uso por modelo e
+fonte.
+
+<ManualScreenshot
+  caseId="agents/stats"
+  alt="Estatísticas do agente Lotti mostrando a atividade de ativação do Projeto Waddle, uso diário de token e gráficos de modelo"
+  caption="A frota de exemplo do Projeto Waddle está mais ocupada com verificações de habitat e planejamento de lançamento; as seções de modelo e origem tornam essa atividade atribuível."
+/>
+
+Use esta página para responder a três perguntas diferentes:
+
+- **Quando os agentes correram?** Leia o gráfico de vigília de 24 horas.
+- **Quanta inferência eles usaram?** Compare os gráficos diários e por modelo.
+- **Qual responsabilidade o motivou?** Revise o detalhamento do modelo/fonte.
+
+Um pico não é automaticamente uma falha. Um dia de revisão de lançamento deve ser mais movimentado
+do que um dia comum de colônia. Investigue atividades inesperadas abrindo o
+modelo ou instância de origem antes de alterar um limite de simultaneidade global.
+
+## Inspecione as instâncias em execução
+
+Abra **Instâncias** para ver todas as sessões de agente e evolução. As linhas expõem o
+tipo de agente, ciclo de vida, modelo atribuído e alma. Agrupar por alma é útil
+quando diversas responsabilidades compartilham uma voz e um estilo de decisão.
+
+<ManualScreenshot
+  caseId="agents/instances"
+  alt="Instâncias do agente Lotti agrupadas pelo Almirante Pebble, Dr. Flipper, Capitão Sardina e uma sessão de evolução"
+  caption="O Inspetor de Focas Habitat, o Planejador do Projeto Waddle e o Coordenador de Carga de Sardinha permanecem instâncias separadas, mesmo quando compartilham recursos no nível do sistema."
+/>
+
+Selecione uma instância para inspecionar seus componentes internos. A guia **Estatísticas** mostra o modelo
+uso, seu modelo, rota de inferência atual, controles de ciclo de vida, contagem de despertares,
+e estado de agendamento.
+
+<ManualScreenshot
+  caseId="agents/instance-detail"
+  alt="Detalhe da instância do Habitat Seal Inspector com uso de token, modelo Orbital Habitat Sentinel, rota de inferência, controles de ciclo de vida e estado de ativação"
+  caption="A instância mantém procedência suficiente para explicar qual modelo e rota produziu seu trabalho antes de você pausá-la, analisá-la novamente ou destruí-la."
+/>
+
+As guias de instância restantes preservam evidências diferentes:
+
+- **Relatórios** contém os instantâneos de relatórios salvos do agente.
+- **Conversas** agrupa mensagens por ciclo de ativação.
+- **Observações** expõe as descobertas capturadas sem misturá-las em relatórios.
+- **Atividade** mostra a mensagem cronológica e a trilha da ferramenta.
+
+**Pause** mantém a instância, mas interrompe o trabalho normal. **Reanalisar** solicita uma tarefa
+agente reconsidere seu assunto atual. **Destruir** é destrutivo e deve
+ser usado somente quando a própria instância não for mais desejada; mudando o
+modelo para agentes futuros não requer a destruição de instâncias não relacionadas.
+
+## Entenda os ciclos de despertar
+
+Abra **Wake Cycles** para ver o trabalho que está em execução agora e o trabalho a ser concluído mais tarde. Um
+**Pendente** despertar foi solicitado pelo agente. Um velório **Programado** foi feito por
+o sistema ou planejador. Cada linha mantém visível a tarefa, o projeto ou o dia vinculado
+ao lado do agente responsável e uma contagem regressiva ao vivo.
+
+<ManualScreenshot
+  caseId="agents/pending-wakes"
+  alt="Lotti Wake Cycles mostrando a inspeção do habitat em execução e os despertares programados do Projeto Waddle e da logística da sardinha"
+  caption="A fila distingue um acompanhamento de habitat solicitado pelo agente do dia de lançamento e dos cronogramas de carga, de modo que uma contagem regressiva sempre tem um motivo e um proprietário."
+/>
+
+Excluir uma ativação na fila remove esse cronômetro; ele não exclui o agente ou seu
+tarefa vinculada. Se uma ativação retornar imediatamente, inspecione o estado do agente ou o
+automação que o solicitou, em vez de excluir repetidamente o sintoma.
+
+Continue com [Modelos de agente e almas](./agent-blueprints.mdx) para definir
+o que essas instâncias fazem e como elas se comunicam.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/models-and-profiles.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/models-and-profiles.mdx
@@ -7,7 +7,7 @@ description: Descreva os recursos do modelo uma vez e, em seguida, use perfis de
 
 Um provedor informa a Lotti onde se conectar. Um modelo registra um ID de modelo de provedor
 e suas capacidades. Um perfil de inferência então atribui esses modelos ao
-empregos que Lotti entende. Isso mantém “qual modelo lida com áudio?” de cada
+às tarefas que Lotti entende. Isso mantém “qual modelo lida com áudio?” fora de cada
 tarefa individual e regra de automação.
 
 ## Revise os modelos salvos

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/models-and-profiles.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/models-and-profiles.mdx
@@ -1,0 +1,126 @@
+---
+title: Rotear trabalho com modelos e perfis
+description: Descreva os recursos do modelo uma vez e, em seguida, use perfis de inferência para direcionar a geração de pensamento, visão, áudio e imagem.
+---
+
+# Rota de trabalho com modelos e perfis
+
+Um provedor informa a Lotti onde se conectar. Um modelo registra um ID de modelo de provedor
+e suas capacidades. Um perfil de inferência então atribui esses modelos ao
+empregos que Lotti entende. Isso mantém “qual modelo lida com áudio?” de cada
+tarefa individual e regra de automação.
+
+## Revise os modelos salvos
+
+Abra **Configurações → Configurações de IA → Modelos**. A lista agrupa modelos por provedor
+e expõe filtros de capacidade para texto, visão, áudio e raciocínio.
+
+<ManualScreenshot
+  caseId="ai/models"
+  alt="Lista de modelos Lotti AI com modelos de texto, raciocínio, visão, transcrição e geração de imagens do Projeto Waddle"
+  caption="O espaço de trabalho do Project Waddle combina modelos locais e de nuvem, mantendo explícitos os recursos de cada modelo."
+/>
+
+O controle **Agente simultâneo é ativado** na parte superior das configurações de IA limita como
+muitos agentes diferentes podem executar inferências ao mesmo tempo. Um valor mais alto pode melhorar
+taxa de transferência, mas também aumenta as solicitações simultâneas do provedor e locais
+carga do dispositivo. Seja conservador quando um provedor tiver limites de taxas rígidos ou um
+o servidor do modelo local tem memória limitada.
+
+## Adicione ou edite um modelo
+
+Selecione um modelo de cartão ou use **+** para adicionar um. Uma definição de modelo inclui:
+
+- a conexão do provedor;
+- um nome de exibição amigável e uma descrição opcional;
+- o ID exato do modelo do fornecedor;
+- o limite máximo de tokens de conclusão;
+- modalidades de entrada e saída; e
+- sinalizadores de capacidade, como raciocínio ou chamada de função.
+
+<ManualScreenshot
+  caseId="ai/model-editor"
+  alt="Editor de modelo Lotti para Waddle Command 70B mostrando provedor, ID do modelo do provedor, limite de conclusão, modalidades e capacidade de raciocínio"
+  caption="Os metadados de capacidade são importantes: Lotti os utiliza para decidir quais modelos são elegíveis para cada slot de perfil e seletor único."
+/>
+
+Use o identificador exato esperado pelo provedor. O nome de exibição é apenas para
+pessoas; alterá-lo não altera o que o provedor executa. Não reivindique imagem,
+suporte de áudio, ferramenta ou raciocínio, a menos que esse modelo e endpoint realmente
+fornecê-lo.
+
+## Crie um perfil de inferência
+
+Abra **Configurações → Configurações de IA → Perfis de inferência**. Cada perfil é reutilizável
+política de roteamento. A visão geral mostra qual modelo atende cada slot configurado.
+
+<ManualScreenshot
+  caseId="ai/profiles"
+  alt="Perfis de inferência de Lotti para o Projeto Waddle Command, Habitat Local-First e Fish Diplomacy com seus modelos roteados"
+  caption="Os perfis podem ser otimizados para diferentes limites: um perfil amplo de nuvem, um perfil local somente para desktop ou um perfil de raciocínio especializado."
+/>
+
+Edite um perfil para atribuir modelos aos recursos que você usa:
+
+- **Pensar** é o modelo de texto geral necessário.
+- **Thinking (High-End)** pode lidar com trabalhos que solicitam explicitamente mais
+  caminho de raciocínio capaz.
+- **Reconhecimento de imagem** analisa imagens.
+- **Transcrição** converte áudio em texto.
+- **Geração de imagens** cria arte de tarefas e outras imagens geradas. O
+  o caminho de geração de imagem integrado atual usa um provedor remoto configurado, então
+  escolha esse fornecedor e as referências que você envia com o mesmo cuidado que qualquer
+  outra rota de inferência na nuvem.
+
+<ManualScreenshot
+  caseId="ai/profile-editor"
+  alt="Editor de perfil do Project Waddle Command atribuindo modelos de pensamento, raciocínio sofisticado, reconhecimento de imagem, transcrição e geração de imagem"
+  caption="Um perfil roteia cada modalidade do Project Waddle sem repetir escolhas de modelo entre tarefas."
+/>
+
+**Somente desktop** oculta um perfil em plataformas móveis, o que é útil quando
+depende de um modelo acessível apenas a partir de uma estação de trabalho. A fixação do dispositivo é para
+processamento automatizado de áudio sincronizado: fixe somente quando o dispositivo selecionado anunciar
+os provedores necessários para o perfil. Sem dispositivo fixado, o áudio sincronizado não é
+transcrito automaticamente por esse perfil.
+
+## Escolha um modelo sem memorizar IDs
+
+Os seletores de modelos começam com o provedor e mostram apenas modelos salvos compatíveis.
+O seletor em um slot de perfil, por exemplo, não oferecerá modelo somente de áudio
+para raciocínio de texto.
+
+<ManualScreenshot
+  caseId="ai/model-picker"
+  alt="Lotti Escolha um modelo modal listando os provedores OpenRouter, Ollama e Google Gemini no editor de perfil do Projeto Waddle"
+  caption="Escolha primeiro o provedor; Lotti então restringe a próxima página aos modelos elegíveis dessa conexão."
+/>
+
+## Defina um padrão de categoria
+
+Uma categoria pode escolher um perfil de inferência padrão em **Configurações →
+Definições → Categorias**. Novos trabalhos nessa categoria podem então herdar uma
+política de roteamento coerente. Selecione o perfil cuja privacidade e capacidade se combinam
+corresponde à categoria em vez de escolher apenas pela velocidade.
+
+<ManualScreenshot
+  caseId="ai/profile-picker"
+  alt="Editor da categoria Penguin Operations com um modal que oferece perfis do Projeto Waddle Command, Habitat Local-First e Fish Diplomacy"
+  caption="O emblema somente para desktop torna as restrições da plataforma visíveis antes que uma categoria padrão seja selecionada."
+/>
+
+## Rota do perfil legado
+
+A rota autônoma mais antiga **Perfis de inferência** permanece disponível para
+compatibilidade e edita os mesmos registros de perfil armazenados. Ele expõe o interior
+IDs de modelo e fornece menos contexto de dependência do que configurações de IA, então prefira o
+página atual **Configurações de IA → Perfis de inferência** para manutenção normal.
+
+<ManualScreenshot
+  caseId="ai/legacy-profiles"
+  alt="Página Legacy Lotti Inference Profiles mostrando slots de perfil do Project Waddle como identificadores de modelo interno"
+  caption="Use esta tela de compatibilidade somente quando um link mais antigo o levar até lá; os cartões de perfil atuais das configurações de IA são mais fáceis de auditar."
+/>
+
+Continue com [Habilidades de IA](./skills.mdx) para ver como o perfil selecionado se torna
+uma ação em uma tarefa ou entrada.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/provider-setup.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/provider-setup.mdx
@@ -1,0 +1,85 @@
+---
+title: Conecte um provedor de IA
+description: Conecte nuvem ou inferência local, inspecione seus modelos e mantenha credenciais e endpoints sob controle.
+---
+
+# Conecte um provedor de IA
+
+Lotti separa uma configuração de IA em três camadas: um **provedor** é o serviço que ele
+ao qual se conecta, um **modelo** é um modelo exposto por meio desse serviço e um
+**perfil de inferência** roteia cada tipo de trabalho para um modelo. Comece com o
+provedor e, em seguida, revise os modelos e perfis criados em torno dele.
+
+<ManualScreenshot
+  caseId="ai/providers"
+  alt="Configurações de Lotti AI mostrando os provedores Mission Control Router, Habitat Local Lab, Orbital Vision e Penguin Audio Bay"
+  caption="As configurações de IA mantêm as conexões locais e na nuvem juntas. Cada cartão mostra o estado da conexão e quantos modelos salvos a utilizam."
+/>
+
+## Escolha local ou remoto
+
+- Um provedor de nuvem geralmente é a configuração mais rápida e geralmente requer uma API
+  chave. Texto, áudio ou imagens enviados por meio dele saem do dispositivo.
+- Um provedor local pode manter a inferência em sua própria máquina ou em um endpoint local
+  você controla, mas seu serviço deve estar em execução e acessível a partir do dispositivo
+  onde Lotti o invoca. Um endereço LAN ainda pode mover um prompt entre o seu
+  dispositivos; “local” significa que não é enviado para um provedor de modelo hospedado, não que nenhum
+  existe salto de rede.
+- Um URL base personalizado pode apontar um tipo de provedor compatível para um proxy compatível
+  ou portal. O tipo de provedor ainda controla o comportamento específico do protocolo.
+
+## Conecte um provedor
+
+1. Abra **Configurações → Configurações de IA → Provedores**.
+2. Selecione o botão **+**.
+3. Escolha um provedor compatível.
+4. Insira seu nome de exibição, endpoint e chave de API quando necessário.
+5. Adicione os modelos sugeridos desejados e salve.
+
+Para provedores de primeira execução com suporte, Lotti semeia modelos úteis e um ou mais
+perfis de inferência. A tela de resultados resume o que foi criado.
+
+<ManualScreenshot
+  caseId="ai/provider-editor"
+  alt="Editor de provedor Lotti para Mission Control Router com OpenRouter selecionado, URL base, chave de API mascarada e modelos sugeridos"
+  caption="As credenciais permanecem mascaradas. Os modelos sugeridos são atalhos, não um requisito. Você pode adicionar IDs de modelo específicos do provedor posteriormente."
+/>
+
+## Inspecione e mantenha uma conexão
+
+Abra um cartão de provedor para inspecionar sua credencial mascarada, URL base, modelos salvos,
+e qualquer perfil ativo que dependa desses modelos. A partir daqui você pode editar o
+conexão, adicione outro modelo ou remova o provedor.
+
+<ManualScreenshot
+  caseId="ai/provider-detail"
+  alt="Detalhe do provedor do Mission Control Router mostrando sua conexão, modelos do Waddle Command e perfil ativo do Project Waddle"
+  caption="O resumo da dependência torna o raio de explosão visível antes de você alterar ou remover um provedor."
+/>
+
+A alteração de um URL base ou chave de API afeta todos os modelos anexados a esse provedor.
+Depois de alterar qualquer um dos valores, verifique uma ação representativa da IA antes de assumir
+a conexão está saudável. A remoção de um provedor também pode afetar perfis que
+encaminhar o trabalho através de seus modelos; revise as informações de dependência primeiro.
+
+## Revise o roteamento do perfil
+
+Abra [Modelos e perfis de inferência](./models-and-profiles.mdx) para verificar o que
+o provedor expõe e como Lotti roteia cada recurso. As categorias podem definir um
+perfil padrão para seu trabalho, enquanto a automação individual pode selecionar ou
+substituir um modelo onde o fluxo de trabalho oferece essa escolha.
+
+## Limite de privacidade
+
+Antes de enviar texto, áudio ou imagens sensíveis, confirme se o configurado
+o endpoint é local ou remoto. Um nome amigável como “Habitat Local Lab” não é
+o limite de segurança – o URL base, o caminho da rede e a máquina que atende
+são. Lotti armazena o diário de bordo localmente de qualquer maneira; esta decisão controla o
+chamada de inferência em si.
+
+:::warning Chaves API
+
+Trate as chaves do provedor como segredos. Nunca cole-os em documentação, problemas ou
+capturas de tela.
+
+:::

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/provider-setup.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/provider-setup.mdx
@@ -77,7 +77,7 @@ o limite de segurança – o URL base, o caminho da rede e a máquina que atende
 são. Lotti armazena o diário de bordo localmente de qualquer maneira; esta decisão controla o
 chamada de inferência em si.
 
-:::warning Chaves API
+:::warning[Chaves de API]
 
 Trate as chaves do provedor como segredos. Nunca cole-os em documentação, problemas ou
 capturas de tela.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/skills.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/skills.mdx
@@ -13,7 +13,7 @@ requer uma gravação.
 <ManualScreenshot
   caseId="ai/skills"
   alt="Imagem do habitat do projeto Waddle com a oferta modal Gerar foto do habitat Inspecionar"
-  caption="Numa imagem de habitat ligada à tarefa, a ação aplicável procura anomalias nos manómetros e danos visíveis nas focas."
+  caption="Numa imagem de habitat ligada à tarefa, a ação aplicável procura anomalias nos manómetros e danos visíveis nas vedações."
 />
 
 ## Execute uma habilidade

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/skills.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/skills.mdx
@@ -1,0 +1,54 @@
+---
+title: Execute habilidades contextuais de IA
+description: Use o menu Gerar para executar apenas as ações de IA que se aplicam à tarefa, gravação, imagem ou entrada atual.
+---
+
+# Execute habilidades contextuais de IA
+
+As habilidades de IA são ações nomeadas com instruções e requisitos de entrada. Lotti
+filtra o menu **Gerar…** para a entidade atual, para que uma tarefa não ofereça
+uma ação de transcrição apenas de áudio e uma imagem não oferece uma ação que
+requer uma gravação.
+
+<ManualScreenshot
+  caseId="ai/skills"
+  alt="Imagem do habitat do projeto Waddle com a oferta modal Gerar foto do habitat Inspecionar"
+  caption="Numa imagem de habitat ligada à tarefa, a ação aplicável procura anomalias nos manómetros e danos visíveis nas focas."
+/>
+
+## Execute uma habilidade
+
+1. Abra uma tarefa ou entrada de diário suportada.
+2. Selecione a ação do assistente descrita no cabeçalho da entrada. Isso abre
+   **Gerar…**.
+3. Leia a descrição da habilidade e selecione a ação desejada.
+4. Se Lotti oferecer um seletor de modelo ou modo de pensamento, confirme o padrão ou
+   escolha uma substituição única.
+5. Continue trabalhando enquanto a inferência é executada; o resultado está anexado ao
+   tarefa ou entrada relevante quando concluída.
+
+O menu disponível muda com o contexto:
+
+- as tarefas podem oferecer ações de texto e de contexto de tarefa;
+- as entradas de áudio podem oferecer transcrição e ações com reconhecimento de áudio;
+- as imagens podem oferecer análise visual; e
+- as entradas de texto podem oferecer ações de prompt ou de geração que aceitam texto.
+
+Algumas habilidades precisam de uma tarefa vinculada porque leem o contexto mais amplo da tarefa ou escrevem
+seu resultado de volta para essa tarefa. Se uma ação estiver ausente, primeiro verifique a entrada
+tipo e link de tarefa e, em seguida, verifique se o perfil de inferência ativo possui um modelo para
+a capacidade necessária.
+
+## As substituições de modelo são temporárias
+
+Quando uma habilidade oferece um seletor de modelo, essa escolha se aplica ao atual
+invocação. Ele não reescreve silenciosamente o padrão ou inferência da categoria
+perfil. Para alterar a rota normal, edite o perfil em
+[Modelos e perfis de inferência](./models-and-profiles.mdx).
+
+## Trate a saída gerada como um rascunho
+
+Revise prompts gerados, resumos, transcrições, análise de imagens e arte
+antes de confiar neles. O contexto da tarefa pode estar incompleto, os provedores podem retornar
+saída incorreta, e um modelo capaz ainda pode interpretar mal um problema muito sério
+emergência da sardinha.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/usage.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/ai-and-automation/usage.mdx
@@ -1,0 +1,59 @@
+---
+title: Revise o uso e o impacto da IA
+description: Compare solicitações de IA por período, categoria e modelo, incluindo custo estimado, energia, emissões e uso de token.
+---
+
+# Revise o uso e o impacto da IA
+
+Abra **Configurações → Configurações de IA → Uso e impacto** para entender como configurado
+modelos de nuvem estão sendo usados. A mesma análise também pode ser acessada pela IA
+rota do painel de impacto.
+
+<ManualScreenshot
+  caseId="ai/usage"
+  alt="Painel Lotti AI Impact para julho de 2026 mostrando custo, energia, equivalente de dióxido de carbono, tokens, solicitações e barras de categoria"
+  caption="O mês de exemplo do Projeto Waddle separa o Controle da Missão e as Operações Penguin, mantendo visível a pegada total da solicitação."
+/>
+
+## Leia os cartões de resumo
+
+Os cartões superiores resumem o período selecionado:
+
+- **Custo** estima os gastos do provedor.
+- **Energia** estima a eletricidade atribuível à inferência medida na nuvem.
+- **CO₂e** expressa a estimativa de emissões associadas.
+- **Tokens** conta tokens de modelo processados.
+- **Solicitações** conta chamadas de inferência.
+
+O indicador de comparação utiliza o período equivalente anterior quando se
+disponível. Um aumento percentual é contexto, não automaticamente um problema: um
+a semana de revisão de lançamento não deve ser comparada cegamente com uma semana de colônia ociosa.
+
+Energia, CO₂e e custo são medidos apenas para modelos de nuvem. A inferência local pode
+consumir energia substancial do dispositivo sem aparecer nas estimativas da nuvem,
+portanto, esta página não é um medidor de energia completo para todo o sistema.
+
+## Alterar a análise
+
+Use o controle de período e os botões de seta para avançar no tempo ou pule para
+**Este mês** e **Este ano**. Em seguida, escolha **Ambos**, **Por categoria** ou **Por
+modelo**. Dentro de um gráfico, alterne entre valores por dia, totais acumulados e
+compartilhe quando disponível.
+
+As visualizações de categoria respondem “qual área de trabalho impulsionou o uso?” Resposta das visualizações do modelo
+“qual modelo configurado impulsionou o uso?” Use ambos antes de alterar um perfil: a
+modelo de alto custo pode ser justificado para uma categoria especializada, mas um desperdício como
+padrão geral.
+
+## Agir com base em um resultado surpreendente
+
+Se o uso aumentar inesperadamente:
+
+1. restringir o período ao primeiro dia afetado;
+2. comparar categorias e modelos;
+3. revisar a automação e a simultaneidade dos agentes;
+4. inspecionar o perfil de inferência atribuído à categoria afetada; e
+5. verificar o faturamento do fornecedor antes de tratar a estimativa de Lotti como uma fatura.
+
+Para alterar a rota responsável pelas chamadas futuras, volte para
+[Modelos e perfis de inferência](./models-and-profiles.mdx).

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -1,0 +1,80 @@
+---
+title: Crie sua primeira tarefa
+description: Crie uma tarefa e dê-lhe estrutura suficiente para ser útil.
+---
+
+# Crie sua primeira tarefa
+
+Uma tarefa é o local para um resultado, sua lista de verificação e as notas, gravações,
+imagens ou registros de tempo que explicam o trabalho.
+
+## Comece pelo caminho mais rápido
+
+Se você ainda estiver na integração, fale o resultado ou escolha **Prefere digitar?**.
+Escolha a área onde a tarefa pertence; Lotti usa essa categoria para manter o
+tarefa visível nas visualizações corretas e para selecionar sua automação configurada.
+
+<ManualScreenshot
+  caseId="onboarding/first-task"
+  alt="Captura de voz na primeira tarefa com o orbe do shader de produção, forma de onda ao vivo e destinos de operações e controle de missão da Penguin"
+  caption="Enquanto o microfone está aberto, o verdadeiro orbe e forma de onda do shader controlado por dBFS respondem à sua voz. Escolha o destino antes de finalizar a captura."
+/>
+
+Após Lotti estruturar a captura, ele mostra o título real da tarefa antes
+saindo da integração. Abra o cartão para continuar no espaço de trabalho normal da tarefa.
+
+<ManualScreenshot
+  caseId="onboarding/task-created"
+  alt="Criação bem-sucedida da primeira tarefa mostrando a tarefa estruturada de revezamento da sardinha Europa pronta para ser aberta"
+/>
+
+## Crie uma tarefa da lista de tarefas
+
+1. Abra **Tarefas**.
+2. Use a ação **+** e escolha **Tarefa**.
+3. Escreva um título orientado para os resultados.
+4. Escolha uma categoria quando houver uma claramente aplicável.
+5. Salve a tarefa.
+
+O espaço de trabalho de tarefas mantém a lista e a tarefa selecionada juntas na área de trabalho. Ligado
+mobile, selecionar uma tarefa abre a visualização de detalhes em tela inteira. Em ambos os layouts,
+a arte da capa da tarefa e o contexto da categoria facilitam a verificação de uma lista ocupada.
+
+<ManualScreenshot
+  caseId="tasks/workspace"
+  alt="Espaço de trabalho de tarefas com tarefas do Project Waddle, miniaturas de capa distintas, prioridades, categorias e detalhes da tarefa selecionada"
+/>
+
+“Publicar o manual V1” é mais útil do que “Documentação” porque o título
+diz como é o acabamento.
+
+## Adicione contexto útil
+
+Abra a tarefa e use sua ação adicionar para anexar uma nota, gravação, imagem ou
+outra entrada. Mantenha o material com a tarefa quando isso ajudar você - ou uma IA
+assistente – entenda a próxima ação mais tarde.
+
+<ManualScreenshot
+  caseId="entries/create-menu"
+  alt="Menu Adicionar com reconhecimento de tarefas com ações de lista de verificação, tarefa, gravação de áudio, cronômetro, entrada de texto, importação de imagem e captura de tela"
+/>
+
+<ManualScreenshot
+  caseId="tasks/detail"
+  alt="Detalhe da tarefa para inspecionar o habitat orbital do pinguim com data de vencimento, categoria, rótulos, resumo de IA, descrição, registros de tempo e capa"
+/>
+
+## Torne-o acionável
+
+Adicione uma pequena lista de verificação com etapas concretas. Se um fornecedor de IA e a entidade relevante
+habilidades são configuradas, Lotti também pode transformar uma gravação ou contexto escrito em
+sugestões de lista de verificação. Revise as alterações propostas antes de aplicá-las.
+
+## Decida quando é importante
+
+- Defina uma data de vencimento quando houver um prazo real.
+- Defina prioridade para expressar urgência.
+- Traga a tarefa para um check-in diário do sistema operacional quando ela pertencer ao plano de hoje.
+
+Continue com [gerenciamento de tarefas](../organize-and-reflect/tasks.mdx) para prioridade,
+filtragem e fluxos de trabalho assistidos por voz.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/mental-model.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/mental-model.mdx
@@ -1,0 +1,99 @@
+---
+title: O modelo mental de Lotti
+description: Entenda os poucos blocos de construção que tornam o resto do Lotti mais fácil.
+---
+
+# O modelo mental de Lotti
+
+<div className="manual-hero manual-hero--model">
+  <div className="manual-eyebrow">O atrito útil é o ponto</div>
+  <h1>Sua vida não é uma pendência.</h1>
+  <div className="manual-hero-copy">Lotti é um registro de intenções, decisões, realidade e aprendizado – e não uma lista faminta que classifica tudo em “feito” ou “não feito”. O plano pode mudar. O registro pode dizer a verdade.</div>
+</div>
+
+## O ciclo: diga, escolha, viva, aprenda com ele
+
+<div className="manual-flow" role="list" aria-label="The Lotti planning and reflection loop">
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">01</span>
+    <strong>Dê um nome</strong>
+    <p>Uma categoria cria um limite útil. Uma tarefa nomeia um resultado. Notas, gravações, imagens e listas de verificação mantêm a verdade por perto.</p>
+    <span className="manual-flow-examples">Categoria · tarefa · entrada</span>
+  </div>
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">02</span>
+    <strong>Escolha hoje de propósito</strong>
+    <p>O Daily OS transforma o trabalho que importa em um bloco proposto. É uma decisão para este dia, não uma reescrita da tarefa ou uma promessa para um eu futuro.</p>
+    <span className="manual-flow-examples">Plano · bloco planejado</span>
+  </div>
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">03</span>
+    <strong>Deixe a realidade responder</strong>
+    <p>Acompanhe o tempo que você realmente gastou. Adicione a nota, foto, medição ou gravação de voz que explique o que realmente aconteceu – confuso, útil e intacto.</p>
+    <span className="manual-flow-examples">Registro de tempo · evidência</span>
+  </div>
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">04</span>
+    <strong>Observe o padrão</strong>
+    <p>Hábitos, medições, painéis e análises de tempo transformam muitos dias comuns em algo com o qual você pode aprender. Então a próxima decisão será mais sábia.</p>
+    <span className="manual-flow-examples">Hábito · mensurável · painel</span>
+  </div>
+</div>
+
+<ManualScreenshot
+  caseId="daily-os/agenda"
+  alt="Agenda Lotti Daily OS com miniaturas de tarefas do Project Waddle, blocos planejados e contexto de tempo"
+  caption="Um bloco diário do sistema operacional indica o que você escolheu para hoje. A tarefa vinculada e o registro de tempo continuam sendo coisas honestas."
+/>
+
+## Os blocos de construção, sem fingir que são todos iguais
+
+| Bloco de construção | Use-o para | Exemplo |
+| --- | --- | --- |
+| Categoria | Uma área significativa da vida ou do trabalho | Saúde, Família, Pesquisa |
+| Tarefa | Um resultado que precisa de progresso | Prepare a versão V1 |
+| Lista de verificação | Passos concretos dentro de uma tarefa | Verifique as notas de lançamento |
+| Entrada | Contexto ou evidência | Nota, imagem, gravação de áudio |
+| Bloco planejado | Um horário proposto no dia | Revisão de lançamento, 10h00–11h00 |
+| Registro de tempo | O que realmente aconteceu | Revisão de lançamento, 10h18–11h07 |
+| Hábito | Um comportamento recorrente que você avalia | Tomar medicação |
+| Mensurável | Uma observação numérica | Frequência cardíaca em repouso |
+| Painel | Uma visão sobre medições úteis | Visão geral do treinamento |
+
+## Os agentes são convidados, não coproprietários
+
+Um agente pode ler o contexto que você fornece, formar uma opinião, resumir uma situação complicada
+tarefa e propor uma próxima mudança útil. O seu relatório é uma opinião com
+proveniência, não um fato novo em sua história. Tarefa proposta, lista de verificação, status,
+ou alterações de data aguardam que você as confirme ou descarte. As exceções estreitas
+são um título ou idioma inicial para uma tarefa vazia - depois disso, o
+a mesma regra de aprovação humana se aplica.
+
+Isso não é educação aparafusada a um aviso. Lotti mantém o diário pessoal
+e a memória de trabalho do agente separadas, para que o agente não possa tratar seu histórico como um
+bloco de notas. Você pode usar IA, ajustá-la ou deixá-la totalmente sozinha.
+
+## Uma primeira órbita prática
+
+1. Crie categorias que você realmente usa para tomar decisões.
+2. Capture o trabalho como tarefas e mantenha material de apoio anexado a elas.
+3. Use o Daily OS para decidir o que pertence a um determinado dia.
+4. Registre o tempo real e as observações sem forçá-los a corresponder ao plano.
+5. Revise hábitos e painéis em busca de padrões, em vez de perfeição individual
+   dias.
+
+## Mantenha a propriedade clara
+
+- Uma tarefa vinculada possui seu título e categoria.
+- Um bloco Daily OS possui seu posicionamento e duração.
+- Uma entrada de tempo possui o registro do que aconteceu.
+- A IA propõe; você analisa e decide.
+
+:::tip A questão não é uma linha do tempo imaculadaSe o plano mudou, deixe-o mudar. Se o dia correu mal, registre o que aconteceu
+acontecer. Um sistema útil ajuda você a ver o formato da sua vida; não pergunta
+você realizar um trabalho mais produtivo para o banco de dados.
+
+:::
+
+Em seguida, [crie uma primeira tarefa](./first-task.mdx) ou vá diretamente para
+[OS diário](../plan-and-capture/daily-os.mdx).

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/mental-model.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/mental-model.mdx
@@ -69,7 +69,7 @@ ou alterações de data aguardam que você as confirme ou descarte. As exceçõe
 são um título ou idioma inicial para uma tarefa vazia - depois disso, o
 a mesma regra de aprovação humana se aplica.
 
-Isso não é educação aparafusada a um aviso. Lotti mantém o diário pessoal
+Isso não é treinamento acoplado a um prompt. Lotti mantém o diário pessoal
 e a memória de trabalho do agente separadas, para que o agente não possa tratar seu histórico como um
 bloco de notas. Você pode usar IA, ajustá-la ou deixá-la totalmente sozinha.
 
@@ -89,7 +89,9 @@ bloco de notas. Você pode usar IA, ajustá-la ou deixá-la totalmente sozinha.
 - Uma entrada de tempo possui o registro do que aconteceu.
 - A IA propõe; você analisa e decide.
 
-:::tip A questão não é uma linha do tempo imaculadaSe o plano mudou, deixe-o mudar. Se o dia correu mal, registre o que aconteceu
+:::tip[A questão não é uma linha do tempo imaculada]
+
+Se o plano mudou, deixe-o mudar. Se o dia correu mal, registre o que aconteceu
 acontecer. Um sistema útil ajuda você a ver o formato da sua vida; não pergunta
 você realizar um trabalho mais produtivo para o banco de dados.
 

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/onboarding.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/onboarding.mdx
@@ -1,0 +1,144 @@
+---
+title: Configure Lotti com integração
+description: Conecte um provedor de IA, escolha o estilo de gravação e as áreas de trabalho e transforme um primeiro pensamento em uma tarefa real.
+---
+
+# Configure Lotti com integração
+
+A integração conecta as peças mínimas necessárias para a tarefa assistida por IA de Lotti
+fluxo de trabalho: um provedor, um estilo de gravação, pelo menos uma categoria e um primeiro
+verdadeira tarefa. É uma configuração guiada, não um ambiente de demonstração separado – provedores,
+categorias e tarefas criadas aqui permanecem no aplicativo normal.
+
+Abra **Configurações → Integração** sempre que quiser iniciar ou reproduzir o fluxo.
+A página também mostra se este perfil já criou seu primeiro
+Tarefa estruturada por IA.
+
+<ManualScreenshot
+  caseId="onboarding/settings"
+  alt="Configurações do Lotti Onboarding mostrando um status ativado e a ação de integração do Replay"
+  caption="Este perfil do Projeto Waddle já criou sua primeira tarefa de IA. A integração do replay permanece disponível após a ativação."
+/>
+
+## Comece com a promessa de boas-vindas
+
+<ManualScreenshot
+  caseId="onboarding/welcome"
+  alt="Painel de boas-vindas de integração da Lotti convidando o usuário a conectar um cérebro de IA e transformar a fala em uma tarefa estruturada"
+  caption="O painel de boas-vindas é aberto no aplicativo atual. Escolha seu cérebro de IA para continuar ou saia do fluxo sem alterar a configuração."
+/>
+
+Escolha **Escolha seu cérebro de IA** para começar. **Olhe ao redor primeiro**, a luz esmaecida
+área fora do painel e a ação de retorno do sistema saem da integração sem
+conectando qualquer coisa. Você pode retornar das Configurações mais tarde.
+
+Lotti também pode oferecer boas-vindas automaticamente a um perfil elegível. O
+o prompt automático tem uma cadência de novas tentativas limitada; a entrada Configurações não, então
+você sempre mantém um caminho de volta.
+
+## Escolha onde a estruturação de tarefas é executada
+
+<ManualScreenshot
+  caseId="onboarding/providers"
+  alt="Seletor de provedor de integração Lotti com Melious.ai, Mistral, Gemini, Qwen, OpenAI e Ollama"
+  caption="Os provedores hospedados primários aparecem primeiro. Expanda Mais opções para OpenAI e o caminho local do Ollama."
+/>
+
+A página do provedor identifica as opções hospedadas e locais disponíveis:
+
+- **Melious.ai** é o padrão recomendado hospedado na UE com modelo dinâmico
+  roteamento.
+- **Mistral**, **Gemini** e **Qwen** expõem suas hospedagens correspondentes
+  regiões.
+- **OpenAI** está disponível nas opções expandidas.
+- **Ollama** se conecta a um endpoint local compatível e não requer um
+  chave de API hospedada.
+
+<ManualScreenshot
+  caseId="onboarding/api-key"
+  alt="Painel de verificação do provedor de integração Lotti mostrando uma conexão local verificada do Ollama"
+  caption="Lotti verifica o provedor escolhido antes de ativar o Connect. Os provedores hospedados usam a mesma etapa com um campo de chave de API."
+/>
+
+Para um provedor hospedado, cole a chave de API do provedor. Lotti verifica o
+conexão antes de ativar **Conectar**. Ollama verifica o local configurado
+modelos acessíveis de endpoint e relatórios. Uma conexão bem-sucedida persiste
+provedor e semeia os modelos e perfil de inferência usados pelos demais
+passos.
+
+<ManualScreenshot
+  caseId="onboarding/success"
+  alt="Confirmação de integração da Lotti de que o provedor de IA está conectado e pronto"
+  caption="A confirmação da conexão é intencionalmente calma; o maior retorno é reservado para a primeira tarefa real."
+/>
+
+O texto da tarefa capturado é enviado ao provedor atribuído à categoria selecionada
+para estruturação. Escolha um provedor cujo modelo de implantação e tratamento de dados
+se adapta ao material que você planeja capturar. Um endpoint local acessível do Ollama mantém
+essa solicitação de estruturação na máquina que a executa.
+
+## Escolha a sensação de gravação e as áreas de trabalho
+
+<ManualScreenshot
+  caseId="onboarding/recording-style"
+  alt="Seletor de estilo de gravação integrado Lotti com opções de orbe de energia moderno e medidor VU analógico"
+  caption="Escolha o visual de gravação que pareça mais claro. Ambas as opções usam o mesmo pipeline de captura."
+/>
+
+Após a conexão ser bem-sucedida, escolha o estilo de gravação usado pela primeira tarefa
+captura e posteriormente superfícies de captura de voz. Você pode alterá-lo novamente em
+**Configurações → Estilo de gravação**.
+
+<ManualScreenshot
+  caseId="onboarding/categories"
+  alt="Seletor de área de trabalho de integração Lotti com Trabalho, Fitness, Família, Amigos e Adicione suas próprias escolhas"
+  caption="Escolha uma ou mais áreas para o novo provedor. Texto dimensionado e layouts estreitos usam automaticamente uma opção de largura total por linha."
+/>
+
+A seguir, selecione uma ou mais áreas de trabalho. As predefinições cobrem categorias comuns, como
+Trabalho, Fitness, Família e Amigos; **Adicione o seu próprio** cria uma categoria com um
+nome que corresponda ao seu espaço de trabalho. A integração reutiliza uma categoria existente com
+o mesmo nome em vez de criar uma duplicata, restaura-o quando necessário e
+conecta-o ao perfil de inferência recém-propagado.
+
+O jogo manual cria dois destinos reais—**Penguin Operations** e
+**Controle da missão** — portanto, a próxima etapa demonstra a mesma escolha de categoria que
+conta de trabalho vê.
+
+## Capture a primeira tarefa real
+
+<ManualScreenshot
+  caseId="onboarding/first-task"
+  alt="Painel de integração de primeira tarefa Lotti com captura de voz, operações Penguin e destinos de controle de missão, sugestões e tipo Rather"
+  caption="Escolha onde a tarefa deve chegar e fale naturalmente, use uma sugestão inicial ou selecione Em vez de digitar. Operações Penguin são selecionadas aqui."
+/>
+
+O painel da primeira tarefa usa o pipeline de captura normal de Lotti. Escolha o alvo
+categoria e use um dos três caminhos:
+
+1. Selecione a gravação visual e fale a tarefa em uma frase normal.
+2. Escolha uma sugestão inicial para tentar o caminho de estruturação imediatamente.
+3. Escolha **Prefere digitar?** e insira o pensamento sem usar o microfone.
+
+Lotti ecoa as palavras capturadas enquanto as estrutura. O resultado é um verdadeiro
+tarefa na categoria escolhida, e não dados de amostra apenas de integração. Ao estruturar
+produz sugestões de checklist, elas chegam à tarefa como propostas para que você
+pode confirmá-los em vez de alterar silenciosamente a tarefa.
+
+<ManualScreenshot
+  caseId="onboarding/task-created"
+  alt="Painel de sucesso de integração da Lotti mostrando a tarefa criada Inspecionar o revezamento da sardinha Europa"
+  caption="O pensamento digitado do Projeto Waddle torna-se “Inspecione o revezamento da sardinha Europa”. A tarefa permanece no painel até que você a escolha."
+/>
+
+Escolha o cartão de tarefas criado para fechar a integração e abrir sua página de tarefas normal.
+A partir daí você pode revisar propostas de listas de verificação, adicionar capas ou evidências, definir um
+data de vencimento e prioridade, e trazer a tarefa para o Daily OS.
+
+Se você fechar o fluxo após conectar um provedor, Lotti mantém esse provedor
+configuração e trata as boas-vindas como concluídas. A repetição da integração mais tarde permanece
+seguro: é uma ação explícita de configurações, em vez de outro prompt automático.
+
+Continue com [crie sua primeira tarefa](./first-task.mdx),
+[gerenciar categorias](../organize-and-reflect/categories.mdx), e
+[configurar provedores](../ai-and-automation/provider-setup.mdx).

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,109 @@
+---
+id: index
+title: Manual Lotti
+slug: /
+sidebar_label: Bem vindo
+description: Aprenda como planejar, capturar, organizar e refletir com Lotti.
+---
+
+<div className="manual-hero manual-hero--welcome">
+  <div className="manual-eyebrow">Um diário de bordo privado, não um panóptico de produtividade</div>
+  <h1>Mantenha os fatos. Torne o dia seu.</h1>
+  <div className="manual-hero-copy">Tarefas, tempo, notas de voz, hábitos, dados de saúde e qualquer pensamento útil merecem um destino melhor do que o purgatório de guias. Lotti mantém o registro; você decide o que acontece a seguir.</div>
+  <div className="manual-hero-principles">
+    <div><strong>Sua história permanece sua.</strong><span>Ela reside em seu diário de bordo local, não em uma conta na nuvem Lotti.</span></div>
+    <div><strong>AI pergunta; você decide.</strong><span>Os agentes podem perceber, pensar e propor. Eles não têm as chaves da sua vida.</span></div>
+    <div><strong>Torne-o memorável.</strong><span>Útil, sério, deliciosamente estranho: o espaço de trabalho pode soar como você.</span></div>
+  </div>
+</div>
+
+<ManualScreenshot
+  caseId="tasks/detail"
+  alt="Página de tarefas Lotti para o habitat orbital do pinguim do Projeto Waddle, com contexto da tarefa, arte da capa, lista de verificação e registros de tempo"
+  caption="Uma tarefa é um registro vivo: o resultado, seu contexto, seus próximos movimentos e a evidência do trabalho viajam juntos."
+/>
+
+## Não é mais uma máquina para fingir que tudo correu conforme planejado
+
+Lotti distingue as coisas que você pretendia fazer das coisas que realmente
+aconteceu. Uma tarefa pode ser importante sem ocupar o dia inteiro. Um plano pode ser
+reorganizados sem falsificar a história. Um registro de tempo pode dizer, honestamente, que
+a reunião se prolongou e a boa ideia surgiu enquanto você voltava para casa.
+
+Essa separação é o ponto, não a papelada. Dá a você um registro que você pode
+confie quando a semana ficar barulhenta.
+
+:::note Sobre os pinguins (e outras bobagens excelentes)
+
+Os pinguins, o habitat orbital, as sardinhas e o **Projeto Waddle** aparecem apenas em
+o espaço de trabalho de demonstração fictício **Intergalactic Penguin Logistics** deste manual.
+Eles fazem com que as capturas de tela pareçam uma história coerente, enquanto os controles,
+fluxos e comportamento do produto mostrados são o verdadeiro aplicativo Lotti. Seu próprio espaço de trabalho
+pode ser tão comum – ou tão deliciosamente estranho – quanto você quiser. A arte da capa da tarefa é
+opcional; uma boa metáfora visual pode tornar uma semana lotada muito mais fácil de ler.
+
+A paisagem mundial não é um conteúdo inicial e nunca é adicionada ao seu perfil. É
+uma captura de tela determinística: uma operação logística boba, recorrente
+personagens e capas de tarefas distintas tornam possível seguir um recurso de
+a agenda para a tarefa, projeto, diário e painel sem confundir
+dados de amostra para uma promessa de produto. A arte da capa é igualmente opcional em real
+trabalho: crie-o em Lotti quando uma imagem útil, séria ou gloriosamente peculiar
+torna o trabalho mais fácil de reconhecer.
+
+:::
+
+## Comece onde está o atrito
+
+<div className="manual-cards">
+  <a className="manual-card" href="getting-started/mental-model/">
+    <strong>Sua vida não é um atraso</strong>
+    Veja como a intenção, os planos, o tempo real, as evidências e a reflexão permanecem distintos e úteis.
+  </a>
+  <a className="manual-card" href="plan-and-capture/daily-os/">
+    <strong>Construa um dia que possa respirar</strong>
+    Transforme um check-in falado ou digitado em um plano diário editável e consciente da realidade.
+  </a>
+  <a className="manual-card" href="organize-and-reflect/tasks/">
+    <strong>Dê um lar ao trabalho</strong>
+    Crie tarefas, anexe contexto, defina prioridades e transforme a ambigüidade em próximos passos.
+  </a>
+  <a className="manual-card" href="ai-and-automation/provider-setup/">
+    <strong>Escolha um cérebro com responsabilidade</strong>
+    Escolha deliberadamente a inferência local ou na nuvem – privacidade, retenção, região e energia fazem parte da escolha.
+  </a>
+</div>
+
+## IA é opcional. Suas consequências não são.
+
+Lotti não tem back-end de inferência nem cópia da entrada do seu modelo. Armazenamento local
+e a inferência local são escolhas relacionadas, mas não são a mesma promessa:
+seu diário de bordo permanece em seus dispositivos de qualquer maneira. Com um provedor local, selecionado
+o material é processado pela máquina ou endpoint local que você configura. Com um
+provedor de nuvem, o contexto escolhido vai diretamente para esse provedor em
+**sua** conta e chave de API. Isso torna a decisão sua - mas também torna
+a devida diligência é sua.
+
+<div className="manual-responsibility-grid">
+  <div className="manual-responsibility-card">
+    <strong>Privacidade é uma decisão de roteamento.</strong><p>Para material confidencial, execute um modelo capaz localmente ou escolha um fornecedor somente após verificar sua retenção, treinamento, jurisdição e configurações de conta. “Nuvem” nunca significa automaticamente “nada é armazenado”.</p>
+  </div>
+  <div className="manual-responsibility-card">
+    <strong>A energia também é uma decisão de roteamento.</strong>
+    <p>A IA funciona em locais físicos. Prefira uma configuração ou fornecedor local cujas declarações de eletricidade, localização e carbono você possa realmente verificar. Uma rota movida a energia renovável pode evitar a terceirização dos custos de saúde e climáticos da computação movida a combustíveis fósseis – especialmente a geração de turbinas a gás – para comunidades com menos poder para recusá-la.</p>
+  </div>
+  <div className="manual-responsibility-card">
+    <strong>A aprovação humana é uma regra do produto.</strong>
+    <p>Os agentes podem analisar alterações de contexto e de rascunho, mas as alterações em seu registro esperam por você. As únicas exceções restritas são um título ou idioma inicial para uma tarefa vazia. Lotti não transforma “útil” em “inexplicável”.</p>
+  </div>
+</div>
+
+A regra prática: se você não conseguir encontrar um caminho de dados e energia, ficará feliz em
+fique para trás, deixe a IA desligada. Lotti continua útil sem ele.
+
+:::tip Comece pequeno
+
+Crie algumas categorias significativas, uma tarefa real e um sistema operacional diário
+check-in. Adicione mais estrutura somente quando ela merecer seu lugar; você está construindo um
+registro de uma vida, não alimentando uma máquina de produtividade.
+
+:::

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/index.mdx
@@ -33,7 +33,7 @@ a reunião se prolongou e a boa ideia surgiu enquanto você voltava para casa.
 Essa separação é o ponto, não a papelada. Dá a você um registro que você pode
 confie quando a semana ficar barulhenta.
 
-:::note Sobre os pinguins (e outras bobagens excelentes)
+:::note[Sobre os pinguins (e outras bobagens excelentes)]
 
 Os pinguins, o habitat orbital, as sardinhas e o **Projeto Waddle** aparecem apenas em
 o espaço de trabalho de demonstração fictício **Intergalactic Penguin Logistics** deste manual.
@@ -56,7 +56,7 @@ torna o trabalho mais fácil de reconhecer.
 
 <div className="manual-cards">
   <a className="manual-card" href="getting-started/mental-model/">
-    <strong>Sua vida não é um atraso</strong>
+    <strong>Sua vida não é uma lista de pendências</strong>
     Veja como a intenção, os planos, o tempo real, as evidências e a reflexão permanecem distintos e úteis.
   </a>
   <a className="manual-card" href="plan-and-capture/daily-os/">
@@ -100,7 +100,7 @@ a devida diligência é sua.
 A regra prática: se você não conseguir encontrar um caminho de dados e energia, ficará feliz em
 fique para trás, deixe a IA desligada. Lotti continua útil sem ele.
 
-:::tip Comece pequeno
+:::tip[Comece pequeno]
 
 Crie algumas categorias significativas, uma tarefa real e um sistema operacional diário
 check-in. Adicione mais estrutura somente quando ela merecer seu lugar; você está construindo um

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/categories.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/categories.mdx
@@ -1,0 +1,80 @@
+---
+title: Organize com categorias
+description: Use categorias como limites significativos para filtragem, planejamento, privacidade e automação.
+---
+
+# Organize com categorias
+
+Uma categoria é a principal estrutura estrutural de uma entrada. Use um quando um corpo de
+o trabalho precisa de suas próprias regras de planejamento, limites de privacidade, identidade visual ou IA
+contexto. No espaço de trabalho de demonstração, **Penguin Operations**, **Mission Control**,
+**Diplomacia dos Peixes** e **Manutenção Humana** separam
+áreas da expedição.
+
+<ManualScreenshot
+  caseId="categories/list"
+  alt="Configurações de categoria contendo operações de pinguins, controle de missão, diplomacia de peixes e manutenção humana com contagens de tarefas e ícones de status"
+  caption="A lista é pesquisável e mostra contagens de tarefas. Os ícones identificam rapidamente as categorias favoritas, privadas e inativas."
+/>
+
+## Crie uma categoria
+
+1. Abra **Configurações → Categorias**.
+2. Selecione **Criar categoria**.
+3. Insira um nome, cor e ícone distintos.
+4. Crie-o e abra a categoria novamente para configurar seu comportamento.
+
+A criação começa intencionalmente com os campos de identificação. Planejamento, privacidade,
+idioma e opções de automação ficam no editor completo após a categoria
+existe.
+
+## Configurar o comportamento da categoria
+
+<ManualScreenshot
+  caseId="categories/detail"
+  alt="Editor da categoria Penguin Operations mostrando seu nome, identidade de voo roxa e opções favoritas, privadas, ativas e de planejamento diário"
+/>
+
+O editor controla mais do que a aparência:
+
+- **Favorito** torna uma categoria importante mais fácil de reconhecer e selecionar.
+- **Privado** oculta seu conteúdo, a menos que entradas privadas estejam sendo mostradas. É
+  um limite de visibilidade, não uma criptografia separada para a categoria em si.
+- **Ativo** controla se a categoria pode ser selecionada para novas entradas.
+  Desativá-lo preserva os dados existentes.
+- **Planejamento diário** permite que a categoria participe do planejamento diário do SO.
+- **Idioma** fornece o idioma padrão para novas tarefas na categoria.
+
+Use o **planejamento diário** seletivamente. Ativá-lo para todas as categorias amplia o
+contexto do planejador e torna o ritual diário mais barulhento.
+
+## Adicione contexto de automação específico da categoria
+
+Uma categoria pode fornecer padrões para novas tarefas: um perfil de inferência e um
+modelo de agente. Estes são padrões, não bloqueios permanentes; escolhas em nível de tarefa podem
+ainda mudar mais tarde.
+
+<ManualScreenshot
+  caseId="categories/automation"
+  alt="Configurações avançadas do Penguin Operations com vocabulário de fala do Project Waddle e correções de lista de verificação aprendidas para Sir Flaps-a-Lot"
+  caption="Os termos de fala são separados por ponto e vírgula. As correções da lista de verificação são aprendidas nas edições e podem ser revisadas ou excluídas aqui."
+/>
+
+O dicionário **Reconhecimento de fala** é útil para nomes, locais, siglas,
+e vocabulário de domínio que a transcrição muitas vezes perde. Operações Penguin, para
+exemplo, ensina Lotti `Project Waddle`, `Sir Flaps-a-Lot`, `sardine` e
+`Europa`.
+
+Quando você corrige manualmente os títulos das listas de verificação geradas, Lotti pode reter os
+exemplos de antes e depois para sugestões futuras de IA. Revise os exemplos aqui
+e remova qualquer correção que não deva orientar a saída posterior.
+
+## Categorias versus rótulos
+
+Use uma categoria para a residência principal de trabalho e um [rótulo](./labels.mdx) para um
+propriedade transversal. **Operações Penguin** é uma categoria; **Habitat
+crítico** é um rótulo que também pode ser aplicado ao trabalho de Controle da Missão.
+
+Mantenha o sistema de categorias pequeno o suficiente para que a escolha de uma seja óbvia. Adicione um novo
+categoria quando altera o planejamento, a filtragem, a privacidade ou a automação - não apenas
+porque um novo substantivo apareceu.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/dashboards.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/dashboards.mdx
@@ -1,0 +1,112 @@
+---
+title: Crie painéis úteis
+description: Combine hábitos, medições, saúde, pesquisas e exercícios em uma visão operacional reutilizável.
+---
+
+# Crie painéis úteis
+
+Um painel agrupa gráficos que respondem a uma pergunta recorrente. ** Colônia
+operações** traz pressão de habitat, demanda de sardinha e número de expedições
+juntos; **A preparação da missão** mantém separada uma análise privada do lançamento. Construir
+em torno de uma decisão, em vez de coletar todos os números disponíveis.
+
+<ManualScreenshot
+  caseId="dashboards/settings-list"
+  alt="Configurações do painel contendo operações da Colônia e o painel privado de prontidão da missão"
+/>
+
+## Crie um painel
+
+1. Abra **Configurações → Gerenciamento do painel**.
+2. Selecione **Criar painel**.
+3. Adicione um nome claro e uma descrição da pergunta que deve ser respondida.
+4. Opcionalmente, atribua uma categoria e uma configuração de privacidade.
+5. Adicione e organize gráficos e salve.
+
+<ManualScreenshot
+  caseId="dashboards/settings-detail"
+  alt="Editor do painel de operações da colônia atribuído à Penguin Operations com privacidade e opções ativas"
+/>
+
+- **Categoria** disponibiliza o painel para filtragem baseada em categoria.
+- **Privado** oculta o painel, a menos que entradas privadas sejam mostradas.
+- **Ativo** controla se ele aparece na lista de Painéis sem
+  excluindo a definição.
+
+## Compor e ordenar gráficos
+
+<ManualScreenshot
+  caseId="dashboards/charts"
+  alt="Lista de gráficos de operações da colônia com média diária de pressão do habitat, sardinhas consumidas na soma diária e pinguins contabilizados na soma diária"
+  caption="Arraste com a alça para reordenar. Selecione o controle de ajuste em um gráfico de medição para alterar sua agregação ou remova-o com ×."
+/>
+
+A ordem do gráfico é a ordem do painel. Coloque primeiro o sinal que enquadra o resto. Para
+Operações de colônia, a pressão do habitat leva porque um habitat inseguro muda a forma como
+todos os outros números devem ser interpretados.
+
+Os gráficos de medição mantêm sua própria agregação no item do painel. Isso permite
+o mesmo mensurável aparece com um resumo diferente em outro painel
+sem alterar as observações subjacentes.
+
+## Adicione gráficos de fontes suportadas
+
+<ManualScreenshot
+  caseId="dashboards/sources"
+  alt="Editor de painel que oferece hábitos, medições, saúde, pesquisas e exercícios como fontes de gráficos, além de exportação JSON"
+/>
+
+O editor pode adicionar:
+
+- **Hábitos** para histórico de conclusão.
+- **Medições** para observações numéricas definidas pelo usuário.
+- Dados de **Saúde** suportados pela plataforma e permissões atuais.
+- **Pesquisas** para resultados de questionários configurados.
+- **Exercícios** importados de fontes de saúde suportadas.
+
+Expanda uma origem, selecione um ou mais gráficos e adicione-os. A disponibilidade depende
+nas definições e dados de plataforma existentes; solicitações de permissão de saúde e
+os tipos suportados variam de acordo com o dispositivo.
+
+## Abra e interprete um painel
+
+Abra o **Insights** para ver os painéis ativos. A lista mostra cada painel
+ícone, nome e finalidade da categoria. Use o filtro no cabeçalho para focar em um
+ou mais categorias.
+
+<ManualScreenshot
+  caseId="dashboards/list"
+  alt="Lista de painéis Lotti Insights com operações de colônia e painéis privados de prontidão para missões"
+  caption="Desktop reserva o painel direito para o painel selecionado; mobile abre o painel selecionado como uma página separada."
+/>
+
+Selecione **Operações de colônia** para abrir seus gráficos. No desktop, a lista e
+painel selecionado permanecem lado a lado. No celular, o painel é aberto conforme
+própria página com um botão Voltar.
+
+<ManualScreenshot
+  caseId="dashboards/view"
+  alt="Painel de operações da colônia mostrando 90 dias de pressão no habitat e sardinhas consumidas com a lista de painéis ao lado no desktop"
+  caption="O cabeçalho fixo mantém os controles de intervalo de 30, 90, 180 e 365 dias visíveis enquanto os gráficos rolam abaixo."
+/>
+
+O intervalo selecionado se aplica a todos os gráficos da página. Os cartões gráficos retêm
+suas próprias unidades e agregação: a pressão do habitat usa uma média diária enquanto
+o consumo de sardinha e o número de pinguins usam somas diárias. Selecione **+** em um
+cartão de medição para registrar uma nova observação desse tipo.
+
+<ManualScreenshot
+  caseId="dashboards/view-crew"
+  alt="Painel de operações da colônia rolado para sardinhas consumidas e pinguins contabilizados nos gráficos"
+  caption="Uma breve queda para 36 pinguins é visível nos 90 dias de história da tripulação; os dias circundantes voltam ao esperado 37."
+/>
+
+Trate um gráfico como evidência, não como um veredicto. Verifique a agregação, unidades, data
+alcance, observações faltantes e estado de privacidade antes de tirar conclusões.
+
+## Exportar configuração do painel
+
+**Salvar e copiar JSON** persiste no painel e depois copia sua configuração
+e definições mensuráveis referenciadas. Isto é útil para inspeção ou movimentação
+uma configuração, mas não é um link de sincronização ao vivo: edições posteriores não atualizam um
+carga útil já copiada.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/events.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/events.mdx
@@ -1,0 +1,115 @@
+---
+title: Lembre-se de eventos significativos
+description: Planeje os próximos momentos, reúna suas fotos e anotações e mantenha as tarefas relacionadas ao lado da memória.
+---
+
+# Lembre-se de eventos significativos
+
+Os eventos dão aos momentos significativos um lugar próprio em Lotti. Use um evento para um
+lançamento, viagem, comemoração, conferência ou outro momento que você queira revisitar. Usar
+tarefas para o trabalho de preparação e acompanhamento em torno dele.
+
+Os eventos são atualmente um recurso opcional. Abra **Configurações → Avançado → Sinalizadores**
+e ative **Ativar eventos**. O destino **Eventos** aparece então na
+barra lateral do computador e em **Mais** no celular.
+
+<ManualScreenshot
+  caseId="events/overview"
+  alt="Visão geral dos eventos com a próxima cimeira do futuro da sardinha Europa e celebrações concluídas do Projeto Waddle"
+  caption="A visão geral promove o próximo evento e agrupa o arquivo por ano. Cada exemplo usa um momento distinto e uma foto de capa da Intergalactic Penguin Logistics."
+/>
+
+## Navegue e filtre seus eventos
+
+A visão geral é conduzida por fotos para que um evento seja reconhecível antes de você ler seu
+título. O evento futuro mais próximo aparece no herói **Próximos**. Eventos anteriores
+são agrupados por ano, os mais recentes primeiro.
+
+Use **Pesquisar eventos** para encontrar um evento pelo texto. Selecione um chip de categoria - como
+como **Operações Penguin**, **Controle de Missão** ou **Diplomacia de Peixes** — para restringir
+o arquivo completo. A filtragem é aplicada à coleção de eventos armazenados, não
+apenas para os cartões atualmente visíveis na tela.
+
+Lotti carrega um arquivo longo em páginas e renderiza apenas as linhas próximas. Centenas de
+eventos ricos em fotos, portanto, permanecem práticos sem carregar todas as capas em
+uma vez.
+
+## Crie um evento
+
+Selecione **Novo evento**. Um novo evento é aberto na página de detalhes, onde você pode adicionar um
+título, categoria, data e hora, status, foto da capa e entradas de apoio.
+
+Escolha um título que nomeie o momento e não a sua preparação. Por exemplo,
+**Gala de lançamento do Projeto Waddle** é o evento; **Recalibre o peixe de gravidade zero
+feeder** é uma tarefa vinculada.
+
+## Leia e edite os detalhes do evento
+
+<ManualScreenshot
+  caseId="events/detail"
+  alt="Evento de gala de lançamento do Projeto Waddle com um herói fotográfico, status concluído, classificação de cinco estrelas, resumo, três fotos e duas tarefas vinculadas"
+  caption="A mesma página de detalhes de produção se torna um layout de duas colunas no desktop e se acumula em uma rolagem no celular."
+/>
+
+O herói mantém a identidade do evento e os principais controles juntos:
+
+- selecione o título para editá-lo;
+- selecione a categoria ou pílula de status para alterá-la;
+- selecione a data e hora para remarcar o evento;
+- selecione uma estrela para alterar a classificação de um evento concluído; e
+- abra o menu flutuante para alterar a capa ou excluir o evento.
+
+As alterações são salvas na página de detalhes; não existe um formulário separado para reabrir. Um
+a classificação aparece após a conclusão de um evento ou sempre que o evento já tiver um
+classificação.
+
+O resumo usa a resposta de IA vinculada mais recente, quando existe. Caso contrário,
+mostra a própria nota do evento. Trate isso como uma rápida recapitulação e, em seguida, use as fotos e
+linha do tempo para o registro subjacente.
+
+## Construa um registro fotográfico
+
+A seção **Fotos** coleta todas as imagens vinculadas ao evento em ordem de tempo.
+Selecione uma miniatura para abrir o visualizador em tela inteira e deslize entre as fotos ou
+aperte para ampliar. Uma grande coleção é limitada a uma visualização compacta; a última telha
+mostra quantas fotos a mais estão disponíveis.
+
+A capa é uma das fotos vinculadas do evento. Se nenhuma capa for escolhida,
+Lotti pode usar a primeira foto vinculada. Use **Alterar capa** no menu flutuante
+para escolher outra imagem ou adicionar uma nova foto do mesmo seletor.
+
+## Siga o cronograma e trabalhos relacionados
+
+<ManualScreenshot
+  caseId="events/timeline"
+  alt="Cronograma do evento do Projeto Waddle com fotos de controle da missão, uma nota de vedação de pressão, imagens de carga de sardinha e duas tarefas relacionadas"
+  caption="Fotos, notas, gravações e tarefas de acompanhamento permanecem conectadas ao evento sem transformar o evento em si em uma tarefa."
+/>
+
+A linha do tempo classifica as entradas vinculadas da mais antiga para a mais recente. Pode conter:
+
+- fotos e suas legendas;
+- notas;
+- entradas de áudio e notas de voz; e
+- registros de tempo, mostrados como início, fim e intervalo decorrido.
+
+Selecione um item da linha do tempo para abrir sua entrada de origem. Selecione **Adicionar** ao lado
+**Linha do tempo** para criar uma nota, foto, entrada de áudio ou outra entrada suportada que
+é vinculado a este evento automaticamente.
+
+A seção **Tarefas** é para preparação e acompanhamento. Selecione uma tarefa existente
+para abri-lo ou selecione **Adicionar** para criar uma tarefa já vinculada ao evento. Ligado
+na área de trabalho, as tarefas permanecem visíveis no painel direito enquanto você lê o evento; sobremobile, eles seguem a linha do tempo na mesma rolagem.
+
+## Evento ou tarefa?
+
+Use esta distinção ao decidir onde algo pertence:
+
+| Use um evento para… | Use uma tarefa para… |
+| --- | --- |
+| Um momento com data, fotos, recapitulação e valor de memória | Uma ação com status, estimativa, lista de verificação ou sessão de trabalho |
+| Gala de lançamento do Projeto Waddle | Recalibrar o alimentador de peixes com gravidade zero |
+| Cimeira Europa sobre o futuro da sardinha | Confirme as cápsulas interplanetárias de carga de sardinha |
+
+Vincule os dois quando o trabalho apoiar o momento. Isso mantém o evento agradável
+revisitar enquanto seu trabalho operacional permanece acionável.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/habits-and-measurables.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/habits-and-measurables.mdx
@@ -1,0 +1,160 @@
+---
+title: Rastreie hábitos e medições
+description: Configure comportamentos recorrentes e observações numéricas e registre cada um honestamente.
+---
+
+# Rastreie hábitos e medições
+
+Um hábito responde **este comportamento recorrente aconteceu?** Uma resposta mensurável
+**que valor numérico observei?** Eles podem apoiar o mesmo objetivo sem
+sendo intercambiáveis: “Chamada do pinguim imperador” é um hábito, enquanto “Pinguins
+contabilizado” é um valor mensurável.
+
+## Trabalhe com hábitos
+
+A página Hábitos organiza as definições ativas no que é devido agora, agendado
+para mais tarde e concluído. Seu resumo diário, histórico de consistência, sequências e
+O gráfico de taxa de conclusão ajuda você a perceber padrões sem tratar um dia perdido
+como toda a história.
+
+<ManualScreenshot
+  caseId="habits/today"
+  alt="Painel de hábitos de operações de pinguins mostrando verificações de habitat, lista de pinguins, inventário de sardinhas, estado de conclusão, listras e histórico recente"
+/>
+
+### Crie e encontre definições de hábitos
+
+1. Abra **Configurações → Hábitos**.
+2. Selecione **Criar hábito**.
+3. Dê ao comportamento um nome concreto e repetível e uma descrição útil.
+4. Escolha sua categoria, opções e programação.
+5. Salve.
+
+<ManualScreenshot
+  caseId="habits/settings-list"
+  alt="Configurações de hábitos contendo chamada de pinguim-imperador, revisão da previsão de sardinhas e caminhada pelas focas de habitat com estados favoritos, inativos e privados"
+  caption="Pesquise definições aqui. A estrela, o olho oculto e o cadeado identificam hábitos favoritos, inativos e privados."
+/>
+
+<ManualScreenshot
+  caseId="habits/settings-detail"
+  alt="Editor de hábitos de chamada do pinguim-imperador com descrição da expedição, categoria de operações do pinguim e opções favoritas, privadas e ativas"
+/>
+
+O editor de definição inclui:
+
+- **Categoria** para filtragem e contexto visual.
+- **Painel** quando o hábito deve aparecer como um gráfico em um painel selecionado.
+- **Favorito** para maior destaque.
+- **Privado** para ocultá-lo, a menos que entradas privadas sejam mostradas.
+- **Ativo** para controlar se ele aparece na página de Hábitos sem excluir
+  sua história.
+
+### Programe um hábito diário
+
+<ManualScreenshot
+  caseId="habits/schedule"
+  alt="Programação da chamada do pinguim-imperador a partir de 1º de julho, exibida a partir das 06h com alerta às 06h30"
+/>
+
+O editor atual prioriza diariamente. Defina uma **data de início** e, opcionalmente, adie quando
+o hábito é **mostrado a partir de** e, opcionalmente, escolha quando Lotti deve **mostrar um
+alerta**. O modelo de dados também compreende programações semanais e mensais, mas o
+O presente editor expõe os controles de tempo mais ricos para hábitos diários.
+
+### Registre o que realmente aconteceu
+
+Abra um hábito devido ou use sua ação rápida. O formulário de preenchimento detalhado suporta
+três resultados:
+
+- **Sucesso** — o comportamento aconteceu.
+- **Perdido** — era esperado e possível, mas não aconteceu.
+- **Pular** — não se aplicava razoavelmente naquele dia.
+
+<ManualScreenshot
+  caseId="habits/record"
+  alt="Formulário de preenchimento de hábito para inspecionar as focas do habitat dos pinguins, com resultados de Sucesso, Pular e Perdido, além de data e notas"
+/>
+
+Use o estado que preserva a realidade. Uma história sincera é mais útil do que uma
+gráfico de aparência perfeita. Os registros de conclusão são lançamentos contábeis manuais, portanto, visualizações posteriores
+pode reconstruir o resultado efetivo para cada hábito e dia.
+
+## Trabalhe com mensuráveis
+
+Uma definição mensurável descreve o número antes de você registrá-lo: seu nome,
+unidade, privacidade e como múltiplas observações se combinam nos gráficos.
+
+<ManualScreenshot
+  caseId="measurables/settings-list"
+  alt="Configurações mensuráveis contendo pressão do habitat, pinguins contabilizados e sardinhas consumidas"
+/>
+
+### Crie um tipo de dados mensurável
+
+1. Abra **Configurações → Tipos de dados mensuráveis**.
+2. Selecione a ação adicionar.
+3. Adicione um nome, uma descrição opcional e uma abreviatura concisa da unidade.
+4. Escolha a agregação padrão usada pelos gráficos.
+5. Decida se deve ser favorito ou privado e salve.
+
+<ManualScreenshot
+  caseId="measurables/settings-detail"
+  alt="Editor mensurável de pressão de habitat usando kPa e agregação média diária"
+/>
+
+Escolha a agregação com base no significado das leituras repetidas:
+
+| Agregação | Use-o quando |
+| --- | --- |
+| Sem agregação | Cada observação individual é importante |
+| Soma diária | Acumulam-se leituras, como sardinhas consumidas |
+| Máximo diário | O pico do dia é o sinal importante |
+| Média diária | As leituras mostram um valor variável, como a pressão do habitat |
+| Soma horária | A acumulação precisa de intervalos horários mais precisos |
+
+A unidade é um contexto de exibição, não um conversor. Se você definir a pressão do habitat como
+`kPa`, registre valores em kPa de forma consistente. Crie um mensurável separado se um
+unidade diferente representa uma série genuinamente diferente.
+
+### Registrar uma medição
+
+Abra um painel que contém o mensurável e selecione a ação adicionar em seu
+gráfico. Insira o valor observado; Lotti mantém a unidade ao lado do número para que
+está claro o que será salvo. Valores distintos recentes aparecem como **Log rápido**
+ações quando repetir uma delas é útil.
+
+<ManualScreenshot
+  caseId="measurements/capture"
+  alt="Editor de medição de consumo de sardinhas aberto em seu gráfico de painel preenchido, com 84 sardinhas, sugestões de registro rápido, tempo observado, comentário e ação para salvar"
+/>
+
+Use **Observado em** para o momento em que a leitura foi realmente realizada, em vez de
+a hora em que você entrou nele. A primeira página seleciona a data do calendário.
+**Hoje** retorna diretamente para a data atual.
+
+<ManualScreenshot
+  caseId="measurements/date"
+  alt="Observado no calendário selecionando sexta-feira, 17 de julho de 2026 para a medição da sardinha"
+/>
+
+Role até a seção de hora para definir a hora e os minutos. **Agora** restaura o
+hora atual. Selecione **Concluído** para retornar ao rascunho de medição ainda preenchido,
+em seguida, **Salvar** para criar o lançamento contábil manual.
+
+<ManualScreenshot
+  caseId="measurements/time"
+  alt="Observado no horário ajustado às 10h30 para medição da sardinha"
+/>
+
+O comentário é opcional, mas é útil quando um número necessita de
+contexto - por exemplo, uma entrega, uma mudança incomum ou uma medição alterada
+método. Salvar uma medição não altera a definição mensurável ou sua
+regra de agregação.
+
+## Conecte os dois sem confundi-los
+
+Uma chamada pode ser concluída com sucesso mesmo que apenas 36 pinguins tenham sido
+contado – o hábito registra se o procedimento aconteceu, enquanto o mensurável
+registra o resultado. Coloque ambos em um [dashboard](./dashboards.mdx) quando seus
+relacionamento responde a uma questão operacional recorrente.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/habits-and-measurables.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/habits-and-measurables.mdx
@@ -32,7 +32,7 @@ como toda a história.
 
 <ManualScreenshot
   caseId="habits/settings-list"
-  alt="Configurações de hábitos contendo chamada de pinguim-imperador, revisão da previsão de sardinhas e caminhada pelas focas de habitat com estados favoritos, inativos e privados"
+  alt="Configurações de hábitos contendo chamada de pinguim-imperador, revisão da previsão de sardinhas e caminhada pelas vedações do habitat com estados favoritos, inativos e privados"
   caption="Pesquise definições aqui. A estrela, o olho oculto e o cadeado identificam hábitos favoritos, inativos e privados."
 />
 
@@ -73,7 +73,7 @@ três resultados:
 
 <ManualScreenshot
   caseId="habits/record"
-  alt="Formulário de preenchimento de hábito para inspecionar as focas do habitat dos pinguins, com resultados de Sucesso, Pular e Perdido, além de data e notas"
+  alt="Formulário de preenchimento de hábito para inspecionar as vedações do habitat dos pinguins, com resultados de Sucesso, Pular e Perdido, além de data e notas"
 />
 
 Use o estado que preserva a realidade. Uma história sincera é mais útil do que uma

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/journal.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/journal.mdx
@@ -1,0 +1,176 @@
+---
+title: Mantenha um diário útil
+description: Encontre notas, fotos, gravações, eventos e resultados de IA em um feed e conecte a atividade de suporte por trás de cada entrada.
+---
+
+# Mantenha um diário útil
+
+O Journal é o feed de entrada mista de Lotti. Traz notas, fotos, gravações,
+eventos, listas de verificação, medições e respostas de IA juntos sem virar
+em tarefas. Use-o quando quiser lembrar, inspecionar ou conectar o que
+aconteceu; use **Tarefas** quando a entrada em si for um trabalho que você ainda precisa fazer.
+
+<ManualScreenshot
+  caseId="journal/overview"
+  alt="Feed de diário contendo uma foto de lançamento do Projeto Waddle, registro de missão, mensagem de voz da sardinha Europa, evento de cúpula e resumo de telemetria de carga"
+  caption="Os glifos de tipo tornam o feed misto escaneável, enquanto as cores das categorias, rótulos, estrelas, sinalizadores, durações e chips de status mantêm o contexto útil próximo a cada entrada."
+/>
+
+## Leia o feed misto
+
+Cada cartão inicia com seu conteúdo e usa um glifo colorido para identificar o
+tipo de entrada. A cor vem da categoria da inscrição, então **Penguin
+Operações**, **Controle de Missão** e **Diplomacia de Pesca** permanecem reconhecíveis
+mesmo quando vários tipos de entrada aparecem juntos.
+
+Os cartões adicionam os metadados importantes para seu tipo. Por exemplo:
+
+- um memorando de áudio mostra sua duração e sinalizador;
+- um evento mostra seu status, data, classificação e nota;
+- uma lista de verificação mostra o progresso da conclusão;
+- uma medida mostra o seu valor e unidade; e
+- uma resposta de IA é marcada como gerada por IA.
+
+O feed é carregado em páginas, portanto, um diário longo não precisa renderizar todo o seu conteúdo.
+história de uma vez.
+
+## Pesquise por palavras ou significado
+
+Use **Texto Completo** para encontrar as palavras armazenadas em uma entrada. Quando a pesquisa vetorial é
+ativado, mude para **Vetor** para procurar entradas com significado semelhante, mesmo
+quando usam palavras diferentes. Os resultados do vetor são retornados como um conjunto classificado
+em vez de um feed com páginas infinitas.
+
+Se a pesquisa vetorial não estiver disponível ou for desativada posteriormente, Lotti retornará o Diário
+para o modo de texto completo em vez de deixar a pesquisa em um estado inutilizável.
+
+## Filtre o que aparece
+
+<ManualScreenshot
+  caseId="journal/filters"
+  alt="Caixa de diálogo de filtro de diário com controles com estrela, sinalizado, privado, tipo de entrada e categoria no feed de logística do pinguim"
+  caption="Combine propriedades, tipos e categorias de entrada para transformar o feed misto na fatia que você precisa."
+/>
+
+Abra o botão de filtro ao lado de Pesquisar. Você pode restringir o Diário para:
+
+- entradas marcadas com estrela, sinalizadas ou privadas;
+- um ou mais tipos de entrada, incluindo Texto, Evento, Áudio, Foto, Lista de Verificação,
+  Tarefas e Resposta de IA; e
+- uma ou mais categorias.
+
+Essas escolhas são mantidas para o Diário. Os filtros de tarefas são armazenados
+separadamente, portanto, alterar a visualização do Diário não reorganiza inesperadamente o
+Página de tarefas.
+
+## Adicione uma entrada
+
+<ManualScreenshot
+  caseId="journal/create"
+  alt="Adicionar menu oferecendo Evento, Tarefa, Gravação de Áudio, Entrada de Texto, Importar Imagem e Captura de Tela no diário do Projeto Waddle"
+  caption="O menu oferece apenas ações suportadas pela plataforma e contexto atuais."
+/>
+
+Selecione **+** para abrir o menu Adicionar. No Diário principal você pode criar um texto
+entrada, tarefa, evento ou gravação de áudio, importe uma foto ou faça uma captura de tela.
+A colagem de imagens da área de transferência pode aparecer quando uma imagem está disponível. A criação de eventos é
+mostrado quando o recurso Eventos está ativado.
+
+O mesmo menu se adapta dentro de uma entrada existente. Lá também pode criar um cronômetro
+já vinculado à entrada e os detalhes da tarefa podem oferecer uma lista de verificação vinculada.
+Imagens importadas, coladas, descartadas e capturadas podem participar do processo automático
+análise de imagem quando essa automação está configurada.
+
+## Ler e editar uma entrada
+
+<ManualScreenshot
+  caseId="journal/detail"
+  alt="Detalhe do registro da missão do Projeto Waddle com categoria, rótulos, estrela, duração, rich text, filtros de atividades e uma foto de lançamento vinculada"
+  caption="A entrada continua sendo a fonte da verdade; fotos de suporte, cronômetros, prompts e links de entrada permanecem anexados abaixo dele."
+/>
+
+O cabeçalho de detalhes mantém a data de entrada, categoria, rótulos, estrela, bandeira, privacidade,
+e transbordar ações juntas. Selecione o corpo para editar rich text. Salvar do
+controles do editor ou use **Ctrl+S** no Windows e Linux e **Command+S** em
+macOS. O texto não salvo é mantido como rascunho; descartar restaura o último salvo
+conteúdo.
+
+O menu flutuante contém as ações que se aplicam ao tipo de entrada atual,
+incluindo ações de cópia, exclusão e mídia. Na área de trabalho, entradas de imagem e áudio
+também pode revelar seu arquivo de origem no gerenciador de arquivos.
+
+### Alterar a data e a duração de uma entrada
+
+Selecione a data ou duração no cabeçalho da entrada para abrir **Data e hora**. Por um
+entrada no mesmo dia, escolha uma data e defina a hora de início e de término de forma independente.
+O resumo da duração é atualizado conforme as rodas se movem. Ative **Escolha um final separado
+data** para uma entrada noturna ou de vários dias e use a ação **Agora** paramova esse endpoint para a data e hora atuais.
+
+<ManualScreenshot
+  caseId="journal/date-time"
+  alt="Editor de data e hora para o registro da missão do Projeto Waddle com data de 17 de julho, início às 8h10, término às 8h40 e duração de 30 minutos"
+/>
+
+Selecione o botão de data para abrir a página do calendário. **Hoje** retorna ao
+dia atual, **Concluído** retorna ao editor de intervalo e **Salvar** aplica o
+intervalo inicial/final completo para a entrada.
+
+<ManualScreenshot
+  caseId="journal/date-picker"
+  alt="Calendário de data de início selecionando sexta-feira, 17 de julho de 2026 para o registro da missão do Projeto Waddle"
+/>
+
+A alteração do carimbo de data/hora afeta onde a entrada aparece em ordem cronológica
+visualizações. Ele não reescreve o texto de entrada nem desvincula sua atividade vinculada.
+
+## Siga a atividade vinculada
+
+<ManualScreenshot
+  caseId="journal/activity"
+  alt="Atividade vinculada do Projeto Waddle com um prompt de codificação de IA, um ensaio de chamada de 23 minutos e a tarefa de revisão de lançamento recebida"
+  caption="A atividade de saída responde ao que esta entrada contém; Vinculado de mostra quais outras entradas apontam para ele."
+/>
+
+As inscrições podem ser vinculadas a fotos, cronômetros, áudio, resultados de IA, notas e outros
+registros de apoio. As pílulas de atividade permitem mostrar ou ocultar o **Temporizador**,
+Entradas de **Áudio**, **Imagens** e **Código**. Abra o controle de classificação para alternar
+entre a ordem mais recente e a mais antiga, inclua links ocultos ou mostre
+apenas atividade sinalizada.
+
+As duas direções significam coisas diferentes:
+
+- a atividade abaixo da entrada está vinculada **a esta entrada**; e
+- **Linked from** lista entradas que apontam **para esta entrada**.
+
+Por exemplo, o registro da missão do Projeto Waddle contém sua foto de lançamento,
+prompt de diagnóstico e cronômetro de chamada, enquanto a tarefa de revisão de lançamento aparece
+em **Linked from** porque essa tarefa também faz referência ao log.
+
+Abra o painel de classificação para preparar várias alterações de visibilidade juntas. Escolha o
+ordem, se entradas ocultas devem ser incluídas e se apenas sinalizadas
+as entradas devem permanecer. A lista de atividades muda quando você seleciona a marca de seleção
+terminar a folha; fechá-lo de outra forma descarta as escolhas encenadas.
+
+<ManualScreenshot
+  caseId="journal/linked-filter"
+  alt="Filtrar e classificar planilha sobre a atividade vinculada do Projeto Waddle com a mais antiga primeiro e Mostrar entradas ocultas selecionadas"
+/>
+
+## Abra e salve uma foto
+
+Selecione uma foto embutida para abrir o visualizador em tela cheia. Aperte ou use o visualizador
+controles para zoom e panorâmica e, em seguida, redefina a imagem quando necessário. Salvar usa o
+arquivo original em vez da visualização menor: o celular grava na foto
+biblioteca após a permissão ser concedida, enquanto a área de trabalho abre o salvamento do sistema
+caixa de diálogo para que você escolha o destino.
+
+## Diário ou tarefa?
+
+| Use o Diário para… | Usar tarefas para… |
+| --- | --- |
+| Um registro de missão, foto, mensagem de voz, medição, memória de eventos ou resultado de IA | Uma ação com status, prioridade, estimativa, lista de verificação ou sessão de trabalho |
+| “As sardinhas da Europa estão mais frias do que o protocolo diplomático exige” | “Recalibrar o alimentador de peixes com gravidade zero” |
+| Evidências e contexto que você pode querer revisitar | Trabalho que você precisa planejar, executar e concluir |
+
+Vincule-os quando uma tarefa precisar de evidências do Diário. Isso mantém a ação
+focado enquanto preserva o histórico operacional mais rico por trás dele.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/labels.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/labels.mdx
@@ -1,0 +1,70 @@
+---
+title: Marcar trabalho com rótulos
+description: Use rótulos para contexto transversal que abrange categorias e tarefas.
+---
+
+# Tag funciona com rótulos
+
+As etiquetas adicionam uma segunda camada flexível de organização. Uma tarefa tem um principal
+categoria, mas pode carregar vários rótulos para iniciativas, urgência, espera
+estados ou outra propriedade que ultrapasse os limites da categoria.
+
+<ManualScreenshot
+  caseId="labels/list"
+  alt="Configurações de rótulo contendo Aguardando Controle de Missão, Habitat Crítico, Projeto Waddle e Sardinha sensíveis ao mercado com contagens de uso de tarefas"
+  caption="As contagens de uso revelam quais rótulos estão ativos no espaço de trabalho; o cadeado marca uma marca própria."
+/>
+
+O espaço de trabalho Intergalactic Penguin Logistics usa rótulos deliberadamente:
+
+- **Projeto Waddle** conecta o trabalho de lançamento nas Operações Penguin, Missão
+  Controle e Diplomacia dos Peixes.
+- **Habitat crítico** identifica o trabalho que deve ser concluído antes da expedição
+  entra no habitat orbital.
+- **Aguardando Controle da Missão** registra um estado de bloqueio real.
+- **Sardinha sensível ao mercado** mantém o trabalho de negociação privada identificável.
+
+## Crie e edite um rótulo
+
+1. Abra **Configurações → Etiquetas**.
+2. Selecione **Criar etiqueta**.
+3. Adicione um nome conciso e uma descrição opcional.
+4. Escolha uma cor que permaneça distinguível de outras etiquetas.
+5. Decida se o rótulo é privado e quais categorias podem utilizá-lo.
+6. Salve.
+
+<ManualScreenshot
+  caseId="labels/detail"
+  alt="Editor de rótulos do Projeto Waddle mostrando sua descrição crítica de lançamento, cor azul, opção de privacidade e três categorias aplicáveis"
+/>
+
+Vale a pena escrever descrições quando um rótulo pode ser interpretado em mais de
+uma maneira. Eles fornecem o significado operacional sem forçar essa explicação
+em cada título de tarefa.
+
+**Categorias aplicáveis** restringem onde o rótulo pode ser selecionado. Projeto
+Waddle está disponível nas três partes da expedição envolvidas no lançamento,
+enquanto um rótulo especializado pode permanecer limitado a uma categoria. Isso mantém os selecionadores
+relevantes em vez de apresentar todos os rótulos em todos os lugares.
+
+## Aplicar rótulos às tarefas
+
+Abra uma tarefa e use seu controle de rótulo para adicionar ou remover rótulos. Etiquetas funcionam
+junto com filtros de status, prioridade e categoria da tarefa, para que você possa perguntar com foco
+questões como “mostrar trabalho aberto P1 crítico para o habitat” sem inventar um novo
+categoria para essa visão temporária.
+
+A remoção de um rótulo de uma tarefa é tratada como uma rejeição intencional quando
+sugestões automáticas de rótulos estão habilitadas. Lotti registra essa escolha da mesma forma
+sugestão não é imediatamente reaplicada sem nova razão.
+
+## Mantenha os rótulos úteis
+
+- Prefira rótulos que alterem uma decisão, filtro ou revisão.
+- Reutilize um rótulo estável em vez de criar variantes ortográficas.
+- Verifique as contagens de uso antes de excluir ou consolidar rótulos.
+- Use a privacidade quando o próprio nome do rótulo revelar um contexto confidencial.
+- Retire os rótulos que não descrevem mais o trabalho ao vivo.
+
+Se algo for o principal e durável lar do trabalho, faça dele um
+[categoria](./categories.mdx) em vez disso.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/projects.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/projects.mdx
@@ -1,0 +1,130 @@
+---
+title: Executar trabalhos como projetos
+description: Agrupe tarefas relacionadas, acompanhe a saúde do projeto e mantenha um relatório operacional útil ao lado do trabalho.
+---
+
+# Execute o trabalho como projetos
+
+Os projetos ficam entre categorias e tarefas. Uma categoria como **Penguin
+Operações** define uma ampla área de responsabilidade; **Grupos do Projeto Waddle**
+as tarefas concretas necessárias para preparar o habitat orbital dos pinguins.
+
+<ManualScreenshot
+  caseId="projects/list"
+  alt="Projetos agrupados em Operações Penguin, Controle de Missão, Diplomacia Pesqueira e Manutenção Humana, incluindo o Projeto Waddle e a cadeia de frio da sardinha Europa"
+  caption="Cada linha combina status, progresso da tarefa, data prevista e uma breve declaração de propósito. A área de trabalho mantém espaço para um projeto selecionado à direita; mobile usa toda a largura da lista."
+/>
+
+## Encontre o projeto que você precisa
+
+A pesquisa corresponde aos títulos dos projetos, ao texto do projeto armazenado e aos nomes das categorias. O
+o controle de filtro restringe a lista por status ou categoria do projeto. Um filtro permanece
+inativo até você selecionar **Aplicar**.
+
+<ManualScreenshot
+  caseId="projects/filters"
+  alt="Caixa de diálogo de filtro de projeto com controles de status e categoria na lista de projetos da Intergalactic Penguin Logistics"
+/>
+
+Os projetos permanecem agrupados por categoria após a filtragem. Isto faz da mesma forma
+os esforços nomeados são mais fáceis de distinguir e mantêm cada área operacional visível.
+
+## Crie um projeto
+
+Selecione o botão **+** em Projetos e digite:
+
+- um título obrigatório;
+- uma categoria opcional; e
+- uma data prevista opcional.
+
+<ManualScreenshot
+  caseId="projects/create"
+  alt="Criar formulário de projeto para Estabelecer a reserva lunar de sardinha na categoria Penguin Operations"
+  caption="O formulário de criação é uma página inferior no celular e uma caixa de diálogo centralizada no desktop."
+/>
+
+Um novo projeto começa **Aberto**. Se sua categoria tiver um modelo de agente de projeto,
+Lotti também provisiona esse agente após o projeto ser salvo. O projeto ainda
+funciona normalmente quando não existe nenhum modelo correspondente.
+
+Use um título que descreva o resultado ou a missão duradoura. “Estabelecer o
+reserva lunar de sardinhas” diz mais do que “Sardinhas”.
+
+## Editar configurações do projeto
+
+A rota de configurações do projeto fornece o editor de formulário completo para status, título,
+data prevista, integridade, atribuição do agente, alterações propostas ao agente e informações vinculadas
+tarefas. Ele também mantém as ações **Cancelar** e **Salvar** fixadas na parte inferior, para
+as alterações pendentes no formulário são explícitas.
+
+<ManualScreenshot
+  caseId="projects/editor"
+  alt="Editor de configurações do projeto Waddle mostrando seu status ativo, título, data prevista, integridade, atribuição de agente e tarefas vinculadas"
+  caption="Este é o editor de configurações de produção. Ele é separado do espaço de trabalho do projeto de leitura inicial mostrado abaixo."
+/>
+
+## Entenda o status do projeto
+
+| Estado | Use-o quando |
+| --- | --- |
+| Abrir | O projeto existe, mas a execução ativa ainda não foi iniciada. |
+| Ativo | O trabalho está em andamento e pertence ao planejamento do dia. |
+| Monitoramento | Nenhuma obra está programada, mas o resultado ainda precisa de observação. |
+| Em espera | O trabalho está pausado por um motivo conhecido. |
+| Concluído | O resultado pretendido foi alcançado. |
+| Arquivado | O projeto é mantido para história, mas não está mais operacional. |
+
+Selecione o ícone de status na página de detalhes do projeto para alterá-lo. Mudanças de status,
+alterações de categoria e alterações de data prevista são salvas imediatamente; não há separado
+botão salvar nesta superfície de detalhes de leitura primeiro.
+
+## Leia a integridade do projeto e seu relatório
+
+<ManualScreenshot
+  caseId="projects/detail"
+  alt="Detalhe do Projeto Waddle mostrando uma pontuação de integridade de 82, cinco das oito tarefas concluídas, um bloqueador e um relatório de IA atualizado há duas horas"
+  caption="O Desktop mantém a lista e os detalhes do projeto lado a lado. O celular abre os mesmos detalhes de uma página inteira."
+/>
+
+O painel de saúde resume a avaliação atual do agente do projeto:
+
+- a pontuação de saúde é um sinal compacto, não um substituto para o subjacente
+  trabalho;
+- o progresso da tarefa mostra contagens concluídas e bloqueadas;
+- o relatório apresenta um resumo actualizado e pode expandir-se até ao seu conteúdo completo; e
+- as recomendações chamam a atenção para as próximas ações concretas.
+
+No Projeto Waddle, uma pontuação de 82 e cinco tarefas concluídas são encorajadoras, mas
+o alimentador de peixes com gravidade zero ainda é um bloqueador de lançamento. Leia a explicação
+antes de tratar uma pontuação como um veredicto.
+
+Quando um agente de projeto é configurado, o menu de relatório pode solicitar um novo relatório
+ou cancelar um velório programado. Sem agente, o projeto ainda mostra suas tarefas
+e qualquer texto de projeto armazenado.
+
+## Mantenha o trabalho do projeto nas tarefas
+
+<ManualScreenshot
+  caseId="projects/tasks"
+  alt="Painel de tarefas do Projeto Waddle listando inspeção de habitat, calibração de comedouros de peixes em gravidade zero e confirmação de cápsula de carga de sardinha com estimativas e status"
+/>
+
+As linhas de tarefas do projeto mostram o título de cada tarefa, breve resumo, estimativa e informações atuais
+estado. Selecione uma linha para abrir a tarefa em si. Os detalhes da tarefa continuam sendo a fonte de
+verdade para descrições, gravações, listas de verificação, imagens, registros de tempo e
+arte da capa.
+
+Atribua uma tarefa a um projeto no controle do projeto no cabeçalho da tarefa. Projetos
+têm escopo definido por categoria, portanto, atribua uma categoria à tarefa antes de escolher um projeto.
+Uma tarefa pertence no máximo a um projeto por vez; atribuindo outro projeto
+move o link em vez de duplicá-lo.
+
+## Projetos, categorias e tarefasUse os três níveis deliberadamente:
+
+- **Categoria:** uma área operacional durável, como Operações Penguin.
+- **Projeto:** um resultado multitarefa, como o Projeto Waddle.
+- **Tarefa:** uma unidade executável, como recalibrar o peixe em gravidade zero
+  alimentador.
+
+Evite criar um projeto para uma única ação simples. Use um quando vários
+as tarefas precisam de uma data prevista, status, acúmulo de progresso ou relatório operacional compartilhado.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/projects.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/projects.mdx
@@ -99,7 +99,7 @@ o alimentador de peixes com gravidade zero ainda é um bloqueador de lançamento
 antes de tratar uma pontuação como um veredicto.
 
 Quando um agente de projeto é configurado, o menu de relatório pode solicitar um novo relatório
-ou cancelar um velório programado. Sem agente, o projeto ainda mostra suas tarefas
+ou cancelar um despertar programado. Sem agente, o projeto ainda mostra suas tarefas
 e qualquer texto de projeto armazenado.
 
 ## Mantenha o trabalho do projeto nas tarefas

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -1,0 +1,228 @@
+---
+title: Trabalhar com tarefas
+description: Use status, prioridade, listas de verificação e contexto anexado para avançar os resultados.
+---
+
+#Trabalhe com tarefas
+
+As tarefas agrupam um resultado com o contexto e as etapas necessárias para concluí-lo. Mantenha
+títulos orientados para resultados e colocam notas de apoio, imagens, gravações e tempo
+registros dentro da tarefa.
+
+<ManualScreenshot
+  caseId="tasks/workspace"
+  alt="Espaço de trabalho de tarefas de produção mostrando linhas de tarefas reais com miniaturas de capas dos dados de demonstração da Interplanetary Penguin Logistics"
+/>
+
+No desktop, a lista de tarefas permanece visível ao lado da tarefa selecionada para que você possa
+avançar no trabalho sem perder o contexto. No celular, selecionar uma tarefa abre seu
+visualização detalhada em tela cheia. A arte da capa segue a tarefa onde quer que ela apareça,
+incluindo a lista de tarefas e os itens vinculados da agenda do sistema operacional diário.
+
+A arte da capa é opcional, mas pode tornar um espaço de trabalho denso muito mais fácil de digitalizar.
+Use-o como uma dica visual útil, uma referência de produto ou uma metáfora memorável
+para o trabalho. As ilustrações do Projeto Waddle neste manual são apenas uma
+exemplo: uma capa pode ser tão prática, divertida ou maravilhosamente estranha quanto você
+quero.
+
+<ManualScreenshot
+  caseId="tasks/detail"
+  alt="Página de detalhes da tarefa de produção para inspecionar o habitat orbital dos pinguins, com a mesma capa usada pelas miniaturas das tarefas"
+/>
+
+A mesma tarefa pode conter uma descrição, categoria, rótulos, data de vencimento, registros de tempo,
+itens da lista de verificação, imagens, links e gravações de áudio.
+
+## Atribuir um agente de tarefa
+
+Uma tarefa pode ter um agente de tarefa. Atribuir um dá a essa tarefa uma IA persistente
+assistente com sua própria configuração de inferência, relatório, estado de ativação e proposta
+história. O agente lê a tarefa e seu contexto vinculado, destila o atual
+situação em um breve relatório e pode apresentar tarefas propostas ou lista de verificação
+alterações para você confirmar ou rejeitar.
+
+O agente atribuído aparece abaixo das listas de verificação e das tarefas vinculadas da tarefa. É
+o cartão recolhido mantém o resumo mais recente, controle de atualização automática, **Wake
+ação do agente ** e rota do modelo ativo visíveis sem tornar a página da tarefa
+sinta-se como um console de IA.
+
+<ManualScreenshot
+  caseId="tasks/agent-card"
+  alt="Agente de tarefa Habitat Watcher atribuído na tarefa de habitat do pinguim orbital, mostrando seu resumo atual, atualizações automáticas, ação de despertar e rota do modelo do Projeto Waddle"
+  caption="O Habitat Watcher é designado para esta tarefa; atribuição e atualizações automáticas são opções separadas."
+/>
+
+Escolha **Leia mais** para expandir o relatório completo. O cartão expandido
+mantém a tarefa visível, adiciona a avaliação de apoio do relatório e recomenda
+próxima etapa e oferece **Abertos internos do agente** quando você precisar de relatórios,
+conversas, observações ou detalhes do tempo de execução.
+
+<ManualScreenshot
+  caseId="tasks/agent-card-expanded"
+  alt="Cartão expandido do agente de tarefas do Habitat Watcher com a avaliação completa do habitat do Projeto Waddle e a próxima etapa recomendada"
+  caption="O relatório completo se expande dentro da tarefa em vez de enviar você para uma página separada."
+/>
+
+### Revise as alterações propostas
+
+Uma ativação concluída pode atualizar o relatório e adicionar alterações propostas. Automático
+as atualizações decidem *quando o agente acorda*; eles não dão permissão ao agente para
+edite a tarefa. As propostas permanecem pendentes até que você tome providências.
+
+<ManualScreenshot
+  caseId="tasks/agent-suggestions"
+  alt="Cartão de agente de tarefas do Habitat Watcher com duas propostas pendentes do Projeto Waddle, ações individuais de dispensa e confirmação e uma ação Confirmar todas"
+  caption="O agente propõe um item da lista de verificação de teste do alimentador e uma estimativa revisada; nenhuma das alterações foi aplicada ainda."
+/>
+
+Use a cruz para **Rejeitar** uma proposta ou o cheque para **Confirmar** e aplicar
+isso. Você também pode deslizar uma proposta para a esquerda para descartar ou para a direita para confirmar. Quando
+várias propostas estão pendentes, **Confirme todas** aplica-se a lista atualmente listada
+muda juntos. Revise as propostas em massa com cuidado, especialmente status, data,
+e alterações na lista de verificação.
+
+Abra o **Histórico** para revisitar os resultados recentes. Distingue confirmado
+mudanças dos demitidos. Uma entrada rejeitada pode representar tanto o seu
+decisão ou uma proposta que o agente retirou depois que o contexto da tarefa mais recente a fez
+obsoleto.
+
+Um **Agente de despertar** manual pode produzir os mesmos tipos de relatórios e propostas que
+um despertar automático. Desativar as atualizações automáticas interrompe o histórico futuro
+acorda; não aplica, descarta ou de outra forma resolve propostas que sejam
+já estou aguardando sua decisão.
+
+### Escolha atualizações automáticas ou manuais
+
+Novos agentes de tarefas começam com **Atualizações automáticas desativadas**. A atribuição por si só não
+gastar tokens em segundo plano. Enquanto as atualizações estão desativadas, Lotti continua a
+notar alterações relevantes na tarefa e suas entradas vinculadas, marca um antigo
+resumo como desatualizado e espera que você escolha **Ativar agente**. Um manual
+wake permanece disponível sempre que o agente tiver uma configuração de IA funcionando.
+
+<ManualScreenshot
+  caseId="tasks/agent-card-manual"
+  alt="Cartão de agente de tarefas do Habitat Watcher com atualizações automáticas desativadas, um aviso de relatório desatualizado e uma ação manual do agente Wake"
+  caption="O modo manual observa alterações e relata a desatualização sem iniciar a inferência."
+/>
+
+Quando **Atualizações automáticas** estão ativadas, Lotti agrupa alterações de tarefas correspondentes paracerca de dois minutos antes de agendar uma atualização. Essa coalescência evita um agente
+acorde para cada pequena edição. **Agente de ativação** ainda está disponível por um período imediato,
+atualização solicitada pelo usuário.
+
+Desativar as atualizações automáticas limpa a contagem regressiva pendente e a fila
+atualizações automáticas, mas não cancela uma ativação que você solicitou explicitamente.
+Ativá-lo novamente se aplica a alterações futuras; ele não reproduz alterações que
+chegou enquanto a automação estava desligada.
+
+## Prioridade
+
+Lotti usa quatro níveis de prioridade compactos:
+
+| Prioridade | Significado | Use-o para |
+| --- | --- | --- |
+| P0 | Urgente | Trabalho que realmente precisa de atenção em seguida |
+| P1 | Alto | Obra importante que deve acontecer em breve |
+| P2 | Médio | O padrão normal |
+| P3 | Baixo | Trabalho que pode esperar |
+
+Abra uma tarefa e use o controle de prioridade em seu cabeçalho para alterar o nível.
+As tarefas existentes sem uma prioridade explícita comportam-se como P2.
+
+## Filtre e ordene a lista de tarefas
+
+Abra os filtros de tarefas e selecione uma ou mais prioridades. Limpe essa seleção para
+retornar a todas as prioridades. A prioridade é um dos vários filtros que podem ser
+combinado com categorias e outras propriedades da tarefa.
+
+<ManualScreenshot
+  caseId="tasks/filters"
+  alt="Folha de filtro de tarefas com controles de classificação, status, prioridade, categoria e rótulo"
+/>
+
+A ordem de prioridade padrão é P0 a P3. Dentro de uma prioridade, tarefas mais recentes
+aparecem primeiro, a menos que outra visualização ou classificação ativa altere o resultado.
+
+## Use listas de verificação para a próxima camada abaixo
+
+Um item da lista de verificação deve ser menor e mais concreto do que a sua tarefa. “Publicar
+o manual” é uma tarefa; “verificar todos os links de navegação” é um item da lista de verificação.
+As listas de verificação podem ser editadas diretamente e também podem ser propostas pela IA configurada
+habilidades do contexto da tarefa.
+
+## Adicionar contexto de tarefa
+
+Use a ação **Adicionar** da tarefa para anexar uma lista de verificação, outra tarefa, um áudio
+gravação, um cronômetro, uma entrada de texto ou uma imagem sem sair da tarefa. O
+as ações disponíveis dependem da plataforma e do contexto atuais.
+
+<ManualScreenshot
+  caseId="entries/create-menu"
+  alt="Adicionar menu sobre a tarefa do habitat orbital com ações de captura com reconhecimento de tarefa"
+/>
+
+Consulte [Adicionar entradas e contexto](../plan-and-capture/entries.mdx) para saber quando usar
+cada tipo de entrada.
+
+## Gere arte de capa a partir de imagens de tarefas reais
+
+Se uma habilidade de geração de imagem estiver configurada, abra o menu de geração da tarefa
+e escolha sua ação de capa. Lotti primeiro mostra imagens já anexadas a
+a tarefa, além de imagens de capa disponíveis de tarefas vinculadas. Selecione até cinco
+referências para orientar o resultado ou continuar sem referência.
+
+A capa gerada é criada no Lotti a partir do contexto da tarefa e de qualquer
+referências que você selecionar. É um auxílio visual, não um campo obrigatório: use-o quando um
+imagem distinta torna o trabalho mais fácil ou mais agradável de reconhecer. O
+rota de geração de imagem atual usa o provedor configurado, então trate o
+prompt de geração e referências selecionadas como dados que você está enviando intencionalmente
+para esse provedor; um pensamento local ou uma rota de transcrição não oferece cobertura
+geração local.
+
+<ManualScreenshot
+  caseId="tasks/cover-references"
+  alt="Gere uma folha de capa mostrando cinco imagens de referência distintas do Projeto Waddle a partir do contexto da tarefa"
+  caption="O seletor usa as mesmas imagens de tarefa visíveis em toda a demonstração do Projeto Waddle."
+/>
+
+Depois de continuar, a geração da imagem será executada em segundo plano. O progresso
+view usa o visualizador de pensamento de produção do Lotti e pode ser fechado sem
+cancelando o trabalho.
+
+<ManualScreenshot
+  caseId="tasks/cover-generating"
+  alt="Geração de arte de capa de tarefa em andamento com o visualizador de shader de produção de Lotti"
+/>
+
+A imagem gerada torna-se a capa da tarefa e segue a tarefa na lista,
+detalhes, projetos e visualizações diárias do sistema operacional. Uma cobertura forte deve permanecer reconhecível
+quando a imagem de origem ampla é cortada em uma miniatura compacta de tarefa. Pode ser
+evidência literal, uma metáfora contida, ou tão estranha quanto a obra merece;
+o único teste útil é se você consegue reconhecer a tarefa mais rapidamente mais tarde.
+
+## Tarefas relacionadas ao link
+
+Abra a seção **Vinculada** da tarefa e opte por vincular uma tarefa existente. Pesquisar
+o seletor e selecione o resultado relacionado. Lotti exclui a tarefa atual
+e tarefas que já estão vinculadas nessa direção.
+
+<ManualScreenshot
+  caseId="tasks/link-picker"
+  alt="Seletor de links de tarefas de produção listando tarefas relacionadas do Project Waddle e seu status, prioridade, categoria e contexto de data de vencimento"
+/>
+
+Os links de tarefas são direcionais: a tarefa atual aponta para a tarefa que você escolher.Ambos os lados permanecem acessíveis através de suas seções de entrada vinculada, enquanto cada
+tarefa mantém seu próprio status, agendamento e anexos.
+
+## Use a voz sem perder o controle
+
+Registre uma nota dentro da tarefa quando for mais rápido explicar a situação em voz alta.
+Com a transcrição e as habilidades de tarefa configuradas, Lotti pode transformar esse contexto em
+texto e alterações propostas na lista de verificação. Revise o resultado, especialmente os nomes,
+datas e mudanças destrutivas. Consulte [Gravar áudio](../plan-and-capture/recordings.mdx)
+para os controles de gravação e opções de processamento.
+
+:::tip
+
+Use P0 com moderação. Se tudo for urgente, a etiqueta deixa de levar informações.
+
+:::

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/time-analysis.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/time-analysis.mdx
@@ -1,0 +1,161 @@
+---
+title: Entenda para onde foi o seu tempo
+description: Divida o tempo monitorado por categoria, siga as áreas de foco e compare períodos equivalentes sem sair do Daily OS.
+---
+
+# Entenda para onde foi seu tempo
+
+A análise de tempo transforma suas sessões gravadas em um detalhamento de categorias. Use-o
+para responder quanto tempo você rastreou, para onde foi e se a mixagem mudou
+do período anterior. O exemplo do Projeto Waddle separa **Penguin
+Operações**, **Controle de Missão**, **Diplomacia Pesqueira**, **Pesquisa Orbital** e
+**Manutenção Humana**, ao mesmo tempo que expõe o tempo não categorizado que precisa
+atenção.
+
+No desktop, abra **Daily OS** e selecione **Time Analysis** abaixo da barra lateral
+calendário. O painel preenche a área de conteúdo para que o gráfico e a tabela exata possam
+ser lidos juntos. Seus controles refluem em larguras estreitas sem alterar o que
+eles fazem.
+
+<ManualScreenshot
+  caseId="time-analysis/overview"
+  alt="Painel de análise de tempo mostrando o tempo do projeto Waddle em cinco categorias operacionais e trabalho não categorizado"
+  caption="A visão geral combina totais de títulos, um gráfico empilhado de sete dias e a tabela de categorias exata. Mude o manual para celular ou desktop e claro ou escuro para inspecionar cada layout de produção."
+/>
+
+## Leia os cartões de título
+
+A primeira linha resume o período selecionado:
+
+- **TOTAL** é todo o tempo monitorado. Sua legenda nomeia a maior categoria e seu
+  compartilhar, para que o cartão responda onde passou a maior parte do tempo e quanto foi
+  gravado.
+- **FOCUS** adiciona as categorias que você escolheu assistir. No exemplo, Pinguim
+  Operações e Controle da Missão formam o conjunto de foco.
+- **OUTRO** é tudo fora desse conjunto de foco.
+
+Antes de existir um conjunto de foco, Lotti mostra **Escolher categorias de foco** em vez de
+duas cartas de valor zero. Selecione-o, escolha uma ou mais categorias ativas e
+termine com **Concluído**. Use o botão de sintonia no cartão Focus sempre que o conjunto
+precisa mudar. Esta preferência é local para Lotti e não altera a
+categorias em qualquer entrada.
+
+## Escolha um período útil
+
+Selecione a unidade do período para alternar entre **Dia**, **Semana**, **Mês**,
+**Trimestre** e **Ano**. Use as divisas para mover um período completo de cada vez.
+tempo. A divisa direta para no período atual, portanto o painel nunca
+navega para um intervalo futuro vazio.
+
+Selecione o rótulo da data para abrir o calendário e ir diretamente para o período
+contendo outro dia. Os limites da semana seguem o primeiro dia da semana configurado por
+a região do dispositivo.
+
+Dois atalhos cobrem as perguntas mais comuns:
+
+- **Este mês** mostra o acumulado do mês; e
+- **Este ano** mostra o acumulado do ano.
+
+Esses intervalos terminam hoje, em vez de adicionar dias futuros vazios. O rótulo inclui
+**(até agora)**, e as médias usam apenas os dias decorridos.
+
+## Leia o gráfico e a tabela juntos
+
+As barras empilhadas mostram como cada categoria contribuiu para cada hora, dia ou
+semana na faixa. Passe o mouse ou pressione uma barra para ver os valores da categoria por trás disso
+balde.
+
+### Acompanhe o total em execução
+
+Selecione **Total em execução** quando a pergunta mudar de “o que aconteceu neste
+balde?” para “quanto acumulei desde o início desta faixa?” Lotti se transforma
+cada categoria em uma área cumulativa:
+
+- a espessura de uma faixa colorida em uma data é o tempo rastreado daquela categoria
+  desde o início do intervalo selecionado até essa data;
+- a borda superior da pilha completa é todo o tempo registrado acumulado ao longo do
+  mesmo intervalo; e
+- as bandas só podem segurar ou subir. Uma seção plana significa que nenhum tempo foi adicionado
+  essa categoria durante esses períodos; não subtrai o trabalho anterior.
+
+<ManualScreenshot
+  caseId="time-analysis/running-total"
+  alt="Gráfico de análise de tempo total em execução acumulando categorias do Projeto Waddle ao longo do mês selecionado"
+  caption="O total acumulado acumula cada categoria desde o início do intervalo. A borda superior é o tempo total rastreado até o momento; cada banda mostra o quanto sua categoria contribuiu para esse total."
+/>
+
+O intervalo selecionado determina onde a contagem começa. Mudando para outro
+período reinicia o total no primeiro intervalo desse período. **Dia** usa por hora
+intervalos mais curtos de vários dias usam intervalos diários e intervalos longos usam
+intervalos semanais, mas o significado cumulativo permanece o mesmo. Numa corrente,
+período inacabado, Lotti interrompe a área no último intervalo decorrido
+de traçar uma linha plana enganosa através de datas futuras.A execução do total altera apenas a projeção do gráfico. **TOTAL**, **FOCO**,
+**OUTRO**, e a tabela de categorias continua descrevendo todo o selecionado
+alcance. Passe o mouse ou pressione a área para ver o valor em execução para cada categoria em
+esse ponto. Selecione **Por dia**, **Por semana** ou **Por hora** para retornar a
+valores de bucket individuais. Se apenas um balde tiver decorrido, Lotti mantém as barras
+porque uma linha contínua de um ponto não comunicaria uma tendência.
+
+A tabela é a pesquisa precisa. Ele ordena categorias por tempo rastreado e
+mostra seu total, participação, média por dia e uma barra de dados relativa. Um cinza
+A linha **Sem categoria** é deliberada: torna visível a atribuição ausente
+em vez de escondê-lo silenciosamente. Abra as entradas ou tarefas relacionadas e atribua um
+categoria quando esse tempo deveria pertencer a uma área operacional.
+
+## Compare períodos equivalentes
+
+<ManualScreenshot
+  caseId="time-analysis/compare"
+  alt="Comparação de análise de tempo para o Projeto Waddle mostrando o horário atual, o período anterior e alterações percentuais por categoria"
+  caption="Comparar usa os mesmos dias decorridos em cada período. A direção é comunicada por uma seta, um sinal e uma cor, enquanto o gráfico permanece focado no período atual."
+/>
+
+Selecione **Comparar** para adicionar o período anterior. Para uma semana, mês,
+trimestre, ou ano, Lotti compara a parcela decorrida com o mesmo número de
+dias imediatamente antes. Um resultado acumulado do mês de domingo, portanto, não é
+em comparação com um mês anterior completo.
+
+Os cartões de título ganham sua variação percentual e valor anterior. A mesa
+muda para **CURRENT**, **PREVIOUS** e **Change**. Em larguras estreitas o
+A coluna anterior de prioridade mais baixa é omitida, enquanto Atual e Mudança permanecem
+visível. Um resultado para cima ou para baixo também usa uma seta e um sinal explícito
+como cor; mudanças muito pequenas permanecem neutras e um resultado sem
+a linha de base é mostrada como nova.
+
+O gráfico continua mostrando apenas o período atual. A nota **Comparação
+mostrado na tabela abaixo** aponta para os valores exatos e evita um segundo conjunto
+de barras ofusquem o mix de categorias.
+
+## O que Lotti conta
+
+A Análise de Tempo conta lançamentos cronometrados cujo final é posterior ao seu
+começar. A duração do áudio não é contada separadamente, porque uma gravação feita
+durante um cronômetro em execução, caso contrário, contaria duas vezes.
+
+A atribuição da categoria segue o trabalho:
+
+1. Se a entrada de horas estiver vinculada a uma tarefa com uma categoria, a categoria da tarefa
+   vence.
+2. Caso contrário, será utilizada a própria categoria do registro de horas.
+3. Se nenhum deles existir, a hora aparecerá como Sem categoria.
+
+Temporizadores sobrepostos na mesma categoria são mesclados antes que o total seja
+calculado. As sobreposições em diferentes categorias permanecem em ambas as categorias,
+porque representam tipos separados de atividade registrada. Entradas abrangendo
+meia-noite são divididos nos dias do calendário local corretos. As entradas privadas obedecem
+a configuração global de visibilidade de dados privados e o painel é atualizado quando
+entradas, links, categorias de tarefas ou alterações na configuração de visibilidade.
+
+## Mantenha a imagem confiável
+
+Use categorias de forma consistente em tarefas que possuem trabalho registrado. Revise o
+Linha não categorizada periodicamente e escolha categorias de foco que respondam a uma
+questão real em vez de tentar incluir tudo. Para o Projeto Waddle,
+assistir às Operações Penguin e ao Controle da Missão torna o cartão Focus um
+sinal de prontidão operacional enquanto a Diplomacia dos Peixes e a Manutenção Humana permanecem
+visível na análise completa.
+
+Atualmente, o Time Analysis não exporta CSV, agrupa resultados por projeto ou desenha
+o período anterior como outra série de gráficos. Os valores exatos de comparação são
+mantidos na tabela, onde são mais fáceis de ler e menos propensos a distorcer o
+quadro do período atual.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/time-tracking.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/time-tracking.mdx
@@ -1,0 +1,78 @@
+---
+title: Acompanhe e avalie o trabalho focado
+description: Registre o tempo de uma entrada, feche a sessão de forma limpa e preserve um julgamento rápido sobre produtividade, energia, foco e desafio.
+---
+
+# Rastreie e avalie o trabalho focado
+
+Lotti registra o trabalho focado como lançamentos diários cronometrados. Inicie um cronômetro a partir do
+entrada ou tarefa que possui o trabalho para que sua duração e contexto permaneçam juntos.
+Quando a sessão terminar, você poderá adicionar uma classificação estruturada enquanto a experiência é
+ainda fresco.
+
+O exemplo do Projeto Waddle avalia uma chamada de 23 minutos do pinguim-imperador
+ensaio. A folha de classificação mostrada aqui é a interface de produção desse
+entrada em tempo real, não um modelo de documentação.
+
+<ManualScreenshot
+  caseId="time-tracking/session-rating"
+  alt="Folha de classificação da sessão sobre uma entrada de tempo do Projeto Waddle com produtividade, energia, foco, desafio e uma nota de controle da missão"
+  caption="As três barras são escalas contínuas. O desafio usa escolhas explícitas e Salvar fica disponível somente depois que cada dimensão tiver uma resposta."
+/>
+
+## Registre o tempo no contexto certo
+
+Abra uma entrada ou tarefa e use sua ação de timer. Um cronômetro criado a partir de uma tarefa ou
+outra entrada de diário está vinculada a essa fonte, então o trabalho ao redor
+permanece visível na atividade vinculada. A duração é atualizada durante a gravação e
+a ação stop fecha a sessão na mesma entrada de horário.
+
+Use um cronômetro para um trecho coerente de trabalho. Se o propósito mudar – de
+inspeção de habitat à diplomacia da sardinha, por exemplo – pare o cronômetro atual
+e inicie outro na tarefa ou categoria correta. Isso mantém tanto o
+histórico de entrada e [Análise de Tempo](./time-analysis.mdx) significativo.
+
+## Classifique uma sessão concluída
+
+Após o término de uma gravação de pelo menos um minuto, Lotti mostra uma estrela ao lado
+a duração. Ele pulsa brevemente e permanece disponível até você salvar um
+classificação ou reinicie a gravação. Para um cronômetro mostrado dentro da atividade vinculada, o
+O menu de ação de entrada também oferece **Avaliar sessão** ou **Ver avaliação**.
+
+O catálogo de sessões faz quatro perguntas:
+
+- **Produtividade** é uma escala contínua do improdutivo ao pico
+  produtividade.
+- **A energia** vai de drenada a totalmente energizada.
+- **O foco** vai da distração constante ao foco ininterrupto.
+- **Este trabalho pareceu…** registros **Muito fácil**, **Perfeito** ou **Muito
+  desafiador**. **Na medida certa** representa o desafio/habilidade pretendido
+  equilíbrio.
+
+Arraste ou selecione qualquer lugar em uma barra contínua; os valores não se restringem ao
+marcas de escala visíveis. Adicione uma nota opcional para contexto de que os números não podem
+carregar. **Salvar** permanece desativado até que todas as quatro respostas estejam presentes. **Pular**
+fecha a folha sem escrever uma avaliação.
+
+## Revise e revise uma classificação
+
+Uma classificação salva é armazenada como seu próprio lançamento contábil manual e vinculada ao registro de hora
+descreve. Reabra **Ver classificação** para alterar as respostas ou a nota. Os salvos
+o resumo mantém o texto da pergunta e da opção usado no momento, portanto sincronizado
+as classificações permanecem compreensíveis mesmo se o catálogo for alterado posteriormente.
+
+As classificações de sessão estão disponíveis quando o sinalizador de configuração **Classificações de sessão**
+está habilitado. Um cliente que recebe um catálogo de classificação que não reconhece pode
+ainda exibe as respostas armazenadas, mas mantém essa classificação somente leitura em vez
+do que adivinhar como editar dados desconhecidos.
+
+## Use classificações como observações, não como notas
+
+As quatro dimensões descrevem uma sessão, não o desempenho pessoal. Um baixo
+a pontuação de energia pode explicar por que um trabalho que de outra forma seria útil parecia difícil; um alto
+pontuação de foco combinada com **Muito fácil** pode sugerir que a próxima sessão precisa de mais
+alcance ambicioso. As notas são especialmente úteis para anomalias como
+sardinha, uma interrupção ou um briefing extraordinariamente tranquilo do Controle da Missão.
+
+As classificações complementam a duração em vez de alterá-la. O temporizador permanece o
+fonte de quanto tempo o trabalho demorou, enquanto a classificação registra como foi esse tempo.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -1,0 +1,203 @@
+---
+title: Planeje e feche um dia com o Daily OS
+description: Transforme um check-in falado ou digitado em um plano editável, opere-o ao lado do tempo registrado e leve o trabalho certo adiante.
+---
+
+# Planeje e feche um dia com o Daily OS
+
+O Daily OS transforma um check-in falado ou digitado em um plano de um dia. Não
+substituir tarefas ou registros de tempo: as tarefas descrevem o trabalho, o plano diário descreve
+intenção e as sessões gravadas descrevem o que realmente aconteceu.
+
+Os exemplos acompanham a Diretora Aurora durante um dia deliberadamente agitado na
+Logística Interplanetária de Pinguins. O planejador protege o lançamento do Projeto Waddle
+revisão, avança nas negociações da sardinha e mantém uma demonstração do alimentador de peixes em gravidade zero
+claro. A situação do seu pinguim pode variar.
+
+## Antes do seu primeiro check-in
+
+Abra **Configurações → SO Diário**. Escolha o perfil de inferência que deve planejar
+seus dias e digite o nome que o Daily OS deve usar ao se dirigir a você. O
+o aviso de privacidade identifica o fornecedor selecionado e se o processamento está ativado
+este dispositivo ou controle remoto.
+
+<ManualScreenshot
+  alt="Configurações diárias do sistema operacional definidas para o Director Aurora e o perfil de inferência do Project Waddle"
+  caseId="daily-os/settings"
+  caption="O Diretor Aurora usa o perfil Project Waddle Command, Waddle Command 70B e o provedor Mission Control Router."
+/>
+
+Em seguida, abra **Configurações → Categorias** e ative **Planejamento diário** apenas para o
+categorias que o planejador pode usar. Uma lista de permissões intencional não está relacionada
+tarefas fora do planejamento e evita que o Daily OS altere o trabalho fora dessas
+categorias.
+
+## 1. Diga o que o dia precisa
+
+Abra **Daily OS**, escolha a data e selecione **Falar um check-in**. Mencionar:
+
+- compromissos e prazos fixos;
+- os resultados que importam;
+- durações aproximadas e capacidade disponível;
+- pausas, restrições energéticas e trabalhos que não devem acontecer demasiado tarde;
+- qualquer coisa já em andamento ou que provavelmente será transferida.
+
+Escolha **Digitar** quando falar for inconveniente. Após o reconhecimento,
+revise a transcrição completa e corrija nomes, números ou outros erros
+no lugar.
+
+<ManualScreenshot
+  alt="A transcrição completa do check-in diário do sistema operacional pronta para revisão"
+  caseId="daily-os/capture-review"
+  caption="Revise o texto reconhecido antes que o Daily OS combine-o com as tarefas do Project Waddle."
+/>
+
+Escolha **Regravar** para recomeçar ou **Revisar** para continuar. Construindo o dia
+permanece indisponível até que o passe correspondente seja concluído.
+
+## 2. Concilie a fala com o trabalho real
+
+Reconciliar é a verificação de segurança entre o que o assistente ouviu e o que Lotti
+mudará:
+
+- **Correspondente** aponta para uma tarefa existente. Confirme se é a tarefa que você quis dizer.
+- **Novo** é uma frase que pode virar trabalho hoje.
+- **Atualização** propõe uma alteração em uma tarefa existente.
+- Os rótulos de confiança e de âncora de tempo mostram onde a revisão é mais útil.
+
+<ManualScreenshot
+  alt="SO diário reconciliando um check-in falado com o trabalho novo e existente do Projeto Waddle"
+  caseId="daily-os/reconcile"
+  caption="A inspeção do habitat orbital é compatível com o trabalho real, enquanto novas solicitações permanecem como decisões explícitas."
+/>
+
+O Daily OS também apresenta trabalhos que estão em andamento, vencidos, com vencimento hoje ou
+perdeu recentemente. Decida o que pertence hoje em vez de importar todo o
+atraso.
+
+## 3. Julgue o rascunho
+
+Escolha **Construir meu dia** depois que as decisões de reconciliação parecerem corretas. O
+o resultado abre em **Agenda**. O cartão de capacidade responde “isso cabe?” antes
+a lista numerada responde “o que importa?” As linhas apoiadas por tarefas mantêm sua real
+categoria, status, estimativa e miniatura da capa.
+
+<ManualScreenshot
+  alt="Uma agenda do Project Waddle Daily OS com capacidade, miniaturas de tarefas, prioridades e totais de categorias"
+  caseId="daily-os/agenda"
+  caption="Cada tarefa na agenda mantém sua própria capa do Projeto Waddle, incluindo o trabalho concluído."
+/>
+
+Use os ajustes rápidos quando a forma estiver errada:
+
+- **Demais** pede um plano menor.
+**Mova-se com mais leveza** afasta trabalhos exigentes de períodos de baixa energia.
+- **Adicionar buffer** cria espaço para respirar.
+- **Refinar** abre um ajuste de voz ou texto de formato livre.
+
+Escolha **Parece bom** somente quando o rascunho for genuinamente aceitável.
+
+## 4. Revise cada refinamento proposto
+
+O Refine nunca reescreve silenciosamente o cronograma. Descreva a mudança e inspecione
+cada bloco adicionado, movido ou descartado com seu horário antigo e proposto e o
+razão do planejador. Aceite ou rejeite propostas individualmente, escolha **Reverter** para
+descarte o conjunto pendente ou continue falando para solicitar outra passagem.
+
+<ManualScreenshot
+  alt="Daily OS propõe duas mudanças de horário revisadas para as negociações da sardinha e a demonstração do alimentador de peixes"
+  caseId="daily-os/refine"
+  caption="As negociações da Sardinha avançam mais tarde para proteger a revisão de lançamento do Controle da Missão; a demonstração do alimentador de peixes segue o novo buffer."
+/>
+
+Somente as propostas aceitas passam a fazer parte do rascunho. **Parece bom** sai do
+revise assim que o plano disser o que você pretende.
+
+## 5. Bloqueie o diaA página **Lock it in** dá ao rascunho completo uma leitura final: ordem,
+duração, resultados e capacidade restante. Segure o controle de confirmação por
+um segundo para passar o plano de elaborado para comprometido. Os usuários de teclado podem se concentrar
+o controle e pressione Enter ou Espaço; ativação de tecnologia assistiva confirma
+diretamente.
+
+<ManualScreenshot
+  alt="O rascunho do Projeto Waddle e a ação deliberada de espera para confirmação na página de compromisso do Daily OS"
+  caseId="daily-os/commit"
+  caption="Oito trabalhos ocupam 8h 45m de um dia de 9h, deixando uma margem de 15 minutos antes da diretora Aurora encerrar."
+/>
+
+Cometer bloqueios nos ossos do plano, não na sua capacidade de adaptação. Você ainda pode
+use **Refinar** posteriormente, mas as alterações propostas permanecem passíveis de revisão.
+
+## 6. Compare o plano com a realidade
+
+Mude de **Agenda** para **Dia** para a projeção do calendário. Na área de trabalho,
+Plano e Real compartilham um eixo temporal. Em um telefone, deslize horizontalmente entre
+as pistas planejadas e registradas. Os blocos planejados utilizam um tratamento mais leve e
+as sessões gravadas são preenchidas, então o desvio permanece visível sem reescrever
+história.
+
+<ManualScreenshot
+  alt="Cronograma diário do sistema operacional comparando os blocos planejados do Projeto Waddle com o tempo registrado"
+  caseId="daily-os/timeline"
+  caption="As páginas telefônicas entre as faixas planejadas e gravadas; desktop mostra ambos em um eixo de tempo."
+/>
+
+Inicie e pare o registro de tempo da tarefa vinculada normalmente. Leituras diárias do sistema operacional
+esses registros como realidade; não fabrica trabalhos concluídos a partir do
+plano.
+
+## 7. Mova, redimensione ou edite um bloco
+
+Escolha a ação de quatro setas **Organizar** acima da linha do tempo. Arraste o corpo de um bloco
+para movê-lo ou arraste sua alça superior ou inferior para alterar seu início ou fim.
+As alterações são ajustadas em incrementos de 15 minutos e permanecem dentro do dia selecionado. Usar
+**Desfazer** na mensagem de confirmação quando o slot antigo era melhor.
+
+<ManualScreenshot
+  alt="Modo de organização diária do sistema operacional com controles de movimentação e redimensionamento nos blocos do Projeto Waddle"
+  caseId="daily-os/arrange"
+  caption="O modo Organizar expõe as mesmas ações diretas de movimentação e redimensionamento no telefone e no desktop."
+/>
+
+A ação do lápis abre o editor de blocos. Um bloco vinculado a tarefas mantém seu
+título e categoria de propriedade da tarefa somente leitura; escolha **Abrir tarefa** para alterá-las
+na fonte. Seu início e fim programados permanecem editáveis ​​no Daily OS.
+
+<ManualScreenshot
+  alt="Editor diário de blocos de sistema operacional para a tarefa de alimentação de peixes em gravidade zero"
+  caseId="daily-os/block-editor"
+  caption="A tarefa vinculada possui seu título e categoria Penguin Operations; O Daily OS possui o horário das 14h30 às 16h e o motivo do planejamento."
+/>
+
+Blocos de plano independentes podem editar seu próprio título e categoria porque nenhuma tarefa
+possui esses metadados.
+
+## 8. Encerre o dia
+
+Após um dia comprometido, escolha **Encerramento**. O desligamento separa as decisões que
+não deve ser confundido:
+
+- **O que você fez** lista o trabalho concluído com a duração real monitorada.
+- **Carries forward** permite agendar trabalhos inacabados para amanhã, escolher um
+  data, ou abandoná-lo.
+- As métricas resumem o tempo de foco, sessões de fluxo, mudanças de contexto e energia.
+- Uma reflexão de uma linha alimenta o próximo rascunho.
+- **O que aprendi** permite que você confirme ou esqueça o conhecimento durável do planejador.
+- **Para amanhã** preserva a nota concisa de transferência.
+
+<ManualScreenshot
+  alt="Desligamento diário do sistema operacional com trabalho concluído do Projeto Waddle, opções de transferência, métricas, reflexão e preferências aprendidas"
+  caseId="daily-os/shutdown"
+  caption="A Diretora Aurora concluiu a inspeção do habitat, a revisão do lançamento e o acordo da sardinha; a demonstração do comedouro de peixes e a questão dos passageiros permanecem decisões de transição explícitas."
+/>
+
+Escolha **Salvar e fechar** para deixar a avaliação sem declarar o dia encerrado,
+ou **Fechar o dia** quando as decisões de transferência e aprendizagem estiverem prontas.
+
+## A regra de propriedade
+
+- As tarefas descrevem o trabalho e os próprios metadados da tarefa.
+- O plano diário descreve a intenção e possui blocos programados.
+- Os registros de tempo descrevem a realidade.
+- Os registros de conhecimento do planejador revisaram as preferências para os dias futuros.
+- O assistente propõe; você decide.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -73,7 +73,7 @@ mudará:
 
 O Daily OS também apresenta trabalhos que estão em andamento, vencidos, com vencimento hoje ou
 perdeu recentemente. Decida o que pertence hoje em vez de importar todo o
-atraso.
+lista de pendências.
 
 ## 3. Julgue o rascunho
 
@@ -139,7 +139,7 @@ história.
 <ManualScreenshot
   alt="Cronograma diário do sistema operacional comparando os blocos planejados do Projeto Waddle com o tempo registrado"
   caseId="daily-os/timeline"
-  caption="As páginas telefônicas entre as faixas planejadas e gravadas; desktop mostra ambos em um eixo de tempo."
+  caption="O celular alterna entre as faixas planejadas e gravadas; o desktop mostra ambas em um eixo de tempo."
 />
 
 Inicie e pare o registro de tempo da tarefa vinculada normalmente. Leituras diárias do sistema operacional

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/entries.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/entries.mdx
@@ -1,0 +1,42 @@
+---
+title: Adicione entradas e contexto
+description: Crie tarefas, notas, gravações, temporizadores, imagens e listas de verificação no mesmo menu contextual.
+---
+
+# Adicione entradas e contexto
+
+Lotti usa um menu **Adicionar** para as coisas que você captura durante o dia. Abra
+do diário para uma entrada independente ou de uma tarefa para manter a nova entrada
+anexado a essa tarefa.
+
+<ManualScreenshot
+  caseId="entries/create-menu"
+  alt="Menu Adicionar produção sobre a tarefa Inspecionar habitat de pinguim orbital, com ações de lista de verificação, tarefa, gravação de áudio, cronômetro, entrada de texto, importação de imagem e captura de tela"
+/>
+
+## Escolha a entrada que corresponde ao material
+
+| Ação | Use-o para |
+| --- | --- |
+| **Lista de verificação** | Um breve conjunto de passos concretos dentro da tarefa atual |
+| **Tarefa** | Um resultado separado que precisa de status e contexto próprios |
+| **Gravação de áudio** | Uma nota de voz que pode ser reproduzida ou transcrita |
+| **Temporizador** | Uma sessão de trabalho cronometrada ligada ao contexto atual |
+| **Entrada de texto** | Notas, decisões, observações ou informações coladas |
+| **Importar imagem** | Uma imagem existente do dispositivo |
+| **Captura de tela** | Uma nova captura de tela da área de trabalho anexada como entrada de imagem |
+
+O menu é contextual. **Lista de verificação** está disponível quando uma tarefa pode possuir o
+itens, enquanto ações específicas do dispositivo, como **Captura de tela**, só aparecem onde
+a plataforma os suporta.
+
+## Mantenha o contexto com o trabalho
+
+Quando você abre **Adicionar** em uma tarefa, Lotti vincula a nova entrada a essa tarefa.
+Isso mantém gravações, notas, imagens e registros de tempo juntos na tarefa
+página de detalhes. Use um lançamento contábil autônomo quando o material não pertencer
+para um resultado específico ainda; ele pode ser vinculado posteriormente.
+
+Consulte [Gravar áudio](./recordings.mdx) para captura e transcrição, ou
+[Trabalhar com tarefas](../organize-and-reflect/tasks.mdx) para estrutura de tarefas, cobertura
+arte e links de tarefas.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/recordings.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/recordings.mdx
@@ -1,0 +1,69 @@
+---
+title: Gravar áudio
+description: Capture uma nota de voz e decida qual processamento automatizado deve seguir.
+---
+
+# Gravar áudio
+
+O áudio é útil quando falar é mais rápido do que digitar ou quando o tom e os detalhes
+importa. Uma gravação pode ser independente ou estar dentro de uma tarefa.
+
+## Capture uma gravação
+
+1. Abra o diário ou a tarefa que deverá possuir a gravação.
+2. Use a ação **+** e escolha **Gravação de áudio**.
+3. Revise as opções de processamento disponíveis.
+4. Comece a gravar, fale claramente e pare quando terminar.
+
+<ManualScreenshot
+  caseId="recordings/active"
+  alt="Folha de gravação de áudio ativa mostrando o visualizador ao vivo, tempo decorrido, pausar, descartar, parar e controles de reconhecimento de fala"
+/>
+
+Durante a captura, a planilha mantém o tempo decorrido e o visualizador de entrada ao vivo em
+ver. Você pode pausar e retomar sem encerrar a gravação, descartar a tomada,
+ou escolha **Parar** para salvá-lo. Quando a transcrição com reconhecimento de tarefa está disponível, o
+A opção **Reconhecimento de fala** controla se o processamento deve começar após
+a gravação é salva.
+
+Quando um perfil de inferência e uma habilidade de transcrição são configurados, Lotti pode
+transcrever a gravação após a captura. As gravações de tarefas também podem oferecer
+processamento com reconhecimento de tarefas, como lista de verificação ou atualizações de resumo.
+
+## Revise as transcrições salvas
+
+Abra uma entrada de áudio, use seu menu ***…** e escolha **Reconhecimento de fala**.
+A folha de revisão mantém todas as transcrições salvas com a gravação, em vez de
+substituindo um resultado anterior. Cada linha mostra quando o processamento foi executado, quanto tempo demorou
+pegou, o idioma detectado e o provedor e modelo que o produziu.
+
+<ManualScreenshot
+  caseId="recordings/transcripts"
+  alt="Folha de reconhecimento de fala sobre uma entrada de áudio do Projeto Waddle com inglês selecionado e dois resultados de transcrição salvos de Mistral e Whisper"
+  caption="A gravação de origem permanece visível atrás da folha, enquanto cada resultado de reconhecimento mantém a sua própria proveniência."
+/>
+
+O seletor de idioma oferece atualmente **Auto**, **Inglês** e **Deutsch**.
+Use **Auto** quando o provedor precisar detectar o idioma ou selecionar um idioma
+antes de executar o reconhecimento quando você já sabe disso. A escolha é armazenada em
+a entrada de áudio.
+
+Selecione a divisa dupla em um resultado para revelar o texto completo e selecionável.
+Expandir uma linha também revela sua ação de exclusão. Excluir uma transcrição remove
+esse resultado de reconhecimento, não a gravação de origem ou as outras transcrições.
+
+<ManualScreenshot
+  caseId="recordings/transcript-expanded"
+  alt="Transcrição expandida do Projeto Waddle descrevendo a carga de sardinha Europa, 37 pinguins imperadores e o alimentador de peixes com gravidade zero"
+  caption="Revise o texto completo e a origem do fornecedor antes de usar o texto gerado como contexto de tarefa."
+/>
+
+## Escolha a automação deliberadamente
+
+As opções de processamento são solicitações para habilidades de IA configuradas. O provedor selecionado
+pode ser local ou remoto, portanto verifique o perfil de inferência ativo antes de usar
+material sensível. Revise o texto gerado e as alterações propostas nas tarefas, em vez de
+tratando-os como fonte de verdade.
+
+Consulte [Configuração do provedor de IA](../ai-and-automation/provider-setup.mdx) para controlar onde
+inferência é executada.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/surveys.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/surveys.mdx
@@ -1,0 +1,80 @@
+---
+title: Completar e revisitar pesquisas
+description: Inicie os questionários agrupados a partir de um painel, envie uma resposta por vez e mantenha as pontuações resultantes no Diário.
+---
+
+# Completar e revisitar pesquisas
+
+Lotti inclui três questionários fixos: **CFQ-11**, **GHQ-12** e
+**PANAS**. Adicione a pesquisa que você usa a um painel e selecione a ação **+**
+em seu gráfico sempre que desejar registrar outra resposta. O painel é
+tanto o ponto de lançamento quanto o local onde as pontuações concluídas se tornam uma tendência.
+
+Os exemplos abaixo iniciam a tarefa PANAS real das **Operações da Colônia**
+painel. O questionário e sua navegação vêm da mesma produção
+executor de pesquisa usado pelo aplicativo.
+
+<ManualScreenshot
+  caseId="surveys/panas-intro"
+  alt="Instruções de pesquisa PANAS abertas no painel de operações da Colônia"
+  caption="Leia o prazo e a escala de resposta do instrumento antes de continuar. O indicador de progresso conta cada instrução, pergunta e etapa de conclusão."
+/>
+
+## Adicione uma pesquisa a um painel
+
+Abra **Configurações → Definições → Painéis**, edite um painel e adicione um gráfico
+de **Pesquisas**. Os instrumentos disponíveis são:
+
+- **CFQ-11**, Escala de Fadiga de Chalder;
+- **GHQ-12**, Questionário de Saúde Geral; e
+- **PANAS**, o Cronograma de Afetos Positivos e Negativos.
+
+Volte para **Painéis** e abra o painel. O gráfico mostra os envios
+resultados para seu instrumento. Selecione sua ação **+** para iniciar uma nova resposta.
+Cada gráfico lança o questionário correspondente; não existe uma forma genérica que
+altera suas questões com base nos dados da documentação.
+
+## Responda a pergunta atual
+
+A etapa de instrução explica o prazo solicitado e o significado do
+escala de resposta. Selecione **PRÓXIMO** para começar. PANAS então apresenta 20 palavras de efeito, uma
+de cada vez e pede uma escolha na escala de cinco pontos. O instrumento
+instruções, palavras afetadas, cópia de conclusão e rótulos de escala seguem o aplicativo
+linguagem; esta captura de tela em inglês mostra **Muito pouco ou nada** através
+**Extremamente**.
+
+<ManualScreenshot
+  caseId="surveys/panas-question"
+  alt="PANAS Pergunta de interesse com cinco opções de resposta de Muito ligeiramente ou nada a Extremamente"
+  caption="As perguntas são apresentadas sequencialmente. Escolha uma resposta, continue e use a contagem de progresso para ver onde você está no questionário."
+/>
+
+As outras pesquisas agrupadas usam suas próprias perguntas fixas e definições de pontuação.
+Escolha a resposta que corresponda ao texto e ao prazo mostrado pelo
+instrumento; Lotti não reinterpreta ou preenche automaticamente as respostas.
+
+## Enviar ou cancelar deliberadamente
+
+Continue com a etapa de conclusão para enviar. Lotti armazena a tarefa bruta
+resultado e seus intervalos de pontuação calculados como uma entrada de pesquisa no Diário. O
+painel lê essas entradas de volta em seu gráfico, então outra pesquisa concluída
+adiciona outra observação datada.
+
+Fechar a tarefa pergunta se o resultado atual deve ser descartado. Uma pesquisa cancelada
+não é armazenado, incluindo trabalhos parcialmente respondidos. Se a resposta for importante,
+termine a etapa de conclusão antes de sair da planilha.
+
+## Entenda as pontuações salvas
+
+A entrada persistente mantém as respostas individuais e as calculadas
+resumo usado pelos gráficos:
+
+- **CFQ-11** produz sua pontuação de fadiga configurada;
+- **GHQ-12** produz sua pontuação de saúde geral configurada; e
+- **PANAS** produz **Afeto Positivo** e **Afeto Negativo** separados
+  totais.
+
+Abra a entrada correspondente do Diário para inspecionar o resumo da pesquisa salvo. Usar
+o painel para alterações ao longo do tempo e o Diário para o registro de origem datado.
+Os gráficos de pesquisa não substituem as instruções do questionário, e Lotti
+não fornece um sistema de autoria de pesquisas para alterar essas definições agrupadas.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
@@ -1,0 +1,153 @@
+---
+title: Use as configurações avançadas com segurança
+description: Controle sinalizadores e registros de recursos, execute ferramentas de manutenção, inspecione métricas de integração e verifique a versão Lotti instalada.
+---
+
+# Use configurações avançadas com segurança
+
+Abra **Configurações → Configurações avançadas** para controles de usuário avançado, diagnósticos e
+manutenção. Estas páginas mudam a forma como Lotti funciona ou opera diretamente no local
+dados, portanto, a personalização comum pertence a outro lugar nas Configurações.
+
+Desktop mantém a árvore de configurações ao lado da página selecionada. O celular abre um
+página por vez e fornece um botão Voltar. Os mesmos controles e persistiram
+valores são usados em ambos os layouts.
+
+<ManualScreenshot
+  caseId="advanced-settings/hub"
+  alt="Hub de configurações avançadas Lotti com sinalizadores de configuração, animações, idioma, registro, manutenção, métricas de integração e sobre Lotti"
+  caption="As Configurações Avançadas agrupam os controles operacionais das preferências do dia a dia. Algumas entradas variam de acordo com a plataforma e os recursos habilitados."
+/>
+
+## Escolha o idioma do manual
+
+Abra **Idioma** para decidir qual manual publicado o aplicativo abre. **Seguir
+o sistema** é o padrão e escolhe o Manual em inglês, alemão, francês, tcheco,
+romeno ou português com base no idioma do seu dispositivo. Selecione **Inglês**,
+**Alemão**, **Francês**, **Tcheco**, **Romeno** ou **Português** para manter uma
+escolha diferente. A entrada **Manual** no final de Configurações e **Ajuda →
+Manual** no macOS usam essa configuração.
+
+## Capacidades de controle com Config Flags
+
+<ManualScreenshot
+  caseId="advanced-settings/flags"
+  alt="Página Lotti Config Flags com opções pesquisáveis para entradas privadas, notificações, gravação de localização, dicas de ferramentas e streaming de IA"
+  caption="A pesquisa corresponde aos nomes e às descrições dos sinalizadores. Cada switch altera imediatamente sua capacidade de tempo de execução armazenado."
+/>
+
+**Config Flags** é o painel de controle de capacidade. Inclui controles para:
+
+- visibilidade de entrada privada, notificações, captura de localização e dicas de ferramentas;
+- Streaming de resposta de IA e reprodução de resumo;
+- comportamento de registro e sincronização de matriz;
+- apresentam páginas como hábitos, painéis, eventos, projetos e novidades;
+- incorporações e pesquisa vetorial; e
+- indicadores operacionais, como atividade de sincronização, ativação de agente pendente e bifurcação
+  cura.
+
+Use **Sinalizadores de pesquisa** para restringir a lista por título ou descrição. Selecione uma linha
+ou seu switch para mudar a bandeira. O novo valor persiste imediatamente; lá
+não há ação Salvar separada.
+
+Os sinalizadores podem expor comportamento experimental ou de diagnóstico. Mude um deliberadamente,
+em seguida, verifique o fluxo de trabalho afetado antes de alterar outro. O **Mostrar privado
+entradas?** sinalizador controla se o conteúdo confidencial é incluído nas listas e
+seletores; ele não criptografa, exporta, exclui ou altera a privacidade de um
+entrada.
+
+## Escolha o que Lotti registra
+
+<ManualScreenshot
+  caseId="advanced-settings/logging"
+  alt="Configurações do Lotti Logging com um switch mestre de registro, domínios operacionais individuais e registro de consulta lenta"
+  caption="O switch mestre controla os controles por domínio. O dispositivo Project Waddle mantém Sincronização, IA e Tarefas habilitadas para diagnósticos focados."
+/>
+
+**Logging** começa com a opção global **Enable Logging**. Quando estiver ligado,
+habilite apenas os domínios necessários para uma investigação, como Sync, AI, Tasks,
+Rótulos, Saúde, Hábitos, Navegação, Notificações ou Sistema Operacional Diário. **Registro lento
+consultas** adiciona diagnósticos de desempenho do banco de dados.
+
+Desligar o switch mestre desativa os controles de domínio. Os erros ainda são
+escrito para o diário `error-*.log`; essas chaves controlam diagnósticos adicionais
+registro, não o registro de erro mínimo. Desative domínios barulhentos após um
+investigação para que os logs permaneçam focados e o uso do armazenamento permaneça previsível.
+
+## Execute ações de manutenção deliberadamente
+
+<ManualScreenshot
+  caseId="advanced-settings/maintenance"
+  alt="Página Lotti Maintenance com visualizações de integração, ações de redefinição, exclusão de banco de dados, limpeza, índice de pesquisa, incorporações e diagnósticos de repintura"
+  caption="A manutenção combina visualizações seguras com ações destrutivas e de diagnóstico. Leia a confirmação e o escopo antes de continuar."
+/>
+
+**Manutenção** contém vários tipos diferentes de ação:
+
+- **Mostrar boas-vindas à integração** e **Galeria de animação de integração** estão ao vivo
+  visualizações para desenvolvimento e controle de qualidade.
+- **Redefinir dicas no aplicativo** torna dicas únicas elegíveis para aparecerem novamente.
+- **Redefinir caixa de diálogo de configuração do Gemini** limpa sua dispensa para que o prompt do provedor possa
+  ser testado novamente.
+- **Excluir banco de dados do editor** remove rascunhos do editor.
+- **Excluir banco de dados de agentes** remove o banco de dados de agentes e sai do Lotti para que o
+  o aplicativo pode ser reiniciado em um armazenamento limpo.
+- **Limpar itens excluídos** limpa permanentemente registros excluídos de forma reversível por meio de um
+  fluxo de confirmação dedicado.
+- **Recriar índice de texto completo** reconstrói dados de pesquisa local sem recriar
+  entradas de diário.
+- **Gerar Embeddings** aparece quando a loja de embeddings está disponível e
+  preenche categorias selecionadas.
+- **Repintar sobreposição de arco-íris** pisca regiões de repintura para diagnóstico da IU. Istoé mantido na memória e retorna para desligado após a reinicialização.
+
+As ações de visualização e redefinição não compartilham o mesmo risco que a exclusão e a eliminação.
+Para ações destrutivas, confirme se o alvo é o armazém local pretendido
+e deixe qualquer operação atual de sincronização ou gravação terminar primeiro.
+
+## Inspecione o funil de integração
+
+<ManualScreenshot
+  caseId="advanced-settings/onboarding-metrics"
+  alt="Página Lotti Onboarding Metrics mostrando tempo de instalação, quatro dias ativos, status de ativação e contagens de eventos sem conteúdo"
+  caption="O dispositivo manual determinístico atingiu seu verdadeiro aha ao longo de quatro dias ativos após conectar um provedor e registrar várias capturas."
+/>
+
+**Métricas de integração** é uma superfície para desenvolvedores e controle de qualidade. Deriva um funil local
+de eventos e shows sem conteúdo:
+
+- o carimbo de data/hora visto pela primeira vez em UTC;
+- total de dias ativos e dias ativos durante os primeiros sete dias;
+- se a instalação pertence à coorte de base pré-FTUE;
+- se o marco real de ativação foi alcançado; e
+- uma contagem para cada evento de integração.
+
+A página registra nomes de eventos e metadados de baixa cardinalidade, não texto de diário,
+títulos de tarefas, transcrições ou detalhes sensíveis à sardinha do Projeto Waddle.
+
+**Redefinir o estado do teste de integração** limpa a cadência do prompt de integração e o local
+métricas de funil após confirmação. Não exclui dados do diário, configuração
+sinalizadores ou histórico real do plano diário do sistema operacional. Um perfil que já planejou um dia
+portanto, permanece inelegível para o caminho exato do primeiro plano do perfil limpo.
+
+## Verifique os totais locais e de compilação
+
+<ManualScreenshot
+  caseId="advanced-settings/about"
+  alt="Página Lotti Sobre mostrando versão, plataforma, tipo de compilação, 2.604 entradas de diário, 11 entradas sinalizadas e contagens de tarefas"
+  caption="Sobre Lotti identifica a construção em execução e resume os dados locais. O dispositivo do Projeto Waddle contém 2.604 entradas e 65 tarefas em cinco estados."
+/>
+
+**Sobre Lotti** é o lugar mais rápido para verificar qual compilação está realmente em execução.
+Ele mostra a versão do aplicativo e o número da compilação, a plataforma e o tipo de compilação. Incluir
+esses valores em um relatório de diagnóstico para que um comportamento possa ser correspondido ao correto
+código e lançamento.
+
+O cartão **Seus dados** resume lançamentos contábeis locais, lançamentos sinalizados e
+contagens de tarefas divididas em abertas, em andamento, em espera, bloqueadas e concluídas. O
+O espaço de trabalho do Project Waddle estabelecido no manual demonstra uma conta não vazia:
+2.604 lançamentos contábeis manuais, 11 entradas sinalizadas e 65 tarefas em vez de espaço reservado
+zeros.
+
+Os efeitos de conclusão têm seu próprio guia: consulte
+**[Personalize as celebrações de conclusão](./completion-celebrations.mdx)** para o
+Página de animações e seu playground ao vivo.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/appearance.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/appearance.mdx
@@ -1,0 +1,44 @@
+---
+title: Escolha a aparência de Lotti
+description: Defina o modo de exibição claro, escuro ou automático e escolha uma paleta para cada aparência.
+---
+
+# Escolha a aparência de Lotti
+
+Abra **Configurações → Temas** para controlar a aparência de Lotti. O modo de exibição e
+as duas opções de paleta são independentes, para que você possa combinar um dia claro
+tema com um tema noturno completamente diferente.
+
+<ManualScreenshot
+  caseId="theming/preferences"
+  alt="Configurações de tema Lotti com modos Escuro, Automático e Claro, além de seleções de temas Sakura e Outer Space"
+  caption="A demo combina Sakura para o modo claro com Outer Space para o modo escuro. Sua seleção se aplica imediatamente."
+/>
+
+## Selecione um modo de exibição
+
+Escolha um dos três modos:
+
+- **Escuro** sempre usa o tema escuro selecionado.
+- **Automático** segue a configuração atual de claro ou escuro do sistema operacional.
+- **Light** sempre usa o tema claro selecionado.
+
+O modo automático é útil quando o dispositivo muda de aparência de acordo com uma programação.
+Lotti segue essa mudança, mantendo a paleta escolhida para cada lado.
+
+## Escolha as paletas claras e escuras
+
+1. Selecione **Tema claro** ou **Tema escuro**.
+2. Escolha uma paleta nomeada na planilha.
+3. Repita para a outra aparência, se necessário.
+
+<ManualScreenshot
+  caseId="theming/picker"
+  alt="Seletor de tema Lotti listando as paletas nomeadas disponíveis"
+  caption="O seletor de tema usa o mesmo shell de configurações de celular ou desktop do aplicativo."
+/>
+
+Não há botão Salvar. O modo de exibição e as opções de paleta persistem assim que
+você os seleciona. O interruptor claro e escuro do manual é separado: ele muda
+a documentação e escolhe automaticamente a variante de captura de tela correspondente,
+mas isso não altera suas configurações do Lotti.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/completion-celebrations.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/completion-celebrations.mdx
@@ -1,0 +1,61 @@
+---
+title: Personalize celebrações de conclusão
+description: Configure animações de conclusão, sensação ao toque, estilos e seu playground ao vivo.
+---
+
+# Personalize as celebrações de conclusão
+
+Abra **Configurações → Configurações avançadas → Animações** para decidir como Lotti responde
+quando você termina uma tarefa, completa um hábito ou marca um item da lista de verificação.
+
+<ManualScreenshot
+  caseId="celebrations/controls"
+  alt="Configurações de Lotti Animations com interruptores de celebração para hábitos, itens de lista de verificação, tarefas e sensação tátil de conclusão"
+  caption="As celebrações visuais têm um interruptor mestre e interruptores de eventos separados. A sensação ao toque de conclusão permanece independente."
+/>
+
+## Escolha onde as celebrações aparecem
+
+- **Animações de celebração** são a chave mestra para floreios visuais.
+- **Hábitos**, **Itens da lista de verificação** e **Tarefas** controlam independentemente seus
+  efeitos de conclusão visual.
+- **A sensação tátil de conclusão** controla a resposta física curta e permanece
+  disponível mesmo quando as animações estão desativadas.
+
+Desativar uma animação nunca reverte a conclusão em si. Se a operação
+sistema solicita movimento reduzido, Lotti suprime os efeitos enquanto preserva
+seus estilos selecionados para mais tarde.
+
+## Atribua um estilo a cada tipo de conclusão
+
+<ManualScreenshot
+  caseId="celebrations/styles"
+  alt="Seletor de estilo de celebração Lotti com tarefas selecionadas e Sparks, Fireworks, Confetti, Embers, Bubbles, Random e Combine duas opções"
+  caption="Tarefas, hábitos e itens da lista de verificação podem usar estilos diferentes. Selecione um cartão para visualizá-lo e aplicá-lo."
+/>
+
+Para cada tipo de conclusão, escolha **Sparks**, **Fireworks**, **Confetti**,
+**Brasas** ou **Bolhas**. Escolha **Aleatório** para um estilo novo e único em cada
+conclusão ou **Combine dois** para sobrepor dois estilos selecionados aleatoriamente.
+
+Use **Experimente** para visualizar a seleção atual sem alterar a tarefa real ou
+dados de hábitos.
+
+## Ajuste um estilo individual
+
+Selecione a ação personalizar em um estilo fixo para abrir sua tela inteira
+parque infantil.
+
+<ManualScreenshot
+  caseId="celebrations/playground"
+  alt="Playground de celebração do Lotti Sparks com visualização de tarefas ao vivo e controles agrupados de forma, movimento e aparência"
+  caption="As alterações são salvas e aplicadas em todos os lugares imediatamente. Reproduza a amostra após cada ajuste."
+/>
+
+Os controles disponíveis dependem do efeito e são agrupados por **Forma**,
+**Movimento** e **Aparência**. Ajuste os controles deslizantes e use a amostra destacada ou
+**Repetir** para ver o resultado. **Redefinir para o padrão** restaura o estilo integrado;
+a confirmação oferece **Desfazer** se a redefinição foi acidental.
+
+A personalização é global para esse estilo. Não está anexado à tarefa de exemplo
+mostrado no playground ou para uma tarefa real específica.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/keyboard-shortcuts.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/keyboard-shortcuts.mdx
@@ -1,0 +1,65 @@
+---
+title: Trabalhar com atalhos de teclado
+description: Encontre e use as ligações de comando da área de trabalho de Lotti.
+---
+
+# Trabalhe com atalhos de teclado
+
+Desktop Lotti expõe um catálogo pesquisável de todo o aplicativo e contextual
+comandos. Abra **Configurações → Atalhos de teclado** para ver cada comando com o
+vinculação resolvida para sua plataforma.
+
+<ManualScreenshot
+  caseId="keyboard-shortcuts/catalog"
+  alt="Configurações de atalhos do teclado Lotti mostrando comandos da área de trabalho agrupados por finalidade com suas combinações de teclas atuais"
+  caption="Primário significa Comando no macOS e Controle no Windows ou Linux; o catálogo renderiza os símbolos corretos para a plataforma atual."
+/>
+
+## Abra a ajuda do atalho rapidamente
+
+Pressione **F1** ou **Primary + ?** para abrir a referência de atalho sem sair
+seu trabalho atual. **Primário** significa Comando no macOS e Controle no Windows ou
+Linux.
+
+Comandos frequentemente úteis para todo o aplicativo incluem:
+
+| Ação | Atalho |
+| --- | --- |
+| Abra a paleta de comandos | Primário + K |
+| Crie uma entrada de texto | Primário + N |
+| Crie uma tarefa | Primário + T |
+| Tarefas abertas, sistema operacional diário, projetos ou hábitos | Primário + 1/2/3/4 |
+| Abra painéis, diário, eventos ou configurações | Primário + 5/6/7/8 |
+
+Páginas individuais adicionam comandos contextuais, como salvar, atualizar, pesquisar ou
+criar. Sua disponibilidade pode depender do foco atual ou se
+há alterações não salvas.
+
+## Execute um comando sem sair do seu trabalho
+
+Pressione **Primary + K** para abrir a paleta de comandos na página atual. Isso
+combina ações em todo o aplicativo – criação de entradas, abertura de tarefas, navegação e
+zoom – com comandos fornecidos pela página ativa.
+
+<ManualScreenshot
+  caseId="keyboard-shortcuts/palette"
+  alt="A paleta de comandos Lotti é aberta em atalhos de teclado, listando os comandos disponíveis de criação, navegação, visualização e edição"
+  caption="Somente comandos que estão disponíveis no contexto atual aparecem. A visualização Móvel demonstra a mesma paleta da área de trabalho em uma janela estreita; comandos de teclado são um recurso da área de trabalho."
+/>
+
+Comece a digitar para restringir a lista por nome de ação, grupo ou combinação de teclas. Usar
+as setas para cima e para baixo para mover o destaque, **Enter** para executá-lo e
+**Escape** para fechar a paleta. Como a paleta é contextual, um comando
+como **Salvar** só aparece quando o editor em foco pode salvar no momento.
+
+## Pesquise por ação ou chave
+
+<ManualScreenshot
+  caseId="keyboard-shortcuts/search"
+  alt="Catálogo de atalhos de teclado Lotti filtrado com uma consulta de pesquisa"
+  caption="Pesquise o catálogo em vez de memorizá-lo. Os resultados são atualizados conforme você digita."
+/>
+
+Use o campo de pesquisa quando souber a ação ou parte de sua chave
+combinação. O catálogo no aplicativo será a autoridade se uma vinculação for alterada em um
+versão posterior de Lotti.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -1,0 +1,83 @@
+---
+title: Faça a manutenção deste manual
+description: O fluxo de trabalho de contribuição leve para conteúdo manual e capturas de tela.
+---
+
+# Mantenha este manual
+
+A fonte reside no repositório do aplicativo, portanto, uma mudança de comportamento e sua
+a documentação pode pousar junto. Capturas de tela geradas ao vivo no irmão
+`lotti-docs` e nunca são comprometidos com a árvore da aplicação.
+
+## Editar prosa
+
+1. Edite ou adicione o arquivo MDX em inglês em `docs-site/docs`.
+2. Atualize o arquivo correspondente para cada localidade publicada em
+   `docs-site/i18n/<locale>/docusaurus-plugin-content-docs/current`.
+3. Adicione uma nova página a `docs-site/sidebars.ts`.
+4. Atualize `docs-site/metadata/features.json` quando a cobertura mudar.
+5. Atualize as entradas correspondentes em
+   `docs-site/metadata/surface-inventory.json`. Uma superfície torna-se **verificada**
+   somente quando sua interface de produção atual, prosa e cobertura de captura de tela tiverem
+   tudo foi revisado.
+6. Execute `make manual_check`.
+7. Revise a construção de produção localmente com `make manual_serve`, incluindo o
+   seletor de idioma e todas as rotas localizadas.
+
+A validação exige que cada árvore de tradução publicada contenha a mesma página
+caminhos como a árvore de origem em inglês. Também rejeita corpos de páginas traduzidos que
+são idênticos ao inglês, portanto, novas páginas não podem ser enviadas silenciosamente como não traduzidas
+cópias. Os URLs públicos em inglês permanecem inalterados; outras línguas são
+publicado abaixo de seu próprio prefixo de localidade com versão.
+
+## Mantenha o inventário de cobertura oficial
+
+O inventário define os limites do manual inglês V1: cada página do Beamer, cada
+Folha ou editor de configurações V2 e todos os principais fluxos de trabalho que criam ou materialmente
+altera dados ou configuração transversal. Cada entrada registra sua propriedade
+arquivo de origem e uma âncora de texto de origem. A validação falhará se um deles desaparecer,
+o que força uma mudança de rota ou UI para atualizar a auditoria manual em vez de sair
+uma linha obsoleta invisível.
+
+Os estados de cobertura têm significados deliberadamente estritos:
+
+- **Planejado** significa que a superfície é conhecida, mas ainda não possui cobertura completa.
+- **Documentado** significa que existe prosa útil, mas capturas de tela da produção atual
+  ou ainda falta uma revisão de precisão de ponta a ponta.
+- **Verificado** significa que a página do recurso relevante foi verificada e apoiada por
+  capturas de tela de produção registradas.
+
+Execute `npm --prefix docs-site run coverage:complete` para a porta de liberação. Isso
+falha até que todas as superfícies inventariadas sejam verificadas; manual incremental comum
+compilações continuam a relatar as contagens restantes sem bloquear o tamanho do tópico
+compromete.
+
+## Adicione um caso de captura de tela
+
+1. Adicione ou reutilize um conjunto determinístico de captura de tela do Flutter.
+2. Registre o caso e suas quatro imagens de origem em
+   `docs-site/metadata/screenshot-cases.json`.
+3. Coloque uma cópia visível do fixture atrás de `manualScreenshotText(...)` para cada
+   localidade suportada quando ainda não foi fornecida pela localização do aplicativo
+   arquivos.
+4. Capture todos os locais em `../lotti-docs`; nunca neste repositório.
+5. Gere e valide o manifesto de mídia.
+6. Consulte o caso com `<ManualScreenshot caseId="…" alt="…" />` na
+   cada página de idioma.
+
+Cada captura de tela do aplicativo em uma página de autoria deve usar `ManualScreenshot`. Direto
+links para imagens `lotti-docs` antigas falham na validação manual porque não podem
+siga a escolha global Mobile/Desktop ou o tema claro/escuro do manual.
+
+Todo caso automatizado deve fornecer mobile-light, mobile-dark, desktop-light,
+e variantes desktop-dark em cada localidade publicada. O componente manual
+escolhe o idioma e o tema correspondentes. Alterando Mobile/Desktop em qualquer imagem
+atualiza todas as capturas de tela imediatamente e persiste nas páginas e no manual aberto
+guias.
+
+## Publicar um lançamento
+
+A fonte manual não é copiada para todas as versões do aplicativo. A tag de lançamento do aplicativo já
+preserva sua origem exata. CI verifica essa tag, constrói com
+`MANUAL_VERSION=<version>`, e publica um diretório estático imutável. O
+O menu suspenso de lançamento é um pequeno manifesto desses diretórios.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/recording-style.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/recording-style.mdx
@@ -1,0 +1,34 @@
+---
+title: Escolha um estilo de gravação
+description: Selecione e visualize o medidor visual mostrado durante a gravação de áudio.
+---
+
+# Escolha um estilo de gravação
+
+Abra **Configurações → Estilo de gravação** para escolher a visualização mostrada durante
+Lotti grava áudio. Isto altera apenas a apresentação; ambos os estilos representam o
+mesmo processo de gravação.
+
+<ManualScreenshot
+  caseId="recording-style/preview"
+  alt="Configurações de estilo de gravação Lotti comparando o orbe de energia moderno com o medidor VU analógico"
+  caption="Selecione um estilo para persisti-lo imediatamente e, em seguida, visualize a resposta com níveis simulados ou com seu microfone."
+/>
+
+## Compare os dois estilos
+
+- **Moderno** mostra um orbe de energia animado que reage ao nível atual.
+- **Analógico** mostra um medidor VU tradicional com uma agulha em movimento.
+
+Selecione um dos cartões para torná-lo o estilo ativo. Não há nenhum salvamento ou
+Continuar a ação.
+
+## Visualize com sua voz
+
+Ative **Tente com sua voz** para conduzir a visualização do microfone. Fale
+à distância que você espera usar durante a gravação e observe como o selecionado
+visual responde. Desative a opção quando terminar de comparar estilos.
+
+A visualização ajuda você a escolher uma linguagem visual; não é um ganho de entrada ou
+ferramenta de calibração de qualidade de gravação. Consulte [Gravar áudio](../plan-and-capture/recordings.mdx)
+para o fluxo de trabalho de gravação real.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/settings.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/settings.mdx
@@ -1,0 +1,56 @@
+---
+title: Encontrar configurações
+description: Navegue pelas configurações do Lotti no celular e no desktop.
+---
+
+# Encontre configurações
+
+As configurações são agrupadas pela capacidade que controlam. Desktop usa um persistente
+árvore com a página selecionada ao lado; mobile usa uma lista focada e abre uma
+página de configurações por vez.
+
+Escolha **Manual** na seção final distinta de Configurações para abrir este guia
+no seu navegador padrão. No macOS, **Ajuda → Manual** fornece o mesmo link.
+O guia segue o idioma do seu sistema por padrão; escolha um idioma diferente
+em **Configurações → Configurações avançadas → Idioma** quando necessário.
+
+<ManualScreenshot
+  alt="A página inicial de configurações do Lotti mostrando grupos de configuração"
+  caseId="settings/home"
+  caption="Use a opção Móvel/Desktop acima. A imagem também segue o tema claro ou escuro deste manual."
+/>
+
+Destinos comuns incluem:
+
+- **[Aparência](./appearance.mdx)** para exibição clara, escura e automática
+  modos mais paletas de temas independentes.
+- **[Estilo de gravação](./recording-style.mdx)** para orbe de energia ou analógico
+  medidor mostrado durante a gravação.
+- **[Fala](./speech.mdx)** para a voz, modelo e velocidade do dispositivo usados para
+  leia os resumos das tarefas em voz alta.
+- **[Atalhos de teclado](./keyboard-shortcuts.mdx)** para a área de trabalho pesquisável
+  catálogo de comandos.
+- **[Celebrações de conclusão](./completion-celebrations.mdx)** para animações,
+  sensação ao vivo, estilos e seu playground ao vivo.
+- **[Configurações avançadas](./advanced-settings.mdx)** para sinalizadores de recursos, registro,
+  ações de manutenção, diagnósticos de integração e informações de construção.
+- **Categorias** para limites de planejamento e **Rótulos** para tags transversais.
+- **Hábitos** e **Painéis** para estruturas de reflexão.
+- **Configurações de IA** para fornecedores, modelos, perfis e habilidades.
+- **SO diário** para perfil de inferência e saudação do planejador.
+- **Sincronização** para conexão e estado de atividade.
+
+O conjunto exato pode variar de acordo com os recursos da plataforma e os recursos habilitados.
+
+## Gerenciar definições
+
+Abra **Configurações → Definições** para gerenciar as estruturas que organizam seu
+dados. As categorias definem limites de planejamento e privacidade, os rótulos marcam as tarefas
+categorias, hábitos definem rotinas recorrentes, painéis organizam reflexão
+visualizações e mensuráveis definem os números que você acompanha ao longo do tempo.
+
+<ManualScreenshot
+  alt="O hub de configurações de Definições lista categorias, rótulos, hábitos, painéis e mensuráveis"
+  caseId="settings/definitions"
+  caption="Mobile mostra a lista de Definições em foco; desktop mantém a árvore de configurações completa visível ao lado dele."
+/>

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/speech.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/speech.mdx
@@ -1,0 +1,51 @@
+---
+title: Escolha a voz de leitura
+description: Configure a voz, o modelo e a velocidade de reprodução do dispositivo usado para ler resumos de tarefas em voz alta.
+---
+
+# Escolha a voz de leitura
+
+Quando a leitura em voz alta estiver disponível, abra **Configurações → Fala**. Esses controles
+aplicar a resumos de IA de tarefas; eles não alteram a captura do microfone ou qual IA
+provedor transcreve uma gravação.
+
+<ManualScreenshot
+  caseId="speech/settings"
+  alt="Configurações de Lotti Speech com Masculino 3 selecionado, modelo Supertonic 3 no dispositivo e velocidade de leitura de 1,25"
+  caption="O exemplo de configuração de controle de missão usa Macho 3 a 1,25× para briefings rápidos do Projeto Waddle."
+/>
+
+## Escolha uma voz
+
+Use a opção **Female / Male** para navegar pelos dois grupos e selecione um dos
+as cinco vozes numeradas nesse grupo. Mudar de grupo apenas altera o
+lista visível; selecione uma voz numerada para torná-la ativa.
+
+<ManualScreenshot
+  caseId="speech/voice-options"
+  alt="Configurações de Lotti Speech mostrando as cinco opções de voz feminina no dispositivo"
+  caption="Estão disponíveis dez estilos de voz agrupados: Feminino 1–5 e Masculino 1–5."
+/>
+
+A voz selecionada é uma preferência local do dispositivo. Isso permite que cada dispositivo use um
+voz que se adapta aos alto-falantes e ao ambiente de audição sem alterar o
+escolha em seus outros dispositivos.
+
+## Download do modelo e privacidade
+
+Lotti atualmente usa **Supertonic 3** para leitura em voz alta. A síntese é executada no
+dispositivo em vez de enviar o resumo para um serviço de fala na nuvem. O modelo é
+grande e é baixado na primeira vez que for necessário, então reserve tempo, rede
+largura de banda e armazenamento para essa configuração inicial.
+
+## Defina a velocidade de leitura
+
+Escolha uma velocidade de **0,5×** a **2×**. Uma configuração de **1×** é o natural
+taxa; valores mais baixos retardam o briefing e valores mais altos o encurtam. O
+a velocidade selecionada também é armazenada apenas no dispositivo atual.
+
+O botão de leitura em voz alta aparece apenas quando o recurso está habilitado, a plataforma
+suporta o mecanismo de fala e a tarefa possui um resumo de IA não vazio.
+
+Para entrada falada e resultados de reconhecimento salvos, consulte
+[Gravar áudio](../plan-and-capture/recordings.mdx).

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/whats-new.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/whats-new.mdx
@@ -1,0 +1,67 @@
+---
+title: Navegar pelas novidades
+description: Revise a versão mais recente do Lotti, percorra as notas de versão mais antigas e controle quais atualizações permanecem invisíveis.
+---
+
+# Procure o que há de novo
+
+Novidades apresenta notas de lançamento dentro do Lotti, correspondentes à versão que você está
+correndo. Ele pode abrir automaticamente após um primeiro lançamento ou versão elegível
+alteração e também está disponível na entrada **Novidades** em Configurações quando
+esse recurso está habilitado.
+
+As notas de versão são ordenadas mais recentes primeiro. Cada página combina um lançamento específico
+imagem principal, sua versão exata do aplicativo e um breve relato do usuário visível
+mudanças.
+
+<ManualScreenshot
+  caseId="whats-new/latest"
+  alt="Lotti Novidades modal para a versão 0.9.1049 com um banner de controle de missão do Projeto Waddle e notas de lançamento"
+  caption="O último lançamento inédito traz um NOVO emblema. Este acessório explica as melhorias do sistema operacional diário e do espaço de trabalho de tarefas por trás do lançamento orbital do Projeto Waddle."
+/>
+
+## Leia a versão atual
+
+O emblema da versão identifica o lançamento cujas notas estão na tela. **NOVO**
+marca o mais novo lançamento do conjunto atual; isso não significa todos os itens do
+a página está inacabada ou experimental.
+
+O corpo rola de forma independente quando o lançamento é maior que o disponível
+altura. Os links usam o manipulador de link Lotti normal e as imagens são carregadas antes de
+a página muda quando disponível, para que a movimentação entre as versões seja tranquila.
+
+## Percorrer o histórico de lançamentos
+
+<ManualScreenshot
+  caseId="whats-new/past-release"
+  alt="Lotti Novidades modal para a versão 0.9.1048 com arte de capa do mercado de sardinhas de pinguim e navegação de versão mais antiga"
+  caption="Use as divisas do rodapé ou os marcadores de posição para mover-se entre as versões. A nota mais antiga do Projeto Waddle cobre comparação de tempo e telemetria de sardinha pronta para painel."
+/>
+
+Use os controles de rodapé para navegar:
+
+- a divisa direita abre a próxima versão mais antiga;
+- o chevron esquerdo retorna para uma versão mais recente;
+- os marcadores de posição mostram onde está a página atual no conjunto carregado;
+- **Skip** fecha um conjunto de vários lançamentos antes da última página e marca o todo
+  conjunto carregado como visto; e
+- **Concluído** aparece na página mais antiga e também marca todo o conjunto como visto.
+
+Fechar o modal arrastando-o ou descartando a barreira circundante é
+mais conservador: Lotti marca apenas os lançamentos que você realmente alcançou, através
+a página mais distante visualizada. Os lançamentos que você não alcançou podem, portanto, aparecer
+na próxima vez que o Novidades for aberto.
+
+## Revisite notas que você já dispensou
+
+Quando não resta nenhum lançamento não visto, abrir Novidades mostra um **Vocês todos foram pegos
+para cima** estado. Escolha **Ver lançamentos anteriores** para limpar os marcadores locais vistos e
+navegue novamente no conjunto de versões disponíveis. Isso altera apenas a nota de lançamento local
+história; isso não altera a versão do aplicativo instalado nem baixa outra versão.
+
+O que há de novo nunca mostra notas para uma versão mais recente que o Lotti instalado
+versão. Se o conteúdo da versão não puder ser carregado, o aplicativo volta para um vazio
+estado em vez de apresentar notas para a construção errada.
+
+Para obter o número exato da compilação, plataforma, totais de entradas locais e contagens de tarefas, consulte
+[Sobre Lotti](./advanced-settings.mdx#verifique-os-totais-locais-e-de-compilação).

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/conflicts.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/conflicts.mdx
@@ -58,7 +58,7 @@ Revise todos os campos listados antes de selecionar **Aplicar combinado**. O
 entrada resolvida recebe um histórico de sincronização mesclado para que as mesmas duas edições não
 imediatamente entrar em conflito novamente.
 
-:::caution Uma resolução altera o resultado compartilhado
+:::caution[Uma resolução altera o resultado compartilhado]
 
 Manter um lado ou aplicar uma versão combinada escreve o vencedor localmente e
 permite sincronizar com outros dispositivos. Leia a comparação completa antes

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/conflicts.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/conflicts.mdx
@@ -1,0 +1,70 @@
+---
+title: Resolver conflitos de sincronização
+description: Compare as edições simultâneas campo por campo e mantenha ou combine as informações corretas.
+---
+
+# Resolver conflitos de sincronização
+
+Um conflito aparece quando dois dispositivos alteram a mesma entrada de forma independente e
+nenhuma das versões é claramente mais recente. Lotti preserva ambas as versões em vez de
+silenciosamente escolhendo um.
+
+Abra **Configurações → Sincronizar → Conflitos**. A lista separa problemas não resolvidos e
+itens resolvidos e identifica o tipo de entidade e o horário de cada conflito.
+
+<ManualScreenshot
+  caseId="sync/conflicts"
+  alt="Lista de conflitos de sincronização Lotti com tarefas não resolvidas do Projeto Waddle e conflitos de manifesto de sardinha, além de uma tarefa resolvida"
+  caption="Resolva os itens atuais primeiro. Os itens resolvidos permanecem visíveis como uma trilha de auditoria de decisões anteriores."
+/>
+
+## Compare as duas versões
+
+Abra um conflito para ver todos os campos diferentes. As alterações de texto incluem nível de palavra
+destaques; campos inalterados são resumidos para que a página não oculte quanto
+da entrada ainda concorda.
+
+<ManualScreenshot
+  caseId="sync/conflict-detail"
+  alt="Detalhe do conflito Lotti comparando títulos e descrições de tarefas locais e sincronizadas do Projeto Waddle campo por campo"
+  caption="Este dispositivo manteve o imperador final e o porão de carga; a versão sincronizada eliminou todos os 37 pinguins e agendou o lançamento da sardinha. Ambos os fatos são importantes."
+/>
+
+Os três caminhos de resolução são:
+
+- **Use este dispositivo** mantém a versão local completa.
+- **Usar da sincronização** mantém a versão recebida completa.
+- **Combinar** permite escolher um lado inicial e depois selecionar o vencedor
+  cada campo independentemente mesclável.
+
+Manter um lado completo é apropriado quando o outro está simplesmente obsoleto.
+**Combinar** é a escolha mais segura quando campos separados contêm trabalho válido de
+ambos os dispositivos; Lotti marca como recomendado quando vários campos mescláveis
+diferem.
+
+## Combine campos sem redigitar
+
+Selecione **Combinar**, escolha a versão para começar e alterne individualmente
+campos para o outro lado. Os campos que não podem ser mesclados de forma independente seguem
+a versão inicial selecionada.
+
+<ManualScreenshot
+  caseId="sync/conflict-combine"
+  alt="Lotti Combine editor de conflitos com controle de versão inicial e opções separadas para o título e corpo da tarefa"
+  caption="Comece com uma entrada estruturalmente completa e, em seguida, obtenha o melhor título e corpo deste dispositivo ou da sincronização."
+/>
+
+Revise todos os campos listados antes de selecionar **Aplicar combinado**. O
+entrada resolvida recebe um histórico de sincronização mesclado para que as mesmas duas edições não
+imediatamente entrar em conflito novamente.
+
+:::caution Uma resolução altera o resultado compartilhado
+
+Manter um lado ou aplicar uma versão combinada escreve o vencedor localmente e
+permite sincronizar com outros dispositivos. Leia a comparação completa antes
+confirmando. Se um lado excluiu a entrada enquanto o outro a editou, Lotti
+mostra a opção mais segura de excluir versus editar em vez de uma mesclagem de campo normal.
+
+:::
+
+Volte para [Sincronizar dispositivos](./sync.mdx) para inspecionar a entrega e a integridade da atualização.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/health-import.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/health-import.mdx
@@ -1,0 +1,36 @@
+---
+title: Importar dados de saúde
+description: Importe um intervalo de datas selecionado do armazenamento de dados de saúde do telefone.
+---
+
+# Importar dados de saúde
+
+A importação de saúde está disponível para iOS e Android. Abra **Configurações → Avançado →
+Health Import**, escolha uma data de início e término e selecione a família de dados que você
+quero que Lotti leia o armazenamento de dados de saúde do telefone.
+
+<ManualScreenshot
+  caseId="health-import/overview"
+  alt="Importação de saúde com data de início, data de término e ações de importação separadas para atividade, sono, frequência cardíaca, pressão arterial, medidas corporais e treinos"
+  caption="A visualização Mobile mostra a tela de importação. A importação de saúde está intencionalmente ausente da árvore de configurações avançadas da área de trabalho, demonstrada pela visualização da área de trabalho."
+/>
+
+As importações disponíveis são:
+
+- **Atividade** para totais de atividades;
+- **Sono** para amostras de sono;
+- **Frequência cardíaca** para observações de pulso;
+- **Pressão Arterial** para leituras de pressão arterial;
+- **Medida Corporal** para medidas como métricas corporais; e
+- **Treino** para treinos gravados.
+
+Cada botão importa apenas sua própria família de dados no intervalo de datas exibido.
+A alteração do intervalo não inicia uma importação por si só.
+
+Seu sistema operacional pode solicitar permissão para dados de saúde. Lotti só sabe ler
+os tipos que você concede. Se uma família de dados esperada estiver faltando, verifique o aplicativo
+permissões de saúde nas configurações do sistema do telefone e tente importar novamente.
+
+A importação de integridade não é exibida no desktop porque o status de integridade móvel subjacente
+lojas não estão disponíveis lá. As observações importadas ainda podem ser visualizadas em
+os painéis Lotti relevantes depois de sincronizados com outro dispositivo.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/maintenance.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/maintenance.mdx
@@ -1,0 +1,40 @@
+---
+title: Manutenção de sincronização
+description: Use ações de reparo e limpeza de sincronização da Matrix deliberadamente, desde o reenvio de registros até a reconstrução do histórico de sequência.
+---
+
+# Manutenção de sincronização
+
+Abra **Configurações → Sincronização → Manutenção** para reparo e limpeza no nível do banco de dados.
+Essas ações não fazem parte do emparelhamento de rotina ou da sincronização diária.
+Antes de usá-los, deixe as gravações ativas terminarem e mantenha um backup atual dos dados
+você não pode recriar.
+
+<ManualScreenshot
+  caseId="sync/maintenance"
+  alt="Lotti Matrix Sync Maintenance com exclusão de banco de dados de sincronização, sincronização de definição, ressincronização de mensagens, preenchimento de log de sequência e limpeza de caixa de saída enviada"
+  caption="A manutenção agrupa ações destrutivas, de repetição e de limpeza em uma página. O texto de confirmação define o escopo de cada operação."
+/>
+
+## Escolha o reparo mais estreito
+
+- **Excluir banco de dados de sincronização** remove o banco de dados de sincronização local. Isso é destrutivo
+  recuperação local, não uma maneira normal de desconectar um dispositivo.
+- **Sincronizar definições** envia novamente os registros de definição atuais, como
+  categorias e outras configurações compartilhadas.
+- **Ressincronizar mensagens** reproduz mensagens selecionadas quando o estado remoto está ausente
+  ou uma entrega anterior precisa ser repetida.
+- **Popular log de sequência** reconstrói o histórico de sequência local usado para
+  detectar lacunas e impulsionar o preenchimento.
+- **Limpar itens antigos da caixa de saída enviados** exclui o histórico da fila de diagnóstico já enviado
+  após o seu período de retenção. Ele não remove trabalhos pendentes ou com falha.
+
+Comece com a menor operação que corresponda ao sintoma. Um anexo preso
+pertence à [Caixa de saída](./sync.mdx#inspecione-a-caixa-de-saída); lacunas de sequência persistentes
+pertencem ao Backfill; duas edições simultâneas válidas pertencem a
+[Conflitos](./conflicts.mdx). A exclusão do banco de dados de sincronização deve ser o último recurso
+redefinição local realizada com um par em bom estado e backup disponível.
+
+Após um reparo, retorne para **Sincronizar estatísticas**, confirme se o trabalho processado foi
+avançando sem uma contagem crescente de falhas e verifique se a Caixa de saída e
+Aterramento de liquidação de contagem faltante.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -119,8 +119,9 @@ a contagem permanece inalterada enquanto todos os dispositivos esperados estão 
 />
 
 O cartão de mensagem enviada agrupa tipos de eventos Matrix. **Principais KPIs** resume
-mensagens processadas, falhas e novas tentativas programadas, enquanto a entidade totalizamostre quais famílias de carga útil Lotti contribuíram para esse trabalho. Um aumento processado
-contar com falhas estáveis é saudável. Falhas ou tentativas repetidas que nunca
+mensagens processadas, falhas e novas tentativas programadas, enquanto os totais de entidades mostram
+quais famílias de carga útil da Lotti contribuíram para esse trabalho. Uma contagem crescente de mensagens
+processadas com falhas estáveis é saudável. Falhas ou tentativas repetidas que nunca
 chamada clara para verificar a caixa de saída e a conectividade do outro dispositivo.
 
 ## Inspecione a caixa de saída

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -1,0 +1,151 @@
+---
+title: Sincronizar dispositivos
+description: Emparelhe dispositivos, verifique sua identidade, monitore a entrega e recupere dados perdidos sem adivinhar.
+---
+
+# Sincronizar dispositivos
+
+Lotti Sync mantém os dados suportados alinhados entre seus dispositivos. Cada dispositivo tem
+seu próprio banco de dados local; A sincronização move as alterações pela conta de sincronização configurada
+e recupera um dispositivo depois que ele fica off-line. A sincronização não move o
+sistema de registro em uma nuvem Lotti: os relés de serviço Matrix configurados
+cargas criptografadas de ponta a ponta entre seus dispositivos enquanto cada dispositivo retém
+sua própria cópia local.
+
+Abra **Configurações → Sincronizar** para ver a configuração, integridade e recuperação disponíveis
+páginas. O número ao lado de **Caixa de saída** é o trabalho que não atingiu a sincronização
+serviço ainda.
+
+<ManualScreenshot
+  caseId="sync/hub"
+  alt="Configurações do Lotti Sync com sincronização provisionada, identidade do dispositivo, preenchimento, estatísticas, caixa de saída, conflitos e manutenção"
+  caption="O hub de sincronização mantém o status diário próximo às ferramentas de diagnóstico e recuperação. O Projeto Waddle atualmente tem três itens de caixa de saída para inspecionar."
+/>
+
+## Parear outro dispositivo
+
+Comece em um dispositivo que já esteja conectado:
+
+1. Abra **Configurações → Sincronização → Sincronização Provisionada**.
+2. No desktop, mostre o código QR de entrega. Mantenha esta tela privada: o pacote
+   concede acesso à sua conta e sala de sincronização.
+3. No novo dispositivo, abra a mesma página e escaneie o código QR ou cole o
+   pacote completo de provisionamento.
+4. Revise o servidor, o usuário e a sala decodificados antes de selecionar **Importar**.
+5. Deixe a primeira sincronização terminar antes de fechar qualquer um dos aplicativos.
+
+<ManualScreenshot
+  caseId="sync/status"
+  alt="Status de sincronização provisionado no celular e código QR de entrega segura do dispositivo no desktop"
+  caption="O desktop pode apresentar o código QR de entrega; mobile mostra a conta conectada e o estado de verificação. Trate o código QR como uma senha."
+/>
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Revisão de importação de provisionamento de Lotti mostrando o servidor de sincronização, usuário e sala do Project Waddle"
+  caption="Importe somente quando cada valor decodificado pertencer à conta de sincronização à qual você pretende ingressar."
+/>
+
+Se a importação reportar um erro, mantenha o dispositivo original conectado, gere um
+novo pacote de transferência e tente novamente com o valor total. Não edite manualmente o
+pacote codificado.
+
+## Verifique o novo dispositivo
+
+O emparelhamento conecta o dispositivo; verificação confirma que ambos os dispositivos estão
+conversando entre si sem um dispositivo desconhecido no meio.
+
+<ManualScreenshot
+  caseId="sync/verification"
+  alt="Verificação do dispositivo Lotti comparando uma sequência de emoji de pinguim, peixe, foguete, gelo, Terra, lua, estrela e telescópio"
+  caption="Compare toda a sequência de emojis em ambos os dispositivos. Aceite apenas quando todas as imagens e sua ordem corresponderem exatamente."
+/>
+
+Compare o emoji pessoalmente ou por meio de uma chamada confiável. Selecione **Aceitar** em ambos
+dispositivos somente quando a sequência completa corresponder. Se pelo menos um emoji for diferente,
+cancelar a verificação e investigar os nomes da conta e do dispositivo antes
+tentando novamente.
+
+## Nomeie dispositivos e anuncie recursos
+
+**Perfil do nó de sincronização** identifica o dispositivo atual para o restante da sincronização
+grupo. Dê-lhe um nome que distinga a máquina física, como
+“Mission Control Mac” em vez de “Desktop”.
+
+<ManualScreenshot
+  caseId="sync/node-profile"
+  alt="Perfil do nó Lotti Sync para Mission Control Mac com recursos de inferência local e dispositivos conhecidos do Project Waddle"
+  caption="Nomes de dispositivos claros tornam a verificação, o diagnóstico e a inferência local fixada no dispositivo muito mais fáceis de auditar."
+/>
+
+A página também lista os recursos que o dispositivo pode fornecer, como áudio local
+transcrição ou inferência do modelo de idioma local. Dispositivos conhecidos mostram o que
+outros nós anunciados mais recentemente. A disponibilidade de capacidade é descritiva;
+o perfil de IA relevante ainda deve estar configurado para usá-lo.
+
+## Entenda o catch-up e o backfill
+
+A sincronização normal processa as alterações à medida que elas chegam. **Preenchimento** detecta lacunas no
+sequência recebida de dispositivos conhecidos e solicita novamente os registros ausentes.
+
+<ManualScreenshot
+  caseId="sync/backfill"
+  alt="Página Lotti Sync Backfill mostrando status de entrada, ausente e ignorado, além de estatísticas de sequência e preenchimento automático"
+  caption="O Projeto Waddle recebeu 2.868 registros de sequência e atualmente conhece cerca de quatro registros ausentes em dois IDs de dispositivos."
+/>
+
+- **Entrada** é o trabalho atualmente aguardando na fila de entrada.
+- **Em falta** é o número de lacunas de sequência conhecidas.
+- **Ignorado** é o trabalho que a fila de entrada abandonou depois que não pôde ser
+  processado normalmente.
+- **Preenchimento automático** solicita continuamente lacunas recuperáveis e é o
+  padrão correto para uso normal.
+- **Recuperação avançada** contém controles manuais para uma investigação. Use-o
+  somente depois que a sincronização normal e o preenchimento automático tiverem tempo de se estabilizar.
+
+Uma contagem ausente diferente de zero não é automaticamente perda de dados: outro dispositivo pode
+ainda estar off-line ou a solicitação já pode estar em andamento. Investigue quando o
+a contagem permanece inalterada enquanto todos os dispositivos esperados estão online.
+
+## Ler estatísticas de sincronização
+
+**Estatísticas de sincronização** separa o volume de mensagens da integridade do processamento. É
+útil quando os dados parecem desatualizados, mas a conta ainda informa como conectada.
+
+<ManualScreenshot
+  caseId="sync/stats"
+  alt="Lotti Matrix Sync Statistics com contagens de mensagens enviadas, principais KPIs de processamento, tipos de mensagens, falhas, novas tentativas e totais de entidades"
+  caption="As contagens estabelecem se as mensagens estão sendo movidas; falhas e novas tentativas programadas mostram se o pipeline está se movendo de maneira limpa."
+/>
+
+O cartão de mensagem enviada agrupa tipos de eventos Matrix. **Principais KPIs** resume
+mensagens processadas, falhas e novas tentativas programadas, enquanto a entidade totalizamostre quais famílias de carga útil Lotti contribuíram para esse trabalho. Um aumento processado
+contar com falhas estáveis é saudável. Falhas ou tentativas repetidas que nunca
+chamada clara para verificar a caixa de saída e a conectividade do outro dispositivo.
+
+## Inspecione a caixa de saída
+
+A **Caixa de saída** é a fila local de alterações aguardando para serem enviadas. Filtre por
+estado para separar o trabalho ativo das falhas.
+
+<ManualScreenshot
+  caseId="sync/outbox"
+  alt="Lotti Sync Outbox filtrada para uma foto de vedação de pressão do habitat do Projeto Waddle com falha com ações de repetição e remoção"
+  caption="Os itens com falha mantêm seu assunto, detalhes de carga útil, histórico de novas tentativas e caminho de anexo local para que a recuperação seja específica e não cega."
+/>
+
+- **Itens pendentes** estão aguardando sua vez.
+- **Enviando** itens estão atualmente em andamento.
+- **Itens com falha** esgotaram a tentativa atual e permanecem disponíveis para
+  inspeção.
+- **Os itens enviados** foram entregues e estão retidos temporariamente para
+  diagnóstico.
+
+Use **Repetir tudo** depois que o problema subjacente de conexão ou conta for corrigido.
+Remova um item com falha somente quando você intencionalmente não quiser que essa alteração ocorra.
+alcançar outros dispositivos. Removê-lo da caixa de saída não substitui
+reparando a entrada ou anexo local correspondente.
+
+Continue com [Resolver conflitos de sincronização](./conflicts.mdx) quando dois dispositivos editaram
+a mesma entrada de forma independente ou [Manutenção de sincronização](./maintenance.mdx) para
+ferramentas de recuperação em nível de banco de dados.

--- a/docs-site/i18n/pt/docusaurus-theme-classic/footer.json
+++ b/docs-site/i18n/pt/docusaurus-theme-classic/footer.json
@@ -1,0 +1,30 @@
+{
+  "link.title.Manual": {
+    "message": "Manual",
+    "description": "The title of the footer links column with title=Manual in the footer"
+  },
+  "link.title.Project": {
+    "message": "Projeto",
+    "description": "The title of the footer links column with title=Project in the footer"
+  },
+  "link.item.label.Start here": {
+    "message": "Comece aqui",
+    "description": "The label of footer link with label=Start here linking to /"
+  },
+  "link.item.label.Daily OS": {
+    "message": "Daily OS",
+    "description": "The label of footer link with label=Daily OS linking to /plan-and-capture/daily-os/"
+  },
+  "link.item.label.Tasks": {
+    "message": "Tarefas",
+    "description": "The label of footer link with label=Tasks linking to /organize-and-reflect/tasks/"
+  },
+  "link.item.label.Source code": {
+    "message": "Código-fonte",
+    "description": "The label of footer link with label=Source code linking to https://github.com/matthiasn/lotti"
+  },
+  "link.item.label.Report a documentation issue": {
+    "message": "Informar um problema na documentação",
+    "description": "The label of footer link with label=Report a documentation issue linking to https://github.com/matthiasn/lotti/issues/new"
+  }
+}

--- a/docs-site/i18n/pt/docusaurus-theme-classic/navbar.json
+++ b/docs-site/i18n/pt/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Manual do Lotti",
+    "description": "The title in the navbar"
+  },
+  "item.label.Guide": {
+    "message": "Guia",
+    "description": "Navbar item with label Guide"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
@@ -13,7 +13,7 @@ Desktopul păstrează arborele de setări lângă pagina selectată. Mobilul des
 
 ## Alegeți limba manualului
 
-Deschideți **Limbă** pentru a decide ce manual publicat deschide aplicația. **Urmați sistemul** este valoarea implicită și alege manualul în engleză, germană, franceză, cehă sau română după limba dispozitivului. Selectați **Engleză**, **Germană**, **Franceză**, **Cehă** sau **Română** pentru a păstra o alegere diferită. Intrarea Manual din partea de jos a Setărilor și **Ajutor → Manual** pe macOS folosesc ambele această setare.
+Deschideți **Limbă** pentru a decide ce manual publicat deschide aplicația. **Urmați sistemul** este valoarea implicită și alege manualul în engleză, germană, franceză, cehă, română sau portugheză după limba dispozitivului. Selectați **Engleză**, **Germană**, **Franceză**, **Cehă**, **Română** sau **Portugheză** pentru a păstra o alegere diferită. Intrarea Manual din partea de jos a Setărilor și **Ajutor → Manual** pe macOS folosesc ambele această setare.
 
 ## Controlați capabilitățile cu indicatori de configurare
 

--- a/docs-site/metadata/screenshot-cases.json
+++ b/docs-site/metadata/screenshot-cases.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "defaultLocale": "en",
-  "locales": ["en", "de", "fr", "es", "cs", "ro"],
+  "locales": ["en", "de", "fr", "es", "cs", "ro", "pt"],
   "cases": [
     {
       "id": "daily-os/agenda",

--- a/docs-site/scripts/smoke-built-site.mjs
+++ b/docs-site/scripts/smoke-built-site.mjs
@@ -52,6 +52,16 @@ const localeExpectations = {
     mobile: 'Mobil',
     openViewer: 'Deschideți vizualizatorul capturilor de ecran',
   },
+  pt: {
+    allScreenshots: 'Todas as capturas de tela',
+    desktop: 'Computador',
+    firstTaskTitle: 'Crie sua primeira tarefa',
+    layoutLabel: 'Layout das capturas de tela para todas as imagens',
+    mobile: 'Celular',
+    openViewer: 'Abrir visualizador de capturas de tela',
+    translationDisclosure:
+      'Esta tradução foi gerada automaticamente e ainda não foi revisada.',
+  },
 };
 const translatedLocales = screenshotRegistry.locales.filter(
   (locale) => locale !== screenshotRegistry.defaultLocale,
@@ -134,7 +144,14 @@ for (const locale of translatedLocales) {
     translatedSettingsHtml,
     new RegExp(`data-translation-notice=["']?${locale}["']?`),
   );
-  assert.match(translatedSettingsHtml, /GPT 5\.6 Sol xHigh/);
+  if (expected.translationDisclosure) {
+    assert.ok(
+      translatedSettingsHtml.includes(expected.translationDisclosure),
+      `The ${locale} manual must include its translation disclosure.`,
+    );
+  } else {
+    assert.match(translatedSettingsHtml, /GPT 5\.6 Sol xHigh/);
+  }
   assert.match(
     translatedSettingsHtml,
     new RegExp(`aria-label="${expected.layoutLabel}"`),

--- a/docs-site/tests/browser-locale-preference.test.mjs
+++ b/docs-site/tests/browser-locale-preference.test.mjs
@@ -13,15 +13,23 @@ test('browser locale matching uses the first supported language', () => {
   assert.equal(
     preferredSupportedLocale(
       ['ro-RO', 'fr-FR', 'cs-CZ', 'de-DE', 'en-US'],
-      ['en', 'de', 'fr', 'es', 'cs', 'ro'],
+      ['en', 'de', 'fr', 'es', 'cs', 'ro', 'pt'],
       'en',
     ),
     'ro',
   );
   assert.equal(
     preferredSupportedLocale(
+      ['pt-BR', 'fr-FR', 'de-DE', 'en-US'],
+      ['en', 'de', 'fr', 'es', 'cs', 'ro', 'pt'],
+      'en',
+    ),
+    'pt',
+  );
+  assert.equal(
+    preferredSupportedLocale(
       ['es-ES', 'fr-FR', 'cs-CZ', 'de-DE', 'en-US'],
-      ['en', 'de', 'fr', 'es', 'cs', 'ro'],
+      ['en', 'de', 'fr', 'es', 'cs', 'ro', 'pt'],
       'en',
     ),
     'es',
@@ -29,7 +37,7 @@ test('browser locale matching uses the first supported language', () => {
   assert.equal(
     preferredSupportedLocale(
       ['fr-FR', 'cs-CZ', 'de-DE', 'en-US'],
-      ['en', 'de', 'fr', 'es', 'cs', 'ro'],
+      ['en', 'de', 'fr', 'es', 'cs', 'ro', 'pt'],
       'en',
     ),
     'fr',
@@ -95,6 +103,10 @@ test('locale root URLs preserve the default route and add alternatives', () => {
     '/lotti/manual/development/ro/',
   );
   assert.equal(
+    localeRootUrl('/lotti/manual/development/', 'pt', 'en'),
+    '/lotti/manual/development/pt/',
+  );
+  assert.equal(
     localeRootUrl('/lotti/manual/development/', 'es', 'en'),
     '/lotti/manual/development/es/',
   );
@@ -118,6 +130,7 @@ test('an explicit locale dropdown choice is persisted', () => {
       es: {htmlLang: 'es-ES'},
       cs: {htmlLang: 'cs-CZ'},
       ro: {htmlLang: 'ro-RO'},
+      pt: {htmlLang: 'pt-BR'},
     },
     storage: {setItem: (key, value) => stored.set(key, value)},
   });

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -41,6 +41,7 @@
     </release>
     <release version="0.9.1051" date="2026-07-17">
       <description>
+          <p>Portuguese is now available throughout Lotti and its Manual. The app follows Portuguese system locales, and Settings → Advanced → Language can open the matching Portuguese manual explicitly.</p>
           <p>French, Spanish, and Romanian now read more naturally throughout the app. Agent controls, AI and Sync setup, dashboards, health import, and task actions keep the selected language's own register and terminology instead of exposing literal or mixed-language copy.</p>
           <p>The Manual link now opens English, German, French, Czech, or Romanian documentation to match your system language. You can choose a different language from Settings → Advanced → Language at any time.</p>
           <p>Manual is now a distinct final entry in Settings and is also available from the desktop Help menu, keeping the navigation sidebar focused on the app.</p>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -25,6 +25,7 @@
 		<string>de</string>
 		<string>es</string>
 		<string>fr</string>
+		<string>pt</string>
 		<string>ro</string>
 	</array>
 	<key>CFBundleName</key>

--- a/lib/features/settings/README.md
+++ b/lib/features/settings/README.md
@@ -581,7 +581,7 @@ It is an Advanced leaf on both settings surfaces (`advanced/manual-language` →
 `/settings/advanced/manual-language`), and its body is embedded in the desktop
 detail pane through the `advanced-manual-language` panel registration.
 
-The manual currently publishes English, German, French, Czech, and Romanian. `Follow system` is
+The manual currently publishes English, German, French, Czech, Romanian, and Portuguese. `Follow system` is
 the default: [`ManualLanguageController`](state/manual_language_controller.dart)
 matches the device locale to that catalog and falls back to English when no
 manual translation exists. Selecting a language persists only that explicit
@@ -591,7 +591,7 @@ later device-language change is reflected the next time the user opens Manual.
 ```mermaid
 flowchart LR
   Choice["Advanced → Language"] --> Preference{"Explicit override?"}
-  Preference -->|yes| Override["English / German / French / Czech / Romanian"]
+  Preference -->|yes| Override["English / German / French / Czech / Romanian / Portuguese"]
   Preference -->|no| System["Platform system locale"]
   System --> Catalog{"Published manual locale?"}
   Catalog -->|yes| Matched["Matching manual route"]

--- a/lib/features/settings/state/manual_language_controller.dart
+++ b/lib/features/settings/state/manual_language_controller.dart
@@ -18,7 +18,8 @@ enum ManualLanguage {
   german('de'),
   french('fr'),
   czech('cs'),
-  romanian('ro');
+  romanian('ro'),
+  portuguese('pt');
 
   const ManualLanguage(this.languageCode);
 

--- a/lib/features/settings/ui/pages/advanced/manual_language_settings_page.dart
+++ b/lib/features/settings/ui/pages/advanced/manual_language_settings_page.dart
@@ -80,6 +80,13 @@ class ManualLanguageSettingsBody extends ConsumerWidget {
             selected: selectedOverride == ManualLanguage.romanian,
             onTap: () =>
                 unawaited(controller.setOverride(ManualLanguage.romanian)),
+            showDivider: true,
+          ),
+          _ManualLanguageOption(
+            title: messages.settingsManualLanguagePortugueseTitle,
+            selected: selectedOverride == ManualLanguage.portuguese,
+            onTap: () =>
+                unawaited(controller.setOverride(ManualLanguage.portuguese)),
           ),
         ],
       ),

--- a/lib/features/tasks/ui/widgets/task_action_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar.dart
@@ -103,7 +103,7 @@ class TaskActionBar extends ConsumerStatefulWidget {
   /// affordance is included. Checklist is dropped second (after image)
   /// when the row would otherwise overflow.
   @visibleForTesting
-  static const double minWidthForChecklistButton = 340;
+  static const double minWidthForChecklistButton = 374;
 
   /// Minimum [LayoutBuilder] inner width at which the image affordance
   /// is included. Image is dropped first (before checklist) when the
@@ -305,10 +305,10 @@ class _TaskActionBarState extends ConsumerState<TaskActionBar> {
                 // checklist; both stay reachable via the "..." (more) menu.
                 //
                 // Thresholds include the widest translated idle pill
-                // (French "Suivre le temps"), 48 px round buttons, and
+                // (Portuguese "Monitorar o tempo"), 48 px round buttons, and
                 // step4 (12 px) gaps. Adding each extra button costs ≈60 px,
                 // so the five-control row needs 416 px and the four-control
-                // row needs ≈340 px.
+                // row needs 374 px.
                 final showImage =
                     constraints.maxWidth >=
                     TaskActionBar.minWidthForImageButton;

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3661,6 +3661,7 @@
   "settingsManualLanguageFollowSystemTitle": "Používat jazyk systému",
   "settingsManualLanguageFrenchTitle": "Francouzština",
   "settingsManualLanguageGermanTitle": "Němčina",
+  "settingsManualLanguagePortugueseTitle": "Portugalština",
   "settingsManualLanguageRomanianTitle": "Rumunština",
   "settingsManualLanguageTitle": "Jazyk",
   "settingsMatrixAccept": "Přijmout",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3654,6 +3654,7 @@
   "settingsManualLanguageFollowSystemTitle": "Systemsprache verwenden",
   "settingsManualLanguageFrenchTitle": "Französisch",
   "settingsManualLanguageGermanTitle": "Deutsch",
+  "settingsManualLanguagePortugueseTitle": "Portugiesisch",
   "settingsManualLanguageRomanianTitle": "Rumänisch",
   "settingsManualLanguageTitle": "Sprache",
   "settingsMatrixAccept": "Akzeptieren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4392,6 +4392,7 @@
   "settingsManualLanguageFollowSystemTitle": "Follow system",
   "settingsManualLanguageFrenchTitle": "French",
   "settingsManualLanguageGermanTitle": "German",
+  "settingsManualLanguagePortugueseTitle": "Portuguese",
   "settingsManualLanguageRomanianTitle": "Romanian",
   "settingsManualLanguageTitle": "Language",
   "settingsMatrixAccept": "Accept",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3654,6 +3654,7 @@
   "settingsManualLanguageFollowSystemTitle": "Seguir el sistema",
   "settingsManualLanguageFrenchTitle": "Francés",
   "settingsManualLanguageGermanTitle": "Alemán",
+  "settingsManualLanguagePortugueseTitle": "Portugués",
   "settingsManualLanguageRomanianTitle": "Rumano",
   "settingsManualLanguageTitle": "Idioma",
   "settingsMatrixAccept": "Aceptar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3654,6 +3654,7 @@
   "settingsManualLanguageFollowSystemTitle": "Suivre le système",
   "settingsManualLanguageFrenchTitle": "Français",
   "settingsManualLanguageGermanTitle": "Allemand",
+  "settingsManualLanguagePortugueseTitle": "Portugais",
   "settingsManualLanguageRomanianTitle": "Roumain",
   "settingsManualLanguageTitle": "Langue",
   "settingsMatrixAccept": "Accepter",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15504,17 +15504,17 @@ abstract class AppLocalizations {
   /// **'Room invite'**
   String get settingsMatrixRoomInviteTitle;
 
-  /// No description provided for @settingsMatrixSentMessageType.
-  ///
-  /// In en, this message translates to:
-  /// **'Sent ({eventType})'**
-  String settingsMatrixSentMessageType(String eventType);
-
   /// No description provided for @settingsMatrixSentMessagesLabel.
   ///
   /// In en, this message translates to:
   /// **'Sent messages:'**
   String get settingsMatrixSentMessagesLabel;
+
+  /// No description provided for @settingsMatrixSentMessageType.
+  ///
+  /// In en, this message translates to:
+  /// **'Sent ({eventType})'**
+  String settingsMatrixSentMessageType(String eventType);
 
   /// No description provided for @settingsMatrixStartVerificationLabel.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10,6 +10,7 @@ import 'app_localizations_de.dart';
 import 'app_localizations_en.dart';
 import 'app_localizations_es.dart';
 import 'app_localizations_fr.dart';
+import 'app_localizations_pt.dart';
 import 'app_localizations_ro.dart';
 
 // ignore_for_file: type=lint
@@ -104,6 +105,7 @@ abstract class AppLocalizations {
     Locale('en', 'GB'),
     Locale('es'),
     Locale('fr'),
+    Locale('pt'),
     Locale('ro'),
   ];
 
@@ -15370,6 +15372,12 @@ abstract class AppLocalizations {
   /// **'German'**
   String get settingsManualLanguageGermanTitle;
 
+  /// No description provided for @settingsManualLanguagePortugueseTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Portuguese'**
+  String get settingsManualLanguagePortugueseTitle;
+
   /// No description provided for @settingsManualLanguageRomanianTitle.
   ///
   /// In en, this message translates to:
@@ -18114,6 +18122,7 @@ class _AppLocalizationsDelegate
     'en',
     'es',
     'fr',
+    'pt',
     'ro',
   ].contains(locale.languageCode);
 
@@ -18146,6 +18155,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       return AppLocalizationsEs();
     case 'fr':
       return AppLocalizationsFr();
+    case 'pt':
+      return AppLocalizationsPt();
     case 'ro':
       return AppLocalizationsRo();
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -9128,12 +9128,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsMatrixRoomInviteTitle => 'Pozvánka do místnosti';
 
   @override
+  String get settingsMatrixSentMessagesLabel => 'Odeslané zprávy:';
+
+  @override
   String settingsMatrixSentMessageType(String eventType) {
     return 'Odesláno ($eventType)';
   }
-
-  @override
-  String get settingsMatrixSentMessagesLabel => 'Odeslané zprávy:';
 
   @override
   String get settingsMatrixStartVerificationLabel => 'Spustit ověření';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -9054,6 +9054,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsManualLanguageGermanTitle => 'Němčina';
 
   @override
+  String get settingsManualLanguagePortugueseTitle => 'Portugalština';
+
+  @override
   String get settingsManualLanguageRomanianTitle => 'Rumunština';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8983,6 +8983,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsManualLanguageGermanTitle => 'Deutsch';
 
   @override
+  String get settingsManualLanguagePortugueseTitle => 'Portugiesisch';
+
+  @override
   String get settingsManualLanguageRomanianTitle => 'Rumänisch';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -9056,12 +9056,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsMatrixRoomInviteTitle => 'Raumeinladung';
 
   @override
+  String get settingsMatrixSentMessagesLabel => 'Gesendete Nachrichten:';
+
+  @override
   String settingsMatrixSentMessageType(String eventType) {
     return 'Gesendet ($eventType)';
   }
-
-  @override
-  String get settingsMatrixSentMessagesLabel => 'Gesendete Nachrichten:';
 
   @override
   String get settingsMatrixStartVerificationLabel => 'Verifizierung starten';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8876,6 +8876,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsManualLanguageGermanTitle => 'German';
 
   @override
+  String get settingsManualLanguagePortugueseTitle => 'Portuguese';
+
+  @override
   String get settingsManualLanguageRomanianTitle => 'Romanian';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8948,12 +8948,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsMatrixRoomInviteTitle => 'Room invite';
 
   @override
+  String get settingsMatrixSentMessagesLabel => 'Sent messages:';
+
+  @override
   String settingsMatrixSentMessageType(String eventType) {
     return 'Sent ($eventType)';
   }
-
-  @override
-  String get settingsMatrixSentMessagesLabel => 'Sent messages:';
 
   @override
   String get settingsMatrixStartVerificationLabel => 'Start Verification';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9070,6 +9070,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsManualLanguageGermanTitle => 'Alemán';
 
   @override
+  String get settingsManualLanguagePortugueseTitle => 'Portugués';
+
+  @override
   String get settingsManualLanguageRomanianTitle => 'Rumano';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9145,12 +9145,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsMatrixRoomInviteTitle => 'Invitación a sala';
 
   @override
+  String get settingsMatrixSentMessagesLabel => 'Mensajes enviados:';
+
+  @override
   String settingsMatrixSentMessageType(String eventType) {
     return 'Enviado ($eventType)';
   }
-
-  @override
-  String get settingsMatrixSentMessagesLabel => 'Mensajes enviados:';
 
   @override
   String get settingsMatrixStartVerificationLabel => 'Iniciar verificación';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -9110,6 +9110,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsManualLanguageGermanTitle => 'Allemand';
 
   @override
+  String get settingsManualLanguagePortugueseTitle => 'Portugais';
+
+  @override
   String get settingsManualLanguageRomanianTitle => 'Roumain';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -9185,12 +9185,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsMatrixRoomInviteTitle => 'Invitation au salon';
 
   @override
+  String get settingsMatrixSentMessagesLabel => 'Messages envoyés :';
+
+  @override
   String settingsMatrixSentMessageType(String eventType) {
     return 'Envoyé ($eventType)';
   }
-
-  @override
-  String get settingsMatrixSentMessagesLabel => 'Messages envoyés :';
 
   @override
   String get settingsMatrixStartVerificationLabel => 'Démarrer la vérification';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1154,10 +1154,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get aiCapabilityChipTranscription => 'Transcrição';
 
   @override
-  String get aiCardEmptyProposals =>
-      'Nenhuma proposta aberta · o agente apresentará novas alterações aqui';
-
-  @override
   String aiCardHistoryToggle(int count) {
     return 'História · $count';
   }
@@ -6731,6 +6727,124 @@ class AppLocalizationsPt extends AppLocalizations {
   String get manageLinks => 'Gerenciar links...';
 
   @override
+  String get matrixStatsCatchupBatches => 'Lotes de recuperação';
+
+  @override
+  String get matrixStatsCircuitOpens => 'Aberturas de circuito';
+
+  @override
+  String get matrixStatsConflicts => 'Conflitos';
+
+  @override
+  String get matrixStatsCopyDiagnostics => 'Copiar diagnósticos';
+
+  @override
+  String get matrixStatsCopyDiagnosticsTooltip =>
+      'Copie os diagnósticos de sincronização para a área de transferência';
+
+  @override
+  String get matrixStatsDbApplied => 'BD aplicado';
+
+  @override
+  String get matrixStatsDbApply => 'Aplicar BD';
+
+  @override
+  String get matrixStatsDbIgnoredVectorClock => 'BD ignorado (VectorClock)';
+
+  @override
+  String get matrixStatsDbMissingBase => 'BD sem base';
+
+  @override
+  String matrixStatsDroppedByType(Object type) {
+    return 'Descartado ($type)';
+  }
+
+  @override
+  String get matrixStatsEntryLinkNoops => 'Operações sem efeito de EntryLink';
+
+  @override
+  String get matrixStatsFailures => 'Falhas';
+
+  @override
+  String get matrixStatsFlushes => 'Descargas';
+
+  @override
+  String get matrixStatsForceRescan => 'Forçar nova verificação';
+
+  @override
+  String get matrixStatsForceRescanTooltip =>
+      'Force uma nova verificação e atualize agora';
+
+  @override
+  String get matrixStatsLegend => 'Legenda';
+
+  @override
+  String get matrixStatsLegendTooltip =>
+      'Legenda:\n• processed.<type> = mensagens de sincronização processadas por tipo de carga\n• droppedByType.<type> = descartes por tipo após novas tentativas ou ao ignorar mensagens antigas\n• dbApplied = linhas gravadas no banco de dados\n• dbIgnoredByVectorClock = dados recebidos mais antigos ou idênticos ignorados pelo banco de dados\n• conflictsCreated = vetores de relógio simultâneos registrados\n• dbMissingBase = ignorado enquanto aguarda uma dependência ou linha de base ausente\n• staleAttachmentPurges = descritores obsoletos em cache removidos antes da atualização';
+
+  @override
+  String get matrixStatsProcessed => 'Processado';
+
+  @override
+  String matrixStatsProcessedByType(Object type) {
+    return 'Processado ($type)';
+  }
+
+  @override
+  String get matrixStatsRefresh => 'Atualizar';
+
+  @override
+  String get matrixStatsReliability => 'Confiabilidade';
+
+  @override
+  String get matrixStatsRetriesScheduled => 'Novas tentativas agendadas';
+
+  @override
+  String get matrixStatsRetryNow => 'Tentar novamente agora';
+
+  @override
+  String get matrixStatsRetryNowTooltip =>
+      'Tente novamente as falhas pendentes agora';
+
+  @override
+  String get matrixStatsSignalLatencyLast => 'Latência do sinal (últimos ms)';
+
+  @override
+  String get matrixStatsSignalLatencyMax => 'Latência do sinal (máx. ms)';
+
+  @override
+  String get matrixStatsSignalLatencyMin => 'Latência do sinal (mín. ms)';
+
+  @override
+  String get matrixStatsSignals => 'Sinais';
+
+  @override
+  String get matrixStatsSignalsClientStream => 'Sinais (fluxo do cliente)';
+
+  @override
+  String get matrixStatsSignalsConnectivity => 'Sinais (conectividade)';
+
+  @override
+  String get matrixStatsSignalsTimelineCallbacks =>
+      'Sinais (callbacks da linha do tempo)';
+
+  @override
+  String get matrixStatsSkipped => 'Ignorado';
+
+  @override
+  String get matrixStatsSkippedRetryCap =>
+      'Ignorado (limite de novas tentativas)';
+
+  @override
+  String get matrixStatsStaleAttachmentPurges => 'Limpezas de anexos obsoletos';
+
+  @override
+  String get matrixStatsThroughput => 'Taxa de transferência';
+
+  @override
+  String get matrixStatsTopKpis => 'Principais KPIs';
+
+  @override
   String get measurableDeleteConfirm => 'SIM, EXCLUIR ESTE MENSURÁVEL';
 
   @override
@@ -8990,6 +9104,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsMatrixSentMessagesLabel => 'Mensagens enviadas:';
 
   @override
+  String settingsMatrixSentMessageType(String eventType) {
+    return 'Enviado ($eventType)';
+  }
+
+  @override
   String get settingsMatrixStartVerificationLabel => 'Iniciar verificação';
 
   @override
@@ -9672,14 +9791,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Escolha uma configuração de IA antes de ativar as atualizações automáticas.';
 
   @override
-  String get taskAgentAutomaticUpdatesOffDescription =>
-      'As atualizações automáticas estão desativadas. Acorde o agente quando quiser um novo relatório.';
-
-  @override
-  String get taskAgentAutomaticUpdatesSummary =>
-      'Agrupe alterações de tarefas e atualize após dois minutos.';
-
-  @override
   String get taskAgentCancelTimerTooltip =>
       'Cancelar atualização automática pendente';
 
@@ -9728,6 +9839,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get taskAgentModelPickerTitle => 'Escolha o modelo de pensamento';
 
   @override
+  String taskAgentNextUpdateIn(String countdown) {
+    return 'Próxima atualização em $countdown';
+  }
+
+  @override
   String get taskAgentNoAiSetup => 'Sem configuração de IA';
 
   @override
@@ -9758,11 +9874,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get taskAgentProfileDefaultBadge => 'Perfil padrão';
 
   @override
-  String get taskAgentReportOutdatedDescription =>
-      'A tarefa mudou depois que esse resumo foi gerado.';
+  String get taskAgentReportOutdatedTitle => 'Este resumo está desatualizado';
 
   @override
-  String get taskAgentReportOutdatedTitle => 'Este resumo está desatualizado';
+  String get taskAgentReportUpToDate => 'O resumo está atualizado';
 
   @override
   String get taskAgentRouteVia => 'através de';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1,0 +1,10498 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Portuguese (`pt`).
+class AppLocalizationsPt extends AppLocalizations {
+  AppLocalizationsPt([String locale = 'pt']) : super(locale);
+
+  @override
+  String get activeLabel => 'Ativo';
+
+  @override
+  String get addActionAddAudioRecording => 'Gravação de áudio';
+
+  @override
+  String get addActionAddChecklist => 'Lista de verificação';
+
+  @override
+  String get addActionAddEvent => 'Evento';
+
+  @override
+  String get addActionAddImageFromClipboard => 'Colar imagem';
+
+  @override
+  String get addActionAddScreenshot => 'Captura de tela';
+
+  @override
+  String get addActionAddTask => 'Tarefa';
+
+  @override
+  String get addActionAddText => 'Entrada de texto';
+
+  @override
+  String get addActionAddTimer => 'Temporizador';
+
+  @override
+  String get addActionAddTimeRecording => 'Entrada do temporizador';
+
+  @override
+  String get addActionImportImage => 'Importar imagem';
+
+  @override
+  String get addHabitCommentLabel => 'Comentário';
+
+  @override
+  String get addHabitDateLabel => 'Concluído em';
+
+  @override
+  String get addMeasurementCommentLabel => 'Comentário';
+
+  @override
+  String get addMeasurementDateLabel => 'Observado em';
+
+  @override
+  String get addMeasurementSaveButton => 'Salvar';
+
+  @override
+  String get addToDictionary => 'Adicionar ao dicionário';
+
+  @override
+  String get addToDictionaryDuplicate => 'O termo já existe no dicionário';
+
+  @override
+  String get addToDictionaryNoCategory =>
+      'Não é possível adicionar ao dicionário: a tarefa não tem categoria';
+
+  @override
+  String get addToDictionarySaveFailed => 'Falha ao salvar o dicionário';
+
+  @override
+  String get addToDictionarySuccess => 'Termo adicionado ao dicionário';
+
+  @override
+  String get addToDictionaryTooLong =>
+      'Prazo muito longo (máximo de 50 caracteres)';
+
+  @override
+  String agentABComparisonChoose(String option) {
+    return 'Escolha $option';
+  }
+
+  @override
+  String agentABComparisonOption(String option) {
+    return 'Opção $option';
+  }
+
+  @override
+  String agentABComparisonPrefer(String option) {
+    return 'Eu prefiro a opção $option';
+  }
+
+  @override
+  String get agentBinaryChoiceNo => 'Não';
+
+  @override
+  String get agentBinaryChoiceYes => 'Sim';
+
+  @override
+  String get agentCategoryRatingsScaleMax => 'Corrija primeiro';
+
+  @override
+  String get agentCategoryRatingsScaleMin => 'Deixe';
+
+  @override
+  String agentCategoryRatingsStarLabel(int starIndex, int totalStars) {
+    return '$starIndex de $totalStars estrelas';
+  }
+
+  @override
+  String get agentCategoryRatingsSubmit => 'Use essas prioridades';
+
+  @override
+  String get agentCategoryRatingsSubtitle =>
+      'Quão importante é que eu corrija cada um deles? 1 significa deixar como está, 5 significa consertar primeiro.';
+
+  @override
+  String get agentCategoryRatingsTitle => 'Ajude-me a priorizar';
+
+  @override
+  String agentControlsActionError(String error) {
+    return 'Falha na ação: $error';
+  }
+
+  @override
+  String get agentControlsDeleteButton => 'Excluir permanentemente';
+
+  @override
+  String get agentControlsDeleteDialogContent =>
+      'Isso excluirá permanentemente todos os dados deste agente, incluindo histórico, relatórios e observações. Isto não pode ser desfeito.';
+
+  @override
+  String get agentControlsDeleteDialogTitle => 'Excluir agente?';
+
+  @override
+  String get agentControlsDestroyButton => 'Destruir';
+
+  @override
+  String get agentControlsDestroyDialogContent =>
+      'Isso desativará permanentemente o agente. Sua história será preservada para auditoria.';
+
+  @override
+  String get agentControlsDestroyDialogTitle => 'Destruir Agente?';
+
+  @override
+  String get agentControlsDestroyedMessage => 'Este agente foi destruído.';
+
+  @override
+  String get agentControlsPauseButton => 'Pausa';
+
+  @override
+  String get agentControlsReanalyzeButton => 'Reanalisar';
+
+  @override
+  String get agentControlsResumeButton => 'Currículo';
+
+  @override
+  String get agentConversationEmpty => 'Nenhuma conversa ainda.';
+
+  @override
+  String agentConversationThreadSummary(
+    int messageCount,
+    int toolCallCount,
+    String shortId,
+  ) {
+    return '$messageCount mensagens, $toolCallCount chamadas de ferramenta · $shortId';
+  }
+
+  @override
+  String agentConversationTokenCount(String tokenCount) {
+    return '$tokenCount tokens';
+  }
+
+  @override
+  String get agentDefaultProfileLabel => 'Perfil de inferência padrão';
+
+  @override
+  String agentDetailErrorLoading(String error) {
+    return 'Erro ao carregar o agente: $error';
+  }
+
+  @override
+  String get agentDetailNotFound => 'Agente não encontrado.';
+
+  @override
+  String get agentDetailUnexpectedType => 'Tipo de entidade inesperado.';
+
+  @override
+  String get agentEvolutionApprovalRate => 'Taxa de aprovação';
+
+  @override
+  String get agentEvolutionChartMttrTrend => 'Tendência MTTR';
+
+  @override
+  String get agentEvolutionChartSuccessRateTrend => 'Tendência de sucesso';
+
+  @override
+  String get agentEvolutionChartVersionPerformance => 'Por versão';
+
+  @override
+  String get agentEvolutionChartWakeHistory => 'Histórico de despertar';
+
+  @override
+  String get agentEvolutionChatPlaceholder =>
+      'Compartilhe comentários ou pergunte sobre desempenho...';
+
+  @override
+  String get agentEvolutionCurrentDirectives => 'Diretivas Atuais';
+
+  @override
+  String get agentEvolutionDashboardTitle => 'Desempenho';
+
+  @override
+  String get agentEvolutionHistoryTitle => 'História da Evolução';
+
+  @override
+  String get agentEvolutionMetricActive => 'Ativo';
+
+  @override
+  String get agentEvolutionMetricAvgDuration => 'Duração média';
+
+  @override
+  String get agentEvolutionMetricFailures => 'Falhas';
+
+  @override
+  String get agentEvolutionMetricSuccess => 'Sucesso';
+
+  @override
+  String get agentEvolutionMetricWakes => 'Acorda';
+
+  @override
+  String get agentEvolutionNoSessions => 'Nenhuma sessão de evolução ainda';
+
+  @override
+  String get agentEvolutionNoteRecorded => 'Nota gravada';
+
+  @override
+  String get agentEvolutionProposalApprovalFailed =>
+      'Falha na aprovação. Tente novamente';
+
+  @override
+  String get agentEvolutionProposalRationale => 'Justificativa';
+
+  @override
+  String get agentEvolutionProposalRejected =>
+      'Proposta rejeitada – continue a conversa';
+
+  @override
+  String get agentEvolutionProposalTitle => 'Mudanças propostas';
+
+  @override
+  String get agentEvolutionProposedDirectives => 'Diretivas propostas';
+
+  @override
+  String get agentEvolutionSessionAbandoned =>
+      'A sessão terminou sem alterações';
+
+  @override
+  String agentEvolutionSessionCompleted(int version) {
+    return 'Sessão concluída — versão $version criada';
+  }
+
+  @override
+  String get agentEvolutionSessionCount => 'Sessões';
+
+  @override
+  String get agentEvolutionSessionError =>
+      'Falha ao iniciar a sessão de evolução';
+
+  @override
+  String agentEvolutionSessionProgress(int sessionNumber, int totalSessions) {
+    return 'Sessão $sessionNumber de $totalSessions';
+  }
+
+  @override
+  String get agentEvolutionSessionStarting => 'Iniciando sessão de evolução...';
+
+  @override
+  String agentEvolutionSessionTitle(int sessionNumber) {
+    return 'Evolução #$sessionNumber';
+  }
+
+  @override
+  String agentEvolutionSoulCurrentField(String field) {
+    return 'Atual — $field';
+  }
+
+  @override
+  String agentEvolutionSoulProposedField(String field) {
+    return 'Proposta — $field';
+  }
+
+  @override
+  String get agentEvolutionStatusAbandoned => 'Abandonado';
+
+  @override
+  String get agentEvolutionStatusActive => 'Ativo';
+
+  @override
+  String get agentEvolutionStatusCompleted => 'Concluído';
+
+  @override
+  String get agentEvolutionTimelineFeedbackLabel => 'Comentários';
+
+  @override
+  String get agentEvolutionVersionProposed => 'Versão proposta';
+
+  @override
+  String get agentFeedbackCategoryAccuracy => 'Precisão';
+
+  @override
+  String get agentFeedbackCategoryBreakdownTitle => 'Divisão de categorias';
+
+  @override
+  String get agentFeedbackCategoryCommunication => 'Comunicação';
+
+  @override
+  String get agentFeedbackCategoryGeneral => 'Geral';
+
+  @override
+  String get agentFeedbackCategoryPrioritization => 'Priorização';
+
+  @override
+  String get agentFeedbackCategoryTimeliness => 'Oportunidade';
+
+  @override
+  String get agentFeedbackCategoryTooling => 'Ferramentas';
+
+  @override
+  String get agentFeedbackClassificationTitle => 'Classificação de Feedback';
+
+  @override
+  String get agentFeedbackExcellenceTitle => 'Notas de Excelência';
+
+  @override
+  String get agentFeedbackGrievancesTitle => 'Queixas';
+
+  @override
+  String get agentFeedbackHighPriorityTitle => 'Feedback de alta prioridade';
+
+  @override
+  String agentFeedbackItemCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens',
+      one: '1 item',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get agentFeedbackSourceDecision => 'Decisão';
+
+  @override
+  String get agentFeedbackSourceMetric => 'Métrica';
+
+  @override
+  String get agentFeedbackSourceObservation => 'Observação';
+
+  @override
+  String get agentFeedbackSourceRating => 'Avaliação';
+
+  @override
+  String get agentInstancesEmptyFiltered =>
+      'Nenhuma instância corresponde aos seus filtros.';
+
+  @override
+  String get agentInstancesFilterClearAll => 'Limpar tudo';
+
+  @override
+  String get agentInstancesFilterClearSection => 'Limpar';
+
+  @override
+  String get agentInstancesFilterSectionSoul => 'Alma';
+
+  @override
+  String get agentInstancesFilterSectionStatus => 'Estado';
+
+  @override
+  String get agentInstancesFilterSectionType => 'Tipo';
+
+  @override
+  String agentInstancesGroupActiveCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ativo',
+      one: '1 ativo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get agentInstancesGroupBySoul => 'Alma';
+
+  @override
+  String get agentInstancesGroupByStatus => 'Estado';
+
+  @override
+  String get agentInstancesGroupByType => 'Tipo';
+
+  @override
+  String get agentInstancesKindEvolution => 'Evolução';
+
+  @override
+  String get agentInstancesKindTaskAgent => 'Agente de Tarefas';
+
+  @override
+  String get agentInstancesPageTitle => 'Instâncias de agente';
+
+  @override
+  String agentInstancesResultCountAll(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count instâncias',
+      one: '1 instância',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String agentInstancesResultCountFiltered(int filtered, int total) {
+    return '$filtered de $total';
+  }
+
+  @override
+  String get agentInstancesSearchClear => 'Limpar pesquisa';
+
+  @override
+  String get agentInstancesSearchPlaceholder => 'Pesquisar instâncias…';
+
+  @override
+  String get agentInstancesSortName => 'Nome';
+
+  @override
+  String get agentInstancesSortOldest => 'Mais antigo';
+
+  @override
+  String get agentInstancesSortRecent => 'Recente';
+
+  @override
+  String get agentInstancesTitle => 'Instâncias';
+
+  @override
+  String get agentInstancesToolbarFilters => 'Filtros';
+
+  @override
+  String get agentInstancesToolbarGroupBy => 'Agrupar por';
+
+  @override
+  String get agentInstancesUnassignedSoul => 'Não atribuído';
+
+  @override
+  String get agentLifecycleActive => 'Ativo';
+
+  @override
+  String get agentLifecycleCreated => 'Criado';
+
+  @override
+  String get agentLifecycleDestroyed => 'Destruído';
+
+  @override
+  String get agentLifecycleDormant => 'Dormente';
+
+  @override
+  String get agentMessageKindAction => 'Ação';
+
+  @override
+  String get agentMessageKindMilestone => 'Marco';
+
+  @override
+  String get agentMessageKindObservation => 'Observação';
+
+  @override
+  String get agentMessageKindRetraction => 'Retração';
+
+  @override
+  String get agentMessageKindSummary => 'Resumo';
+
+  @override
+  String get agentMessageKindSystem => 'Sistema';
+
+  @override
+  String get agentMessageKindSystemPrompt => 'Alerta do sistema';
+
+  @override
+  String get agentMessageKindThought => 'Pensamento';
+
+  @override
+  String get agentMessageKindToolResult => 'Resultado da ferramenta';
+
+  @override
+  String get agentMessageKindUser => 'Usuário';
+
+  @override
+  String get agentMessagePayloadEmpty => '(sem conteúdo)';
+
+  @override
+  String get agentMessagesEmpty => 'Nenhuma mensagem ainda.';
+
+  @override
+  String agentMessagesErrorLoading(String error) {
+    return 'Falha ao carregar mensagens: $error';
+  }
+
+  @override
+  String get agentObservationsEmpty => 'Nenhuma observação registrada ainda.';
+
+  @override
+  String agentPendingWakesActivityHourDetail(
+    String hour,
+    int count,
+    String reasons,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count wakes',
+      one: '1 wake',
+    );
+    return '$hour: $_temp0 ($reasons)';
+  }
+
+  @override
+  String get agentPendingWakesActivityTitle => 'Atividade de Despertar (24h)';
+
+  @override
+  String agentPendingWakesActivityTotal(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count total de despertares',
+      one: '1 total de despertares',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get agentPendingWakesDeleteTooltip => 'Remover despertar';
+
+  @override
+  String get agentPendingWakesEmptyFiltered =>
+      'Nenhuma ativação corresponde aos seus filtros.';
+
+  @override
+  String get agentPendingWakesFilterSectionType => 'Tipo';
+
+  @override
+  String get agentPendingWakesGroupByType => 'Tipo';
+
+  @override
+  String get agentPendingWakesPendingLabel => 'Pendente';
+
+  @override
+  String agentPendingWakesRunningHeading(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Em execução agora ($count)',
+      one: 'Em execução agora',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get agentPendingWakesScheduledLabel => 'Agendado';
+
+  @override
+  String get agentPendingWakesSearchPlaceholder => 'A pesquisa acorda…';
+
+  @override
+  String get agentPendingWakesSortDueLatest => 'Vencimento mais recente';
+
+  @override
+  String get agentPendingWakesSortDueSoonest => 'Prazo mais breve';
+
+  @override
+  String get agentPendingWakesTitle => 'Ciclos de despertar';
+
+  @override
+  String get agentReportHistoryBadge => 'Relatório';
+
+  @override
+  String get agentReportHistoryEmpty =>
+      'Ainda não há instantâneos de relatório.';
+
+  @override
+  String get agentReportHistoryError =>
+      'Ocorreu um erro ao carregar o histórico do relatório.';
+
+  @override
+  String get agentReportNone => 'Nenhum relatório disponível ainda.';
+
+  @override
+  String get agentRitualReviewAction => 'Iniciar conversa';
+
+  @override
+  String get agentRitualReviewNegativeSignals => 'Negativo';
+
+  @override
+  String get agentRitualReviewNeutralSignals => 'Neutro';
+
+  @override
+  String get agentRitualReviewNoFeedback =>
+      'Nenhum sinal de feedback nesta janela';
+
+  @override
+  String get agentRitualReviewNoNegativeSignals =>
+      'Nenhum sinal de feedback negativo nesta guia';
+
+  @override
+  String get agentRitualReviewNoNeutralSignals =>
+      'Nenhum sinal de feedback neutro nesta guia';
+
+  @override
+  String get agentRitualReviewNoPositiveSignals =>
+      'Nenhum sinal de feedback positivo nesta guia';
+
+  @override
+  String get agentRitualReviewPositiveSignals => 'Positivo';
+
+  @override
+  String get agentRitualReviewProposalSection => 'Proposta Atual';
+
+  @override
+  String get agentRitualReviewSessionHistory => 'Histórico da sessão';
+
+  @override
+  String get agentRitualReviewTitle => '1 contra 1';
+
+  @override
+  String get agentRitualSummaryApprovedChangesHeading => 'Alterações aprovadas';
+
+  @override
+  String get agentRitualSummaryConversationHeading => 'Conversa';
+
+  @override
+  String get agentRitualSummaryRecapHeading => 'Recapitulação da sessão';
+
+  @override
+  String get agentRitualSummaryRoleAssistant => 'Agente';
+
+  @override
+  String get agentRitualSummaryRoleUser => 'Você';
+
+  @override
+  String get agentRitualSummaryStartHint =>
+      'Comece uma conversa individual para revisar o que o incomodou, o que funcionou e o que deve mudar a seguir.';
+
+  @override
+  String get agentRitualSummarySubtitle =>
+      'Encontros individuais recentes, atividades reais de despertar e as mudanças com as quais você concordou.';
+
+  @override
+  String get agentRitualSummaryTokensSinceLast =>
+      'Tokens desde o último 1 contra 1';
+
+  @override
+  String get agentRitualSummaryWakeHistory30Days =>
+      'Atividade de despertar (últimos 30 dias)';
+
+  @override
+  String get agentRitualSummaryWakesSinceLast =>
+      'Acorda desde o último confronto individual';
+
+  @override
+  String get agentRunningIndicator => 'Correndo';
+
+  @override
+  String get agentSessionProgressTitle => 'Progresso da sessão';
+
+  @override
+  String get agentSettingsSubtitle => 'Modelos, instâncias e monitoramento';
+
+  @override
+  String get agentSettingsTitle => 'Agentes';
+
+  @override
+  String get agentSoulAntiSycophancyLabel => 'Política Anti-Bajulação';
+
+  @override
+  String get agentSoulAssignedTemplatesTitle => 'Modelos atribuídos';
+
+  @override
+  String get agentSoulAssignmentLabel => 'Alma';
+
+  @override
+  String get agentSoulCoachingStyleLabel => 'Estilo de treinamento';
+
+  @override
+  String get agentSoulCreatedSuccess => 'Alma criada';
+
+  @override
+  String get agentSoulCreateTitle => 'Criar alma';
+
+  @override
+  String get agentSoulDeleteConfirmBody =>
+      'Isto removerá a alma e todas as suas versões.';
+
+  @override
+  String get agentSoulDeleteConfirmTitle => 'Excluir alma';
+
+  @override
+  String get agentSoulDetailTitle => 'Detalhe da Alma';
+
+  @override
+  String get agentSoulDisplayNameLabel => 'Nome';
+
+  @override
+  String get agentSoulEvolutionHistoryTitle => 'História da Evolução da Alma';
+
+  @override
+  String get agentSoulEvolutionNoSessions =>
+      'Nenhuma sessão de evolução da alma ainda';
+
+  @override
+  String get agentSoulFieldAntiSycophancy => 'Anti-bajulação';
+
+  @override
+  String get agentSoulFieldCoachingStyle => 'Estilo de treinamento';
+
+  @override
+  String get agentSoulFieldToneBounds => 'Limites de tom';
+
+  @override
+  String get agentSoulFieldVoice => 'Voz';
+
+  @override
+  String get agentSoulInfoTab => 'Informações';
+
+  @override
+  String get agentSoulNoneAssigned => 'Nenhuma alma designada';
+
+  @override
+  String get agentSoulNotFound => 'Alma não encontrada';
+
+  @override
+  String get agentSoulProposalSubtitle => 'Mudanças de personalidade propostas';
+
+  @override
+  String get agentSoulProposalTitle => 'Proposta de Personalidade da Alma';
+
+  @override
+  String get agentSoulReviewHeroSubtitle =>
+      'Refine a personalidade em todos os modelos que compartilham essa alma. O agente de evolução recebe feedback de cada modelo que usa essa personalidade.';
+
+  @override
+  String get agentSoulReviewStartAction => 'Iniciar revisão de personalidade';
+
+  @override
+  String get agentSoulReviewStartHint =>
+      'Inicie uma sessão focada na personalidade para revisar o feedback e evoluir a voz, o tom, o estilo de coaching e a franqueza.';
+
+  @override
+  String agentSoulReviewTemplateCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count modelos compartilhando esta alma',
+      one: '1 modelo compartilhando esta alma',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get agentSoulReviewTitle => 'Alma 1 contra 1';
+
+  @override
+  String get agentSoulRollbackAction => 'Reverter para esta versão';
+
+  @override
+  String agentSoulRollbackConfirm(int version) {
+    return 'Reverter para a versão $version? Todos os modelos que usam esta alma receberão a mudança.';
+  }
+
+  @override
+  String get agentSoulSelectTitle => 'Selecione Alma';
+
+  @override
+  String get agentSoulsEmptyFiltered =>
+      'Nenhuma alma corresponde aos seus filtros.';
+
+  @override
+  String get agentSoulSettingsTab => 'Configurações';
+
+  @override
+  String get agentSoulsSearchPlaceholder => 'Procure almas…';
+
+  @override
+  String get agentSoulsTitle => 'Almas';
+
+  @override
+  String get agentSoulToneBoundsLabel => 'Limites de tom';
+
+  @override
+  String get agentSoulVersionHistoryTitle => 'Histórico de versões';
+
+  @override
+  String agentSoulVersionLabel(int version) {
+    return 'Versão $version';
+  }
+
+  @override
+  String get agentSoulVersionSaved => 'Nova versão do soul salva';
+
+  @override
+  String get agentSoulVoiceDirectiveLabel => 'Diretiva de Voz';
+
+  @override
+  String get agentStateConsecutiveFailures => 'Falhas consecutivas';
+
+  @override
+  String agentStateErrorLoading(String error) {
+    return 'Falha ao carregar o estado: $error';
+  }
+
+  @override
+  String get agentStateHeading => 'Informações do estado';
+
+  @override
+  String get agentStateLastWake => 'Último velório';
+
+  @override
+  String get agentStateNextWake => 'Próximo despertar';
+
+  @override
+  String get agentStateRevision => 'Revisão';
+
+  @override
+  String get agentStateSleepingUntil => 'Dormindo até';
+
+  @override
+  String get agentStateWakeCount => 'Contagem de despertares';
+
+  @override
+  String get agentStatsAllDayLegend => 'O dia todo';
+
+  @override
+  String get agentStatsAverageLabel => 'Média';
+
+  @override
+  String agentStatsByTimeLegend(String time) {
+    return 'Diariamente às $time';
+  }
+
+  @override
+  String get agentStatsCacheRateLabel => 'Taxa de cache';
+
+  @override
+  String get agentStatsDailyUsageHeading => 'Uso Diário';
+
+  @override
+  String get agentStatsInputLabel => 'Entrada';
+
+  @override
+  String get agentStatsNoUsage =>
+      'Nenhum uso de token registrado nos últimos 7 dias.';
+
+  @override
+  String get agentStatsOutputLabel => 'Saída';
+
+  @override
+  String agentStatsSourceActiveFor(String duration) {
+    return 'Ativo por $duration';
+  }
+
+  @override
+  String get agentStatsSourceActivityHeading => 'Atividade do agente';
+
+  @override
+  String agentStatsSourceWakes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count wakes',
+      one: '1 wake',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get agentStatsTabTitle => 'Estatísticas';
+
+  @override
+  String get agentStatsThoughtsLabel => 'Pensamentos';
+
+  @override
+  String get agentStatsTodayLabel => 'Hoje';
+
+  @override
+  String get agentStatsTokensPerWakeLabel => 'Tokens / Despertar';
+
+  @override
+  String get agentStatsTokensUnit => 'fichas';
+
+  @override
+  String agentStatsUsageAboveAverage(String time) {
+    return 'Você está usando mais tokens hoje do que normalmente usa até $time.';
+  }
+
+  @override
+  String agentStatsUsageBelowAverage(String time) {
+    return 'Você está usando menos tokens hoje do que normalmente usa até $time.';
+  }
+
+  @override
+  String get agentStatsWakesLabel => 'Acorda';
+
+  @override
+  String get agentSuggestionTimeEntryUpdateCurrent => 'Atual';
+
+  @override
+  String get agentSuggestionTimeEntryUpdateNoChange => '(inalterado)';
+
+  @override
+  String get agentSuggestionTimeEntryUpdateProposed => 'Proposto';
+
+  @override
+  String get agentSuggestionTimeEntryUpdateUnavailable =>
+      'Entrada original não disponível';
+
+  @override
+  String get agentTabActivity => 'Atividade';
+
+  @override
+  String get agentTabConversations => 'Conversas';
+
+  @override
+  String get agentTabObservations => 'Observações';
+
+  @override
+  String get agentTabReports => 'Relatórios';
+
+  @override
+  String get agentTabStats => 'Estatísticas';
+
+  @override
+  String get agentTemplateAggregateTokenUsageHeading => 'Uso agregado de token';
+
+  @override
+  String get agentTemplateAssignedLabel => 'Modelo';
+
+  @override
+  String get agentTemplateCreatedSuccess => 'Modelo criado';
+
+  @override
+  String get agentTemplateCreateTitle => 'Criar modelo';
+
+  @override
+  String get agentTemplateDeleteConfirm =>
+      'Excluir este modelo? Isto não pode ser desfeito.';
+
+  @override
+  String get agentTemplateDeleteHasInstances =>
+      'Não é possível excluir: os agentes ativos estão usando este modelo.';
+
+  @override
+  String get agentTemplateDisplayNameLabel => 'Nome';
+
+  @override
+  String get agentTemplateEditTitle => 'Editar modelo';
+
+  @override
+  String get agentTemplateEvolveApprove => 'Aprovar e salvar';
+
+  @override
+  String get agentTemplateEvolveReject => 'Rejeitar';
+
+  @override
+  String get agentTemplateGeneralDirectiveHint =>
+      'Defina a personalidade, ferramentas, objetivos e estilo de interação do agente...';
+
+  @override
+  String get agentTemplateGeneralDirectiveLabel => 'Diretiva Geral';
+
+  @override
+  String get agentTemplateInstanceBreakdownHeading =>
+      'Detalhamento por instância';
+
+  @override
+  String get agentTemplateKindDayAgent => 'Agente diurno';
+
+  @override
+  String get agentTemplateKindEventAgent => 'Agente de Eventos';
+
+  @override
+  String get agentTemplateKindImprover => 'Melhorador de modelo';
+
+  @override
+  String get agentTemplateKindProjectAgent => 'Agente de Projeto';
+
+  @override
+  String get agentTemplateKindTaskAgent => 'Agente de Tarefas';
+
+  @override
+  String get agentTemplateMetricsTotalWakes => 'Total de despertares';
+
+  @override
+  String get agentTemplateNoneAssigned => 'Nenhum modelo atribuído';
+
+  @override
+  String get agentTemplateNoTemplates =>
+      'Nenhum modelo disponível. Crie um em Configurações primeiro.';
+
+  @override
+  String get agentTemplateNotFound => 'Modelo não encontrado';
+
+  @override
+  String get agentTemplateNoVersions => 'Nenhuma versão';
+
+  @override
+  String get agentTemplateReportDirectiveHint =>
+      'Defina a estrutura do relatório, seções obrigatórias e regras de formatação...';
+
+  @override
+  String get agentTemplateReportDirectiveLabel => 'Diretiva de Relatório';
+
+  @override
+  String get agentTemplateReportsEmpty => 'Ainda não há relatórios.';
+
+  @override
+  String get agentTemplateReportsTab => 'Relatórios';
+
+  @override
+  String get agentTemplateRollbackAction => 'Reverter para esta versão';
+
+  @override
+  String agentTemplateRollbackConfirm(int version) {
+    return 'Reverter para a versão $version? O agente utilizará esta versão em seu próximo wake.';
+  }
+
+  @override
+  String get agentTemplateSaveNewVersion => 'Salvar';
+
+  @override
+  String get agentTemplateSelectTitle => 'Selecione o modelo';
+
+  @override
+  String get agentTemplatesEmptyFiltered =>
+      'Nenhum modelo corresponde aos seus filtros.';
+
+  @override
+  String get agentTemplateSettingsTab => 'Configurações';
+
+  @override
+  String get agentTemplatesFilterSectionKind => 'Gentil';
+
+  @override
+  String get agentTemplatesGroupByKind => 'Gentil';
+
+  @override
+  String get agentTemplatesGroupNone => 'Todos';
+
+  @override
+  String get agentTemplatesSearchPlaceholder => 'Pesquisar modelos…';
+
+  @override
+  String get agentTemplateStatsTab => 'Estatísticas';
+
+  @override
+  String get agentTemplateStatusActive => 'Ativo';
+
+  @override
+  String get agentTemplateStatusArchived => 'Arquivado';
+
+  @override
+  String get agentTemplatesTitle => 'Modelos de agente';
+
+  @override
+  String get agentTemplateSwitchHint =>
+      'Para usar um modelo diferente, destrua este agente e crie um novo.';
+
+  @override
+  String get agentTemplateVersionHistoryTitle => 'Histórico de versões';
+
+  @override
+  String agentTemplateVersionLabel(int version) {
+    return 'Versão $version';
+  }
+
+  @override
+  String get agentTemplateVersionSaved => 'Nova versão salva';
+
+  @override
+  String get agentThreadReportLabel =>
+      'Relatório produzido durante este velório';
+
+  @override
+  String get agentTokenUsageCachedTokens => 'Em cache';
+
+  @override
+  String get agentTokenUsageEmpty => 'Nenhum uso de token registrado ainda.';
+
+  @override
+  String agentTokenUsageErrorLoading(String error) {
+    return 'Falha ao carregar o uso do token: $error';
+  }
+
+  @override
+  String get agentTokenUsageHeading => 'Uso de token';
+
+  @override
+  String get agentTokenUsageInputTokens => 'Entrada';
+
+  @override
+  String get agentTokenUsageModel => 'Modelo';
+
+  @override
+  String get agentTokenUsageOutputTokens => 'Saída';
+
+  @override
+  String get agentTokenUsageThoughtsTokens => 'Pensamentos';
+
+  @override
+  String get agentTokenUsageTotalTokens => 'Total';
+
+  @override
+  String get agentTokenUsageWakeCount => 'Acorda';
+
+  @override
+  String get aggregationDailyAvg => 'Média diária';
+
+  @override
+  String get aggregationDailyMax => 'Máximo diário';
+
+  @override
+  String get aggregationDailySum => 'Soma diária';
+
+  @override
+  String get aggregationHourlySum => 'Soma horária';
+
+  @override
+  String get aggregationNone => 'Valores brutos';
+
+  @override
+  String get aiAssistantTitle => 'Gerar…';
+
+  @override
+  String get aiBatchToggleTooltip => 'Mudar para gravação padrão';
+
+  @override
+  String get aiCapabilityChipImageGeneration => 'Geração de imagem';
+
+  @override
+  String get aiCapabilityChipImageRecognition => 'Reconhecimento de imagem';
+
+  @override
+  String get aiCapabilityChipThinking => 'Pensando';
+
+  @override
+  String get aiCapabilityChipTranscription => 'Transcrição';
+
+  @override
+  String get aiCardEmptyProposals =>
+      'Nenhuma proposta aberta · o agente apresentará novas alterações aqui';
+
+  @override
+  String aiCardHistoryToggle(int count) {
+    return 'História · $count';
+  }
+
+  @override
+  String get aiCardMenuActionDelete => 'Excluir';
+
+  @override
+  String get aiCardMenuActionEdit => 'Editar';
+
+  @override
+  String get aiCardMenuTooltip => 'Mais ações';
+
+  @override
+  String get aiCardOpenAgentInternals => 'Abra os internos do agente';
+
+  @override
+  String get aiCardProposalConfirmed => 'Confirmado';
+
+  @override
+  String get aiCardProposalDismissed => 'Dispensado';
+
+  @override
+  String get aiCardProposalKindAdd => 'Adicionar';
+
+  @override
+  String get aiCardProposalKindDue => 'Devido';
+
+  @override
+  String get aiCardProposalKindEstimate => 'Estimativa';
+
+  @override
+  String get aiCardProposalKindLabel => 'Etiqueta';
+
+  @override
+  String get aiCardProposalKindPriority => 'Prioridade';
+
+  @override
+  String get aiCardProposalKindRemove => 'Remover';
+
+  @override
+  String get aiCardProposalKindStatus => 'Estado';
+
+  @override
+  String get aiCardProposalKindUpdate => 'Atualizar';
+
+  @override
+  String get aiCardReadMore => 'Leia mais';
+
+  @override
+  String get aiCardShowLess => 'Mostrar menos';
+
+  @override
+  String get aiCardTitle => 'Resumo de IA';
+
+  @override
+  String get aiChatMessageCopied => 'Copiado para a área de transferência';
+
+  @override
+  String get aiConfigFailedToLoadModelsGeneric =>
+      'Falha ao carregar modelos. Por favor, tente novamente.';
+
+  @override
+  String get aiConfigNoModelsAvailable =>
+      'Nenhum modelo de IA está configurado ainda. Adicione um nas configurações.';
+
+  @override
+  String get aiConfigNoSuitableModelsAvailable =>
+      'Nenhum modelo atende aos requisitos deste prompt. Configure modelos que suportem os recursos necessários.';
+
+  @override
+  String get aiConfigSelectProviderModalTitle =>
+      'Selecione o provedor de inferência';
+
+  @override
+  String get aiConfigSelectProviderTypeModalTitle =>
+      'Selecione o tipo de provedor';
+
+  @override
+  String get aiConfigUseReasoningFieldLabel => 'Use o raciocínio';
+
+  @override
+  String aiConsumptionCallsLine(int count, int measured) {
+    return 'Chamadas de IA: $count · impacto medido para $measured';
+  }
+
+  @override
+  String aiConsumptionCostLine(String cost) {
+    return 'Custo: $cost';
+  }
+
+  @override
+  String aiConsumptionImpactLine(String energy, String carbon, String water) {
+    return 'Impacto: $energy · $carbon CO₂e · $water água';
+  }
+
+  @override
+  String aiConsumptionLedgerCap(int limit) {
+    return 'Mostrando as chamadas $limit mais recentes neste período';
+  }
+
+  @override
+  String get aiConsumptionLedgerTitle => 'Chamadas recentes';
+
+  @override
+  String get aiConsumptionMetricsNotReported => 'Não relatado';
+
+  @override
+  String aiConsumptionTokensLabel(String tokens) {
+    return '$tokens tokens';
+  }
+
+  @override
+  String aiConsumptionTokensLine(String input, String output) {
+    return 'Tokens: $input entrada · $output saída';
+  }
+
+  @override
+  String get aiConsumptionTypeAgentTurn => 'Turno do agente';
+
+  @override
+  String get aiConsumptionTypeAudioTranscription => 'Transcrição';
+
+  @override
+  String get aiConsumptionTypeImageAnalysis => 'Análise de imagem';
+
+  @override
+  String get aiConsumptionTypeImageGeneration => 'Geração de imagem';
+
+  @override
+  String get aiConsumptionTypePromptGeneration => 'Geração de prompt';
+
+  @override
+  String get aiConsumptionTypeTextGeneration => 'Geração de texto';
+
+  @override
+  String aiDeleteToastCascadeDescription(int count, String names) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Também removeu $count modelos: $names',
+      one: 'Também removeu 1 modelo: $names',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String aiDeleteToastErrorTitle(String name) {
+    return 'Não foi possível excluir $name';
+  }
+
+  @override
+  String get aiDeleteToastModelTitle => 'Modelo excluído';
+
+  @override
+  String get aiDeleteToastProfileTitle => 'Perfil excluído';
+
+  @override
+  String get aiDeleteToastPromptTitle => 'Prompt excluído';
+
+  @override
+  String get aiDeleteToastProviderTitle => 'Provedor excluído';
+
+  @override
+  String get aiDeleteToastSkillTitle => 'Habilidade excluída';
+
+  @override
+  String get aiDeleteToastUndoAction => 'Desfazer';
+
+  @override
+  String get aiFormCancel => 'Cancelar';
+
+  @override
+  String get aiFormFixErrors => 'Corrija os erros antes de salvar';
+
+  @override
+  String get aiFormNoChanges => 'Nenhuma alteração não salva';
+
+  @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Padrão';
+
+  @override
+  String get aiImageAnalysisPickerTitle =>
+      'Escolha um modelo de análise de imagem';
+
+  @override
+  String get aiImageGenerationPickerTitle =>
+      'Escolha um modelo de geração de imagem';
+
+  @override
+  String get aiImpactBreakdownBoth => 'Ambos';
+
+  @override
+  String get aiImpactBreakdownCategory => 'Por categoria';
+
+  @override
+  String get aiImpactBreakdownModel => 'Por modelo';
+
+  @override
+  String get aiImpactCategoryTitle => 'Divisão por categoria';
+
+  @override
+  String get aiImpactChartHint =>
+      'Toque em uma barra para definir o escopo das chamadas · toque em uma série para isolar';
+
+  @override
+  String get aiImpactChartShareCaption => 'Composição ao longo do tempo';
+
+  @override
+  String get aiImpactChartShareSegment => 'Compartilhar';
+
+  @override
+  String aiImpactChartTitle(String metric) {
+    return '$metric por categoria';
+  }
+
+  @override
+  String aiImpactChartTitleModel(String metric) {
+    return '$metric por modelo';
+  }
+
+  @override
+  String get aiImpactCoverageNote =>
+      'Energia, CO₂e e custo são medidos apenas para modelos de nuvem.';
+
+  @override
+  String get aiImpactEmptyBody =>
+      'As chamadas de IA de suas tarefas e agentes aparecerão aqui.';
+
+  @override
+  String get aiImpactEmptyTitle => 'Nenhum uso de IA neste intervalo';
+
+  @override
+  String get aiImpactKpiCarbon => 'CO₂E';
+
+  @override
+  String get aiImpactKpiCost => 'CUSTO';
+
+  @override
+  String aiImpactKpiDeltaBaseline(String period) {
+    return 'vs $period';
+  }
+
+  @override
+  String get aiImpactKpiEnergy => 'ENERGIA';
+
+  @override
+  String get aiImpactKpiRequests => 'PEDIDOS';
+
+  @override
+  String get aiImpactKpiTokens => 'FICHAS';
+
+  @override
+  String get aiImpactLedgerClearFilter => 'Mostrar tudo';
+
+  @override
+  String get aiImpactLoadError =>
+      'Não foi possível carregar os dados de impacto da IA';
+
+  @override
+  String get aiImpactLocationColumn => 'LOCALIZAÇÃO';
+
+  @override
+  String get aiImpactLocationTitle => 'Impacto por localização';
+
+  @override
+  String get aiImpactLocationUnknown => 'Desconhecido';
+
+  @override
+  String get aiImpactMetricCarbon => 'CO₂e';
+
+  @override
+  String get aiImpactMetricCost => 'Custo';
+
+  @override
+  String get aiImpactMetricEnergy => 'Energia';
+
+  @override
+  String get aiImpactMetricRequests => 'Solicitações';
+
+  @override
+  String get aiImpactMetricTokens => 'Fichas';
+
+  @override
+  String aiImpactModelCallsLabel(String count) {
+    return '$count chamadas';
+  }
+
+  @override
+  String get aiImpactModelColumn => 'MODELO';
+
+  @override
+  String get aiImpactModelCostHeavy => 'caro';
+
+  @override
+  String get aiImpactModelCoverageNote =>
+      'Os modelos locais estão excluídos deste gráfico.';
+
+  @override
+  String get aiImpactModelOther => 'Outros modelos';
+
+  @override
+  String aiImpactModelRatePerMillion(String cost) {
+    return '$cost/1 milhão de tokens';
+  }
+
+  @override
+  String get aiImpactModelTitle => 'Detalhamento do modelo';
+
+  @override
+  String get aiImpactModelUnknown => 'Modelo desconhecido';
+
+  @override
+  String get aiImpactRenewableColumn => 'RENOVÁVEL';
+
+  @override
+  String get aiImpactTitle => 'Impacto da IA';
+
+  @override
+  String get aiInferenceErrorAuthenticationTitle => 'Falha na autenticação';
+
+  @override
+  String get aiInferenceErrorConnectionFailedTitle => 'Falha na conexão';
+
+  @override
+  String get aiInferenceErrorInvalidRequestTitle => 'Solicitação inválida';
+
+  @override
+  String get aiInferenceErrorRateLimitTitle => 'Limite de taxa excedido';
+
+  @override
+  String get aiInferenceErrorRetryButton => 'Tente novamente';
+
+  @override
+  String get aiInferenceErrorServerTitle => 'Erro no servidor';
+
+  @override
+  String get aiInferenceErrorSuggestionsTitle => 'Sugestões:';
+
+  @override
+  String get aiInferenceErrorTimeoutTitle => 'Solicitação expirou';
+
+  @override
+  String get aiInferenceErrorUnknownTitle => 'Erro';
+
+  @override
+  String get aiInternalsTitle => 'Internos do agente';
+
+  @override
+  String get aiModelDownloadCloseButton => 'Fechar';
+
+  @override
+  String aiModelDownloadDialogDescription(String modelName) {
+    return 'Lotti fará o download de $modelName no cache de áudio MLX e o usará para processamento de fala local.';
+  }
+
+  @override
+  String aiModelDownloadDialogTitle(String modelName) {
+    return 'Instale $modelName';
+  }
+
+  @override
+  String get aiModelDownloadInstallTooltip => 'Instalar modelo';
+
+  @override
+  String get aiModelDownloadOpenProgressTooltip =>
+      'Mostrar progresso do download';
+
+  @override
+  String get aiModelDownloadStatusChecking => 'Verificando o status do modelo';
+
+  @override
+  String aiModelDownloadStatusDownloading(int percent) {
+    return 'Baixando $percent%';
+  }
+
+  @override
+  String get aiModelDownloadStatusDownloadingIndeterminate => 'Baixando';
+
+  @override
+  String get aiModelDownloadStatusFailed => 'Falha no download';
+
+  @override
+  String get aiModelDownloadStatusInstalled => 'Instalado';
+
+  @override
+  String get aiModelDownloadStatusNotInstalled => 'Não instalado';
+
+  @override
+  String get aiModelDownloadStatusUnsupported => 'Apple Silicon necessário';
+
+  @override
+  String get aiModelInstallChoiceCancelButton => 'Cancelar';
+
+  @override
+  String get aiModelInstallChoiceDescription =>
+      'Escolha o modelo local de fala para texto para fazer o download primeiro. Você pode instalar os outros posteriormente na lista de modelos.';
+
+  @override
+  String get aiModelInstallChoiceInstallButton => 'Instalar modelo';
+
+  @override
+  String get aiModelInstallChoiceRecommended => 'Recomendado';
+
+  @override
+  String get aiModelInstallChoiceTitle => 'Escolha o modelo de áudio MLX';
+
+  @override
+  String get aiModelPickerByProviderLabel => 'Escolha um provedor';
+
+  @override
+  String get aiModelPickerCurrentDefaultLabel => 'Padrão atual';
+
+  @override
+  String aiModelPickerProviderModelCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count modelos',
+      one: '1 modelo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String aiOllamaModelInstalledSuccessfully(String modelName) {
+    return 'Modelo \"$modelName\" instalado com sucesso!';
+  }
+
+  @override
+  String get aiPickProviderBadgeDesktopOnly => 'SOMENTE PARA COMPUTADOR';
+
+  @override
+  String get aiPickProviderBadgeNew => 'NOVO';
+
+  @override
+  String get aiPickProviderBadgeRecommended => 'RECOMENDADO';
+
+  @override
+  String get aiPickProviderContinueButton => 'Continuar';
+
+  @override
+  String get aiPickProviderDontShowAgainButton => 'Não mostre novamente';
+
+  @override
+  String get aiPickProviderFooterHint =>
+      'Você pode adicionar mais provedores posteriormente em Configurações → IA. Sua chave de API é armazenada localmente.';
+
+  @override
+  String get aiPickProviderModalTitle => 'Configurar recursos de IA';
+
+  @override
+  String get aiPickProviderSubtitle =>
+      'Escolha um provedor para começar. Configuraremos modelos e um perfil inicial automaticamente.';
+
+  @override
+  String get aiProfileCardActiveBadge => 'Ativo';
+
+  @override
+  String get aiProfileModelPickerSearchHint => 'Pesquisar modelos…';
+
+  @override
+  String get aiProfileSlotModelMissing => 'faltando';
+
+  @override
+  String get aiPromptGenerationPickerTitle =>
+      'Escolha um modelo de geração de prompt';
+
+  @override
+  String get aiProviderAlibabaDescription =>
+      'Família de modelos Qwen da Alibaba Cloud via API DashScope';
+
+  @override
+  String get aiProviderAlibabaName => 'Nuvem Alibaba (Qwen)';
+
+  @override
+  String get aiProviderAnthropicDescription =>
+      'Família Claude de assistentes de IA da Anthropic';
+
+  @override
+  String get aiProviderAnthropicName => 'Claude antrópico';
+
+  @override
+  String get aiProviderCardDraftBadge => 'ESBOÇO';
+
+  @override
+  String get aiProviderCardFixButton => 'Correção';
+
+  @override
+  String aiProviderCardModelCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count modelos',
+      one: '1 modelo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String aiProviderCardModelCountWithLastUsed(int count, String lastUsed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count modelos · último usado $lastUsed',
+      one: '1 modelo · último usado $lastUsed',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get aiProviderCardOllamaHint =>
+      'Certifique-se de que Ollama esteja em execução';
+
+  @override
+  String aiProviderCardStatusConnected(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Conectado · $count modelos',
+      one: 'Conectado · 1 modelo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get aiProviderCardStatusConnectedShort => 'Conectado';
+
+  @override
+  String get aiProviderCardStatusInvalidKey => 'Chave inválida';
+
+  @override
+  String get aiProviderCardStatusOffline =>
+      'Off-line · Certifique-se de que Ollama esteja em execução';
+
+  @override
+  String get aiProviderCardStatusOfflineShort => 'Off-line';
+
+  @override
+  String get aiProviderConnectBackToProviders => 'Voltar para provedores';
+
+  @override
+  String get aiProviderConnectBreadcrumbAdd => 'Adicionar provedor';
+
+  @override
+  String get aiProviderConnectFieldBaseUrlHint =>
+      'Deixe em branco para usar o endpoint oficial';
+
+  @override
+  String get aiProviderConnectFieldBaseUrlLabelOptional =>
+      'URL base (opcional)';
+
+  @override
+  String get aiProviderConnectFieldBaseUrlPlaceholder =>
+      'https://api.example.com';
+
+  @override
+  String get aiProviderConnectFieldDisplayNameHint =>
+      'Exibido na sua lista de provedores';
+
+  @override
+  String get aiProviderConnectionCheckingLabel =>
+      'Verificando chave, listando modelos disponíveis…';
+
+  @override
+  String aiProviderConnectionFailedBadResponseDetail(String type) {
+    return 'Formato de resposta inesperado: $type';
+  }
+
+  @override
+  String aiProviderConnectionFailedHttpDetail(int status, String message) {
+    return 'HTTP $status · $message';
+  }
+
+  @override
+  String get aiProviderConnectionFailedInvalidBaseUrlDetail =>
+      'O URL base deve incluir esquema http(s) e host (por exemplo, https://api.example.com)';
+
+  @override
+  String aiProviderConnectionFailedNetworkDetail(String message) {
+    return '$message';
+  }
+
+  @override
+  String get aiProviderConnectionFailedTimeoutDetail => 'A solicitação expirou';
+
+  @override
+  String aiProviderConnectionFailedTitle(String providerName) {
+    return 'Não foi possível entrar em contato com $providerName. Verifique a chave ou sua rede.';
+  }
+
+  @override
+  String get aiProviderConnectionRetestButton => 'Teste novamente';
+
+  @override
+  String get aiProviderConnectionRetryButton => 'Tentar novamente';
+
+  @override
+  String aiProviderConnectionVerifiedSubtitle(int count, int ms) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count modelos disponíveis em sua conta · respondeu em ${ms}ms',
+      one: '1 modelo disponível em sua conta · respondeu em ${ms}ms',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get aiProviderConnectionVerifiedTitle => 'Conexão verificada';
+
+  @override
+  String aiProviderConnectKeyHelperLink(String url) {
+    return 'Obtenha uma chave em $url';
+  }
+
+  @override
+  String get aiProviderConnectKeyHiddenLabel => 'Oculto';
+
+  @override
+  String get aiProviderConnectKeyPrivacyHint =>
+      'Sua chave API nunca sai do seu dispositivo.';
+
+  @override
+  String aiProviderConnectPageTitle(String providerName) {
+    return 'Conectar $providerName';
+  }
+
+  @override
+  String get aiProviderConnectSaveAndContinue => 'Salvar e continuar';
+
+  @override
+  String get aiProviderConnectSaveAsDraft => 'Salvar como rascunho';
+
+  @override
+  String get aiProviderConnectSavedAsDraftToast => 'Salvo como rascunho';
+
+  @override
+  String get aiProviderConnectStepChoose => 'Escolha o provedor';
+
+  @override
+  String get aiProviderConnectStepConnect => 'Conectar';
+
+  @override
+  String get aiProviderConnectStepReview => 'Revisão';
+
+  @override
+  String get aiProviderDetailActiveProfileTitle => 'Perfil ativo';
+
+  @override
+  String get aiProviderDetailAddModelButton => 'Adicionar modelo';
+
+  @override
+  String get aiProviderDetailApiKeyLabel => 'Chave de API';
+
+  @override
+  String get aiProviderDetailBackTooltip => 'Voltar';
+
+  @override
+  String get aiProviderDetailBaseUrlLabel => 'URL base';
+
+  @override
+  String get aiProviderDetailConnectionTitle => 'Conexão';
+
+  @override
+  String get aiProviderDetailDangerZoneTitle => 'Zona de perigo';
+
+  @override
+  String get aiProviderDetailDisplayNameLabel => 'Nome de exibição';
+
+  @override
+  String get aiProviderDetailEditButton => 'Editar';
+
+  @override
+  String get aiProviderDetailEditTooltip => 'Editar provedor';
+
+  @override
+  String get aiProviderDetailLoadError =>
+      'Não foi possível carregar este provedor. Tente novamente na lista Configurações de IA.';
+
+  @override
+  String get aiProviderDetailMissingMessage =>
+      'Este provedor não está mais disponível.';
+
+  @override
+  String aiProviderDetailModelsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Modelos · $count',
+      one: 'Modelos · 1',
+      zero: 'Models',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get aiProviderDetailNoModelsMessage =>
+      'Ainda não há modelos. Adicione um para começar a usar este provedor.';
+
+  @override
+  String get aiProviderDetailPageTitle => 'Detalhes do provedor';
+
+  @override
+  String get aiProviderDetailRemoveButton => 'Remover provedor';
+
+  @override
+  String get aiProviderDetailRemoveDescription =>
+      'Exclui o provedor e todos os modelos que dependem dele. Isto não pode ser desfeito.';
+
+  @override
+  String get aiProviderDetailRemoveTitle => 'Remover este provedor';
+
+  @override
+  String get aiProviderDetailValueUnset => 'Não definido';
+
+  @override
+  String get aiProviderEmbeddedRuntimeHint =>
+      'É executado integrado no processo do aplicativo Apple. Nenhum servidor local ou URL base é necessário.';
+
+  @override
+  String get aiProviderGeminiDescription => 'Modelos Gemini AI do Google';
+
+  @override
+  String get aiProviderGeminiName => 'Google Gêmeos';
+
+  @override
+  String get aiProviderGenericOpenAiDescription =>
+      'API compatível com formato OpenAI';
+
+  @override
+  String get aiProviderGenericOpenAiName => 'Compatível com OpenAI';
+
+  @override
+  String get aiProviderMeliousDescription =>
+      'Inferência hospedada na Europa com catálogo de modelos dinâmicos, roteamento, áudio e imagens';
+
+  @override
+  String get aiProviderMeliousName => 'Melious.ai';
+
+  @override
+  String get aiProviderMistralDescription =>
+      'API de nuvem Mistral AI com transcrição de áudio nativa';
+
+  @override
+  String get aiProviderMistralName => 'Mistral';
+
+  @override
+  String get aiProviderMlxAudioDescription =>
+      'Modelos de áudio MLX incorporados para STT e TTS locais no Apple Silicon';
+
+  @override
+  String get aiProviderMlxAudioName => 'Áudio MLX (local)';
+
+  @override
+  String get aiProviderNebiusAiStudioDescription =>
+      'Modelos do Nebius AI Studio';
+
+  @override
+  String get aiProviderNebiusAiStudioName => 'Estúdio de IA Nebius';
+
+  @override
+  String get aiProviderOllamaDescription =>
+      'Execute inferência localmente com Ollama';
+
+  @override
+  String get aiProviderOllamaName => 'Ollama';
+
+  @override
+  String get aiProviderOmlxDescription =>
+      'Inferência oMLX compatível com OpenAI local para modelos MLX';
+
+  @override
+  String get aiProviderOmlxName => 'oMLX (local)';
+
+  @override
+  String get aiProviderOpenAiDescription => 'Modelos GPT da OpenAI';
+
+  @override
+  String get aiProviderOpenAiName => 'OpenAI';
+
+  @override
+  String get aiProviderOpenRouterDescription => 'Modelos do OpenRouter';
+
+  @override
+  String get aiProviderOpenRouterName => 'OpenRouter';
+
+  @override
+  String get aiProviderTaglineAlibaba =>
+      'Modelos Qwen · multimodal · contexto longo';
+
+  @override
+  String get aiProviderTaglineAnthropic => 'Família Claude · contexto longo';
+
+  @override
+  String get aiProviderTaglineGemini => 'Multimodal · transcrição de áudio';
+
+  @override
+  String get aiProviderTaglineMelious =>
+      'Hospedado na UE · catálogo dinâmico · roteamento ecológico';
+
+  @override
+  String get aiProviderTaglineMlxAudio =>
+      'Incorporado · Apple Silicon · áudio local';
+
+  @override
+  String get aiProviderTaglineOllama =>
+      'Funciona localmente · sem chamadas na nuvem';
+
+  @override
+  String get aiProviderTaglineOmlx =>
+      'Inferência MLX local · Compatível com OpenAI';
+
+  @override
+  String get aiProviderTaglineOpenAi => 'Família GPT · visão + raciocínio';
+
+  @override
+  String get aiProviderUnknownName => 'Provedor de IA';
+
+  @override
+  String get aiProviderVoxtralDescription =>
+      'Transcrição Voxtral local (até 30 minutos de áudio, 13 idiomas)';
+
+  @override
+  String get aiProviderVoxtralName => 'Voxtral (local)';
+
+  @override
+  String get aiProviderWhisperDescription =>
+      'Transcrição Local Whisper com API compatível com OpenAI';
+
+  @override
+  String get aiProviderWhisperName => 'Sussurro (local)';
+
+  @override
+  String get aiRealtimeToggleTooltip => 'Mudar para transcrição ao vivo';
+
+  @override
+  String get aiResponseDeleteCancel => 'Cancelar';
+
+  @override
+  String get aiResponseDeleteConfirm => 'Excluir';
+
+  @override
+  String get aiResponseDeleteError =>
+      'Falha ao excluir a resposta do AI. Por favor, tente novamente.';
+
+  @override
+  String get aiResponseDeleteTitle => 'Excluir resposta de IA';
+
+  @override
+  String get aiResponseDeleteWarning =>
+      'Tem certeza de que deseja excluir esta resposta de IA? Isto não pode ser desfeito.';
+
+  @override
+  String get aiResponseTypeAudioTranscription => 'Transcrição de áudio';
+
+  @override
+  String get aiResponseTypeChecklistUpdates =>
+      'Atualizações da lista de verificação';
+
+  @override
+  String get aiResponseTypeImageAnalysis => 'Análise de imagem';
+
+  @override
+  String get aiResponseTypeImagePromptGeneration => 'Solicitação de imagem';
+
+  @override
+  String get aiResponseTypePromptGeneration => 'Prompt gerado';
+
+  @override
+  String get aiResponseTypeTaskSummary => 'Resumo da tarefa';
+
+  @override
+  String get aiRunningActivityOpenProgress => 'Mostrar o progresso da IA';
+
+  @override
+  String get aiSettingsAddedLabel => 'Adicionado';
+
+  @override
+  String get aiSettingsAddModelButton => 'Adicionar modelo';
+
+  @override
+  String get aiSettingsAddModelErrorDescription =>
+      'Algo deu errado ao adicionar o modelo. Por favor, tente novamente.';
+
+  @override
+  String get aiSettingsAddModelErrorTitle =>
+      'Não foi possível adicionar o modelo';
+
+  @override
+  String get aiSettingsAddModelTooltip =>
+      'Adicione este modelo ao seu provedor';
+
+  @override
+  String get aiSettingsAddProfileButton => 'Adicionar perfil';
+
+  @override
+  String get aiSettingsAddProviderButton => 'Adicionar provedor';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Escolha quantos agentes diferentes podem executar inferência ao mesmo tempo. Valores mais altos respondem mais rapidamente, mas utilizam mais capacidade do provedor e do dispositivo.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel =>
+      'Agente simultâneo é ativado';
+
+  @override
+  String get aiSettingsClearAllFiltersTooltip => 'Limpar todos os filtros';
+
+  @override
+  String get aiSettingsClearFiltersButton => 'Limpar';
+
+  @override
+  String get aiSettingsCounterModels => 'Modelos';
+
+  @override
+  String get aiSettingsCounterProfiles => 'Perfis';
+
+  @override
+  String get aiSettingsCounterProviders => 'Provedores';
+
+  @override
+  String get aiSettingsEmptyDescription =>
+      'Adicione um para desbloquear transcrição, reconhecimento de imagem, geração de imagem e pesquisa semântica.';
+
+  @override
+  String get aiSettingsEmptyTitle => 'Ainda não há provedores';
+
+  @override
+  String aiSettingsFilterByCapabilityTooltip(String capability) {
+    return 'Filtrar por capacidade $capability';
+  }
+
+  @override
+  String aiSettingsFilterByProviderTooltip(String provider) {
+    return 'Filtrar por $provider';
+  }
+
+  @override
+  String get aiSettingsFilterByReasoningTooltip =>
+      'Filtrar por capacidade de raciocínio';
+
+  @override
+  String get aiSettingsFtueBannerDescription =>
+      'Demora cerca de um minuto. Lotti configurará modelos e um perfil inicial para você.';
+
+  @override
+  String get aiSettingsFtueBannerStartButton => 'Iniciar configuração';
+
+  @override
+  String get aiSettingsFtueBannerTitle =>
+      'Adicione seu primeiro provedor de IA';
+
+  @override
+  String get aiSettingsModalityAudio => 'Áudio';
+
+  @override
+  String get aiSettingsModalityText => 'Texto';
+
+  @override
+  String get aiSettingsModalityVision => 'Visão';
+
+  @override
+  String get aiSettingsNoModelsConfigured => 'Nenhum modelo de IA configurado';
+
+  @override
+  String get aiSettingsNoProvidersConfigured =>
+      'Nenhum provedor de IA configurado';
+
+  @override
+  String get aiSettingsPageLead =>
+      'Configure os provedores de IA, os modelos que Lotti pode chamar e os perfis de inferência que decidem qual modelo lida com qual tarefa.';
+
+  @override
+  String get aiSettingsPageTitle => 'Configurações de IA';
+
+  @override
+  String get aiSettingsReasoningLabel => 'Raciocínio';
+
+  @override
+  String get aiSettingsRemoveModelTooltip =>
+      'Remova este modelo do seu provedor';
+
+  @override
+  String get aiSettingsSearchHint =>
+      'Pesquise fornecedores, modelos, perfis...';
+
+  @override
+  String get aiSettingsSearchHintShort => 'Pesquisar';
+
+  @override
+  String get aiSettingsTabModels => 'Modelos';
+
+  @override
+  String get aiSettingsTabProfiles => 'Perfis';
+
+  @override
+  String get aiSettingsTabProviders => 'Provedores';
+
+  @override
+  String get aiSetupPreviewAcceptButton => 'Aceitar e finalizar';
+
+  @override
+  String get aiSetupPreviewAlreadyAddedSectionLabel => 'Já adicionado';
+
+  @override
+  String aiSetupPreviewCategoryFooter(String categoryName) {
+    return 'Configure uma categoria de teste $categoryName para experimentar.';
+  }
+
+  @override
+  String aiSetupPreviewConnectedHeader(String providerName) {
+    return '$providerName conectado';
+  }
+
+  @override
+  String get aiSetupPreviewCustomizeButton => 'Personalizar';
+
+  @override
+  String get aiSetupPreviewLead =>
+      'Revise o que Lotti irá adicionar. Desmarque tudo o que você não deseja; você sempre pode configurá-lo manualmente mais tarde.';
+
+  @override
+  String get aiSetupPreviewLiveBadge => 'Ao vivo';
+
+  @override
+  String aiSetupPreviewModalTitle(String providerName) {
+    return 'Configuração de $providerName';
+  }
+
+  @override
+  String get aiSetupPreviewModelsSectionLabel => 'Modelos';
+
+  @override
+  String get aiSetupPreviewProfileSectionLabel => 'Perfil de inferência';
+
+  @override
+  String get aiSetupPreviewProfileSetActiveBadge => 'Definir ativo';
+
+  @override
+  String aiSetupResultBulletCategoryCreated(String categoryName) {
+    return 'Configure uma categoria de teste $categoryName para experimentar';
+  }
+
+  @override
+  String aiSetupResultBulletCategoryReused(String categoryName) {
+    return 'Reutilizando a categoria de teste existente $categoryName';
+  }
+
+  @override
+  String aiSetupResultBulletModels(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count modelos configurados',
+      one: '1 modelo configurado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String aiSetupResultBulletProfile(String profileName) {
+    return 'Perfil de inferência criado $profileName';
+  }
+
+  @override
+  String aiSetupResultErrorsHeader(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count problemas',
+      one: '1 issue',
+    );
+    return '$_temp0 durante a configuração';
+  }
+
+  @override
+  String aiSetupResultHeader(String providerName) {
+    return '$providerName está conectado';
+  }
+
+  @override
+  String aiSetupResultKnownModelsMissing(String providerName) {
+    return 'Falha ao encontrar as configurações necessárias do modelo $providerName';
+  }
+
+  @override
+  String get aiSetupResultLead =>
+      'Nós configuramos as coisas para você. Os recursos de IA estão prontos para uso em seu diário.';
+
+  @override
+  String aiSetupResultModalTitle(String providerName) {
+    return '$providerName pronto';
+  }
+
+  @override
+  String get aiSetupResultStartUsingButton => 'Comece a usar IA';
+
+  @override
+  String get aiSetupWizardCreatesOptimized =>
+      'Cria modelos otimizados, prompts e uma categoria de teste';
+
+  @override
+  String aiSetupWizardDescription(String providerName) {
+    return 'Configurar ou atualizar modelos, prompts e categoria de teste para $providerName';
+  }
+
+  @override
+  String get aiSetupWizardRunButton => 'Executar configuração';
+
+  @override
+  String get aiSetupWizardRunLabel => 'Execute o assistente de configuração';
+
+  @override
+  String get aiSetupWizardRunningButton => 'Correndo...';
+
+  @override
+  String get aiSetupWizardSafeToRunMultiple =>
+      'É seguro executar várias vezes - os itens existentes serão mantidos';
+
+  @override
+  String get aiSetupWizardTitle => 'Assistente de configuração de IA';
+
+  @override
+  String get aiSummaryPlayTooltip => 'Resumo do jogo';
+
+  @override
+  String get aiSummaryPreparingTooltip => 'Preparando áudio';
+
+  @override
+  String get aiSummarySpeakTooltip => 'Leia o resumo em voz alta localmente';
+
+  @override
+  String get aiSummaryStopTooltip => 'Pare';
+
+  @override
+  String get aiSummaryThinkingLabel => 'Pensando…';
+
+  @override
+  String get aiSummaryTtsUnavailable =>
+      'A conversão de texto em fala não está disponível';
+
+  @override
+  String get aiTaskSummaryTitle => 'Resumo da tarefa de IA';
+
+  @override
+  String get aiTranscriptionPickerDefaultBadge => 'Padrão';
+
+  @override
+  String get aiTranscriptionPickerTitle => 'Escolha um modelo de transcrição';
+
+  @override
+  String get apiKeyAddPageTitle => 'Adicionar provedor';
+
+  @override
+  String get apiKeyAuthenticationDescription => 'Proteja sua conexão API';
+
+  @override
+  String get apiKeyAuthenticationTitle => 'Autenticação';
+
+  @override
+  String get apiKeyAvailableModelsDescription =>
+      'Adicione rapidamente modelos pré-configurados para este provedor';
+
+  @override
+  String get apiKeyAvailableModelsTitle => 'Modelos Disponíveis';
+
+  @override
+  String get apiKeyBaseUrlLabel => 'URL base';
+
+  @override
+  String get apiKeyDisplayNameHint => 'Digite um nome amigável';
+
+  @override
+  String get apiKeyDisplayNameLabel => 'Nome de exibição';
+
+  @override
+  String get apiKeyDynamicModelsDescription =>
+      'Pesquise o catálogo de modelos ao vivo deste fornecedor e adicione qualquer modelo';
+
+  @override
+  String get apiKeyEditGoBackButton => 'Voltar';
+
+  @override
+  String get apiKeyEditLoadError =>
+      'Falha ao carregar a configuração da chave de API';
+
+  @override
+  String get apiKeyEditLoadErrorRetry =>
+      'Tente novamente ou entre em contato com o suporte';
+
+  @override
+  String get apiKeyEditPageTitle => 'Editar provedor';
+
+  @override
+  String get apiKeyHideTooltip => 'Ocultar chave de API';
+
+  @override
+  String get apiKeyInputHint => 'Insira sua chave API';
+
+  @override
+  String get apiKeyInputLabel => 'Chave de API';
+
+  @override
+  String apiKeyKnownModelInputLabel(String modalities) {
+    return 'Em: $modalities';
+  }
+
+  @override
+  String apiKeyKnownModelOutputLabel(String modalities) {
+    return 'Fora: $modalities';
+  }
+
+  @override
+  String get apiKeyProviderConfigDescription =>
+      'Defina as configurações do seu provedor de inferência de IA';
+
+  @override
+  String get apiKeyProviderConfigTitle => 'Configuração do provedor';
+
+  @override
+  String get apiKeyProviderTypeHint => 'Selecione um tipo de provedor';
+
+  @override
+  String get apiKeyProviderTypeLabel => 'Tipo de provedor';
+
+  @override
+  String get apiKeyShowTooltip => 'Mostrar chave de API';
+
+  @override
+  String get audioRecordingCancel => 'CANCELAR';
+
+  @override
+  String get audioRecordingDiscardDialogBody =>
+      'Esta gravação será excluída. Nenhuma entrada de áudio, transcrição ou resumo da tarefa será criada.';
+
+  @override
+  String get audioRecordingDiscardDialogCancel => 'Continue gravando';
+
+  @override
+  String get audioRecordingDiscardDialogConfirm => 'Descartar';
+
+  @override
+  String get audioRecordingDiscardDialogTitle => 'Descartar gravação?';
+
+  @override
+  String get audioRecordingListening => 'Ouvindo...';
+
+  @override
+  String get audioRecordingPause => 'PAUSA';
+
+  @override
+  String get audioRecordingRealtime => 'Transcrição ao vivo';
+
+  @override
+  String get audioRecordingResume => 'RETOMAR';
+
+  @override
+  String get audioRecordings => 'Gravações de áudio';
+
+  @override
+  String get audioRecordingStandard => 'Padrão';
+
+  @override
+  String get audioRecordingStop => 'PARAR';
+
+  @override
+  String backfillAdvancedRecoveryActions(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ações',
+      one: '1 ação',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backfillAdvancedRecoveryTitle => 'Recuperação avançada';
+
+  @override
+  String get backfillAskPeersConfirmAccept => 'Pergunte aos colegas';
+
+  @override
+  String backfillAskPeersConfirmContent(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Isso faz com que todas $count entradas de log de sequência não resolvíveis voltem a ser perdidas, para que a varredura de preenchimento normal pergunte novamente aos pares. Os pares que ainda possuem a carga responderão; entradas verdadeiramente irrecuperáveis serão retiradas novamente após a janela de anistia de 7 dias.',
+      one:
+          'Isso transforma 1 entrada de log de sequência insolúvel de volta em falta, para que a varredura de preenchimento normal pergunte novamente aos pares. Os pares que ainda possuem a carga responderão; entradas verdadeiramente irrecuperáveis ​​serão retiradas novamente após a janela de anistia de 7 dias.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backfillAskPeersConfirmTitle =>
+      'Perguntar novamente aos colegas sobre entradas insolúveis?';
+
+  @override
+  String get backfillAskPeersDescription =>
+      'Inverta todas as entradas de log de sequência não resolvidas de volta para ausentes e deixe o backfill normal varrer novamente os pares.';
+
+  @override
+  String get backfillAskPeersProcessing => 'Reabrindo…';
+
+  @override
+  String get backfillAskPeersTitle => 'Pergunte aos colegas o que é insolúvel';
+
+  @override
+  String backfillAskPeersTrigger(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Peça aos colegas $count entradas',
+      one: 'Peça aos colegas 1 entrada',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backfillCatchUpDescription =>
+      'Extraia entradas ausentes recentes de colegas agora mesmo.';
+
+  @override
+  String backfillDevicesMeta(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count IDs de dispositivo',
+      one: '1 ID de dispositivo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backfillManualDescription =>
+      'Solicite todas as entradas ausentes, independentemente da idade. Use isto para recuperar lacunas de sincronização mais antigas.';
+
+  @override
+  String get backfillManualProcessing => 'Processando...';
+
+  @override
+  String get backfillManualTitle => 'Preenchimento manual';
+
+  @override
+  String get backfillManualTrigger => 'Solicitar entradas ausentes';
+
+  @override
+  String get backfillReRequestDescription =>
+      'Solicite novamente entradas que foram solicitadas, mas nunca recebidas. Use isto quando as respostas estiverem travadas.';
+
+  @override
+  String get backfillReRequestProcessing => 'Solicitando novamente...';
+
+  @override
+  String get backfillReRequestTitle => 'Nova solicitação pendente';
+
+  @override
+  String get backfillReRequestTrigger =>
+      'Solicitar novamente entradas pendentes';
+
+  @override
+  String get backfillResetUnresolvableDescription =>
+      'Redefina as entradas marcadas como insolúveis de volta para ausentes para que possam ser solicitadas novamente. Use após o repovoamento do log de sequência.';
+
+  @override
+  String get backfillResetUnresolvableProcessing => 'Redefinindo...';
+
+  @override
+  String get backfillResetUnresolvableTitle => 'Redefinir insolúvel';
+
+  @override
+  String get backfillResetUnresolvableTrigger =>
+      'Redefinir entradas insolúveis';
+
+  @override
+  String get backfillRetireStuckConfirmAccept => 'Aposente-se agora';
+
+  @override
+  String backfillRetireStuckConfirmContent(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Isso marca $count entradas de log de sequência atualmente abertas (ausentes ou solicitadas) como insolúveis. Use isto para desbloquear a marca d\'água quando as entradas ficarem presas por um tempo sem que o período de anistia de 7 dias tenha passado. As entradas ainda poderão ser ressuscitadas se sua carga chegar posteriormente ao disco com um relógio vetorial válido.',
+      one:
+          'Isso marca 1 entrada de log de sequência atualmente aberta (ausente ou solicitada) como insolúvel. Use isto para desbloquear a marca d\'água quando as entradas ficarem presas por um tempo sem que o período de anistia de 7 dias tenha passado. As entradas ainda poderão ser ressuscitadas se sua carga útil chegar posteriormente ao disco com um relógio de vetor válido.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backfillRetireStuckConfirmTitle =>
+      'Descontinuar entradas travadas agora?';
+
+  @override
+  String get backfillRetireStuckDescription =>
+      'Força todas as entradas de log de sequência solicitadas ou ausentes atualmente abertas a serem insolúveis. Ignora a anistia de 7 dias – use apenas para linhas travadas que bloqueiam a marca d’água.';
+
+  @override
+  String get backfillRetireStuckProcessing => 'Aposentar-se…';
+
+  @override
+  String get backfillRetireStuckTitle => 'Remover entradas travadas';
+
+  @override
+  String backfillRetireStuckTrigger(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Retirar $count entradas travadas',
+      one: 'Retirar 1 entrada travada',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backfillSettingsSubtitle =>
+      'Gerenciar a recuperação de lacunas de sincronização';
+
+  @override
+  String get backfillSettingsTitle => 'Sincronização de preenchimento';
+
+  @override
+  String get backfillStatsBackfilled => 'Preenchido';
+
+  @override
+  String get backfillStatsBurned => 'Queimado';
+
+  @override
+  String get backfillStatsDeleted => 'Excluído';
+
+  @override
+  String get backfillStatsMissing => 'Desaparecido';
+
+  @override
+  String get backfillStatsNoData => 'Não há dados de sincronização disponíveis';
+
+  @override
+  String get backfillStatsReceived => 'Recebido';
+
+  @override
+  String get backfillStatsRefresh => 'Atualizar estatísticas';
+
+  @override
+  String get backfillStatsRequested => 'Solicitado';
+
+  @override
+  String get backfillStatsTitle => 'Sincronizar estatísticas';
+
+  @override
+  String get backfillStatsTotalEntries => 'Total de entradas';
+
+  @override
+  String get backfillStatsUnresolvable => 'Insolúvel';
+
+  @override
+  String get backfillStatusInboundQueue => 'Fila de entrada';
+
+  @override
+  String get backfillStatusMissing => 'Desaparecido';
+
+  @override
+  String get backfillStatusSkipped => 'Ignorado';
+
+  @override
+  String get backfillToggleDescription =>
+      'Solicita entradas ausentes das últimas 24 horas.';
+
+  @override
+  String get backfillToggleTitle => 'Preenchimento automático';
+
+  @override
+  String get basicSettings => 'Configurações básicas';
+
+  @override
+  String get cancelButton => 'Cancelar';
+
+  @override
+  String get categoryActiveDescription =>
+      'As categorias inativas não aparecerão nas listas de seleção';
+
+  @override
+  String get categoryActiveSwitchDescription =>
+      'Selecionável para novas entradas';
+
+  @override
+  String get categoryAiDefaultsDescription =>
+      'Defina o perfil de IA padrão e o modelo de agente para novas tarefas nesta categoria';
+
+  @override
+  String get categoryAiDefaultsTitle => 'Padrões de IA';
+
+  @override
+  String get categoryCreationError =>
+      'Falha ao criar categoria. Por favor, tente novamente.';
+
+  @override
+  String get categoryDayPlanDescription =>
+      'Disponibilize esta categoria para seleção no plano diário';
+
+  @override
+  String get categoryDayPlanLabel => 'Planejamento do dia';
+
+  @override
+  String get categoryDefaultEventTemplateHint => 'Selecione um modelo';
+
+  @override
+  String get categoryDefaultEventTemplateLabel =>
+      'Modelo de agente de eventos padrão';
+
+  @override
+  String get categoryDefaultLanguageDescription =>
+      'Defina um idioma padrão para tarefas nesta categoria';
+
+  @override
+  String get categoryDefaultProfileHint => 'Selecione um perfil';
+
+  @override
+  String get categoryDefaultTemplateHint => 'Selecione um modelo';
+
+  @override
+  String get categoryDefaultTemplateLabel => 'Modelo de agente padrão';
+
+  @override
+  String get categoryDeleteConfirm => 'SIM, EXCLUIR ESTA CATEGORIA';
+
+  @override
+  String get categoryDeleteConfirmation =>
+      'Esta ação não pode ser desfeita. Todas as entradas nesta categoria permanecerão, mas não serão mais categorizadas.';
+
+  @override
+  String get categoryDeleteTitle => 'Excluir categoria?';
+
+  @override
+  String get categoryFavoriteBadgeLabel => 'Favorito';
+
+  @override
+  String get categoryFavoriteDescription =>
+      'Marcar esta categoria como favorita';
+
+  @override
+  String get categoryIconChooseHint => 'Selecione um ícone';
+
+  @override
+  String get categoryIconCreateHint => 'Selecione um ícone';
+
+  @override
+  String get categoryIconEditHint => 'Selecione um ícone diferente';
+
+  @override
+  String get categoryIconLabel => 'Ícone';
+
+  @override
+  String get categoryIconPickerTitle => 'Escolha o ícone';
+
+  @override
+  String get categoryNameRequired => 'O nome da categoria é obrigatório';
+
+  @override
+  String get categoryNotFound => 'Categoria não encontrada';
+
+  @override
+  String get categoryPrivateBadgeLabel => 'Privado';
+
+  @override
+  String get categoryPrivateDescription =>
+      'Visível apenas quando entradas privadas são mostradas';
+
+  @override
+  String get categorySearchPlaceholder => 'Pesquisar categorias...';
+
+  @override
+  String get changeSetCardTitle => 'Mudanças propostas';
+
+  @override
+  String get changeSetConfirmAll => 'Confirme tudo';
+
+  @override
+  String changeSetConfirmAllPartialIssues(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens tiveram problemas parciais',
+      one: '1 item teve problemas parciais',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get changeSetConfirmError => 'Falha ao aplicar a alteração';
+
+  @override
+  String get changeSetItemConfirmed => 'Alteração aplicada';
+
+  @override
+  String changeSetItemConfirmedWithWarning(String warning) {
+    return 'Aplicado com aviso: $warning';
+  }
+
+  @override
+  String get changeSetItemRejected => 'Alteração rejeitada';
+
+  @override
+  String changeSetPendingCount(int count) {
+    return '$count pendentes';
+  }
+
+  @override
+  String get changeSetSwipeConfirm => 'Confirmar';
+
+  @override
+  String get changeSetSwipeReject => 'Rejeitar';
+
+  @override
+  String get chatInputCancelRealtime => 'Cancelar (Esc)';
+
+  @override
+  String get chatInputCancelRecording => 'Cancelar gravação (Esc)';
+
+  @override
+  String get chatInputConfigureModel => 'Configurar modelo';
+
+  @override
+  String get chatInputHintDefault =>
+      'Pergunte sobre suas tarefas e produtividade...';
+
+  @override
+  String get chatInputHintSelectModel =>
+      'Selecione um modelo para começar a conversar';
+
+  @override
+  String get chatInputListening => 'Ouvindo...';
+
+  @override
+  String get chatInputPleaseWait => 'Por favor, espere...';
+
+  @override
+  String get chatInputProcessing => 'Processando...';
+
+  @override
+  String get chatInputRecordVoice => 'Gravar mensagem de voz';
+
+  @override
+  String get chatInputSendTooltip => 'Enviar mensagem';
+
+  @override
+  String get chatInputStartRealtime => 'Iniciar transcrição ao vivo';
+
+  @override
+  String get chatInputStopRealtime => 'Interromper a transcrição ao vivo';
+
+  @override
+  String get chatInputStopTranscribe => 'Pare e transcreva';
+
+  @override
+  String get checklistAddItem => 'Adicionar um novo item';
+
+  @override
+  String checklistAiConfidenceLabel(String level) {
+    return 'Confiança: $level';
+  }
+
+  @override
+  String get checklistAiMarkComplete => 'Marcar como concluído';
+
+  @override
+  String get checklistAiSuggestionBody => 'Este item parece estar concluído:';
+
+  @override
+  String get checklistAiSuggestionTitle => 'Sugestão de IA';
+
+  @override
+  String get checklistAllDone => 'Todos os itens concluídos!';
+
+  @override
+  String get checklistCollapseTooltip => 'Recolher';
+
+  @override
+  String checklistCompletedShort(int completed, int total) {
+    return '$completed/$total concluído';
+  }
+
+  @override
+  String get checklistDelete => 'Excluir lista de verificação?';
+
+  @override
+  String get checklistExpandTooltip => 'Expandir';
+
+  @override
+  String get checklistExportAsMarkdown =>
+      'Exportar lista de verificação como Markdown';
+
+  @override
+  String get checklistExportFailed => 'Falha na exportação';
+
+  @override
+  String get checklistItemArchived => 'Item arquivado';
+
+  @override
+  String get checklistItemArchiveUndo => 'Desfazer';
+
+  @override
+  String get checklistItemDeleteCancel => 'Cancelar';
+
+  @override
+  String get checklistItemDeleteConfirm => 'Confirmar';
+
+  @override
+  String get checklistItemDeleted => 'Item excluído';
+
+  @override
+  String get checklistItemDeleteWarning => 'Esta ação não pode ser desfeita.';
+
+  @override
+  String get checklistMarkdownCopied =>
+      'Lista de verificação copiada como Markdown';
+
+  @override
+  String get checklistMoreTooltip => 'Mais';
+
+  @override
+  String get checklistNoneDone => 'Nenhum item concluído ainda.';
+
+  @override
+  String get checklistNothingToExport => 'Nenhum item para exportar';
+
+  @override
+  String get checklistProgressSemantics => 'Progresso da lista de verificação';
+
+  @override
+  String get checklistShare => 'Compartilhar';
+
+  @override
+  String get checklistShareHint => 'Pressione e segure para compartilhar';
+
+  @override
+  String get checklistsReorder => 'Reordenar';
+
+  @override
+  String get clearButton => 'Limpar';
+
+  @override
+  String get colorCustomLabel => 'Personalizado';
+
+  @override
+  String get colorLabel => 'Cor';
+
+  @override
+  String get commandPaletteNoResults =>
+      'Nenhum comando disponível corresponde à sua pesquisa';
+
+  @override
+  String get commandPaletteSearchHint => 'Comandos de pesquisa…';
+
+  @override
+  String get commandPaletteTitle => 'Paleta de comandos';
+
+  @override
+  String get commonError => 'Erro';
+
+  @override
+  String get commonLoading => 'Carregando...';
+
+  @override
+  String get commonUnknown => 'Desconhecido';
+
+  @override
+  String get completeHabitFailButton => 'Perdido';
+
+  @override
+  String get completeHabitSkipButton => 'Pular';
+
+  @override
+  String get completeHabitSuccessButton => 'Sucesso';
+
+  @override
+  String get configFlagAttemptEmbeddingDescription =>
+      'Quando ativado, o aplicativo tentará gerar incorporações para suas entradas para melhorar a pesquisa e sugestões de conteúdo relacionado.';
+
+  @override
+  String get configFlagDailyOsOnboardingEnabled =>
+      'Passo a passo diário do sistema operacional';
+
+  @override
+  String get configFlagDailyOsOnboardingEnabledDescription =>
+      'Oriente os usuários iniciantes do Daily OS através de um check-in real que transforma a fala em uma tarefa e um plano diário.';
+
+  @override
+  String get configFlagEnableAiStreaming =>
+      'Habilite o streaming de IA para ações de tarefas';
+
+  @override
+  String get configFlagEnableAiStreamingDescription =>
+      'Transmita respostas de IA para ações relacionadas a tarefas. Desligue para armazenar respostas em buffer e manter a IU mais suave.';
+
+  @override
+  String get configFlagEnableAiSummaryTts => 'Reprodução de resumo de IA';
+
+  @override
+  String get configFlagEnableAiSummaryTtsDescription =>
+      'Mostre o botão de conversão de texto em fala local nos resumos de IA de tarefas. Requer um modelo MLX Audio TTS instalado.';
+
+  @override
+  String get configFlagEnableDashboardsPage => 'Ativar página Painéis';
+
+  @override
+  String get configFlagEnableDashboardsPageDescription =>
+      'Mostre a página Painéis na navegação principal. Visualize seus dados e insights em painéis personalizáveis.';
+
+  @override
+  String get configFlagEnableEmbeddings => 'Gerar incorporações';
+
+  @override
+  String get configFlagEnableEvents => 'Habilitar eventos';
+
+  @override
+  String get configFlagEnableEventsDescription =>
+      'Mostre o recurso Eventos para criar, rastrear e gerenciar eventos em seu diário.';
+
+  @override
+  String get configFlagEnableForkHealing => 'Cura do garfo do agente';
+
+  @override
+  String get configFlagEnableForkHealingDescription =>
+      'Cure históricos de agentes divergentes do uso de vários dispositivos, mesclando-os no próximo despertar.';
+
+  @override
+  String get configFlagEnableHabitsPage => 'Habilitar página de hábitos';
+
+  @override
+  String get configFlagEnableHabitsPageDescription =>
+      'Mostre a página Hábitos na navegação principal. Acompanhe e gerencie seus hábitos diários aqui.';
+
+  @override
+  String get configFlagEnableLogging => 'Habilitar registro';
+
+  @override
+  String get configFlagEnableLoggingDescription =>
+      'Habilite o registro detalhado para fins de depuração. Isso pode afetar o desempenho.';
+
+  @override
+  String get configFlagEnableMatrix => 'Ativar sincronização Matrix';
+
+  @override
+  String get configFlagEnableMatrixDescription =>
+      'Habilite a integração do Matrix para sincronizar suas entradas entre dispositivos e com outros usuários do Matrix.';
+
+  @override
+  String get configFlagEnableNotifications => 'Ativar notificações?';
+
+  @override
+  String get configFlagEnableNotificationsDescription =>
+      'Receba notificações de lembretes, atualizações e eventos importantes.';
+
+  @override
+  String get configFlagEnableProjects => 'Habilitar projetos';
+
+  @override
+  String get configFlagEnableProjectsDescription =>
+      'Mostre recursos de gerenciamento de projetos para organizar tarefas em projetos.';
+
+  @override
+  String get configFlagEnableSessionRatings =>
+      'Habilitar classificações de sessão';
+
+  @override
+  String get configFlagEnableSessionRatingsDescription =>
+      'Solicita uma classificação rápida da sessão quando você interrompe um cronômetro.';
+
+  @override
+  String get configFlagEnableTooltip => 'Ativar dicas de ferramentas';
+
+  @override
+  String get configFlagEnableTooltipDescription =>
+      'Mostre dicas úteis em todo o aplicativo para guiá-lo pelos recursos.';
+
+  @override
+  String get configFlagEnableVectorSearch => 'Pesquisa vetorial';
+
+  @override
+  String get configFlagEnableVectorSearchDescription =>
+      'Ative a pesquisa vetorial em filtros de tarefas. Requer que os embeddings estejam habilitados e o Ollama em execução.';
+
+  @override
+  String get configFlagEnableWhatsNew => 'Mostrar o que há de novo';
+
+  @override
+  String get configFlagEnableWhatsNewDescription =>
+      'Destaque novos recursos e alterações na árvore Configurações.';
+
+  @override
+  String get configFlagPrivate => 'Mostrar entradas privadas?';
+
+  @override
+  String get configFlagPrivateDescription =>
+      'Habilite isto para tornar suas entradas privadas por padrão. As entradas privadas são visíveis apenas para você.';
+
+  @override
+  String get configFlagRecordLocation => 'Local de registro';
+
+  @override
+  String get configFlagRecordLocationDescription =>
+      'Registre automaticamente sua localização com novas entradas. Isso ajuda na organização e pesquisa baseada em localização.';
+
+  @override
+  String get configFlagResendAttachments => 'Reenviar anexos';
+
+  @override
+  String get configFlagResendAttachmentsDescription =>
+      'Ative esta opção para reenviar automaticamente uploads de anexos com falha quando a conexão for restaurada.';
+
+  @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Mostrar indicador de atividade de sincronização';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Mostrar um status de sincronização silenciosa na barra lateral; as contagens de fila aparecem apenas enquanto o trabalho está pendente.';
+
+  @override
+  String get conflictApplyButton => 'Aplicar';
+
+  @override
+  String get conflictApplyFailedTitle => 'Não foi possível aplicar a resolução';
+
+  @override
+  String conflictBannerAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dias atrás',
+      one: '1 dia atrás',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String conflictBannerAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count h atrás',
+      one: '1 h atrás',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get conflictBannerAgoJustNow => 'agora mesmo';
+
+  @override
+  String conflictBannerAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count minutos atrás',
+      one: '1 minuto atrás',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String conflictBannerDivergedAgo(String entity, String ago) {
+    return '$entity · divergiu $ago';
+  }
+
+  @override
+  String conflictBannerFieldsDifferList(String fields) {
+    return 'Difere em: $fields';
+  }
+
+  @override
+  String get conflictCombineApply => 'Aplicar combinado';
+
+  @override
+  String get conflictCombineStartFrom => 'Começar de';
+
+  @override
+  String get conflictConfirmDeletion => 'Confirmar exclusão';
+
+  @override
+  String get conflictDeleteVsEditDescription =>
+      'Esta entrada foi editada em um dispositivo e excluída em outro. Nada é removido até que você escolha.';
+
+  @override
+  String get conflictDeleteVsEditTitle => 'Excluído em um dispositivo';
+
+  @override
+  String get conflictDetailEntryNotFoundTitle => 'Entrada não encontrada';
+
+  @override
+  String get conflictDetailLoadErrorTitle =>
+      'Não foi possível carregar o conflito';
+
+  @override
+  String get conflictDetailNotFoundTitle => 'Conflito não encontrado';
+
+  @override
+  String get conflictDiffRecommended => 'Recomendado';
+
+  @override
+  String conflictDiffUnchanged(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count campos inalterados',
+      one: '1 campo inalterado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get conflictFieldBody => 'Corpo';
+
+  @override
+  String get conflictFieldCategory => 'Categoria';
+
+  @override
+  String get conflictFieldDuration => 'Duração';
+
+  @override
+  String get conflictFieldEnd => 'Fim';
+
+  @override
+  String get conflictFieldFlag => 'Bandeira';
+
+  @override
+  String get conflictFieldOther => 'Outros detalhes';
+
+  @override
+  String get conflictFieldOtherDescription =>
+      'Estas versões diferem em detalhes não mostrados individualmente aqui.';
+
+  @override
+  String get conflictFieldPrivate => 'Privado';
+
+  @override
+  String get conflictFieldStarred => 'Com estrela';
+
+  @override
+  String get conflictFieldStart => 'Começar';
+
+  @override
+  String get conflictFieldTitle => 'Título';
+
+  @override
+  String get conflictFieldWordCount => 'contagem de palavras';
+
+  @override
+  String get conflictFlagFollowUp => 'Acompanhamento necessário';
+
+  @override
+  String get conflictFlagImport => 'Importado';
+
+  @override
+  String get conflictFlagNone => 'Nenhum';
+
+  @override
+  String get conflictFooterHelperLocalSelected =>
+      'Manterá sua edição local e descartará a versão sincronizada.';
+
+  @override
+  String get conflictFooterHelperPickASide => 'Escolha um lado para aplicar.';
+
+  @override
+  String get conflictFooterHelperRemoteSelected =>
+      'Aceitará a versão sincronizada e descartará sua edição local.';
+
+  @override
+  String conflictHeaderPillEntries(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count entradas',
+      one: '1 entrada',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String conflictHeaderPillFieldsDiffer(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count campos diferem',
+      one: '1 campo difere',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get conflictKeepEdited => 'Mantenha a versão editada';
+
+  @override
+  String conflictListItemSemanticsLabel(
+    String status,
+    String timestamp,
+    String entityType,
+    String id,
+  ) {
+    return '$status, $timestamp, $entityType, conflito $id';
+  }
+
+  @override
+  String conflictListItemTooltipFullId(String id) {
+    return 'ID do conflito: $id';
+  }
+
+  @override
+  String get conflictMetaLocalEdit => 'edição local';
+
+  @override
+  String get conflictMetaVecPrefix => 'vec';
+
+  @override
+  String get conflictMetaViaSync => 'via sincronização';
+
+  @override
+  String conflictNotificationBody(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count entradas foram editadas em dois dispositivos',
+      one: '1 entrada foi editada em dois dispositivos',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get conflictNotificationTitle =>
+      'A sincronização precisa da sua análise';
+
+  @override
+  String get conflictPageLeadDesktop =>
+      'Diferenças destacadas inline. Clique em um lado para usar essa versão ou abra Editar e mesclar para combiná-los.';
+
+  @override
+  String get conflictPageLeadMobile =>
+      'Diferenças destacadas inline. Toque em um lado para usar essa versão.';
+
+  @override
+  String get conflictPageTitle => 'Conflito de sincronização';
+
+  @override
+  String get conflictPickerCombine => 'Combine…';
+
+  @override
+  String get conflictPickerEditMerge => 'Editar e mesclar…';
+
+  @override
+  String get conflictPickerUseFromSync => 'Usar da sincronização';
+
+  @override
+  String get conflictPickerUseThisDevice => 'Use este dispositivo';
+
+  @override
+  String get conflictResolvedToast => 'Conflito resolvido';
+
+  @override
+  String get conflictsEmptyDescription =>
+      'Tudo está sincronizado agora. Os itens resolvidos permanecem disponíveis no outro filtro.';
+
+  @override
+  String get conflictsEmptyTitle => 'Nenhum conflito detectado';
+
+  @override
+  String get conflictSideFromSync => 'DA SINCRONIZAÇÃO';
+
+  @override
+  String get conflictSideThisDevice => 'ESTE DISPOSITIVO';
+
+  @override
+  String get conflictsResolved => 'resolvido';
+
+  @override
+  String get conflictsUnresolved => 'não resolvido';
+
+  @override
+  String get conflictValueAbsent => 'Não definido';
+
+  @override
+  String get conflictValueNo => 'Não';
+
+  @override
+  String get conflictValueYes => 'Sim';
+
+  @override
+  String conflictWordCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count palavras',
+      one: '$count palavra',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get copyAsMarkdown => 'Copiar como Markdown';
+
+  @override
+  String get copyAsText => 'Copiar como texto';
+
+  @override
+  String get correctionExampleCancel => 'CANCELAR';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Salvando a correção em ${seconds}s...';
+  }
+
+  @override
+  String get correctionExamplesEmpty =>
+      'Nenhuma correção capturada ainda. Edite um item da lista de verificação para adicionar seu primeiro exemplo.';
+
+  @override
+  String get correctionExamplesSectionDescription =>
+      'Quando você corrige manualmente os itens da lista de verificação, essas correções são salvas aqui e usadas para melhorar as sugestões de IA.';
+
+  @override
+  String get correctionExamplesSectionTitle =>
+      'Exemplos de correção de lista de verificação';
+
+  @override
+  String correctionExamplesWarning(int count, int max) {
+    return 'Você tem $count correções. Somente o $max mais recente será usado nos prompts de IA. Considere excluir exemplos antigos ou redundantes.';
+  }
+
+  @override
+  String get coverArtChipActive => 'Capa';
+
+  @override
+  String get coverArtChipSet => 'Definir capa';
+
+  @override
+  String get coverArtGenerationComplete => 'Arte da capa pronta!';
+
+  @override
+  String get coverArtGenerationDismissHint =>
+      'Você pode fechar isto – a geração continua em segundo plano';
+
+  @override
+  String get createButton => 'Criar';
+
+  @override
+  String get createCategoryTitle => 'Criar categoria';
+
+  @override
+  String get createEntryLabel => 'Criar nova entrada';
+
+  @override
+  String get createEntryTitle => 'Adicionar';
+
+  @override
+  String get createNewLinkedTask => 'Criar nova tarefa vinculada...';
+
+  @override
+  String get customColor => 'Cor personalizada';
+
+  @override
+  String get dailyOsDayPlan => 'Plano do dia';
+
+  @override
+  String get dailyOsNextAgendaCapacityComfortable => 'Confortável';
+
+  @override
+  String get dailyOsNextAgendaCapacityNearFull => 'Quase cheio';
+
+  @override
+  String get dailyOsNextAgendaCapacityNoPlan => 'Ainda não há plano';
+
+  @override
+  String dailyOsNextAgendaCapacityOf(String capacity) {
+    return 'de $capacity';
+  }
+
+  @override
+  String get dailyOsNextAgendaCapacityOver => 'Excesso de capacidade';
+
+  @override
+  String get dailyOsNextAgendaDonutLeft => 'esquerda';
+
+  @override
+  String get dailyOsNextAgendaDonutOver => 'acabou';
+
+  @override
+  String dailyOsNextAgendaHeadlineLeft(String duration) {
+    return '$duration restante';
+  }
+
+  @override
+  String dailyOsNextAgendaHeadlineOver(String duration) {
+    return '$duration acabou';
+  }
+
+  @override
+  String get dailyOsNextAgendaNoPlanBody =>
+      'Seu tempo monitorado está aqui de qualquer maneira - faça um check-in e eu elaborarei um rascunho do dia em torno dele.';
+
+  @override
+  String dailyOsNextAgendaNoPlanSummary(String duration) {
+    return '$duration monitorado até agora. Fale um check-in e eu elaborarei um dia em torno disso.';
+  }
+
+  @override
+  String get dailyOsNextAgendaNoPlanTitle => 'Nenhum plano ainda para hoje.';
+
+  @override
+  String get dailyOsNextAgendaStateDone => 'Concluído';
+
+  @override
+  String get dailyOsNextAgendaStateInProgress => 'Em andamento';
+
+  @override
+  String get dailyOsNextAgendaStateOpen => 'Abrir';
+
+  @override
+  String get dailyOsNextAgendaStateOverdue => 'Atrasado';
+
+  @override
+  String dailyOsNextAgendaSummary(String scheduled, String capacity) {
+    return '$scheduled de $capacity comprometido';
+  }
+
+  @override
+  String dailyOsNextAgendaTrackedLegend(String duration, int completedCount) {
+    return 'Rastreado · $duration · $completedCount concluído';
+  }
+
+  @override
+  String get dailyOsNextBlockEditCategoryLabel => 'Categoria';
+
+  @override
+  String get dailyOsNextBlockEditFailed =>
+      'Não foi possível atualizar o bloco. Tente novamente.';
+
+  @override
+  String get dailyOsNextBlockEditNameLabel => 'Título';
+
+  @override
+  String get dailyOsNextBlockEditOpenTask => 'Tarefa aberta';
+
+  @override
+  String get dailyOsNextBlockEditSave => 'Salvar alterações';
+
+  @override
+  String get dailyOsNextBlockEditSaved => 'Cronograma atualizado.';
+
+  @override
+  String get dailyOsNextBlockEditTimeLabel => 'Início e fim';
+
+  @override
+  String get dailyOsNextBlockEditTitle => 'Editar bloco';
+
+  @override
+  String get dailyOsNextBlockEditTooltip => 'Editar bloco';
+
+  @override
+  String get dailyOsNextBlockEditWhyLabel => 'Por que desta vez';
+
+  @override
+  String get dailyOsNextBlockMoveTooltip => 'Mover bloco';
+
+  @override
+  String get dailyOsNextBlockResizeEndTooltip => 'Ajustar final';
+
+  @override
+  String get dailyOsNextBlockResizeStartTooltip => 'Ajustar início';
+
+  @override
+  String get dailyOsNextCaptureCaptured => 'Entendi.';
+
+  @override
+  String get dailyOsNextCaptureDoneCta => 'Concluído';
+
+  @override
+  String get dailyOsNextCaptureErrorMicrophonePermissionDenied =>
+      'A permissão do microfone foi negada.';
+
+  @override
+  String get dailyOsNextCaptureErrorNoActiveRealtimeSession =>
+      'Nenhuma sessão ativa em tempo real.';
+
+  @override
+  String get dailyOsNextCaptureErrorNoAudioRecorded =>
+      'Nenhum áudio foi gravado.';
+
+  @override
+  String get dailyOsNextCaptureErrorRealtimeTranscriptionFailed =>
+      'Falha na transcrição em tempo real.';
+
+  @override
+  String get dailyOsNextCaptureErrorRealtimeTranscriptionStartFailed =>
+      'A transcrição em tempo real não pôde ser iniciada.';
+
+  @override
+  String get dailyOsNextCaptureErrorRecordingStartFailed =>
+      'A gravação não pôde ser iniciada.';
+
+  @override
+  String get dailyOsNextCaptureErrorTranscriptionFailed =>
+      'Falha na transcrição.';
+
+  @override
+  String get dailyOsNextCaptureHeadlineCaptured => 'Isso parece certo?';
+
+  @override
+  String get dailyOsNextCaptureHeadlineLead => 'O que está em sua mente';
+
+  @override
+  String get dailyOsNextCaptureHeadlineListening => 'Estou ouvindo.';
+
+  @override
+  String get dailyOsNextCaptureHeadlineTail => 'para hoje?';
+
+  @override
+  String dailyOsNextCaptureHeadlineTailForDate(String date) {
+    return 'para $date?';
+  }
+
+  @override
+  String get dailyOsNextCaptureHeadlineTailTomorrow => 'para amanhã?';
+
+  @override
+  String get dailyOsNextCaptureHeadlineTailYesterday => 'para ontem?';
+
+  @override
+  String get dailyOsNextCaptureHeadlineTranscribing => 'Escrevendo isso…';
+
+  @override
+  String get dailyOsNextCaptureIdleClick => 'Clique para falar';
+
+  @override
+  String get dailyOsNextCaptureIdleExample =>
+      '“Trabalho intenso esta manhã, uma caminhada depois do almoço, e-mails antes das cinco.”';
+
+  @override
+  String get dailyOsNextCaptureIdleHint =>
+      'Toque para falar · digite em vez disso';
+
+  @override
+  String get dailyOsNextCaptureIdleTalk => 'Toque para falar';
+
+  @override
+  String get dailyOsNextCaptureListeningStatus => 'Ouvindo…';
+
+  @override
+  String dailyOsNextCapturePastPrompt(String date) {
+    return 'Há algo que você ainda queira acompanhar a partir de $date?';
+  }
+
+  @override
+  String get dailyOsNextCaptureReconcileCta => 'Revisão';
+
+  @override
+  String get dailyOsNextCapturesPanelTitle => 'Capturas';
+
+  @override
+  String get dailyOsNextCaptureTranscribing => 'Transcrevendo…';
+
+  @override
+  String get dailyOsNextCaptureTranscriptHint =>
+      'Corrija qualquer coisa errada na transcrição antes de planejar.';
+
+  @override
+  String get dailyOsNextCaptureTranscriptLabel => 'Transcrição da revisão';
+
+  @override
+  String get dailyOsNextCaptureTypeInstead => 'Digite em vez disso';
+
+  @override
+  String get dailyOsNextCaptureVoiceButtonReset => 'Recomeçar';
+
+  @override
+  String get dailyOsNextCaptureVoiceButtonStart => 'Comece a ouvir';
+
+  @override
+  String get dailyOsNextCaptureVoiceButtonStop => 'Pare de ouvir';
+
+  @override
+  String get dailyOsNextCategoryFilterAll => 'Todas as categorias';
+
+  @override
+  String get dailyOsNextCategoryFilterDescription =>
+      'Somente categorias habilitadas para planejamento diário são exibidas para processamento automatizado do Daily OS.';
+
+  @override
+  String get dailyOsNextCategoryFilterEmpty =>
+      'Nenhuma categoria habilitada para planejamento do dia ainda.';
+
+  @override
+  String get dailyOsNextCategoryFilterIncludeAll => 'Incluir tudo';
+
+  @override
+  String get dailyOsNextCategoryFilterTitle => 'Categorias de processamento';
+
+  @override
+  String get dailyOsNextCategoryFilterTooltip =>
+      'Escolha as categorias de processamento diário do sistema operacional';
+
+  @override
+  String dailyOsNextCommitCapacityNote(String scheduled, String capacity) {
+    return '$scheduled de $capacity comprometido. Margem confortável – você pode absorver uma surpresa.';
+  }
+
+  @override
+  String get dailyOsNextCommitDraftOverline => 'SEU DIA, Elaborado';
+
+  @override
+  String get dailyOsNextCommitExplainer =>
+      'Assine para passar hoje do rascunho para o compromisso.';
+
+  @override
+  String get dailyOsNextCommitFinalStepEyebrow => 'ETAPA FINAL';
+
+  @override
+  String get dailyOsNextCommitHeadline => 'Faça com que seja seu.';
+
+  @override
+  String get dailyOsNextCommitHoldHelper => 'Espere um segundo para assinar';
+
+  @override
+  String get dailyOsNextCommitHoldWordDone => 'Comprometido';
+
+  @override
+  String get dailyOsNextCommitHoldWordHolding => 'Continue segurando';
+
+  @override
+  String get dailyOsNextCommitHoldWordIdle => 'Espera';
+
+  @override
+  String get dailyOsNextCommitLockingIn => 'Bloqueando…';
+
+  @override
+  String get dailyOsNextCommitShepherdSubline =>
+      'Eu cuidarei disso – você faz o trabalho.';
+
+  @override
+  String get dailyOsNextCommitSubCaption =>
+      'Você ainda pode falar comigo depois - mas os ossos permanecem no lugar.';
+
+  @override
+  String get dailyOsNextCommitTitle => 'Tranque-o';
+
+  @override
+  String get dailyOsNextCommitTodayIsYours => 'Hoje é seu.';
+
+  @override
+  String get dailyOsNextDayBack => 'Voltar';
+
+  @override
+  String get dailyOsNextDayCheckInCta => 'Fale um check-in';
+
+  @override
+  String get dailyOsNextDayDeleteDialogBody =>
+      'Os blocos elaborados para este dia serão removidos. As capturas e suas gravações de áudio permanecem em seu diário.';
+
+  @override
+  String get dailyOsNextDayDeleteDialogCancel => 'Cancelar';
+
+  @override
+  String get dailyOsNextDayDeleteDialogConfirm => 'Excluir';
+
+  @override
+  String get dailyOsNextDayDeleteDialogTitle => 'Excluir este plano?';
+
+  @override
+  String get dailyOsNextDayLockInCta => 'Bloquear';
+
+  @override
+  String get dailyOsNextDayMenuDeletePlan => 'Excluir plano';
+
+  @override
+  String get dailyOsNextDayMenuInspectAgent => 'Inspecionar agente';
+
+  @override
+  String get dailyOsNextDayMenuSettings =>
+      'Configurações diárias do sistema operacional';
+
+  @override
+  String get dailyOsNextDayMoreTooltip => 'Mais';
+
+  @override
+  String get dailyOsNextDayRefineCta => 'Refinar';
+
+  @override
+  String get dailyOsNextDayRefineFooterHint =>
+      'Fale para reformular o plano – você verá todas as alterações antes que qualquer coisa seja salva.';
+
+  @override
+  String get dailyOsNextDayTitle => 'Seu dia';
+
+  @override
+  String get dailyOsNextDayWhyChipLabel => 'POR QUE';
+
+  @override
+  String get dailyOsNextDayWrapUpCta => 'Concluir';
+
+  @override
+  String get dailyOsNextDraftingBackToDecisions => 'Voltar às decisões';
+
+  @override
+  String get dailyOsNextDraftingHeader => 'Desenhando o seu dia…';
+
+  @override
+  String get dailyOsNextDraftingNudgeAccept => 'Sim, proteja as manhãs';
+
+  @override
+  String get dailyOsNextDraftingNudgeDecline => 'Hoje não';
+
+  @override
+  String get dailyOsNextDraftingProgressBlocks => 'Blocos de desenho';
+
+  @override
+  String get dailyOsNextDraftingProgressMatching => 'Tarefas correspondentes';
+
+  @override
+  String get dailyOsNextDraftingProgressQueued => 'Na fila';
+
+  @override
+  String get dailyOsNextDraftingProgressReading => 'Check-in de leitura';
+
+  @override
+  String get dailyOsNextDraftingProgressSaving => 'Plano de poupança';
+
+  @override
+  String get dailyOsNextDraftingProgressValidating => 'Validando';
+
+  @override
+  String get dailyOsNextDraftingReasoningOverline => '✦ RACIOCÍNIO';
+
+  @override
+  String get dailyOsNextDraftingRecoveryBody =>
+      'O velório não produziu um plano. Tente novamente ou volte e ajuste as decisões antes de redigir.';
+
+  @override
+  String get dailyOsNextDraftingRecoveryTitle => 'Rascunho parado';
+
+  @override
+  String get dailyOsNextDraftingRetry => 'Tente novamente';
+
+  @override
+  String get dailyOsNextDraftingStatusAfternoon => 'Sequenciando a tarde…';
+
+  @override
+  String get dailyOsNextDraftingStatusAlmost => 'Quase lá…';
+
+  @override
+  String get dailyOsNextDraftingStatusBreathing =>
+      'Deixando espaço para respirar…';
+
+  @override
+  String get dailyOsNextDraftingStatusDeepWork =>
+      'Colocando o trabalho profundo em primeiro lugar…';
+
+  @override
+  String get dailyOsNextDraftingStatusMatching =>
+      'Combinando tarefas com o seu dia…';
+
+  @override
+  String get dailyOsNextDraftingStatusReading => 'Lendo seu check-in…';
+
+  @override
+  String get dailyOsNextDraftingStatusTimings => 'Verificando os horários…';
+
+  @override
+  String get dailyOsNextDraftingStatusYesterday =>
+      'Olhando para o ritmo de ontem…';
+
+  @override
+  String get dailyOsNextEditTitleHint => 'Editar título';
+
+  @override
+  String get dailyOsNextGenericError =>
+      'Algo deu errado. Tente novamente em alguns instantes.';
+
+  @override
+  String get dailyOsNextGreetingAfternoon => 'Boa tarde.';
+
+  @override
+  String get dailyOsNextGreetingEvening => 'Boa noite.';
+
+  @override
+  String dailyOsNextGreetingHiName(String name) {
+    return 'Olá $name 👋';
+  }
+
+  @override
+  String get dailyOsNextGreetingMorning => 'Bom dia.';
+
+  @override
+  String get dailyOsNextKnowledgeConfirm => 'Confirmar';
+
+  @override
+  String get dailyOsNextKnowledgeConfirmedHeader => 'Confirmado';
+
+  @override
+  String get dailyOsNextKnowledgeEdit => 'Editar';
+
+  @override
+  String get dailyOsNextKnowledgeEditCancel => 'Cancelar';
+
+  @override
+  String get dailyOsNextKnowledgeEditHookHint => 'Resumo de uma linha';
+
+  @override
+  String get dailyOsNextKnowledgeEditSave => 'Salvar';
+
+  @override
+  String get dailyOsNextKnowledgeEditStatementHint => 'O que devo lembrar?';
+
+  @override
+  String get dailyOsNextKnowledgeEmpty =>
+      'Nada ainda - vou lembrar o que você me disser.';
+
+  @override
+  String dailyOsNextKnowledgeNudge(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count coisas que notei — revise',
+      one: '1 coisa que notei — revise',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get dailyOsNextKnowledgeProposedHeader => 'Aguardando sua confirmação';
+
+  @override
+  String get dailyOsNextKnowledgeRetract => 'Esqueça';
+
+  @override
+  String get dailyOsNextKnowledgeStale => 'Ainda é verdade?';
+
+  @override
+  String get dailyOsNextKnowledgeTitle => 'O que eu aprendi';
+
+  @override
+  String get dailyOsNextParsedCardBreakLinkTooltip => 'Quebrar link';
+
+  @override
+  String get dailyOsNextPlanViewAgenda => 'Agenda';
+
+  @override
+  String get dailyOsNextPlanViewDay => 'Dia';
+
+  @override
+  String get dailyOsNextReconcileBadgeMatched => 'COMBINADO';
+
+  @override
+  String get dailyOsNextReconcileBadgeNew => 'NOVO';
+
+  @override
+  String get dailyOsNextReconcileBadgeUpdate => 'ATUALIZAR';
+
+  @override
+  String get dailyOsNextReconcileBuildDayCta => 'Construa meu dia';
+
+  @override
+  String get dailyOsNextReconcileDecideOverline => 'VALE A PENA DECIDIR';
+
+  @override
+  String dailyOsNextReconcileDecisionProgress(int decided, int total) {
+    return '$decided de $total avaliados';
+  }
+
+  @override
+  String get dailyOsNextReconcileDefaultBehaviorHint =>
+      'Revise os cartões antes de construir o seu dia. As ações escolhidas contribuem para o plano; as cartas deixadas sozinhas permanecem como estão.';
+
+  @override
+  String dailyOsNextReconcileError(String detail) {
+    return 'Algo deu errado: $detail';
+  }
+
+  @override
+  String get dailyOsNextReconcileHeadline => 'Aqui está o que ouvi.';
+
+  @override
+  String get dailyOsNextReconcileHeardEmpty =>
+      'Os cartões de captura aparecerão aqui assim que a análise terminar.';
+
+  @override
+  String get dailyOsNextReconcileHeardOverline => 'OUVI';
+
+  @override
+  String get dailyOsNextReconcileLowConfidence => 'baixa confiança';
+
+  @override
+  String get dailyOsNextReconcileProcessing =>
+      'Ouvindo e combinando com o seu dia…';
+
+  @override
+  String get dailyOsNextReconcileReRecord => 'Regravar';
+
+  @override
+  String get dailyOsNextReconcileVoiceHint =>
+      'Revise as decisões antes de construir o seu dia';
+
+  @override
+  String get dailyOsNextRefineAccept => 'Aceitar';
+
+  @override
+  String get dailyOsNextRefineCurrentPlan => 'PLANO ATUAL';
+
+  @override
+  String get dailyOsNextRefineDiffAdded => 'ADICIONADO';
+
+  @override
+  String get dailyOsNextRefineDiffDropped => 'CAIU';
+
+  @override
+  String get dailyOsNextRefineDiffMoved => 'MOVIDO';
+
+  @override
+  String get dailyOsNextRefineHeadlineDiffReady =>
+      'Aqui está o que eu mudaria.';
+
+  @override
+  String get dailyOsNextRefineHeadlineIdle => 'O que deveria mudar?';
+
+  @override
+  String get dailyOsNextRefineHeadlineThinking => 'Reformulando seu plano…';
+
+  @override
+  String get dailyOsNextRefineKeepTalking => 'Continue falando';
+
+  @override
+  String get dailyOsNextRefineLooksGood => 'Parece bom';
+
+  @override
+  String get dailyOsNextRefineNoChanges =>
+      'Nenhuma mudança de plano voltou. Reformule-o e tente novamente.';
+
+  @override
+  String get dailyOsNextRefineOverline => '🎤 REFINAMENTO';
+
+  @override
+  String get dailyOsNextRefineRevert => 'Reverter';
+
+  @override
+  String get dailyOsNextRefineStatusAccepted => 'Trancado.';
+
+  @override
+  String get dailyOsNextRefineStatusDiffReady => 'Aqui está o que mudou.';
+
+  @override
+  String get dailyOsNextRefineStatusIdle => 'Toque para falar.';
+
+  @override
+  String get dailyOsNextRefineStatusListening => 'Ouvindo…';
+
+  @override
+  String get dailyOsNextRefineStatusThinking => '✦ Reelaborando o plano…';
+
+  @override
+  String get dailyOsNextRefineTitle => 'Refinar o plano';
+
+  @override
+  String get dailyOsNextRenameFailed =>
+      'Não foi possível renomear. Tente novamente.';
+
+  @override
+  String get dailyOsNextReviewAddBuffer => 'Adicionar buffer';
+
+  @override
+  String get dailyOsNextReviewAddBufferPrompt =>
+      'Adicione um buffer realista entre os blocos planejados, especialmente em torno de transições e após trabalhos exigentes.';
+
+  @override
+  String get dailyOsNextReviewAdjust => 'Ajustar';
+
+  @override
+  String get dailyOsNextReviewLooksGood => 'Parece bom';
+
+  @override
+  String get dailyOsNextReviewMoveLighter => 'Mova-se com mais leveza';
+
+  @override
+  String get dailyOsNextReviewMoveLighterPrompt =>
+      'Mova o trabalho mais leve ou de menor energia para mais tarde e mantenha a janela de foco mais forte para a tarefa mais exigente.';
+
+  @override
+  String get dailyOsNextReviewTooMuch => 'Demais';
+
+  @override
+  String get dailyOsNextReviewTooMuchPrompt =>
+      'Este plano é demais para hoje. Reduza a carga, proteja o espaço para respirar e guarde apenas os blocos mais importantes.';
+
+  @override
+  String get dailyOsNextReviewWhyTitle => 'Por que eles chegaram';
+
+  @override
+  String get dailyOsNextShutdownCarryoverDrop => 'Soltar';
+
+  @override
+  String get dailyOsNextShutdownCarryoverDropped => 'Caiu';
+
+  @override
+  String get dailyOsNextShutdownCarryoverOverline => 'VAI EM FRENTE';
+
+  @override
+  String get dailyOsNextShutdownCarryoverPickDate => 'Escolha uma data';
+
+  @override
+  String get dailyOsNextShutdownCarryoverScheduled => 'Agendado';
+
+  @override
+  String get dailyOsNextShutdownCloseDay => 'Fechar o dia';
+
+  @override
+  String get dailyOsNextShutdownCompletedOverline => 'O QUE VOCÊ FEZ';
+
+  @override
+  String get dailyOsNextShutdownMetricEnergy => 'ENERGIA';
+
+  @override
+  String dailyOsNextShutdownMetricEnergyDelta(String delta) {
+    return '$delta vs. semana';
+  }
+
+  @override
+  String get dailyOsNextShutdownMetricFlow => 'SESSÕES DE FLUXO';
+
+  @override
+  String get dailyOsNextShutdownMetricFocus => 'TEMPO DE FOCO';
+
+  @override
+  String get dailyOsNextShutdownMetricSwitches => 'INTERRUPTORES DE CONTEXTO';
+
+  @override
+  String dailyOsNextShutdownMetricSwitchesAvg(String avg) {
+    return 'média $avg esta semana';
+  }
+
+  @override
+  String get dailyOsNextShutdownReflectionOverline =>
+      '💬 REFLEXÃO DE UMA LINHA';
+
+  @override
+  String get dailyOsNextShutdownReflectionPlaceholder =>
+      'por exemplo, a manhã foi nítida, a tarde arrastada depois do café com Sarah demorou muito.';
+
+  @override
+  String get dailyOsNextShutdownReflectionPrompt =>
+      'Como hoje pousou? (Isso alimenta o rascunho de amanhã.)';
+
+  @override
+  String get dailyOsNextShutdownReflectionSpeak => 'Fale';
+
+  @override
+  String get dailyOsNextShutdownReflectionSubmit => 'Pular';
+
+  @override
+  String get dailyOsNextShutdownReflectionThanks =>
+      'Entendi - alimentação amanhã.';
+
+  @override
+  String get dailyOsNextShutdownSaveAndClose => 'Salvar e fechar';
+
+  @override
+  String get dailyOsNextShutdownTitle => 'Encerre o dia';
+
+  @override
+  String get dailyOsNextShutdownTomorrowOverline => '✦ PARA AMANHÃ';
+
+  @override
+  String dailyOsNextStateDueOnDate(String date) {
+    return 'Vencimento em $date';
+  }
+
+  @override
+  String get dailyOsNextStateDueToday => 'Vencimento hoje';
+
+  @override
+  String dailyOsNextStateInProgress(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Em andamento · $count sessões',
+      one: 'Em andamento · 1 sessão',
+      zero: 'Em andamento',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String dailyOsNextStateOverdue(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: 'Atrasado · $days dias',
+      one: 'Atrasado · 1 dia',
+      zero: 'Overdue',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String dailyOsNextStateOverdueOnDate(int days, String date) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: 'Atrasado em $days dias em $date',
+      one: 'Atrasado em 1 dia em $date',
+      zero: 'Atrasado em $date',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get dailyOsNextStateRecurringMissed => 'Recorrente · perdido';
+
+  @override
+  String get dailyOsNextTimelineActual => 'Real';
+
+  @override
+  String get dailyOsNextTimelineArrange => 'Organizar blocos';
+
+  @override
+  String get dailyOsNextTimelineBoth => 'Planejado e real';
+
+  @override
+  String get dailyOsNextTimelineMeridiemAm => 'SOU';
+
+  @override
+  String get dailyOsNextTimelineMeridiemAmShort => 'sou';
+
+  @override
+  String get dailyOsNextTimelineMeridiemPm => 'PM';
+
+  @override
+  String get dailyOsNextTimelineMeridiemPmShort => 'tarde';
+
+  @override
+  String get dailyOsNextTimelinePlanned => 'Plano';
+
+  @override
+  String dailyOsNextTimelineSessionOf(int index, int total) {
+    return 'Sessão $index de $total';
+  }
+
+  @override
+  String get dailyOsNextTimelineShowBoth => 'Mostrar o plano e o real juntos';
+
+  @override
+  String get dailyOsNextTimelineShowPaged => 'Mostrar plano deslizante e real';
+
+  @override
+  String get dailyOsNextTimelineSwipeHint =>
+      'Deslize para real · aperte verticalmente para ampliar';
+
+  @override
+  String get dailyOsNextTimelineTracked => 'rastreado';
+
+  @override
+  String dailyOsNextTimeSpentEarlierSessions(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sessões anteriores',
+      one: '1 sessão anterior',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get dailyOsNextTimeSpentShowLess => 'Mostrar menos';
+
+  @override
+  String dailyOsNextTimeSpentSummary(String duration, int completedCount) {
+    return '$duration · $completedCount concluído';
+  }
+
+  @override
+  String get dailyOsNextTimeSpentTitle => 'HOJE ATÉ AGORA';
+
+  @override
+  String get dailyOsNextTimeSpentTitlePast => 'TEMPO GASTO';
+
+  @override
+  String get dailyOsNextTriageConfirmDefer => 'Adiado';
+
+  @override
+  String get dailyOsNextTriageConfirmDone => 'Marcado como concluído';
+
+  @override
+  String get dailyOsNextTriageConfirmDoNow => 'Feito agora';
+
+  @override
+  String get dailyOsNextTriageConfirmDrop => 'Caiu';
+
+  @override
+  String get dailyOsNextTriageConfirmToday => 'Adicionado a hoje';
+
+  @override
+  String get dailyOsNextTriageDefer => 'Adiar';
+
+  @override
+  String get dailyOsNextTriageDone => 'Concluído';
+
+  @override
+  String get dailyOsNextTriageDoNow => 'Faça agora';
+
+  @override
+  String get dailyOsNextTriageDrop => 'Soltar';
+
+  @override
+  String get dailyOsNextTriageToday => 'Hoje';
+
+  @override
+  String get dailyOsOnboardingCoachCapture =>
+      'Diga o que está chamando sua atenção.';
+
+  @override
+  String get dailyOsOnboardingCoachDrafting =>
+      'O planejador está criando novas tarefas e adaptando o trabalho ao seu dia.';
+
+  @override
+  String get dailyOsOnboardingCoachReconcile =>
+      'Escolha o que pertence hoje. Novos itens se tornam tarefas quando você constrói o dia.';
+
+  @override
+  String get dailyOsOnboardingSpotlightAction => 'Experimente';
+
+  @override
+  String get dailyOsOnboardingSpotlightDismiss => 'Agora não';
+
+  @override
+  String get dailyOsOnboardingSpotlightMessage =>
+      'Toque aqui e diga o que você está pensando – vou transformar isso em uma tarefa e construir o seu dia em torno disso.';
+
+  @override
+  String get dailyOsOnboardingSpotlightTitle =>
+      'Transforme a conversa em um plano';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Substitua apenas o modelo de pensamento do planejador.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle =>
+      'Escolha a substituição do modelo';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Substitua o perfil de inferência completo deste planejador.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle =>
+      'Escolha o perfil diário do sistema operacional';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'O Daily OS envia tarefas relevantes, capturas, planos, preferências aprendidas e outros contextos de planejamento montados ao provedor selecionado para processamento.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Usado pelo Daily OS, a menos que a instância do planejador tenha uma substituição.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Escolha um perfil';
+
+  @override
+  String get dailyOsSettingsDefaultRestored =>
+      'Padrão diário do sistema operacional restaurado';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'A substituição direta do modelo está ativa.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle => 'Perfil de inferência padrão';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup =>
+      'Configuração atual do planejador';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Use o perfil padrão do Daily OS, escolha uma substituição de perfil ou substitua apenas o modelo de pensamento deste planejador.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle =>
+      'Inferência diária do sistema operacional';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'O endpoint selecionado está neste dispositivo.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'O sistema operacional diário agora usa $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Adicionar nome';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Adicionar um nome preferido torna os check-ins mais pessoais. Você pode continuar planejando sem ele.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle =>
+      'Como o Daily OS deve abordar você?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'O sistema operacional diário agora usa $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive =>
+      'Substituição de perfil ativa';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'O Daily OS envia o contexto de planejamento montado para $provider em $host para processamento remoto.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction =>
+      'Configurar o sistema operacional diário';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'O Daily OS precisa da escolha do seu provedor antes de poder processar seu contexto de planejamento.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle =>
+      'Escolha um perfil de inferência';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Escolha como o Daily OS aborda você e qual perfil de inferência planeja seus dias.';
+
+  @override
+  String get dailyOsSettingsTitle => 'SO diário';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Provedor de planejamento, personalização e IA';
+
+  @override
+  String get dailyOsSettingsUseDefault =>
+      'Usar o padrão diário do sistema operacional';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Siga o perfil selecionado nas configurações diárias do sistema operacional.';
+
+  @override
+  String get dailyOsTodayButton => 'Hoje';
+
+  @override
+  String get dashboardActiveLabel => 'Ativo';
+
+  @override
+  String get dashboardActiveSwitchDescription => 'Exibido na lista de painéis';
+
+  @override
+  String get dashboardAddChartsTitle => 'Gráficos';
+
+  @override
+  String get dashboardAddHabitButton => 'Hábitos';
+
+  @override
+  String get dashboardAddHabitTitle => 'Gráficos de hábitos';
+
+  @override
+  String get dashboardAddHealthButton => 'Saúde';
+
+  @override
+  String get dashboardAddHealthTitle => 'Gráficos de saúde';
+
+  @override
+  String get dashboardAddMeasurementButton => 'Medições';
+
+  @override
+  String get dashboardAddMeasurementTitle => 'Adicionar gráficos de medição';
+
+  @override
+  String get dashboardAddMeasurementTooltip => 'Adicionar medição';
+
+  @override
+  String get dashboardAddSurveyButton => 'Pesquisas';
+
+  @override
+  String get dashboardAddSurveyTitle => 'Gráficos de pesquisa';
+
+  @override
+  String get dashboardAddWorkoutButton => 'Exercícios';
+
+  @override
+  String get dashboardAddWorkoutTitle => 'Gráficos de treino';
+
+  @override
+  String get dashboardAggregationApplyImmediately =>
+      'Escolha um resumo. As alterações aplicam-se imediatamente.';
+
+  @override
+  String get dashboardAggregationDailyAverage => 'Média diária';
+
+  @override
+  String get dashboardAggregationDailyMax => 'Máximo diário';
+
+  @override
+  String get dashboardAggregationDailyTotal => 'Total diário';
+
+  @override
+  String get dashboardAggregationHourlyTotal => 'Total por hora';
+
+  @override
+  String get dashboardAggregationLabel => 'Tipo de agregação:';
+
+  @override
+  String get dashboardAggregationTitle => 'Tipo de agregação';
+
+  @override
+  String get dashboardAvailableChartsDescription =>
+      'Escolha um tipo, selecione um ou mais gráficos e adicione-os.';
+
+  @override
+  String get dashboardAvailableChartsTitle => 'Adicione gráficos por tipo';
+
+  @override
+  String get dashboardCategoryLabel => 'Categoria';
+
+  @override
+  String get dashboardChartNoData => 'Não há dados neste intervalo';
+
+  @override
+  String get dashboardConfigurationDescription =>
+      'Salve o painel e copie sua configuração JSON.';
+
+  @override
+  String get dashboardConfigurationTitle => 'Exportar configuração';
+
+  @override
+  String get dashboardCopyHint => 'Salvar e copiar configuração do painel';
+
+  @override
+  String get dashboardCopyLabel => 'Salvar e copiar JSON';
+
+  @override
+  String get dashboardCurrentChartsDescription =>
+      'Arraste para reordenar. Os gráficos de medição podem ser selecionados para alterar sua agregação.';
+
+  @override
+  String get dashboardCurrentChartsTitle => 'Gráficos neste painel';
+
+  @override
+  String get dashboardDeleteConfirm => 'SIM, EXCLUIR ESTE PAINEL';
+
+  @override
+  String get dashboardDeleteHint => 'Excluir painel';
+
+  @override
+  String get dashboardDeleteQuestion => 'Deseja excluir este painel?';
+
+  @override
+  String get dashboardDescriptionLabel => 'Descrição (opcional)';
+
+  @override
+  String get dashboardEditAggregationLabel => 'Editar agregação';
+
+  @override
+  String get dashboardHealthBloodPressure => 'Pressão Arterial';
+
+  @override
+  String get dashboardHealthDiastolic => 'Diastólica';
+
+  @override
+  String get dashboardHealthSystolic => 'Sistólica';
+
+  @override
+  String dashboardMeasurementAddButtonWithCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Adicionar $count gráficos',
+      one: 'Adicionar 1 gráfico',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String dashboardMeasurementAggregationFor(String name) {
+    return 'Modo gráfico para $name';
+  }
+
+  @override
+  String get dashboardMeasurementAggregationHelp =>
+      'Selecione gráficos de medição. Ajuste o modo de gráfico nas linhas selecionadas antes de adicionar.';
+
+  @override
+  String get dashboardNameLabel => 'Nome do painel';
+
+  @override
+  String get dashboardNoChartsAdded =>
+      'Nenhum gráfico adicionado ainda. Adicione um abaixo.';
+
+  @override
+  String get dashboardNoHabitsForCharts =>
+      'Crie primeiro um hábito para adicionar gráficos de hábitos.';
+
+  @override
+  String get dashboardNoMeasurablesForCharts =>
+      'Crie primeiro um mensurável para adicionar gráficos de medição.';
+
+  @override
+  String get dashboardNotFound => 'Painel não encontrado';
+
+  @override
+  String get dashboardPrivateLabel => 'Privado';
+
+  @override
+  String get dashboardRemoveChartLabel => 'Remover gráfico';
+
+  @override
+  String get dashboardReorderChartLabel => 'Reordenar gráfico';
+
+  @override
+  String get dashboardTakeSurveyTooltip => 'Faça uma pesquisa';
+
+  @override
+  String get defaultLanguage => 'Idioma padrão';
+
+  @override
+  String get deleteButton => 'Excluir';
+
+  @override
+  String get deleteDeviceLabel => 'Excluir dispositivo';
+
+  @override
+  String get designSystemActionVariantTitle => 'Com ação';
+
+  @override
+  String get designSystemActivatedLabel => 'Ativado';
+
+  @override
+  String get designSystemAvatarAwayLabel => 'Longe';
+
+  @override
+  String get designSystemAvatarBusyLabel => 'Ocupado';
+
+  @override
+  String get designSystemAvatarConnectedLabel => 'Conectado';
+
+  @override
+  String get designSystemAvatarEnabledLabel => 'Habilitado';
+
+  @override
+  String get designSystemAvatarSizeMatrixTitle => 'Matriz de tamanho';
+
+  @override
+  String get designSystemAvatarStatusMatrixTitle => 'Matriz de status';
+
+  @override
+  String get designSystemBackLabel => 'Voltar';
+
+  @override
+  String get designSystemBreadcrumbCurrentLabel => 'Pão ralado';
+
+  @override
+  String get designSystemBreadcrumbDesignSystemLabel => 'Sistema de projeto';
+
+  @override
+  String get designSystemBreadcrumbHomeLabel => 'Página inicial';
+
+  @override
+  String get designSystemBreadcrumbMobileLabel => 'Móvel';
+
+  @override
+  String get designSystemBreadcrumbProjectsLabel => 'Projetos';
+
+  @override
+  String get designSystemBreadcrumbSampleLabel => 'Pão ralado';
+
+  @override
+  String get designSystemBreadcrumbTrailTitle => 'Trilha de pão ralado';
+
+  @override
+  String get designSystemCalendarPickerLabel => 'Seletor de calendário';
+
+  @override
+  String get designSystemCalendarViewsTitle => 'Visualizações de calendário';
+
+  @override
+  String get designSystemCaptionDescriptionSample =>
+      'A remoção de todos os usuários cancelou a publicação deste projeto. Adicione usuários para publicá-lo novamente.';
+
+  @override
+  String get designSystemCaptionIconLeftLabel => 'Ícone esquerdo';
+
+  @override
+  String get designSystemCaptionIconTopLabel => 'Ícone superior';
+
+  @override
+  String get designSystemCaptionNoIconLabel => 'Nenhum ícone';
+
+  @override
+  String get designSystemCaptionTitleSample => 'Título da legenda';
+
+  @override
+  String get designSystemCaptionVariantsTitle => 'Variantes de legenda';
+
+  @override
+  String get designSystemCaptionWithActionsLabel => 'Com ações';
+
+  @override
+  String get designSystemCaptionWithoutActionsLabel => 'Sem ações';
+
+  @override
+  String get designSystemCheckboxLabel => 'Caixa de seleção';
+
+  @override
+  String get designSystemContextMenuDeleteLabel => 'Excluir';
+
+  @override
+  String get designSystemContextMenuVariantsTitle =>
+      'Variantes do menu de contexto';
+
+  @override
+  String get designSystemCountdownVariantTitle => 'Com contagem regressiva';
+
+  @override
+  String get designSystemDateCardsTitle => 'Cartões de data';
+
+  @override
+  String get designSystemDefaultLabel => 'Padrão';
+
+  @override
+  String get designSystemDisabledLabel => 'Desativado';
+
+  @override
+  String get designSystemDividerLabelText => 'Etiqueta divisória';
+
+  @override
+  String get designSystemDropdownComboboxTitle => 'Caixa de combinação';
+
+  @override
+  String get designSystemDropdownFieldLabel => 'Etiqueta';
+
+  @override
+  String get designSystemDropdownInputLabel => 'Entrada';
+
+  @override
+  String get designSystemDropdownListTitle => 'Lista suspensa';
+
+  @override
+  String get designSystemDropdownMultiselectInputLabel => 'Selecione equipes';
+
+  @override
+  String get designSystemDropdownMultiselectTitle => 'Seleção múltipla';
+
+  @override
+  String get designSystemDropdownOptionAnalytics => 'Análise';
+
+  @override
+  String get designSystemDropdownOptionBackend => 'Back-end';
+
+  @override
+  String get designSystemDropdownOptionDesign => 'Projeto';
+
+  @override
+  String get designSystemDropdownOptionFrontend => 'Interface';
+
+  @override
+  String get designSystemDropdownOptionGrowth => 'Crescimento';
+
+  @override
+  String get designSystemDropdownOptionMobile => 'Móvel';
+
+  @override
+  String get designSystemDropdownOptionQa => 'Controle de qualidade';
+
+  @override
+  String get designSystemErrorLabel => 'Erro';
+
+  @override
+  String get designSystemFileUploadClickLabel => 'Clique para carregar';
+
+  @override
+  String get designSystemFileUploadCompleteLabel => 'Completo';
+
+  @override
+  String get designSystemFileUploadDefaultLabel => 'Padrão';
+
+  @override
+  String get designSystemFileUploadDragLabel => 'ou arraste e solte';
+
+  @override
+  String get designSystemFileUploadDropZoneSectionTitle => 'Zona de lançamento';
+
+  @override
+  String get designSystemFileUploadErrorLabel => 'Erro';
+
+  @override
+  String get designSystemFileUploadFailedText => 'Falha no upload';
+
+  @override
+  String get designSystemFileUploadHintText =>
+      'SVG, PNG, JPG ou GIF (máx. 800×400px)';
+
+  @override
+  String get designSystemFileUploadHoverLabel => 'Passe o mouse';
+
+  @override
+  String get designSystemFileUploadItemSectionTitle => 'Itens de arquivo';
+
+  @override
+  String get designSystemFileUploadRetryLabel => 'Tentar novamente';
+
+  @override
+  String get designSystemFileUploadUploadingLabel => 'Enviando';
+
+  @override
+  String get designSystemFilledLabel => 'Preenchido';
+
+  @override
+  String get designSystemHeaderApiDocumentationLabel => 'Documentação da API';
+
+  @override
+  String get designSystemHeaderBackActionLabel => 'Voltar';
+
+  @override
+  String get designSystemHeaderDesktopSectionTitle => 'Área de trabalho';
+
+  @override
+  String get designSystemHeaderHelpActionLabel => 'Ajuda';
+
+  @override
+  String get designSystemHeaderMobileSectionTitle => 'Móvel';
+
+  @override
+  String get designSystemHeaderNotificationsActionLabel => 'Notificações';
+
+  @override
+  String get designSystemHeaderSearchActionLabel => 'Pesquisar';
+
+  @override
+  String get designSystemHorizontalLabel => 'Horizontais';
+
+  @override
+  String get designSystemHoverLabel => 'Passe o mouse';
+
+  @override
+  String get designSystemInfoLabel => 'Informações';
+
+  @override
+  String get designSystemInputErrorSample => 'Este campo é obrigatório';
+
+  @override
+  String get designSystemInputHelperSample => 'Digite seu nome';
+
+  @override
+  String get designSystemInputHintSample => 'Espaço reservado...';
+
+  @override
+  String get designSystemInputLabelSample => 'Etiqueta';
+
+  @override
+  String get designSystemInputVariantsTitle => 'Variantes de entrada';
+
+  @override
+  String get designSystemInputWithErrorLabel => 'Com erro';
+
+  @override
+  String get designSystemInputWithHelperLabel => 'Com texto auxiliar';
+
+  @override
+  String get designSystemInputWithIconsLabel => 'Com ícones';
+
+  @override
+  String get designSystemListItemActivatedLabel => 'Ativado';
+
+  @override
+  String get designSystemListItemOneLineLabel => 'Uma linha';
+
+  @override
+  String get designSystemListItemSubtitleSample => 'Legenda';
+
+  @override
+  String get designSystemListItemTitleSample => 'Título';
+
+  @override
+  String get designSystemListItemTwoLinesLabel => 'Duas linhas';
+
+  @override
+  String get designSystemListItemVariantsTitle => 'Listar variantes de itens';
+
+  @override
+  String get designSystemListItemWithDividerLabel => 'Com divisória';
+
+  @override
+  String get designSystemMediumLabel => 'Médio';
+
+  @override
+  String designSystemMyDailyDurationHoursMinutesCompact(
+    int hours,
+    int minutes,
+  ) {
+    return '${hours}h ${minutes}m';
+  }
+
+  @override
+  String get designSystemNavigationCollapsedLabel => 'Recolhido';
+
+  @override
+  String get designSystemNavigationDailyFilterSectionTitle => 'Filtro Diário';
+
+  @override
+  String get designSystemNavigationExpandedLabel => 'Expandido';
+
+  @override
+  String get designSystemNavigationFilterByBlockLabel => 'Filtrar por bloco';
+
+  @override
+  String get designSystemNavigationHikingLabel => 'Caminhadas';
+
+  @override
+  String get designSystemNavigationHolidayLabel => 'Feriado';
+
+  @override
+  String get designSystemNavigationInsightsLabel => 'Informações';
+
+  @override
+  String get designSystemNavigationLottiTasksLabel => 'Tarefas Lotti';
+
+  @override
+  String get designSystemNavigationMyDailyLabel => 'Meu Diário';
+
+  @override
+  String get designSystemNavigationNewLabel => 'Novo';
+
+  @override
+  String get designSystemNavigationPlaceholderLabel => 'Espaço reservado';
+
+  @override
+  String get designSystemNavigationSidebarSectionTitle =>
+      'Variantes da barra lateral';
+
+  @override
+  String get designSystemNavigationSubComponentsSectionTitle =>
+      'Subcomponentes';
+
+  @override
+  String get designSystemNavigationTabBarSectionTitle =>
+      'Variantes da barra de guias';
+
+  @override
+  String get designSystemPressedLabel => 'Pressionado';
+
+  @override
+  String get designSystemProgressBarChunkyLabel => 'Robusto';
+
+  @override
+  String get designSystemProgressBarLabelAndPercentageLabel =>
+      'Etiqueta + Porcentagem';
+
+  @override
+  String get designSystemProgressBarLabelOnlyLabel => 'Apenas etiqueta';
+
+  @override
+  String get designSystemProgressBarOffLabel => 'Desligado';
+
+  @override
+  String get designSystemProgressBarPercentageOnlyLabel => 'Porcentagem';
+
+  @override
+  String get designSystemProgressBarQuestBarLabel => 'Barra de missões';
+
+  @override
+  String get designSystemProgressBarQuestLabel => 'Etiqueta de mega prêmio';
+
+  @override
+  String get designSystemProgressBarSampleLabel =>
+      'Etiqueta da barra de progresso';
+
+  @override
+  String get designSystemRadioButtonLabel => 'Botão de rádio';
+
+  @override
+  String get designSystemScrollbarSizesTitle => 'Tamanhos da barra de rolagem';
+
+  @override
+  String get designSystemSearchFilledText => 'Pesquisa lotti';
+
+  @override
+  String get designSystemSearchHintLabel => 'Digite usuário';
+
+  @override
+  String get designSystemSelectedLabel => 'Selecionado';
+
+  @override
+  String get designSystemSizeScaleTitle => 'Escala de tamanho';
+
+  @override
+  String get designSystemSmallLabel => 'Pequeno';
+
+  @override
+  String get designSystemSpinnerPlainLabel => 'Simples';
+
+  @override
+  String get designSystemSpinnerSkeletonPulseLabel => 'Pulso';
+
+  @override
+  String get designSystemSpinnerSkeletonsTitle => 'Esqueletos';
+
+  @override
+  String get designSystemSpinnerSkeletonWaveLabel => 'Onda';
+
+  @override
+  String get designSystemSpinnerSpinnersTitle => 'Fiandeiros';
+
+  @override
+  String get designSystemSpinnerTrackLabel => 'Com pista';
+
+  @override
+  String designSystemSplitButtonDropdownSemantics(String label) {
+    return 'Abra as opções de $label';
+  }
+
+  @override
+  String get designSystemStateMatrixTitle => 'Matriz Estadual';
+
+  @override
+  String get designSystemSuccessLabel => 'Sucesso';
+
+  @override
+  String get designSystemTabBarTitle => 'Barra de guias';
+
+  @override
+  String get designSystemTabPendingLabel => 'Pendente';
+
+  @override
+  String get designSystemTaskListBlockedLabel => 'Bloqueado';
+
+  @override
+  String get designSystemTaskListDefaultLabel => 'Padrão';
+
+  @override
+  String get designSystemTaskListHoverLabel => 'Passe o mouse';
+
+  @override
+  String get designSystemTaskListItemSectionTitle =>
+      'Variantes de itens da lista de tarefas';
+
+  @override
+  String get designSystemTaskListOnHoldLabel => 'Em espera';
+
+  @override
+  String get designSystemTaskListOpenLabel => 'Abrir';
+
+  @override
+  String get designSystemTaskListPressedLabel => 'Pressionado';
+
+  @override
+  String get designSystemTaskListSampleTime => '8h00-9h30';
+
+  @override
+  String get designSystemTaskListSampleTitle => 'Teste de usuário';
+
+  @override
+  String get designSystemTaskListWithDividerLabel => 'Com divisória';
+
+  @override
+  String get designSystemTextareaErrorSample => 'Este campo é obrigatório';
+
+  @override
+  String get designSystemTextareaHelperSample => 'Digite sua mensagem aqui';
+
+  @override
+  String get designSystemTextareaHintSample => 'Digite algo...';
+
+  @override
+  String get designSystemTextareaLabelSample => 'Etiqueta';
+
+  @override
+  String get designSystemTextareaVariantsTitle => 'Variantes de área de texto';
+
+  @override
+  String get designSystemTextareaWithCounterLabel => 'Com contador';
+
+  @override
+  String get designSystemTextareaWithErrorLabel => 'Com erro';
+
+  @override
+  String get designSystemTextareaWithHelperLabel => 'Com texto auxiliar';
+
+  @override
+  String get designSystemTimePickerFormatsTitle => 'Formatos de hora';
+
+  @override
+  String get designSystemTimePickerTwelveHourLabel => '12 horas';
+
+  @override
+  String get designSystemTimePickerTwentyFourHourLabel => '24 horas';
+
+  @override
+  String get designSystemTitleOnlyVariantTitle => 'Variante apenas de título';
+
+  @override
+  String get designSystemToastDetailsLabel => 'Detalhes da notificação';
+
+  @override
+  String get designSystemToggleLabel => 'Alternar rótulo';
+
+  @override
+  String get designSystemTooltipIconMessageSample =>
+      'Informações úteis sobre este campo';
+
+  @override
+  String get designSystemTooltipIconVariantsTitle =>
+      'Ícone de dica de ferramenta';
+
+  @override
+  String get designSystemUndoLabel => 'Desfazer';
+
+  @override
+  String get designSystemVariantMatrixTitle => 'Matriz Variante';
+
+  @override
+  String get designSystemVerticalLabel => 'Verticais';
+
+  @override
+  String get designSystemWarningLabel => 'Aviso';
+
+  @override
+  String get designSystemWeeklyCalendarLabel => 'Calendário Semanal';
+
+  @override
+  String get designSystemWithLabelLabel => 'Com etiqueta';
+
+  @override
+  String get desktopEmptyStateSelectDashboard =>
+      'Selecione um painel para visualizar detalhes';
+
+  @override
+  String get desktopEmptyStateSelectProject =>
+      'Selecione um projeto para ver detalhes';
+
+  @override
+  String get desktopEmptyStateSelectTask =>
+      'Selecione uma tarefa para ver detalhes';
+
+  @override
+  String deviceDeletedSuccess(String deviceName) {
+    return 'Dispositivo $deviceName excluído com sucesso';
+  }
+
+  @override
+  String deviceDeleteFailed(String error) {
+    return 'Falha ao excluir o dispositivo: $error';
+  }
+
+  @override
+  String get doneButton => 'Concluído';
+
+  @override
+  String get editMenuTitle => 'Editar';
+
+  @override
+  String get editorDiscardChanges => 'Descartar alterações';
+
+  @override
+  String get editorInsertDivider => 'Inserir divisória';
+
+  @override
+  String get editorMoreFormatting => 'Mais formatação';
+
+  @override
+  String get editorPlaceholder => 'Insira notas...';
+
+  @override
+  String get embeddingSelectAll => 'Selecionar tudo';
+
+  @override
+  String get embeddingUnselectAll => 'Desmarcar tudo';
+
+  @override
+  String get enhancedPromptFormPreconfiguredPromptDescription =>
+      'Escolha entre modelos de prompt prontos';
+
+  @override
+  String get enterCategoryName => 'Insira o nome da categoria';
+
+  @override
+  String get entryActions => 'Ações';
+
+  @override
+  String get entryLabelsActionSubtitle =>
+      'Atribua rótulos para organizar esta entrada';
+
+  @override
+  String get entryLabelsActionTitle => 'Etiquetas';
+
+  @override
+  String get entryLabelsEditTooltip => 'Editar rótulos';
+
+  @override
+  String get entryLabelsHeaderTitle => 'Etiquetas';
+
+  @override
+  String get entryLabelsNoLabels => 'Nenhum rótulo atribuído';
+
+  @override
+  String get entryTypeLabelAiResponse => 'Resposta de IA';
+
+  @override
+  String get entryTypeLabelChecklist => 'Lista de verificação';
+
+  @override
+  String get entryTypeLabelChecklistItem => 'Fazer';
+
+  @override
+  String get entryTypeLabelHabitCompletionEntry => 'Hábito';
+
+  @override
+  String get entryTypeLabelJournalAudio => 'Áudio';
+
+  @override
+  String get entryTypeLabelJournalEntry => 'Texto';
+
+  @override
+  String get entryTypeLabelJournalEvent => 'Evento';
+
+  @override
+  String get entryTypeLabelJournalImage => 'Foto';
+
+  @override
+  String get entryTypeLabelMeasurementEntry => 'Medido';
+
+  @override
+  String get entryTypeLabelQuantitativeEntry => 'Saúde';
+
+  @override
+  String get entryTypeLabelSurveyEntry => 'Pesquisa';
+
+  @override
+  String get entryTypeLabelTask => 'Tarefa';
+
+  @override
+  String get entryTypeLabelWorkoutEntry => 'Treino';
+
+  @override
+  String get eventNameLabel => 'Evento:';
+
+  @override
+  String get eventsAddCoverPhoto => 'Adicionar foto de capa';
+
+  @override
+  String get eventsAddLabel => 'Adicionar';
+
+  @override
+  String get eventsChangeCover => 'Alterar capa';
+
+  @override
+  String get eventsDeleteEvent => 'Excluir evento';
+
+  @override
+  String get eventsFilterAll => 'Todos';
+
+  @override
+  String eventsMetricPhotos(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fotos',
+      one: '1 foto',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String eventsMetricTasks(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas',
+      one: '1 tarefa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get eventsNewEvent => 'Novo evento';
+
+  @override
+  String get eventsPageTitle => 'Eventos';
+
+  @override
+  String get eventsPhotosSection => 'Fotos';
+
+  @override
+  String get eventsRecapAwaitingContent =>
+      'Adicione uma foto ou nota e a recapitulação aparecerá aqui.';
+
+  @override
+  String get eventsRecapUnavailable =>
+      'Não foi possível carregar a recapitulação.';
+
+  @override
+  String get eventsRegenerateSummary => 'Regenerar resumo';
+
+  @override
+  String get eventsSearchHint => 'Pesquisar eventos';
+
+  @override
+  String get eventsSectionUpcoming => 'Próximos';
+
+  @override
+  String get eventsStatusCancelled => 'Cancelado';
+
+  @override
+  String get eventsStatusCompleted => 'Concluído';
+
+  @override
+  String get eventsStatusMissed => 'Perdido';
+
+  @override
+  String get eventsStatusOngoing => 'Em andamento';
+
+  @override
+  String get eventsStatusPlanned => 'Planejado';
+
+  @override
+  String get eventsStatusPostponed => 'Adiado';
+
+  @override
+  String get eventsStatusRescheduled => 'Reprogramado';
+
+  @override
+  String get eventsStatusTentative => 'Provisório';
+
+  @override
+  String get eventsSummaryTitle => 'Resumo';
+
+  @override
+  String get eventsTasksEmpty =>
+      'Vincule uma tarefa de preparação ou acompanhamento';
+
+  @override
+  String get eventsTasksSection => 'Tarefas';
+
+  @override
+  String get eventsTimelineEmpty =>
+      'Adicione fotos, notas ou uma mensagem de voz';
+
+  @override
+  String get eventsTimelineSection => 'Linha do tempo';
+
+  @override
+  String get eventsTitleHint => 'Título do evento';
+
+  @override
+  String get eventsVoiceNote => 'Nota de voz';
+
+  @override
+  String get favoriteLabel => 'Favorito';
+
+  @override
+  String get fileMenuNewEllipsis => 'Novo ...';
+
+  @override
+  String get fileMenuNewEntry => 'Nova entrada';
+
+  @override
+  String get fileMenuNewScreenshot => 'Captura de tela';
+
+  @override
+  String get fileMenuNewTask => 'Tarefa';
+
+  @override
+  String get fileMenuTitle => 'Arquivo';
+
+  @override
+  String get filterSelectionNoMatches => 'Nenhuma correspondência';
+
+  @override
+  String get geminiThinkingModeHighDescription =>
+      'Raciocínio mais profundo; pode aumentar a latência e o custo.';
+
+  @override
+  String get geminiThinkingModeHighLabel => 'Alto';
+
+  @override
+  String get geminiThinkingModeLowDescription =>
+      'Baixo raciocínio para solicitações rápidas do dia a dia.';
+
+  @override
+  String get geminiThinkingModeLowLabel => 'Baixo';
+
+  @override
+  String get geminiThinkingModeMediumDescription =>
+      'Raciocínio equilibrado para respostas mais cuidadosas.';
+
+  @override
+  String get geminiThinkingModeMediumLabel => 'Médio';
+
+  @override
+  String get geminiThinkingModeMinimalDescription =>
+      'Configuração mais rápida; Gêmeos ainda pode pensar brevemente em instruções complexas.';
+
+  @override
+  String get geminiThinkingModeMinimalLabel => 'Mínimo';
+
+  @override
+  String get generateCoverArt => 'Gerar capa';
+
+  @override
+  String get generateCoverArtSubtitle =>
+      'Criar imagem a partir da descrição de voz';
+
+  @override
+  String get goMenuTitle => 'Vá';
+
+  @override
+  String get habitActiveFromLabel => 'Data de início';
+
+  @override
+  String get habitActiveSwitchDescription => 'Exibido na página Hábitos';
+
+  @override
+  String get habitArchivedLabel => 'Arquivado';
+
+  @override
+  String get habitCategoryHint => 'Selecione uma categoria';
+
+  @override
+  String get habitCategoryLabel => 'Categoria';
+
+  @override
+  String get habitCloseCompletionLabel => 'Fechar a conclusão do hábito';
+
+  @override
+  String habitCompleteSemanticLabel(String habit) {
+    return 'Registrar $habit';
+  }
+
+  @override
+  String get habitCompletionStatusCompleted => 'Concluído';
+
+  @override
+  String get habitCompletionStatusFailed => 'Falha';
+
+  @override
+  String get habitCompletionStatusOpen => 'Abrir';
+
+  @override
+  String get habitCompletionStatusSkipped => 'Ignorado';
+
+  @override
+  String get habitDashboardHint => 'Selecione um painel';
+
+  @override
+  String get habitDashboardLabel => 'Painel (opcional)';
+
+  @override
+  String habitDayStatusSemantic(String habit, String status) {
+    return '$habit, $status';
+  }
+
+  @override
+  String get habitDeleteConfirm => 'SIM, EXCLUA ESTE HÁBITO';
+
+  @override
+  String get habitDeleteQuestion => 'Quer eliminar esse hábito?';
+
+  @override
+  String habitHeatmapDaySemantic(String date, int done, int total) {
+    return '$date, $done de $total concluído';
+  }
+
+  @override
+  String get habitLogOtherDayHint => 'Segure para registrar outro dia';
+
+  @override
+  String get habitNotRecordedLabel => 'Não registrado';
+
+  @override
+  String get habitPriorityLabel => 'Prioridade';
+
+  @override
+  String get habitsAboveGoal => 'No caminho certo';
+
+  @override
+  String habitsActiveHabitsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count hábitos ativos',
+      one: '1 hábito ativo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get habitsAllDoneToday => 'Tudo feito hoje';
+
+  @override
+  String get habitsCompletedHeader => 'Concluído';
+
+  @override
+  String get habitsCompletionRateTitle => 'Taxa de conclusão';
+
+  @override
+  String get habitsConsistencyTitle => 'Consistência';
+
+  @override
+  String habitsDayFailedPercent(int percent) {
+    return '$percent% de falhas registradas';
+  }
+
+  @override
+  String habitsDaySkippedPercent(int percent) {
+    return '$percent% ignorados';
+  }
+
+  @override
+  String habitsDaySuccessfulPercent(int percent) {
+    return '$percent% de sucesso';
+  }
+
+  @override
+  String get habitsDoneTodayLabel => 'Feito hoje';
+
+  @override
+  String get habitSectionOptionsTitle => 'Opções';
+
+  @override
+  String get habitSectionScheduleTitle => 'Cronograma';
+
+  @override
+  String get habitsFilterAll => 'tudo';
+
+  @override
+  String get habitsFilterCompleted => 'feito';
+
+  @override
+  String get habitsFilterOpenNow => 'devido';
+
+  @override
+  String get habitsFilterPendingLater => 'mais tarde';
+
+  @override
+  String get habitsGoalLineLabel => 'Objetivo';
+
+  @override
+  String get habitsHeatmapEmpty =>
+      'Adicione um hábito para começar a construir sua consistência';
+
+  @override
+  String get habitsHeatmapLess => 'Menos';
+
+  @override
+  String get habitsHeatmapMore => 'Mais';
+
+  @override
+  String get habitShowAlertAtLabel => 'Mostrar alerta em';
+
+  @override
+  String get habitShowFromLabel => 'Mostrar de';
+
+  @override
+  String habitsLaggardHint(String habit, int kept, int active) {
+    return '$habit — mantido $kept de $active';
+  }
+
+  @override
+  String get habitsOpenHeader => 'Vencimento agora';
+
+  @override
+  String get habitsPendingLaterHeader => 'Mais tarde hoje';
+
+  @override
+  String habitsPointsToGoal(int points) {
+    String _temp0 = intl.Intl.pluralLogic(
+      points,
+      locale: localeName,
+      other: '$points pontos para a meta',
+      one: '1 ponto para a meta',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get habitsRecordButton => 'Gravar';
+
+  @override
+  String get habitsRollingAverageLabel => 'Média de 7 dias';
+
+  @override
+  String get habitsStartStreakToday => 'Comece uma sequência hoje';
+
+  @override
+  String habitsStreakLongCount(int count) {
+    return '$count em uma sequência de 7 dias';
+  }
+
+  @override
+  String habitsStreakShortCount(int count) {
+    return '$count em uma sequência de 3 dias';
+  }
+
+  @override
+  String get habitsTapForBreakdown => 'Toque em um dia para o detalhamento';
+
+  @override
+  String habitsToGoCount(int count) {
+    return '$count para ir';
+  }
+
+  @override
+  String habitStreakDaysSemantic(int count) {
+    return 'sequência de $count dias';
+  }
+
+  @override
+  String get habitsVsPreviousWeek => 'versus semana anterior';
+
+  @override
+  String get helpMenuCommandPalette => 'Paleta de comandos…';
+
+  @override
+  String get helpMenuKeyboardShortcuts => 'Atalhos de teclado…';
+
+  @override
+  String get helpMenuTitle => 'Ajuda';
+
+  @override
+  String get imageGenerationError => 'Falha ao gerar imagem';
+
+  @override
+  String get imageGenerationGenerating => 'Gerando imagem...';
+
+  @override
+  String get imageGenerationProviderRejectedTitle =>
+      'O provedor de imagem rejeitou esta solicitação';
+
+  @override
+  String imageGenerationWithReferences(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Usando $count imagens de referência',
+      one: 'Usando 1 imagem de referência',
+      zero: 'Sem imagens de referência',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get imagePromptGenerationCardTitle => 'Prompt de imagem AI';
+
+  @override
+  String get imagePromptGenerationCopiedSnackbar =>
+      'Prompt de imagem copiado para a área de transferência';
+
+  @override
+  String get imagePromptGenerationCopyButton => 'Copiar prompt';
+
+  @override
+  String get imagePromptGenerationCopyTooltip =>
+      'Copiar prompt de imagem para a área de transferência';
+
+  @override
+  String get imagePromptGenerationExpandTooltip => 'Mostrar prompt completo';
+
+  @override
+  String get imagePromptGenerationFullPromptLabel =>
+      'Prompt de imagem completo:';
+
+  @override
+  String get images => 'Imagens';
+
+  @override
+  String get imageViewerDownloadFailed => 'Não foi possível salvar a imagem';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Salvando imagem';
+
+  @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Acesso à foto negado – ative-o nas configurações';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return '$fileName salvo';
+  }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'Salvo em fotos';
+
+  @override
+  String get imageViewerDownloadTooltip => 'Baixar imagem';
+
+  @override
+  String get inactiveLabel => 'Inativo';
+
+  @override
+  String get inactiveSwitchDescription =>
+      'Pode ser escolhido para novas entradas quando ativado';
+
+  @override
+  String get inferenceProfileChooseModelTitle => 'Escolha um modelo';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Escolha um perfil de inferência';
+
+  @override
+  String get inferenceProfileCreateTitle => 'Criar perfil';
+
+  @override
+  String get inferenceProfileDescriptionLabel => 'Descrição';
+
+  @override
+  String get inferenceProfileDesktopOnly => 'Somente área de trabalho';
+
+  @override
+  String get inferenceProfileDesktopOnlyDescription =>
+      'Disponível apenas em plataformas desktop (por exemplo, para modelos locais)';
+
+  @override
+  String inferenceProfileDetailLoadError(String error) {
+    return 'Não foi possível carregar o perfil: $error';
+  }
+
+  @override
+  String get inferenceProfileDetailNotFound => 'Perfil não encontrado';
+
+  @override
+  String get inferenceProfileEditTitle => 'Editar perfil';
+
+  @override
+  String get inferenceProfileImageGeneration => 'Geração de imagem';
+
+  @override
+  String get inferenceProfileImageRecognition => 'Reconhecimento de imagem';
+
+  @override
+  String get inferenceProfileModelUnavailable =>
+      'Modelo indisponível – seu fornecedor pode ter sido removido';
+
+  @override
+  String get inferenceProfileNameLabel => 'Nome do perfil';
+
+  @override
+  String get inferenceProfileNameRequired => 'Um nome de perfil é obrigatório';
+
+  @override
+  String get inferenceProfilePinnedHostHelper =>
+      'Quando definido, apenas este dispositivo executa automaticamente a inferência para entradas de áudio sincronizadas que usam este perfil.';
+
+  @override
+  String get inferenceProfilePinnedHostLabel => 'Dispositivo fixado';
+
+  @override
+  String get inferenceProfilePinnedHostNoEligibleNodes =>
+      'Nenhum dispositivo conhecido anuncia os provedores que este perfil usa. Abra as configurações do nó de sincronização no dispositivo de destino.';
+
+  @override
+  String get inferenceProfilePinnedHostNoneHelper =>
+      'As entradas de áudio sincronizadas não são transcritas automaticamente quando nenhum dispositivo está fixado.';
+
+  @override
+  String get inferenceProfilePinnedHostNoneLabel =>
+      'Não fixado (sem acionamento automático)';
+
+  @override
+  String get inferenceProfilePinnedHostThisDeviceSuffix => '(este dispositivo)';
+
+  @override
+  String get inferenceProfileSaveButton => 'Salvar';
+
+  @override
+  String get inferenceProfileSelectModel => 'Escolha um modelo…';
+
+  @override
+  String get inferenceProfileSelectProfile => 'Escolha um perfil…';
+
+  @override
+  String get inferenceProfilesEmpty => 'Ainda não há perfis de inferência';
+
+  @override
+  String inferenceProfileSkillModelRequired(String slotName) {
+    return 'Requer que o modelo $slotName seja definido';
+  }
+
+  @override
+  String get inferenceProfileSkillsSection => 'Habilidades Automatizadas';
+
+  @override
+  String inferenceProfileSkillUsesModel(String slotName) {
+    return 'Usa o modelo $slotName';
+  }
+
+  @override
+  String get inferenceProfilesTitle => 'Perfis de inferência';
+
+  @override
+  String get inferenceProfileThinking => 'Pensando';
+
+  @override
+  String get inferenceProfileThinkingHighEnd => 'Pensando (sofisticado)';
+
+  @override
+  String get inferenceProfileThinkingRequired =>
+      'É necessário um modelo de pensamento';
+
+  @override
+  String get inferenceProfileTranscription => 'Transcrição';
+
+  @override
+  String get inferenceProfileUnavailable => 'Perfil de inferência indisponível';
+
+  @override
+  String get inputDataTypeAudioFilesDescription =>
+      'Use arquivos de áudio como entrada';
+
+  @override
+  String get inputDataTypeAudioFilesName => 'Arquivos de áudio';
+
+  @override
+  String get inputDataTypeImagesDescription => 'Use imagens como entrada';
+
+  @override
+  String get inputDataTypeImagesName => 'Imagens';
+
+  @override
+  String get inputDataTypeTaskDescription => 'Use a tarefa atual como entrada';
+
+  @override
+  String get inputDataTypeTaskName => 'Tarefa';
+
+  @override
+  String get inputDataTypeTasksListDescription =>
+      'Use uma lista de tarefas como entrada';
+
+  @override
+  String get inputDataTypeTasksListName => 'Lista de tarefas';
+
+  @override
+  String get insightsChartCompareCaption => 'Este período versus o anterior';
+
+  @override
+  String get insightsChartCompareCaptionPartial =>
+      'Este período até agora versus o anterior';
+
+  @override
+  String get insightsChartCompareHint => 'Comparação mostrada na tabela abaixo';
+
+  @override
+  String get insightsChartCumulativeCaption =>
+      'Executando total ao longo do intervalo';
+
+  @override
+  String get insightsChartCumulativeShort =>
+      'Ainda não há dias suficientes para um total acumulado';
+
+  @override
+  String get insightsChartDailyCaption => 'Hora por dia';
+
+  @override
+  String get insightsChartHourlyCaption => 'Tempo por hora';
+
+  @override
+  String get insightsChartPerDay => 'Por dia';
+
+  @override
+  String get insightsChartPerHour => 'Por hora';
+
+  @override
+  String get insightsChartPerWeek => 'Por semana';
+
+  @override
+  String get insightsChartRunningTotal => 'Total em execução';
+
+  @override
+  String get insightsChartTitle => 'Tempo por categoria';
+
+  @override
+  String get insightsChartWeeklyCaption => 'Tempo por semana';
+
+  @override
+  String get insightsChooseFocusCategories => 'Escolha categorias de foco';
+
+  @override
+  String get insightsCompare => 'Comparar';
+
+  @override
+  String get insightsCompareFullPeriod => 'período completo';
+
+  @override
+  String get insightsComparePrevious => 'Anterior';
+
+  @override
+  String get insightsCompareSameDays => 'mesmos dias';
+
+  @override
+  String get insightsCompareTooltip => 'Compare com o período anterior';
+
+  @override
+  String get insightsCompareVs => 'contra';
+
+  @override
+  String get insightsDeletedCategory => 'Categoria excluída';
+
+  @override
+  String get insightsDeltaNew => 'novo';
+
+  @override
+  String get insightsEmptyBody =>
+      'O tempo que você acompanha nas entradas e tarefas aparecerá aqui.';
+
+  @override
+  String get insightsEmptyChart => 'Não há dados neste intervalo';
+
+  @override
+  String get insightsEmptyPreviousPeriod => 'Mostrar o período anterior';
+
+  @override
+  String get insightsEmptyShowYear => 'Ver este ano';
+
+  @override
+  String get insightsEmptyTitle => 'Nenhum tempo monitorado neste intervalo';
+
+  @override
+  String get insightsFocusCategoriesEmpty => 'Nenhuma categoria ativa ainda.';
+
+  @override
+  String get insightsFocusCategoriesTitle => 'Categorias de foco';
+
+  @override
+  String get insightsKpiFocus => 'FOCO';
+
+  @override
+  String get insightsKpiFocusHelp => 'Categorias que você está assistindo';
+
+  @override
+  String get insightsKpiOther => 'OUTRO';
+
+  @override
+  String get insightsKpiOtherHelp => 'Todo o resto';
+
+  @override
+  String insightsKpiTopCategory(String category, String share) {
+    return 'A maioria em $category · $share';
+  }
+
+  @override
+  String get insightsKpiTotal => 'TOTAL';
+
+  @override
+  String get insightsLoadError =>
+      'Não foi possível carregar os dados de horário';
+
+  @override
+  String get insightsOtherCategories => 'Outro';
+
+  @override
+  String get insightsPartialWeek => 'semana parcial';
+
+  @override
+  String get insightsPeriodDay => 'Dia';
+
+  @override
+  String get insightsPeriodJump => 'Ir para um encontro';
+
+  @override
+  String get insightsPeriodMonth => 'Mês';
+
+  @override
+  String get insightsPeriodNext => 'Próximo período';
+
+  @override
+  String get insightsPeriodPrevious => 'Período anterior';
+
+  @override
+  String get insightsPeriodQuarter => 'Trimestre';
+
+  @override
+  String get insightsPeriodToDateSuffix => 'até agora';
+
+  @override
+  String get insightsPeriodWeek => 'Semana';
+
+  @override
+  String get insightsPeriodYear => 'Ano';
+
+  @override
+  String get insightsRangeMonthToDate => 'Este mês até agora';
+
+  @override
+  String get insightsRangeMtd => 'Este mês';
+
+  @override
+  String get insightsRangeYearToDate => 'Este ano até agora';
+
+  @override
+  String get insightsRangeYtd => 'Este ano';
+
+  @override
+  String get insightsRefreshError =>
+      'Não foi possível atualizar — mostrando os últimos dados carregados';
+
+  @override
+  String get insightsTableAvgPerDay => 'Média/dia';
+
+  @override
+  String get insightsTableCategory => 'CATEGORIA';
+
+  @override
+  String get insightsTableCompareNote =>
+      'A mudança é em relação ao período anterior';
+
+  @override
+  String get insightsTableCurrent => 'ATUAL';
+
+  @override
+  String get insightsTableDelta => 'Mudança';
+
+  @override
+  String get insightsTablePrevious => 'ANTERIOR';
+
+  @override
+  String get insightsTableShare => 'COMPARTILHE';
+
+  @override
+  String get insightsTableTotal => 'TOTAL';
+
+  @override
+  String get insightsTimeAnalysisTitle => 'Análise de Tempo';
+
+  @override
+  String get insightsUncategorized => 'Sem categoria';
+
+  @override
+  String get journalCopyImageLabel => 'Copiar imagem';
+
+  @override
+  String get journalDateFromLabel => 'Data de:';
+
+  @override
+  String get journalDateInvalid => 'Período inválido';
+
+  @override
+  String get journalDateLabel => 'Data';
+
+  @override
+  String get journalDateNowButton => 'Agora';
+
+  @override
+  String get journalDateSaveButton => 'Salvar';
+
+  @override
+  String get journalDateTimeRangeTitle => 'Data e hora';
+
+  @override
+  String get journalDateToLabel => 'Data para:';
+
+  @override
+  String get journalDeleteConfirm => 'SIM, EXCLUIR ESTA ENTRADA';
+
+  @override
+  String get journalDeleteHint => 'Excluir entrada';
+
+  @override
+  String get journalDeleteQuestion =>
+      'Deseja excluir este lançamento contábil manual?';
+
+  @override
+  String get journalDurationLabel => 'Duração';
+
+  @override
+  String get journalEndDateLabel => 'Data de término';
+
+  @override
+  String get journalEndsAnotherDayHint =>
+      'Escolha uma data de término separada';
+
+  @override
+  String get journalEndsAnotherDayLabel => 'Termina em outro dia';
+
+  @override
+  String get journalEndTimeLabel => 'Hora de término';
+
+  @override
+  String get journalFilterEntryTypesTitle => 'Tipos de entrada';
+
+  @override
+  String get journalFilterFlagged => 'Sinalizado';
+
+  @override
+  String get journalFilterPrivate => 'Privado';
+
+  @override
+  String get journalFilterShowTitle => 'Mostrar';
+
+  @override
+  String get journalFilterStarred => 'Com estrela';
+
+  @override
+  String get journalFilterTitle => 'Filtrar diário';
+
+  @override
+  String get journalHideLinkHint => 'Ocultar link';
+
+  @override
+  String get journalHideMapHint => 'Ocultar mapa';
+
+  @override
+  String get journalLinkedEntriesActivityFilterAudio => 'Áudio';
+
+  @override
+  String get journalLinkedEntriesActivityFilterCode => 'Código';
+
+  @override
+  String get journalLinkedEntriesActivityFilterImages => 'Imagens';
+
+  @override
+  String get journalLinkedEntriesActivityFilterTimer => 'Temporizador';
+
+  @override
+  String get journalLinkedEntriesFilterModalTitle => 'Filtrar e classificar';
+
+  @override
+  String get journalLinkedEntriesShowFlaggedOnly =>
+      'Mostrar apenas entradas sinalizadas';
+
+  @override
+  String get journalLinkedEntriesShowHidden => 'Mostrar entradas ocultas';
+
+  @override
+  String get journalLinkedEntriesSortLabel => 'Classificar por';
+
+  @override
+  String get journalLinkedEntriesSortNewestFirst => 'O mais novo primeiro';
+
+  @override
+  String get journalLinkedEntriesSortOldestFirst => 'Mais antigo primeiro';
+
+  @override
+  String get journalLinkedFromLabel => 'Vinculado de:';
+
+  @override
+  String get journalLinkFromHint => 'Link de';
+
+  @override
+  String get journalLinkToHint => 'Link para';
+
+  @override
+  String journalOvernightNextDay(String date) {
+    return 'Termina em $date (dia seguinte)';
+  }
+
+  @override
+  String get journalPrivateTooltip => 'apenas privado';
+
+  @override
+  String get journalSearchHint => 'Pesquisar diário...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic =>
+      'Defina a data e hora de término para agora';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Defina a data e hora de início para agora';
+
+  @override
+  String get journalShareHint => 'Compartilhar';
+
+  @override
+  String get journalShowLinkHint => 'Mostrar link';
+
+  @override
+  String get journalShowMapHint => 'Mostrar mapa';
+
+  @override
+  String get journalStartDateLabel => 'Data de início';
+
+  @override
+  String get journalStartTimeLabel => 'Hora de início';
+
+  @override
+  String get journalTodayButton => 'Hoje';
+
+  @override
+  String get journalToggleFlaggedTitle => 'Sinalizado';
+
+  @override
+  String get journalTogglePrivateTitle => 'Privado';
+
+  @override
+  String get journalToggleStarredTitle => 'Favorito';
+
+  @override
+  String get journalUnlinkConfirm => 'SIM, DESVINCULAR ENTRADA';
+
+  @override
+  String get journalUnlinkHint => 'Desvincular';
+
+  @override
+  String get journalUnlinkQuestion =>
+      'Tem certeza de que deseja desvincular esta entrada?';
+
+  @override
+  String get keyboardCommandActivate => 'Ativar item em foco';
+
+  @override
+  String get keyboardCommandCategoryCreation => 'Criação';
+
+  @override
+  String get keyboardCommandCategoryEditing => 'Edição';
+
+  @override
+  String get keyboardCommandCategoryGeneral => 'Geral';
+
+  @override
+  String get keyboardCommandCategoryListsAndControls => 'Listas e controles';
+
+  @override
+  String get keyboardCommandCategoryNavigation => 'Navegação';
+
+  @override
+  String get keyboardCommandCategoryView => 'Ver';
+
+  @override
+  String get keyboardCommandCreateInContext => 'Criar na visualização atual';
+
+  @override
+  String get keyboardCommandFocusSearch => 'Pesquisa de foco';
+
+  @override
+  String get keyboardCommandMoveDown => 'Mover o item em foco para baixo';
+
+  @override
+  String get keyboardCommandMoveUp => 'Mover o item em foco para cima';
+
+  @override
+  String keyboardCommandNavigate(String destination) {
+    return 'Vá para $destination';
+  }
+
+  @override
+  String get keyboardCommandNextRegion => 'Focar próximo painel';
+
+  @override
+  String get keyboardCommandOpenPalette => 'Abrir paleta de comandos';
+
+  @override
+  String get keyboardCommandPageDown => 'Descer uma página';
+
+  @override
+  String get keyboardCommandPageUp => 'Subir uma página';
+
+  @override
+  String get keyboardCommandPreviousRegion => 'Focar painel anterior';
+
+  @override
+  String get keyboardCommandRefresh => 'Atualizar visualização atual';
+
+  @override
+  String get keyboardCommandRename => 'Renomear item em foco';
+
+  @override
+  String get keyboardCommandSelectFirst => 'Selecione o primeiro item';
+
+  @override
+  String get keyboardCommandSelectLast => 'Selecione o último item';
+
+  @override
+  String get keyboardCommandSelectNext => 'Selecione o próximo item';
+
+  @override
+  String get keyboardCommandSelectPrevious => 'Selecione o item anterior';
+
+  @override
+  String get keyboardCommandToggle => 'Alternar item em foco';
+
+  @override
+  String get keyboardKeyAlt => 'Alt.';
+
+  @override
+  String get keyboardKeyArrowDown => 'Seta para baixo';
+
+  @override
+  String get keyboardKeyArrowLeft => 'Seta para a esquerda';
+
+  @override
+  String get keyboardKeyArrowRight => 'Seta para a direita';
+
+  @override
+  String get keyboardKeyArrowUp => 'Seta para cima';
+
+  @override
+  String get keyboardKeyControl => 'Ctrl';
+
+  @override
+  String get keyboardKeyDelete => 'Excluir';
+
+  @override
+  String get keyboardKeyEnd => 'Fim';
+
+  @override
+  String get keyboardKeyEnter => 'Entrar';
+
+  @override
+  String get keyboardKeyEscape => 'Fuga';
+
+  @override
+  String get keyboardKeyHome => 'Página inicial';
+
+  @override
+  String get keyboardKeyMinus => 'Menos';
+
+  @override
+  String get keyboardKeyOr => 'ou';
+
+  @override
+  String get keyboardKeyPageDown => 'Página para baixo';
+
+  @override
+  String get keyboardKeyPageUp => 'Página para cima';
+
+  @override
+  String get keyboardKeyPlus => 'Mais';
+
+  @override
+  String get keyboardKeyShift => 'Mudança';
+
+  @override
+  String get keyboardKeySpace => 'Espaço';
+
+  @override
+  String get keyboardResizeDividerLabel => 'Redimensionar painéis';
+
+  @override
+  String get keyboardShortcutsNoResults =>
+      'Nenhum atalho corresponde à sua pesquisa';
+
+  @override
+  String get keyboardShortcutsSearchHint => 'Atalhos de pesquisa…';
+
+  @override
+  String get keyboardShortcutsSubtitle =>
+      'Cada comando da área de trabalho e sua combinação atual de teclado.';
+
+  @override
+  String get keyboardShortcutsTitle => 'Atalhos de teclado';
+
+  @override
+  String knowledgeGraphAgeDaysAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dias atrás',
+      one: '1 dia atrás',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String knowledgeGraphAgeMonthsAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count meses atrás',
+      one: '1 mês atrás',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get knowledgeGraphAgeToday => 'hoje';
+
+  @override
+  String knowledgeGraphAgeWeeksAgo(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count semanas atrás',
+      one: '1 semana atrás',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get knowledgeGraphAgeYesterday => 'ontem';
+
+  @override
+  String get knowledgeGraphBack => 'Voltar';
+
+  @override
+  String get knowledgeGraphCloseDetails => 'Fechar detalhes';
+
+  @override
+  String get knowledgeGraphEmpty => 'Ainda não há links para explorar';
+
+  @override
+  String get knowledgeGraphEntryLoadError =>
+      'Não foi possível carregar esta entrada';
+
+  @override
+  String get knowledgeGraphEntryNotFound => 'Entrada não encontrada';
+
+  @override
+  String get knowledgeGraphError =>
+      'Não foi possível carregar o gráfico de conhecimento';
+
+  @override
+  String knowledgeGraphLinkedSection(int count) {
+    return 'VINCULADO · $count';
+  }
+
+  @override
+  String get knowledgeGraphMoreLinks => 'mais links';
+
+  @override
+  String knowledgeGraphNodeCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count nós',
+      one: '1 nó',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get knowledgeGraphNodeTypeAiSummary => 'Resumo de IA';
+
+  @override
+  String get knowledgeGraphNodeTypeAudioNote => 'Nota de áudio';
+
+  @override
+  String get knowledgeGraphNodeTypeChecklist => 'Lista de verificação';
+
+  @override
+  String get knowledgeGraphNodeTypeChecklistItem =>
+      'Item da lista de verificação';
+
+  @override
+  String get knowledgeGraphNodeTypeNote => 'Nota';
+
+  @override
+  String get knowledgeGraphNodeTypePhoto => 'Foto';
+
+  @override
+  String get knowledgeGraphNodeTypeProject => 'Projeto';
+
+  @override
+  String get knowledgeGraphNodeTypeRating => 'Avaliação';
+
+  @override
+  String get knowledgeGraphNodeTypeTask => 'Tarefa';
+
+  @override
+  String get knowledgeGraphOpenDetails => 'Abrir detalhes';
+
+  @override
+  String get knowledgeGraphRecenter => 'Recentrador';
+
+  @override
+  String get knowledgeGraphRecentToOlder => 'recente → mais antigo';
+
+  @override
+  String get knowledgeGraphRelationAiSource => 'Fonte de IA';
+
+  @override
+  String get knowledgeGraphRelationChecklist => 'lista de verificação';
+
+  @override
+  String get knowledgeGraphRelationInProject => 'em projeto';
+
+  @override
+  String get knowledgeGraphRelationLinkedTask => 'tarefa vinculada';
+
+  @override
+  String get knowledgeGraphRelationNoteLog => 'nota / registro';
+
+  @override
+  String get knowledgeGraphRelationRating => 'classificação';
+
+  @override
+  String get knowledgeGraphSummarySection => 'RESUMO';
+
+  @override
+  String get knowledgeGraphTitle => 'Gráfico de conhecimento';
+
+  @override
+  String get knowledgeGraphTooltip => 'Explorar links';
+
+  @override
+  String knowledgeGraphWalkHint(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count nós',
+      one: '1 node',
+    );
+    return 'Toque em um nó para caminhar · $_temp0';
+  }
+
+  @override
+  String get linkedFromCaption => 'de';
+
+  @override
+  String get linkedTaskImageBadge => 'Da tarefa vinculada';
+
+  @override
+  String get linkedTasksMenuTooltip => 'Opções de tarefas vinculadas';
+
+  @override
+  String get linkedTasksTitle => 'Tarefas Vinculadas';
+
+  @override
+  String get linkedToCaption => 'para';
+
+  @override
+  String get linkExistingTask => 'Vincular tarefa existente...';
+
+  @override
+  String get loggingDomainAgentRuntime => 'Tempo de execução do agente';
+
+  @override
+  String get loggingDomainAgentWorkflow => 'Fluxo de trabalho do agente';
+
+  @override
+  String get loggingDomainAi => 'IA';
+
+  @override
+  String get loggingDomainCalendar => 'Calendário e horário';
+
+  @override
+  String get loggingDomainChat => 'Bate-papo';
+
+  @override
+  String get loggingDomainDailyOs => 'SO diário';
+
+  @override
+  String get loggingDomainDatabase => 'Banco de dados';
+
+  @override
+  String get loggingDomainGeneral => 'Geral';
+
+  @override
+  String get loggingDomainHabits => 'Hábitos';
+
+  @override
+  String get loggingDomainHealth => 'Saúde';
+
+  @override
+  String get loggingDomainLabels => 'Etiquetas';
+
+  @override
+  String get loggingDomainLocation => 'Localização';
+
+  @override
+  String get loggingDomainNavigation => 'Navegação';
+
+  @override
+  String get loggingDomainNotifications => 'Notificações';
+
+  @override
+  String get loggingDomainOnboarding => 'Integração e FTUE';
+
+  @override
+  String get loggingDomainPersistence => 'Persistência';
+
+  @override
+  String get loggingDomainRatings => 'Avaliações';
+
+  @override
+  String get loggingDomainScreenshots => 'Capturas de tela';
+
+  @override
+  String get loggingDomainSettings => 'Configurações';
+
+  @override
+  String get loggingDomainSpeech => 'Fala e áudio';
+
+  @override
+  String get loggingDomainSync => 'Sincronizar';
+
+  @override
+  String get loggingDomainTasks => 'Tarefas e listas de verificação';
+
+  @override
+  String get loggingDomainTheming => 'Tema';
+
+  @override
+  String get loggingDomainWhatsNew => 'O que há de novo';
+
+  @override
+  String get maintenanceDeleteAgentDb => 'Excluir banco de dados de agentes';
+
+  @override
+  String get maintenanceDeleteAgentDbDescription =>
+      'Exclua o banco de dados de agentes e reinicie o aplicativo';
+
+  @override
+  String get maintenanceDeleteDatabaseConfirm => 'SIM, EXCLUIR BANCO DE DADOS';
+
+  @override
+  String maintenanceDeleteDatabaseQuestion(String databaseName) {
+    return 'Tem certeza de que deseja excluir o banco de dados $databaseName?';
+  }
+
+  @override
+  String get maintenanceDeleteEditorDb => 'Excluir banco de dados do editor';
+
+  @override
+  String get maintenanceDeleteEditorDbDescription =>
+      'Excluir banco de dados de rascunhos do editor';
+
+  @override
+  String get maintenanceDeleteSyncDb =>
+      'Excluir banco de dados de sincronização';
+
+  @override
+  String get maintenanceDeleteSyncDbDescription =>
+      'Excluir banco de dados de sincronização';
+
+  @override
+  String get maintenanceGenerateEmbeddings => 'Gerar incorporações';
+
+  @override
+  String get maintenanceGenerateEmbeddingsConfirm => 'SIM, GERAR';
+
+  @override
+  String get maintenanceGenerateEmbeddingsDescription =>
+      'Gere embeddings para entradas em categorias selecionadas';
+
+  @override
+  String get maintenanceGenerateEmbeddingsMessage =>
+      'Selecione categorias para gerar incorporações.';
+
+  @override
+  String maintenanceGenerateEmbeddingsProgress(
+    int processed,
+    int total,
+    int embedded,
+  ) {
+    String _temp0 = intl.Intl.pluralLogic(
+      total,
+      locale: localeName,
+      other: '$processed / $total entradas ($embedded incorporado)',
+      one: '$processed / $total entrada ($embedded incorporado)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get maintenancePopulatePhaseAgentEntities =>
+      'Entidades agentes de processamento...';
+
+  @override
+  String get maintenancePopulatePhaseAgentLinks =>
+      'Processando links de agente...';
+
+  @override
+  String get maintenancePopulatePhaseJournal =>
+      'Processando lançamentos contábeis manuais...';
+
+  @override
+  String get maintenancePopulatePhaseLinks => 'Processando links de entrada...';
+
+  @override
+  String get maintenancePopulateSequenceLog =>
+      'Preencher log de sequência de sincronização';
+
+  @override
+  String maintenancePopulateSequenceLogComplete(int count) {
+    return '$count entradas indexadas';
+  }
+
+  @override
+  String get maintenancePopulateSequenceLogConfirm => 'SIM, POPULAR';
+
+  @override
+  String get maintenancePopulateSequenceLogDescription =>
+      'Indexar entradas existentes para suporte de preenchimento';
+
+  @override
+  String get maintenancePopulateSequenceLogMessage =>
+      'Isso verificará todas as entradas do diário e as adicionará ao log da sequência de sincronização. Isso permite respostas de preenchimento para entradas criadas antes da adição desse recurso.';
+
+  @override
+  String get maintenancePurgeDeleted => 'Limpar itens excluídos';
+
+  @override
+  String get maintenancePurgeDeletedConfirm => 'Sim, limpe tudo';
+
+  @override
+  String get maintenancePurgeDeletedDescription =>
+      'Limpar todos os itens excluídos permanentemente';
+
+  @override
+  String get maintenancePurgeDeletedMessage =>
+      'Tem certeza de que deseja limpar todos os itens excluídos? Esta ação não pode ser desfeita.';
+
+  @override
+  String get maintenancePurgeSentOutbox =>
+      'Limpar itens antigos enviados da caixa de saída';
+
+  @override
+  String get maintenancePurgeSentOutboxConfirm => 'SIM, PURGA';
+
+  @override
+  String get maintenancePurgeSentOutboxDescription =>
+      'Exclua linhas da caixa de saída enviadas com mais de 7 dias e recupere o disco';
+
+  @override
+  String get maintenancePurgeSentOutboxQuestion =>
+      'Limpar itens da caixa de saída enviados há mais de 7 dias? Isso exclui linhas já enviadas em partes e executa VACUUM para recuperar o disco. Os itens pendentes e com erro são mantidos.';
+
+  @override
+  String get maintenanceRecreateFts5 => 'Recrie o índice de texto completo';
+
+  @override
+  String get maintenanceRecreateFts5Confirm => 'SIM, RECRIAR ÍNDICE';
+
+  @override
+  String get maintenanceRecreateFts5Description =>
+      'Recrie o índice de pesquisa de texto completo';
+
+  @override
+  String get maintenanceRecreateFts5Message =>
+      'Tem certeza de que deseja recriar o índice de texto completo? Isso pode levar algum tempo.';
+
+  @override
+  String get maintenanceReSync => 'Sincronizar novamente mensagens';
+
+  @override
+  String get maintenanceReSyncAgentEntities => 'Entidades agentes';
+
+  @override
+  String get maintenanceReSyncDescription =>
+      'Sincronizar novamente mensagens do servidor';
+
+  @override
+  String get maintenanceReSyncEntityTypes => 'Tipos de entidade';
+
+  @override
+  String get maintenanceReSyncJournalEntities => 'Entidades de diário';
+
+  @override
+  String get maintenanceReSyncSelectAtLeastOne =>
+      'Selecione pelo menos um tipo de entidade';
+
+  @override
+  String get maintenanceReSyncStart => 'Começar';
+
+  @override
+  String get maintenanceSyncDefinitions =>
+      'Sincronize mensuráveis, painéis, hábitos, categorias, configurações de IA';
+
+  @override
+  String get maintenanceSyncDefinitionsDescription =>
+      'Sincronize mensuráveis, painéis, hábitos, categorias e configurações de IA';
+
+  @override
+  String get manageLinks => 'Gerenciar links...';
+
+  @override
+  String get measurableDeleteConfirm => 'SIM, EXCLUIR ESTE MENSURÁVEL';
+
+  @override
+  String get measurableDeleteQuestion =>
+      'Deseja excluir este tipo de dados mensuráveis?';
+
+  @override
+  String get measurableNotFound => 'Mensurável não encontrado';
+
+  @override
+  String get measurementCommentHint => 'Adicione uma nota (opcional)';
+
+  @override
+  String get measurementCommentSemantic => 'Comentário, opcional';
+
+  @override
+  String measurementObservedAtChangeSemantic(String dateTime) {
+    return 'Observado em $dateTime. Alterar data e hora.';
+  }
+
+  @override
+  String get measurementQuickAddLabel => 'Registro rápido';
+
+  @override
+  String measurementQuickLogSemantic(String value) {
+    return 'Registrar $value imediatamente';
+  }
+
+  @override
+  String get measurementSaveError =>
+      'Não foi possível salvar esta medida. Tente novamente.';
+
+  @override
+  String get measurementSetObservedAtNowSemantic =>
+      'Definir data e hora observadas para agora';
+
+  @override
+  String get measurementTimeLabel => 'Hora';
+
+  @override
+  String measurementValueSemantic(String measurable) {
+    return 'Valor para $measurable';
+  }
+
+  @override
+  String get mediaShowInFileExplorerAction =>
+      'Mostrar no Explorador de Arquivos';
+
+  @override
+  String get mediaShowInFilesAction => 'Mostrar em arquivos';
+
+  @override
+  String get mediaShowInFinderAction => 'Mostrar no Finder';
+
+  @override
+  String get modalityAudioDescription =>
+      'Capacidades de processamento de áudio';
+
+  @override
+  String get modalityAudioName => 'Áudio';
+
+  @override
+  String get modalityImageDescription =>
+      'Capacidades de processamento de imagem';
+
+  @override
+  String get modalityImageName => 'Imagem';
+
+  @override
+  String get modalityTextDescription =>
+      'Conteúdo e processamento baseado em texto';
+
+  @override
+  String get modalityTextName => 'Texto';
+
+  @override
+  String get modelAddPageTitle => 'Adicionar modelo';
+
+  @override
+  String get modelEditBackTooltip => 'Voltar';
+
+  @override
+  String get modelEditDescriptionHint => 'Descreva este modelo';
+
+  @override
+  String get modelEditDescriptionLabel => 'Descrição';
+
+  @override
+  String get modelEditDisplayNameHint => 'Um nome amigável para este modelo';
+
+  @override
+  String get modelEditDisplayNameLabel => 'Nome de exibição';
+
+  @override
+  String get modelEditFunctionCallingDescription =>
+      'Este modelo suporta chamadas de funções e ferramentas.';
+
+  @override
+  String get modelEditFunctionCallingLabel => 'Chamada de função';
+
+  @override
+  String get modelEditGeminiThinkingModeLabel => 'Modo de pensamento de Gêmeos';
+
+  @override
+  String get modelEditInputModalitiesHint => 'Selecione os tipos de entrada';
+
+  @override
+  String get modelEditInputModalitiesLabel => 'Modalidades de entrada';
+
+  @override
+  String get modelEditLoadError => 'Falha ao carregar a configuração do modelo';
+
+  @override
+  String get modelEditMaxTokensHint =>
+      'Opcional – deixe em branco para ilimitado';
+
+  @override
+  String get modelEditMaxTokensLabel => 'Máximo de tokens de conclusão';
+
+  @override
+  String get modelEditModalityNoneSelected => 'Nenhum selecionado';
+
+  @override
+  String get modelEditOutputModalitiesHint => 'Selecione os tipos de saída';
+
+  @override
+  String get modelEditOutputModalitiesLabel => 'Modalidades de saída';
+
+  @override
+  String get modelEditPageTitle => 'Editar modelo';
+
+  @override
+  String get modelEditProviderHint => 'Selecione um provedor';
+
+  @override
+  String get modelEditProviderLabel => 'Provedor';
+
+  @override
+  String get modelEditProviderModelIdHint => 'por exemplo gpt-4-turbo';
+
+  @override
+  String get modelEditProviderModelIdLabel => 'ID do modelo do provedor';
+
+  @override
+  String get modelEditReasoningDescription =>
+      'Este modelo usa pensamento estendido/cadeia de pensamento.';
+
+  @override
+  String get modelEditReasoningLabel => 'Modelo de raciocínio';
+
+  @override
+  String get modelEditSaveButton => 'Salvar';
+
+  @override
+  String get modelEditSectionCapabilities => 'Capacidades';
+
+  @override
+  String get modelEditSectionIdentity => 'Identidade';
+
+  @override
+  String modelManagementSelectedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 's',
+      one: '',
+    );
+    return '$count modelo$_temp0 selecionado';
+  }
+
+  @override
+  String get multiSelectAddButton => 'Adicionar';
+
+  @override
+  String multiSelectAddButtonWithCount(int count) {
+    return 'Adicionar ($count)';
+  }
+
+  @override
+  String get multiSelectNoItemsFound => 'Nenhum item encontrado';
+
+  @override
+  String get navSidebarManualBrowserHint => 'Abre no seu navegador';
+
+  @override
+  String get navSidebarManualLabel => 'Manuais';
+
+  @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Mais, $count destinos adicionais',
+      one: 'Mais, 1 destino adicional',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get navTabTitleCalendar => 'DailyOS';
+
+  @override
+  String get navTabTitleEvents => 'Eventos';
+
+  @override
+  String get navTabTitleHabits => 'Hábitos';
+
+  @override
+  String get navTabTitleInsights => 'Informações';
+
+  @override
+  String get navTabTitleJournal => 'Diário de bordo';
+
+  @override
+  String get navTabTitleMore => 'Mais';
+
+  @override
+  String get navTabTitleProjects => 'Projetos';
+
+  @override
+  String get navTabTitleSettings => 'Configurações';
+
+  @override
+  String get navTabTitleTasks => 'Tarefas';
+
+  @override
+  String nestedAiResponsesTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 's',
+      one: '',
+    );
+    return '$count Respostas de IA$_temp0';
+  }
+
+  @override
+  String get noDefaultLanguage => 'Nenhum idioma padrão';
+
+  @override
+  String get noTasksFound => 'Nenhuma tarefa encontrada';
+
+  @override
+  String get noTasksToLink => 'Nenhuma tarefa disponível para vincular';
+
+  @override
+  String get notificationBellEmptySemantics =>
+      'Notificações, sem alertas não lidos';
+
+  @override
+  String get notificationBellTooltip => 'Notificações';
+
+  @override
+  String notificationBellUnseenSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'alerts',
+      one: 'alert',
+    );
+    return 'Notificações, $count não lidas $_temp0';
+  }
+
+  @override
+  String get notificationInboxDismiss => 'Ignorar notificação';
+
+  @override
+  String get notificationInboxEmpty => 'Vocês estão todos em dia.';
+
+  @override
+  String get notificationInboxError =>
+      'Não foi possível carregar as notificações.';
+
+  @override
+  String get notificationInboxTitle => 'Notificações';
+
+  @override
+  String get notificationSuggestionAttentionBodyFallback =>
+      'Abra a tarefa para revisar.';
+
+  @override
+  String notificationSuggestionAttentionTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sugestões precisam de sua atenção',
+      one: '1 sugestão precisa de sua atenção',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get onboardingApiKeyConnect => 'Conectar';
+
+  @override
+  String get onboardingApiKeyConnecting => 'Conectando…';
+
+  @override
+  String get onboardingApiKeyEnterKeyHint =>
+      'Insira uma chave válida para continuar.';
+
+  @override
+  String get onboardingApiKeyError =>
+      'Não foi possível conectar. Verifique sua chave e tente novamente.';
+
+  @override
+  String get onboardingApiKeyField => 'Chave de API';
+
+  @override
+  String get onboardingApiKeyGetKeyAt => 'Obtenha uma chave em';
+
+  @override
+  String get onboardingApiKeyHide => 'Ocultar chave';
+
+  @override
+  String get onboardingApiKeyInvalid =>
+      'Essa chave foi rejeitada. Verifique novamente e cole novamente.';
+
+  @override
+  String get onboardingApiKeyLocalNote =>
+      'Funciona no seu dispositivo – sem necessidade de chave.';
+
+  @override
+  String get onboardingApiKeyNoKeyHelp =>
+      'Novo aqui? Faça login, crie uma chave de API e cole-a – grátis para começar.';
+
+  @override
+  String get onboardingApiKeyReveal => 'Mostrar chave';
+
+  @override
+  String get onboardingApiKeyTitle => 'Cole sua chave de API';
+
+  @override
+  String onboardingApiKeyUnreachable(String providerName) {
+    return 'Não foi possível entrar em contato com $providerName. Verifique a chave ou sua conexão e tente novamente.';
+  }
+
+  @override
+  String get onboardingApiKeyVerifying => 'Verificando…';
+
+  @override
+  String get onboardingCaptureCategoryPrompt => 'Onde isso deveria pousar?';
+
+  @override
+  String get onboardingCaptureListening => 'Ouvindo… toque quando terminar';
+
+  @override
+  String get onboardingCaptureOrbLabel => 'Registre seu pensamento';
+
+  @override
+  String get onboardingCaptureRatherType => 'Em vez disso, digite?';
+
+  @override
+  String get onboardingCaptureReassurance =>
+      'Você poderá editar tudo a seguir.';
+
+  @override
+  String get onboardingCaptureThinking =>
+      'Transformando suas palavras em uma tarefa…';
+
+  @override
+  String get onboardingCaptureTypePrompt => 'Digite seu pensamento';
+
+  @override
+  String get onboardingCategoryAddOwn => 'Adicione o seu próprio';
+
+  @override
+  String get onboardingCategoryContinue => 'Continuar';
+
+  @override
+  String get onboardingCategoryExplanation =>
+      'Cada área da sua vida ganha seu próprio espaço. Escolha qualquer um que combine – ou adicione o seu próprio.';
+
+  @override
+  String get onboardingCategoryFamily => 'Família';
+
+  @override
+  String get onboardingCategoryFitness => 'Fitness';
+
+  @override
+  String get onboardingCategoryFriends => 'Amigos';
+
+  @override
+  String get onboardingCategoryTitle => 'Onde sua IA deve funcionar?';
+
+  @override
+  String get onboardingCategoryWhy => 'Por que áreas?';
+
+  @override
+  String onboardingCategoryWhyDetail(String provider) {
+    return 'Cada área pode usar sua própria IA. $provider fornecerá energia às áreas que você escolher aqui. Mais tarde, você poderá atribuir IAs diferentes a áreas diferentes.';
+  }
+
+  @override
+  String get onboardingCategoryWork => 'Trabalho';
+
+  @override
+  String get onboardingConnectGeminiName => 'Gêmeos';
+
+  @override
+  String get onboardingConnectGeminiTagline => 'Estados Unidos';
+
+  @override
+  String get onboardingConnectLessOptions => 'Menos opções';
+
+  @override
+  String get onboardingConnectMistralName => 'Mistral';
+
+  @override
+  String get onboardingConnectMistralTagline => 'União Europeia';
+
+  @override
+  String get onboardingConnectMoreOptions => 'Mais opções';
+
+  @override
+  String get onboardingConnectNotSure => 'Melious.ai é o padrão recomendado.';
+
+  @override
+  String get onboardingConnectOllamaName => 'Ollama';
+
+  @override
+  String get onboardingConnectOpenAiName => 'OpenAI';
+
+  @override
+  String get onboardingConnectQwenName => 'Qwen';
+
+  @override
+  String get onboardingConnectQwenTagline => 'China';
+
+  @override
+  String get onboardingConnectTitle =>
+      'Escolha o cérebro de IA para suas tarefas';
+
+  @override
+  String get onboardingFirstTaskCreatedHint =>
+      'Toque na sua tarefa para abri-la';
+
+  @override
+  String get onboardingFirstTaskCreatedTitle =>
+      'Sua primeira tarefa está pronta';
+
+  @override
+  String get onboardingFirstTaskGuidance =>
+      'Toque para falar e dizer o que precisa ser feito - Lotti transforma isso em uma tarefa real.';
+
+  @override
+  String get onboardingFirstTaskSuggestionDentist =>
+      'Marque uma consulta no dentista';
+
+  @override
+  String get onboardingFirstTaskSuggestionMeeting =>
+      'Prepare-se para a reunião de segunda-feira';
+
+  @override
+  String get onboardingFirstTaskSuggestionPlanWeek => 'Planeje minha semana';
+
+  @override
+  String get onboardingFirstTaskSuggestionsLabel =>
+      'Não está pronto para conversar? Comece com um destes:';
+
+  @override
+  String get onboardingFirstTaskTitle => 'Crie sua primeira tarefa';
+
+  @override
+  String get onboardingMetricsActiveDays => 'Dias ativos';
+
+  @override
+  String get onboardingMetricsActiveDaysInFirstSeven =>
+      'Dias ativos nos primeiros 7';
+
+  @override
+  String get onboardingMetricsBaselineCohort =>
+      'Coorte de linha de base (pré-FTUE)';
+
+  @override
+  String get onboardingMetricsInstallFirstSeenUtc =>
+      'Instalar visto pela primeira vez (UTC)';
+
+  @override
+  String get onboardingMetricsNo => 'não';
+
+  @override
+  String get onboardingMetricsReachedRealAha => 'Alcançado real aha';
+
+  @override
+  String get onboardingMetricsYes => 'sim';
+
+  @override
+  String get onboardingRecordingStyleAnalogue => 'Analógico - medidor VU';
+
+  @override
+  String get onboardingRecordingStyleContinue => 'Continuar';
+
+  @override
+  String get onboardingRecordingStyleExplanation =>
+      'Escolha uma aparência para o microfone. Você pode alterá-lo a qualquer momento em Configurações.';
+
+  @override
+  String get onboardingRecordingStyleModern => 'Moderno - orbe de energia';
+
+  @override
+  String get onboardingRecordingStyleTitle => 'Como deve ser a gravação?';
+
+  @override
+  String get onboardingRecordingStyleTryVoice => 'Tente com sua voz';
+
+  @override
+  String get onboardingSuccessContinue => 'Comece';
+
+  @override
+  String get onboardingSuccessSubtitle =>
+      'Seu cérebro de IA está conectado e pronto para transformar suas palavras em tarefas.';
+
+  @override
+  String get onboardingSuccessTitle => 'Você está pronto';
+
+  @override
+  String get onboardingWelcomeConnectButton => 'Escolha seu cérebro de IA';
+
+  @override
+  String get onboardingWelcomeMessage =>
+      'Conecte seu cérebro de IA, diga um pensamento e observe-o se tornar uma tarefa estruturada.';
+
+  @override
+  String get onboardingWelcomeSkipButton => 'Olhe ao redor primeiro';
+
+  @override
+  String get onboardingWelcomeTitle =>
+      'Fale. Lotti transforma isso em um plano.';
+
+  @override
+  String get optionalCategoryLabel => 'Categoria (opcional)';
+
+  @override
+  String get outboxActionRemove => 'Remover';
+
+  @override
+  String get outboxActionRetry => 'Tentar novamente';
+
+  @override
+  String get outboxFailedReassurance =>
+      'Ainda salvo neste dispositivo – ele será sincronizado assim que o problema for resolvido.';
+
+  @override
+  String get outboxFilterFailed => 'Falha';
+
+  @override
+  String get outboxFilterWaiting => 'Esperando';
+
+  @override
+  String get outboxMonitorAttachmentLabel => 'Anexo';
+
+  @override
+  String get outboxMonitorDelete => 'excluir';
+
+  @override
+  String get outboxMonitorDeleteConfirmLabel => 'Excluir';
+
+  @override
+  String get outboxMonitorDeleteConfirmMessage =>
+      'Tem certeza de que deseja excluir este item de sincronização? Esta ação não pode ser desfeita.';
+
+  @override
+  String get outboxMonitorDeleteFailed =>
+      'Falha na exclusão. Por favor, tente novamente.';
+
+  @override
+  String get outboxMonitorDeleteSuccess => 'Item excluído';
+
+  @override
+  String get outboxMonitorEmptyDescription =>
+      'Não há itens de sincronização nesta visualização.';
+
+  @override
+  String get outboxMonitorEmptyTitle => 'A caixa de saída está limpa';
+
+  @override
+  String get outboxMonitorFetchFailed =>
+      'Não foi possível carregar a caixa de saída. Puxe para atualizar e tente novamente.';
+
+  @override
+  String get outboxMonitorLabelError => 'erro';
+
+  @override
+  String get outboxMonitorLabelPending => 'pendente';
+
+  @override
+  String get outboxMonitorLabelSent => 'enviado';
+
+  @override
+  String get outboxMonitorLabelSuccess => 'sucesso';
+
+  @override
+  String get outboxMonitorNoAttachment => 'sem apego';
+
+  @override
+  String get outboxMonitorPayloadSizeLabel => 'Tamanho';
+
+  @override
+  String get outboxMonitorRetries => 'novas tentativas';
+
+  @override
+  String get outboxMonitorRetriesLabel => 'Novas tentativas';
+
+  @override
+  String get outboxMonitorRetry => 'tente novamente';
+
+  @override
+  String get outboxMonitorRetryConfirmLabel => 'Tente novamente agora';
+
+  @override
+  String get outboxMonitorRetryConfirmMessage =>
+      'Tentar novamente este item de sincronização agora?';
+
+  @override
+  String get outboxMonitorRetryFailed =>
+      'Falha na nova tentativa. Por favor, tente novamente.';
+
+  @override
+  String get outboxMonitorRetryQueued => 'Nova tentativa agendada';
+
+  @override
+  String get outboxMonitorSubjectLabel => 'Assunto';
+
+  @override
+  String get outboxMonitorVolumeChartTitle => 'Volume de sincronização diária';
+
+  @override
+  String get outboxRemoveConfirmMessage =>
+      'Esta alteração ainda não foi sincronizada. Removê-lo aqui significa que ele não alcançará seus outros dispositivos. Ele permanece neste dispositivo.';
+
+  @override
+  String get outboxRemoveConfirmTitle => 'Remover da fila?';
+
+  @override
+  String get outboxRetryAll => 'Tentar tudo novamente';
+
+  @override
+  String get outboxShowDetails => 'Mostrar detalhes técnicos';
+
+  @override
+  String get outboxStatusFailed => 'Não foi possível enviar';
+
+  @override
+  String get outboxStatusSending => 'Enviando';
+
+  @override
+  String get outboxStatusSent => 'Enviado';
+
+  @override
+  String get outboxStatusWaiting => 'Esperando para enviar';
+
+  @override
+  String outboxSummaryFailed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens não puderam ser enviados',
+      one: '1 item não pôde ser enviado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String outboxSummaryOffline(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens serão enviados quando você se reconectar',
+      one: '1 item será enviado quando você se reconectar',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String outboxSummarySending(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Enviando $count itens…',
+      one: 'Enviando 1 item…',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get outboxSummarySynced => 'Tudo está sincronizado';
+
+  @override
+  String outboxSummaryWaiting(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens aguardando envio',
+      one: '1 item aguardando envio',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String outboxTriedTimes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Tentei $count vezes',
+      one: 'Tentei uma vez',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get panasCompletionText => 'Obrigado por preencher o PANAS!';
+
+  @override
+  String get panasCompletionTitle => 'Concluído';
+
+  @override
+  String get panasEmotionActive => 'Ativo';
+
+  @override
+  String get panasEmotionAfraid => 'Com medo';
+
+  @override
+  String get panasEmotionAlert => 'Alerta';
+
+  @override
+  String get panasEmotionAshamed => 'Envergonhado';
+
+  @override
+  String get panasEmotionAttentive => 'Atento';
+
+  @override
+  String get panasEmotionDetermined => 'Determinado';
+
+  @override
+  String get panasEmotionDistressed => 'Angustiado';
+
+  @override
+  String get panasEmotionEnthusiastic => 'Entusiasmado';
+
+  @override
+  String get panasEmotionExcited => 'Animado';
+
+  @override
+  String get panasEmotionGuilty => 'Culpado';
+
+  @override
+  String get panasEmotionHostile => 'Hostil';
+
+  @override
+  String get panasEmotionInspired => 'Inspirado';
+
+  @override
+  String get panasEmotionInterested => 'Interessado';
+
+  @override
+  String get panasEmotionIrritable => 'Irritável';
+
+  @override
+  String get panasEmotionJittery => 'Nervoso';
+
+  @override
+  String get panasEmotionNervous => 'Nervoso';
+
+  @override
+  String get panasEmotionProud => 'Orgulhoso';
+
+  @override
+  String get panasEmotionScared => 'Assustado';
+
+  @override
+  String get panasEmotionStrong => 'Forte';
+
+  @override
+  String get panasEmotionUpset => 'Chateado';
+
+  @override
+  String get panasInstructionFootnote =>
+      'Watson, D., Clark, LA e Tellegen, A. (1988). Desenvolvimento e validação de medidas breves de afeto positivo e negativo: As escalas PANAS. Jornal de Personalidade e Psicologia Social, 54(6), 1063–1070.';
+
+  @override
+  String get panasInstructionText =>
+      'Indique até que ponto você se sente assim agora, ou seja, no momento presente.\n\n1 - Muito pouco ou nada,\n2 – Um pouco,\n3—Moderadamente,\n4 – Bastante,\n5—Extremamente';
+
+  @override
+  String get panasInstructionTitle =>
+      'O Cronograma de Afetos Positivos e Negativos (PANAS; Watson et al., 1988)';
+
+  @override
+  String get panasScaleALittle => 'Um pouco';
+
+  @override
+  String get panasScaleExtremely => 'Extremamente';
+
+  @override
+  String get panasScaleModerately => 'Moderadamente';
+
+  @override
+  String get panasScaleQuiteABit => 'Um pouco';
+
+  @override
+  String get panasScaleVerySlightlyOrNotAtAll => 'Muito pouco ou nada';
+
+  @override
+  String get privateLabel => 'Privado';
+
+  @override
+  String get privateSwitchDescription =>
+      'Visível apenas quando entradas privadas são mostradas';
+
+  @override
+  String get projectAgentNotProvisioned =>
+      'Nenhum agente de projeto foi provisionado para este projeto ainda.';
+
+  @override
+  String get projectAgentSectionTitle => 'Agente';
+
+  @override
+  String projectCountSummary(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count projetos',
+      one: '$count projeto',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectCreateButton => 'Novo Projeto';
+
+  @override
+  String get projectCreateTitle => 'Criar projeto';
+
+  @override
+  String get projectDetailTitle => 'Detalhes do projeto';
+
+  @override
+  String get projectErrorCreateFailed => 'Erro ao criar projeto.';
+
+  @override
+  String get projectErrorLoadFailed => 'Falha ao carregar dados do projeto.';
+
+  @override
+  String get projectErrorLoadProjects => 'Erro ao carregar projetos';
+
+  @override
+  String get projectErrorUpdateFailed =>
+      'Falha ao atualizar o projeto. Por favor, tente novamente.';
+
+  @override
+  String get projectFilterLabel => 'Projeto';
+
+  @override
+  String get projectHealthBandAtRisk => 'Em risco';
+
+  @override
+  String get projectHealthBandBlocked => 'Bloqueado';
+
+  @override
+  String get projectHealthBandOnTrack => 'No caminho certo';
+
+  @override
+  String get projectHealthBandSurviving => 'Sobrevivendo';
+
+  @override
+  String get projectHealthBandWatch => 'Assistir';
+
+  @override
+  String get projectHealthSectionTitle => 'Saúde do projeto';
+
+  @override
+  String projectHealthSummary(int projectCount, int taskCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      projectCount,
+      locale: localeName,
+      other: '$projectCount projetos',
+      one: '$projectCount projeto',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      taskCount,
+      locale: localeName,
+      other: '$taskCount tarefas',
+      one: '$taskCount tarefa',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get projectHealthTitle => 'Projetos';
+
+  @override
+  String projectLinkedTaskCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas vinculadas',
+      one: '$count tarefas vinculadas',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectLinkedTasks => 'Tarefas Vinculadas';
+
+  @override
+  String get projectManageTooltip => 'Gerenciar projetos';
+
+  @override
+  String get projectNoLinkedTasks => 'Nenhuma tarefa vinculada ainda';
+
+  @override
+  String get projectNoProjects => 'Ainda não há projetos';
+
+  @override
+  String get projectNotFound => 'Projeto não encontrado';
+
+  @override
+  String get projectPickerLabel => 'Projeto';
+
+  @override
+  String get projectPickerUnassigned => 'Nenhum projeto';
+
+  @override
+  String get projectRecommendationDismissTooltip => 'Dispensar';
+
+  @override
+  String get projectRecommendationResolveTooltip => 'Marcar como resolvido';
+
+  @override
+  String get projectRecommendationsTitle => 'Próximas etapas recomendadas';
+
+  @override
+  String get projectRecommendationUpdateError =>
+      'Não foi possível atualizar a recomendação. Por favor, tente novamente.';
+
+  @override
+  String get projectsFilterStatusLabel => 'Estado:';
+
+  @override
+  String get projectsFilterTooltip => 'Filtrar projetos';
+
+  @override
+  String get projectShowcaseAiReportTitle => 'Relatório de IA';
+
+  @override
+  String projectShowcaseBlockedLegend(int count) {
+    return '$count bloqueado';
+  }
+
+  @override
+  String projectShowcaseBlockedTaskCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas bloqueadas',
+      one: '$count tarefas bloqueadas',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectShowcaseCompletedLegend(int count) {
+    return '$count concluído';
+  }
+
+  @override
+  String get projectShowcaseDescriptionTitle => 'Descrição';
+
+  @override
+  String projectShowcaseDueDate(String date) {
+    return 'Vencimento em $date';
+  }
+
+  @override
+  String get projectShowcaseHealthScoreDescription =>
+      'Essa pontuação é baseada na velocidade da tarefa, nos bloqueadores e no tempo restante até o prazo final.';
+
+  @override
+  String get projectShowcaseHealthScoreTitle => 'Pontuação de saúde';
+
+  @override
+  String get projectShowcaseNoResults =>
+      'Nenhum projeto corresponde à sua pesquisa.';
+
+  @override
+  String get projectShowcaseOneOnOneReviewsTab => 'Avaliações individuais';
+
+  @override
+  String get projectShowcaseOngoing => 'Em andamento';
+
+  @override
+  String get projectShowcaseProjectTasksTab => 'Tarefas do Projeto';
+
+  @override
+  String get projectShowcaseSearchHint => 'Pesquisar projetos';
+
+  @override
+  String projectShowcaseSessionsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sessões',
+      one: '$count sessão',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectShowcaseTasksCompleted(int completed, int total) {
+    String _temp0 = intl.Intl.pluralLogic(
+      total,
+      locale: localeName,
+      other: '$completed/$total tarefas concluídas',
+      one: '$completed/$total tarefas concluídas',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectShowcaseUpdatedHoursAgo(int hours) {
+    return 'Atualizado há ${hours}h ↻';
+  }
+
+  @override
+  String projectShowcaseUpdatedMinutesAgo(int minutes) {
+    return 'Atualizado há ${minutes}m ↻';
+  }
+
+  @override
+  String get projectShowcaseUsefulness => 'Utilidade';
+
+  @override
+  String get projectShowcaseViewBlocker => 'Ver bloqueador';
+
+  @override
+  String get projectStatusActive => 'Ativo';
+
+  @override
+  String get projectStatusArchived => 'Arquivado';
+
+  @override
+  String get projectStatusChangeTitle => 'Alterar status';
+
+  @override
+  String get projectStatusCompleted => 'Concluído';
+
+  @override
+  String get projectStatusMonitoring => 'Monitoramento';
+
+  @override
+  String get projectStatusOnHold => 'Em espera';
+
+  @override
+  String get projectStatusOpen => 'Abrir';
+
+  @override
+  String get projectSummaryOutdated => 'Resumo desatualizado.';
+
+  @override
+  String projectSummaryOutdatedScheduled(String date, String time) {
+    return 'Resumo desatualizado. Próxima atualização $date às $time.';
+  }
+
+  @override
+  String get projectTargetDateLabel => 'Data prevista';
+
+  @override
+  String get projectTitleLabel => 'Título do projeto';
+
+  @override
+  String get projectTitleRequired => 'O título do projeto não pode ficar vazio';
+
+  @override
+  String get promptDefaultModelBadge => 'Padrão';
+
+  @override
+  String get promptGenerationCardTitle => 'Prompt de codificação AI';
+
+  @override
+  String get promptGenerationCopiedSnackbar =>
+      'Prompt copiado para a área de transferência';
+
+  @override
+  String get promptGenerationCopyButton => 'Copiar prompt';
+
+  @override
+  String get promptGenerationCopyTooltip =>
+      'Copiar prompt para a área de transferência';
+
+  @override
+  String get promptGenerationExpandTooltip => 'Mostrar prompt completo';
+
+  @override
+  String get promptGenerationFullPromptLabel => 'Alerta completo:';
+
+  @override
+  String get promptSelectionModalTitle => 'Selecione o prompt pré-configurado';
+
+  @override
+  String get provisionedSyncBundleImported =>
+      'Código de provisionamento importado';
+
+  @override
+  String get provisionedSyncConfigureButton => 'Configurar';
+
+  @override
+  String get provisionedSyncCopiedToClipboard =>
+      'Copiado para a área de transferência';
+
+  @override
+  String get provisionedSyncDisconnect => 'Desconectar';
+
+  @override
+  String get provisionedSyncDone => 'Sincronização configurada com sucesso';
+
+  @override
+  String get provisionedSyncError => 'Falha na configuração';
+
+  @override
+  String get provisionedSyncErrorConfigurationFailed =>
+      'Ocorreu um erro durante a configuração. Por favor, tente novamente.';
+
+  @override
+  String get provisionedSyncErrorLoginFailed =>
+      'Falha no login. Verifique suas credenciais e tente novamente.';
+
+  @override
+  String get provisionedSyncImportButton => 'Importar';
+
+  @override
+  String get provisionedSyncImportHint =>
+      'Cole o código de provisionamento aqui';
+
+  @override
+  String get provisionedSyncImportTitle => 'Configuração de sincronização';
+
+  @override
+  String get provisionedSyncInvalidBundle =>
+      'Código de provisionamento inválido';
+
+  @override
+  String get provisionedSyncJoiningRoom =>
+      'Entrando na sala de sincronização...';
+
+  @override
+  String get provisionedSyncLoggingIn => 'Fazendo login...';
+
+  @override
+  String get provisionedSyncPasteClipboard => 'Colar da área de transferência';
+
+  @override
+  String get provisionedSyncReady =>
+      'Digitalize este código QR no seu dispositivo móvel';
+
+  @override
+  String get provisionedSyncRetry => 'Tentar novamente';
+
+  @override
+  String get provisionedSyncRotatingPassword => 'Protegendo a conta...';
+
+  @override
+  String get provisionedSyncScanButton => 'Digitalize o código QR';
+
+  @override
+  String get provisionedSyncShowQr => 'Mostrar QR de provisionamento';
+
+  @override
+  String get provisionedSyncSubtitle =>
+      'Configurar a sincronização de um pacote de provisionamento';
+
+  @override
+  String get provisionedSyncSummaryHomeserver => 'Servidor doméstico';
+
+  @override
+  String get provisionedSyncSummaryRoom => 'Quarto';
+
+  @override
+  String get provisionedSyncSummaryUser => 'Usuário';
+
+  @override
+  String get provisionedSyncTitle => 'Sincronização provisionada';
+
+  @override
+  String get provisionedSyncVerifyDevicesTitle => 'Verificação de dispositivo';
+
+  @override
+  String get queueCatchUpNowButton => 'Acompanhe agora';
+
+  @override
+  String get queueCatchUpNowDone =>
+      'Catch-up chutado – a fila está se esgotando.';
+
+  @override
+  String queueCatchUpNowError(String reason) {
+    return 'Falha na atualização: $reason';
+  }
+
+  @override
+  String get queueDepthCardEmpty => 'Fila vazia – o trabalhador está em dia.';
+
+  @override
+  String get queueDepthCardLoading => 'Lendo profundidade da fila…';
+
+  @override
+  String get queueDepthCardTitle => 'Fila de entrada';
+
+  @override
+  String get queueFetchAllHistoryCancel => 'Cancelar';
+
+  @override
+  String queueFetchAllHistoryCancelled(int events) {
+    String _temp0 = intl.Intl.pluralLogic(
+      events,
+      locale: localeName,
+      other: '$events events',
+      one: '1 event',
+      zero: 'no events',
+    );
+    return 'Cancelado — $_temp0 buscados até agora.';
+  }
+
+  @override
+  String get queueFetchAllHistoryClose => 'Fechar';
+
+  @override
+  String get queueFetchAllHistoryDescription =>
+      'Coloca todo o histórico visível da sala na fila. É seguro cancelar; uma execução posterior é retomada de onde a paginação parou.';
+
+  @override
+  String queueFetchAllHistoryDone(int events, int pages) {
+    String _temp0 = intl.Intl.pluralLogic(
+      pages,
+      locale: localeName,
+      other: '$pages páginas',
+      one: '1 page',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      pages,
+      locale: localeName,
+      other: '$pages páginas',
+      one: '1 page',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      events,
+      locale: localeName,
+      other: 'Buscado $events eventos em $_temp0.',
+      one: 'Buscado 1 evento em $_temp1.',
+      zero: 'Nenhum evento obtido.',
+    );
+    return '$_temp2';
+  }
+
+  @override
+  String queueFetchAllHistoryError(String reason) {
+    return 'Busca interrompida: $reason';
+  }
+
+  @override
+  String get queueFetchAllHistoryErrorUnknown => 'Fetch parou inesperadamente.';
+
+  @override
+  String queueFetchAllHistoryProgress(int events, int pages) {
+    String _temp0 = intl.Intl.pluralLogic(
+      events,
+      locale: localeName,
+      other: 'Página $pages · $events eventos obtidos',
+      one: 'Página $pages · 1 evento obtido',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get queueFetchAllHistoryTitle => 'Buscando histórico';
+
+  @override
+  String queueSkippedBadge(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ignorado',
+      one: '1 ignorado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String queueSkippedCardBody(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count eventos de sincronização dos quais a fila desistiu. Toque em tentar novamente para tentar novamente.',
+      one:
+          '1 evento de sincronização do qual a fila desistiu. Toque em tentar novamente para tentar novamente.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get queueSkippedCardTitle => 'Eventos ignorados';
+
+  @override
+  String get queueSkippedRetryAll => 'Tentar novamente eventos ignorados';
+
+  @override
+  String queueSkippedRetryAllDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count eventos na fila para nova tentativa.',
+      one: '1 evento na fila para nova tentativa.',
+      zero: 'Nenhum evento ignorado para nova tentativa.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String queueSkippedRetryAllError(String reason) {
+    return 'Falha na nova tentativa: $reason';
+  }
+
+  @override
+  String get referenceImageContinue => 'Continuar';
+
+  @override
+  String referenceImageContinueWithCount(int count) {
+    return 'Continuar ($count)';
+  }
+
+  @override
+  String get referenceImageLoadError =>
+      'Falha ao carregar imagens. Por favor, tente novamente.';
+
+  @override
+  String get referenceImageSelectionSubtitle =>
+      'Escolha até 5 imagens para orientar o estilo visual da IA';
+
+  @override
+  String get referenceImageSelectionTitle => 'Selecione imagens de referência';
+
+  @override
+  String get referenceImageSkip => 'Pular';
+
+  @override
+  String get saveButton => 'Salvar';
+
+  @override
+  String get saveButtonLabel => 'Salvar';
+
+  @override
+  String get saveLabel => 'Salvar';
+
+  @override
+  String get saveShortcutTooltip => 'Salvar — Ctrl+S (⌘S no Mac)';
+
+  @override
+  String get saveSuccessful => 'Salvo com sucesso';
+
+  @override
+  String get searchHint => 'Pesquisar...';
+
+  @override
+  String get searchModeFullText => 'Texto Completo';
+
+  @override
+  String get searchModeVector => 'Vetor';
+
+  @override
+  String get searchTasksHint => 'Pesquisar tarefas...';
+
+  @override
+  String get selectButton => 'Selecione';
+
+  @override
+  String get selectColor => 'Selecione uma cor';
+
+  @override
+  String get selectLanguage => 'Selecione o idioma';
+
+  @override
+  String get sessionRatingCardLabel => 'Classificação da sessão';
+
+  @override
+  String get sessionRatingChallengeJustRight => 'Certo';
+
+  @override
+  String get sessionRatingChallengeTooEasy => 'Muito fácil';
+
+  @override
+  String get sessionRatingChallengeTooHard => 'Muito desafiador';
+
+  @override
+  String get sessionRatingDifficultyLabel => 'Este trabalho pareceu...';
+
+  @override
+  String get sessionRatingEditButton => 'Editar classificação';
+
+  @override
+  String get sessionRatingEnergyQuestion => 'Quão energizado você se sentiu?';
+
+  @override
+  String get sessionRatingFocusQuestion => 'Quão focado você estava?';
+
+  @override
+  String get sessionRatingNoteHint => 'Nota rápida (opcional)';
+
+  @override
+  String get sessionRatingProductivityQuestion =>
+      'Quão produtiva foi esta sessão?';
+
+  @override
+  String get sessionRatingRateAction => 'Avaliar sessão';
+
+  @override
+  String get sessionRatingSaveButton => 'Salvar';
+
+  @override
+  String get sessionRatingSaveError =>
+      'Falha ao salvar a classificação. Por favor, tente novamente.';
+
+  @override
+  String get sessionRatingSkipButton => 'Pular';
+
+  @override
+  String get sessionRatingTitle => 'Avalie esta sessão';
+
+  @override
+  String get sessionRatingViewAction => 'Ver classificação';
+
+  @override
+  String get settingsAboutAppInformation => 'Informações do aplicativo';
+
+  @override
+  String get settingsAboutAppTagline => 'Seu diário pessoal';
+
+  @override
+  String get settingsAboutBuildType => 'Tipo de construção';
+
+  @override
+  String get settingsAboutDailyOsPersonalizationTitle =>
+      'Personalização diária do sistema operacional';
+
+  @override
+  String get settingsAboutDailyOsUserNameHelper =>
+      'Usado para a saudação diária do sistema operacional e sincronizado em seus dispositivos.';
+
+  @override
+  String get settingsAboutDailyOsUserNameLabel => 'Seu nome';
+
+  @override
+  String get settingsAboutJournalEntries => 'Lançamentos de diário';
+
+  @override
+  String get settingsAboutPlatform => 'Plataforma';
+
+  @override
+  String get settingsAboutTitle => 'Sobre Lotti';
+
+  @override
+  String get settingsAboutVersion => 'Versão';
+
+  @override
+  String get settingsAboutYourData => 'Seus dados';
+
+  @override
+  String get settingsAdvancedAboutSubtitle =>
+      'Saiba mais sobre o aplicativo Lotti';
+
+  @override
+  String get settingsAdvancedHealthImportSubtitle =>
+      'Importe dados relacionados à saúde de fontes externas';
+
+  @override
+  String get settingsAdvancedMaintenanceSubtitle =>
+      'Execute tarefas de manutenção para otimizar o desempenho do aplicativo';
+
+  @override
+  String get settingsAdvancedManualLanguageSubtitle =>
+      'Escolha em qual idioma abrir o Manual Lotti';
+
+  @override
+  String get settingsAdvancedOutboxSubtitle =>
+      'Gerenciar itens de sincronização';
+
+  @override
+  String get settingsAdvancedSubtitle => 'Configurações avançadas e manutenção';
+
+  @override
+  String get settingsAdvancedTitle => 'Configurações avançadas';
+
+  @override
+  String get settingsAgentsInstancesSubtitle => 'Agentes em execução';
+
+  @override
+  String get settingsAgentsPendingWakesSubtitle => 'Despertadores programados';
+
+  @override
+  String get settingsAgentsSoulsSubtitle =>
+      'Personalidades de agentes de longa vida';
+
+  @override
+  String get settingsAgentsStatsSubtitle => 'Uso e atividade de token';
+
+  @override
+  String get settingsAgentsTemplatesSubtitle =>
+      'Projetos de agente compartilhado';
+
+  @override
+  String get settingsAiModelsSubtitle =>
+      'Linhas e recursos do modelo por provedor';
+
+  @override
+  String get settingsAiModelsTitle => 'Modelos';
+
+  @override
+  String get settingsAiProfilesSubtitle => 'Provedores e modelos';
+
+  @override
+  String get settingsAiProfilesTitle => 'Perfis de inferência';
+
+  @override
+  String get settingsAiProvidersSubtitle =>
+      'Provedores e chaves de IA conectada';
+
+  @override
+  String get settingsAiProvidersTitle => 'Provedores';
+
+  @override
+  String get settingsAiSubtitle =>
+      'Configurar provedores, modelos e prompts de IA';
+
+  @override
+  String get settingsAiTitle => 'Configurações de IA';
+
+  @override
+  String get settingsAiUsageSubtitle =>
+      'Custo, energia e CO₂e das chamadas de IA';
+
+  @override
+  String get settingsAiUsageTitle => 'Uso e impacto';
+
+  @override
+  String get settingsBeamPageEditModelTitle => 'Editar modelo';
+
+  @override
+  String get settingsBeamPageEditProfileTitle => 'Editar perfil';
+
+  @override
+  String get settingsCategoriesCreateTitle => 'Criar categoria';
+
+  @override
+  String get settingsCategoriesDetailsLabel => 'Editar categoria';
+
+  @override
+  String get settingsCategoriesEmptyState => 'Nenhuma categoria ainda';
+
+  @override
+  String get settingsCategoriesEmptyStateHint =>
+      'Crie uma categoria para organizar suas entradas';
+
+  @override
+  String get settingsCategoriesErrorLoading => 'Erro ao carregar categorias';
+
+  @override
+  String get settingsCategoriesNameLabel => 'Nome da categoria';
+
+  @override
+  String settingsCategoriesNoMatchQuery(String query) {
+    return 'Nenhuma categoria corresponde a \"$query\"';
+  }
+
+  @override
+  String get settingsCategoriesSearchHint => 'Categorias de pesquisa…';
+
+  @override
+  String get settingsCategoriesSubtitle => 'Categorias com configurações de IA';
+
+  @override
+  String settingsCategoriesTaskCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas',
+      one: '$count tarefa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settingsCategoriesTitle => 'Categorias';
+
+  @override
+  String get settingsCelebrationsChecklistDescription =>
+      'Um estalo e faíscas quando você marca um item';
+
+  @override
+  String get settingsCelebrationsChecklistTitle =>
+      'Itens da lista de verificação';
+
+  @override
+  String get settingsCelebrationsCustomizeTitle => 'Personalizar';
+
+  @override
+  String get settingsCelebrationsCustomizeTooltip => 'Personalize este estilo';
+
+  @override
+  String get settingsCelebrationsEnabledDescription =>
+      'Chave mestre para conclusão floresce. Off oculta todas as animações; a sensação ao toque mantém seu próprio interruptor.';
+
+  @override
+  String get settingsCelebrationsEnabledTitle => 'Animações de celebração';
+
+  @override
+  String get settingsCelebrationsGroupLook => 'Olha';
+
+  @override
+  String get settingsCelebrationsGroupMotion => 'Movimento';
+
+  @override
+  String get settingsCelebrationsGroupShape => 'Forma';
+
+  @override
+  String get settingsCelebrationsHabitsDescription =>
+      'Brilho e faíscas quando você completa um hábito';
+
+  @override
+  String get settingsCelebrationsHabitsTitle => 'Hábitos';
+
+  @override
+  String get settingsCelebrationsHapticsDescription =>
+      'Um breve zumbido quando você termina algo – independente da animação.';
+
+  @override
+  String get settingsCelebrationsHapticsTitle => 'Háptica de conclusão';
+
+  @override
+  String get settingsCelebrationsKnobClearCenter => 'Folga central';
+
+  @override
+  String get settingsCelebrationsKnobCount => 'Partículas';
+
+  @override
+  String get settingsCelebrationsKnobDescClearCenter =>
+      'Espaço vazio no centro';
+
+  @override
+  String get settingsCelebrationsKnobDescCount => 'Quantas partículas voam';
+
+  @override
+  String get settingsCelebrationsKnobDescFallout =>
+      'Quão longe as faíscas descem';
+
+  @override
+  String get settingsCelebrationsKnobDescFanSpread => 'Largura do ventilador';
+
+  @override
+  String get settingsCelebrationsKnobDescGlow => 'Força do brilho';
+
+  @override
+  String get settingsCelebrationsKnobDescGravity =>
+      'Com que rapidez as partículas caem';
+
+  @override
+  String get settingsCelebrationsKnobDescHalo => 'Força do halo';
+
+  @override
+  String get settingsCelebrationsKnobDescInnerRing => 'Tamanho do anel interno';
+
+  @override
+  String get settingsCelebrationsKnobDescLaunch => 'Atraso antes da explosão';
+
+  @override
+  String get settingsCelebrationsKnobDescPop => 'Quando eles estouram';
+
+  @override
+  String get settingsCelebrationsKnobDescReach =>
+      'Quão longe as partículas viajam';
+
+  @override
+  String get settingsCelebrationsKnobDescRise =>
+      'Como as partículas altas sobem';
+
+  @override
+  String get settingsCelebrationsKnobDescSize =>
+      'Qual é o tamanho de cada partícula';
+
+  @override
+  String get settingsCelebrationsKnobDescSpeedSpread =>
+      'Variação na velocidade das partículas';
+
+  @override
+  String get settingsCelebrationsKnobDescSpin => 'Quão rápido as peças giram';
+
+  @override
+  String get settingsCelebrationsKnobDescSpread => 'Largura do spray';
+
+  @override
+  String get settingsCelebrationsKnobDescSway => 'Quanto as peças balançam';
+
+  @override
+  String get settingsCelebrationsKnobDescSwell => 'Quanto eles crescem';
+
+  @override
+  String get settingsCelebrationsKnobDescTrail => 'Comprimento de cada trilha';
+
+  @override
+  String get settingsCelebrationsKnobDescTwinkle => 'Quanta partículas piscam';
+
+  @override
+  String get settingsCelebrationsKnobDescUpward => 'Quão fortemente eles sobem';
+
+  @override
+  String get settingsCelebrationsKnobDescWobble => 'Quanto as peças oscilam';
+
+  @override
+  String get settingsCelebrationsKnobFallout => 'Precipitação';
+
+  @override
+  String get settingsCelebrationsKnobFanSpread => 'Propagação de fãs';
+
+  @override
+  String get settingsCelebrationsKnobGlow => 'Brilho';
+
+  @override
+  String get settingsCelebrationsKnobGravity => 'Gravidade';
+
+  @override
+  String get settingsCelebrationsKnobHalo => 'auréola';
+
+  @override
+  String get settingsCelebrationsKnobInnerRing => 'Anel interno';
+
+  @override
+  String get settingsCelebrationsKnobLaunch => 'Hora de lançamento';
+
+  @override
+  String get settingsCelebrationsKnobPop => 'Ponto pop';
+
+  @override
+  String get settingsCelebrationsKnobReach => 'Alcance';
+
+  @override
+  String get settingsCelebrationsKnobRise => 'Altura de subida';
+
+  @override
+  String get settingsCelebrationsKnobSize => 'Tamanho';
+
+  @override
+  String get settingsCelebrationsKnobSpeedSpread => 'Variação de velocidade';
+
+  @override
+  String get settingsCelebrationsKnobSpin => 'Girar';
+
+  @override
+  String get settingsCelebrationsKnobSpread => 'Espalhe arco';
+
+  @override
+  String get settingsCelebrationsKnobSway => 'Balançar';
+
+  @override
+  String get settingsCelebrationsKnobSwell => 'Inchar';
+
+  @override
+  String get settingsCelebrationsKnobTrail => 'Comprimento da trilha';
+
+  @override
+  String get settingsCelebrationsKnobTwinkle => 'Brilha';
+
+  @override
+  String get settingsCelebrationsKnobUpward => 'Subir';
+
+  @override
+  String get settingsCelebrationsKnobWobble => 'Oscilação';
+
+  @override
+  String get settingsCelebrationsPlaygroundHint =>
+      'Toque na linha destacada para visualizar';
+
+  @override
+  String get settingsCelebrationsPlaygroundLiveNote =>
+      'As alterações são salvas e aplicadas em qualquer lugar instantaneamente';
+
+  @override
+  String get settingsCelebrationsPreviewChecklistItem => 'Verifique-me';
+
+  @override
+  String get settingsCelebrationsPreviewDescription =>
+      'Toque em um controle para reproduzir o estilo selecionado.';
+
+  @override
+  String get settingsCelebrationsPreviewDone => 'Concluído';
+
+  @override
+  String get settingsCelebrationsPreviewHabit => 'Hábito';
+
+  @override
+  String get settingsCelebrationsPreviewSample1 => 'Caminhada matinal';
+
+  @override
+  String get settingsCelebrationsPreviewSample2 => 'Concluir o relatório';
+
+  @override
+  String get settingsCelebrationsPreviewSample3 => 'Regue as plantas';
+
+  @override
+  String get settingsCelebrationsPreviewTitle => 'Experimente';
+
+  @override
+  String get settingsCelebrationsReplay => 'Repetir';
+
+  @override
+  String get settingsCelebrationsResetToast =>
+      'Estilo redefinido para o padrão';
+
+  @override
+  String get settingsCelebrationsResetToDefault => 'Redefinir para o padrão';
+
+  @override
+  String get settingsCelebrationsResetUndo => 'Desfazer';
+
+  @override
+  String get settingsCelebrationsSectionDescription =>
+      'Faça um floreio ao terminar algo. Desligar um mantém a conclusão e sua sensação tátil – apenas pula a animação.';
+
+  @override
+  String get settingsCelebrationsSectionTitle => 'Celebrações de conclusão';
+
+  @override
+  String get settingsCelebrationsStyleDescription =>
+      'Toque em um cartão para visualizar um estilo de celebração e personalizá-lo.';
+
+  @override
+  String get settingsCelebrationsStyleTitle => 'Estilo';
+
+  @override
+  String get settingsCelebrationsSubtitle => 'Celebrações de conclusão';
+
+  @override
+  String get settingsCelebrationsTasksDescription =>
+      'Brilho e faíscas quando você move uma tarefa para Concluído';
+
+  @override
+  String get settingsCelebrationsTasksTitle => 'Tarefas';
+
+  @override
+  String get settingsCelebrationsTitle => 'Animações';
+
+  @override
+  String get settingsCelebrationsVariantBubbles => 'Bolhas';
+
+  @override
+  String get settingsCelebrationsVariantCombine => 'Combine dois';
+
+  @override
+  String get settingsCelebrationsVariantCombineDescription =>
+      'Dois estilos aleatórios, em camadas, de cada vez';
+
+  @override
+  String get settingsCelebrationsVariantConfetti => 'Confete';
+
+  @override
+  String get settingsCelebrationsVariantEmbers => 'Brasas';
+
+  @override
+  String get settingsCelebrationsVariantFireworks => 'Fogos de artifício';
+
+  @override
+  String get settingsCelebrationsVariantRandom => 'Aleatório';
+
+  @override
+  String get settingsCelebrationsVariantRandomDescription =>
+      'Um estilo novo em cada finalização';
+
+  @override
+  String get settingsCelebrationsVariantSparks => 'Faíscas';
+
+  @override
+  String get settingsConflictsTitle => 'Conflitos de sincronização';
+
+  @override
+  String get settingsDashboardDetailsLabel => 'Editar painel';
+
+  @override
+  String get settingsDashboardSaveLabel => 'Salvar';
+
+  @override
+  String get settingsDashboardsCreateTitle => 'Criar painel';
+
+  @override
+  String get settingsDashboardsEmptyState => 'Ainda não há painéis';
+
+  @override
+  String get settingsDashboardsEmptyStateHint =>
+      'Toque no botão + para criar seu primeiro painel.';
+
+  @override
+  String get settingsDashboardsErrorLoading => 'Erro ao carregar painéis';
+
+  @override
+  String settingsDashboardsNoMatchQuery(String query) {
+    return 'Nenhum painel corresponde a \"$query\"';
+  }
+
+  @override
+  String get settingsDashboardsSearchHint => 'Painéis de pesquisa…';
+
+  @override
+  String get settingsDashboardsSubtitle =>
+      'Personalize as visualizações do seu painel';
+
+  @override
+  String get settingsDashboardsTitle => 'Painéis';
+
+  @override
+  String get settingsDefinitionsSubtitle =>
+      'Hábitos, categorias, rótulos, painéis e mensuráveis';
+
+  @override
+  String get settingsDefinitionsTitle => 'Definições';
+
+  @override
+  String get settingsFlagsEmptySearch =>
+      'Nenhuma sinalização corresponde à sua pesquisa';
+
+  @override
+  String get settingsFlagsSearchHint => 'Sinalizadores de pesquisa';
+
+  @override
+  String get settingsFlagsSubtitle =>
+      'Configurar sinalizadores e opções de recursos';
+
+  @override
+  String get settingsFlagsTitle => 'Sinalizadores de configuração';
+
+  @override
+  String get settingsHabitsCreateTitle => 'Crie hábito';
+
+  @override
+  String get settingsHabitsDeleteTooltip => 'Excluir hábito';
+
+  @override
+  String get settingsHabitsDescriptionLabel => 'Descrição (opcional)';
+
+  @override
+  String get settingsHabitsDetailsLabel => 'Editar hábito';
+
+  @override
+  String get settingsHabitsEmptyState => 'Ainda não há hábitos';
+
+  @override
+  String get settingsHabitsEmptyStateHint =>
+      'Toque no botão + para criar seu primeiro hábito.';
+
+  @override
+  String get settingsHabitsErrorLoading => 'Erro ao carregar hábitos';
+
+  @override
+  String get settingsHabitsNameLabel => 'Nome do hábito';
+
+  @override
+  String settingsHabitsNoMatchQuery(String query) {
+    return 'Nenhum hábito corresponde a \"$query\"';
+  }
+
+  @override
+  String get settingsHabitsPrivateLabel => 'Privado:';
+
+  @override
+  String get settingsHabitsSaveLabel => 'Salvar';
+
+  @override
+  String get settingsHabitsSearchHint => 'Hábitos de pesquisa…';
+
+  @override
+  String get settingsHabitsSubtitle => 'Gerencie seus hábitos e rotinas';
+
+  @override
+  String get settingsHabitsTitle => 'Hábitos';
+
+  @override
+  String get settingsHealthImportActivity => 'Importar dados de atividades';
+
+  @override
+  String get settingsHealthImportBloodPressure =>
+      'Importar dados de pressão arterial';
+
+  @override
+  String get settingsHealthImportBodyMeasurement =>
+      'Importar dados de medição corporal';
+
+  @override
+  String get settingsHealthImportFromDate => 'Começar';
+
+  @override
+  String get settingsHealthImportHeartRate =>
+      'Importar dados de frequência cardíaca';
+
+  @override
+  String get settingsHealthImportSleep => 'Importar dados de sono';
+
+  @override
+  String get settingsHealthImportTitle => 'Importação de Saúde';
+
+  @override
+  String get settingsHealthImportToDate => 'Fim';
+
+  @override
+  String get settingsHealthImportWorkout => 'Importar dados de treino';
+
+  @override
+  String get settingsKeyboardShortcutsSubtitle =>
+      'Aprenda as combinações de teclado para navegação e edição mais rápidas na área de trabalho';
+
+  @override
+  String get settingsKeyboardShortcutsTitle => 'Atalhos de teclado';
+
+  @override
+  String get settingsLabelsCategoriesAdd => 'Adicionar categoria';
+
+  @override
+  String get settingsLabelsCategoriesHeading => 'Categorias aplicáveis';
+
+  @override
+  String get settingsLabelsCategoriesNone => 'Aplica-se a todas as categorias';
+
+  @override
+  String get settingsLabelsCategoriesRemoveTooltip => 'Remover';
+
+  @override
+  String get settingsLabelsColorHeading => 'Cor';
+
+  @override
+  String get settingsLabelsColorSubheading => 'Predefinições rápidas';
+
+  @override
+  String get settingsLabelsCreateTitle => 'Criar etiqueta';
+
+  @override
+  String get settingsLabelsDeleteConfirmAction => 'Excluir';
+
+  @override
+  String settingsLabelsDeleteConfirmMessage(Object labelName) {
+    return 'Tem certeza de que deseja excluir \"$labelName\"? As tarefas com este rótulo perderão a atribuição.';
+  }
+
+  @override
+  String get settingsLabelsDeleteConfirmTitle => 'Excluir rótulo';
+
+  @override
+  String settingsLabelsDeleteSuccess(Object labelName) {
+    return 'Rótulo \"$labelName\" excluído';
+  }
+
+  @override
+  String get settingsLabelsDescriptionHint =>
+      'Explique quando aplicar este rótulo';
+
+  @override
+  String get settingsLabelsDescriptionLabel => 'Descrição (opcional)';
+
+  @override
+  String get settingsLabelsEditTitle => 'Editar rótulo';
+
+  @override
+  String get settingsLabelsEmptyState => 'Ainda não há rótulos';
+
+  @override
+  String get settingsLabelsEmptyStateHint =>
+      'Toque no botão + para criar sua primeira etiqueta.';
+
+  @override
+  String get settingsLabelsErrorLoading => 'Falha ao carregar rótulos';
+
+  @override
+  String get settingsLabelsNameHint =>
+      'Bug, bloqueador de lançamento, sincronização…';
+
+  @override
+  String get settingsLabelsNameLabel => 'Nome da etiqueta';
+
+  @override
+  String settingsLabelsNoMatchCreate(String query) {
+    return 'Criar rótulo \"$query\"';
+  }
+
+  @override
+  String settingsLabelsNoMatchQuery(String query) {
+    return 'Nenhum rótulo corresponde a \"$query\"';
+  }
+
+  @override
+  String get settingsLabelsPrivateDescription =>
+      'Visível apenas quando entradas privadas são mostradas';
+
+  @override
+  String get settingsLabelsPrivateTitle => 'Privado';
+
+  @override
+  String get settingsLabelsSearchHint => 'Pesquisar rótulos…';
+
+  @override
+  String get settingsLabelsSubtitle =>
+      'Organize tarefas com etiquetas coloridas';
+
+  @override
+  String get settingsLabelsTitle => 'Etiquetas';
+
+  @override
+  String settingsLabelsUsageCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas',
+      one: '1 tarefa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settingsLoggingDomainsSubtitle =>
+      'Controlar quais domínios gravam no log';
+
+  @override
+  String get settingsLoggingDomainsTitle => 'Registrando Domínios';
+
+  @override
+  String get settingsLoggingGlobalToggle => 'Habilitar registro em log';
+
+  @override
+  String get settingsLoggingGlobalToggleSubtitle =>
+      'Chave mestre para todos os registros';
+
+  @override
+  String get settingsLoggingSlowQueries => 'Consultas lentas ao banco de dados';
+
+  @override
+  String get settingsLoggingSlowQueriesSubtitle =>
+      'Grava consultas lentas em slow_queries-YYYY-MM-DD.log';
+
+  @override
+  String get settingsMaintenanceOnboardingAnimationGallerySubtitle =>
+      'Compare animações de boas-vindas + conecte a página ao vivo (depuração)';
+
+  @override
+  String get settingsMaintenanceOnboardingAnimationGalleryTitle =>
+      'Galeria de animação de integração';
+
+  @override
+  String get settingsMaintenanceOnboardingWelcomeSubtitle =>
+      'Visualize os blocos de boas-vindas + provedor do FTUE (depuração)';
+
+  @override
+  String get settingsMaintenanceOnboardingWelcomeTitle =>
+      'Mostrar boas-vindas à integração';
+
+  @override
+  String get settingsMaintenanceTitle => 'Manutenção';
+
+  @override
+  String get settingsManualLanguageCzechTitle => 'Tcheco';
+
+  @override
+  String get settingsManualLanguageEnglishTitle => 'Inglês';
+
+  @override
+  String get settingsManualLanguageFollowSystemSubtitle =>
+      'Use o idioma do seu dispositivo quando o manual suportar; caso contrário, use o inglês.';
+
+  @override
+  String get settingsManualLanguageFollowSystemTitle => 'Siga o sistema';
+
+  @override
+  String get settingsManualLanguageFrenchTitle => 'Francês';
+
+  @override
+  String get settingsManualLanguageGermanTitle => 'Alemão';
+
+  @override
+  String get settingsManualLanguagePortugueseTitle => 'Português';
+
+  @override
+  String get settingsManualLanguageRomanianTitle => 'Romeno';
+
+  @override
+  String get settingsManualLanguageTitle => 'Idioma';
+
+  @override
+  String get settingsMatrixAccept => 'Aceitar';
+
+  @override
+  String get settingsMatrixAcceptVerificationLabel =>
+      'Outro dispositivo mostra emojis, continue';
+
+  @override
+  String get settingsMatrixCancel => 'Cancelar';
+
+  @override
+  String get settingsMatrixContinueVerificationLabel =>
+      'Aceite em outro dispositivo para continuar';
+
+  @override
+  String get settingsMatrixDiagnosticCopied =>
+      'Informações de diagnóstico copiadas para a área de transferência';
+
+  @override
+  String get settingsMatrixDiagnosticCopyButton =>
+      'Copiar para a área de transferência';
+
+  @override
+  String get settingsMatrixDiagnosticDialogTitle =>
+      'Sincronizar informações de diagnóstico';
+
+  @override
+  String get settingsMatrixDiagnosticShowButton =>
+      'Mostrar informações de diagnóstico';
+
+  @override
+  String get settingsMatrixDone => 'Concluído';
+
+  @override
+  String get settingsMatrixLastUpdated => 'Última atualização:';
+
+  @override
+  String get settingsMatrixListUnverifiedLabel =>
+      'Dispositivos não verificados';
+
+  @override
+  String get settingsMatrixMaintenanceSubtitle =>
+      'Execute tarefas de manutenção e ferramentas de recuperação do Matrix';
+
+  @override
+  String get settingsMatrixMaintenanceTitle => 'Manutenção';
+
+  @override
+  String get settingsMatrixMetrics => 'Métricas de sincronização';
+
+  @override
+  String get settingsMatrixNextPage => 'Próxima página';
+
+  @override
+  String get settingsMatrixNoUnverifiedLabel =>
+      'Nenhum dispositivo não verificado';
+
+  @override
+  String get settingsMatrixPreviousPage => 'Página anterior';
+
+  @override
+  String settingsMatrixRoomInviteMessage(String roomId, String senderId) {
+    return 'Convide para a sala $roomId de $senderId. Aceitar?';
+  }
+
+  @override
+  String get settingsMatrixRoomInviteTitle => 'Convite para sala';
+
+  @override
+  String get settingsMatrixSentMessagesLabel => 'Mensagens enviadas:';
+
+  @override
+  String get settingsMatrixStartVerificationLabel => 'Iniciar verificação';
+
+  @override
+  String get settingsMatrixStatsTitle => 'Estatísticas da Matriz';
+
+  @override
+  String get settingsMatrixTitle => 'Configurações de sincronização';
+
+  @override
+  String get settingsMatrixUnverifiedDevicesPage =>
+      'Dispositivos não verificados';
+
+  @override
+  String get settingsMatrixVerificationCancelledLabel =>
+      'Cancelado em outro dispositivo...';
+
+  @override
+  String get settingsMatrixVerificationSuccessConfirm => 'Entendi';
+
+  @override
+  String settingsMatrixVerificationSuccessLabel(
+    String deviceName,
+    String deviceID,
+  ) {
+    return 'Você verificou $deviceName ($deviceID)';
+  }
+
+  @override
+  String get settingsMatrixVerifyConfirm =>
+      'Confirme em outro dispositivo se os emojis abaixo são exibidos em ambos os dispositivos, na mesma ordem:';
+
+  @override
+  String get settingsMatrixVerifyIncomingConfirm =>
+      'Confirme se os emojis abaixo são exibidos em ambos os dispositivos, na mesma ordem:';
+
+  @override
+  String get settingsMatrixVerifyLabel => 'Verifique';
+
+  @override
+  String get settingsMeasurableAggregationHelper =>
+      'Como as entradas de um dia se combinam nos gráficos';
+
+  @override
+  String get settingsMeasurableAggregationLabel => 'Tipo de agregação padrão';
+
+  @override
+  String get settingsMeasurableDeleteTooltip => 'Excluir tipo mensurável';
+
+  @override
+  String get settingsMeasurableDescriptionLabel => 'Descrição (opcional)';
+
+  @override
+  String get settingsMeasurableDetailsLabel => 'Editar mensurável';
+
+  @override
+  String get settingsMeasurableNameLabel => 'Nome mensurável';
+
+  @override
+  String get settingsMeasurablePrivateLabel => 'Privado:';
+
+  @override
+  String get settingsMeasurableSaveLabel => 'Salvar';
+
+  @override
+  String get settingsMeasurablesCreateTitle => 'Crie mensuráveis';
+
+  @override
+  String get settingsMeasurablesEmptyState => 'Ainda não há mensuráveis';
+
+  @override
+  String get settingsMeasurablesEmptyStateHint =>
+      'Mensuráveis são números que você acompanha ao longo do tempo – peso, água, passos.';
+
+  @override
+  String get settingsMeasurablesErrorLoading => 'Erro ao carregar mensuráveis';
+
+  @override
+  String settingsMeasurablesNoMatchQuery(String query) {
+    return 'Nenhum mensurável corresponde a \"$query\"';
+  }
+
+  @override
+  String get settingsMeasurablesSearchHint => 'Pesquisar mensuráveis…';
+
+  @override
+  String get settingsMeasurablesSubtitle =>
+      'Configurar tipos de dados mensuráveis';
+
+  @override
+  String get settingsMeasurablesTitle => 'Mensuráveis';
+
+  @override
+  String get settingsMeasurableUnitLabel => 'Abreviatura da unidade (opcional)';
+
+  @override
+  String get settingsOnboardingActionSubtitle =>
+      'Reabra o fluxo de boas-vindas – conecte seu cérebro de IA e crie uma tarefa';
+
+  @override
+  String get settingsOnboardingMetricsSubtitle =>
+      'Funil FTUE – instalação, ativação, retenção (depuração)';
+
+  @override
+  String get settingsOnboardingMetricsTitle => 'Métricas de integração';
+
+  @override
+  String get settingsOnboardingReplayTitle => 'Integração de repetição';
+
+  @override
+  String get settingsOnboardingStartTitle => 'Comece a integração';
+
+  @override
+  String get settingsOnboardingStatusActivated =>
+      'Você criou sua primeira tarefa de IA';
+
+  @override
+  String get settingsOnboardingStatusLoading => 'Carregando…';
+
+  @override
+  String get settingsOnboardingStatusNotActivated => 'Ainda não começou';
+
+  @override
+  String get settingsOnboardingStatusTitle => 'Estado';
+
+  @override
+  String get settingsOnboardingSubtitle =>
+      'Repita o fluxo de boas-vindas a qualquer momento';
+
+  @override
+  String get settingsOnboardingTestResetConfirm => 'Redefinir';
+
+  @override
+  String get settingsOnboardingTestResetConfirmQuestion =>
+      'Limpar histórico e métricas de solicitações de integração? Os planos do Daily OS existentes permanecem, portanto, use um perfil limpo para testar o passo a passo completo do Daily OS na primeira execução.';
+
+  @override
+  String get settingsOnboardingTestResetSubtitle =>
+      'Limpar histórico e métricas de prompts; os planos diários existentes do sistema operacional permanecem (depuração)';
+
+  @override
+  String get settingsOnboardingTestResetTitle =>
+      'Redefinir o estado do teste de integração';
+
+  @override
+  String get settingsOnboardingTitle => 'Integração';
+
+  @override
+  String get settingsOptionsTitle => 'Opções';
+
+  @override
+  String get settingsRecordingStyleExplanation =>
+      'Escolha a aparência do microfone enquanto você grava.';
+
+  @override
+  String get settingsRecordingStyleSubtitle =>
+      'Medidor VU ou orbe de energia durante a gravação';
+
+  @override
+  String get settingsRecordingStyleTitle => 'Estilo de gravação';
+
+  @override
+  String get settingsResetGeminiConfirm => 'Redefinir';
+
+  @override
+  String get settingsResetGeminiConfirmQuestion =>
+      'Isso mostrará a caixa de diálogo de configuração do Gemini novamente. Continuar?';
+
+  @override
+  String get settingsResetGeminiSubtitle =>
+      'Mostrar a caixa de diálogo de configuração do Gemini AI novamente';
+
+  @override
+  String get settingsResetGeminiTitle =>
+      'Caixa de diálogo Redefinir configuração do Gemini';
+
+  @override
+  String get settingsResetHintsConfirm => 'Confirmar';
+
+  @override
+  String get settingsResetHintsConfirmQuestion =>
+      'Redefinir dicas no aplicativo exibidas no aplicativo?';
+
+  @override
+  String settingsResetHintsResult(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Redefinir $count dicas',
+      one: 'Redefinir uma dica',
+      zero: 'Redefinir zero dicas',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settingsResetHintsSubtitle =>
+      'Dicas claras e de integração únicas';
+
+  @override
+  String get settingsResetHintsTitle => 'Redefinir dicas no aplicativo';
+
+  @override
+  String get settingsSpeechSubtitle => 'Voz e leitura em voz alta';
+
+  @override
+  String get settingsSpeechTitle => 'Discurso';
+
+  @override
+  String get settingsSyncConflictsSubtitle =>
+      'Resolva conflitos de sincronização para garantir a consistência dos dados';
+
+  @override
+  String get settingsSyncNodeProfileCapabilitiesEmpty =>
+      'Nenhum detectado — o acionamento automático da inferência de áudio sincronizado não terá como alvo este dispositivo.';
+
+  @override
+  String get settingsSyncNodeProfileCapabilitiesLabel =>
+      'Capacidades de IA detectadas';
+
+  @override
+  String get settingsSyncNodeProfileCapabilityMlxAudio => 'Áudio MLX (local)';
+
+  @override
+  String get settingsSyncNodeProfileCapabilityOllamaLlm => 'Ollama LLM';
+
+  @override
+  String get settingsSyncNodeProfileCapabilityOmlxLlm => 'oMLX LLM';
+
+  @override
+  String get settingsSyncNodeProfileCapabilityVoxtral => 'Voxtral (local)';
+
+  @override
+  String get settingsSyncNodeProfileCapabilityWhisper => 'Sussurro (local)';
+
+  @override
+  String get settingsSyncNodeProfileDisplayNameHelper =>
+      'Visível para seus outros dispositivos ao escolher em qual deles fixar um perfil.';
+
+  @override
+  String get settingsSyncNodeProfileDisplayNameLabel =>
+      'Nome de exibição do dispositivo';
+
+  @override
+  String get settingsSyncNodeProfileKnownNodesEmpty =>
+      'Nenhum outro dispositivo publicou um perfil ainda.';
+
+  @override
+  String get settingsSyncNodeProfileKnownNodesTitle =>
+      'Dispositivos de sincronização conhecidos';
+
+  @override
+  String get settingsSyncNodeProfileSaveButton => 'Salvar';
+
+  @override
+  String get settingsSyncNodeProfileSubtitle =>
+      'Dê um nome a este dispositivo e analise os recursos visíveis para seus outros dispositivos.';
+
+  @override
+  String get settingsSyncNodeProfileTitle => 'Este dispositivo';
+
+  @override
+  String get settingsSyncOutboxTitle => 'Sincronizar caixa de saída';
+
+  @override
+  String get settingsSyncStatsSubtitle =>
+      'Inspecione as métricas do pipeline de sincronização';
+
+  @override
+  String get settingsSyncSubtitle =>
+      'Configurar sincronização e visualizar estatísticas';
+
+  @override
+  String get settingsThemingAutomatic => 'Automático';
+
+  @override
+  String get settingsThemingDark => 'Aparência escura';
+
+  @override
+  String get settingsThemingLight => 'Aparência clara';
+
+  @override
+  String get settingsThemingSubtitle =>
+      'Personalize a aparência e os temas do aplicativo';
+
+  @override
+  String get settingsThemingTitle => 'Tema';
+
+  @override
+  String get settingsV2CategoryEmptyBody =>
+      'Escolha uma subconfiguração à esquerda.';
+
+  @override
+  String get settingsV2DetailRootCrumb => 'Configurações';
+
+  @override
+  String get settingsV2EmptyStateBody =>
+      'Escolha uma seção à esquerda para começar.';
+
+  @override
+  String get settingsV2ResizeHandleLabel =>
+      'Redimensionar árvore de configurações';
+
+  @override
+  String get settingsV2UnimplementedTitle => 'Painel ainda não implementado';
+
+  @override
+  String get settingsWhatsNewSubtitle =>
+      'Veja as últimas atualizações e recursos';
+
+  @override
+  String get settingsWhatsNewTitle => 'Novidades';
+
+  @override
+  String get settingThemingDark => 'Tema escuro';
+
+  @override
+  String get settingThemingLight => 'Tema claro';
+
+  @override
+  String get sidebarActiveSectionTitle => 'Atividade';
+
+  @override
+  String get sidebarActivityCollapseTooltip => 'Recolher atividade';
+
+  @override
+  String get sidebarActivityExpandTooltip => 'Expandir atividade';
+
+  @override
+  String get sidebarAudioRecordingStatusLabel => 'Gravação';
+
+  @override
+  String get sidebarRunningTimerLabel => 'Temporizador em execução';
+
+  @override
+  String get sidebarRunningTimerStopTooltip => 'Parar cronômetro';
+
+  @override
+  String get sidebarTimerStatusLabel => 'Temporizador';
+
+  @override
+  String get sidebarToggleCollapseLabel => 'Recolher barra lateral';
+
+  @override
+  String get sidebarToggleExpandLabel => 'Expandir barra lateral';
+
+  @override
+  String sidebarWakesActiveCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ativo',
+      one: '1 ativo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get sidebarWakesCancelTooltip => 'Cancelar agente';
+
+  @override
+  String get sidebarWakesHeader => 'Agentes';
+
+  @override
+  String get sidebarWakesNow => 'agora';
+
+  @override
+  String get sidebarWakesOpenList => 'Lista aberta';
+
+  @override
+  String get sidebarWakesOpenTask => 'Tarefa aberta';
+
+  @override
+  String sidebarWakesQueuedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count na fila',
+      one: '1 na fila',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get sidebarWakesQueuedLabel => 'Na fila';
+
+  @override
+  String get sidebarWakesWorkingLabel => 'Trabalhando';
+
+  @override
+  String get skillsSectionTitle => 'Habilidades';
+
+  @override
+  String get speechDictionaryHelper =>
+      'Termos separados por ponto e vírgula (máximo de 50 caracteres) para melhor reconhecimento de fala';
+
+  @override
+  String get speechDictionaryHint =>
+      'macOS; Kirkjubæjarklaustur; Código Claude';
+
+  @override
+  String get speechDictionaryLabel => 'Dicionário de Fala';
+
+  @override
+  String get speechDictionarySectionDescription =>
+      'Adicione termos que muitas vezes são digitados incorretamente pelo reconhecimento de fala (nomes, lugares, termos técnicos)';
+
+  @override
+  String get speechDictionarySectionTitle => 'Reconhecimento de fala';
+
+  @override
+  String speechDictionaryWarning(Object count) {
+    return 'Dicionário grande ($count termos) pode aumentar os custos da API';
+  }
+
+  @override
+  String get speechModalSelectLanguage => 'Selecione o idioma';
+
+  @override
+  String get speechModalTitle => 'Reconhecimento de fala';
+
+  @override
+  String get speechSettingsModelDescription => 'Modelo de fala no dispositivo';
+
+  @override
+  String get speechSettingsModelDownloadsOnce => 'Baixa uma vez';
+
+  @override
+  String get speechSettingsModelLabel => 'Modelo';
+
+  @override
+  String get speechSettingsRecommendedBadge => 'Recomendado';
+
+  @override
+  String get speechSettingsSpeedDescription =>
+      'Quão rápido os resumos são lidos';
+
+  @override
+  String get speechSettingsSpeedLabel => 'Velocidade de leitura';
+
+  @override
+  String get speechSettingsVoiceDescription =>
+      'Escolha a voz que lê resumos em voz alta';
+
+  @override
+  String get speechSettingsVoiceLabel => 'Voz';
+
+  @override
+  String get speechVoiceGenderFemale => 'Feminino';
+
+  @override
+  String get speechVoiceGenderMale => 'Masculino';
+
+  @override
+  String get speechVoicePreviewTooltip => 'Visualizar voz';
+
+  @override
+  String get surveyBackButton => 'Voltar';
+
+  @override
+  String get surveyCancelConfirmation => 'Cancelar pesquisa?';
+
+  @override
+  String get surveyChooseOneOption => 'Escolha uma opção';
+
+  @override
+  String get surveyChooseOneOrMoreOptions => 'Escolha uma ou mais opções';
+
+  @override
+  String get surveyDiscardConfirmation => 'Descartar resultados e desistir?';
+
+  @override
+  String get surveyInputNumberValidation => 'Digite um número';
+
+  @override
+  String get surveyNextButton => 'Próximo';
+
+  @override
+  String get surveyNoButton => 'Não';
+
+  @override
+  String get surveyProgressOf => 'de';
+
+  @override
+  String get surveyTapToAnswer => 'Toque para responder';
+
+  @override
+  String get surveyValueAnd => 'e';
+
+  @override
+  String get surveyValueBetween => 'Deve estar entre';
+
+  @override
+  String get surveyYesButton => 'Sim';
+
+  @override
+  String get syncActivityIdle => 'ocioso';
+
+  @override
+  String get syncActivityInboxLabel => 'Caixa de entrada';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Atividade de sincronização. Caixa de saída: $outbox. Caixa de entrada: $inbox. Abra a caixa de saída de sincronização.';
+  }
+
+  @override
+  String get syncActivityOutboxLabel => 'Caixa de saída';
+
+  @override
+  String get syncActivitySyncingTitle => 'Sincronizando';
+
+  @override
+  String get syncActivityTitle => 'Sincronizar';
+
+  @override
+  String get syncDeleteConfigConfirm => 'SIM, TENHO CERTEZA';
+
+  @override
+  String get syncDeleteConfigQuestion =>
+      'Deseja excluir a configuração de sincronização?';
+
+  @override
+  String get syncEntitiesConfirm => 'INICIAR SINCRONIZAÇÃO';
+
+  @override
+  String get syncEntitiesMessage =>
+      'Escolha as entidades que deseja sincronizar.';
+
+  @override
+  String get syncEntitiesSuccessDescription => 'Tudo está atualizado.';
+
+  @override
+  String get syncEntitiesSuccessTitle => 'Sincronização concluída';
+
+  @override
+  String syncListCountSummary(String label, int itemCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      itemCount,
+      locale: localeName,
+      other: '$itemCount itens',
+      one: '1 item',
+      zero: '0 itens',
+    );
+    return '$label · $_temp0';
+  }
+
+  @override
+  String get syncListPayloadKindLabel => 'Carga útil';
+
+  @override
+  String get syncListUnknownPayload => 'Carga útil desconhecida';
+
+  @override
+  String get syncNotLoggedInToast => 'A sincronização não está logada';
+
+  @override
+  String get syncPayloadAgentBundle => 'Pacote de agente';
+
+  @override
+  String get syncPayloadAgentEntity => 'Entidade agente';
+
+  @override
+  String get syncPayloadAgentLink => 'Link do agente';
+
+  @override
+  String get syncPayloadAiConfig => 'Configuração de IA';
+
+  @override
+  String get syncPayloadAiConfigDelete => 'Exclusão de configuração de IA';
+
+  @override
+  String get syncPayloadBackfillRequest => 'Solicitação de preenchimento';
+
+  @override
+  String get syncPayloadBackfillResponse => 'Resposta de preenchimento';
+
+  @override
+  String get syncPayloadConfigFlag => 'Sinalizador de configuração';
+
+  @override
+  String get syncPayloadConsumptionEvent => 'Consumo de IA';
+
+  @override
+  String get syncPayloadDailyOsUserName => 'Nome diário do sistema operacional';
+
+  @override
+  String get syncPayloadEntityDefinition => 'Definição de entidade';
+
+  @override
+  String get syncPayloadEntryLink => 'Link de entrada';
+
+  @override
+  String get syncPayloadJournalEntity => 'Lançamento de diário';
+
+  @override
+  String get syncPayloadNotification => 'Notificação';
+
+  @override
+  String get syncPayloadNotificationStateUpdate =>
+      'Atualização do estado da notificação';
+
+  @override
+  String get syncPayloadOutboxBundle => 'Pacote de caixa de saída';
+
+  @override
+  String get syncPayloadSavedTaskFilter => 'Filtro de tarefa salva';
+
+  @override
+  String get syncPayloadSavedTaskFilterDelete =>
+      'Exclusão de filtro de tarefa salva';
+
+  @override
+  String get syncPayloadSyncNodeProfile => 'Perfil do nó de sincronização';
+
+  @override
+  String get syncPayloadThemingSelection => 'Seleção de tema';
+
+  @override
+  String get syncStepAgentEntities => 'Entidades agentes';
+
+  @override
+  String get syncStepAgentLinks => 'Links de agente';
+
+  @override
+  String get syncStepAiSettings => 'Configurações de IA';
+
+  @override
+  String get syncStepBackfillAgentEntityClocks =>
+      'Preencher relógios da entidade do agente';
+
+  @override
+  String get syncStepBackfillAgentLinkClocks =>
+      'Relógios de link do agente de preenchimento';
+
+  @override
+  String get syncStepCategories => 'Categorias';
+
+  @override
+  String get syncStepComplete => 'Completo';
+
+  @override
+  String get syncStepDashboards => 'Painéis';
+
+  @override
+  String get syncStepHabits => 'Hábitos';
+
+  @override
+  String get syncStepLabels => 'Etiquetas';
+
+  @override
+  String get syncStepMeasurables => 'Mensuráveis';
+
+  @override
+  String get syncStepSavedTaskFilters => 'Filtros de tarefas salvas';
+
+  @override
+  String get taskActionBarAudioRecordingActive =>
+      'Gravação de áudio em andamento';
+
+  @override
+  String get taskActionBarMoreActions => 'Mais ações';
+
+  @override
+  String get taskActionBarOpenRunningTimer => 'Abrir cronômetro em execução';
+
+  @override
+  String get taskActionBarStopTracking => 'Parar o monitoramento do tempo';
+
+  @override
+  String get taskActionBarTrackTime => 'Monitorar o tempo';
+
+  @override
+  String get taskAgentAttributionUnavailable => 'Atribuição indisponível';
+
+  @override
+  String get taskAgentAutomaticUpdatesLabel => 'Atualizações automáticas';
+
+  @override
+  String get taskAgentAutomaticUpdatesNeedsSetup =>
+      'Escolha uma configuração de IA antes de ativar as atualizações automáticas.';
+
+  @override
+  String get taskAgentAutomaticUpdatesOffDescription =>
+      'As atualizações automáticas estão desativadas. Acorde o agente quando quiser um novo relatório.';
+
+  @override
+  String get taskAgentAutomaticUpdatesSummary =>
+      'Agrupe alterações de tarefas e atualize após dois minutos.';
+
+  @override
+  String get taskAgentCancelTimerTooltip =>
+      'Cancelar atualização automática pendente';
+
+  @override
+  String get taskAgentChooseModel => 'Escolha um modelo de pensamento';
+
+  @override
+  String get taskAgentChooseProfile => 'Escolha um perfil de inferência';
+
+  @override
+  String taskAgentCountdownTooltip(String countdown) {
+    return 'Próxima execução automática em $countdown';
+  }
+
+  @override
+  String get taskAgentCreateChipLabel => 'Atribuir agente';
+
+  @override
+  String taskAgentCreateError(String error) {
+    return 'Falha ao criar agente: $error';
+  }
+
+  @override
+  String get taskAgentCurrentSetupHeader => 'Configuração atual';
+
+  @override
+  String get taskAgentCurrentSetupLabel => 'Configuração atual';
+
+  @override
+  String get taskAgentDirectModelOverride => 'Substituição direta do modelo';
+
+  @override
+  String get taskAgentDisableConfirmAction => 'Desligue';
+
+  @override
+  String get taskAgentDisableConfirmBody =>
+      'O relatório atual permanece visível, mas este agente não pode ser executado até que você escolha uma configuração.';
+
+  @override
+  String get taskAgentDisableConfirmTitle => 'Desativar a IA para este agente?';
+
+  @override
+  String get taskAgentInferenceProfileLabel => 'Perfil de inferência';
+
+  @override
+  String get taskAgentModelPickerTitle => 'Escolha o modelo de pensamento';
+
+  @override
+  String get taskAgentNoAiSetup => 'Sem configuração de IA';
+
+  @override
+  String get taskAgentNoAiSetupDescription =>
+      'Pausa a inferência do agente até você escolher um perfil ou modelo.';
+
+  @override
+  String get taskAgentNoModelsAvailable =>
+      'Nenhum modelo de pensamento compatível disponível';
+
+  @override
+  String get taskAgentNoProfilesAvailable =>
+      'Nenhum perfil disponível neste dispositivo';
+
+  @override
+  String get taskAgentNoProfileSelected => 'Sem configuração de IA';
+
+  @override
+  String get taskAgentNoProfileSelectedDescription =>
+      'Escolha uma configuração salva ou um modelo de pensamento antes que este agente possa ser executado.';
+
+  @override
+  String taskAgentProfileChangedToast(String profile) {
+    return 'Usar $profile para cada atualização futura do agente até que você o altere.';
+  }
+
+  @override
+  String get taskAgentProfileDefaultBadge => 'Perfil padrão';
+
+  @override
+  String get taskAgentReportOutdatedDescription =>
+      'A tarefa mudou depois que esse resumo foi gerado.';
+
+  @override
+  String get taskAgentReportOutdatedTitle => 'Este resumo está desatualizado';
+
+  @override
+  String get taskAgentRouteVia => 'através de';
+
+  @override
+  String get taskAgentRunNowTooltip => 'Corra agora';
+
+  @override
+  String get taskAgentSavingSetup => 'Salvando a configuração do agente';
+
+  @override
+  String taskAgentSetupAndReportSemantics(String identity) {
+    return 'Este relatório e a configuração atual usam $identity. Ative para alterar a configuração.';
+  }
+
+  @override
+  String get taskAgentSetupBroken =>
+      'A configuração de IA selecionada não está disponível';
+
+  @override
+  String taskAgentSetupChangedToast(String model) {
+    return 'Usando $model para cada atualização futura do agente até que você o altere.';
+  }
+
+  @override
+  String get taskAgentSetupChoiceHelp =>
+      'Escolha um perfil para seus padrões ou substitua apenas o modelo de pensamento.';
+
+  @override
+  String get taskAgentSetupOriginCategory =>
+      'Copiado da categoria padrão quando este agente foi criado';
+
+  @override
+  String get taskAgentSetupOriginDisabled => 'Desativado';
+
+  @override
+  String get taskAgentSetupOriginLegacy => 'Configuração legada';
+
+  @override
+  String get taskAgentSetupOriginTemplate => 'Copiado do modelo';
+
+  @override
+  String get taskAgentSetupOriginUser => 'Você escolheu isso para este agente';
+
+  @override
+  String get taskAgentSetupPersistenceDescription =>
+      'As alterações se aplicam a todas as atualizações futuras até que você as altere.';
+
+  @override
+  String taskAgentSetupSemantics(String identity) {
+    return 'Configuração atual: $identity. Ative para alterar a configuração.';
+  }
+
+  @override
+  String get taskAgentSetupTitle => 'Configuração do agente';
+
+  @override
+  String get taskAgentThinkingModelLabel => 'Modelo de pensamento';
+
+  @override
+  String get taskAgentThisReportHeader => 'Este relatório';
+
+  @override
+  String get taskAgentTurnOffSetup => 'Desative a IA para este agente';
+
+  @override
+  String get taskAgentUseCategoryDefault => 'Copiar categoria padrão';
+
+  @override
+  String get taskAgentUseCategoryDefaultDescription =>
+      'Copia a configuração atual da categoria. Alterações posteriores de categoria não afetarão este agente.';
+
+  @override
+  String get taskAgentUseProfileDefault => 'Usar perfil padrão';
+
+  @override
+  String get taskAgentWakeAgent => 'Agente de despertar';
+
+  @override
+  String get taskCategoryAllLabel => 'tudo';
+
+  @override
+  String get taskCategoryLabel => 'Categoria:';
+
+  @override
+  String get taskCategoryUnassignedLabel => 'não atribuído';
+
+  @override
+  String get taskDueDateLabel => 'Data de vencimento';
+
+  @override
+  String taskDueDateWithDate(String date) {
+    return 'Vencimento: $date';
+  }
+
+  @override
+  String taskDueInDays(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days dias',
+      one: '1 dia',
+    );
+    return 'Vencimento em $_temp0';
+  }
+
+  @override
+  String get taskDueToday => 'Vencimento hoje';
+
+  @override
+  String get taskDueTomorrow => 'Vencimento amanhã';
+
+  @override
+  String get taskDueYesterday => 'Vencimento para ontem';
+
+  @override
+  String get taskEditTitleLabel => 'Editar título da tarefa';
+
+  @override
+  String get taskEstimateLabel => 'Estimativa:';
+
+  @override
+  String get taskEstimateModalTitle => 'Estimativa';
+
+  @override
+  String taskEstimateProgressLabel(String tracked, String estimate) {
+    return '$tracked de $estimate';
+  }
+
+  @override
+  String taskEstimateTooltip(String tracked, String estimate) {
+    return 'Tempo monitorado: $tracked de $estimate estimado';
+  }
+
+  @override
+  String taskLabelsMoreCount(int count) {
+    return '+$count';
+  }
+
+  @override
+  String get taskLabelsShowFewer => 'Mostrar menos';
+
+  @override
+  String get taskLanguageArabic => 'Árabe';
+
+  @override
+  String get taskLanguageBengali => 'bengali';
+
+  @override
+  String get taskLanguageBulgarian => 'Búlgaro';
+
+  @override
+  String get taskLanguageChinese => 'Chinês';
+
+  @override
+  String get taskLanguageCroatian => 'Croata';
+
+  @override
+  String get taskLanguageCzech => 'Tcheco';
+
+  @override
+  String get taskLanguageDanish => 'Dinamarquês';
+
+  @override
+  String get taskLanguageDutch => 'Holandês';
+
+  @override
+  String get taskLanguageEnglish => 'Inglês';
+
+  @override
+  String get taskLanguageEstonian => 'Estónio';
+
+  @override
+  String get taskLanguageFinnish => 'Finlandês';
+
+  @override
+  String get taskLanguageFrench => 'Francês';
+
+  @override
+  String get taskLanguageGerman => 'Alemão';
+
+  @override
+  String get taskLanguageGreek => 'Grego';
+
+  @override
+  String get taskLanguageHebrew => 'Hebraico';
+
+  @override
+  String get taskLanguageHindi => 'Hindi';
+
+  @override
+  String get taskLanguageHungarian => 'Húngaro';
+
+  @override
+  String get taskLanguageIgbo => 'Ibo';
+
+  @override
+  String get taskLanguageIndonesian => 'Indonésio';
+
+  @override
+  String get taskLanguageItalian => 'Italiano';
+
+  @override
+  String get taskLanguageJapanese => 'Japonês';
+
+  @override
+  String get taskLanguageKorean => 'Coreano';
+
+  @override
+  String get taskLanguageLabel => 'Idioma';
+
+  @override
+  String get taskLanguageLatvian => 'Letão';
+
+  @override
+  String get taskLanguageLithuanian => 'Lituano';
+
+  @override
+  String get taskLanguageNigerianPidgin => 'Pidgin nigeriano';
+
+  @override
+  String get taskLanguageNorwegian => 'Norueguês';
+
+  @override
+  String get taskLanguagePolish => 'Polonês';
+
+  @override
+  String get taskLanguagePortuguese => 'Português';
+
+  @override
+  String get taskLanguageRomanian => 'Romeno';
+
+  @override
+  String get taskLanguageRussian => 'Russo';
+
+  @override
+  String get taskLanguageSelectedLabel => 'Atualmente selecionado';
+
+  @override
+  String get taskLanguageSerbian => 'Sérvio';
+
+  @override
+  String get taskLanguageSetAction => 'Definir idioma';
+
+  @override
+  String get taskLanguageSlovak => 'Eslovaco';
+
+  @override
+  String get taskLanguageSlovenian => 'Esloveno';
+
+  @override
+  String get taskLanguageSpanish => 'Espanhol';
+
+  @override
+  String get taskLanguageSwahili => 'suaíli';
+
+  @override
+  String get taskLanguageSwedish => 'Sueco';
+
+  @override
+  String get taskLanguageThai => 'Tailandês';
+
+  @override
+  String get taskLanguageTurkish => 'Turco';
+
+  @override
+  String get taskLanguageTwi => 'Twi';
+
+  @override
+  String get taskLanguageUkrainian => 'Ucraniano';
+
+  @override
+  String get taskLanguageVietnamese => 'Vietnamita';
+
+  @override
+  String get taskLanguageYoruba => 'Iorubá';
+
+  @override
+  String get taskNoDueDateLabel => 'Sem data de vencimento';
+
+  @override
+  String get taskNoEstimateLabel => 'Sem estimativa';
+
+  @override
+  String taskOverdueByDays(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days dias',
+      one: '1 dia',
+    );
+    return 'Atrasado há $_temp0';
+  }
+
+  @override
+  String get taskPriorityHigh => 'Alto';
+
+  @override
+  String get taskPriorityLow => 'Baixo';
+
+  @override
+  String get taskPriorityMedium => 'Médio';
+
+  @override
+  String get taskPriorityUrgent => 'Urgente';
+
+  @override
+  String get tasksAddLabelButton => 'Adicionar rótulo';
+
+  @override
+  String get tasksAgentFilterAll => 'Todos';
+
+  @override
+  String get tasksAgentFilterHasAgent => 'Tem agente';
+
+  @override
+  String get tasksAgentFilterNoAgent => 'Nenhum agente';
+
+  @override
+  String get tasksAgentFilterTitle => 'Agente';
+
+  @override
+  String get tasksFilterApplyTitle => 'Aplicar filtro';
+
+  @override
+  String get tasksFilterClearAll => 'Limpar tudo';
+
+  @override
+  String get tasksFilterTitle => 'Filtrar tarefas';
+
+  @override
+  String get taskShowcaseAudio => 'Áudio';
+
+  @override
+  String taskShowcaseCompletedCount(int completed, int total) {
+    return '$completed / $total concluído';
+  }
+
+  @override
+  String taskShowcaseDueDate(String date) {
+    return 'Vencimento: $date';
+  }
+
+  @override
+  String get taskShowcaseJumpToSection => 'Ir para a seção';
+
+  @override
+  String get taskShowcaseLinked => 'Vinculado';
+
+  @override
+  String get taskShowcaseNoResults =>
+      'Nenhuma tarefa corresponde à sua pesquisa.';
+
+  @override
+  String get taskShowcaseReadMore => 'Leia mais';
+
+  @override
+  String taskShowcaseRecordingsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count gravações',
+      one: '1 gravação',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String taskShowcaseTaskCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas',
+      one: '1 tarefa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get taskShowcaseTaskDescription => 'Descrição da tarefa';
+
+  @override
+  String get taskShowcaseTimeTracker => 'Rastreador de tempo';
+
+  @override
+  String get taskShowcaseTodo => 'Tudo';
+
+  @override
+  String get taskShowcaseTodos => 'Todos';
+
+  @override
+  String get tasksLabelFilterAll => 'Todos';
+
+  @override
+  String get tasksLabelFilterTitle => 'Etiqueta';
+
+  @override
+  String get tasksLabelFilterUnlabeled => 'Sem rótulo';
+
+  @override
+  String get tasksLabelsDialogClose => 'Fechar';
+
+  @override
+  String get tasksLabelsSheetApply => 'Aplicar';
+
+  @override
+  String get tasksLabelsSheetSearchHint => 'Pesquisar rótulos…';
+
+  @override
+  String get tasksLabelsUpdateFailed => 'Falha ao atualizar rótulos';
+
+  @override
+  String get tasksPriorityFilterAll => 'Todos';
+
+  @override
+  String get tasksPriorityFilterTitle => 'Prioridade';
+
+  @override
+  String get tasksPriorityP0 => 'Urgente';
+
+  @override
+  String get tasksPriorityP0Description => 'Urgente (o mais rápido possível)';
+
+  @override
+  String get tasksPriorityP1 => 'Alto';
+
+  @override
+  String get tasksPriorityP1Description => 'Alto (em breve)';
+
+  @override
+  String get tasksPriorityP2 => 'Médio';
+
+  @override
+  String get tasksPriorityP2Description => 'Médio (padrão)';
+
+  @override
+  String get tasksPriorityP3 => 'Baixo';
+
+  @override
+  String get tasksPriorityP3Description => 'Baixo (sempre)';
+
+  @override
+  String get tasksPriorityPickerTitle => 'Selecione prioridade';
+
+  @override
+  String get tasksQuickFilterUnassignedLabel => 'Não atribuído';
+
+  @override
+  String get tasksSavedFilterDeleteConfirmTooltip =>
+      'Toque novamente para excluir';
+
+  @override
+  String get tasksSavedFilterDeleteTooltip => 'Excluir filtro salvo';
+
+  @override
+  String get tasksSavedFilterDragHandleSemantics => 'Arraste para reordenar';
+
+  @override
+  String get tasksSavedFilterRenameSemantics => 'Renomear filtro salvo';
+
+  @override
+  String get tasksSavedFiltersAllShort => 'Todos';
+
+  @override
+  String get tasksSavedFiltersAllTasks => 'Todas as tarefas';
+
+  @override
+  String get tasksSavedFiltersCustom => 'Personalizado';
+
+  @override
+  String get tasksSavedFiltersDeleteConfirmAction => 'Excluir';
+
+  @override
+  String tasksSavedFiltersDeleteConfirmMessage(String name) {
+    return 'Excluir o filtro salvo \'$name\'? Isso não pode ser desfeito.';
+  }
+
+  @override
+  String tasksSavedFiltersDeleteConfirmNamed(String name) {
+    return 'Confirme a exclusão de $name';
+  }
+
+  @override
+  String tasksSavedFiltersDeleteNamed(String name) {
+    return 'Excluir $name';
+  }
+
+  @override
+  String get tasksSavedFiltersDone => 'Concluído';
+
+  @override
+  String get tasksSavedFiltersEdit => 'Editar';
+
+  @override
+  String get tasksSavedFiltersFilterNameLabel => 'Nome do filtro';
+
+  @override
+  String get tasksSavedFiltersGroupSemantics => 'Filtros de tarefas';
+
+  @override
+  String get tasksSavedFiltersManageTooltip => 'Gerenciar filtros de tarefas';
+
+  @override
+  String get tasksSavedFiltersRailButton => 'Filtros';
+
+  @override
+  String tasksSavedFiltersRenameNamed(String name) {
+    return 'Renomear $name';
+  }
+
+  @override
+  String get tasksSavedFiltersReorderHelper =>
+      'Arraste para definir a ordem. Os primeiros cinco filtros aparecem na barra lateral.';
+
+  @override
+  String get tasksSavedFiltersSaveAsNewButtonLabel => 'Salvar como novo…';
+
+  @override
+  String get tasksSavedFiltersSaveAsNewDescription =>
+      'Mantenha o filtro existente inalterado e crie um separado.';
+
+  @override
+  String get tasksSavedFiltersSaveAsNewTitle => 'Salvar como um novo filtro';
+
+  @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Salvar filtro…';
+
+  @override
+  String get tasksSavedFiltersSaveChoiceIntro =>
+      'Escolha se deseja atualizar o filtro salvo ou criar um separado.';
+
+  @override
+  String get tasksSavedFiltersSaveChoiceTitle => 'Salvar filtro';
+
+  @override
+  String get tasksSavedFiltersSaveCurrentAs => 'Salvar filtro atual…';
+
+  @override
+  String get tasksSavedFiltersSaveError =>
+      'Não foi possível salvar este filtro. Tente novamente.';
+
+  @override
+  String get tasksSavedFiltersSavePageHelper =>
+      'Dê um nome curto a este filtro. Você pode reordená-lo posteriormente em Filtros de tarefas.';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Cancelar';
+
+  @override
+  String get tasksSavedFiltersSavePopupHint =>
+      'por exemplo Bloqueado ou em espera';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Salvar';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle => 'Nomeie este filtro';
+
+  @override
+  String get tasksSavedFiltersSheetTitle => 'Filtros de tarefas';
+
+  @override
+  String get tasksSavedFiltersShowLess => 'Mostrar menos';
+
+  @override
+  String tasksSavedFiltersShowMore(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count mais filtros salvos',
+      one: 'mais 1 filtro salvo',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String tasksSavedFiltersTaskCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tarefas',
+      one: '1 tarefa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersUpdateButtonLabel => 'Atualizar filtro';
+
+  @override
+  String get tasksSavedFiltersUpdateExistingDescription =>
+      'Substitua os critérios salvos pela configuração de filtro atual.';
+
+  @override
+  String get tasksSavedFiltersUpdateExistingTitle =>
+      'Atualizar filtro existente';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filtro excluído';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return '\'$name\' salvo';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return '\'$name\' atualizado';
+  }
+
+  @override
+  String get tasksSearchModeLabel => 'Modo de pesquisa';
+
+  @override
+  String get tasksShowCreationDate => 'Mostrar data de criação nos cartões';
+
+  @override
+  String get tasksShowDueDate => 'Mostrar data de vencimento nos cartões';
+
+  @override
+  String get tasksSortByCreationDate => 'Criado';
+
+  @override
+  String get tasksSortByDueDate => 'Data de vencimento';
+
+  @override
+  String get tasksSortByLabel => 'Classificar por';
+
+  @override
+  String get tasksSortByPriority => 'Prioridade';
+
+  @override
+  String get taskStatusAll => 'Todos';
+
+  @override
+  String get taskStatusBlocked => 'Bloqueado';
+
+  @override
+  String get taskStatusDone => 'Concluído';
+
+  @override
+  String get taskStatusGroomed => 'Preparado';
+
+  @override
+  String get taskStatusInProgress => 'Em andamento';
+
+  @override
+  String get taskStatusLabel => 'Estado:';
+
+  @override
+  String get taskStatusOnHold => 'Em espera';
+
+  @override
+  String get taskStatusOpen => 'Abrir';
+
+  @override
+  String get taskStatusRejected => 'Rejeitado';
+
+  @override
+  String get taskTitleEmpty => 'Sem título';
+
+  @override
+  String get taskUntitled => '(sem título)';
+
+  @override
+  String get thinkingDisclosureCopied => 'Raciocínio copiado';
+
+  @override
+  String get thinkingDisclosureCopy => 'Copie o raciocínio';
+
+  @override
+  String get thinkingDisclosureHide => 'Ocultar raciocínio';
+
+  @override
+  String get thinkingDisclosureShow => 'Mostrar raciocínio';
+
+  @override
+  String get thinkingDisclosureStateCollapsed => 'entrou em colapso';
+
+  @override
+  String get thinkingDisclosureStateExpanded => 'expandido';
+
+  @override
+  String get timeEntryItemEnd => 'Fim';
+
+  @override
+  String get timeEntryItemRunning => 'Correndo';
+
+  @override
+  String get timeEntryItemStart => 'Começar';
+
+  @override
+  String get unlinkButton => 'Desvincular';
+
+  @override
+  String get unlinkTaskConfirm =>
+      'Tem certeza de que deseja desvincular esta tarefa?';
+
+  @override
+  String get unlinkTaskTitle => 'Desvincular tarefa';
+
+  @override
+  String vectorSearchTiming(int elapsed, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '${elapsed}ms, $count resultados',
+      one: '${elapsed}ms, $count resultado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get viewMenuTitle => 'Ver';
+
+  @override
+  String get viewMenuZoomIn => 'Ampliar';
+
+  @override
+  String get viewMenuZoomOut => 'Diminuir zoom';
+
+  @override
+  String get viewMenuZoomReset => 'Tamanho real';
+
+  @override
+  String get whatsNewBadgeNew => 'NOVO';
+
+  @override
+  String get whatsNewDoneButton => 'Concluído';
+
+  @override
+  String get whatsNewSkipButton => 'Pular';
+}

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -9173,12 +9173,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsMatrixRoomInviteTitle => 'Invitație la cameră';
 
   @override
+  String get settingsMatrixSentMessagesLabel => 'Mesaje trimise:';
+
+  @override
   String settingsMatrixSentMessageType(String eventType) {
     return 'Trimis ($eventType)';
   }
-
-  @override
-  String get settingsMatrixSentMessagesLabel => 'Mesaje trimise:';
 
   @override
   String get settingsMatrixStartVerificationLabel => 'Începeți verificarea';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -9099,6 +9099,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsManualLanguageGermanTitle => 'Germană';
 
   @override
+  String get settingsManualLanguagePortugueseTitle => 'Portugheză';
+
+  @override
   String get settingsManualLanguageRomanianTitle => 'Română';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -699,7 +699,6 @@
   "aiCapabilityChipImageRecognition": "Reconhecimento de imagem",
   "aiCapabilityChipThinking": "Pensando",
   "aiCapabilityChipTranscription": "Transcrição",
-  "aiCardEmptyProposals": "Nenhuma proposta aberta · o agente apresentará novas alterações aqui",
   "aiCardHistoryToggle": "História · {count}",
   "@aiCardHistoryToggle": {
     "placeholders": {
@@ -3372,6 +3371,52 @@
   "maintenanceSyncDefinitions": "Sincronize mensuráveis, painéis, hábitos, categorias, configurações de IA",
   "maintenanceSyncDefinitionsDescription": "Sincronize mensuráveis, painéis, hábitos, categorias e configurações de IA",
   "manageLinks": "Gerenciar links...",
+  "matrixStatsCatchupBatches": "Lotes de recuperação",
+  "matrixStatsCircuitOpens": "Aberturas de circuito",
+  "matrixStatsConflicts": "Conflitos",
+  "matrixStatsCopyDiagnostics": "Copiar diagnósticos",
+  "matrixStatsCopyDiagnosticsTooltip": "Copie os diagnósticos de sincronização para a área de transferência",
+  "matrixStatsDbApplied": "BD aplicado",
+  "matrixStatsDbApply": "Aplicar BD",
+  "matrixStatsDbIgnoredVectorClock": "BD ignorado (VectorClock)",
+  "matrixStatsDbMissingBase": "BD sem base",
+  "matrixStatsDroppedByType": "Descartado ({type})",
+  "@matrixStatsDroppedByType": {
+    "placeholders": {
+      "type": {}
+    }
+  },
+  "matrixStatsEntryLinkNoops": "Operações sem efeito de EntryLink",
+  "matrixStatsFailures": "Falhas",
+  "matrixStatsFlushes": "Descargas",
+  "matrixStatsForceRescan": "Forçar nova verificação",
+  "matrixStatsForceRescanTooltip": "Force uma nova verificação e atualize agora",
+  "matrixStatsLegend": "Legenda",
+  "matrixStatsLegendTooltip": "Legenda:\n• processed.<type> = mensagens de sincronização processadas por tipo de carga\n• droppedByType.<type> = descartes por tipo após novas tentativas ou ao ignorar mensagens antigas\n• dbApplied = linhas gravadas no banco de dados\n• dbIgnoredByVectorClock = dados recebidos mais antigos ou idênticos ignorados pelo banco de dados\n• conflictsCreated = vetores de relógio simultâneos registrados\n• dbMissingBase = ignorado enquanto aguarda uma dependência ou linha de base ausente\n• staleAttachmentPurges = descritores obsoletos em cache removidos antes da atualização",
+  "matrixStatsProcessed": "Processado",
+  "matrixStatsProcessedByType": "Processado ({type})",
+  "@matrixStatsProcessedByType": {
+    "placeholders": {
+      "type": {}
+    }
+  },
+  "matrixStatsRefresh": "Atualizar",
+  "matrixStatsReliability": "Confiabilidade",
+  "matrixStatsRetriesScheduled": "Novas tentativas agendadas",
+  "matrixStatsRetryNow": "Tentar novamente agora",
+  "matrixStatsRetryNowTooltip": "Tente novamente as falhas pendentes agora",
+  "matrixStatsSignalLatencyLast": "Latência do sinal (últimos ms)",
+  "matrixStatsSignalLatencyMax": "Latência do sinal (máx. ms)",
+  "matrixStatsSignalLatencyMin": "Latência do sinal (mín. ms)",
+  "matrixStatsSignals": "Sinais",
+  "matrixStatsSignalsClientStream": "Sinais (fluxo do cliente)",
+  "matrixStatsSignalsConnectivity": "Sinais (conectividade)",
+  "matrixStatsSignalsTimelineCallbacks": "Sinais (callbacks da linha do tempo)",
+  "matrixStatsSkipped": "Ignorado",
+  "matrixStatsSkippedRetryCap": "Ignorado (limite de novas tentativas)",
+  "matrixStatsStaleAttachmentPurges": "Limpezas de anexos obsoletos",
+  "matrixStatsThroughput": "Taxa de transferência",
+  "matrixStatsTopKpis": "Principais KPIs",
   "measurableDeleteConfirm": "SIM, EXCLUIR ESTE MENSURÁVEL",
   "measurableDeleteQuestion": "Deseja excluir este tipo de dados mensuráveis?",
   "measurableNotFound": "Mensurável não encontrado",
@@ -4380,6 +4425,14 @@
   },
   "settingsMatrixRoomInviteTitle": "Convite para sala",
   "settingsMatrixSentMessagesLabel": "Mensagens enviadas:",
+  "settingsMatrixSentMessageType": "Enviado ({eventType})",
+  "@settingsMatrixSentMessageType": {
+    "placeholders": {
+      "eventType": {
+        "type": "String"
+      }
+    }
+  },
   "settingsMatrixStartVerificationLabel": "Iniciar verificação",
   "settingsMatrixStatsTitle": "Estatísticas da Matriz",
   "settingsMatrixTitle": "Configurações de sincronização",
@@ -4634,8 +4687,6 @@
   "taskAgentAttributionUnavailable": "Atribuição indisponível",
   "taskAgentAutomaticUpdatesLabel": "Atualizações automáticas",
   "taskAgentAutomaticUpdatesNeedsSetup": "Escolha uma configuração de IA antes de ativar as atualizações automáticas.",
-  "taskAgentAutomaticUpdatesOffDescription": "As atualizações automáticas estão desativadas. Acorde o agente quando quiser um novo relatório.",
-  "taskAgentAutomaticUpdatesSummary": "Agrupe alterações de tarefas e atualize após dois minutos.",
   "taskAgentCancelTimerTooltip": "Cancelar atualização automática pendente",
   "taskAgentChooseModel": "Escolha um modelo de pensamento",
   "taskAgentChooseProfile": "Escolha um perfil de inferência",
@@ -4664,6 +4715,16 @@
   "taskAgentDisableConfirmTitle": "Desativar a IA para este agente?",
   "taskAgentInferenceProfileLabel": "Perfil de inferência",
   "taskAgentModelPickerTitle": "Escolha o modelo de pensamento",
+  "taskAgentNextUpdateIn": "Próxima atualização em {countdown}",
+  "@taskAgentNextUpdateIn": {
+    "description": "Indicador de contagem regressiva no rodapé do cartão do agente da tarefa; tocar nele cancela a atualização automática agendada",
+    "placeholders": {
+      "countdown": {
+        "type": "String",
+        "example": "1:30"
+      }
+    }
+  },
   "taskAgentNoAiSetup": "Sem configuração de IA",
   "taskAgentNoAiSetupDescription": "Pausa a inferência do agente até você escolher um perfil ou modelo.",
   "taskAgentNoModelsAvailable": "Nenhum modelo de pensamento compatível disponível",
@@ -4679,8 +4740,8 @@
     }
   },
   "taskAgentProfileDefaultBadge": "Perfil padrão",
-  "taskAgentReportOutdatedDescription": "A tarefa mudou depois que esse resumo foi gerado.",
   "taskAgentReportOutdatedTitle": "Este resumo está desatualizado",
+  "taskAgentReportUpToDate": "O resumo está atualizado",
   "taskAgentRouteVia": "através de",
   "taskAgentRunNowTooltip": "Corra agora",
   "taskAgentSavingSetup": "Salvando a configuração do agente",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1,0 +1,5066 @@
+{
+  "activeLabel": "Ativo",
+  "addActionAddAudioRecording": "Gravação de áudio",
+  "addActionAddChecklist": "Lista de verificação",
+  "addActionAddEvent": "Evento",
+  "addActionAddImageFromClipboard": "Colar imagem",
+  "addActionAddScreenshot": "Captura de tela",
+  "addActionAddTask": "Tarefa",
+  "addActionAddText": "Entrada de texto",
+  "addActionAddTimer": "Temporizador",
+  "addActionAddTimeRecording": "Entrada do temporizador",
+  "addActionImportImage": "Importar imagem",
+  "addHabitCommentLabel": "Comentário",
+  "addHabitDateLabel": "Concluído em",
+  "addMeasurementCommentLabel": "Comentário",
+  "addMeasurementDateLabel": "Observado em",
+  "addMeasurementSaveButton": "Salvar",
+  "addToDictionary": "Adicionar ao dicionário",
+  "addToDictionaryDuplicate": "O termo já existe no dicionário",
+  "addToDictionaryNoCategory": "Não é possível adicionar ao dicionário: a tarefa não tem categoria",
+  "addToDictionarySaveFailed": "Falha ao salvar o dicionário",
+  "addToDictionarySuccess": "Termo adicionado ao dicionário",
+  "addToDictionaryTooLong": "Prazo muito longo (máximo de 50 caracteres)",
+  "agentABComparisonChoose": "Escolha {option}",
+  "@agentABComparisonChoose": {
+    "placeholders": {
+      "option": {
+        "type": "String"
+      }
+    }
+  },
+  "agentABComparisonOption": "Opção {option}",
+  "@agentABComparisonOption": {
+    "placeholders": {
+      "option": {
+        "type": "String"
+      }
+    }
+  },
+  "agentABComparisonPrefer": "Eu prefiro a opção {option}",
+  "@agentABComparisonPrefer": {
+    "placeholders": {
+      "option": {
+        "type": "String"
+      }
+    }
+  },
+  "agentBinaryChoiceNo": "Não",
+  "agentBinaryChoiceYes": "Sim",
+  "agentCategoryRatingsScaleMax": "Corrija primeiro",
+  "agentCategoryRatingsScaleMin": "Deixe",
+  "agentCategoryRatingsStarLabel": "{starIndex} de {totalStars} estrelas",
+  "@agentCategoryRatingsStarLabel": {
+    "placeholders": {
+      "starIndex": {
+        "type": "int"
+      },
+      "totalStars": {
+        "type": "int"
+      }
+    }
+  },
+  "agentCategoryRatingsSubmit": "Use essas prioridades",
+  "agentCategoryRatingsSubtitle": "Quão importante é que eu corrija cada um deles? 1 significa deixar como está, 5 significa consertar primeiro.",
+  "agentCategoryRatingsTitle": "Ajude-me a priorizar",
+  "agentControlsActionError": "Falha na ação: {error}",
+  "@agentControlsActionError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "agentControlsDeleteButton": "Excluir permanentemente",
+  "agentControlsDeleteDialogContent": "Isso excluirá permanentemente todos os dados deste agente, incluindo histórico, relatórios e observações. Isto não pode ser desfeito.",
+  "agentControlsDeleteDialogTitle": "Excluir agente?",
+  "agentControlsDestroyButton": "Destruir",
+  "agentControlsDestroyDialogContent": "Isso desativará permanentemente o agente. Sua história será preservada para auditoria.",
+  "agentControlsDestroyDialogTitle": "Destruir Agente?",
+  "agentControlsDestroyedMessage": "Este agente foi destruído.",
+  "agentControlsPauseButton": "Pausa",
+  "agentControlsReanalyzeButton": "Reanalisar",
+  "agentControlsResumeButton": "Currículo",
+  "agentConversationEmpty": "Nenhuma conversa ainda.",
+  "agentConversationThreadSummary": "{messageCount} mensagens, {toolCallCount} chamadas de ferramenta · {shortId}",
+  "@agentConversationThreadSummary": {
+    "placeholders": {
+      "messageCount": {
+        "type": "int"
+      },
+      "toolCallCount": {
+        "type": "int"
+      },
+      "shortId": {
+        "type": "String"
+      }
+    }
+  },
+  "agentConversationTokenCount": "{tokenCount} tokens",
+  "@agentConversationTokenCount": {
+    "placeholders": {
+      "tokenCount": {
+        "type": "String"
+      }
+    }
+  },
+  "agentDefaultProfileLabel": "Perfil de inferência padrão",
+  "agentDetailErrorLoading": "Erro ao carregar o agente: {error}",
+  "@agentDetailErrorLoading": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "agentDetailNotFound": "Agente não encontrado.",
+  "agentDetailUnexpectedType": "Tipo de entidade inesperado.",
+  "agentEvolutionApprovalRate": "Taxa de aprovação",
+  "agentEvolutionChartMttrTrend": "Tendência MTTR",
+  "agentEvolutionChartSuccessRateTrend": "Tendência de sucesso",
+  "agentEvolutionChartVersionPerformance": "Por versão",
+  "agentEvolutionChartWakeHistory": "Histórico de despertar",
+  "agentEvolutionChatPlaceholder": "Compartilhe comentários ou pergunte sobre desempenho...",
+  "agentEvolutionCurrentDirectives": "Diretivas Atuais",
+  "agentEvolutionDashboardTitle": "Desempenho",
+  "agentEvolutionHistoryTitle": "História da Evolução",
+  "agentEvolutionMetricActive": "Ativo",
+  "agentEvolutionMetricAvgDuration": "Duração média",
+  "agentEvolutionMetricFailures": "Falhas",
+  "agentEvolutionMetricSuccess": "Sucesso",
+  "agentEvolutionMetricWakes": "Acorda",
+  "agentEvolutionNoSessions": "Nenhuma sessão de evolução ainda",
+  "agentEvolutionNoteRecorded": "Nota gravada",
+  "agentEvolutionProposalApprovalFailed": "Falha na aprovação. Tente novamente",
+  "agentEvolutionProposalRationale": "Justificativa",
+  "agentEvolutionProposalRejected": "Proposta rejeitada – continue a conversa",
+  "agentEvolutionProposalTitle": "Mudanças propostas",
+  "agentEvolutionProposedDirectives": "Diretivas propostas",
+  "agentEvolutionSessionAbandoned": "A sessão terminou sem alterações",
+  "agentEvolutionSessionCompleted": "Sessão concluída — versão {version} criada",
+  "@agentEvolutionSessionCompleted": {
+    "placeholders": {
+      "version": {
+        "type": "int"
+      }
+    }
+  },
+  "agentEvolutionSessionCount": "Sessões",
+  "agentEvolutionSessionError": "Falha ao iniciar a sessão de evolução",
+  "agentEvolutionSessionProgress": "Sessão {sessionNumber} de {totalSessions}",
+  "@agentEvolutionSessionProgress": {
+    "placeholders": {
+      "sessionNumber": {
+        "type": "int"
+      },
+      "totalSessions": {
+        "type": "int"
+      }
+    }
+  },
+  "agentEvolutionSessionStarting": "Iniciando sessão de evolução...",
+  "agentEvolutionSessionTitle": "Evolução #{sessionNumber}",
+  "@agentEvolutionSessionTitle": {
+    "placeholders": {
+      "sessionNumber": {
+        "type": "int"
+      }
+    }
+  },
+  "agentEvolutionSoulCurrentField": "Atual — {field}",
+  "@agentEvolutionSoulCurrentField": {
+    "placeholders": {
+      "field": {
+        "type": "String"
+      }
+    }
+  },
+  "agentEvolutionSoulProposedField": "Proposta — {field}",
+  "@agentEvolutionSoulProposedField": {
+    "placeholders": {
+      "field": {
+        "type": "String"
+      }
+    }
+  },
+  "agentEvolutionStatusAbandoned": "Abandonado",
+  "agentEvolutionStatusActive": "Ativo",
+  "agentEvolutionStatusCompleted": "Concluído",
+  "agentEvolutionTimelineFeedbackLabel": "Comentários",
+  "agentEvolutionVersionProposed": "Versão proposta",
+  "agentFeedbackCategoryAccuracy": "Precisão",
+  "agentFeedbackCategoryBreakdownTitle": "Divisão de categorias",
+  "agentFeedbackCategoryCommunication": "Comunicação",
+  "agentFeedbackCategoryGeneral": "Geral",
+  "agentFeedbackCategoryPrioritization": "Priorização",
+  "agentFeedbackCategoryTimeliness": "Oportunidade",
+  "agentFeedbackCategoryTooling": "Ferramentas",
+  "agentFeedbackClassificationTitle": "Classificação de Feedback",
+  "agentFeedbackExcellenceTitle": "Notas de Excelência",
+  "agentFeedbackGrievancesTitle": "Queixas",
+  "agentFeedbackHighPriorityTitle": "Feedback de alta prioridade",
+  "agentFeedbackItemCount": "{count, plural, =1{1 item} other{{count} itens}}",
+  "@agentFeedbackItemCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentFeedbackSourceDecision": "Decisão",
+  "agentFeedbackSourceMetric": "Métrica",
+  "agentFeedbackSourceObservation": "Observação",
+  "agentFeedbackSourceRating": "Avaliação",
+  "agentInstancesEmptyFiltered": "Nenhuma instância corresponde aos seus filtros.",
+  "agentInstancesFilterClearAll": "Limpar tudo",
+  "agentInstancesFilterClearSection": "Limpar",
+  "agentInstancesFilterSectionSoul": "Alma",
+  "agentInstancesFilterSectionStatus": "Estado",
+  "agentInstancesFilterSectionType": "Tipo",
+  "agentInstancesGroupActiveCount": "{count, plural, =1{1 ativo} other{{count} ativo}}",
+  "@agentInstancesGroupActiveCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentInstancesGroupBySoul": "Alma",
+  "agentInstancesGroupByStatus": "Estado",
+  "agentInstancesGroupByType": "Tipo",
+  "agentInstancesKindEvolution": "Evolução",
+  "agentInstancesKindTaskAgent": "Agente de Tarefas",
+  "agentInstancesPageTitle": "Instâncias de agente",
+  "agentInstancesResultCountAll": "{count, plural, =1{1 instância} other{{count} instâncias}}",
+  "@agentInstancesResultCountAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentInstancesResultCountFiltered": "{filtered} de {total}",
+  "@agentInstancesResultCountFiltered": {
+    "placeholders": {
+      "filtered": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "agentInstancesSearchClear": "Limpar pesquisa",
+  "agentInstancesSearchPlaceholder": "Pesquisar instâncias…",
+  "agentInstancesSortName": "Nome",
+  "agentInstancesSortOldest": "Mais antigo",
+  "agentInstancesSortRecent": "Recente",
+  "agentInstancesTitle": "Instâncias",
+  "agentInstancesToolbarFilters": "Filtros",
+  "agentInstancesToolbarGroupBy": "Agrupar por",
+  "agentInstancesUnassignedSoul": "Não atribuído",
+  "agentLifecycleActive": "Ativo",
+  "agentLifecycleCreated": "Criado",
+  "agentLifecycleDestroyed": "Destruído",
+  "agentLifecycleDormant": "Dormente",
+  "agentMessageKindAction": "Ação",
+  "agentMessageKindMilestone": "Marco",
+  "agentMessageKindObservation": "Observação",
+  "agentMessageKindRetraction": "Retração",
+  "agentMessageKindSummary": "Resumo",
+  "agentMessageKindSystem": "Sistema",
+  "agentMessageKindSystemPrompt": "Alerta do sistema",
+  "agentMessageKindThought": "Pensamento",
+  "agentMessageKindToolResult": "Resultado da ferramenta",
+  "agentMessageKindUser": "Usuário",
+  "agentMessagePayloadEmpty": "(sem conteúdo)",
+  "agentMessagesEmpty": "Nenhuma mensagem ainda.",
+  "agentMessagesErrorLoading": "Falha ao carregar mensagens: {error}",
+  "@agentMessagesErrorLoading": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "agentObservationsEmpty": "Nenhuma observação registrada ainda.",
+  "agentPendingWakesActivityHourDetail": "{hour}: {count, plural, =1{1 wake} other{{count} wakes}} ({reasons})",
+  "@agentPendingWakesActivityHourDetail": {
+    "placeholders": {
+      "hour": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      },
+      "reasons": {
+        "type": "String"
+      }
+    }
+  },
+  "agentPendingWakesActivityTitle": "Atividade de Despertar (24h)",
+  "agentPendingWakesActivityTotal": "{count, plural, =1{1 total de despertares} other{{count} total de despertares}}",
+  "@agentPendingWakesActivityTotal": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentPendingWakesDeleteTooltip": "Remover despertar",
+  "agentPendingWakesEmptyFiltered": "Nenhuma ativação corresponde aos seus filtros.",
+  "agentPendingWakesFilterSectionType": "Tipo",
+  "agentPendingWakesGroupByType": "Tipo",
+  "agentPendingWakesPendingLabel": "Pendente",
+  "agentPendingWakesRunningHeading": "{count, plural, =1{Em execução agora} other{Em execução agora ({count})}}",
+  "@agentPendingWakesRunningHeading": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentPendingWakesScheduledLabel": "Agendado",
+  "agentPendingWakesSearchPlaceholder": "A pesquisa acorda…",
+  "agentPendingWakesSortDueLatest": "Vencimento mais recente",
+  "agentPendingWakesSortDueSoonest": "Prazo mais breve",
+  "agentPendingWakesTitle": "Ciclos de despertar",
+  "agentReportHistoryBadge": "Relatório",
+  "agentReportHistoryEmpty": "Ainda não há instantâneos de relatório.",
+  "agentReportHistoryError": "Ocorreu um erro ao carregar o histórico do relatório.",
+  "agentReportNone": "Nenhum relatório disponível ainda.",
+  "agentRitualReviewAction": "Iniciar conversa",
+  "agentRitualReviewNegativeSignals": "Negativo",
+  "agentRitualReviewNeutralSignals": "Neutro",
+  "agentRitualReviewNoFeedback": "Nenhum sinal de feedback nesta janela",
+  "agentRitualReviewNoNegativeSignals": "Nenhum sinal de feedback negativo nesta guia",
+  "agentRitualReviewNoNeutralSignals": "Nenhum sinal de feedback neutro nesta guia",
+  "agentRitualReviewNoPositiveSignals": "Nenhum sinal de feedback positivo nesta guia",
+  "agentRitualReviewPositiveSignals": "Positivo",
+  "agentRitualReviewProposalSection": "Proposta Atual",
+  "agentRitualReviewSessionHistory": "Histórico da sessão",
+  "agentRitualReviewTitle": "1 contra 1",
+  "agentRitualSummaryApprovedChangesHeading": "Alterações aprovadas",
+  "agentRitualSummaryConversationHeading": "Conversa",
+  "agentRitualSummaryRecapHeading": "Recapitulação da sessão",
+  "agentRitualSummaryRoleAssistant": "Agente",
+  "agentRitualSummaryRoleUser": "Você",
+  "agentRitualSummaryStartHint": "Comece uma conversa individual para revisar o que o incomodou, o que funcionou e o que deve mudar a seguir.",
+  "agentRitualSummarySubtitle": "Encontros individuais recentes, atividades reais de despertar e as mudanças com as quais você concordou.",
+  "agentRitualSummaryTokensSinceLast": "Tokens desde o último 1 contra 1",
+  "agentRitualSummaryWakeHistory30Days": "Atividade de despertar (últimos 30 dias)",
+  "agentRitualSummaryWakesSinceLast": "Acorda desde o último confronto individual",
+  "agentRunningIndicator": "Correndo",
+  "agentSessionProgressTitle": "Progresso da sessão",
+  "agentSettingsSubtitle": "Modelos, instâncias e monitoramento",
+  "agentSettingsTitle": "Agentes",
+  "agentSoulAntiSycophancyLabel": "Política Anti-Bajulação",
+  "agentSoulAssignedTemplatesTitle": "Modelos atribuídos",
+  "agentSoulAssignmentLabel": "Alma",
+  "agentSoulCoachingStyleLabel": "Estilo de treinamento",
+  "agentSoulCreatedSuccess": "Alma criada",
+  "agentSoulCreateTitle": "Criar alma",
+  "agentSoulDeleteConfirmBody": "Isto removerá a alma e todas as suas versões.",
+  "agentSoulDeleteConfirmTitle": "Excluir alma",
+  "agentSoulDetailTitle": "Detalhe da Alma",
+  "agentSoulDisplayNameLabel": "Nome",
+  "agentSoulEvolutionHistoryTitle": "História da Evolução da Alma",
+  "agentSoulEvolutionNoSessions": "Nenhuma sessão de evolução da alma ainda",
+  "agentSoulFieldAntiSycophancy": "Anti-bajulação",
+  "agentSoulFieldCoachingStyle": "Estilo de treinamento",
+  "agentSoulFieldToneBounds": "Limites de tom",
+  "agentSoulFieldVoice": "Voz",
+  "agentSoulInfoTab": "Informações",
+  "agentSoulNoneAssigned": "Nenhuma alma designada",
+  "agentSoulNotFound": "Alma não encontrada",
+  "agentSoulProposalSubtitle": "Mudanças de personalidade propostas",
+  "agentSoulProposalTitle": "Proposta de Personalidade da Alma",
+  "agentSoulReviewHeroSubtitle": "Refine a personalidade em todos os modelos que compartilham essa alma. O agente de evolução recebe feedback de cada modelo que usa essa personalidade.",
+  "agentSoulReviewStartAction": "Iniciar revisão de personalidade",
+  "agentSoulReviewStartHint": "Inicie uma sessão focada na personalidade para revisar o feedback e evoluir a voz, o tom, o estilo de coaching e a franqueza.",
+  "agentSoulReviewTemplateCount": "{count, plural, =1{1 modelo compartilhando esta alma} other{{count} modelos compartilhando esta alma}}",
+  "@agentSoulReviewTemplateCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentSoulReviewTitle": "Alma 1 contra 1",
+  "agentSoulRollbackAction": "Reverter para esta versão",
+  "agentSoulRollbackConfirm": "Reverter para a versão {version}? Todos os modelos que usam esta alma receberão a mudança.",
+  "@agentSoulRollbackConfirm": {
+    "placeholders": {
+      "version": {
+        "type": "int"
+      }
+    }
+  },
+  "agentSoulSelectTitle": "Selecione Alma",
+  "agentSoulsEmptyFiltered": "Nenhuma alma corresponde aos seus filtros.",
+  "agentSoulSettingsTab": "Configurações",
+  "agentSoulsSearchPlaceholder": "Procure almas…",
+  "agentSoulsTitle": "Almas",
+  "agentSoulToneBoundsLabel": "Limites de tom",
+  "agentSoulVersionHistoryTitle": "Histórico de versões",
+  "agentSoulVersionLabel": "Versão {version}",
+  "@agentSoulVersionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "int"
+      }
+    }
+  },
+  "agentSoulVersionSaved": "Nova versão do soul salva",
+  "agentSoulVoiceDirectiveLabel": "Diretiva de Voz",
+  "agentStateConsecutiveFailures": "Falhas consecutivas",
+  "agentStateErrorLoading": "Falha ao carregar o estado: {error}",
+  "@agentStateErrorLoading": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "agentStateHeading": "Informações do estado",
+  "agentStateLastWake": "Último velório",
+  "agentStateNextWake": "Próximo despertar",
+  "agentStateRevision": "Revisão",
+  "agentStateSleepingUntil": "Dormindo até",
+  "agentStateWakeCount": "Contagem de despertares",
+  "agentStatsAllDayLegend": "O dia todo",
+  "agentStatsAverageLabel": "Média",
+  "agentStatsByTimeLegend": "Diariamente às {time}",
+  "@agentStatsByTimeLegend": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "agentStatsCacheRateLabel": "Taxa de cache",
+  "agentStatsDailyUsageHeading": "Uso Diário",
+  "agentStatsInputLabel": "Entrada",
+  "agentStatsNoUsage": "Nenhum uso de token registrado nos últimos 7 dias.",
+  "agentStatsOutputLabel": "Saída",
+  "agentStatsSourceActiveFor": "Ativo por {duration}",
+  "@agentStatsSourceActiveFor": {
+    "placeholders": {
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
+  "agentStatsSourceActivityHeading": "Atividade do agente",
+  "agentStatsSourceWakes": "{count, plural, =1{1 wake} other{{count} wakes}}",
+  "@agentStatsSourceWakes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "agentStatsTabTitle": "Estatísticas",
+  "agentStatsThoughtsLabel": "Pensamentos",
+  "agentStatsTodayLabel": "Hoje",
+  "agentStatsTokensPerWakeLabel": "Tokens / Despertar",
+  "agentStatsTokensUnit": "fichas",
+  "agentStatsUsageAboveAverage": "Você está usando mais tokens hoje do que normalmente usa até {time}.",
+  "@agentStatsUsageAboveAverage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "agentStatsUsageBelowAverage": "Você está usando menos tokens hoje do que normalmente usa até {time}.",
+  "@agentStatsUsageBelowAverage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "agentStatsWakesLabel": "Acorda",
+  "agentSuggestionTimeEntryUpdateCurrent": "Atual",
+  "@agentSuggestionTimeEntryUpdateCurrent": {
+    "description": "Label for the current value in an agent-proposed time entry edit diff."
+  },
+  "agentSuggestionTimeEntryUpdateNoChange": "(inalterado)",
+  "@agentSuggestionTimeEntryUpdateNoChange": {
+    "description": "Marker shown next to an unchanged current value in an agent-proposed time entry edit diff."
+  },
+  "agentSuggestionTimeEntryUpdateProposed": "Proposto",
+  "@agentSuggestionTimeEntryUpdateProposed": {
+    "description": "Label for the proposed value in an agent-proposed time entry edit diff."
+  },
+  "agentSuggestionTimeEntryUpdateUnavailable": "Entrada original não disponível",
+  "@agentSuggestionTimeEntryUpdateUnavailable": {
+    "description": "Message shown when the original time entry cannot be loaded for an agent-proposed edit."
+  },
+  "agentTabActivity": "Atividade",
+  "agentTabConversations": "Conversas",
+  "agentTabObservations": "Observações",
+  "agentTabReports": "Relatórios",
+  "agentTabStats": "Estatísticas",
+  "agentTemplateAggregateTokenUsageHeading": "Uso agregado de token",
+  "@agentTemplateAggregateTokenUsageHeading": {
+    "description": "Heading for the aggregate token usage section in agent template stats."
+  },
+  "agentTemplateAssignedLabel": "Modelo",
+  "@agentTemplateAssignedLabel": {
+    "description": "Label shown next to the template assigned to an agent."
+  },
+  "agentTemplateCreatedSuccess": "Modelo criado",
+  "@agentTemplateCreatedSuccess": {
+    "description": "Snackbar message after successfully creating a new template."
+  },
+  "agentTemplateCreateTitle": "Criar modelo",
+  "@agentTemplateCreateTitle": {
+    "description": "Page title for the create-template form."
+  },
+  "agentTemplateDeleteConfirm": "Excluir este modelo? Isto não pode ser desfeito.",
+  "@agentTemplateDeleteConfirm": {
+    "description": "Confirmation dialog message when deleting a template."
+  },
+  "agentTemplateDeleteHasInstances": "Não é possível excluir: os agentes ativos estão usando este modelo.",
+  "@agentTemplateDeleteHasInstances": {
+    "description": "Error message when trying to delete a template that has active instances."
+  },
+  "agentTemplateDisplayNameLabel": "Nome",
+  "@agentTemplateDisplayNameLabel": {
+    "description": "Label for the template display name input field."
+  },
+  "agentTemplateEditTitle": "Editar modelo",
+  "@agentTemplateEditTitle": {
+    "description": "Page title for the edit-template form."
+  },
+  "agentTemplateEvolveApprove": "Aprovar e salvar",
+  "@agentTemplateEvolveApprove": {
+    "description": "Button to accept and save proposed directive changes."
+  },
+  "agentTemplateEvolveReject": "Rejeitar",
+  "@agentTemplateEvolveReject": {
+    "description": "Button to reject the proposed directive changes."
+  },
+  "agentTemplateGeneralDirectiveHint": "Defina a personalidade, ferramentas, objetivos e estilo de interação do agente...",
+  "@agentTemplateGeneralDirectiveHint": {
+    "description": "Placeholder hint for the general directive text field."
+  },
+  "agentTemplateGeneralDirectiveLabel": "Diretiva Geral",
+  "@agentTemplateGeneralDirectiveLabel": {
+    "description": "Label for the general directive text field (persona, tools, objectives)."
+  },
+  "agentTemplateInstanceBreakdownHeading": "Detalhamento por instância",
+  "@agentTemplateInstanceBreakdownHeading": {
+    "description": "Heading for the per-instance breakdown section in agent template stats."
+  },
+  "agentTemplateKindDayAgent": "Agente diurno",
+  "@agentTemplateKindDayAgent": {
+    "description": "Display name for the Daily OS day-agent template kind."
+  },
+  "agentTemplateKindEventAgent": "Agente de Eventos",
+  "agentTemplateKindImprover": "Melhorador de modelo",
+  "@agentTemplateKindImprover": {
+    "description": "Display name for the template-improver agent kind."
+  },
+  "agentTemplateKindProjectAgent": "Agente de Projeto",
+  "@agentTemplateKindProjectAgent": {
+    "description": "Display name for the project-agent template kind."
+  },
+  "agentTemplateKindTaskAgent": "Agente de Tarefas",
+  "@agentTemplateKindTaskAgent": {
+    "description": "Display name for the task-agent template kind."
+  },
+  "agentTemplateMetricsTotalWakes": "Total de despertares",
+  "@agentTemplateMetricsTotalWakes": {
+    "description": "Metric label for the total number of agent wakes."
+  },
+  "agentTemplateNoneAssigned": "Nenhum modelo atribuído",
+  "@agentTemplateNoneAssigned": {
+    "description": "Text shown when an agent has no template assigned."
+  },
+  "agentTemplateNoTemplates": "Nenhum modelo disponível. Crie um em Configurações primeiro.",
+  "@agentTemplateNoTemplates": {
+    "description": "Message shown when no templates exist for agent creation."
+  },
+  "agentTemplateNotFound": "Modelo não encontrado",
+  "@agentTemplateNotFound": {
+    "description": "Error message when a referenced template cannot be found."
+  },
+  "agentTemplateNoVersions": "Nenhuma versão",
+  "@agentTemplateNoVersions": {
+    "description": "Placeholder shown when a template has no version history."
+  },
+  "agentTemplateReportDirectiveHint": "Defina a estrutura do relatório, seções obrigatórias e regras de formatação...",
+  "@agentTemplateReportDirectiveHint": {
+    "description": "Placeholder hint for the report directive text field."
+  },
+  "agentTemplateReportDirectiveLabel": "Diretiva de Relatório",
+  "@agentTemplateReportDirectiveLabel": {
+    "description": "Label for the report directive text field (report formatting)."
+  },
+  "agentTemplateReportsEmpty": "Ainda não há relatórios.",
+  "agentTemplateReportsTab": "Relatórios",
+  "@agentTemplateReportsTab": {
+    "description": "Tab label for the reports tab in agent template detail."
+  },
+  "agentTemplateRollbackAction": "Reverter para esta versão",
+  "@agentTemplateRollbackAction": {
+    "description": "Button label to roll back a template to a previous version."
+  },
+  "agentTemplateRollbackConfirm": "Reverter para a versão {version}? O agente utilizará esta versão em seu próximo wake.",
+  "@agentTemplateRollbackConfirm": {
+    "placeholders": {
+      "version": {
+        "type": "int"
+      }
+    }
+  },
+  "agentTemplateSaveNewVersion": "Salvar",
+  "@agentTemplateSaveNewVersion": {
+    "description": "Button label to save current edits as a new template version."
+  },
+  "agentTemplateSelectTitle": "Selecione o modelo",
+  "@agentTemplateSelectTitle": {
+    "description": "Title for the template selection dialog when creating an agent."
+  },
+  "agentTemplatesEmptyFiltered": "Nenhum modelo corresponde aos seus filtros.",
+  "agentTemplateSettingsTab": "Configurações",
+  "@agentTemplateSettingsTab": {
+    "description": "Tab label for the settings tab in agent template detail."
+  },
+  "agentTemplatesFilterSectionKind": "Gentil",
+  "agentTemplatesGroupByKind": "Gentil",
+  "agentTemplatesGroupNone": "Todos",
+  "agentTemplatesSearchPlaceholder": "Pesquisar modelos…",
+  "agentTemplateStatsTab": "Estatísticas",
+  "@agentTemplateStatsTab": {
+    "description": "Tab label for the stats tab in agent template detail."
+  },
+  "agentTemplateStatusActive": "Ativo",
+  "@agentTemplateStatusActive": {
+    "description": "Label for the active template status."
+  },
+  "agentTemplateStatusArchived": "Arquivado",
+  "@agentTemplateStatusArchived": {
+    "description": "Label for the archived template status."
+  },
+  "agentTemplatesTitle": "Modelos de agente",
+  "@agentTemplatesTitle": {
+    "description": "Page title for the agent templates list."
+  },
+  "agentTemplateSwitchHint": "Para usar um modelo diferente, destrua este agente e crie um novo.",
+  "@agentTemplateSwitchHint": {
+    "description": "Hint explaining that changing an agent's template requires recreating it."
+  },
+  "agentTemplateVersionHistoryTitle": "Histórico de versões",
+  "@agentTemplateVersionHistoryTitle": {
+    "description": "Section title for the list of template version history entries."
+  },
+  "agentTemplateVersionLabel": "Versão {version}",
+  "@agentTemplateVersionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "int"
+      }
+    }
+  },
+  "agentTemplateVersionSaved": "Nova versão salva",
+  "@agentTemplateVersionSaved": {
+    "description": "Snackbar message after successfully saving a new template version."
+  },
+  "agentThreadReportLabel": "Relatório produzido durante este velório",
+  "agentTokenUsageCachedTokens": "Em cache",
+  "agentTokenUsageEmpty": "Nenhum uso de token registrado ainda.",
+  "agentTokenUsageErrorLoading": "Falha ao carregar o uso do token: {error}",
+  "@agentTokenUsageErrorLoading": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "agentTokenUsageHeading": "Uso de token",
+  "agentTokenUsageInputTokens": "Entrada",
+  "agentTokenUsageModel": "Modelo",
+  "agentTokenUsageOutputTokens": "Saída",
+  "agentTokenUsageThoughtsTokens": "Pensamentos",
+  "agentTokenUsageTotalTokens": "Total",
+  "agentTokenUsageWakeCount": "Acorda",
+  "aggregationDailyAvg": "Média diária",
+  "aggregationDailyMax": "Máximo diário",
+  "aggregationDailySum": "Soma diária",
+  "aggregationHourlySum": "Soma horária",
+  "aggregationNone": "Valores brutos",
+  "aiAssistantTitle": "Gerar…",
+  "aiBatchToggleTooltip": "Mudar para gravação padrão",
+  "aiCapabilityChipImageGeneration": "Geração de imagem",
+  "aiCapabilityChipImageRecognition": "Reconhecimento de imagem",
+  "aiCapabilityChipThinking": "Pensando",
+  "aiCapabilityChipTranscription": "Transcrição",
+  "aiCardEmptyProposals": "Nenhuma proposta aberta · o agente apresentará novas alterações aqui",
+  "aiCardHistoryToggle": "História · {count}",
+  "@aiCardHistoryToggle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "aiCardMenuActionDelete": "Excluir",
+  "aiCardMenuActionEdit": "Editar",
+  "aiCardMenuTooltip": "Mais ações",
+  "aiCardOpenAgentInternals": "Abra os internos do agente",
+  "aiCardProposalConfirmed": "Confirmado",
+  "aiCardProposalDismissed": "Dispensado",
+  "aiCardProposalKindAdd": "Adicionar",
+  "aiCardProposalKindDue": "Devido",
+  "aiCardProposalKindEstimate": "Estimativa",
+  "aiCardProposalKindLabel": "Etiqueta",
+  "aiCardProposalKindPriority": "Prioridade",
+  "aiCardProposalKindRemove": "Remover",
+  "aiCardProposalKindStatus": "Estado",
+  "aiCardProposalKindUpdate": "Atualizar",
+  "aiCardReadMore": "Leia mais",
+  "aiCardShowLess": "Mostrar menos",
+  "aiCardTitle": "Resumo de IA",
+  "aiChatMessageCopied": "Copiado para a área de transferência",
+  "aiConfigFailedToLoadModelsGeneric": "Falha ao carregar modelos. Por favor, tente novamente.",
+  "aiConfigNoModelsAvailable": "Nenhum modelo de IA está configurado ainda. Adicione um nas configurações.",
+  "aiConfigNoSuitableModelsAvailable": "Nenhum modelo atende aos requisitos deste prompt. Configure modelos que suportem os recursos necessários.",
+  "aiConfigSelectProviderModalTitle": "Selecione o provedor de inferência",
+  "aiConfigSelectProviderTypeModalTitle": "Selecione o tipo de provedor",
+  "aiConfigUseReasoningFieldLabel": "Use o raciocínio",
+  "aiConsumptionCallsLine": "Chamadas de IA: {count} · impacto medido para {measured}",
+  "@aiConsumptionCallsLine": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "measured": {
+        "type": "int"
+      }
+    }
+  },
+  "aiConsumptionCostLine": "Custo: {cost}",
+  "@aiConsumptionCostLine": {
+    "placeholders": {
+      "cost": {
+        "type": "String"
+      }
+    }
+  },
+  "aiConsumptionImpactLine": "Impacto: {energy} · {carbon} CO₂e · {water} água",
+  "@aiConsumptionImpactLine": {
+    "placeholders": {
+      "energy": {
+        "type": "String"
+      },
+      "carbon": {
+        "type": "String"
+      },
+      "water": {
+        "type": "String"
+      }
+    }
+  },
+  "aiConsumptionLedgerCap": "Mostrando as chamadas {limit} mais recentes neste período",
+  "@aiConsumptionLedgerCap": {
+    "placeholders": {
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "aiConsumptionLedgerTitle": "Chamadas recentes",
+  "aiConsumptionMetricsNotReported": "Não relatado",
+  "aiConsumptionTokensLabel": "{tokens} tokens",
+  "@aiConsumptionTokensLabel": {
+    "placeholders": {
+      "tokens": {
+        "type": "String"
+      }
+    }
+  },
+  "aiConsumptionTokensLine": "Tokens: {input} entrada · {output} saída",
+  "@aiConsumptionTokensLine": {
+    "placeholders": {
+      "input": {
+        "type": "String"
+      },
+      "output": {
+        "type": "String"
+      }
+    }
+  },
+  "aiConsumptionTypeAgentTurn": "Turno do agente",
+  "aiConsumptionTypeAudioTranscription": "Transcrição",
+  "aiConsumptionTypeImageAnalysis": "Análise de imagem",
+  "aiConsumptionTypeImageGeneration": "Geração de imagem",
+  "aiConsumptionTypePromptGeneration": "Geração de prompt",
+  "aiConsumptionTypeTextGeneration": "Geração de texto",
+  "aiDeleteToastCascadeDescription": "{count, plural, =1{Também removeu 1 modelo: {names}} other{Também removeu {count} modelos: {names}}}",
+  "@aiDeleteToastCascadeDescription": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "names": {
+        "type": "String"
+      }
+    }
+  },
+  "aiDeleteToastErrorTitle": "Não foi possível excluir {name}",
+  "@aiDeleteToastErrorTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "aiDeleteToastModelTitle": "Modelo excluído",
+  "aiDeleteToastProfileTitle": "Perfil excluído",
+  "aiDeleteToastPromptTitle": "Prompt excluído",
+  "aiDeleteToastProviderTitle": "Provedor excluído",
+  "aiDeleteToastSkillTitle": "Habilidade excluída",
+  "aiDeleteToastUndoAction": "Desfazer",
+  "aiFormCancel": "Cancelar",
+  "aiFormFixErrors": "Corrija os erros antes de salvar",
+  "aiFormNoChanges": "Nenhuma alteração não salva",
+  "aiImageAnalysisPickerDefaultBadge": "Padrão",
+  "aiImageAnalysisPickerTitle": "Escolha um modelo de análise de imagem",
+  "aiImageGenerationPickerTitle": "Escolha um modelo de geração de imagem",
+  "aiImpactBreakdownBoth": "Ambos",
+  "aiImpactBreakdownCategory": "Por categoria",
+  "aiImpactBreakdownModel": "Por modelo",
+  "aiImpactCategoryTitle": "Divisão por categoria",
+  "aiImpactChartHint": "Toque em uma barra para definir o escopo das chamadas · toque em uma série para isolar",
+  "aiImpactChartShareCaption": "Composição ao longo do tempo",
+  "aiImpactChartShareSegment": "Compartilhar",
+  "aiImpactChartTitle": "{metric} por categoria",
+  "@aiImpactChartTitle": {
+    "placeholders": {
+      "metric": {
+        "type": "String"
+      }
+    }
+  },
+  "aiImpactChartTitleModel": "{metric} por modelo",
+  "@aiImpactChartTitleModel": {
+    "placeholders": {
+      "metric": {
+        "type": "String"
+      }
+    }
+  },
+  "aiImpactCoverageNote": "Energia, CO₂e e custo são medidos apenas para modelos de nuvem.",
+  "aiImpactEmptyBody": "As chamadas de IA de suas tarefas e agentes aparecerão aqui.",
+  "aiImpactEmptyTitle": "Nenhum uso de IA neste intervalo",
+  "aiImpactKpiCarbon": "CO₂E",
+  "aiImpactKpiCost": "CUSTO",
+  "aiImpactKpiDeltaBaseline": "vs {period}",
+  "@aiImpactKpiDeltaBaseline": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "aiImpactKpiEnergy": "ENERGIA",
+  "aiImpactKpiRequests": "PEDIDOS",
+  "aiImpactKpiTokens": "FICHAS",
+  "aiImpactLedgerClearFilter": "Mostrar tudo",
+  "aiImpactLoadError": "Não foi possível carregar os dados de impacto da IA",
+  "aiImpactLocationColumn": "LOCALIZAÇÃO",
+  "aiImpactLocationTitle": "Impacto por localização",
+  "aiImpactLocationUnknown": "Desconhecido",
+  "aiImpactMetricCarbon": "CO₂e",
+  "aiImpactMetricCost": "Custo",
+  "aiImpactMetricEnergy": "Energia",
+  "aiImpactMetricRequests": "Solicitações",
+  "aiImpactMetricTokens": "Fichas",
+  "aiImpactModelCallsLabel": "{count} chamadas",
+  "@aiImpactModelCallsLabel": {
+    "placeholders": {
+      "count": {
+        "type": "String"
+      }
+    }
+  },
+  "aiImpactModelColumn": "MODELO",
+  "aiImpactModelCostHeavy": "caro",
+  "aiImpactModelCoverageNote": "Os modelos locais estão excluídos deste gráfico.",
+  "aiImpactModelOther": "Outros modelos",
+  "aiImpactModelRatePerMillion": "{cost}/1 milhão de tokens",
+  "@aiImpactModelRatePerMillion": {
+    "placeholders": {
+      "cost": {
+        "type": "String"
+      }
+    }
+  },
+  "aiImpactModelTitle": "Detalhamento do modelo",
+  "aiImpactModelUnknown": "Modelo desconhecido",
+  "aiImpactRenewableColumn": "RENOVÁVEL",
+  "aiImpactTitle": "Impacto da IA",
+  "aiInferenceErrorAuthenticationTitle": "Falha na autenticação",
+  "aiInferenceErrorConnectionFailedTitle": "Falha na conexão",
+  "aiInferenceErrorInvalidRequestTitle": "Solicitação inválida",
+  "aiInferenceErrorRateLimitTitle": "Limite de taxa excedido",
+  "aiInferenceErrorRetryButton": "Tente novamente",
+  "aiInferenceErrorServerTitle": "Erro no servidor",
+  "aiInferenceErrorSuggestionsTitle": "Sugestões:",
+  "aiInferenceErrorTimeoutTitle": "Solicitação expirou",
+  "aiInferenceErrorUnknownTitle": "Erro",
+  "aiInternalsTitle": "Internos do agente",
+  "aiModelDownloadCloseButton": "Fechar",
+  "aiModelDownloadDialogDescription": "Lotti fará o download de {modelName} no cache de áudio MLX e o usará para processamento de fala local.",
+  "@aiModelDownloadDialogDescription": {
+    "placeholders": {
+      "modelName": {
+        "type": "String"
+      }
+    }
+  },
+  "aiModelDownloadDialogTitle": "Instale {modelName}",
+  "@aiModelDownloadDialogTitle": {
+    "placeholders": {
+      "modelName": {
+        "type": "String"
+      }
+    }
+  },
+  "aiModelDownloadInstallTooltip": "Instalar modelo",
+  "aiModelDownloadOpenProgressTooltip": "Mostrar progresso do download",
+  "aiModelDownloadStatusChecking": "Verificando o status do modelo",
+  "aiModelDownloadStatusDownloading": "Baixando {percent}%",
+  "@aiModelDownloadStatusDownloading": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "aiModelDownloadStatusDownloadingIndeterminate": "Baixando",
+  "aiModelDownloadStatusFailed": "Falha no download",
+  "aiModelDownloadStatusInstalled": "Instalado",
+  "aiModelDownloadStatusNotInstalled": "Não instalado",
+  "aiModelDownloadStatusUnsupported": "Apple Silicon necessário",
+  "aiModelInstallChoiceCancelButton": "Cancelar",
+  "aiModelInstallChoiceDescription": "Escolha o modelo local de fala para texto para fazer o download primeiro. Você pode instalar os outros posteriormente na lista de modelos.",
+  "aiModelInstallChoiceInstallButton": "Instalar modelo",
+  "aiModelInstallChoiceRecommended": "Recomendado",
+  "aiModelInstallChoiceTitle": "Escolha o modelo de áudio MLX",
+  "aiModelPickerByProviderLabel": "Escolha um provedor",
+  "aiModelPickerCurrentDefaultLabel": "Padrão atual",
+  "aiModelPickerProviderModelCount": "{count, plural, =1{1 modelo} other{{count} modelos}}",
+  "@aiModelPickerProviderModelCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "aiOllamaModelInstalledSuccessfully": "Modelo \"{modelName}\" instalado com sucesso!",
+  "@aiOllamaModelInstalledSuccessfully": {
+    "placeholders": {
+      "modelName": {
+        "type": "String"
+      }
+    }
+  },
+  "aiPickProviderBadgeDesktopOnly": "SOMENTE PARA COMPUTADOR",
+  "aiPickProviderBadgeNew": "NOVO",
+  "aiPickProviderBadgeRecommended": "RECOMENDADO",
+  "aiPickProviderContinueButton": "Continuar",
+  "aiPickProviderDontShowAgainButton": "Não mostre novamente",
+  "aiPickProviderFooterHint": "Você pode adicionar mais provedores posteriormente em Configurações → IA. Sua chave de API é armazenada localmente.",
+  "aiPickProviderModalTitle": "Configurar recursos de IA",
+  "aiPickProviderSubtitle": "Escolha um provedor para começar. Configuraremos modelos e um perfil inicial automaticamente.",
+  "aiProfileCardActiveBadge": "Ativo",
+  "aiProfileModelPickerSearchHint": "Pesquisar modelos…",
+  "aiProfileSlotModelMissing": "faltando",
+  "aiPromptGenerationPickerTitle": "Escolha um modelo de geração de prompt",
+  "aiProviderAlibabaDescription": "Família de modelos Qwen da Alibaba Cloud via API DashScope",
+  "aiProviderAlibabaName": "Nuvem Alibaba (Qwen)",
+  "aiProviderAnthropicDescription": "Família Claude de assistentes de IA da Anthropic",
+  "aiProviderAnthropicName": "Claude antrópico",
+  "aiProviderCardDraftBadge": "ESBOÇO",
+  "aiProviderCardFixButton": "Correção",
+  "aiProviderCardModelCount": "{count, plural, =1{1 modelo} other{{count} modelos}}",
+  "@aiProviderCardModelCount": {
+    "description": "Right-side meta on a connected provider card when no last-used data is available.",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "aiProviderCardModelCountWithLastUsed": "{count, plural, =1{1 modelo · último usado {lastUsed}} other{{count} modelos · último usado {lastUsed}}}",
+  "@aiProviderCardModelCountWithLastUsed": {
+    "description": "Right-side meta on a connected provider card combining model count with a last-used label.",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      },
+      "lastUsed": {
+        "type": "String",
+        "example": "2m ago"
+      }
+    }
+  },
+  "aiProviderCardOllamaHint": "Certifique-se de que Ollama esteja em execução",
+  "aiProviderCardStatusConnected": "{count, plural, =1{Conectado · 1 modelo} other{Conectado · {count} modelos}}",
+  "@aiProviderCardStatusConnected": {
+    "description": "Provider card status line when the provider has a key + at least one model row.",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "aiProviderCardStatusConnectedShort": "Conectado",
+  "aiProviderCardStatusInvalidKey": "Chave inválida",
+  "aiProviderCardStatusOffline": "Off-line · Certifique-se de que Ollama esteja em execução",
+  "aiProviderCardStatusOfflineShort": "Off-line",
+  "aiProviderConnectBackToProviders": "Voltar para provedores",
+  "aiProviderConnectBreadcrumbAdd": "Adicionar provedor",
+  "aiProviderConnectFieldBaseUrlHint": "Deixe em branco para usar o endpoint oficial",
+  "aiProviderConnectFieldBaseUrlLabelOptional": "URL base (opcional)",
+  "aiProviderConnectFieldBaseUrlPlaceholder": "https://api.example.com",
+  "aiProviderConnectFieldDisplayNameHint": "Exibido na sua lista de provedores",
+  "aiProviderConnectionCheckingLabel": "Verificando chave, listando modelos disponíveis…",
+  "aiProviderConnectionFailedBadResponseDetail": "Formato de resposta inesperado: {type}",
+  "@aiProviderConnectionFailedBadResponseDetail": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      }
+    }
+  },
+  "aiProviderConnectionFailedHttpDetail": "HTTP {status} · {message}",
+  "@aiProviderConnectionFailedHttpDetail": {
+    "placeholders": {
+      "status": {
+        "type": "int"
+      },
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "aiProviderConnectionFailedInvalidBaseUrlDetail": "O URL base deve incluir esquema http(s) e host (por exemplo, https://api.example.com)",
+  "aiProviderConnectionFailedNetworkDetail": "{message}",
+  "@aiProviderConnectionFailedNetworkDetail": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "aiProviderConnectionFailedTimeoutDetail": "A solicitação expirou",
+  "aiProviderConnectionFailedTitle": "Não foi possível entrar em contato com {providerName}. Verifique a chave ou sua rede.",
+  "@aiProviderConnectionFailedTitle": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "aiProviderConnectionRetestButton": "Teste novamente",
+  "aiProviderConnectionRetryButton": "Tentar novamente",
+  "aiProviderConnectionVerifiedSubtitle": "{count, plural, =1{1 modelo disponível em sua conta · respondeu em {ms}ms} other{{count} modelos disponíveis em sua conta · respondeu em {ms}ms}}",
+  "@aiProviderConnectionVerifiedSubtitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "ms": {
+        "type": "int"
+      }
+    }
+  },
+  "aiProviderConnectionVerifiedTitle": "Conexão verificada",
+  "aiProviderConnectKeyHelperLink": "Obtenha uma chave em {url}",
+  "@aiProviderConnectKeyHelperLink": {
+    "placeholders": {
+      "url": {
+        "type": "String"
+      }
+    }
+  },
+  "aiProviderConnectKeyHiddenLabel": "Oculto",
+  "aiProviderConnectKeyPrivacyHint": "Sua chave API nunca sai do seu dispositivo.",
+  "aiProviderConnectPageTitle": "Conectar {providerName}",
+  "@aiProviderConnectPageTitle": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "aiProviderConnectSaveAndContinue": "Salvar e continuar",
+  "aiProviderConnectSaveAsDraft": "Salvar como rascunho",
+  "aiProviderConnectSavedAsDraftToast": "Salvo como rascunho",
+  "aiProviderConnectStepChoose": "Escolha o provedor",
+  "aiProviderConnectStepConnect": "Conectar",
+  "aiProviderConnectStepReview": "Revisão",
+  "aiProviderDetailActiveProfileTitle": "Perfil ativo",
+  "aiProviderDetailAddModelButton": "Adicionar modelo",
+  "aiProviderDetailApiKeyLabel": "Chave de API",
+  "aiProviderDetailBackTooltip": "Voltar",
+  "aiProviderDetailBaseUrlLabel": "URL base",
+  "aiProviderDetailConnectionTitle": "Conexão",
+  "aiProviderDetailDangerZoneTitle": "Zona de perigo",
+  "aiProviderDetailDisplayNameLabel": "Nome de exibição",
+  "aiProviderDetailEditButton": "Editar",
+  "aiProviderDetailEditTooltip": "Editar provedor",
+  "aiProviderDetailLoadError": "Não foi possível carregar este provedor. Tente novamente na lista Configurações de IA.",
+  "aiProviderDetailMissingMessage": "Este provedor não está mais disponível.",
+  "aiProviderDetailModelsTitle": "{count, plural, =0{Models} =1{Modelos · 1} other{Modelos · {count}}}",
+  "@aiProviderDetailModelsTitle": {
+    "description": "Models section heading on the provider detail page; suffixes the count when one or more models exist.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "aiProviderDetailNoModelsMessage": "Ainda não há modelos. Adicione um para começar a usar este provedor.",
+  "aiProviderDetailPageTitle": "Detalhes do provedor",
+  "aiProviderDetailRemoveButton": "Remover provedor",
+  "aiProviderDetailRemoveDescription": "Exclui o provedor e todos os modelos que dependem dele. Isto não pode ser desfeito.",
+  "aiProviderDetailRemoveTitle": "Remover este provedor",
+  "aiProviderDetailValueUnset": "Não definido",
+  "aiProviderEmbeddedRuntimeHint": "É executado integrado no processo do aplicativo Apple. Nenhum servidor local ou URL base é necessário.",
+  "aiProviderGeminiDescription": "Modelos Gemini AI do Google",
+  "aiProviderGeminiName": "Google Gêmeos",
+  "aiProviderGenericOpenAiDescription": "API compatível com formato OpenAI",
+  "aiProviderGenericOpenAiName": "Compatível com OpenAI",
+  "aiProviderMeliousDescription": "Inferência hospedada na Europa com catálogo de modelos dinâmicos, roteamento, áudio e imagens",
+  "aiProviderMeliousName": "Melious.ai",
+  "aiProviderMistralDescription": "API de nuvem Mistral AI com transcrição de áudio nativa",
+  "aiProviderMistralName": "Mistral",
+  "aiProviderMlxAudioDescription": "Modelos de áudio MLX incorporados para STT e TTS locais no Apple Silicon",
+  "aiProviderMlxAudioName": "Áudio MLX (local)",
+  "aiProviderNebiusAiStudioDescription": "Modelos do Nebius AI Studio",
+  "aiProviderNebiusAiStudioName": "Estúdio de IA Nebius",
+  "aiProviderOllamaDescription": "Execute inferência localmente com Ollama",
+  "aiProviderOllamaName": "Ollama",
+  "aiProviderOmlxDescription": "Inferência oMLX compatível com OpenAI local para modelos MLX",
+  "aiProviderOmlxName": "oMLX (local)",
+  "aiProviderOpenAiDescription": "Modelos GPT da OpenAI",
+  "aiProviderOpenAiName": "OpenAI",
+  "aiProviderOpenRouterDescription": "Modelos do OpenRouter",
+  "aiProviderOpenRouterName": "OpenRouter",
+  "aiProviderTaglineAlibaba": "Modelos Qwen · multimodal · contexto longo",
+  "aiProviderTaglineAnthropic": "Família Claude · contexto longo",
+  "aiProviderTaglineGemini": "Multimodal · transcrição de áudio",
+  "aiProviderTaglineMelious": "Hospedado na UE · catálogo dinâmico · roteamento ecológico",
+  "aiProviderTaglineMlxAudio": "Incorporado · Apple Silicon · áudio local",
+  "aiProviderTaglineOllama": "Funciona localmente · sem chamadas na nuvem",
+  "aiProviderTaglineOmlx": "Inferência MLX local · Compatível com OpenAI",
+  "aiProviderTaglineOpenAi": "Família GPT · visão + raciocínio",
+  "aiProviderUnknownName": "Provedor de IA",
+  "aiProviderVoxtralDescription": "Transcrição Voxtral local (até 30 minutos de áudio, 13 idiomas)",
+  "aiProviderVoxtralName": "Voxtral (local)",
+  "aiProviderWhisperDescription": "Transcrição Local Whisper com API compatível com OpenAI",
+  "aiProviderWhisperName": "Sussurro (local)",
+  "aiRealtimeToggleTooltip": "Mudar para transcrição ao vivo",
+  "aiResponseDeleteCancel": "Cancelar",
+  "aiResponseDeleteConfirm": "Excluir",
+  "aiResponseDeleteError": "Falha ao excluir a resposta do AI. Por favor, tente novamente.",
+  "aiResponseDeleteTitle": "Excluir resposta de IA",
+  "aiResponseDeleteWarning": "Tem certeza de que deseja excluir esta resposta de IA? Isto não pode ser desfeito.",
+  "aiResponseTypeAudioTranscription": "Transcrição de áudio",
+  "aiResponseTypeChecklistUpdates": "Atualizações da lista de verificação",
+  "aiResponseTypeImageAnalysis": "Análise de imagem",
+  "aiResponseTypeImagePromptGeneration": "Solicitação de imagem",
+  "aiResponseTypePromptGeneration": "Prompt gerado",
+  "aiResponseTypeTaskSummary": "Resumo da tarefa",
+  "aiRunningActivityOpenProgress": "Mostrar o progresso da IA",
+  "aiSettingsAddedLabel": "Adicionado",
+  "aiSettingsAddModelButton": "Adicionar modelo",
+  "aiSettingsAddModelErrorDescription": "Algo deu errado ao adicionar o modelo. Por favor, tente novamente.",
+  "aiSettingsAddModelErrorTitle": "Não foi possível adicionar o modelo",
+  "aiSettingsAddModelTooltip": "Adicione este modelo ao seu provedor",
+  "aiSettingsAddProfileButton": "Adicionar perfil",
+  "aiSettingsAddProviderButton": "Adicionar provedor",
+  "aiSettingsAgentWakeConcurrencyDescription": "Escolha quantos agentes diferentes podem executar inferência ao mesmo tempo. Valores mais altos respondem mais rapidamente, mas utilizam mais capacidade do provedor e do dispositivo.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Agente simultâneo é ativado",
+  "aiSettingsClearAllFiltersTooltip": "Limpar todos os filtros",
+  "aiSettingsClearFiltersButton": "Limpar",
+  "aiSettingsCounterModels": "Modelos",
+  "aiSettingsCounterProfiles": "Perfis",
+  "aiSettingsCounterProviders": "Provedores",
+  "aiSettingsEmptyDescription": "Adicione um para desbloquear transcrição, reconhecimento de imagem, geração de imagem e pesquisa semântica.",
+  "aiSettingsEmptyTitle": "Ainda não há provedores",
+  "aiSettingsFilterByCapabilityTooltip": "Filtrar por capacidade {capability}",
+  "@aiSettingsFilterByCapabilityTooltip": {
+    "placeholders": {
+      "capability": {
+        "type": "String"
+      }
+    }
+  },
+  "aiSettingsFilterByProviderTooltip": "Filtrar por {provider}",
+  "@aiSettingsFilterByProviderTooltip": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "aiSettingsFilterByReasoningTooltip": "Filtrar por capacidade de raciocínio",
+  "aiSettingsFtueBannerDescription": "Demora cerca de um minuto. Lotti configurará modelos e um perfil inicial para você.",
+  "aiSettingsFtueBannerStartButton": "Iniciar configuração",
+  "aiSettingsFtueBannerTitle": "Adicione seu primeiro provedor de IA",
+  "aiSettingsModalityAudio": "Áudio",
+  "aiSettingsModalityText": "Texto",
+  "aiSettingsModalityVision": "Visão",
+  "aiSettingsNoModelsConfigured": "Nenhum modelo de IA configurado",
+  "aiSettingsNoProvidersConfigured": "Nenhum provedor de IA configurado",
+  "aiSettingsPageLead": "Configure os provedores de IA, os modelos que Lotti pode chamar e os perfis de inferência que decidem qual modelo lida com qual tarefa.",
+  "aiSettingsPageTitle": "Configurações de IA",
+  "aiSettingsReasoningLabel": "Raciocínio",
+  "aiSettingsRemoveModelTooltip": "Remova este modelo do seu provedor",
+  "aiSettingsSearchHint": "Pesquise fornecedores, modelos, perfis...",
+  "aiSettingsSearchHintShort": "Pesquisar",
+  "aiSettingsTabModels": "Modelos",
+  "aiSettingsTabProfiles": "Perfis",
+  "aiSettingsTabProviders": "Provedores",
+  "aiSetupPreviewAcceptButton": "Aceitar e finalizar",
+  "aiSetupPreviewAlreadyAddedSectionLabel": "Já adicionado",
+  "aiSetupPreviewCategoryFooter": "Configure uma categoria de teste {categoryName} para experimentar.",
+  "@aiSetupPreviewCategoryFooter": {
+    "placeholders": {
+      "categoryName": {
+        "type": "String",
+        "example": "Test Category Gemini Enabled"
+      }
+    }
+  },
+  "aiSetupPreviewConnectedHeader": "{providerName} conectado",
+  "@aiSetupPreviewConnectedHeader": {
+    "placeholders": {
+      "providerName": {
+        "type": "String",
+        "example": "Google Gemini"
+      }
+    }
+  },
+  "aiSetupPreviewCustomizeButton": "Personalizar",
+  "aiSetupPreviewLead": "Revise o que Lotti irá adicionar. Desmarque tudo o que você não deseja; você sempre pode configurá-lo manualmente mais tarde.",
+  "aiSetupPreviewLiveBadge": "Ao vivo",
+  "aiSetupPreviewModalTitle": "Configuração de {providerName}",
+  "@aiSetupPreviewModalTitle": {
+    "placeholders": {
+      "providerName": {
+        "type": "String",
+        "example": "Google Gemini"
+      }
+    }
+  },
+  "aiSetupPreviewModelsSectionLabel": "Modelos",
+  "aiSetupPreviewProfileSectionLabel": "Perfil de inferência",
+  "aiSetupPreviewProfileSetActiveBadge": "Definir ativo",
+  "aiSetupResultBulletCategoryCreated": "Configure uma categoria de teste {categoryName} para experimentar",
+  "@aiSetupResultBulletCategoryCreated": {
+    "placeholders": {
+      "categoryName": {
+        "type": "String",
+        "example": "Test Category Gemini Enabled"
+      }
+    }
+  },
+  "aiSetupResultBulletCategoryReused": "Reutilizando a categoria de teste existente {categoryName}",
+  "@aiSetupResultBulletCategoryReused": {
+    "placeholders": {
+      "categoryName": {
+        "type": "String",
+        "example": "Test Category Gemini Enabled"
+      }
+    }
+  },
+  "aiSetupResultBulletModels": "{count, plural, =1{1 modelo configurado} other{{count} modelos configurados}}",
+  "@aiSetupResultBulletModels": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "aiSetupResultBulletProfile": "Perfil de inferência criado {profileName}",
+  "@aiSetupResultBulletProfile": {
+    "placeholders": {
+      "profileName": {
+        "type": "String",
+        "example": "Gemini Flash"
+      }
+    }
+  },
+  "aiSetupResultErrorsHeader": "{count, plural, =1{1 issue} other{{count} problemas}} durante a configuração",
+  "@aiSetupResultErrorsHeader": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "aiSetupResultHeader": "{providerName} está conectado",
+  "@aiSetupResultHeader": {
+    "placeholders": {
+      "providerName": {
+        "type": "String",
+        "example": "Google Gemini"
+      }
+    }
+  },
+  "aiSetupResultKnownModelsMissing": "Falha ao encontrar as configurações necessárias do modelo {providerName}",
+  "@aiSetupResultKnownModelsMissing": {
+    "placeholders": {
+      "providerName": {
+        "type": "String",
+        "example": "Google Gemini"
+      }
+    }
+  },
+  "aiSetupResultLead": "Nós configuramos as coisas para você. Os recursos de IA estão prontos para uso em seu diário.",
+  "aiSetupResultModalTitle": "{providerName} pronto",
+  "@aiSetupResultModalTitle": {
+    "placeholders": {
+      "providerName": {
+        "type": "String",
+        "example": "Google Gemini"
+      }
+    }
+  },
+  "aiSetupResultStartUsingButton": "Comece a usar IA",
+  "aiSetupWizardCreatesOptimized": "Cria modelos otimizados, prompts e uma categoria de teste",
+  "aiSetupWizardDescription": "Configurar ou atualizar modelos, prompts e categoria de teste para {providerName}",
+  "@aiSetupWizardDescription": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "aiSetupWizardRunButton": "Executar configuração",
+  "aiSetupWizardRunLabel": "Execute o assistente de configuração",
+  "aiSetupWizardRunningButton": "Correndo...",
+  "aiSetupWizardSafeToRunMultiple": "É seguro executar várias vezes - os itens existentes serão mantidos",
+  "aiSetupWizardTitle": "Assistente de configuração de IA",
+  "aiSummaryPlayTooltip": "Resumo do jogo",
+  "aiSummaryPreparingTooltip": "Preparando áudio",
+  "aiSummarySpeakTooltip": "Leia o resumo em voz alta localmente",
+  "aiSummaryStopTooltip": "Pare",
+  "aiSummaryThinkingLabel": "Pensando…",
+  "aiSummaryTtsUnavailable": "A conversão de texto em fala não está disponível",
+  "aiTaskSummaryTitle": "Resumo da tarefa de IA",
+  "aiTranscriptionPickerDefaultBadge": "Padrão",
+  "aiTranscriptionPickerTitle": "Escolha um modelo de transcrição",
+  "apiKeyAddPageTitle": "Adicionar provedor",
+  "apiKeyAuthenticationDescription": "Proteja sua conexão API",
+  "apiKeyAuthenticationTitle": "Autenticação",
+  "apiKeyAvailableModelsDescription": "Adicione rapidamente modelos pré-configurados para este provedor",
+  "apiKeyAvailableModelsTitle": "Modelos Disponíveis",
+  "apiKeyBaseUrlLabel": "URL base",
+  "apiKeyDisplayNameHint": "Digite um nome amigável",
+  "apiKeyDisplayNameLabel": "Nome de exibição",
+  "apiKeyDynamicModelsDescription": "Pesquise o catálogo de modelos ao vivo deste fornecedor e adicione qualquer modelo",
+  "apiKeyEditGoBackButton": "Voltar",
+  "apiKeyEditLoadError": "Falha ao carregar a configuração da chave de API",
+  "apiKeyEditLoadErrorRetry": "Tente novamente ou entre em contato com o suporte",
+  "apiKeyEditPageTitle": "Editar provedor",
+  "apiKeyHideTooltip": "Ocultar chave de API",
+  "apiKeyInputHint": "Insira sua chave API",
+  "apiKeyInputLabel": "Chave de API",
+  "apiKeyKnownModelInputLabel": "Em: {modalities}",
+  "@apiKeyKnownModelInputLabel": {
+    "placeholders": {
+      "modalities": {
+        "type": "String"
+      }
+    }
+  },
+  "apiKeyKnownModelOutputLabel": "Fora: {modalities}",
+  "@apiKeyKnownModelOutputLabel": {
+    "placeholders": {
+      "modalities": {
+        "type": "String"
+      }
+    }
+  },
+  "apiKeyProviderConfigDescription": "Defina as configurações do seu provedor de inferência de IA",
+  "apiKeyProviderConfigTitle": "Configuração do provedor",
+  "apiKeyProviderTypeHint": "Selecione um tipo de provedor",
+  "apiKeyProviderTypeLabel": "Tipo de provedor",
+  "apiKeyShowTooltip": "Mostrar chave de API",
+  "audioRecordingCancel": "CANCELAR",
+  "audioRecordingDiscardDialogBody": "Esta gravação será excluída. Nenhuma entrada de áudio, transcrição ou resumo da tarefa será criada.",
+  "audioRecordingDiscardDialogCancel": "Continue gravando",
+  "audioRecordingDiscardDialogConfirm": "Descartar",
+  "audioRecordingDiscardDialogTitle": "Descartar gravação?",
+  "audioRecordingListening": "Ouvindo...",
+  "audioRecordingPause": "PAUSA",
+  "audioRecordingRealtime": "Transcrição ao vivo",
+  "audioRecordingResume": "RETOMAR",
+  "audioRecordings": "Gravações de áudio",
+  "audioRecordingStandard": "Padrão",
+  "audioRecordingStop": "PARAR",
+  "backfillAdvancedRecoveryActions": "{count, plural, =1{1 ação} other{{count} ações}}",
+  "@backfillAdvancedRecoveryActions": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "backfillAdvancedRecoveryTitle": "Recuperação avançada",
+  "backfillAskPeersConfirmAccept": "Pergunte aos colegas",
+  "backfillAskPeersConfirmContent": "{count, plural, =1{Isso transforma 1 entrada de log de sequência insolúvel de volta em falta, para que a varredura de preenchimento normal pergunte novamente aos pares. Os pares que ainda possuem a carga responderão; entradas verdadeiramente irrecuperáveis ​​serão retiradas novamente após a janela de anistia de 7 dias.} other{Isso faz com que todas {count} entradas de log de sequência não resolvíveis voltem a ser perdidas, para que a varredura de preenchimento normal pergunte novamente aos pares. Os pares que ainda possuem a carga responderão; entradas verdadeiramente irrecuperáveis serão retiradas novamente após a janela de anistia de 7 dias.}}",
+  "@backfillAskPeersConfirmContent": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "backfillAskPeersConfirmTitle": "Perguntar novamente aos colegas sobre entradas insolúveis?",
+  "backfillAskPeersDescription": "Inverta todas as entradas de log de sequência não resolvidas de volta para ausentes e deixe o backfill normal varrer novamente os pares.",
+  "backfillAskPeersProcessing": "Reabrindo…",
+  "backfillAskPeersTitle": "Pergunte aos colegas o que é insolúvel",
+  "backfillAskPeersTrigger": "{count, plural, =1{Peça aos colegas 1 entrada} other{Peça aos colegas {count} entradas}}",
+  "@backfillAskPeersTrigger": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "backfillCatchUpDescription": "Extraia entradas ausentes recentes de colegas agora mesmo.",
+  "backfillDevicesMeta": "{count, plural, =1{1 ID de dispositivo} other{{count} IDs de dispositivo}}",
+  "@backfillDevicesMeta": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "backfillManualDescription": "Solicite todas as entradas ausentes, independentemente da idade. Use isto para recuperar lacunas de sincronização mais antigas.",
+  "backfillManualProcessing": "Processando...",
+  "backfillManualTitle": "Preenchimento manual",
+  "backfillManualTrigger": "Solicitar entradas ausentes",
+  "backfillReRequestDescription": "Solicite novamente entradas que foram solicitadas, mas nunca recebidas. Use isto quando as respostas estiverem travadas.",
+  "backfillReRequestProcessing": "Solicitando novamente...",
+  "backfillReRequestTitle": "Nova solicitação pendente",
+  "backfillReRequestTrigger": "Solicitar novamente entradas pendentes",
+  "backfillResetUnresolvableDescription": "Redefina as entradas marcadas como insolúveis de volta para ausentes para que possam ser solicitadas novamente. Use após o repovoamento do log de sequência.",
+  "backfillResetUnresolvableProcessing": "Redefinindo...",
+  "backfillResetUnresolvableTitle": "Redefinir insolúvel",
+  "backfillResetUnresolvableTrigger": "Redefinir entradas insolúveis",
+  "backfillRetireStuckConfirmAccept": "Aposente-se agora",
+  "backfillRetireStuckConfirmContent": "{count, plural, =1{Isso marca 1 entrada de log de sequência atualmente aberta (ausente ou solicitada) como insolúvel. Use isto para desbloquear a marca d'água quando as entradas ficarem presas por um tempo sem que o período de anistia de 7 dias tenha passado. As entradas ainda poderão ser ressuscitadas se sua carga útil chegar posteriormente ao disco com um relógio de vetor válido.} other{Isso marca {count} entradas de log de sequência atualmente abertas (ausentes ou solicitadas) como insolúveis. Use isto para desbloquear a marca d'água quando as entradas ficarem presas por um tempo sem que o período de anistia de 7 dias tenha passado. As entradas ainda poderão ser ressuscitadas se sua carga chegar posteriormente ao disco com um relógio vetorial válido.}}",
+  "@backfillRetireStuckConfirmContent": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "backfillRetireStuckConfirmTitle": "Descontinuar entradas travadas agora?",
+  "backfillRetireStuckDescription": "Força todas as entradas de log de sequência solicitadas ou ausentes atualmente abertas a serem insolúveis. Ignora a anistia de 7 dias – use apenas para linhas travadas que bloqueiam a marca d’água.",
+  "backfillRetireStuckProcessing": "Aposentar-se…",
+  "backfillRetireStuckTitle": "Remover entradas travadas",
+  "backfillRetireStuckTrigger": "{count, plural, =1{Retirar 1 entrada travada} other{Retirar {count} entradas travadas}}",
+  "@backfillRetireStuckTrigger": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "backfillSettingsSubtitle": "Gerenciar a recuperação de lacunas de sincronização",
+  "backfillSettingsTitle": "Sincronização de preenchimento",
+  "backfillStatsBackfilled": "Preenchido",
+  "backfillStatsBurned": "Queimado",
+  "backfillStatsDeleted": "Excluído",
+  "backfillStatsMissing": "Desaparecido",
+  "backfillStatsNoData": "Não há dados de sincronização disponíveis",
+  "backfillStatsReceived": "Recebido",
+  "backfillStatsRefresh": "Atualizar estatísticas",
+  "backfillStatsRequested": "Solicitado",
+  "backfillStatsTitle": "Sincronizar estatísticas",
+  "backfillStatsTotalEntries": "Total de entradas",
+  "backfillStatsUnresolvable": "Insolúvel",
+  "backfillStatusInboundQueue": "Fila de entrada",
+  "backfillStatusMissing": "Desaparecido",
+  "backfillStatusSkipped": "Ignorado",
+  "backfillToggleDescription": "Solicita entradas ausentes das últimas 24 horas.",
+  "backfillToggleTitle": "Preenchimento automático",
+  "basicSettings": "Configurações básicas",
+  "cancelButton": "Cancelar",
+  "categoryActiveDescription": "As categorias inativas não aparecerão nas listas de seleção",
+  "categoryActiveSwitchDescription": "Selecionável para novas entradas",
+  "categoryAiDefaultsDescription": "Defina o perfil de IA padrão e o modelo de agente para novas tarefas nesta categoria",
+  "categoryAiDefaultsTitle": "Padrões de IA",
+  "categoryCreationError": "Falha ao criar categoria. Por favor, tente novamente.",
+  "categoryDayPlanDescription": "Disponibilize esta categoria para seleção no plano diário",
+  "categoryDayPlanLabel": "Planejamento do dia",
+  "categoryDefaultEventTemplateHint": "Selecione um modelo",
+  "categoryDefaultEventTemplateLabel": "Modelo de agente de eventos padrão",
+  "categoryDefaultLanguageDescription": "Defina um idioma padrão para tarefas nesta categoria",
+  "categoryDefaultProfileHint": "Selecione um perfil",
+  "categoryDefaultTemplateHint": "Selecione um modelo",
+  "categoryDefaultTemplateLabel": "Modelo de agente padrão",
+  "categoryDeleteConfirm": "SIM, EXCLUIR ESTA CATEGORIA",
+  "categoryDeleteConfirmation": "Esta ação não pode ser desfeita. Todas as entradas nesta categoria permanecerão, mas não serão mais categorizadas.",
+  "categoryDeleteTitle": "Excluir categoria?",
+  "categoryFavoriteBadgeLabel": "Favorito",
+  "categoryFavoriteDescription": "Marcar esta categoria como favorita",
+  "categoryIconChooseHint": "Selecione um ícone",
+  "categoryIconCreateHint": "Selecione um ícone",
+  "categoryIconEditHint": "Selecione um ícone diferente",
+  "categoryIconLabel": "Ícone",
+  "categoryIconPickerTitle": "Escolha o ícone",
+  "categoryNameRequired": "O nome da categoria é obrigatório",
+  "categoryNotFound": "Categoria não encontrada",
+  "categoryPrivateBadgeLabel": "Privado",
+  "categoryPrivateDescription": "Visível apenas quando entradas privadas são mostradas",
+  "categorySearchPlaceholder": "Pesquisar categorias...",
+  "changeSetCardTitle": "Mudanças propostas",
+  "changeSetConfirmAll": "Confirme tudo",
+  "changeSetConfirmAllPartialIssues": "{count, plural, =1{1 item teve problemas parciais} other{{count} itens tiveram problemas parciais}}",
+  "@changeSetConfirmAllPartialIssues": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "changeSetConfirmError": "Falha ao aplicar a alteração",
+  "changeSetItemConfirmed": "Alteração aplicada",
+  "changeSetItemConfirmedWithWarning": "Aplicado com aviso: {warning}",
+  "@changeSetItemConfirmedWithWarning": {
+    "placeholders": {
+      "warning": {
+        "type": "String"
+      }
+    }
+  },
+  "changeSetItemRejected": "Alteração rejeitada",
+  "changeSetPendingCount": "{count} pendentes",
+  "@changeSetPendingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "changeSetSwipeConfirm": "Confirmar",
+  "changeSetSwipeReject": "Rejeitar",
+  "chatInputCancelRealtime": "Cancelar (Esc)",
+  "chatInputCancelRecording": "Cancelar gravação (Esc)",
+  "chatInputConfigureModel": "Configurar modelo",
+  "chatInputHintDefault": "Pergunte sobre suas tarefas e produtividade...",
+  "chatInputHintSelectModel": "Selecione um modelo para começar a conversar",
+  "chatInputListening": "Ouvindo...",
+  "chatInputPleaseWait": "Por favor, espere...",
+  "chatInputProcessing": "Processando...",
+  "chatInputRecordVoice": "Gravar mensagem de voz",
+  "chatInputSendTooltip": "Enviar mensagem",
+  "chatInputStartRealtime": "Iniciar transcrição ao vivo",
+  "chatInputStopRealtime": "Interromper a transcrição ao vivo",
+  "chatInputStopTranscribe": "Pare e transcreva",
+  "checklistAddItem": "Adicionar um novo item",
+  "checklistAiConfidenceLabel": "Confiança: {level}",
+  "@checklistAiConfidenceLabel": {
+    "description": "Confidence level label in the AI suggestion dialog",
+    "placeholders": {
+      "level": {
+        "type": "String",
+        "example": "high"
+      }
+    }
+  },
+  "checklistAiMarkComplete": "Marcar como concluído",
+  "checklistAiSuggestionBody": "Este item parece estar concluído:",
+  "checklistAiSuggestionTitle": "Sugestão de IA",
+  "checklistAllDone": "Todos os itens concluídos!",
+  "checklistCollapseTooltip": "Recolher",
+  "checklistCompletedShort": "{completed}/{total} concluído",
+  "@checklistCompletedShort": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "checklistDelete": "Excluir lista de verificação?",
+  "checklistExpandTooltip": "Expandir",
+  "checklistExportAsMarkdown": "Exportar lista de verificação como Markdown",
+  "checklistExportFailed": "Falha na exportação",
+  "checklistItemArchived": "Item arquivado",
+  "checklistItemArchiveUndo": "Desfazer",
+  "checklistItemDeleteCancel": "Cancelar",
+  "checklistItemDeleteConfirm": "Confirmar",
+  "checklistItemDeleted": "Item excluído",
+  "checklistItemDeleteWarning": "Esta ação não pode ser desfeita.",
+  "checklistMarkdownCopied": "Lista de verificação copiada como Markdown",
+  "checklistMoreTooltip": "Mais",
+  "checklistNoneDone": "Nenhum item concluído ainda.",
+  "checklistNothingToExport": "Nenhum item para exportar",
+  "checklistProgressSemantics": "Progresso da lista de verificação",
+  "checklistShare": "Compartilhar",
+  "checklistShareHint": "Pressione e segure para compartilhar",
+  "checklistsReorder": "Reordenar",
+  "clearButton": "Limpar",
+  "colorCustomLabel": "Personalizado",
+  "colorLabel": "Cor",
+  "commandPaletteNoResults": "Nenhum comando disponível corresponde à sua pesquisa",
+  "commandPaletteSearchHint": "Comandos de pesquisa…",
+  "commandPaletteTitle": "Paleta de comandos",
+  "commonError": "Erro",
+  "commonLoading": "Carregando...",
+  "commonUnknown": "Desconhecido",
+  "completeHabitFailButton": "Perdido",
+  "completeHabitSkipButton": "Pular",
+  "completeHabitSuccessButton": "Sucesso",
+  "configFlagAttemptEmbeddingDescription": "Quando ativado, o aplicativo tentará gerar incorporações para suas entradas para melhorar a pesquisa e sugestões de conteúdo relacionado.",
+  "configFlagDailyOsOnboardingEnabled": "Passo a passo diário do sistema operacional",
+  "configFlagDailyOsOnboardingEnabledDescription": "Oriente os usuários iniciantes do Daily OS através de um check-in real que transforma a fala em uma tarefa e um plano diário.",
+  "configFlagEnableAiStreaming": "Habilite o streaming de IA para ações de tarefas",
+  "configFlagEnableAiStreamingDescription": "Transmita respostas de IA para ações relacionadas a tarefas. Desligue para armazenar respostas em buffer e manter a IU mais suave.",
+  "configFlagEnableAiSummaryTts": "Reprodução de resumo de IA",
+  "configFlagEnableAiSummaryTtsDescription": "Mostre o botão de conversão de texto em fala local nos resumos de IA de tarefas. Requer um modelo MLX Audio TTS instalado.",
+  "configFlagEnableDashboardsPage": "Ativar página Painéis",
+  "configFlagEnableDashboardsPageDescription": "Mostre a página Painéis na navegação principal. Visualize seus dados e insights em painéis personalizáveis.",
+  "configFlagEnableEmbeddings": "Gerar incorporações",
+  "configFlagEnableEvents": "Habilitar eventos",
+  "configFlagEnableEventsDescription": "Mostre o recurso Eventos para criar, rastrear e gerenciar eventos em seu diário.",
+  "configFlagEnableForkHealing": "Cura do garfo do agente",
+  "configFlagEnableForkHealingDescription": "Cure históricos de agentes divergentes do uso de vários dispositivos, mesclando-os no próximo despertar.",
+  "configFlagEnableHabitsPage": "Habilitar página de hábitos",
+  "configFlagEnableHabitsPageDescription": "Mostre a página Hábitos na navegação principal. Acompanhe e gerencie seus hábitos diários aqui.",
+  "configFlagEnableLogging": "Habilitar registro",
+  "configFlagEnableLoggingDescription": "Habilite o registro detalhado para fins de depuração. Isso pode afetar o desempenho.",
+  "configFlagEnableMatrix": "Ativar sincronização Matrix",
+  "configFlagEnableMatrixDescription": "Habilite a integração do Matrix para sincronizar suas entradas entre dispositivos e com outros usuários do Matrix.",
+  "configFlagEnableNotifications": "Ativar notificações?",
+  "configFlagEnableNotificationsDescription": "Receba notificações de lembretes, atualizações e eventos importantes.",
+  "configFlagEnableProjects": "Habilitar projetos",
+  "configFlagEnableProjectsDescription": "Mostre recursos de gerenciamento de projetos para organizar tarefas em projetos.",
+  "configFlagEnableSessionRatings": "Habilitar classificações de sessão",
+  "configFlagEnableSessionRatingsDescription": "Solicita uma classificação rápida da sessão quando você interrompe um cronômetro.",
+  "configFlagEnableTooltip": "Ativar dicas de ferramentas",
+  "configFlagEnableTooltipDescription": "Mostre dicas úteis em todo o aplicativo para guiá-lo pelos recursos.",
+  "configFlagEnableVectorSearch": "Pesquisa vetorial",
+  "configFlagEnableVectorSearchDescription": "Ative a pesquisa vetorial em filtros de tarefas. Requer que os embeddings estejam habilitados e o Ollama em execução.",
+  "configFlagEnableWhatsNew": "Mostrar o que há de novo",
+  "configFlagEnableWhatsNewDescription": "Destaque novos recursos e alterações na árvore Configurações.",
+  "configFlagPrivate": "Mostrar entradas privadas?",
+  "configFlagPrivateDescription": "Habilite isto para tornar suas entradas privadas por padrão. As entradas privadas são visíveis apenas para você.",
+  "configFlagRecordLocation": "Local de registro",
+  "configFlagRecordLocationDescription": "Registre automaticamente sua localização com novas entradas. Isso ajuda na organização e pesquisa baseada em localização.",
+  "configFlagResendAttachments": "Reenviar anexos",
+  "configFlagResendAttachmentsDescription": "Ative esta opção para reenviar automaticamente uploads de anexos com falha quando a conexão for restaurada.",
+  "configFlagShowSyncActivityIndicator": "Mostrar indicador de atividade de sincronização",
+  "configFlagShowSyncActivityIndicatorDescription": "Mostrar um status de sincronização silenciosa na barra lateral; as contagens de fila aparecem apenas enquanto o trabalho está pendente.",
+  "conflictApplyButton": "Aplicar",
+  "conflictApplyFailedTitle": "Não foi possível aplicar a resolução",
+  "conflictBannerAgoDays": "{count, plural, =1{1 dia atrás} other{{count} dias atrás}}",
+  "@conflictBannerAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "conflictBannerAgoHours": "{count, plural, =1{1 h atrás} other{{count} h atrás}}",
+  "@conflictBannerAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "5"
+      }
+    }
+  },
+  "conflictBannerAgoJustNow": "agora mesmo",
+  "conflictBannerAgoMinutes": "{count, plural, =1{1 minuto atrás} other{{count} minutos atrás}}",
+  "@conflictBannerAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "conflictBannerDivergedAgo": "{entity} · divergiu {ago}",
+  "@conflictBannerDivergedAgo": {
+    "description": "Conflict summary banner first line.",
+    "placeholders": {
+      "entity": {
+        "type": "String",
+        "example": "Audio note"
+      },
+      "ago": {
+        "type": "String",
+        "example": "2 min ago"
+      }
+    }
+  },
+  "conflictBannerFieldsDifferList": "Difere em: {fields}",
+  "@conflictBannerFieldsDifferList": {
+    "description": "Conflict summary banner subline listing differing fields, e.g. 'Title · word count differ'.",
+    "placeholders": {
+      "fields": {
+        "type": "String",
+        "example": "Title · word count"
+      }
+    }
+  },
+  "conflictCombineApply": "Aplicar combinado",
+  "conflictCombineStartFrom": "Começar de",
+  "conflictConfirmDeletion": "Confirmar exclusão",
+  "conflictDeleteVsEditDescription": "Esta entrada foi editada em um dispositivo e excluída em outro. Nada é removido até que você escolha.",
+  "conflictDeleteVsEditTitle": "Excluído em um dispositivo",
+  "conflictDetailEntryNotFoundTitle": "Entrada não encontrada",
+  "conflictDetailLoadErrorTitle": "Não foi possível carregar o conflito",
+  "conflictDetailNotFoundTitle": "Conflito não encontrado",
+  "conflictDiffRecommended": "Recomendado",
+  "conflictDiffUnchanged": "{count, plural, =1{1 campo inalterado} other{{count} campos inalterados}}",
+  "@conflictDiffUnchanged": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "conflictFieldBody": "Corpo",
+  "conflictFieldCategory": "Categoria",
+  "conflictFieldDuration": "Duração",
+  "conflictFieldEnd": "Fim",
+  "conflictFieldFlag": "Bandeira",
+  "conflictFieldOther": "Outros detalhes",
+  "conflictFieldOtherDescription": "Estas versões diferem em detalhes não mostrados individualmente aqui.",
+  "conflictFieldPrivate": "Privado",
+  "conflictFieldStarred": "Com estrela",
+  "conflictFieldStart": "Começar",
+  "conflictFieldTitle": "Título",
+  "conflictFieldWordCount": "contagem de palavras",
+  "conflictFlagFollowUp": "Acompanhamento necessário",
+  "conflictFlagImport": "Importado",
+  "conflictFlagNone": "Nenhum",
+  "conflictFooterHelperLocalSelected": "Manterá sua edição local e descartará a versão sincronizada.",
+  "conflictFooterHelperPickASide": "Escolha um lado para aplicar.",
+  "conflictFooterHelperRemoteSelected": "Aceitará a versão sincronizada e descartará sua edição local.",
+  "conflictHeaderPillEntries": "{count, plural, =1{1 entrada} other{{count} entradas}}",
+  "@conflictHeaderPillEntries": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "conflictHeaderPillFieldsDiffer": "{count, plural, =1{1 campo difere} other{{count} campos diferem}}",
+  "@conflictHeaderPillFieldsDiffer": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "conflictKeepEdited": "Mantenha a versão editada",
+  "conflictListItemSemanticsLabel": "{status}, {timestamp}, {entityType}, conflito {id}",
+  "@conflictListItemSemanticsLabel": {
+    "description": "Screen-reader label for a row in the conflicts list. Reads status, timestamp, entity type, and the full conflict id.",
+    "placeholders": {
+      "status": {
+        "type": "String",
+        "example": "Unresolved"
+      },
+      "timestamp": {
+        "type": "String",
+        "example": "2024-03-15 12:34:56"
+      },
+      "entityType": {
+        "type": "String",
+        "example": "Task"
+      },
+      "id": {
+        "type": "String",
+        "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      }
+    }
+  },
+  "conflictListItemTooltipFullId": "ID do conflito: {id}",
+  "@conflictListItemTooltipFullId": {
+    "description": "Tooltip on the truncated conflict id in the list row, revealing the full id.",
+    "placeholders": {
+      "id": {
+        "type": "String",
+        "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      }
+    }
+  },
+  "conflictMetaLocalEdit": "edição local",
+  "conflictMetaVecPrefix": "vec",
+  "conflictMetaViaSync": "via sincronização",
+  "conflictNotificationBody": "{count, plural, =1{1 entrada foi editada em dois dispositivos} other{{count} entradas foram editadas em dois dispositivos}}",
+  "@conflictNotificationBody": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "conflictNotificationTitle": "A sincronização precisa da sua análise",
+  "conflictPageLeadDesktop": "Diferenças destacadas inline. Clique em um lado para usar essa versão ou abra Editar e mesclar para combiná-los.",
+  "conflictPageLeadMobile": "Diferenças destacadas inline. Toque em um lado para usar essa versão.",
+  "conflictPageTitle": "Conflito de sincronização",
+  "conflictPickerCombine": "Combine…",
+  "conflictPickerEditMerge": "Editar e mesclar…",
+  "conflictPickerUseFromSync": "Usar da sincronização",
+  "conflictPickerUseThisDevice": "Use este dispositivo",
+  "conflictResolvedToast": "Conflito resolvido",
+  "conflictsEmptyDescription": "Tudo está sincronizado agora. Os itens resolvidos permanecem disponíveis no outro filtro.",
+  "conflictsEmptyTitle": "Nenhum conflito detectado",
+  "conflictSideFromSync": "DA SINCRONIZAÇÃO",
+  "conflictSideThisDevice": "ESTE DISPOSITIVO",
+  "conflictsResolved": "resolvido",
+  "conflictsUnresolved": "não resolvido",
+  "conflictValueAbsent": "Não definido",
+  "conflictValueNo": "Não",
+  "conflictValueYes": "Sim",
+  "conflictWordCount": "{count, plural, one{{count} palavra} other{{count} palavras}}",
+  "@conflictWordCount": {
+    "description": "Word count shown on the conflict detail meta row.",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "8"
+      }
+    }
+  },
+  "copyAsMarkdown": "Copiar como Markdown",
+  "copyAsText": "Copiar como texto",
+  "correctionExampleCancel": "CANCELAR",
+  "correctionExamplePending": "Salvando a correção em {seconds}s...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": {
+        "type": "int"
+      }
+    }
+  },
+  "correctionExamplesEmpty": "Nenhuma correção capturada ainda. Edite um item da lista de verificação para adicionar seu primeiro exemplo.",
+  "correctionExamplesSectionDescription": "Quando você corrige manualmente os itens da lista de verificação, essas correções são salvas aqui e usadas para melhorar as sugestões de IA.",
+  "correctionExamplesSectionTitle": "Exemplos de correção de lista de verificação",
+  "correctionExamplesWarning": "Você tem {count} correções. Somente o {max} mais recente será usado nos prompts de IA. Considere excluir exemplos antigos ou redundantes.",
+  "@correctionExamplesWarning": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "coverArtChipActive": "Capa",
+  "coverArtChipSet": "Definir capa",
+  "coverArtGenerationComplete": "Arte da capa pronta!",
+  "coverArtGenerationDismissHint": "Você pode fechar isto – a geração continua em segundo plano",
+  "createButton": "Criar",
+  "createCategoryTitle": "Criar categoria",
+  "createEntryLabel": "Criar nova entrada",
+  "createEntryTitle": "Adicionar",
+  "createNewLinkedTask": "Criar nova tarefa vinculada...",
+  "customColor": "Cor personalizada",
+  "dailyOsDayPlan": "Plano do dia",
+  "dailyOsNextAgendaCapacityComfortable": "Confortável",
+  "dailyOsNextAgendaCapacityNearFull": "Quase cheio",
+  "dailyOsNextAgendaCapacityNoPlan": "Ainda não há plano",
+  "dailyOsNextAgendaCapacityOf": "de {capacity}",
+  "@dailyOsNextAgendaCapacityOf": {
+    "placeholders": {
+      "capacity": {
+        "type": "String",
+        "example": "8h"
+      }
+    }
+  },
+  "dailyOsNextAgendaCapacityOver": "Excesso de capacidade",
+  "dailyOsNextAgendaDonutLeft": "esquerda",
+  "dailyOsNextAgendaDonutOver": "acabou",
+  "dailyOsNextAgendaHeadlineLeft": "{duration} restante",
+  "@dailyOsNextAgendaHeadlineLeft": {
+    "placeholders": {
+      "duration": {
+        "type": "String",
+        "example": "15m"
+      }
+    }
+  },
+  "dailyOsNextAgendaHeadlineOver": "{duration} acabou",
+  "@dailyOsNextAgendaHeadlineOver": {
+    "placeholders": {
+      "duration": {
+        "type": "String",
+        "example": "1h"
+      }
+    }
+  },
+  "dailyOsNextAgendaNoPlanBody": "Seu tempo monitorado está aqui de qualquer maneira - faça um check-in e eu elaborarei um rascunho do dia em torno dele.",
+  "dailyOsNextAgendaNoPlanSummary": "{duration} monitorado até agora. Fale um check-in e eu elaborarei um dia em torno disso.",
+  "@dailyOsNextAgendaNoPlanSummary": {
+    "placeholders": {
+      "duration": {
+        "type": "String",
+        "example": "4h 35m"
+      }
+    }
+  },
+  "dailyOsNextAgendaNoPlanTitle": "Nenhum plano ainda para hoje.",
+  "dailyOsNextAgendaStateDone": "Concluído",
+  "dailyOsNextAgendaStateInProgress": "Em andamento",
+  "dailyOsNextAgendaStateOpen": "Abrir",
+  "dailyOsNextAgendaStateOverdue": "Atrasado",
+  "dailyOsNextAgendaSummary": "{scheduled} de {capacity} comprometido",
+  "@dailyOsNextAgendaSummary": {
+    "placeholders": {
+      "scheduled": {
+        "type": "String",
+        "example": "5h 15m"
+      },
+      "capacity": {
+        "type": "String",
+        "example": "8h"
+      }
+    }
+  },
+  "dailyOsNextAgendaTrackedLegend": "Rastreado · {duration} · {completedCount} concluído",
+  "@dailyOsNextAgendaTrackedLegend": {
+    "placeholders": {
+      "duration": {
+        "type": "String",
+        "example": "4h 35m"
+      },
+      "completedCount": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "dailyOsNextBlockEditCategoryLabel": "Categoria",
+  "dailyOsNextBlockEditFailed": "Não foi possível atualizar o bloco. Tente novamente.",
+  "dailyOsNextBlockEditNameLabel": "Título",
+  "dailyOsNextBlockEditOpenTask": "Tarefa aberta",
+  "dailyOsNextBlockEditSave": "Salvar alterações",
+  "dailyOsNextBlockEditSaved": "Cronograma atualizado.",
+  "dailyOsNextBlockEditTimeLabel": "Início e fim",
+  "dailyOsNextBlockEditTitle": "Editar bloco",
+  "dailyOsNextBlockEditTooltip": "Editar bloco",
+  "dailyOsNextBlockEditWhyLabel": "Por que desta vez",
+  "dailyOsNextBlockMoveTooltip": "Mover bloco",
+  "dailyOsNextBlockResizeEndTooltip": "Ajustar final",
+  "dailyOsNextBlockResizeStartTooltip": "Ajustar início",
+  "dailyOsNextCaptureCaptured": "Entendi.",
+  "dailyOsNextCaptureDoneCta": "Concluído",
+  "dailyOsNextCaptureErrorMicrophonePermissionDenied": "A permissão do microfone foi negada.",
+  "dailyOsNextCaptureErrorNoActiveRealtimeSession": "Nenhuma sessão ativa em tempo real.",
+  "dailyOsNextCaptureErrorNoAudioRecorded": "Nenhum áudio foi gravado.",
+  "dailyOsNextCaptureErrorRealtimeTranscriptionFailed": "Falha na transcrição em tempo real.",
+  "dailyOsNextCaptureErrorRealtimeTranscriptionStartFailed": "A transcrição em tempo real não pôde ser iniciada.",
+  "dailyOsNextCaptureErrorRecordingStartFailed": "A gravação não pôde ser iniciada.",
+  "dailyOsNextCaptureErrorTranscriptionFailed": "Falha na transcrição.",
+  "dailyOsNextCaptureHeadlineCaptured": "Isso parece certo?",
+  "dailyOsNextCaptureHeadlineLead": "O que está em sua mente",
+  "dailyOsNextCaptureHeadlineListening": "Estou ouvindo.",
+  "dailyOsNextCaptureHeadlineTail": "para hoje?",
+  "dailyOsNextCaptureHeadlineTailForDate": "para {date}?",
+  "@dailyOsNextCaptureHeadlineTailForDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsNextCaptureHeadlineTailTomorrow": "para amanhã?",
+  "dailyOsNextCaptureHeadlineTailYesterday": "para ontem?",
+  "dailyOsNextCaptureHeadlineTranscribing": "Escrevendo isso…",
+  "dailyOsNextCaptureIdleClick": "Clique para falar",
+  "dailyOsNextCaptureIdleExample": "“Trabalho intenso esta manhã, uma caminhada depois do almoço, e-mails antes das cinco.”",
+  "dailyOsNextCaptureIdleHint": "Toque para falar · digite em vez disso",
+  "dailyOsNextCaptureIdleTalk": "Toque para falar",
+  "dailyOsNextCaptureListeningStatus": "Ouvindo…",
+  "dailyOsNextCapturePastPrompt": "Há algo que você ainda queira acompanhar a partir de {date}?",
+  "@dailyOsNextCapturePastPrompt": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsNextCaptureReconcileCta": "Revisão",
+  "dailyOsNextCapturesPanelTitle": "Capturas",
+  "dailyOsNextCaptureTranscribing": "Transcrevendo…",
+  "dailyOsNextCaptureTranscriptHint": "Corrija qualquer coisa errada na transcrição antes de planejar.",
+  "dailyOsNextCaptureTranscriptLabel": "Transcrição da revisão",
+  "dailyOsNextCaptureTypeInstead": "Digite em vez disso",
+  "dailyOsNextCaptureVoiceButtonReset": "Recomeçar",
+  "dailyOsNextCaptureVoiceButtonStart": "Comece a ouvir",
+  "dailyOsNextCaptureVoiceButtonStop": "Pare de ouvir",
+  "dailyOsNextCategoryFilterAll": "Todas as categorias",
+  "dailyOsNextCategoryFilterDescription": "Somente categorias habilitadas para planejamento diário são exibidas para processamento automatizado do Daily OS.",
+  "dailyOsNextCategoryFilterEmpty": "Nenhuma categoria habilitada para planejamento do dia ainda.",
+  "dailyOsNextCategoryFilterIncludeAll": "Incluir tudo",
+  "dailyOsNextCategoryFilterTitle": "Categorias de processamento",
+  "dailyOsNextCategoryFilterTooltip": "Escolha as categorias de processamento diário do sistema operacional",
+  "dailyOsNextCommitCapacityNote": "{scheduled} de {capacity} comprometido. Margem confortável – você pode absorver uma surpresa.",
+  "@dailyOsNextCommitCapacityNote": {
+    "placeholders": {
+      "scheduled": {
+        "type": "String",
+        "example": "5h 15m"
+      },
+      "capacity": {
+        "type": "String",
+        "example": "8h"
+      }
+    }
+  },
+  "dailyOsNextCommitDraftOverline": "SEU DIA, Elaborado",
+  "dailyOsNextCommitExplainer": "Assine para passar hoje do rascunho para o compromisso.",
+  "dailyOsNextCommitFinalStepEyebrow": "ETAPA FINAL",
+  "dailyOsNextCommitHeadline": "Faça com que seja seu.",
+  "dailyOsNextCommitHoldHelper": "Espere um segundo para assinar",
+  "dailyOsNextCommitHoldWordDone": "Comprometido",
+  "dailyOsNextCommitHoldWordHolding": "Continue segurando",
+  "dailyOsNextCommitHoldWordIdle": "Espera",
+  "dailyOsNextCommitLockingIn": "Bloqueando…",
+  "dailyOsNextCommitShepherdSubline": "Eu cuidarei disso – você faz o trabalho.",
+  "dailyOsNextCommitSubCaption": "Você ainda pode falar comigo depois - mas os ossos permanecem no lugar.",
+  "dailyOsNextCommitTitle": "Tranque-o",
+  "dailyOsNextCommitTodayIsYours": "Hoje é seu.",
+  "dailyOsNextDayBack": "Voltar",
+  "dailyOsNextDayCheckInCta": "Fale um check-in",
+  "dailyOsNextDayDeleteDialogBody": "Os blocos elaborados para este dia serão removidos. As capturas e suas gravações de áudio permanecem em seu diário.",
+  "dailyOsNextDayDeleteDialogCancel": "Cancelar",
+  "dailyOsNextDayDeleteDialogConfirm": "Excluir",
+  "dailyOsNextDayDeleteDialogTitle": "Excluir este plano?",
+  "dailyOsNextDayLockInCta": "Bloquear",
+  "dailyOsNextDayMenuDeletePlan": "Excluir plano",
+  "dailyOsNextDayMenuInspectAgent": "Inspecionar agente",
+  "dailyOsNextDayMenuSettings": "Configurações diárias do sistema operacional",
+  "dailyOsNextDayMoreTooltip": "Mais",
+  "dailyOsNextDayRefineCta": "Refinar",
+  "dailyOsNextDayRefineFooterHint": "Fale para reformular o plano – você verá todas as alterações antes que qualquer coisa seja salva.",
+  "dailyOsNextDayTitle": "Seu dia",
+  "dailyOsNextDayWhyChipLabel": "POR QUE",
+  "dailyOsNextDayWrapUpCta": "Concluir",
+  "dailyOsNextDraftingBackToDecisions": "Voltar às decisões",
+  "dailyOsNextDraftingHeader": "Desenhando o seu dia…",
+  "dailyOsNextDraftingNudgeAccept": "Sim, proteja as manhãs",
+  "dailyOsNextDraftingNudgeDecline": "Hoje não",
+  "dailyOsNextDraftingProgressBlocks": "Blocos de desenho",
+  "dailyOsNextDraftingProgressMatching": "Tarefas correspondentes",
+  "dailyOsNextDraftingProgressQueued": "Na fila",
+  "dailyOsNextDraftingProgressReading": "Check-in de leitura",
+  "dailyOsNextDraftingProgressSaving": "Plano de poupança",
+  "dailyOsNextDraftingProgressValidating": "Validando",
+  "dailyOsNextDraftingReasoningOverline": "✦ RACIOCÍNIO",
+  "dailyOsNextDraftingRecoveryBody": "O velório não produziu um plano. Tente novamente ou volte e ajuste as decisões antes de redigir.",
+  "dailyOsNextDraftingRecoveryTitle": "Rascunho parado",
+  "dailyOsNextDraftingRetry": "Tente novamente",
+  "dailyOsNextDraftingStatusAfternoon": "Sequenciando a tarde…",
+  "dailyOsNextDraftingStatusAlmost": "Quase lá…",
+  "dailyOsNextDraftingStatusBreathing": "Deixando espaço para respirar…",
+  "dailyOsNextDraftingStatusDeepWork": "Colocando o trabalho profundo em primeiro lugar…",
+  "dailyOsNextDraftingStatusMatching": "Combinando tarefas com o seu dia…",
+  "dailyOsNextDraftingStatusReading": "Lendo seu check-in…",
+  "dailyOsNextDraftingStatusTimings": "Verificando os horários…",
+  "dailyOsNextDraftingStatusYesterday": "Olhando para o ritmo de ontem…",
+  "dailyOsNextEditTitleHint": "Editar título",
+  "dailyOsNextGenericError": "Algo deu errado. Tente novamente em alguns instantes.",
+  "dailyOsNextGreetingAfternoon": "Boa tarde.",
+  "dailyOsNextGreetingEvening": "Boa noite.",
+  "dailyOsNextGreetingHiName": "Olá {name} 👋",
+  "@dailyOsNextGreetingHiName": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsNextGreetingMorning": "Bom dia.",
+  "dailyOsNextKnowledgeConfirm": "Confirmar",
+  "dailyOsNextKnowledgeConfirmedHeader": "Confirmado",
+  "dailyOsNextKnowledgeEdit": "Editar",
+  "dailyOsNextKnowledgeEditCancel": "Cancelar",
+  "dailyOsNextKnowledgeEditHookHint": "Resumo de uma linha",
+  "dailyOsNextKnowledgeEditSave": "Salvar",
+  "dailyOsNextKnowledgeEditStatementHint": "O que devo lembrar?",
+  "dailyOsNextKnowledgeEmpty": "Nada ainda - vou lembrar o que você me disser.",
+  "dailyOsNextKnowledgeNudge": "{count, plural, one{1 coisa que notei — revise} other{{count} coisas que notei — revise}}",
+  "@dailyOsNextKnowledgeNudge": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "dailyOsNextKnowledgeProposedHeader": "Aguardando sua confirmação",
+  "dailyOsNextKnowledgeRetract": "Esqueça",
+  "dailyOsNextKnowledgeStale": "Ainda é verdade?",
+  "dailyOsNextKnowledgeTitle": "O que eu aprendi",
+  "dailyOsNextParsedCardBreakLinkTooltip": "Quebrar link",
+  "dailyOsNextPlanViewAgenda": "Agenda",
+  "dailyOsNextPlanViewDay": "Dia",
+  "dailyOsNextReconcileBadgeMatched": "COMBINADO",
+  "dailyOsNextReconcileBadgeNew": "NOVO",
+  "dailyOsNextReconcileBadgeUpdate": "ATUALIZAR",
+  "dailyOsNextReconcileBuildDayCta": "Construa meu dia",
+  "dailyOsNextReconcileDecideOverline": "VALE A PENA DECIDIR",
+  "dailyOsNextReconcileDecisionProgress": "{decided} de {total} avaliados",
+  "@dailyOsNextReconcileDecisionProgress": {
+    "placeholders": {
+      "decided": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "dailyOsNextReconcileDefaultBehaviorHint": "Revise os cartões antes de construir o seu dia. As ações escolhidas contribuem para o plano; as cartas deixadas sozinhas permanecem como estão.",
+  "dailyOsNextReconcileError": "Algo deu errado: {detail}",
+  "@dailyOsNextReconcileError": {
+    "placeholders": {
+      "detail": {
+        "type": "String",
+        "example": "Network unreachable"
+      }
+    }
+  },
+  "dailyOsNextReconcileHeadline": "Aqui está o que ouvi.",
+  "dailyOsNextReconcileHeardEmpty": "Os cartões de captura aparecerão aqui assim que a análise terminar.",
+  "dailyOsNextReconcileHeardOverline": "OUVI",
+  "dailyOsNextReconcileLowConfidence": "baixa confiança",
+  "dailyOsNextReconcileProcessing": "Ouvindo e combinando com o seu dia…",
+  "dailyOsNextReconcileReRecord": "Regravar",
+  "dailyOsNextReconcileVoiceHint": "Revise as decisões antes de construir o seu dia",
+  "dailyOsNextRefineAccept": "Aceitar",
+  "dailyOsNextRefineCurrentPlan": "PLANO ATUAL",
+  "dailyOsNextRefineDiffAdded": "ADICIONADO",
+  "dailyOsNextRefineDiffDropped": "CAIU",
+  "dailyOsNextRefineDiffMoved": "MOVIDO",
+  "dailyOsNextRefineHeadlineDiffReady": "Aqui está o que eu mudaria.",
+  "dailyOsNextRefineHeadlineIdle": "O que deveria mudar?",
+  "dailyOsNextRefineHeadlineThinking": "Reformulando seu plano…",
+  "dailyOsNextRefineKeepTalking": "Continue falando",
+  "dailyOsNextRefineLooksGood": "Parece bom",
+  "dailyOsNextRefineNoChanges": "Nenhuma mudança de plano voltou. Reformule-o e tente novamente.",
+  "dailyOsNextRefineOverline": "🎤 REFINAMENTO",
+  "dailyOsNextRefineRevert": "Reverter",
+  "dailyOsNextRefineStatusAccepted": "Trancado.",
+  "dailyOsNextRefineStatusDiffReady": "Aqui está o que mudou.",
+  "dailyOsNextRefineStatusIdle": "Toque para falar.",
+  "dailyOsNextRefineStatusListening": "Ouvindo…",
+  "dailyOsNextRefineStatusThinking": "✦ Reelaborando o plano…",
+  "dailyOsNextRefineTitle": "Refinar o plano",
+  "dailyOsNextRenameFailed": "Não foi possível renomear. Tente novamente.",
+  "dailyOsNextReviewAddBuffer": "Adicionar buffer",
+  "dailyOsNextReviewAddBufferPrompt": "Adicione um buffer realista entre os blocos planejados, especialmente em torno de transições e após trabalhos exigentes.",
+  "dailyOsNextReviewAdjust": "Ajustar",
+  "dailyOsNextReviewLooksGood": "Parece bom",
+  "dailyOsNextReviewMoveLighter": "Mova-se com mais leveza",
+  "dailyOsNextReviewMoveLighterPrompt": "Mova o trabalho mais leve ou de menor energia para mais tarde e mantenha a janela de foco mais forte para a tarefa mais exigente.",
+  "dailyOsNextReviewTooMuch": "Demais",
+  "dailyOsNextReviewTooMuchPrompt": "Este plano é demais para hoje. Reduza a carga, proteja o espaço para respirar e guarde apenas os blocos mais importantes.",
+  "dailyOsNextReviewWhyTitle": "Por que eles chegaram",
+  "dailyOsNextShutdownCarryoverDrop": "Soltar",
+  "dailyOsNextShutdownCarryoverDropped": "Caiu",
+  "dailyOsNextShutdownCarryoverOverline": "VAI EM FRENTE",
+  "dailyOsNextShutdownCarryoverPickDate": "Escolha uma data",
+  "dailyOsNextShutdownCarryoverScheduled": "Agendado",
+  "dailyOsNextShutdownCloseDay": "Fechar o dia",
+  "dailyOsNextShutdownCompletedOverline": "O QUE VOCÊ FEZ",
+  "dailyOsNextShutdownMetricEnergy": "ENERGIA",
+  "dailyOsNextShutdownMetricEnergyDelta": "{delta} vs. semana",
+  "@dailyOsNextShutdownMetricEnergyDelta": {
+    "placeholders": {
+      "delta": {
+        "type": "String",
+        "example": "⬆ 0.6"
+      }
+    }
+  },
+  "dailyOsNextShutdownMetricFlow": "SESSÕES DE FLUXO",
+  "dailyOsNextShutdownMetricFocus": "TEMPO DE FOCO",
+  "dailyOsNextShutdownMetricSwitches": "INTERRUPTORES DE CONTEXTO",
+  "dailyOsNextShutdownMetricSwitchesAvg": "média {avg} esta semana",
+  "@dailyOsNextShutdownMetricSwitchesAvg": {
+    "placeholders": {
+      "avg": {
+        "type": "String",
+        "example": "8.0"
+      }
+    }
+  },
+  "dailyOsNextShutdownReflectionOverline": "💬 REFLEXÃO DE UMA LINHA",
+  "dailyOsNextShutdownReflectionPlaceholder": "por exemplo, a manhã foi nítida, a tarde arrastada depois do café com Sarah demorou muito.",
+  "dailyOsNextShutdownReflectionPrompt": "Como hoje pousou? (Isso alimenta o rascunho de amanhã.)",
+  "dailyOsNextShutdownReflectionSpeak": "Fale",
+  "dailyOsNextShutdownReflectionSubmit": "Pular",
+  "dailyOsNextShutdownReflectionThanks": "Entendi - alimentação amanhã.",
+  "dailyOsNextShutdownSaveAndClose": "Salvar e fechar",
+  "dailyOsNextShutdownTitle": "Encerre o dia",
+  "dailyOsNextShutdownTomorrowOverline": "✦ PARA AMANHÃ",
+  "dailyOsNextStateDueOnDate": "Vencimento em {date}",
+  "@dailyOsNextStateDueOnDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsNextStateDueToday": "Vencimento hoje",
+  "dailyOsNextStateInProgress": "{count, plural, =0{Em andamento} =1{Em andamento · 1 sessão} other{Em andamento · {count} sessões}}",
+  "@dailyOsNextStateInProgress": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "dailyOsNextStateOverdue": "{days, plural, =0{Overdue} =1{Atrasado · 1 dia} other{Atrasado · {days} dias}}",
+  "@dailyOsNextStateOverdue": {
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "dailyOsNextStateOverdueOnDate": "{days, plural, =0{Atrasado em {date}} =1{Atrasado em 1 dia em {date}} other{Atrasado em {days} dias em {date}}}",
+  "@dailyOsNextStateOverdueOnDate": {
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "3"
+      },
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsNextStateRecurringMissed": "Recorrente · perdido",
+  "dailyOsNextTimelineActual": "Real",
+  "dailyOsNextTimelineArrange": "Organizar blocos",
+  "dailyOsNextTimelineBoth": "Planejado e real",
+  "dailyOsNextTimelineMeridiemAm": "SOU",
+  "dailyOsNextTimelineMeridiemAmShort": "sou",
+  "dailyOsNextTimelineMeridiemPm": "PM",
+  "dailyOsNextTimelineMeridiemPmShort": "tarde",
+  "dailyOsNextTimelinePlanned": "Plano",
+  "dailyOsNextTimelineSessionOf": "Sessão {index} de {total}",
+  "@dailyOsNextTimelineSessionOf": {
+    "placeholders": {
+      "index": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "dailyOsNextTimelineShowBoth": "Mostrar o plano e o real juntos",
+  "dailyOsNextTimelineShowPaged": "Mostrar plano deslizante e real",
+  "dailyOsNextTimelineSwipeHint": "Deslize para real · aperte verticalmente para ampliar",
+  "dailyOsNextTimelineTracked": "rastreado",
+  "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 sessão anterior} other{{count} sessões anteriores}}",
+  "@dailyOsNextTimeSpentEarlierSessions": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "dailyOsNextTimeSpentShowLess": "Mostrar menos",
+  "dailyOsNextTimeSpentSummary": "{duration} · {completedCount} concluído",
+  "@dailyOsNextTimeSpentSummary": {
+    "placeholders": {
+      "duration": {
+        "type": "String"
+      },
+      "completedCount": {
+        "type": "int"
+      }
+    }
+  },
+  "dailyOsNextTimeSpentTitle": "HOJE ATÉ AGORA",
+  "dailyOsNextTimeSpentTitlePast": "TEMPO GASTO",
+  "dailyOsNextTriageConfirmDefer": "Adiado",
+  "dailyOsNextTriageConfirmDone": "Marcado como concluído",
+  "dailyOsNextTriageConfirmDoNow": "Feito agora",
+  "dailyOsNextTriageConfirmDrop": "Caiu",
+  "dailyOsNextTriageConfirmToday": "Adicionado a hoje",
+  "dailyOsNextTriageDefer": "Adiar",
+  "dailyOsNextTriageDone": "Concluído",
+  "dailyOsNextTriageDoNow": "Faça agora",
+  "dailyOsNextTriageDrop": "Soltar",
+  "dailyOsNextTriageToday": "Hoje",
+  "dailyOsOnboardingCoachCapture": "Diga o que está chamando sua atenção.",
+  "dailyOsOnboardingCoachDrafting": "O planejador está criando novas tarefas e adaptando o trabalho ao seu dia.",
+  "dailyOsOnboardingCoachReconcile": "Escolha o que pertence hoje. Novos itens se tornam tarefas quando você constrói o dia.",
+  "dailyOsOnboardingSpotlightAction": "Experimente",
+  "dailyOsOnboardingSpotlightDismiss": "Agora não",
+  "dailyOsOnboardingSpotlightMessage": "Toque aqui e diga o que você está pensando – vou transformar isso em uma tarefa e construir o seu dia em torno disso.",
+  "dailyOsOnboardingSpotlightTitle": "Transforme a conversa em um plano",
+  "dailyOsSettingsChooseModelDescription": "Substitua apenas o modelo de pensamento do planejador.",
+  "dailyOsSettingsChooseModelTitle": "Escolha a substituição do modelo",
+  "dailyOsSettingsChooseProfileDescription": "Substitua o perfil de inferência completo deste planejador.",
+  "dailyOsSettingsChooseProfileTitle": "Escolha o perfil diário do sistema operacional",
+  "dailyOsSettingsDataDisclosure": "O Daily OS envia tarefas relevantes, capturas, planos, preferências aprendidas e outros contextos de planejamento montados ao provedor selecionado para processamento.",
+  "dailyOsSettingsDefaultProfileDescription": "Usado pelo Daily OS, a menos que a instância do planejador tenha uma substituição.",
+  "dailyOsSettingsDefaultProfileMissing": "Escolha um perfil",
+  "dailyOsSettingsDefaultRestored": "Padrão diário do sistema operacional restaurado",
+  "dailyOsSettingsDirectOverrideActive": "A substituição direta do modelo está ativa.",
+  "dailyOsSettingsInferenceTitle": "Perfil de inferência padrão",
+  "dailyOsSettingsInstanceCurrentSetup": "Configuração atual do planejador",
+  "dailyOsSettingsInstanceOverrideDescription": "Use o perfil padrão do Daily OS, escolha uma substituição de perfil ou substitua apenas o modelo de pensamento deste planejador.",
+  "dailyOsSettingsInstanceOverrideTitle": "Inferência diária do sistema operacional",
+  "dailyOsSettingsLocalDisclosure": "O endpoint selecionado está neste dispositivo.",
+  "dailyOsSettingsModelChanged": "O sistema operacional diário agora usa {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Adicionar nome",
+  "dailyOsSettingsNameNudgeBody": "Adicionar um nome preferido torna os check-ins mais pessoais. Você pode continuar planejando sem ele.",
+  "dailyOsSettingsNameNudgeTitle": "Como o Daily OS deve abordar você?",
+  "dailyOsSettingsProfileChanged": "O sistema operacional diário agora usa {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Substituição de perfil ativa",
+  "dailyOsSettingsRemoteDisclosure": "O Daily OS envia o contexto de planejamento montado para {provider} em {host} para processamento remoto.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Configurar o sistema operacional diário",
+  "dailyOsSettingsSetupRequiredBody": "O Daily OS precisa da escolha do seu provedor antes de poder processar seu contexto de planejamento.",
+  "dailyOsSettingsSetupRequiredTitle": "Escolha um perfil de inferência",
+  "dailyOsSettingsSubtitle": "Escolha como o Daily OS aborda você e qual perfil de inferência planeja seus dias.",
+  "dailyOsSettingsTitle": "SO diário",
+  "dailyOsSettingsTreeSubtitle": "Provedor de planejamento, personalização e IA",
+  "dailyOsSettingsUseDefault": "Usar o padrão diário do sistema operacional",
+  "dailyOsSettingsUseDefaultDescription": "Siga o perfil selecionado nas configurações diárias do sistema operacional.",
+  "dailyOsTodayButton": "Hoje",
+  "dashboardActiveLabel": "Ativo",
+  "dashboardActiveSwitchDescription": "Exibido na lista de painéis",
+  "dashboardAddChartsTitle": "Gráficos",
+  "dashboardAddHabitButton": "Hábitos",
+  "dashboardAddHabitTitle": "Gráficos de hábitos",
+  "dashboardAddHealthButton": "Saúde",
+  "dashboardAddHealthTitle": "Gráficos de saúde",
+  "dashboardAddMeasurementButton": "Medições",
+  "dashboardAddMeasurementTitle": "Adicionar gráficos de medição",
+  "dashboardAddMeasurementTooltip": "Adicionar medição",
+  "dashboardAddSurveyButton": "Pesquisas",
+  "dashboardAddSurveyTitle": "Gráficos de pesquisa",
+  "dashboardAddWorkoutButton": "Exercícios",
+  "dashboardAddWorkoutTitle": "Gráficos de treino",
+  "dashboardAggregationApplyImmediately": "Escolha um resumo. As alterações aplicam-se imediatamente.",
+  "dashboardAggregationDailyAverage": "Média diária",
+  "dashboardAggregationDailyMax": "Máximo diário",
+  "dashboardAggregationDailyTotal": "Total diário",
+  "dashboardAggregationHourlyTotal": "Total por hora",
+  "dashboardAggregationLabel": "Tipo de agregação:",
+  "dashboardAggregationTitle": "Tipo de agregação",
+  "dashboardAvailableChartsDescription": "Escolha um tipo, selecione um ou mais gráficos e adicione-os.",
+  "dashboardAvailableChartsTitle": "Adicione gráficos por tipo",
+  "dashboardCategoryLabel": "Categoria",
+  "dashboardChartNoData": "Não há dados neste intervalo",
+  "dashboardConfigurationDescription": "Salve o painel e copie sua configuração JSON.",
+  "dashboardConfigurationTitle": "Exportar configuração",
+  "dashboardCopyHint": "Salvar e copiar configuração do painel",
+  "dashboardCopyLabel": "Salvar e copiar JSON",
+  "dashboardCurrentChartsDescription": "Arraste para reordenar. Os gráficos de medição podem ser selecionados para alterar sua agregação.",
+  "dashboardCurrentChartsTitle": "Gráficos neste painel",
+  "dashboardDeleteConfirm": "SIM, EXCLUIR ESTE PAINEL",
+  "dashboardDeleteHint": "Excluir painel",
+  "dashboardDeleteQuestion": "Deseja excluir este painel?",
+  "dashboardDescriptionLabel": "Descrição (opcional)",
+  "dashboardEditAggregationLabel": "Editar agregação",
+  "dashboardHealthBloodPressure": "Pressão Arterial",
+  "dashboardHealthDiastolic": "Diastólica",
+  "dashboardHealthSystolic": "Sistólica",
+  "dashboardMeasurementAddButtonWithCount": "{count, plural, =1{Adicionar 1 gráfico} other{Adicionar {count} gráficos}}",
+  "@dashboardMeasurementAddButtonWithCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "dashboardMeasurementAggregationFor": "Modo gráfico para {name}",
+  "@dashboardMeasurementAggregationFor": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "dashboardMeasurementAggregationHelp": "Selecione gráficos de medição. Ajuste o modo de gráfico nas linhas selecionadas antes de adicionar.",
+  "dashboardNameLabel": "Nome do painel",
+  "dashboardNoChartsAdded": "Nenhum gráfico adicionado ainda. Adicione um abaixo.",
+  "dashboardNoHabitsForCharts": "Crie primeiro um hábito para adicionar gráficos de hábitos.",
+  "dashboardNoMeasurablesForCharts": "Crie primeiro um mensurável para adicionar gráficos de medição.",
+  "dashboardNotFound": "Painel não encontrado",
+  "dashboardPrivateLabel": "Privado",
+  "dashboardRemoveChartLabel": "Remover gráfico",
+  "dashboardReorderChartLabel": "Reordenar gráfico",
+  "dashboardTakeSurveyTooltip": "Faça uma pesquisa",
+  "defaultLanguage": "Idioma padrão",
+  "deleteButton": "Excluir",
+  "deleteDeviceLabel": "Excluir dispositivo",
+  "designSystemActionVariantTitle": "Com ação",
+  "designSystemActivatedLabel": "Ativado",
+  "designSystemAvatarAwayLabel": "Longe",
+  "designSystemAvatarBusyLabel": "Ocupado",
+  "designSystemAvatarConnectedLabel": "Conectado",
+  "designSystemAvatarEnabledLabel": "Habilitado",
+  "designSystemAvatarSizeMatrixTitle": "Matriz de tamanho",
+  "designSystemAvatarStatusMatrixTitle": "Matriz de status",
+  "designSystemBackLabel": "Voltar",
+  "designSystemBreadcrumbCurrentLabel": "Pão ralado",
+  "designSystemBreadcrumbDesignSystemLabel": "Sistema de projeto",
+  "designSystemBreadcrumbHomeLabel": "Página inicial",
+  "designSystemBreadcrumbMobileLabel": "Móvel",
+  "designSystemBreadcrumbProjectsLabel": "Projetos",
+  "designSystemBreadcrumbSampleLabel": "Pão ralado",
+  "designSystemBreadcrumbTrailTitle": "Trilha de pão ralado",
+  "designSystemCalendarPickerLabel": "Seletor de calendário",
+  "designSystemCalendarViewsTitle": "Visualizações de calendário",
+  "designSystemCaptionDescriptionSample": "A remoção de todos os usuários cancelou a publicação deste projeto. Adicione usuários para publicá-lo novamente.",
+  "designSystemCaptionIconLeftLabel": "Ícone esquerdo",
+  "designSystemCaptionIconTopLabel": "Ícone superior",
+  "designSystemCaptionNoIconLabel": "Nenhum ícone",
+  "designSystemCaptionTitleSample": "Título da legenda",
+  "designSystemCaptionVariantsTitle": "Variantes de legenda",
+  "designSystemCaptionWithActionsLabel": "Com ações",
+  "designSystemCaptionWithoutActionsLabel": "Sem ações",
+  "designSystemCheckboxLabel": "Caixa de seleção",
+  "designSystemContextMenuDeleteLabel": "Excluir",
+  "designSystemContextMenuVariantsTitle": "Variantes do menu de contexto",
+  "designSystemCountdownVariantTitle": "Com contagem regressiva",
+  "designSystemDateCardsTitle": "Cartões de data",
+  "designSystemDefaultLabel": "Padrão",
+  "designSystemDisabledLabel": "Desativado",
+  "designSystemDividerLabelText": "Etiqueta divisória",
+  "designSystemDropdownComboboxTitle": "Caixa de combinação",
+  "designSystemDropdownFieldLabel": "Etiqueta",
+  "designSystemDropdownInputLabel": "Entrada",
+  "designSystemDropdownListTitle": "Lista suspensa",
+  "designSystemDropdownMultiselectInputLabel": "Selecione equipes",
+  "designSystemDropdownMultiselectTitle": "Seleção múltipla",
+  "designSystemDropdownOptionAnalytics": "Análise",
+  "designSystemDropdownOptionBackend": "Back-end",
+  "designSystemDropdownOptionDesign": "Projeto",
+  "designSystemDropdownOptionFrontend": "Interface",
+  "designSystemDropdownOptionGrowth": "Crescimento",
+  "designSystemDropdownOptionMobile": "Móvel",
+  "designSystemDropdownOptionQa": "Controle de qualidade",
+  "designSystemErrorLabel": "Erro",
+  "designSystemFileUploadClickLabel": "Clique para carregar",
+  "designSystemFileUploadCompleteLabel": "Completo",
+  "designSystemFileUploadDefaultLabel": "Padrão",
+  "designSystemFileUploadDragLabel": "ou arraste e solte",
+  "designSystemFileUploadDropZoneSectionTitle": "Zona de lançamento",
+  "designSystemFileUploadErrorLabel": "Erro",
+  "designSystemFileUploadFailedText": "Falha no upload",
+  "designSystemFileUploadHintText": "SVG, PNG, JPG ou GIF (máx. 800×400px)",
+  "designSystemFileUploadHoverLabel": "Passe o mouse",
+  "designSystemFileUploadItemSectionTitle": "Itens de arquivo",
+  "designSystemFileUploadRetryLabel": "Tentar novamente",
+  "designSystemFileUploadUploadingLabel": "Enviando",
+  "designSystemFilledLabel": "Preenchido",
+  "designSystemHeaderApiDocumentationLabel": "Documentação da API",
+  "designSystemHeaderBackActionLabel": "Voltar",
+  "designSystemHeaderDesktopSectionTitle": "Área de trabalho",
+  "designSystemHeaderHelpActionLabel": "Ajuda",
+  "designSystemHeaderMobileSectionTitle": "Móvel",
+  "designSystemHeaderNotificationsActionLabel": "Notificações",
+  "designSystemHeaderSearchActionLabel": "Pesquisar",
+  "designSystemHorizontalLabel": "Horizontais",
+  "designSystemHoverLabel": "Passe o mouse",
+  "designSystemInfoLabel": "Informações",
+  "designSystemInputErrorSample": "Este campo é obrigatório",
+  "designSystemInputHelperSample": "Digite seu nome",
+  "designSystemInputHintSample": "Espaço reservado...",
+  "designSystemInputLabelSample": "Etiqueta",
+  "designSystemInputVariantsTitle": "Variantes de entrada",
+  "designSystemInputWithErrorLabel": "Com erro",
+  "designSystemInputWithHelperLabel": "Com texto auxiliar",
+  "designSystemInputWithIconsLabel": "Com ícones",
+  "designSystemListItemActivatedLabel": "Ativado",
+  "designSystemListItemOneLineLabel": "Uma linha",
+  "designSystemListItemSubtitleSample": "Legenda",
+  "designSystemListItemTitleSample": "Título",
+  "designSystemListItemTwoLinesLabel": "Duas linhas",
+  "designSystemListItemVariantsTitle": "Listar variantes de itens",
+  "designSystemListItemWithDividerLabel": "Com divisória",
+  "designSystemMediumLabel": "Médio",
+  "designSystemMyDailyDurationHoursMinutesCompact": "{hours}h {minutes}m",
+  "@designSystemMyDailyDurationHoursMinutesCompact": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "designSystemNavigationCollapsedLabel": "Recolhido",
+  "designSystemNavigationDailyFilterSectionTitle": "Filtro Diário",
+  "designSystemNavigationExpandedLabel": "Expandido",
+  "designSystemNavigationFilterByBlockLabel": "Filtrar por bloco",
+  "designSystemNavigationHikingLabel": "Caminhadas",
+  "designSystemNavigationHolidayLabel": "Feriado",
+  "designSystemNavigationInsightsLabel": "Informações",
+  "designSystemNavigationLottiTasksLabel": "Tarefas Lotti",
+  "designSystemNavigationMyDailyLabel": "Meu Diário",
+  "designSystemNavigationNewLabel": "Novo",
+  "designSystemNavigationPlaceholderLabel": "Espaço reservado",
+  "designSystemNavigationSidebarSectionTitle": "Variantes da barra lateral",
+  "designSystemNavigationSubComponentsSectionTitle": "Subcomponentes",
+  "designSystemNavigationTabBarSectionTitle": "Variantes da barra de guias",
+  "designSystemPressedLabel": "Pressionado",
+  "designSystemProgressBarChunkyLabel": "Robusto",
+  "designSystemProgressBarLabelAndPercentageLabel": "Etiqueta + Porcentagem",
+  "designSystemProgressBarLabelOnlyLabel": "Apenas etiqueta",
+  "designSystemProgressBarOffLabel": "Desligado",
+  "designSystemProgressBarPercentageOnlyLabel": "Porcentagem",
+  "designSystemProgressBarQuestBarLabel": "Barra de missões",
+  "designSystemProgressBarQuestLabel": "Etiqueta de mega prêmio",
+  "designSystemProgressBarSampleLabel": "Etiqueta da barra de progresso",
+  "designSystemRadioButtonLabel": "Botão de rádio",
+  "designSystemScrollbarSizesTitle": "Tamanhos da barra de rolagem",
+  "designSystemSearchFilledText": "Pesquisa lotti",
+  "designSystemSearchHintLabel": "Digite usuário",
+  "designSystemSelectedLabel": "Selecionado",
+  "designSystemSizeScaleTitle": "Escala de tamanho",
+  "designSystemSmallLabel": "Pequeno",
+  "designSystemSpinnerPlainLabel": "Simples",
+  "designSystemSpinnerSkeletonPulseLabel": "Pulso",
+  "designSystemSpinnerSkeletonsTitle": "Esqueletos",
+  "designSystemSpinnerSkeletonWaveLabel": "Onda",
+  "designSystemSpinnerSpinnersTitle": "Fiandeiros",
+  "designSystemSpinnerTrackLabel": "Com pista",
+  "designSystemSplitButtonDropdownSemantics": "Abra as opções de {label}",
+  "@designSystemSplitButtonDropdownSemantics": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "designSystemStateMatrixTitle": "Matriz Estadual",
+  "designSystemSuccessLabel": "Sucesso",
+  "designSystemTabBarTitle": "Barra de guias",
+  "designSystemTabPendingLabel": "Pendente",
+  "designSystemTaskListBlockedLabel": "Bloqueado",
+  "designSystemTaskListDefaultLabel": "Padrão",
+  "designSystemTaskListHoverLabel": "Passe o mouse",
+  "designSystemTaskListItemSectionTitle": "Variantes de itens da lista de tarefas",
+  "designSystemTaskListOnHoldLabel": "Em espera",
+  "designSystemTaskListOpenLabel": "Abrir",
+  "designSystemTaskListPressedLabel": "Pressionado",
+  "designSystemTaskListSampleTime": "8h00-9h30",
+  "designSystemTaskListSampleTitle": "Teste de usuário",
+  "designSystemTaskListWithDividerLabel": "Com divisória",
+  "designSystemTextareaErrorSample": "Este campo é obrigatório",
+  "designSystemTextareaHelperSample": "Digite sua mensagem aqui",
+  "designSystemTextareaHintSample": "Digite algo...",
+  "designSystemTextareaLabelSample": "Etiqueta",
+  "designSystemTextareaVariantsTitle": "Variantes de área de texto",
+  "designSystemTextareaWithCounterLabel": "Com contador",
+  "designSystemTextareaWithErrorLabel": "Com erro",
+  "designSystemTextareaWithHelperLabel": "Com texto auxiliar",
+  "designSystemTimePickerFormatsTitle": "Formatos de hora",
+  "designSystemTimePickerTwelveHourLabel": "12 horas",
+  "designSystemTimePickerTwentyFourHourLabel": "24 horas",
+  "designSystemTitleOnlyVariantTitle": "Variante apenas de título",
+  "designSystemToastDetailsLabel": "Detalhes da notificação",
+  "designSystemToggleLabel": "Alternar rótulo",
+  "designSystemTooltipIconMessageSample": "Informações úteis sobre este campo",
+  "designSystemTooltipIconVariantsTitle": "Ícone de dica de ferramenta",
+  "designSystemUndoLabel": "Desfazer",
+  "designSystemVariantMatrixTitle": "Matriz Variante",
+  "designSystemVerticalLabel": "Verticais",
+  "designSystemWarningLabel": "Aviso",
+  "designSystemWeeklyCalendarLabel": "Calendário Semanal",
+  "designSystemWithLabelLabel": "Com etiqueta",
+  "desktopEmptyStateSelectDashboard": "Selecione um painel para visualizar detalhes",
+  "desktopEmptyStateSelectProject": "Selecione um projeto para ver detalhes",
+  "desktopEmptyStateSelectTask": "Selecione uma tarefa para ver detalhes",
+  "deviceDeletedSuccess": "Dispositivo {deviceName} excluído com sucesso",
+  "@deviceDeletedSuccess": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      }
+    }
+  },
+  "deviceDeleteFailed": "Falha ao excluir o dispositivo: {error}",
+  "@deviceDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "doneButton": "Concluído",
+  "editMenuTitle": "Editar",
+  "editorDiscardChanges": "Descartar alterações",
+  "editorInsertDivider": "Inserir divisória",
+  "editorMoreFormatting": "Mais formatação",
+  "editorPlaceholder": "Insira notas...",
+  "embeddingSelectAll": "Selecionar tudo",
+  "embeddingUnselectAll": "Desmarcar tudo",
+  "enhancedPromptFormPreconfiguredPromptDescription": "Escolha entre modelos de prompt prontos",
+  "enterCategoryName": "Insira o nome da categoria",
+  "entryActions": "Ações",
+  "entryLabelsActionSubtitle": "Atribua rótulos para organizar esta entrada",
+  "entryLabelsActionTitle": "Etiquetas",
+  "entryLabelsEditTooltip": "Editar rótulos",
+  "entryLabelsHeaderTitle": "Etiquetas",
+  "entryLabelsNoLabels": "Nenhum rótulo atribuído",
+  "entryTypeLabelAiResponse": "Resposta de IA",
+  "entryTypeLabelChecklist": "Lista de verificação",
+  "entryTypeLabelChecklistItem": "Fazer",
+  "entryTypeLabelHabitCompletionEntry": "Hábito",
+  "entryTypeLabelJournalAudio": "Áudio",
+  "entryTypeLabelJournalEntry": "Texto",
+  "entryTypeLabelJournalEvent": "Evento",
+  "entryTypeLabelJournalImage": "Foto",
+  "entryTypeLabelMeasurementEntry": "Medido",
+  "entryTypeLabelQuantitativeEntry": "Saúde",
+  "entryTypeLabelSurveyEntry": "Pesquisa",
+  "entryTypeLabelTask": "Tarefa",
+  "entryTypeLabelWorkoutEntry": "Treino",
+  "eventNameLabel": "Evento:",
+  "eventsAddCoverPhoto": "Adicionar foto de capa",
+  "eventsAddLabel": "Adicionar",
+  "eventsChangeCover": "Alterar capa",
+  "eventsDeleteEvent": "Excluir evento",
+  "eventsFilterAll": "Todos",
+  "eventsMetricPhotos": "{count, plural, =1{1 foto} other{{count} fotos}}",
+  "@eventsMetricPhotos": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "eventsMetricTasks": "{count, plural, =1{1 tarefa} other{{count} tarefas}}",
+  "@eventsMetricTasks": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "eventsNewEvent": "Novo evento",
+  "eventsPageTitle": "Eventos",
+  "eventsPhotosSection": "Fotos",
+  "eventsRecapAwaitingContent": "Adicione uma foto ou nota e a recapitulação aparecerá aqui.",
+  "eventsRecapUnavailable": "Não foi possível carregar a recapitulação.",
+  "eventsRegenerateSummary": "Regenerar resumo",
+  "eventsSearchHint": "Pesquisar eventos",
+  "eventsSectionUpcoming": "Próximos",
+  "eventsStatusCancelled": "Cancelado",
+  "eventsStatusCompleted": "Concluído",
+  "eventsStatusMissed": "Perdido",
+  "eventsStatusOngoing": "Em andamento",
+  "eventsStatusPlanned": "Planejado",
+  "eventsStatusPostponed": "Adiado",
+  "eventsStatusRescheduled": "Reprogramado",
+  "eventsStatusTentative": "Provisório",
+  "eventsSummaryTitle": "Resumo",
+  "eventsTasksEmpty": "Vincule uma tarefa de preparação ou acompanhamento",
+  "eventsTasksSection": "Tarefas",
+  "eventsTimelineEmpty": "Adicione fotos, notas ou uma mensagem de voz",
+  "eventsTimelineSection": "Linha do tempo",
+  "eventsTitleHint": "Título do evento",
+  "eventsVoiceNote": "Nota de voz",
+  "favoriteLabel": "Favorito",
+  "fileMenuNewEllipsis": "Novo ...",
+  "fileMenuNewEntry": "Nova entrada",
+  "fileMenuNewScreenshot": "Captura de tela",
+  "fileMenuNewTask": "Tarefa",
+  "fileMenuTitle": "Arquivo",
+  "filterSelectionNoMatches": "Nenhuma correspondência",
+  "geminiThinkingModeHighDescription": "Raciocínio mais profundo; pode aumentar a latência e o custo.",
+  "geminiThinkingModeHighLabel": "Alto",
+  "geminiThinkingModeLowDescription": "Baixo raciocínio para solicitações rápidas do dia a dia.",
+  "geminiThinkingModeLowLabel": "Baixo",
+  "geminiThinkingModeMediumDescription": "Raciocínio equilibrado para respostas mais cuidadosas.",
+  "geminiThinkingModeMediumLabel": "Médio",
+  "geminiThinkingModeMinimalDescription": "Configuração mais rápida; Gêmeos ainda pode pensar brevemente em instruções complexas.",
+  "geminiThinkingModeMinimalLabel": "Mínimo",
+  "generateCoverArt": "Gerar capa",
+  "generateCoverArtSubtitle": "Criar imagem a partir da descrição de voz",
+  "goMenuTitle": "Vá",
+  "habitActiveFromLabel": "Data de início",
+  "habitActiveSwitchDescription": "Exibido na página Hábitos",
+  "habitArchivedLabel": "Arquivado",
+  "habitCategoryHint": "Selecione uma categoria",
+  "habitCategoryLabel": "Categoria",
+  "habitCloseCompletionLabel": "Fechar a conclusão do hábito",
+  "habitCompleteSemanticLabel": "Registrar {habit}",
+  "@habitCompleteSemanticLabel": {
+    "placeholders": {
+      "habit": {
+        "type": "String"
+      }
+    }
+  },
+  "habitCompletionStatusCompleted": "Concluído",
+  "habitCompletionStatusFailed": "Falha",
+  "habitCompletionStatusOpen": "Abrir",
+  "habitCompletionStatusSkipped": "Ignorado",
+  "habitDashboardHint": "Selecione um painel",
+  "habitDashboardLabel": "Painel (opcional)",
+  "habitDayStatusSemantic": "{habit}, {status}",
+  "@habitDayStatusSemantic": {
+    "placeholders": {
+      "habit": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      }
+    }
+  },
+  "habitDeleteConfirm": "SIM, EXCLUA ESTE HÁBITO",
+  "habitDeleteQuestion": "Quer eliminar esse hábito?",
+  "habitHeatmapDaySemantic": "{date}, {done} de {total} concluído",
+  "@habitHeatmapDaySemantic": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "habitLogOtherDayHint": "Segure para registrar outro dia",
+  "habitNotRecordedLabel": "Não registrado",
+  "habitPriorityLabel": "Prioridade",
+  "habitsAboveGoal": "No caminho certo",
+  "habitsActiveHabitsCount": "{count, plural, one{1 hábito ativo} other{{count} hábitos ativos}}",
+  "@habitsActiveHabitsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsAllDoneToday": "Tudo feito hoje",
+  "habitsCompletedHeader": "Concluído",
+  "habitsCompletionRateTitle": "Taxa de conclusão",
+  "habitsConsistencyTitle": "Consistência",
+  "habitsDayFailedPercent": "{percent}% de falhas registradas",
+  "@habitsDayFailedPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsDaySkippedPercent": "{percent}% ignorados",
+  "@habitsDaySkippedPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsDaySuccessfulPercent": "{percent}% de sucesso",
+  "@habitsDaySuccessfulPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsDoneTodayLabel": "Feito hoje",
+  "habitSectionOptionsTitle": "Opções",
+  "habitSectionScheduleTitle": "Cronograma",
+  "habitsFilterAll": "tudo",
+  "habitsFilterCompleted": "feito",
+  "habitsFilterOpenNow": "devido",
+  "habitsFilterPendingLater": "mais tarde",
+  "habitsGoalLineLabel": "Objetivo",
+  "habitsHeatmapEmpty": "Adicione um hábito para começar a construir sua consistência",
+  "habitsHeatmapLess": "Menos",
+  "habitsHeatmapMore": "Mais",
+  "habitShowAlertAtLabel": "Mostrar alerta em",
+  "habitShowFromLabel": "Mostrar de",
+  "habitsLaggardHint": "{habit} — mantido {kept} de {active}",
+  "@habitsLaggardHint": {
+    "placeholders": {
+      "habit": {
+        "type": "String"
+      },
+      "kept": {
+        "type": "int"
+      },
+      "active": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsOpenHeader": "Vencimento agora",
+  "habitsPendingLaterHeader": "Mais tarde hoje",
+  "habitsPointsToGoal": "{points, plural, one{1 ponto para a meta} other{{points} pontos para a meta}}",
+  "@habitsPointsToGoal": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsRecordButton": "Gravar",
+  "habitsRollingAverageLabel": "Média de 7 dias",
+  "habitsStartStreakToday": "Comece uma sequência hoje",
+  "habitsStreakLongCount": "{count} em uma sequência de 7 dias",
+  "@habitsStreakLongCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsStreakShortCount": "{count} em uma sequência de 3 dias",
+  "@habitsStreakShortCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsTapForBreakdown": "Toque em um dia para o detalhamento",
+  "habitsToGoCount": "{count} para ir",
+  "@habitsToGoCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "habitStreakDaysSemantic": "sequência de {count} dias",
+  "@habitStreakDaysSemantic": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "habitsVsPreviousWeek": "versus semana anterior",
+  "helpMenuCommandPalette": "Paleta de comandos…",
+  "helpMenuKeyboardShortcuts": "Atalhos de teclado…",
+  "helpMenuTitle": "Ajuda",
+  "imageGenerationError": "Falha ao gerar imagem",
+  "imageGenerationGenerating": "Gerando imagem...",
+  "imageGenerationProviderRejectedTitle": "O provedor de imagem rejeitou esta solicitação",
+  "imageGenerationWithReferences": "{count, plural, =0{Sem imagens de referência} =1{Usando 1 imagem de referência} other{Usando {count} imagens de referência}}",
+  "@imageGenerationWithReferences": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "imagePromptGenerationCardTitle": "Prompt de imagem AI",
+  "imagePromptGenerationCopiedSnackbar": "Prompt de imagem copiado para a área de transferência",
+  "imagePromptGenerationCopyButton": "Copiar prompt",
+  "imagePromptGenerationCopyTooltip": "Copiar prompt de imagem para a área de transferência",
+  "imagePromptGenerationExpandTooltip": "Mostrar prompt completo",
+  "imagePromptGenerationFullPromptLabel": "Prompt de imagem completo:",
+  "images": "Imagens",
+  "imageViewerDownloadFailed": "Não foi possível salvar a imagem",
+  "imageViewerDownloadingTooltip": "Salvando imagem",
+  "imageViewerDownloadPermissionDenied": "Acesso à foto negado – ative-o nas configurações",
+  "imageViewerDownloadSaved": "{fileName} salvo",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadSavedToGallery": "Salvo em fotos",
+  "imageViewerDownloadTooltip": "Baixar imagem",
+  "inactiveLabel": "Inativo",
+  "inactiveSwitchDescription": "Pode ser escolhido para novas entradas quando ativado",
+  "inferenceProfileChooseModelTitle": "Escolha um modelo",
+  "inferenceProfileChooseTitle": "Escolha um perfil de inferência",
+  "inferenceProfileCreateTitle": "Criar perfil",
+  "inferenceProfileDescriptionLabel": "Descrição",
+  "inferenceProfileDesktopOnly": "Somente área de trabalho",
+  "inferenceProfileDesktopOnlyDescription": "Disponível apenas em plataformas desktop (por exemplo, para modelos locais)",
+  "inferenceProfileDetailLoadError": "Não foi possível carregar o perfil: {error}",
+  "@inferenceProfileDetailLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "inferenceProfileDetailNotFound": "Perfil não encontrado",
+  "inferenceProfileEditTitle": "Editar perfil",
+  "inferenceProfileImageGeneration": "Geração de imagem",
+  "inferenceProfileImageRecognition": "Reconhecimento de imagem",
+  "inferenceProfileModelUnavailable": "Modelo indisponível – seu fornecedor pode ter sido removido",
+  "inferenceProfileNameLabel": "Nome do perfil",
+  "inferenceProfileNameRequired": "Um nome de perfil é obrigatório",
+  "inferenceProfilePinnedHostHelper": "Quando definido, apenas este dispositivo executa automaticamente a inferência para entradas de áudio sincronizadas que usam este perfil.",
+  "inferenceProfilePinnedHostLabel": "Dispositivo fixado",
+  "inferenceProfilePinnedHostNoEligibleNodes": "Nenhum dispositivo conhecido anuncia os provedores que este perfil usa. Abra as configurações do nó de sincronização no dispositivo de destino.",
+  "inferenceProfilePinnedHostNoneHelper": "As entradas de áudio sincronizadas não são transcritas automaticamente quando nenhum dispositivo está fixado.",
+  "inferenceProfilePinnedHostNoneLabel": "Não fixado (sem acionamento automático)",
+  "inferenceProfilePinnedHostThisDeviceSuffix": "(este dispositivo)",
+  "inferenceProfileSaveButton": "Salvar",
+  "inferenceProfileSelectModel": "Escolha um modelo…",
+  "inferenceProfileSelectProfile": "Escolha um perfil…",
+  "inferenceProfilesEmpty": "Ainda não há perfis de inferência",
+  "inferenceProfileSkillModelRequired": "Requer que o modelo {slotName} seja definido",
+  "@inferenceProfileSkillModelRequired": {
+    "placeholders": {
+      "slotName": {
+        "type": "String"
+      }
+    }
+  },
+  "inferenceProfileSkillsSection": "Habilidades Automatizadas",
+  "inferenceProfileSkillUsesModel": "Usa o modelo {slotName}",
+  "@inferenceProfileSkillUsesModel": {
+    "placeholders": {
+      "slotName": {
+        "type": "String"
+      }
+    }
+  },
+  "inferenceProfilesTitle": "Perfis de inferência",
+  "inferenceProfileThinking": "Pensando",
+  "inferenceProfileThinkingHighEnd": "Pensando (sofisticado)",
+  "inferenceProfileThinkingRequired": "É necessário um modelo de pensamento",
+  "inferenceProfileTranscription": "Transcrição",
+  "inferenceProfileUnavailable": "Perfil de inferência indisponível",
+  "inputDataTypeAudioFilesDescription": "Use arquivos de áudio como entrada",
+  "inputDataTypeAudioFilesName": "Arquivos de áudio",
+  "inputDataTypeImagesDescription": "Use imagens como entrada",
+  "inputDataTypeImagesName": "Imagens",
+  "inputDataTypeTaskDescription": "Use a tarefa atual como entrada",
+  "inputDataTypeTaskName": "Tarefa",
+  "inputDataTypeTasksListDescription": "Use uma lista de tarefas como entrada",
+  "inputDataTypeTasksListName": "Lista de tarefas",
+  "insightsChartCompareCaption": "Este período versus o anterior",
+  "insightsChartCompareCaptionPartial": "Este período até agora versus o anterior",
+  "insightsChartCompareHint": "Comparação mostrada na tabela abaixo",
+  "insightsChartCumulativeCaption": "Executando total ao longo do intervalo",
+  "insightsChartCumulativeShort": "Ainda não há dias suficientes para um total acumulado",
+  "insightsChartDailyCaption": "Hora por dia",
+  "insightsChartHourlyCaption": "Tempo por hora",
+  "insightsChartPerDay": "Por dia",
+  "insightsChartPerHour": "Por hora",
+  "insightsChartPerWeek": "Por semana",
+  "insightsChartRunningTotal": "Total em execução",
+  "insightsChartTitle": "Tempo por categoria",
+  "insightsChartWeeklyCaption": "Tempo por semana",
+  "insightsChooseFocusCategories": "Escolha categorias de foco",
+  "insightsCompare": "Comparar",
+  "insightsCompareFullPeriod": "período completo",
+  "insightsComparePrevious": "Anterior",
+  "insightsCompareSameDays": "mesmos dias",
+  "insightsCompareTooltip": "Compare com o período anterior",
+  "insightsCompareVs": "contra",
+  "insightsDeletedCategory": "Categoria excluída",
+  "insightsDeltaNew": "novo",
+  "insightsEmptyBody": "O tempo que você acompanha nas entradas e tarefas aparecerá aqui.",
+  "insightsEmptyChart": "Não há dados neste intervalo",
+  "insightsEmptyPreviousPeriod": "Mostrar o período anterior",
+  "insightsEmptyShowYear": "Ver este ano",
+  "insightsEmptyTitle": "Nenhum tempo monitorado neste intervalo",
+  "insightsFocusCategoriesEmpty": "Nenhuma categoria ativa ainda.",
+  "insightsFocusCategoriesTitle": "Categorias de foco",
+  "insightsKpiFocus": "FOCO",
+  "insightsKpiFocusHelp": "Categorias que você está assistindo",
+  "insightsKpiOther": "OUTRO",
+  "insightsKpiOtherHelp": "Todo o resto",
+  "insightsKpiTopCategory": "A maioria em {category} · {share}",
+  "@insightsKpiTopCategory": {
+    "placeholders": {
+      "category": {
+        "type": "String"
+      },
+      "share": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsKpiTotal": "TOTAL",
+  "insightsLoadError": "Não foi possível carregar os dados de horário",
+  "insightsOtherCategories": "Outro",
+  "insightsPartialWeek": "semana parcial",
+  "insightsPeriodDay": "Dia",
+  "insightsPeriodJump": "Ir para um encontro",
+  "insightsPeriodMonth": "Mês",
+  "insightsPeriodNext": "Próximo período",
+  "insightsPeriodPrevious": "Período anterior",
+  "insightsPeriodQuarter": "Trimestre",
+  "insightsPeriodToDateSuffix": "até agora",
+  "insightsPeriodWeek": "Semana",
+  "insightsPeriodYear": "Ano",
+  "insightsRangeMonthToDate": "Este mês até agora",
+  "insightsRangeMtd": "Este mês",
+  "insightsRangeYearToDate": "Este ano até agora",
+  "insightsRangeYtd": "Este ano",
+  "insightsRefreshError": "Não foi possível atualizar — mostrando os últimos dados carregados",
+  "insightsTableAvgPerDay": "Média/dia",
+  "insightsTableCategory": "CATEGORIA",
+  "insightsTableCompareNote": "A mudança é em relação ao período anterior",
+  "insightsTableCurrent": "ATUAL",
+  "insightsTableDelta": "Mudança",
+  "insightsTablePrevious": "ANTERIOR",
+  "insightsTableShare": "COMPARTILHE",
+  "insightsTableTotal": "TOTAL",
+  "insightsTimeAnalysisTitle": "Análise de Tempo",
+  "insightsUncategorized": "Sem categoria",
+  "journalCopyImageLabel": "Copiar imagem",
+  "journalDateFromLabel": "Data de:",
+  "journalDateInvalid": "Período inválido",
+  "journalDateLabel": "Data",
+  "journalDateNowButton": "Agora",
+  "journalDateSaveButton": "Salvar",
+  "journalDateTimeRangeTitle": "Data e hora",
+  "journalDateToLabel": "Data para:",
+  "journalDeleteConfirm": "SIM, EXCLUIR ESTA ENTRADA",
+  "journalDeleteHint": "Excluir entrada",
+  "journalDeleteQuestion": "Deseja excluir este lançamento contábil manual?",
+  "journalDurationLabel": "Duração",
+  "journalEndDateLabel": "Data de término",
+  "journalEndsAnotherDayHint": "Escolha uma data de término separada",
+  "journalEndsAnotherDayLabel": "Termina em outro dia",
+  "journalEndTimeLabel": "Hora de término",
+  "journalFilterEntryTypesTitle": "Tipos de entrada",
+  "journalFilterFlagged": "Sinalizado",
+  "journalFilterPrivate": "Privado",
+  "journalFilterShowTitle": "Mostrar",
+  "journalFilterStarred": "Com estrela",
+  "journalFilterTitle": "Filtrar diário",
+  "journalHideLinkHint": "Ocultar link",
+  "journalHideMapHint": "Ocultar mapa",
+  "journalLinkedEntriesActivityFilterAudio": "Áudio",
+  "journalLinkedEntriesActivityFilterCode": "Código",
+  "journalLinkedEntriesActivityFilterImages": "Imagens",
+  "journalLinkedEntriesActivityFilterTimer": "Temporizador",
+  "journalLinkedEntriesFilterModalTitle": "Filtrar e classificar",
+  "journalLinkedEntriesShowFlaggedOnly": "Mostrar apenas entradas sinalizadas",
+  "journalLinkedEntriesShowHidden": "Mostrar entradas ocultas",
+  "journalLinkedEntriesSortLabel": "Classificar por",
+  "journalLinkedEntriesSortNewestFirst": "O mais novo primeiro",
+  "journalLinkedEntriesSortOldestFirst": "Mais antigo primeiro",
+  "journalLinkedFromLabel": "Vinculado de:",
+  "journalLinkFromHint": "Link de",
+  "journalLinkToHint": "Link para",
+  "journalOvernightNextDay": "Termina em {date} (dia seguinte)",
+  "@journalOvernightNextDay": {
+    "description": "Chip shown when an entry's end time is earlier than its start time, indicating it ends on the next day.",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Mon 16 Jun"
+      }
+    }
+  },
+  "journalPrivateTooltip": "apenas privado",
+  "journalSearchHint": "Pesquisar diário...",
+  "journalSetEndDateTimeNowSemantic": "Defina a data e hora de término para agora",
+  "journalSetStartDateTimeNowSemantic": "Defina a data e hora de início para agora",
+  "journalShareHint": "Compartilhar",
+  "journalShowLinkHint": "Mostrar link",
+  "journalShowMapHint": "Mostrar mapa",
+  "journalStartDateLabel": "Data de início",
+  "journalStartTimeLabel": "Hora de início",
+  "journalTodayButton": "Hoje",
+  "journalToggleFlaggedTitle": "Sinalizado",
+  "journalTogglePrivateTitle": "Privado",
+  "journalToggleStarredTitle": "Favorito",
+  "journalUnlinkConfirm": "SIM, DESVINCULAR ENTRADA",
+  "journalUnlinkHint": "Desvincular",
+  "journalUnlinkQuestion": "Tem certeza de que deseja desvincular esta entrada?",
+  "keyboardCommandActivate": "Ativar item em foco",
+  "keyboardCommandCategoryCreation": "Criação",
+  "keyboardCommandCategoryEditing": "Edição",
+  "keyboardCommandCategoryGeneral": "Geral",
+  "keyboardCommandCategoryListsAndControls": "Listas e controles",
+  "keyboardCommandCategoryNavigation": "Navegação",
+  "keyboardCommandCategoryView": "Ver",
+  "keyboardCommandCreateInContext": "Criar na visualização atual",
+  "keyboardCommandFocusSearch": "Pesquisa de foco",
+  "keyboardCommandMoveDown": "Mover o item em foco para baixo",
+  "keyboardCommandMoveUp": "Mover o item em foco para cima",
+  "keyboardCommandNavigate": "Vá para {destination}",
+  "@keyboardCommandNavigate": {
+    "placeholders": {
+      "destination": {
+        "type": "String"
+      }
+    }
+  },
+  "keyboardCommandNextRegion": "Focar próximo painel",
+  "keyboardCommandOpenPalette": "Abrir paleta de comandos",
+  "keyboardCommandPageDown": "Descer uma página",
+  "keyboardCommandPageUp": "Subir uma página",
+  "keyboardCommandPreviousRegion": "Focar painel anterior",
+  "keyboardCommandRefresh": "Atualizar visualização atual",
+  "keyboardCommandRename": "Renomear item em foco",
+  "keyboardCommandSelectFirst": "Selecione o primeiro item",
+  "keyboardCommandSelectLast": "Selecione o último item",
+  "keyboardCommandSelectNext": "Selecione o próximo item",
+  "keyboardCommandSelectPrevious": "Selecione o item anterior",
+  "keyboardCommandToggle": "Alternar item em foco",
+  "keyboardKeyAlt": "Alt.",
+  "keyboardKeyArrowDown": "Seta para baixo",
+  "keyboardKeyArrowLeft": "Seta para a esquerda",
+  "keyboardKeyArrowRight": "Seta para a direita",
+  "keyboardKeyArrowUp": "Seta para cima",
+  "keyboardKeyControl": "Ctrl",
+  "keyboardKeyDelete": "Excluir",
+  "keyboardKeyEnd": "Fim",
+  "keyboardKeyEnter": "Entrar",
+  "keyboardKeyEscape": "Fuga",
+  "keyboardKeyHome": "Página inicial",
+  "keyboardKeyMinus": "Menos",
+  "keyboardKeyOr": "ou",
+  "keyboardKeyPageDown": "Página para baixo",
+  "keyboardKeyPageUp": "Página para cima",
+  "keyboardKeyPlus": "Mais",
+  "keyboardKeyShift": "Mudança",
+  "keyboardKeySpace": "Espaço",
+  "keyboardResizeDividerLabel": "Redimensionar painéis",
+  "keyboardShortcutsNoResults": "Nenhum atalho corresponde à sua pesquisa",
+  "keyboardShortcutsSearchHint": "Atalhos de pesquisa…",
+  "keyboardShortcutsSubtitle": "Cada comando da área de trabalho e sua combinação atual de teclado.",
+  "keyboardShortcutsTitle": "Atalhos de teclado",
+  "knowledgeGraphAgeDaysAgo": "{count, plural, =1{1 dia atrás} other{{count} dias atrás}}",
+  "@knowledgeGraphAgeDaysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "knowledgeGraphAgeMonthsAgo": "{count, plural, =1{1 mês atrás} other{{count} meses atrás}}",
+  "@knowledgeGraphAgeMonthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "knowledgeGraphAgeToday": "hoje",
+  "knowledgeGraphAgeWeeksAgo": "{count, plural, =1{1 semana atrás} other{{count} semanas atrás}}",
+  "@knowledgeGraphAgeWeeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "knowledgeGraphAgeYesterday": "ontem",
+  "knowledgeGraphBack": "Voltar",
+  "knowledgeGraphCloseDetails": "Fechar detalhes",
+  "knowledgeGraphEmpty": "Ainda não há links para explorar",
+  "knowledgeGraphEntryLoadError": "Não foi possível carregar esta entrada",
+  "knowledgeGraphEntryNotFound": "Entrada não encontrada",
+  "knowledgeGraphError": "Não foi possível carregar o gráfico de conhecimento",
+  "knowledgeGraphLinkedSection": "VINCULADO · {count}",
+  "@knowledgeGraphLinkedSection": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "knowledgeGraphMoreLinks": "mais links",
+  "knowledgeGraphNodeCount": "{count, plural, =1{1 nó} other{{count} nós}}",
+  "@knowledgeGraphNodeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "knowledgeGraphNodeTypeAiSummary": "Resumo de IA",
+  "knowledgeGraphNodeTypeAudioNote": "Nota de áudio",
+  "knowledgeGraphNodeTypeChecklist": "Lista de verificação",
+  "knowledgeGraphNodeTypeChecklistItem": "Item da lista de verificação",
+  "knowledgeGraphNodeTypeNote": "Nota",
+  "knowledgeGraphNodeTypePhoto": "Foto",
+  "knowledgeGraphNodeTypeProject": "Projeto",
+  "knowledgeGraphNodeTypeRating": "Avaliação",
+  "knowledgeGraphNodeTypeTask": "Tarefa",
+  "knowledgeGraphOpenDetails": "Abrir detalhes",
+  "knowledgeGraphRecenter": "Recentrador",
+  "knowledgeGraphRecentToOlder": "recente → mais antigo",
+  "knowledgeGraphRelationAiSource": "Fonte de IA",
+  "knowledgeGraphRelationChecklist": "lista de verificação",
+  "knowledgeGraphRelationInProject": "em projeto",
+  "knowledgeGraphRelationLinkedTask": "tarefa vinculada",
+  "knowledgeGraphRelationNoteLog": "nota / registro",
+  "knowledgeGraphRelationRating": "classificação",
+  "knowledgeGraphSummarySection": "RESUMO",
+  "knowledgeGraphTitle": "Gráfico de conhecimento",
+  "knowledgeGraphTooltip": "Explorar links",
+  "knowledgeGraphWalkHint": "Toque em um nó para caminhar · {count, plural, =1{1 node} other{{count} nós}}",
+  "@knowledgeGraphWalkHint": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "linkedFromCaption": "de",
+  "linkedTaskImageBadge": "Da tarefa vinculada",
+  "linkedTasksMenuTooltip": "Opções de tarefas vinculadas",
+  "linkedTasksTitle": "Tarefas Vinculadas",
+  "linkedToCaption": "para",
+  "linkExistingTask": "Vincular tarefa existente...",
+  "loggingDomainAgentRuntime": "Tempo de execução do agente",
+  "loggingDomainAgentWorkflow": "Fluxo de trabalho do agente",
+  "loggingDomainAi": "IA",
+  "loggingDomainCalendar": "Calendário e horário",
+  "loggingDomainChat": "Bate-papo",
+  "loggingDomainDailyOs": "SO diário",
+  "loggingDomainDatabase": "Banco de dados",
+  "loggingDomainGeneral": "Geral",
+  "loggingDomainHabits": "Hábitos",
+  "loggingDomainHealth": "Saúde",
+  "loggingDomainLabels": "Etiquetas",
+  "loggingDomainLocation": "Localização",
+  "loggingDomainNavigation": "Navegação",
+  "loggingDomainNotifications": "Notificações",
+  "loggingDomainOnboarding": "Integração e FTUE",
+  "loggingDomainPersistence": "Persistência",
+  "loggingDomainRatings": "Avaliações",
+  "loggingDomainScreenshots": "Capturas de tela",
+  "loggingDomainSettings": "Configurações",
+  "loggingDomainSpeech": "Fala e áudio",
+  "loggingDomainSync": "Sincronizar",
+  "loggingDomainTasks": "Tarefas e listas de verificação",
+  "loggingDomainTheming": "Tema",
+  "loggingDomainWhatsNew": "O que há de novo",
+  "maintenanceDeleteAgentDb": "Excluir banco de dados de agentes",
+  "maintenanceDeleteAgentDbDescription": "Exclua o banco de dados de agentes e reinicie o aplicativo",
+  "maintenanceDeleteDatabaseConfirm": "SIM, EXCLUIR BANCO DE DADOS",
+  "maintenanceDeleteDatabaseQuestion": "Tem certeza de que deseja excluir o banco de dados {databaseName}?",
+  "@maintenanceDeleteDatabaseQuestion": {
+    "placeholders": {
+      "databaseName": {
+        "type": "String"
+      }
+    }
+  },
+  "maintenanceDeleteEditorDb": "Excluir banco de dados do editor",
+  "maintenanceDeleteEditorDbDescription": "Excluir banco de dados de rascunhos do editor",
+  "maintenanceDeleteSyncDb": "Excluir banco de dados de sincronização",
+  "maintenanceDeleteSyncDbDescription": "Excluir banco de dados de sincronização",
+  "maintenanceGenerateEmbeddings": "Gerar incorporações",
+  "maintenanceGenerateEmbeddingsConfirm": "SIM, GERAR",
+  "maintenanceGenerateEmbeddingsDescription": "Gere embeddings para entradas em categorias selecionadas",
+  "maintenanceGenerateEmbeddingsMessage": "Selecione categorias para gerar incorporações.",
+  "maintenanceGenerateEmbeddingsProgress": "{total, plural, =1{{processed} / {total} entrada ({embedded} incorporado)} other{{processed} / {total} entradas ({embedded} incorporado)}}",
+  "@maintenanceGenerateEmbeddingsProgress": {
+    "placeholders": {
+      "processed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      },
+      "embedded": {
+        "type": "int"
+      }
+    }
+  },
+  "maintenancePopulatePhaseAgentEntities": "Entidades agentes de processamento...",
+  "maintenancePopulatePhaseAgentLinks": "Processando links de agente...",
+  "maintenancePopulatePhaseJournal": "Processando lançamentos contábeis manuais...",
+  "maintenancePopulatePhaseLinks": "Processando links de entrada...",
+  "maintenancePopulateSequenceLog": "Preencher log de sequência de sincronização",
+  "maintenancePopulateSequenceLogComplete": "{count} entradas indexadas",
+  "@maintenancePopulateSequenceLogComplete": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "maintenancePopulateSequenceLogConfirm": "SIM, POPULAR",
+  "maintenancePopulateSequenceLogDescription": "Indexar entradas existentes para suporte de preenchimento",
+  "maintenancePopulateSequenceLogMessage": "Isso verificará todas as entradas do diário e as adicionará ao log da sequência de sincronização. Isso permite respostas de preenchimento para entradas criadas antes da adição desse recurso.",
+  "maintenancePurgeDeleted": "Limpar itens excluídos",
+  "maintenancePurgeDeletedConfirm": "Sim, limpe tudo",
+  "maintenancePurgeDeletedDescription": "Limpar todos os itens excluídos permanentemente",
+  "maintenancePurgeDeletedMessage": "Tem certeza de que deseja limpar todos os itens excluídos? Esta ação não pode ser desfeita.",
+  "maintenancePurgeSentOutbox": "Limpar itens antigos enviados da caixa de saída",
+  "maintenancePurgeSentOutboxConfirm": "SIM, PURGA",
+  "maintenancePurgeSentOutboxDescription": "Exclua linhas da caixa de saída enviadas com mais de 7 dias e recupere o disco",
+  "maintenancePurgeSentOutboxQuestion": "Limpar itens da caixa de saída enviados há mais de 7 dias? Isso exclui linhas já enviadas em partes e executa VACUUM para recuperar o disco. Os itens pendentes e com erro são mantidos.",
+  "maintenanceRecreateFts5": "Recrie o índice de texto completo",
+  "maintenanceRecreateFts5Confirm": "SIM, RECRIAR ÍNDICE",
+  "maintenanceRecreateFts5Description": "Recrie o índice de pesquisa de texto completo",
+  "maintenanceRecreateFts5Message": "Tem certeza de que deseja recriar o índice de texto completo? Isso pode levar algum tempo.",
+  "maintenanceReSync": "Sincronizar novamente mensagens",
+  "maintenanceReSyncAgentEntities": "Entidades agentes",
+  "maintenanceReSyncDescription": "Sincronizar novamente mensagens do servidor",
+  "maintenanceReSyncEntityTypes": "Tipos de entidade",
+  "maintenanceReSyncJournalEntities": "Entidades de diário",
+  "maintenanceReSyncSelectAtLeastOne": "Selecione pelo menos um tipo de entidade",
+  "maintenanceReSyncStart": "Começar",
+  "maintenanceSyncDefinitions": "Sincronize mensuráveis, painéis, hábitos, categorias, configurações de IA",
+  "maintenanceSyncDefinitionsDescription": "Sincronize mensuráveis, painéis, hábitos, categorias e configurações de IA",
+  "manageLinks": "Gerenciar links...",
+  "measurableDeleteConfirm": "SIM, EXCLUIR ESTE MENSURÁVEL",
+  "measurableDeleteQuestion": "Deseja excluir este tipo de dados mensuráveis?",
+  "measurableNotFound": "Mensurável não encontrado",
+  "measurementCommentHint": "Adicione uma nota (opcional)",
+  "measurementCommentSemantic": "Comentário, opcional",
+  "measurementObservedAtChangeSemantic": "Observado em {dateTime}. Alterar data e hora.",
+  "@measurementObservedAtChangeSemantic": {
+    "placeholders": {
+      "dateTime": {
+        "type": "String"
+      }
+    }
+  },
+  "measurementQuickAddLabel": "Registro rápido",
+  "measurementQuickLogSemantic": "Registrar {value} imediatamente",
+  "@measurementQuickLogSemantic": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "measurementSaveError": "Não foi possível salvar esta medida. Tente novamente.",
+  "measurementSetObservedAtNowSemantic": "Definir data e hora observadas para agora",
+  "measurementTimeLabel": "Hora",
+  "measurementValueSemantic": "Valor para {measurable}",
+  "@measurementValueSemantic": {
+    "placeholders": {
+      "measurable": {
+        "type": "String"
+      }
+    }
+  },
+  "mediaShowInFileExplorerAction": "Mostrar no Explorador de Arquivos",
+  "@mediaShowInFileExplorerAction": {
+    "description": "Context menu action that reveals a media file in Windows File Explorer."
+  },
+  "mediaShowInFilesAction": "Mostrar em arquivos",
+  "@mediaShowInFilesAction": {
+    "description": "Context menu action that reveals a media file in the default Linux file manager."
+  },
+  "mediaShowInFinderAction": "Mostrar no Finder",
+  "@mediaShowInFinderAction": {
+    "description": "Context menu action that reveals a media file in macOS Finder."
+  },
+  "modalityAudioDescription": "Capacidades de processamento de áudio",
+  "modalityAudioName": "Áudio",
+  "modalityImageDescription": "Capacidades de processamento de imagem",
+  "modalityImageName": "Imagem",
+  "modalityTextDescription": "Conteúdo e processamento baseado em texto",
+  "modalityTextName": "Texto",
+  "modelAddPageTitle": "Adicionar modelo",
+  "modelEditBackTooltip": "Voltar",
+  "modelEditDescriptionHint": "Descreva este modelo",
+  "modelEditDescriptionLabel": "Descrição",
+  "modelEditDisplayNameHint": "Um nome amigável para este modelo",
+  "modelEditDisplayNameLabel": "Nome de exibição",
+  "modelEditFunctionCallingDescription": "Este modelo suporta chamadas de funções e ferramentas.",
+  "modelEditFunctionCallingLabel": "Chamada de função",
+  "modelEditGeminiThinkingModeLabel": "Modo de pensamento de Gêmeos",
+  "modelEditInputModalitiesHint": "Selecione os tipos de entrada",
+  "modelEditInputModalitiesLabel": "Modalidades de entrada",
+  "modelEditLoadError": "Falha ao carregar a configuração do modelo",
+  "modelEditMaxTokensHint": "Opcional – deixe em branco para ilimitado",
+  "modelEditMaxTokensLabel": "Máximo de tokens de conclusão",
+  "modelEditModalityNoneSelected": "Nenhum selecionado",
+  "modelEditOutputModalitiesHint": "Selecione os tipos de saída",
+  "modelEditOutputModalitiesLabel": "Modalidades de saída",
+  "modelEditPageTitle": "Editar modelo",
+  "modelEditProviderHint": "Selecione um provedor",
+  "modelEditProviderLabel": "Provedor",
+  "modelEditProviderModelIdHint": "por exemplo gpt-4-turbo",
+  "modelEditProviderModelIdLabel": "ID do modelo do provedor",
+  "modelEditReasoningDescription": "Este modelo usa pensamento estendido/cadeia de pensamento.",
+  "modelEditReasoningLabel": "Modelo de raciocínio",
+  "modelEditSaveButton": "Salvar",
+  "modelEditSectionCapabilities": "Capacidades",
+  "modelEditSectionIdentity": "Identidade",
+  "modelManagementSelectedCount": "{count} modelo{count, plural, =1{} other{s}} selecionado",
+  "@modelManagementSelectedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "multiSelectAddButton": "Adicionar",
+  "multiSelectAddButtonWithCount": "Adicionar ({count})",
+  "@multiSelectAddButtonWithCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "multiSelectNoItemsFound": "Nenhum item encontrado",
+  "navSidebarManualBrowserHint": "Abre no seu navegador",
+  "navSidebarManualLabel": "Manuais",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{Mais, 1 destino adicional} other{Mais, {count} destinos adicionais}}",
+  "@navTabMoreSemanticsLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "navTabTitleCalendar": "DailyOS",
+  "navTabTitleEvents": "Eventos",
+  "navTabTitleHabits": "Hábitos",
+  "navTabTitleInsights": "Informações",
+  "navTabTitleJournal": "Diário de bordo",
+  "navTabTitleMore": "Mais",
+  "navTabTitleProjects": "Projetos",
+  "navTabTitleSettings": "Configurações",
+  "navTabTitleTasks": "Tarefas",
+  "nestedAiResponsesTitle": "{count} Respostas de IA{count, plural, =1{} other{s}}",
+  "@nestedAiResponsesTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "noDefaultLanguage": "Nenhum idioma padrão",
+  "noTasksFound": "Nenhuma tarefa encontrada",
+  "noTasksToLink": "Nenhuma tarefa disponível para vincular",
+  "notificationBellEmptySemantics": "Notificações, sem alertas não lidos",
+  "notificationBellTooltip": "Notificações",
+  "notificationBellUnseenSemantics": "Notificações, {count} não lidas {count, plural, =1{alert} other{alerts}}",
+  "@notificationBellUnseenSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "notificationInboxDismiss": "Ignorar notificação",
+  "notificationInboxEmpty": "Vocês estão todos em dia.",
+  "notificationInboxError": "Não foi possível carregar as notificações.",
+  "notificationInboxTitle": "Notificações",
+  "notificationSuggestionAttentionBodyFallback": "Abra a tarefa para revisar.",
+  "notificationSuggestionAttentionTitle": "{count, plural, =1{1 sugestão precisa de sua atenção} other{{count} sugestões precisam de sua atenção}}",
+  "@notificationSuggestionAttentionTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "onboardingApiKeyConnect": "Conectar",
+  "onboardingApiKeyConnecting": "Conectando…",
+  "onboardingApiKeyEnterKeyHint": "Insira uma chave válida para continuar.",
+  "onboardingApiKeyError": "Não foi possível conectar. Verifique sua chave e tente novamente.",
+  "onboardingApiKeyField": "Chave de API",
+  "onboardingApiKeyGetKeyAt": "Obtenha uma chave em",
+  "onboardingApiKeyHide": "Ocultar chave",
+  "onboardingApiKeyInvalid": "Essa chave foi rejeitada. Verifique novamente e cole novamente.",
+  "onboardingApiKeyLocalNote": "Funciona no seu dispositivo – sem necessidade de chave.",
+  "onboardingApiKeyNoKeyHelp": "Novo aqui? Faça login, crie uma chave de API e cole-a – grátis para começar.",
+  "onboardingApiKeyReveal": "Mostrar chave",
+  "onboardingApiKeyTitle": "Cole sua chave de API",
+  "onboardingApiKeyUnreachable": "Não foi possível entrar em contato com {providerName}. Verifique a chave ou sua conexão e tente novamente.",
+  "@onboardingApiKeyUnreachable": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "onboardingApiKeyVerifying": "Verificando…",
+  "onboardingCaptureCategoryPrompt": "Onde isso deveria pousar?",
+  "onboardingCaptureListening": "Ouvindo… toque quando terminar",
+  "onboardingCaptureOrbLabel": "Registre seu pensamento",
+  "onboardingCaptureRatherType": "Em vez disso, digite?",
+  "onboardingCaptureReassurance": "Você poderá editar tudo a seguir.",
+  "onboardingCaptureThinking": "Transformando suas palavras em uma tarefa…",
+  "onboardingCaptureTypePrompt": "Digite seu pensamento",
+  "onboardingCategoryAddOwn": "Adicione o seu próprio",
+  "onboardingCategoryContinue": "Continuar",
+  "onboardingCategoryExplanation": "Cada área da sua vida ganha seu próprio espaço. Escolha qualquer um que combine – ou adicione o seu próprio.",
+  "onboardingCategoryFamily": "Família",
+  "onboardingCategoryFitness": "Fitness",
+  "onboardingCategoryFriends": "Amigos",
+  "onboardingCategoryTitle": "Onde sua IA deve funcionar?",
+  "onboardingCategoryWhy": "Por que áreas?",
+  "onboardingCategoryWhyDetail": "Cada área pode usar sua própria IA. {provider} fornecerá energia às áreas que você escolher aqui. Mais tarde, você poderá atribuir IAs diferentes a áreas diferentes.",
+  "@onboardingCategoryWhyDetail": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "onboardingCategoryWork": "Trabalho",
+  "onboardingConnectGeminiName": "Gêmeos",
+  "onboardingConnectGeminiTagline": "Estados Unidos",
+  "onboardingConnectLessOptions": "Menos opções",
+  "onboardingConnectMistralName": "Mistral",
+  "onboardingConnectMistralTagline": "União Europeia",
+  "onboardingConnectMoreOptions": "Mais opções",
+  "onboardingConnectNotSure": "Melious.ai é o padrão recomendado.",
+  "onboardingConnectOllamaName": "Ollama",
+  "onboardingConnectOpenAiName": "OpenAI",
+  "onboardingConnectQwenName": "Qwen",
+  "onboardingConnectQwenTagline": "China",
+  "onboardingConnectTitle": "Escolha o cérebro de IA para suas tarefas",
+  "onboardingFirstTaskCreatedHint": "Toque na sua tarefa para abri-la",
+  "onboardingFirstTaskCreatedTitle": "Sua primeira tarefa está pronta",
+  "onboardingFirstTaskGuidance": "Toque para falar e dizer o que precisa ser feito - Lotti transforma isso em uma tarefa real.",
+  "onboardingFirstTaskSuggestionDentist": "Marque uma consulta no dentista",
+  "onboardingFirstTaskSuggestionMeeting": "Prepare-se para a reunião de segunda-feira",
+  "onboardingFirstTaskSuggestionPlanWeek": "Planeje minha semana",
+  "onboardingFirstTaskSuggestionsLabel": "Não está pronto para conversar? Comece com um destes:",
+  "onboardingFirstTaskTitle": "Crie sua primeira tarefa",
+  "onboardingMetricsActiveDays": "Dias ativos",
+  "@onboardingMetricsActiveDays": {
+    "description": "Label for the active-day count in the onboarding metrics debug view."
+  },
+  "onboardingMetricsActiveDaysInFirstSeven": "Dias ativos nos primeiros 7",
+  "@onboardingMetricsActiveDaysInFirstSeven": {
+    "description": "Label for the active-day count during the first seven days in the onboarding metrics debug view."
+  },
+  "onboardingMetricsBaselineCohort": "Coorte de linha de base (pré-FTUE)",
+  "@onboardingMetricsBaselineCohort": {
+    "description": "Label for whether a user belongs to the pre-FTUE baseline cohort in the onboarding metrics debug view."
+  },
+  "onboardingMetricsInstallFirstSeenUtc": "Instalar visto pela primeira vez (UTC)",
+  "@onboardingMetricsInstallFirstSeenUtc": {
+    "description": "Label for the first observed install timestamp in the onboarding metrics debug view."
+  },
+  "onboardingMetricsNo": "não",
+  "@onboardingMetricsNo": {
+    "description": "Negative boolean value in the onboarding metrics debug view."
+  },
+  "onboardingMetricsReachedRealAha": "Alcançado real aha",
+  "@onboardingMetricsReachedRealAha": {
+    "description": "Label for whether a user has reached the meaningful onboarding activation event."
+  },
+  "onboardingMetricsYes": "sim",
+  "@onboardingMetricsYes": {
+    "description": "Positive boolean value in the onboarding metrics debug view."
+  },
+  "onboardingRecordingStyleAnalogue": "Analógico - medidor VU",
+  "onboardingRecordingStyleContinue": "Continuar",
+  "onboardingRecordingStyleExplanation": "Escolha uma aparência para o microfone. Você pode alterá-lo a qualquer momento em Configurações.",
+  "onboardingRecordingStyleModern": "Moderno - orbe de energia",
+  "onboardingRecordingStyleTitle": "Como deve ser a gravação?",
+  "onboardingRecordingStyleTryVoice": "Tente com sua voz",
+  "onboardingSuccessContinue": "Comece",
+  "onboardingSuccessSubtitle": "Seu cérebro de IA está conectado e pronto para transformar suas palavras em tarefas.",
+  "onboardingSuccessTitle": "Você está pronto",
+  "onboardingWelcomeConnectButton": "Escolha seu cérebro de IA",
+  "onboardingWelcomeMessage": "Conecte seu cérebro de IA, diga um pensamento e observe-o se tornar uma tarefa estruturada.",
+  "onboardingWelcomeSkipButton": "Olhe ao redor primeiro",
+  "onboardingWelcomeTitle": "Fale. Lotti transforma isso em um plano.",
+  "optionalCategoryLabel": "Categoria (opcional)",
+  "outboxActionRemove": "Remover",
+  "outboxActionRetry": "Tentar novamente",
+  "outboxFailedReassurance": "Ainda salvo neste dispositivo – ele será sincronizado assim que o problema for resolvido.",
+  "outboxFilterFailed": "Falha",
+  "outboxFilterWaiting": "Esperando",
+  "outboxMonitorAttachmentLabel": "Anexo",
+  "outboxMonitorDelete": "excluir",
+  "outboxMonitorDeleteConfirmLabel": "Excluir",
+  "outboxMonitorDeleteConfirmMessage": "Tem certeza de que deseja excluir este item de sincronização? Esta ação não pode ser desfeita.",
+  "outboxMonitorDeleteFailed": "Falha na exclusão. Por favor, tente novamente.",
+  "outboxMonitorDeleteSuccess": "Item excluído",
+  "outboxMonitorEmptyDescription": "Não há itens de sincronização nesta visualização.",
+  "outboxMonitorEmptyTitle": "A caixa de saída está limpa",
+  "outboxMonitorFetchFailed": "Não foi possível carregar a caixa de saída. Puxe para atualizar e tente novamente.",
+  "outboxMonitorLabelError": "erro",
+  "outboxMonitorLabelPending": "pendente",
+  "outboxMonitorLabelSent": "enviado",
+  "outboxMonitorLabelSuccess": "sucesso",
+  "outboxMonitorNoAttachment": "sem apego",
+  "outboxMonitorPayloadSizeLabel": "Tamanho",
+  "outboxMonitorRetries": "novas tentativas",
+  "outboxMonitorRetriesLabel": "Novas tentativas",
+  "outboxMonitorRetry": "tente novamente",
+  "outboxMonitorRetryConfirmLabel": "Tente novamente agora",
+  "outboxMonitorRetryConfirmMessage": "Tentar novamente este item de sincronização agora?",
+  "outboxMonitorRetryFailed": "Falha na nova tentativa. Por favor, tente novamente.",
+  "outboxMonitorRetryQueued": "Nova tentativa agendada",
+  "outboxMonitorSubjectLabel": "Assunto",
+  "outboxMonitorVolumeChartTitle": "Volume de sincronização diária",
+  "outboxRemoveConfirmMessage": "Esta alteração ainda não foi sincronizada. Removê-lo aqui significa que ele não alcançará seus outros dispositivos. Ele permanece neste dispositivo.",
+  "outboxRemoveConfirmTitle": "Remover da fila?",
+  "outboxRetryAll": "Tentar tudo novamente",
+  "outboxShowDetails": "Mostrar detalhes técnicos",
+  "outboxStatusFailed": "Não foi possível enviar",
+  "outboxStatusSending": "Enviando",
+  "outboxStatusSent": "Enviado",
+  "outboxStatusWaiting": "Esperando para enviar",
+  "outboxSummaryFailed": "{count, plural, =1{1 item não pôde ser enviado} other{{count} itens não puderam ser enviados}}",
+  "@outboxSummaryFailed": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "outboxSummaryOffline": "{count, plural, =1{1 item será enviado quando você se reconectar} other{{count} itens serão enviados quando você se reconectar}}",
+  "@outboxSummaryOffline": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "outboxSummarySending": "{count, plural, =1{Enviando 1 item…} other{Enviando {count} itens…}}",
+  "@outboxSummarySending": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "outboxSummarySynced": "Tudo está sincronizado",
+  "outboxSummaryWaiting": "{count, plural, =1{1 item aguardando envio} other{{count} itens aguardando envio}}",
+  "@outboxSummaryWaiting": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "outboxTriedTimes": "{count, plural, =1{Tentei uma vez} other{Tentei {count} vezes}}",
+  "@outboxTriedTimes": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "panasCompletionText": "Obrigado por preencher o PANAS!",
+  "panasCompletionTitle": "Concluído",
+  "panasEmotionActive": "Ativo",
+  "panasEmotionAfraid": "Com medo",
+  "panasEmotionAlert": "Alerta",
+  "panasEmotionAshamed": "Envergonhado",
+  "panasEmotionAttentive": "Atento",
+  "panasEmotionDetermined": "Determinado",
+  "panasEmotionDistressed": "Angustiado",
+  "panasEmotionEnthusiastic": "Entusiasmado",
+  "panasEmotionExcited": "Animado",
+  "panasEmotionGuilty": "Culpado",
+  "panasEmotionHostile": "Hostil",
+  "panasEmotionInspired": "Inspirado",
+  "panasEmotionInterested": "Interessado",
+  "panasEmotionIrritable": "Irritável",
+  "panasEmotionJittery": "Nervoso",
+  "panasEmotionNervous": "Nervoso",
+  "panasEmotionProud": "Orgulhoso",
+  "panasEmotionScared": "Assustado",
+  "panasEmotionStrong": "Forte",
+  "panasEmotionUpset": "Chateado",
+  "panasInstructionFootnote": "Watson, D., Clark, LA e Tellegen, A. (1988). Desenvolvimento e validação de medidas breves de afeto positivo e negativo: As escalas PANAS. Jornal de Personalidade e Psicologia Social, 54(6), 1063–1070.",
+  "panasInstructionText": "Indique até que ponto você se sente assim agora, ou seja, no momento presente.\n\n1 - Muito pouco ou nada,\n2 – Um pouco,\n3—Moderadamente,\n4 – Bastante,\n5—Extremamente",
+  "panasInstructionTitle": "O Cronograma de Afetos Positivos e Negativos (PANAS; Watson et al., 1988)",
+  "panasScaleALittle": "Um pouco",
+  "panasScaleExtremely": "Extremamente",
+  "panasScaleModerately": "Moderadamente",
+  "panasScaleQuiteABit": "Um pouco",
+  "panasScaleVerySlightlyOrNotAtAll": "Muito pouco ou nada",
+  "privateLabel": "Privado",
+  "privateSwitchDescription": "Visível apenas quando entradas privadas são mostradas",
+  "projectAgentNotProvisioned": "Nenhum agente de projeto foi provisionado para este projeto ainda.",
+  "projectAgentSectionTitle": "Agente",
+  "projectCountSummary": "{count, plural, one{{count} projeto} other{{count} projetos}}",
+  "@projectCountSummary": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectCreateButton": "Novo Projeto",
+  "projectCreateTitle": "Criar projeto",
+  "projectDetailTitle": "Detalhes do projeto",
+  "projectErrorCreateFailed": "Erro ao criar projeto.",
+  "projectErrorLoadFailed": "Falha ao carregar dados do projeto.",
+  "projectErrorLoadProjects": "Erro ao carregar projetos",
+  "projectErrorUpdateFailed": "Falha ao atualizar o projeto. Por favor, tente novamente.",
+  "projectFilterLabel": "Projeto",
+  "projectHealthBandAtRisk": "Em risco",
+  "projectHealthBandBlocked": "Bloqueado",
+  "projectHealthBandOnTrack": "No caminho certo",
+  "projectHealthBandSurviving": "Sobrevivendo",
+  "projectHealthBandWatch": "Assistir",
+  "projectHealthSectionTitle": "Saúde do projeto",
+  "projectHealthSummary": "{projectCount, plural, one{{projectCount} projeto} other{{projectCount} projetos}}, {taskCount, plural, one{{taskCount} tarefa} other{{taskCount} tarefas}}",
+  "@projectHealthSummary": {
+    "placeholders": {
+      "projectCount": {
+        "type": "int"
+      },
+      "taskCount": {
+        "type": "int"
+      }
+    }
+  },
+  "projectHealthTitle": "Projetos",
+  "projectLinkedTaskCount": "{count, plural, one{{count} tarefas vinculadas} other{{count} tarefas vinculadas}}",
+  "@projectLinkedTaskCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectLinkedTasks": "Tarefas Vinculadas",
+  "projectManageTooltip": "Gerenciar projetos",
+  "projectNoLinkedTasks": "Nenhuma tarefa vinculada ainda",
+  "projectNoProjects": "Ainda não há projetos",
+  "projectNotFound": "Projeto não encontrado",
+  "projectPickerLabel": "Projeto",
+  "projectPickerUnassigned": "Nenhum projeto",
+  "projectRecommendationDismissTooltip": "Dispensar",
+  "projectRecommendationResolveTooltip": "Marcar como resolvido",
+  "projectRecommendationsTitle": "Próximas etapas recomendadas",
+  "projectRecommendationUpdateError": "Não foi possível atualizar a recomendação. Por favor, tente novamente.",
+  "projectsFilterStatusLabel": "Estado:",
+  "projectsFilterTooltip": "Filtrar projetos",
+  "projectShowcaseAiReportTitle": "Relatório de IA",
+  "projectShowcaseBlockedLegend": "{count} bloqueado",
+  "@projectShowcaseBlockedLegend": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseBlockedTaskCount": "{count, plural, one{{count} tarefas bloqueadas} other{{count} tarefas bloqueadas}}",
+  "@projectShowcaseBlockedTaskCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseCompletedLegend": "{count} concluído",
+  "@projectShowcaseCompletedLegend": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseDescriptionTitle": "Descrição",
+  "projectShowcaseDueDate": "Vencimento em {date}",
+  "@projectShowcaseDueDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "projectShowcaseHealthScoreDescription": "Essa pontuação é baseada na velocidade da tarefa, nos bloqueadores e no tempo restante até o prazo final.",
+  "projectShowcaseHealthScoreTitle": "Pontuação de saúde",
+  "projectShowcaseNoResults": "Nenhum projeto corresponde à sua pesquisa.",
+  "projectShowcaseOneOnOneReviewsTab": "Avaliações individuais",
+  "projectShowcaseOngoing": "Em andamento",
+  "projectShowcaseProjectTasksTab": "Tarefas do Projeto",
+  "projectShowcaseSearchHint": "Pesquisar projetos",
+  "projectShowcaseSessionsCount": "{count, plural, one{{count} sessão} other{{count} sessões}}",
+  "@projectShowcaseSessionsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseTasksCompleted": "{total, plural, one{{completed}/{total} tarefas concluídas} other{{completed}/{total} tarefas concluídas}}",
+  "@projectShowcaseTasksCompleted": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseUpdatedHoursAgo": "Atualizado há {hours}h ↻",
+  "@projectShowcaseUpdatedHoursAgo": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseUpdatedMinutesAgo": "Atualizado há {minutes}m ↻",
+  "@projectShowcaseUpdatedMinutesAgo": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "projectShowcaseUsefulness": "Utilidade",
+  "projectShowcaseViewBlocker": "Ver bloqueador",
+  "projectStatusActive": "Ativo",
+  "projectStatusArchived": "Arquivado",
+  "projectStatusChangeTitle": "Alterar status",
+  "projectStatusCompleted": "Concluído",
+  "projectStatusMonitoring": "Monitoramento",
+  "projectStatusOnHold": "Em espera",
+  "projectStatusOpen": "Abrir",
+  "projectSummaryOutdated": "Resumo desatualizado.",
+  "projectSummaryOutdatedScheduled": "Resumo desatualizado. Próxima atualização {date} às {time}.",
+  "@projectSummaryOutdatedScheduled": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "projectTargetDateLabel": "Data prevista",
+  "projectTitleLabel": "Título do projeto",
+  "projectTitleRequired": "O título do projeto não pode ficar vazio",
+  "promptDefaultModelBadge": "Padrão",
+  "promptGenerationCardTitle": "Prompt de codificação AI",
+  "promptGenerationCopiedSnackbar": "Prompt copiado para a área de transferência",
+  "promptGenerationCopyButton": "Copiar prompt",
+  "promptGenerationCopyTooltip": "Copiar prompt para a área de transferência",
+  "promptGenerationExpandTooltip": "Mostrar prompt completo",
+  "promptGenerationFullPromptLabel": "Alerta completo:",
+  "promptSelectionModalTitle": "Selecione o prompt pré-configurado",
+  "provisionedSyncBundleImported": "Código de provisionamento importado",
+  "provisionedSyncConfigureButton": "Configurar",
+  "provisionedSyncCopiedToClipboard": "Copiado para a área de transferência",
+  "provisionedSyncDisconnect": "Desconectar",
+  "provisionedSyncDone": "Sincronização configurada com sucesso",
+  "provisionedSyncError": "Falha na configuração",
+  "provisionedSyncErrorConfigurationFailed": "Ocorreu um erro durante a configuração. Por favor, tente novamente.",
+  "provisionedSyncErrorLoginFailed": "Falha no login. Verifique suas credenciais e tente novamente.",
+  "provisionedSyncImportButton": "Importar",
+  "provisionedSyncImportHint": "Cole o código de provisionamento aqui",
+  "provisionedSyncImportTitle": "Configuração de sincronização",
+  "provisionedSyncInvalidBundle": "Código de provisionamento inválido",
+  "provisionedSyncJoiningRoom": "Entrando na sala de sincronização...",
+  "provisionedSyncLoggingIn": "Fazendo login...",
+  "provisionedSyncPasteClipboard": "Colar da área de transferência",
+  "provisionedSyncReady": "Digitalize este código QR no seu dispositivo móvel",
+  "provisionedSyncRetry": "Tentar novamente",
+  "provisionedSyncRotatingPassword": "Protegendo a conta...",
+  "provisionedSyncScanButton": "Digitalize o código QR",
+  "provisionedSyncShowQr": "Mostrar QR de provisionamento",
+  "provisionedSyncSubtitle": "Configurar a sincronização de um pacote de provisionamento",
+  "provisionedSyncSummaryHomeserver": "Servidor doméstico",
+  "provisionedSyncSummaryRoom": "Quarto",
+  "provisionedSyncSummaryUser": "Usuário",
+  "provisionedSyncTitle": "Sincronização provisionada",
+  "provisionedSyncVerifyDevicesTitle": "Verificação de dispositivo",
+  "queueCatchUpNowButton": "Acompanhe agora",
+  "queueCatchUpNowDone": "Catch-up chutado – a fila está se esgotando.",
+  "queueCatchUpNowError": "Falha na atualização: {reason}",
+  "@queueCatchUpNowError": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "queueDepthCardEmpty": "Fila vazia – o trabalhador está em dia.",
+  "queueDepthCardLoading": "Lendo profundidade da fila…",
+  "queueDepthCardTitle": "Fila de entrada",
+  "queueFetchAllHistoryCancel": "Cancelar",
+  "queueFetchAllHistoryCancelled": "Cancelado — {events, plural, =0{no events} =1{1 event} other{{events} events}} buscados até agora.",
+  "@queueFetchAllHistoryCancelled": {
+    "placeholders": {
+      "events": {
+        "type": "int"
+      }
+    }
+  },
+  "queueFetchAllHistoryClose": "Fechar",
+  "queueFetchAllHistoryDescription": "Coloca todo o histórico visível da sala na fila. É seguro cancelar; uma execução posterior é retomada de onde a paginação parou.",
+  "queueFetchAllHistoryDone": "{events, plural, =0{Nenhum evento obtido.} =1{Buscado 1 evento em {pages, plural, =1{1 page} other{{pages} páginas}}.} other{Buscado {events} eventos em {pages, plural, =1{1 page} other{{pages} páginas}}.}}",
+  "@queueFetchAllHistoryDone": {
+    "placeholders": {
+      "events": {
+        "type": "int"
+      },
+      "pages": {
+        "type": "int"
+      }
+    }
+  },
+  "queueFetchAllHistoryError": "Busca interrompida: {reason}",
+  "@queueFetchAllHistoryError": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "queueFetchAllHistoryErrorUnknown": "Fetch parou inesperadamente.",
+  "@queueFetchAllHistoryErrorUnknown": {},
+  "queueFetchAllHistoryProgress": "{events, plural, =1{Página {pages} · 1 evento obtido} other{Página {pages} · {events} eventos obtidos}}",
+  "@queueFetchAllHistoryProgress": {
+    "placeholders": {
+      "events": {
+        "type": "int"
+      },
+      "pages": {
+        "type": "int"
+      }
+    }
+  },
+  "queueFetchAllHistoryTitle": "Buscando histórico",
+  "queueSkippedBadge": "{count, plural, =1{1 ignorado} other{{count} ignorado}}",
+  "@queueSkippedBadge": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "queueSkippedCardBody": "{count, plural, =1{1 evento de sincronização do qual a fila desistiu. Toque em tentar novamente para tentar novamente.} other{{count} eventos de sincronização dos quais a fila desistiu. Toque em tentar novamente para tentar novamente.}}",
+  "@queueSkippedCardBody": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "queueSkippedCardTitle": "Eventos ignorados",
+  "queueSkippedRetryAll": "Tentar novamente eventos ignorados",
+  "queueSkippedRetryAllDone": "{count, plural, =0{Nenhum evento ignorado para nova tentativa.} =1{1 evento na fila para nova tentativa.} other{{count} eventos na fila para nova tentativa.}}",
+  "@queueSkippedRetryAllDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "queueSkippedRetryAllError": "Falha na nova tentativa: {reason}",
+  "@queueSkippedRetryAllError": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "referenceImageContinue": "Continuar",
+  "referenceImageContinueWithCount": "Continuar ({count})",
+  "@referenceImageContinueWithCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "referenceImageLoadError": "Falha ao carregar imagens. Por favor, tente novamente.",
+  "referenceImageSelectionSubtitle": "Escolha até 5 imagens para orientar o estilo visual da IA",
+  "referenceImageSelectionTitle": "Selecione imagens de referência",
+  "referenceImageSkip": "Pular",
+  "saveButton": "Salvar",
+  "saveButtonLabel": "Salvar",
+  "saveLabel": "Salvar",
+  "saveShortcutTooltip": "Salvar — Ctrl+S (⌘S no Mac)",
+  "saveSuccessful": "Salvo com sucesso",
+  "searchHint": "Pesquisar...",
+  "searchModeFullText": "Texto Completo",
+  "searchModeVector": "Vetor",
+  "searchTasksHint": "Pesquisar tarefas...",
+  "selectButton": "Selecione",
+  "selectColor": "Selecione uma cor",
+  "selectLanguage": "Selecione o idioma",
+  "sessionRatingCardLabel": "Classificação da sessão",
+  "sessionRatingChallengeJustRight": "Certo",
+  "sessionRatingChallengeTooEasy": "Muito fácil",
+  "sessionRatingChallengeTooHard": "Muito desafiador",
+  "sessionRatingDifficultyLabel": "Este trabalho pareceu...",
+  "sessionRatingEditButton": "Editar classificação",
+  "sessionRatingEnergyQuestion": "Quão energizado você se sentiu?",
+  "sessionRatingFocusQuestion": "Quão focado você estava?",
+  "sessionRatingNoteHint": "Nota rápida (opcional)",
+  "sessionRatingProductivityQuestion": "Quão produtiva foi esta sessão?",
+  "sessionRatingRateAction": "Avaliar sessão",
+  "sessionRatingSaveButton": "Salvar",
+  "sessionRatingSaveError": "Falha ao salvar a classificação. Por favor, tente novamente.",
+  "sessionRatingSkipButton": "Pular",
+  "sessionRatingTitle": "Avalie esta sessão",
+  "sessionRatingViewAction": "Ver classificação",
+  "settingsAboutAppInformation": "Informações do aplicativo",
+  "settingsAboutAppTagline": "Seu diário pessoal",
+  "settingsAboutBuildType": "Tipo de construção",
+  "settingsAboutDailyOsPersonalizationTitle": "Personalização diária do sistema operacional",
+  "settingsAboutDailyOsUserNameHelper": "Usado para a saudação diária do sistema operacional e sincronizado em seus dispositivos.",
+  "settingsAboutDailyOsUserNameLabel": "Seu nome",
+  "settingsAboutJournalEntries": "Lançamentos de diário",
+  "settingsAboutPlatform": "Plataforma",
+  "settingsAboutTitle": "Sobre Lotti",
+  "settingsAboutVersion": "Versão",
+  "settingsAboutYourData": "Seus dados",
+  "settingsAdvancedAboutSubtitle": "Saiba mais sobre o aplicativo Lotti",
+  "settingsAdvancedHealthImportSubtitle": "Importe dados relacionados à saúde de fontes externas",
+  "settingsAdvancedMaintenanceSubtitle": "Execute tarefas de manutenção para otimizar o desempenho do aplicativo",
+  "settingsAdvancedManualLanguageSubtitle": "Escolha em qual idioma abrir o Manual Lotti",
+  "settingsAdvancedOutboxSubtitle": "Gerenciar itens de sincronização",
+  "settingsAdvancedSubtitle": "Configurações avançadas e manutenção",
+  "settingsAdvancedTitle": "Configurações avançadas",
+  "settingsAgentsInstancesSubtitle": "Agentes em execução",
+  "settingsAgentsPendingWakesSubtitle": "Despertadores programados",
+  "settingsAgentsSoulsSubtitle": "Personalidades de agentes de longa vida",
+  "settingsAgentsStatsSubtitle": "Uso e atividade de token",
+  "settingsAgentsTemplatesSubtitle": "Projetos de agente compartilhado",
+  "settingsAiModelsSubtitle": "Linhas e recursos do modelo por provedor",
+  "settingsAiModelsTitle": "Modelos",
+  "settingsAiProfilesSubtitle": "Provedores e modelos",
+  "settingsAiProfilesTitle": "Perfis de inferência",
+  "settingsAiProvidersSubtitle": "Provedores e chaves de IA conectada",
+  "settingsAiProvidersTitle": "Provedores",
+  "settingsAiSubtitle": "Configurar provedores, modelos e prompts de IA",
+  "settingsAiTitle": "Configurações de IA",
+  "settingsAiUsageSubtitle": "Custo, energia e CO₂e das chamadas de IA",
+  "settingsAiUsageTitle": "Uso e impacto",
+  "settingsBeamPageEditModelTitle": "Editar modelo",
+  "settingsBeamPageEditProfileTitle": "Editar perfil",
+  "settingsCategoriesCreateTitle": "Criar categoria",
+  "settingsCategoriesDetailsLabel": "Editar categoria",
+  "settingsCategoriesEmptyState": "Nenhuma categoria ainda",
+  "settingsCategoriesEmptyStateHint": "Crie uma categoria para organizar suas entradas",
+  "settingsCategoriesErrorLoading": "Erro ao carregar categorias",
+  "settingsCategoriesNameLabel": "Nome da categoria",
+  "settingsCategoriesNoMatchQuery": "Nenhuma categoria corresponde a \"{query}\"",
+  "@settingsCategoriesNoMatchQuery": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsCategoriesSearchHint": "Categorias de pesquisa…",
+  "settingsCategoriesSubtitle": "Categorias com configurações de IA",
+  "settingsCategoriesTaskCount": "{count, plural, one{{count} tarefa} other{{count} tarefas}}",
+  "@settingsCategoriesTaskCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settingsCategoriesTitle": "Categorias",
+  "settingsCelebrationsChecklistDescription": "Um estalo e faíscas quando você marca um item",
+  "settingsCelebrationsChecklistTitle": "Itens da lista de verificação",
+  "settingsCelebrationsCustomizeTitle": "Personalizar",
+  "settingsCelebrationsCustomizeTooltip": "Personalize este estilo",
+  "settingsCelebrationsEnabledDescription": "Chave mestre para conclusão floresce. Off oculta todas as animações; a sensação ao toque mantém seu próprio interruptor.",
+  "settingsCelebrationsEnabledTitle": "Animações de celebração",
+  "settingsCelebrationsGroupLook": "Olha",
+  "settingsCelebrationsGroupMotion": "Movimento",
+  "settingsCelebrationsGroupShape": "Forma",
+  "settingsCelebrationsHabitsDescription": "Brilho e faíscas quando você completa um hábito",
+  "settingsCelebrationsHabitsTitle": "Hábitos",
+  "settingsCelebrationsHapticsDescription": "Um breve zumbido quando você termina algo – independente da animação.",
+  "settingsCelebrationsHapticsTitle": "Háptica de conclusão",
+  "settingsCelebrationsKnobClearCenter": "Folga central",
+  "settingsCelebrationsKnobCount": "Partículas",
+  "settingsCelebrationsKnobDescClearCenter": "Espaço vazio no centro",
+  "settingsCelebrationsKnobDescCount": "Quantas partículas voam",
+  "settingsCelebrationsKnobDescFallout": "Quão longe as faíscas descem",
+  "settingsCelebrationsKnobDescFanSpread": "Largura do ventilador",
+  "settingsCelebrationsKnobDescGlow": "Força do brilho",
+  "settingsCelebrationsKnobDescGravity": "Com que rapidez as partículas caem",
+  "settingsCelebrationsKnobDescHalo": "Força do halo",
+  "settingsCelebrationsKnobDescInnerRing": "Tamanho do anel interno",
+  "settingsCelebrationsKnobDescLaunch": "Atraso antes da explosão",
+  "settingsCelebrationsKnobDescPop": "Quando eles estouram",
+  "settingsCelebrationsKnobDescReach": "Quão longe as partículas viajam",
+  "settingsCelebrationsKnobDescRise": "Como as partículas altas sobem",
+  "settingsCelebrationsKnobDescSize": "Qual é o tamanho de cada partícula",
+  "settingsCelebrationsKnobDescSpeedSpread": "Variação na velocidade das partículas",
+  "settingsCelebrationsKnobDescSpin": "Quão rápido as peças giram",
+  "settingsCelebrationsKnobDescSpread": "Largura do spray",
+  "settingsCelebrationsKnobDescSway": "Quanto as peças balançam",
+  "settingsCelebrationsKnobDescSwell": "Quanto eles crescem",
+  "settingsCelebrationsKnobDescTrail": "Comprimento de cada trilha",
+  "settingsCelebrationsKnobDescTwinkle": "Quanta partículas piscam",
+  "settingsCelebrationsKnobDescUpward": "Quão fortemente eles sobem",
+  "settingsCelebrationsKnobDescWobble": "Quanto as peças oscilam",
+  "settingsCelebrationsKnobFallout": "Precipitação",
+  "settingsCelebrationsKnobFanSpread": "Propagação de fãs",
+  "settingsCelebrationsKnobGlow": "Brilho",
+  "settingsCelebrationsKnobGravity": "Gravidade",
+  "settingsCelebrationsKnobHalo": "auréola",
+  "settingsCelebrationsKnobInnerRing": "Anel interno",
+  "settingsCelebrationsKnobLaunch": "Hora de lançamento",
+  "settingsCelebrationsKnobPop": "Ponto pop",
+  "settingsCelebrationsKnobReach": "Alcance",
+  "settingsCelebrationsKnobRise": "Altura de subida",
+  "settingsCelebrationsKnobSize": "Tamanho",
+  "settingsCelebrationsKnobSpeedSpread": "Variação de velocidade",
+  "settingsCelebrationsKnobSpin": "Girar",
+  "settingsCelebrationsKnobSpread": "Espalhe arco",
+  "settingsCelebrationsKnobSway": "Balançar",
+  "settingsCelebrationsKnobSwell": "Inchar",
+  "settingsCelebrationsKnobTrail": "Comprimento da trilha",
+  "settingsCelebrationsKnobTwinkle": "Brilha",
+  "settingsCelebrationsKnobUpward": "Subir",
+  "settingsCelebrationsKnobWobble": "Oscilação",
+  "settingsCelebrationsPlaygroundHint": "Toque na linha destacada para visualizar",
+  "settingsCelebrationsPlaygroundLiveNote": "As alterações são salvas e aplicadas em qualquer lugar instantaneamente",
+  "settingsCelebrationsPreviewChecklistItem": "Verifique-me",
+  "settingsCelebrationsPreviewDescription": "Toque em um controle para reproduzir o estilo selecionado.",
+  "settingsCelebrationsPreviewDone": "Concluído",
+  "settingsCelebrationsPreviewHabit": "Hábito",
+  "settingsCelebrationsPreviewSample1": "Caminhada matinal",
+  "settingsCelebrationsPreviewSample2": "Concluir o relatório",
+  "settingsCelebrationsPreviewSample3": "Regue as plantas",
+  "settingsCelebrationsPreviewTitle": "Experimente",
+  "settingsCelebrationsReplay": "Repetir",
+  "settingsCelebrationsResetToast": "Estilo redefinido para o padrão",
+  "settingsCelebrationsResetToDefault": "Redefinir para o padrão",
+  "settingsCelebrationsResetUndo": "Desfazer",
+  "settingsCelebrationsSectionDescription": "Faça um floreio ao terminar algo. Desligar um mantém a conclusão e sua sensação tátil – apenas pula a animação.",
+  "settingsCelebrationsSectionTitle": "Celebrações de conclusão",
+  "settingsCelebrationsStyleDescription": "Toque em um cartão para visualizar um estilo de celebração e personalizá-lo.",
+  "settingsCelebrationsStyleTitle": "Estilo",
+  "settingsCelebrationsSubtitle": "Celebrações de conclusão",
+  "settingsCelebrationsTasksDescription": "Brilho e faíscas quando você move uma tarefa para Concluído",
+  "settingsCelebrationsTasksTitle": "Tarefas",
+  "settingsCelebrationsTitle": "Animações",
+  "settingsCelebrationsVariantBubbles": "Bolhas",
+  "settingsCelebrationsVariantCombine": "Combine dois",
+  "settingsCelebrationsVariantCombineDescription": "Dois estilos aleatórios, em camadas, de cada vez",
+  "settingsCelebrationsVariantConfetti": "Confete",
+  "settingsCelebrationsVariantEmbers": "Brasas",
+  "settingsCelebrationsVariantFireworks": "Fogos de artifício",
+  "settingsCelebrationsVariantRandom": "Aleatório",
+  "settingsCelebrationsVariantRandomDescription": "Um estilo novo em cada finalização",
+  "settingsCelebrationsVariantSparks": "Faíscas",
+  "settingsConflictsTitle": "Conflitos de sincronização",
+  "settingsDashboardDetailsLabel": "Editar painel",
+  "settingsDashboardSaveLabel": "Salvar",
+  "settingsDashboardsCreateTitle": "Criar painel",
+  "settingsDashboardsEmptyState": "Ainda não há painéis",
+  "settingsDashboardsEmptyStateHint": "Toque no botão + para criar seu primeiro painel.",
+  "settingsDashboardsErrorLoading": "Erro ao carregar painéis",
+  "settingsDashboardsNoMatchQuery": "Nenhum painel corresponde a \"{query}\"",
+  "@settingsDashboardsNoMatchQuery": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsDashboardsSearchHint": "Painéis de pesquisa…",
+  "settingsDashboardsSubtitle": "Personalize as visualizações do seu painel",
+  "settingsDashboardsTitle": "Painéis",
+  "settingsDefinitionsSubtitle": "Hábitos, categorias, rótulos, painéis e mensuráveis",
+  "settingsDefinitionsTitle": "Definições",
+  "settingsFlagsEmptySearch": "Nenhuma sinalização corresponde à sua pesquisa",
+  "settingsFlagsSearchHint": "Sinalizadores de pesquisa",
+  "settingsFlagsSubtitle": "Configurar sinalizadores e opções de recursos",
+  "settingsFlagsTitle": "Sinalizadores de configuração",
+  "settingsHabitsCreateTitle": "Crie hábito",
+  "settingsHabitsDeleteTooltip": "Excluir hábito",
+  "settingsHabitsDescriptionLabel": "Descrição (opcional)",
+  "settingsHabitsDetailsLabel": "Editar hábito",
+  "settingsHabitsEmptyState": "Ainda não há hábitos",
+  "settingsHabitsEmptyStateHint": "Toque no botão + para criar seu primeiro hábito.",
+  "settingsHabitsErrorLoading": "Erro ao carregar hábitos",
+  "settingsHabitsNameLabel": "Nome do hábito",
+  "settingsHabitsNoMatchQuery": "Nenhum hábito corresponde a \"{query}\"",
+  "@settingsHabitsNoMatchQuery": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsHabitsPrivateLabel": "Privado:",
+  "settingsHabitsSaveLabel": "Salvar",
+  "settingsHabitsSearchHint": "Hábitos de pesquisa…",
+  "settingsHabitsSubtitle": "Gerencie seus hábitos e rotinas",
+  "settingsHabitsTitle": "Hábitos",
+  "settingsHealthImportActivity": "Importar dados de atividades",
+  "settingsHealthImportBloodPressure": "Importar dados de pressão arterial",
+  "settingsHealthImportBodyMeasurement": "Importar dados de medição corporal",
+  "settingsHealthImportFromDate": "Começar",
+  "settingsHealthImportHeartRate": "Importar dados de frequência cardíaca",
+  "settingsHealthImportSleep": "Importar dados de sono",
+  "settingsHealthImportTitle": "Importação de Saúde",
+  "settingsHealthImportToDate": "Fim",
+  "settingsHealthImportWorkout": "Importar dados de treino",
+  "settingsKeyboardShortcutsSubtitle": "Aprenda as combinações de teclado para navegação e edição mais rápidas na área de trabalho",
+  "settingsKeyboardShortcutsTitle": "Atalhos de teclado",
+  "settingsLabelsCategoriesAdd": "Adicionar categoria",
+  "settingsLabelsCategoriesHeading": "Categorias aplicáveis",
+  "settingsLabelsCategoriesNone": "Aplica-se a todas as categorias",
+  "settingsLabelsCategoriesRemoveTooltip": "Remover",
+  "settingsLabelsColorHeading": "Cor",
+  "settingsLabelsColorSubheading": "Predefinições rápidas",
+  "settingsLabelsCreateTitle": "Criar etiqueta",
+  "settingsLabelsDeleteConfirmAction": "Excluir",
+  "settingsLabelsDeleteConfirmMessage": "Tem certeza de que deseja excluir \"{labelName}\"? As tarefas com este rótulo perderão a atribuição.",
+  "settingsLabelsDeleteConfirmTitle": "Excluir rótulo",
+  "settingsLabelsDeleteSuccess": "Rótulo \"{labelName}\" excluído",
+  "settingsLabelsDescriptionHint": "Explique quando aplicar este rótulo",
+  "settingsLabelsDescriptionLabel": "Descrição (opcional)",
+  "settingsLabelsEditTitle": "Editar rótulo",
+  "settingsLabelsEmptyState": "Ainda não há rótulos",
+  "settingsLabelsEmptyStateHint": "Toque no botão + para criar sua primeira etiqueta.",
+  "settingsLabelsErrorLoading": "Falha ao carregar rótulos",
+  "settingsLabelsNameHint": "Bug, bloqueador de lançamento, sincronização…",
+  "settingsLabelsNameLabel": "Nome da etiqueta",
+  "settingsLabelsNoMatchCreate": "Criar rótulo \"{query}\"",
+  "@settingsLabelsNoMatchCreate": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsLabelsNoMatchQuery": "Nenhum rótulo corresponde a \"{query}\"",
+  "@settingsLabelsNoMatchQuery": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsLabelsPrivateDescription": "Visível apenas quando entradas privadas são mostradas",
+  "settingsLabelsPrivateTitle": "Privado",
+  "settingsLabelsSearchHint": "Pesquisar rótulos…",
+  "settingsLabelsSubtitle": "Organize tarefas com etiquetas coloridas",
+  "settingsLabelsTitle": "Etiquetas",
+  "settingsLabelsUsageCount": "{count, plural, =1{1 tarefa} other{{count} tarefas}}",
+  "@settingsLabelsUsageCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settingsLoggingDomainsSubtitle": "Controlar quais domínios gravam no log",
+  "settingsLoggingDomainsTitle": "Registrando Domínios",
+  "settingsLoggingGlobalToggle": "Habilitar registro em log",
+  "settingsLoggingGlobalToggleSubtitle": "Chave mestre para todos os registros",
+  "settingsLoggingSlowQueries": "Consultas lentas ao banco de dados",
+  "settingsLoggingSlowQueriesSubtitle": "Grava consultas lentas em slow_queries-YYYY-MM-DD.log",
+  "settingsMaintenanceOnboardingAnimationGallerySubtitle": "Compare animações de boas-vindas + conecte a página ao vivo (depuração)",
+  "@settingsMaintenanceOnboardingAnimationGallerySubtitle": {
+    "description": "Debug-only subtitle for the onboarding animation gallery in Maintenance."
+  },
+  "settingsMaintenanceOnboardingAnimationGalleryTitle": "Galeria de animação de integração",
+  "@settingsMaintenanceOnboardingAnimationGalleryTitle": {
+    "description": "Debug-only title for the onboarding animation gallery in Maintenance."
+  },
+  "settingsMaintenanceOnboardingWelcomeSubtitle": "Visualize os blocos de boas-vindas + provedor do FTUE (depuração)",
+  "@settingsMaintenanceOnboardingWelcomeSubtitle": {
+    "description": "Debug-only subtitle for reopening the onboarding welcome from Maintenance."
+  },
+  "settingsMaintenanceOnboardingWelcomeTitle": "Mostrar boas-vindas à integração",
+  "@settingsMaintenanceOnboardingWelcomeTitle": {
+    "description": "Debug-only title for reopening the onboarding welcome from Maintenance."
+  },
+  "settingsMaintenanceTitle": "Manutenção",
+  "settingsManualLanguageCzechTitle": "Tcheco",
+  "settingsManualLanguageEnglishTitle": "Inglês",
+  "settingsManualLanguageFollowSystemSubtitle": "Use o idioma do seu dispositivo quando o manual suportar; caso contrário, use o inglês.",
+  "settingsManualLanguageFollowSystemTitle": "Siga o sistema",
+  "settingsManualLanguageFrenchTitle": "Francês",
+  "settingsManualLanguageGermanTitle": "Alemão",
+  "settingsManualLanguagePortugueseTitle": "Português",
+  "settingsManualLanguageRomanianTitle": "Romeno",
+  "settingsManualLanguageTitle": "Idioma",
+  "settingsMatrixAccept": "Aceitar",
+  "settingsMatrixAcceptVerificationLabel": "Outro dispositivo mostra emojis, continue",
+  "settingsMatrixCancel": "Cancelar",
+  "settingsMatrixContinueVerificationLabel": "Aceite em outro dispositivo para continuar",
+  "settingsMatrixDiagnosticCopied": "Informações de diagnóstico copiadas para a área de transferência",
+  "settingsMatrixDiagnosticCopyButton": "Copiar para a área de transferência",
+  "settingsMatrixDiagnosticDialogTitle": "Sincronizar informações de diagnóstico",
+  "settingsMatrixDiagnosticShowButton": "Mostrar informações de diagnóstico",
+  "settingsMatrixDone": "Concluído",
+  "settingsMatrixLastUpdated": "Última atualização:",
+  "settingsMatrixListUnverifiedLabel": "Dispositivos não verificados",
+  "settingsMatrixMaintenanceSubtitle": "Execute tarefas de manutenção e ferramentas de recuperação do Matrix",
+  "settingsMatrixMaintenanceTitle": "Manutenção",
+  "settingsMatrixMetrics": "Métricas de sincronização",
+  "settingsMatrixNextPage": "Próxima página",
+  "settingsMatrixNoUnverifiedLabel": "Nenhum dispositivo não verificado",
+  "settingsMatrixPreviousPage": "Página anterior",
+  "settingsMatrixRoomInviteMessage": "Convide para a sala {roomId} de {senderId}. Aceitar?",
+  "@settingsMatrixRoomInviteMessage": {
+    "placeholders": {
+      "roomId": {
+        "type": "String"
+      },
+      "senderId": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMatrixRoomInviteTitle": "Convite para sala",
+  "settingsMatrixSentMessagesLabel": "Mensagens enviadas:",
+  "settingsMatrixStartVerificationLabel": "Iniciar verificação",
+  "settingsMatrixStatsTitle": "Estatísticas da Matriz",
+  "settingsMatrixTitle": "Configurações de sincronização",
+  "settingsMatrixUnverifiedDevicesPage": "Dispositivos não verificados",
+  "settingsMatrixVerificationCancelledLabel": "Cancelado em outro dispositivo...",
+  "settingsMatrixVerificationSuccessConfirm": "Entendi",
+  "settingsMatrixVerificationSuccessLabel": "Você verificou {deviceName} ({deviceID})",
+  "@settingsMatrixVerificationSuccessLabel": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "deviceID": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMatrixVerifyConfirm": "Confirme em outro dispositivo se os emojis abaixo são exibidos em ambos os dispositivos, na mesma ordem:",
+  "settingsMatrixVerifyIncomingConfirm": "Confirme se os emojis abaixo são exibidos em ambos os dispositivos, na mesma ordem:",
+  "settingsMatrixVerifyLabel": "Verifique",
+  "settingsMeasurableAggregationHelper": "Como as entradas de um dia se combinam nos gráficos",
+  "settingsMeasurableAggregationLabel": "Tipo de agregação padrão",
+  "settingsMeasurableDeleteTooltip": "Excluir tipo mensurável",
+  "settingsMeasurableDescriptionLabel": "Descrição (opcional)",
+  "settingsMeasurableDetailsLabel": "Editar mensurável",
+  "settingsMeasurableNameLabel": "Nome mensurável",
+  "settingsMeasurablePrivateLabel": "Privado:",
+  "settingsMeasurableSaveLabel": "Salvar",
+  "settingsMeasurablesCreateTitle": "Crie mensuráveis",
+  "settingsMeasurablesEmptyState": "Ainda não há mensuráveis",
+  "settingsMeasurablesEmptyStateHint": "Mensuráveis são números que você acompanha ao longo do tempo – peso, água, passos.",
+  "settingsMeasurablesErrorLoading": "Erro ao carregar mensuráveis",
+  "settingsMeasurablesNoMatchQuery": "Nenhum mensurável corresponde a \"{query}\"",
+  "@settingsMeasurablesNoMatchQuery": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurablesSearchHint": "Pesquisar mensuráveis…",
+  "settingsMeasurablesSubtitle": "Configurar tipos de dados mensuráveis",
+  "settingsMeasurablesTitle": "Mensuráveis",
+  "settingsMeasurableUnitLabel": "Abreviatura da unidade (opcional)",
+  "settingsOnboardingActionSubtitle": "Reabra o fluxo de boas-vindas – conecte seu cérebro de IA e crie uma tarefa",
+  "settingsOnboardingMetricsSubtitle": "Funil FTUE – instalação, ativação, retenção (depuração)",
+  "settingsOnboardingMetricsTitle": "Métricas de integração",
+  "settingsOnboardingReplayTitle": "Integração de repetição",
+  "settingsOnboardingStartTitle": "Comece a integração",
+  "settingsOnboardingStatusActivated": "Você criou sua primeira tarefa de IA",
+  "settingsOnboardingStatusLoading": "Carregando…",
+  "settingsOnboardingStatusNotActivated": "Ainda não começou",
+  "settingsOnboardingStatusTitle": "Estado",
+  "settingsOnboardingSubtitle": "Repita o fluxo de boas-vindas a qualquer momento",
+  "settingsOnboardingTestResetConfirm": "Redefinir",
+  "settingsOnboardingTestResetConfirmQuestion": "Limpar histórico e métricas de solicitações de integração? Os planos do Daily OS existentes permanecem, portanto, use um perfil limpo para testar o passo a passo completo do Daily OS na primeira execução.",
+  "settingsOnboardingTestResetSubtitle": "Limpar histórico e métricas de prompts; os planos diários existentes do sistema operacional permanecem (depuração)",
+  "settingsOnboardingTestResetTitle": "Redefinir o estado do teste de integração",
+  "settingsOnboardingTitle": "Integração",
+  "settingsOptionsTitle": "Opções",
+  "settingsRecordingStyleExplanation": "Escolha a aparência do microfone enquanto você grava.",
+  "settingsRecordingStyleSubtitle": "Medidor VU ou orbe de energia durante a gravação",
+  "settingsRecordingStyleTitle": "Estilo de gravação",
+  "settingsResetGeminiConfirm": "Redefinir",
+  "settingsResetGeminiConfirmQuestion": "Isso mostrará a caixa de diálogo de configuração do Gemini novamente. Continuar?",
+  "settingsResetGeminiSubtitle": "Mostrar a caixa de diálogo de configuração do Gemini AI novamente",
+  "settingsResetGeminiTitle": "Caixa de diálogo Redefinir configuração do Gemini",
+  "settingsResetHintsConfirm": "Confirmar",
+  "settingsResetHintsConfirmQuestion": "Redefinir dicas no aplicativo exibidas no aplicativo?",
+  "settingsResetHintsResult": "{count, plural, =0{Redefinir zero dicas} one{Redefinir uma dica} other{Redefinir {count} dicas}}",
+  "@settingsResetHintsResult": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settingsResetHintsSubtitle": "Dicas claras e de integração únicas",
+  "settingsResetHintsTitle": "Redefinir dicas no aplicativo",
+  "settingsSpeechSubtitle": "Voz e leitura em voz alta",
+  "settingsSpeechTitle": "Discurso",
+  "settingsSyncConflictsSubtitle": "Resolva conflitos de sincronização para garantir a consistência dos dados",
+  "settingsSyncNodeProfileCapabilitiesEmpty": "Nenhum detectado — o acionamento automático da inferência de áudio sincronizado não terá como alvo este dispositivo.",
+  "settingsSyncNodeProfileCapabilitiesLabel": "Capacidades de IA detectadas",
+  "settingsSyncNodeProfileCapabilityMlxAudio": "Áudio MLX (local)",
+  "settingsSyncNodeProfileCapabilityOllamaLlm": "Ollama LLM",
+  "settingsSyncNodeProfileCapabilityOmlxLlm": "oMLX LLM",
+  "settingsSyncNodeProfileCapabilityVoxtral": "Voxtral (local)",
+  "settingsSyncNodeProfileCapabilityWhisper": "Sussurro (local)",
+  "settingsSyncNodeProfileDisplayNameHelper": "Visível para seus outros dispositivos ao escolher em qual deles fixar um perfil.",
+  "settingsSyncNodeProfileDisplayNameLabel": "Nome de exibição do dispositivo",
+  "settingsSyncNodeProfileKnownNodesEmpty": "Nenhum outro dispositivo publicou um perfil ainda.",
+  "settingsSyncNodeProfileKnownNodesTitle": "Dispositivos de sincronização conhecidos",
+  "settingsSyncNodeProfileSaveButton": "Salvar",
+  "settingsSyncNodeProfileSubtitle": "Dê um nome a este dispositivo e analise os recursos visíveis para seus outros dispositivos.",
+  "settingsSyncNodeProfileTitle": "Este dispositivo",
+  "settingsSyncOutboxTitle": "Sincronizar caixa de saída",
+  "settingsSyncStatsSubtitle": "Inspecione as métricas do pipeline de sincronização",
+  "settingsSyncSubtitle": "Configurar sincronização e visualizar estatísticas",
+  "settingsThemingAutomatic": "Automático",
+  "settingsThemingDark": "Aparência escura",
+  "settingsThemingLight": "Aparência clara",
+  "settingsThemingSubtitle": "Personalize a aparência e os temas do aplicativo",
+  "settingsThemingTitle": "Tema",
+  "settingsV2CategoryEmptyBody": "Escolha uma subconfiguração à esquerda.",
+  "settingsV2DetailRootCrumb": "Configurações",
+  "settingsV2EmptyStateBody": "Escolha uma seção à esquerda para começar.",
+  "settingsV2ResizeHandleLabel": "Redimensionar árvore de configurações",
+  "settingsV2UnimplementedTitle": "Painel ainda não implementado",
+  "settingsWhatsNewSubtitle": "Veja as últimas atualizações e recursos",
+  "settingsWhatsNewTitle": "Novidades",
+  "settingThemingDark": "Tema escuro",
+  "settingThemingLight": "Tema claro",
+  "sidebarActiveSectionTitle": "Atividade",
+  "sidebarActivityCollapseTooltip": "Recolher atividade",
+  "sidebarActivityExpandTooltip": "Expandir atividade",
+  "sidebarAudioRecordingStatusLabel": "Gravação",
+  "sidebarRunningTimerLabel": "Temporizador em execução",
+  "sidebarRunningTimerStopTooltip": "Parar cronômetro",
+  "sidebarTimerStatusLabel": "Temporizador",
+  "sidebarToggleCollapseLabel": "Recolher barra lateral",
+  "sidebarToggleExpandLabel": "Expandir barra lateral",
+  "sidebarWakesActiveCount": "{count, plural, =1{1 ativo} other{{count} ativo}}",
+  "@sidebarWakesActiveCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "sidebarWakesCancelTooltip": "Cancelar agente",
+  "sidebarWakesHeader": "Agentes",
+  "sidebarWakesNow": "agora",
+  "sidebarWakesOpenList": "Lista aberta",
+  "sidebarWakesOpenTask": "Tarefa aberta",
+  "sidebarWakesQueuedCount": "{count, plural, =1{1 na fila} other{{count} na fila}}",
+  "@sidebarWakesQueuedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "sidebarWakesQueuedLabel": "Na fila",
+  "sidebarWakesWorkingLabel": "Trabalhando",
+  "skillsSectionTitle": "Habilidades",
+  "speechDictionaryHelper": "Termos separados por ponto e vírgula (máximo de 50 caracteres) para melhor reconhecimento de fala",
+  "speechDictionaryHint": "macOS; Kirkjubæjarklaustur; Código Claude",
+  "speechDictionaryLabel": "Dicionário de Fala",
+  "speechDictionarySectionDescription": "Adicione termos que muitas vezes são digitados incorretamente pelo reconhecimento de fala (nomes, lugares, termos técnicos)",
+  "speechDictionarySectionTitle": "Reconhecimento de fala",
+  "speechDictionaryWarning": "Dicionário grande ({count} termos) pode aumentar os custos da API",
+  "speechModalSelectLanguage": "Selecione o idioma",
+  "speechModalTitle": "Reconhecimento de fala",
+  "speechSettingsModelDescription": "Modelo de fala no dispositivo",
+  "speechSettingsModelDownloadsOnce": "Baixa uma vez",
+  "speechSettingsModelLabel": "Modelo",
+  "speechSettingsRecommendedBadge": "Recomendado",
+  "speechSettingsSpeedDescription": "Quão rápido os resumos são lidos",
+  "speechSettingsSpeedLabel": "Velocidade de leitura",
+  "speechSettingsVoiceDescription": "Escolha a voz que lê resumos em voz alta",
+  "speechSettingsVoiceLabel": "Voz",
+  "speechVoiceGenderFemale": "Feminino",
+  "speechVoiceGenderMale": "Masculino",
+  "speechVoicePreviewTooltip": "Visualizar voz",
+  "surveyBackButton": "Voltar",
+  "surveyCancelConfirmation": "Cancelar pesquisa?",
+  "surveyChooseOneOption": "Escolha uma opção",
+  "surveyChooseOneOrMoreOptions": "Escolha uma ou mais opções",
+  "surveyDiscardConfirmation": "Descartar resultados e desistir?",
+  "surveyInputNumberValidation": "Digite um número",
+  "surveyNextButton": "Próximo",
+  "surveyNoButton": "Não",
+  "surveyProgressOf": "de",
+  "surveyTapToAnswer": "Toque para responder",
+  "surveyValueAnd": "e",
+  "surveyValueBetween": "Deve estar entre",
+  "surveyYesButton": "Sim",
+  "syncActivityIdle": "ocioso",
+  "syncActivityInboxLabel": "Caixa de entrada",
+  "syncActivityIndicatorSemantics": "Atividade de sincronização. Caixa de saída: {outbox}. Caixa de entrada: {inbox}. Abra a caixa de saída de sincronização.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
+  "syncActivityOutboxLabel": "Caixa de saída",
+  "syncActivitySyncingTitle": "Sincronizando",
+  "syncActivityTitle": "Sincronizar",
+  "syncDeleteConfigConfirm": "SIM, TENHO CERTEZA",
+  "syncDeleteConfigQuestion": "Deseja excluir a configuração de sincronização?",
+  "syncEntitiesConfirm": "INICIAR SINCRONIZAÇÃO",
+  "syncEntitiesMessage": "Escolha as entidades que deseja sincronizar.",
+  "syncEntitiesSuccessDescription": "Tudo está atualizado.",
+  "syncEntitiesSuccessTitle": "Sincronização concluída",
+  "syncListCountSummary": "{label} · {itemCount, plural, =0{0 itens} =1{1 item} other{{itemCount} itens}}",
+  "@syncListCountSummary": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      },
+      "itemCount": {
+        "type": "int"
+      }
+    }
+  },
+  "syncListPayloadKindLabel": "Carga útil",
+  "syncListUnknownPayload": "Carga útil desconhecida",
+  "syncNotLoggedInToast": "A sincronização não está logada",
+  "syncPayloadAgentBundle": "Pacote de agente",
+  "syncPayloadAgentEntity": "Entidade agente",
+  "syncPayloadAgentLink": "Link do agente",
+  "syncPayloadAiConfig": "Configuração de IA",
+  "syncPayloadAiConfigDelete": "Exclusão de configuração de IA",
+  "syncPayloadBackfillRequest": "Solicitação de preenchimento",
+  "syncPayloadBackfillResponse": "Resposta de preenchimento",
+  "syncPayloadConfigFlag": "Sinalizador de configuração",
+  "syncPayloadConsumptionEvent": "Consumo de IA",
+  "syncPayloadDailyOsUserName": "Nome diário do sistema operacional",
+  "syncPayloadEntityDefinition": "Definição de entidade",
+  "syncPayloadEntryLink": "Link de entrada",
+  "syncPayloadJournalEntity": "Lançamento de diário",
+  "syncPayloadNotification": "Notificação",
+  "syncPayloadNotificationStateUpdate": "Atualização do estado da notificação",
+  "syncPayloadOutboxBundle": "Pacote de caixa de saída",
+  "syncPayloadSavedTaskFilter": "Filtro de tarefa salva",
+  "syncPayloadSavedTaskFilterDelete": "Exclusão de filtro de tarefa salva",
+  "syncPayloadSyncNodeProfile": "Perfil do nó de sincronização",
+  "syncPayloadThemingSelection": "Seleção de tema",
+  "syncStepAgentEntities": "Entidades agentes",
+  "syncStepAgentLinks": "Links de agente",
+  "syncStepAiSettings": "Configurações de IA",
+  "syncStepBackfillAgentEntityClocks": "Preencher relógios da entidade do agente",
+  "syncStepBackfillAgentLinkClocks": "Relógios de link do agente de preenchimento",
+  "syncStepCategories": "Categorias",
+  "syncStepComplete": "Completo",
+  "syncStepDashboards": "Painéis",
+  "syncStepHabits": "Hábitos",
+  "syncStepLabels": "Etiquetas",
+  "syncStepMeasurables": "Mensuráveis",
+  "syncStepSavedTaskFilters": "Filtros de tarefas salvas",
+  "taskActionBarAudioRecordingActive": "Gravação de áudio em andamento",
+  "taskActionBarMoreActions": "Mais ações",
+  "taskActionBarOpenRunningTimer": "Abrir cronômetro em execução",
+  "taskActionBarStopTracking": "Parar o monitoramento do tempo",
+  "taskActionBarTrackTime": "Monitorar o tempo",
+  "taskAgentAttributionUnavailable": "Atribuição indisponível",
+  "taskAgentAutomaticUpdatesLabel": "Atualizações automáticas",
+  "taskAgentAutomaticUpdatesNeedsSetup": "Escolha uma configuração de IA antes de ativar as atualizações automáticas.",
+  "taskAgentAutomaticUpdatesOffDescription": "As atualizações automáticas estão desativadas. Acorde o agente quando quiser um novo relatório.",
+  "taskAgentAutomaticUpdatesSummary": "Agrupe alterações de tarefas e atualize após dois minutos.",
+  "taskAgentCancelTimerTooltip": "Cancelar atualização automática pendente",
+  "taskAgentChooseModel": "Escolha um modelo de pensamento",
+  "taskAgentChooseProfile": "Escolha um perfil de inferência",
+  "taskAgentCountdownTooltip": "Próxima execução automática em {countdown}",
+  "@taskAgentCountdownTooltip": {
+    "placeholders": {
+      "countdown": {
+        "type": "String"
+      }
+    }
+  },
+  "taskAgentCreateChipLabel": "Atribuir agente",
+  "taskAgentCreateError": "Falha ao criar agente: {error}",
+  "@taskAgentCreateError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "taskAgentCurrentSetupHeader": "Configuração atual",
+  "taskAgentCurrentSetupLabel": "Configuração atual",
+  "taskAgentDirectModelOverride": "Substituição direta do modelo",
+  "taskAgentDisableConfirmAction": "Desligue",
+  "taskAgentDisableConfirmBody": "O relatório atual permanece visível, mas este agente não pode ser executado até que você escolha uma configuração.",
+  "taskAgentDisableConfirmTitle": "Desativar a IA para este agente?",
+  "taskAgentInferenceProfileLabel": "Perfil de inferência",
+  "taskAgentModelPickerTitle": "Escolha o modelo de pensamento",
+  "taskAgentNoAiSetup": "Sem configuração de IA",
+  "taskAgentNoAiSetupDescription": "Pausa a inferência do agente até você escolher um perfil ou modelo.",
+  "taskAgentNoModelsAvailable": "Nenhum modelo de pensamento compatível disponível",
+  "taskAgentNoProfilesAvailable": "Nenhum perfil disponível neste dispositivo",
+  "taskAgentNoProfileSelected": "Sem configuração de IA",
+  "taskAgentNoProfileSelectedDescription": "Escolha uma configuração salva ou um modelo de pensamento antes que este agente possa ser executado.",
+  "taskAgentProfileChangedToast": "Usar {profile} para cada atualização futura do agente até que você o altere.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "taskAgentProfileDefaultBadge": "Perfil padrão",
+  "taskAgentReportOutdatedDescription": "A tarefa mudou depois que esse resumo foi gerado.",
+  "taskAgentReportOutdatedTitle": "Este resumo está desatualizado",
+  "taskAgentRouteVia": "através de",
+  "taskAgentRunNowTooltip": "Corra agora",
+  "taskAgentSavingSetup": "Salvando a configuração do agente",
+  "taskAgentSetupAndReportSemantics": "Este relatório e a configuração atual usam {identity}. Ative para alterar a configuração.",
+  "@taskAgentSetupAndReportSemantics": {
+    "placeholders": {
+      "identity": {
+        "type": "String"
+      }
+    }
+  },
+  "taskAgentSetupBroken": "A configuração de IA selecionada não está disponível",
+  "taskAgentSetupChangedToast": "Usando {model} para cada atualização futura do agente até que você o altere.",
+  "@taskAgentSetupChangedToast": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "taskAgentSetupChoiceHelp": "Escolha um perfil para seus padrões ou substitua apenas o modelo de pensamento.",
+  "taskAgentSetupOriginCategory": "Copiado da categoria padrão quando este agente foi criado",
+  "taskAgentSetupOriginDisabled": "Desativado",
+  "taskAgentSetupOriginLegacy": "Configuração legada",
+  "taskAgentSetupOriginTemplate": "Copiado do modelo",
+  "taskAgentSetupOriginUser": "Você escolheu isso para este agente",
+  "taskAgentSetupPersistenceDescription": "As alterações se aplicam a todas as atualizações futuras até que você as altere.",
+  "taskAgentSetupSemantics": "Configuração atual: {identity}. Ative para alterar a configuração.",
+  "@taskAgentSetupSemantics": {
+    "placeholders": {
+      "identity": {
+        "type": "String"
+      }
+    }
+  },
+  "taskAgentSetupTitle": "Configuração do agente",
+  "taskAgentThinkingModelLabel": "Modelo de pensamento",
+  "taskAgentThisReportHeader": "Este relatório",
+  "taskAgentTurnOffSetup": "Desative a IA para este agente",
+  "taskAgentUseCategoryDefault": "Copiar categoria padrão",
+  "taskAgentUseCategoryDefaultDescription": "Copia a configuração atual da categoria. Alterações posteriores de categoria não afetarão este agente.",
+  "taskAgentUseProfileDefault": "Usar perfil padrão",
+  "taskAgentWakeAgent": "Agente de despertar",
+  "taskCategoryAllLabel": "tudo",
+  "taskCategoryLabel": "Categoria:",
+  "taskCategoryUnassignedLabel": "não atribuído",
+  "taskDueDateLabel": "Data de vencimento",
+  "taskDueDateWithDate": "Vencimento: {date}",
+  "@taskDueDateWithDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "taskDueInDays": "Vencimento em {days, plural, =1{1 dia} other{{days} dias}}",
+  "@taskDueInDays": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
+  "taskDueToday": "Vencimento hoje",
+  "taskDueTomorrow": "Vencimento amanhã",
+  "taskDueYesterday": "Vencimento para ontem",
+  "taskEditTitleLabel": "Editar título da tarefa",
+  "taskEstimateLabel": "Estimativa:",
+  "taskEstimateModalTitle": "Estimativa",
+  "taskEstimateProgressLabel": "{tracked} de {estimate}",
+  "@taskEstimateProgressLabel": {
+    "placeholders": {
+      "tracked": {
+        "type": "String"
+      },
+      "estimate": {
+        "type": "String"
+      }
+    }
+  },
+  "taskEstimateTooltip": "Tempo monitorado: {tracked} de {estimate} estimado",
+  "@taskEstimateTooltip": {
+    "placeholders": {
+      "tracked": {
+        "type": "String"
+      },
+      "estimate": {
+        "type": "String"
+      }
+    }
+  },
+  "taskLabelsMoreCount": "+{count}",
+  "@taskLabelsMoreCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "taskLabelsShowFewer": "Mostrar menos",
+  "taskLanguageArabic": "Árabe",
+  "taskLanguageBengali": "bengali",
+  "taskLanguageBulgarian": "Búlgaro",
+  "taskLanguageChinese": "Chinês",
+  "taskLanguageCroatian": "Croata",
+  "taskLanguageCzech": "Tcheco",
+  "taskLanguageDanish": "Dinamarquês",
+  "taskLanguageDutch": "Holandês",
+  "taskLanguageEnglish": "Inglês",
+  "taskLanguageEstonian": "Estónio",
+  "taskLanguageFinnish": "Finlandês",
+  "taskLanguageFrench": "Francês",
+  "taskLanguageGerman": "Alemão",
+  "taskLanguageGreek": "Grego",
+  "taskLanguageHebrew": "Hebraico",
+  "taskLanguageHindi": "Hindi",
+  "taskLanguageHungarian": "Húngaro",
+  "taskLanguageIgbo": "Ibo",
+  "taskLanguageIndonesian": "Indonésio",
+  "taskLanguageItalian": "Italiano",
+  "taskLanguageJapanese": "Japonês",
+  "taskLanguageKorean": "Coreano",
+  "taskLanguageLabel": "Idioma",
+  "taskLanguageLatvian": "Letão",
+  "taskLanguageLithuanian": "Lituano",
+  "taskLanguageNigerianPidgin": "Pidgin nigeriano",
+  "taskLanguageNorwegian": "Norueguês",
+  "taskLanguagePolish": "Polonês",
+  "taskLanguagePortuguese": "Português",
+  "taskLanguageRomanian": "Romeno",
+  "taskLanguageRussian": "Russo",
+  "taskLanguageSelectedLabel": "Atualmente selecionado",
+  "taskLanguageSerbian": "Sérvio",
+  "taskLanguageSetAction": "Definir idioma",
+  "taskLanguageSlovak": "Eslovaco",
+  "taskLanguageSlovenian": "Esloveno",
+  "taskLanguageSpanish": "Espanhol",
+  "taskLanguageSwahili": "suaíli",
+  "taskLanguageSwedish": "Sueco",
+  "taskLanguageThai": "Tailandês",
+  "taskLanguageTurkish": "Turco",
+  "taskLanguageTwi": "Twi",
+  "@taskLanguageTwi": {
+    "description": "The Twi language, spoken primarily in Ghana"
+  },
+  "taskLanguageUkrainian": "Ucraniano",
+  "taskLanguageVietnamese": "Vietnamita",
+  "taskLanguageYoruba": "Iorubá",
+  "taskNoDueDateLabel": "Sem data de vencimento",
+  "taskNoEstimateLabel": "Sem estimativa",
+  "taskOverdueByDays": "Atrasado há {days, plural, =1{1 dia} other{{days} dias}}",
+  "@taskOverdueByDays": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
+  "taskPriorityHigh": "Alto",
+  "taskPriorityLow": "Baixo",
+  "taskPriorityMedium": "Médio",
+  "taskPriorityUrgent": "Urgente",
+  "tasksAddLabelButton": "Adicionar rótulo",
+  "tasksAgentFilterAll": "Todos",
+  "tasksAgentFilterHasAgent": "Tem agente",
+  "tasksAgentFilterNoAgent": "Nenhum agente",
+  "tasksAgentFilterTitle": "Agente",
+  "tasksFilterApplyTitle": "Aplicar filtro",
+  "tasksFilterClearAll": "Limpar tudo",
+  "tasksFilterTitle": "Filtrar tarefas",
+  "taskShowcaseAudio": "Áudio",
+  "taskShowcaseCompletedCount": "{completed} / {total} concluído",
+  "@taskShowcaseCompletedCount": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "taskShowcaseDueDate": "Vencimento: {date}",
+  "@taskShowcaseDueDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "taskShowcaseJumpToSection": "Ir para a seção",
+  "taskShowcaseLinked": "Vinculado",
+  "taskShowcaseNoResults": "Nenhuma tarefa corresponde à sua pesquisa.",
+  "taskShowcaseReadMore": "Leia mais",
+  "taskShowcaseRecordingsCount": "{count, plural, =1{1 gravação} other{{count} gravações}}",
+  "@taskShowcaseRecordingsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "taskShowcaseTaskCount": "{count, plural, =1{1 tarefa} other{{count} tarefas}}",
+  "@taskShowcaseTaskCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "taskShowcaseTaskDescription": "Descrição da tarefa",
+  "taskShowcaseTimeTracker": "Rastreador de tempo",
+  "taskShowcaseTodo": "Tudo",
+  "taskShowcaseTodos": "Todos",
+  "tasksLabelFilterAll": "Todos",
+  "tasksLabelFilterTitle": "Etiqueta",
+  "tasksLabelFilterUnlabeled": "Sem rótulo",
+  "tasksLabelsDialogClose": "Fechar",
+  "tasksLabelsSheetApply": "Aplicar",
+  "tasksLabelsSheetSearchHint": "Pesquisar rótulos…",
+  "tasksLabelsUpdateFailed": "Falha ao atualizar rótulos",
+  "tasksPriorityFilterAll": "Todos",
+  "tasksPriorityFilterTitle": "Prioridade",
+  "tasksPriorityP0": "Urgente",
+  "tasksPriorityP0Description": "Urgente (o mais rápido possível)",
+  "tasksPriorityP1": "Alto",
+  "tasksPriorityP1Description": "Alto (em breve)",
+  "tasksPriorityP2": "Médio",
+  "tasksPriorityP2Description": "Médio (padrão)",
+  "tasksPriorityP3": "Baixo",
+  "tasksPriorityP3Description": "Baixo (sempre)",
+  "tasksPriorityPickerTitle": "Selecione prioridade",
+  "tasksQuickFilterUnassignedLabel": "Não atribuído",
+  "tasksSavedFilterDeleteConfirmTooltip": "Toque novamente para excluir",
+  "tasksSavedFilterDeleteTooltip": "Excluir filtro salvo",
+  "tasksSavedFilterDragHandleSemantics": "Arraste para reordenar",
+  "tasksSavedFilterRenameSemantics": "Renomear filtro salvo",
+  "tasksSavedFiltersAllShort": "Todos",
+  "tasksSavedFiltersAllTasks": "Todas as tarefas",
+  "tasksSavedFiltersCustom": "Personalizado",
+  "tasksSavedFiltersDeleteConfirmAction": "Excluir",
+  "tasksSavedFiltersDeleteConfirmMessage": "Excluir o filtro salvo '{name}'? Isso não pode ser desfeito.",
+  "@tasksSavedFiltersDeleteConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFiltersDeleteConfirmNamed": "Confirme a exclusão de {name}",
+  "@tasksSavedFiltersDeleteConfirmNamed": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFiltersDeleteNamed": "Excluir {name}",
+  "@tasksSavedFiltersDeleteNamed": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFiltersDone": "Concluído",
+  "tasksSavedFiltersEdit": "Editar",
+  "tasksSavedFiltersFilterNameLabel": "Nome do filtro",
+  "tasksSavedFiltersGroupSemantics": "Filtros de tarefas",
+  "tasksSavedFiltersManageTooltip": "Gerenciar filtros de tarefas",
+  "tasksSavedFiltersRailButton": "Filtros",
+  "tasksSavedFiltersRenameNamed": "Renomear {name}",
+  "@tasksSavedFiltersRenameNamed": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFiltersReorderHelper": "Arraste para definir a ordem. Os primeiros cinco filtros aparecem na barra lateral.",
+  "tasksSavedFiltersSaveAsNewButtonLabel": "Salvar como novo…",
+  "tasksSavedFiltersSaveAsNewDescription": "Mantenha o filtro existente inalterado e crie um separado.",
+  "tasksSavedFiltersSaveAsNewTitle": "Salvar como um novo filtro",
+  "tasksSavedFiltersSaveButtonLabel": "Salvar filtro…",
+  "tasksSavedFiltersSaveChoiceIntro": "Escolha se deseja atualizar o filtro salvo ou criar um separado.",
+  "tasksSavedFiltersSaveChoiceTitle": "Salvar filtro",
+  "tasksSavedFiltersSaveCurrentAs": "Salvar filtro atual…",
+  "tasksSavedFiltersSaveError": "Não foi possível salvar este filtro. Tente novamente.",
+  "tasksSavedFiltersSavePageHelper": "Dê um nome curto a este filtro. Você pode reordená-lo posteriormente em Filtros de tarefas.",
+  "tasksSavedFiltersSavePopupCancel": "Cancelar",
+  "tasksSavedFiltersSavePopupHint": "por exemplo Bloqueado ou em espera",
+  "tasksSavedFiltersSavePopupSave": "Salvar",
+  "tasksSavedFiltersSavePopupTitle": "Nomeie este filtro",
+  "tasksSavedFiltersSheetTitle": "Filtros de tarefas",
+  "tasksSavedFiltersShowLess": "Mostrar menos",
+  "tasksSavedFiltersShowMore": "{count, plural, =1{mais 1 filtro salvo} other{{count} mais filtros salvos}}",
+  "@tasksSavedFiltersShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersTaskCount": "{count, plural, =1{1 tarefa} other{{count} tarefas}}",
+  "@tasksSavedFiltersTaskCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersUpdateButtonLabel": "Atualizar filtro",
+  "tasksSavedFiltersUpdateExistingDescription": "Substitua os critérios salvos pela configuração de filtro atual.",
+  "tasksSavedFiltersUpdateExistingTitle": "Atualizar filtro existente",
+  "tasksSavedFilterToastDeleted": "Filtro excluído",
+  "tasksSavedFilterToastSaved": "'{name}' salvo",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "'{name}' atualizado",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSearchModeLabel": "Modo de pesquisa",
+  "tasksShowCreationDate": "Mostrar data de criação nos cartões",
+  "tasksShowDueDate": "Mostrar data de vencimento nos cartões",
+  "tasksSortByCreationDate": "Criado",
+  "tasksSortByDueDate": "Data de vencimento",
+  "tasksSortByLabel": "Classificar por",
+  "tasksSortByPriority": "Prioridade",
+  "taskStatusAll": "Todos",
+  "taskStatusBlocked": "Bloqueado",
+  "taskStatusDone": "Concluído",
+  "taskStatusGroomed": "Preparado",
+  "taskStatusInProgress": "Em andamento",
+  "taskStatusLabel": "Estado:",
+  "taskStatusOnHold": "Em espera",
+  "taskStatusOpen": "Abrir",
+  "taskStatusRejected": "Rejeitado",
+  "taskTitleEmpty": "Sem título",
+  "taskUntitled": "(sem título)",
+  "thinkingDisclosureCopied": "Raciocínio copiado",
+  "thinkingDisclosureCopy": "Copie o raciocínio",
+  "thinkingDisclosureHide": "Ocultar raciocínio",
+  "thinkingDisclosureShow": "Mostrar raciocínio",
+  "thinkingDisclosureStateCollapsed": "entrou em colapso",
+  "thinkingDisclosureStateExpanded": "expandido",
+  "timeEntryItemEnd": "Fim",
+  "timeEntryItemRunning": "Correndo",
+  "timeEntryItemStart": "Começar",
+  "unlinkButton": "Desvincular",
+  "unlinkTaskConfirm": "Tem certeza de que deseja desvincular esta tarefa?",
+  "unlinkTaskTitle": "Desvincular tarefa",
+  "vectorSearchTiming": "{count, plural, =1{{elapsed}ms, {count} resultado} other{{elapsed}ms, {count} resultados}}",
+  "@vectorSearchTiming": {
+    "placeholders": {
+      "elapsed": {
+        "type": "int"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "viewMenuTitle": "Ver",
+  "viewMenuZoomIn": "Ampliar",
+  "viewMenuZoomOut": "Diminuir zoom",
+  "viewMenuZoomReset": "Tamanho real",
+  "whatsNewBadgeNew": "NOVO",
+  "@whatsNewBadgeNew": {
+    "description": "Badge displayed on the newest release in the What's New view."
+  },
+  "whatsNewDoneButton": "Concluído",
+  "whatsNewSkipButton": "Pular"
+}

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3654,6 +3654,7 @@
   "settingsManualLanguageFollowSystemTitle": "Urmați sistemul",
   "settingsManualLanguageFrenchTitle": "Franceză",
   "settingsManualLanguageGermanTitle": "Germană",
+  "settingsManualLanguagePortugueseTitle": "Portugheză",
   "settingsManualLanguageRomanianTitle": "Română",
   "settingsManualLanguageTitle": "Limbă",
   "settingsMatrixAccept": "Acceptă",

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -19,6 +19,7 @@
 		<string>de</string>
 		<string>es</string>
 		<string>fr</string>
+		<string>pt</string>
 		<string>ro</string>
 	</array>
 	<key>CFBundleName</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ msix_config:
   publisher: CN=ED722F95-3F7E-428E-A642-9B9C121815D1
   identity_name: NehlsenEDVBeratungGmbH.LottiApp
   capabilities: internetClient, location, microphone
-  languages: en-us, cs-cz, de-de, es-es, fr-fr, ro-ro
+  languages: en-us, cs-cz, de-de, es-es, fr-fr, pt-br, ro-ro
   install_certificate: false
   sign_msix: true
   logo_path: .\assets\icon\app_icon_1024.png

--- a/test/features/settings/state/manual_language_controller_test.dart
+++ b/test/features/settings/state/manual_language_controller_test.dart
@@ -14,6 +14,10 @@ void main() {
       expect(ManualLanguage.fromStoredValue('fr'), ManualLanguage.french);
       expect(ManualLanguage.fromStoredValue('cs'), ManualLanguage.czech);
       expect(ManualLanguage.fromStoredValue('ro'), ManualLanguage.romanian);
+      expect(
+        ManualLanguage.fromStoredValue('pt'),
+        ManualLanguage.portuguese,
+      );
       expect(ManualLanguage.fromStoredValue(null), isNull);
     });
   });
@@ -35,6 +39,10 @@ void main() {
       expect(
         manualLanguageForSystemLocale(const Locale('ro', 'RO')),
         ManualLanguage.romanian,
+      );
+      expect(
+        manualLanguageForSystemLocale(const Locale('pt', 'BR')),
+        ManualLanguage.portuguese,
       );
     });
 
@@ -63,6 +71,10 @@ void main() {
       expect(
         manualUriFor(systemLocale: const Locale('ro')).toString(),
         '${lottiManualBaseUrl}ro/',
+      );
+      expect(
+        manualUriFor(systemLocale: const Locale('pt')).toString(),
+        '${lottiManualBaseUrl}pt/',
       );
     });
 
@@ -120,16 +132,16 @@ void main() {
         manualLanguageControllerProvider.notifier,
       );
 
-      await controller.setOverride(ManualLanguage.romanian);
+      await controller.setOverride(ManualLanguage.portuguese);
 
       expect(
         container.read(manualLanguageControllerProvider),
-        ManualLanguage.romanian,
+        ManualLanguage.portuguese,
       );
       verify(
         () => mocks.settingsDb.saveSettingsItem(
           manualLanguageSettingsKey,
-          'ro',
+          'pt',
         ),
       ).called(1);
 

--- a/test/features/settings/ui/pages/advanced/manual_language_settings_page_test.dart
+++ b/test/features/settings/ui/pages/advanced/manual_language_settings_page_test.dart
@@ -75,7 +75,7 @@ void main() {
       final messages = context.messages;
 
       expect(find.byType(DesignSystemGroupedList), findsOneWidget);
-      expect(find.byType(DesignSystemRadioButton), findsNWidgets(6));
+      expect(find.byType(DesignSystemRadioButton), findsNWidgets(7));
       expect(
         find.text(messages.settingsManualLanguageFollowSystemSubtitle),
         findsOneWidget,
@@ -93,6 +93,7 @@ void main() {
         messages.settingsManualLanguageFrenchTitle,
         messages.settingsManualLanguageCzechTitle,
         messages.settingsManualLanguageRomanianTitle,
+        messages.settingsManualLanguagePortugueseTitle,
       ]) {
         expect(rowFor(tester, title).selected, isFalse);
       }
@@ -138,7 +139,7 @@ void main() {
     final context = tester.element(find.byType(ManualLanguageSettingsBody));
     final messages = context.messages;
 
-    await tester.tap(find.text(messages.settingsManualLanguageRomanianTitle));
+    await tester.tap(find.text(messages.settingsManualLanguagePortugueseTitle));
     await tester.pump();
     await tester.tap(
       find.text(messages.settingsManualLanguageFollowSystemTitle),

--- a/test/features/tasks/ui/widgets/task_action_bar_test.dart
+++ b/test/features/tasks/ui/widgets/task_action_bar_test.dart
@@ -770,7 +770,7 @@ void main() {
     'checklist are hidden so the remaining three affordances fit on a row',
     (tester) async {
       // Outer 360 → inner ~328, which is below
-      // [TaskActionBar.minWidthForChecklistButton] (340).
+      // [TaskActionBar.minWidthForChecklistButton] (374).
       await tester.binding.setSurfaceSize(const Size(360, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
@@ -792,7 +792,7 @@ void main() {
     'image is hidden — checklist stays on the row',
     (tester) async {
       // Outer 420 → inner ~388, which is at-or-above
-      // [TaskActionBar.minWidthForChecklistButton] (340) and below
+      // [TaskActionBar.minWidthForChecklistButton] (374) and below
       // [TaskActionBar.minWidthForImageButton] (416).
       await tester.binding.setSurfaceSize(const Size(420, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -843,6 +843,27 @@ void main() {
         TaskActionBar.trackTimeKey,
         TaskActionBar.audioKey,
         TaskActionBar.checklistKey,
+        TaskActionBar.moreKey,
+      ]);
+    },
+  );
+
+  testWidgets(
+    'hides the checklist before Portuguese Track time text can overflow',
+    (tester) async {
+      // Outer 400 → inner ~370, below the Portuguese checklist threshold.
+      tester.binding.platformDispatcher.localeTestValue = const Locale('pt');
+      addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pumpBar(tester);
+
+      expect(find.byKey(TaskActionBar.imageKey), findsNothing);
+      expect(find.byKey(TaskActionBar.checklistKey), findsNothing);
+      expectSingleRowWithin(tester, const [
+        TaskActionBar.trackTimeKey,
+        TaskActionBar.audioKey,
         TaskActionBar.moreKey,
       ]);
     },

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -680,14 +680,18 @@ void main() {
           find.text(messages.taskAgentReportOutdatedTitle),
           findsOneWidget,
         );
-        expect(
-          find.byKey(const ValueKey('taskAgentWakeIconButton')),
-          findsOneWidget,
-        );
-        expect(
-          find.bySemanticsLabel(messages.taskAgentWakeAgent),
-          findsOneWidget,
-        );
+        if (device.isPhone) {
+          expect(
+            find.byKey(const ValueKey('taskAgentWakeIconButton')),
+            findsOneWidget,
+          );
+          expect(
+            find.bySemanticsLabel(messages.taskAgentWakeAgent),
+            findsOneWidget,
+          );
+        } else {
+          expect(find.text(messages.taskAgentWakeAgent), findsOneWidget);
+        }
         await captureScreenshot(
           tester,
           'task_agent_manual_${viewport}_$theme',

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -121,6 +121,17 @@ Führe den Automatentest aus, hänge das Telemetriebild an und fordere dann die 
 
 Lance le test du distributeur, joins l'image de télémétrie puis demande l'autorisation de lancement.
 ''',
+  pt: '''
+## Última avaliação
+
+- As vedações de pressão A–F permaneceram estáveis durante o turno da noite.
+- São carregadas 840 sardinhas; a calibração do alimentador ainda bloqueia a aprovação.
+- A autorização do Controle da Missão deve ser feita antes da chamada das 06:30.
+
+## Próxima etapa recomendada
+
+Execute o teste do alimentador, anexe a imagem de telemetria e solicite a aprovação do lançamento.
+''',
 );
 
 final AiConfigModel _manualThinkingModel = manualDemoAiModels.firstWhere(
@@ -669,7 +680,14 @@ void main() {
           find.text(messages.taskAgentReportOutdatedTitle),
           findsOneWidget,
         );
-        expect(find.text(messages.taskAgentWakeAgent), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('taskAgentWakeIconButton')),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(messages.taskAgentWakeAgent),
+          findsOneWidget,
+        );
         await captureScreenshot(
           tester,
           'task_agent_manual_${viewport}_$theme',

--- a/test/helpers/manual_screenshot_locale.dart
+++ b/test/helpers/manual_screenshot_locale.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'manual_screenshot_czech_text.dart';
 import 'manual_screenshot_french_text.dart';
+import 'manual_screenshot_portuguese_text.dart';
 import 'manual_screenshot_romanian_text.dart';
 import 'manual_screenshot_spanish_text.dart';
 
@@ -19,11 +20,12 @@ Locale manualScreenshotLocaleFromEnvironment(Map<String, String> environment) {
       languageCode != 'fr' &&
       languageCode != 'es' &&
       languageCode != 'cs' &&
-      languageCode != 'ro') {
+      languageCode != 'ro' &&
+      languageCode != 'pt') {
     throw ArgumentError.value(
       languageCode,
       'LOTTI_MANUAL_LOCALE',
-      'Supported manual screenshot locales are en, de, fr, es, cs, and ro.',
+      'Supported manual screenshot locales are en, de, fr, es, cs, ro, and pt.',
     );
   }
   return Locale(languageCode);
@@ -40,11 +42,13 @@ String manualScreenshotText({
   String? es,
   String? cs,
   String? ro,
+  String? pt,
 }) => switch (manualScreenshotLocale.languageCode) {
   'de' => de,
   'fr' => fr ?? manualScreenshotFrenchText(en) ?? en,
   'es' => es ?? manualScreenshotSpanishText(en) ?? en,
   'cs' => cs ?? manualScreenshotCzechText(en) ?? en,
   'ro' => ro ?? manualScreenshotRomanianText(en) ?? en,
+  'pt' => pt ?? manualScreenshotPortugueseText(en) ?? en,
   _ => en,
 };

--- a/test/helpers/manual_screenshot_locale_test.dart
+++ b/test/helpers/manual_screenshot_locale_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'manual_screenshot_czech_text.dart';
 import 'manual_screenshot_french_text.dart';
 import 'manual_screenshot_locale.dart';
+import 'manual_screenshot_portuguese_text.dart';
 import 'manual_screenshot_romanian_text.dart';
 import 'manual_screenshot_spanish_text.dart';
 
@@ -37,6 +38,12 @@ void main() {
           const {'LOTTI_MANUAL_LOCALE': 'ro'},
         ),
         const Locale('ro'),
+      );
+      expect(
+        manualScreenshotLocaleFromEnvironment(
+          const {'LOTTI_MANUAL_LOCALE': 'pt'},
+        ),
+        const Locale('pt'),
       );
       expect(
         manualScreenshotLocaleFromEnvironment(
@@ -85,6 +92,14 @@ void main() {
         'Inspeccionar hábitat orbital de pingüinos',
       );
       expect(manualScreenshotSpanishText('Unknown fixture'), isNull);
+    });
+
+    test('Portuguese fixture catalog localizes representative demo copy', () {
+      expect(
+        manualScreenshotPortugueseText('Inspect orbital penguin habitat'),
+        'Inspecione o habitat orbital dos pinguins',
+      );
+      expect(manualScreenshotPortugueseText('Unknown fixture'), isNull);
     });
 
     test(

--- a/test/helpers/manual_screenshot_portuguese_text.dart
+++ b/test/helpers/manual_screenshot_portuguese_text.dart
@@ -1,0 +1,550 @@
+// Deterministic Portuguese copy used by the manual screenshot catalog.
+// The catalog translates authored demo data that does not come from the
+// application ARB files, keeping every localized screenshot coherent.
+
+String? manualScreenshotPortugueseText(String english) => _copy[english];
+
+const _copy = <String, String>{
+  'Theming': 'Tema',
+  'Recording Style': 'Estilo de gravação',
+  'Modern — energy orb': 'Moderno - orbe de energia',
+  'Analogue — VU meter': 'Analógico - medidor VU',
+  'Speech': 'Discurso',
+  'Voice': 'Voz',
+  'Male 3': 'Masculino 3',
+  'Female': 'Feminino',
+  'Female 1': 'Feminino 1',
+  'Female 5': 'Feminino 5',
+  'Keyboard shortcuts': 'Atalhos de teclado',
+  'Open command palette': 'Abrir paleta de comandos',
+  'General': 'Geral',
+  'Command palette': 'Paleta de comandos',
+  'Task': 'Tarefa',
+  'more tokens today': 'mais tokens hoje',
+  'AI summary': 'Resumo de IA',
+  'Automatic updates': 'Atualizações automáticas',
+  'Bundle task changes and update after two minutes.':
+      'Agrupe alterações de tarefas e atualize após dois minutos.',
+  'Read more': 'Leia mais',
+  'Open agent internals': 'Abra os internos do agente',
+  'Show less': 'Mostrar menos',
+  '"Run zero-gravity sardine feeder test"':
+      '"Executar teste de alimentador de sardinha em gravidade zero"',
+  'Add: "Run zero-gravity sardine feeder test"':
+      'Adicionar: "Executar teste de alimentador de sardinha em gravidade zero"',
+  'Estimate: 45m → 1h 15m': 'Estimativa: 45m → 1h 15m',
+  '45m → 1h 15m': '45m → 1h 15m',
+  'Automatic updates are off. Wake the agent when you want a fresh report.':
+      'As atualizações automáticas estão desativadas. Acorde o agente quando quiser um novo relatório.',
+  'This summary is out of date': 'Este resumo está desatualizado',
+  'The task changed after this summary was generated.':
+      'A tarefa mudou depois que esse resumo foi gerado.',
+  'Wake agent': 'Agente de despertar',
+  'Filter tasks': 'Filtrar tarefas',
+  'Filter projects': 'Filtrar projetos',
+  'Mission Control Mac': 'Mac de controle de missão',
+  'Orbital Habitat Console': 'Console de Habitat Orbital',
+  'Admiral Pebble’s Phone': 'Telefone do Almirante Pebble',
+  'Inspect orbital penguin habitat before launch':
+      'Inspecione o habitat orbital dos pinguins antes do lançamento',
+  'Launch orbital penguin habitat after seal inspection':
+      'Lançar habitat orbital de pinguins após inspeção de focas',
+  'Mission Control cleared 36 penguins. Recheck pressure seal C and hold the sardine cargo pod until the final emperor arrives.':
+      'O Controle da Missão eliminou 36 pinguins. Verifique novamente o selo de pressão C e segure a cápsula de carga de sardinha até que o último imperador chegue.',
+  'Inspect orbital penguin habitat — before launch':
+      'Inspecione o habitat orbital dos pinguins – antes do lançamento',
+  'Habitat Console cleared all 37 penguins and pressure seal C. Release the zero-gravity sardine cargo pod at 11:20.':
+      'O Habitat Console eliminou todos os 37 pinguins e o selo de pressão C. Solte o pod de carga de sardinha com gravidade zero às 11h20.',
+  'Europa sardine cargo manifest revised by Admiral Pebble.':
+      'Manifesto de carga de sardinha Europa revisado pelo Almirante Pebble.',
+  'Project Waddle node profile': 'Perfil do nó do projeto Waddle',
+  'Project Waddle private-mode flag':
+      'Sinalizador de modo privado do Projeto Waddle',
+  'Show private entries': 'Mostrar entradas privadas',
+  'Habitat pressure-seal photo': 'Foto de vedação de pressão de habitat',
+  'Project Details': 'Detalhes do projeto',
+  'Status': 'Estado',
+  'Category': 'Categoria',
+  'Change status': 'Alterar status',
+  'Target Date': 'Data prevista',
+  'Project health': 'Saúde do projeto',
+  'Time Analysis': 'Análise de Tempo',
+  'TOTAL': 'TOTAL',
+  'FOCUS': 'FOCO',
+  'Running total': 'Total em execução',
+  'Running total over the range': 'Executando total ao longo do intervalo',
+  'Compare': 'Comparar',
+  'Change': 'Mudança',
+  'PREVIOUS': 'ANTERIOR',
+  'Summary': 'Resumo',
+  'Photos': 'Fotos',
+  'Timeline': 'Linha do tempo',
+  'Filter journal': 'Filtrar diário',
+  'Entry types': 'Tipos de entrada',
+  'Event': 'Evento',
+  'Text Entry': 'Entrada de texto',
+  'Date & Time': 'Data e hora',
+  'Start time': 'Hora de início',
+  'End time': 'Hora de término',
+  'Friday, July 17, 2026': 'Sexta-feira, 17 de julho de 2026',
+  'July 2026': 'Julho de 2026',
+  'Images': 'Imagens',
+  'Code': 'Código',
+  'Filter & Sort': 'Filtrar e classificar',
+  'Newest first': 'O mais novo primeiro',
+  'Oldest first': 'Mais antigo primeiro',
+  'Show hidden entries': 'Mostrar entradas ocultas',
+  'Rate this session': 'Avalie esta sessão',
+  'How productive was this session?': 'Quão produtiva foi esta sessão?',
+  'How energized did you feel?': 'Quão energizado você se sentiu?',
+  'How focused were you?': 'Quão focado você estava?',
+  'Just right': 'Certo',
+  'Save': 'Salvar',
+  'Europa sardine futures summit': 'Cimeira Europa sobre o futuro da sardinha',
+  'Project Waddle launch gala': 'Gala de lançamento do Projeto Waddle',
+  'Voice memo: Europa sardines are colder than the diplomatic protocol requires.':
+      'Memorando de voz: As sardinhas Europa são mais frias do que o protocolo diplomático exige.',
+  'Project Waddle voice memo. Europa sardine cargo is holding at minus eighteen degrees. All 37 emperor penguins are present. Recalibrate the zero-gravity fish feeder before the launch review, and ask Sir Flaps-a-Lot to stop saluting the pressure gauge.':
+      'Memorando de voz do Projeto Waddle. A carga de sardinha da Europa está mantida a dezoito graus negativos. Todos os 37 pinguins imperadores estão presentes. Recalibre o alimentador de peixes de gravidade zero antes da revisão do lançamento e peça a Sir Flaps-a-Lot para parar de saudar o manômetro.',
+  'Europa cold-chain check: sardines stable, emperor penguin roll call complete, feeder calibration still pending.':
+      'Verificação da cadeia de frio da Europa: sardinhas estáveis, chamada do pinguim-imperador concluída, calibração do alimentador ainda pendente.',
+  'All 37 emperor penguins': 'Todos os 37 pinguins imperadores',
+  'Generate…': 'Gerar…',
+  'Skills': 'Habilidades',
+  'pressure-gauge anomalies': 'anomalias no manômetro',
+  'Add': 'Adicionar',
+  'Checklist': 'Lista de verificação',
+  'Audio Recording': 'Gravação de áudio',
+  'Timer': 'Temporizador',
+  'Select Reference Images': 'Selecione imagens de referência',
+  'Continue': 'Continuar',
+  'Choose your AI brain': 'Escolha seu cérebro de IA',
+  'More options': 'Mais opções',
+  'Connection verified': 'Conexão verificada',
+  'Connection': 'Conexão',
+  'Edit': 'Editar',
+  'Provider Type': 'Tipo de provedor',
+  'API Key': 'Chave de API',
+  'Edit Model': 'Editar modelo',
+  'Capabilities': 'Capacidades',
+  'Choose a model': 'Escolha um modelo',
+  'AI Impact': 'Impacto da IA',
+  'Cost by category': 'Custo por categoria',
+  'Connect': 'Conectar',
+  'Get started': 'Comece',
+  'How should recording feel?': 'Como deve ser a gravação?',
+  'Where should your AI work?': 'Onde sua IA deve funcionar?',
+  'Add your own': 'Adicione o seu próprio',
+  'Create your first task': 'Crie sua primeira tarefa',
+  'Record your thought': 'Registre seu pensamento',
+  "Listening… tap when you're done": 'Ouvindo… toque quando terminar',
+  'Rather type?': 'Em vez disso, digite?',
+  'Your first task is ready': 'Sua primeira tarefa está pronta',
+  "You've created your first AI task": 'Você criou sua primeira tarefa de IA',
+  'Talk. Lotti turns it into a plan.':
+      'Fale. Lotti transforma isso em um plano.',
+  'Inspect the Europa sardine relay before the emperor penguin roll call':
+      'Inspecione o revezamento da sardinha Europa antes da chamada do pinguim-imperador',
+  'Inspect the Europa sardine relay':
+      'Inspecione o revezamento da sardinha Europa',
+  'Verify relay pressure': 'Verifique a pressão do relé',
+  'Count all emperor penguins': 'Conte todos os pinguins imperadores',
+  'Route the sardine cargo pods': 'Encaminhe os pods de carga de sardinha',
+  'Generating image...': 'Gerando imagem...',
+  'Link existing task...': 'Vincular tarefa existente...',
+  'Go to Tasks': 'Vá para Tarefas',
+  'rename': 'renomear',
+  'Rename focused item': 'Renomear item em foco',
+  'Animations': 'Animações',
+  'Celebration animations': 'Animações de celebração',
+  'Completion haptics': 'Háptica de conclusão',
+  'Style': 'Estilo',
+  'Sparks': 'Faíscas',
+  'Combine two': 'Combine dois',
+  'Try it': 'Experimente',
+  'Count emperor penguins': 'Conte pinguins imperadores',
+  'Route sardine cargo': 'Rota de carga de sardinha',
+  'Brief Mission Control': 'Breve Controle da Missão',
+  'Changes save and apply everywhere instantly':
+      'As alterações são salvas e aplicadas em qualquer lugar instantaneamente',
+  'Shape': 'Forma',
+  'Advanced Settings': 'Configurações avançadas',
+  'Config Flags': 'Sinalizadores de configuração',
+  'Show private entries?': 'Mostrar entradas privadas?',
+  'Import Activity Data': 'Importar dados de atividades',
+  'Purge deleted items': 'Limpar itens excluídos',
+  'Definitions': 'Definições',
+  'Categories': 'Categorias',
+  'Labels': 'Etiquetas',
+  'Habits': 'Hábitos',
+  'Inspect habitat seals': 'Inspecione focas de habitat',
+  'Check the pressure seals before the colony wakes.':
+      'Verifique os selos de pressão antes que a colônia acorde.',
+  'Log penguin roll call': 'Registrar a chamada dos pinguins',
+  'Confirm all 37 emperor penguins are aboard.':
+      'Confirme se todos os 37 pinguins-imperadores estão a bordo.',
+  'Recalibrate fish feeder': 'Recalibrar o alimentador de peixes',
+  'Tune the zero-gravity feeder after the midday delivery.':
+      'Ajuste o alimentador de gravidade zero após a entrega do meio-dia.',
+  'Review sardine inventory': 'Revise o inventário de sardinha',
+  'Reconcile consumed crates with the orbital manifest.':
+      'Reconcilie as caixas consumidas com o manifesto orbital.',
+  'Success': 'Sucesso',
+  'Skip': 'Pular',
+  'Missed': 'Perdido',
+  'Dashboards': 'Painéis',
+  'Measurables': 'Mensuráveis',
+  'Mission Control Router': 'Roteador de controle de missão',
+  'Cloud routing for launch planning and high-stakes reasoning.':
+      'Roteamento na nuvem para planejamento de lançamento e raciocínio de alto risco.',
+  'Habitat Local Lab': 'Laboratório Local de Habitat',
+  'Local models for private colony notes and sardine logistics.':
+      'Modelos locais para notas de colônias privadas e logística de sardinha.',
+  'Orbital Vision': 'Visão Orbital',
+  'Multimodal inspection for habitat imagery and cover art.':
+      'Inspeção multimodal para imagens de habitat e arte de capa.',
+  'Penguin Audio Bay': 'Baía de áudio do pinguim',
+  'Local transcription for mission briefings.':
+      'Transcrição local para briefings de missão.',
+  'Waddle Command 70B': 'Comando Waddle 70B',
+  'Fast tool-calling model for routine Project Waddle operations.':
+      'Modelo de chamada rápida de ferramentas para operações rotineiras do Projeto Waddle.',
+  'Emperor Reasoning XL': 'Raciocínio do Imperador XL',
+  'Deliberate model for launch reviews and unusually formal penguins.':
+      'Modelo deliberado para análises de lançamento e pinguins incomumente formais.',
+  'Sardine Logistics 14B': 'Sardinha Logística 14B',
+  'Local planning model for cargo manifests and feeder calibration.':
+      'Modelo de planejamento local para manifestos de carga e calibração de alimentadores.',
+  'Habitat Vision Pro': 'Habitat Visão Pro',
+  'Checks pressure gauges, ice seals, and suspicious fish-shaped alerts.':
+      'Verifica medidores de pressão, selos de gelo e alertas suspeitos em forma de peixe.',
+  'Voxtral Penguin Briefings': 'Resumos da Voxtral Penguin',
+  'Transcribes habitat voice memos with Project Waddle vocabulary.':
+      'Transcreve memorandos de voz de habitat com o vocabulário do Projeto Waddle.',
+  'Project Waddle Cover Artist': 'Artista da capa do projeto Waddle',
+  'Creates centered 16:9 mission art that survives square thumbnail crops.':
+      'Cria arte de missão centralizada em 16:9 que sobrevive a cortes de miniaturas quadradas.',
+  'Project Waddle Command': 'Comando Waddle do Projeto',
+  'Launch-critical planning, habitat vision, briefings, and cover art.':
+      'Planejamento crítico de lançamento, visão de habitat, briefings e arte de capa.',
+  'Habitat Local-First': 'Habitat local primeiro',
+  'Keeps private colony notes and routine sardine logistics local.':
+      'Mantém anotações locais da colônia privada e logística rotineira de sardinha.',
+  'Fish Diplomacy': 'Diplomacia dos Peixes',
+  'Extra deliberation for Europa sardine markets and passenger law.':
+      'Deliberação extra para os mercados de sardinha na Europa e legislação de passageiros.',
+  'Transcribe habitat briefing': 'Transcrever o briefing do habitat',
+  'Turn a Project Waddle voice memo into punctuated mission notes.':
+      'Transforme um memorando de voz do Projeto Waddle em notas de missão pontuadas.',
+  'Transcribe the mission briefing accurately.':
+      'Transcreva o briefing da missão com precisão.',
+  'Preserve Project Waddle names and terminology.':
+      'Preserve os nomes e a terminologia do Projeto Waddle.',
+  'Inspect habitat photo': 'Inspecione a foto do habitat',
+  'Find pressure-gauge anomalies and task-relevant seal damage.':
+      'Encontre anomalias nos manômetros e danos nas vedações relevantes para a tarefa.',
+  'Inspect the habitat image for operational risks.':
+      'Inspecione a imagem do habitat em busca de riscos operacionais.',
+  'Report only visible and actionable findings.':
+      'Relate apenas descobertas visíveis e acionáveis.',
+  'Generate Project Waddle cover art': 'Gerar capa do Projeto Waddle',
+  'Create centered 16:9 art for the task and its square thumbnail.':
+      'Crie arte 16:9 centralizada para a tarefa e sua miniatura quadrada.',
+  'Create memorable mission cover art.': 'Crie uma capa de missão memorável.',
+  'Keep the penguin subject inside the square-safe area.':
+      'Mantenha o pinguim dentro da área quadrada segura.',
+  'Draft launch-review prompt': 'Prompt de revisão de lançamento de rascunho',
+  'Prepare a complete AI prompt for the next Mission Control review.':
+      'Prepare um prompt completo de IA para a próxima revisão do Controle da Missão.',
+  'Write a precise operational prompt.':
+      'Escreva um prompt operacional preciso.',
+  'Include the task context and outstanding risks.':
+      'Inclua o contexto da tarefa e os riscos pendentes.',
+  'Penguin Operations': 'Operações com pinguins',
+  'Penguin Ops': 'Operações de Pinguim',
+  'Mission Control': 'Controle da Missão',
+  'Human Maintenance': 'Manutenção Humana',
+  'Tasks': 'Tarefas',
+  'Logbook': 'Diário de bordo',
+  'Settings': 'Configurações',
+  'Manual': 'Manuais',
+  'Opens in your browser': 'Abre no seu navegador',
+  'Calendar': 'Calendário',
+  'Habitat critical': 'Habitat crítico',
+  '37 tasks': '37 tarefas',
+  '14 tasks': '14 tarefas',
+  'Edit category': 'Editar categoria',
+  'Project Waddle; Sir Flaps-a-Lot; sardine; Europa':
+      'Projeto Waddle; Senhor Flaps-a-Lot; sardinha; Europa',
+  'Launch-critical work for the first interplanetary penguin habitat.':
+      'Trabalho crítico para o lançamento do primeiro habitat interplanetário de pinguins.',
+  'Must be resolved before emperor penguins enter the orbital habitat.':
+      'Deve ser resolvido antes que os pinguins-imperadores entrem no habitat orbital.',
+  'Awaiting Mission Control': 'Aguardando Controle da Missão',
+  'Blocked until the lunar shift sends clearance.':
+      'Bloqueado até que a mudança lunar envie autorização.',
+  'Sardine market sensitive': 'Mercado de sardinha sensível',
+  'Private negotiations with the Europa fish exchange.':
+      'Negociações privadas com a Bolsa de Peixe Europa.',
+  'Checklist correction examples':
+      'Exemplos de correção de lista de verificação',
+  'Speech recognition': 'Reconhecimento de fala',
+  'Choose an inference profile': 'Escolha um perfil de inferência',
+  'Create category': 'Criar categoria',
+  'No categories yet': 'Nenhuma categoria ainda',
+  'Edit label': 'Editar rótulo',
+  'Project Waddle — launch': 'Projeto Waddle – lançamento',
+  'Emperor penguin roll call': 'Chamada do pinguim-imperador',
+  'Account for all 37 expedition penguins before launch.':
+      'Considere todos os 37 pinguins da expedição antes do lançamento.',
+  'Walk the habitat seals': 'Caminhe pelas focas habitat',
+  'Inspect every pressure seal after the artificial sunrise.':
+      'Inspecione cada vedação de pressão após o nascer do sol artificial.',
+  'Review sardine forecast': 'Revise a previsão da sardinha',
+  'Paused while the Europa exchange recalibrates its fish index.':
+      'Pausado enquanto a bolsa Europa recalibra seu índice de peixes.',
+  'Edit habit': 'Editar hábito',
+  'Schedule': 'Cronograma',
+  'Start date': 'Data de início',
+  'Show from': 'Mostrar de',
+  'Show alert at': 'Mostrar alerta em',
+  'Habitat pressure': 'Pressão do habitat',
+  'Average pressure across the orbital habitat.':
+      'Pressão média em todo o habitat orbital.',
+  'Sardines consumed': 'Sardinhas consumidas',
+  'Daily fish consumption across the orbital habitat.':
+      'Consumo diário de peixes em todo o habitat orbital.',
+  'sardines': 'sardinha',
+  'sardine': 'sardinha',
+  'project waddle habitat': 'projeto habitat waddle',
+  'Project Waddle habitat': 'Habitat do Projeto Waddle',
+  'Dinner shift after the Europa cargo docked':
+      'Turno do jantar após a carga Europa atracar',
+  'Observed at': 'Observado em',
+  'Penguins accounted for': 'Os pinguins foram contabilizados',
+  'Edit measurable': 'Editar mensurável',
+  'Daily average': 'Média diária',
+  'Colony operations': 'Operações de colônia',
+  'Habitat pressure, sardine demand, and crew headcount.':
+      'Pressão do habitat, procura de sardinha e número de tripulantes.',
+  'Mission readiness': 'Prontidão da missão',
+  'Private launch review for Project Waddle.':
+      'Revisão de lançamento privado do Projeto Waddle.',
+  'Habitat pressure — Daily average': 'Pressão do habitat — Média diária',
+  'Sardines consumed — Daily sum': 'Sardinhas consumidas — Soma diária',
+  'Penguins accounted for — Daily sum': 'Pinguins contabilizados – Soma diária',
+  'Add charts by type': 'Adicione gráficos por tipo',
+  'Measurements': 'Medições',
+  'Health': 'Saúde',
+  'The habitat passed inspection, all 37 emperor penguins saluted in roughly the same direction, and the sardine cargo arrived cold.':
+      'O habitat passou na inspeção, todos os 37 pinguins-imperadores saudaram aproximadamente na mesma direção e a carga de sardinha chegou fria.',
+  'Price discovery, cold-chain diplomacy, and formal fish hats.':
+      'Descoberta de preços, diplomacia da cadeia de frio e chapéus formais de peixe.',
+  'Emperor penguin roll-call gala': 'Gala de chamada do pinguim-imperador',
+  'Every penguin was present; two attended twice.':
+      'Todos os pinguins estavam presentes; dois compareceram duas vezes.',
+  'Europa cold-chain grand opening':
+      'Grande inauguração da cadeia de frio na Europa',
+  'The ribbon froze before anyone could cut it.':
+      'A fita congelou antes que alguém pudesse cortá-la.',
+  'Orbital ice-garden opening': 'Abertura orbital do jardim de gelo',
+  'One quiet lap, zero status meetings.':
+      'Uma volta tranquila, zero reuniões de status.',
+  'Mission Control declares the ice-pad trajectory officially waddly.':
+      'O Controle da Missão declara a trajetória da plataforma de gelo oficialmente irregular.',
+  'Pressure seals green. Tiny oxygen packs counted twice.':
+      'Selos de pressão verdes. Pequenos pacotes de oxigênio contavam duas vezes.',
+  'The orbital habitat, five minutes before the ceremonial sardines.':
+      'O habitat orbital, cinco minutos antes do cerimonial das sardinhas.',
+  'Europa cargo pods arrive at a crisp and diplomatic temperature.':
+      'As cápsulas de carga Europa chegam a uma temperatura nítida e diplomática.',
+  'Count every expedition penguin, check the tiny oxygen packs, and record any suspiciously formal salutes.':
+      'Conte todos os pinguins da expedição, verifique os pequenos pacotes de oxigênio e registre qualquer saudação formal suspeita.',
+  'Inspect orbital penguin habitat':
+      'Inspecione o habitat orbital dos pinguins',
+  'Inspect pressure seals, confirm all 37 emperor penguins are present, and route the sardine cargo pods before the live Project Waddle demonstration.':
+      'Inspecione os selos de pressão, confirme se todos os 37 pinguins-imperadores estão presentes e encaminhe os recipientes de carga de sardinha antes da demonstração ao vivo do Projeto Waddle.',
+  'Project Waddle launch review': 'Revisão de lançamento do Projeto Waddle',
+  'Review the ice-pad trajectory, confirm the snack manifest, and make sure Mission Control has removed the fish-shaped cursor from the launch display.':
+      'Revise a trajetória da plataforma de gelo, confirme o manifesto do lanche e certifique-se de que o Controle da Missão tenha removido o cursor em forma de peixe da tela de lançamento.',
+  'Lunch (coffee is not a vegetable)': 'Almoço (café não é vegetal)',
+  'Eat something recognizable as food before the robot nutritionist files another orbital wellness incident.':
+      'Coma algo reconhecível como comida antes que o nutricionista robô registre outro incidente de bem-estar orbital.',
+  'Negotiate sardine futures': 'Negociar o futuro da sardinha',
+  "Lock the colony's Q3 sardine price before the Europa exchange discovers why the emergency fish ceiling is shaped like a penguin.":
+      'Fixe o preço da sardinha no terceiro trimestre da colónia antes que a Bolsa Europa descubra porque é que o teto de emergência para peixes tem a forma de um pinguim.',
+  'Recalibrate the zero-gravity fish feeder':
+      'Recalibre o alimentador de peixes de gravidade zero',
+  'Run the low-orbit sardine test and stop the feeder from launching lunch toward Mission Control.':
+      'Execute o teste da sardinha em órbita baixa e impeça o alimentador de lançar o almoço em direção ao Controle da Missão.',
+  'Confirm the interplanetary sardine cargo pods':
+      'Confirme os pods interplanetários de carga de sardinha',
+  'Reconcile the cold-chain manifest with the colony dashboard before the next supply shuttle leaves Europa.':
+      'Reconcilie o manifesto da cadeia de frio com o painel da colônia antes que o próximo ônibus de abastecimento deixe Europa.',
+  'Ask Legal whether a penguin is a passenger':
+      'Pergunte ao Departamento Jurídico se um pinguim é passageiro',
+  'Resolve whether Sir Flaps-a-Lot needs a boarding pass or a cargo declaration before launch.':
+      'Decida se Sir Flaps-a-Lot precisa de um cartão de embarque ou de uma declaração de carga antes do lançamento.',
+  'Walk without a headset': 'Ande sem fone de ouvido',
+  'Take one quiet lap around the orbital ice garden without turning it into a briefing, podcast, or emergency call.':
+      'Dê uma volta tranquila ao redor do jardim de gelo orbital sem transformá-lo em um briefing, podcast ou chamada de emergência.',
+  'Tomorrow starts with the orbital penguin habitat inspection':
+      'Amanhã começa com a inspeção do habitat dos pinguins orbitais',
+  'Tomorrow I need to inspect the orbital penguin habitat before Mission Control wakes up, run the emperor penguin roll call, and negotiate the sardine futures contract with Reykjavik. At eleven we have the Project Waddle launch review. Please protect lunch because apparently coffee is not a vegetable. In the afternoon I need ninety minutes for the zero-gravity fish feeder, a legal review called Is a penguin a passenger, and the board briefing. Add a buffer before the live habitat demo, then leave thirty minutes for a walk and a debrief with Sir Flaps-a-Lot. Nothing important should begin after five.':
+      'Amanhã preciso inspecionar o habitat orbital dos pinguins antes que o Controle da Missão acorde, fazer a chamada do pinguim-imperador e negociar o contrato futuro de sardinha com Reykjavik. Às onze temos a análise de lançamento do Projeto Waddle. Por favor, proteja o almoço porque aparentemente o café não é um vegetal. À tarde, preciso de noventa minutos para o comedouro de peixes em gravidade zero, uma revisão jurídica chamada O pinguim é passageiro e as instruções do conselho. Adicione um buffer antes da demonstração do habitat ao vivo e, em seguida, reserve trinta minutos para uma caminhada e um interrogatório com Sir Flaps-a-Lot. Nada importante deve começar depois das cinco.',
+  'Orbital habitat inspection': 'Inspeção de habitat orbital',
+  'Zero-gravity fish feeder': 'Alimentador de peixes com gravidade zero',
+  'Best done before Mission Control and the penguins get chatty':
+      'Melhor feito antes que o Controle da Missão e os pinguins fiquem conversando',
+  'Buffer': 'Tampão',
+  'The fish are least suspicious immediately after lunch':
+      'Os peixes ficam menos desconfiados imediatamente após o almoço',
+  'Legal: Is a penguin a passenger?': 'Legal: um pinguim é passageiro?',
+  'HIGH ENERGY': 'ALTA ENERGIA',
+  'POST-LUNCH DIP': 'MERGULHO PÓS-ALMOÇO',
+  'SECOND WIND': 'SEGUNDO VENTO',
+  'Habitat seals green; tiny helmets still pending':
+      'As focas de habitat são verdes; capacetes minúsculos ainda pendentes',
+  'Locked Q3 sardines below the emergency fish ceiling':
+      'Sardinhas trancadas no terceiro trimestre abaixo do teto de emergência para peixes',
+  'Prototype ready for the live habitat demo':
+      'Protótipo pronto para demonstração de habitat ao vivo',
+  'Retrieve penguin from ventilation duct':
+      'Recupere o pinguim do duto de ventilação',
+  'Lunch, technically': 'Almoço, tecnicamente',
+  'Habitat work lands before Mission Control wakes':
+      'O trabalho de habitat chega antes do controle da missão acordar',
+  'Habitat inspections started before the first call run 30% longer before a penguin or executive finds the red button.':
+      'As inspeções de habitat iniciadas antes da primeira chamada duram 30% mais tempo antes que um pinguim ou executivo encontre o botão vermelho.',
+  'Walks get skipped after penguin escapes':
+      'Caminhadas são ignoradas após a fuga do pinguim',
+  'When a penguin enters the ventilation system, the planned walk is usually dropped — protect it explicitly.':
+      'Quando um pinguim entra no sistema de ventilação, a caminhada planejada geralmente é abandonada – proteja-o explicitamente.',
+  'No briefings before 10:00': 'Não há briefings antes das 10:00',
+  'Keep mornings briefing-free until 10:00 — stated preference.':
+      'Mantenha as manhãs livres de briefings até às 10:00 – preferência declarada.',
+  'Move sardine negotiations 30 minutes later':
+      'Mova as negociações da sardinha 30 minutos depois',
+  'Protect the launch review and give Mission Control a buffer.':
+      'Proteja a revisão de lançamento e dê uma proteção ao Controle da Missão.',
+  'Start the fish-feeder demo after the new buffer':
+      'Inicie a demonstração do alimentador de peixes após o novo buffer',
+  'Keep the zero-gravity demo clear of the sardine negotiation.':
+      'Mantenha a demonstração de gravidade zero longe da negociação da sardinha.',
+  'Seals green; all 37 emperor penguins accounted for.':
+      'Selos verdes; todos os 37 pinguins imperadores foram contabilizados.',
+  'Mission Control approved the revised habitat checklist.':
+      'O Controle da Missão aprovou a lista de verificação de habitat revisada.',
+  'Q3 supply secured below the emergency fish ceiling.':
+      'Fornecimento do terceiro trimestre garantido abaixo do teto de emergência para peixes.',
+  'Prototype calibrated; live habitat demo still pending.':
+      'Protótipo calibrado; demonstração de habitat ao vivo ainda pendente.',
+  '→ tomorrow morning': '→ amanhã de manhã',
+  'Mission Control review ran long.':
+      'A revisão do Controle da Missão demorou muito.',
+  '→ tomorrow afternoon': '→ amanhã à tarde',
+  'Start with the live fish-feeder demo at 09:00, then resolve the penguin passenger question before the launch window opens.':
+      'Comece com a demonstração ao vivo do comedouro de peixes às 09h e, em seguida, resolva a questão do passageiro pinguim antes que a janela de lançamento seja aberta.',
+  'Protect the launch review, move sardine negotiations later, and keep the fish-feeder demo clear.':
+      'Proteja a revisão do lançamento, avance as negociações da sardinha para mais tarde e mantenha clara a demonstração do alimentador de peixes.',
+  'Send Project Waddle briefing': 'Enviar briefing do projeto Waddle',
+  'the Project Waddle launch review':
+      'a revisão de lançamento do Projeto Waddle',
+  'Project Waddle launch briefing': 'Briefing de lançamento do Projeto Waddle',
+  'In progress · 2 sessions': 'Em andamento · 2 sessões',
+  'before Mission Control wakes up': 'antes que o Controle da Missão acorde',
+  'run the emperor penguin roll call': 'execute a chamada do pinguim-imperador',
+  'Recurring · weekdays': 'Recorrente · dias úteis',
+  'Mark complete after all 37 answer':
+      'Marcar como concluído depois de todas as 37 respostas',
+  'Replace the diplomatic fish bucket':
+      'Substitua o balde de peixe diplomático',
+  'Started Friday, dignity not included':
+      'Começou sexta-feira, dignidade não incluída',
+  'Renew orbital wildlife permit': 'Renovar licença de vida selvagem orbital',
+  'The penguins are currently technically cargo':
+      'Os pinguins são atualmente tecnicamente carregados',
+  'Practice calm during surprise flapping':
+      'Pratique a calma durante as batidas surpresa',
+  'Last skipped Thursday': 'Última quinta-feira ignorada',
+  'Habitat Watcher': 'Observador de habitat',
+  'All 37 emperor penguins are accounted for. Habitat pressure held at 101.3 kPa overnight; the remaining launch risk is the zero-gravity sardine feeder calibration.':
+      'Todos os 37 pinguins-imperadores foram contabilizados. A pressão do habitat manteve-se em 101,3 kPa durante a noite; o risco de lançamento restante é a calibração do alimentador de sardinha em gravidade zero.',
+  'Habitat stable; zero-gravity sardine feeder blocks sign-off.':
+      'Habitat estável; Alimentador de sardinha com gravidade zero bloqueia a sinalização.',
+  '\n## Latest assessment\n\n- Pressure seals A–F stayed stable across the night shift.\n- 840 sardines are loaded; feeder calibration still blocks sign-off.\n- Mission Control clearance is due before the 06:30 roll call.\n\n## Recommended next step\n\nRun the feeder test, attach the telemetry image, then request launch approval.\n':
+      '## Última avaliação\n\n- As vedações de pressão A–F permaneceram estáveis durante o turno da noite.\n- São carregadas 840 sardinhas; a calibração do alimentador ainda bloqueia a aprovação.\n- A autorização do Controle da Missão deve ser feita antes da chamada das 06:30.\n\n## Próxima etapa recomendada\n\nExecute o teste do alimentador, anexe a imagem de telemetria e solicite a aprovação do lançamento.',
+  'Latest assessment': 'Última avaliação',
+  'Recommended next step': 'Próxima etapa recomendada',
+  'Run zero-gravity sardine feeder test':
+      'Execute o teste do alimentador de sardinha em gravidade zero',
+  'Orbital Habitat Sentinel': 'Sentinela do Habitat Orbital',
+  'Project Waddle Day Planner': 'Planejador do dia do projeto Waddle',
+  'Sardine Supply Watch': 'Vigilância do Abastecimento de Sardinha',
+  'Fish Diplomacy Coach': 'Treinador de Diplomacia de Peixe',
+  'Habitat Seal Inspector': 'Inspetor de focas de habitat',
+  'Project Waddle Planner': 'Planejador de projeto Waddle',
+  'Sardine Cargo Coordinator': 'Coordenador de Carga Sardinha',
+  'Project Waddle Operations': 'Operações do Projeto Waddle',
+  'Cargo Bay': 'Baía de carga',
+  'Interplanetary Relations': 'Relações Interplanetárias',
+  'Habitat Science': 'Ciência do Habitat',
+  'Protect Project Waddle by checking pressure seals, habitat telemetry, and every suspiciously cheerful penguin before launch.':
+      'Proteja o Projeto Waddle verificando os selos de pressão, a telemetria do habitat e todos os pinguins suspeitosamente alegres antes do lançamento.',
+  'End with a concise go/no-go recommendation and list any seals that need a human inspection.':
+      'Termine com uma recomendação concisa de ir/não ir e liste todas as vedações que precisam de inspeção humana.',
+  'Build a realistic day around energy, fixed launch windows, and the colony rule that lunch still counts even during a sardine emergency.':
+      'Construa um dia realista em torno da energia, janelas fixas de lançamento e a regra da colônia de que o almoço ainda conta mesmo durante uma emergência de sardinha.',
+  'Call out over-capacity plans before asking for commitment.':
+      'Apresente planos de excesso de capacidade antes de pedir compromisso.',
+  'Track sardine cargo pods, cold-chain handoffs, and zero-gravity feeder stock without sending private manifests to a cloud model.':
+      'Rastreie cápsulas de carga de sardinha, transferências de cadeia de frio e estoque de alimentação de gravidade zero sem enviar manifestos privados para um modelo de nuvem.',
+  'Report shortages by habitat, pod, and expected penguin impact.':
+      'Relate a escassez por habitat, grupo e impacto esperado dos pinguins.',
+  'Coach agent templates to be clear, skeptical, and gracious during high-stakes fish negotiations.':
+      'Treine os modelos de agente para serem claros, céticos e corteses durante negociações de peixes de alto risco.',
+  'Explain each proposed wording change without flattery.':
+      'Explique cada mudança de redação proposta sem lisonjas.',
+  'Speak like a calm flight director who respects both evidence and penguins. Put the operational decision first.':
+      'Fale como um diretor de vôo calmo que respeita as evidências e os pinguins. Coloque a decisão operacional em primeiro lugar.',
+  'Dry warmth is welcome. Never turn a safety warning into a joke.':
+      'O calor seco é bem-vindo. Nunca transforme um aviso de segurança em uma piada.',
+  'Ask one clarifying question when telemetry is ambiguous, then propose the smallest safe next step.':
+      'Faça uma pergunta esclarecedora quando a telemetria for ambígua e, em seguida, proponha o próximo passo mais seguro.',
+  'Challenge optimistic launch assumptions and cite the observation that changed your conclusion.':
+      'Desafie as suposições otimistas de lançamento e cite a observação que mudou sua conclusão.',
+  'Be curious, precise, and delighted by useful anomalies.':
+      'Seja curioso, preciso e encantado com anomalias úteis.',
+  'No alarmism; distinguish measurements from hypotheses.':
+      'Sem alarmismo; distinguir medições de hipóteses.',
+  'Turn vague concerns into an observable test.':
+      'Transforme preocupações vagas em um teste observável.',
+  'Prefer an awkward fact over an elegant story.':
+      'Prefira um fato estranho a uma história elegante.',
+  'Be brisk, practical, and exact about quantities.':
+      'Seja rápido, prático e exato quanto às quantidades.',
+  'Never shame a penguin for an empty feeder.':
+      'Nunca envergonhe um pinguim por ter um comedouro vazio.',
+  'Name the blocked handoff and the next owner.':
+      'Nomeie a transferência bloqueada e o próximo proprietário.',
+  'Do not declare cargo healthy without pod counts.':
+      'Não declare a carga saudável sem contagem de cápsulas.',
+  'Project Waddle launch day · July 18':
+      'Dia de lançamento do Projeto Waddle · 18 de julho',
+  'Project Waddle launch day': 'Dia de lançamento do Projeto Waddle',
+  'The sentinel caught the pressure anomaly, but its launch report buried the go/no-go decision beneath six paragraphs of fish trivia.':
+      'O sentinela detectou a anomalia de pressão, mas seu relatório de lançamento enterrou a decisão de avançar/não avançar sob seis parágrafos de curiosidades sobre peixes.',
+  'Make seal evidence easier to scan.':
+      'Torne as evidências do selo mais fáceis de digitalizar.',
+  'Put seal anomalies first and make the final launch call explicit.':
+      'Coloque as anomalias do selo em primeiro lugar e torne explícita a chamada de lançamento final.',
+  '## Result\n\n- Evidence now leads each finding.\n- Reports end with a plain-language launch recommendation.':
+      '## Resultado\n\n- As evidências agora conduzem cada descoberta.\n- Os relatórios terminam com uma recomendação de lançamento em linguagem simples.',
+  'Promoted pressure evidence and added an explicit go/no-go ending.':
+      'Promoveu evidências de pressão e adicionou um final explícito de sim/não.',
+  'Admiral Pebble is appropriately skeptical, but should ask fewer questions when a launch hold is already obvious.':
+      'O almirante Pebble está apropriadamente cético, mas deveria fazer menos perguntas quando a suspensão do lançamento já for óbvia.',
+  'pressure anomaly': 'anomalia de pressão',
+  'calm flight director': 'diretor de vôo calmo',
+  'launch hold': 'espera de lançamento',
+};

--- a/test/helpers/manual_screenshot_portuguese_text.dart
+++ b/test/helpers/manual_screenshot_portuguese_text.dart
@@ -48,7 +48,7 @@ const _copy = <String, String>{
   'Inspect orbital penguin habitat before launch':
       'Inspecione o habitat orbital dos pinguins antes do lançamento',
   'Launch orbital penguin habitat after seal inspection':
-      'Lançar habitat orbital de pinguins após inspeção de focas',
+      'Lançar o habitat orbital dos pinguins após a inspeção das vedações',
   'Mission Control cleared 36 penguins. Recheck pressure seal C and hold the sardine cargo pod until the final emperor arrives.':
       'O Controle da Missão eliminou 36 pinguins. Verifique novamente o selo de pressão C e segure a cápsula de carga de sardinha até que o último imperador chegue.',
   'Inspect orbital penguin habitat — before launch':
@@ -177,7 +177,7 @@ const _copy = <String, String>{
   'Categories': 'Categorias',
   'Labels': 'Etiquetas',
   'Habits': 'Hábitos',
-  'Inspect habitat seals': 'Inspecione focas de habitat',
+  'Inspect habitat seals': 'Inspecione as vedações do habitat',
   'Check the pressure seals before the colony wakes.':
       'Verifique os selos de pressão antes que a colônia acorde.',
   'Log penguin roll call': 'Registrar a chamada dos pinguins',
@@ -297,7 +297,7 @@ const _copy = <String, String>{
   'Emperor penguin roll call': 'Chamada do pinguim-imperador',
   'Account for all 37 expedition penguins before launch.':
       'Considere todos os 37 pinguins da expedição antes do lançamento.',
-  'Walk the habitat seals': 'Caminhe pelas focas habitat',
+  'Walk the habitat seals': 'Percorra as vedações do habitat',
   'Inspect every pressure seal after the artificial sunrise.':
       'Inspecione cada vedação de pressão após o nascer do sol artificial.',
   'Review sardine forecast': 'Revise a previsão da sardinha',
@@ -404,7 +404,7 @@ const _copy = <String, String>{
   'POST-LUNCH DIP': 'MERGULHO PÓS-ALMOÇO',
   'SECOND WIND': 'SEGUNDO VENTO',
   'Habitat seals green; tiny helmets still pending':
-      'As focas de habitat são verdes; capacetes minúsculos ainda pendentes',
+      'As vedações do habitat estão boas; capacetes minúsculos ainda pendentes',
   'Locked Q3 sardines below the emergency fish ceiling':
       'Sardinhas trancadas no terceiro trimestre abaixo do teto de emergência para peixes',
   'Prototype ready for the live habitat demo':
@@ -463,7 +463,7 @@ const _copy = <String, String>{
       'Começou sexta-feira, dignidade não incluída',
   'Renew orbital wildlife permit': 'Renovar licença de vida selvagem orbital',
   'The penguins are currently technically cargo':
-      'Os pinguins são atualmente tecnicamente carregados',
+      'Os pinguins são, tecnicamente, carga',
   'Practice calm during surprise flapping':
       'Pratique a calma durante as batidas surpresa',
   'Last skipped Thursday': 'Última quinta-feira ignorada',
@@ -482,7 +482,7 @@ const _copy = <String, String>{
   'Project Waddle Day Planner': 'Planejador do dia do projeto Waddle',
   'Sardine Supply Watch': 'Vigilância do Abastecimento de Sardinha',
   'Fish Diplomacy Coach': 'Treinador de Diplomacia de Peixe',
-  'Habitat Seal Inspector': 'Inspetor de focas de habitat',
+  'Habitat Seal Inspector': 'Inspetor de Vedações do Habitat',
   'Project Waddle Planner': 'Planejador de projeto Waddle',
   'Sardine Cargo Coordinator': 'Coordenador de Carga Sardinha',
   'Project Waddle Operations': 'Operações do Projeto Waddle',

--- a/test/helpers/manual_screenshot_portuguese_text_test.dart
+++ b/test/helpers/manual_screenshot_portuguese_text_test.dart
@@ -10,4 +10,18 @@ void main() {
     );
     expect(manualScreenshotPortugueseText('Unknown fixture'), isNull);
   });
+
+  test('localizes multiline Portuguese agent reports', () {
+    expect(
+      manualScreenshotPortugueseText(
+        '\n## Latest assessment\n\n- Pressure seals A–F stayed stable across '
+        'the night shift.\n- 840 sardines are loaded; feeder calibration '
+        'still blocks sign-off.\n- Mission Control clearance is due before '
+        'the 06:30 roll call.\n\n## Recommended next step\n\nRun the '
+        'feeder test, attach the telemetry image, then request launch '
+        'approval.\n',
+      ),
+      contains('## Última avaliação'),
+    );
+  });
 }

--- a/test/helpers/manual_screenshot_portuguese_text_test.dart
+++ b/test/helpers/manual_screenshot_portuguese_text_test.dart
@@ -24,4 +24,16 @@ void main() {
       contains('## Última avaliação'),
     );
   });
+
+  test('uses Portuguese task and habitat terminology', () {
+    final expectedTranslations = <String, String>{
+      'Inspect habitat seals': 'Inspecione as vedações do habitat',
+      'The penguins are currently technically cargo':
+          'Os pinguins são, tecnicamente, carga',
+    };
+
+    for (final entry in expectedTranslations.entries) {
+      expect(manualScreenshotPortugueseText(entry.key), entry.value);
+    }
+  });
 }

--- a/test/helpers/manual_screenshot_portuguese_text_test.dart
+++ b/test/helpers/manual_screenshot_portuguese_text_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'manual_screenshot_portuguese_text.dart';
+
+void main() {
+  test('localizes representative Portuguese manual fixture copy', () {
+    expect(
+      manualScreenshotPortugueseText('Inspect orbital penguin habitat'),
+      'Inspecione o habitat orbital dos pinguins',
+    );
+    expect(manualScreenshotPortugueseText('Unknown fixture'), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds Portuguese app labels, platform metadata, and a complete Portuguese Manual catalog.
- Adds Portuguese to the Manual site, system-locale routing, deterministic screenshot fixtures, and the manual screenshot matrix.
- Prevents localized task-action controls from overflowing in Portuguese narrow layouts.

## Validation

- Focused localization, Manual-language, and task-action tests passed.
- Full Portuguese screenshot capture and final analyzer/docs checks are in progress; the paired screenshot-media PR will be linked here once published.
- The approximately 27,000-test suite is intentionally delegated to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Portuguese UI/localization support across supported platforms.
  * Added Portuguese as an available Manual language option, including Settings → Advanced → Language selection and system-locale support.
  * Published a Portuguese Manual with localized screenshots and search/navigation.
  * Extended Portuguese documentation coverage across the docs site and reference pages.

* **Bug Fixes**
  * Adjusted task action-bar layout thresholds so checklist affordance visibility matches the updated narrow-width behavior.

* **Documentation**
  * Updated translation contribution guidance to require a real-name, established profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->