### PR TITLE
docs: plan relationship management (ADRs 0037-0041, roadmap, implementation plan)

### DIFF
--- a/docs-site/docs/roadmap.mdx
+++ b/docs-site/docs/roadmap.mdx
@@ -41,3 +41,41 @@ The planned progression:
 Questions and grades come only from content Lotti actually captured — thin
 content yields fewer questions rather than filler, suggestions never run AI
 before you accept, and quizzes never block completing a task.
+
+## Stay close to the people who matter
+
+Relationships become a first-class part of Lotti: one long-running entry
+per person, with its own timeline, alongside your tasks and projects. After
+you see someone, you will be able to log a **check-in** — met in person,
+phone call, video, or message — capturing what you talked about, how the
+interaction felt, and what to pay attention to or avoid next time.
+Relationships link to tasks, so the call you need to prepare or the visit
+you promised sits right on that person's timeline. You will also be able
+to connect a relationship to a contact from your address book — person by
+person, never as a bulk import — and call or message them straight from
+the briefing; when you return to Lotti, it offers to log that interaction
+as a check-in. Mark a relationship as
+**important** and Lotti gently reminds you to check in when too much time
+has passed — you choose the rhythm per person, and only relationships you
+marked important ever produce reminders. Before you next meet someone, an
+**executive briefing** sums up how things are going, the topics from recent
+check-ins, how conversations have felt over time, and what to bring up or
+steer around — like a thoughtful assistant preparing you for the
+conversation.
+
+The planned progression:
+
+1. **Relationships with a timeline** — a person-centered entry with linked
+   notes, photos, and tasks.
+2. **Check-ins** — quick structured capture of each interaction: type,
+   sentiment, topics, and next-time guidance.
+3. **Reminders for important relationships** — cadence-based nudges you
+   control per person.
+4. **Executive briefings** — an AI-prepared summary before your next
+   conversation, grounded only in your own check-ins.
+
+Notes about the people in your life never leave your devices: everything is
+stored locally, sync happens only end-to-end encrypted between your own
+devices, and briefings run on local AI models unless you explicitly choose
+a cloud provider. Handing relationship data to third parties without that
+explicit choice would be irresponsible — so Lotti simply doesn't.

--- a/docs-site/docs/roadmap.mdx
+++ b/docs-site/docs/roadmap.mdx
@@ -57,11 +57,13 @@ the briefing; when you return to Lotti, it offers to log that interaction
 as a check-in. Mark a relationship as
 **important** and Lotti gently reminds you to check in when too much time
 has passed — you choose the rhythm per person, and only relationships you
-marked important ever produce reminders. Before you next meet someone, an
-**executive briefing** sums up how things are going, the topics from recent
-check-ins, how conversations have felt over time, and what to bring up or
-steer around — like a thoughtful assistant preparing you for the
-conversation.
+marked important ever produce reminders. Each relationship gets its own
+dedicated agent — the same durable agents that look after tasks and
+projects — which keeps the picture current and, before you next meet
+someone, prepares an **executive briefing**: how things are going, the
+topics from recent check-ins, how conversations have felt over time, and
+what to bring up or steer around — like a thoughtful assistant preparing
+you for the conversation.
 
 The planned progression:
 
@@ -74,8 +76,13 @@ The planned progression:
 4. **Executive briefings** — an AI-prepared summary before your next
    conversation, grounded only in your own check-ins.
 
-Notes about the people in your life never leave your devices: everything is
-stored locally, sync happens only end-to-end encrypted between your own
-devices, and briefings run on local AI models unless you explicitly choose
-a cloud provider. Handing relationship data to third parties without that
-explicit choice would be irresponsible — so Lotti simply doesn't.
+Relationship data gets the strictest treatment Lotti has: it is stored
+locally on your devices, never on a Lotti server — there is none. If you
+turn on sync, entries travel end-to-end encrypted between your devices, so
+the relay server only ever handles ciphertext. Briefings run on local AI
+models by default; if you explicitly pick a cloud provider, Lotti names it
+before anything is sent — and with a GDPR-compliant provider offering zero
+data retention, inference remains transient processing, with nothing
+stored outside your devices. Handing relationship data to third
+parties without your explicit choice would be irresponsible — so Lotti
+simply doesn't.

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -56,11 +56,12 @@ osobě, nikdy hromadným importem — a přímo z briefingu zavolat nebo napsat;
 po návratu do Lotti ti aplikace nabídne uložit tuto interakci jako
 check-in. Označíš-li vztah jako **důležitý**, Lotti ti šetrně připomene,
 že je čas se ozvat, když uplyne příliš mnoho času — rytmus si u každé osoby
-určuješ ty a připomínky vznikají jen u vztahů označených jako důležité. Než
-se s někým znovu uvidíš, **exekutivní briefing** shrne, jak se věci mají,
-témata z posledních check-inů, jak rozhovory v čase působily a co otevřít
-nebo čemu se raději vyhnout — jako pozorný asistent, který tě připraví na
-rozhovor.
+určuješ ty a připomínky vznikají jen u vztahů označených jako důležité. Každý vztah
+dostane vlastního agenta — stejné trvalé agenty, kteří se starají o úkoly
+a projekty — jenž udržuje obraz aktuální a než se s někým znovu uvidíš,
+připraví **exekutivní briefing**: jak se věci mají, témata z posledních
+check-inů, jak rozhovory v čase působily a co otevřít nebo čemu se raději
+vyhnout — jako pozorný asistent, který tě připraví na rozhovor.
 
 Plánovaný postup:
 
@@ -73,9 +74,12 @@ Plánovaný postup:
 4. **Exekutivní briefingy** — shrnutí připravené AI před dalším rozhovorem,
    opřené jen o tvé vlastní check-iny.
 
-Poznámky o lidech ve tvém životě nikdy neopustí tvá zařízení: vše se ukládá
-lokálně, synchronizace probíhá jen end-to-end šifrovaně mezi tvými
-vlastními zařízeními a briefingy běží na lokálních modelech AI, pokud si
-výslovně nezvolíš cloudového poskytovatele. Předávat data o vztazích třetím
-stranám bez této výslovné volby by bylo nezodpovědné — a tak to Lotti
-prostě nedělá.
+S daty o vztazích zachází Lotti nejpřísněji ze všeho: ukládají se lokálně
+na tvých zařízeních, nikdy na serveru Lotti — žádný neexistuje. Zapneš-li
+synchronizaci, putují záznamy mezi tvými zařízeními end-to-end šifrovaně;
+prostředkující server vidí vždy jen šifrovaný text. Briefingy běží ve výchozím nastavení
+na lokálních modelech AI; zvolíš-li si výslovně cloudového poskytovatele,
+Lotti ho jmenuje, než se cokoli odešle — a u poskytovatele v souladu s
+GDPR a s nulovým uchováváním dat (zero data retention) zůstává inference
+jen prchavým zpracováním: mimo tvá zařízení se nic neukládá. Předávat data o vztazích třetím stranám bez tvé výslovné volby by
+bylo nezodpovědné — a tak to Lotti prostě nedělá.

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -42,3 +42,40 @@ Plánovaný postup:
 Otázky i známky vznikají jen z obsahu, který Lotti skutečně zachytila —
 chudý obsah znamená méně otázek, ne vycpávky; návrhy nikdy nespouštějí AI
 dřív, než souhlasíš, a kvíz nikdy neblokuje dokončení úkolu.
+
+## Zůstaň nablízku lidem, na kterých ti záleží
+
+Vztahy se stanou plnohodnotnou součástí Lotti: jeden dlouhodobý záznam na
+osobu s vlastní časovou osou, hned vedle tvých úkolů a projektů. Po setkání
+půjde zaznamenat **check-in** — osobní setkání, telefonát, video nebo
+zpráva — s tím, o čem jste mluvili, jak setkání působilo a na co si příště
+dát pozor nebo čemu se raději vyhnout. Vztahy se propojují s úkoly, takže
+hovor, který máš připravit, nebo slíbená návštěva leží přímo na časové ose
+dané osoby. Vztah půjde také propojit s kontaktem z adresáře — osobu po
+osobě, nikdy hromadným importem — a přímo z briefingu zavolat nebo napsat;
+po návratu do Lotti ti aplikace nabídne uložit tuto interakci jako
+check-in. Označíš-li vztah jako **důležitý**, Lotti ti šetrně připomene,
+že je čas se ozvat, když uplyne příliš mnoho času — rytmus si u každé osoby
+určuješ ty a připomínky vznikají jen u vztahů označených jako důležité. Než
+se s někým znovu uvidíš, **exekutivní briefing** shrne, jak se věci mají,
+témata z posledních check-inů, jak rozhovory v čase působily a co otevřít
+nebo čemu se raději vyhnout — jako pozorný asistent, který tě připraví na
+rozhovor.
+
+Plánovaný postup:
+
+1. **Vztahy s časovou osou** — záznam zaměřený na osobu s propojenými
+   poznámkami, fotkami a úkoly.
+2. **Check-iny** — rychlé strukturované zachycení každého setkání: typ,
+   pocit, témata a doporučení pro příště.
+3. **Připomínky u důležitých vztahů** — pošťouchnutí v rytmu, který si u
+   každé osoby nastavíš.
+4. **Exekutivní briefingy** — shrnutí připravené AI před dalším rozhovorem,
+   opřené jen o tvé vlastní check-iny.
+
+Poznámky o lidech ve tvém životě nikdy neopustí tvá zařízení: vše se ukládá
+lokálně, synchronizace probíhá jen end-to-end šifrovaně mezi tvými
+vlastními zařízeními a briefingy běží na lokálních modelech AI, pokud si
+výslovně nezvolíš cloudového poskytovatele. Předávat data o vztazích třetím
+stranám bez této výslovné volby by bylo nezodpovědné — a tak to Lotti
+prostě nedělá.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -59,11 +59,13 @@ du vender tilbage til Lotti, tilbyder appen at logge den interaktion som
 et check-in. Markerer du en relation
 som **vigtig**, minder Lotti dig blidt om at tage kontakt, når der er gået
 for lang tid — du vælger rytmen pr. person, og kun relationer markeret som
-vigtige udløser nogensinde påmindelser. Før du ser nogen igen, opsummerer
-en **executive briefing**, hvordan det går, emnerne fra de seneste
-check-ins, hvordan samtalerne har føltes over tid, og hvad du kan tage op
-eller hellere styre udenom — som en opmærksom assistent, der forbereder dig
-på samtalen.
+vigtige udløser nogensinde påmindelser. Hver relation får sin egen
+agent — de samme varige agenter, der tager sig af opgaver og projekter —
+som holder billedet opdateret og, før du ser nogen igen, forbereder en
+**executive briefing**: hvordan det går, emnerne fra de seneste check-ins,
+hvordan samtalerne har føltes over tid, og hvad du kan tage op eller
+hellere styre udenom — som en opmærksom assistent, der forbereder dig på
+samtalen.
 
 Den planlagte rækkefølge:
 
@@ -76,9 +78,13 @@ Den planlagte rækkefølge:
 4. **Executive briefings** — et AI-forberedt resumé før din næste samtale,
    udelukkende baseret på dine egne check-ins.
 
-Noter om menneskene i dit liv forlader aldrig dine enheder: alt gemmes
-lokalt, synkronisering sker kun end-to-end-krypteret mellem dine egne
-enheder, og briefings kører på lokale AI-modeller, medmindre du udtrykkeligt
-vælger en cloud-udbyder. At give relationsdata til tredjeparter uden det
-udtrykkelige valg ville være uansvarligt — så det gør Lotti simpelthen
-ikke.
+Relationsdata får den strengeste behandling, Lotti har: de gemmes lokalt
+på dine enheder, aldrig på en Lotti-server — der findes ingen. Slår du
+synkronisering til, rejser poster end-to-end-krypteret mellem dine
+enheder; den formidlende server ser kun krypteret tekst. Briefings kører som standard på lokale
+AI-modeller; vælger du udtrykkeligt en cloud-udbyder, nævner Lotti den,
+før noget sendes — og med en GDPR-kompatibel udbyder uden datalagring
+(zero data retention) forbliver inferens flygtig behandling: intet gemmes
+uden for dine enheder. At give relationsdata til
+tredjeparter uden dit udtrykkelige valg ville være uansvarligt — så det
+gør Lotti simpelthen ikke.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -43,3 +43,42 @@ Spørgsmål og karakterer kommer kun fra indhold, Lotti faktisk har
 registreret — tyndt indhold giver færre spørgsmål frem for fyld, forslag
 kører aldrig AI, før du siger ja, og en quiz blokerer aldrig for at fuldføre
 en opgave.
