### PR TITLE
Gate docs-site advisories on reachable fixes, not on npm audit alone

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Reject high-severity production advisories
         working-directory: lotti/docs-site
-        run: npm audit --omit=dev --audit-level=high
+        run: npm run audit:gate
 
       - name: Validate, test, type-check, and build
         working-directory: lotti/docs-site

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -128,6 +128,34 @@ from MDX with `ManualScreenshot`. Direct one-off app images are rejected: every
 displayed app screenshot must have the complete four-variant matrix in every
 manual locale.
 
+## Dependency advisories
+
+CI gates production dependencies with `npm run audit:gate`
+(`scripts/audit-gate.mjs`) rather than `npm audit --audit-level=high`
+directly. Same data and same threshold, with one addition: advisories listed
+in `audit-allowlist.json` are reported and skipped instead of failing.
+
+That exists because `npm audit` cannot express *"this advisory has no
+reachable fix"*. When an advisory's vulnerable range covers every published
+version of a transitive package, the audit fails on every branch indefinitely
+and no dependency change clears it — including the bump `npm audit fix
+--force` suggests. Failing forever teaches people to ignore the gate; a
+blanket `|| true` removes it. The allowlist keeps it meaningful:
+
+- An entry waives **one GHSA id**, not a package or a severity level.
+- Every entry needs a `reason` explaining why no fix is reachable, and an
+  `expires` date. Past that date the gate fails on the entry itself, so a
+  waiver cannot quietly become permanent.
+- Anything else at high or above still fails, including a new advisory on an
+  already-waived package.
+- Severity is judged per advisory root, not on npm's rolled-up parent
+  severity, so a moderate root never needs a waiver just because something
+  high sits elsewhere under the same parent.
+
+Before extending an expiry, re-check whether upstream has adopted a patched
+version. `tests/audit-gate.test.mjs` covers the logic against fixture reports
+and asserts the committed allowlist is justified, dated, and not expired.
+
 ## Release model
 
 For app version `1.0.0`, a release build must check out the app's `1.0.0` tag and

--- a/docs-site/audit-allowlist.json
+++ b/docs-site/audit-allowlist.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Advisories the docs site cannot currently resolve by any dependency change. Each entry must state why no fix is reachable and expire, so it fails the build rather than quietly becoming permanent. Re-check upstream before extending an expiry.",
+  "allow": [
+    {
+      "id": "GHSA-mh99-v99m-4gvg",
+      "package": "brace-expansion",
+      "reason": "Vulnerable range is <= 5.0.7, so every published version except 5.0.8 is flagged, and nothing in the tree depends on 5.0.8 yet. Reached only via @docusaurus/core -> serve-handler -> minimatch@3 -> brace-expansion@1.1.16. No fix is reachable: 1.x has no backport (tops out at 1.1.16), `npm audit fix --force` churns 357 packages and leaves the same 22 findings, and an override to ^5.0.8 breaks minimatch@3 at runtime because 5.x exports a named `expand` instead of a callable default. serve-handler backs `docusaurus serve` (local preview); the deployed artifact is a static site that never runs it.",
+      "expires": "2026-10-01"
+    }
+  ]
+}

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "audit:gate": "node scripts/audit-gate.mjs",
     "build": "docusaurus build",
     "check": "npm run typecheck && npm run validate && npm run test && npm run build && npm run smoke",
     "clear": "docusaurus clear",

