### PR TITLE
feat: dependency-aware planning for day agents (ADR 0043)

### DIFF
--- a/docs/adr/0042-typed-task-relationship-links.md
+++ b/docs/adr/0042-typed-task-relationship-links.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adr/0043-dependency-aware-planning.md
+++ b/docs/adr/0043-dependency-aware-planning.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (depends on ADR 0042)
+Accepted
 
 ## Date
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,8 +32,8 @@ Each ADR should contain:
 
 | ADR | Status | Decision ownership |
 | --- | --- | --- |
-| [0042: Typed Task Relationship Links](./0042-typed-task-relationship-links.md) | Proposed | `EntryLink` union variants (blocks, followsUp, duplicates, fixes, supersedes), one stored edge with rendered inverses, derived one-hop readiness, cycle tolerance, suggestion-only lifecycle coupling. |
-| [0043: Dependency-Aware Planning](./0043-dependency-aware-planning.md) | Proposed | Ready frontier consumed by planning: corpus annotation (never exclusion), batch dependency resolver, drafting/digest prompt rules, task-detail visibility, explicit non-goals. |
+| [0042: Typed Task Relationship Links](./0042-typed-task-relationship-links.md) | Accepted | `EntryLink` union variants (blocks, followsUp, duplicates, fixes, supersedes), one stored edge with rendered inverses, derived one-hop readiness, cycle tolerance, suggestion-only lifecycle coupling. |
+| [0043: Dependency-Aware Planning](./0043-dependency-aware-planning.md) | Accepted | Ready frontier consumed by planning: corpus annotation (never exclusion), batch dependency resolver, drafting/digest prompt rules, task-detail visibility, explicit non-goals. |
 
 ### Relationship management decision cluster
 

--- a/lib/features/agents/state/agent_workflow_providers.dart
+++ b/lib/features/agents/state/agent_workflow_providers.dart
@@ -23,6 +23,7 @@ import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/notifications/repository/notification_repository.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
 
