### PR TITLE
test: cover the nine lines #3575 left uncovered

### DIFF
--- a/test/features/design_system/components/lists/design_system_list_item_test.dart
+++ b/test/features/design_system/components/lists/design_system_list_item_test.dart
@@ -135,6 +135,28 @@ void main() {
       expect(richText.overflow, TextOverflow.ellipsis);
     });
 
+    testWidgets(
+      'subtitleEmphasis overrides the ink on the subtitleSpans path too — the '
+      'two subtitle paths must not disagree about which parameter wins',
+      (tester) async {
+        await _pumpListItem(
+          tester,
+          const DesignSystemListItem(
+            title: 'Title',
+            subtitleSpans: [TextSpan(text: 'inline')],
+            subtitleEmphasis: Color(0xFF00FF00),
+          ),
+        );
+
+        final richText = tester.widget<RichText>(
+          find.byWidgetPredicate(
+            (w) => w is RichText && w.text.toPlainText().contains('inline'),
+          ),
+        );
+        expect(richText.text.style?.color, const Color(0xFF00FF00));
+      },
+    );
+
     testWidgets('renders custom title content and metadata spans', (
       tester,
     ) async {

--- a/test/features/tasks/ui/linked_tasks/link_task_modal_test.dart
+++ b/test/features/tasks/ui/linked_tasks/link_task_modal_test.dart
@@ -933,6 +933,68 @@ void main() {
       },
     );
 
+    /// Drives a link commit through to its Undo, with [removeResult] deciding
+    /// what the removal reports back.
+    Future<void> undoWith(
+      WidgetTester tester, {
+      required Future<int> Function() removeResult,
+    }) async {
+      final repo = MockJournalRepository();
+      when(
+        () => repo.removeTypedLink(
+          fromId: any(named: 'fromId'),
+          toId: any(named: 'toId'),
+          linkType: any(named: 'linkType'),
+        ),
+      ).thenAnswer((_) => removeResult());
+      stubTasks([buildTask(id: 'other-task', title: 'Other Task')]);
+      when(
+        () => mockPersistenceLogic.createLink(
+          fromId: any(named: 'fromId'),
+          toId: any(named: 'toId'),
+          // ignore: avoid_redundant_argument_values
+          linkType: EntryLinkType.basic,
+        ),
+      ).thenAnswer((_) async => true);
+
+      await openModal(tester, journalRepo: repo);
+      await tester.tap(find.text('Other Task'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.tap(find.text('Undo').last);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    testWidgets(
+      'an undo that removed nothing says so — the delete returns a row count '
+      'and throws nothing, so silence read exactly like success',
+      (tester) async {
+        await undoWith(tester, removeResult: () async => 0);
+
+        expect(
+          find.text("Couldn't unlink the task. Please try again."),
+          findsWidgets,
+        );
+      },
+    );
+
+    testWidgets(
+      'an undo that throws says so too, rather than leaving the link in place '
+      'behind a dismissed confirmation',
+      (tester) async {
+        await undoWith(
+          tester,
+          removeResult: () async => throw Exception('remove failed'),
+        );
+
+        expect(
+          find.text("Couldn't unlink the task. Please try again."),
+          findsWidgets,
+        );
+      },
+    );
+
     testWidgets(
       'a rejected link is not confirmed and offers no undo',
       (tester) async {

--- a/test/features/tasks/ui/linked_tasks/linked_tasks_widget_actions_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_tasks_widget_actions_test.dart
@@ -69,6 +69,8 @@ void main() {
     bool manageMode = false,
     MediaQueryData? mediaQueryData,
     List<Override> extraOverrides = const [],
+    double? width,
+    Locale? locale,
   }) async {
     final journalRepo = MockJournalRepository();
     when(
@@ -139,8 +141,19 @@ void main() {
           ...extraOverrides,
         ],
         child: WidgetTestBench(
+          locale: locale,
           mediaQueryData: mediaQueryData,
-          child: const LinkedTasksWidget(taskId: 'task-main'),
+          // Align, not a bare SizedBox: the bench hands its child tight
+          // constraints, so a width set any other way is silently ignored.
+          child: width == null
+              ? const LinkedTasksWidget(taskId: 'task-main')
+              : Align(
+                  alignment: Alignment.topLeft,
+                  child: SizedBox(
+                    width: width,
+                    child: const LinkedTasksWidget(taskId: 'task-main'),
+                  ),
+                ),
         ),
       ),
     );
@@ -577,6 +590,26 @@ void main() {
     );
 
     testWidgets(
+      "the empty card's create row opens the flow — it is the screen with "
+      'no links, so this action has no other worded entry point',
+      (tester) async {
+        stubCreateTaskEntry(null);
+        await pumpWidget(
+          tester,
+          incoming: [],
+          outgoing: [],
+          extraOverrides: createFlowOverrides(parentCategoryId: null),
+        );
+
+        await tester.tap(find.text('Create new linked task…'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(DesignSystemDropdown), findsOneWidget);
+      },
+    );
+
+    testWidgets(
       'relationship picker modal defaults to "Link", and dismissing it '
       'without confirming does not create a task',
       (tester) async {
@@ -621,6 +654,52 @@ void main() {
     );
 
     testWidgets(
+      'a rejected NON-blocking link on the create path says so plainly — the '
+      'cycle guard cannot reject a duplicates edge, so naming a cycle would '
+      'state a cause that cannot apply',
+      (tester) async {
+        stubCreateTaskEntry(buildTask(id: 'new-task', title: 'New'));
+
+        await pumpWidget(
+          tester,
+          incoming: [],
+          outgoing: [buildTask(id: 'out-1', title: 'Outgoing Task')],
+          extraOverrides: createFlowOverrides(parentCategoryId: null),
+        );
+        when(
+          () => mockPersistenceLogic.createLink(
+            fromId: any(named: 'fromId'),
+            toId: any(named: 'toId'),
+            linkType: EntryLinkType.duplicates,
+          ),
+        ).thenAnswer((_) async => false);
+
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Create new linked task…'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await pickRelation(tester, 'Duplicates');
+        await tester.tap(find.text('Create'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(
+          find.text("Couldn't create the link. Please try again."),
+          findsWidgets,
+        );
+        expect(
+          find.text(
+            'This would create a blocking cycle — choose a different task.',
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
       'a rejected typed link leaves the auto-created plain link in place, so '
       'the new task is never left unlinked',
       (tester) async {
@@ -660,6 +739,17 @@ void main() {
         await tester.tap(find.text('Create'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
+
+        // ...and the user is told why the relationship they asked for is not
+        // there. A blocks edge is the one thing the cycle guard can reject,
+        // so this case names the cycle rather than offering a retry that
+        // cannot end differently.
+        expect(
+          find.text(
+            'This would create a blocking cycle — choose a different task.',
+          ),
+          findsWidgets,
+        );
 
         // The BasicLink createTask made must survive, or the new task would
         // have no link back to its parent at all.
@@ -936,6 +1026,54 @@ void main() {
             swapDirection: false,
           ),
         ).called(1);
+      },
+    );
+
+    testWidgets(
+      'manage mode reaches the link picker through the overflow — its header '
+      'slot is taken by Done',
+      (tester) async {
+        await pumpWidget(
+          tester,
+          incoming: [],
+          outgoing: [buildTask(id: 'out-1', title: 'Outgoing Task')],
+          manageMode: true,
+        );
+
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Link existing task…'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text('Link existing task'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'a locale whose label will not fit still reaches the link picker — the '
+      'action drops its word, not its function',
+      (tester) async {
+        await pumpWidget(
+          tester,
+          incoming: [],
+          outgoing: [buildTask(id: 'out-1', title: 'Outgoing Task')],
+          width: 357,
+          locale: const Locale('de'),
+        );
+
+        // Icon-only in German: the worded button would truncate the card name.
+        expect(
+          find.widgetWithText(DesignSystemButton, 'Verknüpfen'),
+          findsNothing,
+        );
+
+        await tester.tap(find.byIcon(Icons.add_link));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(DesignSystemDropdown), findsWidgets);
       },
     );
   });


### PR DESCRIPTION
#3575 merged with `codecov/patch` red. Measuring the merge commit's added
lines against local lcov found nine with no test. All nine are reachable
behaviour rather than scaffolding, and several are the error paths that PR
added specifically so failures stop being silent — so they are worth covering
rather than waiving.

| Lines | What was untested |
| --- | --- |
| `link_created_feedback.dart` 74, 76, 83, 85 | Undo reporting a removal that removed nothing, and one that threw. `removeTypedLink` returns a row count and throws nothing when it matches no row, which is exactly why these branches exist. |
| `linked_tasks_widget.dart` 573 | The create path's non-blocking failure message. Only a `blocks` edge can fail the cycle guard; the existing test covered that branch alone, so the plain-failure branch never ran. |
| `linked_tasks_widget.dart` 120 | The empty card's "Create new linked task" row — that screen's only worded entry point to the flow. |
| `linked_tasks_widget.dart` 423 | The link picker reached through manage mode's overflow, where the header slot is taken by Done. |
| `linked_tasks_widget.dart` 386 | The icon-only link action in a locale whose label will not fit. Asserts it still opens the picker: the action drops its word, not its function. |
| `design_system_list_item.dart` 346 | `subtitleEmphasis` on the `subtitleSpans` path, so the two subtitle paths cannot disagree about which parameter wins. |

Six tests, no production changes.

`pumpWidget` in `linked_tasks_widget_actions_test.dart` gained `width` and
`locale`, matching the helper in `linked_tasks_widget_test.dart` — via `Align`,
because the bench hands its child tight constraints and a width set any other
way is silently ignored.

## Verification

Added lines of `fa842e6bc` intersected with `coverage/lcov.info`: **nine
uncovered before, zero after.** `fvm flutter analyze` clean across `lib/` and
`test/features`; 218 tests green in the touched directories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for emphasized subtitle colors in list items.
  * Added validation for unlink failures, including unsuccessful responses and exceptions.
  * Expanded linked-task flow coverage for creating, undoing, managing, and unlinking tasks.
  * Verified responsive layouts and localized action behavior.
  * Strengthened coverage for blocked and non-blocking relationship cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->