### PR TITLE
Replace Siri-wave AI activity indicators with decoder bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1062]
 ### Added
+- **AI activity now uses one consistent decoder-bars animation.** Unified AI
+  progress, entry details, and cover-art generation now match the shader-based
+  activity indicator already used by task details and Daily OS, including
+  smooth entry and exit transitions and tap-to-open progress where available.
 - **Task agents can now read your image analyses.** The AI analyses attached
   to a task's images — brief summaries and full OCR extractions alike — are
   now part of the task agent's context, each with the model that produced it,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
   <releases>
     <release version="0.9.1062" date="2026-07-23">
       <description>
+        <p>AI activity now uses one consistent decoder-bars animation across Unified AI progress, entry details, cover-art generation, task details, and Daily OS, with smooth entry and exit transitions and tap-to-open progress where available.</p>
         <p>Task agents can now read your image analyses: the AI analyses attached to a task's images — brief summaries and full OCR extractions alike — are part of the task agent's context, each with the model that produced it, when it ran, and its full text. The agent can act on what's in an image (e.g. extract an appointment date from a photographed card and propose it as the due date), and a completed analysis now flags the task for the agent's next regular update.</p>
         <p>AI analysis cards are collapsible and visually calmer: long analyses (e.g. a full OCR extraction) under an image or audio entry start fully collapsed — just a Show more toggle and the model pill — and the cards drop their heavy card-on-card look for the tinted AI surface that matches the agent report cards in both light and dark themes.</p>
         <p>Task links now carry real relationships — Blocks, Follows up, Duplicates, Fixes, or Supersedes — in either direction, for both existing and newly-created linked tasks. The Linked Tasks section groups them by relationship, a "Blocked by" chip appears in the header next to the status when a task is blocked, and marking a task Blocked now optionally prompts you to name the blocker on the spot.</p>

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -879,6 +879,55 @@ the decoder-bars thinking shader in the task action bar while inference is
 running, and Daily OS Next uses the voice tension-loop shader around the record
 button while capture or refine listening is active.
 
