### PR TITLE
feat: close ADR 0032 phase-1 leftovers — durable capture parsing + tightened same-day guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The Manual's five walkthrough videos are now available in every
   language Lotti supports** (previously English and German only): French,
   Italian, Spanish, Czech, Dutch, Romanian, Portuguese, Danish, and Swedish.
+- **Voice captures now survive the app closing before they're parsed.**
+  Submitting or retrying a Daily OS capture queues its parsing durably (the
+  same restart-safe queue drafting already uses), so backgrounding or killing
+  the app between recording and parsing no longer loses the parse — it runs
+  when the app reopens.
 
 ### Fixed
+- **Same-day plans can no longer schedule new blocks in the past.** The
+  drafting guard that kept AI and manual blocks from starting before the
+  current time now covers buffer blocks too; only imported calendar events —
+  which legitimately span the current moment — are exempt.
 - **The Settings destination is readable again in Italian and Swedish.**
   Several Settings-related labels (the main navigation destination, agent
   editor tabs, the logging screen, and the Settings breadcrumb) showed

--- a/docs/adr/0032-hierarchical-day-agent-coordination.md
+++ b/docs/adr/0032-hierarchical-day-agent-coordination.md
@@ -479,17 +479,17 @@ Decision section in place.
   agents simply stay `active` indefinitely once created — an accepted
   follow-up, not a regression, since nothing today would trigger dormancy
   correctly.
-- **Phase 1 durable jobs cover `draftPlan`/`refinePlan`, not
+- **Phase 1 durable jobs initially covered `draftPlan`/`refinePlan`, not
   `parseCapture`.** The `DayProcessingJobKind.parseCapture` job kind,
   `DayProcessingOutboxRepository.enqueueParseCapture`, and the executor's
-  dispatch for it are implemented and tested, but `DayAgentCaptureService`'s
-  capture-submit path was not rewired to use them in this slice — it still
-  enqueues a wake directly via `WakeOrchestrator.enqueueManualWake`. Capture
-  intent itself is durable (the `CaptureEntity` is persisted before any
-  wake); only the *wake* that parses it is volatile, same as before phase 1.
-  Wiring `submitCapture`/`retryCapture` onto the durable `parseCapture` job
-  is a scoped, low-risk follow-up using infrastructure that already exists
-  and is tested.
+  dispatch for it shipped implemented and tested in the first slice, but
+  `DayAgentCaptureService`'s capture-submit path still enqueued a volatile
+  wake directly via `WakeOrchestrator.enqueueManualWake`. This was closed in
+  the follow-up slice: `submitCapture` and `retryCapture` now enqueue the
+  durable `parseCapture` job (plus a deferred runtime nudge), and
+  `enqueueParseCapture` re-arms a stuck or terminal job with fresh attempts
+  while attaching to a queued/running one — which is what makes
+  `retryCapture` restart-safe without a separate retry API.
 
 ## Related
 

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -38,6 +38,8 @@
     <release version="0.9.1060" date="2026-07-22">
       <description>
         <p>The Manual's five walkthrough videos are now available in every language Lotti supports (previously English and German only): French, Italian, Spanish, Czech, Dutch, Romanian, Portuguese, Danish, and Swedish.</p>
+        <p>Voice captures now survive the app closing before they're parsed: submitting or retrying a Daily OS capture queues its parsing durably, so backgrounding or killing the app between recording and parsing no longer loses the parse — it runs when the app reopens.</p>
+        <p>Fixed: same-day plans can no longer schedule new blocks in the past. The drafting guard now covers buffer blocks too; only imported calendar events — which legitimately span the current moment — are exempt.</p>
         <p>Fixed: the Settings destination is readable again in Italian and Swedish. Several Settings-related labels showed "Impostazioni delle impostazioni" in Italian and "Miljöer" in Swedish instead of "Settings" — now "Impostazioni" and "Inställningar".</p>
         <p>Fixed: the coding-prompt "Copy Prompt" button is correctly labeled in Dutch — it previously read "Waarschuwing kopiëren" ("Copy warning"); now "Prompt kopiëren".</p>
       </description>

--- a/lib/features/agents/model/seeded_directives.dart
+++ b/lib/features/agents/model/seeded_directives.dart
@@ -194,4 +194,13 @@ const seedDirectiveChangelog = <SeedDirectiveChange>[
         'is for forward-looking learnings only, never day recaps. On '
         'contradiction the deterministic facts line wins over your note.',
   ),
+  SeedDirectiveChange(
+    date: '2026-07-22',
+    kind: AgentTemplateKind.dayAgent,
+    description:
+        'Same-day past-start guard tightened: when drafting today, new '
+        'drafted `buffer` blocks must not start before `currentLocalTime` '
+        'either — the exemption is now `cal` blocks only, since they mirror '
+        'real calendar events that legitimately span the current moment.',
+  ),
 ];

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -282,9 +282,13 @@ sequenceDiagram
   with a fresh `requestedAt`/payload, or attaches to an already-`running` job
   as-is. `refine_<dayId>_<suffix>` jobs are **never coalesced** — each refine
   carries distinct user input and produces its own ChangeSet. `parseJobId(captureId)`
