### PR TITLE
fix: restore Flatpak secure storage access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ordered teardown that stops background services and releases every SQLite
   database before the Flutter engine exits, avoiding the SIGABRT crash seen
   after closing the app.
+- **Secure storage works again in the Flatpak build.** The sandbox can reach
+  the desktop Secret Service, so Matrix credentials and other protected values
+  can be read and persisted instead of failing with a misleading locked-keyring
+  warning.
 
 ## [0.9.1054]
 ### Fixed

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -32,6 +32,15 @@ Flathub repository. Versioned entries add offline sources or patches for
 hosted Pub packages before `flatpak-flutter` emits
 `generated/sources/pubspec.json`.
 
+### Runtime permissions
+
+The manifest grants `--talk-name=org.freedesktop.secrets` because
+`flutter_secure_storage_linux` talks to the desktop Secret Service through
+libsecret. Without this permission, the service is invisible inside the
+sandbox and the plugin reports `KeyringLocked`, even when the host login
+keyring is unlocked. This permission is required for Matrix credentials and
+other protected settings; removing it breaks secure storage in the Flatpak.
+
 ### What It Does
 
 1. Clones flatpak-flutter if not present

--- a/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
+++ b/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
@@ -15,6 +15,10 @@ finish-args:
   - --filesystem=xdg-documents/Lotti:create
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-download/Lotti:create
+  # flutter_secure_storage_linux uses libsecret directly. Without access to
+  # the Secret Service, the plugin reports the unavailable service as
+  # KeyringLocked and Matrix credentials cannot be read or persisted.
+  - --talk-name=org.freedesktop.secrets
   # Cursor theme access (fixes "Unable to load from cursor theme" warning)
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 modules:

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -36,6 +36,7 @@
     <release version="0.9.1055" date="2026-07-20">
       <description>
         <p>Fixed a SIGABRT crash after closing Lotti by stopping background services and releasing every SQLite database before the Flutter engine exits.</p>
+        <p>Restored Flatpak access to the desktop Secret Service so Matrix credentials and other protected values can be read and persisted instead of failing with a misleading locked-keyring warning.</p>
       </description>
     </release>
     <release version="0.9.1054" date="2026-07-18">


### PR DESCRIPTION
## Summary

- restore the Flatpak permission required for `flutter_secure_storage_linux` to reach the desktop Secret Service
- document why direct `org.freedesktop.secrets` access is necessary
- update the current-version changelog and AppStream release metadata

## Root cause

The host login keyring was unlocked, but `org.freedesktop.secrets` was invisible inside the Flatpak sandbox. The Linux secure-storage plugin collapses an unavailable Secret Service and a genuinely locked collection into the same `KeyringLocked` error, so Lotti could not read or persist Matrix credentials and other protected values.

## Impact

The Flatpak can access the desktop Secret Service again, restoring secure storage. The permission is deliberately explicit because the plugin uses libsecret directly and does not use a portal-backed storage implementation.

## Validation

- `fvm dart format .` (4,047 files checked, 0 changed)
- `fvm flutter test test/features/sync/secure_storage_test.dart` (12 tests passed)
- `make analyze` (zero issues)
- `flatpak-builder --show-manifest flatpak/com.matthiasn.lotti.flatpak-flutter.yml`
- `git diff --check`

AppStream validation also parsed the updated metadata; it continues to report one pre-existing warning and two informational findings in older release text unrelated to this change.

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored secure storage functionality in the Flatpak build.
  * Matrix credentials and other protected settings can now be read and saved without misleading locked-keyring warnings.

* **Documentation**
  * Added documentation explaining the required secure-storage permission and its impact on credential persistence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->