### PR TITLE
fix: clean up task agent card typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1054]
 ### Fixed
+- **Task AI summaries are cleaner, more compact, and easier to operate.**
+  Report and proposal text now match editor entries and card summaries, quiet
+  metadata is easier to read, secondary controls have larger interaction
+  targets, and the footer adapts cleanly to narrow layouts and larger text.
 - **Date pickers now start the week according to your device region.** Entry
   dates, entry ranges, due dates, and project target dates show Monday first in
   European regions and Sunday first in the US, including matching weekday

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
   <releases>
     <release version="0.9.1054" date="2026-07-18">
       <description>
+        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, secondary controls have larger interaction targets, and the footer adapts cleanly to narrow layouts and larger text.</p>
         <p>Date pickers now follow the device region's week order. Entry dates, entry ranges, due dates, and project target dates start on Monday in European regions and Sunday in the US, with matching weekday headers and calendar-day positions.</p>
         <p>Screen-reader controls now expose one clear actionable announcement with their label and state. New accessibility labels are also available in Danish, Swedish, and Dutch.</p>
         <p>Matrix sync now finishes catching up after reconnecting during a large burst, even on poor networks. Reconnected devices recover every missed entry instead of stopping after a partial server page.</p>

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -164,10 +164,12 @@ All secondary controls live in a quiet, flat footer pinned to the card bottom
 agent` button or a self-labeled `Next update in m:ss` chip whose dedicated
 close target cancels the scheduled wake. Below it, the tappable model/provider
 identity and automatic-updates control share a row when space permits; at
-narrow widths or large text they stack without truncating the label. Compact
-secondary actions, disclosures, identity links, and the toggle wrapper retain
-the design system's `spacing.step9` interaction height. Meaningful attribution
-uses `aiCard.metaText` rather than the fainter decorative color. When setup is
+narrow widths or large text they stack without truncating the label. Primary
+and destructive controls retain the design system's `spacing.step9`
+interaction height; quiet disclosures and identity links use the denser
+`spacing.step8` row height so their captions do not create oversized bands.
+Meaningful attribution uses `aiCard.metaText` rather than the fainter
+decorative color. When setup is
 missing, the disabled toggle explains itself via an info tooltip. The filled
 accent is reserved for the one wake CTA per state; the TTS play control idles as a whispered
 subtleWash/metaText icon and earns the accent pair only while preparing or

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -150,18 +150,26 @@ stateDiagram-v2
 
 The AI-summary card keeps report reading and agent controls in separate
 information groups. The report is the hero: header, TLDR (reading measure
-capped at ~75 characters even when the card itself is wider), disclosure,
-and proposals form one linear reading column at every width. With no open
+capped at ~75 characters even when the card itself is wider and rendered with
+the editor-aligned `body.bodySmall` typography token), disclosure, and
+proposals form one linear reading column at every width. With no open
 proposals the `0 pending` pill carries the empty state — no placeholder
-band. All secondary controls live in a quiet footer pinned to the card
-bottom (`TaskAgentControlsFooter`), as two fixed rows so no control ever
-relocates between states: a wake row (the manual `Wake agent` button and,
-while an automatic wake is scheduled, a self-labeled `Next update in m:ss`
-chip that cancels the scheduled wake on tap), then the identity row — the
-tappable model/provider line with the automatic-updates toggle pinned
-trailing (caption-weight label; when setup is missing the disabled toggle
-explains itself via an info tooltip). The filled accent is reserved for the
-one wake CTA per state; the TTS play control idles as a whispered
+band. The proposal rail spans the report reading column, keeping History at
+the leading edge and Confirm all at the trailing edge while still wrapping at
+narrow widths. Proposal prose uses the same unmodified `body.bodySmall`
+metrics as the report instead of introducing a separate line height.
+
+All secondary controls live in a quiet, flat footer pinned to the card bottom
+(`TaskAgentControlsFooter`). A wake row contains either the manual `Wake
+agent` button or a self-labeled `Next update in m:ss` chip whose dedicated
+close target cancels the scheduled wake. Below it, the tappable model/provider
+identity and automatic-updates control share a row when space permits; at
+narrow widths or large text they stack without truncating the label. Compact
+secondary actions, disclosures, identity links, and the toggle wrapper retain
+the design system's `spacing.step9` interaction height. Meaningful attribution
+uses `aiCard.metaText` rather than the fainter decorative color. When setup is
+missing, the disabled toggle explains itself via an info tooltip. The filled
+accent is reserved for the one wake CTA per state; the TTS play control idles as a whispered
 subtleWash/metaText icon and earns the accent pair only while preparing or
 playing. While automation is off, `TaskAgentFreshnessStrip`
 holds a constant-geometry slot directly after the summary (and before the

--- a/lib/features/agents/ui/ai_summary_card.dart
+++ b/lib/features/agents/ui/ai_summary_card.dart
@@ -647,14 +647,6 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
         ),
         borderRadius: cardRadius,
         border: Border.all(color: ai.border),
-        boxShadow: [
-          BoxShadow(
-            color: ai.accent.withValues(alpha: 0.2),
-            blurRadius: 24,
-            spreadRadius: -4,
-            offset: const Offset(0, 6),
-          ),
-        ],
       ),
       child: ClipRRect(
         borderRadius: cardRadius,

--- a/lib/features/agents/ui/ai_summary_card.dart
+++ b/lib/features/agents/ui/ai_summary_card.dart
@@ -659,15 +659,15 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
               playbackControl: playbackControl,
             ),
             // Reading order: the summary first, then the update CTA for the
-            // summary just read, then the proposals. One step4 of air between
-            // each block keeps the rhythm even.
+            // summary just read, then the proposals. Quiet links already own
+            // their compact row height, so the section needs only step3 below.
             if (hasReportContent)
               Padding(
                 padding: EdgeInsets.fromLTRB(
                   tokens.spacing.cardPadding,
                   0,
                   tokens.spacing.cardPadding,
-                  tokens.spacing.step4,
+                  tokens.spacing.step3,
                 ),
                 child: reportBody,
               ),

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
@@ -677,7 +677,7 @@ class _ProposalRowState extends ConsumerState<ProposalRow>
                           style: tokens.typography.styles.others.caption
                               .copyWith(
                                 color: intentColor,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: tokens.typography.weight.semiBold,
                               ),
                         ),
                         if (dx < 0) SizedBox(width: tokens.spacing.step2),
@@ -856,8 +856,7 @@ class _ResolveBadge extends StatelessWidget {
           label,
           style: tokens.typography.styles.others.caption.copyWith(
             color: color,
-            fontWeight: FontWeight.w700,
-            height: 1.1,
+            fontWeight: tokens.typography.weight.bold,
           ),
         ),
       ],
@@ -939,7 +938,6 @@ class ProposalRowContent extends StatelessWidget {
       ),
       style: tokens.typography.styles.body.bodySmall.copyWith(
         color: ai.bodyText,
-        height: 1.5,
         decoration: lineThrough ? TextDecoration.lineThrough : null,
       ),
     );

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart
@@ -161,8 +161,7 @@ class ResolvedTag extends StatelessWidget {
                 : messages.aiCardProposalDismissed,
             style: tokens.typography.styles.others.caption.copyWith(
               color: color,
-              fontWeight: FontWeight.w600,
-              height: 1,
+              fontWeight: tokens.typography.weight.semiBold,
             ),
           ),
         ],

--- a/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
@@ -77,7 +77,7 @@ class ProposalsSection extends StatelessWidget {
       ),
       padding: EdgeInsets.symmetric(
         horizontal: tokens.spacing.cardPadding,
-        vertical: tokens.spacing.step4,
+        vertical: tokens.spacing.step3,
       ),
       // Same reading measure as the summary: full-width rows strand the
       // accept/reject actions at the far card edge on wide surfaces.
@@ -159,7 +159,7 @@ class ProposalsSection extends StatelessWidget {
               // already end with their own trailing gap, so only the empty
               // list needs one here.
               if (resolved.isNotEmpty || onConfirmAll != null) ...[
-                if (open.isEmpty) SizedBox(height: tokens.spacing.step3),
+                if (open.isEmpty) SizedBox(height: tokens.spacing.step1),
                 // Wrap, not Row: long translations or large text scales
                 // drop the batch action to its own line instead of
                 // overflowing the constrained card.
@@ -280,7 +280,7 @@ class _HistoryToggle extends StatelessWidget {
             onTap: onPressed,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             child: ConstrainedBox(
-              constraints: BoxConstraints(minHeight: tokens.spacing.step9),
+              constraints: BoxConstraints(minHeight: tokens.spacing.step8),
               // Quiet meta like the footer's model line — the chevron and hit
               // target signal interactivity without spending accent on a
               // low-priority disclosure.

--- a/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
@@ -163,29 +163,33 @@ class ProposalsSection extends StatelessWidget {
                 // Wrap, not Row: long translations or large text scales
                 // drop the batch action to its own line instead of
                 // overflowing the constrained card.
-                Wrap(
-                  alignment: WrapAlignment.spaceBetween,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  spacing: tokens.spacing.step3,
-                  runSpacing: tokens.spacing.step2,
-                  children: [
-                    if (resolved.isNotEmpty)
-                      _HistoryToggle(
-                        open: historyOpen,
-                        count: resolved.length,
-                        onPressed: onToggleHistory,
-                      )
-                    else
-                      const SizedBox.shrink(),
-                    if (onConfirmAll != null)
-                      DesignSystemButton(
-                        label: messages.changeSetConfirmAll,
-                        leadingIcon: Icons.done_all_rounded,
-                        variant: DesignSystemButtonVariant.outlined,
-                        isLoading: confirmAllBusy,
-                        onPressed: () => unawaited(onConfirmAll!()),
-                      ),
-                  ],
+                SizedBox(
+                  key: const ValueKey('proposalBottomRail'),
+                  width: double.infinity,
+                  child: Wrap(
+                    alignment: WrapAlignment.spaceBetween,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: tokens.spacing.step3,
+                    runSpacing: tokens.spacing.step2,
+                    children: [
+                      if (resolved.isNotEmpty)
+                        _HistoryToggle(
+                          open: historyOpen,
+                          count: resolved.length,
+                          onPressed: onToggleHistory,
+                        )
+                      else
+                        const SizedBox.shrink(),
+                      if (onConfirmAll != null)
+                        DesignSystemButton(
+                          label: messages.changeSetConfirmAll,
+                          leadingIcon: Icons.done_all_rounded,
+                          variant: DesignSystemButtonVariant.outlined,
+                          isLoading: confirmAllBusy,
+                          onPressed: () => unawaited(onConfirmAll!()),
+                        ),
+                    ],
+                  ),
                 ),
               ],
               if (resolved.isNotEmpty && historyOpen) ...[
@@ -266,34 +270,40 @@ class _HistoryToggle extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: BorderRadius.circular(tokens.radii.s),
-        child: Padding(
-          padding: EdgeInsets.symmetric(vertical: tokens.spacing.step2),
-          // Quiet meta like the footer's model line — the chevron and hit
-          // target signal interactivity without spending accent on a
-          // low-priority disclosure.
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                open
-                    ? Icons.keyboard_arrow_down_rounded
-                    : Icons.chevron_right_rounded,
-                size: tokens.spacing.step5,
-                color: ai.metaText,
+    return MergeSemantics(
+      child: Semantics(
+        button: true,
+        expanded: open,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(tokens.radii.s),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: tokens.spacing.step9),
+              // Quiet meta like the footer's model line — the chevron and hit
+              // target signal interactivity without spending accent on a
+              // low-priority disclosure.
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    open
+                        ? Icons.keyboard_arrow_down_rounded
+                        : Icons.chevron_right_rounded,
+                    size: tokens.spacing.step5,
+                    color: ai.metaText,
+                  ),
+                  SizedBox(width: tokens.spacing.step2),
+                  Text(
+                    context.messages.aiCardHistoryToggle(count),
+                    style: tokens.typography.styles.others.caption.copyWith(
+                      color: ai.metaText,
+                    ),
+                  ),
+                ],
               ),
-              SizedBox(width: tokens.spacing.step2),
-              Text(
-                context.messages.aiCardHistoryToggle(count),
-                style: tokens.typography.styles.others.caption.copyWith(
-                  color: ai.metaText,
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/agents/ui/ai_summary_card/tldr_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/tldr_section_part.dart
@@ -146,9 +146,9 @@ class TldrBody extends StatelessWidget {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
     final messages = context.messages;
-    // One step above the row/meta text: the ramp, not the sparkle badge,
-    // marks the summary as the card's hero.
-    final bodyStyle = tokens.typography.styles.body.bodyMedium.copyWith(
+    // Match entry-editor prose and compact card summaries; the header and
+    // card treatment provide the hierarchy without enlarging report text.
+    final bodyStyle = tokens.typography.styles.body.bodySmall.copyWith(
       color: ai.bodyText,
     );
     final hasMore = additionalReport?.trim().isNotEmpty ?? false;
@@ -187,6 +187,7 @@ class TldrBody extends StatelessWidget {
                   icon: expanded
                       ? Icons.expand_less_rounded
                       : Icons.expand_more_rounded,
+                  expanded: expanded,
                   onPressed: onToggle,
                 ),
               if (expanded)
@@ -211,36 +212,44 @@ class _QuietDisclosureLink extends StatelessWidget {
     required this.label,
     required this.icon,
     required this.onPressed,
+    this.expanded,
     super.key,
   });
 
   final String label;
   final IconData icon;
   final VoidCallback onPressed;
+  final bool? expanded;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: BorderRadius.circular(tokens.radii.s),
-        child: Padding(
-          padding: EdgeInsets.symmetric(vertical: tokens.spacing.step2),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: tokens.spacing.step5, color: ai.metaText),
-              SizedBox(width: tokens.spacing.step2),
-              Text(
-                label,
-                style: tokens.typography.styles.others.caption.copyWith(
-                  color: ai.metaText,
-                ),
+    return MergeSemantics(
+      child: Semantics(
+        button: true,
+        expanded: expanded,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(tokens.radii.s),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: tokens.spacing.step9),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: tokens.spacing.step5, color: ai.metaText),
+                  SizedBox(width: tokens.spacing.step2),
+                  Text(
+                    label,
+                    style: tokens.typography.styles.others.caption.copyWith(
+                      color: ai.metaText,
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/agents/ui/ai_summary_card/tldr_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/tldr_section_part.dart
@@ -173,7 +173,7 @@ class TldrBody extends StatelessWidget {
           ),
         ],
         if (hasMore || expanded) ...[
-          SizedBox(height: tokens.spacing.step3),
+          SizedBox(height: tokens.spacing.step1),
           Wrap(
             spacing: tokens.spacing.step4,
             runSpacing: tokens.spacing.step2,
@@ -235,7 +235,7 @@ class _QuietDisclosureLink extends StatelessWidget {
             onTap: onPressed,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             child: ConstrainedBox(
-              constraints: BoxConstraints(minHeight: tokens.spacing.step9),
+              constraints: BoxConstraints(minHeight: tokens.spacing.step8),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/lib/features/agents/ui/task_agent_controls_footer.dart
+++ b/lib/features/agents/ui/task_agent_controls_footer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/tldr_section_part.dart';
+import 'package:lotti/features/agents/ui/task_agent_freshness_strip.dart';
 import 'package:lotti/features/agents/ui/task_agent_identity_region.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/agents/ui/wake_countdown_state.dart';
@@ -68,6 +69,44 @@ class TaskAgentControlsFooter extends StatelessWidget {
     final countdownVisible = showCountdown && wakeAt != null;
     final hasWakeRow = showWakeButton || countdownVisible;
 
+    Widget automationControls({required bool expandLabel}) {
+      final label = Text(
+        messages.taskAgentAutomaticUpdatesLabel,
+        style: tokens.typography.styles.others.caption.copyWith(
+          color: ai.metaText,
+        ),
+      );
+      return Row(
+        mainAxisSize: expandLabel ? MainAxisSize.max : MainAxisSize.min,
+        children: [
+          if (expandLabel) Expanded(child: label) else label,
+          SizedBox(width: tokens.spacing.step2),
+          ConstrainedBox(
+            key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
+            constraints: BoxConstraints(
+              minWidth: tokens.spacing.step9,
+              minHeight: tokens.spacing.step9,
+            ),
+            child: DesignSystemToggle(
+              key: const Key('taskAgentAutomaticUpdatesCheckbox'),
+              value: automaticUpdatesEnabled,
+              semanticsLabel: messages.taskAgentAutomaticUpdatesLabel,
+              // The disabled toggle explains itself on demand instead of
+              // spending a permanent caption line on it.
+              tooltipIcon: inferenceAvailable
+                  ? null
+                  : Icons.info_outline_rounded,
+              tooltipMessage: inferenceAvailable
+                  ? null
+                  : messages.taskAgentAutomaticUpdatesNeedsSetup,
+              enabled: inferenceAvailable && !automationBusy,
+              onChanged: onAutomaticUpdatesChanged,
+            ),
+          ),
+        ],
+      );
+    }
+
     return Container(
       key: const ValueKey('taskAgentControlsFooter'),
       decoration: BoxDecoration(
@@ -96,10 +135,10 @@ class TaskAgentControlsFooter extends StatelessWidget {
                 // One wake affordance per state, in a constant-height slot: the
                 // countdown chip replaces the button while an automatic wake is
                 // scheduled (the scheduled update *is* the pending wake). step8
-                // fits the taller of the two (the cancel button) exactly — a
-                // 48px floor left a dead band under the compact controls.
+                // used to fit the visuals exactly; step9 keeps the same compact
+                // chrome inside a full 48px interaction slot.
                 ConstrainedBox(
-                  constraints: BoxConstraints(minHeight: tokens.spacing.step8),
+                  constraints: BoxConstraints(minHeight: tokens.spacing.step9),
                   child: Align(
                     alignment: Alignment.centerLeft,
                     child: countdownVisible
@@ -123,38 +162,41 @@ class TaskAgentControlsFooter extends StatelessWidget {
                 ),
                 SizedBox(height: tokens.spacing.step2),
               ],
-              Row(
-                children: [
-                  Expanded(
-                    child: TaskAgentIdentityRegion(
-                      data: identityData,
-                      onSetupTap: onSetupTap,
-                    ),
-                  ),
-                  SizedBox(width: tokens.spacing.step3),
-                  Text(
-                    messages.taskAgentAutomaticUpdatesLabel,
-                    style: tokens.typography.styles.others.caption.copyWith(
-                      color: ai.metaText,
-                    ),
-                  ),
-                  SizedBox(width: tokens.spacing.step2),
-                  DesignSystemToggle(
-                    key: const Key('taskAgentAutomaticUpdatesCheckbox'),
-                    value: automaticUpdatesEnabled,
-                    semanticsLabel: messages.taskAgentAutomaticUpdatesLabel,
-                    // The disabled toggle explains itself on demand instead of
-                    // spending a permanent caption line on it.
-                    tooltipIcon: inferenceAvailable
-                        ? null
-                        : Icons.info_outline_rounded,
-                    tooltipMessage: inferenceAvailable
-                        ? null
-                        : messages.taskAgentAutomaticUpdatesNeedsSetup,
-                    enabled: inferenceAvailable && !automationBusy,
-                    onChanged: onAutomaticUpdatesChanged,
-                  ),
-                ],
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final textScale = MediaQuery.textScalerOf(context).scale(1);
+                  final compact =
+                      constraints.maxWidth <
+                          TaskAgentFreshnessStrip.compactWidth ||
+                      textScale > 1.3;
+                  if (compact) {
+                    return Column(
+                      key: const ValueKey('taskAgentFooterCompactLayout'),
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        TaskAgentIdentityRegion(
+                          data: identityData,
+                          onSetupTap: onSetupTap,
+                        ),
+                        SizedBox(height: tokens.spacing.step2),
+                        automationControls(expandLabel: true),
+                      ],
+                    );
+                  }
+                  return Row(
+                    key: const ValueKey('taskAgentFooterWideLayout'),
+                    children: [
+                      Expanded(
+                        child: TaskAgentIdentityRegion(
+                          data: identityData,
+                          onSetupTap: onSetupTap,
+                        ),
+                      ),
+                      SizedBox(width: tokens.spacing.step3),
+                      automationControls(expandLabel: false),
+                    ],
+                  );
+                },
               ),
             ],
           ),
@@ -209,54 +251,79 @@ class _CountdownChipState extends State<_CountdownChip>
     // Neutral wash, not accent: an informational timer must not read with
     // the same urgency-class as pending proposals — the ON toggle is the
     // scheduled footer's single accent.
-    return Container(
-      padding: EdgeInsets.only(left: tokens.spacing.step3),
-      decoration: BoxDecoration(
-        color: ai.subtleWashStrong,
-        borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            context.messages.taskAgentNextUpdateIn(
-              formatCountdown(countdownSeconds),
-            ),
-            style: tokens.typography.styles.others.caption.copyWith(
-              color: ai.metaText,
-              fontFeatures: const [FontFeature.tabularFigures()],
-            ),
-          ),
-          Semantics(
-            button: true,
-            label: widget.cancelTooltip,
-            excludeSemantics: true,
-            child: Tooltip(
-              message: widget.cancelTooltip,
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  onTap: widget.onCancel,
-                  borderRadius: BorderRadius.circular(
-                    tokens.radii.badgesPills,
-                  ),
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: tokens.spacing.step3,
-                      vertical: tokens.spacing.step2,
-                    ),
-                    child: Icon(
-                      Icons.close_rounded,
-                      size: tokens.spacing.step4,
-                      color: ai.metaText,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: constraints.maxWidth),
+          child: Stack(
+            alignment: Alignment.centerLeft,
+            children: [
+              Positioned.fill(
+                top: tokens.spacing.step2,
+                bottom: tokens.spacing.step2,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: ai.subtleWashStrong,
+                    borderRadius: BorderRadius.circular(
+                      tokens.radii.badgesPills,
                     ),
                   ),
                 ),
               ),
-            ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Padding(
+                      padding: EdgeInsets.only(left: tokens.spacing.step3),
+                      child: Text(
+                        context.messages.taskAgentNextUpdateIn(
+                          formatCountdown(countdownSeconds),
+                        ),
+                        style: tokens.typography.styles.others.caption.copyWith(
+                          color: ai.metaText,
+                          fontFeatures: const [FontFeature.tabularFigures()],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Semantics(
+                    button: true,
+                    label: widget.cancelTooltip,
+                    excludeSemantics: true,
+                    child: Tooltip(
+                      message: widget.cancelTooltip,
+                      child: Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          onTap: widget.onCancel,
+                          borderRadius: BorderRadius.circular(
+                            tokens.radii.badgesPills,
+                          ),
+                          child: SizedBox(
+                            key: const ValueKey(
+                              'taskAgentCancelCountdownTarget',
+                            ),
+                            width: tokens.spacing.step9,
+                            height: tokens.spacing.step9,
+                            child: Center(
+                              child: Icon(
+                                Icons.close_rounded,
+                                size: tokens.spacing.step4,
+                                color: ai.metaText,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/agents/ui/task_agent_controls_footer.dart
+++ b/lib/features/agents/ui/task_agent_controls_footer.dart
@@ -72,6 +72,8 @@ class TaskAgentControlsFooter extends StatelessWidget {
     Widget automationControls({required bool expandLabel}) {
       final label = Text(
         messages.taskAgentAutomaticUpdatesLabel,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: tokens.typography.styles.others.caption.copyWith(
           color: ai.metaText,
         ),
@@ -79,7 +81,7 @@ class TaskAgentControlsFooter extends StatelessWidget {
       return Row(
         mainAxisSize: expandLabel ? MainAxisSize.max : MainAxisSize.min,
         children: [
-          if (expandLabel) Expanded(child: label) else label,
+          if (expandLabel) Expanded(child: label) else Flexible(child: label),
           SizedBox(width: tokens.spacing.step2),
           ConstrainedBox(
             key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
@@ -115,9 +117,9 @@ class TaskAgentControlsFooter extends StatelessWidget {
       ),
       padding: EdgeInsets.fromLTRB(
         tokens.spacing.cardPadding,
-        tokens.spacing.step3,
+        tokens.spacing.step2,
         tokens.spacing.cardPadding,
-        tokens.spacing.step3,
+        tokens.spacing.step2,
       ),
       // The wash band spans the card, but the content snaps to the same
       // reading measure as the summary and the proposal rows — one shared
@@ -160,7 +162,7 @@ class TaskAgentControlsFooter extends StatelessWidget {
                           ),
                   ),
                 ),
-                SizedBox(height: tokens.spacing.step2),
+                SizedBox(height: tokens.spacing.step1),
               ],
               LayoutBuilder(
                 builder: (context, constraints) {
@@ -178,22 +180,29 @@ class TaskAgentControlsFooter extends StatelessWidget {
                           data: identityData,
                           onSetupTap: onSetupTap,
                         ),
-                        SizedBox(height: tokens.spacing.step2),
+                        SizedBox(height: tokens.spacing.step1),
                         automationControls(expandLabel: true),
                       ],
                     );
                   }
                   return Row(
                     key: const ValueKey('taskAgentFooterWideLayout'),
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Expanded(
+                      Flexible(
                         child: TaskAgentIdentityRegion(
                           data: identityData,
                           onSetupTap: onSetupTap,
                         ),
                       ),
-                      SizedBox(width: tokens.spacing.step3),
-                      automationControls(expandLabel: false),
+                      Flexible(
+                        child: Padding(
+                          padding: EdgeInsets.only(
+                            left: tokens.spacing.step3,
+                          ),
+                          child: automationControls(expandLabel: false),
+                        ),
+                      ),
                     ],
                   );
                 },
@@ -284,6 +293,8 @@ class _CountdownChipState extends State<_CountdownChip>
                           color: ai.metaText,
                           fontFeatures: const [FontFeature.tabularFigures()],
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                   ),

--- a/lib/features/agents/ui/task_agent_freshness_strip.dart
+++ b/lib/features/agents/ui/task_agent_freshness_strip.dart
@@ -37,7 +37,7 @@ class TaskAgentFreshnessStrip extends StatelessWidget {
   /// full-size pill. Sized for the English message + labeled CTA with
   /// localization headroom; a fixed layout breakpoint like the
   /// reading-measure caps.
-  static const double _compactWidth = 440;
+  static const double compactWidth = 440;
 
   @override
   Widget build(BuildContext context) {
@@ -90,7 +90,7 @@ class TaskAgentFreshnessStrip extends StatelessWidget {
       label: isRunning
           ? messages.aiSummaryThinkingLabel
           : messages.taskAgentWakeAgent,
-      enabled: onRunNow != null,
+      enabled: onRunNow != null && !isRunning,
       excludeSemantics: true,
       child: Tooltip(
         message: messages.taskAgentWakeAgent,
@@ -102,8 +102,8 @@ class TaskAgentFreshnessStrip extends StatelessWidget {
             customBorder: const CircleBorder(),
             onTap: isRunning ? null : onRunNow,
             child: SizedBox(
-              width: tokens.spacing.step8,
-              height: tokens.spacing.step8,
+              width: tokens.spacing.step9,
+              height: tokens.spacing.step9,
               child: Center(
                 child: Container(
                   width: tokens.spacing.step7,
@@ -164,7 +164,7 @@ class TaskAgentFreshnessStrip extends StatelessWidget {
       // translation still overflows.
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final compact = constraints.maxWidth < _compactWidth;
+          final compact = constraints.maxWidth < compactWidth;
           return Row(
             children: [
               Expanded(child: messageLine),

--- a/lib/features/agents/ui/task_agent_freshness_strip.dart
+++ b/lib/features/agents/ui/task_agent_freshness_strip.dart
@@ -93,7 +93,9 @@ class TaskAgentFreshnessStrip extends StatelessWidget {
       enabled: onRunNow != null && !isRunning,
       excludeSemantics: true,
       child: Tooltip(
-        message: messages.taskAgentWakeAgent,
+        message: isRunning
+            ? messages.aiSummaryThinkingLabel
+            : messages.taskAgentWakeAgent,
         child: Material(
           color: Colors.transparent,
           shape: const CircleBorder(),

--- a/lib/features/agents/ui/task_agent_identity_region.dart
+++ b/lib/features/agents/ui/task_agent_identity_region.dart
@@ -111,7 +111,7 @@ class _SetupIdentityRow extends StatelessWidget {
         : ai.metaText;
     final iconColor = isError
         ? tokens.colors.alert.error.defaultColor
-        : ai.faintMeta;
+        : ai.metaText;
     return Semantics(
       button: true,
       label: semanticsLabel,
@@ -126,9 +126,7 @@ class _SetupIdentityRow extends StatelessWidget {
             onTap: onTap,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             child: ConstrainedBox(
-              // step8 keeps a compliant tap height without the dead band a
-              // 48px floor put around one caption line.
-              constraints: BoxConstraints(minHeight: tokens.spacing.step8),
+              constraints: BoxConstraints(minHeight: tokens.spacing.step9),
               // Shrink-wrapped so the chevron hugs the value instead of
               // drifting to the far row end next to unrelated controls.
               child: Row(
@@ -187,12 +185,12 @@ class _ReportIdentityRow extends StatelessWidget {
           Icon(
             Icons.description_outlined,
             size: tokens.spacing.step5,
-            color: ai.faintMeta,
+            color: ai.metaText,
           ),
           SizedBox(width: tokens.spacing.step2),
           Text(
             label,
-            style: caption.copyWith(color: ai.faintMeta),
+            style: caption.copyWith(color: ai.metaText),
           ),
           SizedBox(width: tokens.spacing.step2),
           Expanded(

--- a/lib/features/agents/ui/task_agent_identity_region.dart
+++ b/lib/features/agents/ui/task_agent_identity_region.dart
@@ -126,7 +126,7 @@ class _SetupIdentityRow extends StatelessWidget {
             onTap: onTap,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             child: ConstrainedBox(
-              constraints: BoxConstraints(minHeight: tokens.spacing.step9),
+              constraints: BoxConstraints(minHeight: tokens.spacing.step8),
               // Shrink-wrapped so the chevron hugs the value instead of
               // drifting to the far row end next to unrelated controls.
               child: Row(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1054+4227
+version: 0.9.1054+4228
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/ui/ai_summary_card/proposal_row_widgets_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposal_row_widgets_part_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../test_data/change_set_factories.dart';
@@ -90,5 +92,29 @@ void main() {
         expect(find.textContaining('Update · '), findsOneWidget);
       },
     );
+
+    testWidgets('proposal prose uses the unmodified bodySmall metrics', (
+      tester,
+    ) async {
+      final bench = AgentTestBench(
+        suggestions: UnifiedSuggestionList(
+          open: [_pending('set_task_status')],
+          activity: const [],
+        ),
+      );
+
+      await tester.pumpWidget(bench.build());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final text = tester.widget<Text>(
+        find.textContaining('Status · Body for set_task_status'),
+      );
+      final context = tester.element(find.byType(Text).first);
+      final bodySmall = context.designTokens.typography.styles.body.bodySmall;
+      expect(text.style?.fontSize, bodySmall.fontSize);
+      expect(text.style?.height, bodySmall.height);
+      expect(text.style?.fontWeight, bodySmall.fontWeight);
+    });
   });
 }

--- a/test/features/agents/ui/ai_summary_card/proposals_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposals_test.dart
@@ -16,7 +16,7 @@ import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart'
 import 'package:lotti/features/agents/ui/ai_summary_card/proposals_section_part.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/motion/size_fade_entrance.dart';
-import 'package:lotti/features/design_system/theme/motion_tokens.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -845,11 +845,16 @@ void main() {
           of: find.textContaining('History · 1'),
           matching: find.byType(InkWell),
         );
+        final context = tester.element(find.byType(ProposalsSection));
         final confirmAll = find.ancestor(
           of: find.text('Confirm all'),
           matching: find.byType(DesignSystemButton),
         );
         expect(tester.getRect(history).left, closeTo(rail.left, 0.01));
+        expect(
+          tester.getSize(history).height,
+          greaterThanOrEqualTo(context.designTokens.spacing.step8),
+        );
         expect(tester.getRect(confirmAll).right, closeTo(rail.right, 0.01));
         expect(
           tester.getSemantics(history),

--- a/test/features/agents/ui/ai_summary_card/proposals_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposals_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposals_section_part.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/motion/size_fade_entrance.dart';
 import 'package:lotti/features/design_system/theme/motion_tokens.dart';
 import 'package:lotti/utils/consts.dart';
@@ -806,6 +807,81 @@ void main() {
     });
   });
   group('AiSummaryCard – History', () {
+    testWidgets(
+      'bottom rail distributes History left and Confirm all right',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        final bench = AgentTestBench(
+          suggestions: UnifiedSuggestionList(
+            open: [
+              makePending(
+                id: 'open-a',
+                toolName: 'set_task_status',
+                humanSummary: 'Set status to GROOMED',
+              ),
+              makePending(
+                id: 'open-b',
+                toolName: 'update_task_priority',
+                humanSummary: 'Raise priority to P1',
+              ),
+            ],
+            activity: [
+              makeLedgerEntry(
+                id: 'history-a',
+                status: ChangeItemStatus.confirmed,
+              ),
+            ],
+          ),
+        );
+
+        await tester.pumpWidget(bench.build());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final rail = tester.getRect(
+          find.byKey(const ValueKey('proposalBottomRail')),
+        );
+        final history = find.ancestor(
+          of: find.textContaining('History · 1'),
+          matching: find.byType(InkWell),
+        );
+        final confirmAll = find.ancestor(
+          of: find.text('Confirm all'),
+          matching: find.byType(DesignSystemButton),
+        );
+        expect(tester.getRect(history).left, closeTo(rail.left, 0.01));
+        expect(tester.getRect(confirmAll).right, closeTo(rail.right, 0.01));
+        expect(
+          tester.getSemantics(history),
+          matchesSemantics(
+            label: 'History · 1',
+            isButton: true,
+            isFocusable: true,
+            hasExpandedState: true,
+            hasFocusAction: true,
+            hasTapAction: true,
+          ),
+        );
+
+        await tester.tap(history);
+        await tester.pump();
+
+        expect(
+          tester.getSemantics(history),
+          matchesSemantics(
+            label: 'History · 1',
+            isButton: true,
+            isFocusable: true,
+            hasExpandedState: true,
+            isExpanded: true,
+            hasFocusAction: true,
+            hasTapAction: true,
+          ),
+        );
+        semantics.dispose();
+      },
+    );
+
     testWidgets('History toggle expands and collapses resolved entries', (
       tester,
     ) async {

--- a/test/features/agents/ui/ai_summary_card/screenshots_test.dart
+++ b/test/features/agents/ui/ai_summary_card/screenshots_test.dart
@@ -1,6 +1,6 @@
 /// Deterministic design-review captures for the task-agent summary card.
 ///
-/// The same two interaction states are rendered at desktop and mobile widths
+/// The same interaction states are rendered at desktop and phone widths
 /// in dark and light mode. This matrix is intentionally reused for baseline,
 /// iteration, and final captures so expert-panel comparisons judge the same
 /// content, viewport, and state every time.
@@ -32,6 +32,12 @@ import 'test_bench.dart';
 
 const _subdir = 'task_agent_card';
 final _now = DateTime(2026, 7, 16, 21);
+
+// Production centers task content in a 760px column with 15px horizontal
+// insets (`TaskDetailsPage`), leaving a 730px card. Keep desktop captures at
+// that real rendered width instead of stretching the card across the whole
+// screenshot device and creating layout artifacts users never see.
+const _desktopCardWidth = 730.0;
 
 const _summary =
     'New task created from audio dictation about making task agent auto-wake '
@@ -156,7 +162,7 @@ Future<void> _capture(
               : DesignSystemTheme.light(),
           surfaceConstraints: BoxConstraints.tight(device.size),
           padding: padding,
-          width: isDesktop ? device.size.width - 80 : device.size.width - 24,
+          width: isDesktop ? _desktopCardWidth : device.size.width - 24,
         ).build(),
       ),
     );
@@ -194,7 +200,7 @@ void main() {
 
   setUpAll(loadScreenshotFonts);
 
-  for (final device in [desktopDevice, proDevice]) {
+  for (final device in [desktopDevice, proDevice, miniDevice]) {
     for (final brightness in [Brightness.dark, Brightness.light]) {
       for (final automaticUpdates in [true, false]) {
         final theme = brightness == Brightness.dark ? 'dark' : 'light';

--- a/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/tldr_section_part.dart';
+import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tts/ui/widgets/tts_play_button.dart';
 
 import '../../../../widget_test_utils.dart';
@@ -74,6 +76,82 @@ void main() {
   });
 
   group('TldrBody', () {
+    testWidgets('uses editor-aligned bodySmall for all report prose', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidget(const _DisclosureHarness()),
+      );
+
+      final context = tester.element(find.byType(TldrBody));
+      final styles = context.designTokens.typography.styles.body;
+      final collapsedView = tester.widget<AgentMarkdownView>(
+        find.byType(AgentMarkdownView),
+      );
+
+      expect(collapsedView.style?.fontSize, styles.bodySmall.fontSize);
+      expect(collapsedView.style?.fontSize, isNot(styles.bodyMedium.fontSize));
+
+      await tester.tap(find.text('Read more'));
+      await tester.pump();
+
+      final expandedViews = tester
+          .widgetList<AgentMarkdownView>(find.byType(AgentMarkdownView))
+          .toList();
+      expect(expandedViews, hasLength(2));
+      for (final view in expandedViews) {
+        expect(view.style?.fontSize, styles.bodySmall.fontSize);
+        expect(view.style?.fontWeight, styles.bodySmall.fontWeight);
+        expect(view.style?.fontFamily, styles.bodySmall.fontFamily);
+      }
+    });
+
+    testWidgets('disclosure has a step9 target and reports expansion', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        makeTestableWidget(const _DisclosureHarness()),
+      );
+
+      final disclosure = find.byKey(
+        const ValueKey('taskAgentReportDisclosure'),
+      );
+      final context = tester.element(find.byType(TldrBody));
+      expect(
+        tester.getSize(disclosure).height,
+        greaterThanOrEqualTo(context.designTokens.spacing.step9),
+      );
+      expect(
+        tester.getSemantics(disclosure),
+        matchesSemantics(
+          label: 'Read more',
+          isButton: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          hasFocusAction: true,
+          hasTapAction: true,
+        ),
+      );
+
+      await tester.tap(disclosure);
+      await tester.pump();
+
+      expect(
+        tester.getSemantics(disclosure),
+        matchesSemantics(
+          label: 'Show less',
+          isButton: true,
+          isFocusable: true,
+          hasExpandedState: true,
+          isExpanded: true,
+          hasFocusAction: true,
+          hasTapAction: true,
+        ),
+      );
+      semantics.dispose();
+    });
+
     testWidgets('places disclosure below its summary and expands in place', (
       tester,
     ) async {

--- a/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
@@ -106,7 +106,7 @@ void main() {
       }
     });
 
-    testWidgets('disclosure has a step9 target and reports expansion', (
+    testWidgets('disclosure has a compact step8 target and reports expansion', (
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
@@ -120,7 +120,7 @@ void main() {
       final context = tester.element(find.byType(TldrBody));
       expect(
         tester.getSize(disclosure).height,
-        greaterThanOrEqualTo(context.designTokens.spacing.step9),
+        greaterThanOrEqualTo(context.designTokens.spacing.step8),
       );
       expect(
         tester.getSemantics(disclosure),

--- a/test/features/agents/ui/task_agent_controls_footer_test.dart
+++ b/test/features/agents/ui/task_agent_controls_footer_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 import '../../../widget_test_utils.dart';
 
@@ -73,6 +74,10 @@ void main() {
       find.text('Qwen 3.5 Plus · Alibaba · via Melious.ai'),
       findsOneWidget,
     );
+    expect(
+      find.byKey(const ValueKey('taskAgentFooterWideLayout')),
+      findsOneWidget,
+    );
 
     await tester.tap(find.byKey(const ValueKey('taskAgentWakeButton')));
     expect(wakes, 1);
@@ -124,6 +129,17 @@ void main() {
         // The chip itself is informational — only the close button cancels.
         await tester.tap(find.text('Next update in 1:30'));
         expect(cancellations, 0);
+        final context = tester.element(
+          find.byType(TaskAgentControlsFooter),
+        );
+        expect(
+          tester.getSize(
+            find.byKey(
+              const ValueKey('taskAgentCancelCountdownTarget'),
+            ),
+          ),
+          Size.square(context.designTokens.spacing.step9),
+        );
         await tester.tap(find.byIcon(Icons.close_rounded));
       });
 
@@ -246,5 +262,73 @@ void main() {
 
     await tester.tap(find.text('Qwen 3.5 Plus · Alibaba · via Melious.ai'));
     expect(setupTaps, 1);
+  });
+
+  testWidgets(
+    'narrow German footer stacks identity above untruncated automation',
+    (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Center(
+            child: SizedBox(
+              width: 360,
+              child: subject(showWakeButton: false),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(360, 800)),
+          locale: const Locale('de'),
+        ),
+      );
+
+      expect(
+        find.byKey(const ValueKey('taskAgentFooterCompactLayout')),
+        findsOneWidget,
+      );
+      final identity = find.textContaining('Qwen 3.5 Plus').first;
+      final automation = find.text('Automatische Aktualisierungen');
+      expect(automation, findsOneWidget);
+      expect(
+        tester.getBottomLeft(identity).dy,
+        lessThan(tester.getTopLeft(automation).dy),
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('large text selects the compact footer layout', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Center(
+          child: SizedBox(
+            width: 700,
+            child: subject(showWakeButton: false),
+          ),
+        ),
+        mediaQueryData: const MediaQueryData(
+          size: Size(700, 800),
+          textScaler: TextScaler.linear(1.5),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey('taskAgentFooterCompactLayout')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('automatic-updates control has a step9 interaction slot', (
+    tester,
+  ) async {
+    await tester.pumpWidget(makeTestableWidget(subject()));
+
+    final context = tester.element(find.byType(TaskAgentControlsFooter));
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('taskAgentAutomaticUpdatesTarget')),
+      ),
+      Size.square(context.designTokens.spacing.step9),
+    );
   });
 }

--- a/test/features/agents/ui/task_agent_controls_footer_test.dart
+++ b/test/features/agents/ui/task_agent_controls_footer_test.dart
@@ -318,6 +318,70 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets(
+    'wide German automation label stays single-line under constrained width',
+    (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Center(
+            child: SizedBox(
+              width: 520,
+              child: subject(showWakeButton: false),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(
+            size: Size(520, 800),
+            textScaler: TextScaler.linear(1.2),
+          ),
+          locale: const Locale('de'),
+        ),
+      );
+
+      expect(
+        find.byKey(const ValueKey('taskAgentFooterWideLayout')),
+        findsOneWidget,
+      );
+      final label = tester.widget<Text>(
+        find.text('Automatische Aktualisierungen'),
+      );
+      expect(label.maxLines, 1);
+      expect(label.overflow, TextOverflow.ellipsis);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('localized countdown stays single-line at phone width', (
+    tester,
+  ) async {
+    final now = DateTime(2026, 7, 16, 9);
+    await withClock(Clock.fixed(now), () async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Center(
+            child: SizedBox(
+              width: 360,
+              child: subject(
+                automaticUpdatesEnabled: true,
+                showCountdown: true,
+                nextWakeAt: now.add(
+                  const Duration(minutes: 1, seconds: 30),
+                ),
+                onRunNow: () {},
+              ),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(360, 800)),
+          locale: const Locale('de'),
+        ),
+      );
+    });
+
+    final countdown = tester.widget<Text>(find.textContaining('1:30'));
+    expect(countdown.maxLines, 1);
+    expect(countdown.overflow, TextOverflow.ellipsis);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('automatic-updates control has a step9 interaction slot', (
     tester,
   ) async {

--- a/test/features/agents/ui/task_agent_freshness_strip_test.dart
+++ b/test/features/agents/ui/task_agent_freshness_strip_test.dart
@@ -178,6 +178,8 @@ void main() {
       );
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byTooltip('Thinking…'), findsOneWidget);
+      expect(find.byTooltip('Wake agent'), findsNothing);
       expect(
         tester.getSemantics(
           find.byKey(const ValueKey('taskAgentWakeIconButton')),

--- a/test/features/agents/ui/task_agent_freshness_strip_test.dart
+++ b/test/features/agents/ui/task_agent_freshness_strip_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/ui/task_agent_freshness_strip.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 import '../../../widget_test_utils.dart';
 
@@ -141,6 +142,13 @@ void main() {
         find.byKey(const ValueKey('taskAgentWakeIconButton')),
         findsOneWidget,
       );
+      final context = tester.element(find.byType(TaskAgentFreshnessStrip));
+      expect(
+        tester.getSize(
+          find.byKey(const ValueKey('taskAgentWakeIconButton')),
+        ),
+        Size.square(context.designTokens.spacing.step9),
+      );
       expect(find.byTooltip('Wake agent'), findsOneWidget);
 
       await tester.tap(
@@ -170,6 +178,16 @@ void main() {
       );
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(
+        tester.getSemantics(
+          find.byKey(const ValueKey('taskAgentWakeIconButton')),
+        ),
+        matchesSemantics(
+          label: 'Thinking…',
+          isButton: true,
+          hasEnabledState: true,
+        ),
+      );
       await tester.tap(
         find.byKey(const ValueKey('taskAgentWakeIconButton')),
       );

--- a/test/features/agents/ui/task_agent_identity_region_test.dart
+++ b/test/features/agents/ui/task_agent_identity_region_test.dart
@@ -18,7 +18,7 @@ void main() {
     runtimeSettings: {},
   );
 
-  testWidgets('combined row is tappable, accessible, and at least step9 high', (
+  testWidgets('combined row is tappable, accessible, and at least step8 high', (
     tester,
   ) async {
     var taps = 0;
@@ -43,7 +43,7 @@ void main() {
     final context = tester.element(find.byType(TaskAgentIdentityRegion));
     expect(
       tester.getSize(inkWell).height,
-      greaterThanOrEqualTo(context.designTokens.spacing.step9),
+      greaterThanOrEqualTo(context.designTokens.spacing.step8),
     );
     for (final icon in tester.widgetList<Icon>(find.byType(Icon))) {
       expect(icon.color, context.designTokens.colors.aiCard.metaText);

--- a/test/features/agents/ui/task_agent_identity_region_test.dart
+++ b/test/features/agents/ui/task_agent_identity_region_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/agents/model/agent_report_provenance.dart';
 import 'package:lotti/features/agents/ui/task_agent_identity_region.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 import '../../../widget_test_utils.dart';
 
@@ -17,7 +18,7 @@ void main() {
     runtimeSettings: {},
   );
 
-  testWidgets('combined row is tappable, accessible, and at least 40 high', (
+  testWidgets('combined row is tappable, accessible, and at least step9 high', (
     tester,
   ) async {
     var taps = 0;
@@ -39,7 +40,14 @@ void main() {
       findsOneWidget,
     );
     final inkWell = find.byType(InkWell).first;
-    expect(tester.getSize(inkWell).height, greaterThanOrEqualTo(40));
+    final context = tester.element(find.byType(TaskAgentIdentityRegion));
+    expect(
+      tester.getSize(inkWell).height,
+      greaterThanOrEqualTo(context.designTokens.spacing.step9),
+    );
+    for (final icon in tester.widgetList<Icon>(find.byType(Icon))) {
+      expect(icon.color, context.designTokens.colors.aiCard.metaText);
+    }
     expect(
       find.bySemanticsLabel(
         RegExp('This report and current setup use Qwen 3.5 Plus'),


### PR DESCRIPTION
## Summary

- align Task Agent report and proposal prose with the shared `body.bodySmall` typography used by editor entries and compact card summaries
- simplify visual hierarchy by removing the accent glow, strengthening meaningful metadata contrast, and distributing History / Confirm all across the proposal rail
- improve operation at narrow widths and large text scales with a responsive footer, tokenized `spacing.step9` action targets, denser `spacing.step8` quiet rows, and expanded-state semantics
- preserve the release build bump to `0.9.1054+4228` and update the Agents README, changelog, and Flatpak metadata

## Root cause

The report body used the larger `bodyMedium` token while proposal prose added one-off line-height and weight overrides. The footer also assumed a single horizontal identity/automation row and several compact affordances used visual-size hit areas. Together those choices made the card busier than neighboring editor and task-card surfaces and less robust at constrained widths.

## Screenshots

### Desktop proposals — dark

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/before-actual-width/desktop_proposals_dark.png" width="700" alt="Task Agent proposals before cleanup, dark desktop"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/desktop_proposals_dark.png" width="700" alt="Task Agent proposals after cleanup, dark desktop"> |

### Scheduled state — light phone

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/before-actual-width/pro_scheduled_light.png" width="390" alt="Task Agent scheduled state before cleanup, light phone"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/pro_scheduled_light.png" width="390" alt="Task Agent scheduled state after cleanup, light phone"> |

<details>
<summary>Additional after states</summary>

| Mini manual — dark | Mini scheduled — light | Mini proposals — dark |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/mini_manual_dark.png" width="260" alt="Task Agent manual state after cleanup, dark mini phone"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/mini_scheduled_light.png" width="260" alt="Task Agent scheduled state after cleanup, light mini phone"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/mini_proposals_dark.png" width="260" alt="Task Agent proposals after cleanup, dark mini phone"> |

| Desktop manual — dark | Desktop scheduled — light | Desktop proposals — light |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/desktop_manual_dark.png" width="360" alt="Task Agent manual state after cleanup, dark desktop"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/desktop_scheduled_light.png" width="360" alt="Task Agent scheduled state after cleanup, light desktop"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/38eb5040d71d10d17cffc3e2fb77905099512047/pr-screenshots/task-agent-card-cleanliness/after-density/desktop_proposals_light.png" width="360" alt="Task Agent proposals after cleanup, light desktop"> |

</details>

## Validation

- `fvm flutter analyze --no-pub` — no issues
- focused Task Agent card and supporting widget tests — 119 passed; the opt-in screenshot test was intentionally skipped in this run
- screenshot harness — 18/18 desktop, phone, and mini-phone dark/light states passed
- the approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cleaner, more compact Task AI summaries with improved metadata readability, stronger alignment across summary areas, and better responsive behavior for narrow screens and larger text.
  * Enhanced accessibility and usability: larger interaction targets, refined semantics for disclosure/history controls, and improved secondary control tap areas.

* **Bug Fixes**
  * Refined footer and card visuals: more consistent bottom-rail wrapping, updated countdown/wake interactions (including “thinking” behavior while running), and improved typography styling via design tokens.

* **Documentation**
  * Updated changelog, release-note entry, and AI summary card documentation to match the new layouts and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->