-  is deterministic and accumulates (one job per capture, matching the
-  existing `supersede: false` wake semantics) — built and tested, but capture
-  submit does not yet enqueue through it (see the ADR's Amendments section).
+  is deterministic (one job per capture): a queued/running job attaches, and
+  a stuck (`failed`/`waitingForUser`/`waitingForNetwork`) or terminal job is
+  re-armed with fresh attempts. `DayAgentCaptureService.submitCapture` and
+  `retryCapture` enqueue through it (`outbox.enqueueParseCapture` + a
+  deferred runtime nudge) instead of firing a volatile wake directly — the
+  executor enqueues the actual wake when the job runs, so a process kill
+  between capture submit and parse no longer loses the parse.
 - **`RealDayAgent._awaitJobTerminal`** subscribes to the outbox's `changes`
   stream (event-driven, not a poll) and races only a periodic
   cancellation/soft-cap check (1 s tick, 10 min soft cap) against it — never a

--- a/lib/features/daily_os_next/agents/service/day_agent_capture_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_capture_service.dart
@@ -14,15 +14,14 @@ import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/service/task_agent_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
-import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_helpers.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_reads.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_corpus_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_triage_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/create/task_agent_assignment.dart';
@@ -61,11 +60,12 @@ class DayAgentCaptureService {
     required this.journalDb,
     required this.journalRepository,
     required this.fts5Db,
-    required this.orchestrator,
+    required this.outbox,
     required this.domainLogger,
     DayAgentTaskFactory? taskFactory,
     this.taskAgentService,
     this.onPersistedStateChanged,
+    this.nudgeProcessing,
   }) : _taskFactory = taskFactory ?? _defaultTaskFactory,
        _reads = DayAgentCaptureReads(agentRepository: agentRepository) {
     _corpus = DayAgentCorpusService(
@@ -96,11 +96,19 @@ class DayAgentCaptureService {
   /// FTS index used by `match_to_corpus`.
   final Fts5Db fts5Db;
 
-  /// Wake orchestrator used to enqueue capture parsing.
-  final WakeOrchestrator orchestrator;
+  /// Durable job outbox capture parsing is enqueued on (ADR 0032 phase 1):
+  /// the `parseCapture` job survives restarts, and its executor enqueues the
+  /// actual wake when the job runs.
+  final DayProcessingOutboxRepository outbox;
 
   /// Structured logger.
   final DomainLogger domainLogger;
+
+  /// Pokes the day-processing runtime to drain newly enqueued jobs
+  /// immediately instead of waiting for its next scheduled pass. Deferred
+  /// (not the runtime itself) to keep construction acyclic — the runtime's
+  /// executor depends on this service.
+  final void Function()? nudgeProcessing;
 
   final DayAgentTaskFactory _taskFactory;
 
@@ -163,7 +171,7 @@ class DayAgentCaptureService {
     }
   }
 
-  /// Writes a submitted capture and enqueues a parse wake.
+  /// Writes a submitted capture and enqueues its durable parse job.
   ///
   /// [dayId] is the selected planning workspace. It is intentionally
   /// independent of [capturedAt], because Activity may reuse a retained
@@ -210,19 +218,16 @@ class DayAgentCaptureService {
       ..call(captureDayId(capture))
       ..call(capture.id);
 
-    orchestrator.enqueueManualWake(
-      agentId: agentId,
-      reason: dayAgentCaptureSubmittedReason,
-      triggerTokens: {dayAgentCaptureSubmittedToken(capture.id)},
-      // Partition the parse wake by the capture's day workspace (ADR 0022) so
-      // it never supersedes or merges with another day's queued work under one
-      // planner.
-      workspaceKey: dayAgentWorkspaceKey(captureDayId(capture)),
-      // Each capture carries its own transcript to parse; a second capture for
-      // the same day must not drop the first's still-queued parse. Accumulate
-      // instead of superseding so every submission is parsed.
-      supersede: false,
+    // Durable parse intent (ADR 0032 phase 1): the job survives restarts;
+    // when it runs, the executor resolves the owning agent and enqueues the
+    // actual wake, partitioned by the capture's day workspace. One job per
+    // capture, so a second capture for the same day never drops the first's
+    // still-pending parse.
+    await outbox.enqueueParseCapture(
+      dayId: captureDayId(capture),
+      captureId: capture.id,
     );
+    nudgeProcessing?.call();
 
     return capture;
   }
@@ -236,19 +241,18 @@ class DayAgentCaptureService {
   /// Re-enqueues parsing for an already durable capture.
   ///
   /// This is the restart-safe manual continuation path used by Activity: the
-  /// capture remains the durable user intent even if the original in-memory
-  /// wake disappeared with the process.
+  /// capture remains the durable user intent even if the process died. A
+  /// still-queued/running parse job attaches; a stuck or terminal one is
+  /// re-armed by [DayProcessingOutboxRepository.enqueueParseCapture].
   Future<bool> retryCapture(String captureId) async {
     final entity = await agentRepository.getEntity(captureId);
     if (entity is! CaptureEntity || entity.deletedAt != null) return false;
     if ((await parsedItemsForCapture(captureId)).isNotEmpty) return true;
-    orchestrator.enqueueManualWake(
-      agentId: entity.agentId,
-      reason: dayAgentCaptureSubmittedReason,
-      triggerTokens: {dayAgentCaptureSubmittedToken(entity.id)},
-      workspaceKey: dayAgentWorkspaceKey(captureDayId(entity)),
-      supersede: false,
+    await outbox.enqueueParseCapture(
+      dayId: captureDayId(entity),
+      captureId: entity.id,
     );
+    nudgeProcessing?.call();
     return true;
   }
 

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_parser.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_parser.dart
@@ -16,7 +16,7 @@ const _uuid = Uuid();
 /// Validates and parses one model-emitted block into a [PlannedBlock],
 /// throwing [DayAgentCaptureException] on any contract violation: an
 /// out-of-allowlist category, `end` not after `start`, a block outside the
-/// plan day, a drafted today AI/manual block starting before
+/// plan day, a drafted today non-calendar block starting before
 /// [earliestDraftStart], an AI block missing its `reason`, or a `taskId` not
 /// in [decidedTaskIds]/[allowedExistingTaskIds]. Defaults `type` to `ai` and
 /// `state` to `drafted`, and mints a block id when none is supplied.
@@ -58,13 +58,16 @@ PlannedBlock parsePlannedBlock({
       'blocks must stay within the planDate day',
     );
   }
+  // Only `cal` blocks are exempt: they mirror real calendar events, which
+  // legitimately span "now". Everything the agent invents (ai, manual,
+  // buffer) must not plan the past — observed live: models relabel a
+  // past-starting block `buffer` to slip through an ai/manual-only guard.
   if (earliestDraftStart != null &&
       blockState == PlannedBlockState.drafted &&
-      (blockType == PlannedBlockType.ai ||
-          blockType == PlannedBlockType.manual) &&
+      blockType != PlannedBlockType.cal &&
       start.isBefore(earliestDraftStart)) {
     throw const DayAgentCaptureException(
-      'drafted AI/manual blocks for today must not start before '
+      'drafted non-calendar blocks for today must not start before '
       'current time',
     );
   }

--- a/lib/features/daily_os_next/agents/state/day_agent_providers.dart
+++ b/lib/features/daily_os_next/agents/state/day_agent_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/database/fts5_db.dart';
@@ -11,6 +13,7 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_knowledge_
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_week_context_service.dart';
+import 'package:lotti/features/daily_os_next/state/day_processing_runtime_provider.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart';
@@ -46,10 +49,15 @@ DayAgentCaptureService dayAgentCaptureService(Ref ref) {
     journalDb: ref.watch(journalDbProvider),
     journalRepository: ref.watch(journalRepositoryProvider),
     fts5Db: getIt<Fts5Db>(),
-    orchestrator: ref.watch(wakeOrchestratorProvider),
+    outbox: ref.watch(dayProcessingOutboxRepositoryProvider),
     domainLogger: ref.watch(domainLoggerProvider),
     taskAgentService: ref.watch(taskAgentServiceProvider),
     onPersistedStateChanged: persistedStateChangedNotifier(notifications),
+    // Deferred read: the runtime's executor depends on this service, so
+    // resolving the runtime eagerly here would create a provider cycle.
+    nudgeProcessing: () => unawaited(
+      ref.read(dayProcessingRuntimeProvider).nudge(),
+    ),
   );
 }
 

--- a/lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
@@ -63,9 +63,10 @@ Drafting rules:
 - Every `ai` block passed to `draft_day_plan` must include a concrete reason.
 - Keep blocks inside the local plan day and within the user's capacity.
 - The user message includes a `<current_local_time>` section. When `<plan_date>`
-  is the same local day, do not create new drafted `ai` or `manual` blocks that
-  start before that time. Preserve already-started baseline blocks only when
-  they represent existing in-progress, completed, or dropped history.
+  is the same local day, do not create new drafted `ai`, `manual`, or `buffer`
+  blocks that start before that time — only `cal` blocks mirroring real
+  calendar events may span it. Preserve already-started baseline blocks only
+  when they represent existing in-progress, completed, or dropped history.
 - Calendar, buffer, and manual blocks may omit reasons when their purpose is
   self-evident.
 - When this wake's user message carries a `<drafting>` section (i.e. the trigger

--- a/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
@@ -247,8 +247,13 @@ class DayProcessingOutboxRepository {
 
   /// Enqueues the durable parse intent for one submitted capture.
   ///
-  /// Deterministic per capture and never re-armed: a capture is parsed once,
-  /// and repeat submissions of the same capture id return the existing job.
+  /// Deterministic per capture: a queued or running job attaches (repeat
+  /// submissions of the same capture id return the existing job). A job in
+  /// any other state — stuck (`failed`, `waitingForUser`,
+  /// `waitingForNetwork`) or terminal (`succeeded`, `cancelled`) — is
+  /// re-armed with fresh attempts, which is what `retryCapture` relies on:
+  /// the capture is the durable user intent, and asking again means "parse
+  /// it (again)".
   Future<DayProcessingJob> enqueueParseCapture({
     required String dayId,
     required String captureId,
@@ -269,13 +274,34 @@ class DayProcessingOutboxRepository {
       generation: 0,
     );
     final existing = await _readJobOrNull(id);
-    if (existing != null) {
-      _validateImmutableIntent(existing, requested);
+    if (existing == null) {
+      await _write(requested);
+      _notify();
+      return requested;
+    }
+    _validateImmutableIntent(existing, requested);
+    if (existing.status == DayProcessingJobStatus.queued ||
+        existing.status == DayProcessingJobStatus.running) {
       return existing;
     }
-    await _write(requested);
+    final rearmed = existing.copyWith(
+      status: DayProcessingJobStatus.queued,
+      updatedAt: now,
+      requestedAt: now,
+      nextAttemptAt: now,
+      attempts: 0,
+      generation: existing.generation + 1,
+      clearClaimToken: true,
+      clearLeaseUntil: true,
+      clearRetryNotBefore: true,
+      clearLastError: true,
+      clearLastFailureClass: true,
+      clearResultEntityId: true,
+      clearCompletedAt: true,
+    );
+    await _write(rearmed);
     _notify();
-    return requested;
+    return rearmed;
   });
 
   /// Enqueues a durable refine intent for the day.

--- a/test/README.md
+++ b/test/README.md
@@ -284,6 +284,7 @@ All tests in this codebase must use **deterministic time control** instead of re
    - Real `Timer` instances in tests
 4. **Exception**: Tests validating real I/O (network, file system, OS integration) may use real time when necessary
 5. **Exception**: `integration_test/tutorial/` is a video driver, not a CI verification suite — it paces the real app at human speed for screen recording (see `tools/tutorial_videos/README.md`) and intentionally uses wall-clock `Stopwatch` + live pumps. These files are tagged `tutorial-video` (see `dart_test.yaml`) and `make integration_test` runs with `--exclude-tags tutorial-video`, so they never run under plain `flutter test` (no window, and they require `LOTTI_TUTORIAL_MANIFEST`/`LOTTI_TUTORIAL_TIMELINE` env vars). They run only via `fvm flutter drive`, driven by the `tools/tutorial_videos` workbench or the `tutorial-videos` skill.
+6. **Exception**: tests tagged `eval-live` (`test/features/ai/eval/`, `test/features/daily_os_next/eval/`) call a real inference provider and are skipped unless explicitly enabled via their `LOTTI_*_LIVE=1` env gate. They use the real clock deliberately — e.g. `day_agent_draft_live_eval_test.dart` drafts *today's* plan so the same-day "blocks must not start before current time" persist guard interacts with a real model's proposed times, which is the behavior under eval.
 
 ### `fakeAsync` does not fake real file I/O
 

--- a/test/features/agents/state/agent_workflow_providers_test.dart
+++ b/test/features/agents/state/agent_workflow_providers_test.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_se
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_week_context_service.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
+import 'package:lotti/features/daily_os_next/state/day_processing_runtime_provider.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
@@ -61,8 +62,12 @@ void main() {
       final domainLogger = MockDomainLogger();
       final wakeOrchestrator = MockWakeOrchestrator();
       final notifications = MockUpdateNotifications();
+      final dayProcessingOutbox = MockDayProcessingOutboxRepository();
       final container = ProviderContainer(
         overrides: [
+          dayProcessingOutboxRepositoryProvider.overrideWithValue(
+            dayProcessingOutbox,
+          ),
           agentRepositoryProvider.overrideWithValue(repository),
           conversationRepositoryProvider.overrideWith(
             ConversationRepository.new,
@@ -95,7 +100,7 @@ void main() {
         workflow.captureService?.journalRepository,
         same(journalRepository),
       );
-      expect(workflow.captureService?.orchestrator, same(wakeOrchestrator));
+      expect(workflow.captureService?.outbox, same(dayProcessingOutbox));
       expect(workflow.captureService?.domainLogger, same(domainLogger));
       expect(workflow.planService?.agentRepository, same(repository));
       expect(workflow.planService?.syncService, same(syncService));

--- a/test/features/daily_os_next/agents/service/day_agent_capture_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_capture_service_test.dart
@@ -11,9 +11,9 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -132,7 +132,8 @@ void main() {
   late MockJournalDb journalDb;
   late MockJournalRepository journalRepository;
   late MockFts5Db fts5Db;
-  late MockWakeOrchestrator orchestrator;
+  late MockDayProcessingOutboxRepository outbox;
+  late int nudgeCount;
   late MockDomainLogger domainLogger;
   late MockTaskAgentService taskAgentService;
   late Map<String, AgentDomainEntity> agentEntities;
@@ -150,11 +151,12 @@ void main() {
       journalDb: journalDb,
       journalRepository: journalRepository,
       fts5Db: fts5Db,
-      orchestrator: orchestrator,
+      outbox: outbox,
       domainLogger: domainLogger,
       taskFactory: _makeTaskFactory(journalEntities, createdTaskRequests),
       taskAgentService: taskAgentService,
       onPersistedStateChanged: notifications.add,
+      nudgeProcessing: () => nudgeCount++,
     );
   }
 
@@ -164,7 +166,8 @@ void main() {
     journalDb = MockJournalDb();
     journalRepository = MockJournalRepository();
     fts5Db = MockFts5Db();
-    orchestrator = MockWakeOrchestrator();
+    outbox = MockDayProcessingOutboxRepository();
+    nudgeCount = 0;
     domainLogger = MockDomainLogger();
     taskAgentService = MockTaskAgentService();
     agentEntities = {
@@ -215,18 +218,29 @@ void main() {
       return journalEntities[invocation.positionalArguments.single as String];
     });
     when(() => journalDb.getCategoryById(any())).thenAnswer((_) async => null);
-    // Default run-key stub so unstubbed enqueueManualWake calls (this file
-    // mostly asserts via `verify`/`verifyNever`) don't throw on the
-    // now-non-void return type.
+    // Default stub so submit/retry paths (this file mostly asserts via
+    // `verify`/`verifyNever`) get a well-formed durable job back.
     when(
-      () => orchestrator.enqueueManualWake(
-        agentId: any(named: 'agentId'),
-        reason: any(named: 'reason'),
-        triggerTokens: any(named: 'triggerTokens'),
-        workspaceKey: any(named: 'workspaceKey'),
-        supersede: any(named: 'supersede'),
+      () => outbox.enqueueParseCapture(
+        dayId: any(named: 'dayId'),
+        captureId: any(named: 'captureId'),
       ),
-    ).thenReturn('run-key-stub');
+    ).thenAnswer((invocation) async {
+      final captureId = invocation.namedArguments[#captureId] as String;
+      final dayId = invocation.namedArguments[#dayId] as String;
+      return DayProcessingJob(
+        id: 'parse_$captureId',
+        status: DayProcessingJobStatus.queued,
+        dayId: dayId,
+        payload: ParseCapturePayload(captureId: captureId),
+        createdAt: _now,
+        updatedAt: _now,
+        requestedAt: _now,
+        nextAttemptAt: _now,
+        attempts: 0,
+        generation: 0,
+      );
+    });
     when(
       () => journalDb.getOpenTasksForDayAgentCorpus(
         categoryIds: any(named: 'categoryIds'),
@@ -268,40 +282,39 @@ void main() {
   });
 
   group('DayAgentCaptureService', () {
-    test('submitCapture writes a capture and enqueues a parse wake', () async {
-      final service = createService();
+    test(
+      'submitCapture writes a capture and enqueues a durable parse job',
+      () async {
+        final service = createService();
 
-      await withClock(Clock.fixed(_now), () async {
-        final capture = await service.submitCapture(
-          agentId: _agentId,
-          transcript: '  buy milk and prep demo  ',
-          capturedAt: DateTime(2026, 5, 25, 8, 45),
-          dayId: 'dayplan-2026-05-25',
-        );
+        await withClock(Clock.fixed(_now), () async {
+          final capture = await service.submitCapture(
+            agentId: _agentId,
+            transcript: '  buy milk and prep demo  ',
+            capturedAt: DateTime(2026, 5, 25, 8, 45),
+            dayId: 'dayplan-2026-05-25',
+          );
 
-        expect(capture.id, startsWith('capture_'));
-        expect(capture.transcript, 'buy milk and prep demo');
-        // The caller supplies the selected day workspace independently of the
-        // source recording timestamp (ADR 0022).
-        expect(capture.dayId, 'dayplan-2026-05-25');
-        expect(upsertedEntities.single, isA<CaptureEntity>());
-        expect(notifications, containsAll([_agentId, capture.id]));
-        final captured =
-            verify(
-                  () => orchestrator.enqueueManualWake(
-                    agentId: _agentId,
-                    reason: 'capture_submitted',
-                    workspaceKey: 'day:dayplan-2026-05-25',
-                    triggerTokens: captureAny(named: 'triggerTokens'),
-                    // Captures accumulate rather than supersede, so a second
-                    // same-day capture can't drop this one's still-queued parse.
-                    supersede: false,
-                  ),
-                ).captured.single
-                as Set<String>;
-        expect(captured, {dayAgentCaptureSubmittedToken(capture.id)});
-      });
-    });
+          expect(capture.id, startsWith('capture_'));
+          expect(capture.transcript, 'buy milk and prep demo');
+          // The caller supplies the selected day workspace independently of
+          // the source recording timestamp (ADR 0022).
+          expect(capture.dayId, 'dayplan-2026-05-25');
+          expect(upsertedEntities.single, isA<CaptureEntity>());
+          expect(notifications, containsAll([_agentId, capture.id]));
+          // ADR 0032 phase 1: parse intent is a durable outbox job (the
+          // executor enqueues the actual wake when the job runs), and the
+          // runtime is nudged to drain it immediately.
+          verify(
+            () => outbox.enqueueParseCapture(
+              dayId: 'dayplan-2026-05-25',
+              captureId: capture.id,
+            ),
+          ).called(1);
+          expect(nudgeCount, 1);
+        });
+      },
+    );
 
     test('submitCapture rejects empty transcripts', () async {
       await expectLater(
@@ -334,15 +347,15 @@ void main() {
         final retried = await createService().retryCapture(capture.id);
 
         expect(retried, isTrue);
+        // enqueueParseCapture attaches to a queued/running job and re-arms a
+        // stuck or terminal one, so one call covers both retry semantics.
         verify(
-          () => orchestrator.enqueueManualWake(
-            agentId: _agentId,
-            reason: 'capture_submitted',
-            workspaceKey: 'day:dayplan-2026-05-25',
-            triggerTokens: {dayAgentCaptureSubmittedToken(capture.id)},
-            supersede: false,
+          () => outbox.enqueueParseCapture(
+            dayId: 'dayplan-2026-05-25',
+            captureId: capture.id,
           ),
         ).called(1);
+        expect(nudgeCount, 1);
       },
     );
 
@@ -389,14 +402,12 @@ void main() {
 
       expect(await createService().retryCapture(capture.id), isTrue);
       verifyNever(
-        () => orchestrator.enqueueManualWake(
-          agentId: any(named: 'agentId'),
-          reason: any(named: 'reason'),
-          triggerTokens: any(named: 'triggerTokens'),
-          workspaceKey: any(named: 'workspaceKey'),
-          supersede: any(named: 'supersede'),
+        () => outbox.enqueueParseCapture(
+          dayId: any(named: 'dayId'),
+          captureId: any(named: 'captureId'),
         ),
       );
+      expect(nudgeCount, 0);
     });
 
     test(
@@ -2303,7 +2314,7 @@ void main() {
           journalDb: journalDb,
           journalRepository: journalRepository,
           fts5Db: fts5Db,
-          orchestrator: orchestrator,
+          outbox: outbox,
           domainLogger: domainLogger,
           taskFactory:
               ({
@@ -2381,7 +2392,7 @@ void main() {
           journalDb: journalDb,
           journalRepository: journalRepository,
           fts5Db: fts5Db,
-          orchestrator: orchestrator,
+          outbox: outbox,
           domainLogger: domainLogger,
           onPersistedStateChanged: notifications.add,
         );

--- a/test/features/daily_os_next/agents/service/day_agent_plan_parser_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_plan_parser_test.dart
@@ -91,6 +91,61 @@ void main() {
       );
     });
 
+    group('earliestDraftStart guard', () {
+      final earliest = DateTime(2026, 3, 16, 14);
+
+      test('rejects past-starting drafted ai, manual, and buffer blocks', () {
+        // Every agent-invented type is guarded — models were observed live
+        // relabelling a past-starting block `buffer` to slip through an
+        // ai/manual-only guard.
+        for (final type in ['ai', 'manual', 'buffer']) {
+          expect(
+            () => parse(
+              rawBlock(type: type),
+              earliestDraftStart: earliest,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('must not start before current time'),
+              ),
+            ),
+            reason: 'type=$type must be rejected',
+          );
+        }
+      });
+
+      test('exempts cal blocks and non-drafted states from the guard', () {
+        final cal = parse(
+          rawBlock(type: 'cal'),
+          earliestDraftStart: earliest,
+        );
+        expect(cal.type, PlannedBlockType.cal);
+        expect(cal.startTime, DateTime(2026, 3, 16, 9));
+
+        final inProgress = parse(
+          rawBlock()..['state'] = 'inProgress',
+          earliestDraftStart: earliest,
+        );
+        expect(inProgress.state, PlannedBlockState.inProgress);
+      });
+
+      test('accepts drafted blocks starting at or after the boundary', () {
+        final atBoundary = parse(
+          rawBlock(startHour: 14, endHour: 15, type: 'buffer'),
+          earliestDraftStart: earliest,
+        );
+        expect(atBoundary.startTime, earliest);
+
+        final after = parse(
+          rawBlock(startHour: 15, endHour: 16),
+          earliestDraftStart: earliest,
+        );
+        expect(after.startTime, DateTime(2026, 3, 16, 15));
+      });
+    });
+
     test('rejects task ids that are neither decided nor existing', () {
       expect(
         () => parse(rawBlock(taskId: 'task-x')),

--- a/test/features/daily_os_next/agents/state/day_agent_providers_test.dart
+++ b/test/features/daily_os_next/agents/state/day_agent_providers_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
+import 'package:lotti/features/daily_os_next/state/day_processing_runtime_provider.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -165,6 +166,9 @@ void main() {
       final domainLogger = MockDomainLogger();
       final taskAgentService = MockTaskAgentService();
       final notifications = MockUpdateNotifications();
+      final outbox = MockDayProcessingOutboxRepository();
+      final runtime = MockDayProcessingRuntime();
+      when(runtime.nudge).thenAnswer((_) async {});
 
       // Fts5Db is resolved through getIt rather than a Riverpod provider.
       await setUpTestGetIt(
@@ -183,6 +187,8 @@ void main() {
         domainLoggerProvider.overrideWithValue(domainLogger),
         taskAgentServiceProvider.overrideWithValue(taskAgentService),
         updateNotificationsProvider.overrideWithValue(notifications),
+        dayProcessingOutboxRepositoryProvider.overrideWithValue(outbox),
+        dayProcessingRuntimeProvider.overrideWithValue(runtime),
       ]);
 
       final service = container.read(dayAgentCaptureServiceProvider);
@@ -192,9 +198,14 @@ void main() {
       expect(service.journalDb, same(journalDb));
       expect(service.journalRepository, same(journalRepository));
       expect(service.fts5Db, same(fts5Db));
-      expect(service.orchestrator, same(orchestrator));
+      expect(service.outbox, same(outbox));
       expect(service.domainLogger, same(domainLogger));
       expect(service.taskAgentService, same(taskAgentService));
+
+      // The nudge closure defers the runtime read (provider-cycle guard);
+      // invoking it must poke the runtime's drain.
+      service.nudgeProcessing!();
+      verify(runtime.nudge).called(1);
 
       expectPersistedStateNotification(
         callback: service.onPersistedStateChanged,
@@ -216,6 +227,7 @@ void main() {
         final taskAgentService = MockTaskAgentService();
         final notifications = MockUpdateNotifications();
         final persistenceLogic = MockPersistenceLogic();
+        final outbox = MockDayProcessingOutboxRepository();
 
         await setUpTestGetIt(
           additionalSetup: () {
@@ -295,6 +307,7 @@ void main() {
           domainLoggerProvider.overrideWithValue(domainLogger),
           taskAgentServiceProvider.overrideWithValue(taskAgentService),
           updateNotificationsProvider.overrideWithValue(notifications),
+          dayProcessingOutboxRepositoryProvider.overrideWithValue(outbox),
         ]);
 
         final result = await container

--- a/test/features/daily_os_next/eval/day_agent_draft_live_eval_test.dart
+++ b/test/features/daily_os_next/eval/day_agent_draft_live_eval_test.dart
@@ -1,0 +1,230 @@
+@Tags(['eval-live'])
+library;
+
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/constants/provider_config.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/time_service.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+import '../../ai_consumption/test_utils.dart';
+import '../integration/day_agent_pipeline_harness.dart';
+
+/// Live end-to-end eval of the ADR 0032 durable drafting pipeline against a
+/// real inference provider — the same chain the "Drafting your day" UI path
+/// runs (outbox → runtime → executor → orchestrator → workflow → real
+/// [ConversationRepository]/[CloudInferenceRepository] → plan writer),
+/// drafting **today's** plan with the real clock. That deliberately
+/// exercises the same-day "blocks must not start before current time"
+/// guard against a real model, which is the suspected trigger of the
+/// stuck-drafting hang observed live.
+///
+/// Wall-clock time and real `clock.now()` are intentional here (exempt from
+/// the fake-time policy in `test/README.md`): the interaction between the
+/// real current time and the model's proposed block times is the thing
+/// under test.
+///
+/// Run with:
+/// ```bash
+/// set -a; source .env; set +a   # provides MELIOUS_API_KEY / MELIOUS_BASE_URL
+/// LOTTI_DAY_AGENT_DRAFT_EVAL_LIVE=1 fvm flutter test \
+///   test/features/daily_os_next/eval/day_agent_draft_live_eval_test.dart
+/// ```
+/// Override the model list via `DAY_AGENT_DRAFT_EVAL_MODELS` (comma-separated
+/// Melious model ids).
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  final live = Platform.environment['LOTTI_DAY_AGENT_DRAFT_EVAL_LIVE'] == '1';
+  final modelIds =
+      (Platform.environment['DAY_AGENT_DRAFT_EVAL_MODELS'] ??
+              'qwen3.5-397b-a17b,glm-5.2')
+          .split(',')
+          .map((id) => id.trim())
+          .where((id) => id.isNotEmpty)
+          .toList();
+
+  for (final modelId in modelIds) {
+    test(
+      "drafts today's plan through the durable pipeline against $modelId",
+      () async {
+        final attribution = AiInteractionCaptureTestBench.create();
+        await setUpTestGetIt(
+          additionalSetup: () {
+            getIt
+              ..registerSingleton<PersistenceLogic>(MockPersistenceLogic())
+              ..registerSingleton<TimeService>(TimeService());
+            attribution.register();
+          },
+        );
+        addTearDown(tearDownTestGetIt);
+        // The test binding installs a mock HttpOverrides whose client
+        // instantly fails every request with HTTP 400 — clear it so the
+        // eval can reach the real provider.
+        HttpOverrides.global = null;
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final conversationSubscription = container.listen(
+          conversationRepositoryProvider,
+          (_, _) {},
+        );
+        addTearDown(conversationSubscription.close);
+        final cloudRepositorySubscription = container.listen(
+          cloudInferenceRepositoryProvider,
+          (_, _) {},
+        );
+        addTearDown(cloudRepositorySubscription.close);
+
+        final apiKey = Platform.environment['MELIOUS_API_KEY'];
+        if (apiKey == null || apiKey.isEmpty) {
+          fail(
+            'MELIOUS_API_KEY is not set — source .env before running the '
+            'live day-agent draft eval.',
+          );
+        }
+        final provider =
+            AiConfig.inferenceProvider(
+                  id: 'provider-day-eval',
+                  name: 'Melious (day-agent draft eval)',
+                  baseUrl:
+                      Platform.environment['MELIOUS_BASE_URL'] ??
+                      ProviderConfig.defaultBaseUrls[InferenceProviderType
+                          .melious]!,
+                  apiKey: apiKey,
+                  inferenceProviderType: InferenceProviderType.melious,
+                  createdAt: DateTime(2026, 7, 22),
+                )
+                as AiConfigInferenceProvider;
+        final model =
+            AiConfig.model(
+                  id: 'model-day-eval',
+                  name: 'Day-agent draft eval model',
+                  providerModelId: modelId,
+                  inferenceProviderId: provider.id,
+                  createdAt: DateTime(2026, 7, 22),
+                  inputModalities: const [Modality.text],
+                  outputModalities: const [Modality.text],
+                  isReasoningModel: true,
+                  supportsFunctionCalling: true,
+                  description: 'Live model under day-agent draft eval.',
+                )
+                as AiConfigModel;
+        final profile = AiConfigInferenceProfile(
+          id: 'profile-day-eval',
+          name: 'Day-agent draft eval',
+          thinkingModelId: modelId,
+          createdAt: DateTime(2026, 7, 22),
+        );
+
+        // Real clock on purpose: today's date + the actual current time is
+        // the exact live scenario that hung.
+        final startedAt = clock.now();
+        final dayDate = DateTime(
+          startedAt.year,
+          startedAt.month,
+          startedAt.day,
+        );
+        final dayId = dayAgentIdForDate(dayDate);
+
+        final harness = DayAgentPipelineHarness.create(
+          now: startedAt,
+          conversationRepository: container.read(
+            conversationRepositoryProvider.notifier,
+          ),
+          cloudInferenceRepository: container.read(
+            cloudInferenceRepositoryProvider,
+          ),
+          profile: profile,
+          model: model,
+          provider: provider,
+          logToStdout: true,
+        );
+        addTearDown(harness.dispose);
+
+        debugPrint(
+          'day-agent draft eval: model=$modelId dayDate=$dayDate '
+          'startedAt=$startedAt',
+        );
+        final stopwatch = Stopwatch()..start();
+        final draft = await harness.realDayAgent.draftDayPlan(
+          captureId: const CaptureId(''),
+          decidedTaskIds: const [],
+          dayDate: dayDate,
+        );
+        stopwatch.stop();
+
+        final draftJob = await harness.outbox.getById(
+          DayProcessingOutboxRepository.draftJobId(dayId),
+        );
+        debugPrint(
+          'day-agent draft eval: model=$modelId '
+          'latency=${stopwatch.elapsed} '
+          'jobStatus=${draftJob?.status.name} '
+          'attempts=${draftJob?.attempts} '
+          'blocks=${[for (final block in draft.blocks) _formatBlock(block)]}',
+        );
+
+        expect(draft.state, DayState.drafted);
+        expect(
+          draft.blocks,
+          isNotEmpty,
+          reason: 'The model must place at least one block.',
+        );
+        // The same-day persist guard rejects *drafted AI/manual* blocks
+        // starting before "now" (`parsePlannedBlock`); buffer/cal blocks and
+        // non-drafted states are exempt by design. Assert exactly that
+        // contract (small tolerance for the moment the guard sampled the
+        // clock). Observed live: qwen3.5-397b-a17b labels a past-starting
+        // block `buffer` and sails through the exemption.
+        final earliestAllowed = startedAt.subtract(const Duration(minutes: 1));
+        for (final block in draft.blocks) {
+          final guarded =
+              (block.type == TimeBlockType.ai ||
+                  block.type == TimeBlockType.manual) &&
+              block.state == TimeBlockState.drafted;
+          if (!guarded) continue;
+          expect(
+            block.start.isBefore(earliestAllowed),
+            isFalse,
+            reason:
+                'Drafted ${block.type.name} block "${block.title}" starts at '
+                '${block.start}, before the draft began at $startedAt — the '
+                'same-day guard should have rejected it.',
+          );
+        }
+        expect(draftJob, isNotNull);
+        expect(draftJob!.isTerminal, isTrue);
+        expect(draftJob.status.name, 'succeeded');
+      },
+      skip: live
+          ? null
+          : 'Set LOTTI_DAY_AGENT_DRAFT_EVAL_LIVE=1 (plus MELIOUS_API_KEY / '
+                'MELIOUS_BASE_URL) to run the live day-agent draft eval.',
+      // Longer than RealDayAgent's 10-minute job-await soft cap so a hang
+      // surfaces as the soft cap's DayAgentInteractionException (the real
+      // diagnostic) rather than an opaque test timeout.
+      timeout: const Timeout(Duration(minutes: 12)),
+    );
+  }
+}
+
+String _formatBlock(TimeBlock block) {
+  String hhmm(DateTime t) => '${t.hour}:${t.minute.toString().padLeft(2, '0')}';
+  return '${block.title} [${block.type.name}/${block.state.name}] '
+      '${hhmm(block.start)}-${hhmm(block.end)}';
+}

--- a/test/features/daily_os_next/eval/day_agent_draft_live_eval_test.dart
+++ b/test/features/daily_os_next/eval/day_agent_draft_live_eval_test.dart
@@ -185,17 +185,18 @@ void main() {
           isNotEmpty,
           reason: 'The model must place at least one block.',
         );
-        // The same-day persist guard rejects *drafted AI/manual* blocks
-        // starting before "now" (`parsePlannedBlock`); buffer/cal blocks and
-        // non-drafted states are exempt by design. Assert exactly that
-        // contract (small tolerance for the moment the guard sampled the
-        // clock). Observed live: qwen3.5-397b-a17b labels a past-starting
-        // block `buffer` and sails through the exemption.
+        // The same-day persist guard (`parsePlannedBlock`) rejects drafted
+        // non-calendar blocks starting before "now"; `cal` blocks (real
+        // calendar events legitimately spanning the current moment) and
+        // non-drafted states are exempt. Assert exactly that contract (small
+        // tolerance for the moment the guard sampled the clock). The guard
+        // originally covered only ai/manual — qwen3.5-397b-a17b was observed
+        // live labelling a past-starting block `buffer` to slip through,
+        // which is why buffer is guarded now.
         final earliestAllowed = startedAt.subtract(const Duration(minutes: 1));
         for (final block in draft.blocks) {
           final guarded =
-              (block.type == TimeBlockType.ai ||
-                  block.type == TimeBlockType.manual) &&
+              block.type != TimeBlockType.cal &&
               block.state == TimeBlockState.drafted;
           if (!guarded) continue;
           expect(

--- a/test/features/daily_os_next/integration/day_agent_durable_jobs_smoke_test.dart
+++ b/test/features/daily_os_next/integration/day_agent_durable_jobs_smoke_test.dart
@@ -1,21 +1,7 @@
-import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/features/agents/database/agent_database.dart'
-    hide AgentLink;
-import 'package:lotti/features/agents/database/agent_db_conversions.dart';
-import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
-import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/agents/model/agent_link.dart';
-import 'package:lotti/features/agents/model/attention_negotiation.dart';
-import 'package:lotti/features/agents/service/agent_service.dart';
-import 'package:lotti/features/agents/service/agent_template_service.dart';
-import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
-import 'package:lotti/features/agents/wake/wake_queue.dart';
-import 'package:lotti/features/agents/wake/wake_runner.dart';
 import 'package:lotti/features/ai/conversation/conversation_manager.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -23,46 +9,30 @@ import 'package:lotti/features/ai/model/inference_usage.dart';
 import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_identity.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
-import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
-import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
-import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
-import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
-import 'package:lotti/features/daily_os_next/agents/workflow/day_capture_events.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
-import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
-import 'package:lotti/features/daily_os_next/logic/real_day_agent.dart';
-import 'package:lotti/features/daily_os_next/services/day_processing_outbox_processor.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
-import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
-import 'package:lotti/features/daily_os_next/state/day_agent_job_wiring.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
-import '../../agents/sync/in_memory_agent_repository.dart';
 import '../../agents/test_data/ai_config_factories.dart';
-import '../../agents/test_data/template_factories.dart';
+import 'day_agent_pipeline_harness.dart';
 
 /// End-to-end smoke test for the ADR 0032 durable draft/refine pipeline.
 ///
 /// Unlike the unit tests elsewhere in this branch (which fake or mock the
-/// outbox, the executor, or the workflow individually), this wires the real
-/// production classes together — [DayProcessingOutboxRepository] (real,
-/// file-backed), [DayProcessingRuntime], [DayProcessingOutboxProcessor],
-/// `DayAgentJobExecutor` (via the real [buildDayAgentJobExecutor] wiring),
-/// [WakeOrchestrator]/[WakeQueue]/[WakeRunner], [DayAgentWorkflow],
-/// [DayAgentPlanService], [DayAgentCaptureService], [DayAgentService], and
-/// [RealDayAgent] — and drives a draft then a refine through the whole
-/// chain. Only the LLM response is scripted (no network call), matching the
-/// pattern already used by `day_agent_workflow_test.dart`.
+/// outbox, the executor, or the workflow individually), this drives a draft
+/// then a refine through the real production chain assembled by
+/// [DayAgentPipelineHarness]. Only the LLM response is scripted (no network
+/// call), matching the pattern already used by `day_agent_workflow_test.dart`.
 ///
-/// This is the closest thing to a live manual smoke test that is available
-/// without GUI/microphone automation: it proves the new outbox → runtime →
-/// executor → orchestrator → workflow → plan-service → outbox-completion
-/// round trip genuinely works, not just that each link passes its own
-/// mocked unit test.
+/// This is the closest thing to a live manual smoke test that runs in the
+/// normal unit-test lane: it proves the new outbox → runtime → executor →
+/// orchestrator → workflow → plan-service → outbox-completion round trip
+/// genuinely works, not just that each link passes its own mocked unit
+/// test. (The `eval/day_agent_draft_live_eval_test.dart` variant runs the
+/// same chain against a real model.)
 void main() {
   setUpAll(registerAllFallbackValues);
 
@@ -75,260 +45,30 @@ void main() {
   final dayDate = DateTime(2030, 1, 15);
   final dayId = dayAgentIdForDate(dayDate);
 
-  late Directory root;
-  late _TestAgentRepository agentRepository;
-  late _DelegatingAgentSyncService syncService;
-  late MockAgentTemplateService templateService;
-  late MockDomainLogger domainLogger;
-  late MockJournalDb journalDb;
-  late MockFts5Db fts5Db;
-  late MockJournalRepository journalRepository;
-  late MockAiConfigRepository aiConfigRepository;
-  late MockCloudInferenceRepository cloudInferenceRepository;
   late _ScriptedConversationRepository conversationRepository;
-  late WakeQueue wakeQueue;
-  late WakeRunner wakeRunner;
-  late WakeOrchestrator orchestrator;
-  late DayProcessingOutboxRepository outbox;
-  late DayProcessingRuntime runtime;
-  late RealDayAgent realDayAgent;
+  late DayAgentPipelineHarness harness;
 
-  void stubInferenceProfile() {
-    when(
-      () => aiConfigRepository.getConfigById('profile-day'),
-    ).thenAnswer(
-      (_) async => testInferenceProfile(
+  setUp(() {
+    conversationRepository = _ScriptedConversationRepository();
+    harness = DayAgentPipelineHarness.create(
+      now: now,
+      conversationRepository: conversationRepository,
+      cloudInferenceRepository: MockCloudInferenceRepository(),
+      profile: testInferenceProfile(
         id: 'profile-day',
         thinkingModelId: 'models/day',
       ),
-    );
-    when(
-      () => aiConfigRepository.getConfigsByType(AiConfigType.model),
-    ).thenAnswer(
-      (_) async => [
-        testAiModel(
-          id: 'model-day',
-          providerModelId: 'models/day',
-          inferenceProviderId: 'provider-day',
-        ),
-      ],
-    );
-    when(
-      () => aiConfigRepository.getConfigById('provider-day'),
-    ).thenAnswer(
-      (_) async => testInferenceProvider(
+      model: testAiModel(
+        id: 'model-day',
+        providerModelId: 'models/day',
+        inferenceProviderId: 'provider-day',
+      ),
+      provider: testInferenceProvider(
         id: 'provider-day',
         apiKey: 'provider-key',
       ),
     );
-  }
-
-  setUp(() async {
-    root = Directory.systemTemp.createTempSync('day-agent-smoke-test-');
-    agentRepository = _TestAgentRepository();
-    syncService = _DelegatingAgentSyncService(agentRepository);
-    templateService = MockAgentTemplateService();
-    domainLogger = MockDomainLogger();
-    journalDb = MockJournalDb();
-    fts5Db = MockFts5Db();
-    journalRepository = MockJournalRepository();
-    aiConfigRepository = MockAiConfigRepository();
-    cloudInferenceRepository = MockCloudInferenceRepository();
-    conversationRepository = _ScriptedConversationRepository();
-    wakeQueue = WakeQueue();
-    wakeRunner = WakeRunner();
-
-    stubAppendMilestone(syncService);
-
-    when(
-      () => domainLogger.log(
-        any(),
-        any(),
-        subDomain: any(named: 'subDomain'),
-        level: any(named: 'level'),
-      ),
-    ).thenReturn(null);
-    when(
-      () => domainLogger.error(
-        any(),
-        any(),
-        message: any(named: 'message'),
-        stackTrace: any(named: 'stackTrace'),
-        subDomain: any(named: 'subDomain'),
-      ),
-    ).thenReturn(null);
-
-    // Day-agent template: seeded for real (DayAgentService reads it directly
-    // via `repository.getEntity`), version/directives are mocked (only
-    // consumed for prompt rendering by DayAgentWorkflow).
-    agentRepository.seed([
-      AgentDomainEntity.agentTemplate(
-            id: dayAgentTemplateId,
-            agentId: dayAgentTemplateId,
-            displayName: 'Shepherd',
-            kind: AgentTemplateKind.dayAgent,
-            modelId: 'models/day',
-            categoryIds: const {},
-            profileId: 'profile-day',
-            createdAt: now,
-            updatedAt: now,
-            vectorClock: null,
-          )
-          as AgentTemplateEntity,
-    ]);
-    when(() => templateService.getTemplateForAgent(any())).thenAnswer(
-      (_) async => makeTestTemplate(
-        id: dayAgentTemplateId,
-        agentId: dayAgentTemplateId,
-        kind: AgentTemplateKind.dayAgent,
-        modelId: 'models/day',
-        profileId: 'profile-day',
-      ),
-    );
-    when(() => templateService.getActiveVersion(dayAgentTemplateId)).thenAnswer(
-      (_) async => makeTestTemplateVersion(
-        id: 'version-day',
-        agentId: dayAgentTemplateId,
-        generalDirective: 'Plan the day well.',
-        reportDirective: 'Report clearly.',
-        profileId: 'profile-day',
-      ),
-    );
-
-    stubInferenceProfile();
-    when(() => journalDb.getCategoryById(any())).thenAnswer((_) async => null);
-    when(
-      () => journalDb.getOpenTasksForDayAgentCorpus(
-        categoryIds: any(named: 'categoryIds'),
-        limit: any(named: 'limit'),
-      ),
-    ).thenAnswer((_) async => const []);
-    when(
-      () => journalDb.getTasksDueOn(any()),
-    ).thenAnswer((_) async => const []);
-    when(
-      () => journalDb.getTasksDueOnOrBefore(any()),
-    ).thenAnswer((_) async => const []);
-    when(
-      () => journalDb.getInProgressTasks(
-        categoryIds: any(named: 'categoryIds'),
-        limit: any(named: 'limit'),
-      ),
-    ).thenAnswer((_) async => const []);
-    when(
-      () => journalDb.getMissedRecurringTasks(
-        asOf: any(named: 'asOf'),
-        lookbackDays: any(named: 'lookbackDays'),
-        categoryIds: any(named: 'categoryIds'),
-      ),
-    ).thenAnswer((_) async => const []);
-
-    final planService = DayAgentPlanService(
-      agentRepository: agentRepository,
-      syncService: syncService,
-      journalDb: journalDb,
-      domainLogger: domainLogger,
-    );
-    final captureService = DayAgentCaptureService(
-      agentRepository: agentRepository,
-      syncService: syncService,
-      journalDb: journalDb,
-      journalRepository: journalRepository,
-      fts5Db: fts5Db,
-      orchestrator: WakeOrchestrator(
-        repository: agentRepository,
-        queue: wakeQueue,
-        runner: wakeRunner,
-      ),
-      domainLogger: domainLogger,
-    );
-
-    final dayWorkflow = DayAgentWorkflow(
-      agentRepository: agentRepository,
-      conversationRepository: conversationRepository,
-      aiConfigRepository: aiConfigRepository,
-      cloudInferenceRepository: cloudInferenceRepository,
-      syncService: syncService,
-      templateService: templateService,
-      captureService: captureService,
-      planService: planService,
-      domainLogger: domainLogger,
-    );
-
-    orchestrator = WakeOrchestrator(
-      repository: agentRepository,
-      queue: wakeQueue,
-      runner: wakeRunner,
-      domainLogger: domainLogger,
-    );
-    addTearDown(orchestrator.stop);
-    // Routes exactly like the real `wireWakeExecutor` day-agent branch
-    // (agent_wiring.dart), minus the kinds this test never exercises.
-    orchestrator.wakeExecutor = (agentId, runKey, triggers, threadId) async {
-      final identity = await agentRepository.getEntity(agentId);
-      if (identity is! AgentIdentityEntity) return null;
-      final result = await dayWorkflow.execute(
-        agentIdentity: identity,
-        runKey: runKey,
-        triggerTokens: triggers,
-        threadId: threadId,
-      );
-      if (!result.success) {
-        throw StateError(result.error ?? 'Day agent wake failed');
-      }
-      return result.mutatedEntries;
-    };
-
-    final agentService = AgentService(
-      repository: agentRepository,
-      orchestrator: orchestrator,
-      syncService: syncService,
-    );
-    final dayAgentService = DayAgentService(
-      agentService: agentService,
-      repository: agentRepository,
-      orchestrator: orchestrator,
-      syncService: syncService,
-      templateService: templateService,
-      domainLogger: domainLogger,
-    );
-
-    outbox = DayProcessingOutboxRepository(rootDirectory: root);
-    addTearDown(outbox.dispose);
-
-    final executor = buildDayAgentJobExecutor(
-      dayAgentService: dayAgentService,
-      planService: planService,
-      captureService: captureService,
-      orchestrator: orchestrator,
-    );
-    final processor = DayProcessingOutboxProcessor(
-      repository: outbox,
-      // Only the agent-job lane is exercised; this smoke test doesn't touch
-      // transcription.
-      transcribe: (_) async => throw UnimplementedError(),
-      attachTranscript: (_, _) async => false,
-      agentJobExecutor: executor.execute,
-    );
-    runtime = DayProcessingRuntime(
-      repository: outbox,
-      drain: () => processor.drain(kinds: dayAgentJobKinds),
-    )..start();
-    addTearDown(runtime.dispose);
-
-    realDayAgent = RealDayAgent(
-      captureService: captureService,
-      planService: planService,
-      dayAgentService: dayAgentService,
-      journalDb: journalDb,
-      mockFallback: MockDayAgent(),
-      outbox: outbox,
-      nudgeProcessing: () => unawaited(runtime.nudge()),
-    );
-  });
-
-  tearDown(() {
-    if (root.existsSync()) root.deleteSync(recursive: true);
+    addTearDown(() => harness.dispose());
   });
 
   test(
@@ -357,7 +97,7 @@ void main() {
         ),
       ];
 
-      final draft = await realDayAgent.draftDayPlan(
+      final draft = await harness.realDayAgent.draftDayPlan(
         captureId: const CaptureId(''),
         decidedTaskIds: const [],
         dayDate: dayDate,
@@ -371,13 +111,13 @@ void main() {
       // it ran through is on disk, terminal, and succeeded — proving the
       // whole round trip, not just the in-memory return value.
       final dayAgentId = perDayAgentId(dayId);
-      final draftJob = await outbox.getById(
+      final draftJob = await harness.outbox.getById(
         DayProcessingOutboxRepository.draftJobId(dayId),
       );
       expect(draftJob, isNotNull);
       expect(draftJob!.isTerminal, isTrue);
       expect(draftJob.status.name, 'succeeded');
-      final identity = await agentRepository.getEntity(dayAgentId);
+      final identity = await harness.agentRepository.getEntity(dayAgentId);
       expect(identity, isA<AgentIdentityEntity>());
 
       // ── Refine ───────────────────────────────────────────────────────────
@@ -407,7 +147,7 @@ void main() {
         ),
       ];
 
-      final diff = await realDayAgent.proposePlanDiff(
+      final diff = await harness.realDayAgent.proposePlanDiff(
         currentPlan: draft,
         voiceTranscript: 'add a stretch break around 11',
       );
@@ -415,7 +155,7 @@ void main() {
       expect(diff.changes, hasLength(1));
       expect(diff.changes.single.kind, PlanDiffChangeKind.added);
 
-      final refineJobs = (await outbox.getAll())
+      final refineJobs = (await harness.outbox.getAll())
           .where((job) => job.kind.name == 'refinePlan')
           .toList();
       expect(refineJobs, hasLength(1));
@@ -424,33 +164,6 @@ void main() {
       expect(refineJobs.single.resultEntityId, isNotNull);
     },
   );
-}
-
-/// A [MockAgentSyncService] whose writes go straight into the same
-/// in-memory store the repository reads from, so writes made mid-wake
-/// (plan drafts, refine diffs) are visible to later reads in the same test
-/// — real read-after-write semantics without a real Matrix/sqlite backend.
-class _DelegatingAgentSyncService extends MockAgentSyncService {
-  _DelegatingAgentSyncService(this._repository);
-
-  final _TestAgentRepository _repository;
-
-  @override
-  Future<T> runInTransaction<T>(Future<T> Function() action) => action();
-
-  @override
-  Future<void> upsertEntity(
-    AgentDomainEntity entity, {
-    bool fromSync = false,
-  }) => _repository.upsertEntity(entity);
-
-  @override
-  Future<void> upsertLink(AgentLink link, {bool fromSync = false}) =>
-      _repository.upsertLink(link);
-
-  @override
-  Future<AgentStateEntity?> reconciledAgentState(String agentId) =>
-      _repository.getAgentState(agentId);
 }
 
 ChatCompletionMessageToolCall _toolCall({
@@ -521,84 +234,4 @@ class _ScriptedConversationRepository extends ConversationRepository {
   void deleteConversation(String conversationId) {
     _managers.remove(conversationId)?.dispose();
   }
-}
-
-/// Extends the shared [InMemoryAgentRepository] with the additional
-/// real-semantics methods this smoke test's call path needs (wake-run
-/// bookkeeping, agent listing, attention-planning inputs, capture
-/// metadata) that the shared fixture's narrower call graph doesn't cover.
-class _TestAgentRepository extends InMemoryAgentRepository {
-  @override
-  Future<void> insertWakeRun({required WakeRunLogData entry}) async {}
-
-  @override
-  Future<void> updateWakeRunStatus(
-    String runKey,
-    String status, {
-    DateTime? completedAt,
-    String? errorMessage,
-    DateTime? startedAt,
-  }) async {}
-
-  @override
-  Future<void> updateWakeRunTemplate(
-    String runKey,
-    String templateId,
-    String versionId, {
-    String? resolvedModelId,
-    String? soulId,
-    String? soulVersionId,
-  }) async {}
-
-  @override
-  Future<List<AgentIdentityEntity>> getAgentIdentitiesByLifecycle(
-    AgentLifecycle lifecycle,
-  ) async => entities
-      .whereType<AgentIdentityEntity>()
-      .where((e) => e.lifecycle == lifecycle)
-      .toList();
-
-  @override
-  Future<List<AgentIdentityEntity>> getAllAgentIdentities() async =>
-      entities.whereType<AgentIdentityEntity>().toList();
-
-  @override
-  Future<AttentionPlanningInputs> getAttentionPlanningInputsForWindow({
-    required DateTime start,
-    required DateTime end,
-    Set<AttentionClaimStatus> claimStatuses = const {},
-    Set<StandingAgreementStatus> agreementStatuses = const {},
-    Set<StandingAgreementScope>? agreementScopes,
-    int claimLimit = 200,
-    int agreementLimit = 200,
-  }) async => const AttentionPlanningInputs.empty();
-
-  @override
-  Future<List<CaptureEventMeta>> getCaptureEventMetaByAgentId(
-    String agentId,
-  ) async => entities
-      .whereType<CaptureEntity>()
-      .where((c) => c.agentId == agentId && c.deletedAt == null)
-      .map(
-        (c) => (
-          id: c.id,
-          dayId: c.dayId,
-          createdAt: c.createdAt,
-          capturedAt: c.capturedAt,
-        ),
-      )
-      .toList();
-
-  @override
-  Future<List<AgentDomainEntity>> getEntitiesByAgentId(
-    String agentId, {
-    String? type,
-    int limit = -1,
-  }) async => entities
-      .where(
-        (e) =>
-            e.agentId == agentId &&
-            (type == null || AgentDbConversions.entityType(e) == type),
-      )
-      .toList();
 }

--- a/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
+++ b/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
@@ -210,18 +210,19 @@ class DayAgentPipelineHarness {
       journalDb: journalDb,
       domainLogger: domainLogger,
     );
+    final outbox = DayProcessingOutboxRepository(rootDirectory: root);
+    // Deferred: the runtime is built after the capture service (its executor
+    // depends on it), mirroring the deferred-read wiring in production.
+    DayProcessingRuntime? runtimeRef;
     final captureService = DayAgentCaptureService(
       agentRepository: agentRepository,
       syncService: syncService,
       journalDb: journalDb,
       journalRepository: journalRepository,
       fts5Db: fts5Db,
-      orchestrator: WakeOrchestrator(
-        repository: agentRepository,
-        queue: wakeQueue,
-        runner: wakeRunner,
-      ),
+      outbox: outbox,
       domainLogger: domainLogger,
+      nudgeProcessing: () => unawaited(runtimeRef?.nudge()),
     );
 
     final dayWorkflow = DayAgentWorkflow(
@@ -274,8 +275,6 @@ class DayAgentPipelineHarness {
       domainLogger: domainLogger,
     );
 
-    final outbox = DayProcessingOutboxRepository(rootDirectory: root);
-
     final executor = buildDayAgentJobExecutor(
       dayAgentService: dayAgentService,
       planService: planService,
@@ -294,6 +293,7 @@ class DayAgentPipelineHarness {
       repository: outbox,
       drain: () => processor.drain(kinds: dayAgentJobKinds),
     )..start();
+    runtimeRef = runtime;
 
     final realDayAgent = RealDayAgent(
       captureService: captureService,

--- a/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
+++ b/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
@@ -1,0 +1,453 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:lotti/features/agents/database/agent_database.dart'
+    hide AgentLink;
+import 'package:lotti/features/agents/database/agent_db_conversions.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
+import 'package:lotti/features/agents/service/agent_service.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/features/agents/wake/wake_queue.dart';
+import 'package:lotti/features/agents/wake/wake_runner.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
+import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
+import 'package:lotti/features/daily_os_next/agents/workflow/day_capture_events.dart';
+import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
+import 'package:lotti/features/daily_os_next/logic/real_day_agent.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_processor.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
+import 'package:lotti/features/daily_os_next/state/day_agent_job_wiring.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../../agents/sync/in_memory_agent_repository.dart';
+import '../../agents/test_data/template_factories.dart';
+
+/// Wires the full ADR 0032 durable draft/refine pipeline out of real
+/// production classes — [DayProcessingOutboxRepository] (real,
+/// file-backed), [DayProcessingRuntime], [DayProcessingOutboxProcessor],
+/// `DayAgentJobExecutor` (via the real [buildDayAgentJobExecutor] wiring),
+/// [WakeOrchestrator]/[WakeQueue]/[WakeRunner], [DayAgentWorkflow],
+/// [DayAgentPlanService], [DayAgentCaptureService], [DayAgentService], and
+/// [RealDayAgent] — with only the conversation/inference layer injected by
+/// the caller.
+///
+/// Shared by two callers with different LLM layers:
+///
+///  * `day_agent_durable_jobs_smoke_test.dart` — scripted tool calls, no
+///    network, runs in the normal unit-test lane.
+///  * `../eval/day_agent_draft_live_eval_test.dart` — the real
+///    [ConversationRepository] + [CloudInferenceRepository] against a live
+///    provider, gated behind `LOTTI_DAY_AGENT_DRAFT_EVAL_LIVE=1`.
+class DayAgentPipelineHarness {
+  DayAgentPipelineHarness._({
+    required this.root,
+    required this.agentRepository,
+    required this.syncService,
+    required this.templateService,
+    required this.domainLogger,
+    required this.journalDb,
+    required this.wakeRunner,
+    required this.orchestrator,
+    required this.outbox,
+    required this.runtime,
+    required this.realDayAgent,
+  });
+
+  /// Builds the full pipeline. [now] seeds template timestamps; [profile],
+  /// [model], and [provider] are the inference configs the workflow resolves
+  /// (the template's profile points at [profile], whose thinking model must
+  /// equal [model]'s `providerModelId`, which must resolve to [provider]).
+  ///
+  /// With [logToStdout] the otherwise-swallowed domain logs are printed —
+  /// useful for live eval runs where the model's behavior is the thing
+  /// under observation.
+  factory DayAgentPipelineHarness.create({
+    required DateTime now,
+    required ConversationRepository conversationRepository,
+    required CloudInferenceRepository cloudInferenceRepository,
+    required AiConfigInferenceProfile profile,
+    required AiConfigModel model,
+    required AiConfigInferenceProvider provider,
+    bool logToStdout = false,
+  }) {
+    final root = Directory.systemTemp.createTempSync('day-agent-pipeline-');
+    final agentRepository = PipelineAgentRepository();
+    final syncService = DelegatingAgentSyncService(agentRepository);
+    final templateService = MockAgentTemplateService();
+    final domainLogger = MockDomainLogger();
+    final journalDb = MockJournalDb();
+    final fts5Db = MockFts5Db();
+    final journalRepository = MockJournalRepository();
+    final aiConfigRepository = MockAiConfigRepository();
+    final wakeQueue = WakeQueue();
+    final wakeRunner = WakeRunner();
+
+    stubAppendMilestone(syncService);
+
+    when(
+      () => domainLogger.log(
+        any(),
+        any(),
+        subDomain: any(named: 'subDomain'),
+        level: any(named: 'level'),
+      ),
+    ).thenAnswer((invocation) {
+      if (logToStdout) {
+        debugPrint(
+          '[${invocation.positionalArguments[0]}] '
+          '${invocation.positionalArguments[1]}',
+        );
+      }
+    });
+    when(
+      () => domainLogger.error(
+        any(),
+        any(),
+        message: any(named: 'message'),
+        stackTrace: any(named: 'stackTrace'),
+        subDomain: any(named: 'subDomain'),
+      ),
+    ).thenAnswer((invocation) {
+      if (logToStdout) {
+        debugPrint(
+          '[ERROR ${invocation.positionalArguments[0]}] '
+          '${invocation.namedArguments[#message]}: '
+          '${invocation.positionalArguments[1]}',
+        );
+      }
+    });
+
+    // Day-agent template: seeded for real (DayAgentService reads it directly
+    // via `repository.getEntity`), version/directives are mocked (only
+    // consumed for prompt rendering by DayAgentWorkflow).
+    agentRepository.seed([
+      AgentDomainEntity.agentTemplate(
+            id: dayAgentTemplateId,
+            agentId: dayAgentTemplateId,
+            displayName: 'Shepherd',
+            kind: AgentTemplateKind.dayAgent,
+            modelId: model.providerModelId,
+            categoryIds: const {},
+            profileId: profile.id,
+            createdAt: now,
+            updatedAt: now,
+            vectorClock: null,
+          )
+          as AgentTemplateEntity,
+    ]);
+    when(() => templateService.getTemplateForAgent(any())).thenAnswer(
+      (_) async => makeTestTemplate(
+        id: dayAgentTemplateId,
+        agentId: dayAgentTemplateId,
+        kind: AgentTemplateKind.dayAgent,
+        modelId: model.providerModelId,
+        profileId: profile.id,
+      ),
+    );
+    when(() => templateService.getActiveVersion(dayAgentTemplateId)).thenAnswer(
+      (_) async => makeTestTemplateVersion(
+        id: 'version-day',
+        agentId: dayAgentTemplateId,
+        generalDirective: 'Plan the day well.',
+        reportDirective: 'Report clearly.',
+        profileId: profile.id,
+      ),
+    );
+
+    when(
+      () => aiConfigRepository.getConfigById(profile.id),
+    ).thenAnswer((_) async => profile);
+    when(
+      () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+    ).thenAnswer((_) async => [model]);
+    when(
+      () => aiConfigRepository.getConfigById(provider.id),
+    ).thenAnswer((_) async => provider);
+
+    when(() => journalDb.getCategoryById(any())).thenAnswer((_) async => null);
+    when(
+      () => journalDb.getOpenTasksForDayAgentCorpus(
+        categoryIds: any(named: 'categoryIds'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => journalDb.getTasksDueOn(any()),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => journalDb.getTasksDueOnOrBefore(any()),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => journalDb.getInProgressTasks(
+        categoryIds: any(named: 'categoryIds'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => journalDb.getMissedRecurringTasks(
+        asOf: any(named: 'asOf'),
+        lookbackDays: any(named: 'lookbackDays'),
+        categoryIds: any(named: 'categoryIds'),
+      ),
+    ).thenAnswer((_) async => const []);
+
+    final planService = DayAgentPlanService(
+      agentRepository: agentRepository,
+      syncService: syncService,
+      journalDb: journalDb,
+      domainLogger: domainLogger,
+    );
+    final captureService = DayAgentCaptureService(
+      agentRepository: agentRepository,
+      syncService: syncService,
+      journalDb: journalDb,
+      journalRepository: journalRepository,
+      fts5Db: fts5Db,
+      orchestrator: WakeOrchestrator(
+        repository: agentRepository,
+        queue: wakeQueue,
+        runner: wakeRunner,
+      ),
+      domainLogger: domainLogger,
+    );
+
+    final dayWorkflow = DayAgentWorkflow(
+      agentRepository: agentRepository,
+      conversationRepository: conversationRepository,
+      aiConfigRepository: aiConfigRepository,
+      cloudInferenceRepository: cloudInferenceRepository,
+      syncService: syncService,
+      templateService: templateService,
+      captureService: captureService,
+      planService: planService,
+      domainLogger: domainLogger,
+    );
+
+    final orchestrator =
+        WakeOrchestrator(
+            repository: agentRepository,
+            queue: wakeQueue,
+            runner: wakeRunner,
+            domainLogger: domainLogger,
+          )
+          // Routes exactly like the real `wireWakeExecutor` day-agent branch
+          // (agent_wiring.dart), minus the kinds this harness never exercises.
+          ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+            final identity = await agentRepository.getEntity(agentId);
+            if (identity is! AgentIdentityEntity) return null;
+            final result = await dayWorkflow.execute(
+              agentIdentity: identity,
+              runKey: runKey,
+              triggerTokens: triggers,
+              threadId: threadId,
+            );
+            if (!result.success) {
+              throw StateError(result.error ?? 'Day agent wake failed');
+            }
+            return result.mutatedEntries;
+          };
+
+    final agentService = AgentService(
+      repository: agentRepository,
+      orchestrator: orchestrator,
+      syncService: syncService,
+    );
+    final dayAgentService = DayAgentService(
+      agentService: agentService,
+      repository: agentRepository,
+      orchestrator: orchestrator,
+      syncService: syncService,
+      templateService: templateService,
+      domainLogger: domainLogger,
+    );
+
+    final outbox = DayProcessingOutboxRepository(rootDirectory: root);
+
+    final executor = buildDayAgentJobExecutor(
+      dayAgentService: dayAgentService,
+      planService: planService,
+      captureService: captureService,
+      orchestrator: orchestrator,
+    );
+    final processor = DayProcessingOutboxProcessor(
+      repository: outbox,
+      // Only the agent-job lane is exercised; this harness doesn't touch
+      // transcription.
+      transcribe: (_) async => throw UnimplementedError(),
+      attachTranscript: (_, _) async => false,
+      agentJobExecutor: executor.execute,
+    );
+    final runtime = DayProcessingRuntime(
+      repository: outbox,
+      drain: () => processor.drain(kinds: dayAgentJobKinds),
+    )..start();
+
+    final realDayAgent = RealDayAgent(
+      captureService: captureService,
+      planService: planService,
+      dayAgentService: dayAgentService,
+      journalDb: journalDb,
+      mockFallback: MockDayAgent(),
+      outbox: outbox,
+      nudgeProcessing: () => unawaited(runtime.nudge()),
+    );
+
+    return DayAgentPipelineHarness._(
+      root: root,
+      agentRepository: agentRepository,
+      syncService: syncService,
+      templateService: templateService,
+      domainLogger: domainLogger,
+      journalDb: journalDb,
+      wakeRunner: wakeRunner,
+      orchestrator: orchestrator,
+      outbox: outbox,
+      runtime: runtime,
+      realDayAgent: realDayAgent,
+    );
+  }
+
+  final Directory root;
+  final PipelineAgentRepository agentRepository;
+  final DelegatingAgentSyncService syncService;
+  final MockAgentTemplateService templateService;
+  final MockDomainLogger domainLogger;
+  final MockJournalDb journalDb;
+  final WakeRunner wakeRunner;
+  final WakeOrchestrator orchestrator;
+  final DayProcessingOutboxRepository outbox;
+  final DayProcessingRuntime runtime;
+  final RealDayAgent realDayAgent;
+
+  /// Stops the runtime/orchestrator, closes the outbox, and deletes the
+  /// temp directory backing it.
+  Future<void> dispose() async {
+    await orchestrator.stop();
+    await runtime.dispose();
+    await outbox.dispose();
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  }
+}
+
+/// A [MockAgentSyncService] whose writes go straight into the same
+/// in-memory store the repository reads from, so writes made mid-wake
+/// (plan drafts, refine diffs) are visible to later reads in the same test
+/// — real read-after-write semantics without a real Matrix/sqlite backend.
+class DelegatingAgentSyncService extends MockAgentSyncService {
+  DelegatingAgentSyncService(this._repository);
+
+  final PipelineAgentRepository _repository;
+
+  @override
+  AgentRepository get repository => _repository;
+
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) => action();
+
+  @override
+  Future<void> upsertEntity(
+    AgentDomainEntity entity, {
+    bool fromSync = false,
+  }) => _repository.upsertEntity(entity);
+
+  @override
+  Future<void> upsertLink(AgentLink link, {bool fromSync = false}) =>
+      _repository.upsertLink(link);
+
+  @override
+  Future<AgentStateEntity?> reconciledAgentState(String agentId) =>
+      _repository.getAgentState(agentId);
+}
+
+/// Extends the shared [InMemoryAgentRepository] with the additional
+/// real-semantics methods the pipeline's call path needs (wake-run
+/// bookkeeping, agent listing, attention-planning inputs, capture
+/// metadata) that the shared fixture's narrower call graph doesn't cover.
+class PipelineAgentRepository extends InMemoryAgentRepository {
+  @override
+  Future<void> insertWakeRun({required WakeRunLogData entry}) async {}
+
+  @override
+  Future<void> updateWakeRunStatus(
+    String runKey,
+    String status, {
+    DateTime? completedAt,
+    String? errorMessage,
+    DateTime? startedAt,
+  }) async {}
+
+  @override
+  Future<void> updateWakeRunTemplate(
+    String runKey,
+    String templateId,
+    String versionId, {
+    String? resolvedModelId,
+    String? soulId,
+    String? soulVersionId,
+  }) async {}
+
+  @override
+  Future<List<AgentIdentityEntity>> getAgentIdentitiesByLifecycle(
+    AgentLifecycle lifecycle,
+  ) async => entities
+      .whereType<AgentIdentityEntity>()
+      .where((e) => e.lifecycle == lifecycle)
+      .toList();
+
+  @override
+  Future<List<AgentIdentityEntity>> getAllAgentIdentities() async =>
+      entities.whereType<AgentIdentityEntity>().toList();
+
+  @override
+  Future<AttentionPlanningInputs> getAttentionPlanningInputsForWindow({
+    required DateTime start,
+    required DateTime end,
+    Set<AttentionClaimStatus> claimStatuses = const {},
+    Set<StandingAgreementStatus> agreementStatuses = const {},
+    Set<StandingAgreementScope>? agreementScopes,
+    int claimLimit = 200,
+    int agreementLimit = 200,
+  }) async => const AttentionPlanningInputs.empty();
+
+  @override
+  Future<List<CaptureEventMeta>> getCaptureEventMetaByAgentId(
+    String agentId,
+  ) async => entities
+      .whereType<CaptureEntity>()
+      .where((c) => c.agentId == agentId && c.deletedAt == null)
+      .map(
+        (c) => (
+          id: c.id,
+          dayId: c.dayId,
+          createdAt: c.createdAt,
+          capturedAt: c.capturedAt,
+        ),
+      )
+      .toList();
+
+  @override
+  Future<List<AgentDomainEntity>> getEntitiesByAgentId(
+    String agentId, {
+    String? type,
+    int limit = -1,
+  }) async => entities
+      .where(
+        (e) =>
+            e.agentId == agentId &&
+            (type == null || AgentDbConversions.entityType(e) == type),
+      )
+      .toList();
+}

--- a/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
@@ -539,6 +539,83 @@ void main() {
     });
 
     test(
+      'enqueueParseCapture attaches to a running job without re-arming',
+      () async {
+        await repository.enqueueParseCapture(
+          dayId: 'dayplan-2026-07-18',
+          captureId: 'cap-1',
+        );
+        final claim = await repository.claimById('parse_cap-1');
+        expect(claim!.job.status, DayProcessingJobStatus.running);
+
+        final attached = await repository.enqueueParseCapture(
+          dayId: 'dayplan-2026-07-18',
+          captureId: 'cap-1',
+        );
+
+        expect(attached.status, DayProcessingJobStatus.running);
+        expect(attached.generation, claim.job.generation);
+      },
+    );
+
+    test(
+      'enqueueParseCapture re-arms a stuck (failed) job with fresh attempts',
+      () async {
+        await repository.enqueueParseCapture(
+          dayId: 'dayplan-2026-07-18',
+          captureId: 'cap-1',
+        );
+        final claim = await repository.claimById('parse_cap-1');
+        final failed = await repository.markFailure(
+          jobId: 'parse_cap-1',
+          claimToken: claim!.token,
+          failureClass: DayProcessingFailureClass.deterministic,
+          error: 'model refused to parse',
+        );
+        expect(failed.status, DayProcessingJobStatus.failed);
+        expect(failed.attempts, 1);
+
+        final rearmed = await repository.enqueueParseCapture(
+          dayId: 'dayplan-2026-07-18',
+          captureId: 'cap-1',
+        );
+
+        expect(rearmed.status, DayProcessingJobStatus.queued);
+        expect(rearmed.attempts, 0);
+        expect(rearmed.generation, failed.generation + 1);
+        expect(rearmed.lastError, isNull);
+        expect(rearmed.lastFailureClass, isNull);
+      },
+    );
+
+    test(
+      'enqueueParseCapture re-arms a succeeded job (explicit re-parse)',
+      () async {
+        await repository.enqueueParseCapture(
+          dayId: 'dayplan-2026-07-18',
+          captureId: 'cap-1',
+        );
+        final claim = await repository.claimById('parse_cap-1');
+        final succeeded = await repository.markSucceeded(
+          jobId: 'parse_cap-1',
+          claimToken: claim!.token,
+          resultEntityId: 'parsed-1',
+        );
+        expect(succeeded.status, DayProcessingJobStatus.succeeded);
+
+        final rearmed = await repository.enqueueParseCapture(
+          dayId: 'dayplan-2026-07-18',
+          captureId: 'cap-1',
+        );
+
+        expect(rearmed.status, DayProcessingJobStatus.queued);
+        expect(rearmed.attempts, 0);
+        expect(rearmed.resultEntityId, isNull);
+        expect(rearmed.completedAt, isNull);
+      },
+    );
+
+    test(
       'enqueueParseCapture rejects a re-request for a different day',
       () async {
         await repository.enqueueParseCapture(


### PR DESCRIPTION
## What

Closes the two follow-ups flagged in the ADR 0032 Amendments section after #3538, plus adds a live end-to-end eval of the durable drafting pipeline.

### Durable capture parsing
`DayAgentCaptureService.submitCapture` / `retryCapture` now enqueue the durable `parseCapture` outbox job (plus a deferred runtime nudge) instead of firing a volatile wake directly — a process kill between capture submit and parse no longer loses the parse. `enqueueParseCapture` gained attach-vs-re-arm semantics: a queued/running job attaches, a stuck (`failed`/`waitingForUser`/`waitingForNetwork`) or terminal job is re-armed with fresh attempts, which is what makes `retryCapture` restart-safe without a separate retry API.

### Same-day past-start guard covers buffer blocks
`parsePlannedBlock` now rejects drafted `ai`/`manual`/`buffer` blocks starting before the current time on same-day drafts; only `cal` blocks (real calendar events legitimately spanning "now") remain exempt. Observed live: qwen3.5-397b-a17b relabelled a past-starting block `buffer` to slip through the previous ai/manual-only guard. The drafting prompt and seed-directive changelog state the tightened rule.

### Live draft eval (`eval-live`, opt-in)
The durable-jobs smoke test's wiring is extracted into a shared `DayAgentPipelineHarness`, and a new env-gated eval (`LOTTI_DAY_AGENT_DRAFT_EVAL_LIVE=1`) drives the exact "Drafting your day" chain — outbox → runtime → executor → orchestrator → workflow → real `ConversationRepository`/`CloudInferenceRepository` — against Melious (`qwen3.5-397b-a17b`, `glm-5.2`), drafting today's plan with the real clock. Skipped in CI.

## Verification

- `test/features/daily_os_next`: 1713 tests pass
- `test/features/agents`: 5043 tests pass
- Analyzer: no issues
- Live eval: both models pass with the tightened guard; one run demonstrated the durable retry recovering from a genuine transient Melious HTTP 400 (attempts=1 → success)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice captures are now queued for parsing durably, so closing or backgrounding the app no longer loses pending transcription work.
  * Failed or interrupted capture parsing can resume safely without creating duplicate jobs.

* **Bug Fixes**
  * Same-day plans no longer schedule newly drafted blocks in the past.
  * Existing calendar events spanning the current time remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->