### PR TITLE
test: close three gaps in the calendar-block scorer

### DIFF
--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -288,7 +288,8 @@ constraint too, not a pass: an empty rejection list would otherwise read as
 prose, or called only `raise_day_status` and stopped would collect compliance
 credit it did nothing to earn.
 
-`noFabricatedCalendarBlocks` is the one constraint that reads block *type*.
+`noFabricatedCalendarBlocks` is the only constraint that scores a block's
+claimed *provenance* — whether it asserts an origin outside the app at all.
 `PlannedBlockType.cal` means "imported calendar event" and the plan editor
 refuses in-app edits to one, but the day agent is shown no calendar events at
 all — `calendarBlocks` is a deferred parameter `RealDayAgent` drops, and no

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -726,35 +726,34 @@ EvalConstraintResult scoreNoFabricatedCalendarBlocks(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.noFabricatedCalendarBlocks;
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
+  // Every block, not just the scheduled ones. A dropped `cal` block is still
+  // persisted, still projected by `_projectDayPlan` (only the capacity meter
+  // filters dropped), still drawn by the timeline, and still refused by the
+  // plan editor — so the user sees an uneditable phantom calendar event either
+  // way. Dropping is the model declining *work*; it does not retract the
+  // claim that an external event exists.
   final calendarBlocks = [
-    for (final block in _scheduled(outcome))
+    for (final block in outcome.blocks)
       if (block.type == PlannedBlockType.cal) block,
   ];
   if (calendarBlocks.isEmpty) {
     // A plan with real blocks and no calendar claim is a *pass*, not an
     // absence of evidence: the prompt explicitly offers `cal` as the way to
     // place work before the current time, so declining it is the behaviour
-    // being measured. Only a plan with nothing scheduled says nothing.
-    final scheduled = _scheduled(outcome);
-    return scheduled.isEmpty
-        ? const EvalConstraintResult.notApplicable(id, 'no scheduled blocks')
+    // being measured. Only a plan with no blocks at all says nothing.
+    return outcome.blocks.isEmpty
+        ? const EvalConstraintResult.notApplicable(id, 'the plan has no blocks')
         : EvalConstraintResult(
             id: id,
             passed: true,
             detail:
-                '${scheduled.length} scheduled block(s), none claiming to be '
-                'a calendar event',
+                '${outcome.blocks.length} block(s), none claiming to be a '
+                'calendar event',
           );
   }
   final now = outcome.inputs.now;
   final described = [
-    for (final block in calendarBlocks)
-      if (now != null && block.startTime.isBefore(now))
-        '"${block.title ?? block.id}" starts ${_hhmm(block.startTime)}, '
-            'before the ${_hhmm(now)} draft — the past-start guard exempts '
-            '`cal`, so this is how a model plans the past'
-      else
-        '"${block.title ?? block.id}" at ${_hhmm(block.startTime)}',
+    for (final block in calendarBlocks) _describeCalendarClaim(block, now),
   ];
   return EvalConstraintResult(
     id: id,
@@ -763,6 +762,27 @@ EvalConstraintResult scoreNoFabricatedCalendarBlocks(EvalRunOutcome outcome) {
         '${calendarBlocks.length} calendar block(s) with no calendar to '
         'mirror: ${described.join('; ')}',
   );
+}
+
+/// Describes one fabricated calendar claim, naming the *actual* reason it
+/// evaded the same-day guard.
+///
+/// The guard fires only for `state == drafted` and exempts `cal`, so a drafted
+/// past-starting calendar block slipped through on its type, while a
+/// `committed`/`completed`/`inProgress` one would have slipped through as `ai`
+/// or `manual` just as well. Blaming the calendar type in that second case
+/// would point a reader at the wrong fix.
+String _describeCalendarClaim(PlannedBlock block, DateTime? now) {
+  final name = '"${block.title ?? block.id}"';
+  final start = _hhmm(block.startTime);
+  if (now == null || !block.startTime.isBefore(now)) return '$name at $start';
+  if (block.state == PlannedBlockState.drafted) {
+    return '$name starts $start, before the ${_hhmm(now)} draft — the '
+        'past-start guard exempts `cal`, so this is how a model plans the past';
+  }
+  return '$name starts $start, before the ${_hhmm(now)} draft, in state '
+      '${block.state.name} — the past-start guard only covers drafted blocks, '
+      'so the state bypassed it here, not the type';
 }
 
 /// Whether the model produced a legal plan without being corrected.

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1336,11 +1336,11 @@ void main() {
       expect(result.detail, contains('none claiming to be a calendar event'));
     });
 
