### PR TITLE
fix: light-theme alert contrast — add an AA-safe ink step to the alert ramp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1068]
 ### Changed
+- **Warnings, errors and status text are readable in light mode.** The amber,
+  green and blue used for warnings, successes and information were mixed too
+  light to stand out against a white or off-white background — amber measured
+  barely above the page it sat on, so a "blocked" mark or a pending-sync
+  notice could all but disappear. Those three tones are now deep enough to
+  read, and any text carrying one of them — priority labels, status chips,
+  connection results, ledger figures — is picked to stay legible in whichever
+  theme you use. Dark mode is unchanged apart from error text, which lightens
+  slightly on cards.
+
 - **Areas you create during onboarding start with automatic AI on.** Automatic
   transcription and image analysis remain off by default for every category
   you make later — but the onboarding flow, where you connect a provider and

--- a/assets/design_system/tokens.json
+++ b/assets/design_system/tokens.json
@@ -65,22 +65,26 @@
       "error": {
         "default": { "id": "VariableID:2521:549", "light": "#CC3633", "dark": "#D65E5C" },
         "hover":   { "id": "VariableID:2521:550", "light": "#A32B29", "dark": "#E08684" },
-        "pressed": { "id": "VariableID:2521:551", "light": "#7A1F1F", "dark": "#EBB0AE" }
+        "pressed": { "id": "VariableID:2521:551", "light": "#7A1F1F", "dark": "#EBB0AE" },
+        "ink":     { "light": "#A32B29", "dark": "#E08684" }
       },
       "success": {
-        "default": { "id": "VariableID:2521:552", "light": "#59A66B", "dark": "#7AB889" },
+        "default": { "id": "VariableID:2521:552", "light": "#478556", "dark": "#7AB889" },
         "hover":   { "id": "VariableID:2521:553", "light": "#478556", "dark": "#9CC9A6" },
-        "pressed": { "id": "VariableID:2521:554", "light": "#366340", "dark": "#BDDBC4" }
+        "pressed": { "id": "VariableID:2521:554", "light": "#366340", "dark": "#BDDBC4" },
+        "ink":     { "light": "#366340", "dark": "#7AB889" }
       },
       "warning": {
-        "default": { "id": "VariableID:2521:555", "light": "#FA8C05", "dark": "#FBA336" },
+        "default": { "id": "VariableID:2521:555", "light": "#C87005", "dark": "#FBA336" },
         "hover":   { "id": "VariableID:2521:556", "light": "#C87005", "dark": "#FCBA69" },
-        "pressed": { "id": "VariableID:2521:557", "light": "#965402", "dark": "#FDD19B" }
+        "pressed": { "id": "VariableID:2521:557", "light": "#965402", "dark": "#FDD19B" },
+        "ink":     { "light": "#965402", "dark": "#FBA336" }
       },
       "info": {
-        "default": { "id": "VariableID:2521:558", "light": "#1CA3E3", "dark": "#4AB6E8" },
+        "default": { "id": "VariableID:2521:558", "light": "#1783B5", "dark": "#4AB6E8" },
         "hover":   { "id": "VariableID:2521:559", "light": "#1783B5", "dark": "#77C8EE" },
-        "pressed": { "id": "VariableID:2521:560", "light": "#116288", "dark": "#A4DAF4" }
+        "pressed": { "id": "VariableID:2521:560", "light": "#116288", "dark": "#A4DAF4" },
+        "ink":     { "light": "#116288", "dark": "#4AB6E8" }
       }
     },
     "background": {

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
   <releases>
     <release version="0.9.1068" date="2026-07-25">
       <description>
+        <p>Warnings, errors and status text are readable in light mode. The amber, green and blue used for warnings, successes and information were mixed too light to stand out against a white or off-white background — amber measured barely above the page it sat on, so a "blocked" mark or a pending-sync notice could all but disappear. Those three tones are now deep enough to read, and any text carrying one of them — priority labels, status chips, connection results, ledger figures — is picked to stay legible in whichever theme you use. Dark mode is unchanged apart from error text, which lightens slightly on cards.</p>
         <p>Areas created during onboarding now start with automatic AI on. Automatic transcription and image analysis stay off by default for categories you create later, but the onboarding flow — where you connect a provider and record a first capture on purpose — switches it on for the areas it creates, so the app keeps working the way onboarding just showed you. Reusing an area where you had already switched automation off leaves it off.</p>
         <p>Fixed: re-running onboarding restores a bundled profile you had deleted. Setting up a provider through onboarding again now brings back that provider's bundled profile even if you had removed it earlier, so the areas onboarding creates always point at a profile that exists. Deleting it stays permanent everywhere else.</p>
       </description>

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
@@ -831,7 +831,7 @@ class _ResolveBadge extends StatelessWidget {
     final ai = tokens.colors.aiCard;
     final messages = context.messages;
     final accept = kind == ProposalResolveKind.accept;
-    final color = accept ? ai.accent : tokens.colors.alert.error.defaultColor;
+    final color = accept ? ai.accent : tokens.colors.alert.error.ink;
     final label = accept
         ? messages.aiCardProposalConfirmed
         : messages.aiCardProposalDismissed;

--- a/lib/features/agents/ui/listing/agent_listing_shell.dart
+++ b/lib/features/agents/ui/listing/agent_listing_shell.dart
@@ -93,7 +93,7 @@ class _AgentListingShellState extends State<AgentListingShell> {
           padding: EdgeInsets.all(tokens.spacing.step6),
           child: Text(
             messages.commonError,
-            style: TextStyle(color: tokens.colors.alert.error.defaultColor),
+            style: TextStyle(color: tokens.colors.alert.error.ink),
           ),
         ),
       );

--- a/lib/features/agents/ui/listing/widgets/active_filters_row.dart
+++ b/lib/features/agents/ui/listing/widgets/active_filters_row.dart
@@ -89,9 +89,9 @@ class ActiveFiltersRow extends StatelessWidget {
   Color _toneAccent(AgentListPillTone tone, DsColors colors) {
     return switch (tone) {
       AgentListPillTone.interactive => colors.interactive.enabled,
-      AgentListPillTone.warning => colors.alert.warning.defaultColor,
-      AgentListPillTone.error => colors.alert.error.defaultColor,
-      AgentListPillTone.info => colors.alert.info.defaultColor,
+      AgentListPillTone.warning => colors.alert.warning.ink,
+      AgentListPillTone.error => colors.alert.error.ink,
+      AgentListPillTone.info => colors.alert.info.ink,
       AgentListPillTone.muted => colors.text.mediumEmphasis,
       AgentListPillTone.neutral => colors.decorative.level02,
     };

--- a/lib/features/agents/ui/listing/widgets/agent_list_row.dart
+++ b/lib/features/agents/ui/listing/widgets/agent_list_row.dart
@@ -242,9 +242,9 @@ class _Pill extends StatelessWidget {
   Color _toneAccent(AgentListPillTone tone, DsColors colors) {
     return switch (tone) {
       AgentListPillTone.interactive => colors.interactive.enabled,
-      AgentListPillTone.warning => colors.alert.warning.defaultColor,
-      AgentListPillTone.error => colors.alert.error.defaultColor,
-      AgentListPillTone.info => colors.alert.info.defaultColor,
+      AgentListPillTone.warning => colors.alert.warning.ink,
+      AgentListPillTone.error => colors.alert.error.ink,
+      AgentListPillTone.info => colors.alert.info.ink,
       AgentListPillTone.muted => colors.text.mediumEmphasis,
       AgentListPillTone.neutral => colors.text.highEmphasis,
     };

--- a/lib/features/agents/ui/pending_wakes/agent_pending_wakes_page.dart
+++ b/lib/features/agents/ui/pending_wakes/agent_pending_wakes_page.dart
@@ -80,7 +80,7 @@ class _RunningInstancesBlock extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final accent = tokens.colors.alert.success.defaultColor;
+    final accent = tokens.colors.alert.success.ink;
 
     return Container(
       padding: EdgeInsets.symmetric(
@@ -138,7 +138,7 @@ class _RunningInstanceRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
-    final accent = tokens.colors.alert.success.defaultColor;
+    final accent = tokens.colors.alert.success.ink;
     final elapsedLabel = ref.watch(
       wakeCountdownTickerProvider.select((async) {
         final now = async.value;

--- a/lib/features/agents/ui/sidebar_wake_queue.dart
+++ b/lib/features/agents/ui/sidebar_wake_queue.dart
@@ -431,7 +431,7 @@ class _WakeRowState extends ConsumerState<_WakeRow> {
     // Amber only when the wake is imminent (<5 min) — otherwise the ETA is
     // quiet, low-emphasis data, not a standing alert.
     final etaColor = imminent
-        ? tokens.colors.alert.warning.defaultColor
+        ? tokens.colors.alert.warning.ink
         : tokens.colors.text.lowEmphasis;
 
     final titleStyle = tokens.typography.styles.body.bodySmall.copyWith(

--- a/lib/features/agents/ui/task_agent_identity_region.dart
+++ b/lib/features/agents/ui/task_agent_identity_region.dart
@@ -106,9 +106,7 @@ class _SetupIdentityRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
-    final color = isError
-        ? tokens.colors.alert.error.defaultColor
-        : ai.metaText;
+    final color = isError ? tokens.colors.alert.error.ink : ai.metaText;
     final iconColor = isError
         ? tokens.colors.alert.error.defaultColor
         : ai.metaText;

--- a/lib/features/ai/ui/settings/provider/ai_provider_connection_section.dart
+++ b/lib/features/ai/ui/settings/provider/ai_provider_connection_section.dart
@@ -137,7 +137,7 @@ class _ConnectionRow extends StatelessWidget {
             // `fontFamily: 'Inconsolata'` override at the call site.
             style: isMissing
                 ? tokens.typography.styles.body.bodySmall.copyWith(
-                    color: tokens.colors.alert.warning.defaultColor,
+                    color: tokens.colors.alert.warning.ink,
                   )
                 : monoMetaStyle(
                     tokens,

--- a/lib/features/ai/ui/settings/provider/ai_provider_detail_widgets.dart
+++ b/lib/features/ai/ui/settings/provider/ai_provider_detail_widgets.dart
@@ -217,7 +217,7 @@ class _StatusPill extends StatelessWidget {
       AiProviderCardStatus.invalidKey => (
         tokens.colors.alert.error.defaultColor,
         messages.aiProviderCardStatusInvalidKey,
-        tokens.colors.alert.error.defaultColor,
+        tokens.colors.alert.error.ink,
       ),
       AiProviderCardStatus.offline => (
         tokens.colors.text.lowEmphasis,

--- a/lib/features/ai/ui/settings/widgets/ftue/ai_provider_setup_result_modal.dart
+++ b/lib/features/ai/ui/settings/widgets/ftue/ai_provider_setup_result_modal.dart
@@ -333,7 +333,7 @@ class _ErrorsBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final danger = tokens.colors.alert.error.defaultColor;
+    final danger = tokens.colors.alert.error.ink;
     return Container(
       padding: EdgeInsets.all(tokens.spacing.step4),
       decoration: BoxDecoration(

--- a/lib/features/ai/ui/settings/widgets/v2/ai_profile_card.dart
+++ b/lib/features/ai/ui/settings/widgets/v2/ai_profile_card.dart
@@ -224,7 +224,7 @@ class _ProfileSlotRow extends StatelessWidget {
             resolved,
             style: caption.copyWith(
               color: modelName == null
-                  ? tokens.colors.alert.warning.defaultColor
+                  ? tokens.colors.alert.warning.ink
                   : tokens.colors.text.highEmphasis,
               fontWeight: tokens.typography.weight.semiBold,
             ),

--- a/lib/features/ai/ui/settings/widgets/v2/ai_provider_card.dart
+++ b/lib/features/ai/ui/settings/widgets/v2/ai_provider_card.dart
@@ -270,7 +270,7 @@ class _ProviderStatusRow extends StatelessWidget {
             Text(
               messages.aiProviderCardStatusInvalidKey,
               style: caption.copyWith(
-                color: tokens.colors.alert.error.defaultColor,
+                color: tokens.colors.alert.error.ink,
               ),
             ),
             const Spacer(),

--- a/lib/features/ai_consumption/ui/widgets/impact_model_table.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_model_table.dart
@@ -87,10 +87,10 @@ class ImpactModelTable extends StatelessWidget {
         }
       }
     }
-    // Clay accent, matching the caution valence the KPI deltas use.
-    final clay = brightness == Brightness.dark
-        ? tokens.colors.alert.error.hover
-        : tokens.colors.alert.error.pressed;
+    // Clay accent, matching the caution valence the KPI deltas use. `ink`
+    // because it paints the badge's caption text, which owes AA; picking the
+    // ramp step per brightness by hand is what the token now does.
+    final clay = tokens.colors.alert.error.ink;
     Widget costHeavyBadge() => Container(
       padding: EdgeInsets.symmetric(
         horizontal: tokens.spacing.step2,

--- a/lib/features/daily_os_next/ui/pages/capture_page.dart
+++ b/lib/features/daily_os_next/ui/pages/capture_page.dart
@@ -564,7 +564,7 @@ class _TranscriptZone extends StatelessWidget {
                 context.messages.dailyOsNextCaptureIdleHint,
             textAlign: TextAlign.center,
             style: tokens.typography.styles.body.bodySmall.copyWith(
-              color: tokens.colors.alert.error.defaultColor,
+              color: tokens.colors.alert.error.ink,
             ),
           ),
         );

--- a/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
@@ -264,7 +264,7 @@ class _ErrorShell extends StatelessWidget {
           child: Text(
             error,
             style: tokens.typography.styles.body.bodySmall.copyWith(
-              color: tokens.colors.alert.error.defaultColor,
+              color: tokens.colors.alert.error.ink,
             ),
           ),
         ),

--- a/lib/features/daily_os_next/ui/pages/refine_page_widgets.dart
+++ b/lib/features/daily_os_next/ui/pages/refine_page_widgets.dart
@@ -154,11 +154,11 @@ class _StatusLine extends StatelessWidget {
       ),
       RefinePhase.diffReady => (
         messages.dailyOsNextRefineStatusDiffReady,
-        tokens.colors.alert.success.defaultColor,
+        tokens.colors.alert.success.ink,
       ),
       RefinePhase.accepted => (
         messages.dailyOsNextRefineStatusAccepted,
-        tokens.colors.alert.success.defaultColor,
+        tokens.colors.alert.success.ink,
       ),
     };
     return Text(
@@ -190,8 +190,8 @@ class _ProblemNotice extends StatelessWidget {
     };
     final warning = problem == RefineProblem.captureSavedPendingTranscription;
     final color = warning
-        ? tokens.colors.alert.warning.defaultColor
-        : tokens.colors.alert.error.defaultColor;
+        ? tokens.colors.alert.warning.ink
+        : tokens.colors.alert.error.ink;
     return DecoratedBox(
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.10),

--- a/lib/features/daily_os_next/ui/widgets/agenda_view.dart
+++ b/lib/features/daily_os_next/ui/widgets/agenda_view.dart
@@ -254,7 +254,7 @@ class _StatStrip extends StatelessWidget {
                     style: calmPageTitleStyle(
                       tokens,
                       color: !ratioIsCalm(ratio)
-                          ? tokens.colors.alert.error.defaultColor
+                          ? tokens.colors.alert.error.ink
                           : null,
                     ),
                   ),

--- a/lib/features/daily_os_next/ui/widgets/capacity_donut.dart
+++ b/lib/features/daily_os_next/ui/widgets/capacity_donut.dart
@@ -85,7 +85,7 @@ class CapacityDonut extends StatelessWidget {
     // 9h tracked against an 8h day is over, not "1h LEFT").
     final isOver = hasCapacity && remaining < 0;
     final over = !neutral && ratio > 1.0;
-    final overColor = tokens.colors.alert.error.defaultColor;
+    final overColor = tokens.colors.alert.error.ink;
 
     // Without a meaningful capacity there is no remainder to narrate —
     // show the scheduled total with no eyebrow word.

--- a/lib/features/daily_os_next/ui/widgets/day_agent_status_chip.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_agent_status_chip.dart
@@ -36,18 +36,18 @@ class DayAgentStatusChip extends ConsumerWidget {
     final messages = context.messages;
     final (color, icon, label) = switch (persona) {
       DayAgentPersonaState.working => (
-        tokens.colors.alert.info.defaultColor,
+        tokens.colors.alert.info.ink,
         Icons.autorenew_rounded,
         messages.dailyOsNextDayAgentStatusWorking,
       ),
       DayAgentPersonaState.attention => (
-        tokens.colors.alert.warning.defaultColor,
+        tokens.colors.alert.warning.ink,
         Icons.priority_high_rounded,
         messages.dailyOsNextDayAgentStatusAttention,
       ),
       // idle returned above, so the remaining case is celebrating.
       _ => (
-        tokens.colors.alert.success.defaultColor,
+        tokens.colors.alert.success.ink,
         Icons.celebration_outlined,
         messages.dailyOsNextDayAgentStatusDayClosed,
       ),

--- a/lib/features/daily_os_next/ui/widgets/day_timeline_widgets.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline_widgets.dart
@@ -327,7 +327,7 @@ class _SharedHourRail extends StatelessWidget {
                     child: Text(
                       _formatNow(now!),
                       style: tokens.typography.styles.body.bodySmall.copyWith(
-                        color: tokens.colors.alert.error.defaultColor,
+                        color: tokens.colors.alert.error.ink,
                         fontWeight: tokens.typography.weight.bold,
                       ),
                     ),

--- a/lib/features/daily_os_next/ui/widgets/diff_row.dart
+++ b/lib/features/daily_os_next/ui/widgets/diff_row.dart
@@ -125,7 +125,7 @@ class _ChangeBadge extends StatelessWidget {
     final tokens = context.designTokens;
     switch (kind) {
       case PlanDiffChangeKind.moved:
-        return tokens.colors.alert.info.defaultColor;
+        return tokens.colors.alert.info.ink;
       case PlanDiffChangeKind.added:
         return tokens.colors.interactive.enabled;
       case PlanDiffChangeKind.dropped:
@@ -284,7 +284,7 @@ class _TimeChipsRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final accent = change.kind == PlanDiffChangeKind.moved
-        ? tokens.colors.alert.info.defaultColor
+        ? tokens.colors.alert.info.ink
         : tokens.colors.interactive.enabled;
     return Wrap(
       spacing: tokens.spacing.step2,

--- a/lib/features/daily_os_next/ui/widgets/knowledge_panel.dart
+++ b/lib/features/daily_os_next/ui/widgets/knowledge_panel.dart
@@ -142,7 +142,7 @@ class _KnowledgeRow extends ConsumerWidget {
             Text(
               context.messages.dailyOsNextKnowledgeStale,
               style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: tokens.colors.alert.warning.defaultColor,
+                color: tokens.colors.alert.warning.ink,
               ),
             ),
           ],

--- a/lib/features/daily_os_next/ui/widgets/link_badge.dart
+++ b/lib/features/daily_os_next/ui/widgets/link_badge.dart
@@ -17,7 +17,7 @@ class LinkBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final info = tokens.colors.alert.info.defaultColor;
+    final info = tokens.colors.alert.info.ink;
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 220),
       child: DsPill(

--- a/lib/features/daily_os_next/ui/widgets/parsed_card.dart
+++ b/lib/features/daily_os_next/ui/widgets/parsed_card.dart
@@ -86,12 +86,12 @@ class _KindBadge extends StatelessWidget {
         Icons.add_rounded,
       ),
       ParsedItemKind.matched => (
-        tokens.colors.alert.info.defaultColor,
+        tokens.colors.alert.info.ink,
         context.messages.dailyOsNextReconcileBadgeMatched,
         Icons.link_rounded,
       ),
       ParsedItemKind.update => (
-        tokens.colors.alert.success.defaultColor,
+        tokens.colors.alert.success.ink,
         context.messages.dailyOsNextReconcileBadgeUpdate,
         Icons.check_rounded,
       ),
@@ -157,8 +157,8 @@ class _MatchedTaskChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final accent = warning
-        ? tokens.colors.alert.warning.defaultColor
-        : tokens.colors.alert.info.defaultColor;
+        ? tokens.colors.alert.warning.ink
+        : tokens.colors.alert.info.ink;
     return Container(
       decoration: BoxDecoration(
         color: accent.withValues(alpha: 0.08),
@@ -229,7 +229,7 @@ class _ProposedUpdateLine extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final success = tokens.colors.alert.success.defaultColor;
+    final success = tokens.colors.alert.success.ink;
     return Row(
       children: [
         Icon(
@@ -346,7 +346,7 @@ class _LowConfidenceTag extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final warning = tokens.colors.alert.warning.defaultColor;
+    final warning = tokens.colors.alert.warning.ink;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [

--- a/lib/features/daily_os_next/ui/widgets/pending_card.dart
+++ b/lib/features/daily_os_next/ui/widgets/pending_card.dart
@@ -95,17 +95,17 @@ class _StateBadge extends StatelessWidget {
     final messages = context.messages;
     final (color, icon, label) = switch (item.reason) {
       PendingItemReason.overdue => (
-        tokens.colors.alert.error.defaultColor,
+        tokens.colors.alert.error.ink,
         Icons.warning_amber_rounded,
         _overdueLabel(context, item),
       ),
       PendingItemReason.inProgress => (
-        tokens.colors.alert.warning.defaultColor,
+        tokens.colors.alert.warning.ink,
         Icons.adjust_rounded,
         messages.dailyOsNextStateInProgress(item.sessionCount ?? 0),
       ),
       PendingItemReason.missedRecurring => (
-        tokens.colors.alert.info.defaultColor,
+        tokens.colors.alert.info.ink,
         Icons.refresh_rounded,
         messages.dailyOsNextStateRecurringMissed,
       ),

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -101,6 +101,39 @@ The current typed surface is therefore:
 
 Notably, the current importer does not generate separate sizing or motion groups yet. If the token export grows, the seam to update is the generator, not every component downstream.
 
+### The alert ramp: `default` fills, `ink` writes
+
+`colors.alert.{error,success,warning,info}` carries four steps, and which one a
+call site binds is a contrast decision, not a taste one:
+
+| step | role | obligation |
+| --- | --- | --- |
+| `defaultColor` | fills, dots, borders, glyphs, chart series | ≥ 3:1 on `background.level01`/`level02` (WCAG SC 1.4.11) |
+| `hover` / `pressed` | interaction states of a control already using the tone | inherits the control's |
+| `ink` | **any alert-toned text**, and the glyph paired with it | ≥ 4.5:1 on `background.level01`/`level02` (SC 1.4.3) |
+
+`ink` is not a fifth hue. It resolves per brightness to the least-extreme step
+of the same ramp that clears AA — `pressed` in light for success/warning/info,
+`hover` in light for error and in dark for error, `defaultColor` in dark for
+the rest. Widgets used to make that pick by hand with
+`Theme.of(context).brightness` branches; that is now the token's job.
+
+Two consequences worth stating plainly:
+
+- A component that paints the tone as **both** a fill and a label needs both
+  bindings, not one. `DesignSystemBadge` is the reference: the badge fill and
+  the outline border take `defaultColor`, the label and glyph take `ink`.
+- The light ramp's `defaultColor` and `hover` currently coincide for warning,
+  success and info. The exported light `default` sat at 2.15–2.96:1 against
+  level02 — below the non-text floor — so it was moved onto the `hover` value,
+  which is the nearest step that clears it. A future Figma pass should
+  re-derive a distinct light `hover`; nothing binds those three today.
+
+`test/features/design_system/theme/design_tokens_test.dart` pins both floors
+across all four families and both brightnesses. Nothing else in the build
+checks the palette, which is how the light ramp shipped below the floor and
+stayed there.
+
 ## Import Pipeline
 
 `make design_system_import` does two things:

--- a/lib/features/design_system/components/badges/design_system_badge.dart
+++ b/lib/features/design_system/components/badges/design_system_badge.dart
@@ -287,8 +287,15 @@ class _BadgeStyleSpec {
     required _DesignSystemBadgeType type,
     required DesignSystemBadgeTone tone,
   }) {
+    // Two bindings per tone, because the accent plays two roles here. As a
+    // *fill* it owes 3:1 against the host surface (SC 1.4.11) and `default`
+    // carries it. As the *label and glyph* on an untinted or barely tinted
+    // badge it owes 4.5:1 (SC 1.4.3), which `default` misses in light theme —
+    // that is what `ink` is for. Borders are non-text and stay on the accent
+    // so an outlined badge keeps its tone at full saturation.
     if (tone == DesignSystemBadgeTone.secondary) {
       final accentColor = tokens.colors.alert.info.defaultColor;
+      final inkColor = tokens.colors.alert.info.ink;
       final surfaceColor = tokens.colors.surface.enabled;
 
       return switch (type) {
@@ -305,22 +312,34 @@ class _BadgeStyleSpec {
         _DesignSystemBadgeType.filled ||
         _DesignSystemBadgeType.icon => _BadgeStyleSpec(
           backgroundColor: surfaceColor,
-          foregroundColor: accentColor,
+          foregroundColor: inkColor,
           borderColor: null,
         ),
         _DesignSystemBadgeType.outlined => _BadgeStyleSpec(
           backgroundColor: surfaceColor,
-          foregroundColor: accentColor,
+          foregroundColor: inkColor,
           borderColor: accentColor,
         ),
       };
     }
 
-    final accentColor = switch (tone) {
-      DesignSystemBadgeTone.primary => tokens.colors.alert.info.defaultColor,
-      DesignSystemBadgeTone.danger => tokens.colors.alert.error.defaultColor,
-      DesignSystemBadgeTone.warning => tokens.colors.alert.warning.defaultColor,
-      DesignSystemBadgeTone.success => tokens.colors.alert.success.defaultColor,
+    final (accentColor, inkColor) = switch (tone) {
+      DesignSystemBadgeTone.primary => (
+        tokens.colors.alert.info.defaultColor,
+        tokens.colors.alert.info.ink,
+      ),
+      DesignSystemBadgeTone.danger => (
+        tokens.colors.alert.error.defaultColor,
+        tokens.colors.alert.error.ink,
+      ),
+      DesignSystemBadgeTone.warning => (
+        tokens.colors.alert.warning.defaultColor,
+        tokens.colors.alert.warning.ink,
+      ),
+      DesignSystemBadgeTone.success => (
+        tokens.colors.alert.success.defaultColor,
+        tokens.colors.alert.success.ink,
+      ),
       DesignSystemBadgeTone.secondary => throw StateError(
         'Secondary tone must be handled separately.',
       ),
@@ -341,7 +360,7 @@ class _BadgeStyleSpec {
       ),
       _DesignSystemBadgeType.outlined => _BadgeStyleSpec(
         backgroundColor: null,
-        foregroundColor: accentColor,
+        foregroundColor: inkColor,
         borderColor: accentColor,
       ),
     };

--- a/lib/features/design_system/components/context_menus/design_system_context_menu.dart
+++ b/lib/features/design_system/components/context_menus/design_system_context_menu.dart
@@ -113,8 +113,11 @@ class DesignSystemContextMenu extends StatelessWidget {
     _ContextMenuSpec spec,
     DesignSystemContextMenuItem item,
   ) {
+    // Ink, not the default red: this paints the item's label, and the default
+    // step only clears AA against the light surfaces — on a dark menu it
+    // measures 4.25:1.
     final textColor = item.isDestructive
-        ? tokens.colors.alert.error.defaultColor
+        ? tokens.colors.alert.error.ink
         : tokens.colors.text.highEmphasis;
 
     return Semantics(

--- a/lib/features/design_system/components/file_uploads/design_system_file_upload_item.dart
+++ b/lib/features/design_system/components/file_uploads/design_system_file_upload_item.dart
@@ -208,10 +208,10 @@ class _FileItemSpec {
         color: tokens.colors.text.mediumEmphasis,
       ),
       errorLabelStyle: tokens.typography.styles.others.caption.copyWith(
-        color: tokens.colors.alert.error.defaultColor,
+        color: tokens.colors.alert.error.ink,
       ),
       retryLabelStyle: tokens.typography.styles.body.bodySmall.copyWith(
-        color: tokens.colors.alert.error.defaultColor,
+        color: tokens.colors.alert.error.ink,
         fontWeight: FontWeight.w700,
       ),
     );

--- a/lib/features/design_system/components/inputs/design_system_text_input.dart
+++ b/lib/features/design_system/components/inputs/design_system_text_input.dart
@@ -329,7 +329,7 @@ class _TextInputSpec {
         color: tokens.colors.text.mediumEmphasis,
       ),
       errorStyle: tokens.typography.styles.others.caption.copyWith(
-        color: tokens.colors.alert.error.defaultColor,
+        color: tokens.colors.alert.error.ink,
       ),
     );
   }

--- a/lib/features/design_system/components/task_filters/design_system_filter_modal.dart
+++ b/lib/features/design_system/components/task_filters/design_system_filter_modal.dart
@@ -451,7 +451,7 @@ class _SaveFilterChoicePageState extends State<_SaveFilterChoicePage> {
             messages.tasksSavedFiltersSaveError,
             key: DesignSystemFilterSavePageKeys.error,
             style: tokens.typography.styles.body.bodySmall.copyWith(
-              color: tokens.colors.alert.error.defaultColor,
+              color: tokens.colors.alert.error.ink,
             ),
           ),
         ],

--- a/lib/features/design_system/components/task_list_items/design_system_task_list_item.dart
+++ b/lib/features/design_system/components/task_list_items/design_system_task_list_item.dart
@@ -154,20 +154,22 @@ List<InlineSpan> _taskMetadataSpans({
     priorityIcon,
     iconSize,
   ) = switch (priority) {
+    // Ink throughout: this colour tints the glyph *and* the "P0"/"P1"/"P2"
+    // label rendered in the meta style, which is small enough to owe AA.
     DesignSystemTaskPriority.p0 => (
-      tokens.colors.alert.error.defaultColor,
+      tokens.colors.alert.error.ink,
       'P0',
       Icons.priority_high_rounded,
       spec.metaIconSize,
     ),
     DesignSystemTaskPriority.p1 => (
-      tokens.colors.alert.error.defaultColor,
+      tokens.colors.alert.error.ink,
       'P1',
       Icons.local_fire_department_rounded,
       spec.metaIconSize,
     ),
     DesignSystemTaskPriority.p2 => (
-      tokens.colors.alert.warning.defaultColor,
+      tokens.colors.alert.warning.ink,
       'P2',
       Icons.circle,
       spec.priorityDotSize,

--- a/lib/features/design_system/components/textareas/design_system_textarea.dart
+++ b/lib/features/design_system/components/textareas/design_system_textarea.dart
@@ -300,7 +300,7 @@ class _TextareaSpec {
         color: tokens.colors.text.mediumEmphasis,
       ),
       errorStyle: tokens.typography.styles.others.caption.copyWith(
-        color: tokens.colors.alert.error.defaultColor,
+        color: tokens.colors.alert.error.ink,
       ),
       counterStyle: tokens.typography.styles.others.caption.copyWith(
         color: tokens.colors.text.mediumEmphasis,

--- a/lib/features/design_system/theme/generated/design_tokens.g.dart
+++ b/lib/features/design_system/theme/generated/design_tokens.g.dart
@@ -24,21 +24,25 @@ const DsTokens dsTokensLight = DsTokens(
         defaultColor: Color(0xFFCC3633),
         hover: Color(0xFFA32B29),
         pressed: Color(0xFF7A1F1F),
+        ink: Color(0xFFA32B29),
       ),
       success: DsColorsAlertSuccess(
-        defaultColor: Color(0xFF59A66B),
+        defaultColor: Color(0xFF478556),
         hover: Color(0xFF478556),
         pressed: Color(0xFF366340),
+        ink: Color(0xFF366340),
       ),
       warning: DsColorsAlertWarning(
-        defaultColor: Color(0xFFFA8C05),
+        defaultColor: Color(0xFFC87005),
         hover: Color(0xFFC87005),
         pressed: Color(0xFF965402),
+        ink: Color(0xFF965402),
       ),
       info: DsColorsAlertInfo(
-        defaultColor: Color(0xFF1CA3E3),
+        defaultColor: Color(0xFF1783B5),
         hover: Color(0xFF1783B5),
         pressed: Color(0xFF116288),
+        ink: Color(0xFF116288),
       ),
     ),
     background: DsColorsBackground(
@@ -435,21 +439,25 @@ const DsTokens dsTokensDark = DsTokens(
         defaultColor: Color(0xFFD65E5C),
         hover: Color(0xFFE08684),
         pressed: Color(0xFFEBB0AE),
+        ink: Color(0xFFE08684),
       ),
       success: DsColorsAlertSuccess(
         defaultColor: Color(0xFF7AB889),
         hover: Color(0xFF9CC9A6),
         pressed: Color(0xFFBDDBC4),
+        ink: Color(0xFF7AB889),
       ),
       warning: DsColorsAlertWarning(
         defaultColor: Color(0xFFFBA336),
         hover: Color(0xFFFCBA69),
         pressed: Color(0xFFFDD19B),
+        ink: Color(0xFFFBA336),
       ),
       info: DsColorsAlertInfo(
         defaultColor: Color(0xFF4AB6E8),
         hover: Color(0xFF77C8EE),
         pressed: Color(0xFFA4DAF4),
+        ink: Color(0xFF4AB6E8),
       ),
     ),
     background: DsColorsBackground(
@@ -961,22 +969,26 @@ class DsColorsAlertError {
   final Color defaultColor;
   final Color hover;
   final Color pressed;
+  final Color ink;
 
   const DsColorsAlertError({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
+    required this.ink,
   });
 
   DsColorsAlertError copyWith({
     Color? defaultColor,
     Color? hover,
     Color? pressed,
+    Color? ink,
   }) {
     return DsColorsAlertError(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
+      ink: ink ?? this.ink,
     );
   }
 
@@ -989,6 +1001,7 @@ class DsColorsAlertError {
           Color.lerp(defaultColor, other.defaultColor, t) ?? defaultColor,
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
+      ink: Color.lerp(ink, other.ink, t) ?? ink,
     );
   }
 
@@ -1000,11 +1013,12 @@ class DsColorsAlertError {
     return other is DsColorsAlertError &&
         defaultColor == other.defaultColor &&
         hover == other.hover &&
-        pressed == other.pressed;
+        pressed == other.pressed &&
+        ink == other.ink;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed]);
+  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
 }
 
 @immutable
@@ -1012,22 +1026,26 @@ class DsColorsAlertSuccess {
   final Color defaultColor;
   final Color hover;
   final Color pressed;
+  final Color ink;
 
   const DsColorsAlertSuccess({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
+    required this.ink,
   });
 
   DsColorsAlertSuccess copyWith({
     Color? defaultColor,
     Color? hover,
     Color? pressed,
+    Color? ink,
   }) {
     return DsColorsAlertSuccess(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
+      ink: ink ?? this.ink,
     );
   }
 
@@ -1040,6 +1058,7 @@ class DsColorsAlertSuccess {
           Color.lerp(defaultColor, other.defaultColor, t) ?? defaultColor,
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
+      ink: Color.lerp(ink, other.ink, t) ?? ink,
     );
   }
 
@@ -1051,11 +1070,12 @@ class DsColorsAlertSuccess {
     return other is DsColorsAlertSuccess &&
         defaultColor == other.defaultColor &&
         hover == other.hover &&
-        pressed == other.pressed;
+        pressed == other.pressed &&
+        ink == other.ink;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed]);
+  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
 }
 
 @immutable
@@ -1063,22 +1083,26 @@ class DsColorsAlertWarning {
   final Color defaultColor;
   final Color hover;
   final Color pressed;
+  final Color ink;
 
   const DsColorsAlertWarning({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
+    required this.ink,
   });
 
   DsColorsAlertWarning copyWith({
     Color? defaultColor,
     Color? hover,
     Color? pressed,
+    Color? ink,
   }) {
     return DsColorsAlertWarning(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
+      ink: ink ?? this.ink,
     );
   }
 
@@ -1091,6 +1115,7 @@ class DsColorsAlertWarning {
           Color.lerp(defaultColor, other.defaultColor, t) ?? defaultColor,
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
+      ink: Color.lerp(ink, other.ink, t) ?? ink,
     );
   }
 
@@ -1102,11 +1127,12 @@ class DsColorsAlertWarning {
     return other is DsColorsAlertWarning &&
         defaultColor == other.defaultColor &&
         hover == other.hover &&
-        pressed == other.pressed;
+        pressed == other.pressed &&
+        ink == other.ink;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed]);
+  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
 }
 
 @immutable
@@ -1114,22 +1140,26 @@ class DsColorsAlertInfo {
   final Color defaultColor;
   final Color hover;
   final Color pressed;
+  final Color ink;
 
   const DsColorsAlertInfo({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
+    required this.ink,
   });
 
   DsColorsAlertInfo copyWith({
     Color? defaultColor,
     Color? hover,
     Color? pressed,
+    Color? ink,
   }) {
     return DsColorsAlertInfo(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
+      ink: ink ?? this.ink,
     );
   }
 
@@ -1142,6 +1172,7 @@ class DsColorsAlertInfo {
           Color.lerp(defaultColor, other.defaultColor, t) ?? defaultColor,
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
+      ink: Color.lerp(ink, other.ink, t) ?? ink,
     );
   }
 
@@ -1153,11 +1184,12 @@ class DsColorsAlertInfo {
     return other is DsColorsAlertInfo &&
         defaultColor == other.defaultColor &&
         hover == other.hover &&
-        pressed == other.pressed;
+        pressed == other.pressed &&
+        ink == other.ink;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed]);
+  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
 }
 
 @immutable

--- a/lib/features/insights/ui/widgets/insights_delta_chip.dart
+++ b/lib/features/insights/ui/widgets/insights_delta_chip.dart
@@ -58,20 +58,13 @@ class InsightsDeltaChip extends StatelessWidget {
     if (current == 0 && previous == 0) return const SizedBox.shrink();
 
     final neutral = tokens.colors.text.mediumEmphasis;
-    // The chip text is small (caption/bodySmall), so the accent must clear WCAG
-    // AA 4.5:1. The light-theme green `hover` step is only ~4.0:1 on the card
-    // and fails; its darker `pressed` step clears ~6:1. The dark theme is the
-    // mirror image — there `hover` is already a high-contrast light green and
-    // `pressed` is a washed-out pastel — so pick the step per theme: the
-    // darker green in light, the more saturated green in dark. Direction never
-    // rides on color alone regardless (the arrow glyph and +/- sign remain).
-    final light = Theme.of(context).brightness == Brightness.light;
-    final good = light
-        ? tokens.colors.alert.success.pressed
-        : tokens.colors.alert.success.hover;
-    final bad = light
-        ? tokens.colors.alert.error.pressed
-        : tokens.colors.alert.error.hover;
+    // The chip text is small (caption/bodySmall), so the accent must clear
+    // WCAG AA 4.5:1 — which the `default` step does not in light theme. That
+    // is exactly what `ink` resolves, per brightness, at the token level; this
+    // widget used to pick the step by hand. Direction never rides on color
+    // alone regardless (the arrow glyph and +/- sign remain).
+    final good = tokens.colors.alert.success.ink;
+    final bad = tokens.colors.alert.error.ink;
     // Map the true direction to an accent through the valence: an increase is
     // "good" only when more is better; when more is worse (cost/energy/carbon)
     // an increase reads clay; a value-free metric stays neutral either way.

--- a/lib/features/journal/ui/widgets/list_cards/journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/journal_card.dart
@@ -683,7 +683,7 @@ class _EntryCardContent extends StatelessWidget {
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
       style: context.designTokens.typography.styles.subtitle.subtitle2.copyWith(
-        color: context.designTokens.colors.alert.error.defaultColor,
+        color: context.designTokens.colors.alert.error.ink,
         fontWeight: FontWeight.w600,
         fontStyle: FontStyle.italic,
       ),
@@ -986,7 +986,7 @@ class _HabitCompletionContentState extends State<_HabitCompletionContent> {
     final (label, color) = switch (type) {
       HabitCompletionType.success => (
         context.messages.habitCompletionStatusCompleted,
-        context.designTokens.colors.alert.success.defaultColor,
+        context.designTokens.colors.alert.success.ink,
       ),
       HabitCompletionType.skip => (
         context.messages.habitCompletionStatusSkipped,

--- a/lib/features/knowledge_graph_poc/ui/task_knowledge_graph_page.dart
+++ b/lib/features/knowledge_graph_poc/ui/task_knowledge_graph_page.dart
@@ -405,7 +405,7 @@ class _ErrorState extends StatelessWidget {
           context.messages.knowledgeGraphError,
           textAlign: TextAlign.center,
           style: tokens.typography.styles.body.bodySmall.copyWith(
-            color: tokens.colors.alert.error.defaultColor,
+            color: tokens.colors.alert.error.ink,
           ),
         ),
       ),

--- a/lib/features/labels/ui/pages/label_details_page.dart
+++ b/lib/features/labels/ui/pages/label_details_page.dart
@@ -276,7 +276,7 @@ class _LabelDetailsPageState extends ConsumerState<LabelDetailsPage> {
             child: Text(
               state.errorMessage!,
               style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: tokens.colors.alert.error.defaultColor,
+                color: tokens.colors.alert.error.ink,
               ),
             ),
           ),

--- a/lib/features/onboarding/ui/widgets/onboarding_api_key_panel.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_api_key_panel.dart
@@ -229,9 +229,7 @@ class _OnboardingApiKeyPanelState extends ConsumerState<OnboardingApiKeyPanel> {
     final textHigh = tokens.colors.text.highEmphasis;
     final textMed = tokens.colors.text.mediumEmphasis;
     final panelBg = tokens.colors.background.level01;
-    final errorColor = Theme.of(context).brightness == Brightness.dark
-        ? tokens.colors.alert.error.hover
-        : tokens.colors.alert.error.defaultColor;
+    final errorColor = tokens.colors.alert.error.ink;
     final console = aiProviderKeyConsoleUrl(widget.type);
     // Listen (not watch) keeps the verifier alive and feeds the local display
     // state machine, which holds "checking" visible for [_minCheckingVisible].
@@ -619,13 +617,12 @@ class _VerifyStatus extends StatelessWidget {
     final tokens = context.designTokens;
     final messages = context.messages;
     final textMed = tokens.colors.text.mediumEmphasis;
-    final success = tokens.colors.alert.success.defaultColor;
-    // The lighter error tint (the `hover` ramp step) clears WCAG AA on the dark
-    // panel where the base `defaultColor` sits ~3:1; the failure line is the
-    // most anxious moment, so it must be the most readable.
-    final danger = Theme.of(context).brightness == Brightness.dark
-        ? tokens.colors.alert.error.hover
-        : tokens.colors.alert.error.defaultColor;
+    // Both paint status lines in `bodySmall`, so both owe AA — `ink` is the
+    // step that carries it in either brightness. The failure line is the most
+    // anxious moment, so it must be the most readable; picking the ramp step
+    // by hand for that is now the token's job.
+    final success = tokens.colors.alert.success.ink;
+    final danger = tokens.colors.alert.error.ink;
 
     switch (state) {
       case ConnectionCheckIdle():

--- a/lib/features/projects/ui/widgets/project_selection_modal_content.dart
+++ b/lib/features/projects/ui/widgets/project_selection_modal_content.dart
@@ -59,7 +59,7 @@ class ProjectSelectionModalBody extends StatelessWidget {
           child: Text(
             context.messages.projectErrorLoadProjects,
             style: tokens.typography.styles.body.bodyMedium.copyWith(
-              color: tokens.colors.alert.error.defaultColor,
+              color: tokens.colors.alert.error.ink,
             ),
           ),
         ),

--- a/lib/features/settings_v2/ui/tree/settings_tree_row.dart
+++ b/lib/features/settings_v2/ui/tree/settings_tree_row.dart
@@ -234,7 +234,7 @@ class _NodeBadgeChip extends StatelessWidget {
     final (bg, fg) = switch (badge.tone) {
       NodeTone.info => (
         tokens.colors.alert.info.defaultColor.withValues(alpha: bgAlpha),
-        tokens.colors.alert.info.defaultColor,
+        tokens.colors.alert.info.ink,
       ),
       NodeTone.teal => (
         tokens.colors.interactive.enabled.withValues(alpha: bgAlpha),
@@ -242,7 +242,7 @@ class _NodeBadgeChip extends StatelessWidget {
       ),
       NodeTone.error => (
         tokens.colors.alert.error.defaultColor.withValues(alpha: bgAlpha),
-        tokens.colors.alert.error.defaultColor,
+        tokens.colors.alert.error.ink,
       ),
     };
     return Container(

--- a/lib/features/sync/ui/backfill_settings_stats.dart
+++ b/lib/features/sync/ui/backfill_settings_stats.dart
@@ -56,7 +56,7 @@ class StatusRow extends StatelessWidget {
                 label: messages.backfillStatusMissing,
                 value: missing,
                 valueColor: missingActive
-                    ? tokens.colors.alert.warning.defaultColor
+                    ? tokens.colors.alert.warning.ink
                     : tokens.colors.text.highEmphasis,
               ),
             ),
@@ -67,10 +67,10 @@ class StatusRow extends StatelessWidget {
                 label: messages.backfillStatusSkipped,
                 value: skipped,
                 labelColor: skippedActive
-                    ? tokens.colors.alert.error.defaultColor
+                    ? tokens.colors.alert.error.ink
                     : null,
                 valueColor: skippedActive
-                    ? tokens.colors.alert.error.defaultColor
+                    ? tokens.colors.alert.error.ink
                     : tokens.colors.text.highEmphasis,
               ),
             ),
@@ -235,10 +235,10 @@ class _Ledger extends StatelessWidget {
     final messages = context.messages;
     final highEmphasis = tokens.colors.text.highEmphasis;
     final lowEmphasis = tokens.colors.text.lowEmphasis;
-    final success = tokens.colors.alert.success.defaultColor;
-    final warning = tokens.colors.alert.warning.defaultColor;
+    final success = tokens.colors.alert.success.ink;
+    final warning = tokens.colors.alert.warning.ink;
     final interactive = tokens.colors.interactive.enabled;
-    final error = tokens.colors.alert.error.defaultColor;
+    final error = tokens.colors.alert.error.ink;
 
     final missingTone = missingCount > 0 ? warning : lowEmphasis;
     final requestedTone = stats.totalRequested > 0 ? interactive : lowEmphasis;

--- a/lib/features/sync/ui/pages/conflicts/conflict_detail_route.dart
+++ b/lib/features/sync/ui/pages/conflicts/conflict_detail_route.dart
@@ -175,7 +175,7 @@ class _ErrorBody extends StatelessWidget {
       child: Text(
         '$error',
         style: tokens.typography.styles.body.bodyMedium.copyWith(
-          color: tokens.colors.alert.error.defaultColor,
+          color: tokens.colors.alert.error.ink,
         ),
       ),
     );

--- a/lib/features/sync/ui/widgets/conflicts/conflict_resolution_view.dart
+++ b/lib/features/sync/ui/widgets/conflicts/conflict_resolution_view.dart
@@ -317,7 +317,7 @@ class _RecommendedLabel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final accent = tokens.colors.alert.success.defaultColor;
+    final accent = tokens.colors.alert.success.ink;
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [

--- a/lib/features/sync/ui/widgets/outbox/outbox_summary_header.dart
+++ b/lib/features/sync/ui/widgets/outbox/outbox_summary_header.dart
@@ -71,10 +71,10 @@ class OutboxSummaryHeader extends StatelessWidget {
   };
 
   Color _toneColor(QueueState state, DsColors colors) => switch (state) {
-    QueueState.synced => colors.alert.success.defaultColor,
-    QueueState.sending => colors.alert.info.defaultColor,
-    QueueState.waiting => colors.alert.warning.defaultColor,
-    QueueState.failed => colors.alert.error.defaultColor,
+    QueueState.synced => colors.alert.success.ink,
+    QueueState.sending => colors.alert.info.ink,
+    QueueState.waiting => colors.alert.warning.ink,
+    QueueState.failed => colors.alert.error.ink,
     QueueState.offline => colors.text.mediumEmphasis,
   };
 

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -710,10 +710,18 @@ relationship in full, no row carries a per-row caption, and every row on the
 card renders from one template: status glyph, title, status label, trailing
 affordance. A section renders only when it has entries.
 
-"Is blocked by" leads and is the only accented header (an amber label plus a
-leading glyph, matching the task header's own "Blocked by N tasks" chip); every
-other section and every row stays neutral, so one accent reads as signal rather
-than as one more competing hue. Plain links follow under a "Relates to" header,
+"Is blocked by" leads and is the only accented header, matching the task
+header's own "Blocked by N tasks" chip. The accent is carried by the leading ⊘
+glyph alone — the label itself stays at medium emphasis, because the glyph
+already states the blocked semantic and an amber eyebrow beside an amber chip
+was one mark too many. Every other section and every row stays neutral, so one
+accent reads as signal rather than as one more competing hue.
+
+Both amber marks bind `alert.warning.defaultColor`, the ramp's fill strength,
+which is the correct step for a glyph and a border: those owe 3:1 (WCAG SC
+1.4.11), not 4.5:1. Neither is text. If a future iteration ever tints one of
+these *labels*, it has to move to `alert.warning.ink` — see the alert-ramp
+contract in the design system README. Plain links follow under a "Relates to" header,
 shown only when there are typed sections to distinguish them from.
 
 The chip, the section header, and the picker option that creates the link all

--- a/lib/features/tasks/ui/header/desktop_task_header_meta.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_meta.dart
@@ -292,9 +292,16 @@ class _DuePill extends StatelessWidget {
     // (today / overdue) escalates to a tinted accent so it still reads as a
     // warning at a glance.
     final urgent = dueDate.urgency != DesktopTaskHeaderDueUrgency.normal;
+    // Ink, because an urgent chip leaves `labelColor` null and the tinted pill
+    // then paints its label in this colour — the fill strengths only clear the
+    // non-text floor.
     final accent = switch (dueDate.urgency) {
-      DesktopTaskHeaderDueUrgency.overdue => TaskShowcasePalette.error(context),
-      DesktopTaskHeaderDueUrgency.today => TaskShowcasePalette.warning(context),
+      DesktopTaskHeaderDueUrgency.overdue => TaskShowcasePalette.errorInk(
+        context,
+      ),
+      DesktopTaskHeaderDueUrgency.today => TaskShowcasePalette.warningInk(
+        context,
+      ),
       DesktopTaskHeaderDueUrgency.normal => TaskShowcasePalette.mediumText(
         context,
       ),

--- a/lib/features/tasks/ui/widgets/task_showcase_palette.dart
+++ b/lib/features/tasks/ui/widgets/task_showcase_palette.dart
@@ -48,4 +48,16 @@ class TaskShowcasePalette {
 
   static Color info(BuildContext context) =>
       context.designTokens.colors.alert.info.defaultColor;
+
+  /// The AA-safe step of the same ramps, for alert-toned *text*.
+  ///
+  /// [warning] and [error] are fill/glyph strengths: they clear the 3:1
+  /// non-text floor but not the 4.5:1 body-text one on every surface. A chip
+  /// whose label takes the tone — the urgent due chip — has to read these
+  /// instead.
+  static Color warningInk(BuildContext context) =>
+      context.designTokens.colors.alert.warning.ink;
+
+  static Color errorInk(BuildContext context) =>
+      context.designTokens.colors.alert.error.ink;
 }

--- a/lib/pages/create/create_measurement_dialog.dart
+++ b/lib/pages/create/create_measurement_dialog.dart
@@ -471,7 +471,7 @@ class _MeasurementEditorPageState extends State<_MeasurementEditorPage> {
                   saveState.error!,
                   key: const ValueKey('measurement-save-error'),
                   style: tokens.typography.styles.body.bodySmall.copyWith(
-                    color: tokens.colors.alert.error.defaultColor,
+                    color: tokens.colors.alert.error.ink,
                   ),
                 ),
               ),

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -371,8 +371,8 @@ class _GoalChip extends StatelessWidget {
     final messages = context.messages;
     final atGoal = stats.isAtGoal;
     final color = atGoal
-        ? tokens.colors.alert.success.defaultColor
-        : tokens.colors.alert.warning.defaultColor;
+        ? tokens.colors.alert.success.ink
+        : tokens.colors.alert.warning.ink;
     final text = atGoal
         ? messages.habitsAboveGoal
         : messages.habitsPointsToGoal(stats.pointsToGoal);

--- a/lib/widgets/settings/settings_delete_row.dart
+++ b/lib/widgets/settings/settings_delete_row.dart
@@ -25,7 +25,7 @@ class SettingsDeleteRow extends StatelessWidget {
     final tokens = context.designTokens;
     final spacing = tokens.spacing;
     final foreground = enabled
-        ? tokens.colors.alert.error.defaultColor
+        ? tokens.colors.alert.error.ink
         : tokens.colors.text.lowEmphasis;
     // Radius matches the field family so the row reads as part of the
     // form, just charged.

--- a/test/features/ai/ui/settings/widgets/v2/ai_card_action_menu_test.dart
+++ b/test/features/ai/ui/settings/widgets/v2/ai_card_action_menu_test.dart
@@ -84,7 +84,7 @@ void main() {
         final tokens = tester.element(find.text('Delete')).designTokens;
         expect(
           tester.widget<Text>(find.text('Delete')).style!.color,
-          tokens.colors.alert.error.defaultColor,
+          tokens.colors.alert.error.ink,
         );
         expect(
           tester.widget<Text>(find.text('Edit')).style!.color,

--- a/test/features/daily_os_next/ui/widgets/capacity_donut_test.dart
+++ b/test/features/daily_os_next/ui/widgets/capacity_donut_test.dart
@@ -67,7 +67,7 @@ void main() {
         );
         expect(
           eyebrow.style?.color,
-          tokens.colors.alert.error.defaultColor,
+          tokens.colors.alert.error.ink,
         );
       },
     );

--- a/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
@@ -2040,7 +2040,7 @@ void main() {
         // it back from the tree instead of recomputing, so a minute rollover
         // mid-test cannot make the assertion flaky.
         final tokens = tester.element(find.byType(DayTimeline)).designTokens;
-        final errorColor = tokens.colors.alert.error.defaultColor;
+        final errorColor = tokens.colors.alert.error.ink;
         Finder nowBadge() => find.byWidgetPredicate(
           (w) =>
               w is Text &&

--- a/test/features/daily_os_next/ui/widgets/link_badge_test.dart
+++ b/test/features/daily_os_next/ui/widgets/link_badge_test.dart
@@ -23,7 +23,7 @@ void main() {
       final context = tester.element(find.byType(LinkBadge));
       final tokens = context.designTokens;
       final label = tester.widget<Text>(find.text('Q3 strategy deck'));
-      expect(label.style?.color, tokens.colors.alert.info.defaultColor);
+      expect(label.style?.color, tokens.colors.alert.info.ink);
       expect(find.byIcon(Icons.link_rounded), findsOneWidget);
 
       await tester.tap(find.byType(LinkBadge));

--- a/test/features/daily_os_next/ui/widgets/parsed_card_test.dart
+++ b/test/features/daily_os_next/ui/widgets/parsed_card_test.dart
@@ -162,7 +162,7 @@ void main() {
 
       expect(
         matchedTaskIcon().color,
-        tokens.colors.alert.info.defaultColor,
+        tokens.colors.alert.info.ink,
       );
 
       await tester.pumpWidget(const SizedBox.shrink());
@@ -177,7 +177,7 @@ void main() {
 
       expect(
         matchedTaskIcon().color,
-        tokens.colors.alert.warning.defaultColor,
+        tokens.colors.alert.warning.ink,
       );
     });
   });

--- a/test/features/design_system/components/badges/design_system_badge_test.dart
+++ b/test/features/design_system/components/badges/design_system_badge_test.dart
@@ -206,7 +206,7 @@ void main() {
       expectTextStyle(
         richText.text.style!,
         dsTokensLight.typography.styles.others.caption,
-        dsTokensLight.colors.alert.info.defaultColor,
+        dsTokensLight.colors.alert.info.ink,
       );
     });
 
@@ -233,7 +233,7 @@ void main() {
       expectTextStyle(
         richText.text.style!,
         dsTokensLight.typography.styles.others.caption,
-        dsTokensLight.colors.alert.info.defaultColor,
+        dsTokensLight.colors.alert.info.ink,
       );
     });
 

--- a/test/features/design_system/components/context_menus/design_system_context_menu_test.dart
+++ b/test/features/design_system/components/context_menus/design_system_context_menu_test.dart
@@ -132,7 +132,7 @@ void main() {
 
       expect(
         deleteText.style?.color,
-        dsTokensLight.colors.alert.error.defaultColor,
+        dsTokensLight.colors.alert.error.ink,
       );
     });
 

--- a/test/features/design_system/components/task_list_items/design_system_task_list_item_test.dart
+++ b/test/features/design_system/components/task_list_items/design_system_task_list_item_test.dart
@@ -232,19 +232,19 @@ void main() {
         (
           DesignSystemTaskPriority.p0,
           'P0',
-          dsTokensLight.colors.alert.error.defaultColor,
+          dsTokensLight.colors.alert.error.ink,
           Icons.priority_high_rounded,
         ),
         (
           DesignSystemTaskPriority.p1,
           'P1',
-          dsTokensLight.colors.alert.error.defaultColor,
+          dsTokensLight.colors.alert.error.ink,
           Icons.local_fire_department_rounded,
         ),
         (
           DesignSystemTaskPriority.p2,
           'P2',
-          dsTokensLight.colors.alert.warning.defaultColor,
+          dsTokensLight.colors.alert.warning.ink,
           Icons.circle,
         ),
         (

--- a/test/features/design_system/theme/design_tokens_test.dart
+++ b/test/features/design_system/theme/design_tokens_test.dart
@@ -1,11 +1,16 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
+import '../../../test_utils/wcag_contrast.dart';
+
 // Algebraic invariants of the hand-authored `lerp` logic in the generated
-// `design_tokens.g.dart`. The file itself is generated, but the generator's
-// lerp template is non-trivial — a generator regression would silently break
-// theme transitions, so the contract is pinned here from the outside.
+// `design_tokens.g.dart`, plus the palette's accessibility contract. The file
+// itself is generated, but the generator's lerp template is non-trivial — a
+// generator regression would silently break theme transitions — and the
+// palette values it emits carry contrast obligations that nothing else in the
+// build checks. Both are pinned here from the outside.
 //
 // The BuildContext `designTokens` extension getter (the only hand-written
 // code in `design_tokens.dart`) is covered in `design_system_theme_test.dart`
@@ -85,7 +90,115 @@ DsRadii _scaledRadii(DsRadii a, double factor) => a.copyWith(
   smallChips: a.smallChips * factor,
 );
 
+/// AA for body text (SC 1.4.3). The bar for `ink`, which exists precisely so
+/// small alert-toned labels have somewhere safe to bind.
+const _aaText = 4.5;
+
+/// Graphical objects and UI-component state (SC 1.4.11). The bar for
+/// `defaultColor`, which paints dots, borders, glyphs and chart series that
+/// carry their meaning through colour alone.
+const _uiComponent = 3.0;
+
+/// The four alert families, flattened — the generated classes are siblings
+/// with no common supertype, so the ramp has to be projected into records to
+/// be iterated over.
+List<({String name, Color defaultColor, Color ink})> _alertFamilies(
+  DsTokens tokens,
+) {
+  final alert = tokens.colors.alert;
+  return [
+    (
+      name: 'error',
+      defaultColor: alert.error.defaultColor,
+      ink: alert.error.ink,
+    ),
+    (
+      name: 'success',
+      defaultColor: alert.success.defaultColor,
+      ink: alert.success.ink,
+    ),
+    (
+      name: 'warning',
+      defaultColor: alert.warning.defaultColor,
+      ink: alert.warning.ink,
+    ),
+    (name: 'info', defaultColor: alert.info.defaultColor, ink: alert.info.ink),
+  ];
+}
+
+/// The surfaces an alert colour legitimately lands on: the page and the cards
+/// and sheets stacked on it.
+///
+/// `background.level03` is deliberately excluded. It is a mid-grey chip and
+/// panel *fill*, and in dark theme no step of the error ramp can reach AA
+/// against it — pure white tops out at 7.7:1 there, and a red light enough to
+/// clear 4.5:1 has stopped reading as an error. Alert-toned content on
+/// level03 needs a different treatment, not a different ramp step.
+List<({String name, Color color})> _alertSurfaces(DsTokens tokens) => [
+  (name: 'background.level01', color: tokens.colors.background.level01),
+  (name: 'background.level02', color: tokens.colors.background.level02),
+];
+
 void main() {
+  // Nothing in the build pipeline checks the palette the Figma export emits,
+  // so a light-theme ramp anchored for vibrancy shipped three families below
+  // the 1.4.11 floor (warning at 2.15:1 on level02) and stayed there until a
+  // reviewer read the token file by hand. These assertions are the check that
+  // was missing.
+  group('alert palette contrast', () {
+    const themes = [
+      (name: 'light', tokens: dsTokensLight),
+      (name: 'dark', tokens: dsTokensDark),
+    ];
+
+    for (final theme in themes) {
+      for (final family in _alertFamilies(theme.tokens)) {
+        for (final surface in _alertSurfaces(theme.tokens)) {
+          final label = '${theme.name} alert.${family.name} on ${surface.name}';
+
+          test('$label clears its WCAG floor', () {
+            final inkRatio = contrastRatio(family.ink, surface.color);
+            expect(
+              inkRatio,
+              greaterThanOrEqualTo(_aaText),
+              reason:
+                  '$label: ink ${family.ink} measures '
+                  '${inkRatio.toStringAsFixed(2)}:1, below AA text $_aaText:1',
+            );
+
+            final defaultRatio = contrastRatio(
+              family.defaultColor,
+              surface.color,
+            );
+            expect(
+              defaultRatio,
+              greaterThanOrEqualTo(_uiComponent),
+              reason:
+                  '$label: default ${family.defaultColor} measures '
+                  '${defaultRatio.toStringAsFixed(2)}:1, below the '
+                  'non-text floor $_uiComponent:1',
+            );
+          });
+
+          test('$label keeps ink at least as strong as default', () {
+            // The invariant that makes `ink` the always-safe binding: a caller
+            // moving text off `defaultColor` can never lose contrast by it.
+            expect(
+              contrastRatio(family.ink, surface.color),
+              greaterThanOrEqualTo(
+                contrastRatio(
+                  family.defaultColor,
+                  surface.color,
+                ),
+              ),
+              reason: '$label: ink is weaker than default',
+            );
+          });
+        }
+      }
+    }
+  });
+
   group('DsTokens.lerp endpoint identities', () {
     test('t=0 returns the receiver, t=1 returns the other endpoint', () {
       expect(dsTokensLight.lerp(dsTokensDark, 0), dsTokensLight);

--- a/test/features/insights/ui/widgets/insights_delta_chip_test.dart
+++ b/test/features/insights/ui/widgets/insights_delta_chip_test.dart
@@ -100,7 +100,7 @@ void main() {
       final lightIcon = tester.widget<Icon>(
         find.byIcon(Icons.arrow_upward_rounded),
       );
-      expect(lightIcon.color, dsTokensLight.colors.alert.success.pressed);
+      expect(lightIcon.color, dsTokensLight.colors.alert.success.ink);
 
       await pump(
         tester,
@@ -111,7 +111,7 @@ void main() {
       final darkIcon = tester.widget<Icon>(
         find.byIcon(Icons.arrow_upward_rounded),
       );
-      expect(darkIcon.color, dsTokensDark.colors.alert.success.hover);
+      expect(darkIcon.color, dsTokensDark.colors.alert.success.ink);
     });
 
     testWidgets('decline accent uses the AA-safe red per theme', (
@@ -126,7 +126,7 @@ void main() {
       final lightIcon = tester.widget<Icon>(
         find.byIcon(Icons.arrow_downward_rounded),
       );
-      expect(lightIcon.color, dsTokensLight.colors.alert.error.pressed);
+      expect(lightIcon.color, dsTokensLight.colors.alert.error.ink);
 
       await pump(
         tester,
@@ -137,7 +137,7 @@ void main() {
       final darkIcon = tester.widget<Icon>(
         find.byIcon(Icons.arrow_downward_rounded),
       );
-      expect(darkIcon.color, dsTokensDark.colors.alert.error.hover);
+      expect(darkIcon.color, dsTokensDark.colors.alert.error.ink);
     });
 
     // Valence flips the accent while keeping the arrow + sign truthful: for a
@@ -157,7 +157,7 @@ void main() {
       final upIcon = tester.widget<Icon>(
         find.byIcon(Icons.arrow_upward_rounded),
       );
-      expect(upIcon.color, dsTokensLight.colors.alert.error.pressed);
+      expect(upIcon.color, dsTokensLight.colors.alert.error.ink);
 
       await pump(
         tester,
@@ -169,7 +169,7 @@ void main() {
       final downIcon = tester.widget<Icon>(
         find.byIcon(Icons.arrow_downward_rounded),
       );
-      expect(downIcon.color, dsTokensLight.colors.alert.success.pressed);
+      expect(downIcon.color, dsTokensLight.colors.alert.success.ink);
     });
 
     testWidgets('neutral valence keeps the arrow but drops the accent', (
@@ -188,8 +188,8 @@ void main() {
       );
       // The medium-emphasis neutral text colour — neither green nor clay.
       expect(icon.color, dsTokensLight.colors.text.mediumEmphasis);
-      expect(icon.color, isNot(dsTokensLight.colors.alert.success.pressed));
-      expect(icon.color, isNot(dsTokensLight.colors.alert.error.pressed));
+      expect(icon.color, isNot(dsTokensLight.colors.alert.success.ink));
+      expect(icon.color, isNot(dsTokensLight.colors.alert.error.ink));
     });
   });
 }

--- a/test/features/journal/ui/widgets/list_cards/journal_card_test.dart
+++ b/test/features/journal/ui/widgets/list_cards/journal_card_test.dart
@@ -256,7 +256,7 @@ void main() {
       // silently blank card, matching the tasks list row.
       expect(
         text.style?.color,
-        context.designTokens.colors.alert.error.defaultColor,
+        context.designTokens.colors.alert.error.ink,
       );
       expect(text.style?.fontStyle, FontStyle.italic);
     });

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -1255,10 +1255,12 @@ void main() {
       );
     }
 
-    Color paletteError(WidgetTester tester) => TaskShowcasePalette.error(
+    // Ink, not the fill strength: an urgent due pill leaves `labelColor`
+    // null, so this colour also paints the pill's label and owes AA.
+    Color paletteError(WidgetTester tester) => TaskShowcasePalette.errorInk(
       tester.element(find.byType(DesktopTaskHeader)),
     );
-    Color paletteWarning(WidgetTester tester) => TaskShowcasePalette.warning(
+    Color paletteWarning(WidgetTester tester) => TaskShowcasePalette.warningInk(
       tester.element(find.byType(DesktopTaskHeader)),
     );
     Color paletteHigh(WidgetTester tester) => TaskShowcasePalette.highText(

--- a/test/features/tasks/ui/widgets/task_showcase_palette_test.dart
+++ b/test/features/tasks/ui/widgets/task_showcase_palette_test.dart
@@ -85,6 +85,14 @@ void main() {
             TaskShowcasePalette.info(context),
             tokens.colors.alert.info.defaultColor,
           );
+          expect(
+            TaskShowcasePalette.warningInk(context),
+            tokens.colors.alert.warning.ink,
+          );
+          expect(
+            TaskShowcasePalette.errorInk(context),
+            tokens.colors.alert.error.ink,
+          );
         },
       );
     }

--- a/test/test_utils/wcag_contrast.dart
+++ b/test/test_utils/wcag_contrast.dart
@@ -1,0 +1,24 @@
+import 'dart:ui';
+
+/// WCAG 2.1 relative-contrast ratio between two opaque colors.
+///
+/// Defined by SC 1.4.3 as `(L1 + 0.05) / (L2 + 0.05)` where `L1` is the
+/// lighter of the two relative luminances. Order-independent, so callers do
+/// not have to know which of the pair is the background.
+///
+/// Both colors must be opaque: `Color.computeLuminance` ignores alpha, so a
+/// translucent ink measured directly reports the contrast it would have at
+/// full strength — flattering, and wrong. Composite against the surface with
+/// [Color.alphaBlend] first.
+///
+/// Thresholds worth naming, since the call sites all quote them:
+/// - `4.5` — SC 1.4.3 AA for body text
+/// - `3.0` — SC 1.4.3 AA for large text, and SC 1.4.11 for graphical objects
+///   and UI-component state (dots, borders, glyphs that carry meaning alone)
+double contrastRatio(Color a, Color b) {
+  final l1 = a.computeLuminance();
+  final l2 = b.computeLuminance();
+  final brightest = l1 > l2 ? l1 : l2;
+  final darkest = l1 > l2 ? l2 : l1;
+  return (brightest + 0.05) / (darkest + 0.05);
+}


### PR DESCRIPTION
Fixes the light-theme alert palette failing WCAG contrast, at the token source.

## The measurement

The bug was filed against `alert.warning`. Recomputing every step against the
surfaces it actually lands on showed three of the four families miss the floor:

| light `default` | on `background.level01` | on `background.level02` |
| --- | --- | --- |
| `warning` `#FA8C05` | 2.38 ❌ | 2.15 ❌ |
| `info` `#1CA3E3` | 2.84 ❌ | 2.57 ❌ |
| `success` `#59A66B` | 2.96 ❌ | 2.68 ❌ |
| `error` `#CC3633` | 5.07 ✅ | 4.58 ✅ |

All three sit under the 3:1 floor for graphical objects and UI-component state
(SC 1.4.11). Dark theme measures clean for those three, but `error.default`
is 4.25:1 on `level02` — under AA for text, which the original report did not
catch.

Consequence beyond one feature: `warning` is a *semantic* colour. Where a
feature uses it as its only chromatic mark, that meaning stops carrying in
light theme while the same surface measures clean in dark.

Nothing in the build checked the palette, which is how this shipped and stayed.

## The fix

Two changes in `assets/design_system/tokens.json`, both drawn from values
already in the ramp — no invented hexes:

**1. A new `ink` step per family.** The least-extreme step of the same ramp
that clears 4.5:1, resolved per brightness:

| | light `ink` | dark `ink` |
| --- | --- | --- |
| `error` | `#A32B29` (hover) | `#E08684` (hover) |
| `success` | `#366340` (pressed) | `#7AB889` (default) |
| `warning` | `#965402` (pressed) | `#FBA336` (default) |
| `info` | `#116288` (pressed) | `#4AB6E8` (default) |

"Least-extreme that passes" rather than a uniform `pressed`: it keeps error
text a red instead of a maroon, and leaves dark warning/success/info text
pixel-identical to today.

**2. Light `default` moved onto the family's `hover` value** for warning, info
and success, so fills, dots, borders and glyphs clear 3:1. This collapses
`default` and `hover` in light for those three — nothing binds either today,
and a future Figma pass should re-derive a distinct light `hover`. Noted in the
design-system README.

## Consumers

Split by role, not swept wholesale:

- **fills, dots, borders, chart series** keep `defaultColor` — they owe 3:1,
  which the darkened light ramp now delivers, and nothing about them changes in
  dark theme
- **anything painting the tone as text** moves to `ink` — priority labels,
  status chips, connection results, ledger figures, destructive menu items,
  outlined badge labels
- **components doing both** take both bindings. `DesignSystemBadge` is the
  reference: fill and border on the accent, label and glyph on the ink.

Four widgets already hand-rolled exactly this with
`Theme.of(context).brightness` branches — `insights_delta_chip`,
`impact_model_table`, `onboarding_api_key_panel` (×2). Each collapses to a
single token read, and their comments explaining the manual pick are replaced
by a pointer at the token.

## The guard

`design_tokens_test.dart` now pins the contract: 4 families × 2 brightnesses ×
2 surfaces, asserting `ink` ≥ 4.5:1, `default` ≥ 3:1, and that `ink` is never
weaker than `default` — so moving text onto it can never lose contrast.
`background.level03` is excluded deliberately: it is a mid-grey chip and panel
fill, and no step of the dark error ramp can reach AA against it (pure white
tops out at 7.7:1 there).

Verified the guard bites rather than passing vacuously: reverting light
`warning.default` to `#FA8C05` fails exactly the two cases it should, and the
dark `error.ink` miss was caught by the test during development, not by
inspection.

## Notes

- The originating symptom — the task-relationship-links blocked-by chip and
  section header — needed **no widget change**. Both already put amber on a
  border and a ⊘ glyph only and keep their labels at `text.highEmphasis` /
  `text.mediumEmphasis`; those are non-text and now clear their floor. The
  tasks README claimed an amber *label*; corrected to match the code.
- Not fixed here: filled alert badges put white `text.onInteractiveAlert` on
  the accent fill, which is 3.64:1 on the new amber — still under AA for text.
  Closing that needs the ramp darkened much further than the non-text floor
  requires, so it belongs in its own change.

`fvm flutter analyze` clean. ~850 tests across the affected surfaces green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved light-mode readability across warnings, errors, success states, information labels, status chips, priority indicators, and related UI.
  * Updated alert colors to provide stronger contrast against white and off-white backgrounds.
  * Preserved dark-mode appearance, with minor error-text readability improvements on cards.

* **Documentation**
  * Documented alert color usage and contrast guidelines.
  * Updated release notes with the visual accessibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->