### PR TITLE
Undo a link you just made; signpost manage mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1064]
+### Added
+- **Undo a link you just made.** Picking a task in the link or blocker picker
+  still commits on that single tap — but it now says what it wrote ("Blocks:
+  Draft crew rotation schedule") and offers Undo, so a mis-tap or the right
+  task under the wrong relationship is one tap to take back instead of a trip
+  through Manage links.
+
+### Changed
+- **Manage mode says it is on.** The Linked Tasks card now shows a Done button
+  in its header while you are editing links, instead of leaving the only exit
+  inside the same overflow menu you opened it from.
+- On a desktop-sized window the task search field is focused when the link and
+  blocker pickers open, so you can type straight away. Left unfocused on
+  phones, where it would raise the keyboard over the results.
+- The Linked Tasks overflow menu uses the app's own surface and radius rather
+  than Material defaults, so it matches the card it opens from.
+
 ## [0.9.1063]
 ### Changed
 - **Picking what two tasks mean to each other is now one choice, not two.**

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,13 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1064" date="2026-07-25">
+      <description>
+        <p>Undo a link you just made. Picking a task in the link or blocker picker still commits on that single tap, but it now says what it wrote ("Blocks: Draft crew rotation schedule") and offers Undo, so a mis-tap or the right task under the wrong relationship is one tap to take back instead of a trip through Manage links.</p>
+        <p>Manage mode says it is on: the Linked Tasks card shows a Done button in its header while you are editing links, instead of leaving the only exit inside the same overflow menu you opened it from.</p>
+        <p>On a desktop-sized window the task search field is focused when the link and blocker pickers open, so you can type straight away; it is left unfocused on phones, where it would raise the keyboard over the results. The Linked Tasks overflow menu now uses the app's own surface and radius rather than Material defaults, so it matches the card it opens from.</p>
+      </description>
+    </release>
     <release version="0.9.1063" date="2026-07-25">
       <description>
         <p>Picking what two tasks mean to each other is now one choice, not two. The relationship picker was a row of type chips plus a separate direction switch, which put the same word on screen twice — a chip reading "Blocks" directly above a switch whose first option also read "Blocks". You now pick from a single list that completes the sentence "This task…": Relates to, Blocks, Is blocked by, Follows up on, Has follow-up, Duplicates, Is duplicated by, Fixes, Is fixed by, Supersedes, Is superseded by.</p>

--- a/lib/classes/entry_link.dart
+++ b/lib/classes/entry_link.dart
@@ -246,6 +246,21 @@ extension EntryLinkTypeFactory on EntryLinkType {
   }
 }
 
+/// The `linked_entries.type` column value for an [EntryLinkType], without
+/// needing an [EntryLink] instance — used when removing a link the caller
+/// only knows the type of (e.g. undoing a link it just created). Must agree
+/// with [entryLinkTypeName] for every variant.
+String entryLinkTypeDbName(EntryLinkType type) => switch (type) {
+  EntryLinkType.basic => 'BasicLink',
+  EntryLinkType.rating => 'RatingLink',
+  EntryLinkType.project => 'ProjectLink',
+  EntryLinkType.blocks => 'BlocksLink',
+  EntryLinkType.followsUp => 'FollowsUpLink',
+  EntryLinkType.duplicates => 'DuplicatesLink',
+  EntryLinkType.fixes => 'FixesLink',
+  EntryLinkType.supersedes => 'SupersedesLink',
+};
+
 /// The `linked_entries.type` column value for [link]'s union variant. Shared
 /// by `linkedDbEntity` (the write path) and `JournalRepository`'s
 /// `updateLink` change-detection so a variant change is never missed.