+
+## Hold dig tæt på de mennesker, der betyder noget
+
+Relationer bliver en fuldgyldig del af Lotti: én langvarig post pr. person
+med sin egen tidslinje, side om side med dine opgaver og projekter. Efter
+et møde vil du kunne registrere et **check-in** — mødtes personligt,
+telefonopkald, video eller besked — med hvad I talte om, hvordan mødet
+føltes, og hvad du skal være opmærksom på eller undgå næste gang.
+Relationer kan kobles til opgaver, så opkaldet du skal forberede, eller det
+lovede besøg ligger direkte på personens tidslinje. Du vil også kunne
+knytte en relation til en kontakt fra din adressebog — person for person,
+aldrig som masseimport — og ringe eller skrive direkte fra briefingen; når
+du vender tilbage til Lotti, tilbyder appen at logge den interaktion som
+et check-in. Markerer du en relation
+som **vigtig**, minder Lotti dig blidt om at tage kontakt, når der er gået
+for lang tid — du vælger rytmen pr. person, og kun relationer markeret som
+vigtige udløser nogensinde påmindelser. Før du ser nogen igen, opsummerer
+en **executive briefing**, hvordan det går, emnerne fra de seneste
+check-ins, hvordan samtalerne har føltes over tid, og hvad du kan tage op
+eller hellere styre udenom — som en opmærksom assistent, der forbereder dig
+på samtalen.
+
+Den planlagte rækkefølge:
+
+1. **Relationer med en tidslinje** — en personcentreret post med koblede
+   noter, fotos og opgaver.
+2. **Check-ins** — hurtig, struktureret registrering af hvert møde: type,
+   stemning, emner og råd til næste gang.
+3. **Påmindelser for vigtige relationer** — rytmebaserede puf, som du
+   styrer pr. person.
+4. **Executive briefings** — et AI-forberedt resumé før din næste samtale,
+   udelukkende baseret på dine egne check-ins.
+
+Noter om menneskene i dit liv forlader aldrig dine enheder: alt gemmes
+lokalt, synkronisering sker kun end-to-end-krypteret mellem dine egne
+enheder, og briefings kører på lokale AI-modeller, medmindre du udtrykkeligt
+vælger en cloud-udbyder. At give relationsdata til tredjeparter uden det
+udtrykkelige valg ville være uansvarligt — så det gør Lotti simpelthen
+ikke.

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -46,3 +46,46 @@ Fragen und Bewertungen entstehen nur aus Inhalten, die Lotti tatsächlich
 erfasst hat — dünner Inhalt ergibt weniger Fragen statt Füllmaterial,
 Vorschläge starten nie KI, bevor du zustimmst, und ein Quiz blockiert nie
 das Abschließen einer Aufgabe.
+
+## Bleib den Menschen nah, die dir wichtig sind
+
+Beziehungen werden ein vollwertiger Teil von Lotti: ein langlebiger Eintrag
+pro Person mit eigener Chronik, gleichberechtigt neben deinen Aufgaben und
+Projekten. Nach einem Treffen wirst du einen **Check-in** festhalten können
+— persönlich gesehen, telefoniert, Video oder Nachricht — mit dem, worüber
+ihr gesprochen habt, wie sich die Begegnung angefühlt hat und worauf du
+beim nächsten Mal achten oder was du lieber vermeiden willst. Beziehungen
+lassen sich mit Aufgaben verknüpfen, sodass der Anruf, den du vorbereiten
+musst, oder der versprochene Besuch direkt auf der Chronik dieser Person
+liegt. Außerdem wirst du eine Beziehung mit einem Kontakt aus deinem
+Adressbuch verbinden können — Person für Person, nie als Massenimport —
+und direkt aus dem Briefing anrufen oder schreiben; kehrst du zu Lotti
+zurück, bietet es dir an, die Begegnung als Check-in festzuhalten.
+Markierst du eine Beziehung als **wichtig**, erinnert dich Lotti
+behutsam an einen Check-in, wenn zu viel Zeit vergangen ist — den Rhythmus
+bestimmst du pro Person, und nur als wichtig markierte Beziehungen erzeugen
+überhaupt Erinnerungen. Bevor du jemanden wiedersiehst, fasst ein
+**Executive Briefing** zusammen, wie es steht, welche Themen in den letzten
+Check-ins aufkamen, wie sich die Gespräche über die Zeit angefühlt haben
+und was du ansprechen oder lieber umschiffen solltest — wie ein
+aufmerksamer Assistent, der dich aufs Gespräch vorbereitet.
+
+Der geplante Ausbau:
+
+1. **Beziehungen mit Chronik** – ein personenzentrierter Eintrag mit
+   verknüpften Notizen, Fotos und Aufgaben.
+2. **Check-ins** – schnelle, strukturierte Erfassung jeder Begegnung: Art,
+   Stimmung, Themen und Hinweise fürs nächste Mal.
+3. **Erinnerungen für wichtige Beziehungen** – rhythmusbasierte Anstöße,
+   die du pro Person steuerst.
+4. **Executive Briefings** – eine von KI vorbereitete Zusammenfassung vor
+   deinem nächsten Gespräch, ausschließlich auf deine eigenen Check-ins
+   gestützt.
+
+Notizen über die Menschen in deinem Leben verlassen deine Geräte nie:
+Alles wird lokal gespeichert, synchronisiert wird nur
+Ende-zu-Ende-verschlüsselt zwischen deinen eigenen Geräten, und Briefings
+laufen auf lokalen KI-Modellen, sofern du nicht ausdrücklich einen
+Cloud-Anbieter wählst. Beziehungsdaten ohne diese ausdrückliche
+Entscheidung an Dritte zu geben wäre verantwortungslos — also tut Lotti es
+schlicht nicht.

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -64,10 +64,12 @@ zurück, bietet es dir an, die Begegnung als Check-in festzuhalten.
 Markierst du eine Beziehung als **wichtig**, erinnert dich Lotti
 behutsam an einen Check-in, wenn zu viel Zeit vergangen ist — den Rhythmus
 bestimmst du pro Person, und nur als wichtig markierte Beziehungen erzeugen
-überhaupt Erinnerungen. Bevor du jemanden wiedersiehst, fasst ein
-**Executive Briefing** zusammen, wie es steht, welche Themen in den letzten
-Check-ins aufkamen, wie sich die Gespräche über die Zeit angefühlt haben
-und was du ansprechen oder lieber umschiffen solltest — wie ein
+überhaupt Erinnerungen. Jede Beziehung bekommt ihren eigenen
+Agenten — dieselben langlebigen Agenten, die sich um Aufgaben und Projekte
+kümmern —, der das Bild aktuell hält und, bevor du jemanden wiedersiehst,
+ein **Executive Briefing** vorbereitet: wie es steht, welche Themen in den
+letzten Check-ins aufkamen, wie sich die Gespräche über die Zeit angefühlt
+haben und was du ansprechen oder lieber umschiffen solltest — wie ein
 aufmerksamer Assistent, der dich aufs Gespräch vorbereitet.
 
 Der geplante Ausbau:
@@ -82,10 +84,15 @@ Der geplante Ausbau:
    deinem nächsten Gespräch, ausschließlich auf deine eigenen Check-ins
    gestützt.
 
-Notizen über die Menschen in deinem Leben verlassen deine Geräte nie:
-Alles wird lokal gespeichert, synchronisiert wird nur
-Ende-zu-Ende-verschlüsselt zwischen deinen eigenen Geräten, und Briefings
-laufen auf lokalen KI-Modellen, sofern du nicht ausdrücklich einen
-Cloud-Anbieter wählst. Beziehungsdaten ohne diese ausdrückliche
-Entscheidung an Dritte zu geben wäre verantwortungslos — also tut Lotti es
-schlicht nicht.
+Beziehungsdaten behandelt Lotti so streng wie sonst nichts: Sie werden
+lokal auf deinen Geräten gespeichert, nie auf einem Lotti-Server — es gibt
+keinen. Schaltest du die Synchronisation ein, reisen Einträge
+Ende-zu-Ende-verschlüsselt zwischen deinen Geräten; der vermittelnde
+Server sieht immer nur Chiffretext. Briefings laufen standardmäßig auf
+lokalen KI-Modellen; wählst du ausdrücklich einen Cloud-Anbieter, nennt
+Lotti ihn, bevor irgendetwas gesendet wird — und mit einem DSGVO-konformen
+Anbieter ohne Datenspeicherung (Zero Data Retention) bleibt die Inferenz
+flüchtige Verarbeitung, bei der nichts außerhalb deiner Geräte gespeichert
+wird.
+Beziehungsdaten ohne deine ausdrückliche Entscheidung an Dritte zu geben
+wäre verantwortungslos — also tut Lotti es schlicht nicht.

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -66,11 +66,13 @@ volver a Lotti, la app te ofrece registrar esa interacción como check-in.
 Marca una relación como
 **importante** y Lotti te recordará con suavidad que retomes el contacto
 cuando haya pasado demasiado tiempo — tú eliges el ritmo por persona, y
-solo las relaciones marcadas como importantes generan recordatorios. Antes
-de tu próximo encuentro, un **informe ejecutivo** resume cómo van las
-cosas, los temas de los últimos check-ins, cómo se han sentido las
-conversaciones con el tiempo y qué sacar o qué esquivar — como un asistente
-atento que te prepara para la conversación.
+solo las relaciones marcadas como importantes generan recordatorios. Cada
+relación recibe su propio agente — los mismos agentes duraderos que cuidan
+de tareas y proyectos — que mantiene la imagen al día y, antes de tu
+próximo encuentro, prepara un **informe ejecutivo**: cómo van las cosas,
+los temas de los últimos check-ins, cómo se han sentido las conversaciones
+con el tiempo y qué sacar o qué esquivar — como un asistente atento que te
+prepara para la conversación.
 
 La progresión prevista:
 
@@ -83,9 +85,15 @@ La progresión prevista:
 4. **Informes ejecutivos** — un resumen preparado por la IA antes de tu
    próxima conversación, basado solo en tus propios check-ins.
 
-Las notas sobre las personas de tu vida nunca salen de tus dispositivos:
-todo se guarda localmente, la sincronización solo ocurre cifrada de extremo
-a extremo entre tus propios dispositivos, y los informes se generan con
-modelos de IA locales salvo que elijas explícitamente un proveedor en la
-nube. Entregar datos de relaciones a terceros sin esa elección explícita
-sería irresponsable — así que Lotti simplemente no lo hace.
+Los datos de relaciones reciben el trato más estricto de Lotti: se
+guardan localmente en tus dispositivos, nunca en un servidor de Lotti — no
+existe. Si activas la sincronización, las entradas viajan cifradas de
+extremo a extremo entre tus dispositivos; el servidor intermedio solo ve
+texto cifrado. Los informes se generan por defecto
+con modelos de IA locales; si eliges explícitamente un proveedor en la
+nube, Lotti lo nombra antes de enviar nada — y con un proveedor conforme
+al RGPD y sin retención de datos (zero data retention), la inferencia
+sigue siendo un procesamiento transitorio: nada se guarda fuera de tus
+dispositivos. Entregar datos de relaciones a terceros
+sin tu elección explícita sería irresponsable — así que Lotti simplemente
+no lo hace.

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -49,3 +49,43 @@ Las preguntas y las notas solo provienen de contenido que Lotti capturó
 realmente: un contenido escaso produce menos preguntas en lugar de relleno,
 las sugerencias nunca ejecutan la IA antes de que aceptes, y un cuestionario
 nunca bloquea completar una tarea.
+
+## Mantente cerca de las personas que importan
+
+Las relaciones se convierten en una parte de pleno derecho de Lotti: una
+entrada de largo recorrido por persona, con su propia cronología, junto a
+tus tareas y proyectos. Después de ver a alguien podrás registrar un
+**check-in** — encuentro en persona, llamada, vídeo o mensaje — anotando de
+qué hablasteis, cómo se sintió la interacción y a qué prestar atención o
+qué evitar la próxima vez. Las relaciones se vinculan con tareas, de modo
+que la llamada que debes preparar o la visita prometida aparece
+directamente en la cronología de esa persona. También podrás conectar una
+relación con un contacto de tu agenda — persona a persona, nunca como
+importación masiva — y llamar o escribir directamente desde el informe; al
+volver a Lotti, la app te ofrece registrar esa interacción como check-in.
+Marca una relación como
+**importante** y Lotti te recordará con suavidad que retomes el contacto
+cuando haya pasado demasiado tiempo — tú eliges el ritmo por persona, y
+solo las relaciones marcadas como importantes generan recordatorios. Antes
+de tu próximo encuentro, un **informe ejecutivo** resume cómo van las
+cosas, los temas de los últimos check-ins, cómo se han sentido las
+conversaciones con el tiempo y qué sacar o qué esquivar — como un asistente
+atento que te prepara para la conversación.
+
+La progresión prevista:
+
+1. **Relaciones con cronología** — una entrada centrada en la persona con
+   notas, fotos y tareas vinculadas.
+2. **Check-ins** — captura rápida y estructurada de cada interacción: tipo,
+   sentimiento, temas y pautas para la próxima vez.
+3. **Recordatorios para relaciones importantes** — avisos con cadencia que
+   controlas persona a persona.
+4. **Informes ejecutivos** — un resumen preparado por la IA antes de tu
+   próxima conversación, basado solo en tus propios check-ins.
+
+Las notas sobre las personas de tu vida nunca salen de tus dispositivos:
+todo se guarda localmente, la sincronización solo ocurre cifrada de extremo
+a extremo entre tus propios dispositivos, y los informes se generan con
+modelos de IA locales salvo que elijas explícitamente un proveedor en la
+nube. Entregar datos de relaciones a terceros sin esa elección explícita
+sería irresponsable — así que Lotti simplemente no lo hace.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -67,8 +67,10 @@ d’enregistrer cet échange comme check-in. Marque une relation
 comme **importante** et Lotti te rappelle en douceur de prendre des
 nouvelles quand trop de temps a passé — tu choisis le rythme pour chaque
 personne, et seules les relations marquées importantes produisent des
