### PR TITLE
fix: respect regional calendar week start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1054]
 ### Fixed
+- **Date pickers now start the week according to your device region.** Entry
+  dates, entry ranges, due dates, and project target dates show Monday first in
+  European regions and Sunday first in the US, including matching weekday
+  headers and calendar-day positions.
 - **Screen-reader controls now consistently expose one actionable, localized
   announcement.** Back, overflow, chart-baseline, and entry-collapse controls
   retain their labels, actions, and state without duplicate speech; new

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
   <releases>
     <release version="0.9.1054" date="2026-07-18">
       <description>
+        <p>Date pickers now follow the device region's week order. Entry dates, entry ranges, due dates, and project target dates start on Monday in European regions and Sunday in the US, with matching weekday headers and calendar-day positions.</p>
         <p>Screen-reader controls now expose one clear actionable announcement with their label and state. New accessibility labels are also available in Danish, Swedish, and Dutch.</p>
         <p>Matrix sync now finishes catching up after reconnecting during a large burst, even on poor networks. Reconnected devices recover every missed entry instead of stopping after a partial server page.</p>
       </description>

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -273,11 +273,14 @@ stateDiagram-v2
 
 - calendar and time pickers (`components/calendar_pickers/` and
   `components/time_pickers/`) — the shared calendar wraps Material's
-  locale-aware month grid with a full weekday date readout, a contextual
-  **Today** action, `DesignSystemPickerSection` framing, and the shared modal
-  action bar. Calendar inputs are clamped to their configured bounds, and
-  selections retain the caller's UTC/local timezone kind instead of silently
-  converting calendar days. The time-of-day picker uses fixed-extent
+  month grid with a full weekday date readout, a contextual **Today** action,
+  `DesignSystemPickerSection` framing, and the shared modal action bar. Its
+  weekday header and day grid use the device region's CLDR week start through
+  `firstDayOfWeekIndexProvider`, so European regions start on Monday while US
+  regions start on Sunday even when the UI language is English. Calendar
+  inputs are clamped to their configured bounds, and selections retain the
+  caller's UTC/local timezone kind instead of silently converting calendar
+  days. The time-of-day picker uses fixed-extent
   hour/minute wheels with cylindrical
   perspective, non-bouncing settle behavior, a token-selected row, 12/24-hour
   layouts, and adjustable semantics for each column. Desktop pointer-scroll

