### PR TITLE
test: add the day-planning eval matrix runner

### DIFF
--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -329,9 +329,67 @@ that same chain with the capture removed so ADR 0043's rule arrives without
 its data. Fixtures seed through the `journalDb` stubs the pipeline harness
 already installs.
 
-**Not yet wired to a model.** The matrix runner that feeds scenarios to
-providers, and the report it produces, are tracked separately; until then the
-fixtures are verified for internal coherence only.
+The matrix runner (`framework/eval_runner.dart`) drives scenario x model x
+variant x sample through the **real** pipeline via `DayAgentPipelineHarness` —
+outbox, runtime, executor, orchestrator, workflow and plan writer are all
+production code, and only the inference layer is injected. That is what lets
+the same runner drive a scripted model in ordinary CI and a live provider
+behind an opt-in flag. Each cell gets its own harness, so no run can read
+another's plan, jobs or tool log, and a cell that fails is recorded and the
+matrix continues.
+
+```mermaid
+flowchart LR
+  cell["cell:\nscenario x model\nx variant x sample"] --> layer["EvalModelTarget.open()\n(scripted or live)"]
+  layer --> rec["EvalPromptRecorder\nwraps the repository"]
+  rec --> harness["DayAgentPipelineHarness\n(real pipeline)"]
+  harness --> wake["one drafting wake"]
+  wake -->|"agent log:\naction + toolResult"| calls["tool calls,\nincl. rejections"]
+  wake -->|"DayPlanEntity"| plan["persisted blocks"]
+  rec -->|"createConversation /\nsendMessage"| prompts["system + user prompts"]
+  calls --> score["scoreAll()"]
+  plan --> score
+  score --> result["EvalRunResult"]
+  prompts --> result
+```
+
+Four details carry the design:
+
+- **Rejections are recovered from the agent log.** `DayAgentStrategy` writes an
+  `action` message (arguments as its payload) before each tool call and a
+  `toolResult` after it, carrying the rejection text in
+  `metadata.errorMessage`. Nothing else keeps that text, and without it a plan
+  that only became legal on the third attempt is indistinguishable from a
+  first-time-right one.
+- **The prompts are captured by wrapping the conversation repository.** The
+  system prompt is built and handed straight to `createConversation` — it is
+  never persisted, so it cannot be read back. The wrapper also makes the
+  forced-retry path visible: a second `sendMessage` on a drafting wake means
+  the model finished its turn without calling `draft_day_plan`.
+- **The dependency resolver is always wired**, matching production. It gates
+  both the corpus's `blockedBy` annotation and whether ADR 0043's blocked-work
+  rule reaches the prompt at all, so a null resolver would quietly measure a
+  prompt the app never sends.
+- **The capture is seeded directly, without its parse job.** Production's
+  `submitCapture` also enqueues `parseCapture`, which the runtime drains as a
+  *second* wake with its own prompt and tool calls. The unit of measurement
+  here is one drafting wake, so the runner writes the capture entity itself —
+  which is what makes `captureContext` non-null and therefore what renders the
+  transcript and task corpus into the prompt. Parse quality would need its own
+  scenario type.
+
+Variants (`framework/eval_variant.dart`) are a matrix dimension rather than a
+separate run, so one pass yields the A/B. A variant transforms the
+`DayAgentConfig` a scenario asks for, which is what renders into the system
+prompt's planning defaults — and the same effective config is what the scorers
+grade against, so a variant can never be graded against a contract the model
+was not given. The shipped set is the control only: a variant that tightens
+capacity also changes what the scenarios ask for, and would make
+`requiredWorkPlaced` and `withinCapacity` mutually unsatisfiable on a crowded
+day.
+
+**Not yet judged.** The report and judge bundle the runner's results feed are
+tracked separately, as is the live entry point that points it at real models.
 
 ### Measuring that it does not degrade
 

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -363,9 +363,13 @@ Four details carry the design:
   first-time-right one.
 - **The prompts are captured by wrapping the conversation repository.** The
   system prompt is built and handed straight to `createConversation` — it is
-  never persisted, so it cannot be read back. The wrapper also makes the
-  forced-retry path visible: a second `sendMessage` on a drafting wake means
-  the model finished its turn without calling `draft_day_plan`.
+  never persisted, so it cannot be read back. The wrapper records one
+  transcript *per conversation*, which is also what makes the forced-retry
+  signal trustworthy: `_forceDraftDayPlanIfMissing` sends a second message
+  into the **same** conversation, whereas a durable job retry opens a fresh
+  one and sends its normal first prompt. Counting messages across the whole
+  cell would report a transient provider failure as the model ignoring the
+  prompt; `jobAttempts` is where infrastructure retries belong.
 - **The dependency resolver is always wired**, matching production. It gates
   both the corpus's `blockedBy` annotation and whether ADR 0043's blocked-work
   rule reaches the prompt at all, so a null resolver would quietly measure a

--- a/test/README.md
+++ b/test/README.md
@@ -286,6 +286,17 @@ All tests in this codebase must use **deterministic time control** instead of re
 5. **Exception**: `integration_test/tutorial/` is a video driver, not a CI verification suite — it paces the real app at human speed for screen recording (see `tools/tutorial_videos/README.md`) and intentionally uses wall-clock `Stopwatch` + live pumps. These files are tagged `tutorial-video` (see `dart_test.yaml`) and `make integration_test` runs with `--exclude-tags tutorial-video`, so they never run under plain `flutter test` (no window, and they require `LOTTI_TUTORIAL_MANIFEST`/`LOTTI_TUTORIAL_TIMELINE` env vars). They run only via `fvm flutter drive`, driven by the `tools/tutorial_videos` workbench or the `tutorial-videos` skill.
 6. **Exception**: tests tagged `eval-live` (`test/features/ai/eval/`, `test/features/daily_os_next/eval/`) call a real inference provider and are skipped unless explicitly enabled via their `LOTTI_*_LIVE=1` env gate. They use the real clock deliberately — e.g. `day_agent_draft_live_eval_test.dart` drafts *today's* plan so the same-day "blocks must not start before current time" persist guard interacts with a real model's proposed times, which is the behavior under eval.
 
+7. **Exception**: the day-planning eval matrix runner
+   (`test/features/daily_os_next/eval/framework/eval_runner.dart`) anchors
+   same-day scenarios with `withClock` and a **moving** clock
+   (`Clock(() => anchoredAt.add(stopwatch.elapsed))`), not `Clock.fixed`. The
+   plan date has to be the clock's local day or production's same-day
+   past-start guard is inert and the scenario silently stops testing a late
+   start — but the pipeline's job-await soft cap is itself a `clock.now()`
+   deadline, so a frozen clock would turn a hung run into an infinite wait
+   instead of a diagnostic. Wall-clock `Stopwatch` is also what measures run
+   latency there, which is the thing under observation.
+
 ### `fakeAsync` does not fake real file I/O
 
 `fakeAsync` only intercepts `Timer` and the synchronous microtask queue — it