-rappels. Avant ta prochaine rencontre, un **briefing exécutif** résume où
-en sont les choses, les sujets des derniers check-ins, le ressenti des
+rappels. Chaque relation reçoit son propre agent — les mêmes agents
+durables qui s’occupent des tâches et des projets — qui garde une vue à
+jour et, avant ta prochaine rencontre, prépare un **briefing exécutif** :
+où en sont les choses, les sujets des derniers check-ins, le ressenti des
 conversations au fil du temps et ce qu’il faut aborder ou contourner —
 comme un assistant attentionné qui te prépare à la conversation.
 
@@ -83,9 +85,15 @@ La progression prévue :
 4. **Des briefings exécutifs** — un résumé préparé par l’IA avant ta
    prochaine conversation, fondé uniquement sur tes propres check-ins.
 
-Les notes sur les personnes de ta vie ne quittent jamais tes appareils :
-tout est stocké localement, la synchronisation ne se fait que chiffrée de
-bout en bout entre tes propres appareils, et les briefings tournent sur des
-modèles d’IA locaux sauf si tu choisis explicitement un fournisseur cloud.
-Confier des données relationnelles à des tiers sans ce choix explicite
+Les données relationnelles reçoivent le traitement le plus strict de
+Lotti : elles sont stockées localement sur tes appareils, jamais sur un
+serveur Lotti — il n’y en a pas. Si tu actives la synchronisation, les
+entrées voyagent chiffrées de bout en bout entre tes appareils ; le
+serveur relais ne voit jamais que du texte chiffré. Les briefings tournent par
+défaut sur des modèles d’IA locaux ; si tu choisis explicitement un
+fournisseur cloud, Lotti le nomme avant tout envoi — et avec un
+fournisseur conforme au RGPD sans rétention de données (zero data
+retention), l’inférence reste un traitement transitoire : rien n’est
+stocké en dehors de tes appareils.
+Confier des données relationnelles à des tiers sans ton choix explicite
 serait irresponsable — alors Lotti ne le fait tout simplement pas.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -49,3 +49,43 @@ Les questions et les notes ne viennent que du contenu que Lotti a réellement
 capturé — un contenu maigre donne moins de questions plutôt que du
 remplissage, les suggestions ne lancent jamais d’IA avant ton accord, et un
 quiz ne bloque jamais l’achèvement d’une tâche.
+
+## Reste proche des personnes qui comptent
+
+Les relations deviennent un élément à part entière de Lotti : une entrée au
+long cours par personne, avec sa propre chronologie, aux côtés de tes
+tâches et projets. Après avoir vu quelqu’un, tu pourras consigner un
+**check-in** — rencontre en personne, appel, visio ou message — en notant
+de quoi vous avez parlé, comment l’échange s’est ressenti, et ce à quoi
+prêter attention ou ce qu’il vaut mieux éviter la prochaine fois. Les
+relations se lient aux tâches : l’appel à préparer ou la visite promise
+apparaît directement sur la chronologie de la personne. Tu pourras aussi
+associer une relation à un contact de ton carnet d’adresses — personne par
+personne, jamais en import massif — et appeler ou écrire directement
+depuis le briefing ; à ton retour dans Lotti, l’app te propose
+d’enregistrer cet échange comme check-in. Marque une relation
+comme **importante** et Lotti te rappelle en douceur de prendre des
+nouvelles quand trop de temps a passé — tu choisis le rythme pour chaque
+personne, et seules les relations marquées importantes produisent des
+rappels. Avant ta prochaine rencontre, un **briefing exécutif** résume où
+en sont les choses, les sujets des derniers check-ins, le ressenti des
+conversations au fil du temps et ce qu’il faut aborder ou contourner —
+comme un assistant attentionné qui te prépare à la conversation.
+
+La progression prévue :
+
+1. **Des relations avec une chronologie** — une entrée centrée sur la
+   personne, avec notes, photos et tâches liées.
+2. **Des check-ins** — une saisie rapide et structurée de chaque échange :
+   type, ressenti, sujets et conseils pour la prochaine fois.
+3. **Des rappels pour les relations importantes** — des coups de pouce
+   cadencés que tu règles personne par personne.
+4. **Des briefings exécutifs** — un résumé préparé par l’IA avant ta
+   prochaine conversation, fondé uniquement sur tes propres check-ins.
+
+Les notes sur les personnes de ta vie ne quittent jamais tes appareils :
+tout est stocké localement, la synchronisation ne se fait que chiffrée de
+bout en bout entre tes propres appareils, et les briefings tournent sur des
+modèles d’IA locaux sauf si tu choisis explicitement un fournisseur cloud.
+Confier des données relationnelles à des tiers sans ce choix explicite
+serait irresponsable — alors Lotti ne le fait tout simplement pas.

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -47,3 +47,43 @@ Domande e voti nascono solo da contenuti che Lotti ha realmente acquisito —
 un contenuto scarno produce meno domande, non riempitivi; i suggerimenti non
 eseguono mai l’IA prima del tuo consenso e un quiz non blocca mai il
 completamento di un compito.
+
+## Resta vicino alle persone che contano
+
+Le relazioni diventano una parte di prim’ordine di Lotti: una voce di lungo
+corso per ogni persona, con la propria cronologia, accanto ai tuoi compiti
+e progetti. Dopo aver visto qualcuno potrai registrare un **check-in** —
+incontro di persona, telefonata, video o messaggio — annotando di cosa
+avete parlato, com’è stata l’interazione e a cosa prestare attenzione o
+cosa evitare la prossima volta. Le relazioni si collegano ai compiti, così
+la telefonata da preparare o la visita promessa compare direttamente sulla
+cronologia di quella persona. Potrai anche collegare una relazione a un
+contatto della tua rubrica — persona per persona, mai come importazione in
+blocco — e chiamare o scrivere direttamente dal briefing; al tuo ritorno
+in Lotti, l’app ti propone di registrare quell’interazione come check-in.
+Se contrassegni una relazione come
+**importante**, Lotti ti ricorda con delicatezza di farti sentire quando è
+passato troppo tempo — scegli tu il ritmo per ogni persona, e solo le
+relazioni contrassegnate come importanti generano promemoria. Prima del
+prossimo incontro, un **briefing esecutivo** riassume come vanno le cose, i
+temi degli ultimi check-in, come si sono sentite le conversazioni nel tempo
+e cosa affrontare o aggirare — come un assistente premuroso che ti prepara
+alla conversazione.
+
+La progressione prevista:
+
+1. **Relazioni con una cronologia** — una voce centrata sulla persona con
+   note, foto e compiti collegati.
+2. **Check-in** — registrazione rapida e strutturata di ogni interazione:
+   tipo, sentimento, temi e indicazioni per la prossima volta.
+3. **Promemoria per le relazioni importanti** — spinte gentili a cadenza
+   regolare, che controlli persona per persona.
+4. **Briefing esecutivi** — un riepilogo preparato dall’IA prima della tua
+   prossima conversazione, fondato solo sui tuoi check-in.
+
+Le note sulle persone della tua vita non lasciano mai i tuoi dispositivi:
+tutto è salvato in locale, la sincronizzazione avviene solo cifrata
+end-to-end tra i tuoi dispositivi, e i briefing girano su modelli IA locali
+a meno che tu non scelga esplicitamente un provider cloud. Consegnare dati
+sulle relazioni a terzi senza questa scelta esplicita sarebbe
+irresponsabile — perciò Lotti semplicemente non lo fa.

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -68,7 +68,7 @@ relazioni contrassegnate come importanti generano promemoria. Ogni relazione ric
 proprio agente — gli stessi agenti durevoli che si occupano di compiti e
 progetti — che tiene aggiornato il quadro e, prima del prossimo incontro,
 prepara un **briefing esecutivo**: come vanno le cose, i temi degli ultimi
-check-in, come si sono sentite le conversazioni nel tempo e cosa
+check-in, come sono andate le conversazioni nel tempo e cosa
 affrontare o aggirare — come un assistente premuroso che ti prepara alla
 conversazione.
 

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -64,11 +64,13 @@ in Lotti, l’app ti propone di registrare quell’interazione come check-in.
 Se contrassegni una relazione come
 **importante**, Lotti ti ricorda con delicatezza di farti sentire quando è
 passato troppo tempo — scegli tu il ritmo per ogni persona, e solo le
-relazioni contrassegnate come importanti generano promemoria. Prima del
-prossimo incontro, un **briefing esecutivo** riassume come vanno le cose, i
-temi degli ultimi check-in, come si sono sentite le conversazioni nel tempo
-e cosa affrontare o aggirare — come un assistente premuroso che ti prepara
-alla conversazione.
+relazioni contrassegnate come importanti generano promemoria. Ogni relazione riceve un
+proprio agente — gli stessi agenti durevoli che si occupano di compiti e
+progetti — che tiene aggiornato il quadro e, prima del prossimo incontro,
+prepara un **briefing esecutivo**: come vanno le cose, i temi degli ultimi
+check-in, come si sono sentite le conversazioni nel tempo e cosa
+affrontare o aggirare — come un assistente premuroso che ti prepara alla
+conversazione.
 
 La progressione prevista:
 
@@ -81,9 +83,15 @@ La progressione prevista:
 4. **Briefing esecutivi** — un riepilogo preparato dall’IA prima della tua
    prossima conversazione, fondato solo sui tuoi check-in.
 
-Le note sulle persone della tua vita non lasciano mai i tuoi dispositivi:
-tutto è salvato in locale, la sincronizzazione avviene solo cifrata
-end-to-end tra i tuoi dispositivi, e i briefing girano su modelli IA locali
-a meno che tu non scelga esplicitamente un provider cloud. Consegnare dati
-sulle relazioni a terzi senza questa scelta esplicita sarebbe
-irresponsabile — perciò Lotti semplicemente non lo fa.
+I dati sulle relazioni ricevono il trattamento più rigoroso di Lotti:
+sono salvati localmente sui tuoi dispositivi, mai su un server Lotti — non
+esiste. Se attivi la sincronizzazione, le voci viaggiano cifrate
+end-to-end tra i tuoi dispositivi; il server di transito vede sempre e
+solo testo cifrato. I briefing girano per impostazione
+predefinita su modelli IA locali; se scegli esplicitamente un provider
+cloud, Lotti lo indica prima che qualcosa venga inviato — e con un
+provider conforme al GDPR con zero data retention, l’inferenza resta
+un’elaborazione transitoria: nulla viene conservato fuori dai tuoi
+dispositivi. Consegnare dati sulle relazioni a terzi
+senza la tua scelta esplicita sarebbe irresponsabile — perciò Lotti
+semplicemente non lo fa.

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -62,11 +62,13 @@ app aan die interactie als check-in vast te leggen. Markeer je een relatie
 als **belangrijk**, dan herinnert Lotti je er
 vriendelijk aan om weer eens contact op te nemen als er te veel tijd is
 verstreken — jij bepaalt het ritme per persoon, en alleen relaties die je
-als belangrijk hebt gemarkeerd leveren ooit herinneringen op. Vóór je
-iemand weer ziet vat een **executive briefing** samen hoe het ervoor staat,
-welke onderwerpen in recente check-ins speelden, hoe gesprekken door de
-tijd heen voelden en wat je kunt aansnijden of beter kunt omzeilen — als
-een attente assistent die je op het gesprek voorbereidt.
+als belangrijk hebt gemarkeerd leveren ooit herinneringen op. Elke relatie
+krijgt een eigen agent — dezelfde duurzame agenten die taken en projecten
+beheren — die het beeld actueel houdt en, vóór je iemand weer ziet, een
+**executive briefing** voorbereidt: hoe het ervoor staat, welke
+onderwerpen in recente check-ins speelden, hoe gesprekken door de tijd
+heen voelden en wat je kunt aansnijden of beter kunt omzeilen — als een
+attente assistent die je op het gesprek voorbereidt.
 
 De geplande volgorde:
 
@@ -79,9 +81,13 @@ De geplande volgorde:
 4. **Executive briefings** — een door AI voorbereide samenvatting vóór je
    volgende gesprek, uitsluitend gebaseerd op je eigen check-ins.
 