--- a/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
+++ b/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
@@ -1,11 +1,14 @@
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
+import 'package:lotti/utils/device_region.dart';
+import 'package:lotti/utils/first_day_of_week_picker.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 /// The outcome of a design-system calendar modal.
@@ -100,7 +103,7 @@ class DesignSystemPickerSection extends StatelessWidget {
 
 /// The token-backed calendar content shared by standalone and multi-page
 /// date-picking sheets.
-class DesignSystemCalendarPicker extends StatelessWidget {
+class DesignSystemCalendarPicker extends ConsumerWidget {
   const DesignSystemCalendarPicker({
     required this.selectedDate,
     required this.firstDate,
@@ -115,8 +118,12 @@ class DesignSystemCalendarPicker extends StatelessWidget {
   final ValueChanged<DateTime> onDateChanged;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
+    final materialLocalizations = MaterialLocalizations.of(context);
+    final firstDayOfWeekIndex =
+        ref.watch(firstDayOfWeekIndexProvider).value ??
+        materialLocalizations.firstDayOfWeekIndex;
     final effectiveSelectedDate = _clampCalendarDate(
       selectedDate,
       firstDate,
@@ -143,14 +150,17 @@ class DesignSystemCalendarPicker extends StatelessWidget {
               toggleButtonTextStyle: tokens.typography.styles.subtitle.subtitle1
                   .copyWith(color: tokens.colors.text.highEmphasis),
             ),
-            child: CalendarDatePicker(
-              key: ValueKey(effectiveSelectedDate),
-              initialDate: effectiveSelectedDate,
-              currentDate: _today(),
-              firstDate: firstDate,
-              lastDate: lastDate,
-              onDateChanged: (value) => onDateChanged(
-                value.dateOnlyInZoneOf(effectiveSelectedDate),
+            child: firstDayOfWeekPickerBuilder(firstDayOfWeekIndex)(
+              context,
+              CalendarDatePicker(
+                key: ValueKey(effectiveSelectedDate),
+                initialDate: effectiveSelectedDate,
+                currentDate: _today(),
+                firstDate: firstDate,
+                lastDate: lastDate,
+                onDateChanged: (value) => onDateChanged(
+                  value.dateOnlyInZoneOf(effectiveSelectedDate),
+                ),
               ),
             ),
           ),

--- a/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
+++ b/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
+import 'package:lotti/utils/device_region.dart';
 
 import '../../../../test_helper.dart';
 
@@ -42,6 +43,65 @@ void main() {
     expect(result?.date, DateTime(2025, 6, 16));
     expect(result?.cleared, isFalse);
   });
+
+  for (final scenario in [
+    (
+      name: 'German locale',
+      locale: const Locale('de', 'DE'),
+      firstDayOfWeekIndex: DateTime.monday % 7,
+      weekdayLabels: const ['M', 'D', 'M', 'D', 'F', 'S', 'S'],
+      dayOneColumn: 6,
+    ),
+    (
+      name: 'US locale',
+      locale: const Locale('en', 'US'),
+      firstDayOfWeekIndex: DateTime.sunday % 7,
+      weekdayLabels: const ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
+      dayOneColumn: 0,
+    ),
+    (
+      name: 'English UI with a German region',
+      locale: const Locale('en', 'US'),
+      firstDayOfWeekIndex: DateTime.monday % 7,
+      weekdayLabels: const ['M', 'T', 'W', 'T', 'F', 'S', 'S'],
+      dayOneColumn: 6,
+    ),
+  ]) {
+    testWidgets(
+      '${scenario.name} orders the weekday header and month grid regionally',
+      (tester) async {
+        await _pumpLauncher(
+          tester,
+          locale: scenario.locale,
+          firstDayOfWeekIndex: scenario.firstDayOfWeekIndex,
+          onPressed: (context) => showDesignSystemDatePicker(
+            context: context,
+            title: 'Target date',
+            initialDate: DateTime(2025, 6, 15),
+            firstDate: DateTime(2020),
+            lastDate: DateTime(2030),
+          ),
+        );
+        await tester.pump();
+
+        final headerCells = _weekdayHeaderCells(tester);
+        expect(
+          headerCells.map((cell) => cell.label),
+          scenario.weekdayLabels,
+        );
+
+        final dayOne = find.descendant(
+          of: find.byType(CalendarDatePicker),
+          matching: find.text('1'),
+        );
+        expect(dayOne, findsOneWidget);
+        expect(
+          tester.getCenter(dayOne).dx,
+          closeTo(headerCells[scenario.dayOneColumn].dx, 0.1),
+        );
+      },
+    );
+  }
 
   testWidgets('optional Clear is distinct from dismissing the modal', (
     tester,
@@ -156,9 +216,18 @@ void main() {
 Future<void> _pumpLauncher(
   WidgetTester tester, {
   required Future<void> Function(BuildContext context) onPressed,
+  Locale? locale,
+  int? firstDayOfWeekIndex,
 }) async {
   await tester.pumpWidget(
     WidgetTestBench(
+      locale: locale,
+      overrides: [
+        if (firstDayOfWeekIndex != null)
+          firstDayOfWeekIndexProvider.overrideWith(
+            (ref) async => firstDayOfWeekIndex,
+          ),
+      ],
       child: Builder(
         builder: (context) => ElevatedButton(
           onPressed: () => onPressed(context),
@@ -170,4 +239,38 @@ Future<void> _pumpLauncher(
   await tester.tap(find.text('Open picker'));
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 300));
+}
+
+List<({String label, double dx})> _weekdayHeaderCells(WidgetTester tester) {
+  final textElements = find
+      .descendant(
+        of: find.byType(CalendarDatePicker),
+        matching: find.byType(Text),
+      )
+      .evaluate();
+  final singleCharacterCells = <({String label, Offset center})>[];
+
+  for (final element in textElements) {
+    final text = element.widget as Text;
+    final label = text.data;
+    if (label == null || label.runes.length != 1) continue;
+    final renderBox = element.renderObject! as RenderBox;
+    singleCharacterCells.add((
+      label: label,
+      center: renderBox.localToGlobal(renderBox.size.center(Offset.zero)),
+    ));
+  }
+
+  final headerY = singleCharacterCells
+      .map((cell) => cell.center.dy)
+      .reduce((a, b) => a < b ? a : b);
+  final headerCells =
+      singleCharacterCells
+          .where((cell) => (cell.center.dy - headerY).abs() < 0.1)
+          .map((cell) => (label: cell.label, dx: cell.center.dx))
+          .toList()
+        ..sort((a, b) => a.dx.compareTo(b.dx));
+
+  expect(headerCells, hasLength(7));
+  return headerCells;
 }

--- a/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
+++ b/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
@@ -225,7 +225,7 @@ Future<void> _pumpLauncher(
       overrides: [
         if (firstDayOfWeekIndex != null)
           firstDayOfWeekIndexProvider.overrideWith(
-            (ref) async => firstDayOfWeekIndex,
+            (ref) => firstDayOfWeekIndex,
           ),
       ],
       child: Builder(


### PR DESCRIPTION
## Summary

- make the shared design-system date picker use the device region's CLDR first weekday
- reuse `firstDayOfWeekIndexProvider` and `firstDayOfWeekPickerBuilder`, matching the established calendar implementation
- cover German, US, and English-UI/German-region ordering in both weekday headers and the month grid
- document the runtime behavior and add release notes for 0.9.1054

## Root cause

The new shared picker embedded Flutter's `CalendarDatePicker` directly. Material derives its first weekday from the active UI localization, while Lotti resolves week order separately from the device region. That meant an English UI in a European region still rendered Sunday first.

## Impact

Entry dates and ranges, task due dates, project target dates, and measurement dates now start on Monday in European regions and Sunday in the US. Selection and timezone behavior are unchanged.

## Before / After

| Before — Sunday first | After — Monday first for German region |
| --- | --- |
| ![Before: entry date picker starts on Sunday](https://raw.githubusercontent.com/matthiasn/lotti-docs/ae207bb012b97c54b9345fd29ce9f05b438c4e16/pr-screenshots/calendar-start-day/before/entry_date_picker.png) | ![After: entry date picker starts on Monday](https://raw.githubusercontent.com/matthiasn/lotti-docs/ae207bb012b97c54b9345fd29ce9f05b438c4e16/pr-screenshots/calendar-start-day/after/entry_date_picker.png) |

## Validation

- `make analyze`
- `fvm dart format .`
- `fvm flutter test test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart`
- `fvm flutter test test/features/tasks/ui/header/task_due_date_widget_test.dart`
- `fvm flutter test test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart`
- `fvm flutter test test/pages/create/create_measurement_dialog_test.dart`
- opt-in before/after screenshot harness against the base and fixed commits
- Flatpak metainfo XML parse validation

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date pickers now correctly follow the device region’s week order, including weekday headers and the calendar-day grid for entry dates, entry ranges, due dates, and project target dates.
  * European regions start on Monday; US regions start on Sunday (even when the UI language is different).

* **Documentation**
  * Updated the Design System calendar/time picker documentation and release metadata to clearly describe regional week ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->