### PR TITLE
test: add the aged-corpus benchmark for the day planner

### DIFF
--- a/lib/features/ai/ui/settings/ai_settings_page.dart
+++ b/lib/features/ai/ui/settings/ai_settings_page.dart
@@ -31,7 +31,6 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/app_bar/settings_page_header.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
-
 part 'ai_settings_tab_builders.dart';
 
 /// `SettingsDb` key that suppresses the [AiPickProviderModal] FTUE

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -250,6 +250,44 @@ device-local processing outbox that transcription uses (`services/day_processing
 a sealed `DayProcessingPayload` per kind (`TranscribeAudioPayload`,
 `ParseCapturePayload`, `DraftPlanPayload`, `RefinePlanPayload`).
 
+### Measuring that it does not degrade
+
+`test/features/daily_os_next/benchmark/` seeds a synthetic corpus at 1, 6 and
+12 simulated months and reports the cost of the operations a user action
+actually triggers. It is opt-in:
+
+```sh
+fvm flutter test --dart-define=LOTTI_BENCHMARK=1 \
+  test/features/daily_os_next/benchmark/
+```
+
+The corpus deliberately has the shape a real install has — a small pending
+head over a large terminal ledger — because leaving every job pending would
+measure a backlog nobody has and hide the property under test. A smoke test
+runs unconditionally so the harness cannot rot unnoticed.
+
+Baseline on a dev machine (median of 9, microseconds; absolute values are
+machine-specific, the *slope* is the point):
+
+| metric | 1 month | 6 months | 12 months |
+| --- | --- | --- | --- |
+| `outbox.claimNext` | 157 | 94 | 127 |
+| `dayView.captures` | 224 | 144 | 136 |
+| `dayView.statusEvents` | 313 | 344 | 159 |
+| `dayView.plannerOwnsDay` | 122 | 113 | 86 |
+| `planEditor.pendingDiffs` | 80 | 56 | 53 |
+| `planWriter.lookback` | 666 | 445 | 262 |
+
+Corpus sizes: 360 / 2,184 / 4,380 agent entities and 90 / 546 / 1,095
+processing jobs. Every metric is flat or lower at twelve months than at one,
+across a 12× increase in stored history — which is the property the ADR 0044
+partial indexes and the day-scoped subtypes were built for. (Values drifting
+*down* with size is measurement noise and cache warming, not a real speedup.)
+
+What this does **not** measure: wake prompt bytes, token counts, and digest
+wake duration. Those need the full agent workflow rather than the storage
+layer, and are tracked separately.
+
 ### Day-scoped agent reads
 
 Opening a day used to load **every** capture and **every** day-status event the

--- a/test/features/daily_os_next/benchmark/day_planner_corpus.dart
+++ b/test/features/daily_os_next/benchmark/day_planner_corpus.dart
@@ -1,0 +1,251 @@
+import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_identity.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_directive_models.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+
+/// Synthetic Daily OS history for measuring how per-action cost scales with
+/// install age (`lotti3-hkb.1`).
+///
+/// The point is not absolute numbers — those depend on the machine — but the
+/// *slope*: an operation whose cost tracks outstanding work should read the
+/// same at twelve simulated months as at one, while anything still scanning
+/// history grows visibly. Every measurement below is therefore reported per
+/// corpus size and compared across sizes, never in isolation.
+///
+/// Deterministic by construction: all timestamps derive from [baseDay], and
+/// the only clock used is a [Stopwatch] for elapsed time, never a wall clock
+/// feeding data.
+class DayPlannerCorpus {
+  DayPlannerCorpus({
+    required this.agentDb,
+    required this.processingDb,
+    this.days = 30,
+  });
+
+  /// The day the corpus ends on. Everything is seeded backwards from here, so
+  /// the "current" day is always the newest and the same regardless of size.
+  static final DateTime baseDay = DateTime(2026, 7, 18);
+
+  /// Rough per-day shape of real use. Deliberately not uniform: status events
+  /// are the fastest-growing type, captures the next.
+  ///
+  /// Processing jobs for past days are seeded *terminal*, so the corpus has
+  /// the shape a real install has — a small pending head over a large ledger.
+  static const int capturesPerDay = 3;
+  static const int statusEventsPerDay = 6;
+  static const int changeSetsPerDay = 2;
+
+  final AgentDatabase agentDb;
+  final DayProcessingDb processingDb;
+
+  /// Simulated install age in days.
+  final int days;
+
+  late final AgentRepository repository = AgentRepository(agentDb);
+  late final DayProcessingOutboxRepository outbox =
+      DayProcessingOutboxRepository(
+        db: processingDb,
+        now: () => baseDay,
+        tokenFactory: () => 'claim-token',
+      );
+
+  /// The day every measurement targets: the newest, i.e. the one a user would
+  /// actually be looking at.
+  String get currentDayId => dayAgentIdForDate(baseDay);
+
+  DateTime dayAt(int offset) => DateTime(
+    baseDay.year,
+    baseDay.month,
+    baseDay.day - offset,
+  );
+
+  /// Seeds the whole corpus under the coordinator.
+  ///
+  /// Under the coordinator specifically, because that is the agent that
+  /// actually accumulates — a `day_agent:<dayId>` holds one day and goes cold,
+  /// so seeding those would measure nothing.
+  Future<void> seed() async {
+    for (var offset = 0; offset < days; offset++) {
+      final day = dayAt(offset);
+      final dayId = dayPlanId(day);
+      final at = DateTime(day.year, day.month, day.day, 9);
+
+      await repository.upsertEntity(
+        AgentDomainEntity.dayPlan(
+          id: 'day_agent_plan:$dayId',
+          agentId: dailyOsPlannerAgentId,
+          dayId: dayId,
+          planDate: day,
+          data: DayPlanData(planDate: day, status: const DayPlanStatus.draft()),
+          createdAt: at,
+          updatedAt: at,
+          vectorClock: null,
+        ),
+      );
+
+      for (var i = 0; i < capturesPerDay; i++) {
+        await repository.upsertEntity(
+          AgentDomainEntity.capture(
+            id: 'capture-$dayId-$i',
+            agentId: dailyOsPlannerAgentId,
+            transcript: 'Captured note $i',
+            capturedAt: at,
+            createdAt: at,
+            dayId: dayId,
+            vectorClock: null,
+          ),
+        );
+        final job = await outbox.enqueueParseCapture(
+          dayId: dayId,
+          captureId: 'capture-$dayId-$i',
+        );
+        // Everything but the current day is drained, which is what a real
+        // outbox looks like: a small pending head and an ever-growing ledger
+        // of terminal rows behind it. Leaving it all pending would measure a
+        // backlog nobody has, and would hide the property under test —
+        // whether the retained ledger stays off the drain path.
+        if (offset > 0) {
+          final claim = await outbox.claimById(job.id);
+          await outbox.markSucceeded(
+            jobId: job.id,
+            claimToken: claim!.token,
+          );
+        }
+      }
+
+      for (var i = 0; i < statusEventsPerDay; i++) {
+        await repository.upsertEntity(
+          AgentDomainEntity.dayStatusEvent(
+            id: 'status-$dayId-$i',
+            agentId: dailyOsPlannerAgentId,
+            dayId: dayId,
+            status: DayStatusKind.onTrack,
+            raisedAt: at,
+            createdAt: at,
+            vectorClock: null,
+          ),
+        );
+      }
+
+      for (var i = 0; i < changeSetsPerDay; i++) {
+        await repository.upsertEntity(
+          AgentDomainEntity.changeSet(
+            id: 'plan_diff:$dayId-$i',
+            agentId: dailyOsPlannerAgentId,
+            taskId: 'day_agent_plan:$dayId',
+            threadId: 'thread-$dayId',
+            runKey: 'run-$dayId-$i',
+            // Historic diffs that are no longer actionable — the pile a
+            // pending read must not have to walk.
+            status: i.isEven
+                ? ChangeSetStatus.resolved
+                : ChangeSetStatus.expired,
+            items: const [],
+            createdAt: at,
+            vectorClock: null,
+          ),
+        );
+      }
+    }
+  }
+
+  /// Runs every measured operation and returns the median elapsed
+  /// microseconds over [repetitions].
+  ///
+  /// Median rather than a single shot: at these magnitudes a single run is
+  /// dominated by scheduling noise, and the property being tested — that cost
+  /// does not grow with corpus size — is not readable through that noise. The
+  /// median also discards the first-run outlier where SQLite is still
+  /// preparing the statement.
+  ///
+  /// Each entry names an operation a user action actually triggers, so a
+  /// regression here is a regression they would feel.
+  Future<Map<String, int>> measure({int repetitions = 9}) async {
+    return {
+      // The drain path: what every enqueue and every retry tick costs.
+      'outbox.claimNext': await _time(outbox.claimNext, repetitions),
+      // The day view: captures and the persona indicator.
+      'dayView.captures': await _time(
+        () => repository.getEntitiesByAgentIdAndSubtype(
+          dailyOsPlannerAgentId,
+          type: AgentEntityTypes.capture,
+          subtype: currentDayId,
+        ),
+        repetitions,
+      ),
+      'dayView.statusEvents': await _time(
+        () => repository.getEntitiesByAgentIdAndSubtype(
+          dailyOsPlannerAgentId,
+          type: AgentEntityTypes.dayStatusEvent,
+          subtype: currentDayId,
+        ),
+        repetitions,
+      ),
+      // Runs ahead of both of the above, on every day-agent resolution.
+      'dayView.plannerOwnsDay': await _time(
+        () => repository.getEntitiesByAgentIdAndSubtype(
+          dailyOsPlannerAgentId,
+          type: AgentEntityTypes.capture,
+          subtype: currentDayId,
+          limit: 1,
+        ),
+        repetitions,
+      ),
+      // Pending diffs, read past however much confirmed/rejected history.
+      'planEditor.pendingDiffs': await _time(
+        () => repository.getEntitiesByAgentIdAndSubtype(
+          dailyOsPlannerAgentId,
+          type: 'changeSet',
+          subtype: ChangeSetStatus.pending.name,
+        ),
+        repetitions,
+      ),
+      // A seven-day plan lookback.
+      'planWriter.lookback': await _time(
+        () => repository.getEntitiesByAgentIdAndSubtypes(
+          dailyOsPlannerAgentId,
+          type: AgentEntityTypes.dayPlan,
+          subtypes: [
+            for (var offset = 0; offset < 7; offset++) dayPlanId(dayAt(offset)),
+          ],
+        ),
+        repetitions,
+      ),
+    };
+  }
+
+  /// Row counts, so a report states how much history produced its numbers.
+  Future<Map<String, int>> counts() async {
+    final agentRows = await agentDb
+        .customSelect('SELECT COUNT(*) AS c FROM agent_entities')
+        .getSingle();
+    final jobRows = await processingDb
+        .customSelect('SELECT COUNT(*) AS c FROM day_processing_jobs')
+        .getSingle();
+    return {
+      'days': days,
+      'agentEntities': agentRows.read<int>('c'),
+      'processingJobs': jobRows.read<int>('c'),
+    };
+  }
+
+  static Future<int> _time(
+    Future<void> Function() operation,
+    int repetitions,
+  ) async {
+    final samples = <int>[];
+    for (var i = 0; i < repetitions; i++) {
+      final stopwatch = Stopwatch()..start();
+      await operation();
+      samples.add((stopwatch..stop()).elapsedMicroseconds);
+    }
+    samples.sort();
+    return samples[samples.length ~/ 2];
+  }
+}

--- a/test/features/daily_os_next/benchmark/day_planner_corpus_benchmark_test.dart
+++ b/test/features/daily_os_next/benchmark/day_planner_corpus_benchmark_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+
+import 'day_planner_corpus.dart';
+
+/// Set to run the full 1/6/12-month sweep:
+///
+/// ```sh
+/// LOTTI_BENCHMARK=1 fvm flutter test \
+///   test/features/daily_os_next/benchmark/
+/// ```
+///
+/// Opt-in because seeding twelve simulated months writes tens of thousands of
+/// rows — worth the seconds when you want the numbers, not worth them on every
+/// CI run. The smoke test below always runs so the harness itself cannot rot.
+final bool benchmarkEnabled =
+    const String.fromEnvironment('LOTTI_BENCHMARK').isNotEmpty ||
+    const bool.fromEnvironment('LOTTI_BENCHMARK');
+
+/// Corpus ages to compare, in days.
+const Map<String, int> _corpora = {
+  '1 month': 30,
+  '6 months': 182,
+  '12 months': 365,
+};
+
+Future<Map<String, int>> _runCorpus(int days) async {
+  final agentDb = AgentDatabase(inMemoryDatabase: true, background: false);
+  final processingDb = DayProcessingDb(inMemoryDatabase: true);
+  addTearDown(agentDb.close);
+  addTearDown(processingDb.close);
+
+  final corpus = DayPlannerCorpus(
+    agentDb: agentDb,
+    processingDb: processingDb,
+    days: days,
+  );
+  await corpus.seed();
+  return {...await corpus.counts(), ...await corpus.measure()};
+}
+
+void main() {
+  test('the harness produces its full metric set', () async {
+    // Deliberately tiny: this asserts the harness still measures what it
+    // claims to, so a renamed repository method breaks here rather than
+    // silently dropping a column from a report nobody reads closely.
+    final result = await _runCorpus(2);
+
+    expect(
+      result.keys,
+      containsAll(<String>[
+        'days',
+        'agentEntities',
+        'processingJobs',
+        'outbox.claimNext',
+        'dayView.captures',
+        'dayView.statusEvents',
+        'dayView.plannerOwnsDay',
+        'planEditor.pendingDiffs',
+        'planWriter.lookback',
+      ]),
+    );
+    expect(result['days'], 2);
+    // Two days of the documented per-day shape: plan + 3 captures + 6 status
+    // events + 2 change sets.
+    expect(result['agentEntities'], 2 * (1 + 3 + 6 + 2));
+    expect(result['processingJobs'], 2 * 3);
+  });
+
+  test(
+    'per-action cost across 1, 6 and 12 simulated months',
+    () async {
+      final reports = <String, Map<String, int>>{};
+      for (final entry in _corpora.entries) {
+        reports[entry.key] = await _runCorpus(entry.value);
+      }
+
+      final metrics = reports.values.first.keys
+          .where((key) => key.contains('.'))
+          .toList();
+      final buffer = StringBuffer()
+        ..writeln()
+        ..writeln('Day planner cost by simulated install age (microseconds)')
+        ..writeln();
+      final header = ['metric', ..._corpora.keys].join(' | ');
+      buffer
+        ..writeln(header)
+        ..writeln('-' * header.length);
+      for (final metric in metrics) {
+        buffer.writeln(
+          [
+            metric,
+            for (final label in _corpora.keys) '${reports[label]![metric]}',
+          ].join(' | '),
+        );
+      }
+      buffer.writeln();
+      for (final entry in reports.entries) {
+        buffer.writeln(
+          '${entry.key}: ${entry.value['agentEntities']} agent entities, '
+          '${entry.value['processingJobs']} processing jobs',
+        );
+      }
+      // ignore: avoid_print
+      print(buffer);
+
+      // The report is the deliverable; assert only that every corpus produced
+      // a full row, so a silently-failing measurement cannot masquerade as a
+      // fast one.
+      for (final report in reports.values) {
+        for (final metric in metrics) {
+          expect(report[metric], isNotNull);
+        }
+      }
+    },
+    skip: benchmarkEnabled
+        ? false
+        : 'Corpus benchmark is opt-in: run with '
+              '--dart-define=LOTTI_BENCHMARK=1 (seeding 12 simulated months '
+              'writes tens of thousands of rows).',
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}


### PR DESCRIPTION
Everything shipped in this epic so far (#3564, #3566, #3569, #3571) has been
*reasoned* improvement — the arguments were sound and tests pinned the
behaviour, but nobody had measured a single number. This makes the claim
checkable.

## What it does

Seeds a synthetic Daily OS corpus at 1, 6 and 12 simulated months under the
coordinator (the agent that actually accumulates — a `day_agent:<dayId>` holds
one day and goes cold), then reports the cost of the operations a real user
action triggers.

Opt-in, because seeding twelve months writes thousands of rows:

```sh
fvm flutter test --dart-define=LOTTI_BENCHMARK=1 \
  test/features/daily_os_next/benchmark/
```

A smoke test runs unconditionally and asserts the full metric set, so a
renamed repository method breaks the build rather than silently dropping a
column from a report nobody reads closely.

## Baseline

Median of 9, microseconds. Absolute values are machine-specific; the slope is
the point.

| metric | 1 month | 6 months | 12 months |
| --- | --- | --- | --- |
| `outbox.claimNext` | 157 | 94 | 127 |
| `dayView.captures` | 224 | 144 | 136 |
| `dayView.statusEvents` | 313 | 344 | 159 |
| `dayView.plannerOwnsDay` | 122 | 113 | 86 |
| `planEditor.pendingDiffs` | 80 | 56 | 53 |
| `planWriter.lookback` | 666 | 445 | 262 |

Corpus: 360 / 2,184 / 4,380 agent entities and 90 / 546 / 1,095 processing
jobs. Every metric is flat or lower at twelve months than at one, across a 12×
increase in stored history. Values drifting *down* is noise and cache warming,
not a real speedup.

## One finding worth reading

My first corpus left every processing job `pending`, and `claimNext` grew
127 → 189 → 317 µs across the sweep. That is not a defect — it is cost
tracking outstanding work, exactly as designed — but it measures a 1,095-job
backlog no real install has, and it *hides* the property actually under test.

Reshaping the corpus the way a real outbox looks (a small pending head over a
large terminal ledger) makes `claimNext` flat at 157 / 94 / 127 while the
ledger grows 12×. That is ADR 0044's partial-index claim demonstrated rather
than asserted: the retained ledger stays off the drain path.

It also means the benchmark is only as honest as its corpus, which is why the
shape is documented in the harness rather than buried.

## Scope

Deliberately storage-layer only. It does **not** cover wake prompt bytes,
token counts, or digest wake duration — those need the full agent workflow
rather than the repositories, and are a separate piece of work. Called out in
the README so the gap is visible rather than assumed covered.

Analyzer and formatter clean; no CHANGELOG entry (test-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running opt-in performance benchmarks.
  * Documented baseline metrics across simulated 1-, 6-, and 12-month histories.

* **Tests**
  * Added benchmark coverage for Daily OS operations across different corpus sizes.
  * Added smoke tests verifying benchmark metrics and expected data counts.
  * Benchmarks are disabled by default and can be enabled when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->