### PR TITLE
test: add day-planning eval constraint scorers

### DIFF
--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1,0 +1,318 @@
+import 'package:lotti/classes/day_plan.dart';
+
+import 'eval_models.dart';
+
+/// Objective constraints the day planner's output is scored against.
+///
+/// Every scorer here is a pure function over an [EvalRunOutcome] — no I/O, no
+/// provider, no pipeline — so they run in ordinary CI and can be exercised
+/// against hand-built plans.
+///
+/// The set is split deliberately, because the two halves measure different
+/// things:
+///
+/// **Unguarded** constraints are scored on the persisted plan. Nothing in the
+/// write path checks them, so whatever the model produced is what the user
+/// gets. These are the ones that can silently ship a bad day.
+///
+/// **Guarded** constraints are scored on the *rejection count*. The write path
+/// throws on these and hands the message back to the model, which retries — so
+/// the persisted plan is always legal and tells you nothing. What varies, and
+/// what a better prompt improves, is how many corrections the model needed
+/// first. Zero rejections means it complied unaided.
+
+/// Ids of the unguarded constraints, in report order.
+abstract final class EvalConstraintIds {
+  static const noOverlappingBlocks = 'noOverlappingBlocks';
+  static const withinCapacity = 'withinCapacity';
+  static const decidedTasksPlaced = 'decidedTasksPlaced';
+  static const blockerBeforeBlocked = 'blockerBeforeBlocked';
+  static const noFabricatedTaskIds = 'noFabricatedTaskIds';
+  static const noHistoryFabrication = 'noHistoryFabrication';
+  static const uniqueBlockIds = 'uniqueBlockIds';
+
+  /// Guarded — scored on rejections rather than on the plan.
+  static const compliedWithoutRejection = 'compliedWithoutRejection';
+
+  static const all = <String>[
+    noOverlappingBlocks,
+    withinCapacity,
+    decidedTasksPlaced,
+    blockerBeforeBlocked,
+    noFabricatedTaskIds,
+    noHistoryFabrication,
+    uniqueBlockIds,
+    compliedWithoutRejection,
+  ];
+}
+
+/// Scores every constraint against [outcome], in report order.
+List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
+  scoreNoOverlappingBlocks(outcome),
+  scoreWithinCapacity(outcome),
+  scoreDecidedTasksPlaced(outcome),
+  scoreBlockerBeforeBlocked(outcome),
+  scoreNoFabricatedTaskIds(outcome),
+  scoreNoHistoryFabrication(outcome),
+  scoreUniqueBlockIds(outcome),
+  scoreCompliedWithoutRejection(outcome),
+];
+
+/// No two blocks may occupy the same time.
+///
+/// Nothing in the write path checks this, and overlaps additionally
+/// double-count against capacity because `scheduledMinutesFor` naively sums
+/// durations.
+EvalConstraintResult scoreNoOverlappingBlocks(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.noOverlappingBlocks;
+  final blocks = _scheduled(outcome);
+  if (blocks.length < 2) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'fewer than two scheduled blocks',
+    );
+  }
+  final sorted = [...blocks]
+    ..sort((a, b) => a.startTime.compareTo(b.startTime));
+  final clashes = <String>[];
+  for (var i = 1; i < sorted.length; i++) {
+    final previous = sorted[i - 1];
+    final current = sorted[i];
+    // Touching is fine: one block ending exactly when the next begins is a
+    // back-to-back day, not a conflict.
+    if (current.startTime.isBefore(previous.endTime)) {
+      clashes.add(
+        '"${previous.title ?? previous.id}" '
+        '(${_hhmm(previous.startTime)}-${_hhmm(previous.endTime)}) '
+        'overlaps "${current.title ?? current.id}" '
+        '(${_hhmm(current.startTime)}-${_hhmm(current.endTime)})',
+      );
+    }
+  }
+  return EvalConstraintResult(
+    id: id,
+    passed: clashes.isEmpty,
+    detail: clashes.isEmpty
+        ? '${sorted.length} blocks, no overlap'
+        : clashes.join('; '),
+  );
+}
+
+/// Scheduled minutes must fit the day's capacity.
+///
+/// Prompt-contract only in production: the two numbers are stored side by side
+/// and never compared, and `capacityMinutes` is itself a model-supplied tool
+/// argument.
+EvalConstraintResult scoreWithinCapacity(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.withinCapacity;
+  final blocks = _scheduled(outcome);
+  if (blocks.isEmpty) {
+    return const EvalConstraintResult.notApplicable(id, 'no scheduled blocks');
+  }
+  final scheduled = blocks.fold<int>(
+    0,
+    (sum, block) => sum + block.endTime.difference(block.startTime).inMinutes,
+  );
+  final capacity = outcome.inputs.capacityMinutes;
+  return EvalConstraintResult(
+    id: id,
+    passed: scheduled <= capacity,
+    detail:
+        '$scheduled min scheduled against $capacity min capacity'
+        '${scheduled > capacity ? ' (over by ${scheduled - capacity})' : ''}',
+  );
+}
+
+/// Every task the user decided on should appear in the plan.
+///
+/// `decidedTaskIds` is only a permission set in production — nothing checks
+/// that any of them were actually placed, so a plan can honour none of them
+/// and still persist.
+EvalConstraintResult scoreDecidedTasksPlaced(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.decidedTasksPlaced;
+  final decided = outcome.inputs.decidedTaskIds;
+  if (decided.isEmpty) {
+    return const EvalConstraintResult.notApplicable(id, 'no decided tasks');
+  }
+  final placed = {for (final block in outcome.blocks) ?block.taskId};
+  final missing = [
+    for (final id in decided)
+      if (!placed.contains(id)) id,
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: missing.isEmpty,
+    detail: missing.isEmpty
+        ? 'all ${decided.length} decided task(s) placed'
+        : 'not placed: ${missing.join(', ')}',
+  );
+}
+
+/// A blocked task may only be placed when its blocker is scheduled earlier the
+/// same day, or when the block's reason names the blocker (ADR 0043).
+///
+/// Enforced by prompt contract alone — the writer never consults the
+/// dependency resolver, by explicit ADR decision.
+EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.blockerBeforeBlocked;
+  final blocked = <PlannedBlock, EvalCorpusTask>{};
+  for (final block in outcome.blocks) {
+    final taskId = block.taskId;
+    if (taskId == null) continue;
+    final task = outcome.inputs.taskById(taskId);
+    if (task != null && task.isBlocked) blocked[block] = task;
+  }
+  if (blocked.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no blocked task was placed',
+    );
+  }
+  final violations = <String>[];
+  for (final entry in blocked.entries) {
+    final block = entry.key;
+    final task = entry.value;
+    final blockerScheduledEarlier = outcome.blocks.any(
+      (other) =>
+          other.taskId != null &&
+          task.blockedBy.contains(other.taskId) &&
+          other.startTime.isBefore(block.startTime),
+    );
+    if (blockerScheduledEarlier) continue;
+    // The escape hatch the rule grants: place it anyway, but say which
+    // blocker and why it can proceed regardless.
+    final reason = block.reason?.toLowerCase() ?? '';
+    final namesBlocker = task.blockedBy.any((blockerId) {
+      final blocker = outcome.inputs.taskById(blockerId);
+      final title = blocker?.title.toLowerCase();
+      return reason.contains(blockerId.toLowerCase()) ||
+          (title != null && title.isNotEmpty && reason.contains(title));
+    });
+    if (namesBlocker) continue;
+    violations.add(
+      '"${block.title ?? block.taskId}" is blocked by '
+      '${task.blockedBy.isEmpty ? 'status BLOCKED' : task.blockedBy.join(', ')} '
+      'but neither schedules the blocker earlier nor names it in the reason',
+    );
+  }
+  return EvalConstraintResult(
+    id: id,
+    passed: violations.isEmpty,
+    detail: violations.isEmpty
+        ? '${blocked.length} blocked task(s) placed, all justified'
+        : violations.join('; '),
+  );
+}
+
+/// Every `taskId` on the plan must be a task the model was actually shown.
+///
+/// A real hole in production: a taskId is accepted if it appears in the
+/// model's *own* `decidedTaskIds` argument, which is never verified against
+/// the wake context or the database.
+EvalConstraintResult scoreNoFabricatedTaskIds(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.noFabricatedTaskIds;
+  final referenced = [for (final block in outcome.blocks) ?block.taskId];
+  if (referenced.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no block references a task',
+    );
+  }
+  final known = {
+    for (final task in outcome.inputs.corpus) task.taskId,
+    ...outcome.inputs.decidedTaskIds,
+  };
+  final fabricated = {
+    for (final taskId in referenced)
+      if (!known.contains(taskId)) taskId,
+  };
+  return EvalConstraintResult(
+    id: id,
+    passed: fabricated.isEmpty,
+    detail: fabricated.isEmpty
+        ? '${referenced.length} task reference(s), all known'
+        : 'unknown task id(s): ${fabricated.join(', ')}',
+  );
+}
+
+/// A freshly drafted plan must not claim work already happened.
+///
+/// `state` is a model-writable enum that nothing validates, so a model can
+/// assert `completed`/`inProgress` on a brand-new draft — which both fabricates
+/// history and slips the same-day past-start guard, since that guard only
+/// fires for `drafted`.
+EvalConstraintResult scoreNoHistoryFabrication(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.noHistoryFabrication;
+  if (outcome.blocks.isEmpty) {
+    return const EvalConstraintResult.notApplicable(id, 'no blocks');
+  }
+  final fabricated = [
+    for (final block in outcome.blocks)
+      if (block.state == PlannedBlockState.completed ||
+          block.state == PlannedBlockState.inProgress)
+        '"${block.title ?? block.id}" as ${block.state.name}',
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: fabricated.isEmpty,
+    detail: fabricated.isEmpty
+        ? 'no fabricated history'
+        : 'claims history: ${fabricated.join(', ')}',
+  );
+}
+
+/// Block ids must be unique within a plan.
+///
+/// Model-supplied ids are taken verbatim with no uniqueness check; duplicates
+/// make later `move_block` / `drop_block` targeting ambiguous.
+EvalConstraintResult scoreUniqueBlockIds(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.uniqueBlockIds;
+  if (outcome.blocks.length < 2) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'fewer than two blocks',
+    );
+  }
+  final seen = <String>{};
+  final duplicates = <String>{};
+  for (final block in outcome.blocks) {
+    if (!seen.add(block.id)) duplicates.add(block.id);
+  }
+  return EvalConstraintResult(
+    id: id,
+    passed: duplicates.isEmpty,
+    detail: duplicates.isEmpty
+        ? '${outcome.blocks.length} unique block ids'
+        : 'duplicate id(s): ${duplicates.join(', ')}',
+  );
+}
+
+/// Whether the model produced a legal plan without being corrected.
+///
+/// This is the guarded half. The persisted plan is always legal — the write
+/// path rejected anything that was not — so the only observable difference
+/// between a model that got it right and one that needed four attempts is the
+/// rejections it collected on the way.
+EvalConstraintResult scoreCompliedWithoutRejection(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.compliedWithoutRejection;
+  final rejections = outcome.rejections.toList();
+  return EvalConstraintResult(
+    id: id,
+    passed: rejections.isEmpty,
+    detail: rejections.isEmpty
+        ? 'accepted on the first attempt'
+        : '${rejections.length} rejection(s): '
+              '${rejections.map((r) => r.rejectionMessage ?? 'unknown').join(' | ')}',
+  );
+}
+
+/// Blocks that consume capacity — `dropped` ones are recorded but not
+/// scheduled, matching `scheduledMinutesFor` in the parser.
+List<PlannedBlock> _scheduled(EvalRunOutcome outcome) => [
+  for (final block in outcome.blocks)
+    if (block.state != PlannedBlockState.dropped) block,
+];
+
+String _hhmm(DateTime time) =>
+    '${time.hour.toString().padLeft(2, '0')}:'
+    '${time.minute.toString().padLeft(2, '0')}';

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1,0 +1,480 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
+
+import 'eval_constraints.dart';
+import 'eval_models.dart';
+
+/// The scorers are pure, so these run in ordinary CI: no provider, no
+/// database, no pipeline. Every scorer is exercised in both directions,
+/// because a scorer that only ever passes is indistinguishable from one that
+/// is broken.
+void main() {
+  final planDate = DateTime(2026, 7, 18);
+
+  PlannedBlock block({
+    required String id,
+    required int startHour,
+    required int endHour,
+    String? taskId,
+    String? reason,
+    String? title,
+    PlannedBlockState state = PlannedBlockState.drafted,
+  }) => PlannedBlock(
+    id: id,
+    categoryId: 'cat-1',
+    startTime: DateTime(2026, 7, 18, startHour),
+    endTime: DateTime(2026, 7, 18, endHour),
+    taskId: taskId,
+    reason: reason,
+    title: title ?? id,
+    state: state,
+  );
+
+  EvalRunOutcome outcome({
+    List<PlannedBlock> blocks = const [],
+    List<EvalCorpusTask> corpus = const [],
+    List<String> decidedTaskIds = const [],
+    List<EvalToolCall> toolCalls = const [],
+    int capacityMinutes = 480,
+  }) => EvalRunOutcome(
+    inputs: EvalFixtureInputs(
+      dayId: 'dayplan-2026-07-18',
+      planDate: planDate,
+      corpus: corpus,
+      decidedTaskIds: decidedTaskIds,
+      capacityMinutes: capacityMinutes,
+    ),
+    blocks: blocks,
+    toolCalls: toolCalls,
+  );
+
+  group('noOverlappingBlocks', () {
+    test('passes for back-to-back blocks', () {
+      // Touching is a full day, not a conflict — the boundary case that a
+      // naive "start < end" comparison gets wrong.
+      final result = scoreNoOverlappingBlocks(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10),
+            block(id: 'b', startHour: 10, endHour: 11),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails and names both blocks when they overlap', () {
+      final result = scoreNoOverlappingBlocks(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 11, title: 'Deep work'),
+            block(id: 'b', startHour: 10, endHour: 12, title: 'Review'),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Deep work'));
+      expect(result.detail, contains('Review'));
+    });
+
+    test('detects an overlap regardless of input order', () {
+      final result = scoreNoOverlappingBlocks(
+        outcome(
+          blocks: [
+            block(id: 'later', startHour: 10, endHour: 12),
+            block(id: 'earlier', startHour: 9, endHour: 11),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('is not applicable below two blocks', () {
+      final result = scoreNoOverlappingBlocks(
+        outcome(blocks: [block(id: 'a', startHour: 9, endHour: 10)]),
+      );
+
+      expect(result.isApplicable, isFalse);
+    });
+  });
+
+  group('withinCapacity', () {
+    test('passes when scheduled minutes fit', () {
+      final result = scoreWithinCapacity(
+        outcome(
+          blocks: [block(id: 'a', startHour: 9, endHour: 13)],
+          // ignore: avoid_redundant_argument_values
+          capacityMinutes: 480,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails and reports the overrun', () {
+      final result = scoreWithinCapacity(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 8, endHour: 16),
+            block(id: 'b', startHour: 16, endHour: 20),
+          ],
+          // ignore: avoid_redundant_argument_values
+          capacityMinutes: 480,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('over by 240'));
+    });
+
+    test('excludes dropped blocks, matching the parser', () {
+      final result = scoreWithinCapacity(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 8, endHour: 16),
+            block(
+              id: 'b',
+              startHour: 16,
+              endHour: 20,
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+          // ignore: avoid_redundant_argument_values
+          capacityMinutes: 480,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+  });
+
+  group('decidedTasksPlaced', () {
+    test('passes when every decided task has a block', () {
+      final result = scoreDecidedTasksPlaced(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-1'),
+            block(id: 'b', startHour: 10, endHour: 11, taskId: 'task-2'),
+          ],
+          decidedTaskIds: const ['task-1', 'task-2'],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails and names the tasks that were dropped', () {
+      final result = scoreDecidedTasksPlaced(
+        outcome(
+          blocks: [block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-1')],
+          decidedTaskIds: const ['task-1', 'task-2'],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-2'));
+      expect(result.detail, isNot(contains('task-1')));
+    });
+
+    test('is not applicable when nothing was decided', () {
+      expect(scoreDecidedTasksPlaced(outcome()).isApplicable, isFalse);
+    });
+  });
+
+  group('blockerBeforeBlocked', () {
+    const blocker = EvalCorpusTask(
+      taskId: 'task-blocker',
+      title: 'Fix the API',
+    );
+    const blocked = EvalCorpusTask(
+      taskId: 'task-blocked',
+      title: 'Ship the feature',
+      status: 'BLOCKED',
+      blockedBy: ['task-blocker'],
+    );
+
+    test('passes when the blocker is scheduled earlier the same day', () {
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-blocker',
+            ),
+            block(
+              id: 'b',
+              startHour: 11,
+              endHour: 12,
+              taskId: 'task-blocked',
+            ),
+          ],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails when the blocker is scheduled after the blocked work', () {
+      // Ordering matters, not mere presence — the blocker being somewhere in
+      // the day is not the rule.
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-blocked'),
+            block(id: 'b', startHour: 11, endHour: 12, taskId: 'task-blocker'),
+          ],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('passes when the reason names the blocker by title', () {
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-blocked',
+              reason: 'Starting the parts that do not need Fix the API done.',
+            ),
+          ],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('passes when the reason names the blocker by id', () {
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-blocked',
+              reason: 'task-blocker is already in review, so this can start.',
+            ),
+          ],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails when the reason is generic hand-waving', () {
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-blocked',
+              reason: 'High priority work for the morning.',
+            ),
+          ],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-blocker'));
+    });
+
+    test('treats a status-only BLOCKED task as blocked', () {
+      // ADR 0043: the predicate is a union. A manually blocked task carries no
+      // links, and absence of blockedBy is not permission.
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-manual'),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-manual',
+              title: 'Manually blocked',
+              status: 'BLOCKED',
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('status BLOCKED'));
+    });
+
+    test('is not applicable when no blocked task was placed', () {
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-blocker'),
+          ],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.isApplicable, isFalse);
+    });
+  });
+
+  group('noFabricatedTaskIds', () {
+    test('passes for a task that was in the corpus', () {
+      final result = scoreNoFabricatedTaskIds(
+        outcome(
+          blocks: [block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-1')],
+          corpus: const [EvalCorpusTask(taskId: 'task-1', title: 'Real')],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails for a task id the model was never shown', () {
+      final result = scoreNoFabricatedTaskIds(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-invented'),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-1', title: 'Real')],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-invented'));
+    });
+  });
+
+  group('noHistoryFabrication', () {
+    test('passes for an ordinary drafted plan', () {
+      final result = scoreNoHistoryFabrication(
+        outcome(blocks: [block(id: 'a', startHour: 9, endHour: 10)]),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails when a fresh draft claims completed work', () {
+      // Also the same-day guard bypass: the guard only fires for `drafted`,
+      // so a completed block can carry a start time in the past.
+      final result = scoreNoHistoryFabrication(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 6,
+              endHour: 7,
+              title: 'Morning routine',
+              state: PlannedBlockState.completed,
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Morning routine'));
+    });
+  });
+
+  group('uniqueBlockIds', () {
+    test('passes for distinct ids', () {
+      final result = scoreUniqueBlockIds(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10),
+            block(id: 'b', startHour: 10, endHour: 11),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails on a duplicate id', () {
+      final result = scoreUniqueBlockIds(
+        outcome(
+          blocks: [
+            block(id: 'same', startHour: 9, endHour: 10),
+            block(id: 'same', startHour: 10, endHour: 11),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('same'));
+    });
+  });
+
+  group('compliedWithoutRejection', () {
+    test('passes when the first tool call was accepted', () {
+      final result = scoreCompliedWithoutRejection(
+        outcome(
+          toolCalls: const [
+            EvalToolCall(name: 'draft_day_plan', accepted: true),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails and carries the rejection text the model received', () {
+      // The whole point of this scorer: the persisted plan is legal either
+      // way, so the correction the model needed is the only signal.
+      final result = scoreCompliedWithoutRejection(
+        outcome(
+          toolCalls: const [
+            EvalToolCall(
+              name: 'draft_day_plan',
+              accepted: false,
+              rejectionMessage:
+                  'drafted non-calendar blocks for today must not start '
+                  'before current time',
+            ),
+            EvalToolCall(name: 'draft_day_plan', accepted: true),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('must not start before current time'));
+    });
+  });
+
+  group('scoreAll', () {
+    test('returns every constraint in report order', () {
+      final results = scoreAll(outcome());
+
+      expect(
+        results.map((result) => result.id),
+        EvalConstraintIds.all,
+        reason:
+            'a constraint dropped from scoreAll would silently stop being '
+            'measured while the report still looked complete',
+      );
+    });
+
+    test('marks inapplicable constraints rather than passing them', () {
+      // An empty plan must not read as a clean sweep — that would make the
+      // laziest possible model look like the best one.
+      final results = scoreAll(outcome());
+
+      expect(
+        results.where((result) => result.isApplicable).map((r) => r.id),
+        [EvalConstraintIds.compliedWithoutRejection],
+      );
+    });
+  });
+}

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -1,0 +1,155 @@
+import 'package:lotti/classes/day_plan.dart';
+import 'package:meta/meta.dart';
+
+/// Value types the day-planning eval scores over.
+///
+/// Deliberately small and provider-free: the scorers in
+/// `eval_constraints.dart` are pure functions over these, so they can be
+/// unit-tested against hand-built plans in ordinary CI without a model, a
+/// database, or the pipeline.
+
+/// One task as the model saw it in the corpus.
+///
+/// Mirrors the corpus row shape from `DayAgentCorpusService` closely enough to
+/// score against, including the ADR 0043 `blockedBy` annotation.
+@immutable
+class EvalCorpusTask {
+  const EvalCorpusTask({
+    required this.taskId,
+    required this.title,
+    this.status = 'OPEN',
+    this.blockedBy = const [],
+    this.estimateMinutes,
+    this.categoryId,
+  });
+
+  final String taskId;
+  final String title;
+
+  /// Corpus status string, e.g. `OPEN`, `IN PROGRESS`, `BLOCKED`.
+  final String status;
+
+  /// Task ids blocking this one (ADR 0043).
+  final List<String> blockedBy;
+
+  final int? estimateMinutes;
+  final String? categoryId;
+
+  /// ADR 0043's predicate, stated once.
+  ///
+  /// A union, not a choice: a manually blocked task shows `status: BLOCKED`
+  /// with no links, so absence of [blockedBy] means link-ready, not free to
+  /// schedule.
+  bool get isBlocked =>
+      status.toUpperCase() == 'BLOCKED' || blockedBy.isNotEmpty;
+}
+
+/// The inputs a scenario handed the model, kept alongside the result so a
+/// scorer never has to re-derive what the model was asked to do.
+@immutable
+class EvalFixtureInputs {
+  const EvalFixtureInputs({
+    required this.dayId,
+    required this.planDate,
+    this.corpus = const [],
+    this.decidedTaskIds = const [],
+    this.capacityMinutes = 480,
+    this.now,
+  });
+
+  final String dayId;
+  final DateTime planDate;
+  final List<EvalCorpusTask> corpus;
+
+  /// Tasks the user explicitly approved for placement.
+  final List<String> decidedTaskIds;
+
+  final int capacityMinutes;
+
+  /// Wall instant the draft ran at, for same-day scenarios. Null for a
+  /// future-day draft, where "the past" has no meaning.
+  final DateTime? now;
+
+  EvalCorpusTask? taskById(String id) {
+    for (final task in corpus) {
+      if (task.taskId == id) return task;
+    }
+    return null;
+  }
+}
+
+/// One tool call the model made, in order, including rejected ones.
+///
+/// Rejections are first-class: the write path throws on a violated hard
+/// constraint and hands the message back to the model, which then retries. A
+/// plan that only became legal on the fourth attempt is indistinguishable from
+/// a first-time-right plan if you look at the persisted result alone, so the
+/// rejection text is where guarded constraints are actually scored.
+@immutable
+class EvalToolCall {
+  const EvalToolCall({
+    required this.name,
+    required this.accepted,
+    this.rejectionMessage,
+    this.arguments = const {},
+  });
+
+  final String name;
+  final bool accepted;
+
+  /// The failure text the model received. Null when [accepted].
+  final String? rejectionMessage;
+
+  final Map<String, Object?> arguments;
+}
+
+/// Everything one run produced, as the scorers see it.
+@immutable
+class EvalRunOutcome {
+  const EvalRunOutcome({
+    required this.inputs,
+    this.blocks = const [],
+    this.toolCalls = const [],
+    this.planPersisted = true,
+  });
+
+  final EvalFixtureInputs inputs;
+
+  /// Blocks on the persisted plan, in whatever order they were stored.
+  final List<PlannedBlock> blocks;
+
+  final List<EvalToolCall> toolCalls;
+
+  /// False when the run ended without a plan at all — every constraint that
+  /// reads the plan is then inapplicable rather than failed.
+  final bool planPersisted;
+
+  Iterable<EvalToolCall> get rejections =>
+      toolCalls.where((call) => !call.accepted);
+}
+
+/// Outcome of one constraint against one run.
+///
+/// [passed] is nullable because "not applicable" is a distinct answer from
+/// "failed": a scenario with no blocked tasks says nothing about whether the
+/// model respects blockers, and averaging that in as a pass would flatter it.
+@immutable
+class EvalConstraintResult {
+  const EvalConstraintResult({
+    required this.id,
+    required this.passed,
+    required this.detail,
+  });
+
+  const EvalConstraintResult.notApplicable(this.id, this.detail)
+    : passed = null;
+
+  final String id;
+  final bool? passed;
+
+  /// Human-readable, and specific enough to act on — names the offending
+  /// block or task rather than restating the rule.
+  final String detail;
+
+  bool get isApplicable => passed != null;
+}


### PR DESCRIPTION
First task of the day-planning eval framework epic. Pure scorers only — no
runner, no provider, no report yet.

## Why the constraint set is split

Two exploration passes produced an enforcement inventory of the day-plan write
path, and it divides the constraint space in a way the framework has to mirror.

**Hard-enforced** (throws `DayAgentCaptureException`, rejecting the *entire*
`draft_day_plan` call and handing the message back to the model, which then
retries): day boundaries, `end > start`, same-day past-start, allowed
categories, committed-plan overwrite, `capacityMinutes <= 0`, at least one
block.

**Not checked anywhere** — prompt-contract only: block overlap, scheduled
minutes vs `capacityMinutes`, decided tasks actually being placed, ADR 0043
dependency ordering (an explicit ADR non-goal), duplicate block ids, `state`
coherence.

The consequence drives the design: **inspecting only the persisted plan
measures the guards, not the model.** A model that proposes three illegal plans
and succeeds on the fourth is indistinguishable from one that got it right
first time. So:

- *Unguarded* constraints are scored on the persisted plan — whatever the model
  produced is what the user gets.
- *Guarded* constraints are scored on the **rejection count**. Zero rejections
  means the model complied unaided. This is the signal a better prompt actually
  moves, and it is invisible today.

## Deliberate design choices

**"Not applicable" is a third result, not a pass.** A scenario with no blocked
tasks says nothing about whether the model respects blockers; counting that as
a pass would make the laziest possible model look like the best one. A test
asserts that an empty plan scores as inapplicable across the board rather than
as a clean sweep.

**Touching blocks are not an overlap.** One block ending exactly when the next
begins is a back-to-back day. This is the boundary a naive comparison gets
wrong, and it is tested.

**`blockerBeforeBlocked` honours both halves of the ADR 0043 rule** — blocker
scheduled earlier, *or* the block's reason naming the blocker — and treats the
blocked predicate as the union the ADR specifies (`status: BLOCKED` **or**
non-empty `blockedBy`), since a manually blocked task carries no links and
"absence of blockedBy means link-ready, not free to schedule".

## Testing

27 unit tests, every scorer exercised in **both** directions — a scorer that
only ever passes is indistinguishable from one that is broken. Includes the
generic-hand-waving reason failing while a blocker-naming reason passes, and
blocker-scheduled-after failing while blocker-scheduled-before passes, since
ordering is the rule rather than mere presence.

Runs in ordinary CI: no env gate, no network, no database. Analyzer and
formatter clean. No CHANGELOG entry (test-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluation models for daily planning scenarios, including tasks, tool calls, run outcomes, and constraint results.
  * Added automated checks for schedule overlaps, capacity limits, task placement, blocking order, task validity, history accuracy, duplicate blocks, and tool-call compliance.
  * Added consolidated constraint reporting with clear pass, fail, and not-applicable outcomes.

* **Tests**
  * Added comprehensive coverage for evaluation rules, edge cases, reporting order, and failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->