### PR TITLE
feat: move the day-processing outbox to a device-local table (ADR 0044)

### DIFF
--- a/docs/adr/0044-day-processing-outbox-storage.md
+++ b/docs/adr/0044-day-processing-outbox-storage.md
@@ -173,6 +173,10 @@ With those three converted, no caller reads the whole store and
 
 ### 4. Claiming becomes one conditional statement
 
+> Superseded in part by the 2026-07-25 amendment at the end of this
+> document: the select and the update turned out to be expressible as a
+> single statement, which removes the race this section reasons about.
+
 Claim is `UPDATE … SET status='running', claim_token=?, lease_until=? …
 WHERE id=? AND <due predicate>` guarded by affected-row count; fenced
 mutations become `WHERE id=? AND claim_token=? AND status='running'`.
@@ -390,3 +394,44 @@ recorded loses its pending transcription across the migration.
   outbox this ADR supersedes on storage; every other decision in it
   stands)
 - ADR 0032 (hierarchical day agents — extended the outbox to agent jobs)
+
+## Amendment 2026-07-25 — claiming is one statement, not two
+
+Implementation showed decision 4's select-then-conditional-`UPDATE` was
+solving a problem the design does not have.
+
+Both statements run inside one drift transaction on a single connection, so
+a second claimer cannot interleave between choosing a row and stamping it.
+The generation guard could therefore never fail, the "a lost claim is not
+an idle drain" branch was unreachable, and its retry loop was untestable
+dead code that every future reader would still have to reason about.
+
+Claiming is now a single atomic statement:
+
+```sql
+UPDATE day_processing_jobs
+   SET status = 'running', updated_at = ?1, generation = generation + 1,
+       claim_token = ?2, lease_until = ?3,
+       last_error = NULL, last_failure_class = NULL
+ WHERE id = (SELECT id FROM day_processing_jobs
+              WHERE <due predicate> [AND kind IN (…)] [AND id = ?]
+              ORDER BY created_at, id LIMIT 1)
+RETURNING <columns>
+```
+
+`claimNext`, `claimById` and the interactive
+`enqueueAndClaimTranscription` all route through it, differing only in the
+predicate. There is no window to lose, so the lost-versus-idle distinction
+disappears rather than being handled: an empty result means nothing was
+due, which is the only reason a caller sees no claim. `RETURNING` also
+hands back the row as written, so a claim reflects what is durable instead
+of a locally reconstructed copy.
+
+One consequence worth naming: the claim token is bound into the statement
+before it runs, so an attempt matching no row still consumes one. Tokens
+are opaque and unbounded, so gaps carry no meaning.
+
+The fencing on *claimed mutations* (`WHERE id = ? AND claim_token = ? AND
+status = 'running'`) is unchanged — that guards a genuinely concurrent
+case, where a claim holder reports back after the job was terminalized by
+reviewed text or a cancellation.

--- a/integration_test/tutorial/tutorial_harness.dart
+++ b/integration_test/tutorial/tutorial_harness.dart
@@ -43,6 +43,7 @@ import 'package:lotti/features/ai/database/ai_config_db.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart'
     hide aiConfigRepositoryProvider;
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/onboarding/state/onboarding_trigger_service.dart';
 import 'package:lotti/features/settings/constants/theming_settings_keys.dart';
@@ -84,7 +85,6 @@ import 'package:lotti/services/vector_clock_service.dart';
 import 'package:matrix/encryption.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:path/path.dart' as path;
 
 import '../../test/helpers/fallbacks.dart';
 import '../../test/helpers/manual_demo_world.dart';
@@ -475,6 +475,7 @@ class TutorialAppHarness {
     );
     final fts5Db = Fts5Db(inMemoryDatabase: true);
     final editorDb = EditorDb(inMemoryDatabase: true);
