### PR TITLE
docs: ADRs 0042/0043 + plan for typed task relationship links

### DIFF
--- a/docs/adr/0042-typed-task-relationship-links.md
+++ b/docs/adr/0042-typed-task-relationship-links.md
@@ -118,9 +118,18 @@ indexes. The UI offers both phrasings when creating a link and simply swaps
 
 A task is **ready** iff it has no live blocker:
 
-> no non-deleted `blocks` link with `toId == task` whose `fromId` task
-> exists and is not closed (`DONE`/`REJECTED`, the `isClosedTask`
-> predicate).
+> no non-deleted `blocks` link with `toId == task` whose `fromId` task is
+> neither tombstoned (`deletedAt` set) nor closed (`DONE`/`REJECTED`, the
+> `isClosedTask` predicate).
+
+An **unresolvable blocker keeps blocking**: when the link row exists but
+the `fromId` task cannot be loaded (typically a sync gap — the link
+arrived before its task), the dependent stays blocked until the task
+materializes or the link is deleted. Journal entities tombstone rather
+than hard-delete, so a *deliberately* deleted blocker carries `deletedAt`
+and releases its dependents; only a genuinely unresolved reference blocks
+conservatively. The resolver tests must pin all three cases (closed →
+released, tombstoned → released, unresolvable → blocked).
 
 - Readiness is **derived at read time, never stored**. Closing a blocker
   "releases" its dependents implicitly on every device — no unlock write,

