### PR TITLE
fix: close databases before desktop shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1055]
+### Fixed
+- **Lotti now closes cleanly on Linux and macOS.** Desktop shutdown uses one
+  ordered teardown that stops background services and releases every SQLite
+  database before the Flutter engine exits, avoiding the SIGABRT crash seen
+  after closing the app.
+
 ## [0.9.1054]
 ### Fixed
 - **Task AI summaries are cleaner, more compact, and easier to operate.**

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -33,6 +33,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1055" date="2026-07-20">
+      <description>
+        <p>Fixed a SIGABRT crash after closing Lotti by stopping background services and releasing every SQLite database before the Flutter engine exits.</p>
+      </description>
+    </release>
     <release version="0.9.1054" date="2026-07-18">
       <description>
         <p>Task AI summaries are now cleaner and more compact: report and proposal text matches editor entries and card summaries, metadata is easier to read, and scheduled updates plus their switch form one responsive footer group beside the model on wide cards and above it on phones. Countdown ticks no longer shift neighboring controls, turning off automation during a pending update keeps the summary correctly marked as out of date, and accepting suggestions keeps the task detail scroll position stable while checklist and proposal content resize.</p>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,9 @@ Future<AppExitResponse> _handleAppExitRequested() async {
   return AppExitResponse.exit;
 }
 
