### PR TITLE
test: score fabricated calendar blocks in the day-planning eval

### DIFF
--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -279,14 +279,23 @@ therefore split:
 
 | scored on | constraints |
 | --- | --- |
-| the persisted plan | overlap, capacity (as written *and* as estimated), working hours, estimate fidelity, decided tasks placed, required work placed, expected omissions honoured, conflict surfaced, blocker-before-blocked, fabricated task ids, fabricated history, duplicate ids |
+| the persisted plan | overlap, capacity (as written *and* as estimated), working hours, estimate fidelity, decided tasks placed, required work placed, expected omissions honoured, conflict surfaced, blocker-before-blocked, fabricated task ids, fabricated calendar blocks, fabricated history, duplicate ids |
 | the rejection count | whether the model complied without being corrected |
 
-A run that made **no tool calls at all** is inapplicable for the rejection
+A run that never attempted `draft_day_plan` is inapplicable for the rejection
 constraint too, not a pass: an empty rejection list would otherwise read as
-"accepted on the first attempt", so an unreachable model — or one that answered
-in prose and never called the tool — would collect compliance credit it did
-nothing to earn.
+"accepted on the first attempt", so a model that was unreachable, answered in
+prose, or called only `raise_day_status` and stopped would collect compliance
+credit it did nothing to earn.
+
+`noFabricatedCalendarBlocks` is the one constraint that reads block *type*.
+`PlannedBlockType.cal` means "imported calendar event" and the plan editor
+refuses in-app edits to one, but the day agent is shown no calendar events at
+all — `calendarBlocks` is a deferred parameter `RealDayAgent` drops, and no
+context section renders events — so every `cal` block the model emits asserts
+an import that never happened. It also matters for the past-start guard, which
+exempts `cal` alone: that exemption is how a model plans the past without being
+rejected.
 
 A constraint that reads the plan is **inapplicable when no plan was
 persisted** — an empty block list would otherwise read as "no overlaps,

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -282,6 +282,12 @@ therefore split:
 | the persisted plan | overlap, capacity (as written *and* as estimated), working hours, estimate fidelity, decided tasks placed, required work placed, expected omissions honoured, conflict surfaced, blocker-before-blocked, fabricated task ids, fabricated history, duplicate ids |
 | the rejection count | whether the model complied without being corrected |
 
+A run that made **no tool calls at all** is inapplicable for the rejection
+constraint too, not a pass: an empty rejection list would otherwise read as
+"accepted on the first attempt", so an unreachable model — or one that answered
+in prose and never called the tool — would collect compliance credit it did
+nothing to earn.
+
 A constraint that reads the plan is **inapplicable when no plan was
 persisted** — an empty block list would otherwise read as "no overlaps,
 nothing fabricated, every omission honoured" and hand a failed run a clean

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1,4 +1,5 @@
 import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 
 import 'eval_models.dart';
 