--- a/lib/features/design_system/components/search/design_system_search.dart
+++ b/lib/features/design_system/components/search/design_system_search.dart
@@ -24,6 +24,7 @@ class DesignSystemSearch extends StatefulWidget {
     this.size = DesignSystemSearchSize.medium,
     this.controller,
     this.focusNode,
+    this.autofocus = false,
     this.initialText,
     this.enabled = true,
     this.semanticsLabel,
@@ -41,6 +42,11 @@ class DesignSystemSearch extends StatefulWidget {
   final DesignSystemSearchSize size;
   final TextEditingController? controller;
   final FocusNode? focusNode;
+
+  /// Requests focus on first build. Callers should gate this on a pointer/
+  /// wide-window check: on a touch device it raises the keyboard over the
+  /// results the field is meant to filter.
+  final bool autofocus;
   final String? initialText;
   final bool enabled;
   final String? semanticsLabel;
@@ -181,6 +187,7 @@ class _DesignSystemSearchState extends State<DesignSystemSearch> {
                       child: TextField(
                         controller: _controller,
                         focusNode: widget.focusNode,
+                        autofocus: widget.autofocus,
                         enabled: widget.enabled,
                         onChanged: widget.onChanged,
                         onSubmitted: widget.onSubmitted,

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -682,6 +682,13 @@ anchor already touches. The schema's `UNIQUE(from_id, to_id, type)` lets one
 pair hold several different relationships, and direction is part of the
 identity, so the inverse of an existing link stays offerable.
 
+Committing is one tap — picking a candidate row creates the link and pops.
+That speed is the point of the flow, so it is not gated behind a confirm step;
+instead the commit is followed by a SnackBar naming the relation that was
+written ("Blocks: <title>") with an Undo action that removes exactly that
+`(fromId, toId, type)` triple. Undo therefore can only take back the edge the
+message is about, never another relationship the same pair also holds.
+
 `EditLinkTypeModal` retypes or reverses an existing link in place, via the same
 selector pre-seeded to the link's current relation, calling
 `JournalRepository.updateLinkType` (which reuses `updateLink`'s vector-clock,
@@ -713,6 +720,12 @@ Rows compose `DesignSystemListItem`, and `EntityPickerSheet` takes the same
 `rowSize`, so one task title renders at one rank whether it is read on the card
 or in the picker one tap away. The status label sits as a trailing anchor where
 there is width for it and drops to the subtitle slot at narrow widths.
+
+Manage mode (the card's edit/unlink affordances) says so while it is on: the
+header replaces its link action with an inline Done, and the overflow offers
+"Manage links…" only as a way *in*. Previously the mode was visible only as two
+icons appearing per row, and the way out was the same unlabelled menu it was
+entered from.
 
 The card always renders its header, including on a task with no links at all —
 where it shows a worded "Link a task…" action rather than nothing. Rendering

--- a/lib/features/tasks/ui/linked_tasks/blocking_task_picker_modal.dart
+++ b/lib/features/tasks/ui/linked_tasks/blocking_task_picker_modal.dart
@@ -3,7 +3,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/link_created_feedback.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/relationship_type_selector.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/task_search_picker_body.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -39,7 +42,15 @@ class BlockingTaskPickerModal extends ConsumerWidget {
     );
   }
 
-  Future<void> _selectBlocker(BuildContext context, Task blocker) async {
+  Future<void> _selectBlocker(
+    BuildContext context,
+    WidgetRef ref,
+    Task blocker,
+  ) async {
+    // Captured before the pop below, which disposes this modal's context.
+    final messenger = ScaffoldMessenger.of(context);
+    final repository = ref.read(journalRepositoryProvider);
+
     final created = await getIt<PersistenceLogic>().createLink(
       fromId: blocker.meta.id,
       toId: blockedTaskId,
@@ -58,6 +69,20 @@ class BlockingTaskPickerModal extends ConsumerWidget {
     await HapticFeedback.mediumImpact();
 
     if (context.mounted) {
+      showLinkCreatedFeedback(
+        context: context,
+        messenger: messenger,
+        repository: repository,
+        // The picked task blocks the anchor, so from the anchor's side this
+        // is the inverse phrasing — the same words the card will show.
+        relation: const DirectedRelation(
+          EntryLinkType.blocks,
+          inverse: true,
+        ),
+        fromId: blocker.meta.id,
+        toId: blockedTaskId,
+        linkedTaskTitle: blocker.data.title,
+      );
       Navigator.of(context).pop(blocker);
     }
   }
@@ -80,7 +105,7 @@ class BlockingTaskPickerModal extends ConsumerWidget {
 
     return TaskSearchPickerBody(
       excludeIds: {blockedTaskId, ...existingBlockerIds},
-      onTaskSelected: (task) => _selectBlocker(context, task),
+      onTaskSelected: (task) => _selectBlocker(context, ref, task),
     );
   }
 }

--- a/lib/features/tasks/ui/linked_tasks/link_created_feedback.dart
+++ b/lib/features/tasks/ui/linked_tasks/link_created_feedback.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/relationship_type_selector.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// Confirms a link that was just created, and offers to take it back.
+///
+/// Picking a task in the link and blocker pickers commits on the single tap
+/// that selects it — deliberately, since that speed is the point of the flow.
+/// The cost is that a mis-tap, or the right task under the wrong relation,
+/// silently persists a real edge whose only removal path is the card's manage
+/// mode. This restores recovery without reintroducing a confirm step: the
+/// commit still happens on one tap, and undoing it is one more.
+///
+/// Shown on [messenger] rather than the modal's own context because the modal
+/// pops as part of committing — capture the messenger before popping.
+void showLinkCreatedFeedback({
+  required BuildContext context,
+  required ScaffoldMessengerState messenger,
+  required JournalRepository repository,
+  required DirectedRelation relation,
+  required String fromId,
+  required String toId,
+  required String linkedTaskTitle,
+}) {
+  final messages = context.messages;
+  final phrase = directedRelationLabel(context, relation);
+
+  messenger.showSnackBar(
+    SnackBar(
+      content: Text(messages.linkCreatedMessage(phrase, linkedTaskTitle)),
+      action: SnackBarAction(
+        label: messages.linkCreatedUndo,
+        onPressed: () {
+          // Same triple the link was written under, so undo can only ever
+          // remove the edge this message is about — not some other
+          // relationship the two tasks also hold.
+          repository.removeTypedLink(
+            fromId: fromId,
+            toId: toId,
+            linkType: entryLinkTypeDbName(relation.type),
+          );
+        },
+      ),
+    ),
+  );
+}

--- a/lib/features/tasks/ui/linked_tasks/link_task_modal.dart
+++ b/lib/features/tasks/ui/linked_tasks/link_task_modal.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/link_created_feedback.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/relationship_type_selector.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/task_search_picker_body.dart';
 import 'package:lotti/get_it.dart';
@@ -59,9 +61,16 @@ class _LinkTaskModalState extends ConsumerState<LinkTaskModal> {
 
   Future<void> _selectTask(Task task) async {
     final swap = _relation.inverse;
+    final fromId = swap ? task.meta.id : widget.currentTaskId;
+    final toId = swap ? widget.currentTaskId : task.meta.id;
+    // Captured before the pop below: the modal's own context is gone by the
+    // time the confirmation needs a messenger.
+    final messenger = ScaffoldMessenger.of(context);
+    final repository = ref.read(journalRepositoryProvider);
+
     final created = await getIt<PersistenceLogic>().createLink(
-      fromId: swap ? task.meta.id : widget.currentTaskId,
-      toId: swap ? widget.currentTaskId : task.meta.id,
+      fromId: fromId,
+      toId: toId,
       linkType: _relation.type,
     );
 
@@ -77,6 +86,15 @@ class _LinkTaskModalState extends ConsumerState<LinkTaskModal> {
     await HapticFeedback.mediumImpact();
 
     if (mounted) {
+      showLinkCreatedFeedback(
+        context: context,
+        messenger: messenger,
+        repository: repository,
+        relation: _relation,
+        fromId: fromId,
+        toId: toId,
+        linkedTaskTitle: task.data.title,
+      );
       Navigator.of(context).pop(task);
     }
   }

--- a/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
@@ -19,7 +19,6 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/create/create_entry.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/themes/theme.dart';
 
 /// Linked tasks card on the task detail view.
 ///
@@ -231,9 +230,18 @@ class _LinkedTasksHeader extends ConsumerWidget {
               _CountBadge(count: count),
             ],
             const Spacer(),
+            // Manage mode is otherwise invisible except for two icons
+            // appearing per row, and the only way out used to be the same
+            // unlabelled overflow menu it was entered from. While it is on,
+            // the header says so and offers the exit inline.
+            if (manageMode)
+              TextButton(
+                onPressed: notifier.toggleManageMode,
+                child: Text(context.messages.doneButton),
+              ),
             // The link action is worded in the empty state's own row, so the
             // header only carries it once there is a list to add to.
-            if (hasLinkedTasks) ...[
+            if (hasLinkedTasks && !manageMode) ...[
               IconButton(
                 tooltip: context.messages.linkExistingTask,
                 onPressed: () => _showLinkTaskModal(context, ref, taskId),
@@ -254,18 +262,15 @@ class _LinkedTasksHeader extends ConsumerWidget {
             SizedBox(width: tokens.spacing.step3),
             Theme(
               data: Theme.of(context).copyWith(
+                // Tokens rather than Material scheme colours and raw radii,
+                // so the menu belongs to the same surface family as the card
+                // it opens from instead of being a themed island inside it.
                 popupMenuTheme: PopupMenuThemeData(
-                  color: context.colorScheme.surfaceContainerHighest,
-                  elevation: 8,
+                  color: tokens.colors.background.level03,
                   surfaceTintColor: Colors.transparent,
                   shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    side: BorderSide(
-                      color: context.colorScheme.outlineVariant.withValues(
-                        alpha: 0.3,
-                      ),
-                      width: 0.8,
-                    ),
+                    borderRadius: BorderRadius.circular(tokens.radii.m),
+                    side: BorderSide(color: tokens.colors.decorative.level01),
                   ),
                 ),
               ),
@@ -298,25 +303,17 @@ class _LinkedTasksHeader extends ConsumerWidget {
                       ],
                     ),
                   ),
-                  if (hasLinkedTasks)
+                  // Only offered as a way *in*: manage mode now carries its
+                  // own inline exit in the header, so a second "Done" here
+                  // would be two controls for one state.
+                  if (hasLinkedTasks && !manageMode)
                     PopupMenuItem(
                       value: 'manage',
                       child: Row(
                         children: [
-                          Icon(
-                            manageMode
-                                ? Icons.check_rounded
-                                : Icons.edit_rounded,
-                            size: 18,
-                          ),
-                          const SizedBox(width: 8),
-                          Flexible(
-                            child: Text(
-                              manageMode
-                                  ? context.messages.doneButton
-                                  : context.messages.manageLinks,
-                            ),
-                          ),
+                          Icon(Icons.edit_rounded, size: tokens.spacing.step5),
+                          SizedBox(width: tokens.spacing.step3),
+                          Flexible(child: Text(context.messages.manageLinks)),
                         ],
                       ),
                     ),

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2788,6 +2788,18 @@
   "knowledgeGraphTooltip": "Prozkoumat odkazy",
   "knowledgeGraphWalkHint": "Klepni na uzel a přejdi dál · {count, plural, one{1 uzel} few{{count} uzly} other{{count} uzlů}}",
   "linkBlocksCycleErrorMessage": "Tím by vznikl blokující cyklus — vyber jiný úkol.",
+  "linkCreatedMessage": "{relation}: {title}",
+  "@linkCreatedMessage": {
+    "placeholders": {
+      "relation": {
+        "type": "String"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "linkCreatedUndo": "Zpět",
   "linkDirectionLabel": "Tento úkol…",
   "linkedTaskImageBadge": "Z propojené úlohy",
   "linkedTasksBlockedBySectionTitle": "Blokováno",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2781,6 +2781,18 @@
   "knowledgeGraphTooltip": "Verknüpfungen erkunden",
   "knowledgeGraphWalkHint": "Tippe auf einen Knoten · Knoten: {count}",
   "linkBlocksCycleErrorMessage": "Das würde einen blockierenden Kreislauf erzeugen — wähle eine andere Aufgabe.",
+  "linkCreatedMessage": "{relation}: {title}",
+  "@linkCreatedMessage": {
+    "placeholders": {
+      "relation": {
+        "type": "String"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "linkCreatedUndo": "Rückgängig",
   "linkDirectionLabel": "Diese Aufgabe…",
   "linkedTaskImageBadge": "Von verknüpfter Aufgabe",
   "linkedTasksBlockedBySectionTitle": "Blockiert von",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3358,6 +3358,18 @@
     }
   },
   "linkBlocksCycleErrorMessage": "This would create a blocking cycle — choose a different task.",
+  "linkCreatedMessage": "{relation}: {title}",
+  "@linkCreatedMessage": {
+    "placeholders": {
+      "relation": {
+        "type": "String"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "linkCreatedUndo": "Undo",
   "linkDirectionLabel": "This task…",
   "linkedTaskImageBadge": "From linked task",
   "linkedTasksBlockedBySectionTitle": "Blocked by",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2781,6 +2781,18 @@
   "knowledgeGraphTooltip": "Explorar enlaces",
   "knowledgeGraphWalkHint": "Toca un nodo para avanzar · nodos: {count}",
   "linkBlocksCycleErrorMessage": "Esto crearía un ciclo de bloqueo — elige otra tarea.",
+  "linkCreatedMessage": "{relation}: {title}",
+  "@linkCreatedMessage": {
+    "placeholders": {
+      "relation": {
+        "type": "String"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "linkCreatedUndo": "Deshacer",
   "linkDirectionLabel": "Esta tarea…",
   "linkedTaskImageBadge": "De tarea vinculada",
   "linkedTasksBlockedBySectionTitle": "Bloqueada por",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2781,6 +2781,18 @@
   "knowledgeGraphTooltip": "Explorer les liens",
   "knowledgeGraphWalkHint": "Touche un nœud pour avancer · {count, plural, =1{1 nœud} other{{count} nœuds}}",
   "linkBlocksCycleErrorMessage": "Cela créerait un cycle de blocage — choisis une autre tâche.",
+  "linkCreatedMessage": "{relation} : {title}",
+  "@linkCreatedMessage": {
+    "placeholders": {
+      "relation": {
+        "type": "String"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "linkCreatedUndo": "Annuler",
   "linkDirectionLabel": "Cette tâche…",
   "linkedTaskImageBadge": "De la tâche liée",
   "linkedTasksBlockedBySectionTitle": "Bloquée par",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11477,6 +11477,18 @@ abstract class AppLocalizations {
   /// **'This would create a blocking cycle — choose a different task.'**
   String get linkBlocksCycleErrorMessage;
 
+  /// No description provided for @linkCreatedMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'{relation}: {title}'**
+  String linkCreatedMessage(String relation, String title);
+
+  /// No description provided for @linkCreatedUndo.
+  ///
+  /// In en, this message translates to:
+  /// **'Undo'**
+  String get linkCreatedUndo;
+
   /// No description provided for @linkDirectionLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6661,6 +6661,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Tím by vznikl blokující cyklus — vyber jiný úkol.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Zpět';
+
+  @override
   String get linkDirectionLabel => 'Tento úkol…';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6583,6 +6583,14 @@ class AppLocalizationsDa extends AppLocalizations {
       'This would create a blocking cycle — choose a different task.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Undo';
+
+  @override
   String get linkDirectionLabel => 'This task…';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6618,6 +6618,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Das würde einen blockierenden Kreislauf erzeugen — wähle eine andere Aufgabe.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Rückgängig';
+
+  @override
   String get linkDirectionLabel => 'Diese Aufgabe…';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6549,6 +6549,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'This would create a blocking cycle — choose a different task.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Undo';
+
+  @override
   String get linkDirectionLabel => 'This task…';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6668,6 +6668,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Esto crearía un ciclo de bloqueo — elige otra tarea.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Deshacer';
+
+  @override
   String get linkDirectionLabel => 'Esta tarea…';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6695,6 +6695,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Cela créerait un cycle de blocage — choisis une autre tâche.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation : $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Annuler';
+
+  @override
   String get linkDirectionLabel => 'Cette tâche…';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6666,6 +6666,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'This would create a blocking cycle — choose a different task.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Undo';
+
+  @override
   String get linkDirectionLabel => 'This task…';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6602,6 +6602,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'This would create a blocking cycle — choose a different task.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Undo';
+
+  @override
   String get linkDirectionLabel => 'This task…';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6642,6 +6642,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'This would create a blocking cycle — choose a different task.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Undo';
+
+  @override
   String get linkDirectionLabel => 'This task…';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6702,6 +6702,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Aceasta ar crea un ciclu de blocare — alegeți o altă sarcină.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Anulați';
+
+  @override
   String get linkDirectionLabel => 'Această sarcină…';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6584,6 +6584,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'This would create a blocking cycle — choose a different task.';
 
   @override
+  String linkCreatedMessage(String relation, String title) {
+    return '$relation: $title';
+  }
+
+  @override
+  String get linkCreatedUndo => 'Undo';
+
+  @override
   String get linkDirectionLabel => 'This task…';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2781,6 +2781,18 @@
   "knowledgeGraphTooltip": "Explorați legăturile",
   "knowledgeGraphWalkHint": "Atingeți un nod pentru a continua · {count, plural, =1{1 nod} few{{count} noduri} other{{count} de noduri}}",
   "linkBlocksCycleErrorMessage": "Aceasta ar crea un ciclu de blocare — alegeți o altă sarcină.",
+  "linkCreatedMessage": "{relation}: {title}",
+  "@linkCreatedMessage": {
+    "placeholders": {
+      "relation": {
+        "type": "String"
+      },
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "linkCreatedUndo": "Anulați",
   "linkDirectionLabel": "Această sarcină…",
   "linkedTaskImageBadge": "Din sarcina legată",
   "linkedTasksBlockedBySectionTitle": "Blocată de",

--- a/lib/widgets/picker/entity_picker_sheet.dart
+++ b/lib/widgets/picker/entity_picker_sheet.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/design_system/components/glass_strip.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/components/search/design_system_search.dart';
 import 'package:lotti/features/design_system/components/selection/design_system_selection_row.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 /// Whether the picker assigns a single entity or edits a set of entities.
@@ -202,6 +203,10 @@ class _EntityPickerSheetState extends ConsumerState<EntityPickerSheet> {
               // Match the tasks/projects tab search (the small variant), whose
               // radii.l corner also lines up with the selection pills below.
               size: DesignSystemSearchSize.small,
+              // Wide windows only: on a phone this would raise the keyboard
+              // over the very results the field filters, and the list is the
+              // point of the sheet.
+              autofocus: MediaQuery.sizeOf(context).width >= kDesktopBreakpoint,
               controller: _searchController,
               hintText: widget.searchHintText,
               semanticsLabel: widget.searchHintText,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1063+4243
+version: 0.9.1064+4244
 
 msix_config:
   display_name: LottiApp

--- a/test/classes/entry_link_test.dart
+++ b/test/classes/entry_link_test.dart
@@ -638,6 +638,28 @@ void main() {
       },
     );
   });
+
+  group('entryLinkTypeDbName', () {
+    test('maps every link type to its linked_entries.type column value', () {
+      // Undo removes a link the caller only knows the *type* of, so this must
+      // agree with entryLinkTypeName for every variant or an undo would fail
+      // to match the row it just wrote.
+      const expected = {
+        EntryLinkType.basic: 'BasicLink',
+        EntryLinkType.rating: 'RatingLink',
+        EntryLinkType.project: 'ProjectLink',
+        EntryLinkType.blocks: 'BlocksLink',
+        EntryLinkType.followsUp: 'FollowsUpLink',
+        EntryLinkType.duplicates: 'DuplicatesLink',
+        EntryLinkType.fixes: 'FixesLink',
+        EntryLinkType.supersedes: 'SupersedesLink',
+      };
+      expect(expected.keys, containsAll(EntryLinkType.values));
+      for (final entry in expected.entries) {
+        expect(entryLinkTypeDbName(entry.key), entry.value);
+      }
+    });
+  });
 }
 
 enum _GeneratedEntryLinkKind {

--- a/test/features/tasks/ui/linked_tasks/link_task_modal_test.dart
+++ b/test/features/tasks/ui/linked_tasks/link_task_modal_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/link_task_modal.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/relationship_type_selector.dart';
 import 'package:lotti/features/tasks/ui/utils.dart';
@@ -51,9 +52,14 @@ void main() {
       WidgetTester tester, {
       Set<ExistingRelation> existingRelations = const {},
       MediaQueryData? mediaQueryData,
+      MockJournalRepository? journalRepo,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            if (journalRepo != null)
+              journalRepositoryProvider.overrideWithValue(journalRepo),
+          ],
           child: WidgetTestBench(
             mediaQueryData: mediaQueryData,
             child: Builder(
@@ -701,6 +707,80 @@ void main() {
       // The modal actually pops on success, not just createLink firing.
       expect(find.text('Link existing task...'), findsNothing);
     });
+
+    testWidgets(
+      'a committed link is confirmed with an Undo that removes exactly the '
+      'relation just written',
+      (tester) async {
+        final repo = MockJournalRepository();
+        when(
+          () => repo.removeTypedLink(
+            fromId: any(named: 'fromId'),
+            toId: any(named: 'toId'),
+            linkType: any(named: 'linkType'),
+          ),
+        ).thenAnswer((_) async => 1);
+        stubTasks([buildTask(id: 'blocker-task', title: 'Blocker Task')]);
+        when(
+          () => mockPersistenceLogic.createLink(
+            fromId: any(named: 'fromId'),
+            toId: any(named: 'toId'),
+            linkType: EntryLinkType.blocks,
+          ),
+        ).thenAnswer((_) async => true);
+
+        await openModal(tester, journalRepo: repo);
+        await pickRelation(tester, 'Is blocked by');
+        await tester.tap(find.text('Blocker Task'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // Names the relation and the task, so the confirmation says what was
+        // actually written rather than just "linked".
+        expect(find.text('Is blocked by: Blocker Task'), findsWidgets);
+
+        await tester.tap(find.text('Undo').last);
+        await tester.pump();
+
+        // The exact triple the link was created under — not a broader removal
+        // that could take out another relationship the pair also holds.
+        verify(
+          () => repo.removeTypedLink(
+            fromId: 'blocker-task',
+            toId: 'current-task',
+            linkType: 'BlocksLink',
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'a rejected link is not confirmed and offers no undo',
+      (tester) async {
+        stubTasks([buildTask(id: 'blocker-task', title: 'Blocker Task')]);
+        when(
+          () => mockPersistenceLogic.createLink(
+            fromId: any(named: 'fromId'),
+            toId: any(named: 'toId'),
+            linkType: EntryLinkType.blocks,
+          ),
+        ).thenAnswer((_) async => false);
+
+        await openModal(tester);
+        await pickRelation(tester, 'Blocks');
+        await tester.tap(find.text('Blocker Task'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text('Undo'), findsNothing);
+        expect(
+          find.text(
+            'This would create a blocking cycle — choose a different task.',
+          ),
+          findsWidgets,
+        );
+      },
+    );
 
     testWidgets(
       'a task already linked by one relation stays a candidate for a '

--- a/test/features/tasks/ui/linked_tasks/linked_tasks_widget_actions_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_tasks_widget_actions_test.dart
@@ -274,15 +274,17 @@ void main() {
       expect(find.byIcon(Icons.arrow_forward_ios), findsNothing);
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
 
-      // Toggling again returns to browse mode.
-      await tester.tap(find.byIcon(Icons.more_vert));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.tap(find.text('Done'));
+      // The mode now says so in the header and offers its own way out, rather
+      // than hiding the exit back inside the menu it was entered from.
+      final inlineDone = find.widgetWithText(TextButton, 'Done');
+      expect(inlineDone, findsOneWidget);
+
+      await tester.tap(inlineDone);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(find.byIcon(Icons.arrow_forward_ios), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Done'), findsNothing);
       expect(find.byIcon(Icons.close_rounded), findsNothing);
     });
 


### PR DESCRIPTION
Follow-up to #3563, closing out the design-review backlog that PR deliberately
deferred. Tracked as `lotti3-t4m.8`.

## Undo a link you just made

The highest-value item left over. Picking a candidate row commits on that
single tap — deliberately, since the speed is the point of the flow — but there
was no recovery: a mis-tap, or the right task under the wrong relationship,
silently persisted a real edge whose only removal path was the card's manage
mode.

This does not add a confirm step. It adds an undo:

- On success, a message names what was actually written — `Blocks: Draft crew
  rotation schedule` — rather than a generic "linked".
- Undo removes exactly the `(fromId, toId, type)` triple just created, so it
  can only take back the edge the message is about, never another relationship
  the same pair also holds (which #3563 made possible).
- A rejected link (cycle guard) shows the rejection and offers no undo.

Two experts and two personas raised this across review rounds 3-6; the
low-vision and novice personas both scored it an outright blocker, and it was
the largest single contributor to the gap between the panel's 7.17/7.0 and its
8/10 bar.

## Manage mode says it is on

Manage mode was visible only as two icons appearing per row, and the way out
was the same unlabelled overflow menu it was entered from. The header now
swaps its link action for an inline **Done** while the mode is active, and the
overflow offers "Manage links…" only as a way *in* — so the menu item stops
being a second control for the same state.

## Smaller items from the same backlog

- The picker search field autofocuses on desktop-width windows only. On a
  phone it would raise the keyboard over the very results it filters.
- The linked-tasks overflow menu uses the app's own surface colour and radius
  tokens instead of Material scheme defaults, `elevation: 8` and a raw
  `circular(12)` — it was a themed island inside the card it opens from.

## Verified, not assumed

One backlog item turned out to be **based on a wrong premise** and is not
"fixed" here: completed tasks are *not* offered as link candidates. The query
already passes `openTaskStatuses`, which excludes `DONE` and `REJECTED`. The
finding came from tests that stub `getTasks` to return done/rejected tasks
regardless of the filter argument, which made it look reachable in the UI.

## Still deferred, with reasons

- **FTS5 matches beyond the 200-row prefetch.** Search filters an in-memory
  prefetch, so a match outside that window is invisible. Fixing it properly
  means querying by match rather than filtering a page, which is a data-layer
  change, not UI.
- **Create-from-search in the picker.** `EntityPickerSheet` already supports
  `createFromQuery`; wiring it would let the overflow's "Create new linked
  task…" and the last un-migrated `AlertDialog` collapse into one flow. That is
  a flow redesign worth its own review, not a rider here.
- **Reconciling `DesignSystemDropdown`'s field surface with
  `DesignSystemSearch`'s.** Genuine inconsistency, but a design-system-level
  decision affecting every caller of both.

## Testing

- New: undo removes exactly the created triple (verified against the
  repository call, not just the SnackBar); a rejected link offers no undo;
  manage mode's inline exit returns to browse mode; `entryLinkTypeDbName`
  pinned against every `EntryLinkType` variant.
- `flutter analyze` clean project-wide.
- Full patch coverage on new/changed lines.

Version bumped to 0.9.1064+4244 with its own CHANGELOG and flatpak entries.
