### PR TITLE
fix: localize agent screenshot assertion

### DIFF
--- a/test/features/agents/ui/agents_manual_screenshots_test.dart
+++ b/test/features/agents/ui/agents_manual_screenshots_test.dart
@@ -1463,7 +1463,7 @@ void main() {
             );
             expect(
               find.textContaining(
-                _t('Waddle Command', 'Watschelkommando'),
+                _t('Waddle Command 70B', 'Watschelkommando 70B'),
               ),
               findsWidgets,
             );


### PR DESCRIPTION
## Summary

- Makes the agent-instance manual screenshot assertion use the complete localized model identifier.
- Restores Portuguese agent screenshot capture in every viewport and theme.

## Validation

- `LOTTI_MANUAL_LOCALE=pt ... agents_manual_screenshots_test.dart --name agent instance detail`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the agent instance detail screenshot test to verify the localized “Waddle Command 70B” model name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->