### PR TITLE
fix: keep task page stable while accepting AI suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1058]
+### Fixed
+- **Accepting AI suggestions no longer bounces the task page.** Confirming a
+  batch that mixes header changes (labels, due date, priority, status, title)
+  with checklist items used to shove the page down when the header grew and
+  then snap it back, leaving the rest of the batch uncorrected. The task
+  header now reports its height changes to the same pre-paint scroll
+  stabilizer as the checklist, and the page's two stabilization layers now
+  recognize each other's corrections instead of mistaking them for user
+  scrolls and disarming mid-batch.
+
 ## [0.9.1057]
 ### Removed
 - **The agent Stats tab is gone.** Settings > Agents now opens on Templates

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1058" date="2026-07-22">
+      <description>
+        <p>Accepting AI suggestions no longer bounces the task page: header changes (labels, due date, priority, status, title) confirmed together with checklist items keep the proposals pinned in place instead of shoving the page down and snapping it back mid-batch.</p>
+      </description>
+    </release>
     <release version="0.9.1057" date="2026-07-21">
       <description>
         <p>The agent Stats tab has been removed: Settings &gt; Agents now opens on Templates and keeps four views (Templates, Instances, Souls, and Wake Cycles), with AI usage reporting living in the AI Usage view instead.</p>

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -253,7 +253,9 @@ subtle frame in light and dark themes.
   added). `AiSummaryCard` therefore signals `TaskDetailsPage` synchronously when
   a resolve gesture begins, before checklist persistence can relayout the page.
   The page arms its `ViewportStableScrollController`, while
-  `ViewportStableSizeReporter` wraps the checklist band and reports every
+  `ViewportStableSizeReporter` wraps the header band (title, label, due-date,
+  priority, and status chips — all of which confirmed proposals can grow) and
+  the checklist band, and reports every
   measured height delta. The custom scroll position consumes those deltas in
   `correctForNewDimensions`, causing Flutter to repeat viewport layout at the
   corrected offset before anything paints. This matters for Confirm all:
@@ -296,7 +298,15 @@ subtle frame in light and dark themes.
   collapse (`checklistCompletionAnimationDuration` +
   `checklistCompletionFadeDuration` + buffer), and repeated resolve starts
   refresh it for bulk actions. Both stabilization paths release immediately on
-  a user scroll so they never fight deliberate navigation.
+  a user scroll so they never fight deliberate navigation. Because both paths
+  detect user scrolls as *unexpected offset changes*, they cooperate through
+  the `CooperativeScrollStabilizer` interface: the `ScrollAnchor` announces its
+  post-frame jumps via `adoptCorrection` before making them, and it asks the
+  controller `ownsOffset` before treating a silent pre-paint `correctPixels`
+  as user input. Without that channel, a mixed Confirm-all batch (say, a label
+  chip growing the header plus checklist inserts) had each layer's first
+  correction disarm the other, leaving the rest of the batch to paint
+  uncorrected — the page visibly bounced down and up.
 
   Source-entry transcripts and image analysis use the same pre-paint controller
   through `ViewportStableAnimatedSize`. That wrapper arms itself only when its
@@ -891,9 +901,9 @@ has two region adapters backed by the same `ViewportStableScrollController`:
 - `ViewportStableAnimatedSize` animates generated entry text and nested AI
   response height, automatically arming only when the region is fully above the
   viewport.
-- `ViewportStableSizeReporter` adds no motion; the checklist band uses it while
-  a suggestion-resolution hold is armed because its rows already own their
-  entrance/completion animations.
+- `ViewportStableSizeReporter` adds no motion; the header and checklist bands
+  use it while a suggestion-resolution hold is armed because their content
+  already owns its entrance/completion animations.
 
 Both adapters feed exact region-height deltas into the viewport's own layout
 cycle, so the content currently being read never paints at an intermediate

--- a/lib/features/tasks/ui/pages/task_details_page.dart
+++ b/lib/features/tasks/ui/pages/task_details_page.dart
@@ -153,10 +153,12 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
 
   /// Arms both stabilization layers before proposal persistence begins.
   ///