@@ -730,10 +731,20 @@ EvalConstraintResult scoreNoFabricatedCalendarBlocks(EvalRunOutcome outcome) {
       if (block.type == PlannedBlockType.cal) block,
   ];
   if (calendarBlocks.isEmpty) {
-    return const EvalConstraintResult.notApplicable(
-      id,
-      'the plan claims no calendar events',
-    );
+    // A plan with real blocks and no calendar claim is a *pass*, not an
+    // absence of evidence: the prompt explicitly offers `cal` as the way to
+    // place work before the current time, so declining it is the behaviour
+    // being measured. Only a plan with nothing scheduled says nothing.
+    final scheduled = _scheduled(outcome);
+    return scheduled.isEmpty
+        ? const EvalConstraintResult.notApplicable(id, 'no scheduled blocks')
+        : EvalConstraintResult(
+            id: id,
+            passed: true,
+            detail:
+                '${scheduled.length} scheduled block(s), none claiming to be '
+                'a calendar event',
+          );
   }
   final now = outcome.inputs.now;
   final described = [
@@ -762,17 +773,20 @@ EvalConstraintResult scoreNoFabricatedCalendarBlocks(EvalRunOutcome outcome) {
 /// rejections it collected on the way.
 EvalConstraintResult scoreCompliedWithoutRejection(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.compliedWithoutRejection;
-  if (outcome.toolCalls.isEmpty) {
-    // A run that called nothing cannot have complied with anything. Without
-    // this the empty rejection list reads as "accepted on the first attempt",
-    // so a model that was never reached — or that answered in prose and never
-    // called the tool — collects a compliance *pass* it did nothing to earn,
-    // and the leaderboard rewards failing loudest. Not calling the required
-    // tool is a real failure, but it is the wake's failure and shows up in the
-    // job status, not in this constraint.
+  final attemptedDraft = outcome.toolCalls.any(
+    (call) => call.name == DayAgentToolNames.draftDayPlan,
+  );
+  if (!attemptedDraft) {
+    // A run that never reached for the required tool cannot have complied with
+    // anything. Without this the empty rejection list reads as "accepted on
+    // the first attempt", so a model that was never reached, answered in
+    // prose, or called only `raise_day_status` and stopped, collects a
+    // compliance *pass* it did nothing to earn — and aggregate scores reward
+    // failing loudest. Failing to call the tool is a real failure, but it is
+    // the wake's, and it shows up in the job status.
     return const EvalConstraintResult.notApplicable(
       id,
-      'the model made no tool calls',
+      'the model never attempted draft_day_plan',
     );
   }
   final rejections = outcome.rejections.toList();

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -762,6 +762,19 @@ EvalConstraintResult scoreNoFabricatedCalendarBlocks(EvalRunOutcome outcome) {
 /// rejections it collected on the way.
 EvalConstraintResult scoreCompliedWithoutRejection(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.compliedWithoutRejection;
+  if (outcome.toolCalls.isEmpty) {
+    // A run that called nothing cannot have complied with anything. Without
+    // this the empty rejection list reads as "accepted on the first attempt",
+    // so a model that was never reached — or that answered in prose and never
+    // called the tool — collects a compliance *pass* it did nothing to earn,
+    // and the leaderboard rewards failing loudest. Not calling the required
+    // tool is a real failure, but it is the wake's failure and shows up in the
+    // job status, not in this constraint.
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'the model made no tool calls',
+    );
+  }
   final rejections = outcome.rejections.toList();
   return EvalConstraintResult(
     id: id,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -38,6 +38,7 @@ abstract final class EvalConstraintIds {
   static const surfacedConflict = 'surfacedConflict';
   static const noInventedWork = 'noInventedWork';
   static const taskWorkIsTyped = 'taskWorkIsTyped';
+  static const noFabricatedCalendarBlocks = 'noFabricatedCalendarBlocks';
 
   /// Guarded — scored on rejections rather than on the plan.
   static const compliedWithoutRejection = 'compliedWithoutRejection';
@@ -58,6 +59,7 @@ abstract final class EvalConstraintIds {
     surfacedConflict,
     noInventedWork,
     taskWorkIsTyped,
+    noFabricatedCalendarBlocks,
     compliedWithoutRejection,
   ];
 }
@@ -79,6 +81,7 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
   scoreSurfacedConflict(outcome),
   scoreNoInventedWork(outcome),
   scoreTaskWorkIsTyped(outcome),
+  scoreNoFabricatedCalendarBlocks(outcome),
   scoreCompliedWithoutRejection(outcome),
 ];
 
@@ -686,6 +689,68 @@ EvalConstraintResult scoreTaskWorkIsTyped(EvalRunOutcome outcome) {
     detail: mistyped.isEmpty
         ? 'task work is on work blocks'
         : mistyped.join('; '),
+  );
+}
+
+/// A `cal` block claims an imported calendar event, and the day agent has
+/// none to import.
+///
+/// `PlannedBlockType.cal` means "imported calendar event", and the plan editor
+/// treats such a block as owned elsewhere — it refuses in-app edits with
+/// "block is cal-owned — edit it in the source calendar". So a model-emitted
+/// `cal` block leaves the user with a block they cannot edit here and cannot
+/// find in their calendar either.
+///
+/// It can never be legitimate today: the day agent is shown **no calendar
+/// events at all**. `DayAgentInterface.draftDayPlan` documents its
+/// `calendarBlocks` parameter as deferred, `RealDayAgent` drops the argument
+/// on the floor, and no context section renders events into the prompt. The
+/// drafting rules nonetheless tell the model that "only `cal` blocks mirroring
+/// real calendar events may span" the current time — an exemption whose
+/// precondition cannot hold.
+///
+/// That matters most on a same-day draft, where the exemption is the one
+/// remaining hole in the past-start guard (`day_agent_plan_parser.dart`
+/// exempts `cal` alone, after a model was observed relabelling a past-starting
+/// block `buffer` to slip an earlier version). Such a block *is* already
+/// caught by [scoreWithinWorkingHours] — it starts before the draft's own
+/// clock — but reported there as a working-hours violation, which is a
+/// different failure with a different fix. Scoring it here names what actually
+/// happened.
+///
+/// When calendar integration lands, this needs the seeded events to compare
+/// against; until then "unbacked" is not an assumption but the only
+/// possibility.
+EvalConstraintResult scoreNoFabricatedCalendarBlocks(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.noFabricatedCalendarBlocks;
+  final noPlan = _requirePlan(outcome, id);
+  if (noPlan != null) return noPlan;
+  final calendarBlocks = [
+    for (final block in _scheduled(outcome))
+      if (block.type == PlannedBlockType.cal) block,
+  ];
+  if (calendarBlocks.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'the plan claims no calendar events',
+    );
+  }
+  final now = outcome.inputs.now;
+  final described = [
+    for (final block in calendarBlocks)
+      if (now != null && block.startTime.isBefore(now))
+        '"${block.title ?? block.id}" starts ${_hhmm(block.startTime)}, '
+            'before the ${_hhmm(now)} draft — the past-start guard exempts '
+            '`cal`, so this is how a model plans the past'
+      else
+        '"${block.title ?? block.id}" at ${_hhmm(block.startTime)}',
+  ];
+  return EvalConstraintResult(
+    id: id,
+    passed: false,
+    detail:
+        '${calendarBlocks.length} calendar block(s) with no calendar to '
+        'mirror: ${described.join('; ')}',
   );
 }
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -782,6 +782,24 @@ void main() {
   });
 
   group('compliedWithoutRejection', () {
+    test('an accepted non-drafting call earns no compliance credit', () {
+      // The failure mode this guard exists for: a wake that called
+      // `raise_day_status` and stopped has a non-empty tool log and an empty
+      // rejection list, so a naive "no rejections" read would hand it a pass
+      // for a run that never attempted a plan.
+      final result = scoreCompliedWithoutRejection(
+        outcome(
+          planPersisted: false,
+          toolCalls: const [
+            EvalToolCall(name: 'raise_day_status', accepted: true),
+          ],
+        ),
+      );
+
+      expect(result.isApplicable, isFalse);
+      expect(result.detail, contains('draft_day_plan'));
+    });
+
     test('a run that called nothing is not applicable, not compliant', () {
       // An empty rejection list would otherwise read as "accepted on the first
       // attempt", so a model that was never reached, or that answered in prose
@@ -790,7 +808,7 @@ void main() {
       final result = scoreCompliedWithoutRejection(outcome());
 
       expect(result.isApplicable, isFalse);
-      expect(result.detail, contains('no tool calls'));
+      expect(result.detail, contains('draft_day_plan'));
     });
 
     test('a failed run with rejections is still scored as non-compliant', () {
@@ -1305,13 +1323,24 @@ void main() {
       type: PlannedBlockType.cal,
     );
 
-    test('a plan claiming no calendar events is not applicable', () {
+    test('a real plan with no calendar claim passes', () {
+      // The prompt explicitly offers `cal` as the way to place work before the
+      // current time, so declining it is the behaviour being measured. If this
+      // were merely inapplicable the constraint could only ever be n/a or fail
+      // and would never show a success rate.
       final result = scoreNoFabricatedCalendarBlocks(
         outcome(blocks: [block(id: 'b1', startHour: 9, endHour: 10)]),
       );
 
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('none claiming to be a calendar event'));
+    });
+
+    test('a plan with nothing scheduled is not applicable', () {
+      final result = scoreNoFabricatedCalendarBlocks(outcome());
+
       expect(result.isApplicable, isFalse);
-      expect(result.detail, contains('no calendar events'));
+      expect(result.detail, contains('no scheduled blocks'));
     });
 
     test('any calendar block fails, because there is no calendar to mirror', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1259,6 +1259,110 @@ void main() {
     });
   });
 
+  group('noFabricatedCalendarBlocks', () {
+    PlannedBlock calendarBlock({
+      String id = 'cal-1',
+      int startHour = 9,
+      int endHour = 11,
+    }) => PlannedBlock(
+      id: id,
+      categoryId: 'cat-1',
+      startTime: DateTime(2026, 7, 18, startHour),
+      endTime: DateTime(2026, 7, 18, endHour),
+      title: id,
+      type: PlannedBlockType.cal,
+    );
+
+    test('a plan claiming no calendar events is not applicable', () {
+      final result = scoreNoFabricatedCalendarBlocks(
+        outcome(blocks: [block(id: 'b1', startHour: 9, endHour: 10)]),
+      );
+
+      expect(result.isApplicable, isFalse);
+      expect(result.detail, contains('no calendar events'));
+    });
+
+    test('any calendar block fails, because there is no calendar to mirror', () {
+      // The day agent is shown no calendar events at all — `calendarBlocks` is
+      // a deferred parameter RealDayAgent drops — so a `cal` block asserts an
+      // import that never happened, and the plan editor will then refuse to
+      // let the user edit it here.
+      final result = scoreNoFabricatedCalendarBlocks(
+        outcome(blocks: [calendarBlock(startHour: 14, endHour: 15)]),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('no calendar to mirror'));
+      expect(result.detail, contains('14:00'));
+    });
+
+    test('names the past-start guard when the block predates the draft', () {
+      // This is the case the constraint exists for: `cal` is the only type the
+      // parser exempts from the same-day past-start guard, so it is how a
+      // model plans the past without being rejected.
+      final result = scoreNoFabricatedCalendarBlocks(
+        outcome(
+          // ignore: avoid_redundant_argument_values — the hours are the point
+          blocks: [calendarBlock(startHour: 9, endHour: 11)],
+          now: DateTime(2026, 7, 18, 15),
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('past-start guard'));
+      expect(result.detail, contains('09:00'));
+    });
+
+    test('reports a dropped calendar block as no claim at all', () {
+      // A dropped block is the model declining, and production excludes it
+      // from the day; scoring it would punish the right call.
+      final result = scoreNoFabricatedCalendarBlocks(
+        outcome(
+          blocks: [
+            PlannedBlock(
+              id: 'cal-dropped',
+              categoryId: 'cat-1',
+              startTime: DateTime(2026, 7, 18, 9),
+              endTime: DateTime(2026, 7, 18, 10),
+              title: 'cal-dropped',
+              type: PlannedBlockType.cal,
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+        ),
+      );
+
+      expect(result.isApplicable, isFalse);
+    });
+
+    test('is inapplicable when no plan was persisted', () {
+      final result = scoreNoFabricatedCalendarBlocks(
+        outcome(planPersisted: false),
+      );
+
+      expect(result.isApplicable, isFalse);
+    });
+
+    test('catches what withinWorkingHours reports as a different failure', () {
+      // Both fire on the same block, and that is the point: the working-hours
+      // constraint already detected it, but attributed it to a time-window
+      // violation. A report that only said "outside working hours" would send
+      // someone to fix the wrong thing.
+      final subject = outcome(
+        // ignore: avoid_redundant_argument_values — the hours are the point
+        blocks: [calendarBlock(startHour: 9, endHour: 11)],
+        now: DateTime(2026, 7, 18, 15),
+      );
+
+      expect(scoreWithinWorkingHours(subject).passed, isFalse);
+      expect(scoreNoFabricatedCalendarBlocks(subject).passed, isFalse);
+      expect(
+        scoreNoFabricatedCalendarBlocks(subject).detail,
+        isNot(contains('outside')),
+      );
+    });
+  });
+
   group('scoreAll', () {
     test('returns every constraint in report order', () {
       final results = scoreAll(outcome());

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -782,6 +782,38 @@ void main() {
   });
 
   group('compliedWithoutRejection', () {
+    test('a run that called nothing is not applicable, not compliant', () {
+      // An empty rejection list would otherwise read as "accepted on the first
+      // attempt", so a model that was never reached, or that answered in prose
+      // without calling the tool, would collect a compliance pass it did
+      // nothing to earn — and aggregate scores would reward failing loudest.
+      final result = scoreCompliedWithoutRejection(outcome());
+
+      expect(result.isApplicable, isFalse);
+      expect(result.detail, contains('no tool calls'));
+    });
+
+    test('a failed run with rejections is still scored as non-compliant', () {
+      // Inapplicability is about having made no attempt. A model that tried,
+      // was corrected, and still produced nothing has demonstrated exactly
+      // what this constraint measures.
+      final result = scoreCompliedWithoutRejection(
+        outcome(
+          planPersisted: false,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'draft_day_plan',
+              accepted: false,
+              rejectionMessage: 'blocks must stay within the planDate day',
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('1 rejection'));
+    });
+
     test('passes when the first tool call was accepted', () {
       final result = scoreCompliedWithoutRejection(
         outcome(
@@ -1382,8 +1414,11 @@ void main() {
       final results = scoreAll(outcome());
 
       expect(
-        results.where((result) => result.isApplicable).map((r) => r.id),
-        [EvalConstraintIds.compliedWithoutRejection],
+        results.where((result) => result.isApplicable),
+        isEmpty,
+        reason:
+            'an empty run demonstrates nothing at all — including about '
+            'compliance, which it never attempted',
       );
     });
   });


### PR DESCRIPTION
Adds `noFabricatedCalendarBlocks` to the day-planning eval scorers. Test-only; no `lib/` change.

Closes `lotti3-anb.9` — **but not as that issue described it.** The premise turned out to be wrong in one direction and unimplementable in another, so this is worth reading before the diff.

## The issue claimed a past-starting `cal` block "collects no penalty". It does.

I scored exactly that plan through `scoreAll` before writing anything:

```
FAIL withinWorkingHours: outside 15:00-17:00: "Smuggled past work" starts 09:30
```

`scoreWithinWorkingHours` sets `startOfDay = max(workingStart, inputs.now)` and flags any scheduled block starting before it, **regardless of type**. On a same-day draft the evasion is therefore always detected already.

The real defect is **attribution, not detection**. It is reported as a time-window violation, which is a different failure with a different fix, and it conflates "the model ran work past 17:00" with "the model exploited the one exemption the prompt offers to plan the past". For an instrument whose job is to say *why* a plan is weak, that distinction is the whole value. There is a test asserting both constraints fire on the same block, so the overlap is deliberate and documented rather than accidental.

## The issue asked for seeded calendar events. There is no way to seed them.

Acceptance criteria 2 and 3 assumed a fixture could carry calendar events so a legitimate `cal` block is distinguishable from an evasion. It cannot:

- `DayAgentInterface.draftDayPlan` documents `calendarBlocks` as *"deferred — caller passes `calendarBlocks: const []`"*
- `RealDayAgent.draftDayPlan` accepts the parameter and **drops it** — it is not part of `DraftPlanPayload`, so it cannot reach the wake
- no `day_agent_context_builder` section renders calendar events

Adding a calendar field to the fixtures would create an input the model never sees — the same inert-hook mistake as the `allowedCategoryIds` and `hasSeededCalendar` fields removed during #3582's review. So it was deliberately not done.

That makes the constraint simpler and stronger: because the model is shown no calendar events, **every** `cal` block is unbacked by construction. The scorer fails on any of them and names the past-start guard specifically when the block predates the draft clock.

## Why an unbacked `cal` block is a real failure, not a style nit

`PlannedBlockType.cal` means "imported calendar event", and `DayAgentPlanEditor` refuses to edit one: *"block is cal-owned — edit it in the source calendar"*. The user ends up with a block they cannot edit in Lotti and cannot find in their calendar. That is a concrete harm, independent of the guard question.

## Production defect filed separately

The prompt tells the model that "only `cal` blocks mirroring real calendar events may span" the current time, and the parser enforces the exemption — while the model has no calendar events to mirror. An exemption whose precondition can never hold, with the guard's own code comment recording a model already probing this dimension (relabelling a past-starting block `buffer`, which is why `buffer` was added to the guard).

Filed as a P1 with two fix directions: drop the exemption from prompt and parser until calendar integration ships, or wire calendar events into the drafting context. That needs a product decision, so it is not in this PR. This scorer measures the hole either way.

## Verification

- `fvm dart analyze` clean.
- 75 tests in `eval_constraints_test.dart`, six of them new: not-applicable when the plan claims no calendar events, fails on any calendar block, names the past-start guard when the block predates the draft, a dropped block is no claim at all, inapplicable with no persisted plan, and the overlap with `withinWorkingHours`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation now detects plans that claim imported calendar events when no matching calendar data exists.
  * Reports identify the affected calendar block times and distinguish past-start cases from working-hours issues.

* **Tests**
  * Added coverage for missing calendar data, dropped blocks, absent plans, past-start handling, and accurate failure messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->