--- a/docs-site/scripts/audit-gate-lib.mjs
+++ b/docs-site/scripts/audit-gate-lib.mjs
@@ -1,0 +1,77 @@
+// Pure evaluation logic for the production-advisory gate, kept apart from the
+// CLI so it can be tested against fixture reports instead of the live registry.
+
+export const SEVERITY_ORDER = ['info', 'low', 'moderate', 'high', 'critical'];
+
+export function atLeastSeverity(severity, threshold) {
+  return (
+    SEVERITY_ORDER.indexOf(severity) >= SEVERITY_ORDER.indexOf(threshold)
+  );
+}
+
+/// The root advisories a package is flagged for, as id -> severity, following
+/// npm's `via` chain.
+///
+/// npm reports the package that actually carries an advisory with an advisory
+/// object, and every dependent of it with a bare package *name*; it also rolls
+/// a dependent's severity up to the worst anywhere beneath it. So a parent
+/// shows as `high` even when its only high-severity root is several levels
+/// down and its other roots are moderate.
+///
+/// Resolving to roots keeps two things honest: one root advisory stops looking
+/// like eighteen unrelated findings, and the threshold gets applied to each
+/// root's real severity rather than to a rolled-up parent.
+export function advisoryRoots(report, name, seen = new Set()) {
+  if (seen.has(name)) return new Map();
+  seen.add(name);
+
+  const roots = new Map();
+  for (const via of report.vulnerabilities?.[name]?.via ?? []) {
+    if (typeof via === 'string') {
+      for (const [id, severity] of advisoryRoots(report, via, seen)) {
+        roots.set(id, severity);
+      }
+    } else if (via?.url) {
+      const match = /GHSA-[\w-]+/.exec(via.url);
+      if (match) roots.set(match[0], via.severity ?? 'high');
+    }
+  }
+  return roots;
+}
+
+/// Entries whose justification has run out. An exception that outlives its
+/// expiry fails the build rather than quietly becoming permanent.
+export function expiredEntries(allowlist, now = new Date()) {
+  return (allowlist.allow ?? []).filter(
+    (entry) => new Date(entry.expires) < now,
+  );
+}
+
+/// Splits packages into waived and blocking, judging each advisory root on its
+/// own severity. Returns `{ waived, blocking }` of display strings.
+export function evaluate(report, allowlist, threshold = 'high') {
+  const allowed = new Set((allowlist.allow ?? []).map((entry) => entry.id));
+  const waived = [];
+  const blocking = [];
+
+  for (const [name, advisory] of Object.entries(report.vulnerabilities ?? {})) {
+    if (!atLeastSeverity(advisory.severity, threshold)) continue;
+
+    const roots = advisoryRoots(report, name);
+    const atThreshold = [...roots]
+      .filter(([, severity]) => atLeastSeverity(severity, threshold))
+      .map(([id]) => id);
+
+    // Rolled up from something below the threshold; not this gate's business.
+    if (atThreshold.length === 0) continue;
+
+    const unwaived = atThreshold.filter((id) => !allowed.has(id));
+    if (unwaived.length === 0) {
+      waived.push(`${name} (${atThreshold.join(', ')})`);
+    } else {
+      blocking.push(`${name} [${advisory.severity}] ${unwaived.join(', ')}`);
+    }
+  }
+
+  return { waived, blocking };
+}

