### PR TITLE
docs(skills): add documentation localization workflows

### DIFF
--- a/.claude/skills/add-flutter-docusaurus-locale/SKILL.md
+++ b/.claude/skills/add-flutter-docusaurus-locale/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: add-flutter-docusaurus-locale
+description: Add, complete, or audit a locale across a Flutter application's ARB catalogs and a localized Docusaurus manual, including generated localization code, locale selectors, native platform declarations, translated MDX, screenshot fixtures, tests, and parity validation. Use when introducing a new language, finishing an incomplete app or manual translation, aligning manual terminology with UI strings, or reviewing whether a locale is production-ready end to end.
+---
+
+# Add a Flutter and Docusaurus Locale
+
+Treat a locale as an end-to-end product capability, not merely a translated ARB
+file. Preserve message contracts and wire the locale through app runtime,
+platform metadata, manual routing, screenshots, tests, and release validation.
+
+## Build the locale inventory
+
+1. Read repository instructions and localization/manual contributor guides.
+2. Identify the canonical ARB, all locale ARBs, `l10n.yaml`, generation and
+   sorting commands, localization access conventions, and missing-translation
+   report.
+3. Find every locale allowlist: app delegates/controllers, settings UI, native
+   platform metadata, Docusaurus config, screenshot registries, CI matrices,
+   and documentation.
+4. Inspect one recently added locale in version history as a completeness map,
+   but verify every location against current code.
+5. Read [references/end-to-end-checklist.md](references/end-to-end-checklist.md)
+   for platform and manual integration surfaces.
+
+## Translate the Flutter catalog
+
+1. Copy the complete key set from the canonical ARB, including required
+   metadata and `@@locale` conventions.
+2. Translate user-visible messages in context. Preserve ICU syntax, placeholder
+   names, escaping, line breaks with semantic meaning, and product names.
+3. Use the project's tone and register. Keep terminology consistent across
+   related screens; inspect call sites when a source message is ambiguous.
+4. Do not translate internal identifiers, URLs, format skeletons, or values the
+   framework treats as syntax.
+5. Add locale-specific canonical metadata only where the generator or project
+   requires it.
+6. Run the generator and catalog sorter. Never hand-edit generated Dart files.
+
+## Wire the app and platforms
+
+- Add the locale to runtime choices and language-override state.
+- Update visible language names using localized strings where the UI requires
+  them.
+- Add native supported-language declarations for every shipped platform that
+  maintains an explicit list.
+- Update screenshot locale helpers and deterministic visible fixture copy.
+- Add behavior-focused tests for locale parsing, selection, persistence,
+  delegates, and any locale-specific formatting or fallback behavior.
+
+Do not infer that generated `supportedLocales` completes native registration.
+
+## Translate and wire the Docusaurus manual
+
+1. Add the locale to Docusaurus `i18n.localeConfigs`, navigation labels, footer
+   labels, and any search or routing configuration.
+2. Create the standard docs plugin translation files and a complete localized
+   page tree matching the canonical docs paths.
+3. Reuse terms from the target ARB for buttons, settings, statuses, and feature
+   names. Translate the surrounding explanation naturally.
+4. Preserve MDX imports, components, props, links, code, identifiers, and
+   screenshot case IDs.
+5. Add the locale to screenshot registries and produce every required theme and
+   viewport variant using the project's deterministic harness.
+6. Update contributor documentation and public language lists that users see.
+
+## Audit and validate
+
+Run the bundled contract audit before project-specific generation:
+
+```bash
+python3 <skill-dir>/scripts/audit_locale.py \
+  --template-arb path/to/app_en.arb \
+  --target-arb path/to/app_xx.arb \
+  --source-docs path/to/docs \
+  --target-docs path/to/i18n/xx/docusaurus-plugin-content-docs/current
+```
+
+The audit fails on missing/extra ARB keys, placeholder drift, and manual page
+path mismatch. Identical translated page bodies are warnings unless
+`--fail-identical` is passed.
+
+Then run, in repository order:
+
+1. localization generation and ARB sorting;
+2. targeted localization, locale-selection, screenshot-helper, and manual tests;
+3. formatter and static analysis with zero diagnostics;
+4. the full manual typecheck, validation, tests, production build, and smoke test;
+5. focused Flutter tests required by the repository;
+6. rendered review of representative long strings and every translated manual
+   route.
+
+Do not report the locale complete while generated output is stale, translation
+gaps remain, or required checks fail.

