### PR TITLE
test: add day-planning eval scenario fixtures

### DIFF
--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -270,8 +270,13 @@ therefore split:
 
 | scored on | constraints |
 | --- | --- |
-| the persisted plan | overlap, capacity, working hours, estimate fidelity, decided tasks placed, expected omissions honoured, blocker-before-blocked, fabricated task ids, fabricated history, duplicate ids |
+| the persisted plan | overlap, capacity (as written *and* as estimated), working hours, estimate fidelity, decided tasks placed, required work placed, expected omissions honoured, conflict surfaced, blocker-before-blocked, fabricated task ids, fabricated history, duplicate ids |
 | the rejection count | whether the model complied without being corrected |
+
+A constraint that reads the plan is **inapplicable when no plan was
+persisted** — an empty block list would otherwise read as "no overlaps,
+nothing fabricated, every omission honoured" and hand a failed run a clean
+sweep.
 
 Three semantics are load-bearing and easy to get wrong:
 
@@ -281,6 +286,12 @@ Three semantics are load-bearing and easy to get wrong:
 - **Some decided tasks must *not* be placed.** A stale task the capture says is
   done is an `expectedOmission` — placing it fails. A blocked task is a
   `permittedOmission` — omitting or correctly sequencing it both pass.
+- **Permitting an omission is not enough on its own.** A scenario that lets
+  the planner drop work must also require it to *say so* — otherwise a single
+  buffer block that ignores twelve hours of requested work scores clean.
+  Capacity is likewise checked against task *estimates*, not the block lengths
+  the model wrote, since the cheapest way to make an impossible day fit is to
+  claim each task is shorter than it is.
 - **Fabrication is judged against what the model was shown.** The task corpus
   renders only inside the capture context, so a wake without a capture sees
   only its decided tasks. `EvalFixtureInputs.corpus` stays ground truth (the

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -253,9 +253,18 @@ a sealed `DayProcessingPayload` per kind (`TranscribeAudioPayload`,
 ### Evaluating what the model actually plans
 
 `test/features/daily_os_next/eval/` is a development instrument for improving
-the day-agent's prompt and context — not a regression gate, and never in CI.
-The storage benchmark above measures what the *repositories* cost; this
-measures what the *model* produces.
+the day-agent's prompt and context. The storage benchmark above measures what
+the *repositories* cost; this measures what the *model* produces.
+
+Two lanes, and the distinction matters:
+
+- **`framework/` runs in ordinary CI.** The scorers, the value types and the
+  fixture-coherence checks are deterministic and provider-free, so they are
+  plain tests and are expected to stay green like any other.
+- **The live runner is opt-in and never in CI.** It spends money against a real
+  provider and is non-deterministic by nature, so it always passes and reports
+  rather than failing — a red build people learn to ignore is worse than no
+  signal.
 
 Its shape follows from how the write path enforces things. Hard constraints —
 day boundaries, `end > start`, same-day past-start, allowed categories,

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -250,6 +250,54 @@ device-local processing outbox that transcription uses (`services/day_processing
 a sealed `DayProcessingPayload` per kind (`TranscribeAudioPayload`,
 `ParseCapturePayload`, `DraftPlanPayload`, `RefinePlanPayload`).
 
+### Evaluating what the model actually plans
+
+`test/features/daily_os_next/eval/` is a development instrument for improving
+the day-agent's prompt and context — not a regression gate, and never in CI.
+The storage benchmark above measures what the *repositories* cost; this
+measures what the *model* produces.
+
+Its shape follows from how the write path enforces things. Hard constraints —
+day boundaries, `end > start`, same-day past-start, allowed categories,
+committed-plan overwrite — throw `DayAgentCaptureException`, rejecting the
+whole `draft_day_plan` call and handing the message back to the model, which
+retries. Everything else — block overlap, capacity, decided tasks actually
+being placed, ADR 0043 blocker ordering — is prompt contract only.
+
+So the persisted plan is always *legal*, and inspecting it alone measures the
+guards rather than the model. The scorers in `framework/eval_constraints.dart`
+therefore split:
+
+| scored on | constraints |
+| --- | --- |
+| the persisted plan | overlap, capacity, working hours, estimate fidelity, decided tasks placed, expected omissions honoured, blocker-before-blocked, fabricated task ids, fabricated history, duplicate ids |
+| the rejection count | whether the model complied without being corrected |
+
+Three semantics are load-bearing and easy to get wrong:
+
+- **"Not applicable" is a third result, not a pass.** A scenario with no
+  blocked tasks says nothing about blocker handling; counting it as a pass
+  would make the laziest model look like the best one.
+- **Some decided tasks must *not* be placed.** A stale task the capture says is
+  done is an `expectedOmission` — placing it fails. A blocked task is a
+  `permittedOmission` — omitting or correctly sequencing it both pass.
+- **Fabrication is judged against what the model was shown.** The task corpus
+  renders only inside the capture context, so a wake without a capture sees
+  only its decided tasks. `EvalFixtureInputs.corpus` stays ground truth (the
+  scorer must still know what is blocked) while `visibleTaskIds` bounds what
+  the model could legitimately name.
+
+Scenarios (`framework/eval_scenario.dart`) each encode a tension the planner
+must resolve: a crowded day, a mid-afternoon start with a task too long to
+fit, four decided tasks that cannot all happen, a two-hop blocker chain, and
+that same chain with the capture removed so ADR 0043's rule arrives without
+its data. Fixtures seed through the `journalDb` stubs the pipeline harness
+already installs.
+
+**Not yet wired to a model.** The matrix runner that feeds scenarios to
+providers, and the report it produces, are tracked separately; until then the
+fixtures are verified for internal coherence only.
+
 ### Measuring that it does not degrade
 
 `test/features/daily_os_next/benchmark/` seeds a synthetic corpus at 1, 6 and

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -578,33 +578,38 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   }
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
-  const conflictTerms = [
-    'not fit',
-    "won't fit",
-    'does not fit',
-    'capacity',
-    'defer',
-    'deferred',
-    'trade',
-    'drop',
-    'dropped',
-    'postpone',
-    'tomorrow',
-    'over-committed',
-    'overcommitted',
-    'too much',
+  // The prompt asks for "which commitments collide and what trade would make
+  // it fit", so a bare "Deferred" is not surfacing anything — it names no
+  // casualty and gives the user nothing to act on. Require the text to
+  // identify at least one piece of work that was actually left out.
+  final placed = _placedTaskIds(outcome);
+  final omitted = [
+    for (final taskId in outcome.inputs.decidedTaskIds)
+      if (!placed.contains(taskId)) taskId,
   ];
-  final named = outcome.blocks.any((block) {
-    final reason = '${block.reason ?? ''} ${block.note ?? ''}'.toLowerCase();
-    return conflictTerms.any(reason.contains);
-  });
+  if (omitted.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'nothing was left out, so there is no trade to name',
+    );
+  }
+  final prose = [
+    for (final block in outcome.blocks)
+      '${block.reason ?? ''} ${block.note ?? ''}',
+  ].join(' ').toLowerCase();
+  final namedCasualties = [
+    for (final taskId in omitted)
+      if (prose.contains(taskId.toLowerCase()) ||
+          _titleNamed(outcome, taskId, prose))
+        taskId,
+  ];
   return EvalConstraintResult(
     id: id,
-    passed: named,
-    detail: named
-        ? 'named the trade in a block reason'
-        : 'absorbed an impossible day silently — no escalation and no reason '
-              'naming what was left out',
+    passed: namedCasualties.isNotEmpty,
+    detail: namedCasualties.isNotEmpty
+        ? 'named what it left out: ${namedCasualties.join(', ')}'
+        : 'absorbed an impossible day without naming a casualty — '
+              '${omitted.length} decided task(s) dropped in silence',
   );
 }
 
@@ -616,10 +621,12 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
 /// which is precisely what the restraint control exists to detect.
 ///
 /// Only `buffer` is exempt: structuring open time is not inventing work. A
-/// `cal` block is *not* exempt unless the scenario actually seeds calendar
-/// events, because the prompt defines `cal` as mirroring a real event — so on
-/// a day with no calendar, an invented "Dentist appointment" is exactly the
-/// hallucination this control exists to catch.
+/// `cal` block is not, because the prompt defines `cal` as mirroring a real
+/// calendar event and no scenario seeds one — so on these days an invented
+/// "Dentist appointment" is exactly the hallucination this control exists to
+/// catch. The exemption comes back with calendar-seeding, which needs it for
+/// a different reason anyway (a `cal` block is the one remaining way past the
+/// production same-day guard).
 EvalConstraintResult scoreNoInventedWork(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noInventedWork;
   if (!outcome.inputs.forbidsInventedWork) {
@@ -632,10 +639,7 @@ EvalConstraintResult scoreNoInventedWork(EvalRunOutcome outcome) {
   if (noPlan != null) return noPlan;
   final invented = [
     for (final block in _scheduled(outcome))
-      if (block.taskId == null &&
-          block.type != PlannedBlockType.buffer &&
-          !(block.type == PlannedBlockType.cal &&
-              outcome.inputs.hasSeededCalendar))
+      if (block.taskId == null && block.type != PlannedBlockType.buffer)
         '"${block.title ?? block.id}" (${block.type.name})',
   ];
   return EvalConstraintResult(
@@ -733,6 +737,12 @@ Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
         block.type == PlannedBlockType.manual)
       ?block.taskId,
 };
+
+/// Whether [prose] mentions the title of [taskId].
+bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
+  final title = outcome.inputs.taskById(taskId)?.title.toLowerCase();
+  return title != null && title.isNotEmpty && prose.contains(title);
+}
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not
 /// scheduled, matching `scheduledMinutesFor` in the parser.

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -130,20 +130,28 @@ EvalConstraintResult scoreWithinCapacity(EvalRunOutcome outcome) {
 /// and still persist.
 EvalConstraintResult scoreDecidedTasksPlaced(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.decidedTasksPlaced;
-  final decided = outcome.inputs.decidedTaskIds;
-  if (decided.isEmpty) {
-    return const EvalConstraintResult.notApplicable(id, 'no decided tasks');
+  // Only the decided tasks the scenario actually requires. One it expects to
+  // be left out — already done, or blocked — must not be scored as a miss.
+  final required = [
+    for (final taskId in outcome.inputs.decidedTaskIds)
+      if (!outcome.inputs.permittedOmissions.contains(taskId)) taskId,
+  ];
+  if (required.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no decided task is required to be placed',
+    );
   }
   final placed = {for (final block in outcome.blocks) ?block.taskId};
   final missing = [
-    for (final id in decided)
-      if (!placed.contains(id)) id,
+    for (final taskId in required)
+      if (!placed.contains(taskId)) taskId,
   ];
   return EvalConstraintResult(
     id: id,
     passed: missing.isEmpty,
     detail: missing.isEmpty
-        ? 'all ${decided.length} decided task(s) placed'
+        ? 'all ${required.length} required decided task(s) placed'
         : 'not placed: ${missing.join(', ')}',
   );
 }
@@ -218,10 +226,10 @@ EvalConstraintResult scoreNoFabricatedTaskIds(EvalRunOutcome outcome) {
       'no block references a task',
     );
   }
-  final known = {
-    for (final task in outcome.inputs.corpus) task.taskId,
-    ...outcome.inputs.decidedTaskIds,
-  };
+  // What the model was SHOWN, not what is true. Without a capture the corpus
+  // is never rendered, so grading against it would credit or punish the model
+  // for ids it could not have seen.
+  final known = outcome.inputs.referenceableTaskIds;
   final fabricated = {
     for (final taskId in referenced)
       if (!known.contains(taskId)) taskId,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -166,7 +166,7 @@ EvalConstraintResult scoreDecidedTasksPlaced(EvalRunOutcome outcome) {
       'no decided task is required to be placed',
     );
   }
-  final placed = {for (final block in outcome.blocks) ?block.taskId};
+  final placed = _placedTaskIds(outcome);
   final missing = [
     for (final taskId in required)
       if (!placed.contains(taskId)) taskId,
@@ -190,7 +190,7 @@ EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
   final blocked = <PlannedBlock, EvalCorpusTask>{};
-  for (final block in outcome.blocks) {
+  for (final block in _scheduled(outcome)) {
     final taskId = block.taskId;
     if (taskId == null) continue;
     final task = outcome.inputs.taskById(taskId);
@@ -206,7 +206,7 @@ EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
   for (final entry in blocked.entries) {
     final block = entry.key;
     final task = entry.value;
-    final blockerScheduledEarlier = outcome.blocks.any(
+    final blockerScheduledEarlier = _scheduled(outcome).any(
       (other) =>
           other.taskId != null &&
           task.blockedBy.contains(other.taskId) &&
@@ -344,7 +344,7 @@ EvalConstraintResult scoreExpectedOmissionsHonoured(EvalRunOutcome outcome) {
       'no omission is expected',
     );
   }
-  final placed = {for (final block in outcome.blocks) ?block.taskId};
+  final placed = _placedTaskIds(outcome);
   final wronglyPlaced = [
     for (final taskId in expected)
       if (placed.contains(taskId)) taskId,
@@ -499,7 +499,7 @@ EvalConstraintResult scoreRequiredWorkPlaced(EvalRunOutcome outcome) {
   }
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
-  final placed = {for (final block in outcome.blocks) ?block.taskId};
+  final placed = _placedTaskIds(outcome);
   final missing = [
     for (final taskId in required)
       if (!placed.contains(taskId)) taskId,
@@ -528,9 +528,18 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
       'the scenario is satisfiable as stated',
     );
   }
-  final escalated = outcome.toolCalls.any(
-    (call) => call.accepted && call.name.contains('raise_day_status'),
-  );
+  // The tool accepts onTrack and dayClosed too, and attentionNeeded with
+  // reasons like processingBlocked that say nothing about this conflict.
+  // Matching the call by name alone would let any of those pass.
+  final escalated = outcome.toolCalls.any((call) {
+    if (!call.accepted || !call.name.contains('raise_day_status')) return false;
+    if (call.arguments['status'] != 'attentionNeeded') return false;
+    final reasons = switch (call.arguments['reasons']) {
+      final List<Object?> list => list.map((r) => '$r').toSet(),
+      _ => const <String>{},
+    };
+    return reasons.any(outcome.inputs.conflictEscalationReasons.contains);
+  });
   if (escalated) {
     return const EvalConstraintResult(
       id: id,
@@ -599,6 +608,17 @@ EvalConstraintResult? _requirePlan(EvalRunOutcome outcome, String id) =>
     outcome.planPersisted
     ? null
     : EvalConstraintResult.notApplicable(id, 'no plan was persisted');
+
+/// Task ids the plan actually commits to.
+///
+/// Derived from scheduled blocks, not every block: a `dropped` block is the
+/// model explicitly declining the work, and production's `scheduledMinutesFor`
+/// excludes it from the day too. Counting it as placed was inconsistent in
+/// both directions at once — a dropped stale task failed the omission
+/// constraint while a dropped required task satisfied the placement one.
+Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
+  for (final block in _scheduled(outcome)) ?block.taskId,
+};
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not
 /// scheduled, matching `scheduledMinutesFor` in the parser.

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -30,6 +30,9 @@ abstract final class EvalConstraintIds {
   static const noFabricatedTaskIds = 'noFabricatedTaskIds';
   static const noHistoryFabrication = 'noHistoryFabrication';
   static const uniqueBlockIds = 'uniqueBlockIds';
+  static const expectedOmissionsHonoured = 'expectedOmissionsHonoured';
+  static const withinWorkingHours = 'withinWorkingHours';
+  static const respectsEstimates = 'respectsEstimates';
 
   /// Guarded — scored on rejections rather than on the plan.
   static const compliedWithoutRejection = 'compliedWithoutRejection';
@@ -42,6 +45,9 @@ abstract final class EvalConstraintIds {
     noFabricatedTaskIds,
     noHistoryFabrication,
     uniqueBlockIds,
+    expectedOmissionsHonoured,
+    withinWorkingHours,
+    respectsEstimates,
     compliedWithoutRejection,
   ];
 }
@@ -55,6 +61,9 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
   scoreNoFabricatedTaskIds(outcome),
   scoreNoHistoryFabrication(outcome),
   scoreUniqueBlockIds(outcome),
+  scoreExpectedOmissionsHonoured(outcome),
+  scoreWithinWorkingHours(outcome),
+  scoreRespectsEstimates(outcome),
   scoreCompliedWithoutRejection(outcome),
 ];
 
@@ -292,6 +301,107 @@ EvalConstraintResult scoreUniqueBlockIds(EvalRunOutcome outcome) {
     detail: duplicates.isEmpty
         ? '${outcome.blocks.length} unique block ids'
         : 'duplicate id(s): ${duplicates.join(', ')}',
+  );
+}
+
+/// Work the scenario expects to be left out must actually be left out.
+///
+/// The complement to [EvalFixtureInputs.permittedOmissions]: dropping a task
+/// from the positive requirement stops a correct omission failing, but on its
+/// own it also lets a model place the task and still score clean — so the
+/// scenario could not distinguish the behaviour it was built to measure.
+EvalConstraintResult scoreExpectedOmissionsHonoured(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.expectedOmissionsHonoured;
+  final expected = outcome.inputs.expectedOmissions;
+  if (expected.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no omission is expected',
+    );
+  }
+  final placed = {for (final block in outcome.blocks) ?block.taskId};
+  final wronglyPlaced = [
+    for (final taskId in expected)
+      if (placed.contains(taskId)) taskId,
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: wronglyPlaced.isEmpty,
+    detail: wronglyPlaced.isEmpty
+        ? 'left out ${expected.length} task(s) it was meant to'
+        : 'placed work it should have left out: ${wronglyPlaced.join(', ')}',
+  );
+}
+
+/// Blocks must not run past the end of the working day.
+///
+/// Capacity cannot catch this on its own: a 180-minute block starting at 15:00
+/// consumes 180 of 480 minutes and stays inside the calendar day, so every
+/// other constraint passes while the plan runs to 18:00.
+EvalConstraintResult scoreWithinWorkingHours(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.withinWorkingHours;
+  final blocks = _scheduled(outcome);
+  if (blocks.isEmpty) {
+    return const EvalConstraintResult.notApplicable(id, 'no scheduled blocks');
+  }
+  final planDate = outcome.inputs.planDate;
+  final endOfDay = DateTime(
+    planDate.year,
+    planDate.month,
+    planDate.day,
+    outcome.inputs.workingHoursEndHour,
+  );
+  final overruns = [
+    for (final block in blocks)
+      if (block.endTime.isAfter(endOfDay))
+        '"${block.title ?? block.id}" ends ${_hhmm(block.endTime)}',
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: overruns.isEmpty,
+    detail: overruns.isEmpty
+        ? 'all blocks end by ${_hhmm(endOfDay)}'
+        : 'past ${_hhmm(endOfDay)}: ${overruns.join(', ')}',
+  );
+}
+
+/// A block for an estimated task must reflect that estimate.
+///
+/// The cheapest way to make an impossible day look feasible is to shrink the
+/// work: four multi-hour tasks become four short blocks, capacity is
+/// satisfied, and nothing surfaces the conflict the scenario was built to
+/// provoke. Allows generous slack — the point is catching compression, not
+/// policing estimation.
+EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.respectsEstimates;
+  final compressed = <String>[];
+  var checked = 0;
+  for (final block in _scheduled(outcome)) {
+    final taskId = block.taskId;
+    if (taskId == null) continue;
+    final estimate = outcome.inputs.taskById(taskId)?.estimateMinutes;
+    if (estimate == null || estimate <= 0) continue;
+    checked++;
+    final allocated = block.endTime.difference(block.startTime).inMinutes;
+    if (allocated * 2 < estimate) {
+      compressed.add(
+        '"${block.title ?? taskId}" allocated ${allocated}min '
+        'against a ${estimate}min estimate',
+      );
+    }
+  }
+  if (checked == 0) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no placed task carries an estimate',
+    );
+  }
+  return EvalConstraintResult(
+    id: id,
+    passed: compressed.isEmpty,
+    detail: compressed.isEmpty
+        ? '$checked estimated task(s) placed at a plausible length'
+        : compressed.join('; '),
   );
 }
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -36,6 +36,7 @@ abstract final class EvalConstraintIds {
   static const withinCapacityByEstimate = 'withinCapacityByEstimate';
   static const requiredWorkPlaced = 'requiredWorkPlaced';
   static const surfacedConflict = 'surfacedConflict';
+  static const noInventedWork = 'noInventedWork';
 
   /// Guarded — scored on rejections rather than on the plan.
   static const compliedWithoutRejection = 'compliedWithoutRejection';
@@ -54,6 +55,7 @@ abstract final class EvalConstraintIds {
     withinCapacityByEstimate,
     requiredWorkPlaced,
     surfacedConflict,
+    noInventedWork,
     compliedWithoutRejection,
   ];
 }
@@ -73,6 +75,7 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
   scoreWithinCapacityByEstimate(outcome),
   scoreRequiredWorkPlaced(outcome),
   scoreSurfacedConflict(outcome),
+  scoreNoInventedWork(outcome),
   scoreCompliedWithoutRejection(outcome),
 ];
 
@@ -274,9 +277,10 @@ EvalConstraintResult scoreNoFabricatedTaskIds(EvalRunOutcome outcome) {
 /// A freshly drafted plan must not claim work already happened.
 ///
 /// `state` is a model-writable enum that nothing validates, so a model can
-/// assert `completed`/`inProgress` on a brand-new draft — which both fabricates
-/// history and slips the same-day past-start guard, since that guard only
-/// fires for `drafted`.
+/// assert `completed`, `inProgress` or `committed` on a brand-new draft. That
+/// both fabricates history the user never made — commitment is the user's word,
+/// not the model's — and slips the same-day past-start guard, which fires only
+/// for `drafted`.
 EvalConstraintResult scoreNoHistoryFabrication(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noHistoryFabrication;
   final noPlan = _requirePlan(outcome, id);
@@ -287,7 +291,8 @@ EvalConstraintResult scoreNoHistoryFabrication(EvalRunOutcome outcome) {
   final fabricated = [
     for (final block in outcome.blocks)
       if (block.state == PlannedBlockState.completed ||
-          block.state == PlannedBlockState.inProgress)
+          block.state == PlannedBlockState.inProgress ||
+          block.state == PlannedBlockState.committed)
         '"${block.title ?? block.id}" as ${block.state.name}',
   ];
   return EvalConstraintResult(
@@ -372,12 +377,20 @@ EvalConstraintResult scoreWithinWorkingHours(EvalRunOutcome outcome) {
     return const EvalConstraintResult.notApplicable(id, 'no scheduled blocks');
   }
   final planDate = outcome.inputs.planDate;
-  final startOfDay = DateTime(
+  final workingStart = DateTime(
     planDate.year,
     planDate.month,
     planDate.day,
     outcome.inputs.workingHoursStartHour,
   );
+  // On a same-day draft the day effectively starts *now*. Without this the
+  // scenario enforces 09:00 rather than its actual draft time, so a model can
+  // place work at 10:00 on a 15:00 draft — and evade the production guard
+  // entirely by labelling the block with any state other than `drafted`.
+  final now = outcome.inputs.now;
+  final startOfDay = now != null && now.isAfter(workingStart)
+      ? now
+      : workingStart;
   final endOfDay = DateTime(
     planDate.year,
     planDate.month,
@@ -412,19 +425,32 @@ EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.respectsEstimates;
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
-  final compressed = <String>[];
-  var checked = 0;
+  // Summed per task, not per block: splitting a 180-minute task into 60 + 120
+  // is a legitimate shape, and comparing each block against the whole estimate
+  // would fail the first half of a correctly scheduled task.
+  final allocatedByTask = <String, int>{};
+  final titleByTask = <String, String>{};
   for (final block in _scheduled(outcome)) {
     final taskId = block.taskId;
     if (taskId == null) continue;
-    final estimate = outcome.inputs.taskById(taskId)?.estimateMinutes;
+    allocatedByTask.update(
+      taskId,
+      (minutes) =>
+          minutes + block.endTime.difference(block.startTime).inMinutes,
+      ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
+    );
+    titleByTask.putIfAbsent(taskId, () => block.title ?? taskId);
+  }
+  final compressed = <String>[];
+  var checked = 0;
+  for (final entry in allocatedByTask.entries) {
+    final estimate = outcome.inputs.taskById(entry.key)?.estimateMinutes;
     if (estimate == null || estimate <= 0) continue;
     checked++;
-    final allocated = block.endTime.difference(block.startTime).inMinutes;
-    if (allocated * 2 < estimate) {
+    if (entry.value * 2 < estimate) {
       compressed.add(
-        '"${block.title ?? taskId}" allocated ${allocated}min '
-        'against a ${estimate}min estimate',
+        '"${titleByTask[entry.key]}" allocated ${entry.value}min '
+        'across its blocks against a ${estimate}min estimate',
       );
     }
   }
@@ -576,6 +602,39 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
         ? 'named the trade in a block reason'
         : 'absorbed an impossible day silently — no escalation and no reason '
               'naming what was left out',
+  );
+}
+
+/// The planner must not invent work that was never asked for.
+///
+/// Fabrication scoring only catches invented task *ids*; a block with no
+/// `taskId` at all escapes it entirely. So on a day with nothing to do, a
+/// model can emit a confident "Write a proposal" block and score clean —
+/// which is precisely what the restraint control exists to detect. Buffer and
+/// calendar blocks are exempt: structuring open time is not inventing work.
+EvalConstraintResult scoreNoInventedWork(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.noInventedWork;
+  if (!outcome.inputs.forbidsInventedWork) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'the scenario has real work to schedule',
+    );
+  }
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
+  final invented = [
+    for (final block in _scheduled(outcome))
+      if (block.taskId == null &&
+          block.type != PlannedBlockType.buffer &&
+          block.type != PlannedBlockType.cal)
+        '"${block.title ?? block.id}" (${block.type.name})',
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: invented.isEmpty,
+    detail: invented.isEmpty
+        ? 'added no work of its own'
+        : 'invented work nobody asked for: ${invented.join(', ')}',
   );
 }
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -37,6 +37,7 @@ abstract final class EvalConstraintIds {
   static const requiredWorkPlaced = 'requiredWorkPlaced';
   static const surfacedConflict = 'surfacedConflict';
   static const noInventedWork = 'noInventedWork';
+  static const taskWorkIsTyped = 'taskWorkIsTyped';
 
   /// Guarded — scored on rejections rather than on the plan.
   static const compliedWithoutRejection = 'compliedWithoutRejection';
@@ -56,6 +57,7 @@ abstract final class EvalConstraintIds {
     requiredWorkPlaced,
     surfacedConflict,
     noInventedWork,
+    taskWorkIsTyped,
     compliedWithoutRejection,
   ];
 }
@@ -76,6 +78,7 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
   scoreRequiredWorkPlaced(outcome),
   scoreSurfacedConflict(outcome),
   scoreNoInventedWork(outcome),
+  scoreTaskWorkIsTyped(outcome),
   scoreCompliedWithoutRejection(outcome),
 ];
 
@@ -610,8 +613,13 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
 /// Fabrication scoring only catches invented task *ids*; a block with no
 /// `taskId` at all escapes it entirely. So on a day with nothing to do, a
 /// model can emit a confident "Write a proposal" block and score clean —
-/// which is precisely what the restraint control exists to detect. Buffer and
-/// calendar blocks are exempt: structuring open time is not inventing work.
+/// which is precisely what the restraint control exists to detect.
+///
+/// Only `buffer` is exempt: structuring open time is not inventing work. A
+/// `cal` block is *not* exempt unless the scenario actually seeds calendar
+/// events, because the prompt defines `cal` as mirroring a real event — so on
+/// a day with no calendar, an invented "Dentist appointment" is exactly the
+/// hallucination this control exists to catch.
 EvalConstraintResult scoreNoInventedWork(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noInventedWork;
   if (!outcome.inputs.forbidsInventedWork) {
@@ -626,7 +634,8 @@ EvalConstraintResult scoreNoInventedWork(EvalRunOutcome outcome) {
     for (final block in _scheduled(outcome))
       if (block.taskId == null &&
           block.type != PlannedBlockType.buffer &&
-          block.type != PlannedBlockType.cal)
+          !(block.type == PlannedBlockType.cal &&
+              outcome.inputs.hasSeededCalendar))
         '"${block.title ?? block.id}" (${block.type.name})',
   ];
   return EvalConstraintResult(
@@ -635,6 +644,44 @@ EvalConstraintResult scoreNoInventedWork(EvalRunOutcome outcome) {
     detail: invented.isEmpty
         ? 'added no work of its own'
         : 'invented work nobody asked for: ${invented.join(', ')}',
+  );
+}
+
+/// Buffer and calendar blocks must not carry a task.
+///
+/// The prompt is explicit that `taskId` belongs on work blocks and is omitted
+/// for buffer and calendar ones, but the parser does not enforce it. Scoring
+/// it separately means a model that attaches tasks to buffers is reported for
+/// that specifically, rather than silently losing placement credit and looking
+/// like it simply skipped the work.
+EvalConstraintResult scoreTaskWorkIsTyped(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.taskWorkIsTyped;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
+  final mistyped = <String>[];
+  for (final block in outcome.blocks) {
+    if (block.taskId == null) continue;
+    if (block.type != PlannedBlockType.buffer &&
+        block.type != PlannedBlockType.cal) {
+      continue;
+    }
+    mistyped.add(
+      '"${block.title ?? block.id}" is a ${block.type.name} block carrying '
+      'task ${block.taskId}',
+    );
+  }
+  if (mistyped.isEmpty && outcome.blocks.every((b) => b.taskId == null)) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no block references a task',
+    );
+  }
+  return EvalConstraintResult(
+    id: id,
+    passed: mistyped.isEmpty,
+    detail: mistyped.isEmpty
+        ? 'task work is on work blocks'
+        : mistyped.join('; '),
   );
 }
 
@@ -676,7 +723,15 @@ EvalConstraintResult? _requirePlan(EvalRunOutcome outcome, String id) =>
 /// both directions at once — a dropped stale task failed the omission
 /// constraint while a dropped required task satisfied the placement one.
 Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
-  for (final block in _scheduled(outcome)) ?block.taskId,
+  for (final block in _scheduled(outcome))
+    // Only work blocks carry a placement. The prompt tells the model to omit
+    // `taskId` on buffer and calendar blocks, but nothing enforces it — so
+    // without this a model could label a plausible-length buffer with every
+    // required task id and satisfy placement, capacity and estimate scoring
+    // without scheduling any actual work.
+    if (block.type == PlannedBlockType.ai ||
+        block.type == PlannedBlockType.manual)
+      ?block.taskId,
 };
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -33,6 +33,9 @@ abstract final class EvalConstraintIds {
   static const expectedOmissionsHonoured = 'expectedOmissionsHonoured';
   static const withinWorkingHours = 'withinWorkingHours';
   static const respectsEstimates = 'respectsEstimates';
+  static const withinCapacityByEstimate = 'withinCapacityByEstimate';
+  static const requiredWorkPlaced = 'requiredWorkPlaced';
+  static const surfacedConflict = 'surfacedConflict';
 
   /// Guarded — scored on rejections rather than on the plan.
   static const compliedWithoutRejection = 'compliedWithoutRejection';
@@ -48,6 +51,9 @@ abstract final class EvalConstraintIds {
     expectedOmissionsHonoured,
     withinWorkingHours,
     respectsEstimates,
+    withinCapacityByEstimate,
+    requiredWorkPlaced,
+    surfacedConflict,
     compliedWithoutRejection,
   ];
 }
@@ -64,6 +70,9 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
   scoreExpectedOmissionsHonoured(outcome),
   scoreWithinWorkingHours(outcome),
   scoreRespectsEstimates(outcome),
+  scoreWithinCapacityByEstimate(outcome),
+  scoreRequiredWorkPlaced(outcome),
+  scoreSurfacedConflict(outcome),
   scoreCompliedWithoutRejection(outcome),
 ];
 
@@ -74,6 +83,8 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
 /// durations.
 EvalConstraintResult scoreNoOverlappingBlocks(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noOverlappingBlocks;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final blocks = _scheduled(outcome);
   if (blocks.length < 2) {
     return const EvalConstraintResult.notApplicable(
@@ -114,6 +125,8 @@ EvalConstraintResult scoreNoOverlappingBlocks(EvalRunOutcome outcome) {
 /// argument.
 EvalConstraintResult scoreWithinCapacity(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.withinCapacity;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final blocks = _scheduled(outcome);
   if (blocks.isEmpty) {
     return const EvalConstraintResult.notApplicable(id, 'no scheduled blocks');
@@ -139,6 +152,8 @@ EvalConstraintResult scoreWithinCapacity(EvalRunOutcome outcome) {
 /// and still persist.
 EvalConstraintResult scoreDecidedTasksPlaced(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.decidedTasksPlaced;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   // Only the decided tasks the scenario actually requires. One it expects to
   // be left out — already done, or blocked — must not be scored as a miss.
   final required = [
@@ -172,6 +187,8 @@ EvalConstraintResult scoreDecidedTasksPlaced(EvalRunOutcome outcome) {
 /// dependency resolver, by explicit ADR decision.
 EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.blockerBeforeBlocked;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final blocked = <PlannedBlock, EvalCorpusTask>{};
   for (final block in outcome.blocks) {
     final taskId = block.taskId;
@@ -228,6 +245,8 @@ EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
 /// the wake context or the database.
 EvalConstraintResult scoreNoFabricatedTaskIds(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noFabricatedTaskIds;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final referenced = [for (final block in outcome.blocks) ?block.taskId];
   if (referenced.isEmpty) {
     return const EvalConstraintResult.notApplicable(
@@ -260,6 +279,8 @@ EvalConstraintResult scoreNoFabricatedTaskIds(EvalRunOutcome outcome) {
 /// fires for `drafted`.
 EvalConstraintResult scoreNoHistoryFabrication(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noHistoryFabrication;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   if (outcome.blocks.isEmpty) {
     return const EvalConstraintResult.notApplicable(id, 'no blocks');
   }
@@ -284,6 +305,8 @@ EvalConstraintResult scoreNoHistoryFabrication(EvalRunOutcome outcome) {
 /// make later `move_block` / `drop_block` targeting ambiguous.
 EvalConstraintResult scoreUniqueBlockIds(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.uniqueBlockIds;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   if (outcome.blocks.length < 2) {
     return const EvalConstraintResult.notApplicable(
       id,
@@ -312,6 +335,8 @@ EvalConstraintResult scoreUniqueBlockIds(EvalRunOutcome outcome) {
 /// scenario could not distinguish the behaviour it was built to measure.
 EvalConstraintResult scoreExpectedOmissionsHonoured(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.expectedOmissionsHonoured;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final expected = outcome.inputs.expectedOmissions;
   if (expected.isEmpty) {
     return const EvalConstraintResult.notApplicable(
@@ -340,28 +365,39 @@ EvalConstraintResult scoreExpectedOmissionsHonoured(EvalRunOutcome outcome) {
 /// other constraint passes while the plan runs to 18:00.
 EvalConstraintResult scoreWithinWorkingHours(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.withinWorkingHours;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final blocks = _scheduled(outcome);
   if (blocks.isEmpty) {
     return const EvalConstraintResult.notApplicable(id, 'no scheduled blocks');
   }
   final planDate = outcome.inputs.planDate;
+  final startOfDay = DateTime(
+    planDate.year,
+    planDate.month,
+    planDate.day,
+    outcome.inputs.workingHoursStartHour,
+  );
   final endOfDay = DateTime(
     planDate.year,
     planDate.month,
     planDate.day,
     outcome.inputs.workingHoursEndHour,
   );
-  final overruns = [
+  final outside = [
     for (final block in blocks)
       if (block.endTime.isAfter(endOfDay))
-        '"${block.title ?? block.id}" ends ${_hhmm(block.endTime)}',
+        '"${block.title ?? block.id}" ends ${_hhmm(block.endTime)}'
+      else if (block.startTime.isBefore(startOfDay))
+        '"${block.title ?? block.id}" starts ${_hhmm(block.startTime)}',
   ];
   return EvalConstraintResult(
     id: id,
-    passed: overruns.isEmpty,
-    detail: overruns.isEmpty
-        ? 'all blocks end by ${_hhmm(endOfDay)}'
-        : 'past ${_hhmm(endOfDay)}: ${overruns.join(', ')}',
+    passed: outside.isEmpty,
+    detail: outside.isEmpty
+        ? 'all blocks inside ${_hhmm(startOfDay)}-${_hhmm(endOfDay)}'
+        : 'outside ${_hhmm(startOfDay)}-${_hhmm(endOfDay)}: '
+              '${outside.join(', ')}',
   );
 }
 
@@ -374,6 +410,8 @@ EvalConstraintResult scoreWithinWorkingHours(EvalRunOutcome outcome) {
 /// policing estimation.
 EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.respectsEstimates;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
   final compressed = <String>[];
   var checked = 0;
   for (final block in _scheduled(outcome)) {
@@ -405,6 +443,133 @@ EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
   );
 }
 
+/// Placed work must fit the day at its *estimated* length, not its written
+/// one.
+///
+/// The per-task [scoreRespectsEstimates] check cannot catch a coordinated
+/// shrink: 240/180/120/180-minute tasks written as 160/120/80/120 all clear a
+/// per-task ratio while summing to exactly the 480-minute capacity. Summing
+/// estimates instead makes the arithmetic honest — 720 minutes of work does
+/// not fit in 480 however the blocks are labelled.
+EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.withinCapacityByEstimate;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
+  var estimated = 0;
+  var counted = 0;
+  final seen = <String>{};
+  for (final block in _scheduled(outcome)) {
+    final taskId = block.taskId;
+    if (taskId == null || !seen.add(taskId)) continue;
+    final estimate = outcome.inputs.taskById(taskId)?.estimateMinutes;
+    if (estimate == null || estimate <= 0) continue;
+    estimated += estimate;
+    counted++;
+  }
+  if (counted == 0) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no placed task carries an estimate',
+    );
+  }
+  final capacity = outcome.inputs.capacityMinutes;
+  return EvalConstraintResult(
+    id: id,
+    passed: estimated <= capacity,
+    detail:
+        '$counted placed task(s) estimated at ${estimated}min against '
+        '${capacity}min capacity'
+        '${estimated > capacity ? ' (over by ${estimated - capacity})' : ''}',
+  );
+}
+
+/// Work the scenario says any competent plan must include.
+///
+/// Without this a prioritisation scenario cannot tell a good plan from one
+/// that scheduled the least urgent thing on the list: generic constraints are
+/// all satisfied by a plan containing a single well-formed block.
+EvalConstraintResult scoreRequiredWorkPlaced(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.requiredWorkPlaced;
+  final required = outcome.inputs.requiredTaskIds;
+  if (required.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'the scenario names no required work',
+    );
+  }
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
+  final placed = {for (final block in outcome.blocks) ?block.taskId};
+  final missing = [
+    for (final taskId in required)
+      if (!placed.contains(taskId)) taskId,
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: missing.isEmpty,
+    detail: missing.isEmpty
+        ? 'placed all ${required.length} task(s) the day turns on'
+        : 'ignored: ${missing.join(', ')}',
+  );
+}
+
+/// An impossible day has to be named, not quietly absorbed.
+///
+/// Permitting omissions stops a planner being punished for dropping work it
+/// cannot fit — but on its own it also lets one emit a single buffer block,
+/// ignore twelve hours of requested work, and score clean. The prompt gives
+/// two legitimate ways out: escalate via `raise_day_status`, or state the
+/// trade in a block reason. Either satisfies this; silence does not.
+EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.surfacedConflict;
+  if (!outcome.inputs.requiresConflictSurfaced) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'the scenario is satisfiable as stated',
+    );
+  }
+  final escalated = outcome.toolCalls.any(
+    (call) => call.accepted && call.name.contains('raise_day_status'),
+  );
+  if (escalated) {
+    return const EvalConstraintResult(
+      id: id,
+      passed: true,
+      detail: 'escalated through raise_day_status',
+    );
+  }
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
+  const conflictTerms = [
+    'not fit',
+    "won't fit",
+    'does not fit',
+    'capacity',
+    'defer',
+    'deferred',
+    'trade',
+    'drop',
+    'dropped',
+    'postpone',
+    'tomorrow',
+    'over-committed',
+    'overcommitted',
+    'too much',
+  ];
+  final named = outcome.blocks.any((block) {
+    final reason = '${block.reason ?? ''} ${block.note ?? ''}'.toLowerCase();
+    return conflictTerms.any(reason.contains);
+  });
+  return EvalConstraintResult(
+    id: id,
+    passed: named,
+    detail: named
+        ? 'named the trade in a block reason'
+        : 'absorbed an impossible day silently — no escalation and no reason '
+              'naming what was left out',
+  );
+}
+
 /// Whether the model produced a legal plan without being corrected.
 ///
 /// This is the guarded half. The persisted plan is always legal — the write
@@ -423,6 +588,17 @@ EvalConstraintResult scoreCompliedWithoutRejection(EvalRunOutcome outcome) {
               '${rejections.map((r) => r.rejectionMessage ?? 'unknown').join(' | ')}',
   );
 }
+
+/// Guard for every constraint that reads the plan.
+///
+/// A run that produced no plan has not demonstrated anything about plan
+/// quality — its empty block list would otherwise read as "no overlaps, no
+/// fabricated ids, every omission honoured", handing a failed run a clean
+/// sweep. Those constraints are inapplicable, not passed.
+EvalConstraintResult? _requirePlan(EvalRunOutcome outcome, String id) =>
+    outcome.planPersisted
+    ? null
+    : EvalConstraintResult.notApplicable(id, 'no plan was persisted');
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not
 /// scheduled, matching `scheduledMinutesFor` in the parser.

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -35,6 +35,8 @@ void main() {
     List<EvalCorpusTask> corpus = const [],
     List<String> decidedTaskIds = const [],
     Set<String> permittedOmissions = const {},
+    Set<String> expectedOmissions = const {},
+    int workingHoursEndHour = 17,
     Set<String>? visibleTaskIds,
     List<EvalToolCall> toolCalls = const [],
     int capacityMinutes = 480,
@@ -45,7 +47,9 @@ void main() {
       corpus: corpus,
       decidedTaskIds: decidedTaskIds,
       permittedOmissions: permittedOmissions,
+      expectedOmissions: expectedOmissions,
       visibleTaskIds: visibleTaskIds,
+      workingHoursEndHour: workingHoursEndHour,
       capacityMinutes: capacityMinutes,
     ),
     blocks: blocks,
@@ -478,6 +482,122 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('same'));
+    });
+  });
+
+  group('expectedOmissionsHonoured', () {
+    test('passes when the work was left out as expected', () {
+      final result = scoreExpectedOmissionsHonoured(
+        outcome(
+          blocks: [block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-1')],
+          expectedOmissions: const {'task-stale'},
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('fails when the model placed work it should have left out', () {
+      // Without this, permitting the omission would let a model place the
+      // stale task and still score clean — the scenario could not measure
+      // the thing it exists for.
+      final result = scoreExpectedOmissionsHonoured(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-stale'),
+          ],
+          expectedOmissions: const {'task-stale'},
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-stale'));
+    });
+
+    test('is not applicable when nothing is expected to be omitted', () {
+      expect(scoreExpectedOmissionsHonoured(outcome()).isApplicable, isFalse);
+    });
+  });
+
+  group('withinWorkingHours', () {
+    test('passes when the day ends on time', () {
+      final result = scoreWithinWorkingHours(
+        outcome(blocks: [block(id: 'a', startHour: 15, endHour: 17)]),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('catches work pushed past the end of the working day', () {
+      // The failure capacity cannot see: 180 minutes from 15:00 uses only
+      // 180 of 480 and stays inside the calendar day, yet runs to 18:00.
+      final result = scoreWithinWorkingHours(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 15,
+              endHour: 18,
+              title: 'Finish the migration',
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Finish the migration'));
+      expect(result.detail, contains('18:00'));
+    });
+  });
+
+  group('respectsEstimates', () {
+    const bigTask = EvalCorpusTask(
+      taskId: 'task-big',
+      title: 'Rewrite the ingestion pipeline',
+      estimateMinutes: 240,
+    );
+
+    test('passes when the block roughly matches the estimate', () {
+      final result = scoreRespectsEstimates(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 13, taskId: 'task-big'),
+          ],
+          corpus: const [bigTask],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('catches an impossible day made to look feasible by compression', () {
+      // The cheapest way to fit four multi-hour tasks into one day is to
+      // pretend each takes an hour. Capacity alone would call that a pass.
+      final result = scoreRespectsEstimates(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-big'),
+          ],
+          corpus: const [bigTask],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('60min'));
+      expect(result.detail, contains('240min'));
+    });
+
+    test('is not applicable when no placed task carries an estimate', () {
+      final result = scoreRespectsEstimates(
+        outcome(
+          blocks: [block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-x')],
+          corpus: const [
+            EvalCorpusTask(taskId: 'task-x', title: 'No estimate'),
+          ],
+        ),
+      );
+
+      expect(result.isApplicable, isFalse);
     });
   });
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -36,6 +36,10 @@ void main() {
     List<String> decidedTaskIds = const [],
     Set<String> permittedOmissions = const {},
     Set<String> expectedOmissions = const {},
+    Set<String> requiredTaskIds = const {},
+    bool requiresConflictSurfaced = false,
+    bool planPersisted = true,
+    int workingHoursStartHour = 9,
     int workingHoursEndHour = 17,
     Set<String>? visibleTaskIds,
     List<EvalToolCall> toolCalls = const [],
@@ -48,12 +52,16 @@ void main() {
       decidedTaskIds: decidedTaskIds,
       permittedOmissions: permittedOmissions,
       expectedOmissions: expectedOmissions,
+      requiredTaskIds: requiredTaskIds,
+      requiresConflictSurfaced: requiresConflictSurfaced,
       visibleTaskIds: visibleTaskIds,
+      workingHoursStartHour: workingHoursStartHour,
       workingHoursEndHour: workingHoursEndHour,
       capacityMinutes: capacityMinutes,
     ),
     blocks: blocks,
     toolCalls: toolCalls,
+    planPersisted: planPersisted,
   );
 
   group('noOverlappingBlocks', () {
@@ -528,6 +536,22 @@ void main() {
       expect(result.passed, isTrue);
     });
 
+    test('catches work scheduled before the working day starts', () {
+      // On a future-day draft the same-day guard is inert, so without a lower
+      // bound an overnight plan would score clean.
+      final result = scoreWithinWorkingHours(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 6, endHour: 8, title: 'Early grind'),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Early grind'));
+      expect(result.detail, contains('06:00'));
+    });
+
     test('catches work pushed past the end of the working day', () {
       // The failure capacity cannot see: 180 minutes from 15:00 uses only
       // 180 of 480 and stays inside the calendar day, yet runs to 18:00.
@@ -634,6 +658,163 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('must not start before current time'));
+    });
+  });
+
+  group('withinCapacityByEstimate', () {
+    const tasks = [
+      EvalCorpusTask(taskId: 'task-a', title: 'A', estimateMinutes: 240),
+      EvalCorpusTask(taskId: 'task-b', title: 'B', estimateMinutes: 180),
+      EvalCorpusTask(taskId: 'task-c', title: 'C', estimateMinutes: 120),
+      EvalCorpusTask(taskId: 'task-d', title: 'D', estimateMinutes: 180),
+    ];
+
+    test('catches a coordinated shrink that clears every per-task ratio', () {
+      // 160/120/80/120 sums to exactly 480 and each allocation exceeds half
+      // its estimate, so the per-task check passes — but 720 minutes of work
+      // does not fit in 480 however the blocks are labelled.
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(id: '1', startHour: 9, endHour: 11, taskId: 'task-a'),
+            block(id: '2', startHour: 11, endHour: 13, taskId: 'task-b'),
+            block(id: '3', startHour: 13, endHour: 14, taskId: 'task-c'),
+            block(id: '4', startHour: 14, endHour: 16, taskId: 'task-d'),
+          ],
+          corpus: tasks,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('720min'));
+      expect(result.detail, contains('over by 240'));
+    });
+
+    test('passes when the placed work genuinely fits', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(id: '1', startHour: 9, endHour: 13, taskId: 'task-a'),
+            block(id: '2', startHour: 13, endHour: 16, taskId: 'task-b'),
+          ],
+          corpus: tasks,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+  });
+
+  group('requiredWorkPlaced', () {
+    test('fails when the day ignores the work it turns on', () {
+      final result = scoreRequiredWorkPlaced(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 11, taskId: 'task-later'),
+          ],
+          requiredTaskIds: const {'task-overdue', 'task-today'},
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-overdue'));
+    });
+
+    test('passes when every named task is placed', () {
+      final result = scoreRequiredWorkPlaced(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-overdue'),
+            block(id: 'b', startHour: 10, endHour: 11, taskId: 'task-today'),
+          ],
+          requiredTaskIds: const {'task-overdue', 'task-today'},
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+  });
+
+  group('surfacedConflict', () {
+    test('fails when an impossible day is absorbed in silence', () {
+      // The gap permitting omissions opened: one ordinary buffer block,
+      // twelve hours of requested work ignored, nothing said.
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              reason: 'Open buffer for the morning.',
+            ),
+          ],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('silently'));
+    });
+
+    test('passes when a block reason names the trade', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 13,
+              reason: 'Board deck deferred to tomorrow — all four do not fit.',
+            ),
+          ],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('passes when the model escalated instead', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          requiresConflictSurfaced: true,
+          toolCalls: const [
+            EvalToolCall(name: 'raise_day_status', accepted: true),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('is not applicable when the day is satisfiable', () {
+      expect(scoreSurfacedConflict(outcome()).isApplicable, isFalse);
+    });
+  });
+
+  group('a run that produced no plan', () {
+    test('scores every plan-reading constraint as inapplicable', () {
+      // An empty block list would otherwise read as "no overlaps, nothing
+      // fabricated, every omission honoured" — a clean sweep for a failed run.
+      final results = scoreAll(
+        outcome(
+          planPersisted: false,
+          decidedTaskIds: const ['task-1'],
+          expectedOmissions: const {'task-stale'},
+          requiredTaskIds: const {'task-1'},
+          corpus: const [EvalCorpusTask(taskId: 'task-1', title: 'A')],
+        ),
+      );
+
+      for (final result in results) {
+        if (result.id == EvalConstraintIds.compliedWithoutRejection) continue;
+        expect(
+          result.isApplicable,
+          isFalse,
+          reason: '${result.id} credited a run that produced no plan',
+        );
+      }
     });
   });
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -38,6 +38,8 @@ void main() {
     Set<String> expectedOmissions = const {},
     Set<String> requiredTaskIds = const {},
     bool requiresConflictSurfaced = false,
+    bool forbidsInventedWork = false,
+    DateTime? now,
     bool planPersisted = true,
     int workingHoursStartHour = 9,
     int workingHoursEndHour = 17,
@@ -54,6 +56,8 @@ void main() {
       expectedOmissions: expectedOmissions,
       requiredTaskIds: requiredTaskIds,
       requiresConflictSurfaced: requiresConflictSurfaced,
+      forbidsInventedWork: forbidsInventedWork,
+      now: now,
       visibleTaskIds: visibleTaskIds,
       workingHoursStartHour: workingHoursStartHour,
       workingHoursEndHour: workingHoursEndHour,
@@ -574,6 +578,110 @@ void main() {
     });
   });
 
+  group('a same-day draft', () {
+    test('cannot schedule work before the draft began', () {
+      // Enforcing only working hours would let a model place work at 10:00 on
+      // a 15:00 draft — and the production guard misses it too, because that
+      // guard fires only for `drafted` state.
+      final result = scoreWithinWorkingHours(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 10,
+              endHour: 12,
+              title: 'Long migration',
+              state: PlannedBlockState.committed,
+            ),
+          ],
+          now: DateTime(2026, 7, 18, 15),
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Long migration'));
+    });
+
+    test('still allows work after the draft time', () {
+      final result = scoreWithinWorkingHours(
+        outcome(
+          blocks: [block(id: 'a', startHour: 15, endHour: 17)],
+          now: DateTime(2026, 7, 18, 15),
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('a fresh draft may not assert committed state', () {
+      // Commitment is the user's word, not the model's — and asserting it is
+      // also how a block slips the production past-start guard.
+      final result = scoreNoHistoryFabrication(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              title: 'Already agreed',
+              state: PlannedBlockState.committed,
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Already agreed'));
+    });
+  });
+
+  group('noInventedWork', () {
+    test('catches substantive work on a day with nothing to do', () {
+      // The gap the restraint control could not see: no taskId means
+      // fabrication scoring is inapplicable, and everything else passes.
+      final result = scoreNoInventedWork(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 11,
+              title: 'Write a proposal',
+            ),
+          ],
+          forbidsInventedWork: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Write a proposal'));
+    });
+
+    test('a buffer block is structuring open time, not inventing work', () {
+      final result = scoreNoInventedWork(
+        outcome(
+          blocks: [
+            PlannedBlock(
+              id: 'a',
+              categoryId: 'cat-1',
+              startTime: DateTime(2026, 7, 18, 9),
+              endTime: DateTime(2026, 7, 18, 11),
+              title: 'Open buffer',
+              type: PlannedBlockType.buffer,
+            ),
+          ],
+          forbidsInventedWork: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('is not applicable when the day has real work', () {
+      expect(scoreNoInventedWork(outcome()).isApplicable, isFalse);
+    });
+  });
+
   group('respectsEstimates', () {
     const bigTask = EvalCorpusTask(
       taskId: 'task-big',
@@ -609,6 +717,29 @@ void main() {
       expect(result.passed, isFalse);
       expect(result.detail, contains('60min'));
       expect(result.detail, contains('240min'));
+    });
+
+    test('sums a task split across blocks before judging it', () {
+      // 60 + 120 fully schedules a 180-minute task. Comparing each block
+      // against the whole estimate would fail the first half of a correctly
+      // scheduled task.
+      final result = scoreRespectsEstimates(
+        outcome(
+          blocks: [
+            block(id: '1', startHour: 9, endHour: 10, taskId: 'task-split'),
+            block(id: '2', startHour: 10, endHour: 12, taskId: 'task-split'),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-split',
+              title: 'Split work',
+              estimateMinutes: 180,
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
     });
 
     test('is not applicable when no placed task carries an estimate', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -39,7 +39,6 @@ void main() {
     Set<String> requiredTaskIds = const {},
     bool requiresConflictSurfaced = false,
     bool forbidsInventedWork = false,
-    bool hasSeededCalendar = false,
     Set<String> conflictEscalationReasons = const {'overCommitted'},
     DateTime? now,
     bool planPersisted = true,
@@ -59,7 +58,6 @@ void main() {
       requiredTaskIds: requiredTaskIds,
       requiresConflictSurfaced: requiresConflictSurfaced,
       forbidsInventedWork: forbidsInventedWork,
-      hasSeededCalendar: hasSeededCalendar,
       conflictEscalationReasons: conflictEscalationReasons,
       now: now,
       visibleTaskIds: visibleTaskIds,
@@ -684,27 +682,6 @@ void main() {
       expect(result.detail, contains('Dentist appointment'));
     });
 
-    test('a calendar block is legitimate when the scenario seeds one', () {
-      final result = scoreNoInventedWork(
-        outcome(
-          blocks: [
-            PlannedBlock(
-              id: 'a',
-              categoryId: 'cat-1',
-              startTime: DateTime(2026, 7, 18, 9),
-              endTime: DateTime(2026, 7, 18, 10),
-              title: 'Standup',
-              type: PlannedBlockType.cal,
-            ),
-          ],
-          forbidsInventedWork: true,
-          hasSeededCalendar: true,
-        ),
-      );
-
-      expect(result.passed, isTrue);
-    });
-
     test('a buffer block is structuring open time, not inventing work', () {
       final result = scoreNoInventedWork(
         outcome(
@@ -1047,9 +1024,14 @@ void main() {
   });
 
   group('surfacedConflict', () {
+    const dropped = [
+      EvalCorpusTask(taskId: 'task-deck', title: 'Prepare the board deck'),
+      EvalCorpusTask(taskId: 'task-report', title: 'Close the quarterly'),
+    ];
+
     test('fails when an impossible day is absorbed in silence', () {
       // The gap permitting omissions opened: one ordinary buffer block,
-      // twelve hours of requested work ignored, nothing said.
+      // hours of requested work ignored, nothing said.
       final result = scoreSurfacedConflict(
         outcome(
           blocks: [
@@ -1060,15 +1042,38 @@ void main() {
               reason: 'Open buffer for the morning.',
             ),
           ],
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
         ),
       );
 
       expect(result.passed, isFalse);
-      expect(result.detail, contains('silently'));
+      expect(result.detail, contains('without naming a casualty'));
     });
 
-    test('passes when a block reason names the trade', () {
+    test('a conflict word alone is not surfacing anything', () {
+      // "Deferred" names no casualty and gives the user nothing to act on.
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              reason: 'Deferred — preserving capacity.',
+            ),
+          ],
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('passes when the reason names what was left out', () {
       final result = scoreSurfacedConflict(
         outcome(
           blocks: [
@@ -1076,19 +1081,41 @@ void main() {
               id: 'a',
               startHour: 9,
               endHour: 13,
-              reason: 'Board deck deferred to tomorrow — all four do not fit.',
+              reason:
+                  'Prepare the board deck moved to tomorrow — all four '
+                  'do not fit today.',
             ),
           ],
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
         ),
       );
 
       expect(result.passed, isTrue);
+      expect(result.detail, contains('task-deck'));
+    });
+
+    test('is not applicable when nothing was actually left out', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-deck'),
+          ],
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.isApplicable, isFalse);
     });
 
     test('passes when the escalation actually names the conflict', () {
       final result = scoreSurfacedConflict(
         outcome(
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
           toolCalls: const [
             EvalToolCall(
@@ -1111,6 +1138,8 @@ void main() {
       // alone would let a model satisfy this by reporting the day is fine.
       final result = scoreSurfacedConflict(
         outcome(
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
           toolCalls: const [
             EvalToolCall(
@@ -1131,6 +1160,8 @@ void main() {
       // accepting both reasons would have credited it.
       final result = scoreSurfacedConflict(
         outcome(
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
           // ignore: avoid_redundant_argument_values
           conflictEscalationReasons: const {'overCommitted'},
@@ -1153,6 +1184,8 @@ void main() {
     test('an unrelated attentionNeeded reason is not an escalation', () {
       final result = scoreSurfacedConflict(
         outcome(
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
           toolCalls: const [
             EvalToolCall(
@@ -1177,6 +1210,8 @@ void main() {
     test('a rejected escalation does not count', () {
       final result = scoreSurfacedConflict(
         outcome(
+          corpus: dropped,
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
           toolCalls: const [
             EvalToolCall(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -661,6 +661,70 @@ void main() {
     });
   });
 
+  group('dropped blocks are not placements', () {
+    test('a dropped required task does not count as placed', () {
+      // Production excludes dropped blocks from the day, so crediting one as
+      // a placement would let a model satisfy every placement constraint
+      // while committing to nothing.
+      final result = scoreRequiredWorkPlaced(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-overdue',
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+          requiredTaskIds: const {'task-overdue'},
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('a dropped decided task does not count as placed', () {
+      final result = scoreDecidedTasksPlaced(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-1',
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+          decidedTaskIds: const ['task-1'],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('dropping work the scenario wanted omitted honours the omission', () {
+      // The other direction of the same inconsistency: a dropped stale task
+      // used to fail the omission constraint even though it was not scheduled.
+      final result = scoreExpectedOmissionsHonoured(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-stale',
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+          expectedOmissions: const {'task-stale'},
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+  });
+
   group('withinCapacityByEstimate', () {
     const tasks = [
       EvalCorpusTask(taskId: 'task-a', title: 'A', estimateMinutes: 240),
@@ -775,17 +839,87 @@ void main() {
       expect(result.passed, isTrue);
     });
 
-    test('passes when the model escalated instead', () {
+    test('passes when the escalation actually names the conflict', () {
       final result = scoreSurfacedConflict(
         outcome(
           requiresConflictSurfaced: true,
           toolCalls: const [
-            EvalToolCall(name: 'raise_day_status', accepted: true),
+            EvalToolCall(
+              name: 'raise_day_status',
+              accepted: true,
+              arguments: {
+                'status': 'attentionNeeded',
+                'reasons': ['overCommitted'],
+              },
+            ),
           ],
         ),
       );
 
       expect(result.passed, isTrue);
+    });
+
+    test('an onTrack status is not an escalation', () {
+      // The tool accepts onTrack and dayClosed too; matching the call by name
+      // alone would let a model satisfy this by reporting the day is fine.
+      final result = scoreSurfacedConflict(
+        outcome(
+          requiresConflictSurfaced: true,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'raise_day_status',
+              accepted: true,
+              arguments: {'status': 'onTrack'},
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('an unrelated attentionNeeded reason is not an escalation', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          requiresConflictSurfaced: true,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'raise_day_status',
+              accepted: true,
+              arguments: {
+                'status': 'attentionNeeded',
+                'reasons': ['processingBlocked'],
+              },
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        result.passed,
+        isFalse,
+        reason: 'processingBlocked describes a different problem entirely',
+      );
+    });
+
+    test('a rejected escalation does not count', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          requiresConflictSurfaced: true,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'raise_day_status',
+              accepted: false,
+              arguments: {
+                'status': 'attentionNeeded',
+                'reasons': ['overCommitted'],
+              },
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
     });
 
     test('is not applicable when the day is satisfiable', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -39,6 +39,8 @@ void main() {
     Set<String> requiredTaskIds = const {},
     bool requiresConflictSurfaced = false,
     bool forbidsInventedWork = false,
+    bool hasSeededCalendar = false,
+    Set<String> conflictEscalationReasons = const {'overCommitted'},
     DateTime? now,
     bool planPersisted = true,
     int workingHoursStartHour = 9,
@@ -57,6 +59,8 @@ void main() {
       requiredTaskIds: requiredTaskIds,
       requiresConflictSurfaced: requiresConflictSurfaced,
       forbidsInventedWork: forbidsInventedWork,
+      hasSeededCalendar: hasSeededCalendar,
+      conflictEscalationReasons: conflictEscalationReasons,
       now: now,
       visibleTaskIds: visibleTaskIds,
       workingHoursStartHour: workingHoursStartHour,
@@ -657,6 +661,50 @@ void main() {
       expect(result.detail, contains('Write a proposal'));
     });
 
+    test('an invented calendar event is still invented', () {
+      // `cal` mirrors a real event, so on a day with no calendar seeded an
+      // appointment the model made up is exactly what this control is for.
+      final result = scoreNoInventedWork(
+        outcome(
+          blocks: [
+            PlannedBlock(
+              id: 'a',
+              categoryId: 'cat-1',
+              startTime: DateTime(2026, 7, 18, 9),
+              endTime: DateTime(2026, 7, 18, 10),
+              title: 'Dentist appointment',
+              type: PlannedBlockType.cal,
+            ),
+          ],
+          forbidsInventedWork: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('Dentist appointment'));
+    });
+
+    test('a calendar block is legitimate when the scenario seeds one', () {
+      final result = scoreNoInventedWork(
+        outcome(
+          blocks: [
+            PlannedBlock(
+              id: 'a',
+              categoryId: 'cat-1',
+              startTime: DateTime(2026, 7, 18, 9),
+              endTime: DateTime(2026, 7, 18, 10),
+              title: 'Standup',
+              type: PlannedBlockType.cal,
+            ),
+          ],
+          forbidsInventedWork: true,
+          hasSeededCalendar: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
     test('a buffer block is structuring open time, not inventing work', () {
       final result = scoreNoInventedWork(
         outcome(
@@ -856,6 +904,74 @@ void main() {
     });
   });
 
+  group('taskWorkIsTyped', () {
+    PlannedBlock typed({
+      required String id,
+      required PlannedBlockType type,
+      String? taskId,
+      int startHour = 9,
+      int endHour = 11,
+    }) => PlannedBlock(
+      id: id,
+      categoryId: 'cat-1',
+      startTime: DateTime(2026, 7, 18, startHour),
+      endTime: DateTime(2026, 7, 18, endHour),
+      title: id,
+      taskId: taskId,
+      type: type,
+    );
+
+    test('a buffer carrying a task is reported, not silently uncredited', () {
+      final result = scoreTaskWorkIsTyped(
+        outcome(
+          blocks: [
+            typed(
+              id: 'buffer-1',
+              type: PlannedBlockType.buffer,
+              taskId: 'task-1',
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('buffer'));
+      expect(result.detail, contains('task-1'));
+    });
+
+    test('work blocks carrying tasks are fine', () {
+      final result = scoreTaskWorkIsTyped(
+        outcome(
+          blocks: [
+            typed(id: 'ai-1', type: PlannedBlockType.ai, taskId: 'task-1'),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('a task on a buffer earns no placement credit', () {
+      // The attack this closes: label a plausible-length buffer with every
+      // required task id and satisfy placement, capacity and estimates
+      // without scheduling any actual work.
+      final result = scoreRequiredWorkPlaced(
+        outcome(
+          blocks: [
+            typed(
+              id: 'buffer-1',
+              type: PlannedBlockType.buffer,
+              taskId: 'task-required',
+            ),
+          ],
+          requiredTaskIds: const {'task-required'},
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+  });
+
   group('withinCapacityByEstimate', () {
     const tasks = [
       EvalCorpusTask(taskId: 'task-a', title: 'A', estimateMinutes: 240),
@@ -1001,6 +1117,31 @@ void main() {
               name: 'raise_day_status',
               accepted: true,
               arguments: {'status': 'onTrack'},
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
+
+    test('a reason that cannot be true of this day is not an escalation', () {
+      // The scenario seeds no directive, so escalating as
+      // directiveUnsatisfiable claims something false. A shared default
+      // accepting both reasons would have credited it.
+      final result = scoreSurfacedConflict(
+        outcome(
+          requiresConflictSurfaced: true,
+          // ignore: avoid_redundant_argument_values
+          conflictEscalationReasons: const {'overCommitted'},
+          toolCalls: const [
+            EvalToolCall(
+              name: 'raise_day_status',
+              accepted: true,
+              arguments: {
+                'status': 'attentionNeeded',
+                'reasons': ['directiveUnsatisfiable'],
+              },
             ),
           ],
         ),

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -34,6 +34,8 @@ void main() {
     List<PlannedBlock> blocks = const [],
     List<EvalCorpusTask> corpus = const [],
     List<String> decidedTaskIds = const [],
+    Set<String> permittedOmissions = const {},
+    Set<String>? visibleTaskIds,
     List<EvalToolCall> toolCalls = const [],
     int capacityMinutes = 480,
   }) => EvalRunOutcome(
@@ -42,6 +44,8 @@ void main() {
       planDate: planDate,
       corpus: corpus,
       decidedTaskIds: decidedTaskIds,
+      permittedOmissions: permittedOmissions,
+      visibleTaskIds: visibleTaskIds,
       capacityMinutes: capacityMinutes,
     ),
     blocks: blocks,
@@ -182,6 +186,48 @@ void main() {
     test('is not applicable when nothing was decided', () {
       expect(scoreDecidedTasksPlaced(outcome()).isApplicable, isFalse);
     });
+
+    test('a permitted omission is not counted as a miss', () {
+      // The scenario handed the model a task it should deliberately leave
+      // out — already done, or blocked. Requiring it would fail the model
+      // precisely when it behaves correctly.
+      final result = scoreDecidedTasksPlaced(
+        outcome(
+          blocks: [block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-1')],
+          decidedTaskIds: const ['task-1', 'task-stale'],
+          permittedOmissions: const {'task-stale'},
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('is not applicable when every decided task may be omitted', () {
+      final result = scoreDecidedTasksPlaced(
+        outcome(
+          decidedTaskIds: const ['task-blocked'],
+          permittedOmissions: const {'task-blocked'},
+        ),
+      );
+
+      expect(result.isApplicable, isFalse);
+    });
+
+    test(
+      'a required decided task is still enforced alongside one that is not',
+      () {
+        final result = scoreDecidedTasksPlaced(
+          outcome(
+            decidedTaskIds: const ['task-1', 'task-stale'],
+            permittedOmissions: const {'task-stale'},
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-1'));
+        expect(result.detail, isNot(contains('task-stale')));
+      },
+    );
   });
 
   group('blockerBeforeBlocked', () {
@@ -340,6 +386,24 @@ void main() {
       );
 
       expect(result.passed, isTrue);
+    });
+
+    test('judges against what the model was shown, not what is true', () {
+      // Without a capture the corpus is never rendered, so a corpus id the
+      // model could not have seen must not be credited as legitimate.
+      final result = scoreNoFabricatedTaskIds(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 10, taskId: 'task-hidden'),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-hidden', title: 'Real')],
+          decidedTaskIds: const ['task-decided'],
+          visibleTaskIds: const {'task-decided'},
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-hidden'));
     });
 
     test('fails for a task id the model was never shown', () {

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -54,8 +54,10 @@ class EvalFixtureInputs {
     this.corpus = const [],
     this.decidedTaskIds = const [],
     this.permittedOmissions = const {},
+    this.expectedOmissions = const {},
     this.visibleTaskIds,
     this.capacityMinutes = 480,
+    this.workingHoursEndHour = 17,
     this.now,
   });
 
@@ -66,13 +68,23 @@ class EvalFixtureInputs {
   /// Tasks the user explicitly approved for placement.
   final List<String> decidedTaskIds;
 
-  /// Decided tasks whose *omission* is the correct outcome.
+  /// Decided tasks the model *may* leave out without it counting against it.
   ///
-  /// Some scenarios hand the model a decided task it should deliberately not
-  /// place — one the capture says is already done, or one that is blocked. A
-  /// scorer that required every decided task would then fail precisely when
-  /// the model behaves well, which is worse than not measuring at all.
+  /// Distinct from [expectedOmissions]: a blocked task may legitimately be
+  /// placed behind its blocker, so omitting it is acceptable but not required.
+  /// Requiring it would fail a model that correctly declined; forbidding it
+  /// would fail a model that correctly sequenced.
   final Set<String> permittedOmissions;
+
+  /// Decided tasks the model is expected to leave out, where placing them is
+  /// itself the failure.
+  ///
+  /// The stale-task case: the capture says the work is already done, and the
+  /// prompt tells the model not to force the placement. Merely dropping these
+  /// from the positive requirement would let a model place them and still
+  /// score clean, so the scenario could not measure the behaviour it exists
+  /// for.
+  final Set<String> expectedOmissions;
 
   /// Task ids the model could actually reference.
   ///
@@ -84,6 +96,15 @@ class EvalFixtureInputs {
   final Set<String>? visibleTaskIds;
 
   final int capacityMinutes;
+
+  /// Local hour the working day ends, mirroring the planner's own default
+  /// (`DayAgentConfig.workingHoursEnd`, 17:00).
+  ///
+  /// Carried here because capacity alone cannot catch a model that pushes work
+  /// past the end of the day: a 180-minute block from 15:00 consumes only 180
+  /// of 480 minutes and stays inside the calendar day, so every other
+  /// constraint is satisfied while the plan is unusable.
+  final int workingHoursEndHour;
 
   /// Wall instant the draft ran at, for same-day scenarios. Null for a
   /// future-day draft, where "the past" has no meaning.

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -58,6 +58,7 @@ class EvalFixtureInputs {
     this.visibleTaskIds,
     this.requiredTaskIds = const {},
     this.requiresConflictSurfaced = false,
+    this.forbidsInventedWork = false,
     this.conflictEscalationReasons = const {
       'overCommitted',
       'directiveUnsatisfiable',
@@ -114,6 +115,10 @@ class EvalFixtureInputs {
   /// Whether the scenario is impossible as stated, so a competent plan has to
   /// say so rather than quietly absorb it.
   final bool requiresConflictSurfaced;
+
+  /// Whether the scenario has no real work, so any substantive block the
+  /// planner adds is invented rather than scheduled.
+  final bool forbidsInventedWork;
 
   /// `raise_day_status` reasons that count as escalating *this* conflict.
   ///

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -53,6 +53,8 @@ class EvalFixtureInputs {
     required this.planDate,
     this.corpus = const [],
     this.decidedTaskIds = const [],
+    this.permittedOmissions = const {},
+    this.visibleTaskIds,
     this.capacityMinutes = 480,
     this.now,
   });
@@ -64,11 +66,33 @@ class EvalFixtureInputs {
   /// Tasks the user explicitly approved for placement.
   final List<String> decidedTaskIds;
 
+  /// Decided tasks whose *omission* is the correct outcome.
+  ///
+  /// Some scenarios hand the model a decided task it should deliberately not
+  /// place — one the capture says is already done, or one that is blocked. A
+  /// scorer that required every decided task would then fail precisely when
+  /// the model behaves well, which is worse than not measuring at all.
+  final Set<String> permittedOmissions;
+
+  /// Task ids the model could actually reference.
+  ///
+  /// Not the same as [corpus]: the task corpus is rendered only inside the
+  /// capture context, so a wake without a capture sees nothing but its decided
+  /// tasks. [corpus] stays ground truth — it is what makes a scenario's
+  /// blocked work knowable to the *scorer* — while this is what the model was
+  /// shown. Null means everything in [corpus] was visible.
+  final Set<String>? visibleTaskIds;
+
   final int capacityMinutes;
 
   /// Wall instant the draft ran at, for same-day scenarios. Null for a
   /// future-day draft, where "the past" has no meaning.
   final DateTime? now;
+
+  /// Ids the model could legitimately have used.
+  Set<String> get referenceableTaskIds =>
+      visibleTaskIds ??
+      {for (final task in corpus) task.taskId, ...decidedTaskIds};
 
   EvalCorpusTask? taskById(String id) {
     for (final task in corpus) {

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -56,7 +56,10 @@ class EvalFixtureInputs {
     this.permittedOmissions = const {},
     this.expectedOmissions = const {},
     this.visibleTaskIds,
+    this.requiredTaskIds = const {},
+    this.requiresConflictSurfaced = false,
     this.capacityMinutes = 480,
+    this.workingHoursStartHour = 9,
     this.workingHoursEndHour = 17,
     this.now,
   });
@@ -95,7 +98,27 @@ class EvalFixtureInputs {
   /// shown. Null means everything in [corpus] was visible.
   final Set<String>? visibleTaskIds;
 
+  /// Tasks the scenario expects to appear in any competent plan.
+  ///
+  /// Distinct from [decidedTaskIds], which is an *input* the user approved.
+  /// These are the scenario's own expectations — the overdue invoice a
+  /// crowded day must not ignore — and without them a scenario about
+  /// prioritisation cannot tell a good plan from one that scheduled the least
+  /// urgent thing on the list.
+  final Set<String> requiredTaskIds;
+
+  /// Whether the scenario is impossible as stated, so a competent plan has to
+  /// say so rather than quietly absorb it.
+  final bool requiresConflictSurfaced;
+
   final int capacityMinutes;
+
+  /// Local hour the working day starts, mirroring `DayAgentConfig`'s 09:00.
+  ///
+  /// Enforced as well as the end: on a future-day draft the same-day guard is
+  /// deliberately inert, so without a lower bound a plan could run overnight
+  /// and still score clean.
+  final int workingHoursStartHour;
 
   /// Local hour the working day ends, mirroring the planner's own default
   /// (`DayAgentConfig.workingHoursEnd`, 17:00).

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -58,6 +58,10 @@ class EvalFixtureInputs {
     this.visibleTaskIds,
     this.requiredTaskIds = const {},
     this.requiresConflictSurfaced = false,
+    this.conflictEscalationReasons = const {
+      'overCommitted',
+      'directiveUnsatisfiable',
+    },
     this.capacityMinutes = 480,
     this.workingHoursStartHour = 9,
     this.workingHoursEndHour = 17,
@@ -110,6 +114,13 @@ class EvalFixtureInputs {
   /// Whether the scenario is impossible as stated, so a competent plan has to
   /// say so rather than quietly absorb it.
   final bool requiresConflictSurfaced;
+
+  /// `raise_day_status` reasons that count as escalating *this* conflict.
+  ///
+  /// The tool's enum also carries `userDivergence` and `processingBlocked`,
+  /// which describe different problems entirely — an escalation naming one of
+  /// those has not surfaced an over-committed day.
+  final Set<String> conflictEscalationReasons;
 
   final int capacityMinutes;
 

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -59,10 +59,8 @@ class EvalFixtureInputs {
     this.requiredTaskIds = const {},
     this.requiresConflictSurfaced = false,
     this.forbidsInventedWork = false,
-    this.conflictEscalationReasons = const {
-      'overCommitted',
-      'directiveUnsatisfiable',
-    },
+    this.hasSeededCalendar = false,
+    this.conflictEscalationReasons = const {},
     this.capacityMinutes = 480,
     this.workingHoursStartHour = 9,
     this.workingHoursEndHour = 17,
@@ -120,11 +118,20 @@ class EvalFixtureInputs {
   /// planner adds is invented rather than scheduled.
   final bool forbidsInventedWork;
 
+  /// Whether the scenario seeded real calendar events.
+  ///
+  /// A `cal` block mirrors a real event, so on a day with no calendar an
+  /// invented appointment is fabricated work like any other.
+  final bool hasSeededCalendar;
+
   /// `raise_day_status` reasons that count as escalating *this* conflict.
   ///
-  /// The tool's enum also carries `userDivergence` and `processingBlocked`,
-  /// which describe different problems entirely — an escalation naming one of
-  /// those has not surfaced an over-committed day.
+  /// Scenario-specific on purpose. A shared default accepting both
+  /// `overCommitted` and `directiveUnsatisfiable` would let a model escalate
+  /// an over-committed day — which seeds no directive — by claiming its
+  /// directive was unsatisfiable, and be credited for a reason that cannot be
+  /// true. The tool's `userDivergence` and `processingBlocked` describe
+  /// different problems again.
   final Set<String> conflictEscalationReasons;
 
   final int capacityMinutes;

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -59,7 +59,6 @@ class EvalFixtureInputs {
     this.requiredTaskIds = const {},
     this.requiresConflictSurfaced = false,
     this.forbidsInventedWork = false,
-    this.hasSeededCalendar = false,
     this.conflictEscalationReasons = const {},
     this.capacityMinutes = 480,
     this.workingHoursStartHour = 9,
@@ -117,12 +116,6 @@ class EvalFixtureInputs {
   /// Whether the scenario has no real work, so any substantive block the
   /// planner adds is invented rather than scheduled.
   final bool forbidsInventedWork;
-
-  /// Whether the scenario seeded real calendar events.
-  ///
-  /// A `cal` block mirrors a real event, so on a day with no calendar an
-  /// invented appointment is fabricated work like any other.
-  final bool hasSeededCalendar;
 
   /// `raise_day_status` reasons that count as escalating *this* conflict.
   ///

--- a/test/features/daily_os_next/eval/framework/eval_models_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'eval_models.dart';
+
+/// Direct coverage for the eval value types.
+///
+/// These carry real semantics — ADR 0043's blocked predicate, the difference
+/// between what is true and what the model was shown — so they are tested
+/// here rather than incidentally through whichever consumer happens to touch
+/// them.
+void main() {
+  final planDate = DateTime(2026, 7, 18);
+
+  EvalFixtureInputs inputs({
+    List<EvalCorpusTask> corpus = const [],
+    List<String> decidedTaskIds = const [],
+    Set<String>? visibleTaskIds,
+  }) => EvalFixtureInputs(
+    dayId: 'dayplan-2026-07-18',
+    planDate: planDate,
+    corpus: corpus,
+    decidedTaskIds: decidedTaskIds,
+    visibleTaskIds: visibleTaskIds,
+  );
+
+  group('EvalCorpusTask.isBlocked', () {
+    test('a task with blockers is blocked', () {
+      const task = EvalCorpusTask(
+        taskId: 'task-1',
+        title: 'Ship it',
+        blockedBy: ['task-0'],
+      );
+
+      expect(task.isBlocked, isTrue);
+    });
+
+    test('a BLOCKED status with no links is still blocked', () {
+      // ADR 0043's predicate is a union. A manually blocked task carries no
+      // typed links, and absence of blockedBy means link-ready, not free to
+      // schedule.
+      const task = EvalCorpusTask(
+        taskId: 'task-1',
+        title: 'Ship it',
+        status: 'BLOCKED',
+      );
+
+      expect(task.isBlocked, isTrue);
+    });
+
+    test('status matching is case-insensitive', () {
+      const task = EvalCorpusTask(
+        taskId: 'task-1',
+        title: 'Ship it',
+        status: 'blocked',
+      );
+
+      expect(task.isBlocked, isTrue);
+    });
+
+    test('an ordinary open task is not blocked', () {
+      const task = EvalCorpusTask(taskId: 'task-1', title: 'Ship it');
+
+      expect(task.isBlocked, isFalse);
+    });
+  });
+
+  group('EvalFixtureInputs.taskById', () {
+    test('finds a seeded task', () {
+      final found = inputs(
+        corpus: const [EvalCorpusTask(taskId: 'task-1', title: 'Ship it')],
+      ).taskById('task-1');
+
+      expect(found?.title, 'Ship it');
+    });
+
+    test('returns null for an id the fixture never seeded', () {
+      expect(inputs().taskById('nope'), isNull);
+    });
+  });
+
+  group('EvalFixtureInputs.referenceableTaskIds', () {
+    test('defaults to the whole corpus plus decided tasks', () {
+      final referenceable = inputs(
+        corpus: const [EvalCorpusTask(taskId: 'task-corpus', title: 'A')],
+        decidedTaskIds: const ['task-decided'],
+      ).referenceableTaskIds;
+
+      expect(referenceable, {'task-corpus', 'task-decided'});
+    });
+
+    test('collapses to the explicit set when the corpus was not shown', () {
+      // The corpus is rendered only inside the capture context, so a wake
+      // without one can name nothing but its decided tasks — while the corpus
+      // itself stays available as ground truth.
+      final subject = inputs(
+        corpus: const [EvalCorpusTask(taskId: 'task-hidden', title: 'A')],
+        decidedTaskIds: const ['task-decided'],
+        visibleTaskIds: const {'task-decided'},
+      );
+
+      expect(subject.referenceableTaskIds, {'task-decided'});
+      expect(subject.taskById('task-hidden'), isNotNull);
+    });
+  });
+
+  group('EvalConstraintResult', () {
+    test('a not-applicable result is distinguishable from a pass', () {
+      const notApplicable = EvalConstraintResult.notApplicable('x', 'nothing');
+      const passed = EvalConstraintResult(
+        id: 'x',
+        passed: true,
+        detail: 'fine',
+      );
+
+      expect(notApplicable.isApplicable, isFalse);
+      expect(notApplicable.passed, isNull);
+      expect(passed.isApplicable, isTrue);
+    });
+  });
+
+  group('EvalRunOutcome.rejections', () {
+    test('surfaces only the tool calls that were rejected', () {
+      final outcome = EvalRunOutcome(
+        inputs: inputs(),
+        toolCalls: const [
+          EvalToolCall(
+            name: 'draft_day_plan',
+            accepted: false,
+            rejectionMessage: 'blocks must stay within the planDate day',
+          ),
+          EvalToolCall(name: 'draft_day_plan', accepted: true),
+        ],
+      );
+
+      expect(outcome.rejections, hasLength(1));
+      expect(
+        outcome.rejections.single.rejectionMessage,
+        contains('within the planDate day'),
+      );
+    });
+  });
+}

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -1,0 +1,491 @@
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
+import 'package:meta/meta.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+import 'eval_models.dart';
+
+/// Declarative day-planning scenarios.
+///
+/// The point of a scenario is *tension* — a day the planner has to resolve
+/// rather than transcribe. A fixture with nothing in it measures only that the
+/// pipeline runs: the first live run against glm-5.2 produced a single generic
+/// buffer block, which was the right answer to an empty corpus and told us
+/// nothing about planning. Every scenario below therefore gives the model
+/// something it must actually choose between.
+///
+/// Fixtures seed through the `journalDb` stubs the pipeline harness already
+/// installs, plus a fixture-backed [TaskDependencyResolver] for the ADR 0043
+/// cases.
+
+/// A task as the scenario seeds it, in the shape the corpus builder reads.
+@immutable
+class EvalTaskSpec {
+  const EvalTaskSpec({
+    required this.id,
+    required this.title,
+    this.estimateMinutes,
+    this.dueOffsetDays,
+    this.categoryId = evalDefaultCategoryId,
+    this.status = EvalTaskStatus.open,
+    this.blockedBy = const [],
+  });
+
+  final String id;
+  final String title;
+  final int? estimateMinutes;
+
+  /// Days relative to the plan date; negative is overdue. Null means no due
+  /// date, which is the common case for open work.
+  final int? dueOffsetDays;
+
+  final String categoryId;
+  final EvalTaskStatus status;
+
+  /// Task ids blocking this one (ADR 0043).
+  final List<String> blockedBy;
+}
+
+enum EvalTaskStatus { open, inProgress, blocked }
+
+const String evalDefaultCategoryId = 'cat-work';
+const String evalSecondCategoryId = 'cat-personal';
+
+/// One day the planner is asked to handle.
+@immutable
+class EvalScenario {
+  const EvalScenario({
+    required this.id,
+    required this.intent,
+    required this.tasks,
+    this.decidedTaskIds = const [],
+    this.capacityMinutes = 480,
+    this.startHour,
+    this.includeCapture = true,
+    this.captureTranscript,
+    this.allowedCategoryIds = const {evalDefaultCategoryId},
+  });
+
+  final String id;
+
+  /// What this scenario is trying to find out. Read this before the data.
+  final String intent;
+
+  final List<EvalTaskSpec> tasks;
+  final List<String> decidedTaskIds;
+  final int capacityMinutes;
+
+  /// Local hour the draft runs at, for same-day scenarios. Null drafts a
+  /// future day, where "the past" has no meaning and the guard is inert.
+  final int? startHour;
+
+  /// Whether a capture accompanies the wake.
+  ///
+  /// Load-bearing, not cosmetic: `buildTaskCorpusSnapshot` is only called from
+  /// the capture context, so a wake without one receives **no task corpus at
+  /// all** — and therefore no `blockedBy` — while still being told ADR 0043's
+  /// blocked-work rule.
+  final bool includeCapture;
+
+  final String? captureTranscript;
+  final Set<String> allowedCategoryIds;
+
+  /// Blocker map for the fixture-backed resolver.
+  Map<String, List<ResolvedBlocker>> get blockedStatus {
+    final byId = {for (final task in tasks) task.id: task};
+    return {
+      for (final task in tasks)
+        if (task.blockedBy.isNotEmpty)
+          task.id: [
+            for (final blockerId in task.blockedBy)
+              ResolvedBlocker(
+                taskId: blockerId,
+                title: byId[blockerId]?.title,
+                status: byId[blockerId] == null
+                    ? null
+                    : _statusString(byId[blockerId]!.status),
+              ),
+          ],
+    };
+  }
+
+  /// The scorers' view of what the model was given.
+  EvalFixtureInputs inputsFor(DateTime planDate) => EvalFixtureInputs(
+    dayId: 'dayplan-${planDate.toIso8601String().substring(0, 10)}',
+    planDate: planDate,
+    corpus: [
+      for (final task in tasks)
+        EvalCorpusTask(
+          taskId: task.id,
+          title: task.title,
+          status: _statusString(task.status),
+          blockedBy: task.blockedBy,
+          estimateMinutes: task.estimateMinutes,
+          categoryId: task.categoryId,
+        ),
+    ],
+    decidedTaskIds: decidedTaskIds,
+    capacityMinutes: capacityMinutes,
+    now: startHour == null
+        ? null
+        : DateTime(planDate.year, planDate.month, planDate.day, startHour!),
+  );
+
+  /// Journal [Task] rows for the corpus reads.
+  List<Task> tasksFor(DateTime planDate) => [
+    for (final spec in tasks) _taskFrom(spec, planDate),
+  ];
+
+  List<Task> overdueOrDueTodayFor(DateTime planDate) => [
+    for (final spec in tasks)
+      if (spec.dueOffsetDays != null && spec.dueOffsetDays! <= 0)
+        _taskFrom(spec, planDate),
+  ];
+
+  List<Task> inProgressFor(DateTime planDate) => [
+    for (final spec in tasks)
+      if (spec.status == EvalTaskStatus.inProgress) _taskFrom(spec, planDate),
+  ];
+
+  static String _statusString(EvalTaskStatus status) => switch (status) {
+    EvalTaskStatus.open => 'OPEN',
+    EvalTaskStatus.inProgress => 'IN PROGRESS',
+    EvalTaskStatus.blocked => 'BLOCKED',
+  };
+
+  static Task _taskFrom(EvalTaskSpec spec, DateTime planDate) {
+    final createdAt = planDate.subtract(const Duration(days: 7));
+    final due = spec.dueOffsetDays == null
+        ? null
+        : DateTime(
+            planDate.year,
+            planDate.month,
+            planDate.day + spec.dueOffsetDays!,
+            17,
+          );
+    return Task(
+      meta: Metadata(
+        id: spec.id,
+        createdAt: createdAt,
+        updatedAt: createdAt,
+        dateFrom: createdAt,
+        dateTo: createdAt,
+        categoryId: spec.categoryId,
+      ),
+      data: TaskData(
+        status: switch (spec.status) {
+          EvalTaskStatus.inProgress => TaskStatus.inProgress(
+            id: '${spec.id}-status',
+            createdAt: createdAt,
+            utcOffset: 0,
+          ),
+          EvalTaskStatus.blocked => TaskStatus.blocked(
+            id: '${spec.id}-status',
+            createdAt: createdAt,
+            utcOffset: 0,
+            reason: 'waiting on a dependency',
+          ),
+          EvalTaskStatus.open => TaskStatus.open(
+            id: '${spec.id}-status',
+            createdAt: createdAt,
+            utcOffset: 0,
+          ),
+        },
+        dateFrom: createdAt,
+        dateTo: createdAt,
+        statusHistory: const [],
+        title: spec.title,
+        due: due,
+        estimate: spec.estimateMinutes == null
+            ? null
+            : Duration(minutes: spec.estimateMinutes!),
+      ),
+      entryText: EntryText(plainText: spec.title),
+    );
+  }
+}
+
+/// A [TaskDependencyResolver] that answers from a fixture instead of the
+/// journal, so blocked-work scenarios do not need real typed links.
+class EvalFixtureDependencyResolver implements TaskDependencyResolver {
+  EvalFixtureDependencyResolver(this.blockedStatus);
+
+  final Map<String, List<ResolvedBlocker>> blockedStatus;
+
+  @override
+  Future<Map<String, List<ResolvedBlocker>>> resolveBlockedStatus(
+    Set<String> taskIds,
+  ) async => {
+    for (final entry in blockedStatus.entries)
+      if (taskIds.contains(entry.key)) entry.key: entry.value,
+  };
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// The scenario set.
+///
+/// Ordered roughly by how much tension they put on the planner.
+const List<EvalScenario> evalScenarios = [
+  _restraint,
+  _crowdedDay,
+  _lateStart,
+  _overCommitted,
+  _blockedChain,
+  _blockedWithoutCorpus,
+  _staleDecidedTask,
+];
+
+/// Does it invent work when there is none to do?
+///
+/// Kept from the original scenario list but reframed: an empty day tests
+/// restraint, not planning. A model that fabricates tasks here is worse than
+/// one that produces a single buffer block.
+const _restraint = EvalScenario(
+  id: 'restraint',
+  intent:
+      'With nothing to schedule, does the planner stay quiet rather than '
+      'inventing work?',
+  tasks: [],
+  captureTranscript: 'Nothing much on today.',
+);
+
+/// The bread-and-butter day: more candidates than time, mixed shapes.
+const _crowdedDay = EvalScenario(
+  id: 'crowdedDay',
+  intent:
+      'Given more work than fits, does it prioritise overdue and '
+      'in-progress work, batch the small items, and stay inside capacity?',
+  tasks: [
+    EvalTaskSpec(
+      id: 'task-overdue-invoice',
+      title: 'Send the overdue client invoice',
+      estimateMinutes: 30,
+      dueOffsetDays: -3,
+    ),
+    EvalTaskSpec(
+      id: 'task-due-today-review',
+      title: 'Review the security questionnaire',
+      estimateMinutes: 90,
+      dueOffsetDays: 0,
+    ),
+    EvalTaskSpec(
+      id: 'task-inprogress-migration',
+      title: 'Finish the database migration',
+      estimateMinutes: 180,
+      status: EvalTaskStatus.inProgress,
+    ),
+    EvalTaskSpec(
+      id: 'task-deep-architecture',
+      title: 'Draft the sync architecture proposal',
+      estimateMinutes: 150,
+    ),
+    EvalTaskSpec(
+      id: 'task-small-expenses',
+      title: 'File expenses',
+      estimateMinutes: 20,
+    ),
+    EvalTaskSpec(
+      id: 'task-small-replies',
+      title: 'Reply to the three outstanding emails',
+      estimateMinutes: 25,
+    ),
+    EvalTaskSpec(
+      id: 'task-small-booking',
+      title: 'Book the conference travel',
+      estimateMinutes: 20,
+    ),
+    EvalTaskSpec(
+      id: 'task-later-onboarding',
+      title: 'Write the onboarding guide',
+      estimateMinutes: 120,
+      dueOffsetDays: 14,
+    ),
+  ],
+  captureTranscript:
+      'Busy one today. The invoice is late and the migration is half done.',
+);
+
+/// Half the day is already gone.
+const _lateStart = EvalScenario(
+  id: 'lateStart',
+  intent:
+      'Drafted mid-afternoon with a 3-hour task on the list: does it '
+      'defer what cannot fit, or cram it in past the end of the day?',
+  tasks: [
+    EvalTaskSpec(
+      id: 'task-long-migration',
+      title: 'Finish the database migration',
+      estimateMinutes: 180,
+      status: EvalTaskStatus.inProgress,
+    ),
+    EvalTaskSpec(
+      id: 'task-short-invoice',
+      title: 'Send the overdue client invoice',
+      estimateMinutes: 30,
+      dueOffsetDays: -1,
+    ),
+    EvalTaskSpec(
+      id: 'task-short-replies',
+      title: 'Reply to the outstanding emails',
+      estimateMinutes: 25,
+    ),
+  ],
+  startHour: 15,
+  captureTranscript: 'Late start, only the afternoon left.',
+);
+
+/// Everything was decided, and it does not fit.
+const _overCommitted = EvalScenario(
+  id: 'overCommitted',
+  intent:
+      'Twelve hours of explicitly decided work against 480 minutes of '
+      'capacity. Nothing enforces capacity, so does it overpack silently or '
+      'surface the conflict?',
+  tasks: [
+    EvalTaskSpec(
+      id: 'task-a',
+      title: 'Rewrite the ingestion pipeline',
+      estimateMinutes: 240,
+    ),
+    EvalTaskSpec(
+      id: 'task-b',
+      title: 'Prepare the board deck',
+      estimateMinutes: 180,
+    ),
+    EvalTaskSpec(
+      id: 'task-c',
+      title: 'Interview two candidates',
+      estimateMinutes: 120,
+    ),
+    EvalTaskSpec(
+      id: 'task-d',
+      title: 'Close out the quarterly report',
+      estimateMinutes: 180,
+    ),
+  ],
+  decidedTaskIds: ['task-a', 'task-b', 'task-c', 'task-d'],
+  captureTranscript: 'I want all four of these done today.',
+);
+
+/// Shared by the blocked pair below, so the only difference between them is
+/// whether a capture accompanies the wake. Anything else varying would
+/// confound the comparison the pair exists to make.
+const _vendorChainTasks = [
+  EvalTaskSpec(
+    id: 'task-a-root',
+    title: 'Get the vendor API credentials',
+    estimateMinutes: 30,
+  ),
+  EvalTaskSpec(
+    id: 'task-b-middle',
+    title: 'Wire up the vendor integration',
+    estimateMinutes: 120,
+    status: EvalTaskStatus.blocked,
+    blockedBy: ['task-a-root'],
+  ),
+  EvalTaskSpec(
+    id: 'task-c-leaf',
+    title: 'Ship the vendor integration to staging',
+    estimateMinutes: 60,
+    status: EvalTaskStatus.blocked,
+    blockedBy: ['task-b-middle'],
+  ),
+  EvalTaskSpec(
+    id: 'task-unrelated',
+    title: 'Review the security questionnaire',
+    estimateMinutes: 90,
+  ),
+];
+
+/// A chain, not a pair — ADR 0043 resolves one hop only.
+const _blockedChain = EvalScenario(
+  id: 'blockedChain',
+  intent:
+      'C is blocked by B, which is blocked by A. ADR 0043 resolves one '
+      'hop with no transitive closure, so B looks blocked and C looks blocked '
+      'by B — does the plan reach A first, and does it avoid placing C?',
+  tasks: _vendorChainTasks,
+  decidedTaskIds: ['task-c-leaf'],
+  captureTranscript: 'I want to get the vendor integration shipped today.',
+);
+
+/// The rule arrives; the data does not.
+const _blockedWithoutCorpus = EvalScenario(
+  id: 'blockedWithoutCorpus',
+  intent:
+      'Same blocked work, but no capture — so the corpus (and its '
+      'blockedBy) is never rendered while the blocked-work rule still is. '
+      'Measures what the model does when told a rule it cannot apply.',
+  tasks: _vendorChainTasks,
+  decidedTaskIds: ['task-c-leaf'],
+  includeCapture: false,
+);
+
+/// A decided task the evidence does not support.
+const _staleDecidedTask = EvalScenario(
+  id: 'staleDecidedTask',
+  intent:
+      'A decided task that reads as already handled. The prompt says not '
+      'to force a stale placement — does it obey, or place everything it was '
+      'handed?',
+  tasks: [
+    EvalTaskSpec(
+      id: 'task-stale-invoice',
+      title: 'Send the client invoice',
+      estimateMinutes: 30,
+      dueOffsetDays: -5,
+    ),
+    EvalTaskSpec(
+      id: 'task-real-review',
+      title: 'Review the security questionnaire',
+      estimateMinutes: 90,
+      dueOffsetDays: 0,
+    ),
+  ],
+  decidedTaskIds: ['task-stale-invoice', 'task-real-review'],
+  captureTranscript:
+      'I already sent that invoice last week, it is done. Today I need to get '
+      'through the security questionnaire.',
+);
+
+/// Stubs the corpus reads on [journalDb] from [scenario].
+///
+/// The pipeline harness installs empty defaults for all four task sources;
+/// this replaces them so the model is given something to plan. Kept beside the
+/// fixtures rather than in the runner so a scenario is seeded exactly one way.
+void seedScenarioCorpus({
+  required MockJournalDb journalDb,
+  required EvalScenario scenario,
+  required DateTime planDate,
+}) {
+  when(
+    () => journalDb.getOpenTasksForDayAgentCorpus(
+      categoryIds: any(named: 'categoryIds'),
+      limit: any(named: 'limit'),
+    ),
+  ).thenAnswer((_) async => scenario.tasksFor(planDate));
+  when(
+    () => journalDb.getTasksDueOnOrBefore(any()),
+  ).thenAnswer((_) async => scenario.overdueOrDueTodayFor(planDate));
+  when(
+    () => journalDb.getTasksDueOn(any()),
+  ).thenAnswer((_) async => scenario.overdueOrDueTodayFor(planDate));
+  when(
+    () => journalDb.getInProgressTasks(
+      categoryIds: any(named: 'categoryIds'),
+      limit: any(named: 'limit'),
+    ),
+  ).thenAnswer((_) async => scenario.inProgressFor(planDate));
+  when(
+    () => journalDb.journalEntityMapForIds(any()),
+  ).thenAnswer(
+    (_) async => {
+      for (final task in scenario.tasksFor(planDate)) task.id: task,
+    },
+  );
+}

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -66,6 +66,7 @@ class EvalScenario {
     this.requiredTaskIds = const {},
     this.requiresConflictSurfaced = false,
     this.forbidsInventedWork = false,
+    this.conflictEscalationReasons = const {},
     this.capacityMinutes = 480,
     this.startHour,
     this.includeCapture = true,
@@ -103,6 +104,11 @@ class EvalScenario {
   /// Whether this day has no real work, so anything substantive the planner
   /// adds was invented rather than scheduled.
   final bool forbidsInventedWork;
+
+  /// `raise_day_status` reasons that would genuinely describe *this* day's
+  /// conflict. Scenario-specific: a day with no directive cannot honestly be
+  /// escalated as `directiveUnsatisfiable`.
+  final Set<String> conflictEscalationReasons;
 
   final int capacityMinutes;
 
@@ -162,6 +168,7 @@ class EvalScenario {
     requiredTaskIds: requiredTaskIds,
     requiresConflictSurfaced: requiresConflictSurfaced,
     forbidsInventedWork: forbidsInventedWork,
+    conflictEscalationReasons: conflictEscalationReasons,
     // Without a capture the task corpus is never rendered, so the only ids
     // the model can name are its decided ones. The corpus above stays as
     // ground truth for constraints that need to know what is actually true.
@@ -334,6 +341,10 @@ const _crowdedDay = EvalScenario(
       title: 'Draft the sync architecture proposal',
       estimateMinutes: 150,
     ),
+    // The three small items are here as batching material for the qualitative
+    // read, not as scored expectations: requiring them would push the day past
+    // capacity (the corpus totals 635 minutes against 480), and any adjacency
+    // rule I could write would encode a preference I cannot justify.
     EvalTaskSpec(
       id: 'task-small-expenses',
       title: 'File expenses',
@@ -426,6 +437,9 @@ const _overCommitted = EvalScenario(
   // blocks. Together those are what make this scenario measurable.
   permittedOmissions: {'task-a', 'task-b', 'task-c', 'task-d'},
   requiresConflictSurfaced: true,
+  // Only this one: the scenario seeds no directive, so escalating as
+  // `directiveUnsatisfiable` would be a reason that cannot be true.
+  conflictEscalationReasons: {'overCommitted'},
   captureTranscript: 'I want all four of these done today.',
 );
 
@@ -489,6 +503,12 @@ const _blockedWithoutCorpus = EvalScenario(
   tasks: _vendorChainTasks,
   decidedTaskIds: ['task-c-leaf'],
   permittedOmissions: {'task-c-leaf'},
+  // Identical to blockedChain on purpose. Ground truth must not move with
+  // visibility: if this scenario asked less of the model, an identical plan
+  // would be graded differently in the two reports and the rate gap could no
+  // longer be attributed to the corpus being hidden — which is the entire
+  // point of the pair.
+  requiredTaskIds: {'task-a-root'},
   includeCapture: false,
 );
 

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -63,6 +63,8 @@ class EvalScenario {
     this.decidedTaskIds = const [],
     this.permittedOmissions = const {},
     this.expectedOmissions = const {},
+    this.requiredTaskIds = const {},
+    this.requiresConflictSurfaced = false,
     this.capacityMinutes = 480,
     this.startHour,
     this.includeCapture = true,
@@ -87,6 +89,15 @@ class EvalScenario {
   /// Decided tasks the planner is expected to leave out, where placing them is
   /// the failure being measured.
   final Set<String> expectedOmissions;
+
+  /// Work any competent plan for this day must include, independent of what
+  /// the user decided. Without it a prioritisation scenario cannot tell a
+  /// good plan from one that scheduled the least urgent thing available.
+  final Set<String> requiredTaskIds;
+
+  /// Whether this day is impossible as stated, so the planner must say so
+  /// rather than quietly absorbing it.
+  final bool requiresConflictSurfaced;
 
   final int capacityMinutes;
 
@@ -143,6 +154,8 @@ class EvalScenario {
     // be placed is obviously not required to be.
     permittedOmissions: {...permittedOmissions, ...expectedOmissions},
     expectedOmissions: expectedOmissions,
+    requiredTaskIds: requiredTaskIds,
+    requiresConflictSurfaced: requiresConflictSurfaced,
     // Without a capture the task corpus is never rendered, so the only ids
     // the model can name are its decided ones. The corpus above stays as
     // ground truth for constraints that need to know what is actually true.
@@ -279,6 +292,14 @@ const _crowdedDay = EvalScenario(
   intent:
       'Given more work than fits, does it prioritise overdue and '
       'in-progress work, batch the small items, and stay inside capacity?',
+  // Named explicitly, because generic constraints are all satisfied by a plan
+  // containing one well-formed block — a model could schedule only the
+  // onboarding guide due in two weeks and score clean.
+  requiredTaskIds: {
+    'task-overdue-invoice',
+    'task-due-today-review',
+    'task-inprogress-migration',
+  },
   tasks: [
     EvalTaskSpec(
       id: 'task-overdue-invoice',
@@ -389,10 +410,12 @@ const _overCommitted = EvalScenario(
   ],
   decidedTaskIds: ['task-a', 'task-b', 'task-c', 'task-d'],
   // Dropping work is how a planner surfaces an impossible day, so it must not
-  // be scored as a miss. What it must not do is fake the fit by compressing
-  // four multi-hour tasks into short blocks — `respectsEstimates` catches
-  // that, which is what makes this scenario measurable at all.
+  // be scored as a miss — but silence is not surfacing. requiresConflictSurfaced
+  // makes the planner say what it left out, and the estimate-based capacity
+  // check stops it faking the fit by writing four multi-hour tasks as short
+  // blocks. Together those are what make this scenario measurable.
   permittedOmissions: {'task-a', 'task-b', 'task-c', 'task-d'},
+  requiresConflictSurfaced: true,
   captureTranscript: 'I want all four of these done today.',
 );
 

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -62,6 +62,7 @@ class EvalScenario {
     required this.intent,
     required this.tasks,
     this.decidedTaskIds = const [],
+    this.permittedOmissions = const {},
     this.capacityMinutes = 480,
     this.startHour,
     this.includeCapture = true,
@@ -76,6 +77,14 @@ class EvalScenario {
 
   final List<EvalTaskSpec> tasks;
   final List<String> decidedTaskIds;
+
+  /// Decided tasks this scenario expects the planner to leave out.
+  ///
+  /// They are still handed to the model — that is the input under test — but
+  /// omitting them is the correct answer, so they must not count against the
+  /// decided-tasks-placed constraint.
+  final Set<String> permittedOmissions;
+
   final int capacityMinutes;
 
   /// Local hour the draft runs at, for same-day scenarios. Null drafts a
@@ -128,6 +137,11 @@ class EvalScenario {
         ),
     ],
     decidedTaskIds: decidedTaskIds,
+    permittedOmissions: permittedOmissions,
+    // Without a capture the task corpus is never rendered, so the only ids
+    // the model can name are its decided ones. The corpus above stays as
+    // ground truth for constraints that need to know what is actually true.
+    visibleTaskIds: includeCapture ? null : {...decidedTaskIds},
     capacityMinutes: capacityMinutes,
     now: startHour == null
         ? null
@@ -411,6 +425,9 @@ const _blockedChain = EvalScenario(
       'by B — does the plan reach A first, and does it avoid placing C?',
   tasks: _vendorChainTasks,
   decidedTaskIds: ['task-c-leaf'],
+  // Leaving the blocked leaf out is a correct outcome, not a miss — the rule
+  // says place it only behind its blocker or with the blocker named.
+  permittedOmissions: {'task-c-leaf'},
   captureTranscript: 'I want to get the vendor integration shipped today.',
 );
 
@@ -423,6 +440,7 @@ const _blockedWithoutCorpus = EvalScenario(
       'Measures what the model does when told a rule it cannot apply.',
   tasks: _vendorChainTasks,
   decidedTaskIds: ['task-c-leaf'],
+  permittedOmissions: {'task-c-leaf'},
   includeCapture: false,
 );
 
@@ -448,6 +466,10 @@ const _staleDecidedTask = EvalScenario(
     ),
   ],
   decidedTaskIds: ['task-stale-invoice', 'task-real-review'],
+  // The transcript says the invoice is already sent, and the prompt tells the
+  // model not to force a stale placement. Requiring it would fail the model
+  // exactly when it obeys.
+  permittedOmissions: {'task-stale-invoice'},
   captureTranscript:
       'I already sent that invoice last week, it is done. Today I need to get '
       'through the security questionnaire.',

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -52,7 +52,6 @@ class EvalTaskSpec {
 enum EvalTaskStatus { open, inProgress, blocked }
 
 const String evalDefaultCategoryId = 'cat-work';
-const String evalSecondCategoryId = 'cat-personal';
 
 /// One day the planner is asked to handle.
 @immutable
@@ -63,11 +62,11 @@ class EvalScenario {
     required this.tasks,
     this.decidedTaskIds = const [],
     this.permittedOmissions = const {},
+    this.expectedOmissions = const {},
     this.capacityMinutes = 480,
     this.startHour,
     this.includeCapture = true,
     this.captureTranscript,
-    this.allowedCategoryIds = const {evalDefaultCategoryId},
   });
 
   final String id;
@@ -78,12 +77,16 @@ class EvalScenario {
   final List<EvalTaskSpec> tasks;
   final List<String> decidedTaskIds;
 
-  /// Decided tasks this scenario expects the planner to leave out.
+  /// Decided tasks the planner *may* leave out without penalty.
   ///
-  /// They are still handed to the model — that is the input under test — but
-  /// omitting them is the correct answer, so they must not count against the
-  /// decided-tasks-placed constraint.
+  /// A blocked task belongs here rather than in [expectedOmissions]: placing
+  /// it behind its blocker is equally correct, so neither requiring nor
+  /// forbidding it would be right.
   final Set<String> permittedOmissions;
+
+  /// Decided tasks the planner is expected to leave out, where placing them is
+  /// the failure being measured.
+  final Set<String> expectedOmissions;
 
   final int capacityMinutes;
 
@@ -100,7 +103,6 @@ class EvalScenario {
   final bool includeCapture;
 
   final String? captureTranscript;
-  final Set<String> allowedCategoryIds;
 
   /// Blocker map for the fixture-backed resolver.
   Map<String, List<ResolvedBlocker>> get blockedStatus {
@@ -137,7 +139,10 @@ class EvalScenario {
         ),
     ],
     decidedTaskIds: decidedTaskIds,
-    permittedOmissions: permittedOmissions,
+    // Expected omissions are permitted by construction — a task that must not
+    // be placed is obviously not required to be.
+    permittedOmissions: {...permittedOmissions, ...expectedOmissions},
+    expectedOmissions: expectedOmissions,
     // Without a capture the task corpus is never rendered, so the only ids
     // the model can name are its decided ones. The corpus above stays as
     // ground truth for constraints that need to know what is actually true.
@@ -383,6 +388,11 @@ const _overCommitted = EvalScenario(
     ),
   ],
   decidedTaskIds: ['task-a', 'task-b', 'task-c', 'task-d'],
+  // Dropping work is how a planner surfaces an impossible day, so it must not
+  // be scored as a miss. What it must not do is fake the fit by compressing
+  // four multi-hour tasks into short blocks — `respectsEstimates` catches
+  // that, which is what makes this scenario measurable at all.
+  permittedOmissions: {'task-a', 'task-b', 'task-c', 'task-d'},
   captureTranscript: 'I want all four of these done today.',
 );
 
@@ -468,8 +478,9 @@ const _staleDecidedTask = EvalScenario(
   decidedTaskIds: ['task-stale-invoice', 'task-real-review'],
   // The transcript says the invoice is already sent, and the prompt tells the
   // model not to force a stale placement. Requiring it would fail the model
-  // exactly when it obeys.
-  permittedOmissions: {'task-stale-invoice'},
+  // when it obeys; merely permitting the omission would let it place the work
+  // and still score clean. Placing it is the failure.
+  expectedOmissions: {'task-stale-invoice'},
   captureTranscript:
       'I already sent that invoice last week, it is done. Today I need to get '
       'through the security questionnaire.',

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -396,6 +396,13 @@ const _lateStart = EvalScenario(
       estimateMinutes: 25,
     ),
   ],
+  // Without these a single 15:00-16:00 buffer passed everything: no decided
+  // tasks, no required work, no conflict to surface, and the buffer satisfies
+  // capacity and working hours. Silently ignoring all three seeded tasks read
+  // as clean. The two short items fit comfortably in what remains (55 of ~120
+  // minutes), so requiring them makes the real question measurable — defer the
+  // migration and do the urgent short work, or cram it and fail working hours.
+  requiredTaskIds: {'task-short-invoice', 'task-short-replies'},
   startHour: 15,
   captureTranscript: 'Late start, only the afternoon left.',
 );

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -65,6 +65,7 @@ class EvalScenario {
     this.expectedOmissions = const {},
     this.requiredTaskIds = const {},
     this.requiresConflictSurfaced = false,
+    this.forbidsInventedWork = false,
     this.capacityMinutes = 480,
     this.startHour,
     this.includeCapture = true,
@@ -98,6 +99,10 @@ class EvalScenario {
   /// Whether this day is impossible as stated, so the planner must say so
   /// rather than quietly absorbing it.
   final bool requiresConflictSurfaced;
+
+  /// Whether this day has no real work, so anything substantive the planner
+  /// adds was invented rather than scheduled.
+  final bool forbidsInventedWork;
 
   final int capacityMinutes;
 
@@ -156,6 +161,7 @@ class EvalScenario {
     expectedOmissions: expectedOmissions,
     requiredTaskIds: requiredTaskIds,
     requiresConflictSurfaced: requiresConflictSurfaced,
+    forbidsInventedWork: forbidsInventedWork,
     // Without a capture the task corpus is never rendered, so the only ids
     // the model can name are its decided ones. The corpus above stays as
     // ground truth for constraints that need to know what is actually true.
@@ -283,6 +289,10 @@ const _restraint = EvalScenario(
       'With nothing to schedule, does the planner stay quiet rather than '
       'inventing work?',
   tasks: [],
+  // The whole point of the control. Without it a confident "Write a proposal"
+  // block scores identically to staying quiet: it has no taskId, so
+  // fabrication scoring is inapplicable, and every other constraint passes.
+  forbidsInventedWork: true,
   captureTranscript: 'Nothing much on today.',
 );
 
@@ -461,6 +471,11 @@ const _blockedChain = EvalScenario(
   // Leaving the blocked leaf out is a correct outcome, not a miss — the rule
   // says place it only behind its blocker or with the blocker named.
   permittedOmissions: {'task-c-leaf'},
+  // But omitting the leaf and scheduling something unrelated would leave both
+  // hops untouched while every constraint reported clean. The ready root is
+  // the thing a competent plan reaches for, whether or not it gets to the
+  // leaf, so requiring it is what makes the chain measurable.
+  requiredTaskIds: {'task-a-root'},
   captureTranscript: 'I want to get the vendor integration shipped today.',
 );
 

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -148,6 +148,32 @@ void main() {
     );
   });
 
+  test('restraint forbids invented work, or it measures nothing', () {
+    final scenario = byId('restraint');
+
+    expect(scenario.tasks, isEmpty);
+    expect(
+      scenario.forbidsInventedWork,
+      isTrue,
+      reason:
+          'without this the control cannot tell staying quiet from '
+          'confidently inventing a task',
+    );
+  });
+
+  test('blockedChain requires reaching the ready root', () {
+    // Omitting the permitted leaf and scheduling something unrelated would
+    // leave both hops untouched while every constraint reported clean.
+    final scenario = byId('blockedChain');
+
+    expect(scenario.requiredTaskIds, contains('task-a-root'));
+    expect(
+      scenario.permittedOmissions,
+      contains('task-c-leaf'),
+      reason: 'the leaf stays optional; only the root is required',
+    );
+  });
+
   test('crowdedDay names the work a competent plan must include', () {
     // Generic constraints are all satisfied by a single well-formed block, so
     // without this the scenario cannot tell a good plan from one that

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -224,6 +224,30 @@ void main() {
     );
   });
 
+  test('lateStart requires the short work that actually fits', () {
+    // Otherwise a single buffer block ignores every seeded task and reports
+    // clean, and the defer-versus-cram question is never asked.
+    final scenario = byId('lateStart');
+    final remainingMinutes = (17 - scenario.startHour!) * 60;
+    final requiredMinutes = scenario.tasks
+        .where((task) => scenario.requiredTaskIds.contains(task.id))
+        .fold<int>(0, (sum, task) => sum + (task.estimateMinutes ?? 0));
+
+    expect(scenario.requiredTaskIds, isNotEmpty);
+    expect(
+      requiredMinutes,
+      lessThan(remainingMinutes),
+      reason:
+          'requiring more than the day has left would make the scenario '
+          'unsatisfiable rather than discriminating',
+    );
+    expect(
+      scenario.requiredTaskIds,
+      isNot(contains('task-long-migration')),
+      reason: 'the long task is the one that legitimately may be deferred',
+    );
+  });
+
   test('lateStart carries the working-hours end the scenario turns on', () {
     final inputs = byId('lateStart').inputsFor(planDate);
 

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -131,13 +131,45 @@ void main() {
     },
   );
 
-  test('overCommitted may drop work, since that is how it surfaces', () {
+  test('overCommitted may drop work, but must not do so in silence', () {
     final scenario = byId('overCommitted');
 
     expect(
       scenario.permittedOmissions,
       containsAll(scenario.decidedTaskIds),
       reason: 'requiring all four would punish surfacing the conflict',
+    );
+    expect(
+      scenario.requiresConflictSurfaced,
+      isTrue,
+      reason:
+          'permitting every omission without this lets a model ignore '
+          'twelve hours of work and score clean',
+    );
+  });
+
+  test('crowdedDay names the work a competent plan must include', () {
+    // Generic constraints are all satisfied by a single well-formed block, so
+    // without this the scenario cannot tell a good plan from one that
+    // scheduled the least urgent thing available.
+    final scenario = byId('crowdedDay');
+
+    expect(scenario.requiredTaskIds, {
+      'task-overdue-invoice',
+      'task-due-today-review',
+      'task-inprogress-migration',
+    });
+    for (final required in scenario.requiredTaskIds) {
+      expect(
+        scenario.tasks.map((task) => task.id),
+        contains(required),
+        reason: '$required is required but never seeded',
+      );
+    }
+    expect(
+      scenario.requiredTaskIds,
+      isNot(contains('task-later-onboarding')),
+      reason: 'work due in two weeks is exactly what a good plan may skip',
     );
   });
 

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+
+import 'eval_scenario.dart';
+
+/// A fixture that lies about what it contains is worse than no fixture: it
+/// produces a confident report about a scenario that was never actually
+/// exercised. These assert the fixtures are internally coherent, and that the
+/// blocked pair is the controlled comparison it claims to be.
+void main() {
+  final planDate = DateTime(2026, 7, 18);
+
+  EvalScenario byId(String id) =>
+      evalScenarios.firstWhere((scenario) => scenario.id == id);
+
+  test('every scenario has a unique id and states its intent', () {
+    final ids = evalScenarios.map((scenario) => scenario.id).toList();
+
+    expect(ids.toSet(), hasLength(ids.length), reason: 'duplicate scenario id');
+    for (final scenario in evalScenarios) {
+      expect(
+        scenario.intent,
+        isNotEmpty,
+        reason: '${scenario.id} must say what it is trying to find out',
+      );
+    }
+  });
+
+  test('every scenario but the restraint control gives the model work', () {
+    // The first live run produced one generic buffer block against an empty
+    // corpus — correct, and uninformative. Only the control is allowed to be
+    // empty now.
+    for (final scenario in evalScenarios) {
+      if (scenario.id == 'restraint') {
+        expect(scenario.tasks, isEmpty);
+        continue;
+      }
+      expect(
+        scenario.tasks,
+        isNotEmpty,
+        reason: '${scenario.id} would measure only that the pipeline runs',
+      );
+    }
+  });
+
+  test('decided task ids all exist in their scenario corpus', () {
+    for (final scenario in evalScenarios) {
+      final known = {for (final task in scenario.tasks) task.id};
+      for (final decided in scenario.decidedTaskIds) {
+        expect(
+          known,
+          contains(decided),
+          reason:
+              '${scenario.id} decides on $decided, which it never seeds — '
+              'the model would be asked to place a task it cannot see',
+        );
+      }
+    }
+  });
+
+  test('blockedBy references resolve within the scenario', () {
+    for (final scenario in evalScenarios) {
+      final known = {for (final task in scenario.tasks) task.id};
+      for (final task in scenario.tasks) {
+        for (final blockerId in task.blockedBy) {
+          expect(
+            known,
+            contains(blockerId),
+            reason:
+                '${scenario.id}: ${task.id} is blocked by $blockerId, '
+                'which the fixture never seeds',
+          );
+        }
+      }
+    }
+  });
+
+  test('the blocked pair differs only in whether a capture is present', () {
+    // This pair exists to isolate one variable: the corpus is rendered only
+    // inside the capture context, so without a capture the model gets ADR
+    // 0043's rule and none of the data. Anything else differing would
+    // confound that comparison.
+    final withCapture = byId('blockedChain');
+    final withoutCapture = byId('blockedWithoutCorpus');
+
+    expect(withCapture.includeCapture, isTrue);
+    expect(withoutCapture.includeCapture, isFalse);
+    expect(
+      withoutCapture.tasks.map((task) => task.id),
+      withCapture.tasks.map((task) => task.id),
+    );
+    expect(withoutCapture.decidedTaskIds, withCapture.decidedTaskIds);
+    expect(withoutCapture.capacityMinutes, withCapture.capacityMinutes);
+    expect(withoutCapture.startHour, withCapture.startHour);
+  });
+
+  test('overCommitted genuinely does not fit', () {
+    final scenario = byId('overCommitted');
+    final decidedMinutes = scenario.tasks
+        .where((task) => scenario.decidedTaskIds.contains(task.id))
+        .fold<int>(0, (sum, task) => sum + (task.estimateMinutes ?? 0));
+
+    expect(
+      decidedMinutes,
+      greaterThan(scenario.capacityMinutes),
+      reason: 'a scenario named overCommitted that fits proves nothing',
+    );
+  });
+
+  test('lateStart leaves less time than its longest task needs', () {
+    final scenario = byId('lateStart');
+    final longest = scenario.tasks
+        .map((task) => task.estimateMinutes ?? 0)
+        .reduce((a, b) => a > b ? a : b);
+    // Working hours end at 17:00 by default config.
+    final remainingMinutes = (17 - scenario.startHour!) * 60;
+
+    expect(
+      longest,
+      greaterThan(remainingMinutes),
+      reason: 'the tension is a task that cannot fit in what remains',
+    );
+  });
+
+  test('the blocked chain is two hops, which ADR 0043 does not close', () {
+    final scenario = byId('blockedChain');
+    final leaf = scenario.tasks.firstWhere((t) => t.id == 'task-c-leaf');
+    final middle = scenario.tasks.firstWhere((t) => t.id == 'task-b-middle');
+
+    expect(leaf.blockedBy, ['task-b-middle']);
+    expect(middle.blockedBy, ['task-a-root']);
+    expect(
+      scenario.decidedTaskIds,
+      contains('task-c-leaf'),
+      reason:
+          'the decided task must be the far end of the chain, or the '
+          'transitive question never arises',
+    );
+  });
+
+  test('seeded tasks carry the fields the corpus builder reads', () {
+    final scenario = byId('crowdedDay');
+    final tasks = scenario.tasksFor(planDate);
+
+    expect(tasks, hasLength(scenario.tasks.length));
+    final invoice = tasks.firstWhere((t) => t.id == 'task-overdue-invoice');
+    expect(invoice.data.title, 'Send the overdue client invoice');
+    expect(invoice.data.estimate, const Duration(minutes: 30));
+    expect(invoice.meta.categoryId, evalDefaultCategoryId);
+    expect(
+      invoice.data.due!.isBefore(planDate),
+      isTrue,
+      reason: 'a negative dueOffsetDays must land before the plan date',
+    );
+  });
+
+  test('overdue and due-today tasks are the ones offered to the due reads', () {
+    final scenario = byId('crowdedDay');
+
+    final due = scenario.overdueOrDueTodayFor(planDate).map((t) => t.id);
+
+    expect(due, contains('task-overdue-invoice'));
+    expect(due, contains('task-due-today-review'));
+    expect(
+      due,
+      isNot(contains('task-later-onboarding')),
+      reason: 'a task due in two weeks is not due today',
+    );
+  });
+
+  test('in-progress work is offered to the in-progress read', () {
+    final scenario = byId('crowdedDay');
+
+    expect(
+      scenario.inProgressFor(planDate).map((t) => t.id),
+      ['task-inprogress-migration'],
+    );
+  });
+
+  test('scenario inputs mirror the seeded corpus for the scorers', () {
+    final scenario = byId('blockedChain');
+    final inputs = scenario.inputsFor(planDate);
+
+    expect(inputs.corpus.map((task) => task.taskId), [
+      for (final task in scenario.tasks) task.id,
+    ]);
+    final leaf = inputs.taskById('task-c-leaf')!;
+    expect(leaf.isBlocked, isTrue);
+    expect(leaf.blockedBy, ['task-b-middle']);
+    final unrelated = inputs.taskById('task-unrelated')!;
+    expect(unrelated.isBlocked, isFalse);
+  });
+
+  test('the fixture resolver answers only for the ids it was asked about', () {
+    final scenario = byId('blockedChain');
+    final resolver = EvalFixtureDependencyResolver(scenario.blockedStatus);
+
+    return resolver.resolveBlockedStatus({'task-c-leaf'}).then((resolved) {
+      expect(resolved.keys, ['task-c-leaf']);
+      expect(resolved['task-c-leaf']!.single.taskId, 'task-b-middle');
+      expect(
+        resolved['task-c-leaf']!.single.title,
+        'Wire up the vendor integration',
+        reason: 'the blocker title is what the prompt rule lets a reason name',
+      );
+    });
+  });
+
+  test('a task blocked by status alone still reads as blocked', () {
+    // ADR 0043's predicate is a union: absence of blockedBy means link-ready,
+    // not free to schedule.
+    final scenario = byId('blockedChain');
+    final tasks = scenario.tasksFor(planDate);
+    final middle = tasks.firstWhere((t) => t.id == 'task-b-middle');
+
+    expect(middle.data.status, isA<TaskBlocked>());
+  });
+}

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -76,6 +76,21 @@ void main() {
     }
   });
 
+  test('a scenario requiring escalation says what reason would be true', () {
+    // An empty reason set with requiresConflictSurfaced would make escalation
+    // impossible to satisfy, leaving only the reason-text path.
+    for (final scenario in evalScenarios) {
+      if (!scenario.requiresConflictSurfaced) continue;
+      expect(
+        scenario.conflictEscalationReasons,
+        isNotEmpty,
+        reason:
+            '${scenario.id} requires a conflict to be surfaced but names '
+            'no escalation reason that could be true of it',
+      );
+    }
+  });
+
   test('the blocked pair differs only in whether a capture is present', () {
     // This pair exists to isolate one variable: the corpus is rendered only
     // inside the capture context, so without a capture the model gets ADR
@@ -93,6 +108,16 @@ void main() {
     expect(withoutCapture.decidedTaskIds, withCapture.decidedTaskIds);
     expect(withoutCapture.capacityMinutes, withCapture.capacityMinutes);
     expect(withoutCapture.startHour, withCapture.startHour);
+    expect(
+      withoutCapture.requiredTaskIds,
+      withCapture.requiredTaskIds,
+      reason:
+          'ground truth must not move with visibility, or an identical '
+          'plan would be graded differently in the two reports and the rate '
+          'gap could no longer be attributed to the hidden corpus',
+    );
+    expect(withoutCapture.permittedOmissions, withCapture.permittedOmissions);
+    expect(withoutCapture.expectedOmissions, withCapture.expectedOmissions);
   });
 
   test('a stale task must be left out, not merely allowed to be', () {

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -95,45 +95,76 @@ void main() {
     expect(withoutCapture.startHour, withCapture.startHour);
   });
 
-  test('a scenario that wants an omission says so', () {
-    // Otherwise the decided-tasks-placed constraint fails exactly when the
-    // model does the right thing.
+  test('a stale task must be left out, not merely allowed to be', () {
+    // Two different things: permitting the omission stops a correct model
+    // failing, but only expecting it catches a model that places the work
+    // anyway — which is the behaviour this scenario exists to measure.
     final stale = byId('staleDecidedTask');
-    expect(stale.permittedOmissions, contains('task-stale-invoice'));
+
+    expect(stale.expectedOmissions, contains('task-stale-invoice'));
     expect(
-      stale.permittedOmissions,
+      stale.expectedOmissions,
       isNot(contains('task-real-review')),
       reason: 'the genuinely required task must still be required',
     );
-
-    for (final id in ['blockedChain', 'blockedWithoutCorpus']) {
-      expect(
-        byId(id).permittedOmissions,
-        contains('task-c-leaf'),
-        reason: '$id asks the planner to avoid its blocked leaf',
-      );
-    }
-  });
-
-  test('a capture-less scenario hides the corpus from the scorers', () {
-    // The corpus is rendered only inside the capture context, so scoring
-    // reference legitimacy against it would grade the model on ids it never
-    // received. Ground truth stays available for the constraints that need it.
-    final inputs = byId('blockedWithoutCorpus').inputsFor(planDate);
-
-    expect(inputs.referenceableTaskIds, {'task-c-leaf'});
     expect(
-      inputs.corpus.map((task) => task.taskId),
-      contains('task-a-root'),
-      reason: 'ground truth must survive so blocker ordering is still knowable',
+      stale.inputsFor(planDate).permittedOmissions,
+      contains('task-stale-invoice'),
+      reason: 'an expected omission is permitted by construction',
     );
   });
 
-  test('a scenario with a capture leaves the whole corpus referenceable', () {
-    final inputs = byId('blockedChain').inputsFor(planDate);
+  test(
+    'a blocked leaf may be omitted or sequenced, so it is only permitted',
+    () {
+      // Placing it behind its blocker is equally correct, so expecting the
+      // omission would fail a model that sequenced the day properly.
+      for (final id in ['blockedChain', 'blockedWithoutCorpus']) {
+        final scenario = byId(id);
+        expect(scenario.permittedOmissions, contains('task-c-leaf'));
+        expect(
+          scenario.expectedOmissions,
+          isEmpty,
+          reason: '$id must not punish a correctly sequenced placement',
+        );
+      }
+    },
+  );
 
-    expect(inputs.referenceableTaskIds, contains('task-a-root'));
-    expect(inputs.referenceableTaskIds, contains('task-unrelated'));
+  test('overCommitted may drop work, since that is how it surfaces', () {
+    final scenario = byId('overCommitted');
+
+    expect(
+      scenario.permittedOmissions,
+      containsAll(scenario.decidedTaskIds),
+      reason: 'requiring all four would punish surfacing the conflict',
+    );
+  });
+
+  test('lateStart carries the working-hours end the scenario turns on', () {
+    final inputs = byId('lateStart').inputsFor(planDate);
+
+    expect(inputs.workingHoursEndHour, 17);
+    expect(
+      inputs.now!.hour,
+      lessThan(inputs.workingHoursEndHour),
+      reason: 'the draft must start while working hours remain',
+    );
+  });
+
+  test('a capture-less scenario declares the corpus invisible', () {
+    // The visibility semantics themselves are covered in eval_models_test;
+    // what belongs here is that the fixture actually sets them, since the
+    // scenario pair is meaningless otherwise.
+    expect(
+      byId('blockedWithoutCorpus').inputsFor(planDate).visibleTaskIds,
+      isNotNull,
+    );
+    expect(
+      byId('blockedChain').inputsFor(planDate).visibleTaskIds,
+      isNull,
+      reason: 'a scenario with a capture shows the model everything',
+    );
   });
 
   test('overCommitted genuinely does not fit', () {

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -95,6 +95,47 @@ void main() {
     expect(withoutCapture.startHour, withCapture.startHour);
   });
 
+  test('a scenario that wants an omission says so', () {
+    // Otherwise the decided-tasks-placed constraint fails exactly when the
+    // model does the right thing.
+    final stale = byId('staleDecidedTask');
+    expect(stale.permittedOmissions, contains('task-stale-invoice'));
+    expect(
+      stale.permittedOmissions,
+      isNot(contains('task-real-review')),
+      reason: 'the genuinely required task must still be required',
+    );
+
+    for (final id in ['blockedChain', 'blockedWithoutCorpus']) {
+      expect(
+        byId(id).permittedOmissions,
+        contains('task-c-leaf'),
+        reason: '$id asks the planner to avoid its blocked leaf',
+      );
+    }
+  });
+
+  test('a capture-less scenario hides the corpus from the scorers', () {
+    // The corpus is rendered only inside the capture context, so scoring
+    // reference legitimacy against it would grade the model on ids it never
+    // received. Ground truth stays available for the constraints that need it.
+    final inputs = byId('blockedWithoutCorpus').inputsFor(planDate);
+
+    expect(inputs.referenceableTaskIds, {'task-c-leaf'});
+    expect(
+      inputs.corpus.map((task) => task.taskId),
+      contains('task-a-root'),
+      reason: 'ground truth must survive so blocker ordering is still knowable',
+    );
+  });
+
+  test('a scenario with a capture leaves the whole corpus referenceable', () {
+    final inputs = byId('blockedChain').inputsFor(planDate);
+
+    expect(inputs.referenceableTaskIds, contains('task-a-root'));
+    expect(inputs.referenceableTaskIds, contains('task-unrelated'));
+  });
+
   test('overCommitted genuinely does not fit', () {
     final scenario = byId('overCommitted');
     final decidedMinutes = scenario.tasks


### PR DESCRIPTION
Second task of the day-planning eval framework epic (after #3578's scorers).
Fixtures only — the runner that feeds them to a model is next.

## Why this task mattered more than expected

I ran the existing live eval against glm-5.2 for the first time. It passed:
job succeeded, 0 attempts, 5.35s. It also produced exactly this plan:

```
blocks=[Open buffer — wrap-up or capture new tasks [buffer/drafted] 15:45-17:00]
```

One generic buffer block. Before calling that weak, I checked why — the
pipeline harness stubs **every** task source to `const []`
(`day_agent_pipeline_harness.dart:183-208`). The model had nothing to
schedule, so a single buffer block is arguably the correct answer.

Which is the real finding: the existing eval runs against an empty world. Its
only plan assertion is `blocks isNotEmpty`, so a filler block passes. It can
prove the pipeline works; it can never say whether the planning is any good.

## The fixtures

Seven scenarios, each built around a tension the planner must *resolve* rather
than transcribe:

| id | the question it asks |
| --- | --- |
| `restraint` | empty on purpose — the control. Does it invent work when there is none? |
| `crowdedDay` | 8 tasks: overdue, due-today, in-progress, three small items, more than fits. Does it prioritise and batch? |
| `lateStart` | drafted at 15:00 with a 180-minute task on the list. Defer, or cram past the end of day? |
| `overCommitted` | 12 hours of explicitly decided work against 480 capacity. Nothing enforces capacity — overpack silently, or surface the conflict? |
| `blockedChain` | C blocked by B blocked by A, decided task at the far end |
| `blockedWithoutCorpus` | the same fixture with no capture |
| `staleDecidedTask` | a decided task the capture says is already done; the prompt says not to force a stale placement |

`blockedChain` is deliberately a *chain*, not a pair: ADR 0043 resolves one hop
with no transitive closure, so B reads as blocked-by-A and C as blocked-by-B,
and the interesting question is whether the model reaches A at all.

`blockedWithoutCorpus` shares one task list with `blockedChain` and differs in
exactly one field. That is the point — the corpus is rendered only inside the
capture context, so removing the capture removes `blockedBy` while ADR 0043's
rule is still sent. A test asserts the pair differs only in that field rather
than trusting me to have kept them aligned.

## Fixture coherence is tested

A fixture that lies is worse than no fixture: it produces a confident report
about a scenario that never happened. So the tests check the premises hold —
decided ids exist in their own corpus, `blockedBy` references resolve,
`overCommitted` genuinely does not fit (a scenario named that which fits proves
nothing), and `lateStart`'s longest task genuinely does not fit the remaining
day.

## Note for the runner task

The harness constructs `DayAgentWorkflow` **without** `dependencyResolver`, and
that field gates *both* the `blockedBy` corpus annotation *and* whether ADR
0043's blocked-work rule is emitted into the prompt at all. So today the
harness cannot exercise blocked-work planning — the rule never reaches the
model. `EvalFixtureDependencyResolver` here supplies the blockers; wiring it
into the harness belongs with the runner.

41 tests pass; analyzer and formatter clean; runs in ordinary CI. No CHANGELOG
entry (test-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for evaluating daily planning quality, including constraint scoring, omissions, capacity, working hours, and conflict handling.

* **Tests**
  * Added scenario-based evaluation coverage for task placement, estimates, capacity, blockers, visibility, omissions, and surfaced conflicts.
  * Added validation of planner fixture consistency and model behavior when plans are not persisted.
  * Added representative scenarios covering crowded schedules, late starts, blocked work, stale tasks, and overcommitment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->