### PR TITLE
feat: typed task-relationship link substrate (ADR 0042 phase 1)

### DIFF
--- a/lib/classes/entry_link.dart
+++ b/lib/classes/entry_link.dart
@@ -42,6 +42,206 @@ abstract class EntryLink with _$EntryLink {
     DateTime? deletedAt,
   }) = ProjectLink;
 
+  /// `fromId` blocks `toId`; rendered as "is blocked by" from `toId`'s side.
+  /// See ADR 0042 decision 1.
+  const factory EntryLink.blocks({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    bool? hidden,
+    bool? collapsed,
+    DateTime? deletedAt,
+  }) = BlocksLink;
+
+  /// `fromId` follows up on `toId`; rendered as "has follow-up" from
+  /// `toId`'s side. See ADR 0042 decision 1.
+  const factory EntryLink.followsUp({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    bool? hidden,
+    bool? collapsed,
+    DateTime? deletedAt,
+  }) = FollowsUpLink;
+
+  /// `fromId` duplicates `toId` (`toId` is canonical); rendered as
+  /// "is duplicated by" from `toId`'s side. See ADR 0042 decision 1.
+  const factory EntryLink.duplicates({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    bool? hidden,
+    bool? collapsed,
+    DateTime? deletedAt,
+  }) = DuplicatesLink;
+
+  /// `fromId` fixes the defect tracked by `toId`; rendered as "is fixed by"
+  /// from `toId`'s side. See ADR 0042 decision 1.
+  const factory EntryLink.fixes({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    bool? hidden,
+    bool? collapsed,
+    DateTime? deletedAt,
+  }) = FixesLink;
+
+  /// `fromId` supersedes `toId` (`toId` is obsolete); rendered as
+  /// "is superseded by" from `toId`'s side. See ADR 0042 decision 1.
+  const factory EntryLink.supersedes({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    bool? hidden,
+    bool? collapsed,
+    DateTime? deletedAt,
+  }) = SupersedesLink;
+
   factory EntryLink.fromJson(Map<String, dynamic> json) =>
       _$EntryLinkFromJson(json);
