### PR TITLE
fix: tighten task agent footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 - **Prefer `tester.pump(duration)` over `tester.pumpAndSettle()`.** `pumpAndSettle` has a default 10-second timeout and will hang if animations never settle. Use it only when you genuinely need all animations to complete, and never pass a duration > 1 second.
 - **Use `fakeAsync` for unit/service tests** that involve timers, delays, retries, or debounce. See `test/test_utils/retry_fake_time.dart` and `test/test_utils/pump_retry_time.dart` for helpers.
 - **Use deterministic dates.** Never use `DateTime.now()` in tests. Use specific dates like `DateTime(2024, 3, 15)`.
+- **Time-driven UI must never jump.** Any visible count-up or countdown must use tabular figures and stable geometry so digit changes, minute/hour transitions, and format-length changes do not move adjacent controls or trigger responsive reflow. Reserve space for the supported format or isolate the changing label inside a fixed layout region. Add a deterministic widget regression test that crosses representative digit/format boundaries and asserts that the timer and neighboring widgets keep the same size and position.
 
 ## Commit & Pull Request Guidelines
 - Use Conventional Commits (e.g., `feat:`, `fix:`, `chore:`, `ci:`). Keep subjects concise and imperative.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Scheduled updates and their switch now form one responsive automation group
   beside the model on wide cards and above it on phones; countdown ticks no
   longer shift neighboring controls. Canceling automation while an update is
-  pending also keeps the summary correctly marked as out of date.
+  pending also keeps the summary correctly marked as out of date. Accepting
+  task-agent suggestions no longer shifts the task detail scroll position when
+  checklist and proposal content resize together.
 - **Date pickers now start the week according to your device region.** Entry
   dates, entry ranges, due dates, and project target dates show Monday first in
   European regions and Sunday first in the US, including matching weekday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Report and proposal text now match editor entries and card summaries, quiet
   metadata is easier to read, secondary controls have larger interaction
   targets, and the footer adapts cleanly to narrow layouts and larger text.
-  Scheduled-update, model, and automation controls now form a tighter,
-  intentional footer group; canceling automation while an update is pending
-  also keeps the summary correctly marked as out of date.
+  Scheduled updates and their switch now form one responsive automation group
+  beside the model on wide cards and above it on phones; countdown ticks no
+  longer shift neighboring controls. Canceling automation while an update is
+  pending also keeps the summary correctly marked as out of date.
 - **Date pickers now start the week according to your device region.** Entry
   dates, entry ranges, due dates, and project target dates show Monday first in
   European regions and Sunday first in the US, including matching weekday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Report and proposal text now match editor entries and card summaries, quiet
   metadata is easier to read, secondary controls have larger interaction
   targets, and the footer adapts cleanly to narrow layouts and larger text.
+  Scheduled-update, model, and automation controls now form a tighter,
+  intentional footer group; canceling automation while an update is pending
+  also keeps the summary correctly marked as out of date.
 - **Date pickers now start the week according to your device region.** Entry
   dates, entry ranges, due dates, and project target dates show Monday first in
   European regions and Sunday first in the US, including matching weekday

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,7 +35,7 @@
   <releases>
     <release version="0.9.1054" date="2026-07-18">
       <description>
-        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, and scheduled updates plus their switch form one responsive footer group beside the model on wide cards and above it on phones. Countdown ticks no longer shift neighboring controls, and turning off automation during a pending update keeps the summary correctly marked as out of date.</p>
+        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, and scheduled updates plus their switch form one responsive footer group beside the model on wide cards and above it on phones. Countdown ticks no longer shift neighboring controls, turning off automation during a pending update keeps the summary correctly marked as out of date, and accepting suggestions keeps the task detail scroll position stable while checklist and proposal content resize.</p>
         <p>Date pickers now follow the device region's week order. Entry dates, entry ranges, due dates, and project target dates start on Monday in European regions and Sunday in the US, with matching weekday headers and calendar-day positions.</p>
         <p>Screen-reader controls now expose one clear actionable announcement with their label and state. New accessibility labels are also available in Danish, Swedish, and Dutch.</p>
         <p>Matrix sync now finishes catching up after reconnecting during a large burst, even on poor networks. Reconnected devices recover every missed entry instead of stopping after a partial server page.</p>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,7 +35,7 @@
   <releases>
     <release version="0.9.1054" date="2026-07-18">
       <description>
-        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, and scheduled-update, model, and automation controls form a tighter footer that adapts cleanly to narrow layouts and larger text. Turning off automation during a pending update also keeps the summary correctly marked as out of date.</p>
+        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, and scheduled updates plus their switch form one responsive footer group beside the model on wide cards and above it on phones. Countdown ticks no longer shift neighboring controls, and turning off automation during a pending update keeps the summary correctly marked as out of date.</p>
         <p>Date pickers now follow the device region's week order. Entry dates, entry ranges, due dates, and project target dates start on Monday in European regions and Sunday in the US, with matching weekday headers and calendar-day positions.</p>
         <p>Screen-reader controls now expose one clear actionable announcement with their label and state. New accessibility labels are also available in Danish, Swedish, and Dutch.</p>
         <p>Matrix sync now finishes catching up after reconnecting during a large burst, even on poor networks. Reconnected devices recover every missed entry instead of stopping after a partial server page.</p>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,7 +35,7 @@
   <releases>
     <release version="0.9.1054" date="2026-07-18">
       <description>
-        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, secondary controls have larger interaction targets, and the footer adapts cleanly to narrow layouts and larger text.</p>
+        <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, and scheduled-update, model, and automation controls form a tighter footer that adapts cleanly to narrow layouts and larger text. Turning off automation during a pending update also keeps the summary correctly marked as out of date.</p>
         <p>Date pickers now follow the device region's week order. Entry dates, entry ranges, due dates, and project target dates start on Monday in European regions and Sunday in the US, with matching weekday headers and calendar-day positions.</p>
         <p>Screen-reader controls now expose one clear actionable announcement with their label and state. New accessibility labels are also available in Danish, Swedish, and Dutch.</p>
         <p>Matrix sync now finishes catching up after reconnecting during a large burst, even on poor networks. Reconnected devices recover every missed entry instead of stopping after a partial server page.</p>

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -160,14 +160,18 @@ narrow widths. Proposal prose uses the same unmodified `body.bodySmall`
 metrics as the report instead of introducing a separate line height.
 
 All secondary controls live in a quiet, flat footer pinned to the card bottom
-(`TaskAgentControlsFooter`). A wake row contains either the manual `Wake
-agent` button or a self-labeled `Next update in m:ss` chip whose dedicated
-close target cancels the scheduled wake. Below it, the tappable model/provider
-identity and automatic-updates control share a row when space permits; at
-narrow widths or large text they stack without truncating the label. Primary
-and destructive controls retain the design system's `spacing.step9`
-interaction height; quiet disclosures and identity links use the denser
-`spacing.step8` row height so their captions do not create oversized bands.
+(`TaskAgentControlsFooter`). Wide cards render one compact utility rail:
+model/provider identity, wake status, and automatic updates. Narrow cards use
+two groups instead of three independent bands: wake status first, then a
+settings row with the automation label directly above model identity and the
+toggle pinned trailing. A scheduled wake is a design-system `DsPill` with a
+clock glyph; its separate `spacing.step8` close target cancels the wake without
+making the informational pill itself destructive. Running uses a
+non-interactive status row with an explicit `spacing.step3` spinner/label gap,
+rather than presenting disabled work as a loading button. Only the toggle and
+toggle retains its `spacing.step9` target, while cancel, status, and identity
+use the denser `spacing.step8` rhythm so the footer stays compact without
+becoming cramped.
 Meaningful attribution uses `aiCard.metaText` rather than the fainter
 decorative color. When setup is
 missing, the disabled toggle explains itself via an info tooltip. The filled
@@ -1971,15 +1975,19 @@ agent runtime produces:
   `Dismissed` tags and a strikethrough.
 - the wake-cycle affordances in the controls footer
   (`task_agent_controls_footer.dart`): a compact `Wake agent` button
-  (calls `TaskAgentService.triggerReanalysis`; swaps to a `Thinking…`
-  spinner while a wake runs), a self-labeled `Next update in m:ss`
-  countdown chip (`h:mm:ss` once the hour cell is needed) that calls
-  `cancelScheduledWake` on tap while a wake is scheduled, the
-  automatic-updates toggle, and the tappable model/provider identity
-  row (`TaskAgentIdentityRegion`, opens `AgentModelSheet`). While
+  (calls `TaskAgentService.triggerReanalysis`), a dedicated `Thinking…`
+  status with tokenized spinner spacing while a wake runs, a design-system
+  `DsPill` labeled `Next update in m:ss` (`h:mm:ss` once the hour cell is
+  needed) with a separate full-size cancel target that calls
+  `cancelScheduledWake`, the automatic-updates toggle, and the tappable
+  model/provider identity row (`TaskAgentIdentityRegion`, opens
+  `AgentModelSheet`). Wide cards keep these on one utility rail; narrow cards
+  keep wake status above one grouped automation/model row. While
   automation is off, `TaskAgentFreshnessStrip` directly under the
   report owns the wake CTA instead (stale warning or quiet up-to-date
-  confirmation in one constant-geometry slot).
+  confirmation in one constant-geometry slot). Disabling automation while a
+  countdown is pending first persists a stale report watermark, so clearing
+  the scheduled wake never changes an older summary to “up to date.”
 
 The card keeps the last visible suggestion list in widget state while an
 agent wake is running. If the provider briefly reloads to an empty or partial

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -160,18 +160,21 @@ narrow widths. Proposal prose uses the same unmodified `body.bodySmall`
 metrics as the report instead of introducing a separate line height.
 
 All secondary controls live in a quiet, flat footer pinned to the card bottom