-  /// Checklist rows report their height deltas to [_scrollController], which
-  /// corrects during viewport layout so no displaced frame is painted. The
-  /// post-frame [_suggestionsAnchor] remains a fallback for mutations in other
-  /// task regions above the proposals.
+  /// The task header and checklist report their height deltas to
+  /// [_scrollController], which corrects during viewport layout so no
+  /// displaced frame is painted. The post-frame [_suggestionsAnchor] remains a
+  /// fallback for mutations in other task regions above the proposals. The two
+  /// layers cooperate via [CooperativeScrollStabilizer] so neither mistakes
+  /// the other's correction for a user scroll and disarms mid-batch.
   void _holdSuggestionsStable() {
     _scrollController.hold(_suggestionResolveHold);
     _suggestionsAnchor.hold();

--- a/lib/features/tasks/ui/task_form.dart
+++ b/lib/features/tasks/ui/task_form.dart
@@ -17,9 +17,13 @@ import 'package:lotti/features/tasks/ui/widgets/viewport_stable_animated_size.da
 /// [Task], stacks (top to bottom): the [DesktopTaskHeaderConnector] header,
 /// an [EditorWidget] for legacy entries that already contain rich text, the
 /// [ChecklistsWidget], the [LinkedTasksWidget], and the [AiSummaryCard] (whose
-/// proposals can be scrolled into view via [suggestionsFocusKey]). Checklist
-/// geometry is reported to the task page's pre-paint scroll stabilizer.
-/// Renders nothing until the entry loads as a task.
+/// proposals can be scrolled into view via [suggestionsFocusKey]). Header and
+/// checklist geometry are reported to the task page's pre-paint scroll
+/// stabilizer: confirmed agent proposals can grow either region above the AI
+/// card (title/label/due-date/priority/status chips in the header, items in
+/// the checklist), and an unreported change there would displace the
+/// proposals under the user's pointer for a frame before the fallback anchor
+/// snaps them back. Renders nothing until the entry loads as a task.
 class TaskForm extends ConsumerWidget {
   const TaskForm({
     required this.taskId,
@@ -56,7 +60,10 @@ class TaskForm extends ConsumerWidget {
     // leading padding so the staggered entrance cascades evenly.
     return StaggeredEntrance(
       children: [
-        DesktopTaskHeaderConnector(taskId: taskId),
+        ViewportStableSizeReporter(
+          key: ValueKey('header-size-reporter-$taskId'),
+          child: DesktopTaskHeaderConnector(taskId: taskId),
+        ),
         if (hasBody)
           Padding(
             padding: EdgeInsets.only(top: tokens.spacing.sectionGap),

--- a/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
+++ b/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
@@ -15,7 +15,8 @@ import 'package:lotti/features/tasks/util/scroll_anchor.dart';
 /// enough to force a range clamp, the position temporarily retains that
 /// trailing extent until the user scrolls back inside the real range. This
 /// avoids both a one-frame displacement and a delayed jump when the hold ends.
-class ViewportStableScrollController extends ScrollController {
+class ViewportStableScrollController extends ScrollController
+    implements CooperativeScrollStabilizer {
   ViewportStableScrollController({
     super.initialScrollOffset,
     super.keepScrollOffset,
@@ -64,6 +65,19 @@ class ViewportStableScrollController extends ScrollController {
 
   void _beginHold() {
     _expectedOffset = positions.length == 1 ? offset : null;
+  }
+
+  @override
+  bool ownsOffset(double offset) {
+    final expectedOffset = _expectedOffset;
+    return expectedOffset != null &&
+        (offset - expectedOffset).abs() <= _tolerance;
+  }
+
+  @override
+  void adoptCorrection(double target) {
+    if (!_isHolding) return;
+    _expectedOffset = target;
   }
 
   void _releaseOnUnexpectedOffsetChange() {

--- a/lib/features/tasks/util/scroll_anchor.dart
+++ b/lib/features/tasks/util/scroll_anchor.dart
@@ -5,6 +5,25 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
+/// Implemented by scroll controllers that correct their own offset as part of
+/// viewport stabilization (e.g. pre-paint extent-delta compensation in
+/// `ViewportStableScrollController`).
+///
+/// [ScrollAnchor] uses this to cooperate instead of colliding: both mechanisms
+/// bow out when the *user* scrolls, and both detect that via unexpected offset
+/// changes — so without a channel between them, each one's legitimate
+/// correction reads as a user scroll to the other and disarms it mid-batch
+/// (e.g. a confirm-all that mutates both the task header and the checklist).
+abstract interface class CooperativeScrollStabilizer {
+  /// Whether [offset] is one this controller itself established via its own
+  /// stabilization corrections (as opposed to user input).
+  bool ownsOffset(double offset);
+
+  /// Records [target] as an offset an external stabilizer is about to jump
+  /// to, so the resulting change is not mistaken for a user scroll.
+  void adoptCorrection(double target);
+}
+
 /// Returns the global top edge of the viewport containing [renderObject].
 ///
 /// Returns `null` when either object is detached or the viewport is not a
@@ -141,6 +160,14 @@ class ScrollAnchor {
     });
   }
 
+  /// The controller as a cooperating stabilizer, or null when it is a plain
+  /// [ScrollController]. (A pattern match, because the interface is not a
+  /// [ScrollController] subtype and `is` alone would not promote.)
+  CooperativeScrollStabilizer? get _cooperative => switch (controller) {
+    final CooperativeScrollStabilizer stabilizer => stabilizer,
+    _ => null,
+  };
+
   ScrollPosition? _positionForCorrection() {
     final anchorTop = _anchorTop;
     // `positions.length != 1` guards both the no-client case and the
@@ -148,12 +175,18 @@ class ScrollAnchor {
     // controller drives more than one scroll view (possible during route
     // transitions or page-state reuse), which `hasClients` would not catch.
     if (anchorTop == null || controller.positions.length != 1) return null;
-    // The offset moved away from what we set → the user is scrolling. Release
-    // rather than yank them back; the long hold window must never fight input.
+    // The offset moved away from what we set → either the user is scrolling,
+    // or a cooperating stabilizing controller corrected it pre-paint. Adopt
+    // the latter and keep holding; release on the former rather than yank the
+    // user back — the long hold window must never fight input.
     final expected = _expectedOffset;
     if (expected != null && (controller.offset - expected).abs() > tolerance) {
-      _endHold();
-      return null;
+      if (_cooperative?.ownsOffset(controller.offset) ?? false) {
+        _expectedOffset = controller.offset;
+      } else {
+        _endHold();
+        return null;
+      }
     }
     return controller.position;
   }
@@ -173,6 +206,10 @@ class ScrollAnchor {
       tolerance: tolerance,
     );
     if (target != null) {
+      // Announce the jump to a cooperating stabilizing controller first, so
+      // it does not read the offset change as a user scroll and release its
+      // own pre-paint holds mid-batch.
+      _cooperative?.adoptCorrection(target);
       controller.jumpTo(target);
       _expectedOffset = target;
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1057+4232
+version: 0.9.1058+4233
 
 msix_config:
   display_name: LottiApp

--- a/test/features/tasks/ui/task_form_test.dart
+++ b/test/features/tasks/ui/task_form_test.dart
@@ -153,6 +153,16 @@ void main() {
         ),
         findsOneWidget,
       );
+      // The header is reported too: confirmed proposals (labels, due date,
+      // priority, status, title) grow it above the AI card, and unreported
+      // growth there would displace the proposals mid-confirm.
+      expect(
+        find.ancestor(
+          of: find.byType(DesktopTaskHeaderConnector),
+          matching: find.byType(ViewportStableSizeReporter),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('agent report shows content when agent has report', (

--- a/test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart
+++ b/test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart
@@ -474,6 +474,65 @@ void main() {
     );
   });
 
+  testWidgets('an adopted external correction keeps the hold anchoring', (
+    tester,
+  ) async {
+    final key = GlobalKey<_ReportedSizeHarnessState>();
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(_ReportedSizeHarness(key: key)),
+    );
+    await tester.pump();
+
+    final state = key.currentState!..controller.jumpTo(300);
+    await tester.pump();
+    state.hold();
+
+    // A cooperating post-frame anchor (ScrollAnchor) announces its jump
+    // before making it, so the offset change must not read as a user scroll.
+    expect(state.controller.ownsOffset(300), isTrue);
+    expect(state.controller.ownsOffset(340), isFalse);
+    state.controller
+      ..adoptCorrection(340)
+      ..jumpTo(340);
+    await tester.pump();
+    expect(state.controller.ownsOffset(340), isTrue);
+    final markerTopAfterJump = tester
+        .getTopLeft(find.byKey(_reportedMarkerKey))
+        .dy;
+
+    // A reported grow after the adopted jump is still consumed pre-paint:
+    // the offset compensates and the marker stays put — the hold survived.
+    state.resize(150);
+    await tester.pump();
+
+    expect(state.controller.offset, closeTo(440, 0.1));
+    expect(
+      tester.getTopLeft(find.byKey(_reportedMarkerKey)).dy,
+      closeTo(markerTopAfterJump, 0.1),
+    );
+  });
+
+  testWidgets('adoptCorrection without an active hold does not arm anchoring', (
+    tester,
+  ) async {
+    final key = GlobalKey<_ReportedSizeHarnessState>();
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(_ReportedSizeHarness(key: key)),
+    );
+    await tester.pump();
+
+    final state = key.currentState!..controller.jumpTo(300);
+    await tester.pump();
+
+    state.controller.adoptCorrection(300);
+    expect(state.controller.ownsOffset(300), isFalse);
+
+    state.resize(150);
+    await tester.pump();
+
+    expect(state.controller.offset, 300);
+  });
+
   testWidgets('sub-pixel offset noise does not release the hold', (
     tester,
   ) async {

--- a/test/features/tasks/util/scroll_anchor_test.dart
+++ b/test/features/tasks/util/scroll_anchor_test.dart
@@ -233,6 +233,75 @@ void main() {
       expect(state.controller.offset, 260);
     });
 
+    testWidgets(
+      'announces its corrections to a cooperating controller before jumping',
+      (tester) async {
+        final controller = _FakeCooperativeController();
+        addTearDown(controller.dispose);
+        final harnessKey = GlobalKey<_AnchorHarnessState>();
+        await tester.pumpWidget(
+          _AnchorHarness(key: harnessKey, controller: controller),
+        );
+        await tester.pump();
+
+        final state = harnessKey.currentState!;
+        state.controller.jumpTo(120);
+        await tester.pump();
+
+        state.anchor.hold();
+        state.grow(300);
+        await tester.pump();
+        await tester.pump();
+
+        // The anchor corrected the drift — and told the controller first, so
+        // a stabilizing controller would not read the jump as a user scroll.
+        expect(state.controller.offset, closeTo(420, 2));
+        expect(controller.adopted, [closeTo(420, 2)]);
+        expect(state.anchor.isHolding, isTrue);
+      },
+    );
+
+    testWidgets(
+      "adopts a cooperating controller's own correction instead of releasing",
+      (tester) async {
+        final controller = _FakeCooperativeController();
+        addTearDown(controller.dispose);
+        final harnessKey = GlobalKey<_AnchorHarnessState>();
+        await tester.pumpWidget(
+          _AnchorHarness(key: harnessKey, controller: controller),
+        );
+        await tester.pump();
+
+        final state = harnessKey.currentState!;
+        state.controller.jumpTo(120);
+        await tester.pump();
+
+        state.anchor.hold();
+        await tester.pump();
+        expect(state.anchor.isHolding, isTrue);
+
+        // Simulate the controller's own pre-paint compensation: content above
+        // grows 140 and the controller corrects the offset by the same amount
+        // in the same frame, marking the new offset as its own.
+        controller.ownedOffsets.add(260);
+        state.grow(140);
+        state.controller.jumpTo(260);
+        await tester.pump();
+
+        // The anchor recognises the correction as the controller's, not the
+        // user's, and keeps holding at the adopted offset.
+        expect(state.anchor.isHolding, isTrue);
+        expect(state.controller.offset, 260);
+
+        // The surviving hold still corrects a later uncompensated shrink.
+        state.grow(-150);
+        await tester.pump();
+        await tester.pump();
+        expect(state.controller.offset, closeTo(110, 2));
+        expect(state.anchor.isHolding, isTrue);
+      },
+    );
+
     testWidgets('does nothing when locate returns null (anchor absent)', (
       tester,
     ) async {
@@ -265,15 +334,34 @@ void main() {
   });
 }
 
+/// Records cooperation calls and lets a test declare which offsets count as
+/// the controller's own corrections.
+class _FakeCooperativeController extends ScrollController
+    implements CooperativeScrollStabilizer {
+  final List<double> adopted = [];
+  final Set<double> ownedOffsets = {};
+
+  @override
+  bool ownsOffset(double offset) => ownedOffsets.contains(offset);
+
+  @override
+  void adoptCorrection(double target) => adopted.add(target);
+}
+
 class _AnchorHarness extends StatefulWidget {
-  const _AnchorHarness({super.key});
+  const _AnchorHarness({this.controller, super.key});
+
+  /// Externally owned controller; the harness creates (and disposes) its own
+  /// when null.
+  final ScrollController? controller;
 
   @override
   State<_AnchorHarness> createState() => _AnchorHarnessState();
 }
 
 class _AnchorHarnessState extends State<_AnchorHarness> {
-  final ScrollController controller = ScrollController();
+  late final ScrollController controller =
+      widget.controller ?? ScrollController();
   final GlobalKey _anchorKey = GlobalKey();
   late final ScrollAnchor anchor = ScrollAnchor(
     controller: controller,
@@ -297,7 +385,7 @@ class _AnchorHarnessState extends State<_AnchorHarness> {
   @override
   void dispose() {
     anchor.dispose();
-    controller.dispose();
+    if (widget.controller == null) controller.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Problem

Accepting a batch of AI suggestions ("Confirm all") that mixes **header-mutating proposals** (assign label, due date, priority, status, title) with **checklist items** made the task detail page visibly bounce: the page was shoved down when the header grew a chip row, snapped back up a frame later, and the remaining batch mutations painted uncorrected (seen at 01:09 of the create-task-from-audio recording).

Two root causes:

1. **Coverage gap:** only the checklist band reported height deltas to the pre-paint scroll stabilizer (`ViewportStableScrollController`). Header growth (label/due-date/priority/status/title chips) was handled solely by the post-frame `ScrollAnchor` fallback, which by design paints the displaced frame before jumping back.
2. **Mutual disarm:** both stabilization layers detect user scrolls as *unexpected offset changes* — so the anchor's corrective `jumpTo` released the controller's batch hold, and the controller's silent pre-paint `correctPixels` released the anchor. In a mixed batch, whichever layer corrected first killed the other, leaving the rest of the batch unstabilized.

## Fix

- Wrap `DesktopTaskHeaderConnector` in `ViewportStableSizeReporter` so header growth is consumed during viewport layout, before paint — same as the checklist.
- New `CooperativeScrollStabilizer` interface (implemented by `ViewportStableScrollController`): `ScrollAnchor` announces its jumps via `adoptCorrection` before making them, and checks `ownsOffset` before treating a silent offset change as a user scroll. Genuine user scrolls still release both layers immediately.
- Version bumped to 0.9.1058+4233; CHANGELOG and flatpak metainfo updated.

## Tests

- `scroll_anchor_test.dart`: anchor announces corrections to a cooperating controller and stays holding; anchor adopts a controller's own correction instead of releasing, and still corrects a later shrink.
- `viewport_stable_animated_size_test.dart`: an adopted external jump keeps the hold anchoring (deltas still consumed pre-paint); `adoptCorrection` without an active hold is inert.
- `task_form_test.dart`: header band is under a `ViewportStableSizeReporter`.
- Analyzer clean; all targeted suites pass (53 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed task pages bouncing or shifting during batch confirmation of AI suggestions.
  - Task headers and checklist items now remain anchored together while suggestions are accepted.
  - Improved scroll stability when task titles, labels, due dates, priorities, statuses, or checklist content change.

- **Documentation**
  - Updated task-page scroll behavior documentation and release metadata.

- **Tests**
  - Added coverage for header sizing and coordinated scroll corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->