-Notities over de mensen in je leven verlaten je apparaten nooit: alles
-wordt lokaal opgeslagen, synchronisatie gebeurt alleen end-to-end
-versleuteld tussen je eigen apparaten, en briefings draaien op lokale
-AI-modellen tenzij je expliciet een cloudprovider kiest. Relatiegegevens
-zonder die expliciete keuze aan derden geven zou onverantwoord zijn — dus
-doet Lotti dat simpelweg niet.
+Relatiegegevens krijgen de strengste behandeling die Lotti kent: ze
+worden lokaal op je apparaten opgeslagen, nooit op een Lotti-server — die
+bestaat niet. Zet je synchronisatie aan, dan reizen items end-to-end
+versleuteld tussen je apparaten; de tussenliggende server ziet alleen
+versleutelde tekst. Briefings draaien standaard op lokale
+AI-modellen; kies je expliciet een cloudprovider, dan noemt Lotti die
+voordat er iets wordt verzonden — en bij een AVG-conforme provider zonder
+dataretentie (zero data retention) blijft inferentie vluchtige verwerking:
+buiten je apparaten wordt niets opgeslagen. Relatiegegevens zonder jouw expliciete keuze aan
+derden geven zou onverantwoord zijn — dus doet Lotti dat simpelweg niet.

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -45,3 +45,43 @@ Vragen en beoordelingen komen alleen uit inhoud die Lotti echt heeft
 vastgelegd — magere inhoud levert minder vragen op in plaats van opvulling,
 suggesties draaien nooit AI voordat je akkoord gaat, en een quiz blokkeert
 nooit het afronden van een taak.
+
+## Blijf dicht bij de mensen die ertoe doen
+
+Relaties worden een volwaardig onderdeel van Lotti: één langlopende
+invoer per persoon, met een eigen tijdlijn, naast je taken en projecten.
+Na een ontmoeting kun je straks een **check-in** vastleggen — in persoon
+gezien, gebeld, video of bericht — met waar jullie het over hadden, hoe het
+contact voelde en waar je de volgende keer op wilt letten of wat je beter
+vermijdt. Relaties koppel je aan taken, zodat het telefoontje dat je moet
+voorbereiden of het beloofde bezoek direct op de tijdlijn van die persoon
+staat. Je kunt een relatie straks ook koppelen aan een contact uit je
+adresboek — persoon voor persoon, nooit als bulkimport — en direct vanuit
+de briefing bellen of berichten; keer je terug naar Lotti, dan biedt de
+app aan die interactie als check-in vast te leggen. Markeer je een relatie
+als **belangrijk**, dan herinnert Lotti je er
+vriendelijk aan om weer eens contact op te nemen als er te veel tijd is
+verstreken — jij bepaalt het ritme per persoon, en alleen relaties die je
+als belangrijk hebt gemarkeerd leveren ooit herinneringen op. Vóór je
+iemand weer ziet vat een **executive briefing** samen hoe het ervoor staat,
+welke onderwerpen in recente check-ins speelden, hoe gesprekken door de
+tijd heen voelden en wat je kunt aansnijden of beter kunt omzeilen — als
+een attente assistent die je op het gesprek voorbereidt.
+
+De geplande volgorde:
+
+1. **Relaties met een tijdlijn** — een persoonsgerichte invoer met
+   gekoppelde notities, foto's en taken.
+2. **Check-ins** — snelle, gestructureerde vastlegging van elk contact:
+   type, gevoel, onderwerpen en tips voor de volgende keer.
+3. **Herinneringen voor belangrijke relaties** — ritmische duwtjes die je
+   per persoon instelt.
+4. **Executive briefings** — een door AI voorbereide samenvatting vóór je
+   volgende gesprek, uitsluitend gebaseerd op je eigen check-ins.
+
+Notities over de mensen in je leven verlaten je apparaten nooit: alles
+wordt lokaal opgeslagen, synchronisatie gebeurt alleen end-to-end
+versleuteld tussen je eigen apparaten, en briefings draaien op lokale
+AI-modellen tenzij je expliciet een cloudprovider kiest. Relatiegegevens
+zonder die expliciete keuze aan derden geven zou onverantwoord zijn — dus
+doet Lotti dat simpelweg niet.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -47,3 +47,42 @@ As perguntas e as notas nascem apenas de conteúdo que o Lotti realmente
 capturou — conteúdo escasso produz menos perguntas em vez de enchimento, as
 sugestões nunca executam IA antes de aceitar, e um questionário nunca
 bloqueia a conclusão de uma tarefa.
+
+## Fique perto das pessoas que importam
+
+As relações tornam-se uma parte de pleno direito do Lotti: uma entrada de
+longa duração por pessoa, com a sua própria cronologia, ao lado das suas
+tarefas e projetos. Depois de ver alguém, poderá registar um **check-in** —
+encontro em pessoa, chamada, vídeo ou mensagem — anotando sobre o que
+falaram, como a interação se sentiu e a que prestar atenção ou o que evitar
+da próxima vez. As relações ligam-se a tarefas, de modo que a chamada que
+precisa de preparar ou a visita prometida fica diretamente na cronologia
+dessa pessoa. Poderá também associar uma relação a um contacto da sua
+lista de contactos — pessoa a pessoa, nunca como importação em massa — e
+ligar ou enviar mensagem diretamente a partir do briefing; ao regressar ao
+Lotti, a aplicação propõe registar essa interação como check-in. Marque
+uma relação como **importante** e o Lotti lembra-o com
+delicadeza de retomar o contacto quando tiver passado demasiado tempo —
+escolhe o ritmo por pessoa, e apenas as relações marcadas como importantes
+geram lembretes. Antes do próximo encontro, um **briefing executivo** resume
+como as coisas estão, os temas dos check-ins recentes, como as conversas se
+têm sentido ao longo do tempo e o que abordar ou contornar — como um
+assistente atento que o prepara para a conversa.
+
+A progressão planeada:
+
+1. **Relações com cronologia** — uma entrada centrada na pessoa, com notas,
+   fotografias e tarefas ligadas.
+2. **Check-ins** — registo rápido e estruturado de cada interação: tipo,
+   sentimento, temas e orientações para a próxima vez.
+3. **Lembretes para relações importantes** — toques com cadência que
+   controla pessoa a pessoa.
+4. **Briefings executivos** — um resumo preparado pela IA antes da sua
+   próxima conversa, baseado apenas nos seus próprios check-ins.
+
+As notas sobre as pessoas da sua vida nunca saem dos seus dispositivos:
+tudo é guardado localmente, a sincronização acontece apenas cifrada de
+ponta a ponta entre os seus próprios dispositivos, e os briefings correm em
+modelos de IA locais, a menos que escolha explicitamente um fornecedor na
+nuvem. Entregar dados de relações a terceiros sem essa escolha explícita
+seria irresponsável — por isso o Lotti simplesmente não o faz.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -64,10 +64,12 @@ Lotti, a aplicação propõe registar essa interação como check-in. Marque
 uma relação como **importante** e o Lotti lembra-o com
 delicadeza de retomar o contacto quando tiver passado demasiado tempo —
 escolhe o ritmo por pessoa, e apenas as relações marcadas como importantes
-geram lembretes. Antes do próximo encontro, um **briefing executivo** resume
-como as coisas estão, os temas dos check-ins recentes, como as conversas se
-têm sentido ao longo do tempo e o que abordar ou contornar — como um
-assistente atento que o prepara para a conversa.
+geram lembretes. Cada relação recebe o seu próprio agente — os
+mesmos agentes duradouros que cuidam de tarefas e projetos — que mantém o
+quadro atualizado e, antes do próximo encontro, prepara um **briefing
+executivo**: como as coisas estão, os temas dos check-ins recentes, como
+as conversas se têm sentido ao longo do tempo e o que abordar ou contornar
+— como um assistente atento que o prepara para a conversa.
 
 A progressão planeada:
 
@@ -80,9 +82,15 @@ A progressão planeada:
 4. **Briefings executivos** — um resumo preparado pela IA antes da sua
    próxima conversa, baseado apenas nos seus próprios check-ins.
 
-As notas sobre as pessoas da sua vida nunca saem dos seus dispositivos:
-tudo é guardado localmente, a sincronização acontece apenas cifrada de
-ponta a ponta entre os seus próprios dispositivos, e os briefings correm em
-modelos de IA locais, a menos que escolha explicitamente um fornecedor na
-nuvem. Entregar dados de relações a terceiros sem essa escolha explícita
-seria irresponsável — por isso o Lotti simplesmente não o faz.
+Os dados de relações recebem o tratamento mais rigoroso do Lotti: são
+guardados localmente nos seus dispositivos, nunca num servidor do Lotti —
+não existe nenhum. Se ativar a sincronização, as entradas viajam cifradas
+de ponta a ponta entre os seus dispositivos; o servidor intermediário vê
+sempre apenas texto cifrado. Os briefings correm por predefinição
+em modelos de IA locais; se escolher explicitamente um fornecedor na
+nuvem, o Lotti indica-o antes de algo ser enviado — e com um fornecedor
+conforme ao RGPD e sem retenção de dados (zero data retention), a
+inferência permanece um processamento transitório: nada fica guardado
+fora dos seus dispositivos. Entregar dados de
+relações a terceiros sem a sua escolha explícita seria irresponsável — por
+isso o Lotti simplesmente não o faz.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -54,7 +54,7 @@ As relações tornam-se uma parte de pleno direito do Lotti: uma entrada de
 longa duração por pessoa, com a sua própria cronologia, ao lado das suas
 tarefas e projetos. Depois de ver alguém, poderá registar um **check-in** —
 encontro em pessoa, chamada, vídeo ou mensagem — anotando sobre o que
-falaram, como a interação se sentiu e a que prestar atenção ou o que evitar
+falaram, como foi a interação e a que prestar atenção ou o que evitar
 da próxima vez. As relações ligam-se a tarefas, de modo que a chamada que
 precisa de preparar ou a visita prometida fica diretamente na cronologia
 dessa pessoa. Poderá também associar uma relação a um contacto da sua
@@ -68,7 +68,7 @@ geram lembretes. Cada relação recebe o seu próprio agente — os
 mesmos agentes duradouros que cuidam de tarefas e projetos — que mantém o
 quadro atualizado e, antes do próximo encontro, prepara um **briefing
 executivo**: como as coisas estão, os temas dos check-ins recentes, como
-as conversas se têm sentido ao longo do tempo e o que abordar ou contornar
+as conversas têm corrido ao longo do tempo e o que abordar ou contornar
 — como um assistente atento que o prepara para a conversa.
 
 A progressão planeada:

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -65,8 +65,10 @@ propune să înregistrați acea interacțiune ca check-in. Marcați o relație c
 **importantă** și Lotti vă va reaminti cu
 delicatețe să reluați legătura când a trecut prea mult timp — alegeți
 ritmul pentru fiecare persoană, iar doar relațiile marcate ca importante
-generează vreodată mementouri. Înainte de următoarea întâlnire, un
-**briefing executiv** rezumă cum stau lucrurile, temele din check-inurile
+generează vreodată mementouri. Fiecare relație primește propriul
+agent — aceiași agenți durabili care se ocupă de sarcini și proiecte —
+care menține imaginea la zi și, înaintea următoarei întâlniri, pregătește
+un **briefing executiv**: cum stau lucrurile, temele din check-inurile
 recente, cum s-au simțit conversațiile în timp și ce să abordați sau ce să
 ocoliți — ca un asistent atent care vă pregătește pentru conversație.
 
@@ -81,9 +83,14 @@ Progresia planificată:
 4. **Briefinguri executive** — un rezumat pregătit de AI înaintea
    următoarei conversații, întemeiat doar pe propriile check-inuri.
 
-Notițele despre oamenii din viața dvs. nu părăsesc niciodată dispozitivele
-dvs.: totul este stocat local, sincronizarea are loc doar criptată
-end-to-end între propriile dispozitive, iar briefingurile rulează pe modele
-AI locale, cu excepția cazului în care alegeți explicit un furnizor cloud.
-A preda date despre relații unor terți fără această alegere explicită ar fi
-iresponsabil — așa că Lotti pur și simplu nu o face.
+Datele despre relații primesc cel mai strict tratament din Lotti: sunt
+stocate local pe dispozitivele dvs., niciodată pe un server Lotti — nu
+există așa ceva. Dacă activați sincronizarea, înregistrările circulă
+criptate end-to-end între dispozitivele dvs.; serverul intermediar vede
+întotdeauna doar text cifrat. Briefingurile rulează implicit pe
+modele AI locale; dacă alegeți explicit un furnizor cloud, Lotti îl
+numește înainte ca ceva să fie trimis — iar cu un furnizor conform GDPR,
+cu retenție zero a datelor (zero data retention), inferența rămâne o
+prelucrare tranzitorie: nimic nu este stocat în afara dispozitivelor dvs. A preda date despre
+relații unor terți fără alegerea dvs. explicită ar fi iresponsabil — așa
+că Lotti pur și simplu nu o face.

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -48,3 +48,42 @@ Progresia planificată:
 efectiv — conținutul sărac produce mai puține întrebări, nu umplutură;
 sugestiile nu rulează niciodată AI înainte de acordul dvs., iar un
 chestionar nu blochează niciodată finalizarea unei sarcini.