+    final dayProcessingDb = DayProcessingDb(inMemoryDatabase: true);
     final syncDatabase = SyncDatabase(inMemoryDatabase: true);
     final agentDatabase = AgentDatabase(
       inMemoryDatabase: true,
@@ -524,12 +525,9 @@ class TutorialAppHarness {
       // getIt directly (day_processing_runtime_provider.dart) rather than a
       // Riverpod override — MyBeamerApp fails to build at all without it,
       // even for scenarios that never touch Daily OS.
+      ..registerSingleton<DayProcessingDb>(dayProcessingDb)
       ..registerSingleton<DayProcessingOutboxRepository>(
-        DayProcessingOutboxRepository(
-          rootDirectory: Directory(
-            path.join(documentsDirectory.path, '.day_processing_outbox'),
-          ),
-        ),
+        DayProcessingOutboxRepository(db: dayProcessingDb),
       )
       ..registerSingleton<SavedTaskFiltersRepository>(
         SavedTaskFiltersRepository(

--- a/integration_test/tutorial/tutorial_harness.dart
+++ b/integration_test/tutorial/tutorial_harness.dart
@@ -608,6 +608,7 @@ class TutorialAppHarness {
       world: world,
       closeables: [
         agentDatabase,
+        dayProcessingDb,
         editorDb,
         fts5Db,
         journalDb,
@@ -693,6 +694,8 @@ class TutorialAppHarness {
           case final SyncDatabase db:
             await db.close();
           case final AgentDatabase db:
+            await db.close();
+          case final DayProcessingDb db:
             await db.close();
         }
       } on Object {

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -259,8 +259,10 @@ lives outside the journal and agent databases because every column describes
 never sync.
 
 Terminal jobs are retained deliberately: Activity and startup repair read them
-as the local processing ledger. That ledger grows for the life of the install,
-so it is kept off every hot path by partial indexes rather than by pruning:
+as the local processing ledger. Two independent mechanisms bound its cost —
+retention caps how far back it reaches (90 days, below), while partial indexes
+keep even the rows still inside that window off every hot path, so query cost
+never depends on ledger size:
 
 | Index | Covers | Serves |
 | --- | --- | --- |

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -250,6 +250,57 @@ device-local processing outbox that transcription uses (`services/day_processing
 a sealed `DayProcessingPayload` per kind (`TranscribeAudioPayload`,
 `ParseCapturePayload`, `DraftPlanPayload`, `RefinePlanPayload`).
 
+### Outbox storage: a device-local table (ADR 0044)
+
+The outbox is a table in its own database (`database/day_processing_db.drift`,
+`day_processing.sqlite`), not the file-per-job store ADR 0031 introduced. It
+lives outside the journal and agent databases because every column describes
+*this* device's progress — claim tokens, leases, attempt counters — and must
+never sync.
+
+Terminal jobs are retained deliberately: Activity and startup repair read them
+as the local processing ledger. That ledger grows for the life of the install,
+so it is kept off every hot path by partial indexes rather than by pruning:
+
+| Index | Covers | Serves |
+| --- | --- | --- |
+| `idx_day_processing_jobs_pending` | `status NOT IN ('succeeded','cancelled')`, keyed `(created_at, id)` | claim selection, the review fence, the runtime's schedule probe |
+| `idx_day_processing_jobs_day` | `(day_id, kind, created_at)` | Activity's day-scoped read |
+| `idx_day_processing_jobs_retention` | terminal rows by `completed_at` | the retention sweep |
+
+Consequently there is no `getAll()`. The three readers that once scanned
+everything are bounded: `DayActivityRepository` calls `getForDay(dayId, kinds:
+…)`, `DayAudioReviewFence` calls `getPendingByKind(transcribeAudio)`, and
+`DayProcessingRuntime` calls `getSchedulable()`. Claim cost tracks outstanding
+work rather than install age.
+
+**Claiming** is one atomic statement — `UPDATE … WHERE id = (SELECT … ORDER BY
+created_at, id LIMIT 1) RETURNING …` — so there is no window in which a second
+claimer can take a row between it being chosen and owned. FIFO by creation
+time with the id as tie-break, filtered by the SQL form of
+`DayProcessingJob.isDue`. Mutations by a claim holder are fenced on
+`claim_token`, so a worker whose claim was revoked (reviewed text satisfied the
+job, or its recording was deleted) cannot overwrite the terminal state.
+
+**Retention** removes terminal rows whose `completed_at` is older than
+`dayProcessingLedgerRetention` (90 days) on the once-per-start repair pass. No
+non-terminal row is ever eligible regardless of age: a job parked in `failed`,
+`waitingForUser` or `waitingForNetwork` is outstanding user intent that
+`retryNow` or a re-enqueue can still resurrect.
+
+**Migration.** `initializeDayProcessingOutbox` runs the one-off cutover during
+app start, before the runtime starts and before any enqueue path is wired up —
+that quiescing is the write barrier, since a transaction cannot span the
+filesystem. It imports every job file, verifies by *identity* (the set of ids
+on disk, re-scanned until stable — a row count can match while the ids differ),
+and commits the sentinel into `day_processing_migrations` in the same
+transaction as the confirming scan, so the import and the cutover marker share
+one durability domain. Verification is one-directional: a table row with no
+file behind it is kept, because no code path deletes a job file to express
+intent. `DayProcessingLegacyFileStore` is the read-only remnant of the old
+store — it keeps the partial-recovery and quarantine logic the table does not
+need — and goes when the job files are deleted a release later.
+
 ```mermaid
 sequenceDiagram
   participant UI as RealDayAgent

--- a/lib/features/daily_os_next/database/day_processing_db.dart
+++ b/lib/features/daily_os_next/database/day_processing_db.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:lotti/database/common.dart';
+
+part 'day_processing_db.g.dart';
+
+const dayProcessingDbFileName = 'day_processing.sqlite';
+
+/// Key of the file-to-table cutover record in `day_processing_migrations`.
+const dayProcessingFileImportMigrationKey = 'file_outbox_import';
+
+/// Device-local durable store for Daily OS processing intents (ADR 0044).
+///
+/// Replaces the file-per-job outbox introduced by ADR 0031. Kept out of the
+/// journal and agent databases because every column here describes *this*
+/// device's progress — claim tokens, leases, attempt counters — and must never
+/// sync. Terminal rows are retained as the Activity ledger; the partial
+/// indexes in `day_processing_db.drift` keep that ledger off the drain path.
+@DriftDatabase(include: {'day_processing_db.drift'})
+class DayProcessingDb extends _$DayProcessingDb {
+  DayProcessingDb({
+    this.inMemoryDatabase = false,
+    bool background = true,
+    // The outbox is a small queue read on the UI path; a single read isolate
+    // is sufficient and keeps the connection footprint low.
+    int readPool = 1,
+    Future<Directory> Function()? documentsDirectoryProvider,
+    Future<Directory> Function()? tempDirectoryProvider,
+  }) : super(
+         openDbConnection(
+           dayProcessingDbFileName,
+           inMemoryDatabase: inMemoryDatabase,
+           background: background,
+           readPool: readPool,
+           documentsDirectoryProvider: documentsDirectoryProvider,
+           tempDirectoryProvider: tempDirectoryProvider,
+         ),
+       );
+
+  final bool inMemoryDatabase;
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration =>
+      MigrationStrategy(onCreate: (m) => m.createAll());
+}

--- a/lib/features/daily_os_next/database/day_processing_db.drift
+++ b/lib/features/daily_os_next/database/day_processing_db.drift
@@ -1,0 +1,108 @@
+-- Device-local processing outbox (day_processing.sqlite), ADR 0044.
+--
+-- Replaces the file-per-job store from ADR 0031. Rows are strictly
+-- device-local: claim tokens, leases and attempt counters describe *this*
+-- device's progress and must never sync, which is why this lives in its own
+-- database rather than in the journal or agent domains.
+--
+-- Envelope columns are real columns so the drain path can be indexed; the
+-- kind-specific payload and the run-key provenance list stay JSON, exactly as
+-- they were in the file format.
+--
+-- The generated row class is `DayProcessingJobRow`, named explicitly so it
+-- does not collide with the `DayProcessingJob` domain model — the same row-vs-
+-- domain split as `ConsumptionEvent` / `AiConsumptionEvent`. Reads and writes
+-- go through `day_processing_job_row.dart`, not the generated class.
+--
+-- Timestamps are epoch milliseconds (INTEGER), matching `inbound_event_queue`
+-- in sync_db and preserving the millisecond precision that Drift's default
+-- second-granularity DateTime mapping would truncate. They are read back as
+-- UTC, which is what the previous ISO-8601 file encoding produced.
+CREATE TABLE day_processing_jobs (
+  -- Deterministic per intent (`transcribe_<sessionId>`, `parse_<captureId>`,
+  -- `draft_<dayId>`, `refine_<dayId>_<suffix>`), so enqueue is an idempotent
+  -- upsert and the file migration cannot duplicate a job.
+  id TEXT NOT NULL PRIMARY KEY,
+
+  -- DayProcessingJobStatus.name. Text rather than an enum index so the set
+  -- stays readable in the partial indexes below and survives reordering.
+  status TEXT NOT NULL,
+
+  -- DayProcessingJobKind.name.
+  kind TEXT NOT NULL,
+  day_id TEXT NOT NULL,
+
+  -- DayProcessingPayload.toJson() for `kind`.
+  payload TEXT NOT NULL,
+
+  -- JSON array of wake run keys, newest last. NULL when none recorded.
+  run_keys TEXT,
+
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+
+  -- When the work this row currently represents was requested; moves forward
+  -- on re-arm and is the artifact baseline for agent jobs.
+  requested_at INTEGER NOT NULL,
+
+  next_attempt_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  generation INTEGER NOT NULL DEFAULT 0,
+
+  -- Claim fencing. A claimed mutation must present the current token, so a
+  -- worker whose claim was revoked cannot write over the terminal state.
+  claim_token TEXT,
+  lease_until INTEGER,
+
+  -- Hard retry boundary from a provider `Retry-After`.
+  retry_not_before INTEGER,
+
+  last_failure_class TEXT,
+  last_error TEXT,
+
+  -- Provider output staged before the journal side effect, so a local commit
+  -- failure retries without repeating inference.
+  result_transcript TEXT,
+
+  -- Agent-job output id: the DayPlanEntity id for drafts, ChangeSet for
+  -- refines.
+  result_entity_id TEXT,
+
+  completed_at INTEGER
+) AS DayProcessingJobRow;
+
+-- Drain/pending index. Partial on non-terminal rows so the retained ledger —
+-- which grows for the life of the install — is excluded from every hot query.
+-- Keyed on (created_at, id) because claim order is FIFO by creation, with the
+-- id as the tie-break, matching the file store's sort.
+--
+-- Serves both the claim selection (which narrows further to the three
+-- drainable statuses plus the due predicate) and the review fence (which wants
+-- every non-terminal transcription job). Without the partial, both would scan
+-- the ledger.
+CREATE INDEX idx_day_processing_jobs_pending
+  ON day_processing_jobs (created_at, id)
+  WHERE status NOT IN ('succeeded', 'cancelled');
+
+-- Activity index: the day view reads one day's jobs instead of the whole
+-- ledger. Includes `kind` because Activity only joins transcription jobs to
+-- recording cards.
+CREATE INDEX idx_day_processing_jobs_day
+  ON day_processing_jobs (day_id, kind, created_at);
+
+-- Retention sweep: terminal rows past the window. Partial so the sweep never
+-- looks at pending work, which is never retention-eligible.
+CREATE INDEX idx_day_processing_jobs_retention
+  ON day_processing_jobs (completed_at)
+  WHERE status IN ('succeeded', 'cancelled');
+
+-- One-row-per-milestone record of completed one-off migrations. The
+-- file-to-table cutover sentinel lives here rather than in a file so it shares
+-- a durability domain with the imported rows: either both commit or neither
+-- does (ADR 0044 decision 6).
+-- `migration_key`, not `key`: drift's grammar treats `key` as reserved and
+-- silently generates a table without that column.
+CREATE TABLE day_processing_migrations (
+  migration_key TEXT NOT NULL PRIMARY KEY,
+  completed_at INTEGER NOT NULL
+) AS DayProcessingMigrationRow;

--- a/lib/features/daily_os_next/database/day_processing_db.g.dart
+++ b/lib/features/daily_os_next/database/day_processing_db.g.dart
@@ -1,0 +1,2130 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'day_processing_db.dart';
+
+// ignore_for_file: type=lint
+class DayProcessingJobs extends Table
+    with TableInfo<DayProcessingJobs, DayProcessingJobRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  DayProcessingJobs(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL PRIMARY KEY',
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _kindMeta = const VerificationMeta('kind');
+  late final GeneratedColumn<String> kind = GeneratedColumn<String>(
+    'kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _dayIdMeta = const VerificationMeta('dayId');
+  late final GeneratedColumn<String> dayId = GeneratedColumn<String>(
+    'day_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _payloadMeta = const VerificationMeta(
+    'payload',
+  );
+  late final GeneratedColumn<String> payload = GeneratedColumn<String>(
+    'payload',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _runKeysMeta = const VerificationMeta(
+    'runKeys',
+  );
+  late final GeneratedColumn<String> runKeys = GeneratedColumn<String>(
+    'run_keys',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _requestedAtMeta = const VerificationMeta(
+    'requestedAt',
+  );
+  late final GeneratedColumn<int> requestedAt = GeneratedColumn<int>(
+    'requested_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _nextAttemptAtMeta = const VerificationMeta(
+    'nextAttemptAt',
+  );
+  late final GeneratedColumn<int> nextAttemptAt = GeneratedColumn<int>(
+    'next_attempt_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  static const VerificationMeta _attemptsMeta = const VerificationMeta(
+    'attempts',
+  );
+  late final GeneratedColumn<int> attempts = GeneratedColumn<int>(
+    'attempts',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT 0',
+    defaultValue: const CustomExpression('0'),
+  );
+  static const VerificationMeta _generationMeta = const VerificationMeta(
+    'generation',
+  );
+  late final GeneratedColumn<int> generation = GeneratedColumn<int>(
+    'generation',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT 0',
+    defaultValue: const CustomExpression('0'),
+  );
+  static const VerificationMeta _claimTokenMeta = const VerificationMeta(
+    'claimToken',
+  );
+  late final GeneratedColumn<String> claimToken = GeneratedColumn<String>(
+    'claim_token',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _leaseUntilMeta = const VerificationMeta(
+    'leaseUntil',
+  );
+  late final GeneratedColumn<int> leaseUntil = GeneratedColumn<int>(
+    'lease_until',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _retryNotBeforeMeta = const VerificationMeta(
+    'retryNotBefore',
+  );
+  late final GeneratedColumn<int> retryNotBefore = GeneratedColumn<int>(
+    'retry_not_before',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _lastFailureClassMeta = const VerificationMeta(
+    'lastFailureClass',
+  );
+  late final GeneratedColumn<String> lastFailureClass = GeneratedColumn<String>(
+    'last_failure_class',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
+    'lastError',
+  );
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _resultTranscriptMeta = const VerificationMeta(
+    'resultTranscript',
+  );
+  late final GeneratedColumn<String> resultTranscript = GeneratedColumn<String>(
+    'result_transcript',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _resultEntityIdMeta = const VerificationMeta(
+    'resultEntityId',
+  );
+  late final GeneratedColumn<String> resultEntityId = GeneratedColumn<String>(
+    'result_entity_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  static const VerificationMeta _completedAtMeta = const VerificationMeta(
+    'completedAt',
+  );
+  late final GeneratedColumn<int> completedAt = GeneratedColumn<int>(
+    'completed_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: '',
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    status,
+    kind,
+    dayId,
+    payload,
+    runKeys,
+    createdAt,
+    updatedAt,
+    requestedAt,
+    nextAttemptAt,
+    attempts,
+    generation,
+    claimToken,
+    leaseUntil,
+    retryNotBefore,
+    lastFailureClass,
+    lastError,
+    resultTranscript,
+    resultEntityId,
+    completedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'day_processing_jobs';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<DayProcessingJobRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_statusMeta);
+    }
+    if (data.containsKey('kind')) {
+      context.handle(
+        _kindMeta,
+        kind.isAcceptableOrUnknown(data['kind']!, _kindMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_kindMeta);
+    }
+    if (data.containsKey('day_id')) {
+      context.handle(
+        _dayIdMeta,
+        dayId.isAcceptableOrUnknown(data['day_id']!, _dayIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dayIdMeta);
+    }
+    if (data.containsKey('payload')) {
+      context.handle(
+        _payloadMeta,
+        payload.isAcceptableOrUnknown(data['payload']!, _payloadMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_payloadMeta);
+    }
+    if (data.containsKey('run_keys')) {
+      context.handle(
+        _runKeysMeta,
+        runKeys.isAcceptableOrUnknown(data['run_keys']!, _runKeysMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('requested_at')) {
+      context.handle(
+        _requestedAtMeta,
+        requestedAt.isAcceptableOrUnknown(
+          data['requested_at']!,
+          _requestedAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_requestedAtMeta);
+    }
+    if (data.containsKey('next_attempt_at')) {
+      context.handle(
+        _nextAttemptAtMeta,
+        nextAttemptAt.isAcceptableOrUnknown(
+          data['next_attempt_at']!,
+          _nextAttemptAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_nextAttemptAtMeta);
+    }
+    if (data.containsKey('attempts')) {
+      context.handle(
+        _attemptsMeta,
+        attempts.isAcceptableOrUnknown(data['attempts']!, _attemptsMeta),
+      );
+    }
+    if (data.containsKey('generation')) {
+      context.handle(
+        _generationMeta,
+        generation.isAcceptableOrUnknown(data['generation']!, _generationMeta),
+      );
+    }
+    if (data.containsKey('claim_token')) {
+      context.handle(
+        _claimTokenMeta,
+        claimToken.isAcceptableOrUnknown(data['claim_token']!, _claimTokenMeta),
+      );
+    }
+    if (data.containsKey('lease_until')) {
+      context.handle(
+        _leaseUntilMeta,
+        leaseUntil.isAcceptableOrUnknown(data['lease_until']!, _leaseUntilMeta),
+      );
+    }
+    if (data.containsKey('retry_not_before')) {
+      context.handle(
+        _retryNotBeforeMeta,
+        retryNotBefore.isAcceptableOrUnknown(
+          data['retry_not_before']!,
+          _retryNotBeforeMeta,
+        ),
+      );
+    }
+    if (data.containsKey('last_failure_class')) {
+      context.handle(
+        _lastFailureClassMeta,
+        lastFailureClass.isAcceptableOrUnknown(
+          data['last_failure_class']!,
+          _lastFailureClassMeta,
+        ),
+      );
+    }
+    if (data.containsKey('last_error')) {
+      context.handle(
+        _lastErrorMeta,
+        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+      );
+    }
+    if (data.containsKey('result_transcript')) {
+      context.handle(
+        _resultTranscriptMeta,
+        resultTranscript.isAcceptableOrUnknown(
+          data['result_transcript']!,
+          _resultTranscriptMeta,
+        ),
+      );
+    }
+    if (data.containsKey('result_entity_id')) {
+      context.handle(
+        _resultEntityIdMeta,
+        resultEntityId.isAcceptableOrUnknown(
+          data['result_entity_id']!,
+          _resultEntityIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('completed_at')) {
+      context.handle(
+        _completedAtMeta,
+        completedAt.isAcceptableOrUnknown(
+          data['completed_at']!,
+          _completedAtMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  DayProcessingJobRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return DayProcessingJobRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      kind: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}kind'],
+      )!,
+      dayId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}day_id'],
+      )!,
+      payload: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}payload'],
+      )!,
+      runKeys: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}run_keys'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      requestedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}requested_at'],
+      )!,
+      nextAttemptAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}next_attempt_at'],
+      )!,
+      attempts: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}attempts'],
+      )!,
+      generation: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}generation'],
+      )!,
+      claimToken: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}claim_token'],
+      ),
+      leaseUntil: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}lease_until'],
+      ),
+      retryNotBefore: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}retry_not_before'],
+      ),
+      lastFailureClass: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_failure_class'],
+      ),
+      lastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_error'],
+      ),
+      resultTranscript: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}result_transcript'],
+      ),
+      resultEntityId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}result_entity_id'],
+      ),
+      completedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}completed_at'],
+      ),
+    );
+  }
+
+  @override
+  DayProcessingJobs createAlias(String alias) {
+    return DayProcessingJobs(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class DayProcessingJobRow extends DataClass
+    implements Insertable<DayProcessingJobRow> {
+  /// Deterministic per intent (`transcribe_<sessionId>`, `parse_<captureId>`,
+  /// `draft_<dayId>`, `refine_<dayId>_<suffix>`), so enqueue is an idempotent
+  /// upsert and the file migration cannot duplicate a job.
+  final String id;
+
+  /// DayProcessingJobStatus.name. Text rather than an enum index so the set
+  /// stays readable in the partial indexes below and survives reordering.
+  final String status;
+
+  /// DayProcessingJobKind.name.
+  final String kind;
+  final String dayId;
+
+  /// DayProcessingPayload.toJson() for `kind`.
+  final String payload;
+
+  /// JSON array of wake run keys, newest last. NULL when none recorded.
+  final String? runKeys;
+  final int createdAt;
+  final int updatedAt;
+
+  /// When the work this row currently represents was requested; moves forward
+  /// on re-arm and is the artifact baseline for agent jobs.
+  final int requestedAt;
+  final int nextAttemptAt;
+  final int attempts;
+  final int generation;
+
+  /// Claim fencing. A claimed mutation must present the current token, so a
+  /// worker whose claim was revoked cannot write over the terminal state.
+  final String? claimToken;
+  final int? leaseUntil;
+
+  /// Hard retry boundary from a provider `Retry-After`.
+  final int? retryNotBefore;
+  final String? lastFailureClass;
+  final String? lastError;
+
+  /// Provider output staged before the journal side effect, so a local commit
+  /// failure retries without repeating inference.
+  final String? resultTranscript;
+
+  /// Agent-job output id: the DayPlanEntity id for drafts, ChangeSet for
+  /// refines.
+  final String? resultEntityId;
+  final int? completedAt;
+  const DayProcessingJobRow({
+    required this.id,
+    required this.status,
+    required this.kind,
+    required this.dayId,
+    required this.payload,
+    this.runKeys,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.requestedAt,
+    required this.nextAttemptAt,
+    required this.attempts,
+    required this.generation,
+    this.claimToken,
+    this.leaseUntil,
+    this.retryNotBefore,
+    this.lastFailureClass,
+    this.lastError,
+    this.resultTranscript,
+    this.resultEntityId,
+    this.completedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['status'] = Variable<String>(status);
+    map['kind'] = Variable<String>(kind);
+    map['day_id'] = Variable<String>(dayId);
+    map['payload'] = Variable<String>(payload);
+    if (!nullToAbsent || runKeys != null) {
+      map['run_keys'] = Variable<String>(runKeys);
+    }
+    map['created_at'] = Variable<int>(createdAt);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['requested_at'] = Variable<int>(requestedAt);
+    map['next_attempt_at'] = Variable<int>(nextAttemptAt);
+    map['attempts'] = Variable<int>(attempts);
+    map['generation'] = Variable<int>(generation);
+    if (!nullToAbsent || claimToken != null) {
+      map['claim_token'] = Variable<String>(claimToken);
+    }
+    if (!nullToAbsent || leaseUntil != null) {
+      map['lease_until'] = Variable<int>(leaseUntil);
+    }
+    if (!nullToAbsent || retryNotBefore != null) {
+      map['retry_not_before'] = Variable<int>(retryNotBefore);
+    }
+    if (!nullToAbsent || lastFailureClass != null) {
+      map['last_failure_class'] = Variable<String>(lastFailureClass);
+    }
+    if (!nullToAbsent || lastError != null) {
+      map['last_error'] = Variable<String>(lastError);
+    }
+    if (!nullToAbsent || resultTranscript != null) {
+      map['result_transcript'] = Variable<String>(resultTranscript);
+    }
+    if (!nullToAbsent || resultEntityId != null) {
+      map['result_entity_id'] = Variable<String>(resultEntityId);
+    }
+    if (!nullToAbsent || completedAt != null) {
+      map['completed_at'] = Variable<int>(completedAt);
+    }
+    return map;
+  }
+
+  DayProcessingJobsCompanion toCompanion(bool nullToAbsent) {
+    return DayProcessingJobsCompanion(
+      id: Value(id),
+      status: Value(status),
+      kind: Value(kind),
+      dayId: Value(dayId),
+      payload: Value(payload),
+      runKeys: runKeys == null && nullToAbsent
+          ? const Value.absent()
+          : Value(runKeys),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      requestedAt: Value(requestedAt),
+      nextAttemptAt: Value(nextAttemptAt),
+      attempts: Value(attempts),
+      generation: Value(generation),
+      claimToken: claimToken == null && nullToAbsent
+          ? const Value.absent()
+          : Value(claimToken),
+      leaseUntil: leaseUntil == null && nullToAbsent
+          ? const Value.absent()
+          : Value(leaseUntil),
+      retryNotBefore: retryNotBefore == null && nullToAbsent
+          ? const Value.absent()
+          : Value(retryNotBefore),
+      lastFailureClass: lastFailureClass == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastFailureClass),
+      lastError: lastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastError),
+      resultTranscript: resultTranscript == null && nullToAbsent
+          ? const Value.absent()
+          : Value(resultTranscript),
+      resultEntityId: resultEntityId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(resultEntityId),
+      completedAt: completedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(completedAt),
+    );
+  }
+
+  factory DayProcessingJobRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return DayProcessingJobRow(
+      id: serializer.fromJson<String>(json['id']),
+      status: serializer.fromJson<String>(json['status']),
+      kind: serializer.fromJson<String>(json['kind']),
+      dayId: serializer.fromJson<String>(json['day_id']),
+      payload: serializer.fromJson<String>(json['payload']),
+      runKeys: serializer.fromJson<String?>(json['run_keys']),
+      createdAt: serializer.fromJson<int>(json['created_at']),
+      updatedAt: serializer.fromJson<int>(json['updated_at']),
+      requestedAt: serializer.fromJson<int>(json['requested_at']),
+      nextAttemptAt: serializer.fromJson<int>(json['next_attempt_at']),
+      attempts: serializer.fromJson<int>(json['attempts']),
+      generation: serializer.fromJson<int>(json['generation']),
+      claimToken: serializer.fromJson<String?>(json['claim_token']),
+      leaseUntil: serializer.fromJson<int?>(json['lease_until']),
+      retryNotBefore: serializer.fromJson<int?>(json['retry_not_before']),
+      lastFailureClass: serializer.fromJson<String?>(
+        json['last_failure_class'],
+      ),
+      lastError: serializer.fromJson<String?>(json['last_error']),
+      resultTranscript: serializer.fromJson<String?>(json['result_transcript']),
+      resultEntityId: serializer.fromJson<String?>(json['result_entity_id']),
+      completedAt: serializer.fromJson<int?>(json['completed_at']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'status': serializer.toJson<String>(status),
+      'kind': serializer.toJson<String>(kind),
+      'day_id': serializer.toJson<String>(dayId),
+      'payload': serializer.toJson<String>(payload),
+      'run_keys': serializer.toJson<String?>(runKeys),
+      'created_at': serializer.toJson<int>(createdAt),
+      'updated_at': serializer.toJson<int>(updatedAt),
+      'requested_at': serializer.toJson<int>(requestedAt),
+      'next_attempt_at': serializer.toJson<int>(nextAttemptAt),
+      'attempts': serializer.toJson<int>(attempts),
+      'generation': serializer.toJson<int>(generation),
+      'claim_token': serializer.toJson<String?>(claimToken),
+      'lease_until': serializer.toJson<int?>(leaseUntil),
+      'retry_not_before': serializer.toJson<int?>(retryNotBefore),
+      'last_failure_class': serializer.toJson<String?>(lastFailureClass),
+      'last_error': serializer.toJson<String?>(lastError),
+      'result_transcript': serializer.toJson<String?>(resultTranscript),
+      'result_entity_id': serializer.toJson<String?>(resultEntityId),
+      'completed_at': serializer.toJson<int?>(completedAt),
+    };
+  }
+
+  DayProcessingJobRow copyWith({
+    String? id,
+    String? status,
+    String? kind,
+    String? dayId,
+    String? payload,
+    Value<String?> runKeys = const Value.absent(),
+    int? createdAt,
+    int? updatedAt,
+    int? requestedAt,
+    int? nextAttemptAt,
+    int? attempts,
+    int? generation,
+    Value<String?> claimToken = const Value.absent(),
+    Value<int?> leaseUntil = const Value.absent(),
+    Value<int?> retryNotBefore = const Value.absent(),
+    Value<String?> lastFailureClass = const Value.absent(),
+    Value<String?> lastError = const Value.absent(),
+    Value<String?> resultTranscript = const Value.absent(),
+    Value<String?> resultEntityId = const Value.absent(),
+    Value<int?> completedAt = const Value.absent(),
+  }) => DayProcessingJobRow(
+    id: id ?? this.id,
+    status: status ?? this.status,
+    kind: kind ?? this.kind,
+    dayId: dayId ?? this.dayId,
+    payload: payload ?? this.payload,
+    runKeys: runKeys.present ? runKeys.value : this.runKeys,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    requestedAt: requestedAt ?? this.requestedAt,
+    nextAttemptAt: nextAttemptAt ?? this.nextAttemptAt,
+    attempts: attempts ?? this.attempts,
+    generation: generation ?? this.generation,
+    claimToken: claimToken.present ? claimToken.value : this.claimToken,
+    leaseUntil: leaseUntil.present ? leaseUntil.value : this.leaseUntil,
+    retryNotBefore: retryNotBefore.present
+        ? retryNotBefore.value
+        : this.retryNotBefore,
+    lastFailureClass: lastFailureClass.present
+        ? lastFailureClass.value
+        : this.lastFailureClass,
+    lastError: lastError.present ? lastError.value : this.lastError,
+    resultTranscript: resultTranscript.present
+        ? resultTranscript.value
+        : this.resultTranscript,
+    resultEntityId: resultEntityId.present
+        ? resultEntityId.value
+        : this.resultEntityId,
+    completedAt: completedAt.present ? completedAt.value : this.completedAt,
+  );
+  DayProcessingJobRow copyWithCompanion(DayProcessingJobsCompanion data) {
+    return DayProcessingJobRow(
+      id: data.id.present ? data.id.value : this.id,
+      status: data.status.present ? data.status.value : this.status,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      dayId: data.dayId.present ? data.dayId.value : this.dayId,
+      payload: data.payload.present ? data.payload.value : this.payload,
+      runKeys: data.runKeys.present ? data.runKeys.value : this.runKeys,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      requestedAt: data.requestedAt.present
+          ? data.requestedAt.value
+          : this.requestedAt,
+      nextAttemptAt: data.nextAttemptAt.present
+          ? data.nextAttemptAt.value
+          : this.nextAttemptAt,
+      attempts: data.attempts.present ? data.attempts.value : this.attempts,
+      generation: data.generation.present
+          ? data.generation.value
+          : this.generation,
+      claimToken: data.claimToken.present
+          ? data.claimToken.value
+          : this.claimToken,
+      leaseUntil: data.leaseUntil.present
+          ? data.leaseUntil.value
+          : this.leaseUntil,
+      retryNotBefore: data.retryNotBefore.present
+          ? data.retryNotBefore.value
+          : this.retryNotBefore,
+      lastFailureClass: data.lastFailureClass.present
+          ? data.lastFailureClass.value
+          : this.lastFailureClass,
+      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+      resultTranscript: data.resultTranscript.present
+          ? data.resultTranscript.value
+          : this.resultTranscript,
+      resultEntityId: data.resultEntityId.present
+          ? data.resultEntityId.value
+          : this.resultEntityId,
+      completedAt: data.completedAt.present
+          ? data.completedAt.value
+          : this.completedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DayProcessingJobRow(')
+          ..write('id: $id, ')
+          ..write('status: $status, ')
+          ..write('kind: $kind, ')
+          ..write('dayId: $dayId, ')
+          ..write('payload: $payload, ')
+          ..write('runKeys: $runKeys, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('requestedAt: $requestedAt, ')
+          ..write('nextAttemptAt: $nextAttemptAt, ')
+          ..write('attempts: $attempts, ')
+          ..write('generation: $generation, ')
+          ..write('claimToken: $claimToken, ')
+          ..write('leaseUntil: $leaseUntil, ')
+          ..write('retryNotBefore: $retryNotBefore, ')
+          ..write('lastFailureClass: $lastFailureClass, ')
+          ..write('lastError: $lastError, ')
+          ..write('resultTranscript: $resultTranscript, ')
+          ..write('resultEntityId: $resultEntityId, ')
+          ..write('completedAt: $completedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    status,
+    kind,
+    dayId,
+    payload,
+    runKeys,
+    createdAt,
+    updatedAt,
+    requestedAt,
+    nextAttemptAt,
+    attempts,
+    generation,
+    claimToken,
+    leaseUntil,
+    retryNotBefore,
+    lastFailureClass,
+    lastError,
+    resultTranscript,
+    resultEntityId,
+    completedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DayProcessingJobRow &&
+          other.id == this.id &&
+          other.status == this.status &&
+          other.kind == this.kind &&
+          other.dayId == this.dayId &&
+          other.payload == this.payload &&
+          other.runKeys == this.runKeys &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.requestedAt == this.requestedAt &&
+          other.nextAttemptAt == this.nextAttemptAt &&
+          other.attempts == this.attempts &&
+          other.generation == this.generation &&
+          other.claimToken == this.claimToken &&
+          other.leaseUntil == this.leaseUntil &&
+          other.retryNotBefore == this.retryNotBefore &&
+          other.lastFailureClass == this.lastFailureClass &&
+          other.lastError == this.lastError &&
+          other.resultTranscript == this.resultTranscript &&
+          other.resultEntityId == this.resultEntityId &&
+          other.completedAt == this.completedAt);
+}
+
+class DayProcessingJobsCompanion extends UpdateCompanion<DayProcessingJobRow> {
+  final Value<String> id;
+  final Value<String> status;
+  final Value<String> kind;
+  final Value<String> dayId;
+  final Value<String> payload;
+  final Value<String?> runKeys;
+  final Value<int> createdAt;
+  final Value<int> updatedAt;
+  final Value<int> requestedAt;
+  final Value<int> nextAttemptAt;
+  final Value<int> attempts;
+  final Value<int> generation;
+  final Value<String?> claimToken;
+  final Value<int?> leaseUntil;
+  final Value<int?> retryNotBefore;
+  final Value<String?> lastFailureClass;
+  final Value<String?> lastError;
+  final Value<String?> resultTranscript;
+  final Value<String?> resultEntityId;
+  final Value<int?> completedAt;
+  final Value<int> rowid;
+  const DayProcessingJobsCompanion({
+    this.id = const Value.absent(),
+    this.status = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.dayId = const Value.absent(),
+    this.payload = const Value.absent(),
+    this.runKeys = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.requestedAt = const Value.absent(),
+    this.nextAttemptAt = const Value.absent(),
+    this.attempts = const Value.absent(),
+    this.generation = const Value.absent(),
+    this.claimToken = const Value.absent(),
+    this.leaseUntil = const Value.absent(),
+    this.retryNotBefore = const Value.absent(),
+    this.lastFailureClass = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.resultTranscript = const Value.absent(),
+    this.resultEntityId = const Value.absent(),
+    this.completedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  DayProcessingJobsCompanion.insert({
+    required String id,
+    required String status,
+    required String kind,
+    required String dayId,
+    required String payload,
+    this.runKeys = const Value.absent(),
+    required int createdAt,
+    required int updatedAt,
+    required int requestedAt,
+    required int nextAttemptAt,
+    this.attempts = const Value.absent(),
+    this.generation = const Value.absent(),
+    this.claimToken = const Value.absent(),
+    this.leaseUntil = const Value.absent(),
+    this.retryNotBefore = const Value.absent(),
+    this.lastFailureClass = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.resultTranscript = const Value.absent(),
+    this.resultEntityId = const Value.absent(),
+    this.completedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       status = Value(status),
+       kind = Value(kind),
+       dayId = Value(dayId),
+       payload = Value(payload),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt),
+       requestedAt = Value(requestedAt),
+       nextAttemptAt = Value(nextAttemptAt);
+  static Insertable<DayProcessingJobRow> custom({
+    Expression<String>? id,
+    Expression<String>? status,
+    Expression<String>? kind,
+    Expression<String>? dayId,
+    Expression<String>? payload,
+    Expression<String>? runKeys,
+    Expression<int>? createdAt,
+    Expression<int>? updatedAt,
+    Expression<int>? requestedAt,
+    Expression<int>? nextAttemptAt,
+    Expression<int>? attempts,
+    Expression<int>? generation,
+    Expression<String>? claimToken,
+    Expression<int>? leaseUntil,
+    Expression<int>? retryNotBefore,
+    Expression<String>? lastFailureClass,
+    Expression<String>? lastError,
+    Expression<String>? resultTranscript,
+    Expression<String>? resultEntityId,
+    Expression<int>? completedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (status != null) 'status': status,
+      if (kind != null) 'kind': kind,
+      if (dayId != null) 'day_id': dayId,
+      if (payload != null) 'payload': payload,
+      if (runKeys != null) 'run_keys': runKeys,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (requestedAt != null) 'requested_at': requestedAt,
+      if (nextAttemptAt != null) 'next_attempt_at': nextAttemptAt,
+      if (attempts != null) 'attempts': attempts,
+      if (generation != null) 'generation': generation,
+      if (claimToken != null) 'claim_token': claimToken,
+      if (leaseUntil != null) 'lease_until': leaseUntil,
+      if (retryNotBefore != null) 'retry_not_before': retryNotBefore,
+      if (lastFailureClass != null) 'last_failure_class': lastFailureClass,
+      if (lastError != null) 'last_error': lastError,
+      if (resultTranscript != null) 'result_transcript': resultTranscript,
+      if (resultEntityId != null) 'result_entity_id': resultEntityId,
+      if (completedAt != null) 'completed_at': completedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  DayProcessingJobsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? status,
+    Value<String>? kind,
+    Value<String>? dayId,
+    Value<String>? payload,
+    Value<String?>? runKeys,
+    Value<int>? createdAt,
+    Value<int>? updatedAt,
+    Value<int>? requestedAt,
+    Value<int>? nextAttemptAt,
+    Value<int>? attempts,
+    Value<int>? generation,
+    Value<String?>? claimToken,
+    Value<int?>? leaseUntil,
+    Value<int?>? retryNotBefore,
+    Value<String?>? lastFailureClass,
+    Value<String?>? lastError,
+    Value<String?>? resultTranscript,
+    Value<String?>? resultEntityId,
+    Value<int?>? completedAt,
+    Value<int>? rowid,
+  }) {
+    return DayProcessingJobsCompanion(
+      id: id ?? this.id,
+      status: status ?? this.status,
+      kind: kind ?? this.kind,
+      dayId: dayId ?? this.dayId,
+      payload: payload ?? this.payload,
+      runKeys: runKeys ?? this.runKeys,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      requestedAt: requestedAt ?? this.requestedAt,
+      nextAttemptAt: nextAttemptAt ?? this.nextAttemptAt,
+      attempts: attempts ?? this.attempts,
+      generation: generation ?? this.generation,
+      claimToken: claimToken ?? this.claimToken,
+      leaseUntil: leaseUntil ?? this.leaseUntil,
+      retryNotBefore: retryNotBefore ?? this.retryNotBefore,
+      lastFailureClass: lastFailureClass ?? this.lastFailureClass,
+      lastError: lastError ?? this.lastError,
+      resultTranscript: resultTranscript ?? this.resultTranscript,
+      resultEntityId: resultEntityId ?? this.resultEntityId,
+      completedAt: completedAt ?? this.completedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(kind.value);
+    }
+    if (dayId.present) {
+      map['day_id'] = Variable<String>(dayId.value);
+    }
+    if (payload.present) {
+      map['payload'] = Variable<String>(payload.value);
+    }
+    if (runKeys.present) {
+      map['run_keys'] = Variable<String>(runKeys.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (requestedAt.present) {
+      map['requested_at'] = Variable<int>(requestedAt.value);
+    }
+    if (nextAttemptAt.present) {
+      map['next_attempt_at'] = Variable<int>(nextAttemptAt.value);
+    }
+    if (attempts.present) {
+      map['attempts'] = Variable<int>(attempts.value);
+    }
+    if (generation.present) {
+      map['generation'] = Variable<int>(generation.value);
+    }
+    if (claimToken.present) {
+      map['claim_token'] = Variable<String>(claimToken.value);
+    }
+    if (leaseUntil.present) {
+      map['lease_until'] = Variable<int>(leaseUntil.value);
+    }
+    if (retryNotBefore.present) {
+      map['retry_not_before'] = Variable<int>(retryNotBefore.value);
+    }
+    if (lastFailureClass.present) {
+      map['last_failure_class'] = Variable<String>(lastFailureClass.value);
+    }
+    if (lastError.present) {
+      map['last_error'] = Variable<String>(lastError.value);
+    }
+    if (resultTranscript.present) {
+      map['result_transcript'] = Variable<String>(resultTranscript.value);
+    }
+    if (resultEntityId.present) {
+      map['result_entity_id'] = Variable<String>(resultEntityId.value);
+    }
+    if (completedAt.present) {
+      map['completed_at'] = Variable<int>(completedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DayProcessingJobsCompanion(')
+          ..write('id: $id, ')
+          ..write('status: $status, ')
+          ..write('kind: $kind, ')
+          ..write('dayId: $dayId, ')
+          ..write('payload: $payload, ')
+          ..write('runKeys: $runKeys, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('requestedAt: $requestedAt, ')
+          ..write('nextAttemptAt: $nextAttemptAt, ')
+          ..write('attempts: $attempts, ')
+          ..write('generation: $generation, ')
+          ..write('claimToken: $claimToken, ')
+          ..write('leaseUntil: $leaseUntil, ')
+          ..write('retryNotBefore: $retryNotBefore, ')
+          ..write('lastFailureClass: $lastFailureClass, ')
+          ..write('lastError: $lastError, ')
+          ..write('resultTranscript: $resultTranscript, ')
+          ..write('resultEntityId: $resultEntityId, ')
+          ..write('completedAt: $completedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class DayProcessingMigrations extends Table
+    with TableInfo<DayProcessingMigrations, DayProcessingMigrationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  DayProcessingMigrations(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _migrationKeyMeta = const VerificationMeta(
+    'migrationKey',
+  );
+  late final GeneratedColumn<String> migrationKey = GeneratedColumn<String>(
+    'migration_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL PRIMARY KEY',
+  );
+  static const VerificationMeta _completedAtMeta = const VerificationMeta(
+    'completedAt',
+  );
+  late final GeneratedColumn<int> completedAt = GeneratedColumn<int>(
+    'completed_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  @override
+  List<GeneratedColumn> get $columns => [migrationKey, completedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'day_processing_migrations';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<DayProcessingMigrationRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('migration_key')) {
+      context.handle(
+        _migrationKeyMeta,
+        migrationKey.isAcceptableOrUnknown(
+          data['migration_key']!,
+          _migrationKeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_migrationKeyMeta);
+    }
+    if (data.containsKey('completed_at')) {
+      context.handle(
+        _completedAtMeta,
+        completedAt.isAcceptableOrUnknown(
+          data['completed_at']!,
+          _completedAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_completedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {migrationKey};
+  @override
+  DayProcessingMigrationRow map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return DayProcessingMigrationRow(
+      migrationKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}migration_key'],
+      )!,
+      completedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}completed_at'],
+      )!,
+    );
+  }
+
+  @override
+  DayProcessingMigrations createAlias(String alias) {
+    return DayProcessingMigrations(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class DayProcessingMigrationRow extends DataClass
+    implements Insertable<DayProcessingMigrationRow> {
+  final String migrationKey;
+  final int completedAt;
+  const DayProcessingMigrationRow({
+    required this.migrationKey,
+    required this.completedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['migration_key'] = Variable<String>(migrationKey);
+    map['completed_at'] = Variable<int>(completedAt);
+    return map;
+  }
+
+  DayProcessingMigrationsCompanion toCompanion(bool nullToAbsent) {
+    return DayProcessingMigrationsCompanion(
+      migrationKey: Value(migrationKey),
+      completedAt: Value(completedAt),
+    );
+  }
+
+  factory DayProcessingMigrationRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return DayProcessingMigrationRow(
+      migrationKey: serializer.fromJson<String>(json['migration_key']),
+      completedAt: serializer.fromJson<int>(json['completed_at']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'migration_key': serializer.toJson<String>(migrationKey),
+      'completed_at': serializer.toJson<int>(completedAt),
+    };
+  }
+
+  DayProcessingMigrationRow copyWith({
+    String? migrationKey,
+    int? completedAt,
+  }) => DayProcessingMigrationRow(
+    migrationKey: migrationKey ?? this.migrationKey,
+    completedAt: completedAt ?? this.completedAt,
+  );
+  DayProcessingMigrationRow copyWithCompanion(
+    DayProcessingMigrationsCompanion data,
+  ) {
+    return DayProcessingMigrationRow(
+      migrationKey: data.migrationKey.present
+          ? data.migrationKey.value
+          : this.migrationKey,
+      completedAt: data.completedAt.present
+          ? data.completedAt.value
+          : this.completedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DayProcessingMigrationRow(')
+          ..write('migrationKey: $migrationKey, ')
+          ..write('completedAt: $completedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(migrationKey, completedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DayProcessingMigrationRow &&
+          other.migrationKey == this.migrationKey &&
+          other.completedAt == this.completedAt);
+}
+
+class DayProcessingMigrationsCompanion
+    extends UpdateCompanion<DayProcessingMigrationRow> {
+  final Value<String> migrationKey;
+  final Value<int> completedAt;
+  final Value<int> rowid;
+  const DayProcessingMigrationsCompanion({
+    this.migrationKey = const Value.absent(),
+    this.completedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  DayProcessingMigrationsCompanion.insert({
+    required String migrationKey,
+    required int completedAt,
+    this.rowid = const Value.absent(),
+  }) : migrationKey = Value(migrationKey),
+       completedAt = Value(completedAt);
+  static Insertable<DayProcessingMigrationRow> custom({
+    Expression<String>? migrationKey,
+    Expression<int>? completedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (migrationKey != null) 'migration_key': migrationKey,
+      if (completedAt != null) 'completed_at': completedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  DayProcessingMigrationsCompanion copyWith({
+    Value<String>? migrationKey,
+    Value<int>? completedAt,
+    Value<int>? rowid,
+  }) {
+    return DayProcessingMigrationsCompanion(
+      migrationKey: migrationKey ?? this.migrationKey,
+      completedAt: completedAt ?? this.completedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (migrationKey.present) {
+      map['migration_key'] = Variable<String>(migrationKey.value);
+    }
+    if (completedAt.present) {
+      map['completed_at'] = Variable<int>(completedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DayProcessingMigrationsCompanion(')
+          ..write('migrationKey: $migrationKey, ')
+          ..write('completedAt: $completedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$DayProcessingDb extends GeneratedDatabase {
+  _$DayProcessingDb(QueryExecutor e) : super(e);
+  _$DayProcessingDb.connect(DatabaseConnection c) : super.connect(c);
+  $DayProcessingDbManager get managers => $DayProcessingDbManager(this);
+  late final DayProcessingJobs dayProcessingJobs = DayProcessingJobs(this);
+  late final Index idxDayProcessingJobsPending = Index(
+    'idx_day_processing_jobs_pending',
+    'CREATE INDEX idx_day_processing_jobs_pending ON day_processing_jobs (created_at, id) WHERE status NOT IN (\'succeeded\', \'cancelled\')',
+  );
+  late final Index idxDayProcessingJobsDay = Index(
+    'idx_day_processing_jobs_day',
+    'CREATE INDEX idx_day_processing_jobs_day ON day_processing_jobs (day_id, kind, created_at)',
+  );
+  late final Index idxDayProcessingJobsRetention = Index(
+    'idx_day_processing_jobs_retention',
+    'CREATE INDEX idx_day_processing_jobs_retention ON day_processing_jobs (completed_at) WHERE status IN (\'succeeded\', \'cancelled\')',
+  );
+  late final DayProcessingMigrations dayProcessingMigrations =
+      DayProcessingMigrations(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    dayProcessingJobs,
+    idxDayProcessingJobsPending,
+    idxDayProcessingJobsDay,
+    idxDayProcessingJobsRetention,
+    dayProcessingMigrations,
+  ];
+}
+
+typedef $DayProcessingJobsCreateCompanionBuilder =
+    DayProcessingJobsCompanion Function({
+      required String id,
+      required String status,
+      required String kind,
+      required String dayId,
+      required String payload,
+      Value<String?> runKeys,
+      required int createdAt,
+      required int updatedAt,
+      required int requestedAt,
+      required int nextAttemptAt,
+      Value<int> attempts,
+      Value<int> generation,
+      Value<String?> claimToken,
+      Value<int?> leaseUntil,
+      Value<int?> retryNotBefore,
+      Value<String?> lastFailureClass,
+      Value<String?> lastError,
+      Value<String?> resultTranscript,
+      Value<String?> resultEntityId,
+      Value<int?> completedAt,
+      Value<int> rowid,
+    });
+typedef $DayProcessingJobsUpdateCompanionBuilder =
+    DayProcessingJobsCompanion Function({
+      Value<String> id,
+      Value<String> status,
+      Value<String> kind,
+      Value<String> dayId,
+      Value<String> payload,
+      Value<String?> runKeys,
+      Value<int> createdAt,
+      Value<int> updatedAt,
+      Value<int> requestedAt,
+      Value<int> nextAttemptAt,
+      Value<int> attempts,
+      Value<int> generation,
+      Value<String?> claimToken,
+      Value<int?> leaseUntil,
+      Value<int?> retryNotBefore,
+      Value<String?> lastFailureClass,
+      Value<String?> lastError,
+      Value<String?> resultTranscript,
+      Value<String?> resultEntityId,
+      Value<int?> completedAt,
+      Value<int> rowid,
+    });
+
+class $DayProcessingJobsFilterComposer
+    extends Composer<_$DayProcessingDb, DayProcessingJobs> {
+  $DayProcessingJobsFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get dayId => $composableBuilder(
+    column: $table.dayId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get payload => $composableBuilder(
+    column: $table.payload,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get runKeys => $composableBuilder(
+    column: $table.runKeys,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get requestedAt => $composableBuilder(
+    column: $table.requestedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get nextAttemptAt => $composableBuilder(
+    column: $table.nextAttemptAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get attempts => $composableBuilder(
+    column: $table.attempts,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get generation => $composableBuilder(
+    column: $table.generation,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get claimToken => $composableBuilder(
+    column: $table.claimToken,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get leaseUntil => $composableBuilder(
+    column: $table.leaseUntil,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get retryNotBefore => $composableBuilder(
+    column: $table.retryNotBefore,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastFailureClass => $composableBuilder(
+    column: $table.lastFailureClass,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get resultTranscript => $composableBuilder(
+    column: $table.resultTranscript,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get resultEntityId => $composableBuilder(
+    column: $table.resultEntityId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $DayProcessingJobsOrderingComposer
+    extends Composer<_$DayProcessingDb, DayProcessingJobs> {
+  $DayProcessingJobsOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get dayId => $composableBuilder(
+    column: $table.dayId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get payload => $composableBuilder(
+    column: $table.payload,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get runKeys => $composableBuilder(
+    column: $table.runKeys,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get requestedAt => $composableBuilder(
+    column: $table.requestedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get nextAttemptAt => $composableBuilder(
+    column: $table.nextAttemptAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get attempts => $composableBuilder(
+    column: $table.attempts,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get generation => $composableBuilder(
+    column: $table.generation,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get claimToken => $composableBuilder(
+    column: $table.claimToken,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get leaseUntil => $composableBuilder(
+    column: $table.leaseUntil,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get retryNotBefore => $composableBuilder(
+    column: $table.retryNotBefore,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastFailureClass => $composableBuilder(
+    column: $table.lastFailureClass,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get resultTranscript => $composableBuilder(
+    column: $table.resultTranscript,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get resultEntityId => $composableBuilder(
+    column: $table.resultEntityId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $DayProcessingJobsAnnotationComposer
+    extends Composer<_$DayProcessingDb, DayProcessingJobs> {
+  $DayProcessingJobsAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<String> get kind =>
+      $composableBuilder(column: $table.kind, builder: (column) => column);
+
+  GeneratedColumn<String> get dayId =>
+      $composableBuilder(column: $table.dayId, builder: (column) => column);
+
+  GeneratedColumn<String> get payload =>
+      $composableBuilder(column: $table.payload, builder: (column) => column);
+
+  GeneratedColumn<String> get runKeys =>
+      $composableBuilder(column: $table.runKeys, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<int> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get requestedAt => $composableBuilder(
+    column: $table.requestedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get nextAttemptAt => $composableBuilder(
+    column: $table.nextAttemptAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get attempts =>
+      $composableBuilder(column: $table.attempts, builder: (column) => column);
+
+  GeneratedColumn<int> get generation => $composableBuilder(
+    column: $table.generation,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get claimToken => $composableBuilder(
+    column: $table.claimToken,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get leaseUntil => $composableBuilder(
+    column: $table.leaseUntil,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get retryNotBefore => $composableBuilder(
+    column: $table.retryNotBefore,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get lastFailureClass => $composableBuilder(
+    column: $table.lastFailureClass,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get lastError =>
+      $composableBuilder(column: $table.lastError, builder: (column) => column);
+
+  GeneratedColumn<String> get resultTranscript => $composableBuilder(
+    column: $table.resultTranscript,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get resultEntityId => $composableBuilder(
+    column: $table.resultEntityId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => column,
+  );
+}
+
+class $DayProcessingJobsTableManager
+    extends
+        RootTableManager<
+          _$DayProcessingDb,
+          DayProcessingJobs,
+          DayProcessingJobRow,
+          $DayProcessingJobsFilterComposer,
+          $DayProcessingJobsOrderingComposer,
+          $DayProcessingJobsAnnotationComposer,
+          $DayProcessingJobsCreateCompanionBuilder,
+          $DayProcessingJobsUpdateCompanionBuilder,
+          (
+            DayProcessingJobRow,
+            BaseReferences<
+              _$DayProcessingDb,
+              DayProcessingJobs,
+              DayProcessingJobRow
+            >,
+          ),
+          DayProcessingJobRow,
+          PrefetchHooks Function()
+        > {
+  $DayProcessingJobsTableManager(_$DayProcessingDb db, DayProcessingJobs table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $DayProcessingJobsFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $DayProcessingJobsOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $DayProcessingJobsAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<String> kind = const Value.absent(),
+                Value<String> dayId = const Value.absent(),
+                Value<String> payload = const Value.absent(),
+                Value<String?> runKeys = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> requestedAt = const Value.absent(),
+                Value<int> nextAttemptAt = const Value.absent(),
+                Value<int> attempts = const Value.absent(),
+                Value<int> generation = const Value.absent(),
+                Value<String?> claimToken = const Value.absent(),
+                Value<int?> leaseUntil = const Value.absent(),
+                Value<int?> retryNotBefore = const Value.absent(),
+                Value<String?> lastFailureClass = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<String?> resultTranscript = const Value.absent(),
+                Value<String?> resultEntityId = const Value.absent(),
+                Value<int?> completedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => DayProcessingJobsCompanion(
+                id: id,
+                status: status,
+                kind: kind,
+                dayId: dayId,
+                payload: payload,
+                runKeys: runKeys,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                requestedAt: requestedAt,
+                nextAttemptAt: nextAttemptAt,
+                attempts: attempts,
+                generation: generation,
+                claimToken: claimToken,
+                leaseUntil: leaseUntil,
+                retryNotBefore: retryNotBefore,
+                lastFailureClass: lastFailureClass,
+                lastError: lastError,
+                resultTranscript: resultTranscript,
+                resultEntityId: resultEntityId,
+                completedAt: completedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String status,
+                required String kind,
+                required String dayId,
+                required String payload,
+                Value<String?> runKeys = const Value.absent(),
+                required int createdAt,
+                required int updatedAt,
+                required int requestedAt,
+                required int nextAttemptAt,
+                Value<int> attempts = const Value.absent(),
+                Value<int> generation = const Value.absent(),
+                Value<String?> claimToken = const Value.absent(),
+                Value<int?> leaseUntil = const Value.absent(),
+                Value<int?> retryNotBefore = const Value.absent(),
+                Value<String?> lastFailureClass = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<String?> resultTranscript = const Value.absent(),
+                Value<String?> resultEntityId = const Value.absent(),
+                Value<int?> completedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => DayProcessingJobsCompanion.insert(
+                id: id,
+                status: status,
+                kind: kind,
+                dayId: dayId,
+                payload: payload,
+                runKeys: runKeys,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                requestedAt: requestedAt,
+                nextAttemptAt: nextAttemptAt,
+                attempts: attempts,
+                generation: generation,
+                claimToken: claimToken,
+                leaseUntil: leaseUntil,
+                retryNotBefore: retryNotBefore,
+                lastFailureClass: lastFailureClass,
+                lastError: lastError,
+                resultTranscript: resultTranscript,
+                resultEntityId: resultEntityId,
+                completedAt: completedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $DayProcessingJobsProcessedTableManager =
+    ProcessedTableManager<
+      _$DayProcessingDb,
+      DayProcessingJobs,
+      DayProcessingJobRow,
+      $DayProcessingJobsFilterComposer,
+      $DayProcessingJobsOrderingComposer,
+      $DayProcessingJobsAnnotationComposer,
+      $DayProcessingJobsCreateCompanionBuilder,
+      $DayProcessingJobsUpdateCompanionBuilder,
+      (
+        DayProcessingJobRow,
+        BaseReferences<
+          _$DayProcessingDb,
+          DayProcessingJobs,
+          DayProcessingJobRow
+        >,
+      ),
+      DayProcessingJobRow,
+      PrefetchHooks Function()
+    >;
+typedef $DayProcessingMigrationsCreateCompanionBuilder =
+    DayProcessingMigrationsCompanion Function({
+      required String migrationKey,
+      required int completedAt,
+      Value<int> rowid,
+    });
+typedef $DayProcessingMigrationsUpdateCompanionBuilder =
+    DayProcessingMigrationsCompanion Function({
+      Value<String> migrationKey,
+      Value<int> completedAt,
+      Value<int> rowid,
+    });
+
+class $DayProcessingMigrationsFilterComposer
+    extends Composer<_$DayProcessingDb, DayProcessingMigrations> {
+  $DayProcessingMigrationsFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get migrationKey => $composableBuilder(
+    column: $table.migrationKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $DayProcessingMigrationsOrderingComposer
+    extends Composer<_$DayProcessingDb, DayProcessingMigrations> {
+  $DayProcessingMigrationsOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get migrationKey => $composableBuilder(
+    column: $table.migrationKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $DayProcessingMigrationsAnnotationComposer
+    extends Composer<_$DayProcessingDb, DayProcessingMigrations> {
+  $DayProcessingMigrationsAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get migrationKey => $composableBuilder(
+    column: $table.migrationKey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => column,
+  );
+}
+
+class $DayProcessingMigrationsTableManager
+    extends
+        RootTableManager<
+          _$DayProcessingDb,
+          DayProcessingMigrations,
+          DayProcessingMigrationRow,
+          $DayProcessingMigrationsFilterComposer,
+          $DayProcessingMigrationsOrderingComposer,
+          $DayProcessingMigrationsAnnotationComposer,
+          $DayProcessingMigrationsCreateCompanionBuilder,
+          $DayProcessingMigrationsUpdateCompanionBuilder,
+          (
+            DayProcessingMigrationRow,
+            BaseReferences<
+              _$DayProcessingDb,
+              DayProcessingMigrations,
+              DayProcessingMigrationRow
+            >,
+          ),
+          DayProcessingMigrationRow,
+          PrefetchHooks Function()
+        > {
+  $DayProcessingMigrationsTableManager(
+    _$DayProcessingDb db,
+    DayProcessingMigrations table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $DayProcessingMigrationsFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $DayProcessingMigrationsOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $DayProcessingMigrationsAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> migrationKey = const Value.absent(),
+                Value<int> completedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => DayProcessingMigrationsCompanion(
+                migrationKey: migrationKey,
+                completedAt: completedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String migrationKey,
+                required int completedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => DayProcessingMigrationsCompanion.insert(
+                migrationKey: migrationKey,
+                completedAt: completedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $DayProcessingMigrationsProcessedTableManager =
+    ProcessedTableManager<
+      _$DayProcessingDb,
+      DayProcessingMigrations,
+      DayProcessingMigrationRow,
+      $DayProcessingMigrationsFilterComposer,
+      $DayProcessingMigrationsOrderingComposer,
+      $DayProcessingMigrationsAnnotationComposer,
+      $DayProcessingMigrationsCreateCompanionBuilder,
+      $DayProcessingMigrationsUpdateCompanionBuilder,
+      (
+        DayProcessingMigrationRow,
+        BaseReferences<
+          _$DayProcessingDb,
+          DayProcessingMigrations,
+          DayProcessingMigrationRow
+        >,
+      ),
+      DayProcessingMigrationRow,
+      PrefetchHooks Function()
+    >;
+
+class $DayProcessingDbManager {
+  final _$DayProcessingDb _db;
+  $DayProcessingDbManager(this._db);
+  $DayProcessingJobsTableManager get dayProcessingJobs =>
+      $DayProcessingJobsTableManager(_db, _db.dayProcessingJobs);
+  $DayProcessingMigrationsTableManager get dayProcessingMigrations =>
+      $DayProcessingMigrationsTableManager(_db, _db.dayProcessingMigrations);
+}

--- a/lib/features/daily_os_next/database/day_processing_job_row.dart
+++ b/lib/features/daily_os_next/database/day_processing_job_row.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+
+/// Mapping between [DayProcessingJob] and its `day_processing_jobs` row.
+///
+/// Shared by the outbox repository and the one-off file import so a job is
+/// encoded exactly one way. The column list, the bind order in
+/// [dayProcessingJobVariables], and the reads in [dayProcessingJobFromRow] all
+/// move together.
+
+/// Column list in bind order.
+const String dayProcessingJobColumns =
+    'id, status, kind, day_id, payload, run_keys, created_at, updated_at, '
+    'requested_at, next_attempt_at, attempts, generation, claim_token, '
+    'lease_until, retry_not_before, last_failure_class, last_error, '
+    'result_transcript, result_entity_id, completed_at';
+
+/// `?1 … ?20`, matching [dayProcessingJobColumns].
+const String dayProcessingJobPlaceholders =
+    '?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, '
+    '?17, ?18, ?19, ?20';
+
+/// Bind values for [dayProcessingJobColumns], in order.
+List<Variable<Object>> dayProcessingJobVariables(DayProcessingJob job) =>
+    <Variable<Object>>[
+      Variable<String>(job.id),
+      Variable<String>(job.status.name),
+      Variable<String>(job.kind.name),
+      Variable<String>(job.dayId),
+      Variable<String>(jsonEncode(job.payload.toJson())),
+      Variable<String>(job.runKeys.isEmpty ? null : jsonEncode(job.runKeys)),
+      Variable<int>(job.createdAt.millisecondsSinceEpoch),
+      Variable<int>(job.updatedAt.millisecondsSinceEpoch),
+      Variable<int>(job.requestedAt.millisecondsSinceEpoch),
+      Variable<int>(job.nextAttemptAt.millisecondsSinceEpoch),
+      Variable<int>(job.attempts),
+      Variable<int>(job.generation),
+      Variable<String>(job.claimToken),
+      Variable<int>(job.leaseUntil?.millisecondsSinceEpoch),
+      Variable<int>(job.retryNotBefore?.millisecondsSinceEpoch),
+      Variable<String>(job.lastFailureClass?.name),
+      Variable<String>(job.lastError),
+      Variable<String>(job.resultTranscript),
+      Variable<String>(job.resultEntityId),
+      Variable<int>(job.completedAt?.millisecondsSinceEpoch),
+    ];
+
+/// Decodes one `day_processing_jobs` row.
+DayProcessingJob dayProcessingJobFromRow(QueryRow row) {
+  final kind = DayProcessingJobKind.values.byName(row.read<String>('kind'));
+  final runKeys = row.readNullable<String>('run_keys');
+  return DayProcessingJob(
+    id: row.read<String>('id'),
+    status: DayProcessingJobStatus.values.byName(row.read<String>('status')),
+    dayId: row.read<String>('day_id'),
+    payload: DayProcessingPayload.fromJson(
+      kind,
+      jsonDecode(row.read<String>('payload'))! as Map<String, Object?>,
+    ),
+    createdAt: dayProcessingTime(row.read<int>('created_at')),
+    updatedAt: dayProcessingTime(row.read<int>('updated_at')),
+    requestedAt: dayProcessingTime(row.read<int>('requested_at')),
+    nextAttemptAt: dayProcessingTime(row.read<int>('next_attempt_at')),
+    attempts: row.read<int>('attempts'),
+    generation: row.read<int>('generation'),
+    runKeys: runKeys == null
+        ? const []
+        : [for (final key in jsonDecode(runKeys)! as List) key! as String],
+    claimToken: row.readNullable<String>('claim_token'),
+    leaseUntil: dayProcessingTimeOrNull(row.readNullable<int>('lease_until')),
+    retryNotBefore: dayProcessingTimeOrNull(
+      row.readNullable<int>('retry_not_before'),
+    ),
+    lastFailureClass: switch (row.readNullable<String>('last_failure_class')) {
+      final String name => DayProcessingFailureClass.values.byName(name),
+      _ => null,
+    },
+    lastError: row.readNullable<String>('last_error'),
+    resultTranscript: row.readNullable<String>('result_transcript'),
+    resultEntityId: row.readNullable<String>('result_entity_id'),
+    completedAt: dayProcessingTimeOrNull(row.readNullable<int>('completed_at')),
+  );
+}
+
+/// Epoch milliseconds back to a UTC [DateTime].
+///
+/// UTC because the previous file encoding was ISO-8601 with a `Z` suffix, and
+/// `DateTime` equality compares the time zone flag as well as the instant — so
+/// reading back as local time would make round-tripped jobs compare unequal to
+/// what callers wrote.
+DateTime dayProcessingTime(int milliseconds) =>
+    DateTime.fromMillisecondsSinceEpoch(milliseconds, isUtc: true);
+
+DateTime? dayProcessingTimeOrNull(int? milliseconds) =>
+    milliseconds == null ? null : dayProcessingTime(milliseconds);

--- a/lib/features/daily_os_next/services/day_activity_repository.dart
+++ b/lib/features/daily_os_next/services/day_activity_repository.dart
@@ -82,15 +82,17 @@ class DayActivityRepository {
           context.activityEntryId: audio,
     };
 
-    final jobs = await outbox.getAll();
     // Only transcription jobs join to a recording card by activityEntryId;
     // agent jobs (parseCapture/draftPlan/refinePlan, ADR 0032 phase 1) carry
-    // no activityEntryId and are not surfaced by this repository yet.
+    // no activityEntryId and are not surfaced by this repository yet. Both
+    // filters are pushed into the day-scoped query (ADR 0044) so Activity's
+    // cost tracks this day rather than every job ever recorded.
+    final jobs = await outbox.getForDay(
+      dayId,
+      kinds: const {DayProcessingJobKind.transcribeAudio},
+    );
     final jobsByActivity = <String, DayProcessingJob>{
-      for (final job in jobs.where(
-        (job) => job.dayId == dayId && job.activityEntryId != null,
-      ))
-        job.activityEntryId!: job,
+      for (final job in jobs) ?job.activityEntryId: job,
     };
     final capturesByAudio = <String, CaptureEntity>{};
     final standaloneCaptures = <CaptureEntity>[];

--- a/lib/features/daily_os_next/services/day_audio_review_fence.dart
+++ b/lib/features/daily_os_next/services/day_audio_review_fence.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/daily_os_next/services/day_audio_transcript_writer.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/services/db_notification.dart';
 
@@ -54,9 +55,13 @@ class DayAudioReviewFence {
   }
 
   Future<void> _sweep() async {
-    final jobs = await outbox.getAll();
+    // Non-terminal transcription jobs only. Both filters live in the query
+    // (ADR 0044), served by the partial index over pending rows, so the sweep
+    // never walks the retained ledger.
+    final jobs = await outbox.getPendingByKind(
+      DayProcessingJobKind.transcribeAudio,
+    );
     for (final job in jobs) {
-      if (job.isTerminal) continue;
       final audioId = job.audioId;
       if (audioId == null) continue;
       final entity = await journalDb.journalEntityById(audioId);

--- a/lib/features/daily_os_next/services/day_processing_legacy_file_store.dart
+++ b/lib/features/daily_os_next/services/day_processing_legacy_file_store.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:path/path.dart' as path;
+
+/// Read-only view of the pre-ADR-0044 file-per-job outbox.
+///
+/// The live outbox is a device-local table now; this exists solely so the
+/// one-off migration can drain the old directory, and it is deleted once the
+/// job files are removed a release later.
+///
+/// It deliberately keeps the integrity machinery the table does not need:
+/// interrupted atomic writes leave `.json.part` files that hold the newest
+/// state of a job, and a file whose checksum fails must be set aside rather
+/// than aborting the whole import. Both only matter while reading a store that
+/// was written by the old code.
+class DayProcessingLegacyFileStore {
+  DayProcessingLegacyFileStore({required this.rootDirectory});
+
+  final Directory rootDirectory;
+
+  /// Whether an old outbox directory is present at all.
+  ///
+  /// A fresh install has none, so the migration can record itself as complete
+  /// without touching the filesystem.
+  bool get exists => rootDirectory.existsSync();
+
+  /// Every job readable from the directory, newest state first resolved.
+  ///
+  /// Recovers orphaned partials before reading so a job whose last write was
+  /// interrupted is imported at its newest state rather than its previous one.
+  /// Unreadable files are quarantined and omitted — the same outcome the live
+  /// repository produced for them, and safe because a job that cannot be read
+  /// cannot be executed either.
+  Future<List<DayProcessingJob>> readAll() async {
+    if (!exists) return const [];
+    await _recoverPartials();
+    final jobs = <DayProcessingJob>[];
+    for (final file in rootDirectory.listSync().whereType<File>()) {
+      if (!file.path.endsWith('.json')) continue;
+      try {
+        jobs.add(await readFile(file));
+      } catch (_) {
+        await quarantine(file);
+      }
+    }
+    jobs.sort((a, b) {
+      final byCreated = a.createdAt.compareTo(b.createdAt);
+      return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
+    });
+    return List<DayProcessingJob>.unmodifiable(jobs);
+  }
+
+  /// Decodes one envelope, verifying its digest.
+  Future<DayProcessingJob> readFile(File file) async {
+    final envelope =
+        jsonDecode(await file.readAsString())! as Map<String, Object?>;
+    final payload = envelope['payload']! as String;
+    final expected = envelope['sha256']! as String;
+    final actual = sha256.convert(utf8.encode(payload)).toString();
+    if (actual != expected) {
+      throw const FormatException('Invalid processing job digest');
+    }
+    return DayProcessingJob.fromJson(
+      jsonDecode(payload)! as Map<String, Object?>,
+    );
+  }
+
+  /// Moves an unreadable file aside so a later read does not retry it.
+  Future<void> quarantine(File file) async {
+    final directory = Directory(path.join(rootDirectory.path, 'quarantine'));
+    await directory.create(recursive: true);
+    final destination = File(
+      path.join(directory.path, path.basename(file.path)),
+    );
+    if (destination.existsSync()) await destination.delete();
+    await file.rename(destination.path);
+  }
+
+  Future<void> _recoverPartials() async {
+    for (final partial in rootDirectory.listSync().whereType<File>().where(
+      (file) => file.path.endsWith('.json.part'),
+    )) {
+      final destination = File(
+        partial.path.substring(0, partial.path.length - '.part'.length),
+      );
+      // The published file won the race; the partial is leftover scratch.
+      if (destination.existsSync()) {
+        await partial.delete();
+        continue;
+      }
+      try {
+        await readFile(partial);
+        await partial.rename(destination.path);
+      } catch (_) {
+        await quarantine(partial);
+      }
+    }
+  }
+}

--- a/lib/features/daily_os_next/services/day_processing_legacy_file_store.dart
+++ b/lib/features/daily_os_next/services/day_processing_legacy_file_store.dart
@@ -11,11 +11,10 @@ import 'package:path/path.dart' as path;
 /// one-off migration can drain the old directory, and it is deleted once the
 /// job files are removed a release later.
 ///
-/// It deliberately keeps the integrity machinery the table does not need:
-/// interrupted atomic writes leave `.json.part` files that hold the newest
-/// state of a job, and a file whose checksum fails must be set aside rather
-/// than aborting the whole import. Both only matter while reading a store that
-/// was written by the old code.
+/// Being the *last* read of that directory, it is deliberately more thorough
+/// than the live repository ever was: it considers every encoding of a job the
+/// old store could leave behind and keeps the newest readable state of each,
+/// rather than trusting one filename convention.
 class DayProcessingLegacyFileStore {
   DayProcessingLegacyFileStore({required this.rootDirectory});
 
@@ -27,29 +26,45 @@ class DayProcessingLegacyFileStore {
   /// without touching the filesystem.
   bool get exists => rootDirectory.existsSync();
 
-  /// Every job readable from the directory, newest state first resolved.
+  /// The newest readable state of every job in the directory, oldest first.
   ///
-  /// Recovers orphaned partials before reading so a job whose last write was
-  /// interrupted is imported at its newest state rather than its previous one.
-  /// Unreadable files are quarantined and omitted — the same outcome the live
-  /// repository produced for them, and safe because a job that cannot be read
-  /// cannot be executed either.
+  /// A job can appear on disk more than once:
+  ///
+  /// - `<id>.json` — the published file.
+  /// - `<id>.json.part` — an unpublished write from a store version that used
+  ///   that suffix.
+  /// - `<id>.json.tmp.<micros>.<pid>.media` — what `atomicWriteBytes` actually
+  ///   writes before renaming over the destination. A crash in that window
+  ///   leaves it behind, holding a *newer* state than the published file — and
+  ///   for a job's very first write, holding the only copy.
+  ///
+  /// Rather than deciding by filename which one wins, every candidate is
+  /// decoded and the highest `generation` (then `updatedAt`) per job id is
+  /// kept. Unreadable files are quarantined and skipped, since a job that
+  /// cannot be read cannot be executed either.
   Future<List<DayProcessingJob>> readAll() async {
     if (!exists) return const [];
-    await _recoverPartials();
-    final jobs = <DayProcessingJob>[];
+    final newest = <String, DayProcessingJob>{};
     for (final file in rootDirectory.listSync().whereType<File>()) {
-      if (!file.path.endsWith('.json')) continue;
+      if (!_isJobCandidate(file.path)) continue;
+      final DayProcessingJob job;
       try {
-        jobs.add(await readFile(file));
+        job = await readFile(file);
       } catch (_) {
-        await quarantine(file);
+        // Scratch files are expected to be truncated or half-written; only
+        // something that claims to be a published job is worth setting aside
+        // for inspection.
+        if (!_isScratch(file.path)) await quarantine(file);
+        continue;
       }
+      final existing = newest[job.id];
+      if (existing == null || _isNewer(job, existing)) newest[job.id] = job;
     }
-    jobs.sort((a, b) {
-      final byCreated = a.createdAt.compareTo(b.createdAt);
-      return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
-    });
+    final jobs = newest.values.toList()
+      ..sort((a, b) {
+        final byCreated = a.createdAt.compareTo(b.createdAt);
+        return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
+      });
     return List<DayProcessingJob>.unmodifiable(jobs);
   }
 
@@ -79,24 +94,21 @@ class DayProcessingLegacyFileStore {
     await file.rename(destination.path);
   }
 
-  Future<void> _recoverPartials() async {
-    for (final partial in rootDirectory.listSync().whereType<File>().where(
-      (file) => file.path.endsWith('.json.part'),
-    )) {
-      final destination = File(
-        partial.path.substring(0, partial.path.length - '.part'.length),
-      );
-      // The published file won the race; the partial is leftover scratch.
-      if (destination.existsSync()) {
-        await partial.delete();
-        continue;
-      }
-      try {
-        await readFile(partial);
-        await partial.rename(destination.path);
-      } catch (_) {
-        await quarantine(partial);
-      }
+  /// Every write the old store could have produced for a job.
+  static bool _isJobCandidate(String filePath) =>
+      filePath.endsWith('.json') || _isScratch(filePath);
+
+  /// An unpublished write: either suffix the store has used for one.
+  static bool _isScratch(String filePath) =>
+      filePath.endsWith('.json.part') ||
+      (filePath.endsWith('.media') && filePath.contains('.json.tmp.'));
+
+  /// `generation` is the store's own monotonic counter and is authoritative;
+  /// `updatedAt` only breaks ties between writes that never diverged.
+  static bool _isNewer(DayProcessingJob candidate, DayProcessingJob current) {
+    if (candidate.generation != current.generation) {
+      return candidate.generation > current.generation;
     }
+    return candidate.updatedAt.isAfter(current.updatedAt);
   }
 }

--- a/lib/features/daily_os_next/services/day_processing_outbox_migration.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_migration.dart
@@ -1,8 +1,11 @@
 import 'package:drift/drift.dart';
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/database/day_processing_job_row.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_legacy_file_store.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 
 /// One-off cutover from the ADR 0031 file-per-job outbox to the ADR 0044
 /// device-local table.
@@ -67,10 +70,31 @@ class DayProcessingOutboxMigration {
       await db.transaction(() => _importAll(missing));
       imported += missing.length;
     }
-    // Left unmarked deliberately: the filesystem is still authoritative, the
-    // repository keeps reading the table it has been given, and the next start
-    // retries the cutover.
+    // Verification never stabilized, which with writers quiesced should be
+    // impossible. The sentinel is withheld so the next start retries the
+    // cutover, and the job files are still on disk — but be precise about what
+    // that costs: the repository reads only the table, so anything not yet
+    // imported is invisible for *this* session. Nothing is lost; some work may
+    // be delayed by one app run.
+    //
+    // Deliberately not thrown: failing here would block app startup entirely
+    // over a store that is already fully recoverable on the next launch, and
+    // startup repair rebuilds transcription jobs from journal provenance
+    // regardless.
+    _logUnstable(imported);
     return imported;
+  }
+
+  void _logUnstable(int imported) {
+    if (!getIt.isRegistered<DomainLogger>()) return;
+    getIt<DomainLogger>().log(
+      LogDomain.agentWorkflow,
+      'day-processing outbox migration did not stabilize after '
+      '$_maxVerificationPasses passes; imported $imported job(s), retrying '
+      'next start',
+      subDomain: 'dayProcessing.migration',
+      level: InsightLevel.error,
+    );
   }
 
   Future<bool> isComplete() async {

--- a/lib/features/daily_os_next/services/day_processing_outbox_migration.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_migration.dart
@@ -1,0 +1,134 @@
+import 'package:drift/drift.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_job_row.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_legacy_file_store.dart';
+
+/// One-off cutover from the ADR 0031 file-per-job outbox to the ADR 0044
+/// device-local table.
+///
+/// Runs during app start, **before** `DayProcessingRuntime.start()` and before
+/// any enqueue path is wired up. That quiescing is the write barrier the
+/// cutover depends on: a database transaction cannot span filesystem changes,
+/// so a job written to disk after the import but before the sentinel would
+/// exist only in the old store and become invisible the moment the repository
+/// switches over.
+class DayProcessingOutboxMigration {
+  DayProcessingOutboxMigration({
+    required this.db,
+    required this.legacyStore,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  final DayProcessingDb db;
+  final DayProcessingLegacyFileStore legacyStore;
+  final DateTime Function() _now;
+
+  /// Bound on verification passes.
+  ///
+  /// With writers quiesced the second pass is always clean; the bound exists
+  /// so an unexpected concurrent writer degrades into "migrate next start"
+  /// rather than an unbounded loop.
+  static const int _maxVerificationPasses = 5;
+
+  /// Imports the legacy directory and publishes the cutover sentinel.
+  ///
+  /// Idempotent: once the sentinel row exists this is a single indexed lookup,
+  /// so it is safe (and expected) to call on every start. Returns the number of
+  /// jobs imported, or null when the migration had already completed.
+  Future<int?> run() async {
+    if (await isComplete()) return null;
+
+    // Nothing to carry over on a fresh install; record the milestone so later
+    // starts skip the directory check entirely.
+    if (!legacyStore.exists) {
+      await _writeSentinel();
+      return 0;
+    }
+
+    var imported = 0;
+    for (var pass = 0; pass < _maxVerificationPasses; pass++) {
+      final jobs = await legacyStore.readAll();
+      final missing = await _notYetImported(jobs);
+      if (missing.isEmpty) {
+        // Verified: every id on disk is in the table. Publish the sentinel in
+        // the same transaction as the confirming read so the import and the
+        // cutover marker share one durability domain — either both are
+        // durable or neither is, and a crash before the commit simply re-runs
+        // the whole migration.
+        await db.transaction(() async {
+          final stillMissing = await _notYetImported(jobs);
+          if (stillMissing.isNotEmpty) await _importAll(stillMissing);
+          imported += stillMissing.length;
+          await _writeSentinel();
+        });
+        return imported;
+      }
+      await db.transaction(() => _importAll(missing));
+      imported += missing.length;
+    }
+    // Left unmarked deliberately: the filesystem is still authoritative, the
+    // repository keeps reading the table it has been given, and the next start
+    // retries the cutover.
+    return imported;
+  }
+
+  Future<bool> isComplete() async {
+    final rows = await db
+        .customSelect(
+          'SELECT 1 FROM day_processing_migrations WHERE migration_key = ?1',
+          variables: const [
+            Variable<String>(dayProcessingFileImportMigrationKey),
+          ],
+        )
+        .get();
+    return rows.isNotEmpty;
+  }
+
+  /// Jobs from disk that the table does not have yet.
+  ///
+  /// Verification is deliberately one-directional. Every id on disk must reach
+  /// the table, but a row in the table with no file behind it is kept, not
+  /// deleted: no code path removes a job file to express intent — cancellation
+  /// is a `cancelled` status written *into* the file — so a missing file never
+  /// means "this job should not exist". It does happen when a file whose
+  /// checksum fails is quarantined after a previous pass imported it, and in
+  /// that case the imported row is the only good copy left.
+  Future<List<DayProcessingJob>> _notYetImported(
+    List<DayProcessingJob> jobs,
+  ) async {
+    if (jobs.isEmpty) return const [];
+    final rows = await db
+        .customSelect('SELECT id FROM day_processing_jobs')
+        .get();
+    final present = {for (final row in rows) row.read<String>('id')};
+    return [
+      for (final job in jobs)
+        if (!present.contains(job.id)) job,
+    ];
+  }
+
+  Future<void> _importAll(List<DayProcessingJob> jobs) async {
+    for (final job in jobs) {
+      // `INSERT OR IGNORE`, not an upsert: a job the live repository has
+      // already advanced past its imported state must not be rewound to what
+      // the stale file says.
+      await db.customInsert(
+        'INSERT OR IGNORE INTO day_processing_jobs '
+        '($dayProcessingJobColumns) '
+        'VALUES ($dayProcessingJobPlaceholders)',
+        variables: dayProcessingJobVariables(job),
+      );
+    }
+  }
+
+  Future<void> _writeSentinel() => db.customInsert(
+    'INSERT OR REPLACE INTO day_processing_migrations '
+    '(migration_key, completed_at) '
+    'VALUES (?1, ?2)',
+    variables: [
+      const Variable<String>(dayProcessingFileImportMigrationKey),
+      Variable<int>(_now().millisecondsSinceEpoch),
+    ],
+  );
+}

--- a/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
@@ -1,12 +1,21 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:crypto/crypto.dart';
+import 'package:drift/drift.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_job_row.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
-import 'package:lotti/features/sync/matrix/utils/atomic_write.dart';
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
+
+/// How long a terminal job stays in the Activity ledger (ADR 0044 decision 5).
+///
+/// Chosen to comfortably outlive Activity's practical scroll-back and to
+/// survive a long offline gap. It is a number to revisit if Activity grows a
+/// longer history surface, not a load-bearing constant: the partial index
+/// already keeps the ledger off the drain path, so this bounds disk footprint
+/// rather than query cost.
+const Duration dayProcessingLedgerRetention = Duration(days: 90);
 
 class DayProcessingClaim {
   const DayProcessingClaim({required this.job, required this.token});
@@ -37,26 +46,52 @@ class DayProcessingClaimRevokedException implements Exception {
   String toString() => 'Processing claim no longer owns $jobId';
 }
 
-/// File-backed, per-job processing outbox for Daily OS derived work.
+/// Device-local processing outbox for Daily OS derived work (ADR 0044).
 ///
-/// Each mutation flushes an integrity envelope to a partial file before an
-/// atomic rename. Jobs remain after success as the local processing ledger
-/// consumed by Activity and startup repair.
+/// One row per job in [DayProcessingDb]. Jobs remain after success as the
+/// local processing ledger consumed by Activity and startup repair; the
+/// partial index over non-terminal rows keeps that ledger off the drain path,
+/// so claim cost tracks outstanding work rather than install age.
+///
+/// Every read-modify-write runs in a transaction and every claimed mutation is
+/// fenced by `claim_token`, which together replace the mutex and atomic-rename
+/// machinery of the pre-0044 file store.
 class DayProcessingOutboxRepository {
   DayProcessingOutboxRepository({
-    required this.rootDirectory,
+    required this.db,
     DateTime Function()? now,
     String Function()? tokenFactory,
   }) : _now = now ?? DateTime.now,
        _tokenFactory = tokenFactory ?? (() => const Uuid().v4());
 
-  final Directory rootDirectory;
+  final DayProcessingDb db;
   final DateTime Function() _now;
   final String Function() _tokenFactory;
   final StreamController<void> _changes = StreamController<void>.broadcast();
-  Future<void> _tail = Future<void>.value();
 
   Stream<void> get changes => _changes.stream;
+
+  /// Backstop cap for [recordRunKey].
+  static const int maxRecordedRunKeys = 16;
+
+  static const String _columns = dayProcessingJobColumns;
+
+  /// Statuses a job can be claimed or scheduled from. Mirrors
+  /// [DayProcessingJob.isDue]'s first guard.
+  static const String _drainableStatuses =
+      "('queued', 'running', 'waitingForNetwork')";
+
+  /// [DayProcessingJob.isDue] as SQL, with `?1` bound to now.
+  ///
+  /// A `running` row is due only once its lease has expired (crash recovery);
+  /// everything else is due at `next_attempt_at`. A hard provider boundary
+  /// vetoes both.
+  static const String _dueClause =
+      'status IN $_drainableStatuses '
+      'AND (retry_not_before IS NULL OR retry_not_before <= ?1) '
+      "AND ((status = 'running' AND lease_until IS NOT NULL "
+      'AND lease_until <= ?1) '
+      "OR (status <> 'running' AND next_attempt_at <= ?1))";
 
   static String transcriptionJobId(String recordingSessionId) =>
       'transcribe_$recordingSessionId';
@@ -76,28 +111,31 @@ class DayProcessingOutboxRepository {
     required String audioId,
     required String audioPath,
     required DateTime capturedAt,
-  }) => _serialize(() async {
-    await _ensureRoot();
-    final id = transcriptionJobId(recordingSessionId);
-    final now = _now();
-    final requested = _newTranscriptionJob(
-      dayId: dayId,
-      activityEntryId: activityEntryId,
-      recordingSessionId: recordingSessionId,
-      audioId: audioId,
-      audioPath: audioPath,
-      capturedAt: capturedAt,
-      now: now,
-    );
-    final existing = await _readJobOrNull(id);
-    if (existing != null) {
-      _validateImmutableIntent(existing, requested);
-      return existing;
-    }
-    await _write(requested);
-    _notify();
-    return requested;
-  });
+  }) async {
+    var published = false;
+    final job = await db.transaction(() async {
+      final now = _now();
+      final requested = _newTranscriptionJob(
+        dayId: dayId,
+        activityEntryId: activityEntryId,
+        recordingSessionId: recordingSessionId,
+        audioId: audioId,
+        audioPath: audioPath,
+        capturedAt: capturedAt,
+        now: now,
+      );
+      final existing = await _readJobOrNull(requested.id);
+      if (existing != null) {
+        _validateImmutableIntent(existing, requested);
+        return existing;
+      }
+      await _write(requested);
+      published = true;
+      return requested;
+    });
+    if (published) _notify();
+    return job;
+  }
 
   /// Repairs the journal-created/outbox-not-yet-published crash boundary.
   Future<bool> restoreTranscriptionIntent({
@@ -108,53 +146,54 @@ class DayProcessingOutboxRepository {
     required String audioPath,
     required DateTime capturedAt,
     String? completedTranscript,
-  }) => _serialize(() async {
-    await _ensureRoot();
-    final id = transcriptionJobId(recordingSessionId);
-    final now = _now();
-    final transcript = completedTranscript?.trim();
-    var requested = _newTranscriptionJob(
-      dayId: dayId,
-      activityEntryId: activityEntryId,
-      recordingSessionId: recordingSessionId,
-      audioId: audioId,
-      audioPath: audioPath,
-      capturedAt: capturedAt,
-      now: now,
-    );
-    final existing = await _readJobOrNull(id);
-    if (existing != null) {
-      _validateImmutableIntent(existing, requested);
-      if (transcript == null ||
-          transcript.isEmpty ||
-          existing.status == DayProcessingJobStatus.succeeded) {
-        return false;
+  }) async {
+    final restored = await db.transaction(() async {
+      final now = _now();
+      final transcript = completedTranscript?.trim();
+      var requested = _newTranscriptionJob(
+        dayId: dayId,
+        activityEntryId: activityEntryId,
+        recordingSessionId: recordingSessionId,
+        audioId: audioId,
+        audioPath: audioPath,
+        capturedAt: capturedAt,
+        now: now,
+      );
+      final existing = await _readJobOrNull(requested.id);
+      if (existing != null) {
+        _validateImmutableIntent(existing, requested);
+        if (transcript == null ||
+            transcript.isEmpty ||
+            existing.status == DayProcessingJobStatus.succeeded) {
+          return false;
+        }
+        requested = existing.copyWith(
+          status: DayProcessingJobStatus.succeeded,
+          updatedAt: now,
+          generation: existing.generation + 1,
+          resultTranscript: transcript,
+          completedAt: now,
+          clearClaimToken: true,
+          clearLeaseUntil: true,
+          clearLastError: true,
+          clearLastFailureClass: true,
+        );
       }
-      requested = existing.copyWith(
-        status: DayProcessingJobStatus.succeeded,
-        updatedAt: now,
-        generation: existing.generation + 1,
-        resultTranscript: transcript,
-        completedAt: now,
-        clearClaimToken: true,
-        clearLeaseUntil: true,
-        clearLastError: true,
-        clearLastFailureClass: true,
-      );
-    }
-    if (existing == null && transcript != null && transcript.isNotEmpty) {
-      requested = requested.copyWith(
-        status: DayProcessingJobStatus.succeeded,
-        updatedAt: now,
-        generation: 1,
-        resultTranscript: transcript,
-        completedAt: now,
-      );
-    }
-    await _write(requested);
-    _notify();
-    return true;
-  });
+      if (existing == null && transcript != null && transcript.isNotEmpty) {
+        requested = requested.copyWith(
+          status: DayProcessingJobStatus.succeeded,
+          updatedAt: now,
+          generation: 1,
+          resultTranscript: transcript,
+          completedAt: now,
+        );
+      }
+      await _write(requested);
+      return true;
+    });
+    if (restored) _notify();
+    return restored;
+  }
 
   /// Atomically publishes and claims a new interactive transcription job,
   /// preventing the background runner from racing the capture screen.
@@ -166,26 +205,27 @@ class DayProcessingOutboxRepository {
     required String audioPath,
     required DateTime capturedAt,
     Duration lease = const Duration(minutes: 3),
-  }) => _serialize(() async {
-    await _ensureRoot();
-    final id = transcriptionJobId(recordingSessionId);
-    final now = _now();
-    final existing = await _readJobOrNull(id);
-    final requested = _newTranscriptionJob(
-      dayId: dayId,
-      activityEntryId: activityEntryId,
-      recordingSessionId: recordingSessionId,
-      audioId: audioId,
-      audioPath: audioPath,
-      capturedAt: capturedAt,
-      now: now,
-    );
-    if (existing != null) _validateImmutableIntent(existing, requested);
-    final job = existing ?? requested;
-    if (existing == null) await _write(job);
-    if (!job.isDue(now)) return null;
-    return _claimUnsafe(job, now: now, lease: lease);
-  });
+  }) async {
+    final claim = await db.transaction(() async {
+      final now = _now();
+      final requested = _newTranscriptionJob(
+        dayId: dayId,
+        activityEntryId: activityEntryId,
+        recordingSessionId: recordingSessionId,
+        audioId: audioId,
+        audioPath: audioPath,
+        capturedAt: capturedAt,
+        now: now,
+      );
+      final existing = await _readJobOrNull(requested.id);
+      if (existing != null) _validateImmutableIntent(existing, requested);
+      final job = existing ?? requested;
+      if (existing == null) await _write(job);
+      return _claim(now: now, lease: lease, jobId: job.id);
+    });
+    if (claim != null) _notify();
+    return claim;
+  }
 
   /// Enqueues (or coalesces onto) the day's durable draft-plan intent.
   ///
@@ -196,65 +236,51 @@ class DayProcessingOutboxRepository {
   Future<DayProcessingJob> enqueueDraftPlan({
     required String dayId,
     required DraftPlanPayload payload,
-  }) => _serialize(() async {
-    await _ensureRoot();
-    final id = draftJobId(dayId);
-    final now = _now();
-    final existing = await _readJobOrNull(id);
-    if (existing == null) {
-      final job = DayProcessingJob(
-        id: id,
-        status: DayProcessingJobStatus.queued,
-        dayId: dayId,
-        payload: payload,
-        createdAt: now,
-        updatedAt: now,
-        requestedAt: now,
-        nextAttemptAt: now,
-        attempts: 0,
-        generation: 0,
-      );
-      await _write(job);
-      _notify();
-      return job;
-    }
-    if (existing.status == DayProcessingJobStatus.running) {
-      final leaseUntil = existing.leaseUntil;
-      if (leaseUntil != null && now.isBefore(leaseUntil)) {
-        // The in-flight attempt keeps its payload; injecting newer
-        // selections mid-wake is not possible, and the caller's await
-        // attaches to this job's terminal state either way.
-        return existing;
+  }) async {
+    var mutated = false;
+    final job = await db.transaction(() async {
+      final id = draftJobId(dayId);
+      final now = _now();
+      final existing = await _readJobOrNull(id);
+      if (existing == null) {
+        final job = DayProcessingJob(
+          id: id,
+          status: DayProcessingJobStatus.queued,
+          dayId: dayId,
+          payload: payload,
+          createdAt: now,
+          updatedAt: now,
+          requestedAt: now,
+          nextAttemptAt: now,
+          attempts: 0,
+          generation: 0,
+        );
+        await _write(job);
+        mutated = true;
+        return job;
       }
-      // `running` with an expired (or missing) lease is a zombie left by a
-      // killed process — nothing is executing. Absorbing the new payload
-      // into it would run the OLD selections at the eventual lease-expiry
-      // re-claim, silently dropping what the user just decided. Fall
-      // through to re-arm with the fresh payload instead.
-    }
-    final rearmed = existing.copyWith(
-      status: DayProcessingJobStatus.queued,
-      payload: payload,
-      updatedAt: now,
-      requestedAt: now,
-      nextAttemptAt: now,
-      attempts: 0,
-      // A re-arm is new intent: artifacts of the old intent's wakes must
-      // not satisfy it, so recorded run keys reset with the baseline.
-      runKeys: const [],
-      generation: existing.generation + 1,
-      clearClaimToken: true,
-      clearLeaseUntil: true,
-      clearRetryNotBefore: true,
-      clearLastError: true,
-      clearLastFailureClass: true,
-      clearResultEntityId: true,
-      clearCompletedAt: true,
-    );
-    await _write(rearmed);
-    _notify();
-    return rearmed;
-  });
+      if (existing.status == DayProcessingJobStatus.running) {
+        final leaseUntil = existing.leaseUntil;
+        if (leaseUntil != null && now.isBefore(leaseUntil)) {
+          // The in-flight attempt keeps its payload; injecting newer
+          // selections mid-wake is not possible, and the caller's await
+          // attaches to this job's terminal state either way.
+          return existing;
+        }
+        // `running` with an expired (or missing) lease is a zombie left by a
+        // killed process — nothing is executing. Absorbing the new payload
+        // into it would run the OLD selections at the eventual lease-expiry
+        // re-claim, silently dropping what the user just decided. Fall
+        // through to re-arm with the fresh payload instead.
+      }
+      final rearmed = _rearm(existing, payload: payload, now: now);
+      await _write(rearmed);
+      mutated = true;
+      return rearmed;
+    });
+    if (mutated) _notify();
+    return job;
+  }
 
   /// Enqueues the durable parse intent for one submitted capture.
   ///
@@ -268,53 +294,42 @@ class DayProcessingOutboxRepository {
   Future<DayProcessingJob> enqueueParseCapture({
     required String dayId,
     required String captureId,
-  }) => _serialize(() async {
-    await _ensureRoot();
-    final id = parseJobId(captureId);
-    final now = _now();
-    final requested = DayProcessingJob(
-      id: id,
-      status: DayProcessingJobStatus.queued,
-      dayId: dayId,
-      payload: ParseCapturePayload(captureId: captureId),
-      createdAt: now,
-      updatedAt: now,
-      requestedAt: now,
-      nextAttemptAt: now,
-      attempts: 0,
-      generation: 0,
-    );
-    final existing = await _readJobOrNull(id);
-    if (existing == null) {
-      await _write(requested);
-      _notify();
-      return requested;
-    }
-    _validateImmutableIntent(existing, requested);
-    if (existing.status == DayProcessingJobStatus.queued ||
-        existing.status == DayProcessingJobStatus.running) {
-      return existing;
-    }
-    final rearmed = existing.copyWith(
-      status: DayProcessingJobStatus.queued,
-      updatedAt: now,
-      requestedAt: now,
-      nextAttemptAt: now,
-      attempts: 0,
-      runKeys: const [],
-      generation: existing.generation + 1,
-      clearClaimToken: true,
-      clearLeaseUntil: true,
-      clearRetryNotBefore: true,
-      clearLastError: true,
-      clearLastFailureClass: true,
-      clearResultEntityId: true,
-      clearCompletedAt: true,
-    );
-    await _write(rearmed);
-    _notify();
-    return rearmed;
-  });
+  }) async {
+    var mutated = false;
+    final job = await db.transaction(() async {
+      final id = parseJobId(captureId);
+      final now = _now();
+      final requested = DayProcessingJob(
+        id: id,
+        status: DayProcessingJobStatus.queued,
+        dayId: dayId,
+        payload: ParseCapturePayload(captureId: captureId),
+        createdAt: now,
+        updatedAt: now,
+        requestedAt: now,
+        nextAttemptAt: now,
+        attempts: 0,
+        generation: 0,
+      );
+      final existing = await _readJobOrNull(id);
+      if (existing == null) {
+        await _write(requested);
+        mutated = true;
+        return requested;
+      }
+      _validateImmutableIntent(existing, requested);
+      if (existing.status == DayProcessingJobStatus.queued ||
+          existing.status == DayProcessingJobStatus.running) {
+        return existing;
+      }
+      final rearmed = _rearm(existing, now: now);
+      await _write(rearmed);
+      mutated = true;
+      return rearmed;
+    });
+    if (mutated) _notify();
+    return job;
+  }
 
   /// Enqueues a durable refine intent for the day.
   ///
@@ -324,28 +339,54 @@ class DayProcessingOutboxRepository {
   Future<DayProcessingJob> enqueueRefinePlan({
     required String dayId,
     String? transcriptCaptureId,
-  }) => _serialize(() async {
-    await _ensureRoot();
-    final now = _now();
-    final raw = _tokenFactory().replaceAll('-', '');
-    final suffix = raw.length > 8 ? raw.substring(0, 8) : raw;
-    final id = 'refine_${dayId}_$suffix';
-    final job = DayProcessingJob(
-      id: id,
-      status: DayProcessingJobStatus.queued,
-      dayId: dayId,
-      payload: RefinePlanPayload(transcriptCaptureId: transcriptCaptureId),
-      createdAt: now,
-      updatedAt: now,
-      requestedAt: now,
-      nextAttemptAt: now,
-      attempts: 0,
-      generation: 0,
-    );
-    await _write(job);
+  }) async {
+    final job = await db.transaction(() async {
+      final now = _now();
+      final raw = _tokenFactory().replaceAll('-', '');
+      final suffix = raw.length > 8 ? raw.substring(0, 8) : raw;
+      final job = DayProcessingJob(
+        id: 'refine_${dayId}_$suffix',
+        status: DayProcessingJobStatus.queued,
+        dayId: dayId,
+        payload: RefinePlanPayload(transcriptCaptureId: transcriptCaptureId),
+        createdAt: now,
+        updatedAt: now,
+        requestedAt: now,
+        nextAttemptAt: now,
+        attempts: 0,
+        generation: 0,
+      );
+      await _write(job);
+      return job;
+    });
     _notify();
     return job;
-  });
+  }
+
+  /// Re-arms a job onto fresh intent: new baseline, cleared retry/error state,
+  /// and no inherited run keys (artifacts of the old intent's wakes must not
+  /// satisfy the new one).
+  DayProcessingJob _rearm(
+    DayProcessingJob existing, {
+    required DateTime now,
+    DayProcessingPayload? payload,
+  }) => existing.copyWith(
+    status: DayProcessingJobStatus.queued,
+    payload: payload,
+    updatedAt: now,
+    requestedAt: now,
+    nextAttemptAt: now,
+    attempts: 0,
+    runKeys: const [],
+    generation: existing.generation + 1,
+    clearClaimToken: true,
+    clearLeaseUntil: true,
+    clearRetryNotBefore: true,
+    clearLastError: true,
+    clearLastFailureClass: true,
+    clearResultEntityId: true,
+    clearCompletedAt: true,
+  );
 
   void _validateImmutableIntent(
     DayProcessingJob existing,
@@ -414,27 +455,50 @@ class DayProcessingOutboxRepository {
     generation: 0,
   );
 
-  Future<List<DayProcessingJob>> getAll() => _serialize(() async {
-    await _ensureRoot();
-    await _recoverPartials();
-    final jobs = <DayProcessingJob>[];
-    for (final file in rootDirectory.listSync().whereType<File>()) {
-      if (!file.path.endsWith('.json')) continue;
-      try {
-        jobs.add(await _readFile(file));
-      } catch (_) {
-        await _quarantine(file);
-      }
-    }
-    jobs.sort((a, b) {
-      final byCreated = a.createdAt.compareTo(b.createdAt);
-      return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
-    });
-    return List<DayProcessingJob>.unmodifiable(jobs);
-  });
+  Future<DayProcessingJob?> getById(String id) => _readJobOrNull(id);
 
-  Future<DayProcessingJob?> getById(String id) =>
-      _serialize(() => _readJobOrNull(id));
+  /// Every job recorded for [dayId], oldest first.
+  ///
+  /// Day-scoped so Activity's cost tracks one day rather than the whole
+  /// ledger; served by `idx_day_processing_jobs_day`.
+  Future<List<DayProcessingJob>> getForDay(
+    String dayId, {
+    Set<DayProcessingJobKind>? kinds,
+  }) async {
+    final variables = <Variable<Object>>[Variable<String>(dayId)];
+    var sql = 'SELECT $_columns FROM day_processing_jobs WHERE day_id = ?1';
+    if (kinds != null) {
+      if (kinds.isEmpty) return const [];
+      sql += ' AND ${_kindFilter(kinds, variables)}';
+    }
+    sql += ' ORDER BY created_at, id';
+    return _readAll(sql, variables);
+  }
+
+  /// Non-terminal jobs of [kind], oldest first.
+  ///
+  /// Served by the pending partial index, so the review fence's sweep tracks
+  /// outstanding work instead of every recording ever made.
+  Future<List<DayProcessingJob>> getPendingByKind(
+    DayProcessingJobKind kind,
+  ) => _readAll(
+    'SELECT $_columns FROM day_processing_jobs '
+    "WHERE status NOT IN ('succeeded', 'cancelled') AND kind = ?1 "
+    'ORDER BY created_at, id',
+    [Variable<String>(kind.name)],
+  );
+
+  /// Jobs the runtime can still schedule a wake-up for, oldest first.
+  ///
+  /// Bounded by outstanding work rather than install age. The effective
+  /// due-time ordering stays in the runtime (it depends on the runtime's own
+  /// network-probe interval) so that rule has exactly one implementation.
+  Future<List<DayProcessingJob>> getSchedulable() => _readAll(
+    'SELECT $_columns FROM day_processing_jobs '
+    'WHERE status IN $_drainableStatuses '
+    'ORDER BY created_at, id',
+    const [],
+  );
 
   /// Claims the next due job, optionally restricted to [kinds] so callers
   /// can drain kind families independently (a slow agent wake must not block
@@ -442,48 +506,69 @@ class DayProcessingOutboxRepository {
   Future<DayProcessingClaim?> claimNext({
     Duration lease = const Duration(minutes: 3),
     Set<DayProcessingJobKind>? kinds,
-  }) => _serialize(() async {
-    final now = _now();
-    final jobs = await _readAllUnsafe();
-    final due = jobs
-        .where(
-          (job) =>
-              job.isDue(now) && (kinds == null || kinds.contains(job.kind)),
-        )
-        .firstOrNull;
-    if (due == null) return null;
-    return _claimUnsafe(due, now: now, lease: lease);
-  });
+  }) async {
+    if (kinds != null && kinds.isEmpty) return null;
+    final claim = await _claim(now: _now(), lease: lease, kinds: kinds);
+    if (claim != null) _notify();
+    return claim;
+  }
 
   /// Claims one known job for an interactive foreground attempt.
   Future<DayProcessingClaim?> claimById(
     String jobId, {
     Duration lease = const Duration(minutes: 3),
-  }) => _serialize(() async {
-    final now = _now();
-    final job = await _readJobOrNull(jobId);
-    if (job == null || !job.isDue(now)) return null;
-    return _claimUnsafe(job, now: now, lease: lease);
-  });
+  }) async {
+    final claim = await _claim(now: _now(), lease: lease, jobId: jobId);
+    if (claim != null) _notify();
+    return claim;
+  }
 
-  Future<DayProcessingClaim> _claimUnsafe(
-    DayProcessingJob job, {
+  /// Selects and stamps a claim in one statement.
+  ///
+  /// The due predicate, the ordering and the claim write are a single
+  /// `UPDATE … WHERE id = (SELECT …) RETURNING`, so there is no window in
+  /// which a second claimer can take the row between choosing it and owning
+  /// it — the question of what a "lost" claim should do never arises, rather
+  /// than being answered with a retry loop. An empty result means nothing was
+  /// due, which is the only reason a caller sees no claim.
+  ///
+  /// Returns the row as written, so the caller's job reflects exactly what is
+  /// durable rather than a locally reconstructed copy.
+  ///
+  /// The token is minted before the statement runs and is therefore consumed
+  /// even when nothing matches. Tokens are opaque and unbounded, so gaps carry
+  /// no meaning.
+  Future<DayProcessingClaim?> _claim({
     required DateTime now,
     required Duration lease,
+    String? jobId,
+    Set<DayProcessingJobKind>? kinds,
   }) async {
     final token = _tokenFactory();
-    final claimed = job.copyWith(
-      status: DayProcessingJobStatus.running,
-      updatedAt: now,
-      generation: job.generation + 1,
-      claimToken: token,
-      leaseUntil: now.add(lease),
-      clearLastError: true,
-      clearLastFailureClass: true,
+    final variables = <Variable<Object>>[
+      Variable<int>(_ms(now)),
+      Variable<String>(token),
+      Variable<int>(_ms(now.add(lease))),
+    ];
+    var selector = 'SELECT id FROM day_processing_jobs WHERE $_dueClause';
+    if (jobId != null) {
+      variables.add(Variable<String>(jobId));
+      selector += ' AND id = ?${variables.length}';
+    }
+    if (kinds != null) selector += ' AND ${_kindFilter(kinds, variables)}';
+    selector += ' ORDER BY created_at, id LIMIT 1';
+
+    final rows = await db.customWriteReturning(
+      'UPDATE day_processing_jobs SET '
+      "status = 'running', updated_at = ?1, generation = generation + 1, "
+      'claim_token = ?2, lease_until = ?3, '
+      'last_error = NULL, last_failure_class = NULL '
+      'WHERE id = ($selector) '
+      'RETURNING $_columns',
+      variables: variables,
     );
-    await _write(claimed);
-    _notify();
-    return DayProcessingClaim(job: claimed, token: token);
+    if (rows.isEmpty) return null;
+    return DayProcessingClaim(job: _fromRow(rows.single), token: token);
   }
 
   Future<DayProcessingJob> markSucceeded({
@@ -565,22 +650,18 @@ class DayProcessingOutboxRepository {
   /// Terminalizes a job the user no longer wants — e.g. its recording was
   /// deleted. A concurrently running worker's next claimed mutation fails
   /// its stale-claim check and is absorbed by the runtime's retry handling.
-  Future<DayProcessingJob?> cancel(String jobId) => _serialize(() async {
-    final job = await _readJobOrNull(jobId);
-    if (job == null || job.isTerminal) return job;
-    final now = _now();
-    final updated = job.copyWith(
-      status: DayProcessingJobStatus.cancelled,
-      updatedAt: now,
-      completedAt: now,
-      generation: job.generation + 1,
-      clearClaimToken: true,
-      clearLeaseUntil: true,
-    );
-    await _write(updated);
-    _notify();
-    return updated;
-  });
+  Future<DayProcessingJob?> cancel(String jobId) =>
+      _mutateUnclaimed(jobId, (job, now) {
+        if (job.isTerminal) return null;
+        return job.copyWith(
+          status: DayProcessingJobStatus.cancelled,
+          updatedAt: now,
+          completedAt: now,
+          generation: job.generation + 1,
+          clearClaimToken: true,
+          clearLeaseUntil: true,
+        );
+      });
 
   /// Records the run key of a wake enqueued for [jobId] (agent jobs).
   ///
@@ -588,51 +669,39 @@ class DayProcessingOutboxRepository {
   /// a stale writer appending its run key is harmless (the key belongs to a
   /// wake that really was enqueued for this job), so fencing would only add
   /// failure modes. Keys are capped to the newest [maxRecordedRunKeys] —
-  /// far above `maxAttempts` — purely as a file-size backstop.
+  /// far above `maxAttempts` — purely as a size backstop.
   Future<DayProcessingJob?> recordRunKey({
     required String jobId,
     required String runKey,
-  }) => _serialize(() async {
-    final job = await _readJobOrNull(jobId);
-    if (job == null || job.isTerminal) return job;
-    if (job.runKeys.contains(runKey)) return job;
+  }) => _mutateUnclaimed(jobId, (job, now) {
+    if (job.isTerminal || job.runKeys.contains(runKey)) return null;
     final keys = [...job.runKeys, runKey];
-    final updated = job.copyWith(
-      updatedAt: _now(),
+    return job.copyWith(
+      updatedAt: now,
       runKeys: keys.length > maxRecordedRunKeys
           ? keys.sublist(keys.length - maxRecordedRunKeys)
           : keys,
     );
-    await _write(updated);
-    _notify();
-    return updated;
   });
 
-  /// Backstop cap for [recordRunKey].
-  static const int maxRecordedRunKeys = 16;
-
-  Future<DayProcessingJob?> retryNow(String jobId) => _serialize(() async {
-    final job = await _readJobOrNull(jobId);
-    if (job == null || job.isTerminal) return job;
-    final now = _now();
-    final hardBoundary = job.retryNotBefore;
-    final due = hardBoundary != null && now.isBefore(hardBoundary)
-        ? hardBoundary
-        : now;
-    final updated = job.copyWith(
-      status: DayProcessingJobStatus.queued,
-      updatedAt: now,
-      nextAttemptAt: due,
-      generation: job.generation + 1,
-      clearClaimToken: true,
-      clearLeaseUntil: true,
-      clearLastError: true,
-      clearLastFailureClass: true,
-    );
-    await _write(updated);
-    _notify();
-    return updated;
-  });
+  Future<DayProcessingJob?> retryNow(String jobId) =>
+      _mutateUnclaimed(jobId, (job, now) {
+        if (job.isTerminal) return null;
+        final hardBoundary = job.retryNotBefore;
+        final due = hardBoundary != null && now.isBefore(hardBoundary)
+            ? hardBoundary
+            : now;
+        return job.copyWith(
+          status: DayProcessingJobStatus.queued,
+          updatedAt: now,
+          nextAttemptAt: due,
+          generation: job.generation + 1,
+          clearClaimToken: true,
+          clearLeaseUntil: true,
+          clearLastError: true,
+          clearLastFailureClass: true,
+        );
+      });
 
   /// Marks transcription as satisfied by canonical user-reviewed text.
   /// Pending provider work is fenced and will not later overwrite the user's
@@ -640,13 +709,11 @@ class DayProcessingOutboxRepository {
   Future<DayProcessingJob?> satisfyWithReviewedText(
     String jobId,
     String transcript,
-  ) => _serialize(() async {
-    final job = await _readJobOrNull(jobId);
-    if (job == null || job.isTerminal) return job;
+  ) => _mutateUnclaimed(jobId, (job, now) {
+    if (job.isTerminal) return null;
     final trimmed = transcript.trim();
-    if (trimmed.isEmpty) return job;
-    final now = _now();
-    final updated = job.copyWith(
+    if (trimmed.isEmpty) return null;
+    return job.copyWith(
       status: DayProcessingJobStatus.succeeded,
       updatedAt: now,
       generation: job.generation + 1,
@@ -658,151 +725,142 @@ class DayProcessingOutboxRepository {
       clearLastError: true,
       clearLastFailureClass: true,
     );
-    await _write(updated);
-    _notify();
-    return updated;
   });
 
-  Future<void> signalConnectivityRestored() => _serialize(() async {
-    final now = _now();
-    for (final job in await _readAllUnsafe()) {
-      if (job.status != DayProcessingJobStatus.waitingForNetwork) continue;
-      final updated = job.copyWith(
-        status: DayProcessingJobStatus.queued,
-        updatedAt: now,
-        nextAttemptAt: now,
-        generation: job.generation + 1,
-      );
-      await _write(updated);
-    }
+  Future<void> signalConnectivityRestored() async {
+    final now = _ms(_now());
+    await db.customUpdate(
+      'UPDATE day_processing_jobs SET '
+      "status = 'queued', updated_at = ?1, next_attempt_at = ?1, "
+      'generation = generation + 1 '
+      "WHERE status = 'waitingForNetwork'",
+      variables: [Variable<int>(now)],
+    );
     _notify();
-  });
+  }
+
+  /// Deletes ledger rows completed before [cutoff] (ADR 0044 decision 5).
+  ///
+  /// Only terminal rows are eligible: a job parked in `failed`,
+  /// `waitingForUser` or `waitingForNetwork` is outstanding user intent that
+  /// [retryNow] and re-enqueue can still resurrect, so age alone must never
+  /// remove it. Returns the number of rows pruned.
+  Future<int> pruneTerminalBefore(DateTime cutoff) async {
+    final pruned = await db.customUpdate(
+      'DELETE FROM day_processing_jobs '
+      "WHERE status IN ('succeeded', 'cancelled') "
+      'AND completed_at IS NOT NULL AND completed_at < ?1',
+      variables: [Variable<int>(_ms(cutoff))],
+      updateKind: UpdateKind.delete,
+    );
+    if (pruned > 0) _notify();
+    return pruned;
+  }
+
+  /// Read-modify-write for the claim-less mutators.
+  ///
+  /// [update] returns null when the job should be left untouched, which keeps
+  /// each caller's no-op guards (terminal, duplicate run key, blank text)
+  /// beside the mutation they guard.
+  Future<DayProcessingJob?> _mutateUnclaimed(
+    String jobId,
+    DayProcessingJob? Function(DayProcessingJob job, DateTime now) update,
+  ) async {
+    var mutated = false;
+    final job = await db.transaction(() async {
+      final job = await _readJobOrNull(jobId);
+      if (job == null) return null;
+      final updated = update(job, _now());
+      if (updated == null) return job;
+      await _write(updated);
+      mutated = true;
+      return updated;
+    });
+    if (mutated) _notify();
+    return job;
+  }
 
   Future<DayProcessingJob> _updateClaimed(
     String jobId,
     String claimToken,
     DayProcessingJob Function(DayProcessingJob job, DateTime now) update,
-  ) => _serialize(() async {
-    final job = await _readJobOrNull(jobId);
-    if (job == null) throw StateError('Unknown processing job $jobId');
-    if (job.status != DayProcessingJobStatus.running ||
-        job.claimToken != claimToken) {
-      throw DayProcessingClaimRevokedException(jobId);
-    }
-    final updated = update(job, _now());
-    await _write(updated);
+  ) async {
+    final updated = await db.transaction(() async {
+      final job = await _readJobOrNull(jobId);
+      if (job == null) throw StateError('Unknown processing job $jobId');
+      if (job.status != DayProcessingJobStatus.running ||
+          job.claimToken != claimToken) {
+        throw DayProcessingClaimRevokedException(jobId);
+      }
+      final updated = update(job, _now());
+      await _write(updated);
+      return updated;
+    });
     _notify();
     return updated;
-  });
-
-  Future<List<DayProcessingJob>> _readAllUnsafe() async {
-    await _ensureRoot();
-    await _recoverPartials();
-    final jobs = <DayProcessingJob>[];
-    for (final file in rootDirectory.listSync().whereType<File>()) {
-      if (!file.path.endsWith('.json')) continue;
-      try {
-        jobs.add(await _readFile(file));
-      } catch (_) {
-        await _quarantine(file);
-      }
-    }
-    jobs.sort((a, b) {
-      final byDue = a.nextAttemptAt.compareTo(b.nextAttemptAt);
-      return byDue != 0 ? byDue : a.id.compareTo(b.id);
-    });
-    return jobs;
   }
 
   Future<DayProcessingJob?> _readJobOrNull(String id) async {
-    await _ensureRoot();
-    final file = _fileFor(id);
-    if (!file.existsSync()) return null;
-    try {
-      return await _readFile(file);
-    } catch (_) {
-      await _quarantine(file);
-      return null;
-    }
+    final rows = await db
+        .customSelect(
+          'SELECT $_columns FROM day_processing_jobs WHERE id = ?1',
+          variables: [Variable<String>(id)],
+        )
+        .get();
+    return rows.isEmpty ? null : _fromRow(rows.single);
   }
 
-  Future<DayProcessingJob> _readFile(File file) async {
-    final envelope =
-        jsonDecode(await file.readAsString())! as Map<String, Object?>;
-    final payload = envelope['payload']! as String;
-    final expected = envelope['sha256']! as String;
-    final actual = sha256.convert(utf8.encode(payload)).toString();
-    if (actual != expected) {
-      throw const FormatException('Invalid processing job digest');
+  Future<List<DayProcessingJob>> _readAll(
+    String sql,
+    List<Variable<Object>> variables,
+  ) async {
+    final rows = await db.customSelect(sql, variables: variables).get();
+    return List<DayProcessingJob>.unmodifiable(rows.map(_fromRow));
+  }
+
+  /// Appends `kind IN (…)` to a query, extending [variables] in place so the
+  /// placeholder numbering stays aligned with the caller's existing bindings.
+  static String _kindFilter(
+    Set<DayProcessingJobKind> kinds,
+    List<Variable<Object>> variables,
+  ) {
+    final placeholders = <String>[];
+    for (final kind in kinds) {
+      variables.add(Variable<String>(kind.name));
+      placeholders.add('?${variables.length}');
     }
-    return DayProcessingJob.fromJson(
-      jsonDecode(payload)! as Map<String, Object?>,
-    );
+    return 'kind IN (${placeholders.join(', ')})';
   }
 
   Future<void> _write(DayProcessingJob job) async {
-    await _ensureRoot();
-    final destination = _fileFor(job.id);
-    final payload = jsonEncode(job.toJson());
-    final envelope = jsonEncode(<String, Object?>{
-      'payload': payload,
-      'sha256': sha256.convert(utf8.encode(payload)).toString(),
-    });
-    await atomicWriteString(
-      text: envelope,
-      filePath: destination.path,
-      subDomain: 'daily_os.processing_outbox',
+    const assignments =
+        'status = excluded.status, kind = excluded.kind, '
+        'day_id = excluded.day_id, payload = excluded.payload, '
+        'run_keys = excluded.run_keys, created_at = excluded.created_at, '
+        'updated_at = excluded.updated_at, '
+        'requested_at = excluded.requested_at, '
+        'next_attempt_at = excluded.next_attempt_at, '
+        'attempts = excluded.attempts, generation = excluded.generation, '
+        'claim_token = excluded.claim_token, '
+        'lease_until = excluded.lease_until, '
+        'retry_not_before = excluded.retry_not_before, '
+        'last_failure_class = excluded.last_failure_class, '
+        'last_error = excluded.last_error, '
+        'result_transcript = excluded.result_transcript, '
+        'result_entity_id = excluded.result_entity_id, '
+        'completed_at = excluded.completed_at';
+    await db.customInsert(
+      'INSERT INTO day_processing_jobs ($_columns) VALUES '
+      '($dayProcessingJobPlaceholders) '
+      'ON CONFLICT(id) DO UPDATE SET $assignments',
+      variables: dayProcessingJobVariables(job),
     );
   }
 
-  Future<void> _recoverPartials() async {
-    for (final partial in rootDirectory.listSync().whereType<File>().where(
-      (file) => file.path.endsWith('.json.part'),
-    )) {
-      final destination = File(
-        partial.path.substring(0, partial.path.length - '.part'.length),
-      );
-      if (destination.existsSync()) {
-        await partial.delete();
-        continue;
-      }
-      try {
-        await _readFile(partial);
-        await partial.rename(destination.path);
-      } catch (_) {
-        await _quarantine(partial);
-      }
-    }
-  }
+  static DayProcessingJob _fromRow(QueryRow row) =>
+      dayProcessingJobFromRow(row);
 
-  Future<void> _quarantine(File file) async {
-    final quarantine = Directory(path.join(rootDirectory.path, 'quarantine'));
-    await quarantine.create(recursive: true);
-    final destination = File(
-      path.join(quarantine.path, path.basename(file.path)),
-    );
-    if (destination.existsSync()) await destination.delete();
-    await file.rename(destination.path);
-  }
-
-  File _fileFor(String id) {
-    final safe = id.replaceAll(RegExp('[^A-Za-z0-9_-]'), '_');
-    return File(path.join(rootDirectory.path, '$safe.json'));
-  }
-
-  Future<void> _ensureRoot() => rootDirectory.create(recursive: true);
-
-  Future<T> _serialize<T>(Future<T> Function() operation) {
-    final completer = Completer<T>();
-    _tail = _tail.then((_) async {
-      try {
-        completer.complete(await operation());
-      } catch (error, stackTrace) {
-        completer.completeError(error, stackTrace);
-      }
-    });
-    return completer.future;
-  }
+  static int _ms(DateTime value) => value.millisecondsSinceEpoch;
 
   void _notify() {
     if (!_changes.isClosed) _changes.add(null);

--- a/lib/features/daily_os_next/services/day_processing_runtime.dart
+++ b/lib/features/daily_os_next/services/day_processing_runtime.dart
@@ -79,7 +79,11 @@ class DayProcessingRuntime {
       }
       await drain();
       final now = _now();
-      final jobs = (await repository.getAll()).where(_canSchedule).toList()
+      // Only rows that can still be scheduled, bounded by outstanding work
+      // rather than install age (ADR 0044). The effective-due ordering stays
+      // here rather than in SQL because it depends on this runtime's own
+      // [networkProbeInterval], and the rule should have one implementation.
+      final jobs = (await repository.getSchedulable()).toList()
         ..sort((a, b) => _effectiveDue(a).compareTo(_effectiveDue(b)));
       if (jobs.isEmpty) {
         _scheduleGeneration += 1;
@@ -98,13 +102,6 @@ class DayProcessingRuntime {
       _scheduleNext(failureRetryDelay);
     }
   }
-
-  bool _canSchedule(DayProcessingJob job) => switch (job.status) {
-    DayProcessingJobStatus.queued ||
-    DayProcessingJobStatus.running ||
-    DayProcessingJobStatus.waitingForNetwork => true,
-    _ => false,
-  };
 
   DateTime _effectiveDue(DayProcessingJob job) {
     final retryBoundary = job.retryNotBefore;

--- a/lib/features/daily_os_next/services/day_processing_startup.dart
+++ b/lib/features/daily_os_next/services/day_processing_startup.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_legacy_file_store.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_migration.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:path/path.dart' as path;
+
+/// Directory the pre-ADR-0044 file-per-job outbox wrote to.
+///
+/// Only the migration reads it now. It stays on disk for one release after the
+/// cutover as a rollback path, then goes.
+const String legacyDayProcessingOutboxDirectory = '.day_processing_outbox';
+
+/// Prepares the day-processing outbox for use and returns its repository.
+///
+/// Call once during app start, **before** `DayProcessingRuntime.start()` and
+/// before any enqueue path is wired up. That ordering is the write barrier the
+/// ADR 0044 cutover depends on: a database transaction cannot span the
+/// filesystem, so a job written to the old store after the import but before
+/// the sentinel would become invisible the moment the repository switches to
+/// the table.
+///
+/// Returns the repository rather than registering it, so the caller owns
+/// service-locator concerns and this stays unit-testable.
+Future<DayProcessingOutboxRepository> initializeDayProcessingOutbox({
+  required DayProcessingDb db,
+  required Directory documentsDirectory,
+}) async {
+  await DayProcessingOutboxMigration(
+    db: db,
+    legacyStore: DayProcessingLegacyFileStore(
+      rootDirectory: Directory(
+        path.join(documentsDirectory.path, legacyDayProcessingOutboxDirectory),
+      ),
+    ),
+  ).run();
+  return DayProcessingOutboxRepository(db: db);
+}

--- a/lib/features/daily_os_next/state/day_processing_runtime_provider.dart
+++ b/lib/features/daily_os_next/state/day_processing_runtime_provider.dart
@@ -113,6 +113,13 @@ final Provider<DayProcessingRuntime> dayProcessingRuntimeProvider = Provider((
       return counts[0] + counts[1];
     },
     repair: () async {
+      // Retention (ADR 0044 decision 5) rides the once-per-start repair pass
+      // rather than owning a scheduler: terminal ledger rows past the window
+      // go, pending work never does regardless of age. A partial prune is
+      // harmless — the remainder is collected on the next start.
+      await outbox.pruneTerminalBefore(
+        DateTime.now().subtract(dayProcessingLedgerRetention),
+      );
       final currentHostId = await getIt<VectorClockService>().getHost();
       return DayProcessingOutboxRepair(
         repository: outbox,

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -29,7 +29,9 @@ import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dar
 import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
 import 'package:lotti/features/ai_consumption/service/transcript_attribution_coordinator.dart';
 import 'package:lotti/features/ai_consumption/sync/consumption_sync_service.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_startup.dart';
 import 'package:lotti/features/labels/services/label_assignment_event_service.dart';
 import 'package:lotti/features/labels/services/label_assignment_processor.dart';
 import 'package:lotti/features/labels/services/label_validator.dart';
@@ -88,7 +90,6 @@ import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/location.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path;
 
 part 'get_it_helpers.dart';
 part 'get_it_maintenance.dart';
@@ -155,13 +156,16 @@ Future<void> registerSingletons() async {
 
   await vod.init();
   final documentsDirectory = getIt<Directory>();
-  getIt.registerSingleton<DayProcessingOutboxRepository>(
-    DayProcessingOutboxRepository(
-      rootDirectory: Directory(
-        path.join(documentsDirectory.path, '.day_processing_outbox'),
+  final dayProcessingDb = DayProcessingDb();
+  getIt
+    ..registerSingleton<DayProcessingDb>(dayProcessingDb)
+    ..registerSingleton<DayProcessingOutboxRepository>(
+      // Runs the ADR 0044 cutover before the processing runtime exists.
+      await initializeDayProcessingOutbox(
+        db: dayProcessingDb,
+        documentsDirectory: documentsDirectory,
       ),
-    ),
-  );
+    );
   final client = await createMatrixClient(
     documentsDirectory: documentsDirectory,
   );

--- a/test/features/daily_os_next/integration/day_agent_durable_jobs_smoke_test.dart
+++ b/test/features/daily_os_next/integration/day_agent_durable_jobs_smoke_test.dart
@@ -20,6 +20,7 @@ import 'package:openai_dart/openai_dart.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../agents/test_data/ai_config_factories.dart';
+import '../services/day_processing_test_db.dart';
 import 'day_agent_pipeline_harness.dart';
 
 /// End-to-end smoke test for the ADR 0032 durable draft/refine pipeline.
@@ -158,9 +159,9 @@ void main() {
       expect(diff.changes, hasLength(1));
       expect(diff.changes.single.kind, PlanDiffChangeKind.added);
 
-      final refineJobs = (await harness.outbox.getAll())
-          .where((job) => job.kind.name == 'refinePlan')
-          .toList();
+      final refineJobs = (await allDayProcessingJobs(
+        harness.outbox.db,
+      )).where((job) => job.kind.name == 'refinePlan').toList();
       expect(refineJobs, hasLength(1));
       expect(refineJobs.single.isTerminal, isTrue);
       expect(refineJobs.single.status.name, 'succeeded');

--- a/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
+++ b/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
@@ -35,6 +35,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../../agents/sync/in_memory_agent_repository.dart';
 import '../../agents/test_data/template_factories.dart';
+import '../services/day_processing_test_db.dart';
 
 /// Wires the full ADR 0032 durable draft/refine pipeline out of real
 /// production classes — [DayProcessingOutboxRepository] (real,
@@ -212,7 +213,9 @@ class DayAgentPipelineHarness {
       journalDb: journalDb,
       domainLogger: domainLogger,
     );
-    final outbox = DayProcessingOutboxRepository(rootDirectory: root);
+    final outbox = DayProcessingOutboxRepository(
+      db: createTestDayProcessingDb(),
+    );
     // Deferred: the runtime is built after the capture service (its executor
     // depends on it), mirroring the deferred-read wiring in production.
     DayProcessingRuntime? runtimeRef;

--- a/test/features/daily_os_next/logic/real_day_agent_test.dart
+++ b/test/features/daily_os_next/logic/real_day_agent_test.dart
@@ -107,8 +107,9 @@ class _FakeOutboxState {
     when(() => mock.getById(any())).thenAnswer(
       (inv) async => _jobs[inv.positionalArguments[0] as String],
     );
-    // ignore: unnecessary_lambdas
-    when(() => mock.getAll()).thenAnswer((_) async => all);
+    when(mock.getSchedulable).thenAnswer(
+      (_) async => all.where((job) => !job.isTerminal).toList(),
+    );
     when(
       () => mock.enqueueDraftPlan(
         dayId: any(named: 'dayId'),
@@ -533,7 +534,7 @@ void main() {
         await pumpEventQueue();
 
         final jobId = DayProcessingOutboxRepository.draftJobId(dayId);
-        expect((await bench.outbox.getAll()).map((j) => j.id), [jobId]);
+        expect(bench.fakeOutbox.all.map((j) => j.id), [jobId]);
 
         await bench.completeJob(jobId);
         final results = await Future.wait([firstFuture, secondFuture]);
@@ -2007,7 +2008,7 @@ void main() {
           ),
           throwsA(isA<DayAgentInteractionException>()),
         );
-        expect(await bench.outbox.getAll(), isEmpty);
+        expect(bench.fakeOutbox.all, isEmpty);
       },
     );
 
@@ -2034,7 +2035,7 @@ void main() {
         ),
         throwsA(isA<DayAgentInteractionException>()),
       );
-      expect(await bench.outbox.getAll(), isEmpty);
+      expect(bench.fakeOutbox.all, isEmpty);
     });
 
     test(
@@ -2117,7 +2118,7 @@ void main() {
         );
         await pumpEventQueue();
 
-        final jobs = await bench.outbox.getAll();
+        final jobs = bench.fakeOutbox.all;
         expect(jobs, hasLength(1));
         expect(jobs.single.kind, DayProcessingJobKind.refinePlan);
         expect(
@@ -2189,7 +2190,7 @@ void main() {
         );
         await pumpEventQueue();
 
-        final jobs = await bench.outbox.getAll();
+        final jobs = bench.fakeOutbox.all;
         await bench.completeJob(jobs.single.id, resultEntityId: 'diff-missing');
 
         await expectLater(
@@ -2237,7 +2238,7 @@ void main() {
         );
         await pumpEventQueue();
 
-        final jobs = await bench.outbox.getAll();
+        final jobs = bench.fakeOutbox.all;
         expect(
           (jobs.single.payload as RefinePlanPayload).transcriptCaptureId,
           isNull,
@@ -2287,7 +2288,7 @@ void main() {
           voiceTranscript: 'no change comes',
         );
         await pumpEventQueue();
-        final jobs = await bench.outbox.getAll();
+        final jobs = bench.fakeOutbox.all;
         await bench.failJob(
           jobs.single.id,
           failureClass: DayProcessingFailureClass.timeout,

--- a/test/features/daily_os_next/services/day_activity_repository_test.dart
+++ b/test/features/daily_os_next/services/day_activity_repository_test.dart
@@ -11,6 +11,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 import '../../agents/test_data/entity_factories.dart';
+import 'day_processing_test_db.dart';
 
 void main() {
   final capturedAt = DateTime(2026, 7, 18, 8);
@@ -67,7 +68,7 @@ void main() {
     root = Directory.systemTemp.createTempSync('day-activity-test-');
     journalDb = MockJournalDb();
     outbox = DayProcessingOutboxRepository(
-      rootDirectory: Directory('${root.path}/outbox'),
+      db: createTestDayProcessingDb(),
       now: () => capturedAt,
     );
     repository = DayActivityRepository(

--- a/test/features/daily_os_next/services/day_audio_review_fence_test.dart
+++ b/test/features/daily_os_next/services/day_audio_review_fence_test.dart
@@ -13,6 +13,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 
 import '../../../mocks/mocks.dart';
+import 'day_processing_test_db.dart';
 
 void main() {
   final now = DateTime.utc(2026, 7, 18, 8);
@@ -25,7 +26,7 @@ void main() {
   setUp(() async {
     root = Directory.systemTemp.createTempSync('day-review-fence-');
     repository = DayProcessingOutboxRepository(
-      rootDirectory: Directory(path.join(root.path, 'outbox')),
+      db: createTestDayProcessingDb(),
       now: () => now,
       tokenFactory: () => 'claim-token',
     );

--- a/test/features/daily_os_next/services/day_processing_legacy_file_store_test.dart
+++ b/test/features/daily_os_next/services/day_processing_legacy_file_store_test.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_legacy_file_store.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  late Directory root;
+  late DayProcessingLegacyFileStore store;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('day-processing-legacy-test-');
+    store = DayProcessingLegacyFileStore(rootDirectory: root);
+  });
+
+  tearDown(() {
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  DayProcessingJob job(
+    String sessionId, {
+    DateTime? createdAt,
+    DayProcessingJobStatus status = DayProcessingJobStatus.queued,
+  }) {
+    final at = createdAt ?? DateTime.utc(2026, 7, 18, 7, 40);
+    return DayProcessingJob(
+      id: 'transcribe_$sessionId',
+      status: status,
+      dayId: 'dayplan-2026-07-18',
+      payload: TranscribeAudioPayload(
+        activityEntryId: 'activity-$sessionId',
+        recordingSessionId: sessionId,
+        audioId: 'audio-$sessionId',
+        audioPath: path.join(root.path, '$sessionId.m4a'),
+      ),
+      createdAt: at,
+      updatedAt: at,
+      requestedAt: at,
+      nextAttemptAt: at,
+      attempts: 0,
+      generation: 0,
+    );
+  }
+
+  /// Writes the pre-ADR-0044 envelope: the job JSON plus its digest.
+  File writeLegacy(DayProcessingJob value, {String suffix = '.json'}) {
+    final payload = jsonEncode(value.toJson());
+    final envelope = jsonEncode(<String, Object?>{
+      'payload': payload,
+      'sha256': sha256.convert(utf8.encode(payload)).toString(),
+    });
+    final safe = value.id.replaceAll(RegExp('[^A-Za-z0-9_-]'), '_');
+    return File(path.join(root.path, '$safe$suffix'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(envelope);
+  }
+
+  test('reports a missing directory rather than creating one', () async {
+    final absent = DayProcessingLegacyFileStore(
+      rootDirectory: Directory(path.join(root.path, 'nope')),
+    );
+
+    expect(absent.exists, isFalse);
+    expect(await absent.readAll(), isEmpty);
+    expect(Directory(path.join(root.path, 'nope')).existsSync(), isFalse);
+  });
+
+  test('reads jobs oldest first with the id as tie-break', () async {
+    final base = DateTime.utc(2026, 7, 18, 7, 40);
+    writeLegacy(job('session-b'));
+    writeLegacy(job('session-a'));
+    writeLegacy(
+      job('session-0', createdAt: base.subtract(const Duration(hours: 1))),
+    );
+
+    final jobs = await store.readAll();
+
+    expect(jobs.map((job) => job.id), [
+      'transcribe_session-0',
+      'transcribe_session-a',
+      'transcribe_session-b',
+    ]);
+  });
+
+  test('round-trips the full envelope, not just the id', () async {
+    final source = job(
+      'session-1',
+      status: DayProcessingJobStatus.waitingForNetwork,
+    ).copyWith(attempts: 3, generation: 7, lastError: 'Offline');
+    writeLegacy(source);
+
+    final restored = (await store.readAll()).single;
+
+    expect(restored.status, DayProcessingJobStatus.waitingForNetwork);
+    expect(restored.attempts, 3);
+    expect(restored.generation, 7);
+    expect(restored.lastError, 'Offline');
+    expect(
+      (restored.payload as TranscribeAudioPayload).recordingSessionId,
+      'session-1',
+    );
+  });
+
+  test("publishes an orphaned partial as the job's newest state", () async {
+    final source = job('session-1');
+    final target = writeLegacy(source);
+    final partial = File('${target.path}.part');
+    target.renameSync(partial.path);
+
+    final jobs = await store.readAll();
+
+    expect(jobs.single.id, source.id);
+    expect(target.existsSync(), isTrue, reason: 'partial was promoted');
+    expect(partial.existsSync(), isFalse);
+  });
+
+  test('drops a stale partial beside its already-published job', () async {
+    final target = writeLegacy(job('session-1'));
+    final partial = File('${target.path}.part')
+      ..writeAsBytesSync(target.readAsBytesSync());
+
+    final jobs = await store.readAll();
+
+    expect(jobs, hasLength(1));
+    expect(target.existsSync(), isTrue);
+    expect(partial.existsSync(), isFalse, reason: 'published file wins');
+  });
+
+  test('quarantines a corrupt orphan partial instead of failing', () async {
+    File(
+      path.join(root.path, 'corrupt.json.part'),
+    ).writeAsStringSync('not an envelope');
+    writeLegacy(job('session-1'));
+
+    final jobs = await store.readAll();
+
+    expect(
+      jobs.single.id,
+      'transcribe_session-1',
+      reason: 'one bad file must not abort the whole read',
+    );
+    expect(
+      File(
+        path.join(root.path, 'quarantine', 'corrupt.json.part'),
+      ).existsSync(),
+      isTrue,
+    );
+  });
+
+  test('quarantines a job whose digest no longer matches', () async {
+    final target = writeLegacy(job('session-1'));
+    // Keep the envelope shape but corrupt the payload, so only the digest
+    // check can catch it.
+    final envelope =
+        jsonDecode(target.readAsStringSync())! as Map<String, Object?>;
+    target.writeAsStringSync(
+      jsonEncode(<String, Object?>{
+        'payload': (envelope['payload']! as String).replaceFirst(
+          'session-1',
+          'tampered',
+        ),
+        'sha256': envelope['sha256'],
+      }),
+    );
+
+    expect(await store.readAll(), isEmpty);
+    expect(
+      File(
+        path.join(root.path, 'quarantine', path.basename(target.path)),
+      ).existsSync(),
+      isTrue,
+    );
+  });
+
+  test('replaces an existing quarantine entry of the same name', () async {
+    Directory(path.join(root.path, 'quarantine')).createSync(recursive: true);
+    File(
+      path.join(root.path, 'quarantine', 'corrupt.json'),
+    ).writeAsStringSync('older');
+    File(path.join(root.path, 'corrupt.json')).writeAsStringSync('newer');
+
+    await store.readAll();
+
+    expect(
+      File(
+        path.join(root.path, 'quarantine', 'corrupt.json'),
+      ).readAsStringSync(),
+      'newer',
+    );
+  });
+}

--- a/test/features/daily_os_next/services/day_processing_legacy_file_store_test.dart
+++ b/test/features/daily_os_next/services/day_processing_legacy_file_store_test.dart
@@ -104,32 +104,81 @@ void main() {
     );
   });
 
-  test("publishes an orphaned partial as the job's newest state", () async {
+  test('reads an orphaned partial that has no published file', () async {
     final source = job('session-1');
     final target = writeLegacy(source);
-    final partial = File('${target.path}.part');
-    target.renameSync(partial.path);
+    target.renameSync('${target.path}.part');
 
     final jobs = await store.readAll();
 
     expect(jobs.single.id, source.id);
-    expect(target.existsSync(), isTrue, reason: 'partial was promoted');
-    expect(partial.existsSync(), isFalse);
   });
 
-  test('drops a stale partial beside its already-published job', () async {
-    final target = writeLegacy(job('session-1'));
-    final partial = File('${target.path}.part')
-      ..writeAsBytesSync(target.readAsBytesSync());
+  test('prefers the newer generation when both copies exist', () async {
+    // A crash between the scratch write and the rename leaves both files, and
+    // the scratch one holds the newer state.
+    final published = writeLegacy(job('session-1'));
+    writeLegacy(
+      job('session-1').copyWith(
+        generation: 4,
+        attempts: 2,
+        status: DayProcessingJobStatus.waitingForNetwork,
+      ),
+      suffix: '.json.part',
+    );
 
-    final jobs = await store.readAll();
+    final restored = (await store.readAll()).single;
 
-    expect(jobs, hasLength(1));
-    expect(target.existsSync(), isTrue);
-    expect(partial.existsSync(), isFalse, reason: 'published file wins');
+    expect(restored.generation, 4);
+    expect(restored.attempts, 2);
+    expect(restored.status, DayProcessingJobStatus.waitingForNetwork);
+    expect(published.existsSync(), isTrue, reason: 'the read is read-only');
   });
 
-  test('quarantines a corrupt orphan partial instead of failing', () async {
+  test('keeps the published copy when the scratch one is older', () async {
+    writeLegacy(job('session-1').copyWith(generation: 6));
+    writeLegacy(job('session-1'), suffix: '.json.part');
+
+    expect((await store.readAll()).single.generation, 6);
+  });
+
+  test(
+    'recovers the atomic-write scratch file the store really uses',
+    () async {
+      // atomicWriteBytes writes `<path>.tmp.<micros>.<pid>.media` and renames
+      // over the destination. A crash in that window on a job's first write
+      // leaves this as the only copy.
+      writeLegacy(
+        job('session-1').copyWith(generation: 3),
+        suffix: '.json.tmp.1737000000000000.4242.media',
+      );
+
+      final restored = (await store.readAll()).single;
+
+      expect(restored.id, 'transcribe_session-1');
+      expect(restored.generation, 3);
+    },
+  );
+
+  test('breaks a generation tie on updatedAt', () async {
+    final base = job('session-1');
+    writeLegacy(base);
+    writeLegacy(
+      base.copyWith(updatedAt: base.updatedAt.add(const Duration(minutes: 5))),
+      suffix: '.json.part',
+    );
+
+    final restored = (await store.readAll()).single;
+
+    expect(
+      restored.updatedAt,
+      DateTime.utc(2026, 7, 18, 7, 45),
+    );
+  });
+
+  test('skips an unreadable scratch file without quarantining it', () async {
+    // Half-written scratch is expected after a crash, not evidence of
+    // corruption, so it is passed over rather than filed for inspection.
     File(
       path.join(root.path, 'corrupt.json.part'),
     ).writeAsStringSync('not an envelope');
@@ -146,7 +195,7 @@ void main() {
       File(
         path.join(root.path, 'quarantine', 'corrupt.json.part'),
       ).existsSync(),
-      isTrue,
+      isFalse,
     );
   });
 

--- a/test/features/daily_os_next/services/day_processing_outbox_migration_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_migration_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,8 +9,12 @@ import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_legacy_file_store.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_migration.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 
+import '../../../mocks/mocks.dart';
 import 'day_processing_test_db.dart';
 
 void main() {
@@ -197,4 +202,90 @@ void main() {
     expect(restored.id, 'transcribe_session-1');
     expect(restored.attempts, 2);
   });
+
+  group('verification that never stabilizes', () {
+    test('withholds the sentinel so the next start retries', () async {
+      final store = _EndlesslyGrowingStore(root);
+
+      final imported = await migration(store: store).run();
+
+      // Every pass imports the one job it can see, then the store produces
+      // another — the shape of a writer that was not quiesced.
+      expect(imported, 5);
+      expect(
+        await migration(store: store).isComplete(),
+        isFalse,
+        reason: 'an unverified cutover must not be published',
+      );
+    });
+
+    test('reports the stall rather than failing silently', () async {
+      final logger = MockDomainLogger();
+      if (getIt.isRegistered<DomainLogger>()) {
+        getIt.unregister<DomainLogger>();
+      }
+      getIt.registerSingleton<DomainLogger>(logger);
+      addTearDown(() => getIt.unregister<DomainLogger>());
+
+      await migration(store: _EndlesslyGrowingStore(root)).run();
+
+      final logged = verify(
+        () => logger.log(
+          any(),
+          captureAny(),
+          subDomain: any(named: 'subDomain'),
+          level: any(named: 'level'),
+        ),
+      ).captured;
+      expect(
+        logged.single,
+        contains('did not stabilize'),
+      );
+    });
+  });
+}
+
+/// A legacy store that reveals one more job on every read, so verification can
+/// never reach a stable pass.
+class _EndlesslyGrowingStore extends DayProcessingLegacyFileStore {
+  _EndlesslyGrowingStore(Directory root) : super(rootDirectory: root);
+
+  int _reads = 0;
+
+  @override
+  bool get exists => true;
+
+  @override
+  Future<List<DayProcessingJob>> readAll() async {
+    _reads += 1;
+    final at = DateTime.utc(2026, 7, 18, 7, 40);
+    return [
+      for (var i = 0; i < _reads; i++)
+        DayProcessingJob(
+          id: 'transcribe_session-$i',
+          status: DayProcessingJobStatus.queued,
+          dayId: 'dayplan-2026-07-18',
+          payload: ParseCapturePayload(captureId: 'cap-$i'),
+          createdAt: at,
+          updatedAt: at,
+          requestedAt: at,
+          nextAttemptAt: at,
+          attempts: 0,
+          generation: 0,
+        ),
+    ]..shuffle(_FixedRandom());
+  }
+}
+
+/// Deterministic no-op shuffle: order is irrelevant here and the repo bans
+/// real randomness in tests.
+class _FixedRandom implements Random {
+  @override
+  bool nextBool() => false;
+
+  @override
+  double nextDouble() => 0;
+
+  @override
+  int nextInt(int max) => 0;
 }

--- a/test/features/daily_os_next/services/day_processing_outbox_migration_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_migration_test.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_legacy_file_store.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_migration.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:path/path.dart' as path;
+
+import 'day_processing_test_db.dart';
+
+void main() {
+  late Directory root;
+  late DayProcessingDb db;
+  late DayProcessingLegacyFileStore legacyStore;
+  late DateTime now;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('day-processing-migration-');
+    now = DateTime.utc(2026, 7, 18, 9);
+    db = createTestDayProcessingDb();
+    legacyStore = DayProcessingLegacyFileStore(rootDirectory: root);
+  });
+
+  tearDown(() {
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  DayProcessingOutboxMigration migration({
+    DayProcessingLegacyFileStore? store,
+  }) => DayProcessingOutboxMigration(
+    db: db,
+    legacyStore: store ?? legacyStore,
+    now: () => now,
+  );
+
+  DayProcessingJob job(
+    String sessionId, {
+    DayProcessingJobStatus status = DayProcessingJobStatus.queued,
+    int attempts = 0,
+    DateTime? createdAt,
+  }) {
+    final at = createdAt ?? DateTime.utc(2026, 7, 18, 7, 40);
+    return DayProcessingJob(
+      id: 'transcribe_$sessionId',
+      status: status,
+      dayId: 'dayplan-2026-07-18',
+      payload: TranscribeAudioPayload(
+        activityEntryId: 'activity-$sessionId',
+        recordingSessionId: sessionId,
+        audioId: 'audio-$sessionId',
+        audioPath: path.join(root.path, '$sessionId.m4a'),
+      ),
+      createdAt: at,
+      updatedAt: at,
+      requestedAt: at,
+      nextAttemptAt: at,
+      attempts: attempts,
+      generation: 0,
+    );
+  }
+
+  File writeLegacy(DayProcessingJob value) {
+    final payload = jsonEncode(value.toJson());
+    final envelope = jsonEncode(<String, Object?>{
+      'payload': payload,
+      'sha256': sha256.convert(utf8.encode(payload)).toString(),
+    });
+    final safe = value.id.replaceAll(RegExp('[^A-Za-z0-9_-]'), '_');
+    return File(path.join(root.path, '$safe.json'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(envelope);
+  }
+
+  test('imports every job file and marks the cutover complete', () async {
+    writeLegacy(job('session-1'));
+    writeLegacy(
+      job('session-2', status: DayProcessingJobStatus.failed, attempts: 4),
+    );
+
+    final imported = await migration().run();
+
+    expect(imported, 2);
+    expect(await migration().isComplete(), isTrue);
+    final jobs = await allDayProcessingJobs(db);
+    expect(jobs.map((job) => job.id), [
+      'transcribe_session-1',
+      'transcribe_session-2',
+    ]);
+    // The envelope must survive, not just the id: a job that was four
+    // attempts into a deterministic failure has to arrive that way, or the
+    // cutover silently resets the user's retry budget.
+    final failed = jobs.firstWhere((job) => job.id == 'transcribe_session-2');
+    expect(failed.status, DayProcessingJobStatus.failed);
+    expect(failed.attempts, 4);
+  });
+
+  test('a second run is a no-op once the sentinel exists', () async {
+    writeLegacy(job('session-1'));
+    expect(await migration().run(), 1);
+
+    // A file appearing after the cutover belongs to no one: the table is
+    // authoritative from the sentinel onward.
+    writeLegacy(job('session-late'));
+
+    expect(await migration().run(), isNull, reason: 'already migrated');
+    expect(await allDayProcessingJobs(db), hasLength(1));
+  });
+
+  test('records the cutover on a fresh install with no directory', () async {
+    final absent = DayProcessingLegacyFileStore(
+      rootDirectory: Directory(path.join(root.path, 'never-existed')),
+    );
+
+    expect(await migration(store: absent).run(), 0);
+    expect(await migration(store: absent).isComplete(), isTrue);
+    expect(await allDayProcessingJobs(db), isEmpty);
+  });
+
+  test('is idempotent when interrupted after a partial import', () async {
+    writeLegacy(job('session-1'));
+    writeLegacy(job('session-2'));
+    // Simulate a crash after importing one job but before the sentinel.
+    final repository = DayProcessingOutboxRepository(db: db, now: () => now);
+    await repository.enqueueTranscription(
+      dayId: 'dayplan-2026-07-18',
+      activityEntryId: 'activity-session-1',
+      recordingSessionId: 'session-1',
+      audioId: 'audio-session-1',
+      audioPath: path.join(root.path, 'session-1.m4a'),
+      capturedAt: DateTime.utc(2026, 7, 18, 7, 40),
+    );
+    addTearDown(repository.dispose);
+
+    final imported = await migration().run();
+
+    expect(imported, 1, reason: 'only the job that was missing');
+    expect(await allDayProcessingJobs(db), hasLength(2));
+    expect(await migration().isComplete(), isTrue);
+  });
+
+  test('never rewinds a row the live repository already advanced', () async {
+    // The file says queued; the table has since taken the job terminal. An
+    // upsert would resurrect finished work and re-spend inference on it.
+    writeLegacy(job('session-1'));
+    final repository = DayProcessingOutboxRepository(
+      db: db,
+      now: () => now,
+      tokenFactory: () => 'claim-1',
+    );
+    addTearDown(repository.dispose);
+    await repository.enqueueTranscription(
+      dayId: 'dayplan-2026-07-18',
+      activityEntryId: 'activity-session-1',
+      recordingSessionId: 'session-1',
+      audioId: 'audio-session-1',
+      audioPath: path.join(root.path, 'session-1.m4a'),
+      capturedAt: DateTime.utc(2026, 7, 18, 7, 40),
+    );
+    final claim = await repository.claimNext();
+    await repository.markSucceeded(
+      jobId: claim!.job.id,
+      claimToken: claim.token,
+    );
+
+    await migration().run();
+
+    final restored = await repository.getById('transcribe_session-1');
+    expect(restored!.status, DayProcessingJobStatus.succeeded);
+  });
+
+  test('keeps a table row whose file was quarantined meanwhile', () async {
+    // One-directional verification: a missing file never means "delete this
+    // job", and the quarantine path is exactly how a file disappears.
+    final file = writeLegacy(job('session-1'));
+    expect(await migration().run(), 1);
+
+    file.writeAsStringSync('corrupt');
+    // Re-running is a no-op thanks to the sentinel, but even a forced second
+    // import must not remove the row that is now the only good copy.
+    expect(await allDayProcessingJobs(db), hasLength(1));
+    expect(await legacyStore.readAll(), isEmpty);
+    expect(await allDayProcessingJobs(db), hasLength(1));
+  });
+
+  test('imports the newest state held in an orphaned partial', () async {
+    final source = job('session-1', attempts: 2);
+    final published = writeLegacy(source);
+    published.renameSync('${published.path}.part');
+
+    expect(await migration().run(), 1);
+
+    final restored = (await allDayProcessingJobs(db)).single;
+    expect(restored.id, 'transcribe_session-1');
+    expect(restored.attempts, 2);
+  });
+}

--- a/test/features/daily_os_next/services/day_processing_outbox_processor_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_processor_test.dart
@@ -11,6 +11,8 @@ import 'package:lotti/features/daily_os_next/services/day_processing_outbox_proc
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:path/path.dart' as path;
 
+import 'day_processing_test_db.dart';
+
 void main() {
   late Directory root;
   late File audio;
@@ -23,7 +25,7 @@ void main() {
     await audio.writeAsBytes(<int>[1, 2, 3], flush: true);
     now = DateTime.utc(2026, 7, 18, 8);
     repository = DayProcessingOutboxRepository(
-      rootDirectory: Directory(path.join(root.path, 'outbox')),
+      db: createTestDayProcessingDb(),
       now: () => now,
       tokenFactory: () => 'claim-token',
     );

--- a/test/features/daily_os_next/services/day_processing_outbox_repair_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_repair_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repo
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
+import 'day_processing_test_db.dart';
 
 void main() {
   late Directory root;
@@ -63,7 +64,7 @@ void main() {
   setUp(() {
     root = Directory.systemTemp.createTempSync('day-outbox-repair-test-');
     repository = DayProcessingOutboxRepository(
-      rootDirectory: Directory('${root.path}/outbox'),
+      db: createTestDayProcessingDb(),
       now: () => now,
     );
     journalDb = MockJournalDb();
@@ -101,7 +102,7 @@ void main() {
       );
 
       final repaired = await repair.repair();
-      final jobs = await repository.getAll();
+      final jobs = await allDayProcessingJobs(repository.db);
 
       expect(repaired, 2);
       expect(jobs, hasLength(2));
@@ -144,7 +145,7 @@ void main() {
     );
 
     expect(await repair.repair(), 0);
-    expect(await repository.getAll(), isEmpty);
+    expect(await allDayProcessingJobs(repository.db), isEmpty);
   });
 
   test('continues through full pages until the final partial page', () async {
@@ -178,7 +179,7 @@ void main() {
     );
 
     expect(await repair.repair(pageSize: 1), 1);
-    expect(await repository.getAll(), hasLength(1));
+    expect(await allDayProcessingJobs(repository.db), hasLength(1));
     verify(
       () => journalDb.getJournalEntities(
         types: const <String>['JournalAudio'],

--- a/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
@@ -1,16 +1,18 @@
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
 
+import 'day_processing_test_db.dart';
+
 void main() {
   late Directory root;
   late DateTime now;
+  late DayProcessingDb db;
   late DayProcessingOutboxRepository repository;
   var tokenCounter = 0;
 
@@ -18,8 +20,9 @@ void main() {
     root = Directory.systemTemp.createTempSync('day-processing-outbox-test-');
     now = DateTime.utc(2026, 7, 18, 7, 42);
     tokenCounter = 0;
+    db = createTestDayProcessingDb();
     repository = DayProcessingOutboxRepository(
-      rootDirectory: root,
+      db: db,
       now: () => now,
       tokenFactory: () => 'claim-${++tokenCounter}',
     );
@@ -39,17 +42,19 @@ void main() {
     capturedAt: DateTime.utc(2026, 7, 18, 7, 40),
   );
 
+  Future<List<DayProcessingJob>> allJobs() => allDayProcessingJobs(db);
+
   test('enqueue is durable across repository restart and idempotent', () async {
     final first = await enqueue();
     final duplicate = await enqueue();
     await repository.dispose();
     repository = DayProcessingOutboxRepository(
-      rootDirectory: root,
+      db: db,
       now: () => now,
       tokenFactory: () => 'restart-claim',
     );
 
-    final restored = await repository.getAll();
+    final restored = await allJobs();
 
     expect(duplicate.id, first.id);
     expect(restored, hasLength(1));
@@ -79,7 +84,7 @@ void main() {
         );
         return enqueue();
       });
-      expect((await repository.getAll()).single.dayId, 'dayplan-2026-07-18');
+      expect((await allJobs()).single.dayId, 'dayplan-2026-07-18');
     },
   );
 
@@ -99,14 +104,14 @@ void main() {
       );
 
       await expectLater(conflict, throwsA(isA<DayProcessingIntentConflict>()));
-      expect((await repository.getAll()).single.dayId, 'dayplan-2026-07-18');
+      expect((await allJobs()).single.dayId, 'dayplan-2026-07-18');
     },
   );
 
   test('default claim tokens are UUIDs', () async {
     await repository.dispose();
     repository = DayProcessingOutboxRepository(
-      rootDirectory: root,
+      db: db,
       now: () => now,
     );
 
@@ -231,7 +236,14 @@ void main() {
 
     expect(missing, isNull);
     expect(claim!.job.id, 'transcribe_session-1');
-    expect(claim.token, 'claim-1');
+    // The returned token is the one actually stamped on the row — asserted by
+    // round-trip rather than by name, because a claim that matches no row
+    // still consumes a token from the factory.
+    expect(claim.token, isNotEmpty);
+    expect(
+      (await repository.getById(claim.job.id))!.claimToken,
+      claim.token,
+    );
     expect(await repository.claimById(claim.job.id), isNull);
   });
 
@@ -253,7 +265,7 @@ void main() {
 
     await repository.dispose();
     repository = DayProcessingOutboxRepository(
-      rootDirectory: root,
+      db: db,
       now: () => now,
     );
     final restored = await repository.getById(ready.id);
@@ -372,7 +384,7 @@ void main() {
       );
     }
 
-    expect((await repository.getAll()).map((job) => job.id), [
+    expect((await allJobs()).map((job) => job.id), [
       'transcribe_session-1',
       'transcribe_session-a',
       'transcribe_session-b',
@@ -395,65 +407,6 @@ void main() {
 
     expect(retried!.nextAttemptAt, now.add(const Duration(minutes: 2)));
     expect(await repository.claimNext(), isNull);
-  });
-
-  test('startup publishes a valid orphan partial job', () async {
-    final job = await enqueue();
-    final target = root.listSync().whereType<File>().single;
-    final partial = File('${target.path}.part');
-    await target.rename(partial.path);
-    await repository.dispose();
-    repository = DayProcessingOutboxRepository(
-      rootDirectory: root,
-      now: () => now,
-    );
-
-    final restored = await repository.getAll();
-
-    expect(restored.single.id, job.id);
-    expect(target.existsSync(), isTrue);
-    expect(partial.existsSync(), isFalse);
-  });
-
-  test('startup removes a stale partial beside its published job', () async {
-    await enqueue();
-    final target = root.listSync().whereType<File>().single;
-    final partial = File('${target.path}.part')
-      ..writeAsBytesSync(target.readAsBytesSync());
-
-    final jobs = await repository.getAll();
-
-    expect(jobs, hasLength(1));
-    expect(target.existsSync(), isTrue);
-    expect(partial.existsSync(), isFalse);
-  });
-
-  test('startup quarantines a corrupt orphan partial', () async {
-    File(
-      path.join(root.path, 'corrupt.json.part'),
-    ).writeAsStringSync('not an envelope');
-
-    expect(await repository.getAll(), isEmpty);
-    expect(
-      File(
-        path.join(root.path, 'quarantine', 'corrupt.json.part'),
-      ).existsSync(),
-      isTrue,
-    );
-  });
-
-  test('lookup quarantines a corrupt job at its deterministic path', () async {
-    await enqueue();
-    final targetPath = root.listSync().whereType<File>().single.path;
-    File(targetPath).writeAsStringSync('corrupt');
-
-    expect(await repository.getById('transcribe_session-1'), isNull);
-    expect(
-      File(
-        path.join(root.path, 'quarantine', path.basename(targetPath)),
-      ).existsSync(),
-      isTrue,
-    );
   });
 
   test(
@@ -488,51 +441,6 @@ void main() {
     },
   );
 
-  test(
-    'getAll skips and quarantines a corrupt job file',
-    () async {
-      await enqueue();
-      final corrupt = File(path.join(root.path, 'corrupt.json'))
-        ..writeAsStringSync('not an envelope');
-
-      final jobs = await repository.getAll();
-
-      expect(jobs.map((job) => job.id), ['transcribe_session-1']);
-      expect(corrupt.existsSync(), isFalse);
-      expect(
-        File(path.join(root.path, 'quarantine', 'corrupt.json')).existsSync(),
-        isTrue,
-      );
-    },
-  );
-
-  test(
-    'corrupt jobs are quarantined instead of blocking healthy work',
-    () async {
-      await enqueue();
-      final corruptPayload = jsonEncode(<String, Object?>{'id': 'bad'});
-      final quarantine = Directory(path.join(root.path, 'quarantine'))
-        ..createSync();
-      final quarantined = File(path.join(quarantine.path, 'corrupt.json'))
-        ..writeAsStringSync('stale quarantine entry');
-      await File(path.join(root.path, 'corrupt.json')).writeAsString(
-        jsonEncode(<String, Object?>{
-          'payload': corruptPayload,
-          'sha256': sha256.convert(utf8.encode('different')).toString(),
-        }),
-        flush: true,
-      );
-
-      final claim = await repository.claimNext();
-
-      expect(claim?.job.id, 'transcribe_session-1');
-      expect(quarantined.existsSync(), isTrue);
-      final quarantinedEnvelope =
-          jsonDecode(await quarantined.readAsString())! as Map<String, Object?>;
-      expect(quarantinedEnvelope['payload'], corruptPayload);
-    },
-  );
-
   group('durable agent jobs (ADR 0032 phase 1)', () {
     test('enqueueParseCapture is deterministic and accumulates', () async {
       final first = await repository.enqueueParseCapture(
@@ -551,7 +459,7 @@ void main() {
       expect(first.id, 'parse_cap-1');
       expect(second.id, 'parse_cap-2');
       expect(duplicate.id, first.id);
-      expect(await repository.getAll(), hasLength(2));
+      expect(await allJobs(), hasLength(2));
     });
 
     test(
@@ -669,7 +577,7 @@ void main() {
         );
         expect(rearmed.requestedAt, now);
         expect(rearmed.generation, first.generation + 1);
-        expect(await repository.getAll(), hasLength(1));
+        expect(await allJobs(), hasLength(1));
       },
     );
 
@@ -843,7 +751,7 @@ void main() {
           (first.payload as RefinePlanPayload).transcriptCaptureId,
           'cap-a',
         );
-        expect(await repository.getAll(), hasLength(2));
+        expect(await allJobs(), hasLength(2));
       },
     );
 
@@ -884,6 +792,243 @@ void main() {
       );
 
       expect(succeeded.resultEntityId, 'parsed-item-1');
+    });
+  });
+
+  group('bounded queries (ADR 0044)', () {
+    Future<DayProcessingJob> transcriptionFor(
+      String sessionId, {
+      String dayId = 'dayplan-2026-07-18',
+    }) => repository.enqueueTranscription(
+      dayId: dayId,
+      activityEntryId: 'activity-$sessionId',
+      recordingSessionId: sessionId,
+      audioId: 'audio-$sessionId',
+      audioPath: path.join(root.path, '$sessionId.m4a'),
+      capturedAt: now,
+    );
+
+    test('getForDay returns only the requested day', () async {
+      await transcriptionFor('session-1');
+      await transcriptionFor('session-2', dayId: 'dayplan-2026-07-19');
+      await repository.enqueueParseCapture(
+        dayId: 'dayplan-2026-07-18',
+        captureId: 'cap-1',
+      );
+
+      final jobs = await repository.getForDay('dayplan-2026-07-18');
+
+      expect(
+        jobs.map((job) => job.id),
+        unorderedEquals([
+          'transcribe_session-1',
+          'parse_cap-1',
+        ]),
+      );
+    });
+
+    test('getForDay narrows to the requested kinds', () async {
+      await transcriptionFor('session-1');
+      await repository.enqueueParseCapture(
+        dayId: 'dayplan-2026-07-18',
+        captureId: 'cap-1',
+      );
+
+      final jobs = await repository.getForDay(
+        'dayplan-2026-07-18',
+        kinds: const {DayProcessingJobKind.transcribeAudio},
+      );
+
+      expect(jobs.map((job) => job.id), ['transcribe_session-1']);
+    });
+
+    test('getForDay with an empty kind set matches nothing', () async {
+      await transcriptionFor('session-1');
+
+      expect(
+        await repository.getForDay('dayplan-2026-07-18', kinds: const {}),
+        isEmpty,
+      );
+    });
+
+    test('getForDay keeps terminal rows — Activity reads the ledger', () async {
+      await transcriptionFor('session-1');
+      final claim = await repository.claimNext();
+      await repository.markSucceeded(
+        jobId: claim!.job.id,
+        claimToken: claim.token,
+      );
+
+      final jobs = await repository.getForDay('dayplan-2026-07-18');
+
+      expect(jobs.single.status, DayProcessingJobStatus.succeeded);
+    });
+
+    test('getPendingByKind excludes terminal rows and other kinds', () async {
+      await transcriptionFor('session-1');
+      await transcriptionFor('session-2');
+      await repository.enqueueParseCapture(
+        dayId: 'dayplan-2026-07-18',
+        captureId: 'cap-1',
+      );
+      final claim = await repository.claimById('transcribe_session-1');
+      await repository.markSucceeded(
+        jobId: claim!.job.id,
+        claimToken: claim.token,
+      );
+
+      final pending = await repository.getPendingByKind(
+        DayProcessingJobKind.transcribeAudio,
+      );
+
+      expect(pending.map((job) => job.id), ['transcribe_session-2']);
+    });
+
+    test(
+      'getPendingByKind keeps parked work the fence can still act on',
+      () async {
+        await transcriptionFor('session-1');
+        final claim = await repository.claimNext();
+        await repository.markFailure(
+          jobId: claim!.job.id,
+          claimToken: claim.token,
+          failureClass: DayProcessingFailureClass.deterministic,
+          error: 'bad audio',
+        );
+
+        final pending = await repository.getPendingByKind(
+          DayProcessingJobKind.transcribeAudio,
+        );
+
+        expect(pending.single.status, DayProcessingJobStatus.failed);
+      },
+    );
+
+    test('getSchedulable drops terminal and non-drainable rows', () async {
+      await transcriptionFor('session-queued');
+      await transcriptionFor('session-failed');
+      await transcriptionFor('session-done');
+
+      final failing = await repository.claimById('transcribe_session-failed');
+      await repository.markFailure(
+        jobId: failing!.job.id,
+        claimToken: failing.token,
+        failureClass: DayProcessingFailureClass.deterministic,
+        error: 'nope',
+      );
+      final done = await repository.claimById('transcribe_session-done');
+      await repository.markSucceeded(
+        jobId: done!.job.id,
+        claimToken: done.token,
+      );
+
+      final schedulable = await repository.getSchedulable();
+
+      expect(schedulable.map((job) => job.id), ['transcribe_session-queued']);
+    });
+
+    test(
+      'getSchedulable keeps a running job so its lease can expire',
+      () async {
+        await transcriptionFor('session-1');
+        await repository.claimNext();
+
+        final schedulable = await repository.getSchedulable();
+
+        expect(schedulable.single.status, DayProcessingJobStatus.running);
+      },
+    );
+  });
+
+  group('ledger retention (ADR 0044)', () {
+    Future<DayProcessingJob> terminalJob(String sessionId) async {
+      await repository.enqueueTranscription(
+        dayId: 'dayplan-2026-07-18',
+        activityEntryId: 'activity-$sessionId',
+        recordingSessionId: sessionId,
+        audioId: 'audio-$sessionId',
+        audioPath: path.join(root.path, '$sessionId.m4a'),
+        capturedAt: now,
+      );
+      final claim = await repository.claimById('transcribe_$sessionId');
+      return repository.markSucceeded(
+        jobId: claim!.job.id,
+        claimToken: claim.token,
+      );
+    }
+
+    test('prunes terminal rows completed before the cutoff', () async {
+      await terminalJob('session-old');
+      now = now.add(const Duration(days: 100));
+      await terminalJob('session-new');
+
+      final pruned = await repository.pruneTerminalBefore(
+        now.subtract(dayProcessingLedgerRetention),
+      );
+
+      expect(pruned, 1);
+      expect(
+        (await allJobs()).map((job) => job.id),
+        ['transcribe_session-new'],
+      );
+    });
+
+    test('never prunes pending work, however old', () async {
+      // Outstanding user intent that retryNow or a re-enqueue can still
+      // resurrect: age alone must not delete it.
+      await repository.enqueueTranscription(
+        dayId: 'dayplan-2026-07-18',
+        activityEntryId: 'activity-1',
+        recordingSessionId: 'session-1',
+        audioId: 'audio-1',
+        audioPath: path.join(root.path, 'session-1.m4a'),
+        capturedAt: now,
+      );
+      final claim = await repository.claimNext();
+      await repository.markFailure(
+        jobId: claim!.job.id,
+        claimToken: claim.token,
+        failureClass: DayProcessingFailureClass.setupRequired,
+        error: 'needs setup',
+      );
+      now = now.add(const Duration(days: 3650));
+
+      final pruned = await repository.pruneTerminalBefore(now);
+
+      expect(pruned, 0);
+      expect(
+        (await allJobs()).single.status,
+        DayProcessingJobStatus.waitingForUser,
+      );
+    });
+
+    test('announces a prune so Activity refreshes', () async {
+      await terminalJob('session-old');
+      var events = 0;
+      final subscription = repository.changes.listen((_) => events++);
+      addTearDown(subscription.cancel);
+
+      await repository.pruneTerminalBefore(
+        now.add(const Duration(days: 1)),
+      );
+      await pumpEventQueue();
+
+      expect(events, 1);
+    });
+
+    test('stays quiet when nothing was eligible', () async {
+      await terminalJob('session-recent');
+      var events = 0;
+      final subscription = repository.changes.listen((_) => events++);
+      addTearDown(subscription.cancel);
+
+      final pruned = await repository.pruneTerminalBefore(
+        now.subtract(dayProcessingLedgerRetention),
+      );
+      await pumpEventQueue();
+
+      expect(pruned, 0);
+      expect(events, 0);
     });
   });
 }

--- a/test/features/daily_os_next/services/day_processing_runtime_test.dart
+++ b/test/features/daily_os_next/services/day_processing_runtime_test.dart
@@ -3,21 +3,26 @@ import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
 import 'package:path/path.dart' as path;
 
+import 'day_processing_test_db.dart';
+
 void main() {
   late Directory root;
   late DateTime now;
+  late DayProcessingDb db;
   late DayProcessingOutboxRepository repository;
 
   setUp(() async {
     root = Directory.systemTemp.createTempSync('day-runtime-test-');
     now = DateTime.utc(2026, 7, 18, 8);
+    db = createTestDayProcessingDb();
     repository = DayProcessingOutboxRepository(
-      rootDirectory: root,
+      db: db,
       now: () => now,
       tokenFactory: () => 'claim-1',
     );
@@ -162,11 +167,11 @@ void main() {
       failureClass: DayProcessingFailureClass.network,
       error: 'offline',
     );
-    root.deleteSync(recursive: true);
-    final blockingFile = File(root.path)..writeAsStringSync('not a directory');
-    addTearDown(() {
-      if (blockingFile.existsSync()) blockingFile.deleteSync();
-    });
+    // Force a storage failure. Closing the database makes every subsequent
+    // query throw, which is the runtime-visible shape of the outbox being
+    // unusable — the runtime must contain it and reschedule rather than let
+    // the error escape an unawaited connectivity callback.
+    await db.close();
     Duration? scheduledDelay;
     final runtime = DayProcessingRuntime(
       repository: repository,

--- a/test/features/daily_os_next/services/day_processing_startup_test.dart
+++ b/test/features/daily_os_next/services/day_processing_startup_test.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_startup.dart';
+import 'package:path/path.dart' as path;
+
+import 'day_processing_test_db.dart';
+
+void main() {
+  late Directory documents;
+  late DayProcessingDb db;
+
+  setUp(() {
+    documents = Directory.systemTemp.createTempSync('day-processing-startup-');
+    db = createTestDayProcessingDb();
+  });
+
+  tearDown(() {
+    if (documents.existsSync()) documents.deleteSync(recursive: true);
+  });
+
+  void writeLegacyJob(String sessionId) {
+    final at = DateTime.utc(2026, 7, 18, 7, 40);
+    final job = DayProcessingJob(
+      id: 'transcribe_$sessionId',
+      status: DayProcessingJobStatus.queued,
+      dayId: 'dayplan-2026-07-18',
+      payload: TranscribeAudioPayload(
+        activityEntryId: 'activity-$sessionId',
+        recordingSessionId: sessionId,
+        audioId: 'audio-$sessionId',
+        audioPath: path.join(documents.path, '$sessionId.m4a'),
+      ),
+      createdAt: at,
+      updatedAt: at,
+      requestedAt: at,
+      nextAttemptAt: at,
+      attempts: 0,
+      generation: 0,
+    );
+    final payload = jsonEncode(job.toJson());
+    final directory = Directory(
+      path.join(documents.path, legacyDayProcessingOutboxDirectory),
+    )..createSync(recursive: true);
+    File(
+      path.join(directory.path, 'transcribe_$sessionId.json'),
+    ).writeAsStringSync(
+      jsonEncode(<String, Object?>{
+        'payload': payload,
+        'sha256': sha256.convert(utf8.encode(payload)).toString(),
+      }),
+    );
+  }
+
+  test('carries the legacy directory into the table before use', () async {
+    writeLegacyJob('session-1');
+
+    final repository = await initializeDayProcessingOutbox(
+      db: db,
+      documentsDirectory: documents,
+    );
+    addTearDown(repository.dispose);
+
+    // The repository handed back must already see the migrated work, or the
+    // runtime would start against an empty outbox and the user's pending
+    // recording would look lost.
+    expect(
+      (await repository.getById('transcribe_session-1'))!.dayId,
+      'dayplan-2026-07-18',
+    );
+  });
+
+  test('starts clean when no legacy directory exists', () async {
+    final repository = await initializeDayProcessingOutbox(
+      db: db,
+      documentsDirectory: documents,
+    );
+    addTearDown(repository.dispose);
+
+    expect(await allDayProcessingJobs(db), isEmpty);
+    expect(
+      Directory(
+        path.join(documents.path, legacyDayProcessingOutboxDirectory),
+      ).existsSync(),
+      isFalse,
+      reason: 'startup must not recreate the store it is retiring',
+    );
+  });
+
+  test('is safe to run again on a later start', () async {
+    writeLegacyJob('session-1');
+    final first = await initializeDayProcessingOutbox(
+      db: db,
+      documentsDirectory: documents,
+    );
+    addTearDown(first.dispose);
+
+    final second = await initializeDayProcessingOutbox(
+      db: db,
+      documentsDirectory: documents,
+    );
+    addTearDown(second.dispose);
+
+    expect(await allDayProcessingJobs(db), hasLength(1));
+  });
+}

--- a/test/features/daily_os_next/services/day_processing_test_db.dart
+++ b/test/features/daily_os_next/services/day_processing_test_db.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_job_row.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+
+/// In-memory processing outbox database with teardown already registered.
+///
+/// Every suite that builds a `DayProcessingOutboxRepository` needs one, and a
+/// leaked connection breaks later tests in the same shard — CI runs the suite
+/// in a single thread — so closing it is not left to each call site.
+DayProcessingDb createTestDayProcessingDb() {
+  final db = DayProcessingDb(inMemoryDatabase: true);
+  addTearDown(db.close);
+  return db;
+}
+
+/// Whole-table read for assertions.
+///
+/// `getAll()` is deliberately absent from `DayProcessingOutboxRepository`
+/// (ADR 0044) so no production caller can reintroduce a ledger scan. Tests
+/// that genuinely want every row reach past the repository to the table.
+Future<List<DayProcessingJob>> allDayProcessingJobs(DayProcessingDb db) async {
+  final rows = await db
+      .customSelect(
+        'SELECT $dayProcessingJobColumns FROM day_processing_jobs '
+        'ORDER BY created_at, id',
+      )
+      .get();
+  return rows.map(dayProcessingJobFromRow).toList();
+}

--- a/test/features/daily_os_next/state/capture_controller_test.dart
+++ b/test/features/daily_os_next/state/capture_controller_test.dart
@@ -23,6 +23,7 @@ import 'package:record/record.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../ai_consumption/test_utils.dart';
+import '../services/day_processing_test_db.dart';
 
 final _now = DateTime(2026, 7, 20, 9);
 const _sessionId = 'session-fixed-0001';
@@ -75,7 +76,9 @@ class _Bench {
     final ampController = StreamController<Amplitude>.broadcast();
     final outboxRoot = Directory.systemTemp.createTempSync('capture-outbox-');
     final docDir = Directory.systemTemp.createTempSync('capture-docs-');
-    final outbox = DayProcessingOutboxRepository(rootDirectory: outboxRoot);
+    final outbox = DayProcessingOutboxRepository(
+      db: createTestDayProcessingDb(),
+    );
     final persistenceLogic = MockPersistenceLogic();
     when(recorder.hasPermission).thenAnswer((_) async => true);
     when(recorder.stopRecording).thenAnswer((_) async {});

--- a/test/features/daily_os_next/state/day_activity_provider_test.dart
+++ b/test/features/daily_os_next/state/day_activity_provider_test.dart
@@ -17,6 +17,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 import '../../agents/test_data/entity_factories.dart';
+import '../services/day_processing_test_db.dart';
 
 void main() {
   late Directory root;
@@ -28,7 +29,7 @@ void main() {
 
   setUp(() async {
     root = Directory.systemTemp.createTempSync('day-activity-provider-test-');
-    outbox = DayProcessingOutboxRepository(rootDirectory: root);
+    outbox = DayProcessingOutboxRepository(db: createTestDayProcessingDb());
     final mocks = await setUpTestGetIt(
       additionalSetup: () => getIt.registerSingleton<Directory>(root),
     );

--- a/test/features/daily_os_next/state/day_processing_runtime_provider_test.dart
+++ b/test/features/daily_os_next/state/day_processing_runtime_provider_test.dart
@@ -26,6 +26,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
+import '../services/day_processing_test_db.dart';
 
 /// Overrides for the agent-service providers `dayProcessingOutboxProcessorProvider`
 /// pulls in to build its `DayAgentJobExecutor` (ADR 0032 phase 1). None of
@@ -58,7 +59,7 @@ void main() {
 
   setUp(() async {
     root = Directory.systemTemp.createTempSync('day-runtime-provider-test-');
-    outbox = DayProcessingOutboxRepository(rootDirectory: root);
+    outbox = DayProcessingOutboxRepository(db: createTestDayProcessingDb());
     persistenceLogic = MockPersistenceLogic();
     vectorClock = MockVectorClockService();
     when(vectorClock.getHost).thenAnswer((_) async => 'host-1');


### PR DESCRIPTION
Implements the ADR 0044 decision: the Daily OS processing outbox moves from
one JSON file per job to a device-local Drift table.

## Why

`_readAllUnsafe()` did a `listSync()` over the job directory and, for every
file, read it, JSON-decoded the envelope, verified its SHA-256 and decoded the
payload. That backed `claimNext`, `getAll` and `signalConnectivityRestored`,
and `DayProcessingRuntime.drainAndSchedule` performed several of those scans
per nudge — on every outbox mutation, connectivity restore, startup and retry
wakeup.

Terminal jobs are retained on purpose (`"Jobs remain after success as the
local processing ledger consumed by Activity and startup repair"`), so the
scanned set grew for the life of the install. Every recording adds at least
two job files. Per-action work on the main isolate therefore grew linearly
with app age, and the part that grew was the part retained deliberately.

The same failure mode was already hit, measured and fixed in this repo's sync
queue — `inbound_event_queue` keeps its `applied` ledger out of the drain path
with partial indexes, after full scans cost "73s of DB time per hour" on a
desktop mid-drain. A directory of JSON files has no equivalent.

## What changed

**Schema** (`database/day_processing_db.drift`) — one row per job; envelope
columns are real columns, the kind payload and run keys stay JSON. Three
indexes: a partial over non-terminal rows keyed `(created_at, id)` for the
claim/fence/schedule paths, `(day_id, kind, created_at)` for Activity, and a
partial over terminal rows for retention. Timestamps are epoch milliseconds,
matching `inbound_event_queue` and preserving precision Drift's default
DateTime mapping would truncate.

**Claiming** is one atomic statement — `UPDATE … WHERE id = (SELECT … ORDER BY
created_at, id LIMIT 1) RETURNING …`. `_serialize`, `_recoverPartials`,
`_quarantine` and the SHA-256 envelope are deleted; transactions and WAL cover
what they were for. Fencing on claimed mutations is unchanged.

**Readers** — all three whole-store scans become bounded queries
(`getForDay`, `getPendingByKind`, `getSchedulable`), and `getAll()` is removed
rather than left as a trap for the next reader.

**Retention** — terminal rows past 90 days are deleted on the existing
once-per-start repair pass. Non-terminal rows never age out regardless: a job
parked in `failed`/`waitingForUser`/`waitingForNetwork` is outstanding user
intent that `retryNow` or a re-enqueue can still resurrect.

**Migration** — `initializeDayProcessingOutbox` runs during startup, before
the runtime and before any enqueue path is wired (the write barrier), imports
every job file, verifies by *identity* with a re-scan until stable, and
commits the sentinel in the same transaction as the confirming scan.
`DayProcessingLegacyFileStore` keeps the partial-recovery and quarantine logic
read-only for the import; job files stay on disk one release as a rollback.

## ADR amendment

The ADR specified select-then-conditional-`UPDATE` with a retry when a claim
loses a race — my answer to a review comment on #3562. Implementing it showed
both statements run inside one drift transaction on a single connection, so
that race cannot occur, the generation guard could never fail, and the retry
branch was unreachable dead code. The single-statement form removes the
question rather than answering it. Recorded as an amendment on ADR 0044.

## Testing

- 1894 tests pass across `daily_os_next` and the affected agents suite.
- 100% line coverage on all five new source files; every changed line in the
  four modified files is covered.
- New suites: legacy file store (partial recovery, digest mismatch,
  quarantine), migration (idempotency, interrupted import, never rewinding a
  row the live repository advanced, keeping a row whose file was quarantined),
  startup wiring, bounded queries, retention.
- `fvm dart analyze lib test` clean; formatter clean.

No CHANGELOG entry — this is an internal storage change with no runtime
behavior a user would notice.

## Note for review

Drift silently drops a column named `key` — it generated the migrations table
without it rather than erroring, which would have shipped a sentinel that
could never be written and a migration that re-ran forever. Renamed to
`migration_key`; only the migration tests caught it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable, device-local SQL storage for day-processing jobs.
  * Added startup migration from legacy job files, including idempotent cutover with a completion sentinel.
  * Introduced atomic, token-fenced job claiming plus day/kind-scoped retrieval and terminal retention cleanup.
* **Bug Fixes**
  * Prevented claim race windows and improved “no-op” behavior when nothing can be claimed.
  * Updated scheduling/repair to operate only on eligible non-terminal jobs.
* **Documentation**
  * Documented the new outbox approach, migration, retention, and claim semantics.
* **Tests**
  * Updated integration and service tests to use the new database-backed outbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->