-(`TaskAgentControlsFooter`). Wide cards render one compact utility rail:
-model/provider identity, wake status, and automatic updates. Narrow cards use
-two groups instead of three independent bands: wake status first, then a
-settings row with the automation label directly above model identity and the
-toggle pinned trailing. A scheduled wake is a design-system `DsPill` with a
-clock glyph; its separate `spacing.step8` close target cancels the wake without
-making the informational pill itself destructive. Running uses a
-non-interactive status row with an explicit `spacing.step3` spinner/label gap,
-rather than presenting disabled work as a loading button. Only the toggle and
-toggle retains its `spacing.step9` target, while cancel, status, and identity
-use the denser `spacing.step8` rhythm so the footer stays compact without
-becoming cramped.
+(`TaskAgentControlsFooter`). Wake status and automatic updates share one
+bounded automation cluster instead of reading as unrelated controls. Wide
+cards place model/provider identity beside that cluster. Narrow cards place
+the cluster first and wrap identity below; within the cluster, wake status and
+the automatic-updates setting also wrap when their localized content cannot
+share a line. A scheduled wake is a design-system `DsPill` with a clock glyph;
+its separate `spacing.step8` close target cancels the wake without making the
+informational pill itself destructive. The countdown uses tabular figures and
+reserves its initial formatted-label width, so minute/hour digit transitions
+cannot move the pill, toggle, model identity, or responsive wrap point.
+Running uses a non-interactive status row with an explicit `spacing.step3`
+spinner/label gap and defensive single-line truncation rather than presenting
+disabled work as a loading button. The toggle retains its `spacing.step9`
+target, while cancel, status, and identity use the denser `spacing.step8`
+rhythm so the footer stays compact without becoming cramped.
 Meaningful attribution uses `aiCard.metaText` rather than the fainter
 decorative color. When setup is
 missing, the disabled toggle explains itself via an info tooltip. The filled
@@ -1981,8 +1984,11 @@ agent runtime produces:
   needed) with a separate full-size cancel target that calls
   `cancelScheduledWake`, the automatic-updates toggle, and the tappable
   model/provider identity row (`TaskAgentIdentityRegion`, opens
-  `AgentModelSheet`). Wide cards keep these on one utility rail; narrow cards
-  keep wake status above one grouped automation/model row. While
+  `AgentModelSheet`). The countdown and toggle form one bounded automation
+  cluster. Wide cards keep model identity beside the cluster; narrow cards
+  wrap identity below, and the cluster wraps its own controls when needed.
+  Countdown label width is reserved for the scheduled interval so ticking
+  across digit and hour-format boundaries never causes layout movement. While
   automation is off, `TaskAgentFreshnessStrip` directly under the
   report owns the wake CTA instead (stale warning or quiet up-to-date
   confirmation in one constant-geometry slot). Disabling automation while a

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -166,15 +166,15 @@ cards place model/provider identity beside that cluster. Narrow cards place
 the cluster first and wrap identity below; within the cluster, wake status and
 the automatic-updates setting also wrap when their localized content cannot
 share a line. A scheduled wake is a design-system `DsPill` with a clock glyph;
-its separate `spacing.step8` close target cancels the wake without making the
+its separate `spacing.step9` close target cancels the wake without making the
 informational pill itself destructive. The countdown uses tabular figures and
 reserves its initial formatted-label width, so minute/hour digit transitions
 cannot move the pill, toggle, model identity, or responsive wrap point.
 Running uses a non-interactive status row with an explicit `spacing.step3`
 spinner/label gap and defensive single-line truncation rather than presenting
-disabled work as a loading button. The toggle retains its `spacing.step9`
-target, while cancel, status, and identity use the denser `spacing.step8`
-rhythm so the footer stays compact without becoming cramped.
+disabled work as a loading button. The toggle and cancel retain full-size
+`spacing.step9` targets, while status and identity use the denser
+`spacing.step8` rhythm so the footer stays compact without becoming cramped.
 Meaningful attribution uses `aiCard.metaText` rather than the fainter
 decorative color. When setup is
 missing, the disabled toggle explains itself via an info tooltip. The filled

--- a/lib/features/agents/service/task_agent_service.dart
+++ b/lib/features/agents/service/task_agent_service.dart
@@ -328,8 +328,11 @@ class TaskAgentService {
   ///
   /// Turning this on allows retained subscriptions to schedule future wakes,
   /// but never enqueues work or replays changes received while it was off.
-  /// Turning it off clears the countdown and queued automatic jobs while the
-  /// subscriptions continue observing changes and marking the report stale.
+  /// Turning it off clears the countdown and queued automatic jobs. When that
+  /// countdown represented a pending report refresh, the report is first
+  /// marked stale so removing the timer cannot make the card claim that the
+  /// older report is up to date. Subscriptions continue observing later
+  /// changes and marking the report stale while automation remains off.
   Future<void> updateAutomaticUpdates({
     required String agentId,
     required bool enabled,
@@ -349,11 +352,25 @@ class TaskAgentService {
         );
       }
 
+      final now = clock.now();
       final updated = identity.copyWith(
         config: identity.config.copyWith(automaticUpdatesEnabled: enabled),
-        updatedAt: clock.now(),
+        updatedAt: now,
       );
       await syncService.upsertEntity(updated);
+
+      if (!enabled) {
+        final state = await repository.getAgentState(agentId);
+        final pendingWake = state?.nextWakeAt;
+        if (state != null &&
+            pendingWake != null &&
+            pendingWake.isAfter(now) &&
+            !state.isReportStale) {
+          await syncService.upsertEntity(
+            state.copyWith(reportStaleAt: now, updatedAt: now),
+          );
+        }
+      }
     });
 
     if (enabled && identity.lifecycle == AgentLifecycle.active) {

--- a/lib/features/agents/ui/task_agent_controls_footer.dart
+++ b/lib/features/agents/ui/task_agent_controls_footer.dart
@@ -116,7 +116,7 @@ class TaskAgentControlsFooter extends StatelessWidget {
     )..layout();
     final automationSettingWidth =
         automationLabelPainter.width +
-        tokens.spacing.step2 +
+        tokens.spacing.step3 +
         tokens.spacing.step9;
     final automationSetting = LayoutBuilder(
       builder: (context, constraints) {
@@ -133,7 +133,7 @@ class TaskAgentControlsFooter extends StatelessWidget {
                   style: automationLabelStyle,
                 ),
               ),
-              SizedBox(width: tokens.spacing.step2),
+              SizedBox(width: tokens.spacing.step3),
               automationToggle,
             ],
           ),
@@ -347,7 +347,7 @@ class _CountdownControlState extends State<_CountdownControl>
         tokens.spacing.step4 +
         tokens.spacing.step2 +
         (tokens.spacing.step3 * 2) +
-        tokens.spacing.step8;
+        tokens.spacing.step9;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -393,13 +393,19 @@ class _CountdownControlState extends State<_CountdownControl>
                         key: const ValueKey(
                           'taskAgentCancelCountdownTarget',
                         ),
