### PR TITLE
perf: bound the remaining full-agent plan and change-set reads

### DIFF
--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -211,6 +211,46 @@ class AgentRepoCore {
     return rows.map(AgentDbConversions.fromEntityRow).toList();
   }
 
+  /// Entities of [type] for [agentId] whose subtype is any of [subtypes].
+  ///
+  /// The multi-value form of [getEntitiesByAgentIdAndSubtype], for callers
+  /// that want a bounded *range* of day-scoped rows — a plan lookback window,
+  /// say — in one round trip rather than one query per day.
+  Future<List<AgentDomainEntity>> getEntitiesByAgentIdAndSubtypes(
+    String agentId, {
+    required String type,
+    required Iterable<String> subtypes,
+  }) async {
+    final result = <AgentDomainEntity>[];
+    for (final chunk in sqliteInClauseChunks(subtypes)) {
+      final placeholders = List.filled(chunk.length, '?').join(', ');
+      final rows = await _db
+          .customSelect(
+            'SELECT * FROM agent_entities '
+            'INDEXED BY idx_agent_entities_agent_type_sub '
+            'WHERE agent_id = ? AND type = ? '
+            'AND subtype IN ($placeholders) '
+            'AND deleted_at IS NULL '
+            'ORDER BY created_at DESC, id DESC',
+            variables: [
+              Variable.withString(agentId),
+              Variable.withString(type),
+              for (final subtype in chunk) Variable.withString(subtype),
+            ],
+            readsFrom: {_db.agentEntities},
+          )
+          .get();
+      for (final row in rows) {
+        result.add(
+          AgentDbConversions.fromEntityRow(
+            await _db.agentEntities.mapFromRow(row),
+          ),
+        );
+      }
+    }
+    return result;
+  }
+
   Future<List<AgentDomainEntity>> getEntitiesByAgentId(
     String agentId, {
     String? type,

--- a/lib/features/agents/database/agent_repository.dart
+++ b/lib/features/agents/database/agent_repository.dart
@@ -125,6 +125,17 @@ class AgentRepository {
     limit: limit,
   );
 
+  /// Entities of [type] for [agentId] whose subtype is any of [subtypes].
+  Future<List<AgentDomainEntity>> getEntitiesByAgentIdAndSubtypes(
+    String agentId, {
+    required String type,
+    required Iterable<String> subtypes,
+  }) => _core.getEntitiesByAgentIdAndSubtypes(
+    agentId,
+    type: type,
+    subtypes: subtypes,
+  );
+
   Future<
     List<
       ({

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_editor.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_editor.dart
@@ -75,11 +75,15 @@ class DayAgentPlanEditor {
         perDayAgentId(dayId),
       },
     };
+    // Only pending sets can produce a visible row, and `changeSet` stores its
+    // status as the indexed subtype — so the confirmed/rejected history, which
+    // grows with every diff the user has ever acted on, never has to be read.
     final entities = <AgentDomainEntity>[
       for (final ownerId in ownerIds)
-        ...await agentRepository.getEntitiesByAgentId(
+        ...await agentRepository.getEntitiesByAgentIdAndSubtype(
           ownerId,
           type: 'changeSet',
+          subtype: ChangeSetStatus.pending.name,
         ),
     ];
     // Per-item filtering: a change set can stay `pending` overall while

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_writer.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_writer.dart
@@ -391,9 +391,18 @@ class DayAgentPlanWriter {
     }
     final asOfDay = localDay(asOf);
     final start = asOfDay.subtract(Duration(days: lookbackDays - 1));
-    final entities = await agentRepository.getEntitiesByAgentId(
+    // Ask for exactly the window's days rather than every plan the agent
+    // ever wrote: dayPlan stores its day as the indexed subtype, so the
+    // lookback costs one indexed read of `lookbackDays` keys.
+    final entities = await agentRepository.getEntitiesByAgentIdAndSubtypes(
       agentId,
       type: AgentEntityTypes.dayPlan,
+      subtypes: [
+        for (var offset = 0; offset < lookbackDays; offset++)
+          dayAgentIdForDate(
+            DateTime(asOfDay.year, asOfDay.month, asOfDay.day - offset),
+          ),
+      ],
     );
     final plans = entities.whereType<DayPlanEntity>().where((plan) {
       final day = localDay(plan.planDate);

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -20,7 +20,6 @@ import 'package:lotti/features/daily_os_next/agents/domain/day_agent_identity.da
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart';
-import 'package:lotti/features/daily_os_next/agents/workflow/day_capture_events.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:uuid/uuid.dart';
 
@@ -205,10 +204,18 @@ class DayAgentService {
         plan.agentId == planner.agentId) {
       return true;
     }
-    final metas = await repository.getCaptureEventMetaByAgentId(
+    // Indexed day lookup rather than a scan of every capture the coordinator
+    // ever owned: this runs on every day-agent identity resolution, i.e.
+    // ahead of every day-view read. Captures store the day as their subtype
+    // (derived for legacy rows that carry no explicit dayId), so one row is
+    // enough to answer the question.
+    final captures = await repository.getEntitiesByAgentIdAndSubtype(
       planner.agentId,
+      type: AgentEntityTypes.capture,
+      subtype: dayId,
+      limit: 1,
     );
-    return metas.any((meta) => captureEventDayId(meta) == dayId);
+    return captures.isNotEmpty;
   }
 
   /// `YYYY-MM-DD` portion of a `dayplan-YYYY-MM-DD` day id.

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -311,6 +311,73 @@ void main() {
     });
   });
 
+  group('multi-subtype reads', () {
+    Future<void> seedPlan(String dayId) => core.upsertEntity(
+      makeTestDayPlan(
+        id: 'day_agent_plan:$dayId',
+        agentId: 'daily_os_planner',
+        dayId: dayId,
+        planDate: DateTime.parse(dayId.substring('dayplan-'.length)),
+      ),
+    );
+
+    test(
+      'returns every requested day and nothing outside the window',
+      () async {
+        for (final day in const [
+          'dayplan-2026-05-23',
+          'dayplan-2026-05-24',
+          'dayplan-2026-05-25',
+          'dayplan-2026-05-26',
+        ]) {
+          await seedPlan(day);
+        }
+
+        final rows = await core.getEntitiesByAgentIdAndSubtypes(
+          'daily_os_planner',
+          type: AgentEntityTypes.dayPlan,
+          subtypes: const ['dayplan-2026-05-24', 'dayplan-2026-05-25'],
+        );
+
+        expect(
+          rows.whereType<DayPlanEntity>().map((p) => p.dayId),
+          unorderedEquals(['dayplan-2026-05-24', 'dayplan-2026-05-25']),
+        );
+      },
+    );
+
+    test('an empty subtype set matches nothing', () async {
+      await seedPlan('dayplan-2026-05-25');
+
+      final rows = await core.getEntitiesByAgentIdAndSubtypes(
+        'daily_os_planner',
+        type: AgentEntityTypes.dayPlan,
+        subtypes: const <String>[],
+      );
+
+      expect(rows, isEmpty);
+    });
+
+    test('excludes soft-deleted rows', () async {
+      await seedPlan('dayplan-2026-05-25');
+      await core.upsertEntity(
+        makeTestDayPlan(
+          id: 'day_agent_plan:dayplan-2026-05-25',
+          agentId: 'daily_os_planner',
+          planDate: DateTime(2026, 5, 25),
+        ).copyWith(deletedAt: DateTime(2026, 5, 25, 12)),
+      );
+
+      final rows = await core.getEntitiesByAgentIdAndSubtypes(
+        'daily_os_planner',
+        type: AgentEntityTypes.dayPlan,
+        subtypes: const ['dayplan-2026-05-25'],
+      );
+
+      expect(rows, isEmpty);
+    });
+  });
+
   group('schema v17 day-subtype backfill', () {
     /// Writes a row straight to the table with a pre-v17 subtype, bypassing
     /// the conversion layer that would now derive the day.

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -674,6 +674,35 @@ void main() {
       });
     });
 
+    group('getEntitiesByAgentIdAndSubtypes', () {
+      test('spans a window of days in one read', () async {
+        for (final day in const [
+          'dayplan-2026-05-24',
+          'dayplan-2026-05-25',
+          'dayplan-2026-05-26',
+        ]) {
+          await repo.upsertEntity(
+            makeTestDayPlan(
+              id: 'day_agent_plan:$day',
+              dayId: day,
+              planDate: DateTime.parse(day.substring('dayplan-'.length)),
+            ),
+          );
+        }
+
+        final results = await repo.getEntitiesByAgentIdAndSubtypes(
+          testAgentId,
+          type: AgentEntityTypes.dayPlan,
+          subtypes: const ['dayplan-2026-05-24', 'dayplan-2026-05-26'],
+        );
+
+        expect(
+          results.whereType<DayPlanEntity>().map((p) => p.dayId),
+          unorderedEquals(['dayplan-2026-05-24', 'dayplan-2026-05-26']),
+        );
+      });
+    });
+
     group('getEntitiesByAgentId', () {
       test('returns all entities for an agent', () async {
         await repo.upsertEntity(makeAgent());

--- a/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/agents/database/agent_db_conversions.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -100,6 +101,58 @@ void main() {
           if (entity.agentId == agentId &&
               (type == null || AgentEntityTypes.dayPlan == type) &&
               entity is DayPlanEntity)
+            entity,
+      ];
+    });
+    // Subtype-scoped reads resolve the subtype through the production
+    // projection, so a fake can never disagree with what the writer stores.
+    Future<List<AgentDomainEntity>> bySubtype(Invocation invocation) async {
+      final agentId = invocation.positionalArguments.single as String;
+      final type = invocation.namedArguments[#type] as String;
+      final subtype = invocation.namedArguments[#subtype] as String;
+      return [
+        for (final entity in agentEntities.values)
+          if (entity.agentId == agentId &&
+              AgentDbConversions.entityType(entity) == type &&
+              AgentDbConversions.entitySubtype(entity) == subtype)
+            entity,
+      ];
+    }
+
+    // Both arities: mocktail matches on the named arguments actually present,
+    // so a stub that requires `limit` never matches a caller that omits it.
+    when(
+      () => agentRepository.getEntitiesByAgentIdAndSubtype(
+        any(),
+        type: any(named: 'type'),
+        subtype: any(named: 'subtype'),
+      ),
+    ).thenAnswer(bySubtype);
+    when(
+      () => agentRepository.getEntitiesByAgentIdAndSubtype(
+        any(),
+        type: any(named: 'type'),
+        subtype: any(named: 'subtype'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer(bySubtype);
+    when(
+      () => agentRepository.getEntitiesByAgentIdAndSubtypes(
+        any(),
+        type: any(named: 'type'),
+        subtypes: any(named: 'subtypes'),
+      ),
+    ).thenAnswer((invocation) async {
+      final agentId = invocation.positionalArguments.single as String;
+      final type = invocation.namedArguments[#type] as String;
+      final subtypes = (invocation.namedArguments[#subtypes] as Iterable)
+          .cast<String>()
+          .toSet();
+      return [
+        for (final entity in agentEntities.values)
+          if (entity.agentId == agentId &&
+              AgentDbConversions.entityType(entity) == type &&
+              subtypes.contains(AgentDbConversions.entitySubtype(entity)))
             entity,
       ];
     });
@@ -463,10 +516,10 @@ void main() {
                   )
                   as ChangeSetEntity;
           when(
-            () => agentRepository.getEntitiesByAgentId(
+            () => agentRepository.getEntitiesByAgentIdAndSubtype(
               any(),
               type: any(named: 'type'),
-              limit: any(named: 'limit'),
+              subtype: any(named: 'subtype'),
             ),
           ).thenAnswer((invocation) async {
             final owner = invocation.positionalArguments.single as String;
@@ -4642,14 +4695,23 @@ void main() {
         );
       }
 
+      /// Change sets are read by their indexed status subtype now, so the
+      /// stub filters the same way the table would rather than handing back
+      /// everything regardless of what was asked for.
       void stubEntitiesWithChangeSets(List<AgentDomainEntity> entities) {
         when(
-          () => agentRepository.getEntitiesByAgentId(
+          () => agentRepository.getEntitiesByAgentIdAndSubtype(
             any(),
             type: any(named: 'type'),
-            limit: any(named: 'limit'),
+            subtype: any(named: 'subtype'),
           ),
-        ).thenAnswer((_) async => entities);
+        ).thenAnswer((invocation) async {
+          final subtype = invocation.namedArguments[#subtype] as String;
+          return [
+            for (final entity in entities)
+              if (AgentDbConversions.entitySubtype(entity) == subtype) entity,
+          ];
+        });
       }
 
       test('returns empty list when no change sets exist', () async {

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -150,7 +150,12 @@ void main() {
     // clean day would create a per-day agent unless a test stubs otherwise.
     when(() => repository.getEntity(any())).thenAnswer((_) async => null);
     when(
-      () => repository.getCaptureEventMetaByAgentId(any()),
+      () => repository.getEntitiesByAgentIdAndSubtype(
+        any(),
+        type: any(named: 'type'),
+        subtype: any(named: 'subtype'),
+        limit: any(named: 'limit'),
+      ),
     ).thenAnswer((_) async => []);
 
     service = DayAgentService(
@@ -1122,15 +1127,21 @@ void main() {
       when(
         () => agentService.getAgent(dailyOsPlannerAgentId),
       ).thenAnswer((_) async => planner);
+      // The ownership probe is an indexed day-scoped read now: one capture
+      // row under the planner for this day is what makes it the owner.
       when(
-        () => repository.getCaptureEventMetaByAgentId(dailyOsPlannerAgentId),
+        () => repository.getEntitiesByAgentIdAndSubtype(
+          dailyOsPlannerAgentId,
+          type: AgentEntityTypes.capture,
+          subtype: testDayId,
+          limit: any(named: 'limit'),
+        ),
       ).thenAnswer(
         (_) async => [
-          (
+          makeTestCapture(
             id: 'cap-1',
+            agentId: dailyOsPlannerAgentId,
             dayId: testDayId,
-            createdAt: now,
-            capturedAt: now,
           ),
         ],
       );
@@ -1155,15 +1166,22 @@ void main() {
         when(
           () => agentService.getAgent(dailyOsPlannerAgentId),
         ).thenAnswer((_) async => identity(id: dailyOsPlannerAgentId));
+        // A capture on another day lives under that day's subtype, so the
+        // probe for *this* day finds nothing — which is the whole point of
+        // the day-scoped read replacing a scan-and-filter.
         when(
-          () => repository.getCaptureEventMetaByAgentId(dailyOsPlannerAgentId),
+          () => repository.getEntitiesByAgentIdAndSubtype(
+            dailyOsPlannerAgentId,
+            type: AgentEntityTypes.capture,
+            subtype: 'dayplan-2026-05-24',
+            limit: any(named: 'limit'),
+          ),
         ).thenAnswer(
           (_) async => [
-            (
+            makeTestCapture(
               id: 'cap-other',
+              agentId: dailyOsPlannerAgentId,
               dayId: 'dayplan-2026-05-24',
-              createdAt: now,
-              capturedAt: now,
             ),
           ],
         );

--- a/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
+++ b/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
@@ -464,4 +464,40 @@ class PipelineAgentRepository extends InMemoryAgentRepository {
             (type == null || AgentDbConversions.entityType(e) == type),
       )
       .toList();
+
+  // Subtype filtering goes through the production projection, so this fake
+  // cannot answer a day-scoped read differently from the real table.
+  @override
+  Future<List<AgentDomainEntity>> getEntitiesByAgentIdAndSubtype(
+    String agentId, {
+    required String type,
+    required String subtype,
+    int limit = -1,
+  }) async => _bySubtypes(agentId, type, {subtype}, limit);
+
+  @override
+  Future<List<AgentDomainEntity>> getEntitiesByAgentIdAndSubtypes(
+    String agentId, {
+    required String type,
+    required Iterable<String> subtypes,
+  }) async => _bySubtypes(agentId, type, subtypes.toSet(), -1);
+
+  List<AgentDomainEntity> _bySubtypes(
+    String agentId,
+    String type,
+    Set<String> subtypes,
+    int limit,
+  ) {
+    final matches = entities
+        .where(
+          (e) =>
+              e.agentId == agentId &&
+              AgentDbConversions.entityType(e) == type &&
+              subtypes.contains(AgentDbConversions.entitySubtype(e)),
+        )
+        .toList();
+    return limit < 0 || matches.length <= limit
+        ? matches
+        : matches.sublist(0, limit);
+  }
 }


### PR DESCRIPTION
Fourth in the "day planner must not degrade as history accumulates" series,
after #3564, #3566 and #3569. Closes out the load-everything-then-filter-in-Dart
pattern.

## What was still unbounded

**`_plannerOwnsDay`** (`day_agent_service.dart`) called
`getCaptureEventMetaByAgentId` with no day filter and scanned the result with
`metas.any(...)`. It runs on **every day-agent identity resolution** — that is,
ahead of every day-view read — which made it the hottest remaining unbounded
path, hotter than the two providers #3569 fixed. Its docstring claimed the
narrow projection "keeps per-wake cost flat instead of O(all captures)", which
is true per row and false overall: the row count and the `json_extract` per row
still scaled with the coordinator's whole capture history.

Because #3569 made captures day-indexed, this is now a single indexed lookup
capped at one row.

**The plan writer** loaded every `dayPlan` the agent had ever written to serve
a 7-day lookback. `dayPlan` already stored its day as the subtype, so it now
asks for exactly the window's days.

**The change-set editor** loaded every `changeSet` ever proposed to find the
pending ones. `changeSet` stores its status as the subtype, so the
confirmed/rejected history — which grows with every diff the user has ever
acted on — is no longer read at all.

## New repository method

`getEntitiesByAgentIdAndSubtypes` (plural) for the range case, so a lookback is
one round trip instead of one query per day. Chunked through
`sqliteInClauseChunks` like the other batched reads.

## Testing

1902 daily_os_next + 496 agents/database tests pass; analyzer and formatter
clean; every changed line covered.

Worth noting about the test changes: several stubs previously returned entities
regardless of what was asked for, so they would have kept passing even if the
production filter were wrong. They now resolve subtypes through
`AgentDbConversions.entitySubtype` — the same projection the writer uses — so a
fake can no longer disagree with the real table. The in-memory harness
repository got the same treatment.

No CHANGELOG entry — no user-visible behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving entities matching multiple subtypes in a single query.
  - Improved day-plan, change-set, and capture lookups with more targeted filtering.

- **Bug Fixes**
  - Excluded deleted entities and unrelated historical records from relevant reads.
  - Improved day ownership detection for captures on specific days.

- **Tests**
  - Added coverage for multi-subtype queries, empty filters, deleted records, and day-scoped lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->