@@ -191,6 +192,7 @@ DayAgentWorkflow dayAgentWorkflow(Ref ref) {
     knowledgeService: ref.watch(dayAgentKnowledgeServiceProvider),
     weekContextService: ref.watch(dayAgentWeekContextServiceProvider),
     directiveService: ref.watch(dayAgentDirectiveServiceProvider),
+    dependencyResolver: ref.watch(taskDependencyResolverProvider),
     soulDocumentService: ref.watch(soulDocumentServiceProvider),
     dayAudioEntryContextService: DayAudioEntryContextService(
       journalDb: ref.watch(journalDbProvider),

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -131,6 +131,17 @@ preferred-name prompt when inference is ready but personalization is missing.
   statements), recent private observations, the day's `day_log`, and — for
   `capture_submitted:<captureId>` wakes — the submitted capture plus a bounded
   task corpus snapshot.
+- **Task corpus snapshot** (`DayAgentCorpusService.buildTaskCorpusSnapshot`,
+  ≤`maxCorpusTasks` rows): open tasks for the wake's allowed categories plus
+  every task due on or before the plan date, deduped and capped, projected to
+  `{taskId, title, status, categoryId, due, estimateMinutes, priority}`. It
+  serves two masters — capture matching (`match_to_corpus`) needs blocked
+  tasks to stay matchable, so the corpus never excludes anything, only
+  annotates it (ADR 0043 §1). When a `TaskDependencyResolver` is configured
+  (see "Dependency-aware planning" below), a row for a task with a live
+  `blocks` link gains a `blockedBy` array; a row with none gains no extra key
+  at all, so a dependency-free plan's corpus stays byte-identical to before —
+  important for prompt-prefix caching.
 - **The user message is tagged plaintext, not a JSON document.** The payload is
   a set of `<snake_case>` sections (`day_agent_prompt_sections.dart`) rather
   than one `jsonEncode`d map: tags keep JSON's named sections and boundary
@@ -1200,6 +1211,85 @@ dot (`dailyOsPlanDaysProvider` — one batched `getEntitiesByIds` lookup over th
 month's deterministic `day_agent_plan:<dayId>` ids), and tapping a day selects
 it via `dailyOsNextSelectedDateProvider`, which the already visible Daily OS
 surface reacts to directly.
+
+### Dependency-aware planning (ADR 0043)
+
+ADR 0042 gives tasks typed `blocks` links (see
+[`tasks/README.md`](../tasks/README.md#typed-relationships-adr-0042)); this
+section covers how the day-agent planning surfaces consume that substrate,
+per ADR 0043.
+
+`TaskDependencyResolver`
+(`lib/features/tasks/repository/task_dependency_resolver.dart`) answers
+"which of these task ids are blocked, and by what" in two bounded batch
+queries — one type-scoped `blocks`-link fetch, one batch status load for the
+distinct blocker ids — mirroring the batch-read discipline used elsewhere in
+this feature (e.g. the week-context service): never per-task fan-out, always
+one call against the whole id set. It is independent of, and not shared code
+with, the task feature's own `TaskBlockersController` (single-task, UI-facing,
+autoDispose-Riverpod-backed); the resolver is stateless, plain-Dart, and
+batch-shaped for a corpus of up to `maxCorpusTasks` ids.
+
+A blocker that resolves to a real, open task serializes with its title and
+status; a blocker link whose target can't be loaded (a sync gap) serializes
+as `{"taskId": "<id>"}` with no `title`/`status` keys — still a non-empty
+`blockedBy` entry, so "still blocked" is never silently downgraded to "ready"
+just because the blocker hasn't synced yet. This deliberately differs from
+the task detail header's `_TaskBlockedByChip`, which renders a bare
+untappable "Blocked" pill for the same case: the corpus is model-facing,
+where a bare id is a usable token, while the chip is human-facing, where a
+raw id is not.
+
+`dependencyResolver` is a single nullable field on `DayAgentWorkflow`
+(`ref.watch(taskDependencyResolverProvider)` in
+`agent_workflow_providers.dart`), threaded through
+`day_agent_context_builder.dart`'s capture-context assembly into
+`DayAgentCorpusService.buildTaskCorpusSnapshot`. One field drives both the
+corpus annotation and the prompt gates below, so they can never drift out of
+sync — there is no separate "is this feature on" flag.
+
+`day_agent_prompt_builder.dart` gates two prompt-contract additions on that
+same field, both empty-string when it's null (so a wake with no
+`TaskDependencyResolver` renders byte-identical to pre-ADR-0043):
+
+- **Blocked-work rules**, appended after the Refine rules, for any drafting or
+  refine wake: a task is "blocked for planning" when its corpus row shows
+  `"status": "BLOCKED"` (self-declared, ADR 0042 §4) **or** carries a
+  non-empty `blockedBy` (computed). Place it only if the same plan schedules
+  its blocker earlier the same day, or the block's `reason` explicitly names
+  the blocker and why the work can proceed anyway; prefer placing the
+  blocker itself when a decided/committed task turns out to be blocked.
+- **A digest-rule bullet**, appended to the ADR 0032 digest rules (coordinator
+  wakes only, and only when `directiveService` is also configured): a
+  directive commitment on blocked-for-planning work should target the
+  blocker instead, or name the blocker in an attention note so the per-day
+  agent inherits the dependency context from the directive itself.
+
+```mermaid
+flowchart LR
+  subgraph links [ADR 0042 substrate]
+    BL[blocks edges<br/>linked_entries]
+  end
+  subgraph reads [bounded batch reads]
+    DR[TaskDependencyResolver<br/>links + blocker statuses]
+  end
+  subgraph consumers
+    CS[corpus snapshot<br/>blockedBy annotation]
+    TD[task detail UI<br/>Blocked by / Blocks]
+  end
+  BL --> DR --> CS
+  BL --> TD
+  CS --> DA[day agent drafting/refine<br/>prompt rules]
+  CS --> CO[coordinator digest<br/>directive rules]
+```
+
+No topological scheduler and no automatic `TaskStatus` writes: ordering same-day
+blocks stays a judgment call the model makes through block `reasons`, and
+computed blockedness never mutates the task's stored status (ADR 0042 §4).
+Non-goals explicitly deferred: dependency-driven wake triggers (waking a day
+agent because a blocker just closed — the daily digest and normal planning
+cadence pick up released work instead), blocker-released notifications, and a
+`link_tasks` agent tool letting capture parsing assert dependencies directly.
 
 ## Keyboard and Accessible Commit Confirmation
 

--- a/lib/features/daily_os_next/agents/service/day_agent_capture_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_capture_service.dart
@@ -23,6 +23,7 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_triage_ser
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/create/task_agent_assignment.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -285,10 +286,12 @@ class DayAgentCaptureService {
     required Set<String> allowedCategoryIds,
     required DateTime day,
     int limit = DayAgentCorpusService.maxCorpusTasks,
+    TaskDependencyResolver? dependencyResolver,
   }) => _corpus.buildTaskCorpusSnapshot(
     allowedCategoryIds: allowedCategoryIds,
     day: day,
     limit: limit,
+    dependencyResolver: dependencyResolver,
   );
 
   /// Finds existing tasks that may match a capture phrase;

--- a/lib/features/daily_os_next/agents/service/day_agent_corpus_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_corpus_service.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart'
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_helpers.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_reads.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 
 /// FTS corpus matching + corpus-snapshot logic for the day-agent capture
 /// flow. The capture service keeps thin delegators so mocks of the service
@@ -35,10 +36,17 @@ class DayAgentCorpusService {
   final DayAgentCaptureReads reads;
 
   /// Build the bounded task corpus embedded in capture-triggered wakes.
+  ///
+  /// When [dependencyResolver] is supplied, blocked rows gain a `blockedBy`
+  /// key (ADR 0043 §1-2) — resolved once against the already-capped id set,
+  /// never per task. Omitting it (the default) keeps every row byte-identical
+  /// to the pre-ADR-0043 shape, which is what makes a dependency-free corpus
+  /// byte-stable.
   Future<List<Map<String, Object?>>> buildTaskCorpusSnapshot({
     required Set<String> allowedCategoryIds,
     required DateTime day,
     int limit = maxCorpusTasks,
+    TaskDependencyResolver? dependencyResolver,
   }) async {
     final dayStart = localDay(day);
     final openTasks = await journalDb.getOpenTasksForDayAgentCorpus(
@@ -60,6 +68,10 @@ class DayAgentCorpusService {
       if (byId.length >= limit) break;
     }
 
+    final blockedBy = dependencyResolver == null
+        ? const <String, List<ResolvedBlocker>>{}
+        : await dependencyResolver.resolveBlockedStatus(byId.keys.toSet());
+
     return [
       for (final task in byId.values)
         {
@@ -70,6 +82,8 @@ class DayAgentCorpusService {
           'due': task.data.due?.toIso8601String(),
           'estimateMinutes': task.data.estimate?.inMinutes,
           'priority': task.data.priority.short,
+          if (blockedBy[task.id] case final blockers?)
+            'blockedBy': [for (final b in blockers) b.toJson()],
         },
     ];
   }

--- a/lib/features/daily_os_next/agents/workflow/day_agent_context_builder.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_context_builder.dart
@@ -576,6 +576,7 @@ extension DayAgentContextBuilder on DayAgentWorkflow {
       final corpus = await service.buildTaskCorpusSnapshot(
         allowedCategoryIds: agentIdentity.allowedCategoryIds,
         day: planDate,
+        dependencyResolver: dependencyResolver,
       );
       return CaptureContext(capture: capture, taskCorpus: corpus);
     }

--- a/lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
@@ -122,7 +122,17 @@ Refine rules:
   your own. After the user commits, the plan is in shepherding mode and
   further edits require an explicit refine.
 - Shutdown and agenda mutation tools are not available yet. Do not claim you
-  shut down a day.${directiveService != null && agentId == dailyOsPlannerAgentId ? '''
+  shut down a day.${dependencyResolver == null ? '' : '''
+
+
+Blocked-work rules (ADR 0043):
+- A task is blocked for planning when its corpus row shows `"status":
+  "BLOCKED"` or carries a non-empty `blockedBy`. Place it only if (a) this
+  same plan schedules its blocker earlier the same day, or (b) the block's
+  `reason` explicitly names the blocker and states why the work can proceed
+  despite it.
+- When a decided/committed task is blocked, prefer placing the blocker
+  instead and say so in the block's reason.'''}${directiveService != null && agentId == dailyOsPlannerAgentId ? '''
 
 
 Digest rules (`<digest>` present — your coordinator ritual, ADR 0032):
@@ -141,7 +151,12 @@ Digest rules (`<digest>` present — your coordinator ritual, ADR 0032):
   days-with-plans count is a trend worth a directive note or a durable
   learning, not something to re-litigate daily.
 - The next digest is scheduled automatically — use `set_next_wake` only for
-  additional day-scoped pre-warms.''' : ''}${weekContextService == null ? '' : '''
+  additional day-scoped pre-warms.${dependencyResolver == null ? '' : '''
+
+- A directive commitment on a task blocked for planning should target its
+  blocker instead, or name the blocker explicitly in an attention note so
+  the per-day agent inherits the dependency context from the directive
+  itself.'''}''' : ''}${weekContextService == null ? '' : '''
 
 
 Week context (`<recent_days>` / `<week_ahead>`):

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -43,6 +43,7 @@ import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tools.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_strategy.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_capture_events.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -68,6 +69,7 @@ class DayAgentWorkflow {
     this.knowledgeService,
     this.weekContextService,
     this.directiveService,
+    this.dependencyResolver,
     this.soulDocumentService,
     this.dayAudioEntryContextService,
     this.onPersistedStateChanged,
@@ -117,6 +119,12 @@ class DayAgentWorkflow {
   /// Directive backend: the coordinator-only `issue_day_directive` tool and
   /// the per-day `<day_directive>` prompt read (ADR 0032 phase 3).
   final DayAgentDirectiveService? directiveService;
+
+  /// Batch one-hop blocker resolver (ADR 0043) — the sole source of truth
+  /// for both the corpus's `blockedBy` annotation and the prompt's
+  /// blocked-work/digest rule blocks, so the two can never drift out of
+  /// sync. Null keeps every prompt/corpus byte-identical to pre-ADR-0043.
+  final TaskDependencyResolver? dependencyResolver;
 
   /// Structured logger.
   final DomainLogger domainLogger;

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -631,6 +631,114 @@ The modal explicitly excludes:
 
 which is a good example of the feature preferring guardrails over polite chaos.
 
+### Typed relationships (ADR 0042)
+
+Beyond the plain "belongs with" `BasicLink`, a task-to-task link can carry one
+of five typed semantics, each an `EntryLink` union variant with the same shape
+as `BasicLink` (id, `fromId`, `toId`, timestamps, vector clock) — the
+relationship lives entirely in the `type` column, so every existing
+`type = 'BasicLink'` consumer (recorded-time attribution, capture attachment)
+stays structurally blind to typed edges. One row is stored per relationship;
+"is blocked by" / "has follow-up" / etc. are rendering labels for the reverse
+direction of that same row, never separate rows:
+
+| Variant      | Reading (from → to)                | Inverse rendering          |
+| ------------ | ----------------------------------- | --------------------------- |
+| `blocks`     | *from* blocks *to*                  | *to* is blocked by *from*   |
+| `followsUp`  | *from* follows up on *to*           | *to* has follow-up *from*   |
+| `duplicates` | *from* duplicates *to* (canonical)  | *to* is duplicated by *from*|
+| `fixes`      | *from* fixes *to* (the defect)      | *to* is fixed by *from*     |
+| `supersedes` | *from* supersedes *to* (obsolete)   | *to* is superseded by *from*|
+
+`RelationshipTypeSelector` (shared by `LinkTaskModal` and
+`BlockingTaskPickerModal`'s callers) renders these as six chips — Link, Blocks,
+Follows up, Duplicates, Fixes, Supersedes — defaulting to plain Link
+(today's behavior, unchanged when untouched). Picking a directional type
+reveals a second segmented toggle for the two phrasings (e.g. "Blocks" / "Is
+blocked by"); picking the inverse phrasing swaps `fromId`/`toId` in
+`LinkTaskModal._selectTask` before persisting, so the canonical stored
+direction is always the one the table above lists (e.g. `blocks`'s `fromId`
+is always the blocker, never the blocked task). `PersistenceLogic.createLink`
+runs a best-effort local cycle guard for `EntryLinkType.blocks` only (surfaced
+as a snackbar via `linkBlocksCycleErrorMessage` on rejection); read-time
+traversal tolerates cycles regardless, since two offline devices can always
+race one into existence.
+
+`TaskLinkGroupsController` (`taskLinkGroupsControllerProvider(taskId)`)
+resolves every plain and typed link touching a task, both directions, from one
+batched `JournalRepository.getTypedLinksForTaskIds` call, and buckets the
+result into `flat` (today's plain-link list) and `typed` (the five
+relationship kinds). `TaskRelationshipSections` renders the `typed` bucket as
+six grouped sections above the flat list: **Blocked by** and **Blocks** are
+`blocks` split by direction (each header alone disambiguates direction, so
+rows carry no caption — this is also the highest-signal relationship, feeding
+the header chip and the status-enrichment flow below); **Follow-ups**,
+**Duplicates**, **Fixes**, and **Supersedes** merge both directions into one
+section, with each row captioned via `relationshipPhrasePair` so a reader
+still knows which way the relationship points. A section renders only when it
+has entries — an empty relationship type is invisible, not an empty header.
+
+### Blockedness: a derived fact, not a stored flag
+
+Readiness is computed at read time from live `blocks` links, never stored
+(ADR 0042 §4): a task is blocked iff a non-deleted `blocks` link exists with
+`toId == task` whose blocker (`fromId`) is neither tombstoned nor closed
+(`DONE`/`REJECTED`). Closing or deleting a blocker therefore "releases" every
+dependent implicitly, on every device, with no unlock write and no sync race.
+An unresolvable blocker (the link row exists but its `fromId` task can't be
+loaded — typically a sync gap) keeps the dependent blocked conservatively,
+distinct from a tombstoned blocker (`deletedAt` set), which releases it.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Ready: no live blocks-link
+  Ready --> Blocked: blocks edge created to an open blocker
+  Blocked --> Ready: blocker closes (DONE/REJECTED) or link tombstoned
+  Blocked --> Blocked: blocker link unresolved (conservative, ADR 0042 §4)
+```
+
+`TaskBlockersController` (`taskBlockersControllerProvider(taskId)`) is the
+dedicated resolver for this: unlike `TaskLinkGroupsController` (which drops a
+tombstoned and an unresolvable blocker identically — fine for display), it
+distinguishes the two cases and reports `TaskBlockersResult(openBlockers,
+unresolvedCount)`, with `isBlocked = openBlockers.isNotEmpty ||
+unresolvedCount > 0`. It runs two bounded queries — one type-scoped link fetch,
+one batch status load for the distinct blocker ids — no transitive closure and
+no per-task fan-out.
+
+Blockedness surfaces in two places, both backed by `TaskBlockersController`:
+
+- `_TaskBlockedByChip` in the task detail header (next to the status pill):
+  hidden when not blocked; a bare "Blocked" pill with no tap target when every
+  blocker is unresolved (nothing to name or navigate to); otherwise a tappable
+  pill naming the single blocker or the count, opening the blocker's detail
+  page directly (single) or a list sheet (multiple).
+- **Status-enrichment prompt**: when `DesktopTaskHeaderConnector` sets a
+  task's status to `BLOCKED` (a change, not a no-op) and `TaskBlockersResult`
+  shows it isn't already named-blocked, it opens `BlockingTaskPickerModal` —
+  a search picker fixed to the `blocks` relationship (no type selector, unlike
+  `LinkTaskModal`) that creates a `blocks` link from the chosen task to this
+  one. Fully skippable: the status write already committed before the modal
+  opens, so dismissing or tapping Skip persists nothing further.
+
+The manual `TaskStatus.blocked` and link-derived blockedness intentionally
+never write to each other automatically — the link layer only *offers* the
+picker after a manual status change, and only when the task isn't already
+named-blocked. Many real blocks are external (a person, a delivery, a
+decision) and have no task to link.
+
+### Phase 3: planning sees blockedness too
+
+The day-agent task corpus (`DayAgentCorpusService.buildTaskCorpusSnapshot`,
+see [`daily_os_next/README.md`](../daily_os_next/README.md)) annotates each
+blocked row with a `blockedBy` list via an independent, read-only
+`TaskDependencyResolver` (`lib/features/tasks/repository/task_dependency_resolver.dart`)
+— the same one-hop `blocks`-link resolution as `TaskBlockersController`
+above, generalized for a batch of tasks instead of one, and deliberately not
+shared code with it (a UI-facing single-task controller and a model-facing
+batch resolver have different call shapes and failure-representation needs).
+See ADR 0043 for the planning-side prompt rules this feeds.
+
 ## Task Progress Calculation
 
 Task progress is calculated from linked work, not from optimism.

--- a/lib/features/tasks/repository/task_dependency_resolver.dart
+++ b/lib/features/tasks/repository/task_dependency_resolver.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_helpers.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:meta/meta.dart';
+
+/// One blocker of a task, as resolved by [TaskDependencyResolver].
+///
+/// `title`/`status` are null when the link exists but its target task could
+/// not be loaded at all (sync gap) — ADR 0042 §4's "unresolvable blocker
+/// keeps blocking" case. The entry is still emitted (never dropped) so a
+/// task whose only blocker is unresolved still serializes to a non-empty
+/// `blockedBy`, keeping it observably blocked rather than silently ready.
+@immutable
+class ResolvedBlocker {
+  const ResolvedBlocker({required this.taskId, this.title, this.status});
+
+  final String taskId;
+  final String? title;
+  final String? status;
+
+  /// True when the blocker link's target could not be loaded as a task.
+  bool get isUnresolved => title == null;
+
+  Map<String, Object?> toJson() => {
+    'taskId': taskId,
+    if (title != null) 'title': title,
+    if (status != null) 'status': status,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is ResolvedBlocker &&
+      other.taskId == taskId &&
+      other.title == title &&
+      other.status == status;
+
+  @override
+  int get hashCode => Object.hash(taskId, title, status);
+}
+
+/// Batch, one-hop, bounded resolver for "which of these tasks are blocked,
+/// and by what" (ADR 0043 §2). Generalizes the single-task classification
+/// `TaskBlockersController._fetch` uses to N tasks in two bounded queries:
+/// one type-scoped link fetch + one batch blocker-status load for the
+/// distinct blocker ids. No transitive closure, no per-task fan-out.
+class TaskDependencyResolver {
+  TaskDependencyResolver({required this.journalRepository});
+
+  final JournalRepository journalRepository;
+
+  /// Returns a map from blocked task id to its open/unresolved blockers.
+  /// Keys are present only for tasks with at least one entry — absence means
+  /// link-ready, mirroring the corpus's own "absence = ready" contract.
+  Future<Map<String, List<ResolvedBlocker>>> resolveBlockedStatus(
+    Set<String> taskIds,
+  ) async {
+    if (taskIds.isEmpty) return const {};
+
+    final links = await journalRepository.getTypedLinksForTaskIds(
+      taskIds,
+      linkTypes: const {'BlocksLink'},
+    );
+
+    final blockerIdsByTarget = <String, Set<String>>{};
+    for (final link in links) {
+      if (link.deletedAt != null) continue;
+      if (!taskIds.contains(link.toId)) continue;
+      blockerIdsByTarget.putIfAbsent(link.toId, () => {}).add(link.fromId);
+    }
+    if (blockerIdsByTarget.isEmpty) return const {};
+
+    final blockerIds = {
+      for (final ids in blockerIdsByTarget.values) ...ids,
+    };
+    final resolved = await journalRepository
+        .getJournalEntitiesByIdsIncludingDeleted(blockerIds);
+    final resolvedById = {for (final e in resolved) e.id: e};
+
+    final result = <String, List<ResolvedBlocker>>{};
+    for (final entry in blockerIdsByTarget.entries) {
+      final blockers = <ResolvedBlocker>[];
+      for (final blockerId in entry.value) {
+        final entity = resolvedById[blockerId];
+        if (entity == null || entity is! Task) {
+          blockers.add(ResolvedBlocker(taskId: blockerId));
+          continue;
+        }
+        if (entity.meta.deletedAt != null) continue;
+        if (isClosedTask(entity)) continue;
+        blockers.add(
+          ResolvedBlocker(
+            taskId: entity.id,
+            title: entity.data.title,
+            status: entity.data.status.toDbString,
+          ),
+        );
+      }
+      if (blockers.isNotEmpty) result[entry.key] = blockers;
+    }
+    return result;
+  }
+}
+
+final taskDependencyResolverProvider = Provider<TaskDependencyResolver>(
+  taskDependencyResolver,
+  name: 'taskDependencyResolverProvider',
+);
+TaskDependencyResolver taskDependencyResolver(Ref ref) {
+  return TaskDependencyResolver(
+    journalRepository: ref.watch(journalRepositoryProvider),
+  );
+}

--- a/test/features/agents/state/agent_workflow_providers_test.dart
+++ b/test/features/agents/state/agent_workflow_providers_test.dart
@@ -22,6 +22,7 @@ import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
@@ -115,6 +116,11 @@ void main() {
       expect(
         workflow.dayAudioEntryContextService?.assetRoot?.path,
         Directory.systemTemp.path,
+      );
+      expect(workflow.dependencyResolver, isA<TaskDependencyResolver>());
+      expect(
+        workflow.dependencyResolver?.journalRepository,
+        same(journalRepository),
       );
       workflow.onPersistedStateChanged?.call('day-agent-001');
       verify(

--- a/test/features/daily_os_next/agents/service/day_agent_capture_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_capture_service_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_m
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -508,6 +509,52 @@ void main() {
           snapshot.first['due'],
           DateTime(2026, 5, 25, 12).toIso8601String(),
         );
+      },
+    );
+
+    test(
+      'buildTaskCorpusSnapshot forwards dependencyResolver to the '
+      'underlying corpus service',
+      () async {
+        final open = _task(
+          id: 'task-1',
+          title: 'Open work',
+          status: _openStatus(),
+        );
+        when(
+          () => journalDb.getTasksDueOnOrBefore(any()),
+        ).thenAnswer((_) async => const <Task>[]);
+        when(
+          () => journalDb.getOpenTasksForDayAgentCorpus(
+            categoryIds: any(named: 'categoryIds'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => [open]);
+
+        final resolver = MockTaskDependencyResolver();
+        when(
+          () => resolver.resolveBlockedStatus({'task-1'}),
+        ).thenAnswer(
+          (_) async => {
+            'task-1': [
+              const ResolvedBlocker(
+                taskId: 'blocker-1',
+                title: 'Blocker',
+                status: 'OPEN',
+              ),
+            ],
+          },
+        );
+
+        final snapshot = await createService().buildTaskCorpusSnapshot(
+          allowedCategoryIds: {'work'},
+          day: DateTime(2026, 5, 25, 8),
+          dependencyResolver: resolver,
+        );
+
+        expect(snapshot.single['blockedBy'], [
+          {'taskId': 'blocker-1', 'title': 'Blocker', 'status': 'OPEN'},
+        ]);
       },
     );
 

--- a/test/features/daily_os_next/agents/service/day_agent_corpus_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_corpus_service_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_reads.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_corpus_service.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -134,6 +135,162 @@ void main() {
 
       expect(snapshot, hasLength(1));
     });
+
+    test(
+      'no dependencyResolver supplied — no row gains a blockedBy key '
+      '(byte-stability for dependency-free corpora)',
+      () async {
+        when(
+          () => journalDb.getOpenTasksForDayAgentCorpus(
+            categoryIds: any(named: 'categoryIds'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _task(id: 't-open', title: 'Open', status: _openStatus()),
+          ],
+        );
+        when(
+          () => journalDb.getTasksDueOnOrBefore(any()),
+        ).thenAnswer((_) async => const <Task>[]);
+
+        final snapshot = await createService().buildTaskCorpusSnapshot(
+          allowedCategoryIds: {'work'},
+          day: _day,
+        );
+
+        expect(snapshot.single.containsKey('blockedBy'), isFalse);
+      },
+    );
+
+    test(
+      'dependencyResolver supplied — only the blocked row gains blockedBy',
+      () async {
+        when(
+          () => journalDb.getOpenTasksForDayAgentCorpus(
+            categoryIds: any(named: 'categoryIds'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _task(id: 't-open', title: 'Open', status: _openStatus()),
+            _task(id: 't-blocked', title: 'Blocked', status: _openStatus()),
+          ],
+        );
+        when(
+          () => journalDb.getTasksDueOnOrBefore(any()),
+        ).thenAnswer((_) async => const <Task>[]);
+
+        final resolver = MockTaskDependencyResolver();
+        when(
+          () => resolver.resolveBlockedStatus({'t-open', 't-blocked'}),
+        ).thenAnswer(
+          (_) async => {
+            't-blocked': [
+              const ResolvedBlocker(
+                taskId: 'blocker-1',
+                title: 'Blocker',
+                status: 'OPEN',
+              ),
+            ],
+          },
+        );
+
+        final snapshot = await createService().buildTaskCorpusSnapshot(
+          allowedCategoryIds: {'work'},
+          day: _day,
+          dependencyResolver: resolver,
+        );
+
+        final byId = {for (final row in snapshot) row['taskId']: row};
+        expect(byId['t-open']!.containsKey('blockedBy'), isFalse);
+        expect(byId['t-blocked']!['blockedBy'], [
+          {'taskId': 'blocker-1', 'title': 'Blocker', 'status': 'OPEN'},
+        ]);
+        verify(
+          () => resolver.resolveBlockedStatus({'t-open', 't-blocked'}),
+        ).called(1);
+      },
+    );
+
+    test(
+      'a manually-BLOCKED task with no resolver entry keeps status BLOCKED '
+      'and no blockedBy key',
+      () async {
+        final blockedStatus = TaskStatus.blocked(
+          id: 'status-blocked',
+          createdAt: DateTime(2026, 5, 20),
+          utcOffset: 120,
+          reason: 'needs a reason',
+        );
+        when(
+          () => journalDb.getOpenTasksForDayAgentCorpus(
+            categoryIds: any(named: 'categoryIds'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _task(id: 't-manual', title: 'Manual', status: blockedStatus),
+          ],
+        );
+        when(
+          () => journalDb.getTasksDueOnOrBefore(any()),
+        ).thenAnswer((_) async => const <Task>[]);
+
+        final resolver = MockTaskDependencyResolver();
+        when(
+          () => resolver.resolveBlockedStatus({'t-manual'}),
+        ).thenAnswer((_) async => const {});
+
+        final snapshot = await createService().buildTaskCorpusSnapshot(
+          allowedCategoryIds: {'work'},
+          day: _day,
+          dependencyResolver: resolver,
+        );
+
+        expect(snapshot.single['status'], 'BLOCKED');
+        expect(snapshot.single.containsKey('blockedBy'), isFalse);
+      },
+    );
+
+    test(
+      'resolver-returned unresolved-only entry serializes with no title or '
+      'status keys',
+      () async {
+        when(
+          () => journalDb.getOpenTasksForDayAgentCorpus(
+            categoryIds: any(named: 'categoryIds'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _task(id: 't-blocked', title: 'Blocked', status: _openStatus()),
+          ],
+        );
+        when(
+          () => journalDb.getTasksDueOnOrBefore(any()),
+        ).thenAnswer((_) async => const <Task>[]);
+
+        final resolver = MockTaskDependencyResolver();
+        when(
+          () => resolver.resolveBlockedStatus({'t-blocked'}),
+        ).thenAnswer(
+          (_) async => {
+            't-blocked': [const ResolvedBlocker(taskId: 'missing-blocker')],
+          },
+        );
+
+        final snapshot = await createService().buildTaskCorpusSnapshot(
+          allowedCategoryIds: {'work'},
+          day: _day,
+          dependencyResolver: resolver,
+        );
+
+        expect(snapshot.single['blockedBy'], [
+          {'taskId': 'missing-blocker'},
+        ]);
+      },
+    );
   });
 
   group('matchToCorpus', () {

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -31,6 +31,7 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_se
 import 'package:lotti/features/daily_os_next/agents/service/day_audio_entry_context_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -170,6 +171,7 @@ void main() {
     MockDayAgentKnowledgeService? knowledgeService,
     MockDayAgentWeekContextService? weekContextService,
     MockDayAgentDirectiveService? directiveService,
+    TaskDependencyResolver? dependencyResolver,
     DayAudioEntryContextService? dayAudioEntryContextService,
   }) {
     return DayAgentWorkflow(
@@ -185,6 +187,7 @@ void main() {
       knowledgeService: knowledgeService,
       weekContextService: weekContextService,
       directiveService: directiveService,
+      dependencyResolver: dependencyResolver,
       dayAudioEntryContextService: dayAudioEntryContextService,
       domainLogger: domainLogger,
       onPersistedStateChanged: changedTokens.add,
@@ -336,6 +339,7 @@ void main() {
       () => captureService.buildTaskCorpusSnapshot(
         allowedCategoryIds: any(named: 'allowedCategoryIds'),
         day: any(named: 'day'),
+        dependencyResolver: any(named: 'dependencyResolver'),
       ),
     ).thenAnswer((_) async => const []);
   }
@@ -562,6 +566,7 @@ void main() {
           () => captureService.buildTaskCorpusSnapshot(
             allowedCategoryIds: any(named: 'allowedCategoryIds'),
             day: any(named: 'day'),
+            dependencyResolver: any(named: 'dependencyResolver'),
           ),
         ).thenAnswer((_) async => const []);
         when(
@@ -2773,6 +2778,7 @@ void main() {
         () => captureService.buildTaskCorpusSnapshot(
           allowedCategoryIds: const <String>{},
           day: DateTime(2026, 5, 25),
+          dependencyResolver: any(named: 'dependencyResolver'),
         ),
       ).thenAnswer(
         (_) async => const [
@@ -3255,6 +3261,7 @@ void main() {
           () => captureService.buildTaskCorpusSnapshot(
             allowedCategoryIds: const <String>{},
             day: DateTime(2026, 5, 25),
+            dependencyResolver: any(named: 'dependencyResolver'),
           ),
         ).thenAnswer((_) async => const []);
         when(
@@ -5067,6 +5074,202 @@ void main() {
         );
       },
     );
+
+    group('dependency-aware planning (ADR 0043)', () {
+      test(
+        'adds Blocked-work rules to the system prompt only when a '
+        'dependencyResolver is configured',
+        () async {
+          final resolver = MockTaskDependencyResolver();
+
+          await execute(workflow(dependencyResolver: resolver));
+          expect(
+            conversationRepository.lastSystemMessage,
+            contains('Blocked-work rules (ADR 0043)'),
+          );
+          // The gated block keeps exactly one blank line on the seam.
+          expect(
+            conversationRepository.lastSystemMessage,
+            contains('shut down a day.\n\nBlocked-work rules'),
+          );
+
+          await execute(workflow());
+          expect(
+            conversationRepository.lastSystemMessage,
+            isNot(contains('Blocked-work rules')),
+          );
+        },
+      );
+
+      test(
+        'the digest gains its blocked-dependency bullet only when both '
+        'directiveService and dependencyResolver are configured',
+        () async {
+          final directiveService = MockDayAgentDirectiveService();
+          when(
+            () => directiveService.directiveForDay(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => repository.getDayStatusEventsSince(
+              any(),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => const []);
+          final resolver = MockTaskDependencyResolver();
+
+          Future<WakeResult> executeDigest(DayAgentWorkflow sut) {
+            stubCoordinatorReads();
+            return withClock(
+              Clock.fixed(now),
+              () => sut.execute(
+                agentIdentity: makeTestIdentity(
+                  id: dailyOsPlannerAgentId,
+                  agentId: dailyOsPlannerAgentId,
+                  kind: AgentKinds.dayAgent,
+                  displayName: 'Shepherd',
+                  currentStateId: 'state-$dailyOsPlannerAgentId',
+                  config: const AgentConfig(
+                    profileId: 'profile-day',
+                    maxTurnsPerWake: 5,
+                  ),
+                  createdAt: now,
+                  updatedAt: now,
+                ),
+                runKey: runKey,
+                triggerTokens: {dayAgentDigestToken(dayId)},
+                threadId: threadId,
+              ),
+            );
+          }
+
+          // directiveService alone: base digest text present, new bullet
+          // absent.
+          final withoutResolver = await executeDigest(
+            workflow(directiveService: directiveService),
+          );
+          expect(
+            withoutResolver.success,
+            isTrue,
+            reason: withoutResolver.error,
+          );
+          expect(
+            conversationRepository.lastSystemMessage,
+            contains('Digest rules'),
+          );
+          expect(
+            conversationRepository.lastSystemMessage,
+            isNot(
+              contains(
+                'A directive commitment on a task blocked for planning',
+              ),
+            ),
+          );
+
+          // Both configured: the new bullet appears, on its own line.
+          final withResolver = await executeDigest(
+            workflow(
+              directiveService: directiveService,
+              dependencyResolver: resolver,
+            ),
+          );
+          expect(withResolver.success, isTrue, reason: withResolver.error);
+          expect(
+            conversationRepository.lastSystemMessage,
+            contains(
+              'pre-warms.\n'
+              '- A directive commitment on a task blocked for planning '
+              'should target its\n'
+              '  blocker instead',
+            ),
+          );
+        },
+      );
+
+      test(
+        'passes the exact dependencyResolver instance through to the '
+        'capture service on a capture wake',
+        () async {
+          final resolver = MockTaskDependencyResolver();
+          final capture = makeTestCapture(
+            id: 'capture-1',
+            agentId: agentId,
+            transcript: 'buy milk',
+            capturedAt: DateTime(2026, 5, 25, 7),
+            createdAt: DateTime(2026, 5, 25, 7),
+          );
+          final captureService = MockDayAgentCaptureService();
+          when(() => captureService.getCapture('capture-1')).thenAnswer(
+            (_) async => capture,
+          );
+          when(
+            () => captureService.buildTaskCorpusSnapshot(
+              allowedCategoryIds: const <String>{},
+              day: DateTime(2026, 5, 25),
+              dependencyResolver: resolver,
+            ),
+          ).thenAnswer((_) async => const []);
+          when(
+            () => captureService.executeTool(
+              agentId: agentId,
+              threadId: threadId,
+              runKey: runKey,
+              toolName: DayAgentToolNames.parseCaptureToItems,
+              args: any(named: 'args'),
+            ),
+          ).thenAnswer(
+            (_) async => DayAgentDirectToolResult.success(
+              const {
+                'captureId': 'capture-1',
+                'items': [
+                  {'id': 'parsed-1'},
+                ],
+              },
+            ),
+          );
+          conversationRepository.toolCalls = [
+            _toolCall(
+              name: DayAgentToolNames.parseCaptureToItems,
+              args: const {
+                'captureId': 'capture-1',
+                'items': [
+                  {
+                    'kind': 'newTask',
+                    'title': 'Buy milk',
+                    'categoryId': 'home',
+                    'confidenceScore': 0.4,
+                  },
+                ],
+              },
+            ),
+          ];
+
+          final result = await execute(
+            workflow(
+              captureService: captureService,
+              dependencyResolver: resolver,
+            ),
+            triggerTokens: {
+              dayAgentCaptureSubmittedToken('capture-1'),
+              dayAgentPlanningDayToken(dayId),
+            },
+          );
+
+          expect(result.success, isTrue, reason: result.error);
+          // A mismatched (e.g. differently-instantiated) resolver would not
+          // satisfy this exact-instance stub, so the mock would have no
+          // matching call and this verify would fail — proving the same
+          // instance travels from the workflow field through
+          // _captureContext to the capture service call.
+          verify(
+            () => captureService.buildTaskCorpusSnapshot(
+              allowedCategoryIds: const <String>{},
+              day: DateTime(2026, 5, 25),
+              dependencyResolver: resolver,
+            ),
+          ).called(1);
+        },
+      );
+    });
   });
 }
 

--- a/test/features/tasks/repository/task_dependency_resolver_test.dart
+++ b/test/features/tasks/repository/task_dependency_resolver_test.dart
@@ -1,0 +1,271 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/entity_factories.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  late MockJournalRepository journalRepository;
+  late TaskDependencyResolver resolver;
+
+  final baseDate = DateTime(2024, 9);
+
+  EntryLink blocksLink({
+    required String id,
+    required String fromId,
+    required String toId,
+    DateTime? deletedAt,
+  }) => EntryLink.blocks(
+    id: id,
+    fromId: fromId,
+    toId: toId,
+    createdAt: baseDate,
+    updatedAt: baseDate,
+    vectorClock: null,
+    deletedAt: deletedAt,
+  );
+
+  setUp(() {
+    journalRepository = MockJournalRepository();
+    resolver = TaskDependencyResolver(journalRepository: journalRepository);
+  });
+
+  void stubLinks(Set<String> taskIds, List<EntryLink> links) {
+    when(
+      () => journalRepository.getTypedLinksForTaskIds(
+        taskIds,
+        linkTypes: {'BlocksLink'},
+      ),
+    ).thenAnswer((_) async => links);
+  }
+
+  void stubResolved(List<JournalEntity> entities) {
+    when(
+      () => journalRepository.getJournalEntitiesByIdsIncludingDeleted(any()),
+    ).thenAnswer((_) async => entities);
+  }
+
+  group('TaskDependencyResolver.resolveBlockedStatus', () {
+    test('empty taskIds short-circuits without querying either repository '
+        'method', () async {
+      final result = await resolver.resolveBlockedStatus(<String>{});
+
+      expect(result, isEmpty);
+      verifyNever(
+        () => journalRepository.getTypedLinksForTaskIds(
+          any(),
+          linkTypes: any(named: 'linkTypes'),
+        ),
+      );
+      verifyNever(
+        () => journalRepository.getJournalEntitiesByIdsIncludingDeleted(any()),
+      );
+    });
+
+    test(
+      'one open, resolvable blocker resolves to a named ResolvedBlocker',
+      () async {
+        final blocker = TestTaskFactory.create(id: 'blocker', title: 'Blocker');
+        stubLinks(
+          {'blocked'},
+          [
+            blocksLink(id: 'l1', fromId: 'blocker', toId: 'blocked'),
+          ],
+        );
+        stubResolved([blocker]);
+
+        final result = await resolver.resolveBlockedStatus({'blocked'});
+
+        expect(result.keys, ['blocked']);
+        expect(result['blocked'], [
+          const ResolvedBlocker(
+            taskId: 'blocker',
+            title: 'Blocker',
+            status: 'OPEN',
+          ),
+        ]);
+      },
+    );
+
+    test('blocker is DONE — task absent from the result (released)', () async {
+      final doneBlocker = TestTaskFactory.create(
+        id: 'blocker',
+        title: 'Done blocker',
+        status: TaskStatus.done(id: 's', createdAt: baseDate, utcOffset: 0),
+      );
+      stubLinks(
+        {'blocked'},
+        [
+          blocksLink(id: 'l1', fromId: 'blocker', toId: 'blocked'),
+        ],
+      );
+      stubResolved([doneBlocker]);
+
+      final result = await resolver.resolveBlockedStatus({'blocked'});
+
+      expect(result, isEmpty);
+    });
+
+    test(
+      'blocker is REJECTED — task absent from the result (released)',
+      () async {
+        final rejectedBlocker = TestTaskFactory.create(
+          id: 'blocker',
+          title: 'Rejected blocker',
+          status: TaskStatus.rejected(
+            id: 's',
+            createdAt: baseDate,
+            utcOffset: 0,
+          ),
+        );
+        stubLinks(
+          {'blocked'},
+          [
+            blocksLink(id: 'l1', fromId: 'blocker', toId: 'blocked'),
+          ],
+        );
+        stubResolved([rejectedBlocker]);
+
+        final result = await resolver.resolveBlockedStatus({'blocked'});
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'blocker link is tombstoned (deletedAt set) — task absent (released)',
+      () async {
+        stubLinks(
+          {'blocked'},
+          [
+            blocksLink(
+              id: 'l1',
+              fromId: 'blocker',
+              toId: 'blocked',
+              deletedAt: baseDate,
+            ),
+          ],
+        );
+        stubResolved(const []);
+
+        final result = await resolver.resolveBlockedStatus({'blocked'});
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'blocker id resolves to nothing — still blocked, per ADR 0042 §4',
+      () async {
+        stubLinks(
+          {'blocked'},
+          [
+            blocksLink(id: 'l1', fromId: 'missing-blocker', toId: 'blocked'),
+          ],
+        );
+        stubResolved(const []);
+
+        final result = await resolver.resolveBlockedStatus({'blocked'});
+
+        expect(result.keys, ['blocked']);
+        expect(result['blocked'], [
+          const ResolvedBlocker(taskId: 'missing-blocker'),
+        ]);
+        expect(result['blocked']!.single.isUnresolved, isTrue);
+        expect(result['blocked']!.single.toJson(), {
+          'taskId': 'missing-blocker',
+        });
+      },
+    );
+
+    test('mutual block: both tasks present, each naming the other', () async {
+      final taskA = TestTaskFactory.create(id: 'task-a', title: 'Task A');
+      final taskB = TestTaskFactory.create(id: 'task-b', title: 'Task B');
+      stubLinks(
+        {'task-a', 'task-b'},
+        [
+          blocksLink(id: 'a-blocked-by-b', fromId: 'task-b', toId: 'task-a'),
+          blocksLink(id: 'b-blocked-by-a', fromId: 'task-a', toId: 'task-b'),
+        ],
+      );
+      stubResolved([taskA, taskB]);
+
+      final result = await resolver.resolveBlockedStatus({
+        'task-a',
+        'task-b',
+      });
+
+      expect(result.keys.toSet(), {'task-a', 'task-b'});
+      expect(result['task-a']!.single.taskId, 'task-b');
+      expect(result['task-b']!.single.taskId, 'task-a');
+    });
+
+    test(
+      'direction guard: a blocks link where the queried task is fromId '
+      '(blocks someone else) contributes nothing to its own entry',
+      () async {
+        stubLinks(
+          {'blocked'},
+          [
+            blocksLink(id: 'l1', fromId: 'blocked', toId: 'other-task'),
+          ],
+        );
+        stubResolved(const []);
+
+        final result = await resolver.resolveBlockedStatus({'blocked'});
+
+        expect(result, isEmpty);
+      },
+    );
+  });
+
+  group('ResolvedBlocker', () {
+    test('equals another instance with the same fields', () {
+      const a = ResolvedBlocker(taskId: 'x', title: 'X', status: 'OPEN');
+      const b = ResolvedBlocker(taskId: 'x', title: 'X', status: 'OPEN');
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differs when any field differs', () {
+      const base = ResolvedBlocker(taskId: 'x', title: 'X', status: 'OPEN');
+
+      expect(
+        base,
+        isNot(const ResolvedBlocker(taskId: 'y', title: 'X', status: 'OPEN')),
+      );
+      expect(
+        base,
+        isNot(const ResolvedBlocker(taskId: 'x', title: 'Y', status: 'OPEN')),
+      );
+      expect(
+        base,
+        isNot(const ResolvedBlocker(taskId: 'x', title: 'X', status: 'DONE')),
+      );
+    });
+  });
+
+  group('taskDependencyResolverProvider', () {
+    test(
+      'resolves a TaskDependencyResolver backed by journalRepositoryProvider',
+      () {
+        final mockRepo = MockJournalRepository();
+        final container = ProviderContainer(
+          overrides: [journalRepositoryProvider.overrideWithValue(mockRepo)],
+        );
+        addTearDown(container.dispose);
+
+        final resolved = container.read(taskDependencyResolverProvider);
+
+        expect(resolved.journalRepository, mockRepo);
+      },
+    );
+  });
+}

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -153,6 +153,7 @@ import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/services/sync_node_profile_broadcaster.dart';
 import 'package:lotti/features/sync/services/synced_audio_inference_dispatcher.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/features/tasks/repository/task_progress_repository.dart';
 import 'package:lotti/features/tasks/state/checklist_controller.dart';
 import 'package:lotti/features/tasks/state/linked_tasks_controller.dart';
@@ -1126,6 +1127,9 @@ class MockOnboardingCaptureToTaskService extends Mock
 class MockJournalRepository extends Mock implements JournalRepository {}
 
 class MockChecklistRepository extends Mock implements ChecklistRepository {}
+
+class MockTaskDependencyResolver extends Mock
+    implements TaskDependencyResolver {}
 
 class MockChecklistController extends Mock implements ChecklistController {}
 


### PR DESCRIPTION
## Summary
- Stacked on #3556 (Phase 2) — base branch is `feat/task-dependency-links-p2`, not `main`
- Adds `TaskDependencyResolver`: a batch, one-hop resolver over ADR 0042's `blocks` links (two bounded queries, no per-task fan-out)
- `DayAgentCorpusService.buildTaskCorpusSnapshot` annotates blocked rows with `blockedBy`; byte-stable when no resolver is configured
- Two new prompt-contract rule blocks in `day_agent_prompt_builder.dart` — Blocked-work rules (drafting/refine) and a digest bullet (coordinator) — both gated on the same `dependencyResolver` field that drives the corpus annotation, so prompt and corpus can never drift out of sync
- Wired end-to-end: `DayAgentWorkflow` → `agent_workflow_providers.dart`
- Backfills previously-undocumented Phase 1/2 typed-relationship UI docs into `tasks/README.md`, adds a new "Dependency-aware planning (ADR 0043)" section to `daily_os_next/README.md`, flips ADR 0042/0043 (and the ADR index) to Accepted

## Test plan
- [x] `fvm flutter analyze` clean project-wide
- [x] 223 targeted tests green across `task_dependency_resolver_test.dart`, `day_agent_corpus_service_test.dart`, `day_agent_capture_service_test.dart`, `day_agent_workflow_test.dart`, `task_blockers_controller_test.dart`, `agent_workflow_providers_test.dart`
- [x] 100% local line coverage (lcov) on every new/changed production line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dependency-aware planning that identifies tasks blocked by open blockers.
  * Planning prompts and task summaries now provide blocker context and guidance for handling blocked work.
  * Dependency information is included in task data when available, while dependency-free plans retain their existing format.

* **Documentation**
  * Accepted and documented the decisions for typed task relationships and dependency-aware planning.

* **Tests**
  * Added coverage for blocker resolution, task corpus enrichment, prompt guidance, and workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->