--- a/.claude/skills/add-flutter-docusaurus-locale/agents/openai.yaml
+++ b/.claude/skills/add-flutter-docusaurus-locale/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Flutter and Docusaurus Locale"
+  short_description: "Add a locale across app and manual"
+  default_prompt: "Use $add-flutter-docusaurus-locale to add a locale across this Flutter app and Docusaurus manual."

--- a/.claude/skills/add-flutter-docusaurus-locale/references/end-to-end-checklist.md
+++ b/.claude/skills/add-flutter-docusaurus-locale/references/end-to-end-checklist.md
@@ -1,0 +1,46 @@
+# End-to-end locale checklist
+
+Use this as a discovery checklist; update only surfaces the project actually
+uses.
+
+## Flutter localization
+
+- canonical and target ARB key parity;
+- `@@locale`, descriptions, placeholder metadata, ICU plural/select branches;
+- `l10n.yaml`, `pubspec.yaml`, generator outputs, and missing-translation file;
+- generated delegate `supportedLocales` after regeneration;
+- manual language override, persisted preferences, and fallback behavior;
+- locale-aware dates, numbers, pluralization, and text direction.
+
+## Native platforms
+
+- iOS and macOS `CFBundleLocalizations` or localized resources;
+- Android `res/values-*`, locale config XML, or build-time resource generation;
+- desktop packaging/store metadata if language lists are explicit;
+- web manifest or HTML language metadata when the Flutter web app ships.
+
+## Docusaurus
+
+- `i18n.locales` and `localeConfigs` including `label`, `htmlLang`, and direction;
+- `code.json`, docs plugin `current.json`, navbar, and footer translations;
+- every canonical `.md`/`.mdx` path in the target docs plugin tree;
+- localized titles, descriptions, alt text, callouts, and user-facing props;
+- search tokenization/stemming support and browser-language routing;
+- edit links, canonical URLs, sitemap, 404, version selector, and release aliases.
+
+## Screenshots and fixtures
+
+- locale allowlists in registries, scripts, and CI matrices;
+- target-locale app fixture text not already sourced from ARB;
+- required mobile/desktop and light/dark variants;
+- checksum/dimension manifests and external media repository paths;
+- alt text and screenshot references on every translated page.
+
+## Quality review
+
+- tone/register follows product guidance;
+- UI vocabulary matches the target ARB in the actual screen context;
+- no accidental canonical-language paragraphs or untranslated navigation;
+- long strings do not clip, wrap controls unpredictably, or break fixed layouts;
+- bidirectional layout is reviewed when adding an RTL language;
+- contributor docs and public supported-language lists match reality.

