### PR TITLE
feat: claim the day the user is looking at first

### DIFF
--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -276,6 +276,22 @@ everything are bounded: `DayActivityRepository` calls `getForDay(dayId, kinds:
 `DayProcessingRuntime` calls `getSchedulable()`. Claim cost tracks outstanding
 work rather than install age.
 
+**Claiming order.** All agent job kinds share one serial drain lane, so
+without an ordering rule a 30-second draft for a day nobody is looking at
+blocks a capture just recorded for today. Claim order is therefore tiered:
+anything that has already waited past `dayProcessingPriorityAging` (15 minutes)
+first — so a busy foreground cannot starve another day — then the day the user
+has selected, then today, then tomorrow, then everything else. Ties fall
+through to FIFO by `(created_at, id)`, which preserves ordering *within* a day:
+a capture's parse still runs before that day's draft.
+
+Priority is viewer-relative, so it is a query-time expression rather than a
+stored column, evaluated over the candidate set the pending partial index
+already bounds. `DayProcessingOutboxProcessor.priority` is a resolver called
+per claim (not per drain), reading `dailyOsNextSelectedDateProvider` through
+`ref.read` — navigating between days takes effect on the next job without
+rebuilding the long-lived runtime.
+
 **Claiming** is one atomic statement — `UPDATE … WHERE id = (SELECT … ORDER BY
 created_at, id LIMIT 1) RETURNING …` — so there is no window in which a second
 claimer can take a row between it being chosen and owned. FIFO by creation

--- a/lib/features/daily_os_next/services/day_processing_outbox_processor.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_processor.dart
@@ -32,6 +32,7 @@ class DayProcessingOutboxProcessor {
     required this.attachTranscript,
     this.agentJobExecutor,
     this.onJobFinished,
+    this.priority,
     Future<bool> Function()? isOnline,
     double Function()? randomUnit,
   }) : _isOnline = isOnline ?? (() async => true),
@@ -52,6 +53,11 @@ class DayProcessingOutboxProcessor {
   /// "your plan is ready" notification).
   final void Function(DayProcessingJob terminalJob)? onJobFinished;
 
+  /// Supplies the current day-ordering preference, re-evaluated per claim so
+  /// navigating to another day takes effect on the very next job rather than
+  /// after the drain finishes.
+  final DayProcessingClaimPriority Function()? priority;
+
   final Future<bool> Function() _isOnline;
   final double Function() _randomUnit;
 
@@ -61,7 +67,10 @@ class DayProcessingOutboxProcessor {
   Future<DayProcessingRunResult> processNext({
     Set<DayProcessingJobKind>? kinds,
   }) async {
-    final claim = await repository.claimNext(kinds: kinds);
+    final claim = await repository.claimNext(
+      kinds: kinds,
+      priority: priority?.call(),
+    );
     if (claim == null) return DayProcessingRunResult.idle;
     return switch (claim.job.kind) {
       DayProcessingJobKind.transcribeAudio => _processTranscription(claim),

--- a/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:io';
-
 import 'package:drift/drift.dart';
 import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/database/day_processing_job_row.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
 
@@ -16,6 +16,33 @@ import 'package:uuid/uuid.dart';
 /// already keeps the ledger off the drain path, so this bounds disk footprint
 /// rather than query cost.
 const Duration dayProcessingLedgerRetention = Duration(days: 90);
+
+/// How long a job may wait behind higher-priority days before it outranks
+/// them (ADR 0044 follow-up: head-of-line blocking).
+///
+/// Short enough that a backlog cannot park a job indefinitely, long enough
+/// that ordinary interactive work still wins while the user is looking at it.
+const Duration dayProcessingPriorityAging = Duration(minutes: 15);
+
+/// Ordering hint for [DayProcessingOutboxRepository.claimNext].
+///
+/// Priority is *viewer-relative*, so it cannot be a stored column — the answer
+/// changes as the user navigates. It is applied as a query-time expression
+/// over the candidate set the pending partial index already bounds.
+@immutable
+class DayProcessingClaimPriority {
+  const DayProcessingClaimPriority({
+    required this.dayIds,
+    required this.agingCutoff,
+  });
+
+  /// Day ids in descending priority — typically viewed day, today, tomorrow.
+  final List<String> dayIds;
+
+  /// Jobs enqueued at or before this instant outrank every day tier, so a
+  /// day nobody is looking at cannot be starved by a busy foreground.
+  final DateTime agingCutoff;
+}
 
 class DayProcessingClaim {
   const DayProcessingClaim({required this.job, required this.token});
@@ -506,9 +533,15 @@ class DayProcessingOutboxRepository {
   Future<DayProcessingClaim?> claimNext({
     Duration lease = const Duration(minutes: 3),
     Set<DayProcessingJobKind>? kinds,
+    DayProcessingClaimPriority? priority,
   }) async {
     if (kinds != null && kinds.isEmpty) return null;
-    final claim = await _claim(now: _now(), lease: lease, kinds: kinds);
+    final claim = await _claim(
+      now: _now(),
+      lease: lease,
+      kinds: kinds,
+      priority: priority,
+    );
     if (claim != null) _notify();
     return claim;
   }
@@ -543,6 +576,7 @@ class DayProcessingOutboxRepository {
     required Duration lease,
     String? jobId,
     Set<DayProcessingJobKind>? kinds,
+    DayProcessingClaimPriority? priority,
   }) async {
     final token = _tokenFactory();
     final variables = <Variable<Object>>[
@@ -556,7 +590,9 @@ class DayProcessingOutboxRepository {
       selector += ' AND id = ?${variables.length}';
     }
     if (kinds != null) selector += ' AND ${_kindFilter(kinds, variables)}';
-    selector += ' ORDER BY created_at, id LIMIT 1';
+    selector +=
+        ' ORDER BY ${_priorityOrder(priority, variables)}created_at, id '
+        'LIMIT 1';
 
     final rows = await db.customWriteReturning(
       'UPDATE day_processing_jobs SET '
@@ -816,6 +852,41 @@ class DayProcessingOutboxRepository {
   ) async {
     final rows = await db.customSelect(sql, variables: variables).get();
     return List<DayProcessingJob>.unmodifiable(rows.map(_fromRow));
+  }
+
+  /// Leading `ORDER BY` term that puts the days the user cares about first,
+  /// or an empty string for plain FIFO.
+  ///
+  /// Tiers, in order: anything that has already waited past the aging cutoff,
+  /// then each day in [DayProcessingClaimPriority.dayIds], then everything
+  /// else. Ties fall through to the caller's `created_at, id`, so ordering
+  /// *within* a day — a capture's parse before that day's draft — is
+  /// unchanged.
+  static String _priorityOrder(
+    DayProcessingClaimPriority? priority,
+    List<Variable<Object>> variables,
+  ) {
+    if (priority == null || priority.dayIds.isEmpty) return '';
+    variables.add(
+      Variable<int>(priority.agingCutoff.millisecondsSinceEpoch),
+    );
+    final buffer = StringBuffer('CASE WHEN created_at <= ?')
+      ..write(variables.length)
+      ..write(' THEN 0');
+    var tier = 0;
+    for (final dayId in priority.dayIds) {
+      variables.add(Variable<String>(dayId));
+      buffer
+        ..write(' WHEN day_id = ?')
+        ..write(variables.length)
+        ..write(' THEN ')
+        ..write(++tier);
+    }
+    buffer
+      ..write(' ELSE ')
+      ..write(tier + 1)
+      ..write(' END, ');
+    return buffer.toString();
   }
 
   /// Appends `kind IN (…)` to a query, extending [variables] in place so the

--- a/lib/features/daily_os_next/state/day_processing_runtime_provider.dart
+++ b/lib/features/daily_os_next/state/day_processing_runtime_provider.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
-
+import 'package:clock/clock.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/ai_chat/services/audio_transcription_service.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/daily_os_next/services/day_audio_review_fence.dart';
 import 'package:lotti/features/daily_os_next/services/day_audio_transcript_writer.dart';
@@ -15,6 +16,7 @@ import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repo
 import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_job_wiring.dart';
+import 'package:lotti/features/daily_os_next/state/selected_date_provider.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -42,6 +44,22 @@ dayProcessingOutboxProcessorProvider = Provider((ref) {
     // ADR 0032 §5: event-driven completion surface for jobs that finish
     // while the app is backgrounded — "your plan is ready" as an OS banner.
     onJobFinished: (job) => unawaited(planReadyNotifier.onJobFinished(job)),
+    // Claim the day the user is actually looking at first. `ref.read`, not
+    // `watch`: navigating between days must not tear down and rebuild the
+    // long-lived runtime, and the resolver runs per claim so the current
+    // selection is picked up on the next job either way.
+    priority: () {
+      final selected = ref.read(dailyOsNextSelectedDateProvider);
+      final today = clock.now();
+      return DayProcessingClaimPriority(
+        dayIds: [
+          dayAgentIdForDate(selected),
+          dayAgentIdForDate(today),
+          dayAgentIdForDate(today.add(const Duration(days: 1))),
+        ],
+        agingCutoff: today.subtract(dayProcessingPriorityAging),
+      );
+    },
     // Resolve the planner profile's transcription slot per attempt so a
     // configuration change between retries takes effect immediately;
     // discovery remains the fallback when no profile slot exists.

--- a/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
@@ -1031,4 +1031,134 @@ void main() {
       expect(events, 0);
     });
   });
+
+  group('priority-aware claiming (head-of-line blocking)', () {
+    /// Enqueues a parse job for [dayId]. Parse jobs carry no immutable-intent
+    /// constraints, so they are the cheapest way to build a multi-day queue.
+    Future<DayProcessingJob> queueFor(String dayId, String captureId) =>
+        repository.enqueueParseCapture(dayId: dayId, captureId: captureId);
+
+    DayProcessingClaimPriority priorityFor(
+      List<String> dayIds, {
+      Duration aging = dayProcessingPriorityAging,
+    }) => DayProcessingClaimPriority(
+      dayIds: dayIds,
+      agingCutoff: now.subtract(aging),
+    );
+
+    test('claims the viewed day ahead of an older unrelated day', () async {
+      // The unrelated day is enqueued first, so plain FIFO would take it.
+      await queueFor('dayplan-2026-07-25', 'cap-far');
+      now = now.add(const Duration(minutes: 1));
+      await queueFor('dayplan-2026-07-18', 'cap-viewed');
+
+      final claim = await repository.claimNext(
+        priority: priorityFor(['dayplan-2026-07-18']),
+      );
+
+      expect(claim!.job.id, 'parse_cap-viewed');
+    });
+
+    test('falls through the tiers in order', () async {
+      await queueFor('dayplan-2026-08-01', 'cap-other');
+      await queueFor('dayplan-2026-07-19', 'cap-tomorrow');
+      await queueFor('dayplan-2026-07-18', 'cap-today');
+      await queueFor('dayplan-2026-07-22', 'cap-viewed');
+
+      final order = <String>[];
+      for (var i = 0; i < 4; i++) {
+        final claim = await repository.claimNext(
+          priority: priorityFor([
+            'dayplan-2026-07-22',
+            'dayplan-2026-07-18',
+            'dayplan-2026-07-19',
+          ]),
+        );
+        order.add(claim!.job.id);
+        await repository.markSucceeded(
+          jobId: claim.job.id,
+          claimToken: claim.token,
+        );
+      }
+
+      expect(order, [
+        'parse_cap-viewed',
+        'parse_cap-today',
+        'parse_cap-tomorrow',
+        'parse_cap-other',
+      ]);
+    });
+
+    test('preserves same-day ordering within a tier', () async {
+      // The guarantee the single serial lane used to provide for free: a
+      // day's capture parse still runs before that day's draft.
+      await queueFor('dayplan-2026-07-18', 'cap-1');
+      now = now.add(const Duration(seconds: 30));
+      await repository.enqueueDraftPlan(
+        dayId: 'dayplan-2026-07-18',
+        payload: const DraftPlanPayload(),
+      );
+
+      final claim = await repository.claimNext(
+        priority: priorityFor(['dayplan-2026-07-18']),
+      );
+
+      expect(claim!.job.id, 'parse_cap-1');
+    });
+
+    test(
+      'a job that waited past the aging cutoff outranks the viewed day',
+      () async {
+        await queueFor('dayplan-2026-08-01', 'cap-stale');
+        now = now.add(dayProcessingPriorityAging + const Duration(minutes: 1));
+        await queueFor('dayplan-2026-07-18', 'cap-viewed');
+
+        final claim = await repository.claimNext(
+          priority: priorityFor(['dayplan-2026-07-18']),
+        );
+
+        expect(
+          claim!.job.id,
+          'parse_cap-stale',
+          reason: 'a busy foreground must not starve another day forever',
+        );
+      },
+    );
+
+    test('an empty priority list is plain FIFO', () async {
+      await queueFor('dayplan-2026-08-01', 'cap-first');
+      now = now.add(const Duration(minutes: 1));
+      await queueFor('dayplan-2026-07-18', 'cap-second');
+
+      final claim = await repository.claimNext(
+        priority: DayProcessingClaimPriority(
+          dayIds: const [],
+          agingCutoff: now,
+        ),
+      );
+
+      expect(claim!.job.id, 'parse_cap-first');
+    });
+
+    test('priority does not widen what is claimable', () async {
+      // A viewed-day job that is not due stays unclaimed; priority only
+      // reorders candidates, it never promotes one into the candidate set.
+      final job = await queueFor('dayplan-2026-07-18', 'cap-viewed');
+      final claim = await repository.claimById(job.id);
+      await repository.markFailure(
+        jobId: claim!.job.id,
+        claimToken: claim.token,
+        failureClass: DayProcessingFailureClass.providerBusy,
+        error: 'busy',
+        retryDelay: const Duration(minutes: 10),
+      );
+      await queueFor('dayplan-2026-08-01', 'cap-other');
+
+      final next = await repository.claimNext(
+        priority: priorityFor(['dayplan-2026-07-18']),
+      );
+
+      expect(next!.job.id, 'parse_cap-other');
+    });
+  });
 }

--- a/test/features/daily_os_next/state/day_processing_runtime_provider_test.dart
+++ b/test/features/daily_os_next/state/day_processing_runtime_provider_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai_chat/services/audio_transcription_service.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/daily_os_next/services/day_audio_transcript_writer.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
@@ -19,6 +20,7 @@ import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repo
 import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
 import 'package:lotti/features/daily_os_next/state/day_processing_runtime_provider.dart';
+import 'package:lotti/features/daily_os_next/state/selected_date_provider.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -387,4 +389,72 @@ void main() {
       expect(captured?.provider.id, 'p-profile');
     },
   );
+
+  test('the drain prioritises the day the user is looking at', () async {
+    final container = ProviderContainer(
+      overrides: [
+        audioTranscriptionServiceProvider.overrideWithValue(
+          MockAudioTranscriptionService(),
+        ),
+        ..._agentJobExecutorOverrides(),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // Enqueued first, so plain FIFO order would claim the unviewed day.
+    await outbox.enqueueParseCapture(
+      dayId: 'dayplan-2026-09-09',
+      captureId: 'cap-elsewhere',
+    );
+    await outbox.enqueueParseCapture(
+      dayId: dayAgentIdForDate(DateTime(2026, 7, 18)),
+      captureId: 'cap-viewed',
+    );
+    container
+        .read(dailyOsNextSelectedDateProvider.notifier)
+        .select(DateTime(2026, 7, 18));
+
+    final processor = container.read(dayProcessingOutboxProcessorProvider);
+    final priority = processor.priority!();
+
+    expect(
+      priority.dayIds.first,
+      dayAgentIdForDate(DateTime(2026, 7, 18)),
+      reason: 'the selected date leads the ordering',
+    );
+
+    // And the ordering it produces really does reach the repository.
+    final claim = await outbox.claimNext(priority: priority);
+    expect(claim!.job.id, 'parse_cap-viewed');
+  });
+
+  test('re-reads the selection per claim rather than at build time', () async {
+    final container = ProviderContainer(
+      overrides: [
+        audioTranscriptionServiceProvider.overrideWithValue(
+          MockAudioTranscriptionService(),
+        ),
+        ..._agentJobExecutorOverrides(),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final processor = container.read(dayProcessingOutboxProcessorProvider);
+    final before = processor.priority!().dayIds.first;
+
+    container
+        .read(dailyOsNextSelectedDateProvider.notifier)
+        .select(DateTime(2026, 11, 3));
+
+    // Same processor instance: navigating must not require rebuilding the
+    // long-lived runtime for the new day to win.
+    expect(
+      processor.priority!().dayIds.first,
+      isNot(before),
+    );
+    expect(
+      processor.priority!().dayIds.first,
+      dayAgentIdForDate(DateTime(2026, 11, 3)),
+    );
+  });
 }


### PR DESCRIPTION
Follow-up to #3564. Fixes head-of-line blocking in the processing outbox.

## The problem

All agent job kinds for all days share one serial drain lane
(`day_processing_runtime_provider.dart`), and `processNext` claimed strictly
the first due job. So recording a capture for today while a 30-second draft
for next Tuesday is mid-flight meant waiting behind a day you are not even
looking at. The worse the backlog, the worse the wait for the day that
actually matters.

## Why priority rather than parallelism

ADR 0032 framed cross-day parallelism as the answer. It is the wrong tool for
this case: the user is almost always waiting on exactly one day, and
concurrency does nothing for them — that day already runs at full speed.
Meanwhile the single lane is load-bearing, since it provides same-day
parse-before-draft ordering for free, and one model call at a time bounds
concurrent spend and rate-limit exposure.

Priority removes the pain in the common case without giving any of that up.
Per-day sub-lanes remain tracked separately for the bulk multi-day case
(returning from a weekend offline), gated on evidence that it is a real
problem.

## What changed

Claim order is tiered:

1. Anything enqueued before the aging cutoff (`dayProcessingPriorityAging`,
   15 minutes) — a busy foreground must not starve another day forever.
2. The day the user has selected.
3. Today, then tomorrow.
4. Everything else.

Ties fall through to the existing FIFO `(created_at, id)`, so ordering
*within* a day is unchanged — a capture's parse still runs before that day's
draft.

Priority is viewer-relative, so it cannot be a stored column: the answer
changes as the user navigates, and a column would have to be rewritten on
every move. It is a query-time `CASE` in the claim statement, evaluated over
the candidate set the pending partial index already bounds, so cost still
tracks outstanding work rather than history.

`DayProcessingOutboxProcessor.priority` is a resolver invoked **per claim**,
not per drain, reading `dailyOsNextSelectedDateProvider` via `ref.read` —
navigating takes effect on the very next job, and does not tear down and
rebuild the long-lived runtime.

## Testing

1902 tests pass; every changed line covered.

Repository-level: viewed day beats an older unrelated day, full tier
fall-through, same-day ordering preserved, aging cutoff outranks the viewed
day, empty priority list is plain FIFO, and priority never widens what is
claimable (a not-yet-due viewed-day job stays unclaimed).

Provider-level: the resolver leads with the selected date and reaches the
repository, and the same processor instance reflects a new selection without
being rebuilt.

No CHANGELOG entry — ordering within a background queue, with no
user-visible surface change beyond things arriving sooner.