--- a/test/features/ai_consumption/test_utils.dart
+++ b/test/features/ai_consumption/test_utils.dart
@@ -14,7 +14,8 @@ import '../../mocks/mocks.dart';
 
 class AiInteractionCaptureTestBench {
   AiInteractionCaptureTestBench._(
-    this._sessions, {
+    this._sessions,
+    this._recorded, {
     required this.service,
     required this.identity,
     required this.capture,
@@ -77,12 +78,15 @@ class AiInteractionCaptureTestBench {
         ),
       );
     });
+    final recorded = <AiConsumptionEvent>[];
     when(
       () => service.recordInteraction(
         attributionId: any(named: 'attributionId'),
         event: any(named: 'event'),
       ),
-    ).thenAnswer((_) async {});
+    ).thenAnswer((invocation) async {
+      recorded.add(invocation.namedArguments[#event] as AiConsumptionEvent);
+    });
     when(
       () => service.prepareCompletion(
         attributionId: any(named: 'attributionId'),
@@ -120,6 +124,7 @@ class AiInteractionCaptureTestBench {
 
     return AiInteractionCaptureTestBench._(
       sessions,
+      recorded,
       service: service,
       identity: identity,
       capture: AiInteractionCapture(service, identity),
@@ -130,6 +135,20 @@ class AiInteractionCaptureTestBench {
   final MockAiAttributionIdentityResolver identity;
   final AiInteractionCapture capture;
   final Map<String, AiAttributionSession> _sessions;
+  final List<AiConsumptionEvent> _recorded;
+
+  /// Consumption events recorded since the last [clearRecordedInteractions].
+  ///
+  /// A snapshot, so it survives the next [clearRecordedInteractions]. Kept
+  /// here rather than left to `verify(...).captured` so a caller that runs
+  /// several interactions in one test can attribute events to the right one
+  /// without depending on verification consuming invocations.
+  List<AiConsumptionEvent> get recordedInteractions =>
+      List.unmodifiable(_recorded);
+
+  /// Drops everything recorded so far, so the next stretch of work is
+  /// measured on its own.
+  void clearRecordedInteractions() => _recorded.clear();
 
   void seedAgentWake({
     required String wakeRunKey,

--- a/test/features/daily_os_next/eval/framework/eval_runner.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner.dart
@@ -193,16 +193,41 @@ Future<List<EvalRunResult>> runEvalMatrix({
   if (samples < 1) {
     throw RangeError.value(samples, 'samples', 'must be at least 1');
   }
-  if (!variants.any((variant) => variant.id == evalBaselineVariantId)) {
+  final controls = variants.where(
+    (variant) => variant.id == evalBaselineVariantId,
+  );
+  if (controls.length != 1 || controls.single.configure != null) {
+    // Not just "an entry named baseline": a baseline carrying a transform is
+    // not a control, and every A/B in the report would be a delta against
+    // something that had itself been changed.
     throw ArgumentError.value(
       variants,
       'variants',
-      'must include "$evalBaselineVariantId" — a variant delta without a '
-          'control measures nothing',
+      'must include exactly one "$evalBaselineVariantId" variant with no '
+          'transform — a delta measured against a modified control measures '
+          'nothing',
+    );
+  }
+  // Ids are the report keys — the model id is the leaderboard row, and
+  // `EvalRunRequest.label` is scenario/model/variant. A duplicate anywhere
+  // silently collapses two different cells into one row.
+  _requireUniqueIds(models.map((model) => model.id), 'models');
+  _requireUniqueIds(scenarios.map((scenario) => scenario.id), 'scenarios');
+  _requireUniqueIds(variants.map((variant) => variant.id), 'variants');
+
+  final anchorCandidate = today ?? clock.now();
+  if (anchorCandidate.isUtc) {
+    // Everything downstream is local-day: `localDay`, the working-hours
+    // window, and production's same-day guard. Quietly reinterpreting a UTC
+    // anchor as local would plan a different day than the caller asked for.
+    throw ArgumentError.value(
+      today,
+      'today',
+      'must be a local DateTime — the day agent plans local days',
     );
   }
 
-  final anchor = today ?? clock.now();
+  final anchor = anchorCandidate;
   final results = <EvalRunResult>[];
   for (final scenario in scenarios) {
     for (final model in models) {
@@ -253,6 +278,22 @@ Future<List<EvalRunResult>> runEvalMatrix({
     }
   }
   return results;
+}
+
+void _requireUniqueIds(Iterable<String> ids, String field) {
+  final seen = <String>{};
+  final duplicates = {
+    for (final id in ids)
+      if (!seen.add(id)) id,
+  };
+  if (duplicates.isNotEmpty) {
+    throw ArgumentError.value(
+      duplicates.toList()..sort(),
+      field,
+      'ids must be unique — duplicates collapse distinct cells into one '
+      'report row',
+    );
+  }
 }
 
 /// The day a scenario plans for, given [anchor] as today.
@@ -355,11 +396,16 @@ Future<EvalRunResult> _runCell(
       planDate: planDate,
     );
 
+    // Seeded before the timer starts: agent lookup/creation and fixture
+    // persistence are the harness's cost, not the model's, and including them
+    // only for capture-bearing scenarios would make latency mean a different
+    // thing per scenario type.
+    final captureId = scenario.includeCapture
+        ? await _seedCapture(harness, scenario, planDate)
+        : const CaptureId('');
+
     stopwatch.start();
     try {
-      final captureId = scenario.includeCapture
-          ? await _seedCapture(harness, scenario, planDate)
-          : const CaptureId('');
       await harness.realDayAgent.draftDayPlan(
         captureId: captureId,
         decidedTaskIds: scenario.decidedTaskIds,

--- a/test/features/daily_os_next/eval/framework/eval_runner.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner.dart
@@ -1,0 +1,614 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/ai/conversation/conversation_manager.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/inference_usage.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
+import 'package:lotti/features/ai_consumption/model/ai_consumption_event.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
+import 'package:meta/meta.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import '../../../ai_consumption/test_utils.dart';
+import '../../integration/day_agent_pipeline_harness.dart';
+import 'eval_constraints.dart';
+import 'eval_models.dart';
+import 'eval_scenario.dart';
+import 'eval_variant.dart';
+
+/// Runs day-planning scenarios through the real ADR 0032 pipeline and scores
+/// what comes back.
+///
+/// The matrix is scenario x model x variant x sample. Everything below the
+/// model is real production code — outbox, runtime, executor, orchestrator,
+/// workflow, plan writer — assembled by [DayAgentPipelineHarness]; only the
+/// inference layer is supplied by the caller, which is what lets the same
+/// runner drive a scripted model in ordinary CI and a live provider behind an
+/// opt-in flag.
+///
+/// Each cell gets a fresh harness (fresh temp dir, in-memory agent store and
+/// outbox database), so no run can read another's plan, jobs or tool log.
+
+/// One cell of the matrix, handed to [EvalModelTarget.open] so a caller can
+/// vary the endpoint per scenario if it needs to.
+@immutable
+class EvalRunRequest {
+  const EvalRunRequest({
+    required this.scenario,
+    required this.variant,
+    required this.modelId,
+    required this.sample,
+    required this.planDate,
+  });
+
+  final EvalScenario scenario;
+  final EvalVariant variant;
+  final String modelId;
+
+  /// 1-based sample index within this cell.
+  final int sample;
+
+  final DateTime planDate;
+
+  /// Stable identifier for this cell, for logs and report keys.
+  String get label => '${scenario.id}/$modelId/${variant.id}#$sample';
+}
+
+/// The inference layer for one run, plus the configs the workflow resolves
+/// against it.
+@immutable
+class EvalLlmLayer {
+  const EvalLlmLayer({
+    required this.conversationRepository,
+    required this.cloudInferenceRepository,
+    required this.profile,
+    required this.model,
+    required this.provider,
+    this.close,
+  });
+
+  final ConversationRepository conversationRepository;
+  final CloudInferenceRepository cloudInferenceRepository;
+  final AiConfigInferenceProfile profile;
+  final AiConfigModel model;
+  final AiConfigInferenceProvider provider;
+
+  /// Released after the run, whether or not it succeeded.
+  final Future<void> Function()? close;
+}
+
+/// One model under test and how to reach it.
+@immutable
+class EvalModelTarget {
+  const EvalModelTarget({required this.id, required this.open});
+
+  /// Reported model id — the leaderboard key.
+  final String id;
+
+  /// Builds the inference layer for one run. Called once per cell.
+  final Future<EvalLlmLayer> Function(EvalRunRequest request) open;
+}
+
+/// Everything one cell produced.
+@immutable
+class EvalRunResult {
+  const EvalRunResult({
+    required this.request,
+    required this.outcome,
+    required this.constraints,
+    required this.latency,
+    required this.systemPrompt,
+    required this.userPrompts,
+    required this.jobStatus,
+    required this.jobAttempts,
+    required this.consumption,
+    this.error,
+  });
+
+  final EvalRunRequest request;
+  final EvalRunOutcome outcome;
+  final List<EvalConstraintResult> constraints;
+
+  /// Wall-clock time for the drafting round trip.
+  final Duration latency;
+
+  /// The exact system prompt the model received, as sent.
+  ///
+  /// Captured by wrapping the conversation repository rather than read back
+  /// from the agent log: the workflow hands the system prompt straight to
+  /// `createConversation` and never persists it.
+  final String? systemPrompt;
+
+  /// Every user message sent during the wake, in order.
+  final List<String> userPrompts;
+
+  /// Terminal status of the draft job, or null when no job was found.
+  final String? jobStatus;
+  final int? jobAttempts;
+
+  /// Consumption events recorded during this run. Empty for scripted models,
+  /// which never reach a provider.
+  final List<AiConsumptionEvent> consumption;
+
+  /// The exception the run ended with, if any. A failed run still carries an
+  /// outcome; its plan-reading constraints are inapplicable, not failed.
+  final String? error;
+
+  bool get failed => error != null;
+
+  /// Whether the workflow had to force the artifact.
+  ///
+  /// Derived from the send count: a drafting wake sends one message, and
+  /// `_forceDraftDayPlanIfMissing` sends a second one only when the model
+  /// finished its turn without calling `draft_day_plan`. Worth reporting on
+  /// its own — the retry hides a failure to follow the prompt that the
+  /// persisted plan cannot show.
+  bool get forcedDraftRetry => userPrompts.length > 1;
+}
+
+/// Runs the full matrix, sequentially.
+///
+/// Sequential on purpose: the runs share the ambient `getIt` registrations and
+/// a live provider's rate limit, and overlapping them would make the reported
+/// latency meaningless.
+///
+/// [today] anchors the plan dates and is injectable so tests are deterministic;
+/// it defaults to the current day. Same-day scenarios (those with a
+/// `startHour`) plan for [today] itself and run under a clock shifted to that
+/// hour, so production's same-day guard is live; the rest plan for the
+/// following day, where the guard is legitimately inert.
+///
+/// A cell that throws is recorded and the matrix continues — one model failing
+/// on one scenario must not cost the whole run.
+Future<List<EvalRunResult>> runEvalMatrix({
+  required List<EvalModelTarget> models,
+  List<EvalScenario> scenarios = evalScenarios,
+  List<EvalVariant> variants = evalVariants,
+  int samples = 1,
+  DateTime? today,
+  AiInteractionCaptureTestBench? attribution,
+  void Function(String message)? log,
+}) async {
+  if (models.isEmpty) {
+    throw ArgumentError.value(models, 'models', 'at least one model target');
+  }
+  if (scenarios.isEmpty) {
+    throw ArgumentError.value(scenarios, 'scenarios', 'at least one scenario');
+  }
+  if (samples < 1) {
+    throw RangeError.value(samples, 'samples', 'must be at least 1');
+  }
+  if (!variants.any((variant) => variant.id == evalBaselineVariantId)) {
+    throw ArgumentError.value(
+      variants,
+      'variants',
+      'must include "$evalBaselineVariantId" — a variant delta without a '
+          'control measures nothing',
+    );
+  }
+
+  final anchor = today ?? clock.now();
+  final results = <EvalRunResult>[];
+  for (final scenario in scenarios) {
+    for (final model in models) {
+      for (final variant in variants) {
+        for (var sample = 1; sample <= samples; sample++) {
+          final request = EvalRunRequest(
+            scenario: scenario,
+            variant: variant,
+            modelId: model.id,
+            sample: sample,
+            planDate: evalPlanDateFor(scenario, anchor),
+          );
+          log?.call('run ${request.label}');
+          EvalRunResult result;
+          try {
+            result = await runEvalCell(
+              request: request,
+              model: model,
+              attribution: attribution,
+              log: log,
+            );
+          }
+          // ignore: avoid_catching_errors — a malformed matrix must stay loud
+          on ArgumentError {
+            // A malformed scenario or variant is a bug in the matrix, not a
+            // result about a model. Swallowing it would file the bug as a
+            // finding.
+            rethrow;
+          } catch (e) {
+            log?.call('cell failed ${request.label}: $e');
+            result = _failedResult(
+              request,
+              request.scenario.inputsFor(
+                request.planDate,
+                config: request.variant.apply(request.scenario.baseConfig),
+              ),
+              e,
+            );
+          }
+          log?.call(
+            'done ${request.label}: '
+            '${result.error ?? '${result.outcome.blocks.length} block(s)'} '
+            'in ${result.latency.inMilliseconds}ms',
+          );
+          results.add(result);
+        }
+      }
+    }
+  }
+  return results;
+}
+
+/// The day a scenario plans for, given [anchor] as today.
+DateTime evalPlanDateFor(EvalScenario scenario, DateTime anchor) {
+  final today = DateTime(anchor.year, anchor.month, anchor.day);
+  return scenario.startHour == null
+      ? today.add(const Duration(days: 1))
+      : today;
+}
+
+/// Runs one cell and scores it.
+Future<EvalRunResult> runEvalCell({
+  required EvalRunRequest request,
+  required EvalModelTarget model,
+  AiInteractionCaptureTestBench? attribution,
+  void Function(String message)? log,
+}) {
+  final scenario = request.scenario;
+  if (scenario.includeCapture &&
+      (scenario.captureTranscript?.trim().isEmpty ?? true)) {
+    // Silently drafting without one would turn the scenario into its
+    // no-capture twin — the corpus would never be rendered while the scorers
+    // still believed it was visible.
+    throw ArgumentError.value(
+      scenario.id,
+      'scenario',
+      'includeCapture is set but captureTranscript is empty',
+    );
+  }
+
+  final startHour = scenario.startHour;
+  if (startHour == null) return _runCell(request, model, attribution, log);
+
+  // A same-day scenario is only a same-day scenario if production's clock
+  // agrees. The clock keeps running rather than being frozen: the pipeline's
+  // job-await soft cap is a `clock.now()` deadline, and a frozen clock would
+  // turn a hung run into an infinite wait instead of a diagnostic.
+  final elapsed = Stopwatch()..start();
+  final anchoredAt = DateTime(
+    request.planDate.year,
+    request.planDate.month,
+    request.planDate.day,
+    startHour,
+  );
+  return withClock(
+    Clock(() => anchoredAt.add(elapsed.elapsed)),
+    () => _runCell(request, model, attribution, log),
+  );
+}
+
+Future<EvalRunResult> _runCell(
+  EvalRunRequest request,
+  EvalModelTarget model,
+  AiInteractionCaptureTestBench? attribution,
+  void Function(String message)? log,
+) async {
+  final scenario = request.scenario;
+  final planDate = request.planDate;
+  final config = request.variant.apply(scenario.baseConfig);
+  final inputs = scenario.inputsFor(planDate, config: config);
+
+  attribution?.clearRecordedInteractions();
+  final EvalLlmLayer layer;
+  try {
+    layer = await model.open(request);
+  } catch (e) {
+    // A model that cannot even be reached (bad id, missing credentials) is
+    // one cell's problem, not the matrix's.
+    log?.call('open failed ${request.label}: $e');
+    return _failedResult(request, inputs, e);
+  }
+  final recorder = EvalPromptRecorder(layer.conversationRepository);
+  final harness = DayAgentPipelineHarness.create(
+    now: clock.now(),
+    conversationRepository: recorder,
+    cloudInferenceRepository: layer.cloudInferenceRepository,
+    profile: layer.profile,
+    model: layer.model,
+    provider: layer.provider,
+    // Always non-null, matching production: the resolver gates whether ADR
+    // 0043's blocked-work rule reaches the prompt at all, so a null one would
+    // quietly measure a prompt production never sends. Scenarios without
+    // blockers supply an empty map.
+    dependencyResolver: EvalFixtureDependencyResolver(scenario.blockedStatus),
+    config: config,
+  );
+  seedScenarioCorpus(
+    journalDb: harness.journalDb,
+    scenario: scenario,
+    planDate: planDate,
+  );
+
+  final stopwatch = Stopwatch()..start();
+  String? error;
+  try {
+    final captureId = scenario.includeCapture
+        ? await _seedCapture(harness, scenario, planDate)
+        : const CaptureId('');
+    await harness.realDayAgent.draftDayPlan(
+      captureId: captureId,
+      decidedTaskIds: scenario.decidedTaskIds,
+      dayDate: planDate,
+    );
+  } catch (e) {
+    // Recorded, not rethrown: a matrix that aborts on the first bad cell
+    // cannot report on the models that did work.
+    error = e.toString();
+    log?.call('error ${request.label}: $error');
+  }
+  stopwatch.stop();
+
+  try {
+    final dayId = dayAgentIdForDate(planDate);
+    final identity = await harness.dayAgentService.getDayAgentForDate(planDate);
+    final plan = identity is AgentIdentityEntity
+        ? await harness.planService.draftPlanForDay(
+            agentId: identity.agentId,
+            dayId: dayId,
+          )
+        : null;
+    final job = await harness.outbox.getById(
+      DayProcessingOutboxRepository.draftJobId(dayId),
+    );
+    final outcome = EvalRunOutcome(
+      inputs: inputs,
+      blocks: plan?.data.plannedBlocks ?? const [],
+      toolCalls: evalToolCallsFrom(harness.agentRepository.entities),
+      planPersisted: plan != null,
+    );
+    return EvalRunResult(
+      request: request,
+      outcome: outcome,
+      constraints: scoreAll(outcome),
+      latency: stopwatch.elapsed,
+      systemPrompt: recorder.systemPrompt,
+      userPrompts: List.unmodifiable(recorder.userMessages),
+      jobStatus: job?.status.name,
+      jobAttempts: job?.attempts,
+      consumption: List.unmodifiable(
+        attribution?.recordedInteractions ?? const <AiConsumptionEvent>[],
+      ),
+      error: error,
+    );
+  } finally {
+    await harness.dispose();
+    await layer.close?.call();
+  }
+}
+
+/// A cell that produced nothing, still occupying its slot in the report.
+///
+/// Every constraint is scored so the row keeps the same shape as a successful
+/// one; the plan-reading ones come back inapplicable rather than passed.
+EvalRunResult _failedResult(
+  EvalRunRequest request,
+  EvalFixtureInputs inputs,
+  Object error,
+) {
+  final outcome = EvalRunOutcome(inputs: inputs, planPersisted: false);
+  return EvalRunResult(
+    request: request,
+    outcome: outcome,
+    constraints: scoreAll(outcome),
+    latency: Duration.zero,
+    systemPrompt: null,
+    userPrompts: const [],
+    jobStatus: null,
+    jobAttempts: null,
+    consumption: const [],
+    error: error.toString(),
+  );
+}
+
+/// Writes the scenario's capture directly, without enqueueing its parse job.
+///
+/// Production's `submitCapture` also enqueues a `parseCapture` job, which the
+/// runtime drains as a **second wake** with its own conversation, prompt and
+/// tool calls. That is right for the app and wrong for this measurement: the
+/// unit here is one drafting wake, and letting the parse wake run would mix
+/// two prompts and two tool-call logs into one record, double the live cost of
+/// every cell, and add an uncontrolled second model call to a run whose whole
+/// point is to isolate planning behaviour.
+///
+/// What the drafting wake needs from a capture is the capture *entity* — that
+/// is what makes `captureContext` non-null and therefore what renders both the
+/// transcript and the task corpus into the prompt. Seeding it directly gives
+/// the wake exactly that. Parse quality is a separate question and would need
+/// its own scenario type.
+Future<CaptureId> _seedCapture(
+  DayAgentPipelineHarness harness,
+  EvalScenario scenario,
+  DateTime planDate,
+) async {
+  final identity = await harness.dayAgentService.getOrCreateDayAgentForDate(
+    planDate,
+  );
+  final now = clock.now();
+  final capture =
+      AgentDomainEntity.capture(
+            id: 'capture_${scenario.id}',
+            agentId: identity.agentId,
+            transcript: scenario.captureTranscript!,
+            capturedAt: now,
+            createdAt: now,
+            vectorClock: null,
+            dayId: dayAgentIdForDate(planDate),
+          )
+          as CaptureEntity;
+  await harness.syncService.upsertEntity(capture);
+  return CaptureId(capture.id);
+}
+
+/// Reconstructs the ordered tool-call log from the agent messages one wake
+/// wrote.
+///
+/// This is the whole reason the runner exists rather than a loop: the write
+/// path rejects an illegal `draft_day_plan` and hands the failure text back to
+/// the model, which retries — so the persisted plan is always legal and a plan
+/// that only became legal on the third attempt is indistinguishable from a
+/// first-time-right one. `DayAgentStrategy` records an `action` message (with
+/// the arguments as its payload) before each call and a `toolResult` message
+/// after it, carrying the rejection text in `metadata.errorMessage`, so the
+/// rejections are recoverable even though nothing else keeps them.
+///
+/// [entities] must be in write order, which the harness's in-memory store
+/// preserves (a Dart map iterates in insertion order, and every message id is
+/// a fresh UUID so no write ever re-enters an existing slot).
+List<EvalToolCall> evalToolCallsFrom(List<AgentDomainEntity> entities) {
+  final payloads = {
+    for (final entity in entities.whereType<AgentMessagePayloadEntity>())
+      entity.id: entity.content,
+  };
+  final calls = <EvalToolCall>[];
+  AgentMessageEntity? pendingAction;
+
+  void flushPendingAction() {
+    final action = pendingAction;
+    if (action == null) return;
+    // An action with no result means the loop died mid-call. Reporting it as
+    // accepted would credit a call that never landed.
+    calls.add(
+      EvalToolCall(
+        name: action.metadata.toolName ?? '',
+        accepted: false,
+        rejectionMessage: 'no tool result was recorded',
+        arguments: payloads[action.contentEntryId] ?? const {},
+      ),
+    );
+    pendingAction = null;
+  }
+
+  for (final message in entities.whereType<AgentMessageEntity>()) {
+    switch (message.kind) {
+      case AgentMessageKind.action:
+        // Two actions in a row can only mean the first lost its result.
+        flushPendingAction();
+        pendingAction = message;
+      case AgentMessageKind.toolResult:
+        final toolName = message.metadata.toolName ?? '';
+        final action = pendingAction;
+        // Arguments are only this call's if the pending action is for the same
+        // tool. A tool call whose arguments failed to parse records a result
+        // with no action at all, so pairing blindly would attach the previous
+        // call's arguments to it.
+        final arguments = action != null && action.metadata.toolName == toolName
+            ? payloads[action.contentEntryId] ?? const {}
+            : const <String, dynamic>{};
+        if (action != null && action.metadata.toolName != toolName) {
+          flushPendingAction();
+        }
+        pendingAction = null;
+        calls.add(
+          EvalToolCall(
+            name: toolName,
+            accepted: message.metadata.errorMessage == null,
+            rejectionMessage: message.metadata.errorMessage,
+            arguments: arguments,
+          ),
+        );
+      case AgentMessageKind.user:
+      case AgentMessageKind.thought:
+      case AgentMessageKind.observation:
+      case AgentMessageKind.summary:
+      case AgentMessageKind.system:
+        break;
+    }
+  }
+  flushPendingAction();
+  return calls;
+}
+
+/// Wraps a [ConversationRepository] to capture the prompts the model was sent.
+///
+/// The system prompt is never persisted — the workflow builds it and hands it
+/// straight to `createConversation` — so reading the agent log back recovers
+/// the user message and nothing else. Wrapping also makes the forced-retry
+/// path visible, since it shows up as a second `sendMessage`.
+class EvalPromptRecorder extends ConversationRepository {
+  EvalPromptRecorder(this._inner);
+
+  final ConversationRepository _inner;
+
+  /// Every user message sent, in order.
+  final List<String> userMessages = [];
+
+  /// The system prompt of the wake's conversation.
+  String? systemPrompt;
+
+  @override
+  String createConversation({String? systemMessage, int maxTurns = 20}) {
+    systemPrompt = systemMessage;
+    return _inner.createConversation(
+      systemMessage: systemMessage,
+      maxTurns: maxTurns,
+    );
+  }
+
+  @override
+  ConversationManager? getConversation(String conversationId) =>
+      _inner.getConversation(conversationId);
+
+  @override
+  Future<InferenceUsage?> sendMessage({
+    required String conversationId,
+    required String message,
+    required String model,
+    required AiConfigInferenceProvider provider,
+    required InferenceRepositoryInterface inferenceRepo,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+    double temperature = 0.7,
+    ConversationStrategy? strategy,
+    String? consumptionAgentId,
+    String? consumptionTaskId,
+    String? consumptionCategoryId,
+    String? consumptionWakeRunKey,
+    String? consumptionThreadId,
+    bool rethrowInferenceErrors = false,
+  }) {
+    userMessages.add(message);
+    return _inner.sendMessage(
+      conversationId: conversationId,
+      message: message,
+      model: model,
+      provider: provider,
+      inferenceRepo: inferenceRepo,
+      tools: tools,
+      toolChoice: toolChoice,
+      temperature: temperature,
+      strategy: strategy,
+      consumptionAgentId: consumptionAgentId,
+      consumptionTaskId: consumptionTaskId,
+      consumptionCategoryId: consumptionCategoryId,
+      consumptionWakeRunKey: consumptionWakeRunKey,
+      consumptionThreadId: consumptionThreadId,
+      rethrowInferenceErrors: rethrowInferenceErrors,
+    );
+  }
+
+  @override
+  void deleteConversation(String conversationId) =>
+      _inner.deleteConversation(conversationId);
+}
+
+/// Convenience for a caller that wants the config a cell will use without
+/// running it (the live entry point logs it).
+DayAgentConfig evalConfigFor(EvalScenario scenario, EvalVariant variant) =>
+    variant.apply(scenario.baseConfig);

--- a/test/features/daily_os_next/eval/framework/eval_runner.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner.dart
@@ -103,8 +103,7 @@ class EvalRunResult {
     required this.outcome,
     required this.constraints,
     required this.latency,
-    required this.systemPrompt,
-    required this.userPrompts,
+    required this.wakes,
     required this.jobStatus,
     required this.jobAttempts,
     required this.consumption,
@@ -118,15 +117,13 @@ class EvalRunResult {
   /// Wall-clock time for the drafting round trip.
   final Duration latency;
 
-  /// The exact system prompt the model received, as sent.
+  /// One entry per conversation the cell opened, in order.
   ///
-  /// Captured by wrapping the conversation repository rather than read back
-  /// from the agent log: the workflow hands the system prompt straight to
-  /// `createConversation` and never persists it.
-  final String? systemPrompt;
-
-  /// Every user message sent during the wake, in order.
-  final List<String> userPrompts;
+  /// A cell is normally one wake and therefore one conversation, but the
+  /// durable job retries a transient failure up to `maxAttempts` times and
+  /// each attempt is a *fresh* wake with its own conversation. Keeping them
+  /// separate is what lets [forcedDraftRetry] mean what it says.
+  final List<EvalWakeTranscript> wakes;
 
   /// Terminal status of the draft job, or null when no job was found.
   final String? jobStatus;
@@ -142,14 +139,26 @@ class EvalRunResult {
 
   bool get failed => error != null;
 
-  /// Whether the workflow had to force the artifact.
+  /// The wake that produced the persisted plan — the last one, since any
+  /// earlier attempt failed and was retried. Null when nothing ran.
+  EvalWakeTranscript? get draftWake => wakes.isEmpty ? null : wakes.last;
+
+  /// The system prompt of the wake that produced the plan.
+  String? get systemPrompt => draftWake?.systemPrompt;
+
+  /// The user messages of the wake that produced the plan, in order.
+  List<String> get userPrompts => draftWake?.userMessages ?? const [];
+
+  /// Whether the workflow had to force the artifact out of the model.
   ///
-  /// Derived from the send count: a drafting wake sends one message, and
-  /// `_forceDraftDayPlanIfMissing` sends a second one only when the model
-  /// finished its turn without calling `draft_day_plan`. Worth reporting on
-  /// its own — the retry hides a failure to follow the prompt that the
-  /// persisted plan cannot show.
-  bool get forcedDraftRetry => userPrompts.length > 1;
+  /// Scoped to a single conversation on purpose. `_forceDraftDayPlanIfMissing`
+  /// sends a *second message into the same conversation* when the model
+  /// finished its turn without calling `draft_day_plan`. A durable job retry,
+  /// by contrast, opens a fresh conversation and sends its normal first
+  /// prompt — so counting messages across the whole cell would report a
+  /// transient provider failure as the model ignoring the prompt. [jobAttempts]
+  /// is where infrastructure retries are visible.
+  bool get forcedDraftRetry => wakes.any((wake) => wake.forcedRetry);
 }
 
 /// Runs the full matrix, sequentially.
@@ -248,10 +257,12 @@ Future<List<EvalRunResult>> runEvalMatrix({
 
 /// The day a scenario plans for, given [anchor] as today.
 DateTime evalPlanDateFor(EvalScenario scenario, DateTime anchor) {
-  final today = DateTime(anchor.year, anchor.month, anchor.day);
+  // Next civil date, not +24h: on a DST boundary a fixed day-long duration
+  // lands at 23:00 the same date or 01:00 the next, which would give the cell
+  // the wrong day id and shift every block time by an hour.
   return scenario.startHour == null
-      ? today.add(const Duration(days: 1))
-      : today;
+      ? DateTime(anchor.year, anchor.month, anchor.day + 1)
+      : DateTime(anchor.year, anchor.month, anchor.day);
 }
 
 /// Runs one cell and scores it.
@@ -316,46 +327,52 @@ Future<EvalRunResult> _runCell(
     return _failedResult(request, inputs, e);
   }
   final recorder = EvalPromptRecorder(layer.conversationRepository);
-  final harness = DayAgentPipelineHarness.create(
-    now: clock.now(),
-    conversationRepository: recorder,
-    cloudInferenceRepository: layer.cloudInferenceRepository,
-    profile: layer.profile,
-    model: layer.model,
-    provider: layer.provider,
-    // Always non-null, matching production: the resolver gates whether ADR
-    // 0043's blocked-work rule reaches the prompt at all, so a null one would
-    // quietly measure a prompt production never sends. Scenarios without
-    // blockers supply an empty map.
-    dependencyResolver: EvalFixtureDependencyResolver(scenario.blockedStatus),
-    config: config,
-  );
-  seedScenarioCorpus(
-    journalDb: harness.journalDb,
-    scenario: scenario,
-    planDate: planDate,
-  );
-
-  final stopwatch = Stopwatch()..start();
+  // Every acquired resource is released independently below: the harness holds
+  // a running runtime with a periodic timer, a sqlite database and a temp
+  // directory, so leaking one per failed cell would accumulate across a matrix
+  // that is expected to keep going after a failure.
+  DayAgentPipelineHarness? harness;
+  final stopwatch = Stopwatch();
   String? error;
   try {
-    final captureId = scenario.includeCapture
-        ? await _seedCapture(harness, scenario, planDate)
-        : const CaptureId('');
-    await harness.realDayAgent.draftDayPlan(
-      captureId: captureId,
-      decidedTaskIds: scenario.decidedTaskIds,
-      dayDate: planDate,
+    harness = DayAgentPipelineHarness.create(
+      now: clock.now(),
+      conversationRepository: recorder,
+      cloudInferenceRepository: layer.cloudInferenceRepository,
+      profile: layer.profile,
+      model: layer.model,
+      provider: layer.provider,
+      // Always non-null, matching production: the resolver gates whether ADR
+      // 0043's blocked-work rule reaches the prompt at all, so a null one would
+      // quietly measure a prompt production never sends. Scenarios without
+      // blockers supply an empty map.
+      dependencyResolver: EvalFixtureDependencyResolver(scenario.blockedStatus),
+      config: config,
     );
-  } catch (e) {
-    // Recorded, not rethrown: a matrix that aborts on the first bad cell
-    // cannot report on the models that did work.
-    error = e.toString();
-    log?.call('error ${request.label}: $error');
-  }
-  stopwatch.stop();
+    seedScenarioCorpus(
+      journalDb: harness.journalDb,
+      scenario: scenario,
+      planDate: planDate,
+    );
 
-  try {
+    stopwatch.start();
+    try {
+      final captureId = scenario.includeCapture
+          ? await _seedCapture(harness, scenario, planDate)
+          : const CaptureId('');
+      await harness.realDayAgent.draftDayPlan(
+        captureId: captureId,
+        decidedTaskIds: scenario.decidedTaskIds,
+        dayDate: planDate,
+      );
+    } catch (e) {
+      // Recorded, not rethrown: a matrix that aborts on the first bad cell
+      // cannot report on the models that did work.
+      error = e.toString();
+      log?.call('error ${request.label}: $error');
+    }
+    stopwatch.stop();
+
     final dayId = dayAgentIdForDate(planDate);
     final identity = await harness.dayAgentService.getDayAgentForDate(planDate);
     final plan = identity is AgentIdentityEntity
@@ -378,8 +395,7 @@ Future<EvalRunResult> _runCell(
       outcome: outcome,
       constraints: scoreAll(outcome),
       latency: stopwatch.elapsed,
-      systemPrompt: recorder.systemPrompt,
-      userPrompts: List.unmodifiable(recorder.userMessages),
+      wakes: recorder.wakes,
       jobStatus: job?.status.name,
       jobAttempts: job?.attempts,
       consumption: List.unmodifiable(
@@ -388,8 +404,24 @@ Future<EvalRunResult> _runCell(
       error: error,
     );
   } finally {
-    await harness.dispose();
-    await layer.close?.call();
+    await _release('harness', () => harness?.dispose(), log);
+    await _release('model layer', () => layer.close?.call(), log);
+  }
+}
+
+/// Releases one resource, reporting rather than propagating its failure.
+///
+/// A throwing `dispose` must not prevent the next release from running, and
+/// must not replace a cell's real result with a teardown error.
+Future<void> _release(
+  String what,
+  Future<void>? Function() release,
+  void Function(String message)? log,
+) async {
+  try {
+    await release();
+  } catch (e) {
+    log?.call('failed to release $what: $e');
   }
 }
 
@@ -408,8 +440,7 @@ EvalRunResult _failedResult(
     outcome: outcome,
     constraints: scoreAll(outcome),
     latency: Duration.zero,
-    systemPrompt: null,
-    userPrompts: const [],
+    wakes: const [],
     jobStatus: null,
     jobAttempts: null,
     consumption: const [],
@@ -535,6 +566,33 @@ List<EvalToolCall> evalToolCallsFrom(List<AgentDomainEntity> entities) {
   return calls;
 }
 
+/// One conversation the model was driven through, as it was sent.
+@immutable
+class EvalWakeTranscript {
+  const EvalWakeTranscript({
+    required this.conversationId,
+    required this.systemPrompt,
+    required this.userMessages,
+  });
+
+  final String conversationId;
+
+  /// The system prompt, which is never persisted anywhere else.
+  final String? systemPrompt;
+
+  /// User messages sent into this conversation, in order.
+  final List<String> userMessages;
+
+  /// More than one message in a single conversation means the workflow sent a
+  /// follow-up to force the required tool call.
+  bool get forcedRetry => userMessages.length > 1;
+}
+
+class _MutableWake {
+  String? systemPrompt;
+  final List<String> userMessages = [];
+}
+
 /// Wraps a [ConversationRepository] to capture the prompts the model was sent.
 ///
 /// The system prompt is never persisted — the workflow builds it and hands it
@@ -545,20 +603,33 @@ class EvalPromptRecorder extends ConversationRepository {
   EvalPromptRecorder(this._inner);
 
   final ConversationRepository _inner;
+  final Map<String, _MutableWake> _byConversation = {};
+  final List<String> _order = [];
 
-  /// Every user message sent, in order.
-  final List<String> userMessages = [];
-
-  /// The system prompt of the wake's conversation.
-  String? systemPrompt;
+  /// One transcript per conversation, in the order they were opened.
+  List<EvalWakeTranscript> get wakes => List.unmodifiable([
+    for (final id in _order)
+      EvalWakeTranscript(
+        conversationId: id,
+        systemPrompt: _byConversation[id]!.systemPrompt,
+        userMessages: List.unmodifiable(_byConversation[id]!.userMessages),
+      ),
+  ]);
 
   @override
   String createConversation({String? systemMessage, int maxTurns = 20}) {
-    systemPrompt = systemMessage;
-    return _inner.createConversation(
+    final id = _inner.createConversation(
       systemMessage: systemMessage,
       maxTurns: maxTurns,
     );
+    // Keyed by the id the inner repository chose, so a conversation reusing an
+    // id after deletion appends to one transcript rather than silently
+    // starting a second.
+    _byConversation.putIfAbsent(id, () {
+      _order.add(id);
+      return _MutableWake();
+    }).systemPrompt = systemMessage;
+    return id;
   }
 
   @override
@@ -583,7 +654,7 @@ class EvalPromptRecorder extends ConversationRepository {
     String? consumptionThreadId,
     bool rethrowInferenceErrors = false,
   }) {
-    userMessages.add(message);
+    _byConversation[conversationId]?.userMessages.add(message);
     return _inner.sendMessage(
       conversationId: conversationId,
       message: message,

--- a/test/features/daily_os_next/eval/framework/eval_runner_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner_test.dart
@@ -269,6 +269,99 @@ void main() {
       );
     });
 
+    test('rejects a baseline that carries a transform', () async {
+      // "An entry named baseline" is not a control. A baseline with a
+      // transform makes every A/B a delta against something that was itself
+      // changed — the check has to catch its own subject.
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          variants: const [
+            EvalVariant(
+              id: evalBaselineVariantId,
+              rationale: 'looks like a control, is not one',
+              configure: _halfDay,
+            ),
+          ],
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('no transform'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects two variants claiming to be the control', () async {
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          variants: const [evalBaselineVariant, evalBaselineVariant],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects duplicate ids in any matrix dimension', () async {
+      // Ids are report keys: the model id is the leaderboard row and `label`
+      // is scenario/model/variant, so a duplicate silently merges two cells.
+      final scenario = evalScenarios.first;
+      expect(
+        () => runEvalMatrix(
+          models: [
+            scriptedTarget(id: 'same', turns: const []),
+            scriptedTarget(id: 'same', turns: const []),
+          ],
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('unique'),
+          ),
+        ),
+      );
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          scenarios: [scenario, scenario],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          variants: const [
+            evalBaselineVariant,
+            EvalVariant(id: 'dup', rationale: 'x'),
+            EvalVariant(id: 'dup', rationale: 'x'),
+          ],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects a UTC anchor', () async {
+      // localDay, the working-hours window and production's same-day guard are
+      // all local, so reinterpreting a UTC anchor would plan a different day
+      // than the caller asked for.
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          today: DateTime.utc(2030, 1, 15),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('local DateTime'),
+          ),
+        ),
+      );
+    });
+
     test('rejects an empty matrix or a sample count below one', () async {
       expect(
         () => runEvalMatrix(models: const []),

--- a/test/features/daily_os_next/eval/framework/eval_runner_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner_test.dart
@@ -3,6 +3,7 @@ import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 import 'package:lotti/get_it.dart';
@@ -61,6 +62,7 @@ void main() {
     required List<List<ChatCompletionMessageToolCall>> turns,
     String id = 'scripted',
     void Function()? onOpen,
+    Future<void> Function()? onClose,
     List<ScriptedConversationRepository>? recordInto,
   }) => EvalModelTarget(
     id: id,
@@ -85,6 +87,7 @@ void main() {
           id: 'provider-eval',
           apiKey: 'provider-key',
         ),
+        close: onClose,
       );
     },
   );
@@ -122,6 +125,17 @@ void main() {
           taskId: taskId,
         ),
       ];
+
+  EvalRunRequest requestFor(
+    EvalScenario scenario, {
+    EvalVariant variant = evalBaselineVariant,
+  }) => EvalRunRequest(
+    scenario: scenario,
+    variant: variant,
+    modelId: 'scripted',
+    sample: 1,
+    planDate: evalPlanDateFor(scenario, today),
+  );
 
   group('runEvalMatrix', () {
     test(
@@ -278,17 +292,6 @@ void main() {
   });
 
   group('runEvalCell', () {
-    EvalRunRequest requestFor(
-      EvalScenario scenario, {
-      EvalVariant variant = evalBaselineVariant,
-    }) => EvalRunRequest(
-      scenario: scenario,
-      variant: variant,
-      modelId: 'scripted',
-      sample: 1,
-      planDate: evalPlanDateFor(scenario, today),
-    );
-
     test('captures a rejection, its text, and the forced retry', () async {
       // A future-day scenario so the same-day guard is not what rejects this;
       // the block simply falls outside the plan's day, which the write path
@@ -643,6 +646,112 @@ void main() {
     });
   });
 
+  group('resource release', () {
+    test('releases the model layer after a run', () async {
+      // The harness holds a running runtime, a database and a temp directory,
+      // and the layer may hold a provider connection. A matrix keeps going
+      // after a failure, so anything left open accumulates across cells.
+      final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+      final planDate = evalPlanDateFor(scenario, today);
+      var closed = 0;
+      await runEvalCell(
+        request: requestFor(scenario),
+        model: scriptedTarget(
+          turns: [
+            [draftCall(planDate: planDate, blocks: legalBlocks(planDate))],
+          ],
+          onClose: () async => closed++,
+        ),
+      );
+
+      expect(closed, 1);
+    });
+
+    test('a failing release does not cost the cell its result', () async {
+      // Teardown noise must not be reported as a model result, and one
+      // resource failing to release must not strand the others.
+      final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+      final planDate = evalPlanDateFor(scenario, today);
+      final result = await runEvalCell(
+        request: requestFor(scenario),
+        model: scriptedTarget(
+          turns: [
+            [draftCall(planDate: planDate, blocks: legalBlocks(planDate))],
+          ],
+          onClose: () async => throw StateError('close blew up'),
+        ),
+      );
+
+      expect(result.error, isNull);
+      expect(result.outcome.planPersisted, isTrue);
+      expect(result.jobStatus, 'succeeded');
+    });
+  });
+
+  group('EvalPromptRecorder', () {
+    final inferenceRepo = CloudInferenceWrapper(
+      cloudRepository: MockCloudInferenceRepository(),
+    );
+
+    test('keeps one transcript per conversation', () async {
+      final inner = ScriptedConversationRepository();
+      final recorder = EvalPromptRecorder(inner);
+      final first = recorder.createConversation(systemMessage: 'system A');
+      await recorder.sendMessage(
+        conversationId: first,
+        message: 'user A1',
+        model: 'm',
+        provider: testInferenceProvider(id: 'p', apiKey: 'k'),
+        inferenceRepo: inferenceRepo,
+      );
+      final second = recorder.createConversation(systemMessage: 'system B');
+      await recorder.sendMessage(
+        conversationId: second,
+        message: 'user B1',
+        model: 'm',
+        provider: testInferenceProvider(id: 'p', apiKey: 'k'),
+        inferenceRepo: inferenceRepo,
+      );
+
+      expect(recorder.wakes.map((w) => w.systemPrompt), [
+        'system A',
+        'system B',
+      ]);
+      expect(recorder.wakes.map((w) => w.userMessages), [
+        ['user A1'],
+        ['user B1'],
+      ]);
+      expect(
+        recorder.wakes.every((w) => !w.forcedRetry),
+        isTrue,
+        reason:
+            'Two conversations with one message each is the durable job '
+            'retrying, not the model being forced to call the tool.',
+      );
+    });
+
+    test('a second message in one conversation is a forced retry', () async {
+      final inner = ScriptedConversationRepository();
+      final recorder = EvalPromptRecorder(inner);
+      final id = recorder.createConversation(systemMessage: 'system');
+      for (final message in ['first ask', 'forced follow-up']) {
+        await recorder.sendMessage(
+          conversationId: id,
+          message: message,
+          model: 'm',
+          provider: testInferenceProvider(id: 'p', apiKey: 'k'),
+          inferenceRepo: inferenceRepo,
+        );
+      }
+
+      expect(recorder.wakes.single.forcedRetry, isTrue);
+      expect(recorder.wakes.single.userMessages, [
+        'first ask',
+        'forced follow-up',
+      ]);
+    });
+  });
+
   group('evalPlanDateFor', () {
     test('plans today for a same-day scenario and tomorrow otherwise', () {
       const sameDay = EvalScenario(
@@ -661,6 +770,37 @@ void main() {
         evalPlanDateFor(futureDay, DateTime(2030, 1, 15, 23, 30)),
         DateTime(2030, 1, 16),
       );
+    });
+
+    test('advances by civil date, not by twenty-four hours', () {
+      // On a DST boundary a fixed day-long duration lands at 23:00 the same
+      // date or 01:00 the next, which would hand the cell the wrong day id and
+      // shift every block time by an hour. Month and year ends are the same
+      // normalisation question.
+      const futureDay = EvalScenario(id: 'future', intent: 'x', tasks: []);
+
+      expect(
+        evalPlanDateFor(futureDay, DateTime(2030, 1, 31)),
+        // ignore: avoid_redundant_argument_values — the whole date is the point
+        DateTime(2030, 2, 1),
+      );
+      expect(
+        evalPlanDateFor(futureDay, DateTime(2030, 12, 31)),
+        // ignore: avoid_redundant_argument_values — the whole date is the point
+        DateTime(2031, 1, 1),
+      );
+      for (final anchor in [
+        DateTime(2026, 3, 29, 12),
+        DateTime(2026, 10, 25, 12),
+      ]) {
+        final planDate = evalPlanDateFor(futureDay, anchor);
+        expect(planDate.hour, 0, reason: anchor.toIso8601String());
+        expect(
+          planDate.day,
+          isNot(anchor.day),
+          reason: anchor.toIso8601String(),
+        );
+      }
     });
   });
 

--- a/test/features/daily_os_next/eval/framework/eval_runner_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner_test.dart
@@ -1,0 +1,846 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
+import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/time_service.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import '../../../../helpers/fallbacks.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../widget_test_utils.dart';
+import '../../../agents/test_data/ai_config_factories.dart';
+import '../../../ai_consumption/test_utils.dart';
+import '../../integration/scripted_conversation_repository.dart';
+import 'eval_constraints.dart';
+import 'eval_runner.dart';
+import 'eval_scenario.dart';
+import 'eval_variant.dart';
+
+/// End-to-end coverage of the matrix runner against a **scripted** model, so
+/// the fan-out, capture and scoring all run in the normal unit-test lane with
+/// no provider.
+///
+/// The load-bearing case is the rejection round trip: production rejects an
+/// illegal `draft_day_plan`, hands the failure text back, and the model
+/// retries — so the persisted plan is always legal and only the tool-call log
+/// preserves the fact that it took two tries.
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  // Fixed date so plan dates and the anchored clock are deterministic.
+  final today = DateTime(2030, 1, 15);
+  final tomorrow = DateTime(2030, 1, 16);
+
+  late AiInteractionCaptureTestBench attribution;
+
+  setUp(() async {
+    attribution = AiInteractionCaptureTestBench.create();
+    await setUpTestGetIt(
+      additionalSetup: () {
+        getIt
+          ..registerSingleton<PersistenceLogic>(MockPersistenceLogic())
+          ..registerSingleton<TimeService>(TimeService());
+        attribution.register();
+      },
+    );
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  /// A model target that replays [turns], one per `sendMessage`.
+  ///
+  /// [onOpen] runs inside the cell, after the runner has cleared the
+  /// consumption ledger — the only place a test can stand in for a provider
+  /// reporting usage.
+  EvalModelTarget scriptedTarget({
+    required List<List<ChatCompletionMessageToolCall>> turns,
+    String id = 'scripted',
+    void Function()? onOpen,
+    List<ScriptedConversationRepository>? recordInto,
+  }) => EvalModelTarget(
+    id: id,
+    open: (request) async {
+      onOpen?.call();
+      final repository = ScriptedConversationRepository();
+      turns.forEach(repository.script);
+      recordInto?.add(repository);
+      return EvalLlmLayer(
+        conversationRepository: repository,
+        cloudInferenceRepository: MockCloudInferenceRepository(),
+        profile: testInferenceProfile(
+          id: 'profile-eval',
+          thinkingModelId: 'models/eval',
+        ),
+        model: testAiModel(
+          id: 'model-eval',
+          providerModelId: 'models/eval',
+          inferenceProviderId: 'provider-eval',
+        ),
+        provider: testInferenceProvider(
+          id: 'provider-eval',
+          apiKey: 'provider-key',
+        ),
+      );
+    },
+  );
+
+  Map<String, Object?> block({
+    required DateTime start,
+    required Duration duration,
+    String title = 'Focus block',
+    String? taskId,
+  }) => {
+    'title': title,
+    'categoryId': evalDefaultCategoryId,
+    'start': start.toIso8601String(),
+    'end': start.add(duration).toIso8601String(),
+    'reason': 'Scripted plan block.',
+    'taskId': ?taskId,
+  };
+
+  ChatCompletionMessageToolCall draftCall({
+    required DateTime planDate,
+    required List<Map<String, Object?>> blocks,
+    String id = 'draft-call',
+  }) => scriptedToolCall(
+    id: id,
+    name: DayAgentToolNames.draftDayPlan,
+    args: {'dayId': dayAgentIdForDate(planDate), 'blocks': blocks},
+  );
+
+  /// A single legal morning block for [planDate].
+  List<Map<String, Object?>> legalBlocks(DateTime planDate, {String? taskId}) =>
+      [
+        block(
+          start: planDate.add(const Duration(hours: 10)),
+          duration: const Duration(hours: 1),
+          taskId: taskId,
+        ),
+      ];
+
+  group('runEvalMatrix', () {
+    test(
+      'produces one result per scenario x model x variant x sample',
+      () async {
+        final scenarios = [evalScenarios.first, evalScenarios[1]];
+        final results = await runEvalMatrix(
+          models: [
+            scriptedTarget(
+              id: 'model-a',
+              turns: [
+                [draftCall(planDate: tomorrow, blocks: legalBlocks(tomorrow))],
+              ],
+            ),
+            scriptedTarget(
+              id: 'model-b',
+              turns: [
+                [draftCall(planDate: tomorrow, blocks: legalBlocks(tomorrow))],
+              ],
+            ),
+          ],
+          scenarios: scenarios,
+          samples: 2,
+          today: today,
+        );
+
+        expect(results, hasLength(2 * 2 * 1 * 2));
+        expect(
+          results
+              .map(
+                (r) =>
+                    '${r.request.scenario.id}/${r.request.modelId}/'
+                    '${r.request.variant.id}#${r.request.sample}',
+              )
+              .toSet(),
+          hasLength(8),
+          reason: 'Every cell must be distinguishable in the report.',
+        );
+        expect(
+          results.map((r) => r.request.sample).toSet(),
+          {1, 2},
+          reason: 'Samples are 1-based and both must appear.',
+        );
+      },
+    );
+
+    test('drives every shipped scenario end to end', () async {
+      // The point is not the scores — a scripted model produces the same
+      // block everywhere — but that each fixture can actually be run: its
+      // corpus stubs answer, its capture seeds, its wake reaches a plan. A
+      // fixture that cannot be driven would otherwise only surface during a
+      // paid live run.
+      final results = await runEvalMatrix(
+        models: [
+          EvalModelTarget(
+            id: 'scripted',
+            // 16:00 is inside the 09:00-17:00 contract for every scenario and
+            // after the 15:00 anchor of the same-day one, so a single rule
+            // works across the set.
+            open: (request) async {
+              final repository = ScriptedConversationRepository()
+                ..script([
+                  draftCall(
+                    planDate: request.planDate,
+                    blocks: [
+                      block(
+                        start: request.planDate.add(const Duration(hours: 16)),
+                        duration: const Duration(minutes: 30),
+                      ),
+                    ],
+                  ),
+                ]);
+              return EvalLlmLayer(
+                conversationRepository: repository,
+                cloudInferenceRepository: MockCloudInferenceRepository(),
+                profile: testInferenceProfile(
+                  id: 'profile-eval',
+                  thinkingModelId: 'models/eval',
+                ),
+                model: testAiModel(
+                  id: 'model-eval',
+                  providerModelId: 'models/eval',
+                  inferenceProviderId: 'provider-eval',
+                ),
+                provider: testInferenceProvider(
+                  id: 'provider-eval',
+                  apiKey: 'provider-key',
+                ),
+              );
+            },
+          ),
+        ],
+        today: today,
+      );
+
+      expect(results, hasLength(evalScenarios.length));
+      for (final result in results) {
+        final id = result.request.scenario.id;
+        expect(result.error, isNull, reason: id);
+        expect(result.outcome.planPersisted, isTrue, reason: id);
+        expect(result.jobStatus, 'succeeded', reason: id);
+        expect(
+          result.outcome.rejections,
+          isEmpty,
+          reason: '$id rejected a block that satisfies its own contract',
+        );
+        expect(
+          result.systemPrompt,
+          isNotNull,
+          reason: '$id produced no system prompt to judge',
+        );
+        expect(result.userPrompts, hasLength(1), reason: id);
+      }
+    });
+
+    test('rejects a variant set with no control', () async {
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          variants: const [
+            EvalVariant(id: 'tighter', rationale: 'no control alongside it'),
+          ],
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains(evalBaselineVariantId),
+          ),
+        ),
+      );
+    });
+
+    test('rejects an empty matrix or a sample count below one', () async {
+      expect(
+        () => runEvalMatrix(models: const []),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          scenarios: const [],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => runEvalMatrix(
+          models: [scriptedTarget(turns: const [])],
+          samples: 0,
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+  });
+
+  group('runEvalCell', () {
+    EvalRunRequest requestFor(
+      EvalScenario scenario, {
+      EvalVariant variant = evalBaselineVariant,
+    }) => EvalRunRequest(
+      scenario: scenario,
+      variant: variant,
+      modelId: 'scripted',
+      sample: 1,
+      planDate: evalPlanDateFor(scenario, today),
+    );
+
+    test('captures a rejection, its text, and the forced retry', () async {
+      // A future-day scenario so the same-day guard is not what rejects this;
+      // the block simply falls outside the plan's day, which the write path
+      // rejects outright.
+      final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+      final planDate = evalPlanDateFor(scenario, today);
+      final result = await runEvalCell(
+        request: requestFor(scenario),
+        model: scriptedTarget(
+          turns: [
+            [
+              draftCall(
+                planDate: planDate,
+                id: 'illegal-call',
+                blocks: [
+                  block(
+                    start: planDate.add(const Duration(days: 2, hours: 10)),
+                    duration: const Duration(hours: 1),
+                    title: 'Block on the wrong day',
+                  ),
+                ],
+              ),
+            ],
+            [draftCall(planDate: planDate, blocks: legalBlocks(planDate))],
+          ],
+        ),
+      );
+
+      expect(result.error, isNull);
+      expect(result.outcome.planPersisted, isTrue);
+      expect(
+        result.outcome.blocks.single.title,
+        'Focus block',
+        reason: 'Only the corrected block may survive.',
+      );
+
+      final rejections = result.outcome.rejections.toList();
+      expect(rejections, hasLength(1));
+      expect(rejections.single.name, DayAgentToolNames.draftDayPlan);
+      expect(
+        rejections.single.rejectionMessage,
+        isNotEmpty,
+        reason:
+            'The failure text handed back to the model is the whole signal — '
+            'without it the retry is invisible.',
+      );
+      expect(
+        result.outcome.toolCalls.map((c) => c.accepted),
+        [false, true],
+        reason: 'Order matters: the illegal attempt came first.',
+      );
+      expect(
+        result.forcedDraftRetry,
+        isTrue,
+        reason: 'The second send is the workflow forcing the artifact.',
+      );
+
+      final complied = result.constraints.firstWhere(
+        (c) => c.id == EvalConstraintIds.compliedWithoutRejection,
+      );
+      expect(complied.passed, isFalse);
+      expect(complied.detail, contains('1 rejection'));
+    });
+
+    test('scores a clean run and reports the job as succeeded', () async {
+      final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+      final planDate = evalPlanDateFor(scenario, today);
+      final result = await runEvalCell(
+        request: requestFor(scenario),
+        model: scriptedTarget(
+          turns: [
+            [
+              draftCall(
+                planDate: planDate,
+                blocks: legalBlocks(
+                  planDate,
+                  taskId: 'task-overdue-invoice',
+                ),
+              ),
+            ],
+          ],
+        ),
+      );
+
+      expect(result.error, isNull);
+      expect(result.jobStatus, 'succeeded');
+      expect(
+        result.jobAttempts,
+        0,
+        reason:
+            'The counter records attempts that were charged for a failure; a '
+            'first-time-right job never increments it.',
+      );
+      expect(result.forcedDraftRetry, isFalse);
+      expect(
+        result.constraints
+            .firstWhere(
+              (c) => c.id == EvalConstraintIds.compliedWithoutRejection,
+            )
+            .passed,
+        isTrue,
+      );
+      expect(
+        result.constraints
+            .firstWhere(
+              (c) => c.id == EvalConstraintIds.noFabricatedTaskIds,
+            )
+            .passed,
+        isTrue,
+        reason: 'The placed id is in the scenario corpus.',
+      );
+      expect(
+        result.constraints
+            .firstWhere(
+              (c) => c.id == EvalConstraintIds.requiredWorkPlaced,
+            )
+            .passed,
+        isFalse,
+        reason: 'Two of the three required tasks were never placed.',
+      );
+    });
+
+    test('records an unreachable model instead of aborting the cell', () async {
+      // The live shape of this is a bad model id or missing credentials. One
+      // cell must not cost the whole matrix.
+      final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+      final result = await runEvalCell(
+        request: requestFor(scenario),
+        model: EvalModelTarget(
+          id: 'unreachable',
+          open: (_) async => throw StateError('no credentials'),
+        ),
+      );
+
+      expect(result.error, contains('no credentials'));
+      expect(result.failed, isTrue);
+      expect(result.outcome.planPersisted, isFalse);
+      expect(result.jobStatus, isNull);
+      expect(
+        result.constraints
+            .firstWhere((c) => c.id == EvalConstraintIds.noOverlappingBlocks)
+            .isApplicable,
+        isFalse,
+        reason: 'A run with no plan proves nothing about plan quality.',
+      );
+      expect(
+        result.constraints.map((c) => c.id),
+        containsAll(EvalConstraintIds.all),
+        reason: 'A failed cell still occupies its slot in the report.',
+      );
+    });
+
+    test(
+      'sends the variant config to the model and scores against it',
+      () async {
+        final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+        final planDate = evalPlanDateFor(scenario, today);
+        final repositories = <ScriptedConversationRepository>[];
+        const variant = EvalVariant(
+          id: 'halfDay',
+          rationale: 'Does a tighter contract actually reach the model?',
+          configure: _halfDay,
+        );
+
+        final result = await runEvalCell(
+          request: requestFor(scenario, variant: variant),
+          model: scriptedTarget(
+            recordInto: repositories,
+            turns: [
+              [draftCall(planDate: planDate, blocks: legalBlocks(planDate))],
+            ],
+          ),
+        );
+
+        expect(
+          result.systemPrompt,
+          contains('"capacityMinutes": 240'),
+          reason:
+              'A variant that never reaches the prompt is inert — this is the '
+              'assertion that would catch it.',
+        );
+        expect(repositories.single.lastSystemMessage, result.systemPrompt);
+        expect(
+          result.outcome.inputs.capacityMinutes,
+          240,
+          reason: 'Scoring must use the contract the model was handed.',
+        );
+        expect(result.outcome.inputs.workingHoursEndHour, 13);
+      },
+    );
+
+    test(
+      'passes the ADR 0043 blocked-work data through to the prompt',
+      () async {
+        final scenario = evalScenarios.firstWhere(
+          (s) => s.id == 'blockedChain',
+        );
+        final planDate = evalPlanDateFor(scenario, today);
+        final result = await runEvalCell(
+          request: requestFor(scenario),
+          model: scriptedTarget(
+            turns: [
+              [
+                draftCall(
+                  planDate: planDate,
+                  blocks: legalBlocks(planDate, taskId: 'task-a-root'),
+                ),
+              ],
+            ],
+          ),
+        );
+
+        expect(
+          result.userPrompts.single,
+          contains('task-a-root'),
+          reason:
+              'The corpus must reach the model for the chain to be planned.',
+        );
+        expect(
+          result.userPrompts.single,
+          contains('blockedBy'),
+          reason:
+              'The resolver is what emits the blockedBy annotation; without it '
+              'the blocked scenarios measure nothing.',
+        );
+        expect(
+          result.constraints
+              .firstWhere((c) => c.id == EvalConstraintIds.requiredWorkPlaced)
+              .passed,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'drafts a same-day scenario under a clock anchored to its start hour',
+      () async {
+        final scenario = evalScenarios.firstWhere((s) => s.id == 'lateStart');
+        final planDate = evalPlanDateFor(scenario, today);
+        expect(planDate, today, reason: 'A same-day scenario plans for today.');
+
+        final result = await runEvalCell(
+          request: requestFor(scenario),
+          model: scriptedTarget(
+            turns: [
+              [
+                draftCall(
+                  planDate: planDate,
+                  blocks: [
+                    // 08:00 is before the anchored 15:00 clock, so production's
+                    // same-day guard must reject it.
+                    block(
+                      start: planDate.add(const Duration(hours: 8)),
+                      duration: const Duration(minutes: 30),
+                      title: 'In the past',
+                    ),
+                  ],
+                ),
+              ],
+              [
+                draftCall(
+                  planDate: planDate,
+                  blocks: [
+                    block(
+                      start: planDate.add(const Duration(hours: 16)),
+                      duration: const Duration(minutes: 30),
+                      taskId: 'task-short-invoice',
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        );
+
+        expect(
+          result.outcome.rejections.single.rejectionMessage,
+          isNotNull,
+          reason:
+              'Without the clock anchor the guard is inert and the scenario '
+              'silently stops testing a late start.',
+        );
+        expect(
+          result.outcome.inputs.now,
+          planDate.add(const Duration(hours: 15)),
+        );
+        expect(result.outcome.blocks.single.title, 'Focus block');
+      },
+    );
+
+    test(
+      'attributes consumption events to the run that produced them',
+      () async {
+        final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+        final planDate = evalPlanDateFor(scenario, today);
+        var opened = 0;
+        final model = scriptedTarget(
+          onOpen: () {
+            opened++;
+            if (opened == 1) {
+              attribution.service.recordInteraction(
+                attributionId: 'attr-1',
+                event: makeConsumptionEvent(id: 'evt-run-1'),
+              );
+            }
+          },
+          turns: [
+            [draftCall(planDate: planDate, blocks: legalBlocks(planDate))],
+          ],
+        );
+
+        final first = await runEvalCell(
+          request: requestFor(scenario),
+          model: model,
+          attribution: attribution,
+        );
+        final second = await runEvalCell(
+          request: requestFor(scenario),
+          model: model,
+          attribution: attribution,
+        );
+
+        expect(first.consumption.map((e) => e.id), ['evt-run-1']);
+        expect(
+          second.consumption,
+          isEmpty,
+          reason: "Run 1's usage must not be billed to run 2.",
+        );
+      },
+    );
+
+    test('refuses a scenario that claims a capture it cannot supply', () {
+      const broken = EvalScenario(
+        id: 'broken',
+        intent: 'includeCapture with nothing to submit',
+        tasks: [],
+      );
+
+      expect(
+        () => runEvalCell(
+          request: requestFor(broken),
+          model: scriptedTarget(turns: const []),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('captureTranscript'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('evalPlanDateFor', () {
+    test('plans today for a same-day scenario and tomorrow otherwise', () {
+      const sameDay = EvalScenario(
+        id: 'same',
+        intent: 'x',
+        tasks: [],
+        startHour: 15,
+      );
+      const futureDay = EvalScenario(id: 'future', intent: 'x', tasks: []);
+
+      expect(
+        evalPlanDateFor(sameDay, DateTime(2030, 1, 15, 23, 30)),
+        DateTime(2030, 1, 15),
+      );
+      expect(
+        evalPlanDateFor(futureDay, DateTime(2030, 1, 15, 23, 30)),
+        DateTime(2030, 1, 16),
+      );
+    });
+  });
+
+  group('evalToolCallsFrom', () {
+    AgentMessagePayloadEntity payload(
+      String id,
+      Map<String, dynamic> content,
+    ) =>
+        AgentDomainEntity.agentMessagePayload(
+              id: id,
+              agentId: 'agent-1',
+              createdAt: today,
+              vectorClock: null,
+              content: content,
+            )
+            as AgentMessagePayloadEntity;
+
+    AgentMessageEntity message({
+      required String id,
+      required AgentMessageKind kind,
+      String? toolName,
+      String? errorMessage,
+      String? contentEntryId,
+    }) =>
+        AgentDomainEntity.agentMessage(
+              id: id,
+              agentId: 'agent-1',
+              threadId: 'thread-1',
+              kind: kind,
+              createdAt: today,
+              vectorClock: null,
+              contentEntryId: contentEntryId,
+              metadata: AgentMessageMetadata(
+                runKey: 'run-1',
+                toolName: toolName,
+                errorMessage: errorMessage,
+              ),
+            )
+            as AgentMessageEntity;
+
+    test('pairs each action with its result and keeps the arguments', () {
+      final calls = evalToolCallsFrom([
+        payload('payload-1', {'dayId': 'dayplan-2030-01-16'}),
+        message(
+          id: 'msg-1',
+          kind: AgentMessageKind.action,
+          toolName: DayAgentToolNames.draftDayPlan,
+          contentEntryId: 'payload-1',
+        ),
+        message(
+          id: 'msg-2',
+          kind: AgentMessageKind.toolResult,
+          toolName: DayAgentToolNames.draftDayPlan,
+          errorMessage: 'blocks must stay within the day',
+        ),
+      ]);
+
+      expect(calls, hasLength(1));
+      expect(calls.single.accepted, isFalse);
+      expect(calls.single.rejectionMessage, 'blocks must stay within the day');
+      expect(calls.single.arguments['dayId'], 'dayplan-2030-01-16');
+    });
+
+    test('ignores messages that are not tool traffic', () {
+      final calls = evalToolCallsFrom([
+        message(id: 'msg-1', kind: AgentMessageKind.thought),
+        message(id: 'msg-2', kind: AgentMessageKind.user),
+        message(id: 'msg-3', kind: AgentMessageKind.observation),
+        message(id: 'msg-4', kind: AgentMessageKind.summary),
+        message(id: 'msg-5', kind: AgentMessageKind.system),
+      ]);
+
+      expect(calls, isEmpty);
+    });
+
+    test(
+      'does not attach the previous call arguments to an unpaired result',
+      () {
+        // A tool call whose arguments fail to parse records a result with no
+        // action at all. Pairing blindly would credit it with the last call's
+        // arguments and make the log lie about what was sent.
+        final calls = evalToolCallsFrom([
+          payload('payload-1', {'dayId': 'dayplan-2030-01-16'}),
+          message(
+            id: 'msg-1',
+            kind: AgentMessageKind.action,
+            toolName: DayAgentToolNames.draftDayPlan,
+            contentEntryId: 'payload-1',
+          ),
+          message(
+            id: 'msg-2',
+            kind: AgentMessageKind.toolResult,
+            toolName: DayAgentToolNames.draftDayPlan,
+          ),
+          message(
+            id: 'msg-3',
+            kind: AgentMessageKind.toolResult,
+            toolName: DayAgentToolNames.recordObservations,
+            errorMessage: 'Error: invalid arguments format',
+          ),
+        ]);
+
+        expect(calls, hasLength(2));
+        expect(calls.first.arguments, isNotEmpty);
+        expect(calls.last.arguments, isEmpty);
+        expect(calls.last.accepted, isFalse);
+      },
+    );
+
+    test('reports an action that never got a result as unaccepted', () {
+      final calls = evalToolCallsFrom([
+        payload('payload-1', {'dayId': 'dayplan-2030-01-16'}),
+        message(
+          id: 'msg-1',
+          kind: AgentMessageKind.action,
+          toolName: DayAgentToolNames.draftDayPlan,
+          contentEntryId: 'payload-1',
+        ),
+      ]);
+
+      expect(calls, hasLength(1));
+      expect(calls.single.accepted, isFalse);
+      expect(calls.single.rejectionMessage, 'no tool result was recorded');
+      expect(calls.single.arguments['dayId'], 'dayplan-2030-01-16');
+    });
+
+    test('flushes an orphaned action when the next result is another tool', () {
+      final calls = evalToolCallsFrom([
+        payload('payload-1', {'dayId': 'dayplan-2030-01-16'}),
+        message(
+          id: 'msg-1',
+          kind: AgentMessageKind.action,
+          toolName: DayAgentToolNames.draftDayPlan,
+          contentEntryId: 'payload-1',
+        ),
+        message(
+          id: 'msg-2',
+          kind: AgentMessageKind.action,
+          toolName: DayAgentToolNames.raiseDayStatus,
+        ),
+        message(
+          id: 'msg-3',
+          kind: AgentMessageKind.toolResult,
+          toolName: DayAgentToolNames.raiseDayStatus,
+        ),
+      ]);
+
+      expect(calls.map((c) => c.name), [
+        DayAgentToolNames.draftDayPlan,
+        DayAgentToolNames.raiseDayStatus,
+      ]);
+      expect(calls.first.accepted, isFalse);
+      expect(calls.last.accepted, isTrue);
+    });
+  });
+
+  group('evalConfigFor', () {
+    test('applies the variant on top of the scenario contract', () {
+      final scenario = evalScenarios.firstWhere((s) => s.id == 'crowdedDay');
+
+      expect(
+        evalConfigFor(scenario, evalBaselineVariant).capacityMinutes,
+        scenario.capacityMinutes,
+      );
+      expect(
+        evalConfigFor(
+          scenario,
+          const EvalVariant(id: 'x', rationale: 'x', configure: _halfDay),
+        ).capacityMinutes,
+        240,
+      );
+    });
+  });
+}
+
+/// A tighter contract: half the capacity, mornings only.
+DayAgentConfig _halfDay(DayAgentConfig base) => DayAgentConfig(
+  capacityMinutes: base.capacityMinutes ~/ 2,
+  workingHoursStart: base.workingHoursStart,
+  workingHoursEnd: '13:00',
+  energyBands: base.energyBands,
+  maxRefinementRounds: base.maxRefinementRounds,
+);

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -1,6 +1,7 @@
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
 import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:meta/meta.dart';
 import 'package:mocktail/mocktail.dart';
@@ -145,39 +146,62 @@ class EvalScenario {
     };
   }
 
+  /// The planning contract this scenario asks for, before any variant.
+  DayAgentConfig get baseConfig =>
+      DayAgentConfig(capacityMinutes: capacityMinutes);
+
   /// The scorers' view of what the model was given.
-  EvalFixtureInputs inputsFor(DateTime planDate) => EvalFixtureInputs(
-    dayId: 'dayplan-${planDate.toIso8601String().substring(0, 10)}',
-    planDate: planDate,
-    corpus: [
-      for (final task in tasks)
-        EvalCorpusTask(
-          taskId: task.id,
-          title: task.title,
-          status: _statusString(task.status),
-          blockedBy: task.blockedBy,
-          estimateMinutes: task.estimateMinutes,
-          categoryId: task.categoryId,
-        ),
-    ],
-    decidedTaskIds: decidedTaskIds,
-    // Expected omissions are permitted by construction — a task that must not
-    // be placed is obviously not required to be.
-    permittedOmissions: {...permittedOmissions, ...expectedOmissions},
-    expectedOmissions: expectedOmissions,
-    requiredTaskIds: requiredTaskIds,
-    requiresConflictSurfaced: requiresConflictSurfaced,
-    forbidsInventedWork: forbidsInventedWork,
-    conflictEscalationReasons: conflictEscalationReasons,
-    // Without a capture the task corpus is never rendered, so the only ids
-    // the model can name are its decided ones. The corpus above stays as
-    // ground truth for constraints that need to know what is actually true.
-    visibleTaskIds: includeCapture ? null : {...decidedTaskIds},
-    capacityMinutes: capacityMinutes,
-    now: startHour == null
-        ? null
-        : DateTime(planDate.year, planDate.month, planDate.day, startHour!),
-  );
+  ///
+  /// [config] is the contract actually rendered into the system prompt, so the
+  /// capacity and working hours the scorers grade against are the ones the
+  /// model was told — otherwise a variant that changes the contract would be
+  /// scored against the default one. Defaults to [baseConfig].
+  EvalFixtureInputs inputsFor(
+    DateTime planDate, {
+    DayAgentConfig? config,
+  }) {
+    final effective = config ?? baseConfig;
+    return EvalFixtureInputs(
+      dayId: 'dayplan-${planDate.toIso8601String().substring(0, 10)}',
+      planDate: planDate,
+      corpus: [
+        for (final task in tasks)
+          EvalCorpusTask(
+            taskId: task.id,
+            title: task.title,
+            status: _statusString(task.status),
+            blockedBy: task.blockedBy,
+            estimateMinutes: task.estimateMinutes,
+            categoryId: task.categoryId,
+          ),
+      ],
+      decidedTaskIds: decidedTaskIds,
+      // Expected omissions are permitted by construction — a task that must not
+      // be placed is obviously not required to be.
+      permittedOmissions: {...permittedOmissions, ...expectedOmissions},
+      expectedOmissions: expectedOmissions,
+      requiredTaskIds: requiredTaskIds,
+      requiresConflictSurfaced: requiresConflictSurfaced,
+      forbidsInventedWork: forbidsInventedWork,
+      conflictEscalationReasons: conflictEscalationReasons,
+      // Without a capture the task corpus is never rendered, so the only ids
+      // the model can name are its decided ones. The corpus above stays as
+      // ground truth for constraints that need to know what is actually true.
+      visibleTaskIds: includeCapture ? null : {...decidedTaskIds},
+      capacityMinutes: effective.capacityMinutes,
+      workingHoursStartHour: evalWholeHourOf(
+        effective.workingHoursStart,
+        field: 'workingHoursStart',
+      ),
+      workingHoursEndHour: evalWholeHourOf(
+        effective.workingHoursEnd,
+        field: 'workingHoursEnd',
+      ),
+      now: startHour == null
+          ? null
+          : DateTime(planDate.year, planDate.month, planDate.day, startHour!),
+    );
+  }
 
   /// Journal [Task] rows for the corpus reads.
   List<Task> tasksFor(DateTime planDate) => [
@@ -251,6 +275,29 @@ class EvalScenario {
       entryText: EntryText(plainText: spec.title),
     );
   }
+}
+
+/// Parses `HH:mm` down to a whole hour, rejecting anything else.
+///
+/// [EvalFixtureInputs] carries working hours as integers, so a config of
+/// `09:30` would silently be graded as `09:00` — a scorer half an hour more
+/// lenient than the contract the model was handed. Rather than ship that
+/// leniency invisibly, a non-whole hour is a configuration error.
+int evalWholeHourOf(String value, {required String field}) {
+  final parts = value.split(':');
+  final hour = parts.length == 2 ? int.tryParse(parts.first) : null;
+  final minute = parts.length == 2 ? int.tryParse(parts.last) : null;
+  if (hour == null || minute == null || hour < 0 || hour > 23) {
+    throw ArgumentError.value(value, field, 'expected HH:mm');
+  }
+  if (minute != 0) {
+    throw ArgumentError.value(
+      value,
+      field,
+      'the eval grades working hours as whole hours; use HH:00',
+    );
+  }
+  return hour;
 }
 
 /// A [TaskDependencyResolver] that answers from a fixture instead of the

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
 
 import 'eval_scenario.dart';
 
@@ -394,5 +395,78 @@ void main() {
     final middle = tasks.firstWhere((t) => t.id == 'task-b-middle');
 
     expect(middle.data.status, isA<TaskBlocked>());
+  });
+
+  test('every scenario claiming a capture can actually supply one', () {
+    // A scenario with includeCapture but no transcript would silently become
+    // its no-capture twin: the corpus would never be rendered while the
+    // scorers still believed every task id was visible.
+    for (final scenario in evalScenarios) {
+      if (!scenario.includeCapture) continue;
+      expect(
+        scenario.captureTranscript?.trim(),
+        isNotEmpty,
+        reason: scenario.id,
+      );
+    }
+  });
+
+  group('inputsFor with a variant config', () {
+    test('scores against the contract the model was handed', () {
+      final inputs = byId('crowdedDay').inputsFor(
+        planDate,
+        config: const DayAgentConfig(
+          capacityMinutes: 240,
+          workingHoursStart: '10:00',
+          workingHoursEnd: '14:00',
+        ),
+      );
+
+      expect(inputs.capacityMinutes, 240);
+      expect(inputs.workingHoursStartHour, 10);
+      expect(inputs.workingHoursEndHour, 14);
+    });
+
+    test('defaults to the scenario contract', () {
+      final scenario = byId('crowdedDay');
+      final inputs = scenario.inputsFor(planDate);
+
+      expect(inputs.capacityMinutes, scenario.capacityMinutes);
+      expect(inputs.workingHoursStartHour, 9);
+      expect(inputs.workingHoursEndHour, 17);
+    });
+  });
+
+  group('evalWholeHourOf', () {
+    test('reads a whole hour', () {
+      expect(evalWholeHourOf('09:00', field: 'start'), 9);
+      expect(evalWholeHourOf('0:00', field: 'start'), 0);
+    });
+
+    test('refuses a part-hour rather than silently rounding it down', () {
+      // Working hours are graded as integers, so 09:30 would be scored as
+      // 09:00 — half an hour more lenient than the contract the model was
+      // given.
+      expect(
+        () => evalWholeHourOf('09:30', field: 'workingHoursStart'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('whole hours'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses malformed input', () {
+      for (final bad in ['9', '09:00:00', 'nine', '24:00', '', ':']) {
+        expect(
+          () => evalWholeHourOf(bad, field: 'workingHoursEnd'),
+          throwsA(isA<ArgumentError>()),
+          reason: bad,
+        );
+      }
+    });
   });
 }

--- a/test/features/daily_os_next/eval/framework/eval_variant.dart
+++ b/test/features/daily_os_next/eval/framework/eval_variant.dart
@@ -1,0 +1,59 @@
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
+import 'package:meta/meta.dart';
+
+/// A named change to the planning contract the model is told about.
+///
+/// Variants are a matrix dimension rather than a separate run, so one pass
+/// yields the A/B directly instead of two runs that may also differ in model,
+/// sampling, or fixture. [evalBaselineVariantId] is mandatory in any variant
+/// set (`runEvalMatrix` enforces it): a delta without a control measures
+/// nothing.
+///
+/// Scope is deliberately narrow. [DayAgentConfig] is the only prompt input the
+/// pipeline harness can vary without touching production code — it renders
+/// into the system prompt's `Planning defaults:` block — so that is what a
+/// variant may change. Swapping a prompt section or reordering context needs a
+/// production seam that does not exist yet.
+@immutable
+class EvalVariant {
+  const EvalVariant({
+    required this.id,
+    required this.rationale,
+    this.configure,
+  });
+
+  final String id;
+
+  /// What this variant is trying to find out. Read this before the config.
+  final String rationale;
+
+  /// Transforms the config derived from the scenario. Null leaves it alone.
+  final DayAgentConfig Function(DayAgentConfig base)? configure;
+
+  /// The config this variant hands the model, given the scenario's own.
+  DayAgentConfig apply(DayAgentConfig base) => configure?.call(base) ?? base;
+}
+
+/// Id of the mandatory control variant.
+const String evalBaselineVariantId = 'baseline';
+
+/// Production defaults, unchanged — the control every other variant is read
+/// against.
+const EvalVariant evalBaselineVariant = EvalVariant(
+  id: evalBaselineVariantId,
+  rationale:
+      'Production planning defaults, unchanged. Every other variant is a '
+      'delta against this.',
+);
+
+/// The default variant set: control only.
+///
+/// Deliberately not seeded with speculative variants. A variant that tightens
+/// the contract also changes what the *scenarios* ask for: `crowdedDay`
+/// requires three tasks totalling 300 minutes, so halving capacity makes
+/// `requiredWorkPlaced` and `withinCapacity` mutually unsatisfiable and the
+/// cell fails whatever the model does — a result that reads as a finding but
+/// is an artefact of the fixture. Variants are worth adding once a judged
+/// baseline run says which part of the prompt is actually weak, and each one
+/// has to be checked against the scenarios it will run under.
+const List<EvalVariant> evalVariants = [evalBaselineVariant];

--- a/test/features/daily_os_next/eval/framework/eval_variant_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_variant_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
+
+import 'eval_variant.dart';
+
+/// The variant dimension only means anything if the control is guaranteed and
+/// a variant's transform actually reaches the config the model is told about.
+void main() {
+  // ignore: avoid_redundant_argument_values
+  const base = DayAgentConfig(capacityMinutes: 480);
+
+  group('EvalVariant.apply', () {
+    test('the baseline leaves the scenario contract untouched', () {
+      final applied = evalBaselineVariant.apply(base);
+
+      expect(applied.capacityMinutes, base.capacityMinutes);
+      expect(applied.workingHoursStart, base.workingHoursStart);
+      expect(applied.workingHoursEnd, base.workingHoursEnd);
+    });
+
+    test('a configured variant transforms the contract it is given', () {
+      const variant = EvalVariant(
+        id: 'shortDay',
+        rationale: 'Does a tighter budget change what gets dropped?',
+        configure: _shortDay,
+      );
+
+      final applied = variant.apply(base);
+
+      expect(applied.capacityMinutes, 240);
+      expect(applied.workingHoursEnd, '13:00');
+    });
+
+    test(
+      'the transform reads the scenario contract rather than the default',
+      () {
+        const variant = EvalVariant(
+          id: 'shortDay',
+          rationale: 'x',
+          configure: _shortDay,
+        );
+
+        expect(
+          variant
+              .apply(const DayAgentConfig(capacityMinutes: 600))
+              .capacityMinutes,
+          300,
+          reason:
+              'A variant is a delta on the scenario, not a fixed replacement — '
+              'a scenario with an unusual capacity must still be halved from '
+              'its own number.',
+        );
+      },
+    );
+  });
+
+  group('evalVariants', () {
+    test('always contains the control', () {
+      expect(
+        evalVariants.where((v) => v.id == evalBaselineVariantId),
+        hasLength(1),
+      );
+    });
+
+    test('ids are unique', () {
+      expect(
+        evalVariants.map((v) => v.id).toSet(),
+        hasLength(evalVariants.length),
+        reason: 'Duplicate ids would collapse two cells into one report row.',
+      );
+    });
+
+    test('every variant states what it is trying to find out', () {
+      for (final variant in evalVariants) {
+        expect(variant.rationale.trim(), isNotEmpty, reason: variant.id);
+      }
+    });
+  });
+}
+
+DayAgentConfig _shortDay(DayAgentConfig base) => DayAgentConfig(
+  capacityMinutes: base.capacityMinutes ~/ 2,
+  workingHoursStart: base.workingHoursStart,
+  workingHoursEnd: '13:00',
+  energyBands: base.energyBands,
+  maxRefinementRounds: base.maxRefinementRounds,
+);

--- a/test/features/daily_os_next/integration/day_agent_durable_jobs_smoke_test.dart
+++ b/test/features/daily_os_next/integration/day_agent_durable_jobs_smoke_test.dart
@@ -1,27 +1,20 @@
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/ai/conversation/conversation_manager.dart';
-import 'package:lotti/features/ai/conversation/conversation_repository.dart';
-import 'package:lotti/features/ai/model/ai_config.dart';
-import 'package:lotti/features/ai/model/inference_usage.dart';
-import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_identity.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
-import 'package:openai_dart/openai_dart.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../agents/test_data/ai_config_factories.dart';
 import '../services/day_processing_test_db.dart';
 import 'day_agent_pipeline_harness.dart';
+import 'scripted_conversation_repository.dart';
 
 /// End-to-end smoke test for the ADR 0032 durable draft/refine pipeline.
 ///
@@ -49,11 +42,11 @@ void main() {
   final dayDate = DateTime(2030, 1, 15);
   final dayId = dayAgentIdForDate(dayDate);
 
-  late _ScriptedConversationRepository conversationRepository;
+  late ScriptedConversationRepository conversationRepository;
   late DayAgentPipelineHarness harness;
 
   setUp(() {
-    conversationRepository = _ScriptedConversationRepository();
+    conversationRepository = ScriptedConversationRepository();
     harness = DayAgentPipelineHarness.create(
       now: now,
       conversationRepository: conversationRepository,
@@ -80,8 +73,8 @@ void main() {
     'orchestrator/workflow chain, with only the LLM response scripted',
     () async {
       // ── Draft ────────────────────────────────────────────────────────────
-      conversationRepository.toolCalls = [
-        _toolCall(
+      conversationRepository.script([
+        scriptedToolCall(
           id: 'draft-call',
           name: DayAgentToolNames.draftDayPlan,
           args: {
@@ -99,7 +92,7 @@ void main() {
             ],
           },
         ),
-      ];
+      ]);
 
       final draft = await harness.realDayAgent.draftDayPlan(
         captureId: const CaptureId(''),
@@ -125,8 +118,8 @@ void main() {
       expect(identity, isA<AgentIdentityEntity>());
 
       // ── Refine ───────────────────────────────────────────────────────────
-      conversationRepository.toolCalls = [
-        _toolCall(
+      conversationRepository.script([
+        scriptedToolCall(
           id: 'refine-call',
           name: DayAgentToolNames.proposePlanDiff,
           args: {
@@ -149,7 +142,7 @@ void main() {
             ],
           },
         ),
-      ];
+      ]);
 
       final diff = await harness.realDayAgent.proposePlanDiff(
         currentPlan: draft,
@@ -177,8 +170,8 @@ void main() {
       // The coordinator identity must exist for a digest to run under it.
       final coordinator = await harness.dayAgentService
           .getOrCreatePlannerAgent();
-      conversationRepository.toolCalls = [
-        _toolCall(
+      conversationRepository.script([
+        scriptedToolCall(
           id: 'issue-call',
           name: DayAgentToolNames.issueDayDirective,
           args: {
@@ -195,7 +188,7 @@ void main() {
             'attentionNotes': ['Light day after two heavy ones.'],
           },
         ),
-      ];
+      ]);
       final digestRunKey = harness.orchestrator.enqueueManualWake(
         agentId: coordinator.agentId,
         reason: dayAgentDigestReason,
@@ -227,8 +220,8 @@ void main() {
       expect(nextDigest!.status, ScheduledWakeStatus.pending);
 
       // ── A draft wake for the same day sees the directive ─────────────────
-      conversationRepository.toolCalls = [
-        _toolCall(
+      conversationRepository.script([
+        scriptedToolCall(
           id: 'draft-call',
           name: DayAgentToolNames.draftDayPlan,
           args: {
@@ -246,7 +239,7 @@ void main() {
             ],
           },
         ),
-      ];
+      ]);
       final draft = await harness.realDayAgent.draftDayPlan(
         captureId: const CaptureId(''),
         decidedTaskIds: const [],
@@ -266,8 +259,8 @@ void main() {
       final dayAgent = await harness.agentRepository.getEntity(
         perDayAgentId(dayId),
       );
-      conversationRepository.toolCalls = [
-        _toolCall(
+      conversationRepository.script([
+        scriptedToolCall(
           id: 'status-call',
           name: DayAgentToolNames.raiseDayStatus,
           args: {
@@ -277,7 +270,7 @@ void main() {
             'note': 'The afternoon filled up.',
           },
         ),
-      ];
+      ]);
       final statusRunKey = harness.orchestrator.enqueueManualWake(
         agentId: (dayAgent! as AgentIdentityEntity).agentId,
         reason: dayAgentDraftingReason,
@@ -302,76 +295,4 @@ void main() {
       expect(events.single.agentId, perDayAgentId(dayId));
     },
   );
-}
-
-ChatCompletionMessageToolCall _toolCall({
-  required String id,
-  required String name,
-  required Map<String, Object?> args,
-}) {
-  return ChatCompletionMessageToolCall(
-    id: id,
-    type: ChatCompletionMessageToolCallType.function,
-    function: ChatCompletionMessageFunctionCall(
-      name: name,
-      arguments: jsonEncode(args),
-    ),
-  );
-}
-
-/// Fake, in-process [ConversationRepository]: applies the scripted
-/// [toolCalls] through the *real* `DayAgentStrategy`/tool dispatch (so real
-/// production tool handlers run), without any network call. Mirrors
-/// `_ConversationHarness` in `day_agent_workflow_test.dart`.
-class _ScriptedConversationRepository extends ConversationRepository {
-  final Map<String, ConversationManager> _managers = {};
-  int _createdCount = 0;
-
-  List<ChatCompletionMessageToolCall> toolCalls = const [];
-  String? lastUserMessage;
-
-  @override
-  String createConversation({String? systemMessage, int maxTurns = 20}) {
-    _createdCount++;
-    final id = 'conversation-$_createdCount';
-    _managers[id] = ConversationManager(conversationId: id, maxTurns: maxTurns)
-      ..initialize(systemMessage: systemMessage);
-    return id;
-  }
-
-  @override
-  ConversationManager? getConversation(String conversationId) =>
-      _managers[conversationId];
-
-  @override
-  Future<InferenceUsage?> sendMessage({
-    required String conversationId,
-    required String message,
-    required String model,
-    required AiConfigInferenceProvider provider,
-    required InferenceRepositoryInterface inferenceRepo,
-    List<ChatCompletionTool>? tools,
-    ChatCompletionToolChoiceOption? toolChoice,
-    double temperature = 0.7,
-    ConversationStrategy? strategy,
-    String? consumptionAgentId,
-    String? consumptionTaskId,
-    String? consumptionCategoryId,
-    String? consumptionWakeRunKey,
-    String? consumptionThreadId,
-    bool rethrowInferenceErrors = false,
-  }) async {
-    lastUserMessage = message;
-    final manager = _managers[conversationId]!..addUserMessage(message);
-    if (toolCalls.isNotEmpty) {
-      manager.addAssistantMessage(toolCalls: toolCalls);
-      await strategy!.processToolCalls(toolCalls: toolCalls, manager: manager);
-    }
-    return null;
-  }
-
-  @override
-  void deleteConversation(String conversationId) {
-    _managers.remove(conversationId)?.dispose();
-  }
 }

--- a/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
+++ b/test/features/daily_os_next/integration/day_agent_pipeline_harness.dart
@@ -18,6 +18,7 @@ import 'package:lotti/features/agents/wake/wake_runner.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_directive_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
@@ -30,6 +31,7 @@ import 'package:lotti/features/daily_os_next/services/day_processing_outbox_proc
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_job_wiring.dart';
+import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -67,12 +69,25 @@ class DayAgentPipelineHarness {
     required this.runtime,
     required this.realDayAgent,
     required this.dayAgentService,
+    required this.planService,
   });
 
   /// Builds the full pipeline. [now] seeds template timestamps; [profile],
   /// [model], and [provider] are the inference configs the workflow resolves
   /// (the template's profile points at [profile], whose thinking model must
   /// equal [model]'s `providerModelId`, which must resolve to [provider]).
+  ///
+  /// [dependencyResolver] is the ADR 0043 blocker resolver. Production wires
+  /// it unconditionally (`agent_workflow_providers.dart`), and the workflow
+  /// gates *both* the corpus's `blockedBy` annotation and the prompt's
+  /// blocked-work rule on it being non-null — so leaving it null does not
+  /// merely hide blocked tasks, it sends a materially different prompt than
+  /// production does. Callers that care what the model was told should pass
+  /// one (an empty fixture resolver is enough when no task is blocked).
+  ///
+  /// [config] renders into the system prompt's planning defaults, so it is
+  /// the lever for varying the capacity/working-hours contract the model is
+  /// given.
   ///
   /// With [logToStdout] the otherwise-swallowed domain logs are printed —
   /// useful for live eval runs where the model's behavior is the thing
@@ -84,6 +99,8 @@ class DayAgentPipelineHarness {
     required AiConfigInferenceProfile profile,
     required AiConfigModel model,
     required AiConfigInferenceProvider provider,
+    TaskDependencyResolver? dependencyResolver,
+    DayAgentConfig config = const DayAgentConfig(),
     bool logToStdout = false,
   }) {
     final root = Directory.systemTemp.createTempSync('day-agent-pipeline-');
@@ -245,6 +262,8 @@ class DayAgentPipelineHarness {
       captureService: captureService,
       planService: planService,
       directiveService: directiveService,
+      dependencyResolver: dependencyResolver,
+      config: config,
       domainLogger: domainLogger,
     );
 
@@ -330,6 +349,7 @@ class DayAgentPipelineHarness {
       runtime: runtime,
       realDayAgent: realDayAgent,
       dayAgentService: dayAgentService,
+      planService: planService,
     );
   }
 
@@ -345,6 +365,11 @@ class DayAgentPipelineHarness {
   final DayProcessingRuntime runtime;
   final RealDayAgent realDayAgent;
   final DayAgentService dayAgentService;
+
+  /// The plan read/write service, exposed so callers can read the persisted
+  /// [DayPlanEntity] (and its `PlannedBlock`s) through the production read
+  /// path rather than reaching into the repository.
+  final DayAgentPlanService planService;
 
   /// Stops the runtime/orchestrator, closes the outbox, and deletes the
   /// temp directory backing it.

--- a/test/features/daily_os_next/integration/scripted_conversation_repository.dart
+++ b/test/features/daily_os_next/integration/scripted_conversation_repository.dart
@@ -1,0 +1,109 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:lotti/features/ai/conversation/conversation_manager.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/inference_usage.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+/// Fake, in-process [ConversationRepository]: replays scripted tool calls
+/// through the *real* strategy/tool dispatch, so production tool handlers,
+/// parsers and guards all run without a network call.
+///
+/// Turns are a queue, not a single value, because one wake can send more than
+/// one message: when the model fails to produce the wake's required artifact,
+/// `DayAgentWorkflow` issues a second `sendMessage` to force it. Scripting an
+/// illegal first turn followed by a legal second is therefore how a
+/// rejection-then-correction round trip is exercised offline — the shape the
+/// eval's guarded constraints are scored on.
+///
+/// A send with nothing left in the queue yields no tool calls, which is how
+/// production behaves when a model answers in prose: the workflow's forced
+/// retry fires and, still empty-handed, the wake fails.
+class ScriptedConversationRepository extends ConversationRepository {
+  final Map<String, ConversationManager> _managers = {};
+  final Queue<List<ChatCompletionMessageToolCall>> _turns = Queue();
+  var _createdCount = 0;
+
+  /// Every user message sent, in order.
+  final List<String> userMessages = [];
+
+  /// System prompt of the most recently created conversation.
+  String? lastSystemMessage;
+
+  /// The most recent user message, or null when nothing has been sent.
+  String? get lastUserMessage =>
+      userMessages.isEmpty ? null : userMessages.last;
+
+  /// Turns scripted but not yet consumed.
+  int get pendingTurns => _turns.length;
+
+  /// Queues one model turn. Call once per expected `sendMessage`.
+  void script(List<ChatCompletionMessageToolCall> toolCalls) =>
+      _turns.add(toolCalls);
+
+  @override
+  String createConversation({String? systemMessage, int maxTurns = 20}) {
+    _createdCount++;
+    final id = 'conversation-$_createdCount';
+    lastSystemMessage = systemMessage;
+    _managers[id] = ConversationManager(conversationId: id, maxTurns: maxTurns)
+      ..initialize(systemMessage: systemMessage);
+    return id;
+  }
+
+  @override
+  ConversationManager? getConversation(String conversationId) =>
+      _managers[conversationId];
+
+  @override
+  Future<InferenceUsage?> sendMessage({
+    required String conversationId,
+    required String message,
+    required String model,
+    required AiConfigInferenceProvider provider,
+    required InferenceRepositoryInterface inferenceRepo,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+    double temperature = 0.7,
+    ConversationStrategy? strategy,
+    String? consumptionAgentId,
+    String? consumptionTaskId,
+    String? consumptionCategoryId,
+    String? consumptionWakeRunKey,
+    String? consumptionThreadId,
+    bool rethrowInferenceErrors = false,
+  }) async {
+    userMessages.add(message);
+    final manager = _managers[conversationId]!..addUserMessage(message);
+    final toolCalls = _turns.isEmpty
+        ? const <ChatCompletionMessageToolCall>[]
+        : _turns.removeFirst();
+    if (toolCalls.isNotEmpty) {
+      manager.addAssistantMessage(toolCalls: toolCalls);
+      await strategy!.processToolCalls(toolCalls: toolCalls, manager: manager);
+    }
+    return null;
+  }
+
+  @override
+  void deleteConversation(String conversationId) {
+    _managers.remove(conversationId)?.dispose();
+  }
+}
+
+/// Builds one scripted tool call with JSON-encoded [args].
+ChatCompletionMessageToolCall scriptedToolCall({
+  required String id,
+  required String name,
+  required Map<String, Object?> args,
+}) => ChatCompletionMessageToolCall(
+  id: id,
+  type: ChatCompletionMessageToolCallType.function,
+  function: ChatCompletionMessageFunctionCall(
+    name: name,
+    arguments: jsonEncode(args),
+  ),
+);


### PR DESCRIPTION
Runs scenario × model × variant × sample through the **real** ADR 0032 pipeline via `DayAgentPipelineHarness` — outbox, runtime, executor, orchestrator, workflow and plan writer are all production code, and only the inference layer is injected. That is what lets the same runner drive a scripted model in ordinary CI and a live provider behind an opt-in flag later. Each cell gets its own harness, so no run can read another's plan, jobs or tool log, and a cell that fails is recorded rather than aborting the matrix.

Closes the third task of the day-planning eval epic. Test-only: nothing under `lib/` changes except the feature README.

## Why the runner is more than a loop

The write path rejects an illegal `draft_day_plan` outright and hands the failure text back to the model, which retries. So the persisted plan is **always legal**, and a plan that only became legal on the second attempt is indistinguishable from a first-time-right one if you look at the plan alone. The rejection text is where the guarded constraints are actually scored.

No production seam was needed for it: `DayAgentStrategy` already writes an `action` message (arguments as its payload) before each tool call and a `toolResult` after it, carrying the rejection text in `metadata.errorMessage`. The runner reconstructs the ordered log from those.

## Two harness gaps this closes

**The ADR 0043 dependency resolver was never wired.** This is wider than "the blocked scenarios don't work". Production wires it unconditionally (`agent_workflow_providers.dart:195`), and `DayAgentWorkflow` gates *both* the corpus's `blockedBy` annotation *and* whether the blocked-work rule reaches the prompt at all on it being non-null. So **every** scenario merged so far was being sent a materially different prompt than the app sends. The runner now always passes one — an empty fixture map when a scenario has no blockers.

**Capture submission runs a second wake.** `RealDayAgent.submitCapture` enqueues a `parseCapture` job that the runtime drains as its own wake, with its own conversation, prompt and tool calls. The first version of the runner merged both into one record: the system prompt was overwritten by the second conversation and the tool-call log mixed the two. The runner now seeds the `CaptureEntity` directly, without the parse job, so one cell is one drafting wake — which is the unit being measured, and halves the live cost per cell.

*Consequence worth stating plainly: the eval does not measure capture-parse quality at all. That would need its own scenario type.*

## Other details that carry the design

- **The system prompt is never persisted** — it goes straight to `createConversation` — so it is captured by wrapping the caller's `ConversationRepository`. The same wrapper yields the forced-retry signal: a second `sendMessage` on a drafting wake means the model finished its turn without calling `draft_day_plan`.
- **Same-day scenarios run under a moving anchored clock** (`anchoredAt + stopwatch.elapsed`), not `Clock.fixed`. The plan date has to be the clock's local day or production's same-day guard is inert and the scenario silently stops testing a late start — but the pipeline's job-await soft cap is itself a `clock.now()` deadline, so a frozen clock would turn a hang into an infinite wait. Recorded in `test/README.md`.
- **Working hours are validated as whole hours.** `EvalFixtureInputs` carries them as integers, so a `09:30` config would be graded as `09:00` — half an hour more lenient than the contract the model was handed. That is now a configuration error rather than silent leniency.
- **The scripted conversation repository moved out of the smoke test** into a shared helper with a turn queue. The queue is what makes the rejection-then-correction round trip scriptable offline: turn 1 illegal, workflow forces the artifact, turn 2 legal.

## Variants

A variant transforms the `DayAgentConfig` a scenario asks for, which is what renders into the system prompt's planning defaults — and the same effective config is what the scorers grade against, so a variant can never be graded against a contract the model was not given. `runEvalMatrix` refuses a variant set without `baseline`.

The shipped set is **the control alone**, deliberately. A variant that tightens the contract also changes what the scenarios ask for: `crowdedDay` requires three tasks totalling 300 minutes, so halving capacity makes `requiredWorkPlaced` and `withinCapacity` mutually unsatisfiable and the cell fails whatever the model does — a result that reads as a finding but is an artefact of the fixture. Real variants should wait for the first judged run to say which part of the prompt is weak.

## Verification

- `fvm dart analyze lib test integration_test` — clean.
- 134 tests in `test/features/daily_os_next/eval/`, all provider-free and in the normal lane. Includes a run of **every shipped scenario end to end** against a scripted model, which proves each fixture is actually drivable — a fixture that cannot be run would otherwise only surface during a paid live run.
- The rejection round trip is asserted directly: illegal block → rejection recorded with its text → forced retry → corrected plan persisted, with `compliedWithoutRejection` failing.
- 1307 tests re-run across the suites touching the shared `AiInteractionCaptureTestBench` and pipeline harness changes.

## Known scope boundaries

- Nothing here has been judged. `EvalRunResult` has never been read by a report, so its shape is unproven; that is the next task.
- A model that never calls `draft_day_plan` is classified `providerBusy` and retried up to `maxAttempts=5` with exponential backoff. Real production behaviour the eval inherits, and it means a badly-behaved model costs roughly ten inference calls per cell — the live entry point needs to budget for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a day-planning evaluation matrix runner with per-cell model/variant execution, structured results, and graceful continuation on cell failures.
  * Added evaluation instrumentation for prompt capture, tool-call outcomes, forced retries, plan/job status, and AI consumption tracking.
  * Introduced configurable evaluation variants (including a required baseline) and variant-aware planning settings.
  * Added reusable scripted conversation support for integration testing.

* **Documentation**
  * Updated evaluation documentation and clarified same-day matrix timing rules.

* **Tests**
  * Expanded end-to-end and unit coverage for matrix execution, scoring inputs, retries, timing/clock behavior, tool-call reconstruction, and harness integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->