### PR TITLE
fix: round grouped-list focus border to the group's corner radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   digest, so week-level plans and learnings persist while each day keeps a
   small, fast context of its own.
 
+### Fixed
+- **The green focus border in list boxes no longer gets cropped at the
+  corners.** In the task filter box (and every other grouped list, e.g. in
+  Settings), the first and last row's keyboard-focus highlight was drawn as a
+  sharp rectangle and clipped by the box's rounded corners — visible after
+  picking a Status or Project filter. Edge rows now round the highlight to
+  match the box's corner radius.
+
 ## [0.9.1060]
 ### Added
 - **The Manual's five walkthrough videos are now available in every

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -38,6 +38,7 @@
     <release version="0.9.1061" date="2026-07-23">
       <description>
         <p>The Daily OS coordinator now briefs each day's planning agent: a morning digest reviews escalations and recent days, then issues a distilled per-day directive (commitments, capacity budget, carry-overs, cross-day context) which that day's agent must honor when drafting — placing each commitment, trading it away with the collision named, or escalating back via typed status events the coordinator picks up at its next digest.</p>
+        <p>Fixed: the green focus border in list boxes no longer gets cropped at the corners. In the task filter box (and every other grouped list, e.g. in Settings), the first and last row's keyboard-focus highlight was drawn as a sharp rectangle and clipped by the box's rounded corners. Edge rows now round the highlight to match the box's corner radius.</p>
       </description>
     </release>
     <release version="0.9.1060" date="2026-07-22">

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -184,6 +184,14 @@ Representative primitive-ish components:
 - text inputs and textareas
 - chips, badges, avatars, dividers, tooltips
 - dropdowns, lists, spinners, progress bars, scrollbars
+- grouped lists (`components/lists/design_system_grouped_list.dart`) — the
+  rounded, outlined card that groups list-item rows and clips them to its
+  corner radius. The group wraps its first and last child in a
+  `DesignSystemGroupedListCorners` inherited scope
+  (`components/lists/design_system_grouped_list_corners.dart`);
+  `DesignSystemListItem` reads it and rounds its state fill and
+  keyboard-focus border to the group's corners, so the focus outline is
+  never cropped by the clip
 - grouped-card row surfaces
   (`components/lists/grouped_card_row_surface.dart`) — selection, pointer
   hover, and keyboard focus paint through one background layer. Focus reuses

--- a/lib/features/design_system/components/lists/design_system_grouped_list.dart
+++ b/lib/features/design_system/components/lists/design_system_grouped_list.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list_corners.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 /// A rounded, bordered container for grouping design-system list-item rows.
 ///
 /// Applies the standard design-system background, border, and corner radius.
 /// Wrap a [Column] of list items inside this widget to get the grouped visual