+
+## Rămâneți aproape de oamenii care contează
+
+Relațiile devin o parte de sine stătătoare a Lotti: o înregistrare de lungă
+durată pentru fiecare persoană, cu propria cronologie, alături de sarcinile
+și proiectele dvs. După o întâlnire veți putea consemna un **check-in** —
+întâlnire în persoană, apel, video sau mesaj — notând despre ce ați vorbit,
+cum s-a simțit interacțiunea și la ce să fiți atent sau ce să evitați data
+viitoare. Relațiile se leagă de sarcini, astfel încât apelul pe care
+trebuie să îl pregătiți sau vizita promisă apare direct pe cronologia acelei
+persoane. Veți putea, de asemenea, conecta o relație la un contact din
+agenda dvs. — persoană cu persoană, niciodată ca import în masă — și puteți
+suna sau scrie direct din briefing; la revenirea în Lotti, aplicația vă
+propune să înregistrați acea interacțiune ca check-in. Marcați o relație ca
+**importantă** și Lotti vă va reaminti cu
+delicatețe să reluați legătura când a trecut prea mult timp — alegeți
+ritmul pentru fiecare persoană, iar doar relațiile marcate ca importante
+generează vreodată mementouri. Înainte de următoarea întâlnire, un
+**briefing executiv** rezumă cum stau lucrurile, temele din check-inurile
+recente, cum s-au simțit conversațiile în timp și ce să abordați sau ce să
+ocoliți — ca un asistent atent care vă pregătește pentru conversație.
+
+Progresia planificată:
+
+1. **Relații cu cronologie** — o înregistrare centrată pe persoană, cu
+   notițe, fotografii și sarcini legate.
+2. **Check-inuri** — consemnare rapidă și structurată a fiecărei
+   interacțiuni: tip, sentiment, teme și îndrumări pentru data viitoare.
+3. **Mementouri pentru relațiile importante** — impulsuri cu cadență, pe
+   care le controlați pentru fiecare persoană.
+4. **Briefinguri executive** — un rezumat pregătit de AI înaintea
+   următoarei conversații, întemeiat doar pe propriile check-inuri.
+
+Notițele despre oamenii din viața dvs. nu părăsesc niciodată dispozitivele
+dvs.: totul este stocat local, sincronizarea are loc doar criptată
+end-to-end între propriile dispozitive, iar briefingurile rulează pe modele
+AI locale, cu excepția cazului în care alegeți explicit un furnizor cloud.
+A preda date despre relații unor terți fără această alegere explicită ar fi
+iresponsabil — așa că Lotti pur și simplu nu o face.

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -43,3 +43,42 @@ Frågor och betyg kommer bara från innehåll som Lotti faktiskt har fångat —
 tunt innehåll ger färre frågor i stället för utfyllnad, förslag kör aldrig
 AI innan du godkänner, och ett quiz blockerar aldrig slutförandet av en
 uppgift.
+
+## Håll dig nära människorna som betyder något
+
+Relationer blir en fullvärdig del av Lotti: en långlivad post per person
+med sin egen tidslinje, sida vid sida med dina uppgifter och projekt. Efter
+att du träffat någon kommer du att kunna registrera en **check-in** —
+träffades personligen, telefonsamtal, video eller meddelande — med vad ni
+pratade om, hur mötet kändes och vad du ska vara uppmärksam på eller
+undvika nästa gång. Relationer kopplas till uppgifter, så att samtalet du
+behöver förbereda eller det utlovade besöket ligger direkt på personens
+tidslinje. Du kommer också att kunna koppla en relation till en kontakt i
+din adressbok — person för person, aldrig som massimport — och ringa eller
+skriva direkt från briefingen; när du kommer tillbaka till Lotti erbjuder
+appen att logga interaktionen som en check-in. Markerar du en relation som
+**viktig** påminner Lotti dig
+varsamt om att höra av dig när det gått för lång tid — du väljer rytmen per
+person, och bara relationer du markerat som viktiga ger någonsin
+påminnelser. Innan du ses igen sammanfattar en **executive briefing** hur
+det går, ämnena från de senaste check-ins, hur samtalen har känts över tid
+och vad du kan ta upp eller hellre styra runt — som en omtänksam assistent
+som förbereder dig inför samtalet.
+
+Den planerade utbyggnaden:
+
+1. **Relationer med en tidslinje** — en personcentrerad post med länkade
+   anteckningar, foton och uppgifter.
+2. **Check-ins** — snabb, strukturerad registrering av varje möte: typ,
+   känsla, ämnen och råd inför nästa gång.
+3. **Påminnelser för viktiga relationer** — rytmbaserade knuffar som du
+   styr per person.
+4. **Executive briefings** — en AI-förberedd sammanfattning inför ditt
+   nästa samtal, enbart grundad på dina egna check-ins.
+
+Anteckningar om människorna i ditt liv lämnar aldrig dina enheter: allt
+lagras lokalt, synkronisering sker bara end-to-end-krypterad mellan dina
+egna enheter, och briefings körs på lokala AI-modeller om du inte
+uttryckligen väljer en molnleverantör. Att lämna relationsdata till tredje
+part utan det uttryckliga valet vore oansvarigt — så Lotti gör helt enkelt
+inte det.

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/roadmap.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/roadmap.mdx
@@ -60,7 +60,9 @@ appen att logga interaktionen som en check-in. Markerar du en relation som
 **viktig** påminner Lotti dig
 varsamt om att höra av dig när det gått för lång tid — du väljer rytmen per
 person, och bara relationer du markerat som viktiga ger någonsin
-påminnelser. Innan du ses igen sammanfattar en **executive briefing** hur
+påminnelser. Varje relation får sin egen agent — samma
+varaktiga agenter som sköter uppgifter och projekt — som håller bilden
+aktuell och, innan du ses igen, förbereder en **executive briefing**: hur
 det går, ämnena från de senaste check-ins, hur samtalen har känts över tid
 och vad du kan ta upp eller hellre styra runt — som en omtänksam assistent
 som förbereder dig inför samtalet.
@@ -76,9 +78,13 @@ Den planerade utbyggnaden:
 4. **Executive briefings** — en AI-förberedd sammanfattning inför ditt
    nästa samtal, enbart grundad på dina egna check-ins.
 
-Anteckningar om människorna i ditt liv lämnar aldrig dina enheter: allt
-lagras lokalt, synkronisering sker bara end-to-end-krypterad mellan dina
-egna enheter, och briefings körs på lokala AI-modeller om du inte
-uttryckligen väljer en molnleverantör. Att lämna relationsdata till tredje
-part utan det uttryckliga valet vore oansvarigt — så Lotti gör helt enkelt
-inte det.
+Relationsdata får den strängaste behandling Lotti har: de lagras lokalt
+på dina enheter, aldrig på en Lotti-server — någon sådan finns inte. Slår
+du på synkronisering färdas poster end-to-end-krypterade mellan dina
+enheter; den förmedlande servern ser bara krypterad text. Briefings körs som standard på lokala
+AI-modeller; väljer du uttryckligen en molnleverantör anger Lotti den
+innan något skickas — och med en GDPR-förenlig leverantör utan
+datalagring (zero data retention) förblir inferensen flyktig bearbetning:
+inget lagras utanför dina enheter. Att lämna
+relationsdata till tredje part utan ditt uttryckliga val vore oansvarigt —
+så Lotti gör helt enkelt inte det.

--- a/docs/adr/0037-relationship-on-device-storage-and-privacy.md
+++ b/docs/adr/0037-relationship-on-device-storage-and-privacy.md
@@ -1,0 +1,87 @@
+# ADR 0037: Relationship Data Stays On-Device
+
+- Status: Proposed
+- Date: 2026-07-22
+
+## Context
+
+Relationship management makes Lotti store observations about third parties:
+who the user knows, when they interacted, what was discussed, how the
+interaction felt, and what to watch out for next time. This is the most
+sensitive data class the app will hold — more sensitive than the user's own
+journal, because the data subjects are other people who never consented to
+being described. Handing that data to a third-party service would be
+irresponsible; the feature is only acceptable under the app's existing
+privacy posture.
+
+That posture already exists (see `PRIVACY.md`): all data lives in local
+SQLite databases, there is no Lotti cloud service and no telemetry, and the
+only way data leaves a device is the optional end-to-end encrypted Matrix
+sync between the user's own devices, with keys exchanged via QR code and
+never transmitted. Journal entities sync payload-agnostically
+(`SyncMessage.journalEntity` in `lib/features/sync/model/sync_message.dart`),
+so new entity types inherit this posture automatically. AI inference can run
+fully locally (Ollama, OMLX/MLX — `InferenceProviderType` in
+`lib/features/ai/model/ai_config.dart`) or against a cloud provider the user
+configured with their own API key.
+
+Under GDPR, a private individual keeping personal notes about their own
+relationships falls under the household exemption (Art. 2(2)(c)) — but only
+as long as the processing stays personal. Software that silently ships such
+notes to a vendor's servers would break that framing and turn the vendor
+into a processor. Lotti must therefore never receive or retain relationship
+data, and any cloud AI use must be an explicit, user-configured choice.
+
+## Decision
+
+1. **Local journal storage only.** Relationship entities and check-ins are
+   `JournalEntity` subtypes stored in the existing `journal` table
+   (serialized-JSON-in-column, ADR 0038). No new storage layer, no external
+   service, no Lotti-operated backend. Reminders live in the existing local
+   `NotificationsDb`; briefings are agent reports in the agent database.
+2. **Sync stays opt-in and end-to-end encrypted.** Relationship data rides
+   the existing payload-agnostic Matrix sync between the user's own devices.
+   No server ever sees plaintext; users who never configure sync keep the
+   data on a single device.
+3. **Zero retention outside the user's devices.** No telemetry, analytics,
+   or crash payloads ever include relationship data. Executive briefings
+   (ADR 0040) default to local inference; a cloud provider is used only when
+   the user has explicitly configured one and selected it via an inference
+   profile, requests are transient, and the UI states which provider will
+   see the data before the user triggers a briefing. Retention at a cloud
+   provider is governed by the user's own account with that provider — Lotti
+   adds no storage of its own.
+4. **The `private` flag applies.** Relationships and check-ins honor the
+   existing `Metadata.private` semantics, so they can be excluded from
+   surfaces that respect the private filter.
+5. **Deletion and export are local and complete.** Relationship entities use
+   the app's normal soft-delete + purge lifecycle. Deleting a relationship
+   also deletes its linked check-ins, its agent reports, and any pending
+   reminder rows — the cascade is explicit so no orphaned data about a
+   person survives. Relationship data is included in the existing full data
+   export. This makes the data-subject rights that matter (erasure, access,
+   portability) trivially implementable, entirely on-device.
+6. **Document the stance.** `PRIVACY.md` gains a short section on
+   relationship data restating the above; the manual page states it in user
+   terms.
+
+## Consequences
+
+- No server-side capability exists by design: reminders must be computed and
+  scheduled on-device (ADR 0039), and there is no push infrastructure.
+- Briefing quality on the default local-inference path is bounded by local
+  model capability; users trade that off knowingly when selecting a cloud
+  profile.
+- The deletion cascade (check-ins, reports, notifications) is a real
+  implementation obligation, not just policy prose, and needs tests.
+- Because Lotti never receives the data, the GDPR household exemption
+  framing holds: the user remains the sole controller of their personal
+  notes, and Lotti (the software vendor) is not a processor.
+
+## Related
+
+- [ADR 0038: Relationship Domain Model](./0038-relationship-domain-model.md)
+- [ADR 0039: Relationship Check-In Reminders](./0039-relationship-check-in-reminders.md)
+- [ADR 0040: Relationship Executive Briefing](./0040-relationship-executive-briefing.md)
+- [Implementation plan](../implementation_plans/2026-07-22_relationship_management.md)
+- `PRIVACY.md`

--- a/docs/adr/0037-relationship-on-device-storage-and-privacy.md
+++ b/docs/adr/0037-relationship-on-device-storage-and-privacy.md
@@ -43,14 +43,17 @@ data, and any cloud AI use must be an explicit, user-configured choice.
    the existing payload-agnostic Matrix sync between the user's own devices.
    No server ever sees plaintext; users who never configure sync keep the
    data on a single device.
-3. **Zero retention outside the user's devices.** No telemetry, analytics,
+3. **No Lotti-side retention anywhere.** No telemetry, analytics,
    or crash payloads ever include relationship data. Executive briefings
    (ADR 0040) default to local inference; a cloud provider is used only when
    the user has explicitly configured one and selected it via an inference
    profile, requests are transient, and the UI states which provider will
    see the data before the user triggers a briefing. Retention at a cloud
    provider is governed by the user's own account with that provider — Lotti
-   adds no storage of its own.
+   adds no storage of its own. Provider-setup guidance steers users toward
+   GDPR-compliant providers with zero-data-retention terms, under which a
+   cloud briefing is transient processing and nothing is stored outside the
+   user's devices.
 4. **The `private` flag applies.** Relationships and check-ins honor the
    existing `Metadata.private` semantics, so they can be excluded from
    surfaces that respect the private filter.