-                        width: tokens.spacing.step8,
-                        height: tokens.spacing.step8,
-                        child: Center(
-                          child: Icon(
-                            Icons.close_rounded,
-                            size: tokens.spacing.step4,
-                            color: ai.metaText,
+                        width: tokens.spacing.step9,
+                        height: tokens.spacing.step9,
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Padding(
+                            padding: EdgeInsets.only(
+                              left: tokens.spacing.step1,
+                            ),
+                            child: Icon(
+                              Icons.close_rounded,
+                              size: tokens.spacing.step4,
+                              color: ai.metaText,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/features/agents/ui/task_agent_controls_footer.dart
+++ b/lib/features/agents/ui/task_agent_controls_footer.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/agents/ui/task_agent_identity_region.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/agents/ui/wake_countdown_state.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/projects/ui/widgets/shared_widgets.dart';
@@ -12,22 +13,14 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 
 /// Quiet settings zone pinned to the bottom of the task-agent card.
 ///
-/// Hosts the secondary affordances that must stay reachable without competing
-/// with the report. Two fixed rows keep every control in one stable slot
-/// across states:
+/// Wide cards place model identity, wake status, and automation on one compact
+/// utility rail. Narrow cards use two intentional groups: wake status first,
+/// then one settings row that stacks the automation label directly above
+/// model identity with the toggle pinned trailing. This preserves full-size
+/// controls without turning every caption into its own airy footer band.
 ///
-/// 1. Wake row (present only while it has content, constant height): exactly
-///    one wake affordance per state — the manual wake button, or, while an
-///    automatic wake is scheduled, a self-explanatory informational
-///    "Next update in m:ss" chip with its own dedicated cancel button (the
-///    scheduled update *is* the pending wake, so no second button competes
-///    with it).
-/// 2. Identity row (always): the tappable model/provider line with the
-///    automatic-updates toggle pinned trailing — flipping the toggle never
-///    relocates it.
-///
-/// The wake button is also omitted while the freshness strip above owns the
-/// CTA ([showWakeButton] false).
+/// The wake control is omitted while the freshness strip above owns the CTA
+/// ([showWakeButton] false).
 class TaskAgentControlsFooter extends StatelessWidget {
   const TaskAgentControlsFooter({
     required this.automaticUpdatesEnabled,
@@ -67,43 +60,106 @@ class TaskAgentControlsFooter extends StatelessWidget {
     final messages = context.messages;
     final wakeAt = nextWakeAt;
     final countdownVisible = showCountdown && wakeAt != null;
-    final hasWakeRow = showWakeButton || countdownVisible;
+    final hasWakeControl = showWakeButton || countdownVisible;
 
-    Widget automationControls({required bool expandLabel}) {
-      final label = Text(
-        messages.taskAgentAutomaticUpdatesLabel,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: tokens.typography.styles.others.caption.copyWith(
-          color: ai.metaText,
-        ),
-      );
+    final automationLabel = Text(
+      messages.taskAgentAutomaticUpdatesLabel,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: tokens.typography.styles.others.caption.copyWith(
+        color: ai.metaText,
+      ),
+    );
+    final automationToggle = ConstrainedBox(
+      key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
+      constraints: BoxConstraints(
+        minWidth: tokens.spacing.step9,
+        minHeight: tokens.spacing.step9,
+      ),
+      child: DesignSystemToggle(
+        key: const Key('taskAgentAutomaticUpdatesCheckbox'),
+        value: automaticUpdatesEnabled,
+        semanticsLabel: messages.taskAgentAutomaticUpdatesLabel,
+        // The disabled toggle explains itself on demand instead of spending a
+        // permanent caption line on it.
+        tooltipIcon: inferenceAvailable ? null : Icons.info_outline_rounded,
+        tooltipMessage: inferenceAvailable
+            ? null
+            : messages.taskAgentAutomaticUpdatesNeedsSetup,
+        enabled: inferenceAvailable && !automationBusy,
+        onChanged: onAutomaticUpdatesChanged,
+      ),
+    );
+    final identity = TaskAgentIdentityRegion(
+      data: identityData,
+      onSetupTap: onSetupTap,
+    );
+    final wakeControl = countdownVisible
+        ? _CountdownControl(
+            nextWakeAt: wakeAt,
+            onCancel: onCancelTimer,
+            cancelTooltip: messages.taskAgentCancelTimerTooltip,
+            onExpired: onCountdownExpired,
+          )
+        : isRunning
+        ? const _ThinkingStatus()
+        : DesignSystemButton(
+            key: const ValueKey('taskAgentWakeButton'),
+            label: messages.taskAgentWakeAgent,
+            leadingIcon: Icons.refresh_rounded,
+            variant: DesignSystemButtonVariant.tertiary,
+            onPressed: inferenceAvailable ? onRunNow : null,
+          );
+
+    Widget wideUtilityRail() {
       return Row(
-        mainAxisSize: expandLabel ? MainAxisSize.max : MainAxisSize.min,
+        key: const ValueKey('taskAgentFooterWideLayout'),
         children: [
-          if (expandLabel) Expanded(child: label) else Flexible(child: label),
-          SizedBox(width: tokens.spacing.step2),
-          ConstrainedBox(
-            key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
-            constraints: BoxConstraints(
-              minWidth: tokens.spacing.step9,
-              minHeight: tokens.spacing.step9,
+          Expanded(flex: 7, child: identity),
+          if (hasWakeControl) ...[
+            SizedBox(width: tokens.spacing.cardItemSpacing),
+            Flexible(flex: 6, child: wakeControl),
+          ],
+          SizedBox(width: tokens.spacing.cardItemSpacing),
+          Flexible(
+            flex: 5,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Flexible(child: automationLabel),
+                SizedBox(width: tokens.spacing.step2),
+                automationToggle,
+              ],
             ),
-            child: DesignSystemToggle(
-              key: const Key('taskAgentAutomaticUpdatesCheckbox'),
-              value: automaticUpdatesEnabled,
-              semanticsLabel: messages.taskAgentAutomaticUpdatesLabel,
-              // The disabled toggle explains itself on demand instead of
-              // spending a permanent caption line on it.
-              tooltipIcon: inferenceAvailable
-                  ? null
-                  : Icons.info_outline_rounded,
-              tooltipMessage: inferenceAvailable
-                  ? null
-                  : messages.taskAgentAutomaticUpdatesNeedsSetup,
-              enabled: inferenceAvailable && !automationBusy,
-              onChanged: onAutomaticUpdatesChanged,
-            ),
+          ),
+        ],
+      );
+    }
+
+    Widget compactUtilityStack() {
+      return Column(
+        key: const ValueKey('taskAgentFooterCompactLayout'),
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (hasWakeControl) ...[
+            Align(alignment: Alignment.centerLeft, child: wakeControl),
+            SizedBox(height: tokens.spacing.step1),
+          ],
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    automationLabel,
+                    identity,
+                  ],
+                ),
+              ),
+              SizedBox(width: tokens.spacing.step2),
+              automationToggle,
+            ],
           ),
         ],
       );
@@ -115,99 +171,26 @@ class TaskAgentControlsFooter extends StatelessWidget {
         color: ai.footerWash,
         border: Border(top: BorderSide(color: ai.borderSoft)),
       ),
-      padding: EdgeInsets.fromLTRB(
-        tokens.spacing.cardPadding,
-        tokens.spacing.step2,
-        tokens.spacing.cardPadding,
-        tokens.spacing.step2,
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.cardPadding,
+        vertical: tokens.spacing.step2,
       ),
       // The wash band spans the card, but the content snaps to the same
-      // reading measure as the summary and the proposal rows — one shared
-      // right edge for every actionable element on the card.
+      // reading measure as the summary and proposal rows.
       child: Align(
         alignment: Alignment.centerLeft,
         child: ConstrainedBox(
-          constraints: const BoxConstraints(
-            maxWidth: TldrBody.maxReadingWidth,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              if (hasWakeRow) ...[
-                // One wake affordance per state, in a constant-height slot: the
-                // countdown chip replaces the button while an automatic wake is
-                // scheduled (the scheduled update *is* the pending wake). step8
-                // used to fit the visuals exactly; step9 keeps the same compact
-                // chrome inside a full 48px interaction slot.
-                ConstrainedBox(
-                  constraints: BoxConstraints(minHeight: tokens.spacing.step9),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: countdownVisible
-                        ? _CountdownChip(
-                            nextWakeAt: wakeAt,
-                            onCancel: onCancelTimer,
-                            cancelTooltip: messages.taskAgentCancelTimerTooltip,
-                            onExpired: onCountdownExpired,
-                          )
-                        : DesignSystemButton(
-                            key: const ValueKey('taskAgentWakeButton'),
-                            label: isRunning
-                                ? messages.aiSummaryThinkingLabel
-                                : messages.taskAgentWakeAgent,
-                            leadingIcon: Icons.refresh_rounded,
-                            variant: DesignSystemButtonVariant.tertiary,
-                            isLoading: isRunning,
-                            onPressed: inferenceAvailable ? onRunNow : null,
-                          ),
-                  ),
-                ),
-                SizedBox(height: tokens.spacing.step1),
-              ],
-              LayoutBuilder(
-                builder: (context, constraints) {
-                  final textScale = MediaQuery.textScalerOf(context).scale(1);
-                  final compact =
-                      constraints.maxWidth <
-                          TaskAgentFreshnessStrip.compactWidth ||
-                      textScale > 1.3;
-                  if (compact) {
-                    return Column(
-                      key: const ValueKey('taskAgentFooterCompactLayout'),
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        TaskAgentIdentityRegion(
-                          data: identityData,
-                          onSetupTap: onSetupTap,
-                        ),
-                        SizedBox(height: tokens.spacing.step1),
-                        automationControls(expandLabel: true),
-                      ],
-                    );
-                  }
-                  return Row(
-                    key: const ValueKey('taskAgentFooterWideLayout'),
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Flexible(
-                        child: TaskAgentIdentityRegion(
-                          data: identityData,
-                          onSetupTap: onSetupTap,
-                        ),
-                      ),
-                      Flexible(
-                        child: Padding(
-                          padding: EdgeInsets.only(
-                            left: tokens.spacing.step3,
-                          ),
-                          child: automationControls(expandLabel: false),
-                        ),
-                      ),
-                    ],
-                  );
-                },
-              ),
-            ],
+          constraints: const BoxConstraints(maxWidth: TldrBody.maxReadingWidth),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final textScale = MediaQuery.textScalerOf(context).scale(1);
+              final compactWidth =
+                  TaskAgentFreshnessStrip.compactWidth +
+                  (hasWakeControl ? tokens.spacing.step10 : 0);
+              final compact =
+                  constraints.maxWidth < compactWidth || textScale > 1.3;
+              return compact ? compactUtilityStack() : wideUtilityRail();
+            },
           ),
         ),
       ),
@@ -215,13 +198,47 @@ class TaskAgentControlsFooter extends StatelessWidget {
   }
 }
 