+`AiRunningDecoderBars` is the provider-driven adapter. It watches
+`inferenceRunningControllerProvider` for one entity and a set of response types,
+listens to the matching `inferenceErrorControllerProvider` instances, and
+delegates its visual lifecycle to `AiThinkingShaderPresence`. Interactive hosts
+also use it as the labelled tap target that resolves the active prompt and opens
+`UnifiedAiProgressContent`.
+
+Provider-driven decoder bars appear in:
+
+- `TaskDetailsPage`, above the sticky task action row;
+- `UnifiedAiProgressContent`, while an inference is running but has not emitted
+  progress text, and `UnifiedAiProgressUtils.progressPage`, in the sticky modal
+  action bar;
+- `EntryDetailsPage`, as the interactive bottom overlay for image analysis,
+  audio transcription, and prompt generation.
+
+`AiThinkingShaderPresence` is the local-state adapter for surfaces that already
+own a busy flag and therefore must not depend on an entry inference provider.
+It drives the cover-art generation modal, the Daily OS draft/refinement
+surfaces (`DraftingPage` and `DayPlanningThinkingShader`), and the onboarding
+hero. The cover-art modal keeps the presence widget mounted in a fixed status
+region while its local `isRunning` value changes, so the shader can complete its
+exit envelope as the error or completion icon appears.
+
+```mermaid
+flowchart LR
+  Status["InferenceStatus per entity + response type"] --> Running["inferenceRunningControllerProvider"]
+  Error["inferenceErrorControllerProvider"] --> Decoder["AiRunningDecoderBars"]
+  Running --> Decoder
+  Decoder --> Presence["AiThinkingShaderPresence"]
+  Local["Surface-owned busy state"] --> Presence
+  Presence --> Shader["AiThinkingLineShader<br/>decoderBars route"]
+  Decoder -->|"interactive tap + active prompt"| Progress["UnifiedAiProgressContent modal"]
+```
+
+The presence envelope is a concrete lifecycle rather than a visibility toggle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Hidden
+  Hidden --> Entering: isRunning becomes true
+  Entering --> Visible: forward animation completes
+  Entering --> Exiting: isRunning becomes false
+  Visible --> Exiting: isRunning becomes false
+  Exiting --> Entering: isRunning becomes true
+  Exiting --> Hidden: reverse animation completes
+  Hidden --> [*]
+```
+
 Skill inference failures are retained separately from the coarse
 `InferenceStatus` lifecycle by `inferenceErrorControllerProvider`. The task and
 entry activity widgets listen for that detail: when the running animation ends
@@ -908,10 +957,10 @@ Two Flutter runtime-effect shaders are registered in `pubspec.yaml`:
 - `shaders/ai_thinking_line.frag` renders five horizontal thinking routes:
   quiet thread, packet scan, circuit trace, probability band, and decoder bars,
   sized for action-bar use. `AiRunningDecoderBars` selects the decoder-bars
-  route and feeds it the same `inferenceRunningControllerProvider` state as the
-  legacy Siri-wave wrapper. It animates both the reserved vertical height and
-  shader amplitude and opacity when activity starts or stops, then removes the
-  shader subtree once the exit animation is fully collapsed.
+  route and feeds it `inferenceRunningControllerProvider` state. It animates
+  both the reserved vertical height and shader amplitude and opacity when
+  activity starts or stops, then removes the shader subtree once the exit
+  animation is fully collapsed.
 
 The Widgetbook use cases expose knobs for speed, intensity,
 geometry, colors, randomness, and dBFS. The thinking matrix renders every

--- a/lib/features/ai/ui/animation/ai_running_animation.dart
+++ b/lib/features/ai/ui/animation/ai_running_animation.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:glass_kit/glass_kit.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/active_inference_controller.dart';
 import 'package:lotti/features/ai/state/consts.dart';
@@ -13,9 +12,7 @@ import 'package:lotti/features/design_system/components/toasts/design_system_toa
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
-import 'package:siri_wave/siri_wave.dart';
 
 void _listenForInferenceErrors({
   required BuildContext context,
@@ -49,91 +46,6 @@ void _listenForInferenceErrors({
         }
       });
     });
-  }
-}
-
-/// Bare iOS-9-style Siri waveform sized to [height].
-///
-/// The visual primitive only — it carries no inference state. Wrap it in
-/// [AiRunningAnimationWrapper] to gate it on a running entry, or use
-/// [AiRunningDecoderBars] for the shader-based variant.
-class AiRunningAnimation extends ConsumerStatefulWidget {
-  const AiRunningAnimation({
-    required this.height,
-    super.key,
-  });
-
-  final double height;
-
-  @override
-  ConsumerState<AiRunningAnimation> createState() => _AIRunningAnimationState();
-}
-
-class _AIRunningAnimationState extends ConsumerState<AiRunningAnimation> {
-  SiriWaveformController controller = IOS9SiriWaveformController();
-
-  @override
-  Widget build(BuildContext context) {
-    controller.speed = 0.02;
-    controller.amplitude = 1;
-
-    return SiriWaveform.ios9(
-      controller: controller as IOS9SiriWaveformController,
-      options: IOS9SiriWaveformOptions(height: widget.height),
-    );
-  }
-}
-
-/// [AiRunningAnimation] gated on whether inference is running for an entry.
-///
-/// Watches the inference-running signal for [entryId] / [responseTypes] and
-/// renders nothing when idle. When [isInteractive] is true, tapping the
-/// waveform opens the AI progress view for that entry.
-class AiRunningAnimationWrapper extends ConsumerWidget {
-  const AiRunningAnimationWrapper({
-    required this.entryId,
-    required this.height,
-    required this.responseTypes,
-    this.isInteractive = false,
-    super.key,
-  });
-
-  final String entryId;
-  final double height;
-  final Set<AiResponseType> responseTypes;
-  final bool isInteractive;
-
-  Future<void> _handleTap(BuildContext context, WidgetRef ref) async {
-    await _handleAiActivityTap(
-      context: context,
-      ref: ref,
-      entryId: entryId,
-      responseTypes: responseTypes,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final provider = inferenceRunningControllerProvider((
-      id: entryId,
-      responseTypes: responseTypes,
-    ));
-    final isRunning = ref.watch(provider);
-
-    if (!isRunning) {
-      return const SizedBox.shrink();
-    }
-
-    final animation = AiRunningAnimation(height: height);
-
-    if (isInteractive) {
-      return GestureDetector(
-        onTap: () => _handleTap(context, ref),
-        child: animation,
-      );
-    }
-
-    return animation;
   }
 }
 
@@ -441,60 +353,4 @@ Future<void> _handleAiActivityTap({
       showExisting: true,
     ),
   );
-}
-
-/// [AiRunningAnimationWrapper] wrapped in a glass card.
-///
-/// Same per-entry gating as [AiRunningAnimationWrapper] (renders nothing when
-/// idle), but presents the waveform inside a frosted-glass container for
-/// surfaces that need a self-contained card rather than an inline indicator.
-class AiRunningAnimationWrapperCard extends ConsumerWidget {
-  const AiRunningAnimationWrapperCard({
-    required this.entryId,
-    required this.height,
-    required this.responseTypes,
-    this.isInteractive = false,
-    super.key,
-  });
-
-  final String entryId;
-  final double height;
-  final Set<AiResponseType> responseTypes;
-  final bool isInteractive;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    _listenForInferenceErrors(
-      context: context,
-      ref: ref,
-      entryId: entryId,
-      responseTypes: responseTypes,
-    );
-    final provider = inferenceRunningControllerProvider((
-      id: entryId,
-      responseTypes: responseTypes,
-    ));
-    final isRunning = ref.watch(provider);
-
-    if (!isRunning) {
-      return const SizedBox.shrink();
-    }
-
-    return GlassContainer.clearGlass(
-      elevation: 0,
-      height: height,
-      width: double.infinity,
-      blur: 12,
-      color: context.colorScheme.surface.withAlpha(128),
-      borderWidth: 0,
-      child: Center(
-        child: AiRunningAnimationWrapper(
-          entryId: entryId,
-          height: height,
-          responseTypes: responseTypes,
-          isInteractive: isInteractive,
-        ),
-      ),
-    );
-  }
 }

--- a/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
+++ b/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
 import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/ai/ui/image_generation/reference_image_selection_widget.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
@@ -18,7 +19,7 @@ import 'package:lotti/widgets/modal/modal_utils.dart';
 /// generation via the skill system.
 ///
 /// After the user selects reference images and taps "Continue", the modal
-/// transitions to a progress view showing the Siri waveform animation.
+/// transitions to a progress view showing the decoder-bars thinking shader.
 /// The user can dismiss the modal at any time without stopping the background
 /// generation, which continues via `SkillInferenceRunner.runImageGeneration`.
 class CoverArtSkillModal extends ConsumerStatefulWidget {
@@ -192,32 +193,38 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
             imageGenerationErrorControllerProvider(widget.linkedTaskId),
           )
         : null;
+    final spacing = context.designTokens.spacing;
 
     return Padding(
-      padding: const EdgeInsets.all(24),
+      padding: EdgeInsets.all(spacing.step6),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const SizedBox(height: 24),
-          // Status icon or animation
-          if (isRunning)
-            const SizedBox(
-              height: 60,
-              child: AiRunningAnimation(height: 60),
-            )
-          else if (isError)
-            Icon(
-              Icons.error_outline_rounded,
-              size: 48,
-              color: colorScheme.error,
-            )
-          else if (isComplete)
-            Icon(
-              Icons.check_circle_outline_rounded,
-              size: 48,
-              color: colorScheme.primary,
+          SizedBox(height: spacing.step6),
+          // Keep one stable status region while the shader exits and the
+          // terminal icon appears.
+          SizedBox(
+            height: spacing.step10,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                AiThinkingShaderPresence(isRunning: isRunning),
+                if (isError)
+                  Icon(
+                    Icons.error_outline_rounded,
+                    size: spacing.step9,
+                    color: colorScheme.error,
+                  )
+                else if (isComplete)
+                  Icon(
+                    Icons.check_circle_outline_rounded,
+                    size: spacing.step9,
+                    color: colorScheme.primary,
+                  ),
+              ],
             ),
-          const SizedBox(height: 24),
+          ),
+          SizedBox(height: spacing.step6),
           // Status text
           Text(
             _statusText(
@@ -229,7 +236,7 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
             textAlign: TextAlign.center,
             style: context.textTheme.titleMedium,
           ),
-          const SizedBox(height: 8),
+          SizedBox(height: spacing.step3),
           // Subtitle with reference image count
           Text(
             _subtitleText(
@@ -243,7 +250,7 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
               color: colorScheme.onSurfaceVariant,
             ),
           ),
-          const SizedBox(height: 32),
+          SizedBox(height: spacing.step7),
         ],
       ),
     );

--- a/lib/features/ai/ui/unified_ai_progress_view.dart
+++ b/lib/features/ai/ui/unified_ai_progress_view.dart
@@ -230,9 +230,8 @@ class _UnifiedAiProgressContentState
         if (isRunning && state.isEmpty) {
           // Show only the animation when no progress text yet
           return Center(
-            child: AiRunningAnimationWrapper(
+            child: AiRunningDecoderBars(
               entryId: widget.entityId,
-              height: 50,
               responseTypes: {promptConfig.aiResponseType},
             ),
           );
@@ -453,9 +452,8 @@ class UnifiedAiProgressUtils {
       scrollController: scrollController,
       stickyActionBar: Align(
         alignment: Alignment.bottomCenter,
-        child: AiRunningAnimationWrapper(
+        child: AiRunningDecoderBars(
           entryId: entityId,
-          height: 50,
           responseTypes: {prompt.aiResponseType},
         ),
       ),

--- a/lib/features/journal/ui/pages/entry_details_page.dart
+++ b/lib/features/journal/ui/pages/entry_details_page.dart
@@ -244,9 +244,8 @@ class _EntryDetailsPageState extends ConsumerState<EntryDetailsPage>
               ),
               Align(
                 alignment: Alignment.bottomCenter,
-                child: AiRunningAnimationWrapperCard(
+                child: AiRunningDecoderBars(
                   entryId: widget.itemId,
-                  height: 50,
                   isInteractive: true,
                   responseTypes: const {
                     AiResponseType.imageAnalysis,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2646,14 +2646,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.4"
-  siri_wave:
-    dependency: "direct main"
-    description:
-      name: siri_wave
-      sha256: ea815d6627dc297f6be883bb0dd7a579a5f5f9729242d47c10e95850cccf169a
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,7 +115,6 @@ dependencies:
   rxdart: ^0.28.0
   share_plus: ^12.0.0
   shared_preferences: ^2.3.2
-  siri_wave: ^2.3.0
   sqflite_common_ffi: ^2.3.3
   sqlite3: ^2.4.5
   sqlite3_flutter_libs: ^0.5.42

--- a/test/features/ai/ui/animation/ai_running_animation_test.dart
+++ b/test/features/ai/ui/animation/ai_running_animation_test.dart
@@ -1,14 +1,8 @@
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:glass_kit/glass_kit.dart';
-import 'package:lotti/features/ai/database/ai_config_db.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
-import 'package:lotti/features/ai/repository/ai_config_repository.dart'
-    show AiConfigRepository;
 import 'package:lotti/features/ai/state/active_inference_controller.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_error_controller.dart';
@@ -17,817 +11,192 @@ import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.da
 import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/ai/ui/animation/ai_state_shader_animation.dart';
 import 'package:lotti/features/ai/ui/unified_ai_progress_view.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/services/domain_logging.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:siri_wave/siri_wave.dart';
 
-import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
-import '../../../../widget_test_utils.dart';
 
 void main() {
-  /// Creates a [ProviderContainer] with a teardown safety net: when an
-  /// assertion throws before the in-body `container.dispose()` runs, the
-  /// teardown still disposes the container so it never leaks into the next
-  /// test. The in-body dispose calls stay because they run *before* the
-  /// binding's pending-timer check and cancel cacheFor keep-alive timers
-  /// (addTearDown runs after that check, so it cannot replace them).
-  /// Riverpod's dispose() is a no-op on an already-disposed container.
   ProviderContainer makeContainer({List<Override> overrides = const []}) {
     final container = ProviderContainer(overrides: overrides);
     addTearDown(container.dispose);
     return container;
   }
 
-  group('AiRunningAnimation', () {
-    testWidgets('should render SiriWaveform with correct height', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        const WidgetTestBench(
-          child: AiRunningAnimation(height: 100),
-        ),
-      );
-
-      // Verify the SiriWaveform widget is rendered
-      expect(find.byType(SiriWaveform), findsOneWidget);
-
-      // Verify it uses the correct controller type
-      final waveformWidget = tester.widget<SiriWaveform>(
-        find.byType(SiriWaveform),
-      );
-      expect(waveformWidget.controller, isA<IOS9SiriWaveformController>());
-
-      // Verify the height is set correctly
-      final options = waveformWidget.options as IOS9SiriWaveformOptions;
-      expect(options.height, 100);
-    });
-  });
-
-  group('AiRunningAnimationWrapper', () {
-    const testId = 'test-id';
-    const testType = AiResponseType.taskSummary;
-    final testSet = {testType};
-
-    testWidgets('should render nothing when isRunning is false', (
-      tester,
-    ) async {
-      // The default state for inference is idle, so we don't need any overrides
-      await tester.pumpWidget(
-        ProviderScope(
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapper(
-              entryId: testId,
-              height: 100,
-              responseTypes: testSet,
-            ),
-          ),
-        ),
-      );
-
-      // Should render nothing (SizedBox.shrink)
-      expect(find.byType(AiRunningAnimation), findsNothing);
-      expect(find.byType(SizedBox), findsOneWidget);
-    });
-
-    testWidgets('should render animation when isRunning is true', (
-      tester,
-    ) async {
-      // Create a provider container to manage state
-      final container = makeContainer();
-
-      // Set the inference status to running
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapper(
-              entryId: testId,
-              height: 100,
-              responseTypes: testSet,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Should render the animation
-      expect(find.byType(AiRunningAnimation), findsOneWidget);
-
-      container.dispose();
-    });
-
-    testWidgets('should wrap with GestureDetector when isInteractive is true', (
-      tester,
-    ) async {
-      // Create a provider container to manage state
-      final container = makeContainer();
-
-      // Set the inference status to running
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapper(
-              entryId: testId,
-              height: 100,
-              responseTypes: testSet,
-              isInteractive: true,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Should render the animation wrapped in GestureDetector
-      expect(find.byType(AiRunningAnimation), findsOneWidget);
-      expect(find.byType(GestureDetector), findsOneWidget);
-
-      container.dispose();
-    });
-
-    testWidgets(
-      'should not wrap with GestureDetector when isInteractive is false',
-      (tester) async {
-        // Create a provider container to manage state
-        final container = makeContainer();
-
-        // Set the inference status to running
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapper(
-                entryId: testId,
-                height: 100,
-                responseTypes: testSet,
-              ),
-            ),
-          ),
-        );
-
-        // Allow widget to build
-        await tester.pump();
-
-        // Should render the animation without GestureDetector
-        expect(find.byType(AiRunningAnimation), findsOneWidget);
-        expect(find.byType(GestureDetector), findsNothing);
-
-        container.dispose();
-      },
+  Widget buildSubject(
+    ProviderContainer container,
+    Widget child,
+  ) {
+    return UncontrolledProviderScope(
+      container: container,
+      child: WidgetTestBench(child: child),
     );
+  }
 
-    testWidgets('should handle tap when interactive with active inference', (
-      tester,
-    ) async {
-      // This test verifies the _handleTap method executes without error
-      // Full modal display testing would require more complex setup
-
-      // Create a provider container to manage state
-      final container = makeContainer();
-
-      // Set the inference status to running
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapper(
-              entryId: testId,
-              height: 100,
-              responseTypes: testSet,
-              isInteractive: true,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Find and tap the GestureDetector
-      final gesture = find.byType(GestureDetector);
-      expect(gesture, findsOneWidget);
-
-      // No active inference is registered (only the status is running), so
-      // the tap must be a no-op: no progress modal opens and nothing throws.
-      // The modal-opening path is covered in the 'modal interaction' group.
-      await tester.tap(gesture);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 600));
-
-      expect(find.byType(UnifiedAiProgressContent), findsNothing);
-      expect(find.byType(AiRunningAnimation), findsOneWidget);
-      expect(tester.takeException(), isNull);
-
-      container.dispose();
-    });
-
-    testWidgets('should handle multiple response types', (tester) async {
-      // Test with multiple response types in the set
-      final multipleTypes = {
-        AiResponseType.taskSummary,
-        AiResponseType.audioTranscription,
-        AiResponseType.imageAnalysis,
-      };
-
-      // Create a provider container to manage state
-      final container = makeContainer();
-
-      // Set one of the inference statuses to running
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: AiResponseType.audioTranscription,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapper(
-              entryId: testId,
-              height: 100,
-              responseTypes: multipleTypes,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Should render the animation when any type is running
-      expect(find.byType(AiRunningAnimation), findsOneWidget);
-
-      container.dispose();
-    });
-  });
-
-  group('AiRunningAnimationWrapperCard', () {
-    const testId = 'test-id';
-    const testType = AiResponseType.taskSummary;
-    final testSet = {testType};
-
-    testWidgets('should render nothing when isRunning is false', (
-      tester,
-    ) async {
-      // The default state for inference is idle, so we don't need any overrides
-      await tester.pumpWidget(
-        ProviderScope(
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapperCard(
-              entryId: testId,
-              height: 100,
-              responseTypes: testSet,
-            ),
-          ),
-        ),
-      );
-
-      // Should render nothing
-      expect(find.byType(AiRunningAnimation), findsNothing);
-      expect(find.byType(GlassContainer), findsNothing);
-    });
-
-    testWidgets(
-      'should render glass container with animation when isRunning is true',
-      (tester) async {
-        // Create a provider container to manage state
-        final container = makeContainer();
-
-        // Set the inference status to running
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapperCard(
-                entryId: testId,
-                height: 100,
-                responseTypes: testSet,
-              ),
-            ),
-          ),
-        );
-
-        // Allow widget to build
-        await tester.pump();
-
-        // Should render the glass container with animation
-        expect(find.byType(AiRunningAnimation), findsOneWidget);
-        expect(find.byType(GlassContainer), findsOneWidget);
-        expect(find.byType(Center), findsOneWidget);
-
-        container.dispose();
-      },
-    );
-
-    testWidgets('should render with isInteractive parameter', (tester) async {
-      // Create a provider container to manage state
-      final container = makeContainer();
-
-      // Set the inference status to running
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapperCard(
-              entryId: testId,
-              height: 100,
-              responseTypes: testSet,
-              isInteractive: true,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Should render the glass container with animation
-      expect(find.byType(AiRunningAnimation), findsOneWidget);
-      expect(find.byType(GlassContainer), findsOneWidget);
-
-      // The AiRunningAnimationWrapper inside should be interactive — and that
-      // must translate into a real tap target: the inner wrapper wires up a
-      // GestureDetector only when isInteractive is true.
-      final wrapper = tester.widget<AiRunningAnimationWrapper>(
-        find.byType(AiRunningAnimationWrapper),
-      );
-      expect(wrapper.isInteractive, isTrue);
-      expect(
-        find.descendant(
-          of: find.byType(GlassContainer),
-          matching: find.byType(GestureDetector),
-        ),
-        findsOneWidget,
-      );
-
-      container.dispose();
-    });
-
-    testWidgets(
-      'should not be interactive by default (no GestureDetector)',
-      (tester) async {
-        final container = makeContainer();
-
-        // Set the inference status to running
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapperCard(
-                entryId: testId,
-                height: 100,
-                responseTypes: testSet,
-              ),
-            ),
-          ),
-        );
-
-        // Allow widget to build
-        await tester.pump();
-
-        // The inner wrapper must not be interactive and no tap target exists.
-        final wrapper = tester.widget<AiRunningAnimationWrapper>(
-          find.byType(AiRunningAnimationWrapper),
-        );
-        expect(wrapper.isInteractive, isFalse);
-        expect(find.byType(GestureDetector), findsNothing);
-
-        container.dispose();
-      },
-    );
-
-    testWidgets('should handle multiple response types in card', (
-      tester,
-    ) async {
-      // Test with multiple response types
-      final multipleTypes = {
-        AiResponseType.taskSummary,
-        AiResponseType.audioTranscription,
-      };
-
-      // Create a provider container to manage state
-      final container = makeContainer();
-
-      // Set the inference status to running for one type
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: AiResponseType.taskSummary,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapperCard(
-              entryId: testId,
-              height: 100,
-              responseTypes: multipleTypes,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Should render when any type is running
-      expect(find.byType(AiRunningAnimation), findsOneWidget);
-      expect(find.byType(GlassContainer), findsOneWidget);
-
-      container.dispose();
-    });
-
-    testWidgets('should properly set height for glass container', (
-      tester,
-    ) async {
-      // Create a provider container to manage state
-      final container = makeContainer();
-      const testHeight = 150.0;
-
-      // Set the inference status to running
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )).notifier,
-          )
-          .setStatus(InferenceStatus.running);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: WidgetTestBench(
-            child: AiRunningAnimationWrapperCard(
-              entryId: testId,
-              height: testHeight,
-              responseTypes: testSet,
-            ),
-          ),
-        ),
-      );
-
-      // Allow widget to build
-      await tester.pump();
-
-      // Verify the height is passed correctly
-      final glassContainer = tester.widget<GlassContainer>(
-        find.byType(GlassContainer),
-      );
-      expect(glassContainer.height, testHeight);
-
-      container.dispose();
-    });
-  });
+  void setInferenceStatus({
+    required ProviderContainer container,
+    required String entryId,
+    required AiResponseType responseType,
+    required InferenceStatus status,
+  }) {
+    container
+        .read(
+          inferenceStatusControllerProvider((
+            id: entryId,
+            aiResponseType: responseType,
+          )).notifier,
+        )
+        .setStatus(status);
+  }
 
   group('AiRunningDecoderBars', () {
     const testId = 'test-id';
     const testPromptId = 'test-prompt-id';
-    const testType = AiResponseType.taskSummary;
-    final testSet = {testType};
-
-    void setInferenceStatus(
-      ProviderContainer container,
-      InferenceStatus status,
-    ) {
-      container
-          .read(
-            inferenceStatusControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )).notifier,
-          )
-          .setStatus(status);
-    }
+    const testType = AiResponseType.promptGeneration;
+    const testSet = {testType};
 
     testWidgets('renders nothing when no matching inference is running', (
       tester,
     ) async {
+      final container = makeContainer();
+
       await tester.pumpWidget(
-        ProviderScope(
-          child: WidgetTestBench(
-            child: AiRunningDecoderBars(
-              entryId: testId,
-              responseTypes: testSet,
-            ),
+        buildSubject(
+          container,
+          const AiRunningDecoderBars(
+            entryId: testId,
+            responseTypes: testSet,
           ),
         ),
       );
 
       expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsNothing);
       expect(find.byType(AiThinkingLineShader), findsNothing);
+      container.dispose();
     });
 
-    testWidgets('renders decoder-bars shader when inference is running', (
+    testWidgets('renders the decoder route with the configured height', (
       tester,
     ) async {
       final container = makeContainer();
-      try {
-        setInferenceStatus(container, InferenceStatus.running);
+      setInferenceStatus(
+        container: container,
+        entryId: testId,
+        responseType: testType,
+        status: InferenceStatus.running,
+      );
 
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningDecoderBars(
-                entryId: testId,
-                responseTypes: testSet,
-              ),
-            ),
+      await tester.pumpWidget(
+        buildSubject(
+          container,
+          const AiRunningDecoderBars(
+            entryId: testId,
+            responseTypes: testSet,
+            height: 50,
           ),
-        );
-        await tester.pump(AiRunningDecoderBars.transitionDuration);
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
 
-        expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsOneWidget);
-        expect(find.byType(AiThinkingLineShader), findsOneWidget);
-        final shader = tester.widget<AiThinkingLineShader>(
-          find.byType(AiThinkingLineShader),
-        );
-        expect(shader.route, AiThinkingShaderRoute.decoderBars);
-        expect(shader.speed, AiRunningDecoderBars.defaultSpeed);
-        expect(shader.height, AiRunningDecoderBars.defaultHeight);
-        expect(shader.amplitude, AiRunningDecoderBars.defaultAmplitude);
-        expect(shader.randomness, AiRunningDecoderBars.defaultRandomness);
-        expect(shader.pulse, AiRunningDecoderBars.defaultPulse);
-        expect(shader.opacity, 1);
-      } finally {
-        container.dispose();
-      }
+      expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsOneWidget);
+      final shader = tester.widget<AiThinkingLineShader>(
+        find.byType(AiThinkingLineShader),
+      );
+      expect(shader.route, AiThinkingShaderRoute.decoderBars);
+      expect(shader.speed, AiRunningDecoderBars.defaultSpeed);
+      expect(shader.height, 50);
+      expect(shader.amplitude, AiRunningDecoderBars.defaultAmplitude);
+      expect(shader.randomness, AiRunningDecoderBars.defaultRandomness);
+      expect(shader.pulse, AiRunningDecoderBars.defaultPulse);
+      expect(shader.opacity, 1);
+      container.dispose();
     });
 
-    testWidgets('surfaces a detailed inference error after bars stop', (
+    testWidgets('runs when any configured response type is active', (
+      tester,
+    ) async {
+      const responseTypes = {
+        AiResponseType.promptGeneration,
+        AiResponseType.audioTranscription,
+        AiResponseType.imageAnalysis,
+      };
+      final container = makeContainer();
+      setInferenceStatus(
+        container: container,
+        entryId: testId,
+        responseType: AiResponseType.audioTranscription,
+        status: InferenceStatus.running,
+      );
+
+      await tester.pumpWidget(
+        buildSubject(
+          container,
+          const AiRunningDecoderBars(
+            entryId: testId,
+            responseTypes: responseTypes,
+          ),
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+
+      expect(find.byType(AiThinkingLineShader), findsOneWidget);
+      expect(
+        tester
+            .widget<AiThinkingLineShader>(find.byType(AiThinkingLineShader))
+            .route,
+        AiThinkingShaderRoute.decoderBars,
+      );
+      container.dispose();
+    });
+
+    testWidgets('surfaces and consumes detailed inference errors', (
       tester,
     ) async {
       final container = makeContainer();
-      try {
-        setInferenceStatus(container, InferenceStatus.running);
+      setInferenceStatus(
+        container: container,
+        entryId: testId,
+        responseType: testType,
+        status: InferenceStatus.running,
+      );
 
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningDecoderBars(
-                entryId: testId,
-                responseTypes: testSet,
-              ),
-            ),
+      await tester.pumpWidget(
+        buildSubject(
+          container,
+          const AiRunningDecoderBars(
+            entryId: testId,
+            responseTypes: testSet,
           ),
-        );
-        await tester.pump(AiRunningDecoderBars.transitionDuration);
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
 
-        container
-            .read(
-              inferenceErrorControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setError(
-              'HTTP 503 · Melious · request melious-audio-123 failed',
-            );
-        setInferenceStatus(container, InferenceStatus.error);
-        await tester.pump();
-
-        expect(
-          find.text(
+      final errorProvider = inferenceErrorControllerProvider((
+        id: testId,
+        aiResponseType: testType,
+      ));
+      container
+          .read(errorProvider.notifier)
+          .setError(
             'HTTP 503 · Melious · request melious-audio-123 failed',
-          ),
-          findsOneWidget,
-        );
-        expect(
-          container.read(
-            inferenceErrorControllerProvider((
-              id: testId,
-              aiResponseType: testType,
-            )),
-          ),
-          isNull,
-        );
-        await tester.pumpWidget(const SizedBox.shrink());
-      } finally {
-        container.dispose();
-      }
+          );
+      setInferenceStatus(
+        container: container,
+        entryId: testId,
+        responseType: testType,
+        status: InferenceStatus.error,
+      );
+      await tester.pump();
+
+      expect(
+        find.text('HTTP 503 · Melious · request melious-audio-123 failed'),
+        findsOneWidget,
+      );
+      expect(container.read(errorProvider), isNull);
+      container.dispose();
     });
 
-    testWidgets('wraps decoder bars in a tap target when interactive', (
+    testWidgets('opens existing progress when interactive bars are tapped', (
       tester,
     ) async {
-      final container = makeContainer();
-      try {
-        setInferenceStatus(container, InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningDecoderBars(
-                entryId: testId,
-                responseTypes: testSet,
-                isInteractive: true,
-              ),
-            ),
-          ),
-        );
-        await tester.pump(AiRunningDecoderBars.transitionDuration);
-
-        expect(find.byType(GestureDetector), findsOneWidget);
-        expect(find.byType(AiThinkingLineShader), findsOneWidget);
-      } finally {
-        container.dispose();
-      }
-    });
-
-    testWidgets(
-      'animates reserved height and shader amplitude before removing shader',
-      (tester) async {
-        final container = makeContainer();
-        try {
-          await tester.pumpWidget(
-            UncontrolledProviderScope(
-              container: container,
-              child: WidgetTestBench(
-                child: Align(
-                  alignment: Alignment.topCenter,
-                  child: AiRunningDecoderBars(
-                    entryId: testId,
-                    responseTypes: testSet,
-                  ),
-                ),
-              ),
-            ),
-          );
-
-          expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsNothing);
-          expect(find.byType(AiThinkingLineShader), findsNothing);
-
-          setInferenceStatus(container, InferenceStatus.running);
-          await tester.pump();
-          await tester.pump(
-            Duration(
-              milliseconds:
-                  AiRunningDecoderBars.transitionDuration.inMilliseconds ~/ 2,
-            ),
-          );
-
-          final enteringSize = tester.getSize(
-            find.byKey(AiRunningDecoderBars.indicatorKey),
-          );
-          final enteringShader = tester.widget<AiThinkingLineShader>(
-            find.byType(AiThinkingLineShader),
-          );
-          expect(enteringSize.height, greaterThan(0));
-          expect(
-            enteringShader.height,
-            lessThan(AiRunningDecoderBars.defaultHeight),
-          );
-          expect(
-            enteringShader.amplitude,
-            lessThan(AiRunningDecoderBars.defaultAmplitude),
-          );
-          expect(enteringShader.opacity, lessThan(1));
-
-          await tester.pump(AiRunningDecoderBars.transitionDuration);
-          final visibleSize = tester.getSize(
-            find.byKey(AiRunningDecoderBars.indicatorKey),
-          );
-          final visibleShader = tester.widget<AiThinkingLineShader>(
-            find.byType(AiThinkingLineShader),
-          );
-          expect(visibleSize.height, greaterThan(enteringSize.height));
-          expect(visibleShader.height, AiRunningDecoderBars.defaultHeight);
-          expect(
-            visibleShader.amplitude,
-            AiRunningDecoderBars.defaultAmplitude,
-          );
-          expect(visibleShader.opacity, 1);
-
-          setInferenceStatus(container, InferenceStatus.idle);
-          await tester.pump();
-          await tester.pump(
-            Duration(
-              milliseconds:
-                  AiRunningDecoderBars.transitionDuration.inMilliseconds ~/ 2,
-            ),
-          );
-
-          final exitingSize = tester.getSize(
-            find.byKey(AiRunningDecoderBars.indicatorKey),
-          );
-          final exitingShader = tester.widget<AiThinkingLineShader>(
-            find.byType(AiThinkingLineShader),
-          );
-          expect(exitingSize.height, lessThan(visibleSize.height));
-          expect(
-            exitingShader.amplitude,
-            lessThan(AiRunningDecoderBars.defaultAmplitude),
-          );
-          expect(exitingShader.opacity, lessThan(1));
-
-          await tester.pump(AiRunningDecoderBars.transitionDuration);
-
-          expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsNothing);
-          expect(find.byType(AiThinkingLineShader), findsNothing);
-        } finally {
-          container.dispose();
-        }
-      },
-    );
-
-    test('resolves shader width from constraints before media size', () {
-      expect(
-        AiRunningDecoderBars.resolveShaderWidth(
-          const BoxConstraints.tightFor(width: 320),
-          const Size(800, 600),
-        ),
-        320,
-      );
-      expect(
-        AiRunningDecoderBars.resolveShaderWidth(
-          const BoxConstraints(),
-          const Size(800, 600),
-        ),
-        800,
-      );
-    });
-
-    testWidgets('opens existing progress modal when tapped', (tester) async {
       final prompt = AiConfigPrompt(
         id: testPromptId,
         name: 'Decoder prompt',
@@ -847,458 +216,190 @@ void main() {
           ).overrideWith((ref) async => prompt),
         ],
       );
+      container
+          .read(
+            activeInferenceControllerProvider((
+              entityId: testId,
+              aiResponseType: testType,
+            )).notifier,
+          )
+          .startInference(promptId: testPromptId);
+      setInferenceStatus(
+        container: container,
+        entryId: testId,
+        responseType: testType,
+        status: InferenceStatus.running,
+      );
 
-      try {
-        container
-            .read(
-              activeInferenceControllerProvider((
-                entityId: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .startInference(promptId: testPromptId);
-        setInferenceStatus(container, InferenceStatus.running);
+      await tester.pumpWidget(
+        buildSubject(
+          container,
+          const AiRunningDecoderBars(
+            entryId: testId,
+            responseTypes: testSet,
+            isInteractive: true,
+          ),
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+
+      final tapTarget = find.ancestor(
+        of: find.byKey(AiRunningDecoderBars.indicatorKey),
+        matching: find.byType(GestureDetector),
+      );
+      expect(tapTarget, findsOneWidget);
+
+      await tester.tap(tapTarget);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('Decoder prompt'), findsOneWidget);
+      expect(find.byType(UnifiedAiProgressContent), findsOneWidget);
+
+      await tester.tap(
+        find.widgetWithIcon(IconButton, Icons.arrow_back_rounded),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.byType(UnifiedAiProgressContent), findsNothing);
+      container.dispose();
+    });
+
+    testWidgets('does not add a tap target when bars are not interactive', (
+      tester,
+    ) async {
+      final container = makeContainer();
+      setInferenceStatus(
+        container: container,
+        entryId: testId,
+        responseType: testType,
+        status: InferenceStatus.running,
+      );
+
+      await tester.pumpWidget(
+        buildSubject(
+          container,
+          const AiRunningDecoderBars(
+            entryId: testId,
+            responseTypes: testSet,
+          ),
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+
+      expect(find.byType(AiThinkingLineShader), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.byKey(AiRunningDecoderBars.indicatorKey),
+          matching: find.byType(GestureDetector),
+        ),
+        findsNothing,
+      );
+      container.dispose();
+    });
+
+    testWidgets(
+      'animates reserved height and shader amplitude before collapsing',
+      (tester) async {
+        final container = makeContainer();
 
         await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
+          buildSubject(
+            container,
+            const Align(
+              alignment: Alignment.topCenter,
               child: AiRunningDecoderBars(
                 entryId: testId,
                 responseTypes: testSet,
-                isInteractive: true,
               ),
             ),
           ),
         );
+
+        expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsNothing);
+
+        setInferenceStatus(
+          container: container,
+          entryId: testId,
+          responseType: testType,
+          status: InferenceStatus.running,
+        );
+        await tester.pump();
+        await tester.pump(AiRunningDecoderBars.transitionDuration ~/ 2);
+
+        final enteringSize = tester.getSize(
+          find.byKey(AiRunningDecoderBars.indicatorKey),
+        );
+        final enteringShader = tester.widget<AiThinkingLineShader>(
+          find.byType(AiThinkingLineShader),
+        );
+        expect(enteringSize.height, greaterThan(0));
+        expect(
+          enteringShader.height,
+          lessThan(AiRunningDecoderBars.defaultHeight),
+        );
+        expect(
+          enteringShader.amplitude,
+          lessThan(AiRunningDecoderBars.defaultAmplitude),
+        );
+        expect(enteringShader.opacity, lessThan(1));
+
         await tester.pump(AiRunningDecoderBars.transitionDuration);
-
-        final decoderTapTarget = find.ancestor(
-          of: find.byKey(AiRunningDecoderBars.indicatorKey),
-          matching: find.byType(GestureDetector),
+        final visibleSize = tester.getSize(
+          find.byKey(AiRunningDecoderBars.indicatorKey),
         );
-        expect(decoderTapTarget, findsOneWidget);
+        final visibleShader = tester.widget<AiThinkingLineShader>(
+          find.byType(AiThinkingLineShader),
+        );
+        expect(visibleSize.height, greaterThan(enteringSize.height));
+        expect(visibleShader.height, AiRunningDecoderBars.defaultHeight);
+        expect(visibleShader.amplitude, AiRunningDecoderBars.defaultAmplitude);
+        expect(visibleShader.opacity, 1);
 
-        await tester.tap(decoderTapTarget);
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-
-        expect(find.text('Decoder prompt'), findsOneWidget);
-        expect(find.byType(UnifiedAiProgressContent), findsOneWidget);
-
-        await tester.tap(
-          find.widgetWithIcon(IconButton, Icons.arrow_back_rounded),
+        setInferenceStatus(
+          container: container,
+          entryId: testId,
+          responseType: testType,
+          status: InferenceStatus.idle,
         );
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pump(AiRunningDecoderBars.transitionDuration ~/ 2);
 
-        expect(find.byType(UnifiedAiProgressContent), findsNothing);
-      } finally {
+        final exitingSize = tester.getSize(
+          find.byKey(AiRunningDecoderBars.indicatorKey),
+        );
+        final exitingShader = tester.widget<AiThinkingLineShader>(
+          find.byType(AiThinkingLineShader),
+        );
+        expect(exitingSize.height, lessThan(visibleSize.height));
+        expect(
+          exitingShader.amplitude,
+          lessThan(AiRunningDecoderBars.defaultAmplitude),
+        );
+        expect(exitingShader.opacity, lessThan(1));
+
+        await tester.pump(AiRunningDecoderBars.transitionDuration);
+        expect(find.byKey(AiRunningDecoderBars.indicatorKey), findsNothing);
+        expect(find.byType(AiThinkingLineShader), findsNothing);
         container.dispose();
-      }
-    });
-  });
+      },
+    );
 
-  // ── Transplanted from ai_animation_modal_interaction_test.dart so this
-  // file remains the single mirror of ai_running_animation.dart (one test
-  // file per source rule). The GetIt/mock harness is scoped to this group.
-  group('modal interaction', () {
-    late MockDomainLogger mockLoggingService;
-    late MockAiConfigRepository mockAiConfigRepository;
-    late MockAiConfigDb mockAiConfigDb;
-
-    setUpAll(() {
-      registerFallbackValue(StackTrace.current);
-      registerFallbackValue(AiConfigType.prompt);
-    });
-
-    setUp(() async {
-      mockLoggingService = MockDomainLogger();
-      mockAiConfigRepository = MockAiConfigRepository();
-      mockAiConfigDb = MockAiConfigDb();
-
-      // setUpTestGetIt registers a real DomainLogger; swap in the mock so the
-      // log stubs below are hit, and add the AI config services on top.
-      await setUpTestGetIt(
-        additionalSetup: () {
-          getIt
-            ..unregister<DomainLogger>()
-            ..registerSingleton<DomainLogger>(mockLoggingService)
-            ..registerSingleton<AiConfigRepository>(mockAiConfigRepository)
-            ..registerSingleton<AiConfigDb>(mockAiConfigDb);
-        },
-      );
-
-      // Setup mock behaviors
-      when(
-        () => mockLoggingService.log(
-          any<LogDomain>(),
-          any<String>(),
-          subDomain: any(named: 'subDomain'),
+    test('resolves shader width from constraints before media size', () {
+      expect(
+        AiRunningDecoderBars.resolveShaderWidth(
+          const BoxConstraints.tightFor(width: 320),
+          const Size(800, 600),
         ),
-      ).thenReturn(null);
-
-      // Setup AI config repository mock behavior
-      when(
-        () => mockAiConfigRepository.getConfigById(any<String>()),
-      ).thenAnswer((_) async => null);
-
-      when(
-        () => mockAiConfigRepository.watchConfigsByType(any<AiConfigType>()),
-      ).thenAnswer((_) => const Stream.empty());
-    });
-
-    tearDown(tearDownTestGetIt);
-
-    group('AI Animation Modal Interaction Tests', () {
-      const testId = 'test-entity-id';
-      const testPromptId = 'test-prompt-id';
-      const testType = AiResponseType.taskSummary;
-      final testTypes = {testType};
-
-      late AiConfigPrompt testPrompt;
-
-      setUp(() {
-        testPrompt = AiConfigPrompt(
-          id: testPromptId,
-          name: 'Test Prompt',
-          description: 'Test Description',
-          systemMessage: 'Test system message',
-          userMessage: 'Test user message',
-          defaultModelId: 'test-model',
-          modelIds: ['test-model'],
-          createdAt: DateTime(2024, 3, 15, 10, 30),
-          useReasoning: false,
-          requiredInputData: const [],
-          aiResponseType: AiResponseType.taskSummary,
-        );
-      });
-
-      testWidgets(
-        'tapping animation opens progress modal when inference is active',
-        (tester) async {
-          final container = makeContainer(
-            overrides: [
-              // Override the AI config provider
-              aiConfigByIdProvider(
-                testPromptId,
-              ).overrideWith((ref) async => testPrompt),
-            ],
-          );
-
-          // Set up active inference
-          container
-              .read(
-                activeInferenceControllerProvider((
-                  entityId: testId,
-                  aiResponseType: testType,
-                )).notifier,
-              )
-              .startInference(
-                promptId: testPromptId,
-              );
-
-          // Set status to running
-          container
-              .read(
-                inferenceStatusControllerProvider((
-                  id: testId,
-                  aiResponseType: testType,
-                )).notifier,
-              )
-              .setStatus(InferenceStatus.running);
-
-          await tester.pumpWidget(
-            UncontrolledProviderScope(
-              container: container,
-              child: WidgetTestBench(
-                child: AiRunningAnimationWrapper(
-                  entryId: testId,
-                  height: 100,
-                  responseTypes: testTypes,
-                  isInteractive: true,
-                ),
-              ),
-            ),
-          );
-
-          await tester.pump();
-
-          // Verify animation is shown and is interactive
-          expect(find.byType(AiRunningAnimation), findsOneWidget);
-          expect(find.byType(GestureDetector), findsOneWidget);
-
-          // Tapping must actually open the progress modal: the Wolt sheet
-          // page is titled with the prompt name. The sheet hosts the looping
-          // running animation, so settle would never finish — bounded pumps.
-          await tester.tap(find.byType(GestureDetector));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 600));
-
-          expect(find.text(testPrompt.name), findsOneWidget);
-
-          container.dispose();
-        },
+        320,
       );
-
-      testWidgets('animation does not open modal when not interactive', (
-        tester,
-      ) async {
-        final container = makeContainer();
-
-        // Set status to running
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapper(
-                entryId: testId,
-                height: 100,
-                responseTypes: testTypes,
-              ),
-            ),
-          ),
-        );
-
-        await tester.pump();
-
-        // Verify animation is shown but no GestureDetector
-        expect(find.byType(AiRunningAnimation), findsOneWidget);
-        expect(find.byType(GestureDetector), findsNothing);
-
-        container.dispose();
-      });
-
-      testWidgets('handles missing active inference gracefully', (
-        tester,
-      ) async {
-        final container = makeContainer();
-
-        // Set status to running but no active inference
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapper(
-                entryId: testId,
-                height: 100,
-                responseTypes: testTypes,
-                isInteractive: true,
-              ),
-            ),
-          ),
-        );
-
-        await tester.pump();
-
-        // Verify animation exists
-        expect(find.byType(GestureDetector), findsOneWidget);
-
-        // Tap the animation (no active inference, so nothing should happen)
-        await tester.tap(find.byType(GestureDetector));
-        await tester.pump();
-
-        container.dispose();
-      });
-
-      testWidgets('shows existing inference progress with showExisting flag', (
-        tester,
-      ) async {
-        final container = makeContainer(
-          overrides: [
-            aiConfigByIdProvider(
-              testPromptId,
-            ).overrideWith((ref) async => testPrompt),
-          ],
-        );
-
-        // Set up active inference
-        container
-            .read(
-              activeInferenceControllerProvider((
-                entityId: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .startInference(
-              promptId: testPromptId,
-            );
-
-        // Set status to running
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: testType,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapper(
-                entryId: testId,
-                height: 100,
-                responseTypes: testTypes,
-                isInteractive: true,
-              ),
-            ),
-          ),
-        );
-
-        await tester.pump();
-
-        // Verify animation is shown and interactive
-        expect(find.byType(AiRunningAnimation), findsOneWidget);
-        expect(find.byType(GestureDetector), findsOneWidget);
-
-        container.dispose();
-      });
-
-      testWidgets('handles multiple response types correctly', (tester) async {
-        final multipleTypes = {
-          AiResponseType.taskSummary,
-          AiResponseType.audioTranscription,
-          AiResponseType.imageAnalysis,
-        };
-
-        final container = makeContainer(
-          overrides: [
-            aiConfigByIdProvider(
-              testPromptId,
-            ).overrideWith((ref) async => testPrompt),
-          ],
-        );
-
-        // Set up active inference for audioTranscription
-        container
-            .read(
-              activeInferenceControllerProvider((
-                entityId: testId,
-                aiResponseType: AiResponseType.audioTranscription,
-              )).notifier,
-            )
-            .startInference(
-              promptId: testPromptId,
-            );
-
-        // Set status to running for audioTranscription
-        container
-            .read(
-              inferenceStatusControllerProvider((
-                id: testId,
-                aiResponseType: AiResponseType.audioTranscription,
-              )).notifier,
-            )
-            .setStatus(InferenceStatus.running);
-
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: WidgetTestBench(
-              child: AiRunningAnimationWrapper(
-                entryId: testId,
-                height: 100,
-                responseTypes: multipleTypes,
-                isInteractive: true,
-              ),
-            ),
-          ),
-        );
-
-        await tester.pump();
-
-        // Verify animation is shown
-        expect(find.byType(AiRunningAnimation), findsOneWidget);
-        expect(find.byType(GestureDetector), findsOneWidget);
-
-        container.dispose();
-      });
-
-      testWidgets(
-        'AiRunningAnimationWrapperCard shows animation and handles tap',
-        (tester) async {
-          final container = makeContainer(
-            overrides: [
-              aiConfigByIdProvider(
-                testPromptId,
-              ).overrideWith((ref) async => testPrompt),
-            ],
-          );
-
-          // Set up active inference
-          container
-              .read(
-                activeInferenceControllerProvider((
-                  entityId: testId,
-                  aiResponseType: testType,
-                )).notifier,
-              )
-              .startInference(
-                promptId: testPromptId,
-              );
-
-          // Set status to running
-          container
-              .read(
-                inferenceStatusControllerProvider((
-                  id: testId,
-                  aiResponseType: testType,
-                )).notifier,
-              )
-              .setStatus(InferenceStatus.running);
-
-          await tester.pumpWidget(
-            UncontrolledProviderScope(
-              container: container,
-              child: WidgetTestBench(
-                child: AiRunningAnimationWrapperCard(
-                  entryId: testId,
-                  height: 50,
-                  responseTypes: testTypes,
-                  isInteractive: true,
-                ),
-              ),
-            ),
-          );
-
-          await tester.pump();
-
-          // Verify glass container and animation are shown
-          expect(find.byType(AiRunningAnimation), findsOneWidget);
-          expect(find.byType(GestureDetector), findsOneWidget);
-
-          // Verify it's wrapped in the glass container
-          expect(
-            find.ancestor(
-              of: find.byType(AiRunningAnimation),
-              matching: find.byType(GlassContainer),
-            ),
-            findsOneWidget,
-          );
-
-          container.dispose();
-        },
+      expect(
+        AiRunningDecoderBars.resolveShaderWidth(
+          const BoxConstraints(),
+          const Size(800, 600),
+        ),
+        800,
       );
     });
   });
@@ -1306,39 +407,72 @@ void main() {
   group('AiThinkingShaderPresence', () {
     const key = ValueKey('presence-box');
 
-    testWidgets('adopts a new transitionDuration on rebuild', (tester) async {
-      // Seeded fully shown at mount with a short exit duration.
+    testWidgets('uses local running state for entry and exit transitions', (
+      tester,
+    ) async {
       await tester.pumpWidget(
-        makeTestableWidget(
-          const Center(
-            child: AiThinkingShaderPresence(
-              isRunning: true,
-              transitionDuration: Duration(milliseconds: 100),
-              indicatorKey: key,
-            ),
+        const WidgetTestBench(
+          child: AiThinkingShaderPresence(
+            isRunning: false,
+            indicatorKey: key,
+          ),
+        ),
+      );
+      expect(find.byKey(key), findsNothing);
+
+      await tester.pumpWidget(
+        const WidgetTestBench(
+          child: AiThinkingShaderPresence(
+            isRunning: true,
+            indicatorKey: key,
+          ),
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+      expect(find.byKey(key), findsOneWidget);
+      expect(
+        tester
+            .widget<AiThinkingLineShader>(find.byType(AiThinkingLineShader))
+            .route,
+        AiThinkingShaderRoute.decoderBars,
+      );
+
+      await tester.pumpWidget(
+        const WidgetTestBench(
+          child: AiThinkingShaderPresence(
+            isRunning: false,
+            indicatorKey: key,
+          ),
+        ),
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+      expect(find.byKey(key), findsNothing);
+    });
+
+    testWidgets('adopts a new transition duration on rebuild', (tester) async {
+      await tester.pumpWidget(
+        const WidgetTestBench(
+          child: AiThinkingShaderPresence(
+            isRunning: true,
+            transitionDuration: Duration(milliseconds: 100),
+            indicatorKey: key,
           ),
         ),
       );
       expect(find.byKey(key), findsOneWidget);
 
-      // Rebuild with isRunning false AND a much longer transitionDuration:
-      // didUpdateWidget must adopt the new duration for the exit animation.
       await tester.pumpWidget(
-        makeTestableWidget(
-          const Center(
-            child: AiThinkingShaderPresence(
-              isRunning: false,
-              transitionDuration: Duration(seconds: 1),
-              indicatorKey: key,
-            ),
+        const WidgetTestBench(
+          child: AiThinkingShaderPresence(
+            isRunning: false,
+            transitionDuration: Duration(seconds: 1),
+            indicatorKey: key,
           ),
         ),
       );
       await tester.pump();
-
-      // Past the OLD 100ms duration the shader would be gone; with the
-      // adopted 1s duration it is still mid-exit.
       await tester.pump(const Duration(milliseconds: 300));
+
       expect(find.byKey(key), findsOneWidget);
       final shader = tester.widget<AiThinkingLineShader>(
         find.byType(AiThinkingLineShader),
@@ -1346,7 +480,6 @@ void main() {
       expect(shader.opacity, greaterThan(0));
       expect(shader.opacity, lessThan(1));
 
-      // After the full new duration it collapses away.
       await tester.pump(const Duration(seconds: 1));
       expect(find.byKey(key), findsNothing);
       expect(find.byType(AiThinkingLineShader), findsNothing);

--- a/test/features/ai/ui/image_generation/cover_art_skill_modal_test.dart
+++ b/test/features/ai/ui/image_generation/cover_art_skill_modal_test.dart
@@ -9,6 +9,8 @@ import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/state/reference_image_selection_controller.dart';
 import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
+import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
+import 'package:lotti/features/ai/ui/animation/ai_state_shader_animation.dart';
 import 'package:lotti/features/ai/ui/image_generation/cover_art_skill_modal.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:lotti/get_it.dart';
@@ -134,6 +136,8 @@ void main() {
 
         // Should now show the progress view with "Generating image..." text
         expect(find.text('Generating image...'), findsOneWidget);
+        expect(find.byType(AiThinkingShaderPresence), findsOneWidget);
+        expect(find.byType(AiThinkingLineShader), findsOneWidget);
       },
     );
 
@@ -393,6 +397,7 @@ void main() {
       await tester.pump();
       await tester.pump();
       await tester.pump();
+      expect(find.byType(AiThinkingLineShader), findsOneWidget);
 
       // Now transition to idle (completion)
       final container = ProviderScope.containerOf(
@@ -410,6 +415,20 @@ void main() {
 
       // Should show completion state
       expect(find.text('Cover art ready!'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline_rounded), findsOneWidget);
+      expect(
+        tester
+            .widget<AiThinkingShaderPresence>(
+              find.byType(AiThinkingShaderPresence),
+            )
+            .isRunning,
+        isFalse,
+      );
+
+      // The local presence envelope exits before removing the shader while
+      // the completion icon remains visible in the stable status region.
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+      expect(find.byType(AiThinkingLineShader), findsNothing);
       expect(find.byIcon(Icons.check_circle_outline_rounded), findsOneWidget);
     });
 
@@ -549,6 +568,17 @@ void main() {
 
       // Should show error state
       expect(find.text('Failed to generate image'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
+      expect(
+        tester
+            .widget<AiThinkingShaderPresence>(
+              find.byType(AiThinkingShaderPresence),
+            )
+            .isRunning,
+        isFalse,
+      );
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+      expect(find.byType(AiThinkingLineShader), findsNothing);
       expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
     });
 

--- a/test/features/ai/ui/unified_ai_progress_view_test.dart
+++ b/test/features/ai/ui/unified_ai_progress_view_test.dart
@@ -771,7 +771,7 @@ void main() {
 
       await tester.pump();
 
-      expect(find.byType(AiRunningAnimationWrapper), findsOneWidget);
+      expect(find.byType(AiRunningDecoderBars), findsOneWidget);
     });
   });
 
@@ -810,7 +810,7 @@ void main() {
               // Sticky action bar hosts the running animation keyed to this
               // entity and the prompt's response type.
               final align = page.stickyActionBar! as Align;
-              final animation = align.child! as AiRunningAnimationWrapper;
+              final animation = align.child! as AiRunningDecoderBars;
               expect(animation.entryId, 'test-entity');
               expect(
                 animation.responseTypes,

--- a/test/features/journal/ui/pages/TEST_REVIEW.md
+++ b/test/features/journal/ui/pages/TEST_REVIEW.md
@@ -97,8 +97,8 @@ The `HighlightScrollMixin` is tested directly in `test/features/journal/ui/mixin
 - [x] **[LOW]** `infinite_journal_page.dart:19-23` — the `selectedCategoryIds.length == 1` → single `categoryId` logic is tested in `infinite_journal_page_bottom_padding_test.dart:127-170`, which is good. The `length > 1` → `null` branch is also covered implicitly (multi-select → null FAB categoryId). Coverage appears adequate here.
   **RESOLVED:** done — the `length > 1` branch was only "covered implicitly" with no explicit assertion. Added a sibling test in `infinite_journal_page_test.dart` ('passes null categoryId to FloatingAddActionButton when multiple categories are selected') that drives the page with two `selectedCategoryIds` and asserts `fab.categoryId` is `null`, mirroring the existing single-id test and making the ternary's else branch explicitly verified.
 