--- a/.claude/skills/add-flutter-docusaurus-locale/scripts/audit_locale.py
+++ b/.claude/skills/add-flutter-docusaurus-locale/scripts/audit_locale.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Audit one Flutter ARB and Docusaurus locale against canonical sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+FORMATTED_ARGUMENT = re.compile(
+    r"\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*"
+    r"(?:plural|select|selectordinal|number|date|time)\b"
+)
+SIMPLE_PLACEHOLDER = re.compile(r"\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}")
+
+
+def message_keys(catalog: dict[str, object]) -> set[str]:
+    return {key for key in catalog if not key.startswith("@")}
+
+
+def placeholders(
+    catalog: dict[str, object], key: str, expected: set[str] | None = None
+) -> set[str]:
+    metadata = catalog.get(f"@{key}")
+    if isinstance(metadata, dict) and isinstance(metadata.get("placeholders"), dict):
+        return set(metadata["placeholders"])
+
+    value = catalog.get(key)
+    if not isinstance(value, str):
+        return set()
+
+    found = set(FORMATTED_ARGUMENT.findall(value))
+    if not found:
+        # Without ICU formatted arguments every {word} is a placeholder.
+        # Inside ICU messages, branch bodies such as one{eins} defeat that
+        # scan, so there we only search for the expected names below.
+        return set(SIMPLE_PLACEHOLDER.findall(value))
+    for name in expected or ():
+        if re.search(rf"\{{\s*{re.escape(name)}\s*(?:\}}|,)", value):
+            found.add(name)
+    return found
+
+
+def pages(root: Path) -> set[Path]:
+    return {
+        path.relative_to(root)
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".md", ".mdx"}
+    }
+
+
+def body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n").strip()
+    if text.startswith("---\n"):
+        _, separator, remainder = text[4:].partition("\n---\n")
+        if separator:
+            return remainder.strip()
+    return text
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template-arb", type=Path, required=True)
+    parser.add_argument("--target-arb", type=Path, required=True)
+    parser.add_argument("--source-docs", type=Path, required=True)
+    parser.add_argument("--target-docs", type=Path, required=True)
+    parser.add_argument("--fail-identical", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    template = json.loads(args.template_arb.read_text(encoding="utf-8"))
+    target = json.loads(args.target_arb.read_text(encoding="utf-8"))
+    template_keys = message_keys(template)
+    target_keys = message_keys(target)
+    missing_keys = sorted(template_keys - target_keys)
+    extra_keys = sorted(target_keys - template_keys)
+    placeholder_drift = []
+    for key in sorted(template_keys & target_keys):
+        expected = placeholders(template, key)
+        if expected != placeholders(target, key, expected):
+            placeholder_drift.append(key)
+
+    source_pages = pages(args.source_docs)
+    target_pages = pages(args.target_docs)
+    missing_pages = sorted(source_pages - target_pages)
+    extra_pages = sorted(target_pages - source_pages)
+    identical_pages = sorted(
+        relative
+        for relative in source_pages & target_pages
+        if body(args.source_docs / relative) == body(args.target_docs / relative)
+    )
+
+    groups = (
+        ("missing ARB key", missing_keys),
+        ("extra ARB key", extra_keys),
+        ("placeholder drift", placeholder_drift),
+        ("missing manual page", missing_pages),
+        ("extra manual page", extra_pages),
+    )
+    for label, values in groups:
+        for value in values:
+            rendered = value.as_posix() if isinstance(value, Path) else value
+            print(f"{label}: {rendered}")
+    for relative in identical_pages:
+        print(f"review identical manual body: {relative.as_posix()}")
+
+    print(
+        f"ARB {len(target_keys)}/{len(template_keys)} keys; "
+        f"manual {len(target_pages)}/{len(source_pages)} pages; "
+        f"{len(placeholder_drift)} placeholder mismatches; "
+        f"{len(identical_pages)} identical manual bodies"
+    )
+
+    failed = any(values for _, values in groups)
+    if args.fail_identical and identical_pages:
+        failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/maintain-docusaurus-manual/SKILL.md
+++ b/.claude/skills/maintain-docusaurus-manual/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: maintain-docusaurus-manual
+description: Maintain a Docusaurus product manual whose prose, navigation, localized page trees, screenshots, coverage metadata, and release build must stay aligned with the application. Use when adding or revising manual pages, documenting a product change, updating translated MDX, repairing locale parity, adding registered screenshots, auditing stale documentation, or validating a multilingual Docusaurus site before publication.
+---
+
+# Maintain a Docusaurus Manual
+
+Treat the running product and source code as authoritative. Keep documentation,
+translations, navigation, screenshots, inventories, and generated site behavior
+consistent in the same change.
+
+## Discover the project contract
+
+1. Read the repository instructions and the manual's own contributor guide.
+2. Locate the Docusaurus config, source docs, localized docs, sidebar, package
+   scripts, validation scripts, screenshot registry, coverage inventory, and CI.
+3. Identify the canonical locale, supported locales, URL/version scheme, and
+   whether localized pages may fall back or must have exact path parity.
+4. Locate app strings or another terminology source before translating UI names.
+5. Read [references/discovery-and-review.md](references/discovery-and-review.md)
+   when the repository has custom inventories, generated screenshots, or
+   versioned publishing.
+
+Do not assume conventional paths when the repository declares its own.
+
+## Update the manual
+
+1. Verify the current product behavior from implementation and focused tests.
+2. Update the canonical page with concrete, task-oriented prose. Describe only
+   controls, states, limitations, and workflows that exist.
+3. Preserve stable frontmatter identifiers, component calls, links, anchors,
+   admonitions, and code unless the change intentionally modifies them.
+4. Add new pages to navigation and every repository-owned coverage or surface
+   inventory.
+5. Update every published locale required by the project. Translate meaning,
+   not sentence shape; preserve product terminology from the localized app.
+6. Record questionable product wording separately unless changing UI copy is
+   explicitly in scope.
+
+## Handle screenshots as evidence
+
+- Prefer the repository's deterministic screenshot harness and registry.
+- Capture the real production widget or route with representative state.
+- Keep required locale, viewport, and theme variants complete.
+- Reference screenshots through the site's component or registry rather than
+  hard-coded media URLs when such an abstraction exists.
+- Keep generated media outside the source repository when that is the declared
+  architecture.
+
+If the task is only a one-off application screenshot, use the repository's
+screenshot skill instead of extending the manual pipeline.
+
+## Validate in increasing scope
+
+1. Run the bundled parity audit when the site uses standard Docusaurus locale
+   trees:
+
+   ```bash
+   python3 <skill-dir>/scripts/audit_docusaurus_locales.py \
+     --site-root path/to/site
+   ```
+
+   Pass `--fail-identical` only when identical localized page bodies are
+   forbidden. Treat its default identical-page output as a review warning.
+
+2. Run focused repository validators and tests for touched metadata or helpers.
+3. Run type checking, link/content validation, unit tests, and the production
+   Docusaurus build through repository scripts.
+4. Smoke-test built routes, locale switching, assets, search, and base URLs.
+5. Review the rendered page at representative widths and in every changed
+   locale. A successful build does not prove prose accuracy or layout quality.
+
+Do not claim completion while required checks fail. Report any validation that
+could not run and why.

--- a/.claude/skills/maintain-docusaurus-manual/agents/openai.yaml
+++ b/.claude/skills/maintain-docusaurus-manual/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docusaurus Manual Maintenance"
+  short_description: "Maintain a localized, verified manual site"
+  default_prompt: "Use $maintain-docusaurus-manual to update and validate this localized Docusaurus manual."

--- a/.claude/skills/maintain-docusaurus-manual/references/discovery-and-review.md
+++ b/.claude/skills/maintain-docusaurus-manual/references/discovery-and-review.md
@@ -1,0 +1,45 @@
+# Discovery and review
+
+Use this reference when a manual has more than a simple `docs/` tree.
+
+## Repository discovery
+
+Search for:
+
+- `docusaurus.config.*`, `sidebars.*`, `package.json`, and site-local README files;
+- `i18n/*/docusaurus-plugin-content-docs/*` locale trees;
+- custom MDX components for screenshots, callouts, release badges, or fallbacks;
+- manifests named `features`, `surfaces`, `coverage`, `screenshots`, or `releases`;
+- build, validation, smoke, link-check, and deployment commands in CI and Makefiles;
+- app localization catalogs used as the terminology authority;
+- deterministic screenshot tests and generated-media repositories.
+
+## Accuracy review
+
+For each changed page, verify:
+
+1. Entry point: route, menu, button, keyboard path, or prerequisite.
+2. State: loading, empty, configured, error, permission, and platform variants.
+3. Actions: what each control changes and whether the change persists or syncs.
+4. Boundaries: unsupported platforms, optional dependencies, privacy, and cost.
+5. Vocabulary: visible labels match the selected locale's product strings.
+6. Evidence: screenshots show production UI and the described state.
+
+## Translation review
+
+- Keep frontmatter slugs and explicit IDs stable unless localized URLs are a
+  deliberate product decision.
+- Preserve MDX imports, JSX component names, prop names, code, paths, URLs, and
+  placeholder syntax.
+- Translate titles, descriptions, alt text, prose, table text, and user-facing
+  component props.
+- Check tone and grammatical agreement in context. Do not validate translations
+  by dictionary equivalence alone.
+- Search for accidental canonical-language paragraphs after translation.
+
+## Release and routing review
+
+Confirm the production base URL, default locale URL, non-default locale prefix,
+version selector, canonical links, sitemap, 404 behavior, and browser-language
+routing. When releases are built from application tags, do not create copied
+version directories unless the repository explicitly uses Docusaurus versioning.

--- a/.claude/skills/maintain-docusaurus-manual/scripts/audit_docusaurus_locales.py
+++ b/.claude/skills/maintain-docusaurus-manual/scripts/audit_docusaurus_locales.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Audit page parity across standard Docusaurus documentation locale trees."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def page_paths(root: Path) -> set[Path]:
+    return {
+        path.relative_to(root)
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".md", ".mdx"}
+    }
+
+
+def normalized_body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n").strip()
+    if text.startswith("---\n"):
+        _, separator, body = text[4:].partition("\n---\n")
+        if separator:
+            return body.strip()
+    return text
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--site-root", type=Path, required=True)
+    parser.add_argument("--docs-dir", default="docs")
+    parser.add_argument("--i18n-dir", default="i18n")
+    parser.add_argument(
+        "--plugin-path", default="docusaurus-plugin-content-docs/current"
+    )
+    parser.add_argument("--locales", help="Comma-separated locale allowlist")
+    parser.add_argument("--fail-identical", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    site_root = args.site_root.resolve()
+    source_root = site_root / args.docs_dir
+    i18n_root = site_root / args.i18n_dir
+    if not source_root.is_dir() or not i18n_root.is_dir():
+        raise SystemExit("Expected source docs and i18n directories were not found.")
+
+    source_pages = page_paths(source_root)
+    requested = set(args.locales.split(",")) if args.locales else None
+    locale_dirs = sorted(path for path in i18n_root.iterdir() if path.is_dir())
+    failures = 0
+
+    for locale_dir in locale_dirs:
+        locale = locale_dir.name
+        if requested is not None and locale not in requested:
+            continue
+        translated_root = locale_dir / args.plugin_path
+        if not translated_root.is_dir():
+            print(f"{locale}: missing docs tree {translated_root}")
+            failures += 1
+            continue
+
+        translated_pages = page_paths(translated_root)
+        missing = sorted(source_pages - translated_pages)
+        extra = sorted(translated_pages - source_pages)
+        identical = sorted(
+            relative
+            for relative in source_pages & translated_pages
+            if normalized_body(source_root / relative)
+            == normalized_body(translated_root / relative)
+        )
+
+        print(
+            f"{locale}: {len(translated_pages)} pages, "
+            f"{len(missing)} missing, {len(extra)} extra, "
+            f"{len(identical)} identical bodies"
+        )
+        for label, paths in (("missing", missing), ("extra", extra)):
+            for path in paths:
+                print(f"  {label}: {path.as_posix()}")
+        for path in identical:
+            print(f"  review identical: {path.as_posix()}")
+
+        failures += bool(missing or extra)
+        if args.fail_identical:
+            failures += bool(identical)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add a reusable `maintain-docusaurus-manual` skill for multilingual manual content, navigation, screenshot evidence, coverage metadata, and publication checks
- add a reusable `add-flutter-docusaurus-locale` skill for end-to-end locale work across Flutter ARB catalogs, native registration, Docusaurus translations, screenshot fixtures, and tests
- include portable reference checklists and executable audits for Docusaurus page parity, ARB key parity, ICU placeholder preservation, and suspicious untranslated pages
- include Codex skill metadata so each directory can be copied and discovered independently

## Why

The recent manual and localization work established repeatable workflows, but those practices only lived in repository documentation and implementation history. Packaging them as skills makes the process reusable by future agents and other projects.

## Impact

Developer workflow only. There is no runtime or user-visible application change, so no CHANGELOG or Flatpak metainfo entry is needed.

## Validation

- both skills pass `quick_validate.py`
- both Python audit scripts compile successfully
- all ten translated locales pass the audits: 3,009 ARB messages and 37 manual pages per locale, with no placeholder or page-path drift
- the incomplete-locale failure path is detected as expected
- `npm --prefix docs-site run check` passes:
  - TypeScript typecheck
  - manual validation
  - 20 Node tests
  - all-locale Docusaurus production build
  - built-site smoke test
- `git diff --check` passes

The approximately 27,000-test Flutter suite is intentionally delegated to CI, where it runs in 10 shards, per the repository validation policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided workflows for adding Flutter app and Docusaurus manual locales, plus ongoing maintenance and validation guidance.
  * Added end-to-end locale checklists covering app/platform localization, localized documentation parity, and screenshot/fixture quality review.
  * Introduced locale audit tooling to flag ARB key differences, placeholder drift, missing/extra documentation pages, and identical manual content (with optional stricter enforcement).
  * Added reference documentation to support Docusaurus discovery, translation/release review, and routing/canonical link checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->