--- a/docs/adr/0038-relationship-domain-model.md
+++ b/docs/adr/0038-relationship-domain-model.md
@@ -1,0 +1,116 @@
+# ADR 0038: Relationship Domain Model
+
+- Status: Proposed
+- Date: 2026-07-22
+
+## Context
+
+A relationship is a long-running entity tied to one person — closer to a
+project than to a task: it has no natural end date, it accumulates a
+timeline of interactions, and it should link to tasks (a call to prepare, a
+meeting scheduled as a task). Lotti has no person or contact concept today
+(the old tags system was removed), so this is greenfield.
+
+The journal core gives us everything needed:
+
+- `JournalEntity` (`lib/classes/journal_entities.dart`) is a sealed freezed
+  union of 16 subtypes sharing a `Metadata` envelope, stored as serialized
+  JSON in the `journal` Drift table with denormalized query columns.
+  `ProjectEntry`/`ProjectData` (`lib/classes/project_data.dart`) is the
+  precedent for a long-running container entity with a status union and
+  status history.
+- `EntryLink` (`lib/classes/entry_link.dart`) is a freezed union
+  (`basic`/`rating`/`project`) over the `linked_entries` table; the task
+  timeline UI (`LinkedEntriesController`) is assembled purely from links.
+- Sync is payload-agnostic for journal entities: a new subtype syncs as soon
+  as its JSON round-trips and `toDbEntity` maps it — no new sync message.
+
+## Decision
+
+1. **New subtype `JournalEntity.relationship` with `RelationshipData`.**
+   One relationship per person; the person's identity is embedded in the
+   payload rather than split into a separate contact entity. Fields:
+   - `title` — the person's display name (plus optional `nickname`).
+   - `important` (`bool`, default `false`) — the flag that arms reminders
+     (ADR 0039).
+   - `status` — a `RelationshipStatus` sealed union mirroring
+     `ProjectStatus` in shape (`id`, `createdAt`, `utcOffset`, optional
+     `timezone`/`geolocation` per entry): `active`, `dormant` (kept but not
+     currently nurtured; excluded from reminders), `archived`. With
+     `statusHistory` for the trajectory.
+   - `checkInCadenceDays` (`int?`) — desired check-in interval; only
+     meaningful when `important` is set.
+   - `birthday` (`DateTime?`) — optional, for future nudges.
+   - `profileId` (`String?`) — inference profile for the relationship agent
+     (ADR 0040), mirroring `ProjectData.profileId`.
+   - `languageCode` (`String?`), `coverArtId` (`String?`) — same roles as on
+     tasks/projects.
+   - `contactChannels` (`List<ContactChannel>`, default empty) and
+     `contactRefs` (per-platform contact identifiers) — communication
+     channels and optional OS-contact linkage per ADR 0041; excluded from
+     AI context.
+   Free-form notes about the person live in the shared `entryText`.
+   `meta.dateFrom` is when tracking started; `meta.dateTo` advances like a
+   project's.
+2. **New subtype `JournalEntity.checkIn` with `CheckInData`.** One check-in
+   per logged interaction. Fields:
+   - `interactionType` — enum: `inPerson`, `call`, `videoCall`, `message`,
+     `other`.
+   - `sentiment` (`CheckInSentiment?`) — enum: `delightful`, `good`,
+     `neutral`, `strained`, `difficult`. Optional; explicit user judgment,
+     never AI-filled.
+   - `topics` (`List<String>`, default empty) — what was discussed.
+   - `payAttentionTo` (`String?`) and `avoid` (`String?`) — the "next time"
+     guidance the briefing later surfaces.
+   The narrative ("what we talked about") is the entry's `entryText`; the
+   interaction time is `meta.dateFrom`/`dateTo`, so check-ins sit naturally
+   on calendars and timelines.
+3. **Linking reuses `linked_entries` with a new `RelationshipLink` variant**
+   of `EntryLink`, mirroring `ProjectLink`: relationship → check-in and
+   relationship → task (and task → relationship queries via the reverse
+   direction). Typed link rows allow indexed queries such as
+   "relationships for task" without scanning basic links. The relationship
+   timeline is the existing linked-entries mechanism — the same
+   `LinkedEntriesController` path tasks use — so text, audio, and photos can
+   be linked onto a relationship exactly like onto a task.
+4. **No journal schema change initially.** Both subtypes ride the
+   `serialized` column with `type` strings `'Relationship'` and `'CheckIn'`;
+   list queries filter by `type` and links. Denormalized columns (e.g. an
+   indexed `relationship_id` on check-ins) are deferred until a measured
+   query needs them, following the `project_id` precedent.
+5. **Reminders and briefings are not journal entities.** Reminders are
+   `NotificationEntity` rows in `NotificationsDb` (ADR 0039); briefings are
+   `AgentReportEntity` rows owned by the relationship agent (ADR 0040). The
+   journal holds only what the user authored.
+6. **Exhaustive-switch audit is the integration checklist.** Adding the two
+   subtypes must update: `affectedIds` in `journal_entities.dart`, the
+   `entity.map` in `lib/database/conversions.dart`, `folderForJournalEntity`
+   and `typeSuffix` in `lib/utils/file_utils.dart`, the journal card switch
+   in `journal_card.dart`, the detail-section switches in
+   `entry_details_widget.dart`, creation ops in
+   `lib/logic/persistence_logic.dart`, and the `link.map` in
+   `conversions.dart` for the new link variant. The compiler enforces most
+   of these.
+
+## Consequences
+
+- Sync, vector clocks, soft delete, `private`, categories, and export all
+  work for relationships and check-ins with zero new infrastructure.
+- Embedding person identity in `RelationshipData` means renaming a person is
+  editing the relationship — acceptable for a 1:1 person-to-relationship
+  model, and a future shared contact directory could be layered on without
+  migrating existing data.
+- Check-ins being ordinary journal entities means they appear in generic
+  journal surfaces; those surfaces' switches need deliberate rendering
+  decisions rather than falling through to defaults.
+- The structured qualitative fields (`sentiment`, `payAttentionTo`, `avoid`)
+  give the briefing generator explainable inputs instead of forcing it to
+  infer everything from prose.
+
+## Related
+
+- [ADR 0037: Relationship Data Stays On-Device](./0037-relationship-on-device-storage-and-privacy.md)
+- [ADR 0039: Relationship Check-In Reminders](./0039-relationship-check-in-reminders.md)
+- [ADR 0040: Relationship Executive Briefing](./0040-relationship-executive-briefing.md)
+- [ADR 0041: Relationship Contact Linking and Communication Actions](./0041-relationship-contact-linking.md)
+- [Implementation plan](../implementation_plans/2026-07-22_relationship_management.md)

--- a/docs/adr/0039-relationship-check-in-reminders.md
+++ b/docs/adr/0039-relationship-check-in-reminders.md
@@ -36,9 +36,14 @@ notification, rather than a periodic job.
 2. **Deterministic, local eligibility rule.** A reminder is due for a
    relationship iff `important == true`, status is `active`, and
    `now - lastCheckInDate >= checkInCadenceDays` (default 30 when unset).
-   The last check-in date is the newest linked check-in's `meta.dateFrom`.
-   Relationships that are not important never produce reminders — the flag
-   is the single consent switch for proactive behavior.
+   The last check-in date is the newest linked check-in's `meta.dateFrom`;
+   for a relationship with no linked check-ins yet, the baseline is the
+   relationship's own `meta.dateFrom`, so the first reminder fires one
+   cadence after tracking starts — marking someone important is itself the
+   request to be nudged, so reminders are never suppressed waiting for a
+   first check-in. Relationships that are not important never produce
+   reminders — the flag is the single consent switch for proactive
+   behavior.
 3. **Event-driven producer, no background scheduler.** A
    `RelationshipReminderService` recomputes the next due date and
    (re)schedules via `NotificationScheduler`:

--- a/docs/adr/0039-relationship-check-in-reminders.md
+++ b/docs/adr/0039-relationship-check-in-reminders.md
@@ -1,0 +1,83 @@
+# ADR 0039: Relationship Check-In Reminders
+
+- Status: Proposed
+- Date: 2026-07-22
+
+## Context
+
+When a relationship is marked important, Lotti should proactively remind the
+user to check in. Per ADR 0037 there is no server, so reminders must be
+computed and scheduled entirely on-device.
+
+The app has two notification layers that fit together:
+
+- `NotificationService` (`lib/services/notification_service.dart`) wraps
+  `flutter_local_notifications` with timezone-aware `zonedSchedule`. OS
+  scheduling works on iOS, macOS, and Android; Windows and Linux are
+  skipped. Everything is gated on `enableNotificationsFlag`.
+- The synced notification inbox (`lib/features/notifications/`): durable
+  `NotificationEntity` rows in `NotificationsDb` that sync over Matrix,
+  with `seenAt`/`actedOnAt` lifecycle, an in-app bell, and a
+  `NotificationScheduler` that bridges rows to OS notifications using
+  stable FNV-1a ids. Its `reconcile()` (re-arm OS alerts after restart) is
+  built and tested but currently has no production caller, and the
+  `taskOverdue` producer path is similarly dormant.
+
+Habits set the precedent for scheduling without background workers: a
+rolling model where saving or completing an entity re-arms the next OS
+notification, rather than a periodic job.
+
+## Decision
+
+1. **New inbox variant `NotificationEntity.relationshipCheckIn`** carrying
+   `linkedRelationshipId`, `title`, and `body`, alongside the existing
+   `taskSuggestion`/`taskOverdue` variants. Reminders are durable inbox rows
+   first, OS notifications second.
+2. **Deterministic, local eligibility rule.** A reminder is due for a
+   relationship iff `important == true`, status is `active`, and
+   `now - lastCheckInDate >= checkInCadenceDays` (default 30 when unset).
+   The last check-in date is the newest linked check-in's `meta.dateFrom`.
+   Relationships that are not important never produce reminders — the flag
+   is the single consent switch for proactive behavior.
+3. **Event-driven producer, no background scheduler.** A
+   `RelationshipReminderService` recomputes the next due date and
+   (re)schedules via `NotificationScheduler`:
+   - when a check-in is saved (pushes the next reminder out by one cadence),
+   - when a relationship is saved (arming, disarming, or re-cadencing),
+   - at app startup via `NotificationScheduler.reconcile()` — which this
+     feature finally wires into the launch sequence, fixing the dormant gap
+     for all notification types at once.
+4. **Stable identity and cross-device convergence.** Notification ids derive
+   from the relationship id plus due date (the existing FNV-1a scheme), so
+   two devices computing the same reminder converge on one row after sync,
+   and acting on a reminder on one device (`actedOnAt`) clears the pending
+   alert everywhere via the existing `SyncNotification` path.
+5. **Platform behavior.** iOS/macOS/Android get OS notifications through
+   `zonedSchedule`. Windows and Linux surface due reminders through the
+   in-app inbox bell only, populated at startup reconcile — an accepted
+   limitation inherited from `NotificationService`.
+6. **Controls.** Globally gated by the existing `enableNotificationsFlag`;
+   per-relationship control is the `important` flag and cadence itself.
+   Reminder copy is localized and deliberately vague on lock screens
+   ("Check in with Anna?" — no interaction details), since notification
+   content leaves the app sandbox.
+
+## Consequences
+
+- No new dependencies (no workmanager/background_fetch); the reminder
+  machinery is a thin producer over existing, tested infrastructure.
+- On desktop platforms without OS scheduling, reminders appear only when the
+  app runs — consistent with the local-only design, and mitigated by the
+  synced inbox (a phone will still alert).
+- Wiring `reconcile()` at startup is a behavior change that also revives OS
+  alerts for other inbox notification types; it needs its own tests.
+- If the app is not opened for a long period on a single-device setup, no
+  reminder fires beyond the last scheduled OS notification — an accepted
+  cost of having no server (ADR 0037).
+
+## Related
+
+- [ADR 0037: Relationship Data Stays On-Device](./0037-relationship-on-device-storage-and-privacy.md)
+- [ADR 0038: Relationship Domain Model](./0038-relationship-domain-model.md)
+- [ADR 0027: Wake Notification Propagation and Storm Prevention](./0027-wake-notification-propagation-and-storm-prevention.md)
+- [Implementation plan](../implementation_plans/2026-07-22_relationship_management.md)