--- a/docs-site/scripts/audit-gate.mjs
+++ b/docs-site/scripts/audit-gate.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Production-dependency advisory gate.
+//
+// `npm audit --audit-level=high` cannot express "this advisory has no
+// reachable fix yet". When an advisory's vulnerable range covers every
+// published version of a transitive package, the audit fails on every branch,
+// forever, and no dependency change clears it — `npm audit fix --force`
+// included. Left alone that blocks every merge; silenced with `|| true` it
+// stops catching anything.
+//
+// So: same data, same threshold, but advisories listed in
+// `audit-allowlist.json` are reported and skipped rather than failing the
+// build, and each entry must carry a reason and an expiry — after which this
+// fails on the entry itself. An exception that outlives its justification
+// becomes a build failure instead of a habit.
+
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { evaluate, expiredEntries } from './audit-gate-lib.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const siteRoot = resolve(here, '..');
+const allowlistPath = resolve(siteRoot, 'audit-allowlist.json');
+const THRESHOLD = 'high';
+
+/// `npm audit` exits non-zero whenever it finds anything at its own threshold,
+/// so a non-zero exit is expected — the JSON on stdout is the result. Only a
+/// missing or unparseable report is a real failure.
+function runAudit() {
+  return new Promise((resolvePromise, reject) => {
+    execFile(
+      'npm',
+      ['audit', '--json', '--omit=dev'],
+      { cwd: siteRoot, maxBuffer: 32 * 1024 * 1024 },
+      (error, stdout) => {
+        if (!stdout) {
+          reject(error ?? new Error('npm audit produced no output'));
+          return;
+        }
+        try {
+          resolvePromise(JSON.parse(stdout));
+        } catch (parseError) {
+          reject(parseError);
+        }
+      },
+    );
+  });
+}
+
+async function readAllowlist() {
+  try {
+    return JSON.parse(await readFile(allowlistPath, 'utf8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') return { allow: [] };
+    throw error;
+  }
+}
+
+const [report, allowlist] = await Promise.all([runAudit(), readAllowlist()]);
+
+const expired = expiredEntries(allowlist);
+if (expired.length > 0) {
+  console.error('Audit allowlist entries have expired — re-check upstream:');
+  for (const entry of expired) {
+    console.error(`  ${entry.id} expired ${entry.expires}: ${entry.reason}`);
+  }
+  process.exit(1);
+}
+
+const { waived, blocking } = evaluate(report, allowlist, THRESHOLD);
+
+if (waived.length > 0) {
+  console.log(`Waived ${waived.length} allowlisted advisory path(s):`);
+  for (const line of waived) console.log(`  ${line}`);
+}
+
+if (blocking.length > 0) {
+  console.error(
+    `\n${blocking.length} production advisory path(s) at ${THRESHOLD}+ with no allowlist entry:`,
+  );
+  for (const line of blocking) console.error(`  ${line}`);
+  console.error(
+    '\nFix them, or add a justified, dated entry to audit-allowlist.json.',
+  );
+  process.exit(1);
+}
+
+console.log(`No unwaived production advisories at ${THRESHOLD} or above.`);

--- a/docs-site/tests/audit-gate.test.mjs
+++ b/docs-site/tests/audit-gate.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+
+import {
+  advisoryRoots,
+  evaluate,
+  expiredEntries,
+} from '../scripts/audit-gate-lib.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/// Mirrors the shape npm emits: the package carrying an advisory has an
+/// advisory object in `via`; each dependent names the package it is vulnerable
+/// through, and inherits the worst severity beneath it.
+const report = {
+  vulnerabilities: {
+    'brace-expansion': {
+      severity: 'high',
+      via: [
+        {
+          source: 1,
+          url: 'https://github.com/advisories/GHSA-mh99-v99m-4gvg',
+          severity: 'high',
+        },
+      ],
+    },
+    uuid: {
+      severity: 'moderate',
+      via: [
+        {
+          source: 2,
+          url: 'https://github.com/advisories/GHSA-w5hq-g745-h8pq',
+          severity: 'moderate',
+        },
+      ],
+    },
+    minimatch: { severity: 'high', via: ['brace-expansion'] },
+    'serve-handler': { severity: 'high', via: ['minimatch'] },
+    sockjs: { severity: 'moderate', via: ['uuid'] },
+    // Rolled up to high by brace-expansion, but also carries a moderate root.
+    '@docusaurus/core': { severity: 'high', via: ['serve-handler', 'sockjs'] },
+  },
+};
+
+const allowBraceExpansion = {
+  allow: [
+    {
+      id: 'GHSA-mh99-v99m-4gvg',
+      reason: 'no reachable fix',
+      expires: '2999-01-01',
+    },
+  ],
+};
+
+test('resolves a dependent to the root advisories it is vulnerable through', () => {
+  assert.deepEqual(
+    [...advisoryRoots(report, '@docusaurus/core')].sort(),
+    [
+      ['GHSA-mh99-v99m-4gvg', 'high'],
+      ['GHSA-w5hq-g745-h8pq', 'moderate'],
+    ].sort(),
+  );
+});
+
+test('allowlisting one root waives every package flagged only through it', () => {
+  const { waived, blocking } = evaluate(report, allowBraceExpansion);
+
+  assert.deepEqual(blocking, []);
+  // The moderate uuid root neither blocks nor needs an allowlist entry.
+  assert.ok(waived.some((line) => line.startsWith('@docusaurus/core')));
+  assert.ok(waived.some((line) => line.startsWith('brace-expansion')));
+});
+
+test('an unlisted high advisory still blocks — the gate is not a no-op', () => {
+  const { blocking } = evaluate(report, { allow: [] });
+
+  assert.ok(blocking.length > 0);
+  assert.ok(blocking.every((line) => line.includes('GHSA-mh99-v99m-4gvg')));
+});
+
+test('a new high advisory blocks even while another is waived', () => {
+  const withNewFinding = {
+    vulnerabilities: {
+      ...report.vulnerabilities,
+      'something-else': {
+        severity: 'critical',
+        via: [
+          {
+            url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
+            severity: 'critical',
+          },
+        ],
+      },
+    },
+  };
+
+  const { blocking } = evaluate(withNewFinding, allowBraceExpansion);
+  assert.deepEqual(blocking, [
+    'something-else [critical] GHSA-aaaa-bbbb-cccc',
+  ]);
+});
+
+test('a moderate-only advisory never blocks at the high threshold', () => {
+  const moderateOnly = {
+    vulnerabilities: {
+      uuid: report.vulnerabilities.uuid,
+      sockjs: report.vulnerabilities.sockjs,
+    },
+  };
+
+  const { waived, blocking } = evaluate(moderateOnly, { allow: [] });
+  assert.deepEqual(blocking, []);
+  assert.deepEqual(waived, []);
+});
+
+test('an expired entry is reported so a waiver cannot outlive its reason', () => {
+  const expired = expiredEntries({
+    allow: [{ id: 'GHSA-x', reason: 'stale', expires: '2020-01-01' }],
+  });
+  assert.equal(expired.length, 1);
+
+  assert.deepEqual(expiredEntries(allowBraceExpansion), []);
+});
+
+test('the committed allowlist is valid and every entry is justified and dated', async () => {
+  const allowlist = JSON.parse(
+    await readFile(resolve(here, '..', 'audit-allowlist.json'), 'utf8'),
+  );
+
+  assert.ok(Array.isArray(allowlist.allow));
+  for (const entry of allowlist.allow) {
+    assert.match(entry.id, /^GHSA-[\w-]+$/, 'entry needs a GHSA id');
+    assert.ok(entry.reason?.length > 40, `${entry.id} needs a real reason`);
+    assert.ok(
+      !Number.isNaN(new Date(entry.expires).getTime()),
+      `${entry.id} needs a parseable expiry`,
+    );
+  }
+  // Committed entries must not already be expired, or CI is red on arrival.
+  assert.deepEqual(expiredEntries(allowlist), []);
+});


### PR DESCRIPTION
Fixes `lotti3-5a9`. The docs-site audit step has failed on **every branch,
including `main`**, since 2026-07-24 — with no code change involved.

## Why it started failing

`npm audit` queries the live advisory database at run time, so an unchanged
lockfile flips from pass to fail purely with the clock:

| | |
|---|---|
| `main`'s last passing run of this job | 20:42:48Z |
| GHSA-mh99-v99m-4gvg published | **21:53:14Z** |
| First failing PR run | 22:15:56Z |

`package.json` and `package-lock.json` were byte-identical across all three.

## Why no dependency change fixes it

This is the part that matters, and it is why the PR does not simply bump
something:

- The advisory's vulnerable range is **`<= 5.0.7`**, so every published
  `brace-expansion` *except* `5.0.8` is flagged — and nothing in the tree
  depends on `5.0.8`.
- The `1.x` line has no backport; it tops out at `1.1.16`, which is what we
  resolve to via `@docusaurus/core → serve-handler → minimatch@3`.
- **`npm audit fix --force` does not fix it.** npm suggests a breaking bump of
  `@easyops-cn/docusaurus-search-local`; I ran it — it changes 357 packages
  and leaves *the same 22 findings*.
- **Forcing an override to `^5.0.8` resolves the audit and breaks the site.**
  `brace-expansion@5` exports a named `expand` instead of a callable default,
  so `minimatch@3` throws `TypeError: expand is not a function` on the first
  brace pattern. Verified before discarding the approach — it would have
  merged green and broken `docusaurus serve`.

So the finding is not *unfixed*, it is currently *unfixable*. Failing forever
teaches people to ignore the gate; `|| true` deletes it.

## What this does instead

`npm run audit:gate` reads the same report at the same threshold, but
advisories listed in `audit-allowlist.json` are reported and skipped:

- An entry waives **one GHSA id** — not a package, not a severity level.
- Every entry must state **why no fix is reachable**, and carry an **expiry**.
  Past that date the gate fails *on the entry itself*, so a waiver cannot
  quietly become permanent.
- Anything else at high or above still fails, **including a new advisory on an
  already-waived package**.
- Severity is judged **per advisory root**, not on npm's rolled-up parent
  severity. Without that, one high root makes sixteen parents look high and
  drags their unrelated moderate roots along — a moderate `uuid` finding would
  have needed a waiver it does not deserve.

## Proving it is not a no-op

A gate that cannot fail is worse than no gate, so this is tested four ways —
each asserted to **fail**:

| Scenario | Result |
|---|---|
| Empty allowlist | fails |
| Entry with a past expiry | fails, naming the entry |
| Entry with the wrong GHSA id | fails |
| A new critical advisory alongside a waived one | fails on the new one only |
| Committed allowlist, real registry data | passes |

`tests/audit-gate.test.mjs` covers the logic against fixture reports and
additionally asserts the committed allowlist is justified, dated, and not
already expired.

## Scope

- **No dependency changes.** `package-lock.json` diff is 0 lines; the only
  `package.json` change is the new script.
- Full `npm run check` passes locally: typecheck, validate, tests, build
  across all 11 locales, and the built-site smoke test.

The waiver expires **2026-10-01**. Before extending it, re-check whether
`minimatch`/`serve-handler` have adopted `brace-expansion@5.0.8`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production dependency audit gate that detects high- and critical-severity advisories.
  * Added controlled advisory allowlisting with required explanations and expiration dates.
  * Added an allowlisted exception for a documented `brace-expansion` advisory.

* **Documentation**
  * Documented audit checks, waiver requirements, expiry handling, and failure conditions.

* **Tests**
  * Added coverage for advisory resolution, allowlists, severity thresholds, expiry validation, and blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->