--- a/docs/adr/0042-typed-task-relationship-links.md
+++ b/docs/adr/0042-typed-task-relationship-links.md
@@ -1,0 +1,206 @@
+# ADR 0042: Typed Task Relationship Links
+
+## Status
+
+Proposed
+
+## Date
+
+2026-07-23
+
+## Context
+
+### Tasks relate to each other, but the link model cannot say how
+
+Lotti links journal entities through `EntryLink`
+(`lib/classes/entry_link.dart`), a freezed union with three variants —
+`basic`, `rating`, `project` — persisted in the `linked_entries` table.
+`BasicLink` is deliberately semantics-free: it means "belongs with", and
+that vagueness is load-bearing. Basic links attach time entries, audio,
+images, and comments to tasks; recorded-time attribution
+(`basicLinksForEntryIds` → `resolveTimeEntries`) walks them to credit
+tracked time to tasks and categories; the task detail page renders them as
+the linked-entries timeline; capture parsing attaches phrases to tasks
+through them.
+
+What the model cannot express is a *directed semantic relationship between
+two tasks*: this task cannot start until that one finishes; this task is a
+follow-up spawned by that one; these two are the same work filed twice;
+this task fixes a defect that task tracks; this task replaces that obsolete
+one. Every mainstream task system models some subset of these (Jira:
+blocks / is blocked by, duplicates, causes, clones; Linear: blocks,
+related, duplicate of; GitHub: fixes/closes; Beads: blocks/depends-on,
+parent-child, relates-to, duplicates, supersedes). Without them:
+
+- The planning agents' task corpus is a flat open/due list
+  (`DayAgentCorpusService.buildTaskCorpusSnapshot`), so a day plan can
+  schedule "Deploy release" before "Fix the blocker" — nothing in context
+  says B waits on A (consumed by ADR 0043).
+- The user has a manual `TaskStatus.blocked`, but it is a self-declared
+  flag with no machine-readable cause: nothing identifies *what* blocks the
+  task, nothing clears it when the blocker closes, and agents can only echo
+  it back.
+- Duplicate and superseded work accumulates silently; closing the canonical
+  task does nothing visible to its twins.
+
+### What already exists that typed links can reuse
+
+The storage and sync substrate needs **no schema change**:
+
+- `linked_entries` already has a `type TEXT NOT NULL` column, a
+  `UNIQUE(from_id, to_id, type)` constraint, and indexes on `from_id`,
+  `to_id`, `type`, and `(to_id, type)`. The type column is derived from the
+  union variant on write (`linkedDbEntity`: `'BasicLink'`, `'RatingLink'`,
+  `'ProjectLink'`), so precedent exists for multiple coexisting link types
+  between the same pair.
+- Consumers are already type-scoped: `basicLinksForEntryIds` filters
+  `type = 'BasicLink'` at the SQL layer, so time attribution, the
+  linked-entries timeline, and capture attribution are structurally
+  invisible to any new type. Nothing leaks by construction.
+- Creation, vector-clock stamping, outbox sync (`SyncMessage.entryLink`),
+  and change notifications all run through `PersistenceLogic.createLink` /
+  `JournalDb.upsertEntryLink`, which handle `EntryLink` generically.
+- `EntryLink` is declared `@Freezed(fallbackUnion: 'basic')`: an older
+  build receiving an unknown variant over sync deserializes it as a plain
+  `BasicLink` instead of crashing — unknown semantics degrade to a visible
+  generic link.
+
+## Decision
+
+### 1. New `EntryLink` union variants, not a field on `BasicLink`
+
+Task relationships become first-class union variants:
+
+| Variant      | Reading (from → to)              | Inverse rendering    |
+| ------------ | -------------------------------- | -------------------- |
+| `blocks`     | *from* blocks *to*               | *to* is blocked by *from* |
+| `followsUp`  | *from* follows up on *to*        | *to* has follow-up *from* |
+| `duplicates` | *from* duplicates *to* (canonical) | *to* is duplicated by *from* |
+| `fixes`      | *from* fixes *to* (the defect)   | *to* is fixed by *from* |
+| `supersedes` | *from* supersedes *to* (obsolete) | *to* is superseded by *from* |
+
+Each variant carries the same shape as `BasicLink` (id, fromId, toId,
+timestamps, vector clock, hidden/collapsed, deletedAt) — the semantics live
+entirely in the type. Rationale for variants over a `linkType` field on
+`BasicLink`:
+
+- The `type` column derives from the union map, so every existing
+  `type = 'BasicLink'` consumer stays correct without an audit — a field
+  would put typed edges *inside* the basic result set and require touching
+  every basic-link read (time attribution above all) defensively.
+- `fallbackUnion: 'basic'` gives forward compatibility for free: an old
+  build shows an unknown typed edge as a plain link (see Consequences for
+  the write-back caveat).
+- `UNIQUE(from_id, to_id, type)` naturally allows a pair to hold a basic
+  link *and* a `blocks` edge simultaneously, and dedupes repeated
+  assertions of the same relationship.
+
+### 2. One stored edge per relationship; inverses are rendering
+
+"Is blocked by", "has follow-up", "is duplicated by" etc. are **labels for
+the reverse direction of the same row**, never separate rows. Both
+directions are queryable through the existing `from_id` and `(to_id, type)`
+indexes. The UI offers both phrasings when creating a link and simply swaps
+`fromId`/`toId` before persisting the canonical direction.
+
+### 3. `relates to` stays `BasicLink`; hierarchy stays out
+
+- A generic "these are related" association is exactly what `BasicLink`
+  already is between two tasks. No new `relatesTo` variant.
+- **No cross-task parent/child variant.** Sub-structure inside a task is
+  checklists; grouping across tasks is categories and `ProjectLink`. A
+  parallel task-hierarchy edge would compete with both. Revisit only if
+  projects prove insufficient.
+- `causes`/`clones` (Jira) are deferred — no consumer in the app would read
+  them today.
+
+### 4. Ready semantics: derived, one hop, status-aware
+
+A task is **ready** iff it has no live blocker:
+
+> no non-deleted `blocks` link with `toId == task` whose `fromId` task
+> exists and is not closed (`DONE`/`REJECTED`, the `isClosedTask`
+> predicate).
+
+- Readiness is **derived at read time, never stored**. Closing a blocker
+  "releases" its dependents implicitly on every device — no unlock write,
+  nothing to converge, no sync race.
+- One hop only: a task with an open blocker is blocked; transitive chains
+  emerge naturally because the blocker itself stays unready until its own
+  blockers close. (Chain *display* may traverse; readiness never needs to.)
+- The `hidden` flag stays a pure UI affordance and does not affect
+  readiness; `deletedAt` tombstones do.
+- The manual `TaskStatus.blocked` **coexists and is never mutated by the
+  link layer**. It remains the user's self-declared flag (blocked on
+  something outside the system); link-derived blockedness is computed and
+  names its cause. The two enrich each other without coupling: when the
+  user sets the status to blocked, the UI *offers* to name the blocking
+  task (which persists a `blocks` edge) — optional, never required, since
+  many blocks are external (waiting on a person, a delivery, a decision).
+  Conversely, creating a blocking link may *suggest* the status. No
+  automation writes task status from links in either direction.
+
+### 5. Cycles: guarded at creation, tolerated at read
+
+Concurrent offline writes on two devices can always create a cycle
+(A blocks B on one device, B blocks A on the other), so cycles cannot be
+prevented — they must be survivable:
+
+- **Creation-time guard (best effort, local):** creating a `blocks` edge
+  runs a bounded local traversal and rejects the write if it would close a
+  cycle visible on this device.
+- **Read-time tolerance:** all traversals use a visited set and a depth
+  cap. Members of a cycle each have an open blocker, so all of them are
+  unready — the deadlock is made *visible* (surfaced in the UI as a mutual
+  block), never hidden or "resolved" silently.
+
+### 6. Lifecycle semantics are suggestions, not automation
+
+- Closing a task that others `duplicate` → the UI offers to close the
+  duplicates; nothing auto-closes.
+- Creating a `supersedes` edge → the UI offers to close the superseded
+  task; nothing auto-closes.
+- `fixes`/`followsUp` carry no lifecycle coupling; they are navigation and
+  context.
+
+This keeps the user the only writer of task status (consistent with the
+ChangeSet philosophy of ADR 0006: agents and derived systems propose, the
+user disposes).
+
+## Consequences
+
+- **No migration.** Purely additive: new union variants, new type-column
+  values, existing rows untouched, existing queries unaffected.
+- **New read surface needed:** a type-scoped batch query (typed links for a
+  set of task ids, both directions) mirroring `basicLinksForEntryIds`,
+  served by the existing `(to_id, type)` and `from_id` indexes.
+- **Old-build degradation is bounded but real.** An old build folds an
+  unknown variant to `BasicLink` (fallback union) and *displays* it as a
+  generic link — acceptable. If that old build then **mutates** the link
+  (hide, collapse, delete), it re-serializes it as `basic`, permanently
+  down-typing the edge for everyone. Links are rarely mutated after
+  creation, and the same exposure already exists for every new
+  `AgentDomainEntity` variant; accepted, documented here, mitigated by
+  shipping the model variants at least one release before any UI writes
+  them (standard rollout ordering).
+- **The typed vocabulary is closed by design.** Five verbs cover the
+  standard task-system semantics; anything fuzzier belongs in `BasicLink`
+  or in text. Growing the vocabulary requires an amendment here, not an ad
+  hoc string.
+- Planning integration (ready frontier in the agent corpus, directive
+  rules) is deliberately split into ADR 0043 — this ADR is complete without
+  it, and the link layer must not depend on the agents feature.
+
+## Related
+
+- ADR 0003 — linked-context contract (the read pattern typed links extend).
+- ADR 0006 — user-as-final-validator, mirrored by decision 6.
+- ADR 0032 — hierarchical day-agent coordination (the consumer side's
+  architecture).
+- ADR 0043 — dependency-aware planning (the ready frontier consuming these
+  edges).
+- Implementation plan:
+  `docs/implementation_plans/2026-07-23_task_dependency_links.md`.
+- Prior art: Jira link types, Linear relations, Beads
+  (github.com/steveyegge/beads) — the blocks/ready-frontier model for
+  agent-facing task graphs.