--- a/docs/adr/0040-relationship-executive-briefing.md
+++ b/docs/adr/0040-relationship-executive-briefing.md
@@ -1,0 +1,89 @@
+# ADR 0040: Relationship Executive Briefing
+
+- Status: Proposed
+- Date: 2026-07-22
+
+## Context
+
+Before the user next engages with a person, Lotti should hand them what a
+good executive assistant would: how things are going, what was discussed
+recently, how interactions have felt, what to bring up, what to pay
+attention to, and what to avoid.
+
+The AI layer is mid-migration: the legacy prompt-driven `AiResponseType`
+path is deprecated for summaries, superseded by the agent system
+(`lib/features/agents/`). The established pattern — used by task, project,
+event, and day agents — is: an agent kind plus link type binds a durable
+agent to an entity; a workflow runs profile-resolved inference with tool
+calls; the output is an `AgentReportEntity` (`content` markdown, `tldr`,
+`oneLiner`) with a latest-report head; consumers resolve it like
+`TaskSummaryResolver` does. The project agent additionally emits a
+structured health band (`ProjectHealthMetrics`: band, rationale,
+confidence) parsed from report provenance and rendered as a chip. Local
+inference (Ollama, OMLX/MLX) is a first-class provider option, and
+inference profiles can pin capability slots to local models.
+
+## Decision
+
+1. **A durable relationship agent per relationship.** New
+   `AgentKinds.relationshipAgent`, `AgentLinkTypes.agentRelationship`, and
+   `AgentTemplateKind.relationshipAgent`; a `RelationshipAgentService`
+   creates the agent lazily and links it to the relationship entity,
+   mirroring `TaskAgentService`/`ProjectAgentService`. All exhaustive
+   agent-kind switches are audited as part of the change.
+2. **The briefing is an `AgentReportEntity`.** `content` is the full
+   executive briefing (state of the relationship, key topics from recent
+   check-ins, sentiment trajectory, suggested talking points, pay-attention
+   list, avoid list); `tldr` is the card summary; `oneLiner` the compact
+   tagline. Latest-wins via the report head; shown in the relationship
+   detail header through a resolver in the `TaskSummaryResolver` style.
+3. **Structured relationship health in provenance.** The report contract
+   defines a `relationship_health` band — `thriving`, `steady`,
+   `needsAttention`, `strained` — with free-text rationale and optional
+   confidence, parsed and rendered exactly like `ProjectHealthMetrics`.
+   The band must be grounded first in the explicit `CheckInData.sentiment`
+   values (user judgment), with prose only as secondary evidence.
+4. **Strict context boundary.** The workflow assembles: the relationship
+   entity and its `entryText`, the most recent N check-ins (structured
+   fields plus narrative), linked tasks' titles and statuses, and the
+   previous report. Nothing else from the journal is included. This keeps
+   briefings explainable, keeps token budgets bounded, and minimizes what a
+   cloud model could ever see when one is selected.
+5. **Triggers.** On-demand ("Brief me" on the relationship detail page) and
+   an automatic debounced refresh after a new check-in is saved, so the
+   briefing is already fresh when a reminder (ADR 0039) brings the user
+   back. No scheduled or speculative runs beyond that.
+6. **Privacy-weighted model routing.** The profile is resolved from
+   `RelationshipData.profileId`, falling back to the category default.
+   Local-model profiles are the recommended default for this data class;
+   when the resolved profile routes to a cloud provider, the trigger surface
+   names the provider before running (ADR 0037). No inference ever runs
+   without an explicit user-facing trigger or the post-check-in refresh the
+   user enabled by using the feature.
+7. **Honesty rules in the template.** The briefing may only reference
+   captured check-ins and linked entities, must state recency ("last spoke
+   five weeks ago"), must say when there is not enough data rather than
+   pad, and must keep `payAttentionTo`/`avoid` guidance traceable to the
+   check-ins that produced it.
+
+## Consequences
+
+- The feature inherits agent-system infrastructure wholesale: report
+  storage, sync, head resolution, profile routing, and UI patterns — the
+  new code is one service, one workflow, one report contract, and rendering.
+- Briefing quality tracks check-in quality; thin capture yields thin
+  briefings by design (honesty rules), which is the correct incentive.
+- Local-first routing means weaker prose on low-end hardware; users can
+  opt into cloud per profile, with the trade-off made visible.
+- A second consumer of the health-band pattern will pressure the provenance
+  parsing into a shared helper rather than a copy — worth doing during
+  implementation.
+
+## Related
+
+- [ADR 0037: Relationship Data Stays On-Device](./0037-relationship-on-device-storage-and-privacy.md)
+- [ADR 0038: Relationship Domain Model](./0038-relationship-domain-model.md)
+- [ADR 0039: Relationship Check-In Reminders](./0039-relationship-check-in-reminders.md)
+- [ADR 0016: Agent-Derived State as a Projection of the Append-Only Log](./0016-agent-state-as-log-projection.md)
+- [ADR 0023: Durable Domain Agents and Time Negotiation](./0023-durable-domain-agents-and-time-negotiation.md)
+- [Implementation plan](../implementation_plans/2026-07-22_relationship_management.md)

--- a/docs/adr/0040-relationship-executive-briefing.md
+++ b/docs/adr/0040-relationship-executive-briefing.md
@@ -56,8 +56,11 @@ inference profiles can pin capability slots to local models.
 6. **Privacy-weighted model routing.** The profile is resolved from
    `RelationshipData.profileId`, falling back to the category default.
    Local-model profiles are the recommended default for this data class;
-   when the resolved profile routes to a cloud provider, the trigger surface
-   names the provider before running (ADR 0037). No inference ever runs
+   cloud providers are an equally legitimate route when they are
+   GDPR-compliant with zero-data-retention terms — then inference is
+   transient processing and nothing is stored outside the user's devices.
+   Either way, the trigger surface names the provider before running
+   (ADR 0037). No inference ever runs
    without an explicit user-facing trigger or the post-check-in refresh the
    user enabled by using the feature.
 7. **Honesty rules in the template.** The briefing may only reference

--- a/docs/adr/0041-relationship-contact-linking.md
+++ b/docs/adr/0041-relationship-contact-linking.md
@@ -1,0 +1,82 @@
+# ADR 0041: Relationship Contact Linking and Communication Actions
+
+- Status: Proposed
+- Date: 2026-07-22
+
+## Context
+
+An executive briefing (ADR 0040) prepares the user for a conversation; the
+natural next step is starting that conversation — calling or messaging the
+person right from the briefing. That requires the relationship to know the
+person's contact channels. Retyping phone numbers is friction, so pulling
+them from the OS address book is attractive. It also closes the tracking
+loop: an interaction Lotti itself initiated is the easiest possible
+check-in to capture.
+
+Two forces constrain the design. First, curation: relationships are a small
+deliberate set of people (ADR 0038); importing an address book wholesale
+would create hundreds of dormant relationship entities and destroy the
+signal the reminders and briefings depend on. Second, platform reality:
+OS contact pickers are well supported on iOS and Android, weakly on macOS,
+and effectively unavailable on Linux/Windows; contact identifiers are
+platform-local, so a contact reference cannot resolve on a synced peer
+device. `url_launcher` (already a dependency) covers `tel:`, `sms:`, and
+`mailto:` launching; no contacts plugin is currently in the dependency set.
+
+## Decision
+
+1. **No bulk import — selective linking only.** Contact integration is
+   per-relationship and user-initiated: a "Link contact" action on the
+   relationship opens the OS contact picker and copies the selected
+   contact's channels into the relationship. The address book permission is
+   requested only when the picker is invoked, never at startup, and Lotti
+   never enumerates or reads the address book in the background.
+2. **Channels are plain relationship data, not a live dependency.**
+   `RelationshipData` gains `contactChannels`
+   (`List<ContactChannel>` — `type` enum `phone`/`mobile`/`email`/
+   `messaging`, optional `label`, `value`) and `contactRefs`
+   (per-platform map of contact identifiers, used only for an explicit
+   "Update from contact" refresh on the device that owns the contact).
+   Channels are manually editable on every platform, so Linux/Windows get
+   full feature parity through manual entry; the picker is a convenience,
+   not a requirement. Snapshot data syncs and cascades like everything else
+   in the relationship (ADR 0037).
+3. **Quick actions via OS URL schemes.** Call, message, and email buttons
+   appear on the relationship detail header and on the executive briefing
+   card, launched through `url_launcher` (`tel:`/`sms:`/`mailto:`). Lotti
+   contains no telephony code and never accesses call logs or content.
+4. **Contact-initiated check-in capture.** When the user launches a call or
+   message from Lotti, a transient pending-interaction marker (relationship
+   id, channel type, timestamp — device-local, not synced) is recorded. On
+   next app resume, a dismissable prompt offers to log a check-in
+   pre-filled with the interaction type and time. Check-ins are never
+   auto-created; declining leaves no trace.
+5. **Channels are excluded from AI context.** The briefing context boundary
+   (ADR 0040 §4) explicitly excludes `contactChannels` and `contactRefs` —
+   the model has no need for phone numbers or email addresses, so they
+   never reach any provider, local or cloud.
+6. **Dependency scope.** The OS picker ships for iOS and Android first
+   (e.g. `flutter_contacts` — new dependency, added at implementation
+   time); macOS via the native Contacts framework is a later candidate.
+   Desktop relies on manual entry until then.
+
+## Consequences
+
+- The curated-relationship model survives contact integration: the address
+  book never drives entity creation, only enriches entities the user
+  already chose to create.
+- Per-platform `contactRefs` mean "Update from contact" works only on a
+  device that has the contact — synced peers still see the channel values,
+  which is what the quick actions need.
+- The post-interaction prompt is a resume heuristic, not call detection: it
+  can fire when no conversation happened (unanswered call) and misses
+  interactions started outside Lotti. Accepted — it is an offer, not a log.
+- One new mobile dependency (contacts picker); the action buttons
+  themselves add none.
+
+## Related
+
+- [ADR 0037: Relationship Data Stays On-Device](./0037-relationship-on-device-storage-and-privacy.md)
+- [ADR 0038: Relationship Domain Model](./0038-relationship-domain-model.md)
+- [ADR 0040: Relationship Executive Briefing](./0040-relationship-executive-briefing.md)
+- [Implementation plan](../implementation_plans/2026-07-22_relationship_management.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,16 @@ Each ADR should contain:
 
 ## Index
 
+### Relationship management decision cluster
+
+| ADR | Status | Decision ownership |
+| --- | --- | --- |
+| [0037: Relationship Data Stays On-Device](./0037-relationship-on-device-storage-and-privacy.md) | Proposed | Local-only storage, opt-in E2E sync, zero external retention, explicit cloud-AI consent, deletion cascade, GDPR framing. |
+| [0038: Relationship Domain Model](./0038-relationship-domain-model.md) | Proposed | `relationship`/`checkIn` journal subtypes, embedded person identity, status union, `RelationshipLink` task/timeline linking, no schema change. |
+| [0039: Relationship Check-In Reminders](./0039-relationship-check-in-reminders.md) | Proposed | Importance-gated cadence rule, event-driven scheduling on the synced notification inbox, startup reconcile, platform limits. |
+| [0040: Relationship Executive Briefing](./0040-relationship-executive-briefing.md) | Proposed | Relationship agent + report contract, health band, strict context boundary, privacy-weighted model routing, honesty rules. |
+| [0041: Relationship Contact Linking](./0041-relationship-contact-linking.md) | Proposed | Selective per-relationship contact linking (no bulk import), channel snapshots, call/message actions from the briefing, post-interaction check-in prompt. |
+
 ### Learning verification decision cluster
 
 | ADR | Status | Decision ownership |
@@ -75,3 +85,8 @@ Each ADR should contain:
 - [`0034-hybrid-understanding-evaluation.md`](./0034-hybrid-understanding-evaluation.md)
 - [`0035-learning-verification-session-persistence.md`](./0035-learning-verification-session-persistence.md)
 - [`0036-learning-understanding-rating.md`](./0036-learning-understanding-rating.md)
+- [`0037-relationship-on-device-storage-and-privacy.md`](./0037-relationship-on-device-storage-and-privacy.md)
+- [`0038-relationship-domain-model.md`](./0038-relationship-domain-model.md)
+- [`0039-relationship-check-in-reminders.md`](./0039-relationship-check-in-reminders.md)
+- [`0040-relationship-executive-briefing.md`](./0040-relationship-executive-briefing.md)
+- [`0041-relationship-contact-linking.md`](./0041-relationship-contact-linking.md)

--- a/docs/implementation_plans/2026-07-22_relationship_management.md
+++ b/docs/implementation_plans/2026-07-22_relationship_management.md
@@ -12,8 +12,9 @@
 
 Relationships as a first-class, long-running concept: one entity per person
 with a timeline, structured check-ins, importance-gated reminders, and an
-AI executive briefing before the next interaction. Entirely on-device
-(ADR 0037); pre-1.0 roadmap item.
+AI executive briefing before the next interaction. Local-first per
+ADR 0037: on-device storage, opt-in end-to-end encrypted sync, cloud AI
+only by explicit choice. Pre-1.0 roadmap item.
 
 ## Data model summary
 

--- a/docs/implementation_plans/2026-07-22_relationship_management.md
+++ b/docs/implementation_plans/2026-07-22_relationship_management.md
@@ -122,8 +122,9 @@ tests cover list/detail/capture; analyzer clean.
 1. `NotificationEntity.relationshipCheckIn` variant + exhaustive-switch
    updates in the notifications feature and sync event processor.
 2. `RelationshipReminderService`: eligibility rule (important + active +
-   cadence elapsed), producer hooks on check-in save and relationship save,
-   stable ids per ADR 0039 §4.
+   cadence elapsed; baseline is the relationship's `meta.dateFrom` until
+   the first check-in exists), producer hooks on check-in save and
+   relationship save, stable ids per ADR 0039 §4.
 3. Wire `NotificationScheduler.reconcile()` into app startup; tests for
    restart re-arming (fake time, no real timers per `test/README.md`).
 4. Inbox rendering + tap-through to the relationship detail page;
@@ -167,7 +168,7 @@ tests; health band renders; no inference without a trigger.
 2. `PRIVACY.md`: relationship-data section per ADR 0037 §6.
 3. Feature README kept current throughout; CHANGELOG entry under the
    then-current version when the feature ships.
-4. Flip ADRs 0037–0040 to Accepted as their phases land.
+4. Flip ADRs 0037–0041 to Accepted as their phases land.
 
 ## Testing and quality gates (every phase)
 

--- a/docs/implementation_plans/2026-07-22_relationship_management.md
+++ b/docs/implementation_plans/2026-07-22_relationship_management.md
@@ -1,0 +1,186 @@
+# Relationship Management — Implementation Plan
+
+- Date: 2026-07-22
+- Status: Plan (nothing implemented)
+- ADRs: [0037](../adr/0037-relationship-on-device-storage-and-privacy.md),
+  [0038](../adr/0038-relationship-domain-model.md),
+  [0039](../adr/0039-relationship-check-in-reminders.md),
+  [0040](../adr/0040-relationship-executive-briefing.md),
+  [0041](../adr/0041-relationship-contact-linking.md)
+
+## Goal
+
+Relationships as a first-class, long-running concept: one entity per person
+with a timeline, structured check-ins, importance-gated reminders, and an
+AI executive briefing before the next interaction. Entirely on-device
+(ADR 0037); pre-1.0 roadmap item.
+
+## Data model summary
+
+```mermaid
+erDiagram
+    RELATIONSHIP ||--o{ CHECK_IN : "RelationshipLink"
+    RELATIONSHIP ||--o{ TASK : "RelationshipLink"
+    RELATIONSHIP ||--o| RELATIONSHIP_AGENT : "AgentLink agent_relationship"
+    RELATIONSHIP_AGENT ||--o{ AGENT_REPORT : "briefings (latest via head)"
+    RELATIONSHIP ||--o{ NOTIFICATION : "relationshipCheckIn reminders"
+
+    RELATIONSHIP {
+        string title "person display name"
+        string nickname "optional"
+        bool important "arms reminders"
+        union status "active | dormant | archived + history"
+        int checkInCadenceDays "optional, default 30"
+        datetime birthday "optional"
+        string profileId "inference profile"
+        string languageCode
+        string coverArtId
+        list contactChannels "phone | mobile | email | messaging; excluded from AI context"
+        map contactRefs "per-platform contact ids, explicit refresh only"
+        text entryText "free-form notes"
+    }
+    CHECK_IN {
+        enum interactionType "inPerson | call | videoCall | message | other"
+        enum sentiment "delightful | good | neutral | strained | difficult"
+        list topics
+        string payAttentionTo
+        string avoid
+        text entryText "narrative"
+        datetime dateFrom "interaction time"
+    }
+    AGENT_REPORT {
+        markdown content "full briefing"
+        string tldr
+        string oneLiner
+        provenance relationship_health "thriving | steady | needsAttention | strained"
+    }
+```
+
+Both new entities are `JournalEntity` subtypes (JSON in the `journal`
+table); links reuse `linked_entries` with a new `RelationshipLink` variant;
+reminders are `NotificationEntity.relationshipCheckIn` rows in
+`NotificationsDb`; briefings are `AgentReportEntity` rows. No journal
+schema migration in phase 1.
+
+## Phase 1 — Domain model and persistence
+
+1. `lib/classes/relationship_data.dart`: `RelationshipStatus` sealed union
+   (`active`/`dormant`/`archived`, mirroring `ProjectStatus` field shape)
+   and `RelationshipData` per ADR 0038.
+2. `lib/classes/check_in_data.dart`: `CheckInInteractionType`,
+   `CheckInSentiment`, `CheckInData`.
+3. `lib/classes/journal_entities.dart`: `JournalEntity.relationship` and
+   `JournalEntity.checkIn` factories; extend the `affectedIds` switch.
+4. `lib/classes/entry_link.dart`: `RelationshipLink` variant.
+5. Exhaustive-switch sweep (compiler-driven):
+   `lib/database/conversions.dart` (`type` strings `Relationship`/`CheckIn`,
+   link `type` mapping), `lib/utils/file_utils.dart`
+   (`folderForJournalEntity`, `typeSuffix`),
+   `lib/features/journal/ui/widgets/list_cards/journal_card.dart`,
+   `lib/features/journal/ui/widgets/entry_details_widget.dart`.
+6. `lib/logic/persistence_logic.dart`: `createRelationshipEntry`,
+   `createCheckInEntry` (auto-links check-in to its relationship).
+7. Deletion cascade: deleting a relationship soft-deletes linked check-ins,
+   agent links/reports, and pending reminder rows (ADR 0037 §5).
+8. `make build_runner`; unit tests for JSON round-trips, conversions,
+   cascade, and link queries.
+
+Exit: analyzer clean, targeted tests green, sync round-trip test for both
+subtypes (payload-agnostic path needs no new sync code).
+
+## Phase 2 — UI: list, detail, check-in capture, task linking
+
+1. `lib/features/relationships/` feature module (state, repository facade
+   over `JournalRepository`, UI) plus feature README with lifecycle
+   Mermaid diagram.
+2. Relationships list page (nav entry): name, one-liner (from briefing when
+   present), importance star, last-check-in recency; sorted by recency.
+3. Relationship detail page: header (name, status, importance, cadence,
+   briefing card placeholder), timeline via the existing
+   `LinkedEntriesController` machinery, "Log check-in" action.
+4. Check-in capture sheet: interaction type, date, sentiment selector,
+   topics, pay-attention/avoid fields, narrative text; editable afterwards
+   like any journal entry.
+5. Task linking: "Link task" from relationship detail and "Link person"
+   from task detail, writing `RelationshipLink` rows; linked tasks section
+   on the relationship page.
+6. Contact channels (ADR 0041): editable channel list on the relationship
+   editor (all platforms); "Link contact" OS picker on iOS/Android (new
+   dependency, e.g. `flutter_contacts`) with explicit "Update from
+   contact" refresh; call/message/email quick actions on the detail header
+   via `url_launcher`; pending-interaction marker + post-resume check-in
+   prompt pre-filled with interaction type and time.
+7. All strings in all six ARB files (`make l10n`, informal tone; Romanian
+   formal); design-system tokens only; widget tests per touched widget.
+
+Exit: full flow usable end-to-end on desktop and mobile layouts; widget
+tests cover list/detail/capture; analyzer clean.
+
+## Phase 3 — Reminders
+
+1. `NotificationEntity.relationshipCheckIn` variant + exhaustive-switch
+   updates in the notifications feature and sync event processor.
+2. `RelationshipReminderService`: eligibility rule (important + active +
+   cadence elapsed), producer hooks on check-in save and relationship save,
+   stable ids per ADR 0039 §4.
+3. Wire `NotificationScheduler.reconcile()` into app startup; tests for
+   restart re-arming (fake time, no real timers per `test/README.md`).
+4. Inbox rendering + tap-through to the relationship detail page;
+   localized, content-minimal notification copy.
+5. Windows/Linux: verify inbox-only behavior degrades gracefully.
+
+Exit: reminder fires for an important relationship past cadence on
+iOS/macOS/Android; acting on it syncs `actedOnAt` across devices; service
+and scheduler tests green.
+
+## Phase 4 — Executive briefing
+
+1. Agent registration: `AgentKinds.relationshipAgent`,
+   `AgentLinkTypes.agentRelationship`,
+   `AgentTemplateKind.relationshipAgent`; audit every exhaustive switch.
+2. `RelationshipAgentService` (lazy create + link, mirroring
+   `TaskAgentService`).
+3. `relationship_agent_workflow.dart`: context assembly per ADR 0040 §4,
+   profile-resolved inference, `update_report` tool emitting
+   content/tldr/oneLiner + `relationship_health` provenance.
+4. Report contract file mirroring `project_agent_report_contract.dart`;
+   extract the shared health-band provenance parsing into a common helper
+   used by both project and relationship metrics.
+5. Briefing UI: card in the relationship detail header (resolver in the
+   `TaskSummaryResolver` style), health-band chip, "Brief me" trigger with
+   provider disclosure when the profile routes to a cloud model, debounced
+   post-check-in refresh, and the call/message quick-action row on the
+   briefing card (ADR 0041).
+6. Template honesty rules (grounding, recency, not-enough-data) with tests
+   on the context builder and provenance parsing.
+
+Exit: briefing generates from seeded check-ins against a local profile in
+tests; health band renders; no inference without a trigger.
+
+## Phase 5 — Documentation and release readiness
+
+1. Manual: promote the roadmap section into a full feature page under
+   `docs-site/docs/organize-and-reflect/` with registered screenshot cases
+   (`features.json`, `screenshot-cases.json`, capture tests), all 11
+   locales; trim the roadmap entry accordingly.
+2. `PRIVACY.md`: relationship-data section per ADR 0037 §6.
+3. Feature README kept current throughout; CHANGELOG entry under the
+   then-current version when the feature ships.
+4. Flip ADRs 0037–0040 to Accepted as their phases land.
+
+## Testing and quality gates (every phase)
+
+- `dart-mcp.analyze_files` zero warnings; `fvm dart format .`.
+- One test file per source file; centralized mocks/fallbacks;
+  `makeTestableWidget`; fake time only; deterministic dates.
+- No dependencies from new code on deprecated legacy AI paths
+  (`AiResponseType.taskSummary` et al.).
+
+## Open questions (decide before the affected phase)
+
+- Phase 2: does the relationships list live in the main nav or under a
+  hub page? (Nav real estate decision — needs product input.)
+- Phase 3: default cadence 30 days — confirm, and whether cadence presets
+  (weekly/monthly/quarterly) beat a free integer field.
+- Phase 4: whether birthdays produce their own reminder variant or wait for
+  a later iteration.


### PR DESCRIPTION
## Summary

Design-only PR introducing relationship management as a pre-1.0 roadmap item: five ADRs, a phased implementation plan, and a manual roadmap entry in all 11 locales. No app code changes.

**Design highlights** (grounded in existing infrastructure):

- **ADR 0037 — On-device storage & privacy**: relationship data lives in the local journal DB only, syncs solely via the user's opt-in E2E-encrypted Matrix rooms, zero external retention, explicit consent before any cloud AI sees relationship data, explicit deletion cascade, GDPR household-exemption framing. `PRIVACY.md` update planned alongside implementation.
- **ADR 0038 — Domain model**: two new `JournalEntity` subtypes — `relationship` (person identity, importance flag, status union with history, check-in cadence, contact channels) and `checkIn` (interaction type, explicit sentiment, topics, pay-attention-to/avoid). Linking and the timeline reuse `linked_entries` with a new `RelationshipLink` variant; sync is automatic via the payload-agnostic journal sync; no schema migration.
- **ADR 0039 — Reminders**: new `relationshipCheckIn` variant on the synced notification inbox; deterministic importance + cadence rule; event-driven rescheduling like habits; finally wires the currently dormant `NotificationScheduler.reconcile()` into startup. OS alerts on iOS/macOS/Android, inbox-only on Windows/Linux.
- **ADR 0040 — Executive briefing**: a durable relationship agent mirroring the project agent, emitting `AgentReportEntity` briefings with a structured `relationship_health` band (project-health-band pattern), a strict context boundary, local-model-first routing with cloud-provider disclosure, and honesty rules.
- **ADR 0041 — Contact linking**: selective per-relationship contact linking (explicitly no bulk import), channel snapshots editable on every platform, call/message/email quick actions on the briefing via `url_launcher`, post-resume check-in prompt for interactions Lotti initiated; contact channels excluded from AI context.

**Roadmap entry**: new "Stay close to the people who matter" section on `docs-site/docs/roadmap.mdx`, translated in all 10 non-English locales (informal register, formal Romanian).

**Implementation plan**: `docs/implementation_plans/2026-07-22_relationship_management.md` — five phases (domain model → UI → reminders → briefing → docs/release) with concrete file lists from the exhaustive-switch sites, per-phase exit criteria, and open product questions (nav placement, cadence defaults, birthday reminders).

## Validation

- `docs-site/scripts/validate-manual.mjs` passes (34 features, 38 pages × 11 locales, 133 screenshot cases).
- Locale parity audit passes for all 10 translated locales (no missing/extra/identical pages).
- Docs-only change; analyzer/tests unaffected. Full Docusaurus production build left to CI (prose-only MDX additions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added roadmap coverage for planned relationship management, including per-person timelines, structured check-ins, relationship reminders for marked-important people, contact-link actions, and executive briefings.
  * Documented a local-first privacy model for relationship data, including end-to-end encrypted syncing and explicit, opt-in cloud behavior for briefings.
  * Published new decision records (ADRs) for relationship data, check-in reminders, executive briefings, and contact linking, plus an updated ADR index.
* **Planning**
  * Added a detailed “Relationship Management” implementation plan outlining phased delivery from data model through reminders, briefings, and release readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->