-/// style used on settings, categories, and labels pages.
+/// style used on settings, categories, and labels pages. The first and last
+/// child are wrapped in a [DesignSystemGroupedListCorners] scope so edge rows
+/// can round their own decorations to the group's corners instead of painting
+/// square outlines into the clip.
 class DesignSystemGroupedList extends StatelessWidget {
   const DesignSystemGroupedList({
     required this.children,
@@ -29,6 +33,7 @@ class DesignSystemGroupedList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
+    final cornerRadius = Radius.circular(tokens.radii.m);
 
     return Padding(
       padding:
@@ -43,7 +48,21 @@ class DesignSystemGroupedList extends StatelessWidget {
           borderRadius: BorderRadius.circular(tokens.radii.m),
           child: Column(
             mainAxisSize: MainAxisSize.min,
-            children: children,
+            children: [
+              for (final (index, child) in children.indexed)
+                if (index == 0 || index == children.length - 1)
+                  DesignSystemGroupedListCorners(
+                    borderRadius: BorderRadius.vertical(
+                      top: index == 0 ? cornerRadius : Radius.zero,
+                      bottom: index == children.length - 1
+                          ? cornerRadius
+                          : Radius.zero,
+                    ),
+                    child: child,
+                  )
+                else
+                  child,
+            ],
           ),
         ),
       ),

--- a/lib/features/design_system/components/lists/design_system_grouped_list_corners.dart
+++ b/lib/features/design_system/components/lists/design_system_grouped_list_corners.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+/// Tells a grouped-list child which of the group's rounded corners it owns.
+///
+/// A grouped-list container (e.g. `DesignSystemGroupedList`) clips its
+/// children with the group's corner radius, so a child that paints a
+/// full-bleed decoration of its own (for example the keyboard-focus border
+/// on a list item) would get cropped into the rounded corners. The container
+/// wraps its first and last child in this scope so such decorations can
+/// round themselves to match the clip.
+class DesignSystemGroupedListCorners extends InheritedWidget {
+  const DesignSystemGroupedListCorners({
+    required this.borderRadius,
+    required super.child,
+    super.key,
+  });
+
+  /// The subset of the group's corner radius covering this child.
+  final BorderRadius borderRadius;
+
+  static BorderRadius? maybeOf(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<DesignSystemGroupedListCorners>()
+      ?.borderRadius;
+
+  @override
+  bool updateShouldNotify(DesignSystemGroupedListCorners oldWidget) =>
+      borderRadius != oldWidget.borderRadius;
+}

--- a/lib/features/design_system/components/lists/design_system_list_item.dart
+++ b/lib/features/design_system/components/lists/design_system_list_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list_corners.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_palette.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/utils/disabled_overlay.dart';
@@ -26,6 +27,10 @@ enum DesignSystemListItemVisualState {
 /// [onTap]/[onHoverChanged]; [forcedState] pins a
 /// [DesignSystemListItemVisualState] for widgetbook/tests. An optional bottom
 /// divider is configurable via [showDivider]/[dividerIndent]/[dividerColor].
+/// Inside a grouped list, edge rows read the enclosing
+/// [DesignSystemGroupedListCorners] scope and round their state fill and
+/// focus border to the group's corner radius so neither is cropped by the
+/// group's clip.
 class DesignSystemListItem extends StatefulWidget {
   const DesignSystemListItem({
     this.title,
@@ -171,6 +176,9 @@ class _DesignSystemListItemState extends State<DesignSystemListItem> {
                   tokens.colors.surface.focusPressed,
           };
     final focused = visualState == DesignSystemListItemVisualState.focused;
+    // Rows at the edge of a grouped list round their decoration to the
+    // group's clip, so the focus border is not cropped at the corners.
+    final groupCorners = DesignSystemGroupedListCorners.maybeOf(context);
 
     final item = Column(
       mainAxisSize: MainAxisSize.min,
@@ -180,6 +188,7 @@ class _DesignSystemListItemState extends State<DesignSystemListItem> {
           child: Ink(
             decoration: BoxDecoration(
               color: backgroundColor,
+              borderRadius: groupCorners,
               border: Border.all(
                 color: focused
                     ? tokens.colors.interactive.enabled

--- a/test/features/design_system/components/lists/design_system_grouped_list_corners_test.dart
+++ b/test/features/design_system/components/lists/design_system_grouped_list_corners_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list_corners.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('DesignSystemGroupedListCorners', () {
+    testWidgets('maybeOf returns the scoped radius to descendants', (
+      tester,
+    ) async {
+      const corners = BorderRadius.vertical(top: Radius.circular(12));
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          const Scaffold(
+            body: DesignSystemGroupedListCorners(
+              borderRadius: corners,
+              child: Text('Scoped'),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        DesignSystemGroupedListCorners.maybeOf(
+          tester.element(find.text('Scoped')),
+        ),
+        corners,
+      );
+    });
+
+    testWidgets('maybeOf returns null without an enclosing scope', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidget2(const Scaffold(body: Text('Unscoped'))),
+      );
+
+      expect(
+        DesignSystemGroupedListCorners.maybeOf(
+          tester.element(find.text('Unscoped')),
+        ),
+        isNull,
+      );
+    });
+
+    test('updateShouldNotify fires only when the radius changes', () {
+      const child = SizedBox.shrink();
+      const square = DesignSystemGroupedListCorners(
+        borderRadius: BorderRadius.zero,
+        child: child,
+      );
+      final rounded = DesignSystemGroupedListCorners(
+        borderRadius: BorderRadius.circular(8),
+        child: child,
+      );
+
+      expect(rounded.updateShouldNotify(square), isTrue);
+      expect(
+        square.updateShouldNotify(
+          const DesignSystemGroupedListCorners(
+            borderRadius: BorderRadius.zero,
+            child: child,
+          ),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/design_system/components/lists/design_system_grouped_list_test.dart
+++ b/test/features/design_system/components/lists/design_system_grouped_list_test.dart
@@ -1,26 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list_corners.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 import '../../../../widget_test_utils.dart';
 
 void main() {
-  Future<void> pumpList(WidgetTester tester) {
+  Future<void> pumpList(
+    WidgetTester tester, {
+    List<Widget> children = const [Text('Row 1'), Text('Row 2')],
+  }) {
     return tester.pumpWidget(
       makeTestableWidget2(
         Theme(
           data: DesignSystemTheme.dark(),
-          child: const Scaffold(
+          child: Scaffold(
             body: DesignSystemGroupedList(
-              children: [Text('Row 1'), Text('Row 2')],
+              children: children,
             ),
           ),
         ),
       ),
     );
   }
+
+  BorderRadius? cornersOf(WidgetTester tester, String text) =>
+      DesignSystemGroupedListCorners.maybeOf(tester.element(find.text(text)));
 
   group('DesignSystemGroupedList', () {
     testWidgets('paints token background, border, and corner radius', (
@@ -107,6 +114,50 @@ void main() {
       expect(
         decoration.border!.top.color,
         dsTokensDark.colors.decorative.level01,
+      );
+    });
+  });
+
+  group('DesignSystemGroupedList corner scopes', () {
+    testWidgets('first child owns only the top corners', (tester) async {
+      await pumpList(
+        tester,
+        children: const [Text('First'), Text('Middle'), Text('Last')],
+      );
+
+      expect(
+        cornersOf(tester, 'First'),
+        BorderRadius.vertical(top: Radius.circular(dsTokensDark.radii.m)),
+      );
+    });
+
+    testWidgets('middle children get no corner scope', (tester) async {
+      await pumpList(
+        tester,
+        children: const [Text('First'), Text('Middle'), Text('Last')],
+      );
+
+      expect(cornersOf(tester, 'Middle'), isNull);
+    });
+
+    testWidgets('last child owns only the bottom corners', (tester) async {
+      await pumpList(
+        tester,
+        children: const [Text('First'), Text('Middle'), Text('Last')],
+      );
+
+      expect(
+        cornersOf(tester, 'Last'),
+        BorderRadius.vertical(bottom: Radius.circular(dsTokensDark.radii.m)),
+      );
+    });
+
+    testWidgets('a sole child owns all four corners', (tester) async {
+      await pumpList(tester, children: const [Text('Only')]);
+
+      expect(
+        cornersOf(tester, 'Only'),
+        BorderRadius.circular(dsTokensDark.radii.m),
       );
     });
   });

--- a/test/features/design_system/components/lists/design_system_list_item_test.dart
+++ b/test/features/design_system/components/lists/design_system_list_item_test.dart
@@ -2,6 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list_corners.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_palette.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
@@ -347,16 +349,8 @@ void main() {
           ),
         );
 
-        final ink = tester.widget<Ink>(
-          find.descendant(
-            of: find.byKey(itemKey),
-            matching: find.byType(Ink),
-          ),
-        );
-        final decoration = ink.decoration! as BoxDecoration;
-
         final expected = DesignSystemListPalette.activatedFill(dsTokensLight);
-        expect(decoration.color, expected);
+        expect(_inkDecoration(tester, itemKey).color, expected);
       },
     );
 
@@ -417,15 +411,7 @@ void main() {
         ),
       );
 
-      final ink = tester.widget<Ink>(
-        find.descendant(
-          of: find.byKey(itemKey),
-          matching: find.byType(Ink),
-        ),
-      );
-      final decoration = ink.decoration! as BoxDecoration;
-
-      expect(decoration.color, activeColor);
+      expect(_inkDecoration(tester, itemKey).color, activeColor);
     });
 
     testWidgets('applies hover background via forced state', (tester) async {
@@ -441,16 +427,85 @@ void main() {
         ),
       );
 
-      final ink = tester.widget<Ink>(
-        find.descendant(
-          of: find.byKey(itemKey),
-          matching: find.byType(Ink),
+      expect(
+        _inkDecoration(tester, itemKey).color,
+        dsTokensLight.colors.surface.hover,
+      );
+    });
+
+    testWidgets('applies pressed background via forced state', (tester) async {
+      const itemKey = Key('pressed-item');
+
+      await _pumpListItem(
+        tester,
+        DesignSystemListItem(
+          key: itemKey,
+          title: 'Pressed',
+          forcedState: DesignSystemListItemVisualState.pressed,
+          onTap: () {},
         ),
       );
-      final decoration = ink.decoration! as BoxDecoration;
 
-      expect(decoration.color, dsTokensLight.colors.surface.hover);
+      expect(
+        _inkDecoration(tester, itemKey).color,
+        dsTokensLight.colors.surface.focusPressed,
+      );
     });
+
+    testWidgets('uses overridden pressed background color', (tester) async {
+      const itemKey = Key('custom-pressed-item');
+      const pressedColor = Colors.purple;
+
+      await _pumpListItem(
+        tester,
+        DesignSystemListItem(
+          key: itemKey,
+          title: 'Pressed',
+          forcedState: DesignSystemListItemVisualState.pressed,
+          pressedBackgroundColor: pressedColor,
+          onTap: () {},
+        ),
+      );
+
+      expect(_inkDecoration(tester, itemKey).color, pressedColor);
+    });
+
+    testWidgets(
+      'excludeFromSemantics removes the internal semantics node while the '
+      'row stays visible',
+      (tester) async {
+        const itemKey = Key('exclude-semantics-item');
+        final handle = tester.ensureSemantics();
+        // The inner label merges with the row text, so match a substring.
+        final label = RegExp('Row label');
+
+        await _pumpListItem(
+          tester,
+          DesignSystemListItem(
+            key: itemKey,
+            title: 'Row',
+            semanticsLabel: 'Row label',
+            onTap: () {},
+          ),
+        );
+        expect(find.bySemanticsLabel(label), findsOneWidget);
+
+        await _pumpListItem(
+          tester,
+          DesignSystemListItem(
+            key: itemKey,
+            title: 'Row',
+            semanticsLabel: 'Row label',
+            excludeFromSemantics: true,
+            onTap: () {},
+          ),
+        );
+        expect(find.bySemanticsLabel(label), findsNothing);
+        expect(find.text('Row'), findsOneWidget);
+
+        handle.dispose();
+      },
+    );
 
     testWidgets('applies disabled opacity when onTap is null', (
       tester,
@@ -555,6 +610,204 @@ void main() {
       expect(divider.indent, customIndent);
     });
 
+    testWidgets(
+      'real keyboard focus paints the accent border and reports '
+      'onFocusChanged on gain and loss',
+      (tester) async {
+        const itemKey = Key('keyboard-focus-item');
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+        final events = <bool>[];
+
+        await _pumpListItem(
+          tester,
+          DesignSystemListItem(
+            key: itemKey,
+            title: 'Focusable',
+            focusNode: focusNode,
+            onTap: () {},
+            onFocusChanged: events.add,
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(events, [true]);
+        expect(
+          _inkDecoration(tester, itemKey).border!.top.color,
+          dsTokensLight.colors.interactive.enabled,
+        );
+
+        focusNode.unfocus();
+        await tester.pump();
+        expect(events, [true, false]);
+        // The focus-loss callback lands after the first frame; one more
+        // frame renders the reverted border.
+        await tester.pump();
+        expect(
+          _inkDecoration(tester, itemKey).border!.top.color,
+          Colors.transparent,
+        );
+      },
+    );
+
+    testWidgets(
+      'changing forcedState clears stale transient focus visuals',
+      (tester) async {
+        const itemKey = Key('reset-item');
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        Future<void> pump(DesignSystemListItemVisualState? forcedState) {
+          return _pumpListItem(
+            tester,
+            DesignSystemListItem(
+              key: itemKey,
+              title: 'Resettable',
+              focusNode: focusNode,
+              forcedState: forcedState,
+              onTap: () {},
+            ),
+          );
+        }
+
+        await pump(null);
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(
+          _inkDecoration(tester, itemKey).border!.top.color,
+          dsTokensLight.colors.interactive.enabled,
+        );
+
+        await pump(DesignSystemListItemVisualState.idle);
+        expect(
+          _inkDecoration(tester, itemKey).border!.top.color,
+          Colors.transparent,
+        );
+
+        // Back to free-running: the reset cleared the stale focus flag, so
+        // the border stays idle even though the node itself kept focus.
+        await pump(null);
+        expect(focusNode.hasFocus, isTrue);
+        expect(
+          _inkDecoration(tester, itemKey).border!.top.color,
+          Colors.transparent,
+        );
+      },
+    );
+
+    testWidgets(
+      'focus border stays square outside a grouped list',
+      (tester) async {
+        const itemKey = Key('ungrouped-focused-item');
+
+        await _pumpListItem(
+          tester,
+          DesignSystemListItem(
+            key: itemKey,
+            title: 'Focused',
+            forcedState: DesignSystemListItemVisualState.focused,
+            onTap: () {},
+          ),
+        );
+
+        expect(_inkDecoration(tester, itemKey).borderRadius, isNull);
+      },
+    );
+
+    testWidgets(
+      'focus border follows the grouped-list corner scope so it is not '
+      'cropped by the group clip',
+      (tester) async {
+        const itemKey = Key('grouped-focused-item');
+        final corners = BorderRadius.vertical(
+          top: Radius.circular(dsTokensLight.radii.m),
+        );
+
+        await _pumpListItem(
+          tester,
+          DesignSystemGroupedListCorners(
+            borderRadius: corners,
+            child: DesignSystemListItem(
+              key: itemKey,
+              title: 'Focused edge row',
+              forcedState: DesignSystemListItemVisualState.focused,
+              onTap: () {},
+            ),
+          ),
+        );
+
+        final decoration = _inkDecoration(tester, itemKey);
+        expect(decoration.borderRadius, corners);
+        expect(
+          decoration.border!.top.color,
+          dsTokensLight.colors.interactive.enabled,
+        );
+      },
+    );
+
+    testWidgets(
+      'focused edge row inside a real DesignSystemGroupedList rounds to '
+      'the group corner radius',
+      (tester) async {
+        const firstKey = Key('grouped-list-first-item');
+
+        await _pumpListItem(
+          tester,
+          DesignSystemGroupedList(
+            padding: EdgeInsets.zero,
+            children: [
+              DesignSystemListItem(
+                key: firstKey,
+                title: 'First',
+                forcedState: DesignSystemListItemVisualState.focused,
+                onTap: () {},
+              ),
+              DesignSystemListItem(title: 'Last', onTap: () {}),
+            ],
+          ),
+        );
+
+        final decoration = _inkDecoration(tester, firstKey);
+        expect(
+          decoration.borderRadius,
+          BorderRadius.vertical(top: Radius.circular(dsTokensLight.radii.m)),
+        );
+        expect(
+          decoration.border!.top.color,
+          dsTokensLight.colors.interactive.enabled,
+        );
+      },
+    );
+
+    testWidgets(
+      'state fill also rounds to the corner scope when the row is not '
+      'focused',
+      (tester) async {
+        const itemKey = Key('grouped-hover-item');
+        final corners = BorderRadius.vertical(
+          bottom: Radius.circular(dsTokensLight.radii.m),
+        );
+
+        await _pumpListItem(
+          tester,
+          DesignSystemGroupedListCorners(
+            borderRadius: corners,
+            child: DesignSystemListItem(
+              key: itemKey,
+              title: 'Hovered edge row',
+              forcedState: DesignSystemListItemVisualState.hover,
+              onTap: () {},
+            ),
+          ),
+        );
+
+        final decoration = _inkDecoration(tester, itemKey);
+        expect(decoration.borderRadius, corners);
+        expect(decoration.border!.top.color, Colors.transparent);
+      },
+    );
+
     testWidgets('uses small size spec with reduced padding', (tester) async {
       const itemKey = Key('small-item');
 
@@ -604,4 +857,14 @@ Future<void> _pumpListItem(
       theme: DesignSystemTheme.light(),
     ),
   );
+}
+
+BoxDecoration _inkDecoration(WidgetTester tester, Key itemKey) {
+  final ink = tester.widget<Ink>(
+    find.descendant(
+      of: find.byKey(itemKey),
+      matching: find.byType(Ink),
+    ),
+  );
+  return ink.decoration! as BoxDecoration;
 }


### PR DESCRIPTION
## Summary

- round the keyboard-focus border of grouped-list rows to the group's corner radius, so it is no longer cropped at the box corners on the first and last row
- introduce `DesignSystemGroupedListCorners`, an inherited scope in its own file: `DesignSystemGroupedList` wraps its first and last child with the corners they own (top / bottom / all four for a sole child), and `DesignSystemListItem` rounds its state fill and focus border to whatever the scope provides
- the fix applies to every grouped list in the app at zero call-site cost — the task filter box, Settings lists, category/label pages, and the Projects filter
- 100% line coverage on all three touched source files, including a composed regression test (focused edge row inside a real `DesignSystemGroupedList`), real focus-gain/loss wiring, `forcedState` reset, pressed fills, and `excludeFromSemantics`

## Root cause

`DesignSystemGroupedList` clips its children with a rounded `ClipRRect`, while the focus border on `DesignSystemListItem` was painted as a sharp rectangle. On edge rows the square stroke ran straight into the rounded clip and got cut off — visible right after picking a Status or Project filter, because the filter flow restores keyboard focus to the row that was edited.

## Screenshots

### Status filter set — focus returns to the first row

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/before/task_filter_status_focused_desktop_dark.png" width="700" alt="Filter box with cropped focus border on the Status row, before"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/after/task_filter_status_focused_desktop_dark.png" width="700" alt="Filter box with rounded focus border on the Status row, after"> |

### Zoomed: top corners of the first row

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/before/zoom_status_top_corners.png" width="520" alt="Square focus-border corners clipped by the rounded box, before"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/after/zoom_status_top_corners.png" width="520" alt="Focus border following the box corner radius, after"> |

### Zoomed: bottom corners of the last row (Project)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/before/zoom_project_bottom_corners.png" width="520" alt="Square focus-border corners on the Project row, before"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/after/zoom_project_bottom_corners.png" width="520" alt="Rounded focus border on the Project row, after"> |

<details>
<summary>Mobile (bottom-sheet) variants</summary>

| Status focused — before | Status focused — after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/before/task_filter_status_focused_mobile_dark.png" width="390" alt="Mobile filter sheet before"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/after/task_filter_status_focused_mobile_dark.png" width="390" alt="Mobile filter sheet after"> |

| Project focused — before | Project focused — after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/before/task_filter_project_focused_mobile_dark.png" width="390" alt="Mobile filter sheet before"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/e680a41f8c4a08c7210d3c17af628745b864faa0/pr-screenshots/grouped-list-focus-border/after/task_filter_project_focused_mobile_dark.png" width="390" alt="Mobile filter sheet after"> |

</details>

### Also verified: Projects — "Filter projects" modal

The Projects filter delegates to the same shared `showDesignSystemFilterModal` flow, so the fix applies there with no additional code. Verified on this branch (first row = Status, top corners; last row = Category, bottom corners):

| Status focused (first row) | Category focused (last row) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/b3ebeaf6cf9a77ad3b1f063aebf7fa32a167ed85/pr-screenshots/grouped-list-focus-border/after/projects_filter_status_focused_desktop_dark.png" width="520" alt="Projects filter with rounded focus border on the Status row"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/b3ebeaf6cf9a77ad3b1f063aebf7fa32a167ed85/pr-screenshots/grouped-list-focus-border/after/projects_filter_category_focused_desktop_dark.png" width="520" alt="Projects filter with rounded focus border on the Category row"> |

Captured with the reusable screenshot harness (`test/test_utils/screenshot_harness.dart`) driving the real filter modal through the reported repro — open, pick "In Progress" on the Status page, Done — which restores keyboard focus to the edited row. "Before" from a `main` worktree, "after" from this branch; identical crop regions for the zoom pairs.

## Validation

- `fvm dart analyze` — no issues
- 43 focused tests across `design_system_grouped_list_test.dart`, `design_system_grouped_list_corners_test.dart`, and `design_system_list_item_test.dart` — all pass
- focused coverage: `design_system_grouped_list.dart` 22/22, `design_system_grouped_list_corners.dart` 6/6, `design_system_list_item.dart` 143/143 executable lines (100%)
- all 14 `DesignSystemGroupedList` call sites audited: every one passes one row per child and none renders a divider under its last child, so edge-corner rounding cannot notch an interior row
- CHANGELOG entry under 0.9.1060, paired with `flatpak/com.matthiasn.lotti.metainfo.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard-focus highlights in grouped and filtered list boxes so the first and last rows follow the container’s rounded corners instead of appearing cropped.
  * Updated list-item focus and state visuals for consistent corner rendering across task filters and Settings lists.

* **Documentation**
  * Added release notes and design-system guidance for the corrected grouped-list behavior.

* **Tests**
  * Added coverage for grouped-list corners, focus styling, visual states, and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->