-    test('a plan with nothing scheduled is not applicable', () {
+    test('a plan with no blocks at all is not applicable', () {
       final result = scoreNoFabricatedCalendarBlocks(outcome());
 
       expect(result.isApplicable, isFalse);
-      expect(result.detail, contains('no scheduled blocks'));
+      expect(result.detail, contains('no blocks'));
     });
 
     test('any calendar block fails, because there is no calendar to mirror', () {
@@ -1374,9 +1374,12 @@ void main() {
       expect(result.detail, contains('09:00'));
     });
 
-    test('reports a dropped calendar block as no claim at all', () {
-      // A dropped block is the model declining, and production excludes it
-      // from the day; scoring it would punish the right call.
+    test('a dropped calendar block is still a fabricated claim', () {
+      // Dropping declines the *work*; it does not retract the claim that an
+      // external event exists. The block is still persisted, still projected
+      // (only the capacity meter filters dropped), still drawn on the
+      // timeline, and still refused by the plan editor — so the user sees an
+      // uneditable phantom calendar event either way.
       final result = scoreNoFabricatedCalendarBlocks(
         outcome(
           blocks: [
@@ -1393,7 +1396,38 @@ void main() {
         ),
       );
 
-      expect(result.isApplicable, isFalse);
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('cal-dropped'));
+    });
+
+    test('blames the state, not the type, when the block is not drafted', () {
+      // The guard fires only for `state == drafted`, so a committed block
+      // would have slipped through as `ai` or `manual` too. Blaming `cal`
+      // here would point a reader at the wrong fix.
+      final result = scoreNoFabricatedCalendarBlocks(
+        outcome(
+          blocks: [
+            PlannedBlock(
+              id: 'cal-committed',
+              categoryId: 'cat-1',
+              startTime: DateTime(2026, 7, 18, 9),
+              endTime: DateTime(2026, 7, 18, 11),
+              title: 'cal-committed',
+              type: PlannedBlockType.cal,
+              state: PlannedBlockState.committed,
+            ),
+          ],
+          now: DateTime(2026, 7, 18, 15),
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('the state bypassed it here'));
+      expect(
+        result.detail,
+        isNot(contains('exempts `cal`')),
+        reason: 'the calendar exemption is not what let this through',
+      );
     });
 
     test('is inapplicable when no plan was persisted', () {


### PR DESCRIPTION
Three follow-up findings that arrived on #3587 **after** it merged, so they are fixed here against main. All three verified in code before accepting.

## A dropped calendar block is still a fabricated claim

The scorer inspected only scheduled blocks, so a `cal` block with `state: dropped` evaded it completely — passing if anything else was scheduled, inapplicable if it was the only block.

That was my error in reasoning: I reused the "dropped means the model declined, and production excludes it" rule from the capacity scorers, where it is correct. It does not transfer. Dropping declines the *work*; it does not retract the assertion that an external calendar event exists. Verified what actually happens to such a block:

- `_projectDayPlan` iterates `entity.data.plannedBlocks` unconditionally — only `scheduledMinutes` filters dropped
- the timeline draws `for (final block in blocks)`, all of them
- `DayAgentPlanEditor` refuses *every* `cal` block: "block is calendar-owned — edit it in the source calendar"

So the user is left with a visible, uneditable phantom calendar event either way. The constraint now reads `outcome.blocks`.

## Blame the state, not the type, when the block is not drafted

The past-start guard fires only for `state == drafted` and exempts `cal`. My detail text blamed the calendar exemption for *any* past-starting `cal` block — but a `committed`, `completed` or `inProgress` one would have slipped through as `ai` or `manual` just as well, because the guard never looked at it. Reporting the type as the cause would send someone to fix the wrong thing.

The diagnostic now distinguishes the two, and names the state when the state is what bypassed the guard. (That second case is `lotti3-abp`, tracked separately as a production defect.)

## A false claim in the feature README

I wrote that this was "the one constraint that reads block *type*". That is simply wrong — `scoreNoInventedWork` branches on `block.type` and so does `scoreTaskWorkIsTyped`. I asserted it without checking. Reworded to what is actually distinctive: it is the only constraint that scores a block's claimed **provenance** — whether it asserts an origin outside the app at all.

## Verification

- `fvm dart analyze` clean.
- 114 tests in the eval framework. New/changed: a dropped calendar block now fails rather than being ignored, a non-drafted past-starting block blames the state and explicitly does *not* mention the calendar exemption, and the not-applicable case is now "no blocks at all" rather than "no scheduled blocks".