### PR TITLE
perf: make day-scoped capture and status-event reads indexed

### DIFF
--- a/lib/classes/day_plan.dart
+++ b/lib/classes/day_plan.dart
@@ -8,6 +8,24 @@ part 'day_plan.g.dart';
 String dayPlanId(DateTime date) =>
     'dayplan-${date.toIso8601String().substring(0, 10)}';
 
+/// Normalizes [date] to the local calendar day used by DayPlan IDs.
+///
+/// Converts to local time first so a UTC-typed [date] (e.g. a timestamp
+/// deserialized as UTC) is bucketed to the user's actual local calendar day
+/// rather than the UTC day, which would shift near midnight. A no-op for the
+/// already-local timestamps the app produces via `clock.now()`.
+DateTime localDay(DateTime date) {
+  final local = date.toLocal();
+  return DateTime(local.year, local.month, local.day);
+}
+
+/// Stable day-agent subject ID for a local calendar [date].
+///
+/// Lives here rather than with the Daily OS slot helpers because the agent
+/// persistence layer derives a capture's day workspace when writing its
+/// indexed subtype, and must not depend on a feature package.
+String dayAgentIdForDate(DateTime date) => dayPlanId(localDay(date));
+
 /// Reasons why a day plan needs review after being agreed.
 enum DayPlanReviewReason {
   /// A task with due date was added for this day

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
-
 import 'package:drift/drift.dart';
 import 'package:lotti/database/common.dart';
+import 'package:lotti/features/agents/database/agent_db_conversions.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 
 part 'agent_database.g.dart';
 
@@ -30,7 +32,55 @@ class AgentDatabase extends _$AgentDatabase {
   final bool inMemoryDatabase;
 
   @override
-  int get schemaVersion => 16;
+  int get schemaVersion => 17;
+
+  /// Re-derives `subtype` for the entity types that became day-scoped.
+  ///
+  /// `capture` used to store the capture's own id (redundant with the primary
+  /// key) and `dayStatusEvent` its status name, so neither could serve a
+  /// day-scoped read and both were loaded whole and filtered in Dart. Both now
+  /// store the day workspace, which `idx_agent_entities_agent_type_sub`
+  /// already indexes.
+  ///
+  /// Deliberately run through the Dart projection rather than as a SQL
+  /// `UPDATE … json_extract(…)`: a capture with no `dayId` derives its day
+  /// from `capturedAt` **in local time**, and the backfill must agree with the
+  /// writer exactly. A row whose subtype disagreed would simply go missing
+  /// from its day.
+  Future<void> _backfillDayScopedSubtypes() async {
+    const types = <String>[
+      AgentEntityTypes.capture,
+      AgentEntityTypes.dayStatusEvent,
+    ];
+    for (final type in types) {
+      final rows = await customSelect(
+        'SELECT id, serialized FROM agent_entities WHERE type = ?1',
+        variables: [Variable.withString(type)],
+      ).get();
+      for (final row in rows) {
+        final AgentDomainEntity entity;
+        try {
+          entity = AgentDbConversions.fromSerialized(
+            row.read<String>('serialized'),
+          );
+        } catch (_) {
+          // A row that cannot be decoded cannot be read by the app either;
+          // leaving its stale subtype behind is strictly better than aborting
+          // the upgrade for every other row.
+          continue;
+        }
+        final subtype = AgentDbConversions.entitySubtype(entity);
+        if (subtype == null) continue;
+        await customUpdate(
+          'UPDATE agent_entities SET subtype = ?1 WHERE id = ?2',
+          variables: [
+            Variable.withString(subtype),
+            Variable.withString(row.read<String>('id')),
+          ],
+        );
+      }
+    }
+  }
 
   @override
   MigrationStrategy get migration {
@@ -378,6 +428,10 @@ class AgentDatabase extends _$AgentDatabase {
             r"AND json_extract(serialized, '$.status') = 'pending' "
             r"AND json_extract(serialized, '$.scheduledAt') IS NOT NULL",
           );
+          await customStatement('ANALYZE');
+        }
+        if (from < 17) {
+          await _backfillDayScopedSubtypes();
           await customStatement('ANALYZE');
         }
       },

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -5,6 +5,7 @@ import 'package:lotti/database/common.dart';
 import 'package:lotti/features/agents/database/agent_db_conversions.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:meta/meta.dart';
 
 part 'agent_database.g.dart';
 
@@ -47,7 +48,8 @@ class AgentDatabase extends _$AgentDatabase {
   /// from `capturedAt` **in local time**, and the backfill must agree with the
   /// writer exactly. A row whose subtype disagreed would simply go missing
   /// from its day.
-  Future<void> _backfillDayScopedSubtypes() async {
+  @visibleForTesting
+  Future<void> backfillDayScopedSubtypes() async {
     const types = <String>[
       AgentEntityTypes.capture,
       AgentEntityTypes.dayStatusEvent,
@@ -431,7 +433,7 @@ class AgentDatabase extends _$AgentDatabase {
           await customStatement('ANALYZE');
         }
         if (from < 17) {
-          await _backfillDayScopedSubtypes();
+          await backfillDayScopedSubtypes();
           await customStatement('ANALYZE');
         }
       },

--- a/lib/features/agents/database/agent_db_conversions.dart
+++ b/lib/features/agents/database/agent_db_conversions.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-
 import 'package:drift/drift.dart';
+import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -108,8 +108,17 @@ class AgentDbConversions {
   /// - `AgentStateEntity` counters: legacy scalar `wakeCounter` /
   ///   `totalSessionsCompleted` / `weeklyReviewCount` seeded into their per-host
   ///   `*ByHost` G-counter maps (see [_migrateGCounters]).
-  static AgentDomainEntity fromEntityRow(AgentEntity row) {
-    final json = jsonDecode(row.serialized) as Map<String, dynamic>;
+  static AgentDomainEntity fromEntityRow(AgentEntity row) =>
+      fromSerialized(row.serialized);
+
+  /// Decodes the stored payload, applying the same in-place format
+  /// migrations [fromEntityRow] does.
+  ///
+  /// Exposed for schema migrations that re-derive projected columns and must
+  /// use the identical decode path, so a backfilled value can never disagree
+  /// with what the writer would produce.
+  static AgentDomainEntity fromSerialized(String serialized) {
+    final json = jsonDecode(serialized) as Map<String, dynamic>;
     _migrateReportContent(json);
     _migrateGCounters(json);
     return AgentDomainEntity.fromJson(json);
@@ -269,12 +278,20 @@ class AgentDbConversions {
       agentReportHead: (head) => head.scope,
       scheduledWake: (wake) => wake.status.name,
       plannerKnowledge: (k) => k.key,
-      capture: (capture) => capture.id,
+      // The day workspace, not the capture's own id (which the primary key
+      // already carries): this is what makes a day-scoped read of a busy
+      // agent's captures an indexed lookup instead of a full scan. Derived
+      // for captures synced from peers old enough to carry no dayId.
+      capture: (capture) => capture.dayId.isNotEmpty
+          ? capture.dayId
+          : dayAgentIdForDate(capture.capturedAt),
       parsedItem: (item) => item.kind.name,
       dayPlan: (plan) => plan.dayId,
       daySummary: (e) => e.dayId,
       dayDirective: (e) => e.dayId,
-      dayStatusEvent: (e) => e.status.name,
+      // The day, not the status: status events are the fastest-growing entity
+      // type here and are always read day-scoped.
+      dayStatusEvent: (e) => e.dayId,
       attentionRequest: (request) => request.scopeKind.name,
       attentionClaimDisposition: (disposition) => disposition.requestId,
       attentionAward: (award) => award.dayId,

--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -192,6 +192,25 @@ class AgentRepoCore {
   ///
   /// Results are always sorted newest-first (`created_at DESC`). Pass [limit]
   /// to cap the number of rows returned (defaults to unlimited).
+  /// Entities of [type] for [agentId] narrowed to one [subtype].
+  ///
+  /// Served by `idx_agent_entities_agent_type_sub`, so cost tracks the rows
+  /// actually returned rather than everything the agent owns. This is what
+  /// makes a day-scoped read of a long-lived agent's captures or status
+  /// events viable — the alternative is loading the agent's whole history and
+  /// filtering in Dart.
+  Future<List<AgentDomainEntity>> getEntitiesByAgentIdAndSubtype(
+    String agentId, {
+    required String type,
+    required String subtype,
+    int limit = -1,
+  }) async {
+    final rows = await _db
+        .getAgentEntitiesByTypeAndSubtype(agentId, type, subtype, limit)
+        .get();
+    return rows.map(AgentDbConversions.fromEntityRow).toList();
+  }
+
   Future<List<AgentDomainEntity>> getEntitiesByAgentId(
     String agentId, {
     String? type,

--- a/lib/features/agents/database/agent_repository.dart
+++ b/lib/features/agents/database/agent_repository.dart
@@ -111,6 +111,20 @@ class AgentRepository {
     int limit = -1,
   }) => _core.getEntitiesByAgentId(agentId, type: type, limit: limit);
 
+  /// Entities of [type] for [agentId] narrowed to one [subtype], served by the
+  /// `(agent_id, type, subtype, …)` index.
+  Future<List<AgentDomainEntity>> getEntitiesByAgentIdAndSubtype(
+    String agentId, {
+    required String type,
+    required String subtype,
+    int limit = -1,
+  }) => _core.getEntitiesByAgentIdAndSubtype(
+    agentId,
+    type: type,
+    subtype: subtype,
+    limit: limit,
+  );
+
   Future<
     List<
       ({

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -250,6 +250,29 @@ device-local processing outbox that transcription uses (`services/day_processing
 a sealed `DayProcessingPayload` per kind (`TranscribeAudioPayload`,
 `ParseCapturePayload`, `DraftPlanPayload`, `RefinePlanPayload`).
 
+### Day-scoped agent reads
+
+Opening a day used to load **every** capture and **every** day-status event the
+owning agent had ever recorded and filter them in Dart. That cost grew with the
+user's whole history on the main day surface, and it bit hardest on
+planner-owned days: a `day_agent:<dayId>` is self-limiting by construction,
+but the coordinator accumulates forever and owns every pre-cutover day.
+
+The cause was the projected `subtype` column. `capture` stored the capture's
+own id (redundant with the primary key) and `dayStatusEvent` its status name,
+so neither could serve a day-scoped query — while `dayPlan`/`daySummary`/
+`dayDirective` already stored the day and were indexed. Both now store the day
+workspace, so `capturesForDateProvider` and `dayAgentPersonaStateProvider` read
+through `idx_agent_entities_agent_type_sub` instead of scanning.
+
+A capture that carries no explicit `dayId` (synced from a peer old enough to
+predate it) derives one from `capturedAt` in local time, the same rule
+`captureDayId` applies on read — so legacy rows land on the right day rather
+than needing a Dart-side fallback scan. Schema v17 backfills existing rows
+through that same Dart projection rather than a SQL `json_extract` update,
+because a backfilled value that disagreed with the writer would silently drop
+rows out of their day.
+
 ### Outbox storage: a device-local table (ADR 0044)
 
 The outbox is a table in its own database (`database/day_processing_db.drift`,

--- a/lib/features/daily_os_next/agents/domain/day_agent_identity.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_identity.dart
@@ -1,5 +1,4 @@
 import 'package:lotti/classes/day_plan.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 
 /// Deterministic identity id of the Daily OS coordinator (ADR 0022/0032).
 ///

--- a/lib/features/daily_os_next/agents/domain/day_agent_slots.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_slots.dart
@@ -2,25 +2,16 @@ import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 
+// Re-exported so the many Daily OS call sites that reach for these through
+// the slot helpers keep working; they now live beside dayPlanId so the agent
+// persistence layer can derive a capture's day without depending on a feature.
+export 'package:lotti/classes/day_plan.dart' show dayAgentIdForDate, localDay;
+
 /// Slot helpers for day-agent identities.
 extension DayAgentSlots on AgentSlots {
   /// Whether this state is bound to a Daily OS day plan.
   bool get hasActiveDay => activeDayId != null && activeDayId!.isNotEmpty;
 }
-
-/// Normalizes [date] to the local calendar day used by DayPlan IDs.
-///
-/// Converts to local time first so a UTC-typed [date] (e.g. a timestamp
-/// deserialized as UTC) is bucketed to the user's actual local calendar day
-/// rather than the UTC day, which would shift near midnight. A no-op for the
-/// already-local timestamps the app produces via `clock.now()`.
-DateTime localDay(DateTime date) {
-  final local = date.toLocal();
-  return DateTime(local.year, local.month, local.day);
-}
-
-/// Stable day-agent subject ID for a local calendar [date].
-String dayAgentIdForDate(DateTime date) => dayPlanId(localDay(date));
 
 /// Day workspace a capture belongs to (ADR 0022), derived-on-read.
 ///

--- a/lib/features/daily_os_next/agents/domain/week_context.dart
+++ b/lib/features/daily_os_next/agents/domain/week_context.dart
@@ -1,6 +1,5 @@
 import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/prompt/day_agent_prompt_sections.dart';
 
 /// Pure renderer for the planner's week context: the `<recent_days>` and

--- a/lib/features/daily_os_next/agents/domain/week_rollup.dart
+++ b/lib/features/daily_os_next/agents/domain/week_rollup.dart
@@ -10,7 +10,6 @@ library;
 
 import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/week_context.dart';
 import 'package:lotti/features/daily_os_next/agents/prompt/day_agent_prompt_sections.dart';
 

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_diff.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_diff.dart
@@ -2,7 +2,6 @@ import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart'
     show DayAgentCaptureException;
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_parser.dart';

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_parser.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_parser.dart
@@ -2,7 +2,6 @@ import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_plan_models.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart'
     show DayAgentCaptureException;
 import 'package:uuid/uuid.dart';

--- a/lib/features/daily_os_next/logic/real_day_agent.dart
+++ b/lib/features/daily_os_next/logic/real_day_agent.dart
@@ -10,7 +10,6 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_plan_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';

--- a/lib/features/daily_os_next/state/day_agent_persona_provider.dart
+++ b/lib/features/daily_os_next/state/day_agent_persona_provider.dart
@@ -55,9 +55,12 @@ final dayAgentPersonaStateProvider = FutureProvider.autoDispose
       );
       if (owner is! AgentIdentityEntity) return DayAgentPersonaState.idle;
       final repository = ref.watch(agentRepositoryProvider);
-      final rows = await repository.getEntitiesByAgentId(
+      // Day-scoped and indexed: status events are the fastest-growing entity
+      // the day surface reads, and this provider runs on every day view.
+      final rows = await repository.getEntitiesByAgentIdAndSubtype(
         owner.agentId,
         type: AgentEntityTypes.dayStatusEvent,
+        subtype: dayId,
       );
       DayStatusEventEntity? newest;
       for (final row in rows) {

--- a/lib/features/daily_os_next/state/day_agent_provider.dart
+++ b/lib/features/daily_os_next/state/day_agent_provider.dart
@@ -156,14 +156,16 @@ final capturesForDateProvider = FutureProvider.autoDispose
       final agentIds = <String>{agent.agentId, dailyOsPlannerAgentId};
       final rows = <AgentDomainEntity>[
         for (final agentId in agentIds)
-          ...await agentRepository.getEntitiesByAgentId(
+          ...await agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: dayId,
           ),
       ];
-      // Day-scope the list: an owner can hold many days' captures (the
-      // coordinator always does), so filter to this date's workspace.
-      // captureDayId derives the day for legacy captures with no dayId.
+      // The subtype filter above already scopes to this day (the stored
+      // subtype is derived by captureDayId's rule, so legacy captures with no
+      // dayId land on the right day too). captureDayId stays as a belt-and-
+      // braces check against a row whose subtype predates the backfill.
       final seenIds = <String>{};
       final captures = rows
           .whereType<CaptureEntity>()

--- a/test/features/agents/database/agent_db_conversions_test.dart
+++ b/test/features/agents/database/agent_db_conversions_test.dart
@@ -403,7 +403,7 @@ void main() {
   });
 
   group('AgentDbConversions — Daily OS capture reconcile variants', () {
-    test('toEntityCompanion writes capture type and timestamps', () {
+    test('toEntityCompanion writes capture type, day subtype, timestamps', () {
       final entity = AgentDomainEntity.capture(
         id: 'capture-001',
         agentId: agentId,
@@ -417,9 +417,30 @@ void main() {
 
       expect(companion.id, const Value('capture-001'));
       expect(companion.type, const Value(AgentEntityTypes.capture));
-      expect(companion.subtype, const Value('capture-001'));
+      // The day workspace, not the capture id: this is the key a day-scoped
+      // read indexes on. Derived from capturedAt because this capture carries
+      // no explicit dayId, exactly as captureDayId would.
+      expect(companion.subtype, const Value('dayplan-2026-02-21'));
       expect(companion.createdAt, Value(createdAt));
       expect(companion.updatedAt, Value(createdAt));
+    });
+
+    test('an explicit capture dayId wins over the derived one', () {
+      final entity = AgentDomainEntity.capture(
+        id: 'capture-002',
+        agentId: agentId,
+        transcript: 'Prep demo',
+        capturedAt: DateTime(2026, 2, 21, 8, 15),
+        createdAt: createdAt,
+        dayId: 'dayplan-2026-02-20',
+        vectorClock: null,
+      );
+
+      final companion = AgentDbConversions.toEntityCompanion(entity);
+
+      // A capture recorded after midnight can still belong to the previous
+      // planning day; the stored day must follow the capture, not the clock.
+      expect(companion.subtype, const Value('dayplan-2026-02-20'));
     });
 
     test('fromEntityRow roundtrips parsedItem variant', () {
@@ -603,15 +624,16 @@ void main() {
       expect(companion.updatedAt, Value(updatedAt));
     });
 
-    test('dayStatusEvent writes type and status-name subtype', () {
+    test('dayStatusEvent writes type and day subtype', () {
       final entity = makeTestDayStatusEvent(createdAt: createdAt);
 
       final companion = AgentDbConversions.toEntityCompanion(entity);
 
       expect(companion.type, const Value(AgentEntityTypes.dayStatusEvent));
-      // Subtype is the status name so a filtered scan (e.g. only
-      // attentionNeeded) can use the type+subtype index.
-      expect(companion.subtype, const Value('attentionNeeded'));
+      // Subtype is the day, so the persona provider's per-day read uses the
+      // type+subtype index instead of scanning every event the agent ever
+      // raised.
+      expect(companion.subtype, const Value('dayplan-2026-05-25'));
       expect(companion.createdAt, Value(createdAt));
       // Append-only variant: updated_at mirrors created_at.
       expect(companion.updatedAt, Value(createdAt));

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Variable;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/database/agent_attention_projection.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
@@ -305,6 +308,149 @@ void main() {
       );
 
       expect(rows.whereType<CaptureEntity>().single.id, 'capture-legacy');
+    });
+  });
+
+  group('schema v17 day-subtype backfill', () {
+    /// Writes a row straight to the table with a pre-v17 subtype, bypassing
+    /// the conversion layer that would now derive the day.
+    Future<void> insertStale({
+      required String id,
+      required String type,
+      required String subtype,
+      required String serialized,
+    }) => db.customInsert(
+      'INSERT INTO agent_entities '
+      '(id, agent_id, type, subtype, created_at, updated_at, serialized) '
+      'VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6)',
+      variables: [
+        Variable.withString(id),
+        Variable.withString('daily_os_planner'),
+        Variable.withString(type),
+        Variable.withString(subtype),
+        Variable.withDateTime(DateTime(2026, 5, 25, 9)),
+        Variable.withString(serialized),
+      ],
+    );
+
+    Future<String?> subtypeOf(String id) async {
+      final rows = await db
+          .customSelect(
+            'SELECT subtype FROM agent_entities WHERE id = ?1',
+            variables: [Variable.withString(id)],
+          )
+          .get();
+      return rows.single.readNullable<String>('subtype');
+    }
+
+    test('rewrites a capture from its own id to its day', () async {
+      final capture = AgentDomainEntity.capture(
+        id: 'capture-1',
+        agentId: 'daily_os_planner',
+        transcript: 'note',
+        capturedAt: DateTime(2026, 5, 25, 9),
+        createdAt: DateTime(2026, 5, 25, 9),
+        dayId: 'dayplan-2026-05-25',
+        vectorClock: null,
+      );
+      await insertStale(
+        id: 'capture-1',
+        type: AgentEntityTypes.capture,
+        subtype: 'capture-1',
+        serialized: jsonEncode(capture.toJson()),
+      );
+
+      await db.backfillDayScopedSubtypes();
+
+      expect(await subtypeOf('capture-1'), 'dayplan-2026-05-25');
+      // And the point of the rewrite: the day-scoped read now finds it.
+      final rows = await core.getEntitiesByAgentIdAndSubtype(
+        'daily_os_planner',
+        type: AgentEntityTypes.capture,
+        subtype: 'dayplan-2026-05-25',
+      );
+      expect(rows.single.id, 'capture-1');
+    });
+
+    test('derives the day for a legacy capture with no dayId', () async {
+      final capture = AgentDomainEntity.capture(
+        id: 'capture-legacy',
+        agentId: 'daily_os_planner',
+        transcript: 'from an old peer',
+        capturedAt: DateTime(2026, 5, 25, 9),
+        createdAt: DateTime(2026, 5, 25, 9),
+        vectorClock: null,
+      );
+      await insertStale(
+        id: 'capture-legacy',
+        type: AgentEntityTypes.capture,
+        subtype: 'capture-legacy',
+        serialized: jsonEncode(capture.toJson()),
+      );
+
+      await db.backfillDayScopedSubtypes();
+
+      expect(await subtypeOf('capture-legacy'), 'dayplan-2026-05-25');
+    });
+
+    test('rewrites a status event from its status name to its day', () async {
+      final event = makeTestDayStatusEvent(createdAt: DateTime(2026, 5, 25, 9));
+      await insertStale(
+        id: event.id,
+        type: AgentEntityTypes.dayStatusEvent,
+        subtype: 'attentionNeeded',
+        serialized: jsonEncode(event.toJson()),
+      );
+
+      await db.backfillDayScopedSubtypes();
+
+      expect(await subtypeOf(event.id), 'dayplan-2026-05-25');
+    });
+
+    test('skips an undecodable row instead of aborting the upgrade', () async {
+      final capture = AgentDomainEntity.capture(
+        id: 'capture-ok',
+        agentId: 'daily_os_planner',
+        transcript: 'note',
+        capturedAt: DateTime(2026, 5, 25, 9),
+        createdAt: DateTime(2026, 5, 25, 9),
+        dayId: 'dayplan-2026-05-25',
+        vectorClock: null,
+      );
+      await insertStale(
+        id: 'capture-broken',
+        type: AgentEntityTypes.capture,
+        subtype: 'capture-broken',
+        serialized: 'not json',
+      );
+      await insertStale(
+        id: 'capture-ok',
+        type: AgentEntityTypes.capture,
+        subtype: 'capture-ok',
+        serialized: jsonEncode(capture.toJson()),
+      );
+
+      await db.backfillDayScopedSubtypes();
+
+      // One unreadable row must not cost every other row its index entry.
+      expect(await subtypeOf('capture-ok'), 'dayplan-2026-05-25');
+      expect(await subtypeOf('capture-broken'), 'capture-broken');
+    });
+
+    test('leaves types it does not own alone', () async {
+      final plan = makeTestDayPlan(
+        id: 'day_agent_plan:dayplan-2026-05-25',
+        agentId: 'daily_os_planner',
+      );
+      await core.upsertEntity(plan);
+
+      await db.backfillDayScopedSubtypes();
+
+      expect(
+        await subtypeOf(plan.id),
+        'dayplan-2026-05-25',
+        reason: 'dayPlan already stored the day and is not rewritten',
+      );
     });
   });
 }

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -250,4 +250,61 @@ void main() {
       expect(metas.single.capturedAt, DateTime(2026, 3, 15, 10));
     });
   });
+
+  group('day-scoped subtype reads (ADR 0044 follow-up)', () {
+    test('returns only the requested day and skips the rest', () async {
+      for (final day in ['dayplan-2026-05-25', 'dayplan-2026-05-26']) {
+        for (var i = 0; i < 2; i++) {
+          await core.upsertEntity(
+            AgentDomainEntity.capture(
+              id: 'capture-$day-$i',
+              agentId: 'daily_os_planner',
+              transcript: 'note $i',
+              capturedAt: DateTime(2026, 5, 25, 9),
+              createdAt: DateTime(2026, 5, 25, 9),
+              dayId: day,
+              vectorClock: null,
+            ),
+          );
+        }
+      }
+
+      final rows = await core.getEntitiesByAgentIdAndSubtype(
+        'daily_os_planner',
+        type: AgentEntityTypes.capture,
+        subtype: 'dayplan-2026-05-25',
+      );
+
+      expect(
+        rows.whereType<CaptureEntity>().map((c) => c.id),
+        unorderedEquals([
+          'capture-dayplan-2026-05-25-0',
+          'capture-dayplan-2026-05-25-1',
+        ]),
+      );
+    });
+
+    test('finds a legacy capture by its derived day', () async {
+      // No explicit dayId: the stored subtype is derived from capturedAt, so
+      // a day-scoped read still finds it without a Dart-side fallback scan.
+      await core.upsertEntity(
+        AgentDomainEntity.capture(
+          id: 'capture-legacy',
+          agentId: 'daily_os_planner',
+          transcript: 'from an old peer',
+          capturedAt: DateTime(2026, 5, 25, 9),
+          createdAt: DateTime(2026, 5, 25, 9),
+          vectorClock: null,
+        ),
+      );
+
+      final rows = await core.getEntitiesByAgentIdAndSubtype(
+        'daily_os_planner',
+        type: AgentEntityTypes.capture,
+        subtype: 'dayplan-2026-05-25',
+      );
+
+      expect(rows.whereType<CaptureEntity>().single.id, 'capture-legacy');
+    });
+  });
 }

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -629,6 +629,51 @@ void main() {
       expect(agent.config.maxTurnsPerWake, 10);
     });
 
+    group('getEntitiesByAgentIdAndSubtype', () {
+      test("narrows to one day and excludes the agent's other days", () async {
+        await repo.upsertEntity(
+          makeTestCapture(
+            id: 'capture-target',
+            dayId: 'dayplan-2026-05-25',
+          ),
+        );
+        await repo.upsertEntity(
+          makeTestCapture(
+            id: 'capture-other-day',
+            dayId: 'dayplan-2026-05-26',
+          ),
+        );
+
+        final results = await repo.getEntitiesByAgentIdAndSubtype(
+          testAgentId,
+          type: AgentEntityTypes.capture,
+          subtype: 'dayplan-2026-05-25',
+        );
+
+        expect(results.map((e) => e.id), ['capture-target']);
+      });
+
+      test('honours the limit', () async {
+        for (var i = 0; i < 3; i++) {
+          await repo.upsertEntity(
+            makeTestCapture(
+              id: 'capture-$i',
+              dayId: 'dayplan-2026-05-25',
+            ),
+          );
+        }
+
+        final results = await repo.getEntitiesByAgentIdAndSubtype(
+          testAgentId,
+          type: AgentEntityTypes.capture,
+          subtype: 'dayplan-2026-05-25',
+          limit: 2,
+        );
+
+        expect(results, hasLength(2));
+      });
+    });
+
     group('getEntitiesByAgentId', () {
       test('returns all entities for an agent', () async {
         await repo.upsertEntity(makeAgent());

--- a/test/features/daily_os_next/logic/real_day_agent_test.dart
+++ b/test/features/daily_os_next/logic/real_day_agent_test.dart
@@ -15,7 +15,6 @@ import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_identity.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_plan_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
-import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
 import 'package:lotti/features/daily_os_next/logic/real_day_agent.dart';

--- a/test/features/daily_os_next/state/day_agent_persona_provider_test.dart
+++ b/test/features/daily_os_next/state/day_agent_persona_provider_test.dart
@@ -32,9 +32,10 @@ void main() {
   }) {
     final repository = MockAgentRepository();
     when(
-      () => repository.getEntitiesByAgentId(
+      () => repository.getEntitiesByAgentIdAndSubtype(
         any(),
         type: AgentEntityTypes.dayStatusEvent,
+        subtype: any(named: 'subtype'),
       ),
     ).thenAnswer((_) async => ownerEntities);
     when(

--- a/test/features/daily_os_next/state/day_agent_provider_test.dart
+++ b/test/features/daily_os_next/state/day_agent_provider_test.dart
@@ -254,9 +254,10 @@ void main() {
       // (ADR 0032); default the coordinator leg to empty so owner-focused
       // tests stay unchanged. Specific stubs registered later win.
       when(
-        () => agentRepository.getEntitiesByAgentId(
+        () => agentRepository.getEntitiesByAgentIdAndSubtype(
           any(),
           type: any(named: 'type'),
+          subtype: any(named: 'subtype'),
         ),
       ).thenAnswer((_) async => const <AgentDomainEntity>[]);
     });
@@ -305,9 +306,10 @@ void main() {
 
       expect(captures, isEmpty);
       verifyNever(
-        () => agentRepository.getEntitiesByAgentId(
+        () => agentRepository.getEntitiesByAgentIdAndSubtype(
           any(),
           type: any(named: 'type'),
+          subtype: any(named: 'subtype'),
         ),
       );
     });
@@ -325,9 +327,10 @@ void main() {
           ),
         );
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => const <AgentDomainEntity>[]);
 
@@ -336,9 +339,10 @@ void main() {
         // The provider re-derives the day-agent id from the supplied date.
         verify(() => dayAgentService.getDayAgentForDate(forDate)).called(1);
         verify(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).called(1);
       },
@@ -367,9 +371,10 @@ void main() {
           deletedAt: dayAt,
         );
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [live, tombstone]);
         when(
@@ -422,9 +427,10 @@ void main() {
                 )
                 as CaptureEntity;
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [today, otherDay]);
 
@@ -461,15 +467,17 @@ void main() {
           agentId: dailyOsPlannerAgentId,
         );
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             ownerId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [ownCapture, sharedOwn]);
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             dailyOsPlannerAgentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [plannerCapture, sharedPlanner]);
 
@@ -498,9 +506,10 @@ void main() {
         );
         final typed = makeCapture(id: 'cap-typed', agentId: agentId);
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [typed]);
 
@@ -539,9 +548,10 @@ void main() {
           data: testAudioEntry.data,
         );
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [capture]);
         when(
@@ -575,9 +585,10 @@ void main() {
           audioRef: audioRef,
         );
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             agentId,
             type: AgentEntityTypes.capture,
+            subtype: any(named: 'subtype'),
           ),
         ).thenAnswer((_) async => [capture]);
         when(

--- a/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
@@ -2060,8 +2060,18 @@ void main() {
         // now-line must survive the rebuild.
         await tester.pump(const Duration(minutes: 1));
 
-        expect(nowBadge(), findsOneWidget);
         expect(find.text('Anchor block'), findsOneWidget);
+        // The timer callback reads the *real* clock, not the test binding's,
+        // so a run that straddles local midnight legitimately moves "now"
+        // outside this draft's day and retires the badge. Assert the badge
+        // only while the wall clock is still on the day the draft was built
+        // for; the survives-a-tick property is carried by the block above and
+        // the mounted check below either way.
+        final wallAfter = clock.now();
+        final sameDay =
+            DateTime(wallAfter.year, wallAfter.month, wallAfter.day) == today;
+        expect(nowBadge(), sameDay ? findsOneWidget : findsNothing);
+        expect(find.byType(DayTimeline), findsOneWidget);
 
         // Dispose cancels the live (rescheduled) timer; a leaked timer would
         // fail the test, proving the reschedule produced a cancellable timer.


### PR DESCRIPTION
Third of the "day planner must not degrade as history accumulates" series,
after #3564 (outbox → table) and #3566 (priority claiming).

## The problem

Opening a day loaded **every** capture and **every** day-status event the
owning agent had ever recorded, then filtered them in Dart:

- `day_agent_provider.dart` — `getEntitiesByAgentId(ownerId, type: capture)`
  for both owners, no limit, day-filtered afterwards. Its own comment conceded
  "an owner can hold many days' captures (the coordinator always does)".
- `day_agent_persona_provider.dart` — every `dayStatusEvent` for the owner,
  filtered to the day in Dart. Status events drive the activity indicator and
  are the fastest-growing entity type in the feature.

Both are Riverpod providers on the main day surface, so the cost of opening one
day grew with the user's entire history.

Severity was not uniform, which is worth stating: a `day_agent:<dayId>` is
self-limiting by construction — it holds one day's rows and then goes cold
forever. The coordinator is the accumulator, and it owns every pre-cutover day
(`day_agent_service.dart` leaves those under the monolith permanently).

## Cause

The projected `subtype` column. `capture` stored the capture's own id —
redundant with the primary key — and `dayStatusEvent` stored its status name,
so neither could serve a day-scoped lookup. Meanwhile `dayPlan`, `daySummary`
and `dayDirective` already stored the day and were served by
`idx_agent_entities_agent_type_sub`.

Neither old value was used as a query key anywhere, so repurposing them is
safe. `subtype` is a locally-derived projection, not part of the synced
payload, so a device on an older build keeps deriving its own — no sync skew.

## What changed

- `entitySubtype` writes the day workspace for both types; the two providers
  read through `getEntitiesByAgentIdAndSubtype`.
- `localDay`/`dayAgentIdForDate` move to `lib/classes/day_plan.dart` beside
  `dayPlanId`, so the agent persistence layer can derive a capture's day
  without depending on a feature package.
- A capture with no explicit `dayId` (synced from a peer predating it) derives
  one from `capturedAt` in **local time** — the same rule `captureDayId`
  applies on read — so legacy rows land on the right day instead of needing a
  Dart-side fallback scan.
- Schema v17 backfills existing rows through that same Dart projection rather
  than a SQL `json_extract` update. That is deliberate: the local-time
  derivation cannot be expressed faithfully in SQL, and a backfilled value that
  disagreed with the writer would silently drop rows out of their day.
  Undecodable rows are skipped rather than aborting the upgrade.

## Testing

1902 daily_os_next + 5066 agents tests pass; analyzer and formatter clean.

New coverage: day-scoped reads return only the requested day; a legacy capture
with no `dayId` is found by its derived day; an explicit `dayId` wins over the
derivation (a capture recorded after midnight can belong to the previous
planning day); and the conversion tests now pin the day subtype for both types.

No CHANGELOG entry — no runtime behavior a user would notice beyond the day
view getting cheaper.

## Still open in this area

`_plannerOwnsDay` (`day_agent_service.dart`) still scans the planner's whole
capture history via `getCaptureEventMetaByAgentId` on every day-agent
resolution, which runs *ahead* of both providers. It is now a one-line query
change on top of this index and I left it out to keep the schema migration
reviewable on its own — happy to fold it in here if you would rather.