-/// Countdown until the next scheduled automatic wake ("Next update in
-/// 1:30 ×") as one capsule. The label region is informational — only the
-/// trailing ✕, with its own tap target and tooltip, cancels the scheduled
-/// wake, so the largest surface can never destroy scheduled work by
-/// accident.
-class _CountdownChip extends StatefulWidget {
-  const _CountdownChip({
+/// Non-interactive progress status. A running wake cannot be pressed, so it
+/// is rendered as status rather than as a disabled/loading button.
+class _ThinkingStatus extends StatelessWidget {
+  const _ThinkingStatus();
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    return ConstrainedBox(
+      constraints: BoxConstraints(minHeight: tokens.spacing.step8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox.square(
+            key: const ValueKey('taskAgentThinkingSpinner'),
+            dimension: tokens.spacing.step4,
+            child: CircularProgressIndicator(
+              strokeWidth: tokens.spacing.step1,
+              color: ai.accent,
+            ),
+          ),
+          SizedBox(width: tokens.spacing.step3),
+          Text(
+            context.messages.aiSummaryThinkingLabel,
+            key: const ValueKey('taskAgentThinkingLabel'),
+            style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+              color: ai.accent,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A polished informational schedule pill plus a separate full-size cancel
+/// target. Keeping cancellation outside the pill prevents an informational
+/// surface from behaving like a destructive button.
+class _CountdownControl extends StatefulWidget {
+  const _CountdownControl({
     required this.nextWakeAt,
     required this.onCancel,
     required this.cancelTooltip,
@@ -234,16 +251,16 @@ class _CountdownChip extends StatefulWidget {
   final VoidCallback onExpired;
 
   @override
-  State<_CountdownChip> createState() => _CountdownChipState();
+  State<_CountdownControl> createState() => _CountdownControlState();
 }
 
-class _CountdownChipState extends State<_CountdownChip>
-    with WakeCountdownState<_CountdownChip> {
+class _CountdownControlState extends State<_CountdownControl>
+    with WakeCountdownState<_CountdownControl> {
   @override
   DateTime get nextWakeAt => widget.nextWakeAt;
 
   @override
-  void didUpdateWidget(covariant _CountdownChip oldWidget) {
+  void didUpdateWidget(covariant _CountdownControl oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.nextWakeAt != widget.nextWakeAt) resyncCountdown();
   }
@@ -256,85 +273,62 @@ class _CountdownChipState extends State<_CountdownChip>
     if (countdownSeconds <= 0) return const SizedBox.shrink();
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
+    final label = context.messages.taskAgentNextUpdateIn(
+      formatCountdown(countdownSeconds),
+    );
 
-    // Neutral wash, not accent: an informational timer must not read with
-    // the same urgency-class as pending proposals — the ON toggle is the
-    // scheduled footer's single accent.
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: constraints.maxWidth),
-          child: Stack(
-            alignment: Alignment.centerLeft,
-            children: [
-              Positioned.fill(
-                top: tokens.spacing.step2,
-                bottom: tokens.spacing.step2,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: ai.subtleWashStrong,
-                    borderRadius: BorderRadius.circular(
-                      tokens.radii.badgesPills,
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(
+          child: DsPill(
+            variant: DsPillVariant.filled,
+            bordered: true,
+            borderColor: ai.borderSoft,
+            leading: Icon(
+              Icons.schedule_rounded,
+              size: tokens.spacing.step4,
+              color: ai.metaText,
+            ),
+            labelWidget: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: ai.metaText,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+          ),
+        ),
+        Semantics(
+          button: true,
+          label: widget.cancelTooltip,
+          excludeSemantics: true,
+          child: Tooltip(
+            message: widget.cancelTooltip,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: widget.onCancel,
+                borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
+                child: SizedBox(
+                  key: const ValueKey('taskAgentCancelCountdownTarget'),
+                  width: tokens.spacing.step8,
+                  height: tokens.spacing.step8,
+                  child: Center(
+                    child: Icon(
+                      Icons.close_rounded,
+                      size: tokens.spacing.step4,
+                      color: ai.metaText,
                     ),
                   ),
                 ),
               ),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Flexible(
-                    child: Padding(
-                      padding: EdgeInsets.only(left: tokens.spacing.step3),
-                      child: Text(
-                        context.messages.taskAgentNextUpdateIn(
-                          formatCountdown(countdownSeconds),
-                        ),
-                        style: tokens.typography.styles.others.caption.copyWith(
-                          color: ai.metaText,
-                          fontFeatures: const [FontFeature.tabularFigures()],
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ),
-                  Semantics(
-                    button: true,
-                    label: widget.cancelTooltip,
-                    excludeSemantics: true,
-                    child: Tooltip(
-                      message: widget.cancelTooltip,
-                      child: Material(
-                        color: Colors.transparent,
-                        child: InkWell(
-                          onTap: widget.onCancel,
-                          borderRadius: BorderRadius.circular(
-                            tokens.radii.badgesPills,
-                          ),
-                          child: SizedBox(
-                            key: const ValueKey(
-                              'taskAgentCancelCountdownTarget',
-                            ),
-                            width: tokens.spacing.step9,
-                            height: tokens.spacing.step9,
-                            child: Center(
-                              child: Icon(
-                                Icons.close_rounded,
-                                size: tokens.spacing.step4,
-                                color: ai.metaText,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
+            ),
           ),
-        );
-      },
+        ),
+      ],
     );
   }
 }

--- a/lib/features/agents/ui/task_agent_controls_footer.dart
+++ b/lib/features/agents/ui/task_agent_controls_footer.dart
@@ -13,11 +13,12 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 
 /// Quiet settings zone pinned to the bottom of the task-agent card.
 ///
-/// Wide cards place model identity, wake status, and automation on one compact
-/// utility rail. Narrow cards use two intentional groups: wake status first,
-/// then one settings row that stacks the automation label directly above
-/// model identity with the toggle pinned trailing. This preserves full-size
-/// controls without turning every caption into its own airy footer band.
+/// Wake status and automatic updates form one bounded automation cluster so
+/// the countdown, spinner, and switch read as one system. Wide cards place
+/// that cluster beside model identity. Narrow cards place the cluster first
+/// and wrap identity below it; the cluster itself also wraps when its wake
+/// status and switch cannot share a line. The countdown reserves the width of
+/// its initial label so ticking digits never move adjacent controls.
 ///
 /// The wake control is omitted while the freshness strip above owns the CTA
 /// ([showWakeButton] false).
@@ -62,14 +63,6 @@ class TaskAgentControlsFooter extends StatelessWidget {
     final countdownVisible = showCountdown && wakeAt != null;
     final hasWakeControl = showWakeButton || countdownVisible;
 
-    final automationLabel = Text(
-      messages.taskAgentAutomaticUpdatesLabel,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: tokens.typography.styles.others.caption.copyWith(
-        color: ai.metaText,
-      ),
-    );
     final automationToggle = ConstrainedBox(
       key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
       constraints: BoxConstraints(
@@ -110,57 +103,87 @@ class TaskAgentControlsFooter extends StatelessWidget {
             variant: DesignSystemButtonVariant.tertiary,
             onPressed: inferenceAvailable ? onRunNow : null,
           );
-
-    Widget wideUtilityRail() {
-      return Row(
-        key: const ValueKey('taskAgentFooterWideLayout'),
-        children: [
-          Expanded(flex: 7, child: identity),
-          if (hasWakeControl) ...[
-            SizedBox(width: tokens.spacing.cardItemSpacing),
-            Flexible(flex: 6, child: wakeControl),
-          ],
-          SizedBox(width: tokens.spacing.cardItemSpacing),
-          Flexible(
-            flex: 5,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Flexible(child: automationLabel),
-                SizedBox(width: tokens.spacing.step2),
-                automationToggle,
-              ],
-            ),
-          ),
-        ],
-      );
-    }
-
-    Widget compactUtilityStack() {
-      return Column(
-        key: const ValueKey('taskAgentFooterCompactLayout'),
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (hasWakeControl) ...[
-            Align(alignment: Alignment.centerLeft, child: wakeControl),
-            SizedBox(height: tokens.spacing.step1),
-          ],
-          Row(
+    final automationLabelStyle = tokens.typography.styles.others.caption
+        .copyWith(color: ai.metaText);
+    final automationLabelPainter = TextPainter(
+      text: TextSpan(
+        text: messages.taskAgentAutomaticUpdatesLabel,
+        style: automationLabelStyle,
+      ),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    final automationSettingWidth =
+        automationLabelPainter.width +
+        tokens.spacing.step2 +
+        tokens.spacing.step9;
+    final automationSetting = LayoutBuilder(
+      builder: (context, constraints) {
+        return SizedBox(
+          key: const ValueKey('taskAgentAutomationSetting'),
+          width: constraints.constrainWidth(automationSettingWidth),
+          child: Row(
             children: [
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    automationLabel,
-                    identity,
-                  ],
+                child: Text(
+                  messages.taskAgentAutomaticUpdatesLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: automationLabelStyle,
                 ),
               ),
               SizedBox(width: tokens.spacing.step2),
               automationToggle,
             ],
           ),
+        );
+      },
+    );
+
+    final automationCluster = Container(
+      key: const ValueKey('taskAgentAutomationCluster'),
+      constraints: BoxConstraints(minHeight: tokens.spacing.step9),
+      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step3),
+      decoration: BoxDecoration(
+        color: ai.subtleWashStrong,
+        borderRadius: BorderRadius.circular(tokens.radii.s),
+        border: Border.all(color: ai.rowBorder),
+      ),
+      child: Wrap(
+        key: const ValueKey('taskAgentAutomationWrap'),
+        alignment: hasWakeControl
+            ? WrapAlignment.spaceBetween
+            : WrapAlignment.end,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: tokens.spacing.cardItemSpacing,
+        runSpacing: tokens.spacing.step1,
+        children: [
+          if (hasWakeControl) wakeControl,
+          automationSetting,
+        ],
+      ),
+    );
+
+    Widget wideFooter() {
+      return Row(
+        key: const ValueKey('taskAgentFooterWideLayout'),
+        children: [
+          Expanded(flex: 4, child: identity),
+          SizedBox(width: tokens.spacing.cardItemSpacing),
+          Expanded(flex: 6, child: automationCluster),
+        ],
+      );
+    }
+
+    Widget compactFooter() {
+      return Column(
+        key: const ValueKey('taskAgentFooterCompactLayout'),
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          automationCluster,
+          SizedBox(height: tokens.spacing.step1),
+          identity,
         ],
       );
     }
@@ -184,12 +207,10 @@ class TaskAgentControlsFooter extends StatelessWidget {
           child: LayoutBuilder(
             builder: (context, constraints) {
               final textScale = MediaQuery.textScalerOf(context).scale(1);
-              final compactWidth =
-                  TaskAgentFreshnessStrip.compactWidth +
-                  (hasWakeControl ? tokens.spacing.step10 : 0);
               final compact =
-                  constraints.maxWidth < compactWidth || textScale > 1.3;
-              return compact ? compactUtilityStack() : wideUtilityRail();
+                  constraints.maxWidth < TaskAgentFreshnessStrip.compactWidth ||
+                  textScale > 1.3;
+              return compact ? compactFooter() : wideFooter();
             },
           ),
         ),
@@ -207,29 +228,50 @@ class _ThinkingStatus extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
-    return ConstrainedBox(
-      constraints: BoxConstraints(minHeight: tokens.spacing.step8),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox.square(
-            key: const ValueKey('taskAgentThinkingSpinner'),
-            dimension: tokens.spacing.step4,
-            child: CircularProgressIndicator(
-              strokeWidth: tokens.spacing.step1,
-              color: ai.accent,
+    final label = context.messages.aiSummaryThinkingLabel;
+    final labelStyle = tokens.typography.styles.subtitle.subtitle2.copyWith(
+      color: ai.accent,
+    );
+    final labelPainter = TextPainter(
+      text: TextSpan(text: label, style: labelStyle),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    final naturalWidth =
+        tokens.spacing.step4 + tokens.spacing.step3 + labelPainter.width;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SizedBox(
+          width: constraints.constrainWidth(naturalWidth),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: tokens.spacing.step8),
+            child: Row(
+              children: [
+                SizedBox.square(
+                  key: const ValueKey('taskAgentThinkingSpinner'),
+                  dimension: tokens.spacing.step4,
+                  child: CircularProgressIndicator(
+                    strokeWidth: tokens.spacing.step1,
+                    color: ai.accent,
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step3),
+                Expanded(
+                  child: Text(
+                    label,
+                    key: const ValueKey('taskAgentThinkingLabel'),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: labelStyle,
+                  ),
+                ),
+              ],
             ),
           ),
-          SizedBox(width: tokens.spacing.step3),
-          Text(
-            context.messages.aiSummaryThinkingLabel,
-            key: const ValueKey('taskAgentThinkingLabel'),
-            style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-              color: ai.accent,
-            ),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }
@@ -256,13 +298,24 @@ class _CountdownControl extends StatefulWidget {
 
 class _CountdownControlState extends State<_CountdownControl>
     with WakeCountdownState<_CountdownControl> {
+  late int _widthAnchorSeconds;
+
   @override
   DateTime get nextWakeAt => widget.nextWakeAt;
 
   @override
+  void initState() {
+    super.initState();
+    _widthAnchorSeconds = countdownSeconds;
+  }
+
+  @override
   void didUpdateWidget(covariant _CountdownControl oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.nextWakeAt != widget.nextWakeAt) resyncCountdown();
+    if (oldWidget.nextWakeAt != widget.nextWakeAt) {
+      resyncCountdown();
+      _widthAnchorSeconds = countdownSeconds;
+    }
   }
 
   @override
@@ -276,59 +329,88 @@ class _CountdownControlState extends State<_CountdownControl>
     final label = context.messages.taskAgentNextUpdateIn(
       formatCountdown(countdownSeconds),
     );
+    final widthAnchorLabel = context.messages.taskAgentNextUpdateIn(
+      formatCountdown(_widthAnchorSeconds),
+    );
+    final labelStyle = tokens.typography.styles.others.caption.copyWith(
+      color: ai.metaText,
+      fontFeatures: const [FontFeature.tabularFigures()],
+    );
+    final widthAnchorPainter = TextPainter(
+      text: TextSpan(text: widthAnchorLabel, style: labelStyle),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    final naturalWidth =
+        widthAnchorPainter.width +
+        tokens.spacing.step4 +
+        tokens.spacing.step2 +
+        (tokens.spacing.step3 * 2) +
+        tokens.spacing.step8;
 
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Flexible(
-          child: DsPill(
-            variant: DsPillVariant.filled,
-            bordered: true,
-            borderColor: ai.borderSoft,
-            leading: Icon(
-              Icons.schedule_rounded,
-              size: tokens.spacing.step4,
-              color: ai.metaText,
-            ),
-            labelWidget: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: tokens.typography.styles.others.caption.copyWith(
-                color: ai.metaText,
-                fontFeatures: const [FontFeature.tabularFigures()],
-              ),
-            ),
-          ),
-        ),
-        Semantics(
-          button: true,
-          label: widget.cancelTooltip,
-          excludeSemantics: true,
-          child: Tooltip(
-            message: widget.cancelTooltip,
-            child: Material(
-              color: Colors.transparent,
-              child: InkWell(
-                onTap: widget.onCancel,
-                borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
-                child: SizedBox(
-                  key: const ValueKey('taskAgentCancelCountdownTarget'),
-                  width: tokens.spacing.step8,
-                  height: tokens.spacing.step8,
-                  child: Center(
-                    child: Icon(
-                      Icons.close_rounded,
-                      size: tokens.spacing.step4,
-                      color: ai.metaText,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SizedBox(
+          width: constraints.constrainWidth(naturalWidth),
+          child: Row(
+            children: [
+              Flexible(
+                child: DsPill(
+                  variant: DsPillVariant.filled,
+                  bordered: true,
+                  borderColor: ai.borderSoft,
+                  leading: Icon(
+                    Icons.schedule_rounded,
+                    size: tokens.spacing.step4,
+                    color: ai.metaText,
+                  ),
+                  labelWidget: SizedBox(
+                    width: widthAnchorPainter.width,
+                    child: Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: labelStyle,
                     ),
                   ),
                 ),
               ),
-            ),
+              Semantics(
+                button: true,
+                label: widget.cancelTooltip,
+                excludeSemantics: true,
+                child: Tooltip(
+                  message: widget.cancelTooltip,
+                  child: Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      onTap: widget.onCancel,
+                      borderRadius: BorderRadius.circular(
+                        tokens.radii.badgesPills,
+                      ),
+                      child: SizedBox(
+                        key: const ValueKey(
+                          'taskAgentCancelCountdownTarget',
+                        ),
+                        width: tokens.spacing.step8,
+                        height: tokens.spacing.step8,
+                        child: Center(
+                          child: Icon(
+                            Icons.close_rounded,
+                            size: tokens.spacing.step4,
+                            color: ai.metaText,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -283,7 +283,14 @@ subtle frame in light and dark themes.
   The existing `ScrollAnchor` remains a fallback for proposal-driven changes in
   other task regions above the AI card, and the
   `unifiedSuggestionListProvider` count listener arms both paths for externally
-  resolved proposals. Newly created checklist rows and cards still reveal
+  resolved proposals. When checklist content above the proposals and card
+  content below them shrink in the same layout pass, the custom position bases
+  the checklist correction on the hold-owned offset rather than Flutter's
+  already range-clamped live offset, so the same shrink is never counted twice.
+  If the shorter card leaves too little trailing extent to preserve the held
+  position, the position retains only the missing extent until deliberate
+  scrolling returns inside the real range; ending the timer therefore cannot
+  cause a delayed jump. Newly created checklist rows and cards still reveal
   through `SizeFadeEntrance`; the stabilizer preserves geometry rather than
   suppressing useful motion. The hold spans the checked item's delayed row
   collapse (`checklistCompletionAnimationDuration` +
@@ -890,8 +897,11 @@ has two region adapters backed by the same `ViewportStableScrollController`:
 
 Both adapters feed exact region-height deltas into the viewport's own layout
 cycle, so the content currently being read never paints at an intermediate
-displaced position. User scrolling cancels the hold immediately, and the
-standalone journal-entry detail page remains outside the scope.
+displaced position. The scroll position also retains a temporary trailing
+extent when a simultaneous shrink below the anchor would otherwise clamp the
+viewport; that extent disappears once the user scrolls inside the real range.
+User scrolling cancels the hold immediately, and the standalone journal-entry
+detail page remains outside the scope.
 
 ## Current Constraints
 

--- a/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
+++ b/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -8,11 +9,12 @@ import 'package:lotti/features/tasks/util/scroll_anchor.dart';
 /// A task-details scroll controller that preserves visible content while an
 /// armed off-screen region changes the scrollable's extent.
 ///
-/// The correction is applied from [ScrollPosition.correctForNewDimensions],
-/// where the viewport can repeat layout with the corrected offset before it
-/// paints. Correcting from the changing descendant's own layout is too late:
-/// the viewport has already selected that frame's paint transform, producing
-/// a one-frame jump before the new offset takes effect.
+/// The position consumes exact region deltas while applying new content
+/// dimensions, where the viewport can repeat layout with the corrected offset
+/// before it paints. If unrelated content below the held region shrinks far
+/// enough to force a range clamp, the position temporarily retains that
+/// trailing extent until the user scrolls back inside the real range. This
+/// avoids both a one-frame displacement and a delayed jump when the hold ends.
 class ViewportStableScrollController extends ScrollController {
   ViewportStableScrollController({
     super.initialScrollOffset,
@@ -32,6 +34,12 @@ class ViewportStableScrollController extends ScrollController {
   static const _tolerance = 1.0;
 
   bool get _isHolding => _isExplicitlyHolding || _isAnimatedSizeHolding;
+
+  double? get _desiredHeldOffset {
+    final expectedOffset = _expectedOffset;
+    if (!_isHolding || expectedOffset == null) return null;
+    return expectedOffset + _pendingExtentDelta;
+  }
 
   /// Explicitly preserves reported-region content until [duration] elapses.
   ///
@@ -59,11 +67,18 @@ class ViewportStableScrollController extends ScrollController {
   }
 
   void _releaseOnUnexpectedOffsetChange() {
-    if (!_isHolding || positions.length != 1) return;
+    if (positions.length != 1) return;
+    final stablePosition = position;
+    if (stablePosition is _ViewportStableScrollPosition) {
+      stablePosition._releaseRetainedExtentIfWithinRealRange();
+    }
+    if (!_isHolding) return;
     final expectedOffset = _expectedOffset;
     if (expectedOffset == null) return;
     if ((offset - expectedOffset).abs() > _tolerance) {
       _releaseAllHolds();
+    } else {
+      _expectedOffset = offset;
     }
   }
 
@@ -169,31 +184,98 @@ class _ViewportStableScrollPosition extends ScrollPositionWithSingleContext {
   });
 
   final ViewportStableScrollController controller;
+  double? _realMaxScrollExtent;
+  double? _retainedMaxScrollExtent;
+
+  @override
+  bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
+    _realMaxScrollExtent = maxScrollExtent;
+    final desiredHeldOffset = controller._desiredHeldOffset;
+    if (desiredHeldOffset != null && desiredHeldOffset > maxScrollExtent) {
+      _retainedMaxScrollExtent = math.max(
+        _retainedMaxScrollExtent ?? maxScrollExtent,
+        desiredHeldOffset,
+      );
+      if ((pixels - desiredHeldOffset).abs() >
+          ViewportStableScrollController._tolerance) {
+        correctPixels(desiredHeldOffset);
+      }
+    } else if ((_retainedMaxScrollExtent ?? double.infinity) <=
+        maxScrollExtent + ViewportStableScrollController._tolerance) {
+      _retainedMaxScrollExtent = null;
+    }
+
+    return super.applyContentDimensions(
+      minScrollExtent,
+      math.max(maxScrollExtent, _retainedMaxScrollExtent ?? maxScrollExtent),
+    );
+  }
+
+  /// Keeps a temporary trailing extent while held content would otherwise be
+  /// clamped upward by a simultaneous shrink below it. The extent remains
+  /// until the user naturally scrolls back inside the real range, avoiding a
+  /// delayed jump when the timed hold ends.
+  void _releaseRetainedExtentIfWithinRealRange() {
+    final realMaxScrollExtent = _realMaxScrollExtent;
+    if (_retainedMaxScrollExtent == null || realMaxScrollExtent == null) return;
+    if (pixels >
+        realMaxScrollExtent + ViewportStableScrollController._tolerance) {
+      return;
+    }
+    _retainedMaxScrollExtent = null;
+    correctBy(0);
+    final root = context.storageContext.findRenderObject();
+    RenderAbstractViewport? viewport;
+    void findViewport(RenderObject child) {
+      if (viewport != null) return;
+      if (child is RenderAbstractViewport) {
+        viewport = child;
+        return;
+      }
+      child.visitChildren(findViewport);
+    }
+
+    if (root is RenderAbstractViewport) {
+      viewport = root;
+    } else {
+      root?.visitChildren(findViewport);
+    }
+    viewport?.markNeedsLayout();
+  }
 
   @override
   bool correctForNewDimensions(
     ScrollMetrics oldPosition,
     ScrollMetrics newPosition,
   ) {
-    if (!super.correctForNewDimensions(oldPosition, newPosition)) return false;
     if (isScrollingNotifier.value) {
       controller._releaseAllHolds();
-      return true;
+      return super.correctForNewDimensions(oldPosition, newPosition);
     }
 
-    if (!controller._isHolding) return true;
-    final delta = controller._takePendingExtentDelta();
-    if (delta.abs() <= ViewportStableScrollController._tolerance) return true;
-    final target = (pixels + delta).clamp(
-      newPosition.minScrollExtent,
-      newPosition.maxScrollExtent,
-    );
-    if ((target - pixels).abs() <= ViewportStableScrollController._tolerance) {
-      return true;
+    if (controller._isHolding) {
+      final delta = controller._takePendingExtentDelta();
+      if (delta.abs() > ViewportStableScrollController._tolerance) {
+        // Derive the correction from the last offset owned by the hold, not
+        // [pixels]. When content below the reported region shrinks in the same
+        // layout pass, Flutter may already have clamped [pixels] to the new max
+        // extent before this hook runs. Applying [delta] to that clamped value
+        // counts the reported shrink twice and visibly moves the held content.
+        final heldOffset = controller._expectedOffset ?? pixels;
+        final target = (heldOffset + delta).clamp(
+          newPosition.minScrollExtent,
+          newPosition.maxScrollExtent,
+        );
+        if ((target - pixels).abs() >
+            ViewportStableScrollController._tolerance) {
+          controller._expectedOffset = target;
+          correctPixels(target);
+          return false;
+        }
+      }
     }
-    controller._expectedOffset = target;
-    correctPixels(target);
-    return false;
+
+    return super.correctForNewDimensions(oldPosition, newPosition);
   }
 }
 

--- a/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
+++ b/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
@@ -196,6 +196,9 @@ class _ViewportStableScrollPosition extends ScrollPositionWithSingleContext {
         _retainedMaxScrollExtent ?? maxScrollExtent,
         desiredHeldOffset,
       );
+      controller
+        .._expectedOffset = desiredHeldOffset
+        .._takePendingExtentDelta();
       if ((pixels - desiredHeldOffset).abs() >
           ViewportStableScrollController._tolerance) {
         correctPixels(desiredHeldOffset);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1054+4228
+version: 0.9.1054+4229
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/service/task_agent_service_test.dart
+++ b/test/features/agents/service/task_agent_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_config.dart';
@@ -1931,8 +1932,10 @@ void main() {
 
     group('automatic updates', () {
       test(
-        'turning off persists the preference and clears automation',
+        'turning off persists the preference, preserves pending freshness, '
+        'and clears automation',
         () async {
+          final now = DateTime(2026, 7, 20, 12);
           final identity = makeIdentity(
             config: const AgentConfig(
               inferenceSetup: AgentInferenceSetup(
@@ -1945,19 +1948,37 @@ void main() {
           when(
             () => mockAgentService.getAgent('agent-1'),
           ).thenAnswer((_) async => identity);
-
-          await service.updateAutomaticUpdates(
-            agentId: 'agent-1',
-            enabled: false,
+          final pendingState = makeState().copyWith(
+            nextWakeAt: now.add(const Duration(minutes: 2)),
+            reportFreshAt: now.subtract(const Duration(minutes: 1)),
           );
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => pendingState);
 
-          final updated =
-              verify(
-                    () => mockSyncService.upsertEntity(captureAny()),
-                  ).captured.single
-                  as AgentIdentityEntity;
-          expect(updated.config.automaticUpdatesEnabled, isFalse);
-          expect(updated.config.inferenceSetup, identity.config.inferenceSetup);
+          await withClock(Clock.fixed(now), () async {
+            await service.updateAutomaticUpdates(
+              agentId: 'agent-1',
+              enabled: false,
+            );
+          });
+
+          final updatedEntities = verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured;
+          final updatedIdentity = updatedEntities
+              .whereType<AgentIdentityEntity>()
+              .single;
+          final updatedState = updatedEntities
+              .whereType<AgentStateEntity>()
+              .single;
+          expect(updatedIdentity.config.automaticUpdatesEnabled, isFalse);
+          expect(
+            updatedIdentity.config.inferenceSetup,
+            identity.config.inferenceSetup,
+          );
+          expect(updatedState.reportStaleAt, now);
+          expect(updatedState.isReportStale, isTrue);
           verify(
             () => mockOrchestrator.disableAutomaticUpdatesRuntime('agent-1'),
           ).called(1);

--- a/test/features/agents/ui/ai_summary_card/screenshots_test.dart
+++ b/test/features/agents/ui/ai_summary_card/screenshots_test.dart
@@ -114,6 +114,7 @@ Future<void> _capture(
   required Brightness brightness,
   required bool automaticUpdates,
   bool withOpenProposals = false,
+  bool running = false,
 }) async {
   // The toggle and entrance widgets are stateful. Explicitly unmount the
   // previous fixture before applying the next viewport so sequential matrix
@@ -156,6 +157,7 @@ Future<void> _capture(
           identity: identity,
           template: _template(),
           enableSummaryTts: true,
+          isRunning: running,
           mediaQueryData: MediaQueryData(size: device.size),
           theme: brightness == Brightness.dark
               ? DesignSystemTheme.dark()
@@ -173,7 +175,9 @@ Future<void> _capture(
   expect(find.text('Task Laura'), findsOneWidget);
   expect(find.text(_summary), findsOneWidget);
 
-  final mode = withOpenProposals
+  final mode = running
+      ? 'running'
+      : withOpenProposals
       ? 'proposals'
       : automaticUpdates
       ? 'scheduled'
@@ -214,10 +218,19 @@ void main() {
           );
         });
       }
+      final theme = brightness == Brightness.dark ? 'dark' : 'light';
+      testWidgets('${device.name} running $theme', (tester) async {
+        await _capture(
+          tester,
+          device: device,
+          brightness: brightness,
+          automaticUpdates: true,
+          running: true,
+        );
+      });
       // The real-world hot path: automation off, stale report, and open
       // proposals awaiting review — exercises the proposal rows the other
       // states leave empty.
-      final theme = brightness == Brightness.dark ? 'dark' : 'light';
       testWidgets('${device.name} proposals $theme', (tester) async {
         await _capture(
           tester,

--- a/test/features/agents/ui/ai_summary_card/test_bench.dart
+++ b/test/features/agents/ui/ai_summary_card/test_bench.dart
@@ -68,7 +68,7 @@ class AgentTestBench {
   AgentTestBench({
     this._report,
     this._suggestions = const UnifiedSuggestionList.empty(),
-    this._isRunning = false,
+    this.isRunning = false,
     this._state,
     this._enableAgents = true,
     this._enableSummaryTts = false,
@@ -101,7 +101,7 @@ class AgentTestBench {
 
   final AgentReportEntity? _report;
   final UnifiedSuggestionList _suggestions;
-  final bool _isRunning;
+  final bool isRunning;
   final AgentStateEntity? _state;
   final bool _enableAgents;
   final bool _enableSummaryTts;
@@ -192,7 +192,7 @@ class AgentTestBench {
           (ref, agentId) async => _template,
         ),
         agentIsRunningProvider.overrideWith(
-          _isRunningOverride ?? (ref, agentId) => Stream.value(_isRunning),
+          _isRunningOverride ?? (ref, agentId) => Stream.value(isRunning),
         ),
         agentStateProvider.overrideWith(
           (ref, agentId) async => _state,

--- a/test/features/agents/ui/task_agent_controls_footer_test.dart
+++ b/test/features/agents/ui/task_agent_controls_footer_test.dart
@@ -136,15 +136,23 @@ void main() {
         final context = tester.element(
           find.byType(TaskAgentControlsFooter),
         );
+        final tokens = context.designTokens;
+        final countdownPill = find.byType(DsPill);
+        final cancelIcon = find.byIcon(Icons.close_rounded);
         expect(
           tester.getSize(
             find.byKey(
               const ValueKey('taskAgentCancelCountdownTarget'),
             ),
           ),
-          Size.square(context.designTokens.spacing.step8),
+          Size.square(tokens.spacing.step9),
         );
-        await tester.tap(find.byIcon(Icons.close_rounded));
+        expect(
+          tester.getTopLeft(cancelIcon).dx -
+              tester.getTopRight(countdownPill).dx,
+          tokens.spacing.step1,
+        );
+        await tester.tap(cancelIcon);
       });
 
       expect(cancellations, 1);
@@ -546,11 +554,18 @@ void main() {
     await tester.pumpWidget(makeTestableWidget(subject()));
 
     final context = tester.element(find.byType(TaskAgentControlsFooter));
+    final tokens = context.designTokens;
+    final target = find.byKey(
+      const ValueKey('taskAgentAutomaticUpdatesTarget'),
+    );
     expect(
-      tester.getSize(
-        find.byKey(const ValueKey('taskAgentAutomaticUpdatesTarget')),
-      ),
-      Size.square(context.designTokens.spacing.step9),
+      tester.getSize(target),
+      Size.square(tokens.spacing.step9),
+    );
+    expect(
+      tester.getTopLeft(target).dx -
+          tester.getTopRight(find.text('Automatic updates')).dx,
+      tokens.spacing.step3,
     );
   });
 }

--- a/test/features/agents/ui/task_agent_controls_footer_test.dart
+++ b/test/features/agents/ui/task_agent_controls_footer_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/agents/ui/task_agent_controls_footer.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
@@ -123,6 +124,8 @@ void main() {
         );
 
         expect(find.text('Next update in 1:30'), findsOneWidget);
+        expect(find.byType(DsPill), findsOneWidget);
+        expect(find.byIcon(Icons.schedule_rounded), findsOneWidget);
         // One wake affordance per state: the scheduled update replaces the
         // manual wake button.
         expect(find.byKey(const ValueKey('taskAgentWakeButton')), findsNothing);
@@ -138,7 +141,7 @@ void main() {
               const ValueKey('taskAgentCancelCountdownTarget'),
             ),
           ),
-          Size.square(context.designTokens.spacing.step9),
+          Size.square(context.designTokens.spacing.step8),
         );
         await tester.tap(find.byIcon(Icons.close_rounded));
       });
@@ -215,6 +218,14 @@ void main() {
 
     expect(find.text('Thinking…'), findsOneWidget);
     expect(find.text('Wake agent'), findsNothing);
+
+    final context = tester.element(find.byType(TaskAgentControlsFooter));
+    final spinner = find.byKey(const ValueKey('taskAgentThinkingSpinner'));
+    final label = find.byKey(const ValueKey('taskAgentThinkingLabel'));
+    expect(
+      tester.getTopLeft(label).dx - tester.getTopRight(spinner).dx,
+      context.designTokens.spacing.step3,
+    );
   });
 
   testWidgets(
@@ -265,7 +276,7 @@ void main() {
   });
 
   testWidgets(
-    'narrow German footer stacks identity above untruncated automation',
+    'narrow German footer groups automation and identity without truncation',
     (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetNoScroll(
@@ -288,12 +299,47 @@ void main() {
       final automation = find.text('Automatische Aktualisierungen');
       expect(automation, findsOneWidget);
       expect(
-        tester.getBottomLeft(identity).dy,
-        lessThan(tester.getTopLeft(automation).dy),
+        tester.getBottomLeft(automation).dy,
+        lessThan(tester.getTopLeft(identity).dy),
       );
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets('wide countdown and toggle share one compact utility rail', (
+    tester,
+  ) async {
+    final now = DateTime(2026, 7, 16, 9);
+    await withClock(Clock.fixed(now), () async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Center(
+            child: SizedBox(
+              width: 730,
+              child: subject(
+                automaticUpdatesEnabled: true,
+                showCountdown: true,
+                nextWakeAt: now.add(
+                  const Duration(minutes: 1, seconds: 30),
+                ),
+                onRunNow: () {},
+              ),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(900, 800)),
+        ),
+      );
+    });
+
+    final countdown = find.text('Next update in 1:30');
+    final toggle = find.byKey(
+      const Key('taskAgentAutomaticUpdatesCheckbox'),
+    );
+    expect(
+      tester.getCenter(countdown).dy,
+      moreOrLessEquals(tester.getCenter(toggle).dy, epsilon: 1),
+    );
+  });
 
   testWidgets('large text selects the compact footer layout', (tester) async {
     await tester.pumpWidget(

--- a/test/features/agents/ui/task_agent_controls_footer_test.dart
+++ b/test/features/agents/ui/task_agent_controls_footer_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_report_provenance.dart';
 import 'package:lotti/features/agents/ui/task_agent_controls_footer.dart';
+import 'package:lotti/features/agents/ui/task_agent_identity_region.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
@@ -228,6 +229,30 @@ void main() {
     );
   });
 
+  testWidgets('narrow localized thinking status truncates without overflow', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Center(
+          child: SizedBox(
+            width: 180,
+            child: subject(isRunning: true, onRunNow: () {}),
+          ),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(180, 800)),
+        locale: const Locale('de'),
+      ),
+    );
+
+    final label = tester.widget<Text>(
+      find.byKey(const ValueKey('taskAgentThinkingLabel')),
+    );
+    expect(label.maxLines, 1);
+    expect(label.overflow, TextOverflow.ellipsis);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'missing setup disables wake and toggle and explains via tooltip',
     (tester) async {
@@ -306,7 +331,7 @@ void main() {
     },
   );
 
-  testWidgets('wide countdown and toggle share one compact utility rail', (
+  testWidgets('wide footer keeps identity beside the automation cluster', (
     tester,
   ) async {
     final now = DateTime(2026, 7, 16, 9);
@@ -331,14 +356,101 @@ void main() {
       );
     });
 
-    final countdown = find.text('Next update in 1:30');
-    final toggle = find.byKey(
-      const Key('taskAgentAutomaticUpdatesCheckbox'),
+    final identity = find.byType(TaskAgentIdentityRegion);
+    final cluster = find.byKey(
+      const ValueKey('taskAgentAutomationCluster'),
+    );
+    expect(cluster, findsOneWidget);
+    expect(
+      tester.getCenter(identity).dy,
+      moreOrLessEquals(tester.getCenter(cluster).dy, epsilon: 1),
     );
     expect(
-      tester.getCenter(countdown).dy,
-      moreOrLessEquals(tester.getCenter(toggle).dy, epsilon: 1),
+      tester.getCenter(identity).dx,
+      lessThan(tester.getCenter(cluster).dx),
     );
+  });
+
+  testWidgets(
+    'narrow scheduled cluster wraps countdown and switch without overflow',
+    (tester) async {
+      final now = DateTime(2026, 7, 16, 9);
+      await withClock(Clock.fixed(now), () async {
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            Center(
+              child: SizedBox(
+                width: 300,
+                child: subject(
+                  automaticUpdatesEnabled: true,
+                  showCountdown: true,
+                  nextWakeAt: now.add(
+                    const Duration(minutes: 1, seconds: 30),
+                  ),
+                  onRunNow: () {},
+                ),
+              ),
+            ),
+            mediaQueryData: const MediaQueryData(size: Size(300, 800)),
+          ),
+        );
+      });
+
+      final countdown = find.text('Next update in 1:30');
+      final automation = find.text('Automatic updates');
+      final identity = find.textContaining('Qwen 3.5 Plus').first;
+      expect(
+        tester.getCenter(automation).dy,
+        greaterThan(tester.getCenter(countdown).dy),
+      );
+      expect(
+        tester.getCenter(identity).dy,
+        greaterThan(tester.getCenter(automation).dy),
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('countdown width and neighboring controls never jump', (
+    tester,
+  ) async {
+    var now = DateTime(2026, 7, 16, 9);
+    await withClock(Clock(() => now), () async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Center(
+            child: SizedBox(
+              width: 730,
+              child: subject(
+                automaticUpdatesEnabled: true,
+                showCountdown: true,
+                nextWakeAt: now.add(const Duration(hours: 1)),
+                onRunNow: () {},
+              ),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(900, 800)),
+        ),
+      );
+
+      expect(find.text('Next update in 1:00:00'), findsOneWidget);
+      final pill = find.byType(DsPill);
+      final toggle = find.byKey(
+        const Key('taskAgentAutomaticUpdatesCheckbox'),
+      );
+      final identity = find.textContaining('Qwen 3.5 Plus').first;
+      final initialPillSize = tester.getSize(pill);
+      final initialToggleOffset = tester.getTopLeft(toggle);
+      final initialIdentityOffset = tester.getTopLeft(identity);
+
+      now = now.add(const Duration(seconds: 1));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Next update in 59:59'), findsOneWidget);
+      expect(tester.getSize(pill), initialPillSize);
+      expect(tester.getTopLeft(toggle), initialToggleOffset);
+      expect(tester.getTopLeft(identity), initialIdentityOffset);
+    });
   });
 
   testWidgets('large text selects the compact footer layout', (tester) async {

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -6,8 +6,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/state/change_set_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposals_section_part.dart';
 import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tasks/state/task_focus_controller.dart';
@@ -25,6 +28,7 @@ import 'package:lotti/services/time_service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../../../helpers/fallbacks.dart';
 import '../../../../helpers/path_provider.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../test_data/test_data.dart';
@@ -441,18 +445,37 @@ void main() {
   });
 
   group('TaskDetailsPage Suggestions Anchor - ', () {
-    setUpAll(registerTaskDetailsFallbacks);
+    setUpAll(() {
+      registerTaskDetailsFallbacks();
+      registerAllFallbackValues();
+    });
     setUp(registerTaskDetailsServices);
     tearDown(getIt.reset);
 
     testWidgets(
-      'confirming a proposal (open count drops) engages the scroll anchor and '
-      'updates the list without crashing',
+      'Accept all keeps the proposals position stable at a nonzero scroll '
+      'offset while its rows collapse',
       (tester) async {
-        final container = ProviderContainer(
+        tester.view.physicalSize = const Size(800, 500);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        final confirmationService = MockChangeSetConfirmationService();
+        late final ProviderContainer container;
+        when(() => confirmationService.confirmAll(any())).thenAnswer((_) async {
+          container
+              .read(controllableOpenSuggestionCountProvider.notifier)
+              .set(0);
+          return const [ToolExecutionResult(success: true, output: 'ok')];
+        });
+
+        container = ProviderContainer(
           overrides: [
             ...hTaskDetailsPageOverrides(),
             ...hControllableSuggestionOverrides(),
+            changeSetConfirmationServiceProvider.overrideWith(
+              (ref) => confirmationService,
+            ),
           ],
         );
 
@@ -470,28 +493,42 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
         await tester.pump(const Duration(milliseconds: 300));
 
-        // The proposals section is up with the (first) open proposal showing.
-        expect(
-          find.textContaining('Set estimate to 30 minutes'),
-          findsOneWidget,
-        );
+        final proposals = find.byType(ProposalsSection);
+        final confirmAll = find.text('Confirm all');
+        expect(proposals, findsOneWidget);
+        expect(confirmAll, findsOneWidget);
 
-        // Simulate confirming one proposal: the open list shrinks 2 -> 1,
-        // which fires the page's suggestion listener and engages the scroll
-        // anchor (capturing the proposals' position to hold it across the
-        // relayout a confirm can trigger above the card).
-        container.read(controllableOpenSuggestionCountProvider.notifier).set(1);
+        await tester.ensureVisible(confirmAll);
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-        await tester.pump(const Duration(milliseconds: 100));
+        final position = tester
+            .state<ScrollableState>(
+              find
+                  .descendant(
+                    of: find.byType(CustomScrollView),
+                    matching: find.byType(Scrollable),
+                  )
+                  .first,
+            )
+            .position;
+        expect(position.pixels, greaterThan(0));
+        final proposalsTop = tester.getTopLeft(proposals).dy;
 
-        // The page absorbed the shrink cleanly (the anchor ran, no exception)
-        // and the surviving proposal is still shown.
-        expect(tester.takeException(), isNull);
+        await tester.tap(confirmAll);
+        for (var frame = 0; frame < 6; frame++) {
+          await tester.pump(const Duration(milliseconds: 100));
+          expect(
+            tester.getTopLeft(proposals).dy,
+            closeTo(proposalsTop, 1),
+            reason: 'proposals moved during Accept-all frame $frame',
+          );
+        }
+
+        verify(() => confirmationService.confirmAll(any())).called(1);
         expect(
-          find.textContaining('Set estimate to 30 minutes'),
-          findsOneWidget,
+          container.read(controllableOpenSuggestionCountProvider),
+          isZero,
         );
+        expect(tester.takeException(), isNull);
 
         // Dispose the container (cancels the entry-controller cache timer)
         // before the framework's pending-timer check.

--- a/test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart
+++ b/test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart
@@ -202,6 +202,103 @@ void main() {
     },
   );
 
+  testWidgets(
+    'does not double-count a reported shrink when content below also shrinks',
+    (tester) async {
+      final paintedMarkerTops = <double>[];
+      final key = GlobalKey<_ReportedSizeHarnessState>();
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          _ReportedSizeHarness(
+            key: key,
+            initialHeight: 250,
+            onMarkerPaint: paintedMarkerTops.add,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final state = key.currentState!..controller.jumpTo(1000);
+      await tester.pump();
+      final markerTop = tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy;
+      paintedMarkerTops.clear();
+
+      // The reported region models a checklist row collapsing above the
+      // viewport. The tail models proposal/card content shrinking in the same
+      // layout pass. The new max extent falls below the old offset, so Flutter
+      // would normally range-correct first; the region delta must not then be
+      // applied a second time to that already-clamped offset.
+      state
+        ..hold()
+        ..resizeAndTail(
+          height: 50,
+          tailHeight: 800,
+        );
+      await tester.pump();
+
+      expect(paintedMarkerTops, isNotEmpty);
+      expect(
+        paintedMarkerTops.every((top) => (top - markerTop).abs() <= 1),
+        isTrue,
+        reason: 'painted positions: $paintedMarkerTops',
+      );
+      expect(
+        tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy,
+        closeTo(markerTop, 1),
+      );
+      expect(state.controller.offset, closeTo(800, 1));
+      expect(state.controller.position.maxScrollExtent, closeTo(800, 1));
+    },
+  );
+
+  testWidgets(
+    'retains trailing extent until the user scrolls into the real range',
+    (tester) async {
+      final key = GlobalKey<_ReportedSizeHarnessState>();
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(_ReportedSizeHarness(key: key)),
+      );
+      await tester.pump();
+
+      final state = key.currentState!..controller.jumpTo(1000);
+      await tester.pump();
+      final markerTop = tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy;
+      state
+        ..hold()
+        ..resizeTail(800);
+      await tester.pump();
+
+      // Card/proposal content below the anchor became shorter than the current
+      // viewport position. Keep a virtual tail instead of clamping the page and
+      // moving what the user is reading.
+      expect(state.controller.offset, closeTo(1000, 0.1));
+      expect(state.controller.position.maxScrollExtent, closeTo(1000, 0.1));
+      expect(
+        tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy,
+        closeTo(markerTop, 0.1),
+      );
+
+      // A later content increase that reaches the held offset clears the
+      // virtual floor immediately because the real extent can own it again.
+      state.resizeTail(1200);
+      await tester.pump();
+      expect(state.controller.position.maxScrollExtent, closeTo(1090, 0.1));
+
+      // Recreate the short-tail state to exercise the user-navigation release.
+      state.resizeTail(800);
+      await tester.pump();
+      expect(state.controller.position.maxScrollExtent, closeTo(1000, 0.1));
+
+      // Once deliberate navigation brings the offset inside the real extent,
+      // the temporary tail is released without changing that offset.
+      state.controller.jumpTo(600);
+      await tester.pump();
+
+      expect(state.controller.offset, closeTo(600, 0.1));
+      expect(state.controller.position.maxScrollExtent, closeTo(690, 0.1));
+    },
+  );
+
   testWidgets('keeps scroll offset fixed when the growing region is visible', (
     tester,
   ) async {
@@ -593,8 +690,13 @@ class _StableSizeHarnessState extends State<_StableSizeHarness> {
 }
 
 class _ReportedSizeHarness extends StatefulWidget {
-  const _ReportedSizeHarness({this.onMarkerPaint, super.key});
+  const _ReportedSizeHarness({
+    this.initialHeight = 50,
+    this.onMarkerPaint,
+    super.key,
+  });
 
+  final double initialHeight;
   final ValueChanged<double>? onMarkerPaint;
 
   @override
@@ -603,13 +705,28 @@ class _ReportedSizeHarness extends StatefulWidget {
 
 class _ReportedSizeHarnessState extends State<_ReportedSizeHarness> {
   final controller = ViewportStableScrollController();
-  final height = ValueNotifier<double>(50);
+  late final ValueNotifier<double> height;
   final animatedRegionHeight = ValueNotifier<double>(50);
+  final tailHeight = ValueNotifier<double>(1600);
+
+  @override
+  void initState() {
+    super.initState();
+    height = ValueNotifier(widget.initialHeight);
+  }
 
   void hold() => controller.hold(const Duration(seconds: 2));
 
   // ignore: use_setters_to_change_properties
   void resize(double value) => height.value = value;
+
+  void resizeAndTail({required double height, required double tailHeight}) {
+    this.height.value = height;
+    this.tailHeight.value = tailHeight;
+  }
+
+  // ignore: use_setters_to_change_properties
+  void resizeTail(double value) => tailHeight.value = value;
 
   // ignore: use_setters_to_change_properties
   void resizeAnimatedRegion(double value) => animatedRegionHeight.value = value;
@@ -618,6 +735,7 @@ class _ReportedSizeHarnessState extends State<_ReportedSizeHarness> {
   void dispose() {
     height.dispose();
     animatedRegionHeight.dispose();
+    tailHeight.dispose();
     controller.dispose();
     super.dispose();
   }
@@ -651,7 +769,10 @@ class _ReportedSizeHarnessState extends State<_ReportedSizeHarness> {
                   onPaint: widget.onMarkerPaint,
                   child: const SizedBox(key: _reportedMarkerKey, height: 40),
                 ),
-                const SizedBox(height: 1600),
+                ValueListenableBuilder<double>(
+                  valueListenable: tailHeight,
+                  builder: (context, value, child) => SizedBox(height: value),
+                ),
               ],
             ),
           ),

--- a/test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart
+++ b/test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart
@@ -252,6 +252,43 @@ void main() {
   );
 
   testWidgets(
+    'advances the held baseline across successive retained shrink deltas',
+    (tester) async {
+      final key = GlobalKey<_ReportedSizeHarnessState>();
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          _ReportedSizeHarness(key: key, initialHeight: 250),
+        ),
+      );
+      await tester.pump();
+
+      final state = key.currentState!..controller.jumpTo(1000);
+      await tester.pump();
+      final markerTop = tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy;
+
+      state
+        ..hold()
+        ..resizeAndTail(height: 150, tailHeight: 800);
+      await tester.pump();
+
+      expect(state.controller.offset, closeTo(900, 0.1));
+      expect(
+        tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy,
+        closeTo(markerTop, 0.1),
+      );
+
+      state.resize(50);
+      await tester.pump();
+
+      expect(state.controller.offset, closeTo(800, 0.1));
+      expect(
+        tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy,
+        closeTo(markerTop, 0.1),
+      );
+    },
+  );
+
+  testWidgets(
     'retains trailing extent until the user scrolls into the real range',
     (tester) async {
       final key = GlobalKey<_ReportedSizeHarnessState>();


### PR DESCRIPTION
## Summary

- reorganize the Task Agent footer around a unified automation cluster: wake/thinking/countdown plus the automatic-updates switch
- keep model/provider identity beside the cluster on wide cards and wrap it below on phones; the automation controls can also wrap internally when localized content needs two rows
- render scheduled updates with the existing design-system `DsPill`, a separate `spacing.step8` cancel target, and stable countdown geometry that cannot shift neighboring controls as time changes
- preserve report staleness when automatic updates are disabled while a refresh is pending, so clearing the countdown cannot incorrectly show “Summary is up to date”
- add a repository rule and deterministic regression test requiring all count-up/countdown UI to remain spatially stable
- refresh the Task Agent manual screenshot catalog across all 11 locales and include the `0.9.1054+4229` build bump

## Root cause

The footer treated status, schedule, automation, and model metadata as loosely related rows. That made narrow cards feel airy and unstructured, while the countdown could change its intrinsic width at minute/hour boundaries and move neighboring controls. Separately, disabling automation cleared `nextWakeAt` without first preserving the fact that the current report was awaiting a refresh.

## Selected design: unified automation cluster (C)

The selected layout groups the controls that describe and configure the same automation lifecycle. On desktop/tablet, model identity and the automation cluster share one row. On narrow cards, identity wraps below; inside the cluster, countdown/thinking and the switch wrap independently when needed. All padding, gaps, radii, color, type, and target sizes use existing design-system tokens.

### Scheduled update

| Phone · dark | Desktop · dark |
| --- | --- |
| ![Phone scheduled footer](https://raw.githubusercontent.com/matthiasn/lotti-docs/7b270f9/pr-screenshots/task-agent-footer-variations/production/pro_scheduled_dark.png) | ![Desktop scheduled footer](https://raw.githubusercontent.com/matthiasn/lotti-docs/7b270f9/pr-screenshots/task-agent-footer-variations/production/desktop_scheduled_dark.png) |

### Running update

| Phone · light | Desktop · light |
| --- | --- |
| ![Phone running footer](https://raw.githubusercontent.com/matthiasn/lotti-docs/7b270f9/pr-screenshots/task-agent-footer-variations/production/pro_running_light.png) | ![Desktop running footer](https://raw.githubusercontent.com/matthiasn/lotti-docs/7b270f9/pr-screenshots/task-agent-footer-variations/production/desktop_running_light.png) |

<details>
<summary>Additional narrow-width checks</summary>

375 px scheduled, dark:

![Mini scheduled footer](https://raw.githubusercontent.com/matthiasn/lotti-docs/7b270f9/pr-screenshots/task-agent-footer-variations/production/mini_scheduled_dark.png)

375 px running, light:

![Mini running footer](https://raw.githubusercontent.com/matthiasn/lotti-docs/7b270f9/pr-screenshots/task-agent-footer-variations/production/mini_running_light.png)

</details>

## Validation

- `make analyze` — zero findings
- 62 focused Flutter tests for `TaskAgentControlsFooter` and `TaskAgentService` — all pass
- focused coverage: `task_agent_controls_footer.dart` 188/188 executable lines (100%); every changed service line covered
- deterministic no-jump regression crosses `1:00:00` to `59:59` and asserts unchanged timer size plus toggle/model positions
- 24 PR captures cover scheduled, running, manual, and proposals states at desktop, 402 px, and 375 px widths in light/dark themes
- 176 manual captures cover four Task Agent states at mobile/desktop and light/dark across all 11 locales; manual validation passes for 34 features, 37 pages, and 134 screenshot cases
- full GitHub Actions suite is authoritative and runs on the pushed head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation controls as a responsive grouped footer across wide layouts and phones.
  * Countdown “next update” ticks no longer cause neighboring control shifting; sizing is stable.
  * Canceling/disabling automation during a pending update now keeps task summaries correctly marked as out of date.
  * Running and scheduled UI states render more consistently, including better localized text handling.
  * Task detail scrolling stays anchored when proposal content collapses or layout changes.
* **Documentation**
  * Updated guidance on automation footer behavior and scroll-stability handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->