-- [x] **[LOW]** `entry_details_page.dart:114-186` — the `AiRunningAnimationWrapperCard` at the bottom of the Stack is never directly asserted in any test. Any regression in its placement or configuration would be invisible.
-  **RESOLVED:** done — the 'Text Entry is rendered' test now asserts `find.byType(AiRunningAnimationWrapperCard)` is present, so a regression that drops the card from the page Stack (source lines 171-183) would fail the test.
+- [x] **[LOW]** `entry_details_page.dart:114-186` — the AI activity indicator at the bottom of the Stack was never directly asserted in any test. Any regression in its placement or configuration would be invisible.
+  **RESOLVED:** done — the 'Text Entry is rendered' test asserts the interactive `AiRunningDecoderBars` configuration, including the entry ID and image-analysis, transcription, and prompt-generation response types.
 
 ---
 

--- a/test/features/journal/ui/pages/entry_details_page_test.dart
+++ b/test/features/journal/ui/pages/entry_details_page_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
@@ -199,10 +200,18 @@ void main() {
       // test text entry is starred
       expect(find.byIcon(Icons.star_rounded), findsOneWidget);
 
-      // The AI running animation card is mounted at the bottom of the page
-      // Stack (source lines 171-183); a regression in its placement would
-      // remove it from the tree.
-      expect(find.byType(AiRunningAnimationWrapperCard), findsOneWidget);
+      // Decoder bars are mounted at the bottom of the page Stack and retain
+      // the three entry-processing routes plus tap-to-progress behavior.
+      final decoderBars = tester.widget<AiRunningDecoderBars>(
+        find.byType(AiRunningDecoderBars),
+      );
+      expect(decoderBars.entryId, testTextEntry.meta.id);
+      expect(decoderBars.isInteractive, isTrue);
+      expect(decoderBars.responseTypes, {
+        AiResponseType.imageAnalysis,
+        AiResponseType.audioTranscription,
+        AiResponseType.promptGeneration,
+      });
     });
 
     testWidgets('save command persists the current text entry', (tester) async {


### PR DESCRIPTION
## Summary

- replace the remaining Siri-style activity waveforms in Unified AI progress and Entry Details with the established shader-based decoder bars
- drive cover-art generation from its existing local `isRunning` state through `AiThinkingShaderPresence`, keeping a stable status region while the shader exits into completion or error
- remove `AiRunningAnimation`, `AiRunningAnimationWrapper`, `AiRunningAnimationWrapperCard`, and the direct `siri_wave` dependency
- preserve provider gating, detailed inference-error toasts, multi-response matching, and tap-to-open progress behavior
- document every production decoder-bar surface and update the 0.9.1062 changelog plus Flatpak metainfo

## Why

Task Details and Daily OS already used the shared decoder-bars visual, while Unified AI progress, Entry Details, and cover-art generation still showed the older iOS-style waveform. This completes the migration so AI activity has one consistent visual language and the obsolete package and compatibility widgets can be deleted.

## User impact

Running AI work is now represented consistently across task details, journal entries, progress modals, Daily OS, and cover-art generation. Entry Details remains interactive and continues surfacing detailed provider failures. Cover-art generation keeps its status area stable as the animation transitions to success or error.

## Screenshots

| Before — legacy Siri waveforms | After — decoder bars |
| --- | --- |
| ![Legacy Siri activity indicators](https://raw.githubusercontent.com/matthiasn/lotti-docs/4c7652efb006f6400ec4cfaa59520f602c2af67f/pr-screenshots/replace-siri-animation/before/ai_activity_surfaces_before.png) | ![Unified decoder-bar activity indicators](https://raw.githubusercontent.com/matthiasn/lotti-docs/4c7652efb006f6400ec4cfaa59520f602c2af67f/pr-screenshots/replace-siri-animation/after/ai_activity_surfaces_after.png) |

The comparison uses the real production widgets and runtime shaders in an isolated review harness. The temporary harness was removed after capture; PNGs live in the external `lotti-docs` screenshot workflow, not the application repository.

## Verification

- `fvm flutter pub get` — removed `siri_wave 2.3.1` from `pubspec.lock`
- `fvm flutter test test/features/ai/ui/animation/ai_running_animation_test.dart` — 10 passed
- `fvm flutter test test/features/ai/ui/unified_ai_progress_view_test.dart` — 27 passed
- `fvm flutter test test/features/journal/ui/pages/entry_details_page_test.dart` — 23 passed
- `fvm flutter test test/features/ai/ui/image_generation/cover_art_skill_modal_test.dart` — 10 passed
- `make analyze` — zero warnings or infos
- `fvm dart format .`
- `git diff --check`
- reference searches find no remaining `siri_wave`, `SiriWaveform`, `IOS9SiriWaveform`, or legacy wrapper classes in production/test Dart

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. CI and Codecov are authoritative for the full-suite and patch-coverage results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified decoder-bars animation for AI activity across progress views, entry details, cover-art generation, task details, and Daily OS.
  * Added smooth enter and exit transitions for AI activity indicators.
  * Enabled tapping activity indicators to open progress details where supported.

* **Bug Fixes**
  * Improved consistency of AI activity visuals and completion or error state transitions.

* **Documentation**
  * Updated release notes and AI activity visualization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->