--- a/docs/adr/0043-dependency-aware-planning.md
+++ b/docs/adr/0043-dependency-aware-planning.md
@@ -52,9 +52,19 @@ Blocked tasks stay in the corpus. Rows for blocked tasks gain one field:
 }
 ```
 
-Ready tasks carry no `blockedBy` key at all (absence means ready), so the
-common case adds zero tokens and the snapshot stays byte-stable for
-prompt-prefix caching except where a dependency genuinely exists.
+Ready tasks carry no `blockedBy` key at all, so the common case adds zero
+tokens and the snapshot stays byte-stable for prompt-prefix caching except
+where a dependency genuinely exists.
+
+**Absence of `blockedBy` means link-ready, not free to schedule.** The
+manual `TaskStatus.blocked` stays independent of typed links (ADR 0042
+§4), and every corpus row already carries `status` — so a manually blocked
+task with no named blocker is visible as `"status": "BLOCKED"` with no
+`blockedBy` key. "Blocked for planning" is the union of both signals:
+`status == BLOCKED` (self-declared, cause possibly external/unnamed) **or**
+a non-empty `blockedBy` (computed, cause named). The prompt rules below
+and their tests use this union definition; the corpus shape needs no
+second flag for it.
 
 ### 2. A batch dependency resolver, one hop, bounded
 
@@ -68,11 +78,14 @@ batch-read discipline as `getEntitiesByIds` in the week-context service).
 
 ### 3. Prompt contract: schedule blockers, don't schedule blocked work
 
-Drafting/refine rules (day agents):
+Drafting/refine rules (day agents), one predicate, stated once and
+mirrored verbatim by the implementation plan:
 
-- Do not place a task carrying `blockedBy` unless the plan also places (or
-  the day log shows completed) work on its blocker; placing blocked work
-  deliberately requires the block's `reason` to name the blocker.
+> A task that is blocked for planning (`status == BLOCKED` or non-empty
+> `blockedBy`) may be placed **only if** (a) the same plan places work on
+> its blocker earlier in the day, **or** (b) the block's `reason`
+> explicitly names the blocker and why the work can proceed despite it.
+
 - When a decided/committed task is blocked, prefer placing the blocker and
   say so in the reason.
 

--- a/docs/adr/0043-dependency-aware-planning.md
+++ b/docs/adr/0043-dependency-aware-planning.md
@@ -1,0 +1,159 @@
+# ADR 0043: Dependency-Aware Planning (Ready Frontier)
+
+## Status
+
+Proposed (depends on ADR 0042)
+
+## Date
+
+2026-07-23
+
+## Context
+
+### The planning agents see tasks as a flat list
+
+The day-agent task corpus (`DayAgentCorpusService.buildTaskCorpusSnapshot`)
+assembles open tasks plus overdue/due-today tasks into a bounded snapshot
+(≤200 rows: taskId, title, status, categoryId, due, estimateMinutes,
+priority) that capture parsing matches against and drafting places from.
+The coordinator's digest (ADR 0032) distills commitments into per-day
+directives from the same flat view. Nothing in either context expresses
+that one task waits on another, so today:
+
+- Drafting can place a blocked task into a plan while the blocker sits
+  unscheduled — the plan is executable on paper and stuck in practice.
+- A directive can commit minutes to work that cannot start, burning one of
+  the ≤12 bounded commitment slots on a no-op.
+- The agent cannot give the genuinely useful advice — "schedule the
+  blocker first" — because the dependency is invisible.
+
+ADR 0042 adds the missing substrate: typed `blocks` edges between tasks
+and a derived, one-hop readiness rule (no live blocker whose task is not
+`DONE`/`REJECTED`). This ADR decides how planning consumes it.
+
+### Constraint: the corpus serves two masters
+
+The corpus is not only a planning input — capture matching
+(`match_to_corpus`) resolves spoken phrases against it. A blocked task must
+still be *matchable* ("I talked to legal about the contract review" must
+link to the blocked contract-review task). Any design that removes blocked
+tasks from the corpus breaks capture attribution.
+
+## Decision
+
+### 1. Annotate, never exclude
+
+Blocked tasks stay in the corpus. Rows for blocked tasks gain one field:
+
+```json
+{
+  "taskId": "…", "title": "…", "status": "OPEN", "…": "…",
+  "blockedBy": [{"taskId": "…", "title": "Fix the blocker", "status": "IN PROGRESS"}]
+}
+```
+
+Ready tasks carry no `blockedBy` key at all (absence means ready), so the
+common case adds zero tokens and the snapshot stays byte-stable for
+prompt-prefix caching except where a dependency genuinely exists.
+
+### 2. A batch dependency resolver, one hop, bounded
+
+A dependency-resolution seam (extending the corpus/journal read layer)
+answers "which of these task ids are blocked, and by what" in two bounded
+queries: one type-scoped link fetch (`to_id IN (…) AND type = <blocks>`,
+served by the existing `(to_id, type)` index), one batch task-status load
+for the distinct blocker ids. No transitive closure — readiness is one hop
+by ADR 0042 decision 4 — and no per-task fan-out (the same
+batch-read discipline as `getEntitiesByIds` in the week-context service).
+
+### 3. Prompt contract: schedule blockers, don't schedule blocked work
+
+Drafting/refine rules (day agents):
+
+- Do not place a task carrying `blockedBy` unless the plan also places (or
+  the day log shows completed) work on its blocker; placing blocked work
+  deliberately requires the block's `reason` to name the blocker.
+- When a decided/committed task is blocked, prefer placing the blocker and
+  say so in the reason.
+
+Digest rules (coordinator, extends the ADR 0032 digest ritual):
+
+- Directive commitments should reference ready work. A commitment on a
+  blocked task must either target the blocker instead or name the blocker
+  in an attention note, so the per-day agent inherits the dependency
+  context inside the directive itself.
+
+These are prompt-contract rules in `day_agent_prompt_builder.dart`,
+enforced the same way the binding-directive contract is: by instruction and
+by review, not by hard validation — the LLM may still have good reasons
+(a blocked task's independent subtask, a deadline forcing parallel prep).
+
+### 4. UI: blockedness is visible where tasks are
+
+- Task detail: a "Blocked by …" affordance (and the inverse "Blocks …")
+  rendered from typed links, tappable to the other task, alongside the
+  existing linked-tasks section; follow-ups, duplicates, fixes, and
+  supersedes render as labeled groups in the same surface.
+- Creating typed links reuses the existing link-task modal
+  (`link_task_modal.dart`) with a relationship picker.
+- List-level badges (a blocked glyph on task rows) are a later polish
+  step, not part of the core decision.
+
+### 5. Non-goals
+
+- **No topological scheduler.** Ordering a handful of same-day blocks is
+  soft judgment the LLM already exercises through block `reasons`; a
+  constraint solver would fight the human-in-the-loop model for marginal
+  gain.
+- **No automatic status writes.** Computed blockedness never mutates
+  `TaskStatus` (ADR 0042 decision 4).
+- **No dependency-driven wake triggers** (waking a day agent because a
+  blocker closed) in the first iteration — the daily digest and normal
+  planning cadence pick up released work; event-driven release
+  notifications are a listed follow-up, not a commitment.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  subgraph links [ADR 0042 substrate]
+    BL[blocks edges<br/>linked_entries]
+  end
+  subgraph reads [bounded batch reads]
+    DR[dependency resolver<br/>links + blocker statuses]
+  end
+  subgraph consumers
+    CS[corpus snapshot<br/>blockedBy annotation]
+    TD[task detail UI<br/>Blocked by / Blocks]
+  end
+  BL --> DR --> CS
+  BL --> TD
+  CS --> DA[day agent drafting/refine<br/>prompt rules]
+  CS --> CO[coordinator digest<br/>directive rules]
+```
+
+## Consequences
+
+- Token cost is proportional to actual dependencies (annotation only on
+  blocked rows), and the resolver adds two bounded queries per corpus
+  build.
+- Capture matching is unaffected — blocked tasks remain in the corpus.
+- The prompt contract grows two rule blocks (drafting, digest); both are
+  conditional on the dependency data existing, so pre-rollout prompts are
+  byte-identical.
+- Cycle tolerance is inherited from ADR 0042: mutually blocking tasks are
+  all annotated as blocked, which surfaces the deadlock to the agent and
+  the user rather than hiding it.
+- Deferred follow-ups (explicitly out of scope until proven needed):
+  blocker-closed release notifications, list-row badges, a `link_tasks`
+  agent tool letting capture parsing assert dependencies ("X waits on Y"),
+  and duplicate/supersede close-time suggestions (ADR 0042 decision 6's UI).
+
+## Related
+
+- ADR 0042 — typed task relationship links (the substrate).
+- ADR 0032 — hierarchical day-agent coordination (digest/directive
+  surfaces extended here).
+- ADR 0003 — linked-context contract.
+- Implementation plan:
+  `docs/implementation_plans/2026-07-23_task_dependency_links.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,13 @@ Each ADR should contain:
 
 ## Index
 
+### Task graph decision cluster
+
+| ADR | Status | Decision ownership |
+| --- | --- | --- |
+| [0042: Typed Task Relationship Links](./0042-typed-task-relationship-links.md) | Proposed | `EntryLink` union variants (blocks, followsUp, duplicates, fixes, supersedes), one stored edge with rendered inverses, derived one-hop readiness, cycle tolerance, suggestion-only lifecycle coupling. |
+| [0043: Dependency-Aware Planning](./0043-dependency-aware-planning.md) | Proposed | Ready frontier consumed by planning: corpus annotation (never exclusion), batch dependency resolver, drafting/digest prompt rules, task-detail visibility, explicit non-goals. |
+
 ### Relationship management decision cluster
 
 | ADR | Status | Decision ownership |
@@ -90,3 +97,5 @@ Each ADR should contain:
 - [`0039-relationship-check-in-reminders.md`](./0039-relationship-check-in-reminders.md)
 - [`0040-relationship-executive-briefing.md`](./0040-relationship-executive-briefing.md)
 - [`0041-relationship-contact-linking.md`](./0041-relationship-contact-linking.md)
+- [`0042-typed-task-relationship-links.md`](./0042-typed-task-relationship-links.md)
+- [`0043-dependency-aware-planning.md`](./0043-dependency-aware-planning.md)

--- a/docs/implementation_plans/2026-07-23_task_dependency_links.md
+++ b/docs/implementation_plans/2026-07-23_task_dependency_links.md
@@ -1,0 +1,163 @@
+# Typed Task Relationship Links — Implementation Plan
+
+Grounds ADR 0042 (typed task relationship links) and ADR 0043
+(dependency-aware planning) in the code as it exists on main. Written
+2026-07-23.
+
+## Goal
+
+Give tasks first-class semantic relationships — blocks / is blocked by,
+follows up on, duplicates, fixes, supersedes — on the existing
+`EntryLink`/`linked_entries` substrate, then feed the derived ready
+frontier into the planning agents' task corpus and the coordinator's
+directive ritual, and surface the relationships in the task UI.
+
+## What the code audit established
+
+- `linked_entries` needs **no schema change**: `type TEXT NOT NULL`,
+  `UNIQUE(from_id, to_id, type)`, and indexes on `from_id`, `to_id`,
+  `type`, `(to_id, type)` already exist. The type column is derived from
+  the `EntryLink` union variant on write (`linkedDbEntity` in
+  `lib/database/conversions.dart`).
+- Every basic-link consumer is already type-scoped
+  (`basicLinksForEntryIds` filters `type = 'BasicLink'` in SQL), so time
+  attribution, the linked-entries timeline, and capture attribution cannot
+  see new types by construction.
+- `EntryLink` is `@Freezed(fallbackUnion: 'basic')`: old builds
+  deserialize unknown variants as `BasicLink` (visible generic link, no
+  crash). Old-build *mutation* of a typed link would down-type it on
+  re-serialization — rare (links are barely mutated after creation), and
+  mitigated by shipping model variants one release before UI writes them.
+- Creation/sync path is generic: `PersistenceLogic.createLink` (uuid v1,
+  vector-clock scope, `SyncMessage.entryLink` outbox enqueue, update
+  notifications) and `JournalDb.upsertEntryLink` (equality precheck +
+  triple-conflict guard) work for any variant; only the hardcoded
+  `EntryLink.basic(...)` constructor call needs a type parameter. The sync
+  receive path deserializes via `EntryLink.fromJson` and is likewise
+  generic.
+- Task statuses: `open | inProgress | groomed | blocked | onHold | done |
+  rejected`; `isClosedTask` = `DONE | REJECTED`
+  (`day_agent_capture_helpers.dart`). The manual `blocked` status stays
+  and can be optionally enriched with a named blocker (ADR 0042 §4).
+- Task-link UI today: `lib/features/tasks/ui/linked_tasks/`
+  (`linked_tasks_widget.dart`, `link_task_modal.dart`).
+- Agent corpus: `DayAgentCorpusService.buildTaskCorpusSnapshot`
+  (`getOpenTasksForDayAgentCorpus` + `getTasksDueOnOrBefore`, cap 200)
+  serves both capture matching and drafting — blocked tasks must stay in
+  it (annotate, never exclude; ADR 0043 §1).
+
+## Phases
+
+```mermaid
+flowchart LR
+  P1[Phase 1<br/>link substrate] --> P2[Phase 2<br/>task UI]
+  P1 --> P3[Phase 3<br/>ready frontier + agents]
+  P2 -.close-time suggestions.-> P4[Phase 4<br/>lifecycle polish]
+  P3 -.release triggers, link_tasks tool.-> P4
+```
+
+### Phase 1 — Link substrate (model, storage, sync)
+
+1. **Union variants** in `lib/classes/entry_link.dart`: `blocks`,
+   `followsUp`, `duplicates`, `fixes`, `supersedes` — same field shape as
+   `BasicLink`. Regenerate freezed/json.
+2. **Type derivation**: extend the `link.map(...)` in `linkedDbEntity`
+   (compile-time exhaustive, the compiler finds every fold site). Type
+   strings follow the existing convention (`'BlocksLink'`, …).
+3. **Typed batch query** in `database_links_ratings.dart`:
+   `typedLinksForTaskIds(Set<String> ids, {required Set<String> types})`
+   returning live links where `to_id IN ids` or `from_id IN ids` for the
+   requested types (two indexed selects, union in Dart). Mirror the
+   `basicLinksForEntryIds` snapshot discipline; coalescing only if a
+   profiler shows the same fan-out pressure.
+4. **Creation/deletion**: `PersistenceLogic.createLink` gains a link-type
+   parameter (default basic — zero call-site churn); the existing
+   tombstone/delete path is verified for typed links. Direct-cycle guard
+   for `blocks` (bounded local traversal, reject on visible cycle;
+   ADR 0042 §5).
+5. **Sync verification**: round-trip test through the sync processor for a
+   typed link (serialize → receive → upsert → read back), plus a
+   fallback-union test pinning that an unknown future type degrades to
+   `BasicLink` without crashing.
+6. **Tests**: conversions (type column per variant), query (direction +
+   type scoping + tombstone exclusion), persistence (vector clock, outbox
+   enqueue, UNIQUE-triple upsert), cycle guard.
+
+Phase 1 ships alone (model-first rollout, no UI writes) to open the
+old-build compatibility window before any device can create typed links.
+
+### Phase 2 — Task UI
+
+1. **Relationship picker** in `link_task_modal.dart`: choose the relation
+   when linking task→task (both phrasings per ADR 0042 §2 — picking
+   "is blocked by" swaps from/to before persisting `blocks`).
+2. **Grouped rendering** in `linked_tasks_widget.dart`: labeled sections —
+   Blocks, Blocked by, Follow-ups, Duplicates, Fixes, Superseded by — with
+   inverse labels computed from direction; tap navigates to the task.
+3. **Blocked affordance on task detail**: a chip/banner naming the open
+   blocker(s) when the ready computation says blocked; mutual-block
+   (cycle) rendering per ADR 0042 §5.
+4. **Status enrichment (optional path)**: setting `TaskStatus.blocked`
+   offers — never requires — picking the blocking task, persisting a
+   `blocks` edge alongside the status.
+5. **l10n**: every label in all six arb files (informal tone; `en_GB`
+   only when spelling differs), `make l10n` + `make sort_arb_files`.
+   Design-system tokens only for all styling.
+6. **Tests**: modal flow (direction swap verified against the persisted
+   row), grouped rendering with meaningful assertions, blocked-chip
+   states, status-enrichment flow.
+
+### Phase 3 — Ready frontier + agents (ADR 0043)
+
+1. **Dependency resolver**: batch seam answering blocked-status for a set
+   of task ids — one `(to_id, type)`-indexed link fetch + one batch
+   blocker-status load; one hop, visited-set safe, no per-task fan-out.
+2. **Corpus annotation**: `buildTaskCorpusSnapshot` rows gain `blockedBy:
+   [{taskId, title, status}]` on blocked rows only (absence = ready).
+3. **Prompt rules** in `day_agent_prompt_builder.dart`, conditional on the
+   dependency data path being configured: drafting/refine (don't place
+   blocked work without placing the blocker or naming it in the reason;
+   prefer scheduling blockers) and digest (commitments target ready work
+   or name the blocker in an attention note).
+4. **Tests**: resolver (direction, closed-blocker release, tombstones,
+   cycles → all-blocked), corpus annotation shape and absence-when-ready,
+   workflow prompt assertions for both rule blocks, byte-stability of the
+   snapshot for dependency-free corpora.
+5. **Docs**: feature READMEs (tasks, daily_os_next) updated with the new
+   sections and a state/flow diagram; ADR 0042/0043 status flipped to
+   Accepted with amendments for any deviations found while building.
+
+### Phase 4 — Lifecycle polish (deferred, separately justified)
+
+Not committed by this plan; listed so they are decided deliberately later:
+
+- Close-time suggestions: canonical closed → offer closing duplicates;
+  `supersedes` created → offer closing the superseded task (ADR 0042 §6).
+- `link_tasks` agent tool so capture parsing can assert dependencies the
+  user speaks ("the deploy waits on the fix") behind the ChangeSet gate.
+- Blocker-closed release notifications / wake triggers.
+- Task-list row badges for blocked state.
+
+## Acceptance criteria
+
+- Analyzer zero warnings; all suites green; patch coverage ≥99%.
+- A typed link created on device A renders with correct semantics on
+  device B (sync round-trip) and as a plain link on a pre-rollout build
+  without crashing.
+- Time attribution and the linked-entries timeline are byte-identical
+  before/after (typed links invisible to `type = 'BasicLink'` consumers) —
+  pinned by regression tests.
+- A blocked task remains matchable by capture parsing and is annotated,
+  not hidden, in the drafting corpus.
+- Phase gating: no UI write path ships in the same release as the model
+  variants (old-build mutation window, ADR 0042 Consequences).
+
+## Risks
+
+| Risk | Handling |
+| --- | --- |
+| Old build mutates a typed link and down-types it | Model-first rollout (phase 1 alone), rarity of link mutation; accepted in ADR 0042 |
+| Concurrent cross-device cycle creation | Read-time visited-set tolerance; cycle = mutual block, surfaced not hidden |
+| Corpus token growth | Annotation only on blocked rows; absence means ready |
+| Vocabulary creep | Closed set; additions require an ADR 0042 amendment |
+| Capture matching regression from corpus changes | Annotate-never-exclude rule + explicit test |

--- a/docs/implementation_plans/2026-07-23_task_dependency_links.md
+++ b/docs/implementation_plans/2026-07-23_task_dependency_links.md
@@ -113,16 +113,26 @@ old-build compatibility window before any device can create typed links.
    of task ids — one `(to_id, type)`-indexed link fetch + one batch
    blocker-status load; one hop, visited-set safe, no per-task fan-out.
 2. **Corpus annotation**: `buildTaskCorpusSnapshot` rows gain `blockedBy:
-   [{taskId, title, status}]` on blocked rows only (absence = ready).
+   [{taskId, title, status}]` on link-blocked rows only. Absence means
+   *link-ready*, not free to schedule: "blocked for planning" is the union
+   `status == BLOCKED || blockedBy.isNotEmpty` (ADR 0043 §1) — the manual
+   status is already visible in every row's `status` field, so the corpus
+   shape needs no second flag.
 3. **Prompt rules** in `day_agent_prompt_builder.dart`, conditional on the
-   dependency data path being configured: drafting/refine (don't place
-   blocked work without placing the blocker or naming it in the reason;
-   prefer scheduling blockers) and digest (commitments target ready work
-   or name the blocker in an attention note).
-4. **Tests**: resolver (direction, closed-blocker release, tombstones,
-   cycles → all-blocked), corpus annotation shape and absence-when-ready,
-   workflow prompt assertions for both rule blocks, byte-stability of the
-   snapshot for dependency-free corpora.
+   dependency data path being configured. Drafting/refine carry the ADR
+   0043 §3 predicate verbatim: a task blocked for planning
+   (`status == BLOCKED` or non-empty `blockedBy`) may be placed only if
+   (a) the same plan places work on its blocker earlier in the day, or
+   (b) the block's `reason` explicitly names the blocker and why the work
+   can proceed despite it; prefer scheduling blockers. Digest: commitments
+   target ready work or name the blocker in an attention note.
+4. **Tests**: resolver (direction; closed blocker → released; tombstoned
+   blocker → released; unresolvable blocker (link without loadable task)
+   → still blocked, per ADR 0042 §4; cycles → all-blocked), corpus
+   annotation shape including the manually-blocked-without-links case
+   (status `BLOCKED`, no `blockedBy` key), workflow prompt assertions for
+   both rule blocks, byte-stability of the snapshot for dependency-free
+   corpora.
 5. **Docs**: feature READMEs (tasks, daily_os_next) updated with the new
    sections and a state/flow diagram; ADR 0042/0043 status flipped to
    Accepted with amendments for any deviations found while building.


### PR DESCRIPTION
Docs-only PR: two proposed ADRs and an implementation plan for typed task-to-task relationships, grounded in a code audit of the existing link substrate.

**ADR 0042 — Typed Task Relationship Links.** New `EntryLink` union variants (`blocks`, `followsUp`, `duplicates`, `fixes`, `supersedes`) on the existing `linked_entries` table — no schema change: the `type` column, `UNIQUE(from_id, to_id, type)`, and the type-scoped consumers (`basicLinksForEntryIds` filters `type = 'BasicLink'`, so time attribution can't see new types) already support this, and `fallbackUnion: 'basic'` degrades unknown variants to a visible plain link on old builds. One stored edge per relationship with inverse labels as rendering; readiness derived at read time (no live open blocker, one hop, nothing stored); cycles tolerated with visited-set traversal (mutual blocks surfaced, not hidden); lifecycle coupling is suggestion-only. The manual `TaskStatus.blocked` stays and can optionally be enriched with a named blocker — never required.

**ADR 0043 — Dependency-Aware Planning.** The ready frontier feeds the planning agents: blocked corpus rows gain a `blockedBy` annotation (never excluded — capture matching must still resolve phrases against blocked tasks), a batch dependency resolver keeps reads bounded, and drafting/digest prompt rules teach "schedule the blocker, don't schedule blocked work". Explicit non-goals: no topological scheduler, no automatic status writes, no dependency wake triggers initially.

**Implementation plan** (`docs/implementation_plans/2026-07-23_task_dependency_links.md`): four phases — link substrate first and alone (opens the old-build compatibility window before any UI writes), task UI with relationship picker/grouped rendering/optional status enrichment, ready frontier + agent integration, deferred lifecycle polish — with acceptance criteria and a risk table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADRs defining typed task relationship links, dependency-aware planning (“ready frontier”), blocked/ready semantics, and lifecycle rules.
  * Added an implementation plan outlining the phased rollout for typed relationship links, task UI updates, dependency resolution, agent prompt/corpus behavior, testing, and acceptance criteria.
  * Updated the ADR index/README to include the new decision records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->