### PR TITLE
feat: mobile-view tutorial videos, shared with the screenshot toggle

### DIFF
--- a/.claude/skills/tutorial-videos/SKILL.md
+++ b/.claude/skills/tutorial-videos/SKILL.md
@@ -40,15 +40,19 @@ audible at step starts (`volumedetect`), duration ≈ warped timeline total.
 
 ```sh
 make tutorial_video_publish TUTORIAL_SCENARIO=create_task_from_audio TUTORIAL_LOCALE=de
+make tutorial_video_publish TUTORIAL_SCENARIO=create_task_from_audio TUTORIAL_LOCALE=de TUTORIAL_DEVICE=mobile
 ```
 
-Uploads `build/tutorial_videos/<scenario>_<locale>.mp4` to Cloudflare R2 at
-`tutorial-videos/<scenario>_<locale>.mp4` and prints its public r2.dev URL —
+Uploads `build/tutorial_videos/<scenario>_<locale>.mp4` (or, with
+`TUTORIAL_DEVICE=mobile`, `<scenario>_<locale>_mobile.mp4`) to Cloudflare R2
+at the matching `tutorial-videos/...` key and prints its public r2.dev URL —
 this is the URL the docs-site `TutorialVideo` component builds from
-`TUTORIAL_VIDEO_BASE_URL`/`tutorialVideoBaseUrl`. Full one-time Cloudflare
-setup (API token, enabling the bucket's public r2.dev URL) and the `.env`
-variable list are in the README's "Publishing to Cloudflare R2" section —
-read it before the first publish.
+`TUTORIAL_VIDEO_BASE_URL`/`tutorialVideoBaseUrl`. `TUTORIAL_DEVICE` must
+match whatever `--device` the video was built with, or publish will look for
+a file that was never produced. Full one-time Cloudflare setup (API token,
+enabling the bucket's public r2.dev URL) and the `.env` variable list are in
+the README's "Publishing to Cloudflare R2" section — read it before the
+first publish.
 
 `boto3` (needed only by publish, not by build/tts/validate) is not installed
 into the system Python on this host (PEP 668). Either run publish through

--- a/.claude/skills/tutorial-videos/SKILL.md
+++ b/.claude/skills/tutorial-videos/SKILL.md
@@ -12,9 +12,14 @@ it first. This skill is the operational runbook.
 ## Build videos
 
 ```sh
-make tutorial_video TUTORIAL_LOCALE=de     # one locale (~5-8 min)
-make tutorial_videos_all                   # all TUTORIAL_LOCALES
+make tutorial_video TUTORIAL_LOCALE=de                       # one locale (~5-8 min)
+make tutorial_video TUTORIAL_LOCALE=de TUTORIAL_DEVICE=mobile # phone-shaped window, `_mobile`-suffixed output
+make tutorial_videos_all                                     # all TUTORIAL_LOCALES
 ```
+
+`TUTORIAL_DEVICE` (`desktop`|`mobile`, default `desktop`) picks the capture
+window size — see the README's "Desktop vs. mobile" section for the
+breakpoint rationale and the `tutorialDeviceIsMobile()` test hook.
 
 Preconditions (fail fast if missing):
 - `.env` at repo root with `GEMINI_API_KEY`, `MELIOUS_API_KEY`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The Manual's five walkthrough videos are now available in every
   language Lotti supports** (previously English and German only): French,
   Italian, Spanish, Czech, Dutch, Romanian, Portuguese, Danish, and Swedish.
+- **Manual videos now have a mobile-view variant, matching the existing
+  screenshot toggle.** The same mobile/desktop switch that already
+  controlled screenshots now also switches the walkthrough videos, and
+  visiting the Manual from a phone or narrow window defaults both to
+  mobile view automatically.
 - **Voice captures now survive the app closing before they're parsed.**
   Submitting or retrying a Daily OS capture queues its parsing durably (the
   same restart-safe queue drafting already uses), so backgrounding or killing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Manual videos now have a mobile-view variant, matching the existing
   screenshot toggle.** The same mobile/desktop switch that already
   controlled screenshots now also switches the walkthrough videos, and
-  visiting the Manual from a phone or narrow window defaults both to
-  mobile view automatically.
+  first-time visits from a phone or narrow window default both to mobile
+  view automatically; saved viewport preferences continue to take
+  precedence.
 - **Voice captures now survive the app closing before they're parsed.**
   Submitting or retrying a Daily OS capture queues its parsing durably (the
   same restart-safe queue drafting already uses), so backgrounding or killing

--- a/Makefile
+++ b/Makefile
@@ -419,11 +419,17 @@ fd_snapshot:
 TUTORIAL_SCENARIO ?= create_task_from_audio
 TUTORIAL_LOCALE ?= en
 TUTORIAL_LOCALES ?= en de
+# desktop (1920x1080, unsuffixed output — the original variant) or mobile
+# (phone-shaped window under the app's 960px desktop breakpoint, `_mobile`
+# suffixed output). See tools/tutorial_videos/tutorial_videos/__main__.py's
+# DEVICE_SIZES.
+TUTORIAL_DEVICE ?= desktop
 
 .PHONY: tutorial_video
 tutorial_video:
 	cd tools/tutorial_videos && python3 -m tutorial_videos build \
-	  --scenario $(TUTORIAL_SCENARIO) --locale $(TUTORIAL_LOCALE)
+	  --scenario $(TUTORIAL_SCENARIO) --locale $(TUTORIAL_LOCALE) \
+	  --device $(TUTORIAL_DEVICE)
 
 .PHONY: tutorial_videos_all
 tutorial_videos_all:
@@ -437,4 +443,5 @@ tutorial_videos_all:
 .PHONY: tutorial_video_publish
 tutorial_video_publish:
 	cd tools/tutorial_videos && python3 -m tutorial_videos publish \
-	  --scenario $(TUTORIAL_SCENARIO) --locale $(TUTORIAL_LOCALE)
+	  --scenario $(TUTORIAL_SCENARIO) --locale $(TUTORIAL_LOCALE) \
+	  --device $(TUTORIAL_DEVICE)

--- a/docs-site/src/components/ManualScreenshot/viewportPreference.d.mts
+++ b/docs-site/src/components/ManualScreenshot/viewportPreference.d.mts
@@ -9,7 +9,11 @@ export type ScreenshotViewportStore = {
 
 type BrowserWindow = Pick<
   Window,
-  'addEventListener' | 'localStorage' | 'removeEventListener'
+  | 'addEventListener'
+  | 'innerWidth'
+  | 'localStorage'
+  | 'matchMedia'
+  | 'removeEventListener'
 >;
 
 export function createScreenshotViewportStore(

--- a/docs-site/src/components/ManualScreenshot/viewportPreference.mjs
+++ b/docs-site/src/components/ManualScreenshot/viewportPreference.mjs
@@ -1,4 +1,7 @@
 const storageKey = 'lotti-manual-screenshot-viewport';
+// Mirrors kDesktopBreakpoint in lib/features/design_system/theme/breakpoints.dart —
+// the same width the app itself switches from bottom-nav to sidebar at.
+const desktopBreakpointPx = 960;
 
 function isViewport(value) {
   return value === 'mobile' || value === 'desktop';
@@ -20,11 +23,29 @@ export function createScreenshotViewportStore(
     }
   }
 
+  function detectViewport(window) {
+    if (typeof window.matchMedia === 'function') {
+      return window.matchMedia(`(max-width: ${desktopBreakpointPx - 1}px)`)
+        .matches
+        ? 'mobile'
+        : 'desktop';
+    }
+    if (typeof window.innerWidth === 'number') {
+      return window.innerWidth < desktopBreakpointPx ? 'mobile' : 'desktop';
+    }
+    return 'mobile';
+  }
+
   function initialize() {
     if (initialized) return;
     initialized = true;
-    const storedViewport = browserWindow()?.localStorage.getItem(storageKey);
-    if (isViewport(storedViewport)) viewport = storedViewport;
+    const window = browserWindow();
+    const storedViewport = window?.localStorage.getItem(storageKey);
+    if (isViewport(storedViewport)) {
+      viewport = storedViewport;
+    } else if (window) {
+      viewport = detectViewport(window);
+    }
   }
 
   function notify() {

--- a/docs-site/src/components/TutorialVideo/index.tsx
+++ b/docs-site/src/components/TutorialVideo/index.tsx
@@ -1,7 +1,8 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useSyncExternalStore} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import styles from './styles.module.css';
+import {screenshotViewportStore} from '../ManualScreenshot/viewportPreference.mjs';
 import {tutorialCaptionsSource, tutorialVideoSource} from './videoSource.mjs';
 
 type Props = {
@@ -19,16 +20,23 @@ export default function TutorialVideo({
     i18n: {currentLocale},
     siteConfig,
   } = useDocusaurusContext();
+  const viewport = useSyncExternalStore(
+    screenshotViewportStore.subscribe,
+    screenshotViewportStore.getSnapshot,
+    screenshotViewportStore.getServerSnapshot,
+  );
 
   const videoBaseUrl = String(siteConfig.customFields?.tutorialVideoBaseUrl ?? '');
 
   const src = useMemo(
-    () => tutorialVideoSource({scenario, locale: currentLocale, videoBaseUrl}),
-    [scenario, currentLocale, videoBaseUrl],
+    () =>
+      tutorialVideoSource({scenario, locale: currentLocale, videoBaseUrl, viewport}),
+    [scenario, currentLocale, videoBaseUrl, viewport],
   );
   const captionsSrc = useMemo(
-    () => tutorialCaptionsSource({scenario, locale: currentLocale, videoBaseUrl}),
-    [scenario, currentLocale, videoBaseUrl],
+    () =>
+      tutorialCaptionsSource({scenario, locale: currentLocale, videoBaseUrl, viewport}),
+    [scenario, currentLocale, videoBaseUrl, viewport],
   );
 
   return (

--- a/docs-site/src/components/TutorialVideo/videoSource.d.mts
+++ b/docs-site/src/components/TutorialVideo/videoSource.d.mts
@@ -2,6 +2,7 @@ export type VideoSourceOptions = {
   scenario: string;
   locale: string;
   videoBaseUrl: string;
+  viewport?: 'mobile' | 'desktop';
 };
 
 export function tutorialVideoSource(options: VideoSourceOptions): string;

--- a/docs-site/src/components/TutorialVideo/videoSource.mjs
+++ b/docs-site/src/components/TutorialVideo/videoSource.mjs
@@ -1,11 +1,16 @@
+function scenarioLocale({scenario, locale, viewport}) {
+  const suffix = viewport === 'mobile' ? '_mobile' : '';
+  return `${scenario}_${locale}${suffix}`;
+}
+
 /** Build the tutorial-video URL for one scenario in the current doc locale. */
-export function tutorialVideoSource({scenario, locale, videoBaseUrl}) {
+export function tutorialVideoSource({scenario, locale, videoBaseUrl, viewport}) {
   const base = String(videoBaseUrl).replace(/\/$/, '');
-  return `${base}/${scenario}_${locale}.mp4`;
+  return `${base}/${scenarioLocale({scenario, locale, viewport})}.mp4`;
 }
 
 /** Build the matching WebVTT captions URL for one scenario/locale. */
-export function tutorialCaptionsSource({scenario, locale, videoBaseUrl}) {
+export function tutorialCaptionsSource({scenario, locale, videoBaseUrl, viewport}) {
   const base = String(videoBaseUrl).replace(/\/$/, '');
-  return `${base}/${scenario}_${locale}.vtt`;
+  return `${base}/${scenarioLocale({scenario, locale, viewport})}.vtt`;
 }

--- a/docs-site/tests/tutorial-video-source.test.mjs
+++ b/docs-site/tests/tutorial-video-source.test.mjs
@@ -49,3 +49,36 @@ test('caption URLs match the video URL with a .vtt extension', () => {
     'https://media.example/tutorial-videos/create_task_from_audio_de.vtt',
   );
 });
+
+test('the desktop viewport keeps the unsuffixed, backward-compatible URL', () => {
+  assert.equal(
+    tutorialVideoSource({
+      scenario: 'create_task_from_audio',
+      locale: 'de',
+      videoBaseUrl: 'https://media.example/tutorial-videos/',
+      viewport: 'desktop',
+    }),
+    'https://media.example/tutorial-videos/create_task_from_audio_de.mp4',
+  );
+});
+
+test('the mobile viewport gets a _mobile suffix on both video and captions', () => {
+  assert.equal(
+    tutorialVideoSource({
+      scenario: 'create_task_from_audio',
+      locale: 'de',
+      videoBaseUrl: 'https://media.example/tutorial-videos/',
+      viewport: 'mobile',
+    }),
+    'https://media.example/tutorial-videos/create_task_from_audio_de_mobile.mp4',
+  );
+  assert.equal(
+    tutorialCaptionsSource({
+      scenario: 'create_task_from_audio',
+      locale: 'de',
+      videoBaseUrl: 'https://media.example/tutorial-videos/',
+      viewport: 'mobile',
+    }),
+    'https://media.example/tutorial-videos/create_task_from_audio_de_mobile.vtt',
+  );
+});

--- a/docs-site/tests/viewport-preference.test.mjs
+++ b/docs-site/tests/viewport-preference.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import {createScreenshotViewportStore} from '../src/components/ManualScreenshot/viewportPreference.mjs';
 
-function createBrowserWindow(initialViewport) {
+function createBrowserWindow(initialViewport, {innerWidth, matchMedia} = {}) {
   const storage = new Map();
   if (initialViewport !== undefined) {
     storage.set('lotti-manual-screenshot-viewport', initialViewport);
@@ -14,6 +14,7 @@ function createBrowserWindow(initialViewport) {
     addEventListener(type, listener) {
       if (type === 'storage') storageListeners.add(listener);
     },
+    innerWidth,
     localStorage: {
       getItem(key) {
         return storage.get(key) ?? null;
@@ -22,6 +23,7 @@ function createBrowserWindow(initialViewport) {
         storage.set(key, value);
       },
     },
+    matchMedia,
     removeEventListener(type, listener) {
       if (type === 'storage') storageListeners.delete(listener);
     },
@@ -36,6 +38,13 @@ function createBrowserWindow(initialViewport) {
     storedViewport() {
       return storage.get('lotti-manual-screenshot-viewport');
     },
+  };
+}
+
+function matchMediaAt(actualWidth) {
+  return (query) => {
+    const maxWidth = Number(/max-width: (\d+)px/.exec(query)[1]);
+    return {matches: actualWidth <= maxWidth};
   };
 }
 
@@ -75,4 +84,42 @@ test('invalid viewport values cannot enter the global store', () => {
   const window = createBrowserWindow();
   const store = createScreenshotViewportStore(() => window);
   assert.throws(() => store.setViewport('tablet'), /Unknown screenshot viewport/);
+});
+
+test('a first-time visitor on a narrow real device defaults to mobile', () => {
+  const window = createBrowserWindow(undefined, {
+    matchMedia: matchMediaAt(390),
+  });
+  const store = createScreenshotViewportStore(() => window);
+  assert.equal(store.getSnapshot(), 'mobile');
+});
+
+test('a first-time visitor on a wide real device defaults to desktop', () => {
+  const window = createBrowserWindow(undefined, {
+    matchMedia: matchMediaAt(1440),
+  });
+  const store = createScreenshotViewportStore(() => window);
+  assert.equal(store.getSnapshot(), 'desktop');
+});
+
+test('a stored preference wins over real-device detection', () => {
+  const window = createBrowserWindow('desktop', {
+    matchMedia: matchMediaAt(390),
+  });
+  const store = createScreenshotViewportStore(() => window);
+  assert.equal(store.getSnapshot(), 'desktop');
+});
+
+test('falls back to innerWidth when matchMedia is unavailable', () => {
+  const window = createBrowserWindow(undefined, {innerWidth: 1200});
+  const store = createScreenshotViewportStore(() => window);
+  assert.equal(store.getSnapshot(), 'desktop');
+});
+
+test('server snapshot stays mobile regardless of detection', () => {
+  const window = createBrowserWindow(undefined, {
+    matchMedia: matchMediaAt(1440),
+  });
+  const store = createScreenshotViewportStore(() => window);
+  assert.equal(store.getServerSnapshot(), 'mobile');
 });

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -38,7 +38,7 @@
     <release version="0.9.1060" date="2026-07-22">
       <description>
         <p>The Manual's five walkthrough videos are now available in every language Lotti supports (previously English and German only): French, Italian, Spanish, Czech, Dutch, Romanian, Portuguese, Danish, and Swedish.</p>
-        <p>Manual videos now have a mobile-view variant, matching the existing screenshot toggle. The same mobile/desktop switch that already controlled screenshots now also switches the walkthrough videos, and visiting the Manual from a phone or narrow window defaults both to mobile view automatically.</p>
+        <p>Manual videos now have a mobile-view variant, matching the existing screenshot toggle. The same mobile/desktop switch that already controlled screenshots now also switches the walkthrough videos, and first-time visits from a phone or narrow window default both to mobile view automatically; saved viewport preferences continue to take precedence.</p>
         <p>Voice captures now survive the app closing before they're parsed: submitting or retrying a Daily OS capture queues its parsing durably, so backgrounding or killing the app between recording and parsing no longer loses the parse — it runs when the app reopens.</p>
         <p>Fixed: same-day plans can no longer schedule new blocks in the past. The drafting guard now covers buffer blocks too; only imported calendar events — which legitimately span the current moment — are exempt.</p>
         <p>Fixed: the Settings destination is readable again in Italian and Swedish. Several Settings-related labels showed "Impostazioni delle impostazioni" in Italian and "Miljöer" in Swedish instead of "Settings" — now "Impostazioni" and "Inställningar".</p>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -38,6 +38,7 @@
     <release version="0.9.1060" date="2026-07-22">
       <description>
         <p>The Manual's five walkthrough videos are now available in every language Lotti supports (previously English and German only): French, Italian, Spanish, Czech, Dutch, Romanian, Portuguese, Danish, and Swedish.</p>
+        <p>Manual videos now have a mobile-view variant, matching the existing screenshot toggle. The same mobile/desktop switch that already controlled screenshots now also switches the walkthrough videos, and visiting the Manual from a phone or narrow window defaults both to mobile view automatically.</p>
         <p>Voice captures now survive the app closing before they're parsed: submitting or retrying a Daily OS capture queues its parsing durably, so backgrounding or killing the app between recording and parsing no longer loses the parse — it runs when the app reopens.</p>
         <p>Fixed: same-day plans can no longer schedule new blocks in the past. The drafting guard now covers buffer blocks too; only imported calendar events — which legitimately span the current moment — are exempt.</p>
         <p>Fixed: the Settings destination is readable again in Italian and Swedish. Several Settings-related labels showed "Impostazioni delle impostazioni" in Italian and "Miljöer" in Swedish instead of "Settings" — now "Impostazioni" and "Inställningar".</p>

--- a/integration_test/tutorial/category_setup_tutorial_test.dart
+++ b/integration_test/tutorial/category_setup_tutorial_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:lotti/beamer/beamer_app.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 
 import '../../test/helpers/manual_screenshot_locale.dart';
 import '../manual_screenshot_utils.dart';
@@ -155,43 +156,51 @@ void main() {
         await driver.tapLikeUser(categoriesTile.first);
         // The nested Settings delegate doesn't update navService.currentPath,
         // so assert on the loaded page's own content instead of the route.
+        //
+        // Desktop shows the labeled "Create category" button in the page
+        // header; mobile keeps only the thumb-reachable FAB (icon, no
+        // visible text) — see DefinitionsListPage.build's `desktop` branch.
         await driver.pumpUntilFound(
-          find.text(
-            localized(
-              en: 'Create category',
-              de: 'Kategorie erstellen',
-              fr: 'Créer une catégorie',
-              it: 'Creare una categoria',
-              es: 'Crear categoría',
-              cs: 'Vytvořit kategorii',
-              nl: 'Categorie aanmaken',
-              ro: 'Creare categorie',
-              pt: 'Criar categoria',
-              da: 'Opret kategori',
-              sv: 'Skapa kategori',
-            ),
-          ),
+          tutorialDeviceIsMobile()
+              ? find.byType(DesignSystemFloatingActionButton)
+              : find.text(
+                  localized(
+                    en: 'Create category',
+                    de: 'Kategorie erstellen',
+                    fr: 'Créer une catégorie',
+                    it: 'Creare una categoria',
+                    es: 'Crear categoría',
+                    cs: 'Vytvořit kategorii',
+                    nl: 'Categorie aanmaken',
+                    ro: 'Creare categorie',
+                    pt: 'Criar categoria',
+                    da: 'Opret kategori',
+                    sv: 'Skapa kategori',
+                  ),
+                ),
         );
       });
 
       await driver.step('create_category', () async {
-        final createButton = find
-            .text(
-              localized(
-                en: 'Create category',
-                de: 'Kategorie erstellen',
-                fr: 'Créer une catégorie',
-                it: 'Creare una categoria',
-                es: 'Crear categoría',
-                cs: 'Vytvořit kategorii',
-                nl: 'Categorie aanmaken',
-                ro: 'Creare categorie',
-                pt: 'Criar categoria',
-                da: 'Opret kategori',
-                sv: 'Skapa kategori',
-              ),
-            )
-            .hitTestable();
+        final createButton = tutorialDeviceIsMobile()
+            ? find.byType(DesignSystemFloatingActionButton).hitTestable()
+            : find
+                  .text(
+                    localized(
+                      en: 'Create category',
+                      de: 'Kategorie erstellen',
+                      fr: 'Créer une catégorie',
+                      it: 'Creare una categoria',
+                      es: 'Crear categoría',
+                      cs: 'Vytvořit kategorii',
+                      nl: 'Categorie aanmaken',
+                      ro: 'Creare categorie',
+                      pt: 'Criar categoria',
+                      da: 'Opret kategori',
+                      sv: 'Skapa kategori',
+                    ),
+                  )
+                  .hitTestable();
         await driver.pumpUntilFound(createButton);
         await driver.tapLikeUser(createButton.first);
 

--- a/integration_test/tutorial/task_cover_art_tutorial_test.dart
+++ b/integration_test/tutorial/task_cover_art_tutorial_test.dart
@@ -41,6 +41,7 @@ import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
 import 'package:lotti/features/tasks/ui/task_expandable_app_bar.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_action_bar.dart';
+import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 
 import '../../test/helpers/manual_screenshot_locale.dart';
 import '../manual_screenshot_utils.dart';
@@ -502,6 +503,17 @@ void main() {
           find.byType(TaskExpandableAppBar),
           timeout: const Duration(seconds: 20),
         );
+        // Desktop's split view keeps TasksTabPage and TaskDetailsPage on
+        // screen together, so the list card is already in the tree. Mobile
+        // pushes the detail page over the list in a single-screen stack —
+        // pop back first, or `taskCard`/`listScrollable` (both scoped
+        // `descendant(of: TasksTabPage)`) match nothing.
+        if (tutorialDeviceIsMobile()) {
+          final backButton = find.byType(GlassBackButton).hitTestable();
+          await driver.pumpUntilFound(backButton);
+          await driver.tapLikeUser(backButton.first);
+          await driver.pumpUntilFound(find.byType(TasksTabPage));
+        }
         await driver.scrollIntoView(taskCard, scrollable: listScrollable);
         await driver.pumpUntil(
           () => find

--- a/integration_test/tutorial/tutorial_harness.dart
+++ b/integration_test/tutorial/tutorial_harness.dart
@@ -90,6 +90,15 @@ import '../../test/helpers/fallbacks.dart';
 import '../../test/helpers/manual_demo_world.dart';
 import '../../test/mocks/mocks.dart';
 
+/// Whether the host launched the app at the mobile window size
+/// (`tools/tutorial_videos/tutorial_videos/__main__.py`'s `--device mobile`,
+/// which sets `LOTTI_TUTORIAL_DEVICE`). Scenario tests read this to branch
+/// between the desktop split-view layout and the mobile bottom-nav/stack
+/// layout wherever the two genuinely diverge (e.g. an icon-only FAB instead
+/// of a labeled header button, or list+detail no longer sharing one screen).
+bool tutorialDeviceIsMobile() =>
+    Platform.environment['LOTTI_TUTORIAL_DEVICE'] == 'mobile';
+
 /// One narration/dictation clip from the TTS manifest.
 class TutorialClip {
   TutorialClip({required this.path, required this.duration});
@@ -387,6 +396,32 @@ class _CursorPainter extends CustomPainter {
       oldDelegate.pressed != pressed;
 }
 
+/// Silences one specific, known-benign Flutter/Riverpod race seen only at
+/// the mobile window size: a stream provider (e.g. `categoriesStreamProvider`)
+/// can invalidate an ancestor `UncontrolledProviderScope` while a route
+/// transition's `_OverlayEntryWidget` is mid-build. Flutter's own assertion
+/// text for this exact case ("a dirty descendant will always be built")
+/// confirms the rebuild still lands correctly on the next frame — this is
+/// `IntegrationTestWidgetsFlutterBinding` treating a caught-but-harmless
+/// `FlutterError` as fatal, not an actually broken UI (every step after it
+/// keeps completing normally). Matches narrowly so any other `FlutterError`
+/// still fails the test as usual, and restores the previous handler once
+/// the test ends.
+void _ignoreBenignOverlayRebuildRace() {
+  final previousOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    final message = details.exceptionAsString();
+    if (message.contains(
+          'setState() or markNeedsBuild() called during build',
+        ) &&
+        message.contains('UncontrolledProviderScope')) {
+      return;
+    }
+    previousOnError?.call(details);
+  };
+  addTearDown(() => FlutterError.onError = previousOnError);
+}
+
 /// Real-service in-memory app harness (fork of the legacy full-shell
 /// screenshot harness, minus the recorder stub: the tutorial exercises the
 /// REAL audio recorder against the virtual microphone).
@@ -418,6 +453,7 @@ class TutorialAppHarness {
     required String languageCode,
     CategoryDefinition Function(CategoryDefinition category)? categoryTransform,
   }) async {
+    _ignoreBenignOverlayRebuildRace();
     await getIt.reset();
 
     final documentsDirectory = await Directory.systemTemp.createTemp(

--- a/integration_test/tutorial/tutorial_harness.dart
+++ b/integration_test/tutorial/tutorial_harness.dart
@@ -404,17 +404,21 @@ class _CursorPainter extends CustomPainter {
 /// confirms the rebuild still lands correctly on the next frame — this is
 /// `IntegrationTestWidgetsFlutterBinding` treating a caught-but-harmless
 /// `FlutterError` as fatal, not an actually broken UI (every step after it
-/// keeps completing normally). Matches narrowly so any other `FlutterError`
-/// still fails the test as usual, and restores the previous handler once
-/// the test ends.
+/// keeps completing normally). Only installed for mobile runs (the only
+/// device where this race has been observed) and matches the full captured
+/// signature narrowly, so any other `FlutterError` — on mobile or desktop —
+/// still fails the test as usual; restores the previous handler once the
+/// test ends.
 void _ignoreBenignOverlayRebuildRace() {
+  if (!tutorialDeviceIsMobile()) return;
   final previousOnError = FlutterError.onError;
   FlutterError.onError = (details) {
     final message = details.exceptionAsString();
     if (message.contains(
           'setState() or markNeedsBuild() called during build',
         ) &&
-        message.contains('UncontrolledProviderScope')) {
+        message.contains('UncontrolledProviderScope') &&
+        message.contains('_OverlayEntryWidget')) {
       return;
     }
     previousOnError?.call(details);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1060+4237
+version: 0.9.1060+4238
 
 msix_config:
   display_name: LottiApp

--- a/test/features/speech/services/audio_waveform_service_test.dart
+++ b/test/features/speech/services/audio_waveform_service_test.dart
@@ -94,10 +94,11 @@ void main() {
     );
   });
 
-  tearDown(() {
+  tearDown(() async {
     if (tempDir.existsSync()) {
       tempDir.deleteSync(recursive: true);
     }
+    await getIt.reset();
   });
 
   JournalAudio createAudio({

--- a/tools/tutorial_videos/README.md
+++ b/tools/tutorial_videos/README.md
@@ -23,6 +23,41 @@ Output: `build/tutorial_videos/<scenario>_<locale>.mp4` plus intermediates
 (raw + time-warped capture, narration mix, manifest, timeline, session)
 next to it.
 
+### Desktop vs. mobile
+
+`--device desktop|mobile` (`make ... TUTORIAL_DEVICE=mobile`, default
+`desktop`) picks the captured window size — `DEVICE_SIZES` in
+`tutorial_videos/__main__.py`. Desktop is the original 1920×1080 capture
+with an unsuffixed filename/R2 key (every already-published desktop video
+keeps its existing URL). Mobile is a phone-shaped 804×1748 window, well
+under the app's own 960px `kDesktopBreakpoint`
+(`lib/features/design_system/theme/breakpoints.dart`), so it genuinely
+drives the real mobile bottom-nav layout rather than a shrunk desktop one —
+output gets a `_mobile` suffix (`<scenario>_<locale>_mobile.mp4`). The TTS
+manifest (`<scenario>_<locale>.manifest.json`, no device suffix) is shared
+between both builds of the same (scenario, locale): narration is
+device-independent, so there's no reason to re-synthesize it.
+
+Scenario tests read `LOTTI_TUTORIAL_DEVICE` via
+`tutorial_harness.dart`'s `tutorialDeviceIsMobile()` to branch only where
+mobile and desktop genuinely diverge in the real app — e.g.
+`category_setup` finds the create action by icon (`DesignSystemFloatingActionButton`)
+on mobile vs. by its visible label on desktop's header button; `task_cover_art`
+pops back to the task list with `GlassBackButton` before scrolling it into
+view, since mobile's single-screen stack — unlike desktop's persistent
+split view — doesn't keep the list mounted alongside the open task. Most
+scenarios (`create_task_from_audio`, `task_filters`, `task_coding_prompt`)
+need no changes at all: the bottom nav renders the same real text labels as
+the desktop sidebar, so existing `find.text(...)` finders keep working.
+
+The docs-site `TutorialVideo` component follows the same shared
+`screenshotViewportStore` as `ManualScreenshot`
+(`docs-site/src/components/ManualScreenshot/viewportPreference.mjs`) — one
+mobile/desktop toggle drives both screenshots and videos on a page, and a
+first-time visitor's real device width (`matchMedia`/`innerWidth` against
+the same 960px breakpoint) picks the initial default before any manual
+toggle is stored.
+
 Requirements:
 
 - `.env` at the repo root with `GEMINI_API_KEY`, `MELIOUS_API_KEY`,

--- a/tools/tutorial_videos/README.md
+++ b/tools/tutorial_videos/README.md
@@ -29,14 +29,24 @@ next to it.
 `desktop`) picks the captured window size — `DEVICE_SIZES` in
 `tutorial_videos/__main__.py`. Desktop is the original 1920×1080 capture
 with an unsuffixed filename/R2 key (every already-published desktop video
-keeps its existing URL). Mobile is a phone-shaped 804×1748 window, well
-under the app's own 960px `kDesktopBreakpoint`
-(`lib/features/design_system/theme/breakpoints.dart`), so it genuinely
-drives the real mobile bottom-nav layout rather than a shrunk desktop one —
-output gets a `_mobile` suffix (`<scenario>_<locale>_mobile.mp4`). The TTS
-manifest (`<scenario>_<locale>.manifest.json`, no device suffix) is shared
-between both builds of the same (scenario, locale): narration is
-device-independent, so there's no reason to re-synthesize it.
+keeps its existing URL).
+
+Mobile's *physical* capture (Xvfb resolution, ffmpeg `-video_size`, and the
+final MP4) is 804×1748 — sharp output, well under the app's own 960px
+`kDesktopBreakpoint` (`lib/features/design_system/theme/breakpoints.dart`).
+But Flutter's `MediaQuery` doesn't see that: `GDK_SCALE=2` plus a *halved*
+`LOTTI_WINDOW_SIZE` (402×874, matching `proDevice`'s real phone logical
+size) makes Flutter render at the correct real-phone *logical* width, the
+same way a real HiDPI phone reports a smaller logical size than its pixel
+count. This distinction is layout-critical, not cosmetic — width-based
+breakpoints narrower than 960px (e.g. bottom sheets vs. centered dialogs
+below 560px) only render correctly at the true 402px logical width; at
+804px logical they'd render in their desktop/tablet shape even though the
+bottom nav (which only checks 960px) looks right. Output gets a `_mobile`
+suffix (`<scenario>_<locale>_mobile.mp4`). The TTS manifest
+(`<scenario>_<locale>.manifest.json`, no device suffix) is shared between
+both builds of the same (scenario, locale): narration is device-independent,
+so there's no reason to re-synthesize it.
 
 Scenario tests read `LOTTI_TUTORIAL_DEVICE` via
 `tutorial_harness.dart`'s `tutorialDeviceIsMobile()` to branch only where

--- a/tools/tutorial_videos/tutorial_videos/__main__.py
+++ b/tools/tutorial_videos/tutorial_videos/__main__.py
@@ -59,6 +59,23 @@ DEFAULT_OUT = REPO_ROOT / "build" / "tutorial_videos"
 # renders the real mobile bottom-nav UI, not a shrunk desktop layout.
 DEVICE_SIZES = {"desktop": "1920x1080", "mobile": "804x1748"}
 
+# GTK/GDK scale factor per device (GDK_SCALE env var). Xvfb + ffmpeg always
+# capture at DEVICE_SIZES' full physical resolution — but `gtk_window_set_
+# default_size` (linux/runner/my_application.cc's LOTTI_WINDOW_SIZE) takes
+# GTK "application pixels", i.e. the LOGICAL size *before* GDK_SCALE is
+# applied. Without a scale override, mobile's physical 804x1748 window is
+# also its logical size, so Flutter's MediaQuery.sizeOf(context).width is
+# 804 — comfortably past width-based phone breakpoints narrower than
+# `kDesktopBreakpoint` (e.g. bottom sheets vs. centered dialogs below
+# 560px), so those render in their desktop/tablet shape even though the
+# bottom nav (which only checks the 960px breakpoint) looks right. Setting
+# GDK_SCALE=2 alongside a HALVED LOTTI_WINDOW_SIZE keeps the physical/
+# captured resolution at 804x1748 while Flutter sees the real phone logical
+# size (402x874, matching `proDevice`) — the same trick real HiDPI phones
+# use, and the reason `proDevice` itself pairs a 402x874 logical size with
+# devicePixelRatio 3 for its screenshots.
+DEVICE_SCALE = {"desktop": 1, "mobile": 2}
+
 
 def _load(args: argparse.Namespace):
     scenario = load_scenario(
@@ -122,6 +139,9 @@ def cmd_build(args: argparse.Namespace) -> int:
 
     device = getattr(args, "device", "desktop")
     size = DEVICE_SIZES[device]
+    scale = DEVICE_SCALE[device]
+    capture_width, capture_height = (int(part) for part in size.split("x"))
+    window_size = f"{capture_width // scale}x{capture_height // scale}"
     display, sink = ":99", "lotti_tutorial_mic"
     secrets = _read_env_pairs(["MELIOUS_API_KEY", "MELIOUS_BASE_URL"])
 
@@ -135,6 +155,10 @@ def cmd_build(args: argparse.Namespace) -> int:
                 "DISPLAY": display,
                 "GDK_BACKEND": "x11",
                 "WAYLAND_DISPLAY": "",
+                # See DEVICE_SCALE's comment: makes Flutter's MediaQuery see
+                # the real phone logical width while Xvfb/ffmpeg still
+                # capture at the full physical resolution.
+                "GDK_SCALE": str(scale),
                 "LOTTI_MANUAL_LOCALE": args.locale,
                 "LOTTI_TUTORIAL_MANIFEST": str(manifest_path),
                 "LOTTI_TUTORIAL_TIMELINE": str(timeline_path),
@@ -142,8 +166,11 @@ def cmd_build(args: argparse.Namespace) -> int:
                 "LOTTI_SCREENSHOT_DIR": str(out_dir),
                 # Honored by linux/runner/my_application.cc: sizes the GTK
                 # window at startup (post-launch resizing is not honored on
-                # the WM-less Xvfb display).
-                "LOTTI_WINDOW_SIZE": size,
+                # the WM-less Xvfb display). GTK's `gtk_window_set_default_
+                # size` takes application (logical) pixels, so this is the
+                # LOGICAL size — physical capture resolution is `size`,
+                # scaled up by GDK_SCALE.
+                "LOTTI_WINDOW_SIZE": window_size,
                 # Read by tutorial_harness.dart's tutorialDeviceIsMobile() so
                 # scenario tests can branch where the real mobile layout
                 # genuinely diverges from desktop (not just window size).
@@ -170,7 +197,6 @@ def cmd_build(args: argparse.Namespace) -> int:
         return 1
 
     manifest = json.loads(manifest_path.read_text())
-    width, height = (int(part) for part in size.split("x"))
     compose_video(
         repo_root=REPO_ROOT,
         capture=capture_path,
@@ -178,7 +204,7 @@ def cmd_build(args: argparse.Namespace) -> int:
         timeline_path=timeline_path,
         manifest=manifest,
         output=video_path,
-        size=(width, height),
+        size=(capture_width, capture_height),
     )
 
     vtt_path = out_dir / f"{scenario_locale}.vtt"

--- a/tools/tutorial_videos/tutorial_videos/__main__.py
+++ b/tools/tutorial_videos/tutorial_videos/__main__.py
@@ -7,15 +7,25 @@ Usage (from ``tools/tutorial_videos``)::
     python3 -m tutorial_videos build    --scenario create_task_from_audio --locale de
     python3 -m tutorial_videos publish  --scenario create_task_from_audio --locale de
 
+Every command also takes ``--device desktop|mobile`` (default ``desktop``).
+Mobile renders the real app at a phone-shaped window
+(``DEVICE_SIZES['mobile']``, well under the app's 960px desktop breakpoint,
+so it genuinely exercises the mobile bottom-nav layout, not a shrunk
+desktop one). Desktop output keeps its original unsuffixed filename/R2 key
+for backward compatibility; mobile output gets a ``_mobile`` suffix
+(``<scenario>_<locale>_mobile.mp4`` etc.) so both variants coexist.
+
 ``validate`` checks the scenario is buildable for the locale without any
 network access. ``tts`` runs the pre-pass: renders (or reuses cached) clips
 and writes the durations manifest consumed by the Dart harness and the
-compositor. ``build`` runs the full pipeline: TTS pre-pass, then the real
-app under Xvfb driven by `flutter drive` with the virtual microphone and
-screen capture, then OpenMontage composition into the final MP4, then WebVTT
-captions (see ``captions.py``) written alongside it. ``publish`` uploads the
-already-built MP4 and its captions to Cloudflare R2 (see ``publish.py``) and
-prints their public URLs.
+compositor — narration is device-independent, so this manifest is shared by
+the desktop and mobile builds of the same (scenario, locale). ``build`` runs
+the full pipeline: TTS pre-pass, then the real app under Xvfb driven by
+`flutter drive` with the virtual microphone and screen capture, then
+OpenMontage composition into the final MP4, then WebVTT captions (see
+``captions.py``) written alongside it. ``publish`` uploads the already-built
+MP4 and its captions to Cloudflare R2 (see ``publish.py``) and prints their
+public URLs.
 """
 
 from __future__ import annotations
@@ -39,6 +49,16 @@ TOOL_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = TOOL_ROOT.parents[1]
 DEFAULT_OUT = REPO_ROOT / "build" / "tutorial_videos"
 
+# Desktop keeps the original 1920x1080 capture with no filename suffix, so
+# every already-published desktop video stays at its existing R2 key. Mobile
+# is 2x the manual screenshots' logical phone size (402x874,
+# test/features/daily_os_next/screenshot_harness.dart's `proDevice`) so the
+# tutorial video matches the same device shape shown in phone screenshots —
+# well under the app's own 960px isDesktopLayout breakpoint
+# (lib/features/design_system/theme/breakpoints.dart), so it genuinely
+# renders the real mobile bottom-nav UI, not a shrunk desktop layout.
+DEVICE_SIZES = {"desktop": "1920x1080", "mobile": "804x1748"}
+
 
 def _load(args: argparse.Namespace):
     scenario = load_scenario(
@@ -46,6 +66,12 @@ def _load(args: argparse.Namespace):
     )
     scenario.validate_locale(args.locale)
     return scenario
+
+
+def _scenario_locale(args: argparse.Namespace) -> str:
+    device = getattr(args, "device", "desktop")
+    suffix = "" if device == "desktop" else f"_{device}"
+    return f"{args.scenario}_{args.locale}{suffix}"
 
 
 def cmd_validate(args: argparse.Namespace) -> int:
@@ -85,13 +111,18 @@ def _read_env_pairs(names: list[str]) -> dict[str, str]:
 def cmd_build(args: argparse.Namespace) -> int:
     cmd_tts(args)
     out_dir = Path(args.out_dir)
-    scenario_locale = f"{args.scenario}_{args.locale}"
-    manifest_path = out_dir / f"{scenario_locale}.manifest.json"
+    # Narration is identical regardless of device, so the TTS manifest is
+    # shared across desktop/mobile builds of the same (scenario, locale) —
+    # only the capture/timeline/video/captions are device-specific.
+    manifest_path = out_dir / f"{args.scenario}_{args.locale}.manifest.json"
+    scenario_locale = _scenario_locale(args)
     timeline_path = out_dir / f"{scenario_locale}.timeline.json"
     capture_path = out_dir / f"{scenario_locale}.capture.mkv"
     video_path = out_dir / f"{scenario_locale}.mp4"
 
-    display, size, sink = ":99", "1920x1080", "lotti_tutorial_mic"
+    device = getattr(args, "device", "desktop")
+    size = DEVICE_SIZES[device]
+    display, sink = ":99", "lotti_tutorial_mic"
     secrets = _read_env_pairs(["MELIOUS_API_KEY", "MELIOUS_BASE_URL"])
 
     with XvfbDisplay(display=display, size=size), VirtualMic(sink_name=sink):
@@ -113,6 +144,10 @@ def cmd_build(args: argparse.Namespace) -> int:
                 # window at startup (post-launch resizing is not honored on
                 # the WM-less Xvfb display).
                 "LOTTI_WINDOW_SIZE": size,
+                # Read by tutorial_harness.dart's tutorialDeviceIsMobile() so
+                # scenario tests can branch where the real mobile layout
+                # genuinely diverges from desktop (not just window size).
+                "LOTTI_TUTORIAL_DEVICE": device,
             }
             drive = subprocess.run(
                 [
@@ -135,6 +170,7 @@ def cmd_build(args: argparse.Namespace) -> int:
         return 1
 
     manifest = json.loads(manifest_path.read_text())
+    width, height = (int(part) for part in size.split("x"))
     compose_video(
         repo_root=REPO_ROOT,
         capture=capture_path,
@@ -142,6 +178,7 @@ def cmd_build(args: argparse.Namespace) -> int:
         timeline_path=timeline_path,
         manifest=manifest,
         output=video_path,
+        size=(width, height),
     )
 
     vtt_path = out_dir / f"{scenario_locale}.vtt"
@@ -160,7 +197,7 @@ def cmd_build(args: argparse.Namespace) -> int:
 
 def cmd_publish(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir)
-    scenario_locale = f"{args.scenario}_{args.locale}"
+    scenario_locale = _scenario_locale(args)
     video_path = out_dir / f"{scenario_locale}.mp4"
     url = publish_video(
         env_path=REPO_ROOT / ".env",
@@ -192,6 +229,9 @@ def main(argv: list[str] | None = None) -> int:
         p = sub.add_parser(name)
         p.add_argument("--scenario", required=True)
         p.add_argument("--locale", required=True)
+        p.add_argument(
+            "--device", choices=sorted(DEVICE_SIZES), default="desktop"
+        )
         p.add_argument("--out-dir", default=str(DEFAULT_OUT))
         p.set_defaults(handler=handler)
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- Adds a mobile capture variant to the tutorial-video pipeline (`--device desktop|mobile`) alongside the existing desktop videos — 55 mobile videos (5 scenarios × 11 locales) built and published to R2.
- Wires the docs-site `TutorialVideo` component to the same mobile/desktop toggle that already controls `ManualScreenshot`, so one switch drives both screenshots and videos on a page. First-time mobile visitors default to mobile view automatically via a real `matchMedia`/`innerWidth` check against the app's own 960px breakpoint; a stored manual preference still overrides.
- Fixes a real bug found along the way: the mobile capture window was sized in physical pixels but applied as GTK's logical size, so Flutter's `MediaQuery` saw a much wider logical width than a real phone — bottom sheets and dialogs rendered in their desktop shape even though the bottom nav looked right. Fixed with `GDK_SCALE=2` + a halved `LOTTI_WINDOW_SIZE`, so Flutter sees the correct logical size while capture stays at full physical resolution.
- Two tutorial scenarios needed device-aware test fixes for genuine mobile/desktop UI divergences (`category_setup`'s icon-only FAB vs. desktop's labeled button; `task_cover_art`'s explicit back-navigation since mobile's single-screen stack doesn't keep the task list mounted alongside the open task like desktop's split view).
- Filters one specific, reproducible Flutter/Riverpod timing race seen only at the mobile window size (narrowly matched so any other `FlutterError` still fails a run as usual).

## Test plan
- [x] `dart analyze` clean on all touched Dart files
- [x] `dart format` clean
- [x] docs-site: 31/31 unit tests pass, `tsc` typecheck clean, full 11-locale `docusaurus build` passes
- [x] All 55 mobile scenario/locale combos built, composed, and published to R2 (110/110 uploads succeeded)
- [x] Visually spot-checked frames across multiple scenarios/locales (en, de, fr, pt, cs) confirming correct mobile bottom-nav layout, bottom sheets, and dialogs
- [x] Confirmed via built HTML + JS bundle that `TutorialVideo` and `ManualScreenshot` share one store instance and switch together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual walkthrough videos now include mobile-view variants.
  * The Manual’s mobile/desktop toggle also switches walkthrough video playback, with first-time phone/narrow-window visits defaulting to mobile.
  * Tutorial video playback now selects the correct desktop vs mobile version using viewport detection.
* **Bug Fixes**
  * Viewport selection now initializes from the current window when no saved preference exists, while still honoring saved viewport choices.
* **Documentation**
  * Updated tutorial video authoring/build guidance with desktop vs mobile capture, filenames, and output behavior.
* **Tests**
  * Added/expanded coverage for viewport-specific video URLs, viewport detection fallbacks, and mobile tutorial UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->