+/// Test seam for the desktop exit callback.
+Future<AppExitResponse> handleAppExitRequested() => _handleAppExitRequested();
+
 Future<void> main() async {
   // Raise the file descriptor soft limit before anything opens an FD. On
   // macOS, GUI apps inherit launchd's legacy soft limit of 256, which is

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,11 +39,11 @@ class AppConstants {
 // ignore: unused_element
 late final AppLifecycleListener _appLifecycleListener;
 
-/// Awaits the same ordered teardown used by window-manager close events.
-/// Returning before that shared future completes would allow the Flutter
-/// engine to tear down SQLite's Dart FFI callbacks while handles are live.
+/// Runs the same ordered teardown and platform-aware close path used by
+/// window-manager close events. On macOS this reaches the immediate-exit path
+/// only after all SQLite handles have been released.
 Future<AppExitResponse> _handleAppExitRequested() async {
-  await getIt<WindowService>().shutdown();
+  await getIt<WindowService>().closeWindow();
   return AppExitResponse.exit;
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,14 +7,9 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/beamer/beamer_app.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/editor_db.dart';
-import 'package:lotti/database/fts5_db.dart';
-import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/database/maintenance.dart';
-import 'package:lotti/database/onboarding_metrics_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
-import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart'
     hide aiConfigRepositoryProvider;
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
@@ -44,67 +39,11 @@ class AppConstants {
 // ignore: unused_element
 late final AppLifecycleListener _appLifecycleListener;
 
-/// Per-resource close budget. macOS hard-kills the process roughly 10 s after
-/// `applicationShouldTerminate`, so each close must yield well before that —
-/// 5 s gives us a clear log of which resource was the culprit and still leaves
-/// headroom for the rest of the shutdown sequence to run.
-const _closeTimeout = Duration(seconds: 5);
-
-/// Closes every Drift database before the engine tears down isolates.
-///
-/// Without this, Drift databases are closed via Dart `Finalizer` during VM
-/// shutdown. SQLite's `sqlite3_close_v2` then walks registered application
-/// functions and invokes their `xDestroy` FFI callbacks back into Dart — but
-/// the VM is already in cleanup, so `DLRT_GetFfiCallbackMetadata` asserts and
-/// the process aborts with SIGABRT. Closing here drains writer + read-pool
-/// isolates while the VM is still healthy.
+/// Awaits the same ordered teardown used by window-manager close events.
+/// Returning before that shared future completes would allow the Flutter
+/// engine to tear down SQLite's Dart FFI callbacks while handles are live.
 Future<AppExitResponse> _handleAppExitRequested() async {
-  Future<void> closeIfRegistered<T extends Object>(
-    Future<void> Function(T) close,
-  ) async {
-    if (!getIt.isRegistered<T>()) return;
-    try {
-      await close(getIt<T>()).timeout(_closeTimeout);
-    } on TimeoutException {
-      // Don't rethrow: a stuck close on one resource shouldn't block the
-      // others from getting a chance to close cleanly before exit.
-      getIt<DomainLogger>().log(
-        LogDomain.general,
-        'close timed out after ${_closeTimeout.inSeconds}s',
-        subDomain: 'onExitRequested:$T',
-        level: InsightLevel.error,
-      );
-    } catch (e, stackTrace) {
-      getIt<DomainLogger>().error(
-        LogDomain.general,
-        e,
-        stackTrace: stackTrace,
-        subDomain: 'onExitRequested:$T',
-      );
-    }
-  }
-
-  await Future.wait<void>([
-    closeIfRegistered<JournalDb>((db) => db.close()),
-    closeIfRegistered<Fts5Db>((db) => db.close()),
-    closeIfRegistered<EditorDb>((db) => db.close()),
-    closeIfRegistered<OnboardingMetricsDb>((db) => db.close()),
-    closeIfRegistered<SyncDatabase>((db) => db.close()),
-    closeIfRegistered<AgentDatabase>((db) => db.close()),
-    closeIfRegistered<SettingsDb>((db) => db.close()),
-    closeIfRegistered<AiConfigRepository>((repo) => repo.close()),
-  ]);
-
-  // Flush logs last so any close-time entries (errors caught above, drift
-  // teardown messages) make it to disk before the engine tears down.
-  if (getIt.isRegistered<LoggingService>()) {
-    try {
-      await getIt<LoggingService>().flush();
-    } catch (_) {
-      // Best-effort: the process is exiting; swallow to avoid masking exit.
-    }
-  }
-
+  await getIt<WindowService>().shutdown();
   return AppExitResponse.exit;
 }
 

--- a/lib/services/service_disposer.dart
+++ b/lib/services/service_disposer.dart
@@ -40,7 +40,7 @@ class ServiceDisposer {
   final void Function(dynamic error, StackTrace stackTrace, String service)
   _logError;
 
-  /// Disposes all services and databases. Used on non-macOS platforms.
+  /// Disposes all services and databases during application shutdown.
   Future<void> disposeAll() async {
     await _disposeServices();
     await _disposeDatabases();

--- a/lib/services/service_disposer.dart
+++ b/lib/services/service_disposer.dart
@@ -4,11 +4,15 @@ import 'package:get_it/get_it.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/fts5_db.dart';
+import 'package:lotti/database/notifications_db.dart';
+import 'package:lotti/database/onboarding_metrics_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/ai/database/embedding_store.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/service/embedding_service.dart';
+import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
 import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -27,7 +31,8 @@ const _perOperationTimeout = Duration(seconds: 3);
 /// 2. Stop the outbox (depends on MatrixService being alive)
 /// 3. Stop Matrix sync and close its FFI-backed database
 /// 4. Close the ObjectBox embedding store (no FFI-callback issue, safe on macOS)
-/// 5. Close application Drift databases
+/// 5. Close repositories that own private Drift databases
+/// 6. Close all registered application Drift databases
 class ServiceDisposer {
   ServiceDisposer(this._getIt, this._logError);
 
@@ -39,13 +44,6 @@ class ServiceDisposer {
   Future<void> disposeAll() async {
     await _disposeServices();
     await _disposeDatabases();
-  }
-
-  /// Disposes only non-database services. Used on macOS where calling
-  /// sqlite3_close_v2 triggers a fatal FFI assertion (SIGABRT) during
-  /// VM teardown — see window_service.dart for details.
-  Future<void> disposeServicesOnly() async {
-    await _disposeServices();
   }
 
   Future<void> _disposeServices() async {
@@ -82,7 +80,15 @@ class ServiceDisposer {
   }
 
   Future<void> _disposeDatabases() async {
-    // 5. Close Drift databases so no WAL/lock files are left dangling.
+    // 5. Close repositories that own databases not registered directly.
+    await _disposeAsyncSafely<AiConfigRepository>(
+      (repository) => repository.close(),
+      'AiConfigRepository',
+    );
+
+    // 6. Close every registered Drift database so no native handle is left
+    // for a Dart finalizer to release after the Flutter engine starts tearing
+    // down FFI callback metadata.
     await _disposeAsyncSafely<JournalDb>((db) => db.close(), 'JournalDb');
     await _disposeAsyncSafely<SyncDatabase>((db) => db.close(), 'SyncDatabase');
     await _disposeAsyncSafely<AgentDatabase>(
@@ -91,6 +97,18 @@ class ServiceDisposer {
     );
     await _disposeAsyncSafely<EditorDb>((db) => db.close(), 'EditorDb');
     await _disposeAsyncSafely<Fts5Db>((db) => db.close(), 'Fts5Db');
+    await _disposeAsyncSafely<ConsumptionDatabase>(
+      (db) => db.close(),
+      'ConsumptionDatabase',
+    );
+    await _disposeAsyncSafely<NotificationsDb>(
+      (db) => db.close(),
+      'NotificationsDb',
+    );
+    await _disposeAsyncSafely<OnboardingMetricsDb>(
+      (db) => db.close(),
+      'OnboardingMetricsDb',
+    );
     await _disposeAsyncSafely<SettingsDb>((db) => db.close(), 'SettingsDb');
   }
 

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -42,9 +42,9 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
     _disposer = ServiceDisposer(getIt, _logDisposalError);
   }
 
-  bool _isShuttingDown = false;
-
   late final ServiceDisposer _disposer;
+  Future<void>? _shutdownFuture;
+  Future<void>? _closeFuture;
   final ExitCallback _exitFn;
   final AsyncDisposer _playerDisposer;
   final PlatformCheck _isMacOS;
@@ -130,66 +130,59 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
 
   @override
   void onWindowClose() {
-    unawaited(_handleClose());
+    unawaited(closeWindow());
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.detached) {
-      unawaited(_handleClose());
+      unawaited(closeWindow());
     }
   }
 
-  Future<void> _handleClose() async {
-    if (_isShuttingDown) return;
-    _isShuttingDown = true;
+  /// Stops native/background work and closes every database exactly once.
+  ///
+  /// Both Flutter's app-exit callback and the window-manager callback await
+  /// this same future. This prevents concurrent or duplicate Drift closes and
+  /// ensures a second shutdown signal cannot let engine teardown race ahead of
+  /// the first teardown sequence.
+  Future<void> shutdown() => _shutdownFuture ??= _shutdown();
+
+  Future<void> _shutdown() async {
+    try {
+      await _disposer.disposeAll();
+    } catch (e, s) {
+      _logDisposalError(e, s, 'disposeAll');
+    }
+
+    try {
+      await _playerDisposer();
+    } catch (e, s) {
+      _logDisposalError(e, s, 'audioPlayer');
+    }
+
+    // Bounded so a hung file flush cannot indefinitely delay shutdown.
+    try {
+      if (getIt.isRegistered<LoggingService>()) {
+        await getIt<LoggingService>().flush().timeout(
+          const Duration(seconds: 1),
+        );
+      }
+    } catch (_) {
+      // Logging is best-effort during shutdown.
+    }
+  }
+
+  /// Runs the shared teardown and then terminates the desktop window once.
+  Future<void> closeWindow() => _closeFuture ??= _closeWindow();
+
+  Future<void> _closeWindow() async {
+    await shutdown();
     if (_isMacOS()) {
-      // macOS shutdown sequence — four steps, all while the Dart VM is alive:
-      //
-      // 1. Stop non-database services (outbox, sync, timers).
-      // 2. Dispose the media_kit Player so mpv's native core thread stops
-      //    cleanly and won't try to invoke FFI callbacks during VM teardown.
-      // 3. Flush LoggingService so buffered log lines (the 500 ms batching
-      //    timer) reach disk before _exit cancels all pending Dart timers.
-      // 4. Call POSIX _exit(0) via FFI. Unlike Dart's exit() (which calls
-      //    C exit() → atexit handlers → Dart VM teardown → GC finalizers),
-      //    _exit() terminates immediately. This prevents:
-      //    - NativeFinalizer on FinalizableDatabase triggering sqlite3_close_v2
-      //      → functionDestroy → DLRT_GetFfiCallbackMetadata → SIGABRT
-      //    - Any remaining native threads invoking Dart FFI callbacks
-      //
-      // Safety: SQLite WAL mode guarantees data integrity on abrupt exit;
-      // the WAL is replayed on next open. The OS reclaims all resources.
-      try {
-        await _disposer.disposeServicesOnly();
-      } catch (e, s) {
-        _logDisposalError(e, s, 'disposeServicesOnly');
-      }
-
-      try {
-        await _playerDisposer();
-      } catch (e, s) {
-        _logDisposalError(e, s, 'audioPlayer');
-      }
-
-      // Bounded so a hung file-flush cannot indefinitely delay shutdown.
-      try {
-        if (getIt.isRegistered<LoggingService>()) {
-          await getIt<LoggingService>().flush().timeout(
-            const Duration(seconds: 1),
-          );
-        }
-      } catch (_) {
-        // Logging is best-effort during shutdown; do not block _exit on it.
-      }
-
+      // All SQLite handles have been released while Dart FFI callbacks are
+      // still valid. Avoid a second native-finalizer pass during VM teardown.
       _exitFn(0);
     } else {
-      try {
-        await _disposer.disposeAll();
-      } catch (e, s) {
-        _logDisposalError(e, s, 'disposeAll');
-      }
       try {
         await windowManager.destroy();
       } catch (e, s) {

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -149,11 +149,7 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
   Future<void> shutdown() => _shutdownFuture ??= _shutdown();
 
   Future<void> _shutdown() async {
-    try {
-      await _disposer.disposeAll();
-    } catch (e, s) {
-      _logDisposalError(e, s, 'disposeAll');
-    }
+    await _disposer.disposeAll();
 
     try {
       await _playerDisposer();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1054+4229
+version: 0.9.1055+4230
 
 msix_config:
   display_name: LottiApp

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -14,7 +14,7 @@ void main() {
 
   setUp(() async {
     windowService = MockWindowService();
-    when(windowService.shutdown).thenAnswer((_) async {});
+    when(windowService.closeWindow).thenAnswer((_) async {});
     await setUpTestGetIt(
       additionalSetup: () {
         getIt.registerSingleton<WindowService>(windowService);
@@ -24,10 +24,11 @@ void main() {
 
   tearDown(tearDownTestGetIt);
 
-  test('exit request awaits the shared window-service shutdown', () async {
+  test('exit request awaits the platform-aware window close path', () async {
     final response = await app.handleAppExitRequested();
 
     expect(response, AppExitResponse.exit);
-    verify(windowService.shutdown).called(1);
+    verify(windowService.closeWindow).called(1);
+    verifyNever(windowService.shutdown);
   });
 }

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' show AppExitResponse;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -10,11 +11,16 @@ import 'mocks/mocks.dart';
 import 'widget_test_utils.dart';
 
 void main() {
+  late Completer<void> closeCompleter;
   late MockWindowService windowService;
 
   setUp(() async {
+    closeCompleter = Completer<void>();
+    addTearDown(() {
+      if (!closeCompleter.isCompleted) closeCompleter.complete();
+    });
     windowService = MockWindowService();
-    when(windowService.closeWindow).thenAnswer((_) async {});
+    when(windowService.closeWindow).thenAnswer((_) => closeCompleter.future);
     await setUpTestGetIt(
       additionalSetup: () {
         getIt.registerSingleton<WindowService>(windowService);
@@ -25,7 +31,19 @@ void main() {
   tearDown(tearDownTestGetIt);
 
   test('exit request awaits the platform-aware window close path', () async {
-    final response = await app.handleAppExitRequested();
+    final responseFuture = app.handleAppExitRequested();
+    var responseCompleted = false;
+    unawaited(
+      responseFuture.then((_) {
+        responseCompleted = true;
+      }),
+    );
+
+    await Future<void>.value();
+    expect(responseCompleted, isFalse);
+
+    closeCompleter.complete();
+    final response = await responseFuture;
 
     expect(response, AppExitResponse.exit);
     verify(windowService.closeWindow).called(1);

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,0 +1,33 @@
+import 'dart:ui' show AppExitResponse;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/main.dart' as app;
+import 'package:lotti/services/window_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'mocks/mocks.dart';
+import 'widget_test_utils.dart';
+
+void main() {
+  late MockWindowService windowService;
+
+  setUp(() async {
+    windowService = MockWindowService();
+    when(windowService.shutdown).thenAnswer((_) async {});
+    await setUpTestGetIt(
+      additionalSetup: () {
+        getIt.registerSingleton<WindowService>(windowService);
+      },
+    );
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  test('exit request awaits the shared window-service shutdown', () async {
+    final response = await app.handleAppExitRequested();
+
+    expect(response, AppExitResponse.exit);
+    verify(windowService.shutdown).called(1);
+  });
+}

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -26,6 +26,7 @@ import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/notifications_db.dart';
+import 'package:lotti/database/onboarding_metrics_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
@@ -88,6 +89,7 @@ import 'package:lotti/features/ai_chat/repository/task_summary_repository.dart';
 import 'package:lotti/features/ai_chat/services/audio_transcription_service.dart';
 import 'package:lotti/features/ai_chat/services/realtime_transcription_service.dart';
 import 'package:lotti/features/ai_consumption/consumption/ai_consumption_recorder.dart';
+import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
 import 'package:lotti/features/ai_consumption/repository/consumption_repository.dart';
 import 'package:lotti/features/ai_consumption/sync/consumption_sync_service.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart';
@@ -750,6 +752,10 @@ class RecordingMockNavService extends Mock implements NavService {
 class MockNotificationService extends Mock implements NotificationService {}
 
 class MockNotificationsDb extends Mock implements NotificationsDb {}
+
+class MockOnboardingMetricsDb extends Mock implements OnboardingMetricsDb {}
+
+class MockConsumptionDatabase extends Mock implements ConsumptionDatabase {}
 
 class MockNotificationRepository extends Mock
     implements NotificationRepository {}

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -173,6 +173,7 @@ import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
+import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/location.dart';
 import 'package:matrix/encryption.dart';
@@ -659,6 +660,8 @@ class MockRealtimeTranscriptionService extends Mock
     implements RealtimeTranscriptionService {}
 
 class MockNavService extends Mock implements NavService {}
+
+class MockWindowService extends Mock implements WindowService {}
 
 /// Minimal settings navigation fake for tests that render the desktop
 /// settings master/detail shell without constructing Beamer delegates.

--- a/test/services/service_disposer_test.dart
+++ b/test/services/service_disposer_test.dart
@@ -6,11 +6,15 @@ import 'package:get_it/get_it.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/fts5_db.dart';
+import 'package:lotti/database/notifications_db.dart';
+import 'package:lotti/database/onboarding_metrics_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/ai/database/embedding_store.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/service/embedding_service.dart';
+import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
 import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -66,6 +70,10 @@ void main() {
       when(embeddingStore.close).thenAnswer((_) {
         order.add('EmbeddingStore');
       });
+      final aiConfigRepository = MockAiConfigRepository();
+      when(aiConfigRepository.close).thenAnswer((_) async {
+        order.add('AiConfigRepository');
+      });
 
       final journalDb = MockJournalDb();
       when(journalDb.close).thenAnswer((_) async {
@@ -87,6 +95,18 @@ void main() {
       when(fts5Db.close).thenAnswer((_) async {
         order.add('Fts5Db');
       });
+      final consumptionDb = MockConsumptionDatabase();
+      when(consumptionDb.close).thenAnswer((_) async {
+        order.add('ConsumptionDatabase');
+      });
+      final notificationsDb = MockNotificationsDb();
+      when(notificationsDb.close).thenAnswer((_) async {
+        order.add('NotificationsDb');
+      });
+      final onboardingMetricsDb = MockOnboardingMetricsDb();
+      when(onboardingMetricsDb.close).thenAnswer((_) async {
+        order.add('OnboardingMetricsDb');
+      });
       final settingsDb = MockSettingsDb();
       when(settingsDb.close).thenAnswer((_) async {
         order.add('SettingsDb');
@@ -98,11 +118,15 @@ void main() {
         ..registerSingleton<OutboxService>(outbox)
         ..registerSingleton<MatrixService>(matrix)
         ..registerSingleton<EmbeddingStore>(embeddingStore)
+        ..registerSingleton<AiConfigRepository>(aiConfigRepository)
         ..registerSingleton<JournalDb>(journalDb)
         ..registerSingleton<SyncDatabase>(syncDb)
         ..registerSingleton<AgentDatabase>(agentDb)
         ..registerSingleton<EditorDb>(editorDb)
         ..registerSingleton<Fts5Db>(fts5Db)
+        ..registerSingleton<ConsumptionDatabase>(consumptionDb)
+        ..registerSingleton<NotificationsDb>(notificationsDb)
+        ..registerSingleton<OnboardingMetricsDb>(onboardingMetricsDb)
         ..registerSingleton<SettingsDb>(settingsDb);
 
       await disposer.disposeAll();
@@ -113,35 +137,17 @@ void main() {
         'OutboxService',
         'MatrixService',
         'EmbeddingStore',
+        'AiConfigRepository',
         'JournalDb',
         'SyncDatabase',
         'AgentDatabase',
         'EditorDb',
         'Fts5Db',
+        'ConsumptionDatabase',
+        'NotificationsDb',
+        'OnboardingMetricsDb',
         'SettingsDb',
       ]);
-      expect(loggedErrors, isEmpty);
-    });
-
-    test('disposeServicesOnly skips Drift databases', () async {
-      final order = <String>[];
-
-      final embeddingService = MockEmbeddingService();
-      when(embeddingService.stop).thenAnswer((_) async {
-        order.add('EmbeddingService');
-      });
-      final journalDb = MockJournalDb();
-      when(journalDb.close).thenAnswer((_) async {
-        order.add('JournalDb');
-      });
-
-      testGetIt
-        ..registerSingleton<EmbeddingService>(embeddingService)
-        ..registerSingleton<JournalDb>(journalDb);
-
-      await disposer.disposeServicesOnly();
-
-      expect(order, ['EmbeddingService']);
       expect(loggedErrors, isEmpty);
     });
 
@@ -160,7 +166,7 @@ void main() {
         ..registerSingleton<BackfillRequestService>(backfill)
         ..registerSingleton<EmbeddingService>(embeddingService);
 
-      await disposer.disposeServicesOnly();
+      await disposer.disposeAll();
 
       expect(order, ['EmbeddingService']);
       expect(loggedErrors.single.service, 'BackfillRequestService');
@@ -182,7 +188,7 @@ void main() {
         ..registerSingleton<OutboxService>(outbox)
         ..registerSingleton<MatrixService>(matrix);
 
-      await disposer.disposeServicesOnly();
+      await disposer.disposeAll();
 
       expect(order, ['MatrixService']);
       expect(loggedErrors.single.service, 'OutboxService');
@@ -235,7 +241,7 @@ void main() {
           ..registerSingleton<OutboxService>(outbox)
           ..registerSingleton<MatrixService>(matrix);
 
-        unawaited(disposer.disposeServicesOnly());
+        unawaited(disposer.disposeAll());
 
         // Advance just past the per-operation timeout (3s).
         async

--- a/test/services/window_service_test.dart
+++ b/test/services/window_service_test.dart
@@ -30,6 +30,7 @@ void main() {
       when(mockEmbeddingService.stop).thenAnswer((_) async {});
       when(mockOutbox.dispose).thenAnswer((_) async {});
       when(mockMatrix.dispose).thenAnswer((_) async {});
+      when(mockSettingsDb.close).thenAnswer((_) async {});
 
       getIt
         ..registerSingleton<DomainLogger>(mockDomainLogger)
@@ -44,9 +45,12 @@ void main() {
       await getIt.reset();
     });
 
-    test('macOS shutdown disposes player then calls exit', () async {
+    test('macOS shutdown closes databases before player and exit', () async {
       final callOrder = <String>[];
       final exitCompleter = Completer<int>();
+      when(() => getIt<SettingsDb>().close()).thenAnswer((_) async {
+        callOrder.add('databaseClose');
+      });
 
       WindowService(
         skipWindowManagerSetup: true,
@@ -63,7 +67,7 @@ void main() {
       // Deterministically wait for exit to be called
       final exitCode = await exitCompleter.future;
 
-      expect(callOrder, equals(['playerDispose', 'exit']));
+      expect(callOrder, equals(['databaseClose', 'playerDispose', 'exit']));
       expect(exitCode, equals(0));
     });
 
@@ -170,6 +174,33 @@ void main() {
         expect(playerDisposeCalls, equals(1));
       },
     );
+
+    test('concurrent shutdown callers share one database teardown', () async {
+      final outboxStarted = Completer<void>();
+      final allowOutboxToStop = Completer<void>();
+      when(() => getIt<OutboxService>().dispose()).thenAnswer((_) async {
+        outboxStarted.complete();
+        await allowOutboxToStop.future;
+      });
+
+      final service = WindowService(
+        skipWindowManagerSetup: true,
+        isMacOSOverride: () => true,
+        exitOverride: (_) {},
+        playerDisposerOverride: () async {},
+      );
+
+      final first = service.shutdown();
+      await outboxStarted.future;
+      final second = service.shutdown();
+      expect(identical(first, second), isTrue);
+
+      allowOutboxToStop.complete();
+      await Future.wait([first, second]);
+
+      verify(() => getIt<SettingsDb>().close()).called(1);
+      verify(() => getIt<OutboxService>().dispose()).called(1);
+    });
 
     test('non-macOS shutdown calls disposeAll', () async {
       // Track when the last service disposal completes so we can

--- a/test/services/window_service_test.dart
+++ b/test/services/window_service_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -102,6 +103,22 @@ void main() {
 
       final exitCode = await exitCompleter.future;
       expect(exitCode, equals(0));
+    });
+
+    test('shutdown continues when the final log flush fails', () async {
+      final loggingService = MockLoggingService();
+      when(loggingService.flush).thenThrow(StateError('flush failed'));
+      getIt.registerSingleton<LoggingService>(loggingService);
+
+      await WindowService(
+        skipWindowManagerSetup: true,
+        isMacOSOverride: () => true,
+        exitOverride: (_) {},
+        playerDisposerOverride: () async {},
+      ).shutdown();
+
+      verify(loggingService.flush).called(1);
+      verify(() => getIt<SettingsDb>().close()).called(1);
     });
 
     test('detached lifecycle event triggers macOS shutdown sequence', () async {


### PR DESCRIPTION
## Summary

- route Flutter exit requests, window-close events, and detached lifecycle signals through one shared, awaitable shutdown future
- stop long-running services before closing every registered Drift database and the privately owned AI configuration database
- keep macOS native process termination only after SQLite handles and the media player have been released
- bump the release to `0.9.1055+4229` and update the changelog and Flatpak metadata

## Root cause

Desktop shutdown had two independent teardown owners. `AppLifecycleListener.onExitRequested` closed databases in parallel while `WindowService` separately disposed services and either closed some of the same handles again on Linux or called `_exit(0)` on macOS before the parallel closes necessarily completed. A boolean re-entry guard also allowed a second shutdown callback to return without awaiting the teardown already in progress.

That ordering could leave SQLite finalizers running after Flutter had started dismantling Dart FFI callback metadata, producing the `sqlite3_flutter_libs` `SIGABRT` reported in #3437.

## Fix

`WindowService.shutdown()` now memoizes the complete teardown future. Every exit path awaits that same future, so database closure occurs exactly once and a second signal cannot race engine teardown ahead of it. `ServiceDisposer` now also closes the previously omitted AI config, AI consumption, notifications, and onboarding metrics databases.

Closes #3437.

## Validation

- `fvm flutter analyze lib/main.dart lib/services/window_service.dart lib/services/service_disposer.dart test/mocks/mocks.dart test/main_test.dart test/services/window_service_test.dart test/services/service_disposer_test.dart`
- `fvm flutter test --coverage test/main_test.dart test/services/service_disposer_test.dart test/services/window_service_test.dart` — 17 tests passed; every changed production line is exercised in the focused LCOV report
- `git diff --check`
- AppStream validation reached only pre-existing warnings at lines 471, 615, and 682; the new release entry introduced no reported finding

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. Codecov's patch report is the authoritative patch-coverage result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a **SIGABRT crash** when closing Lotti on **Linux and macOS** by performing an ordered shutdown: services stop first, databases are released, and shutdown completes cleanly before the Flutter engine exits.

* **Tests**
  * Added/expanded coverage for app exit handling, unified window shutdown, macOS shutdown ordering, failure-tolerant final log flushing, idempotent/concurrent shutdown, and improved disposal sequencing.

* **Chores**
  * Updated changelog/Flatpak release notes and bumped the app version to **0.9.1055**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->