### PR TITLE
ci: restore sharded coverage, drop serial coverage chunk lane

### DIFF
--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -58,14 +58,18 @@ jobs:
         run: dart pub global activate very_good_cli
       - name: Run Flutter tests (standard)
         run: |
-          # Shards gate test PASSING only. Coverage moved to the dedicated
-          # `coverage` job below: coverage recording under the sharded
-          # very_good runner proved unreliable (whole suites' hits vanished
-          # from every shard's lcov nondeterministically between runs while
-          # their tests passed), so the fast lane no longer records it.
-          very_good test --exclude-tags glados -- \
+          very_good test --coverage --exclude-tags glados -- \
             --total-shards=10 \
             --shard-index=${{ matrix.shard_index }}
+      - uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: matthiasn/lotti
+          version: v11.2.8
+          fail_ci_if_error: true
+          flags: standard
+          name: standard-shard-${{ matrix.shard_label }}
+          files: coverage/lcov.info
 
   glados:
     name: Glados Property Tests (Linux)
@@ -101,122 +105,16 @@ jobs:
           flags: glados
           files: coverage/lcov.info
 
-  coverage:
-    name: Coverage (chunk ${{ matrix.chunk }}/6)
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        chunk: [0, 1, 2, 3, 4, 5]
-    steps:
-      - uses: actions/checkout@v5
-      - name: Cache Pub Packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-      - uses: kuhnroyal/flutter-fvm-config-action@v2
-        id: fvm-config-action
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
-          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
-          cache: true
-      - name: Get dependencies
-        run: flutter pub get
-      # Plain `flutter test --coverage` in serial mode is the one collection
-      # mode that records reliably (the sharded very_good lane dropped whole
-      # suites' hits from its lcov nondeterministically while tests passed,
-      # and parallel isolates flake suites hardened for same-thread
-      # execution — see test/README.md). Serial for the whole suite exceeds
-      # the job timeout, so six chunk jobs each run a deterministic
-      # round-robin slice serially; the publish job merges the slices
-      # client-side into one upload.
-      - name: Run Flutter tests with coverage (chunk slice)
-        run: |
-          readarray -t FILES < <(find test -name '*_test.dart' | sort \
-            | awk "NR % 6 == ${{ matrix.chunk }}")
-          echo "chunk ${{ matrix.chunk }}: ${#FILES[@]} suites"
-          flutter test --coverage --concurrency=1 --exclude-tags glados \
-            "${FILES[@]}"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: coverage-chunk-${{ matrix.chunk }}
-          path: coverage/lcov.info
-          retention-days: 1
-          if-no-files-found: error
-
   codecov:
     name: Publish Codecov Status
     permissions:
       contents: read
     runs-on: ubuntu-latest
     needs:
-      - coverage
+      - test
       - glados
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-chunk-*
-          path: coverage-artifacts
-      - name: Merge chunk coverage
-        run: |
-          python3 - <<'EOF'
-          import collections
-          import glob
-          import os
-
-          # Union per (file, line) by max hits. All chunks come from plain
-          # `flutter test --coverage` on the same commit, so instrumentation
-          # (the DA line sets) is consistent across inputs. Only SF/DA matter
-          # to Codecov's line coverage.
-          hits = collections.defaultdict(dict)
-          inputs = sorted(glob.glob('coverage-artifacts/**/lcov.info',
-                                    recursive=True))
-          assert len(inputs) == 6, f'expected 6 chunk reports: {inputs}'
-          for path in inputs:
-              sf = None
-              for line in open(path):
-                  line = line.strip()
-                  if line.startswith('SF:'):
-                      sf = line[3:]
-                  elif line.startswith('DA:') and sf:
-                      number, hit = line[3:].split(',')[:2]
-                      number = int(number)
-                      hit = int(hit)
-                      per_file = hits[sf]
-                      per_file[number] = max(per_file.get(number, 0), hit)
-                  elif line == 'end_of_record':
-                      sf = None
-          os.makedirs('coverage', exist_ok=True)
-          with open('coverage/lcov.info', 'w') as out:
-              for sf in sorted(hits):
-                  out.write(f'SF:{sf}\n')
-                  per_file = hits[sf]
-                  for number in sorted(per_file):
-                      out.write(f'DA:{number},{per_file[number]}\n')
-                  covered = sum(1 for v in per_file.values() if v > 0)
-                  out.write(f'LF:{len(per_file)}\nLH:{covered}\n')
-                  out.write('end_of_record\n')
-          total = sum(len(v) for v in hits.values())
-          covered = sum(
-              1 for v in hits.values() for h in v.values() if h > 0)
-          print(f'merged {len(hits)} files, {covered}/{total} lines '
-                f'({covered / total:.2%})')
-          EOF
-      - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: matthiasn/lotti
-          version: v11.2.8
-          fail_ci_if_error: true
-          flags: standard
-          name: standard-merged
-          files: coverage/lcov.info
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,10 @@
 codecov:
   notify:
-    # The dedicated full-suite coverage job makes ONE standard-flag upload
-    # (the sharded very_good lane dropped whole suites' hits from its lcov
-    # nondeterministically, so it gates test passing only); the Glados job
-    # uploads its own flag. Two processed uploads total before the workflow
-    # sends its single notification.
-    after_n_builds: 2
+    # Sharded coverage uploads arrive independently, so do not let Codecov
+    # publish transient project statuses from a partial report set.
+    # Ten standard shards plus the Glados shard must be processed before the
+    # GitHub workflow sends its single notification.
+    after_n_builds: 11
     manual_trigger: true
     wait_for_ci: true
 


### PR DESCRIPTION
## Summary

PR #3544 (day-agent feature) also restructured the Linux test workflow as a side change: it stripped `--coverage` from the 10 fast `very_good test` shards and added a second full run of the entire test suite as six serial `flutter test --coverage --concurrency=1` chunk jobs (~28 min each), merged and uploaded by a publish job.

That took every branch push from ~60 to ~215 runner-minutes and kept six half-hour jobs holding concurrency slots per push, so PR checks across the repo queued for hours.

This reverts the workflow and `codecov.yml` to their pre-#3544 state, verified byte-for-byte against the old blobs:

- The 10 shards run `very_good test --coverage` again and each uploads its own Codecov report (flag `standard`).
- The six coverage chunk jobs and the client-side lcov merge/publish job are removed.
- `codecov.yml` `after_n_builds` goes back to 11 (ten standard shards + glados) so Codecov only notifies once all uploads are processed.

## Trade-off

The chunk lane existed because sharded very_good coverage occasionally drops a whole suite's hits from the lcov nondeterministically. Restoring the sharded uploads accepts that known flake: if a patch status randomly fails, rerunning the affected shard fixes it. Fast, unblocked PRs won over belt-and-braces coverage collection.

## Test plan

- CI on this PR runs the restored workflow itself: 10 shards (~4 min each) + glados, all uploading to Codecov, single notification after 11 builds.
- No Dart code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Linux unit and widget test shards now collect and upload coverage independently.
  * Coverage collection continues to exclude Glados-specific tests from standard shards.

* **Chores**
  * Coverage reporting now waits for all standard and Glados test shards before publishing results.
  * Simplified coverage processing by removing the previous artifact-merging workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->