+}
+
+/// The closed vocabulary of task-relationship semantics an [EntryLink] can
+/// carry, plus the pre-existing untyped variants. Growing this enum requires
+/// an ADR 0042 amendment (see "the typed vocabulary is closed by design").
+enum EntryLinkType {
+  basic,
+  rating,
+  project,
+  blocks,
+  followsUp,
+  duplicates,
+  fixes,
+  supersedes,
+}
+
+/// Builds the [EntryLink] union member matching this [EntryLinkType], so
+/// creation call sites can select the relationship semantics through one
+/// parameter instead of naming the factory constructor directly.
+extension EntryLinkTypeFactory on EntryLinkType {
+  EntryLink buildLink({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    bool? hidden,
+    bool? collapsed,
+    DateTime? deletedAt,
+  }) {
+    switch (this) {
+      case EntryLinkType.basic:
+        return EntryLink.basic(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.rating:
+        return EntryLink.rating(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.project:
+        return EntryLink.project(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.blocks:
+        return EntryLink.blocks(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.followsUp:
+        return EntryLink.followsUp(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.duplicates:
+        return EntryLink.duplicates(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.fixes:
+        return EntryLink.fixes(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+      case EntryLinkType.supersedes:
+        return EntryLink.supersedes(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+          hidden: hidden,
+          collapsed: collapsed,
+          deletedAt: deletedAt,
+        );
+    }
+  }
 }

--- a/lib/classes/entry_link.freezed.dart
+++ b/lib/classes/entry_link.freezed.dart
@@ -23,6 +23,26 @@ EntryLink _$EntryLinkFromJson(
           return ProjectLink.fromJson(
             json
           );
+                case 'blocks':
+          return BlocksLink.fromJson(
+            json
+          );
+                case 'followsUp':
+          return FollowsUpLink.fromJson(
+            json
+          );
+                case 'duplicates':
+          return DuplicatesLink.fromJson(
+            json
+          );
+                case 'fixes':
+          return FixesLink.fromJson(
+            json
+          );
+                case 'supersedes':
+          return SupersedesLink.fromJson(
+            json
+          );
         
           default:
             return BasicLink.fromJson(
@@ -117,13 +137,18 @@ extension EntryLinkPatterns on EntryLink {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( BasicLink value)?  basic,TResult Function( RatingLink value)?  rating,TResult Function( ProjectLink value)?  project,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( BasicLink value)?  basic,TResult Function( RatingLink value)?  rating,TResult Function( ProjectLink value)?  project,TResult Function( BlocksLink value)?  blocks,TResult Function( FollowsUpLink value)?  followsUp,TResult Function( DuplicatesLink value)?  duplicates,TResult Function( FixesLink value)?  fixes,TResult Function( SupersedesLink value)?  supersedes,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case BasicLink() when basic != null:
 return basic(_that);case RatingLink() when rating != null:
 return rating(_that);case ProjectLink() when project != null:
-return project(_that);case _:
+return project(_that);case BlocksLink() when blocks != null:
+return blocks(_that);case FollowsUpLink() when followsUp != null:
+return followsUp(_that);case DuplicatesLink() when duplicates != null:
+return duplicates(_that);case FixesLink() when fixes != null:
+return fixes(_that);case SupersedesLink() when supersedes != null:
+return supersedes(_that);case _:
   return orElse();
 
 }
@@ -141,13 +166,18 @@ return project(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( BasicLink value)  basic,required TResult Function( RatingLink value)  rating,required TResult Function( ProjectLink value)  project,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( BasicLink value)  basic,required TResult Function( RatingLink value)  rating,required TResult Function( ProjectLink value)  project,required TResult Function( BlocksLink value)  blocks,required TResult Function( FollowsUpLink value)  followsUp,required TResult Function( DuplicatesLink value)  duplicates,required TResult Function( FixesLink value)  fixes,required TResult Function( SupersedesLink value)  supersedes,}){
 final _that = this;
 switch (_that) {
 case BasicLink():
 return basic(_that);case RatingLink():
 return rating(_that);case ProjectLink():
-return project(_that);case _:
+return project(_that);case BlocksLink():
+return blocks(_that);case FollowsUpLink():
+return followsUp(_that);case DuplicatesLink():
+return duplicates(_that);case FixesLink():
+return fixes(_that);case SupersedesLink():
+return supersedes(_that);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -164,13 +194,18 @@ return project(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( BasicLink value)?  basic,TResult? Function( RatingLink value)?  rating,TResult? Function( ProjectLink value)?  project,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( BasicLink value)?  basic,TResult? Function( RatingLink value)?  rating,TResult? Function( ProjectLink value)?  project,TResult? Function( BlocksLink value)?  blocks,TResult? Function( FollowsUpLink value)?  followsUp,TResult? Function( DuplicatesLink value)?  duplicates,TResult? Function( FixesLink value)?  fixes,TResult? Function( SupersedesLink value)?  supersedes,}){
 final _that = this;
 switch (_that) {
 case BasicLink() when basic != null:
 return basic(_that);case RatingLink() when rating != null:
 return rating(_that);case ProjectLink() when project != null:
-return project(_that);case _:
+return project(_that);case BlocksLink() when blocks != null:
+return blocks(_that);case FollowsUpLink() when followsUp != null:
+return followsUp(_that);case DuplicatesLink() when duplicates != null:
+return duplicates(_that);case FixesLink() when fixes != null:
+return fixes(_that);case SupersedesLink() when supersedes != null:
+return supersedes(_that);case _:
   return null;
 
 }
@@ -187,12 +222,17 @@ return project(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  basic,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  rating,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  project,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  basic,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  rating,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  project,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  blocks,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  followsUp,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  duplicates,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  fixes,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  supersedes,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case BasicLink() when basic != null:
 return basic(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case RatingLink() when rating != null:
 return rating(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case ProjectLink() when project != null:
-return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case _:
+return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case BlocksLink() when blocks != null:
+return blocks(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case FollowsUpLink() when followsUp != null:
+return followsUp(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case DuplicatesLink() when duplicates != null:
+return duplicates(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case FixesLink() when fixes != null:
+return fixes(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case SupersedesLink() when supersedes != null:
+return supersedes(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case _:
   return orElse();
 
 }
@@ -210,12 +250,17 @@ return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  basic,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  rating,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  project,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  basic,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  rating,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  project,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  blocks,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  followsUp,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  duplicates,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  fixes,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)  supersedes,}) {final _that = this;
 switch (_that) {
 case BasicLink():
 return basic(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case RatingLink():
 return rating(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case ProjectLink():
-return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case _:
+return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case BlocksLink():
+return blocks(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case FollowsUpLink():
+return followsUp(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case DuplicatesLink():
+return duplicates(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case FixesLink():
+return fixes(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case SupersedesLink():
+return supersedes(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -232,12 +277,17 @@ return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  basic,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  rating,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  project,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  basic,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  rating,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  project,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  blocks,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  followsUp,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  duplicates,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  fixes,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  bool? hidden,  bool? collapsed,  DateTime? deletedAt)?  supersedes,}) {final _that = this;
 switch (_that) {
 case BasicLink() when basic != null:
 return basic(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case RatingLink() when rating != null:
 return rating(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case ProjectLink() when project != null:
-return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case _:
+return project(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case BlocksLink() when blocks != null:
+return blocks(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case FollowsUpLink() when followsUp != null:
+return followsUp(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case DuplicatesLink() when duplicates != null:
+return duplicates(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case FixesLink() when fixes != null:
+return fixes(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case SupersedesLink() when supersedes != null:
+return supersedes(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.hidden,_that.collapsed,_that.deletedAt);case _:
   return null;
 
 }
@@ -496,6 +546,451 @@ class _$ProjectLinkCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? hidden = freezed,Object? collapsed = freezed,Object? deletedAt = freezed,}) {
   return _then(ProjectLink(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
+as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,vectorClock: freezed == vectorClock ? _self.vectorClock : vectorClock // ignore: cast_nullable_to_non_nullable
+as VectorClock?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,collapsed: freezed == collapsed ? _self.collapsed : collapsed // ignore: cast_nullable_to_non_nullable
+as bool?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class BlocksLink implements EntryLink {
+  const BlocksLink({required this.id, required this.fromId, required this.toId, required this.createdAt, required this.updatedAt, required this.vectorClock, this.hidden, this.collapsed, this.deletedAt, final  String? $type}): $type = $type ?? 'blocks';
+  factory BlocksLink.fromJson(Map<String, dynamic> json) => _$BlocksLinkFromJson(json);
+
+@override final  String id;
+@override final  String fromId;
+@override final  String toId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  VectorClock? vectorClock;
+@override final  bool? hidden;
+@override final  bool? collapsed;
+@override final  DateTime? deletedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BlocksLinkCopyWith<BlocksLink> get copyWith => _$BlocksLinkCopyWithImpl<BlocksLink>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BlocksLinkToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BlocksLink&&(identical(other.id, id) || other.id == id)&&(identical(other.fromId, fromId) || other.fromId == fromId)&&(identical(other.toId, toId) || other.toId == toId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.collapsed, collapsed) || other.collapsed == collapsed)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fromId,toId,createdAt,updatedAt,vectorClock,hidden,collapsed,deletedAt);
+
+@override
+String toString() {
+  return 'EntryLink.blocks(id: $id, fromId: $fromId, toId: $toId, createdAt: $createdAt, updatedAt: $updatedAt, vectorClock: $vectorClock, hidden: $hidden, collapsed: $collapsed, deletedAt: $deletedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BlocksLinkCopyWith<$Res> implements $EntryLinkCopyWith<$Res> {
+  factory $BlocksLinkCopyWith(BlocksLink value, $Res Function(BlocksLink) _then) = _$BlocksLinkCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fromId, String toId, DateTime createdAt, DateTime updatedAt, VectorClock? vectorClock, bool? hidden, bool? collapsed, DateTime? deletedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$BlocksLinkCopyWithImpl<$Res>
+    implements $BlocksLinkCopyWith<$Res> {
+  _$BlocksLinkCopyWithImpl(this._self, this._then);
+
+  final BlocksLink _self;
+  final $Res Function(BlocksLink) _then;
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? hidden = freezed,Object? collapsed = freezed,Object? deletedAt = freezed,}) {
+  return _then(BlocksLink(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
+as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,vectorClock: freezed == vectorClock ? _self.vectorClock : vectorClock // ignore: cast_nullable_to_non_nullable
+as VectorClock?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,collapsed: freezed == collapsed ? _self.collapsed : collapsed // ignore: cast_nullable_to_non_nullable
+as bool?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class FollowsUpLink implements EntryLink {
+  const FollowsUpLink({required this.id, required this.fromId, required this.toId, required this.createdAt, required this.updatedAt, required this.vectorClock, this.hidden, this.collapsed, this.deletedAt, final  String? $type}): $type = $type ?? 'followsUp';
+  factory FollowsUpLink.fromJson(Map<String, dynamic> json) => _$FollowsUpLinkFromJson(json);
+
+@override final  String id;
+@override final  String fromId;
+@override final  String toId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  VectorClock? vectorClock;
+@override final  bool? hidden;
+@override final  bool? collapsed;
+@override final  DateTime? deletedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FollowsUpLinkCopyWith<FollowsUpLink> get copyWith => _$FollowsUpLinkCopyWithImpl<FollowsUpLink>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$FollowsUpLinkToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FollowsUpLink&&(identical(other.id, id) || other.id == id)&&(identical(other.fromId, fromId) || other.fromId == fromId)&&(identical(other.toId, toId) || other.toId == toId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.collapsed, collapsed) || other.collapsed == collapsed)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fromId,toId,createdAt,updatedAt,vectorClock,hidden,collapsed,deletedAt);
+
+@override
+String toString() {
+  return 'EntryLink.followsUp(id: $id, fromId: $fromId, toId: $toId, createdAt: $createdAt, updatedAt: $updatedAt, vectorClock: $vectorClock, hidden: $hidden, collapsed: $collapsed, deletedAt: $deletedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FollowsUpLinkCopyWith<$Res> implements $EntryLinkCopyWith<$Res> {
+  factory $FollowsUpLinkCopyWith(FollowsUpLink value, $Res Function(FollowsUpLink) _then) = _$FollowsUpLinkCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fromId, String toId, DateTime createdAt, DateTime updatedAt, VectorClock? vectorClock, bool? hidden, bool? collapsed, DateTime? deletedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$FollowsUpLinkCopyWithImpl<$Res>
+    implements $FollowsUpLinkCopyWith<$Res> {
+  _$FollowsUpLinkCopyWithImpl(this._self, this._then);
+
+  final FollowsUpLink _self;
+  final $Res Function(FollowsUpLink) _then;
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? hidden = freezed,Object? collapsed = freezed,Object? deletedAt = freezed,}) {
+  return _then(FollowsUpLink(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
+as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,vectorClock: freezed == vectorClock ? _self.vectorClock : vectorClock // ignore: cast_nullable_to_non_nullable
+as VectorClock?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,collapsed: freezed == collapsed ? _self.collapsed : collapsed // ignore: cast_nullable_to_non_nullable
+as bool?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class DuplicatesLink implements EntryLink {
+  const DuplicatesLink({required this.id, required this.fromId, required this.toId, required this.createdAt, required this.updatedAt, required this.vectorClock, this.hidden, this.collapsed, this.deletedAt, final  String? $type}): $type = $type ?? 'duplicates';
+  factory DuplicatesLink.fromJson(Map<String, dynamic> json) => _$DuplicatesLinkFromJson(json);
+
+@override final  String id;
+@override final  String fromId;
+@override final  String toId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  VectorClock? vectorClock;
+@override final  bool? hidden;
+@override final  bool? collapsed;
+@override final  DateTime? deletedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DuplicatesLinkCopyWith<DuplicatesLink> get copyWith => _$DuplicatesLinkCopyWithImpl<DuplicatesLink>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DuplicatesLinkToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DuplicatesLink&&(identical(other.id, id) || other.id == id)&&(identical(other.fromId, fromId) || other.fromId == fromId)&&(identical(other.toId, toId) || other.toId == toId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.collapsed, collapsed) || other.collapsed == collapsed)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fromId,toId,createdAt,updatedAt,vectorClock,hidden,collapsed,deletedAt);
+
+@override
+String toString() {
+  return 'EntryLink.duplicates(id: $id, fromId: $fromId, toId: $toId, createdAt: $createdAt, updatedAt: $updatedAt, vectorClock: $vectorClock, hidden: $hidden, collapsed: $collapsed, deletedAt: $deletedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DuplicatesLinkCopyWith<$Res> implements $EntryLinkCopyWith<$Res> {
+  factory $DuplicatesLinkCopyWith(DuplicatesLink value, $Res Function(DuplicatesLink) _then) = _$DuplicatesLinkCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fromId, String toId, DateTime createdAt, DateTime updatedAt, VectorClock? vectorClock, bool? hidden, bool? collapsed, DateTime? deletedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$DuplicatesLinkCopyWithImpl<$Res>
+    implements $DuplicatesLinkCopyWith<$Res> {
+  _$DuplicatesLinkCopyWithImpl(this._self, this._then);
+
+  final DuplicatesLink _self;
+  final $Res Function(DuplicatesLink) _then;
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? hidden = freezed,Object? collapsed = freezed,Object? deletedAt = freezed,}) {
+  return _then(DuplicatesLink(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
+as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,vectorClock: freezed == vectorClock ? _self.vectorClock : vectorClock // ignore: cast_nullable_to_non_nullable
+as VectorClock?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,collapsed: freezed == collapsed ? _self.collapsed : collapsed // ignore: cast_nullable_to_non_nullable
+as bool?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class FixesLink implements EntryLink {
+  const FixesLink({required this.id, required this.fromId, required this.toId, required this.createdAt, required this.updatedAt, required this.vectorClock, this.hidden, this.collapsed, this.deletedAt, final  String? $type}): $type = $type ?? 'fixes';
+  factory FixesLink.fromJson(Map<String, dynamic> json) => _$FixesLinkFromJson(json);
+
+@override final  String id;
+@override final  String fromId;
+@override final  String toId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  VectorClock? vectorClock;
+@override final  bool? hidden;
+@override final  bool? collapsed;
+@override final  DateTime? deletedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FixesLinkCopyWith<FixesLink> get copyWith => _$FixesLinkCopyWithImpl<FixesLink>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$FixesLinkToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FixesLink&&(identical(other.id, id) || other.id == id)&&(identical(other.fromId, fromId) || other.fromId == fromId)&&(identical(other.toId, toId) || other.toId == toId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.collapsed, collapsed) || other.collapsed == collapsed)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fromId,toId,createdAt,updatedAt,vectorClock,hidden,collapsed,deletedAt);
+
+@override
+String toString() {
+  return 'EntryLink.fixes(id: $id, fromId: $fromId, toId: $toId, createdAt: $createdAt, updatedAt: $updatedAt, vectorClock: $vectorClock, hidden: $hidden, collapsed: $collapsed, deletedAt: $deletedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FixesLinkCopyWith<$Res> implements $EntryLinkCopyWith<$Res> {
+  factory $FixesLinkCopyWith(FixesLink value, $Res Function(FixesLink) _then) = _$FixesLinkCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fromId, String toId, DateTime createdAt, DateTime updatedAt, VectorClock? vectorClock, bool? hidden, bool? collapsed, DateTime? deletedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$FixesLinkCopyWithImpl<$Res>
+    implements $FixesLinkCopyWith<$Res> {
+  _$FixesLinkCopyWithImpl(this._self, this._then);
+
+  final FixesLink _self;
+  final $Res Function(FixesLink) _then;
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? hidden = freezed,Object? collapsed = freezed,Object? deletedAt = freezed,}) {
+  return _then(FixesLink(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
+as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,vectorClock: freezed == vectorClock ? _self.vectorClock : vectorClock // ignore: cast_nullable_to_non_nullable
+as VectorClock?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,collapsed: freezed == collapsed ? _self.collapsed : collapsed // ignore: cast_nullable_to_non_nullable
+as bool?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SupersedesLink implements EntryLink {
+  const SupersedesLink({required this.id, required this.fromId, required this.toId, required this.createdAt, required this.updatedAt, required this.vectorClock, this.hidden, this.collapsed, this.deletedAt, final  String? $type}): $type = $type ?? 'supersedes';
+  factory SupersedesLink.fromJson(Map<String, dynamic> json) => _$SupersedesLinkFromJson(json);
+
+@override final  String id;
+@override final  String fromId;
+@override final  String toId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  VectorClock? vectorClock;
+@override final  bool? hidden;
+@override final  bool? collapsed;
+@override final  DateTime? deletedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SupersedesLinkCopyWith<SupersedesLink> get copyWith => _$SupersedesLinkCopyWithImpl<SupersedesLink>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SupersedesLinkToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SupersedesLink&&(identical(other.id, id) || other.id == id)&&(identical(other.fromId, fromId) || other.fromId == fromId)&&(identical(other.toId, toId) || other.toId == toId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&(identical(other.collapsed, collapsed) || other.collapsed == collapsed)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fromId,toId,createdAt,updatedAt,vectorClock,hidden,collapsed,deletedAt);
+
+@override
+String toString() {
+  return 'EntryLink.supersedes(id: $id, fromId: $fromId, toId: $toId, createdAt: $createdAt, updatedAt: $updatedAt, vectorClock: $vectorClock, hidden: $hidden, collapsed: $collapsed, deletedAt: $deletedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SupersedesLinkCopyWith<$Res> implements $EntryLinkCopyWith<$Res> {
+  factory $SupersedesLinkCopyWith(SupersedesLink value, $Res Function(SupersedesLink) _then) = _$SupersedesLinkCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fromId, String toId, DateTime createdAt, DateTime updatedAt, VectorClock? vectorClock, bool? hidden, bool? collapsed, DateTime? deletedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$SupersedesLinkCopyWithImpl<$Res>
+    implements $SupersedesLinkCopyWith<$Res> {
+  _$SupersedesLinkCopyWithImpl(this._self, this._then);
+
+  final SupersedesLink _self;
+  final $Res Function(SupersedesLink) _then;
+
+/// Create a copy of EntryLink
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? hidden = freezed,Object? collapsed = freezed,Object? deletedAt = freezed,}) {
+  return _then(SupersedesLink(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
 as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable

--- a/lib/classes/entry_link.g.dart
+++ b/lib/classes/entry_link.g.dart
@@ -97,3 +97,160 @@ Map<String, dynamic> _$ProjectLinkToJson(ProjectLink instance) =>
       'deletedAt': instance.deletedAt?.toIso8601String(),
       'runtimeType': instance.$type,
     };
+
+BlocksLink _$BlocksLinkFromJson(Map<String, dynamic> json) => BlocksLink(
+  id: json['id'] as String,
+  fromId: json['fromId'] as String,
+  toId: json['toId'] as String,
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  updatedAt: DateTime.parse(json['updatedAt'] as String),
+  vectorClock: json['vectorClock'] == null
+      ? null
+      : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
+  hidden: json['hidden'] as bool?,
+  collapsed: json['collapsed'] as bool?,
+  deletedAt: json['deletedAt'] == null
+      ? null
+      : DateTime.parse(json['deletedAt'] as String),
+  $type: json['runtimeType'] as String?,
+);
+
+Map<String, dynamic> _$BlocksLinkToJson(BlocksLink instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'fromId': instance.fromId,
+      'toId': instance.toId,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'vectorClock': instance.vectorClock,
+      'hidden': instance.hidden,
+      'collapsed': instance.collapsed,
+      'deletedAt': instance.deletedAt?.toIso8601String(),
+      'runtimeType': instance.$type,
+    };
+
+FollowsUpLink _$FollowsUpLinkFromJson(Map<String, dynamic> json) =>
+    FollowsUpLink(
+      id: json['id'] as String,
+      fromId: json['fromId'] as String,
+      toId: json['toId'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      vectorClock: json['vectorClock'] == null
+          ? null
+          : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
+      hidden: json['hidden'] as bool?,
+      collapsed: json['collapsed'] as bool?,
+      deletedAt: json['deletedAt'] == null
+          ? null
+          : DateTime.parse(json['deletedAt'] as String),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$FollowsUpLinkToJson(FollowsUpLink instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'fromId': instance.fromId,
+      'toId': instance.toId,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'vectorClock': instance.vectorClock,
+      'hidden': instance.hidden,
+      'collapsed': instance.collapsed,
+      'deletedAt': instance.deletedAt?.toIso8601String(),
+      'runtimeType': instance.$type,
+    };
+
+DuplicatesLink _$DuplicatesLinkFromJson(Map<String, dynamic> json) =>
+    DuplicatesLink(
+      id: json['id'] as String,
+      fromId: json['fromId'] as String,
+      toId: json['toId'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      vectorClock: json['vectorClock'] == null
+          ? null
+          : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
+      hidden: json['hidden'] as bool?,
+      collapsed: json['collapsed'] as bool?,
+      deletedAt: json['deletedAt'] == null
+          ? null
+          : DateTime.parse(json['deletedAt'] as String),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$DuplicatesLinkToJson(DuplicatesLink instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'fromId': instance.fromId,
+      'toId': instance.toId,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'vectorClock': instance.vectorClock,
+      'hidden': instance.hidden,
+      'collapsed': instance.collapsed,
+      'deletedAt': instance.deletedAt?.toIso8601String(),
+      'runtimeType': instance.$type,
+    };
+
+FixesLink _$FixesLinkFromJson(Map<String, dynamic> json) => FixesLink(
+  id: json['id'] as String,
+  fromId: json['fromId'] as String,
+  toId: json['toId'] as String,
+  createdAt: DateTime.parse(json['createdAt'] as String),
+  updatedAt: DateTime.parse(json['updatedAt'] as String),
+  vectorClock: json['vectorClock'] == null
+      ? null
+      : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
+  hidden: json['hidden'] as bool?,
+  collapsed: json['collapsed'] as bool?,
+  deletedAt: json['deletedAt'] == null
+      ? null
+      : DateTime.parse(json['deletedAt'] as String),
+  $type: json['runtimeType'] as String?,
+);
+
+Map<String, dynamic> _$FixesLinkToJson(FixesLink instance) => <String, dynamic>{
+  'id': instance.id,
+  'fromId': instance.fromId,
+  'toId': instance.toId,
+  'createdAt': instance.createdAt.toIso8601String(),
+  'updatedAt': instance.updatedAt.toIso8601String(),
+  'vectorClock': instance.vectorClock,
+  'hidden': instance.hidden,
+  'collapsed': instance.collapsed,
+  'deletedAt': instance.deletedAt?.toIso8601String(),
+  'runtimeType': instance.$type,
+};
+
+SupersedesLink _$SupersedesLinkFromJson(Map<String, dynamic> json) =>
+    SupersedesLink(
+      id: json['id'] as String,
+      fromId: json['fromId'] as String,
+      toId: json['toId'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      vectorClock: json['vectorClock'] == null
+          ? null
+          : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
+      hidden: json['hidden'] as bool?,
+      collapsed: json['collapsed'] as bool?,
+      deletedAt: json['deletedAt'] == null
+          ? null
+          : DateTime.parse(json['deletedAt'] as String),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$SupersedesLinkToJson(SupersedesLink instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'fromId': instance.fromId,
+      'toId': instance.toId,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'vectorClock': instance.vectorClock,
+      'hidden': instance.hidden,
+      'collapsed': instance.collapsed,
+      'deletedAt': instance.deletedAt?.toIso8601String(),
+      'runtimeType': instance.$type,
+    };

--- a/lib/database/conversions.dart
+++ b/lib/database/conversions.dart
@@ -261,6 +261,11 @@ LinkedDbEntry linkedDbEntity(EntryLink link) {
       basic: (_) => 'BasicLink',
       rating: (_) => 'RatingLink',
       project: (_) => 'ProjectLink',
+      blocks: (_) => 'BlocksLink',
+      followsUp: (_) => 'FollowsUpLink',
+      duplicates: (_) => 'DuplicatesLink',
+      fixes: (_) => 'FixesLink',
+      supersedes: (_) => 'SupersedesLink',
     ),
   );
 }

--- a/lib/database/database_links_ratings.dart
+++ b/lib/database/database_links_ratings.dart
@@ -307,6 +307,43 @@ mixin _JournalDbLinksRatings
     );
   }
 
+  /// Returns typed links (e.g. `blocks`, `followsUp`) touching any of [ids]
+  /// in either direction, restricted to [types] (the `linked_entries.type`
+  /// column values from [linkedDbEntity], e.g. `'BlocksLink'`).
+  ///
+  /// Two indexed selects — one on `to_id`, one on `from_id`, both scoped by
+  /// `type` — unioned and deduplicated by link id in Dart, mirroring the
+  /// [basicLinksForEntryIds] discipline. Unlike that method, this is not
+  /// microtask-coalesced: callers batch their own id sets, and the type set
+  /// is typically small and stable per call site, so a coalescing wave would
+  /// add complexity without the fan-out pressure that justifies it there.
+  Future<List<EntryLink>> typedLinksForTaskIds(
+    Set<String> ids, {
+    required Set<String> types,
+  }) async {
+    if (ids.isEmpty || types.isEmpty) return <EntryLink>[];
+    final idList = ids.toList(growable: false);
+    final typeList = types.toList(growable: false);
+
+    final toRows = await (select(linkedEntries)..where(
+          (t) => t.toId.isIn(idList) & t.type.isIn(typeList),
+        ))
+        .get();
+    final fromRows = await (select(linkedEntries)..where(
+          (t) => t.fromId.isIn(idList) & t.type.isIn(typeList),
+        ))
+        .get();
+
+    final seenIds = <String>{};
+    final result = <EntryLink>[];
+    for (final row in toRows.followedBy(fromRows)) {
+      if (seenIds.add(row.id)) {
+        result.add(entryLinkFromLinkedDbEntry(row));
+      }
+    }
+    return result;
+  }
+
   Future<List<EntryLink>> linksForEntryIdsBidirectional(Set<String> ids) async {
     if (ids.isEmpty) return <EntryLink>[];
     final idList = ids.toList();

--- a/lib/logic/persistence_entries.dart
+++ b/lib/logic/persistence_entries.dart
@@ -17,6 +17,12 @@ import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 
+/// Depth cap for [PersistenceEntries._wouldCreateBlocksCycle]'s local
+/// traversal. Task-relationship chains are short in practice (ADR 0042 §4:
+/// readiness is one hop, chains are the exception); this bounds the
+/// best-effort creation-time guard without needing a real graph size limit.
+const _blocksCycleGuardMaxHops = 64;
+
 /// Metadata, link and entry-creation entry points of [PersistenceLogic].
 ///
 /// Owns [createMetadata]/[updateMetadata] (delegating to [MetadataService]),
@@ -174,7 +180,17 @@ class PersistenceEntries extends PersistenceCollaboratorBase {
     required String fromId,
     required String toId,
     bool collapsed = false,
+    EntryLinkType linkType = EntryLinkType.basic,
   }) async {
+    // Creation-time cycle guard (ADR 0042 §5): best-effort, local. A cycle
+    // can still be created by concurrent offline writes on two devices, so
+    // read-time traversal must tolerate cycles regardless — this only stops
+    // the common single-device case from creating one in the first place.
+    if (linkType == EntryLinkType.blocks &&
+        await _wouldCreateBlocksCycle(fromId: fromId, toId: toId)) {
+      return false;
+    }
+
     // Invariant: once the link upsert hits disk, the VC counter is claimed on
     // disk and MUST commit. If the upsert reports "no row changed", the
     // counter has no payload and must be burnt instead.
@@ -182,7 +198,7 @@ class PersistenceEntries extends PersistenceCollaboratorBase {
       () async {
         final now = DateTime.now();
 
-        final link = EntryLink.basic(
+        final link = linkType.buildLink(
           id: uuid.v1(),
           fromId: fromId,
           toId: toId,
@@ -229,6 +245,42 @@ class PersistenceEntries extends PersistenceCollaboratorBase {
       },
       commitWhen: (created) => created,
     );
+  }
+
+  /// Whether inserting `blocks` edge `fromId -> toId` would close a cycle
+  /// already visible on this device (ADR 0042 §5): true iff [fromId] is
+  /// reachable by following existing `blocks` edges forward from [toId].
+  ///
+  /// Bounded breadth-first traversal via `JournalDb.typedLinksForTaskIds` —
+  /// batched per hop rather than per-node, and capped at
+  /// `_blocksCycleGuardMaxHops` hops so a pathological chain cannot make
+  /// link creation hang.
+  Future<bool> _wouldCreateBlocksCycle({
+    required String fromId,
+    required String toId,
+  }) async {
+    if (fromId == toId) return true;
+
+    final visited = <String>{toId};
+    var frontier = <String>{toId};
+
+    for (var hop = 0; hop < _blocksCycleGuardMaxHops && frontier.isNotEmpty;
+        hop++) {
+      final links = await journalDb.typedLinksForTaskIds(
+        frontier,
+        types: const {'BlocksLink'},
+      );
+
+      final next = <String>{};
+      for (final link in links) {
+        if (!frontier.contains(link.fromId)) continue;
+        final blocked = link.toId;
+        if (blocked == fromId) return true;
+        if (visited.add(blocked)) next.add(blocked);
+      }
+      frontier = next;
+    }
+    return false;
   }
 
   Future<bool?> createDbEntity(

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/event_data.dart';
 import 'package:lotti/classes/geolocation.dart';
@@ -169,7 +170,13 @@ class PersistenceLogic implements PersistenceLogicContract {
     required String fromId,
     required String toId,
     bool collapsed = false,
-  }) => _entries.createLink(fromId: fromId, toId: toId, collapsed: collapsed);
+    EntryLinkType linkType = EntryLinkType.basic,
+  }) => _entries.createLink(
+    fromId: fromId,
+    toId: toId,
+    collapsed: collapsed,
+    linkType: linkType,
+  );
 
   @override
   Future<bool?> createDbEntity(

--- a/test/classes/entry_link_test.dart
+++ b/test/classes/entry_link_test.dart
@@ -386,9 +386,270 @@ void main() {
       },
     );
   });
+
+  group('Typed task-relationship links (ADR 0042)', () {
+    final typedTestDate = DateTime(2024, 5, 1, 9);
+
+    final variants =
+        <
+          ({
+            String label,
+            EntryLink Function({
+              required String id,
+              required String fromId,
+              required String toId,
+              required DateTime createdAt,
+              required DateTime updatedAt,
+              required VectorClock? vectorClock,
+            })
+            build,
+            String dbType,
+            EntryLinkType linkType,
+          })
+        >[
+          (
+            label: 'blocks',
+            build:
+                ({
+                  required id,
+                  required fromId,
+                  required toId,
+                  required createdAt,
+                  required updatedAt,
+                  required vectorClock,
+                }) => EntryLink.blocks(
+                  id: id,
+                  fromId: fromId,
+                  toId: toId,
+                  createdAt: createdAt,
+                  updatedAt: updatedAt,
+                  vectorClock: vectorClock,
+                ),
+            dbType: 'BlocksLink',
+            linkType: EntryLinkType.blocks,
+          ),
+          (
+            label: 'followsUp',
+            build:
+                ({
+                  required id,
+                  required fromId,
+                  required toId,
+                  required createdAt,
+                  required updatedAt,
+                  required vectorClock,
+                }) => EntryLink.followsUp(
+                  id: id,
+                  fromId: fromId,
+                  toId: toId,
+                  createdAt: createdAt,
+                  updatedAt: updatedAt,
+                  vectorClock: vectorClock,
+                ),
+            dbType: 'FollowsUpLink',
+            linkType: EntryLinkType.followsUp,
+          ),
+          (
+            label: 'duplicates',
+            build:
+                ({
+                  required id,
+                  required fromId,
+                  required toId,
+                  required createdAt,
+                  required updatedAt,
+                  required vectorClock,
+                }) => EntryLink.duplicates(
+                  id: id,
+                  fromId: fromId,
+                  toId: toId,
+                  createdAt: createdAt,
+                  updatedAt: updatedAt,
+                  vectorClock: vectorClock,
+                ),
+            dbType: 'DuplicatesLink',
+            linkType: EntryLinkType.duplicates,
+          ),
+          (
+            label: 'fixes',
+            build:
+                ({
+                  required id,
+                  required fromId,
+                  required toId,
+                  required createdAt,
+                  required updatedAt,
+                  required vectorClock,
+                }) => EntryLink.fixes(
+                  id: id,
+                  fromId: fromId,
+                  toId: toId,
+                  createdAt: createdAt,
+                  updatedAt: updatedAt,
+                  vectorClock: vectorClock,
+                ),
+            dbType: 'FixesLink',
+            linkType: EntryLinkType.fixes,
+          ),
+          (
+            label: 'supersedes',
+            build:
+                ({
+                  required id,
+                  required fromId,
+                  required toId,
+                  required createdAt,
+                  required updatedAt,
+                  required vectorClock,
+                }) => EntryLink.supersedes(
+                  id: id,
+                  fromId: fromId,
+                  toId: toId,
+                  createdAt: createdAt,
+                  updatedAt: updatedAt,
+                  vectorClock: vectorClock,
+                ),
+            dbType: 'SupersedesLink',
+            linkType: EntryLinkType.supersedes,
+          ),
+        ];
+
+    for (final variant in variants) {
+      EntryLink buildLink() => variant.build(
+        id: 'link-${variant.label}',
+        fromId: 'from-${variant.label}',
+        toId: 'to-${variant.label}',
+        createdAt: typedTestDate,
+        updatedAt: typedTestDate,
+        vectorClock: const VectorClock({'host': 3}),
+      );
+
+      test(
+        '${variant.label}: round-trips through JSON preserving the variant',
+        () {
+          final link = buildLink();
+
+          final restored = EntryLink.fromJson(
+            jsonDecode(jsonEncode(link)) as Map<String, dynamic>,
+          );
+
+          expect(restored, equals(link));
+          expect(restored.runtimeType, link.runtimeType);
+          expect(restored.fromId, 'from-${variant.label}');
+          expect(restored.toId, 'to-${variant.label}');
+        },
+      );
+
+      test(
+        '${variant.label}: linkedDbEntity tags rows with the '
+        '${variant.dbType} type',
+        () {
+          final dbLink = linkedDbEntity(buildLink());
+
+          expect(dbLink.type, variant.dbType);
+          expect(dbLink.fromId, 'from-${variant.label}');
+          expect(dbLink.toId, 'to-${variant.label}');
+        },
+      );
+
+      test(
+        '${variant.label}: entryLinkFromLinkedDbEntry round-trips through '
+        'DB rows',
+        () {
+          final link = buildLink();
+
+          final restored = entryLinkFromLinkedDbEntry(linkedDbEntity(link));
+
+          expect(restored, equals(link));
+          expect(restored.runtimeType, link.runtimeType);
+        },
+      );
+
+      test(
+        'EntryLinkType.${variant.label}.buildLink constructs the matching '
+        'variant tagged as ${variant.dbType}',
+        () {
+          final built = variant.linkType.buildLink(
+            id: 'built-${variant.label}',
+            fromId: 'from-x',
+            toId: 'to-x',
+            createdAt: typedTestDate,
+            updatedAt: typedTestDate,
+            vectorClock: null,
+          );
+
+          expect(built.runtimeType, buildLink().runtimeType);
+          expect(linkedDbEntity(built).type, variant.dbType);
+        },
+      );
+    }
+
+    test('EntryLinkType.rating.buildLink constructs a RatingLink', () {
+      final built = EntryLinkType.rating.buildLink(
+        id: 'built-rating',
+        fromId: 'from-x',
+        toId: 'to-x',
+        createdAt: typedTestDate,
+        updatedAt: typedTestDate,
+        vectorClock: null,
+      );
+
+      expect(built, isA<RatingLink>());
+      expect(linkedDbEntity(built).type, 'RatingLink');
+    });
+
+    test('EntryLinkType.project.buildLink constructs a ProjectLink', () {
+      final built = EntryLinkType.project.buildLink(
+        id: 'built-project',
+        fromId: 'from-x',
+        toId: 'to-x',
+        createdAt: typedTestDate,
+        updatedAt: typedTestDate,
+        vectorClock: null,
+      );
+
+      expect(built, isA<ProjectLink>());
+      expect(linkedDbEntity(built).type, 'ProjectLink');
+    });
+
+    test(
+      'fallback union: a genuinely unknown future type degrades to '
+      'BasicLink without crashing',
+      () {
+        // Simulates a build receiving a relationship variant introduced
+        // after it shipped (e.g. the deferred 'causes'/'clones' verbs from
+        // ADR 0042 §3) — must degrade to a visible plain link, not crash.
+        final json = <String, dynamic>{
+          'runtimeType': 'causes',
+          'id': 'link-future',
+          'fromId': 'a',
+          'toId': 'b',
+          'createdAt': typedTestDate.toIso8601String(),
+          'updatedAt': typedTestDate.toIso8601String(),
+          'vectorClock': null,
+        };
+
+        final restored = EntryLink.fromJson(json);
+
+        expect(restored, isA<BasicLink>());
+        expect(restored.id, 'link-future');
+        expect(restored.fromId, 'a');
+        expect(restored.toId, 'b');
+      },
+    );
+  });
 }
 
-enum _GeneratedEntryLinkKind { basic, rating, project }
+enum _GeneratedEntryLinkKind {
+  basic,
+  rating,
+  project,
+  blocks,
+  followsUp,
+  duplicates,
+  fixes,
+  supersedes,
+}
 
 class _GeneratedEntryLink {
   const _GeneratedEntryLink({
@@ -452,6 +713,61 @@ class _GeneratedEntryLink {
         deletedAt: common.deletedAt,
       ),
       _GeneratedEntryLinkKind.project => EntryLink.project(
+        id: common.id,
+        fromId: common.fromId,
+        toId: common.toId,
+        createdAt: common.createdAt,
+        updatedAt: common.updatedAt,
+        vectorClock: common.vectorClock,
+        hidden: common.hidden,
+        collapsed: common.collapsed,
+        deletedAt: common.deletedAt,
+      ),
+      _GeneratedEntryLinkKind.blocks => EntryLink.blocks(
+        id: common.id,
+        fromId: common.fromId,
+        toId: common.toId,
+        createdAt: common.createdAt,
+        updatedAt: common.updatedAt,
+        vectorClock: common.vectorClock,
+        hidden: common.hidden,
+        collapsed: common.collapsed,
+        deletedAt: common.deletedAt,
+      ),
+      _GeneratedEntryLinkKind.followsUp => EntryLink.followsUp(
+        id: common.id,
+        fromId: common.fromId,
+        toId: common.toId,
+        createdAt: common.createdAt,
+        updatedAt: common.updatedAt,
+        vectorClock: common.vectorClock,
+        hidden: common.hidden,
+        collapsed: common.collapsed,
+        deletedAt: common.deletedAt,
+      ),
+      _GeneratedEntryLinkKind.duplicates => EntryLink.duplicates(
+        id: common.id,
+        fromId: common.fromId,
+        toId: common.toId,
+        createdAt: common.createdAt,
+        updatedAt: common.updatedAt,
+        vectorClock: common.vectorClock,
+        hidden: common.hidden,
+        collapsed: common.collapsed,
+        deletedAt: common.deletedAt,
+      ),
+      _GeneratedEntryLinkKind.fixes => EntryLink.fixes(
+        id: common.id,
+        fromId: common.fromId,
+        toId: common.toId,
+        createdAt: common.createdAt,
+        updatedAt: common.updatedAt,
+        vectorClock: common.vectorClock,
+        hidden: common.hidden,
+        collapsed: common.collapsed,
+        deletedAt: common.deletedAt,
+      ),
+      _GeneratedEntryLinkKind.supersedes => EntryLink.supersedes(
         id: common.id,
         fromId: common.fromId,
         toId: common.toId,

--- a/test/database/database_links_ratings_test.dart
+++ b/test/database/database_links_ratings_test.dart
@@ -640,6 +640,178 @@ void main() {
       });
     });
 
+    group('typedLinksForTaskIds -', () {
+      EntryLink buildBlocksLink({
+        required String id,
+        required String fromId,
+        required String toId,
+        required DateTime timestamp,
+      }) {
+        return EntryLink.blocks(
+          id: id,
+          fromId: fromId,
+          toId: toId,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          vectorClock: const VectorClock({'db': 1}),
+        );
+      }
+
+      test('returns empty list for empty ids', () async {
+        final results = await db!.typedLinksForTaskIds(
+          <String>{},
+          types: {'BlocksLink'},
+        );
+        expect(results, isEmpty);
+      });
+
+      test('returns empty list for empty types', () async {
+        await db!.upsertEntryLink(
+          buildBlocksLink(
+            id: 'typed-empty-types',
+            fromId: 'blocker',
+            toId: 'blocked',
+            timestamp: DateTime(2024, 10, 1),
+          ),
+        );
+
+        final results = await db!.typedLinksForTaskIds(
+          {'blocker', 'blocked'},
+          types: <String>{},
+        );
+        expect(results, isEmpty);
+      });
+
+      test('matches a link via the to_id side', () async {
+        await db!.upsertEntryLink(
+          buildBlocksLink(
+            id: 'typed-to-side',
+            fromId: 'blocker-a',
+            toId: 'blocked-a',
+            timestamp: DateTime(2024, 10, 2),
+          ),
+        );
+
+        final results = await db!.typedLinksForTaskIds(
+          {'blocked-a'},
+          types: {'BlocksLink'},
+        );
+
+        expect(results.map((l) => l.id), ['typed-to-side']);
+      });
+
+      test('matches a link via the from_id side', () async {
+        await db!.upsertEntryLink(
+          buildBlocksLink(
+            id: 'typed-from-side',
+            fromId: 'blocker-b',
+            toId: 'blocked-b',
+            timestamp: DateTime(2024, 10, 3),
+          ),
+        );
+
+        final results = await db!.typedLinksForTaskIds(
+          {'blocker-b'},
+          types: {'BlocksLink'},
+        );
+
+        expect(results.map((l) => l.id), ['typed-from-side']);
+      });
+
+      test(
+        'deduplicates a link matching both the from_id and to_id side',
+        () async {
+          await db!.upsertEntryLink(
+            buildBlocksLink(
+              id: 'typed-both-sides',
+              fromId: 'task-x',
+              toId: 'task-y',
+              timestamp: DateTime(2024, 10, 4),
+            ),
+          );
+
+          final results = await db!.typedLinksForTaskIds(
+            {'task-x', 'task-y'},
+            types: {'BlocksLink'},
+          );
+
+          expect(results.map((l) => l.id).toList(), ['typed-both-sides']);
+        },
+      );
+
+      test('restricts results to the requested type set', () async {
+        await db!.upsertEntryLink(
+          buildBlocksLink(
+            id: 'typed-blocks',
+            fromId: 'blocker-c',
+            toId: 'shared-task',
+            timestamp: DateTime(2024, 10, 5),
+          ),
+        );
+        await db!.upsertEntryLink(
+          EntryLink.followsUp(
+            id: 'typed-follows-up',
+            fromId: 'follower-c',
+            toId: 'shared-task',
+            createdAt: DateTime(2024, 10, 5),
+            updatedAt: DateTime(2024, 10, 5),
+            vectorClock: const VectorClock({'db': 1}),
+          ),
+        );
+        await db!.upsertEntryLink(
+          buildEntryLink(
+            id: 'typed-basic',
+            fromId: 'basic-c',
+            toId: 'shared-task',
+            timestamp: DateTime(2024, 10, 5),
+          ),
+        );
+
+        final blocksOnly = await db!.typedLinksForTaskIds(
+          {'shared-task'},
+          types: {'BlocksLink'},
+        );
+        expect(blocksOnly.map((l) => l.id), ['typed-blocks']);
+
+        final blocksAndFollowUps = await db!.typedLinksForTaskIds(
+          {'shared-task'},
+          types: {'BlocksLink', 'FollowsUpLink'},
+        );
+        expect(blocksAndFollowUps.map((l) => l.id).toSet(), {
+          'typed-blocks',
+          'typed-follows-up',
+        });
+      });
+
+      test(
+        'excludes links removed via deleteLink (tombstone exclusion)',
+        () async {
+          await db!.upsertEntryLink(
+            buildBlocksLink(
+              id: 'typed-removed',
+              fromId: 'blocker-d',
+              toId: 'blocked-d',
+              timestamp: DateTime(2024, 10, 6),
+            ),
+          );
+
+          final beforeDelete = await db!.typedLinksForTaskIds(
+            {'blocked-d'},
+            types: {'BlocksLink'},
+          );
+          expect(beforeDelete, hasLength(1));
+
+          await db!.deleteLink('blocker-d', 'blocked-d');
+
+          final afterDelete = await db!.typedLinksForTaskIds(
+            {'blocked-d'},
+            types: {'BlocksLink'},
+          );
+          expect(afterDelete, isEmpty);
+        },
+      );
+    });
+
     group('Rating queries -', () {
       final base = DateTime(2024, 9, 1, 10);
 

--- a/test/features/sync/matrix/sync_event_processor_journal_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_journal_handlers_test.dart
@@ -1,11 +1,13 @@
 // ignore_for_file: avoid_redundant_argument_values
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/database/journal_update_result.dart';
 import 'package:lotti/features/sync/matrix/sync_event_processor.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
@@ -388,6 +390,93 @@ void main() {
       expect(capturedLink.collapsed, isTrue);
       expect(capturedLink.updatedAt, DateTime(2025, 1, 2));
     });
+  });
+
+  group('SyncEventProcessor - typed EntryLink round-trip (ADR 0042)', () {
+    late JournalDb realJournalDb;
+
+    setUp(() {
+      realJournalDb = JournalDb(inMemoryDatabase: true);
+    });
+
+    tearDown(() async {
+      await realJournalDb.close();
+    });
+
+    test(
+      'a typed blocks link serializes, is received over sync, upserts, and '
+      'reads back with its type preserved',
+      () async {
+        final link = EntryLink.blocks(
+          id: 'sync-blocks-link',
+          fromId: 'blocker-task',
+          toId: 'blocked-task',
+          createdAt: DateTime(2024, 6, 1),
+          updatedAt: DateTime(2024, 6, 1),
+          vectorClock: const VectorClock({'host-sync': 1}),
+        );
+        final message = SyncMessage.entryLink(
+          entryLink: link,
+          status: SyncEntryStatus.initial,
+        );
+
+        when(() => event.text).thenReturn(encodeMessage(message));
+
+        await processor.process(event: event, journalDb: realJournalDb);
+
+        final stored = await realJournalDb.entryLinkById('sync-blocks-link');
+        expect(stored, isA<BlocksLink>());
+        expect(stored!.fromId, 'blocker-task');
+        expect(stored.toId, 'blocked-task');
+
+        final typed = await realJournalDb.typedLinksForTaskIds(
+          {'blocked-task'},
+          types: {'BlocksLink'},
+        );
+        expect(typed.map((l) => l.id), ['sync-blocks-link']);
+      },
+    );
+
+    test(
+      'a future/unknown link type received over sync degrades to a plain '
+      'BasicLink and upserts without crashing',
+      () async {
+        final baseMessage = SyncMessage.entryLink(
+          entryLink: EntryLink.basic(
+            id: 'sync-future-link',
+            fromId: 'future-a',
+            toId: 'future-b',
+            createdAt: DateTime(2024, 6, 2),
+            updatedAt: DateTime(2024, 6, 2),
+            vectorClock: null,
+          ),
+          status: SyncEntryStatus.initial,
+        );
+
+        // Simulate the wire payload from a build that already knows a
+        // relationship type this build doesn't (e.g. a deferred ADR 0042 §3
+        // verb like 'causes'): round-trip through real JSON once (so nested
+        // `EntryLink.toJson()` materializes into a plain map, matching what
+        // actually crosses the wire), then mutate the nested runtimeType to
+        // an unknown string.
+        final rawJson =
+            jsonDecode(jsonEncode(baseMessage.toJson()))
+                as Map<String, dynamic>;
+        (rawJson['entryLink']! as Map<String, dynamic>)['runtimeType'] =
+            'causes';
+
+        when(
+          () => event.text,
+        ).thenReturn(base64.encode(utf8.encode(json.encode(rawJson))));
+
+        await processor.process(event: event, journalDb: realJournalDb);
+
+        final stored = await realJournalDb.entryLinkById('sync-future-link');
+        expect(stored, isA<BasicLink>());
+        expect(stored!.fromId, 'future-a');
+        expect(stored.toId, 'future-b');
+      },
+    );
   });
 
   group('EntryLink sequence log recording -', () {

--- a/test/logic/persistence_entries_test.dart
+++ b/test/logic/persistence_entries_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/journal_update_result.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -124,4 +125,302 @@ void main() {
       verifyNever(() => outboxService.enqueueMessage(any()));
     },
   );
+
+  group('createLink linkType -', () {
+    setUp(() {
+      when(
+        () => vectorClockService.getNextVectorClock(),
+      ).thenAnswer((_) async => const VectorClock({'host': 1}));
+      when(
+        () => mocks.journalDb.upsertEntryLink(any()),
+      ).thenAnswer((_) async => 1);
+    });
+
+    test('defaults to a BasicLink and never queries the cycle guard', () async {
+      final created = await entries.createLink(fromId: 'a', toId: 'b');
+
+      expect(created, isTrue);
+      verifyNever(
+        () => mocks.journalDb.typedLinksForTaskIds(
+          any(),
+          types: any(named: 'types'),
+        ),
+      );
+      final persisted =
+          verify(
+                () => mocks.journalDb.upsertEntryLink(captureAny()),
+              ).captured.single
+              as EntryLink;
+      expect(persisted, isA<BasicLink>());
+    });
+
+    test(
+      'a non-blocks linkType skips the cycle guard and persists that variant',
+      () async {
+        final created = await entries.createLink(
+          fromId: 'a',
+          toId: 'b',
+          linkType: EntryLinkType.followsUp,
+        );
+
+        expect(created, isTrue);
+        verifyNever(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            any(),
+            types: any(named: 'types'),
+          ),
+        );
+        final persisted =
+            verify(
+                  () => mocks.journalDb.upsertEntryLink(captureAny()),
+                ).captured.single
+                as EntryLink;
+        expect(persisted, isA<FollowsUpLink>());
+      },
+    );
+
+    test(
+      'rejects a direct self-block without querying the database',
+      () async {
+        final created = await entries.createLink(
+          fromId: 'same',
+          toId: 'same',
+          linkType: EntryLinkType.blocks,
+        );
+
+        expect(created, isFalse);
+        verifyNever(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            any(),
+            types: any(named: 'types'),
+          ),
+        );
+        verifyNever(() => mocks.journalDb.upsertEntryLink(any()));
+      },
+    );
+
+    test(
+      'creates a BlocksLink when no existing chain closes a cycle',
+      () async {
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            any(),
+            types: any(named: 'types'),
+          ),
+        ).thenAnswer((_) async => <EntryLink>[]);
+
+        final created = await entries.createLink(
+          fromId: 'a',
+          toId: 'b',
+          linkType: EntryLinkType.blocks,
+        );
+
+        expect(created, isTrue);
+        final persisted =
+            verify(
+                  () => mocks.journalDb.upsertEntryLink(captureAny()),
+                ).captured.single
+                as EntryLink;
+        expect(persisted, isA<BlocksLink>());
+      },
+    );
+
+    test(
+      'rejects a blocks edge that would immediately close a 1-hop cycle',
+      () async {
+        // b already blocks a, so creating a-blocks-b would close the loop.
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'b'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer(
+          (_) async => [
+            EntryLink.blocks(
+              id: 'existing',
+              fromId: 'b',
+              toId: 'a',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+          ],
+        );
+
+        final created = await entries.createLink(
+          fromId: 'a',
+          toId: 'b',
+          linkType: EntryLinkType.blocks,
+        );
+
+        expect(created, isFalse);
+        verifyNever(() => mocks.journalDb.upsertEntryLink(any()));
+      },
+    );
+
+    test(
+      'rejects a blocks edge that would close a transitive 2-hop cycle',
+      () async {
+        // b blocks c, and c already blocks a, so a-blocks-b would close the
+        // loop two hops out.
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'b'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer(
+          (_) async => [
+            EntryLink.blocks(
+              id: 'hop-1',
+              fromId: 'b',
+              toId: 'c',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+          ],
+        );
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'c'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer(
+          (_) async => [
+            EntryLink.blocks(
+              id: 'hop-2',
+              fromId: 'c',
+              toId: 'a',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+          ],
+        );
+
+        final created = await entries.createLink(
+          fromId: 'a',
+          toId: 'b',
+          linkType: EntryLinkType.blocks,
+        );
+
+        expect(created, isFalse);
+        verifyNever(() => mocks.journalDb.upsertEntryLink(any()));
+      },
+    );
+
+    test(
+      'ignores an inbound link where the frontier task is only the target, '
+      'not the source of the blocks edge',
+      () async {
+        // 'x' blocks 'b' -- 'b' is the target here, not the source, so the
+        // outward-only traversal from 'b' must skip it rather than treating
+        // 'x' as something 'b' blocks.
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'b'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer(
+          (_) async => [
+            EntryLink.blocks(
+              id: 'irrelevant-inbound',
+              fromId: 'x',
+              toId: 'b',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+          ],
+        );
+
+        final created = await entries.createLink(
+          fromId: 'a',
+          toId: 'b',
+          linkType: EntryLinkType.blocks,
+        );
+
+        expect(created, isTrue);
+      },
+    );
+
+    test(
+      'deduplicates a target reached from two frontier nodes in the same '
+      'hop instead of re-querying it twice',
+      () async {
+        // b blocks both c and d; c and d both block e -- e must be queried
+        // exactly once as the next frontier, not twice.
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'b'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer(
+          (_) async => [
+            EntryLink.blocks(
+              id: 'b-blocks-c',
+              fromId: 'b',
+              toId: 'c',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+            EntryLink.blocks(
+              id: 'b-blocks-d',
+              fromId: 'b',
+              toId: 'd',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+          ],
+        );
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'c', 'd'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer(
+          (_) async => [
+            EntryLink.blocks(
+              id: 'c-blocks-e',
+              fromId: 'c',
+              toId: 'e',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+            EntryLink.blocks(
+              id: 'd-blocks-e',
+              fromId: 'd',
+              toId: 'e',
+              createdAt: DateTime(2024),
+              updatedAt: DateTime(2024),
+              vectorClock: null,
+            ),
+          ],
+        );
+        when(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'e'},
+            types: {'BlocksLink'},
+          ),
+        ).thenAnswer((_) async => <EntryLink>[]);
+
+        final created = await entries.createLink(
+          fromId: 'a',
+          toId: 'b',
+          linkType: EntryLinkType.blocks,
+        );
+
+        expect(created, isTrue);
+        verify(
+          () => mocks.journalDb.typedLinksForTaskIds(
+            {'e'},
+            types: {'BlocksLink'},
+          ),
+        ).called(1);
+      },
+    );
+  });
 }

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -2491,6 +2491,37 @@ void main() {
           verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
         },
       );
+
+      test(
+        'createLink forwards linkType through to the persisted variant',
+        () async {
+          when(
+            () => journalDb.upsertEntryLink(any<EntryLink>()),
+          ).thenAnswer((_) async => 1);
+          when(
+            () => journalDb.typedLinksForTaskIds(
+              any(),
+              types: any(named: 'types'),
+            ),
+          ).thenAnswer((_) async => <EntryLink>[]);
+
+          final created = await logic.createLink(
+            fromId: 'blocker-id',
+            toId: 'blocked-id',
+            linkType: EntryLinkType.blocks,
+          );
+
+          expect(created, isTrue);
+          final persisted =
+              verify(
+                    () => journalDb.upsertEntryLink(captureAny<EntryLink>()),
+                  ).captured.single
+                  as EntryLink;
+          expect(persisted, isA<BlocksLink>());
+          expect(persisted.fromId, 'blocker-id');
+          expect(persisted.toId, 'blocked-id');
+        },
+      );
     });
 
     test(


### PR DESCRIPTION
## Summary
- Phase 1 (of 3 active phases) of the plan in `docs/implementation_plans/2026-07-23_task_dependency_links.md` — the link substrate only, ships alone ahead of any UI writes per ADR 0042's old-build compatibility window.
- Adds `blocks`/`followsUp`/`duplicates`/`fixes`/`supersedes` as new `EntryLink` union variants on the existing `linked_entries` table (no schema change) plus an `EntryLinkType` enum with a `buildLink` factory.
- `linkedDbEntity` derives the new type-column strings; `typedLinksForTaskIds` is a new type-scoped batch query (both directions, mirrors `basicLinksForEntryIds`'s discipline).
- `createLink` gains an optional `linkType` parameter (defaults to `basic`, zero call-site churn) and runs a bounded local cycle guard before creating a `blocks` edge (ADR 0042 §5).
- No UI, no ready-frontier/agent integration yet — those are Phases 2 and 3, not included here.

## Test plan
- [x] `flutter analyze` clean project-wide
- [x] 268 tests green across the touched files: variant round-trips + type-column tagging (`entry_link_test.dart`), query direction/type-scoping/tombstone-exclusion (`database_links_ratings_test.dart`), cycle-guard scenarios — self-loop, 1-hop, 2-hop, dedup, inbound-link filtering (`persistence_entries_test.dart`), facade delegation (`persistence_logic_test.dart`), a genuine sync round-trip through `SyncEventProcessor` against a real in-memory DB, and a fallback-union test proving an unknown future type degrades to `BasicLink` without crashing (`sync_event_processor_journal_handlers_test.dart`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed task relationships: blocks, follows up, duplicates, fixes, and supersedes.
  * Added support for creating, storing, syncing, and querying links by relationship type.
  * Prevented creation of circular “blocks” relationships.

* **Bug Fixes**
  * Unknown future relationship types now safely fall back to a basic link.
  * Link queries now correctly deduplicate results and exclude deleted links.

* **Tests**
  * Added coverage for serialization, database persistence, synchronization, filtering, and cycle prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->