### PR TITLE
test: add the day-planning eval report and judge bundle

### DIFF
--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -393,8 +393,47 @@ capacity also changes what the scenarios ask for, and would make
 `requiredWorkPlaced` and `withinCapacity` mutually unsatisfiable on a crowded
 day.
 
-**Not yet judged.** The report and judge bundle the runner's results feed are
-tracked separately, as is the live entry point that points it at real models.
+### Reading a run
+
+`framework/eval_report.dart` aggregates results into JSON + Markdown under the
+git-ignored `tmp/day-planning-eval/` (env-overridable via
+`DAY_PLANNING_EVAL_DIR`, or per-file with `DAY_PLANNING_EVAL_JSON` /
+`DAY_PLANNING_EVAL_MARKDOWN`), so runs accumulate and can be diffed.
+
+The report leads with a **model leaderboard**, then per-constraint rates, cost,
+prompt stability, and failure excerpts. Two properties carry it:
+
+- **Rates are over *applicable* results only.** A constraint that did not apply
+  is neither a pass nor a fail, and folding it in either direction produces a
+  plausible-looking number that is wrong: counting it as a pass makes the
+  laziest model look best, counting it as a fail punishes a scenario for not
+  exercising a dimension. A constraint nothing exercised reports `—`, never
+  100%.
+- **Prompt stability is measured per model across scenarios**, not per cell.
+  Within one scenario the prompt barely varies, so a per-cell figure just
+  restates the prompt size — which is exactly what the first generated report
+  showed before it was fixed. Across wakes it answers the question that
+  matters: how much of the prompt a provider could cache. On the current
+  prompt that is the whole 7.7 KB system message, with all variation in the
+  user message.
+
+Plan *quality* is judged by a person (or Opus 5 reading the repo), not by an
+in-harness LLM judge — that would bake scoring noise and cost into every run
+while saying little you can act on. So the report also emits a **judge
+bundle**: one self-sufficient JSON object per (scenario, model, variant,
+sample) carrying the scenario and its intent, the exact prompts, every tool
+call including rejections and their text, the persisted plan, and that run's
+constraint results and cost.
+
+The bundle is bounded (newest samples per cell) and **states what it dropped**,
+because a truncated bundle that does not say so reads as complete. Each corpus
+row carries `visibleToModel`: the corpus is ground truth and is rendered only
+inside the capture context, so on a capture-less wake the model saw none of it
+— and a judge reading `blockedBy` without that flag would blame the model for
+ignoring a dependency it never received.
+
+**Not yet judged against real models.** The live entry point that points the
+matrix at providers is tracked separately.
 
 ### Measuring that it does not degrade
 

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -396,9 +396,11 @@ day.
 ### Reading a run
 
 `framework/eval_report.dart` aggregates results into JSON + Markdown under the
-git-ignored `tmp/day-planning-eval/` (env-overridable via
-`DAY_PLANNING_EVAL_DIR`, or per-file with `DAY_PLANNING_EVAL_JSON` /
-`DAY_PLANNING_EVAL_MARKDOWN`), so runs accumulate and can be diffed.
+git-ignored `tmp/day-planning-eval/`, with the run's timestamp in the basename
+so runs genuinely accumulate and can be diffed — a fixed name would have each
+invocation overwrite the last. Override the directory with
+`DAY_PLANNING_EVAL_DIR`, or pin an exact fixed path per file with
+`DAY_PLANNING_EVAL_JSON` / `DAY_PLANNING_EVAL_MARKDOWN`.
 
 The report leads with a **model leaderboard**, then per-constraint rates, cost,
 prompt stability, and failure excerpts. Two properties carry it:
@@ -409,7 +411,8 @@ prompt stability, and failure excerpts. Two properties carry it:
   laziest model look best, counting it as a fail punishes a scenario for not
   exercising a dimension. A constraint nothing exercised reports `—`, never
   100%.
-- **Prompt stability is measured per model across scenarios**, not per cell.
+- **Prompt stability is measured per wake, per model, across scenarios** —
+  not per cell.
   Within one scenario the prompt barely varies, so a per-cell figure just
   restates the prompt size — which is exactly what the first generated report
   showed before it was fixed. Across wakes it answers the question that
@@ -426,11 +429,19 @@ call including rejections and their text, the persisted plan, and that run's
 constraint results and cost.
 
 The bundle is bounded (newest samples per cell) and **states what it dropped**,
-because a truncated bundle that does not say so reads as complete. Each corpus
-row carries `visibleToModel`: the corpus is ground truth and is rendered only
-inside the capture context, so on a capture-less wake the model saw none of it
-— and a judge reading `blockedBy` without that flag would blame the model for
-ignoring a dependency it never received.
+because a truncated bundle that does not say so reads as complete. It carries
+every wake of a cell, not just the last: a durable retry opens a fresh
+conversation, and showing one prompt beside tool calls and cost that cover the
+whole cell leaves a judge unable to reconcile them.
+
+Corpus rows carry two separate flags, because conflating them misleads in
+exactly the direction the flags exist to prevent. `corpusRowShown` is whether
+the row — its status, estimate and `blockedBy` — was rendered at all; the
+corpus appears only inside the capture context. `taskIdReferenceable` is the
+weaker fact that the model could name the id, which a *decided* task satisfies
+through its own projection even on a capture-less wake where its corpus row was
+never shown. Reporting the second as the first would print `blockedBy` next to
+"the model saw this".
 
 **Not yet judged against real models.** The live entry point that points the
 matrix at providers is tracked separately.

--- a/test/features/daily_os_next/eval/framework/eval_report.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report.dart
@@ -1,0 +1,786 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:lotti/classes/day_plan.dart';
+import 'package:meta/meta.dart';
+
+import 'eval_constraints.dart';
+import 'eval_runner.dart';
+import 'eval_variant.dart';
+
+/// Aggregates matrix results into a report, and into a bundle a human (or
+/// Opus 5 reading the repo) can judge plan *quality* from without re-running.
+///
+/// The constraint scorers deliberately cover only what is objectively
+/// checkable. Whether a day is sensible — the ordering, the realism, whether
+/// it is overpacked-but-legal — is not one of those things, and an in-harness
+/// LLM judge would bake scoring noise and cost into every run while saying
+/// little you can act on. So the report's job is to make the run legible
+/// enough that judgement can happen afterwards, from artifacts alone.
+
+/// One constraint's outcome across a set of runs.
+///
+/// [applicable] is the denominator, and it is not the run count: a constraint
+/// that did not apply is neither a pass nor a fail. Reporting `passed/total`
+/// would let a scenario that never exercised a dimension inflate the score of
+/// a model that never demonstrated anything about it.
+@immutable
+class EvalConstraintRate {
+  const EvalConstraintRate({
+    required this.constraintId,
+    required this.passed,
+    required this.applicable,
+  });
+
+  final String constraintId;
+  final int passed;
+  final int applicable;
+
+  /// Null when nothing exercised this constraint — rendered as `—`, never as
+  /// 100%.
+  double? get rate => applicable == 0 ? null : passed / applicable;
+
+  String get label => rate == null
+      ? '—'
+      : '${(rate! * 100).toStringAsFixed(0)}% ($passed/$applicable)';
+}
+
+/// Aggregation helper shared by every table in the report.
+EvalConstraintRate _rateFor(
+  String constraintId,
+  Iterable<EvalRunResult> results,
+) {
+  var passed = 0;
+  var applicable = 0;
+  for (final result in results) {
+    for (final constraint in result.constraints) {
+      if (constraint.id != constraintId) continue;
+      if (!constraint.isApplicable) continue;
+      applicable++;
+      if (constraint.passed ?? false) passed++;
+    }
+  }
+  return EvalConstraintRate(
+    constraintId: constraintId,
+    passed: passed,
+    applicable: applicable,
+  );
+}
+
+/// A model's headline standing.
+@immutable
+class EvalModelStanding {
+  const EvalModelStanding({
+    required this.modelId,
+    required this.runs,
+    required this.failedRuns,
+    required this.overall,
+    required this.byConstraint,
+  });
+
+  final String modelId;
+  final int runs;
+
+  /// Runs that ended in an exception rather than a scored plan.
+  final int failedRuns;
+
+  /// Pass rate across every applicable constraint result the model produced.
+  final EvalConstraintRate overall;
+  final List<EvalConstraintRate> byConstraint;
+}
+
+/// Cost and prompt size for one (model, scenario) pair.
+@immutable
+class EvalCostRow {
+  const EvalCostRow({
+    required this.modelId,
+    required this.scenarioId,
+    required this.runs,
+    required this.meanLatencyMs,
+    required this.inputTokens,
+    required this.outputTokens,
+    required this.thoughtsTokens,
+    required this.cachedInputTokens,
+    required this.meanPromptBytes,
+  });
+
+  final String modelId;
+  final String scenarioId;
+  final int runs;
+  final int meanLatencyMs;
+  final int inputTokens;
+  final int outputTokens;
+  final int thoughtsTokens;
+  final int cachedInputTokens;
+
+  /// Mean bytes of system + user prompts actually sent.
+  final int meanPromptBytes;
+}
+
+/// One violation, with enough context to act on.
+@immutable
+class EvalFailureExcerpt {
+  const EvalFailureExcerpt({
+    required this.cell,
+    required this.constraintId,
+    required this.detail,
+    required this.rejections,
+  });
+
+  final String cell;
+  final String constraintId;
+
+  /// The scorer's own account — names the offending block or task.
+  final String detail;
+
+  /// Rejection text the model was handed, which is where a guarded constraint
+  /// is actually observable.
+  final List<String> rejections;
+}
+
+/// The report.
+@immutable
+class EvalReport {
+  const EvalReport({
+    required this.results,
+    required this.standings,
+    required this.costRows,
+    required this.failures,
+    required this.bundleSamplesPerCell,
+    required this.bundledCells,
+    required this.droppedSamples,
+    required this.generatedAt,
+  });
+
+  /// Builds a report from one matrix run.
+  ///
+  /// [bundleSamplesPerCell] bounds the judge bundle so the whole thing stays
+  /// readable in one pass; the highest sample indices are kept, and whatever
+  /// was dropped is counted and stated in the output rather than silently
+  /// omitted.
+  factory EvalReport.fromResults(
+    List<EvalRunResult> results, {
+    required DateTime generatedAt,
+    int bundleSamplesPerCell = 2,
+  }) {
+    if (bundleSamplesPerCell < 1) {
+      throw RangeError.value(
+        bundleSamplesPerCell,
+        'bundleSamplesPerCell',
+        'must be at least 1',
+      );
+    }
+    final modelIds = <String>{
+      for (final r in results) r.request.modelId,
+    }.toList()..sort();
+    final standings =
+        [
+          for (final modelId in modelIds)
+            _standingFor(
+              modelId,
+              results.where((r) => r.request.modelId == modelId),
+            ),
+        ]..sort((a, b) {
+          final left = a.overall.rate;
+          final right = b.overall.rate;
+          if (left == null && right == null) {
+            return a.modelId.compareTo(b.modelId);
+          }
+          if (left == null) return 1;
+          if (right == null) return -1;
+          final byRate = right.compareTo(left);
+          // Deterministic ties, or the leaderboard reorders itself between runs
+          // that measured exactly the same thing.
+          return byRate != 0 ? byRate : a.modelId.compareTo(b.modelId);
+        });
+
+    final cells = _groupIntoCells(results);
+    var dropped = 0;
+    for (final samples in cells.values) {
+      if (samples.length > bundleSamplesPerCell) {
+        dropped += samples.length - bundleSamplesPerCell;
+      }
+    }
+
+    return EvalReport(
+      results: List.unmodifiable(results),
+      standings: List.unmodifiable(standings),
+      costRows: List.unmodifiable(_costRows(results)),
+      failures: List.unmodifiable(_failures(results)),
+      bundleSamplesPerCell: bundleSamplesPerCell,
+      bundledCells: cells.length,
+      droppedSamples: dropped,
+      generatedAt: generatedAt,
+    );
+  }
+
+  final List<EvalRunResult> results;
+
+  /// Leaderboard, best first.
+  final List<EvalModelStanding> standings;
+  final List<EvalCostRow> costRows;
+  final List<EvalFailureExcerpt> failures;
+
+  final int bundleSamplesPerCell;
+  final int bundledCells;
+
+  /// Samples the cap excluded. Stated in the output so a truncated bundle can
+  /// never be mistaken for a complete one.
+  final int droppedSamples;
+
+  final DateTime generatedAt;
+
+  static EvalModelStanding _standingFor(
+    String modelId,
+    Iterable<EvalRunResult> runs,
+  ) {
+    final list = runs.toList();
+    var passed = 0;
+    var applicable = 0;
+    for (final result in list) {
+      for (final constraint in result.constraints) {
+        if (!constraint.isApplicable) continue;
+        applicable++;
+        if (constraint.passed ?? false) passed++;
+      }
+    }
+    return EvalModelStanding(
+      modelId: modelId,
+      runs: list.length,
+      failedRuns: list.where((r) => r.failed).length,
+      overall: EvalConstraintRate(
+        constraintId: 'overall',
+        passed: passed,
+        applicable: applicable,
+      ),
+      byConstraint: [
+        for (final id in EvalConstraintIds.all) _rateFor(id, list),
+      ],
+    );
+  }
+
+  static List<EvalCostRow> _costRows(List<EvalRunResult> results) {
+    // Keyed by the pair itself rather than a joined string: recovering the two
+    // ids by splitting a key breaks the moment either contains a space, and
+    // model ids come from an env var.
+    final byPair = <(String, String), List<EvalRunResult>>{};
+    for (final result in results) {
+      final key = (result.request.modelId, result.request.scenario.id);
+      byPair.putIfAbsent(key, () => []).add(result);
+    }
+    final keys = byPair.keys.toList()
+      ..sort((a, b) {
+        final byModel = a.$1.compareTo(b.$1);
+        return byModel != 0 ? byModel : a.$2.compareTo(b.$2);
+      });
+    return [
+      for (final key in keys)
+        () {
+          final runs = byPair[key]!;
+          final events = runs.expand((r) => r.consumption);
+          return EvalCostRow(
+            modelId: key.$1,
+            scenarioId: key.$2,
+            runs: runs.length,
+            meanLatencyMs: _mean(runs.map((r) => r.latency.inMilliseconds)),
+            inputTokens: _sum(events.map((e) => e.inputTokens)),
+            outputTokens: _sum(events.map((e) => e.outputTokens)),
+            thoughtsTokens: _sum(events.map((e) => e.thoughtsTokens)),
+            cachedInputTokens: _sum(events.map((e) => e.cachedInputTokens)),
+            meanPromptBytes: _mean(runs.map(_promptBytes)),
+          );
+        }(),
+    ];
+  }
+
+  static List<EvalFailureExcerpt> _failures(List<EvalRunResult> results) => [
+    for (final result in results)
+      for (final constraint in result.constraints)
+        if (constraint.passed == false)
+          EvalFailureExcerpt(
+            cell: result.request.label,
+            constraintId: constraint.id,
+            detail: constraint.detail,
+            rejections: [
+              for (final call in result.outcome.rejections)
+                '${call.name}: ${call.rejectionMessage ?? 'no message'}',
+            ],
+          ),
+  ];
+
+  /// The bundle, one entry per (scenario, model, variant, sample), capped.
+  List<Map<String, Object?>> judgeBundle() {
+    final cells = _groupIntoCells(results);
+    final keys = cells.keys.toList()
+      ..sort((a, b) {
+        final byScenario = a.$1.compareTo(b.$1);
+        if (byScenario != 0) return byScenario;
+        final byModel = a.$2.compareTo(b.$2);
+        return byModel != 0 ? byModel : a.$3.compareTo(b.$3);
+      });
+    return [
+      for (final key in keys)
+        ...(cells[key]!..sort(
+              (a, b) => b.request.sample.compareTo(a.request.sample),
+            ))
+            .take(bundleSamplesPerCell)
+            .map(_bundleEntry),
+    ];
+  }
+
+  Map<String, Object?> toJson() => {
+    'kind': 'lotti.dayPlanningEvalReport',
+    'generatedAt': generatedAt.toIso8601String(),
+    'runs': results.length,
+    'bundle': {
+      'samplesPerCell': bundleSamplesPerCell,
+      'cells': bundledCells,
+      'droppedSamples': droppedSamples,
+    },
+    'leaderboard': [
+      for (final standing in standings)
+        {
+          'modelId': standing.modelId,
+          'runs': standing.runs,
+          'failedRuns': standing.failedRuns,
+          'passed': standing.overall.passed,
+          'applicable': standing.overall.applicable,
+          'rate': standing.overall.rate,
+          'byConstraint': {
+            for (final rate in standing.byConstraint)
+              rate.constraintId: {
+                'passed': rate.passed,
+                'applicable': rate.applicable,
+                'rate': rate.rate,
+              },
+          },
+        },
+    ],
+    'promptStability': [
+      for (final standing in standings)
+        () {
+          final runs = results.where(
+            (r) => r.request.modelId == standing.modelId,
+          );
+          final stable = _stablePrefixBytes(runs);
+          final mean = _mean(
+            runs.map((r) => utf8.encode(r.systemPrompt ?? '').length),
+          );
+          return {
+            'modelId': standing.modelId,
+            'wakes': runs.length,
+            'meanSystemPromptBytes': mean,
+            'stablePrefixBytes': stable,
+            'stableFraction': mean == 0 ? null : stable / mean,
+          };
+        }(),
+    ],
+    'scenarioMatrix': _scenarioMatrixJson(),
+    'variantDelta': _variantDeltaJson(),
+    'cost': [
+      for (final row in costRows)
+        {
+          'modelId': row.modelId,
+          'scenarioId': row.scenarioId,
+          'runs': row.runs,
+          'meanLatencyMs': row.meanLatencyMs,
+          'inputTokens': row.inputTokens,
+          'outputTokens': row.outputTokens,
+          'thoughtsTokens': row.thoughtsTokens,
+          'cachedInputTokens': row.cachedInputTokens,
+          'meanPromptBytes': row.meanPromptBytes,
+        },
+    ],
+    'failures': [
+      for (final failure in failures)
+        {
+          'cell': failure.cell,
+          'constraintId': failure.constraintId,
+          'detail': failure.detail,
+          'rejections': failure.rejections,
+        },
+    ],
+    'judgeBundle': judgeBundle(),
+  };
+
+  Map<String, Object?> _scenarioMatrixJson() {
+    final scenarioIds = <String>{
+      for (final r in results) r.request.scenario.id,
+    }.toList()..sort();
+    return {
+      for (final standing in standings)
+        standing.modelId: {
+          for (final scenarioId in scenarioIds)
+            scenarioId: {
+              for (final id in EvalConstraintIds.all)
+                id: _rateFor(
+                  id,
+                  results.where(
+                    (r) =>
+                        r.request.modelId == standing.modelId &&
+                        r.request.scenario.id == scenarioId,
+                  ),
+                ).rate,
+            },
+        },
+    };
+  }
+
+  /// Baseline vs each variant, per constraint, **within the same model**.
+  ///
+  /// Comparing across models would confound the two dimensions the matrix
+  /// exists to separate.
+  Map<String, Object?> _variantDeltaJson() {
+    final variantIds = <String>{
+      for (final r in results) r.request.variant.id,
+    }.where((id) => id != evalBaselineVariantId).toList()..sort();
+    return {
+      for (final standing in standings)
+        standing.modelId: {
+          for (final variantId in variantIds)
+            variantId: {
+              for (final id in EvalConstraintIds.all)
+                id: () {
+                  final base = _rateFor(
+                    id,
+                    results.where(
+                      (r) =>
+                          r.request.modelId == standing.modelId &&
+                          r.request.variant.id == evalBaselineVariantId,
+                    ),
+                  ).rate;
+                  final variant = _rateFor(
+                    id,
+                    results.where(
+                      (r) =>
+                          r.request.modelId == standing.modelId &&
+                          r.request.variant.id == variantId,
+                    ),
+                  ).rate;
+                  // Null when either side never exercised the constraint: a
+                  // delta against nothing is not a zero.
+                  return base == null || variant == null
+                      ? null
+                      : variant - base;
+                }(),
+            },
+        },
+    };
+  }
+
+  Map<String, Object?> _bundleEntry(EvalRunResult result) {
+    final scenario = result.request.scenario;
+    final inputs = result.outcome.inputs;
+    return {
+      'cell': result.request.label,
+      'scenario': {
+        'id': scenario.id,
+        // The judge needs to know what the scenario was trying to find out
+        // before it can say whether the plan was a good answer.
+        'intent': scenario.intent,
+        'planDate': result.request.planDate.toIso8601String(),
+        'capacityMinutes': inputs.capacityMinutes,
+        'workingHours':
+            '${inputs.workingHoursStartHour}:00-'
+            '${inputs.workingHoursEndHour}:00',
+        'draftedAt': inputs.now?.toIso8601String(),
+        'decidedTaskIds': inputs.decidedTaskIds,
+        'requiredTaskIds': inputs.requiredTaskIds.toList()..sort(),
+        'expectedOmissions': inputs.expectedOmissions.toList()..sort(),
+        // `visibleToModel` is not decoration. The corpus here is ground
+        // truth, and it is rendered only inside the capture context — so on a
+        // wake without a capture the model was shown none of it. A judge
+        // reading blockedBy and concluding the model ignored a dependency it
+        // never received would draw exactly the wrong lesson.
+        'corpus': [
+          for (final task in inputs.corpus)
+            {
+              'taskId': task.taskId,
+              'title': task.title,
+              'status': task.status,
+              'estimateMinutes': task.estimateMinutes,
+              'blockedBy': task.blockedBy,
+              'visibleToModel': inputs.referenceableTaskIds.contains(
+                task.taskId,
+              ),
+            },
+        ],
+        'captureTranscript': scenario.captureTranscript,
+      },
+      'prompts': {
+        'system': result.systemPrompt,
+        'user': result.userPrompts,
+        'forcedDraftRetry': result.forcedDraftRetry,
+      },
+      'toolCalls': [
+        for (final call in result.outcome.toolCalls)
+          {
+            'name': call.name,
+            'accepted': call.accepted,
+            'rejectionMessage': call.rejectionMessage,
+            'arguments': call.arguments,
+          },
+      ],
+      'plan': [
+        for (final block in result.outcome.blocks) _blockJson(block),
+      ],
+      'constraints': {
+        for (final constraint in result.constraints)
+          constraint.id: {
+            'passed': constraint.passed,
+            'detail': constraint.detail,
+          },
+      },
+      'job': {
+        'status': result.jobStatus,
+        'attempts': result.jobAttempts,
+        'latencyMs': result.latency.inMilliseconds,
+        'error': result.error,
+      },
+      'cost': {
+        'inputTokens': _sum(result.consumption.map((e) => e.inputTokens)),
+        'outputTokens': _sum(result.consumption.map((e) => e.outputTokens)),
+        'thoughtsTokens': _sum(result.consumption.map((e) => e.thoughtsTokens)),
+        'cachedInputTokens': _sum(
+          result.consumption.map((e) => e.cachedInputTokens),
+        ),
+        'promptBytes': _promptBytes(result),
+      },
+    };
+  }
+
+  static Map<String, Object?> _blockJson(PlannedBlock block) => {
+    'id': block.id,
+    'title': block.title,
+    'type': block.type.name,
+    'state': block.state.name,
+    'start': block.startTime.toIso8601String(),
+    'end': block.endTime.toIso8601String(),
+    'taskId': block.taskId,
+    'reason': block.reason,
+  };
+
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('# Day-planning eval')
+      ..writeln()
+      ..writeln(
+        'Generated ${generatedAt.toIso8601String()} · '
+        '${results.length} run(s)',
+      )
+      ..writeln()
+      ..writeln('## Model leaderboard')
+      ..writeln()
+      ..writeln('| Model | Pass rate | Runs | Failed runs |')
+      ..writeln('| --- | ---: | ---: | ---: |');
+    for (final standing in standings) {
+      buffer.writeln(
+        '| `${standing.modelId}` | ${standing.overall.label} | '
+        '${standing.runs} | ${standing.failedRuns} |',
+      );
+    }
+    buffer
+      ..writeln()
+      ..writeln(
+        'Rates are over *applicable* results only — a constraint that did '
+        'not apply is neither a pass nor a fail, so a scenario that never '
+        'exercised a dimension cannot inflate a score.',
+      )
+      ..writeln()
+      ..writeln('## Constraints by model')
+      ..writeln()
+      ..writeln(
+        '| Constraint | ${standings.map((s) => '`${s.modelId}`').join(' | ')} |',
+      )
+      ..writeln('| --- | ${standings.map((_) => '---:').join(' | ')} |');
+    for (final id in EvalConstraintIds.all) {
+      final cells = [
+        for (final standing in standings)
+          standing.byConstraint
+              .firstWhere((rate) => rate.constraintId == id)
+              .label,
+      ];
+      buffer.writeln('| $id | ${cells.join(' | ')} |');
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('## Cost')
+      ..writeln()
+      ..writeln(
+        '| Model | Scenario | Runs | Mean latency | In | Out | Thoughts | '
+        'Cached | Prompt bytes |',
+      )
+      ..writeln(
+        '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+      );
+    for (final row in costRows) {
+      buffer.writeln(
+        '| `${row.modelId}` | ${row.scenarioId} | ${row.runs} | '
+        '${row.meanLatencyMs} ms | ${row.inputTokens} | ${row.outputTokens} | '
+        '${row.thoughtsTokens} | ${row.cachedInputTokens} | '
+        '${row.meanPromptBytes} |',
+      );
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('## Prompt stability')
+      ..writeln()
+      ..writeln(
+        'How much of the system prompt is identical across *every* wake — '
+        'the part a provider could cache. Measured across scenarios on '
+        'purpose: within one scenario the prompt barely varies, so a per-cell '
+        'figure would just restate the prompt size.',
+      )
+      ..writeln()
+      ..writeln(
+        '| Model | Wakes | Mean system prompt | Stable prefix | Stable |',
+      )
+      ..writeln('| --- | ---: | ---: | ---: | ---: |');
+    for (final standing in standings) {
+      final runs = results.where(
+        (r) => r.request.modelId == standing.modelId,
+      );
+      final stable = _stablePrefixBytes(runs);
+      final mean = _mean(
+        runs.map((r) => utf8.encode(r.systemPrompt ?? '').length),
+      );
+      final fraction = mean == 0
+          ? '—'
+          : '${(stable / mean * 100).toStringAsFixed(0)}%';
+      buffer.writeln(
+        '| `${standing.modelId}` | ${runs.length} | $mean | $stable | '
+        '$fraction |',
+      );
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('## Failures')
+      ..writeln();
+    if (failures.isEmpty) {
+      buffer.writeln('None.');
+    } else {
+      for (final failure in failures) {
+        buffer
+          ..writeln('- **${failure.cell}** · `${failure.constraintId}`')
+          ..writeln('  - ${failure.detail}');
+        for (final rejection in failure.rejections) {
+          buffer.writeln('  - rejected: $rejection');
+        }
+      }
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('## Judge bundle')
+      ..writeln()
+      ..writeln(
+        'The JSON alongside this file carries $bundledCells cell(s) at up to '
+        '$bundleSamplesPerCell sample(s) each'
+        '${droppedSamples == 0 ? '' : ', with $droppedSamples sample(s) '
+                  'excluded by that cap'}. '
+        'Each entry is self-sufficient: the scenario and its intent, the exact '
+        'prompts, every tool call including rejections and their text, the '
+        "persisted plan, and each run's constraint results and cost.",
+      );
+    return buffer.toString();
+  }
+
+  static int _promptBytes(EvalRunResult result) =>
+      utf8.encode(result.systemPrompt ?? '').length +
+      result.userPrompts.fold<int>(
+        0,
+        (sum, prompt) => sum + utf8.encode(prompt).length,
+      );
+
+  /// Bytes shared by every system prompt in [results] — the portion a
+  /// provider could cache across wakes.
+  ///
+  /// With a single run this is the whole prompt, which is honest: nothing
+  /// varied, so nothing has been shown to be unstable.
+  static int _stablePrefixBytes(Iterable<EvalRunResult> results) {
+    final prompts = [
+      for (final result in results)
+        if (result.systemPrompt != null) result.systemPrompt!,
+    ];
+    if (prompts.isEmpty) return 0;
+    var prefix = prompts.first;
+    for (final prompt in prompts.skip(1)) {
+      var i = 0;
+      while (i < prefix.length && i < prompt.length && prefix[i] == prompt[i]) {
+        i++;
+      }
+      prefix = prefix.substring(0, i);
+      if (prefix.isEmpty) break;
+    }
+    return utf8.encode(prefix).length;
+  }
+
+  static Map<(String, String, String), List<EvalRunResult>> _groupIntoCells(
+    List<EvalRunResult> results,
+  ) {
+    final cells = <(String, String, String), List<EvalRunResult>>{};
+    for (final result in results) {
+      final key = (
+        result.request.scenario.id,
+        result.request.modelId,
+        result.request.variant.id,
+      );
+      cells.putIfAbsent(key, () => []).add(result);
+    }
+    return cells;
+  }
+
+  static int _sum(Iterable<int?> values) =>
+      values.fold<int>(0, (sum, value) => sum + (value ?? 0));
+
+  static int _mean(Iterable<int> values) {
+    final list = values.toList();
+    if (list.isEmpty) return 0;
+    return list.reduce((a, b) => a + b) ~/ list.length;
+  }
+}
+
+/// Where a report is written.
+///
+/// Defaults under the git-ignored `tmp/` directory so runs accumulate and can
+/// be diffed, and both paths are env-overridable for a CI or scratch run.
+@immutable
+class EvalReportPaths {
+  const EvalReportPaths({required this.jsonPath, required this.markdownPath});
+
+  factory EvalReportPaths.fromEnvironment({
+    Map<String, String>? environment,
+    String defaultDirectory = 'tmp/day-planning-eval',
+  }) {
+    final env = environment ?? Platform.environment;
+    final directory = env['DAY_PLANNING_EVAL_DIR'] ?? defaultDirectory;
+    return EvalReportPaths(
+      jsonPath:
+          env['DAY_PLANNING_EVAL_JSON'] ?? '$directory/day-planning-eval.json',
+      markdownPath:
+          env['DAY_PLANNING_EVAL_MARKDOWN'] ??
+          '$directory/day-planning-eval.md',
+    );
+  }
+
+  final String jsonPath;
+  final String markdownPath;
+}
+
+/// Writes [report] as JSON and Markdown, creating parent directories.
+///
+/// Returns the paths written, so a caller can point at them from a failure
+/// message.
+EvalReportPaths writeEvalReport(EvalReport report, {EvalReportPaths? paths}) {
+  final target = paths ?? EvalReportPaths.fromEnvironment();
+  (File(target.jsonPath)..parent.createSync(recursive: true)).writeAsStringSync(
+    const JsonEncoder.withIndent('  ').convert(report.toJson()),
+  );
+  (File(
+    target.markdownPath,
+  )..parent.createSync(recursive: true)).writeAsStringSync(report.toMarkdown());
+  return target;
+}

--- a/test/features/daily_os_next/eval/framework/eval_report.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report.dart
@@ -359,16 +359,14 @@ class EvalReport {
     'promptStability': [
       for (final standing in standings)
         () {
-          final runs = results.where(
-            (r) => r.request.modelId == standing.modelId,
-          );
-          final stable = _stablePrefixBytes(runs);
+          final prompts = _systemPromptsFor(results, standing.modelId);
+          final stable = _stablePrefixBytes(prompts);
           final mean = _mean(
-            runs.map((r) => utf8.encode(r.systemPrompt ?? '').length),
+            prompts.map((prompt) => utf8.encode(prompt).length),
           );
           return {
             'modelId': standing.modelId,
-            'wakes': runs.length,
+            'wakes': prompts.length,
             'meanSystemPromptBytes': mean,
             'stablePrefixBytes': stable,
             'stableFraction': mean == 0 ? null : stable / mean,
@@ -403,24 +401,37 @@ class EvalReport {
     'judgeBundle': judgeBundle(),
   };
 
+  /// Per model, per variant, per scenario, per constraint.
+  ///
+  /// Variant is a dimension rather than something pooled: a baseline pass and
+  /// a variant failure averaged into one 50% cell would hide which planning
+  /// contract produced the outcome, which is the whole reason the matrix has
+  /// a variant axis.
   Map<String, Object?> _scenarioMatrixJson() {
     final scenarioIds = <String>{
       for (final r in results) r.request.scenario.id,
     }.toList()..sort();
+    final variantIds = <String>{
+      for (final r in results) r.request.variant.id,
+    }.toList()..sort();
     return {
       for (final standing in standings)
         standing.modelId: {
-          for (final scenarioId in scenarioIds)
-            scenarioId: {
-              for (final id in EvalConstraintIds.all)
-                id: _rateFor(
-                  id,
-                  results.where(
-                    (r) =>
-                        r.request.modelId == standing.modelId &&
-                        r.request.scenario.id == scenarioId,
-                  ),
-                ).rate,
+          for (final variantId in variantIds)
+            variantId: {
+              for (final scenarioId in scenarioIds)
+                scenarioId: {
+                  for (final id in EvalConstraintIds.all)
+                    id: _rateFor(
+                      id,
+                      results.where(
+                        (r) =>
+                            r.request.modelId == standing.modelId &&
+                            r.request.variant.id == variantId &&
+                            r.request.scenario.id == scenarioId,
+                      ),
+                    ).rate,
+                },
             },
         },
     };
@@ -487,11 +498,16 @@ class EvalReport {
         'decidedTaskIds': inputs.decidedTaskIds,
         'requiredTaskIds': inputs.requiredTaskIds.toList()..sort(),
         'expectedOmissions': inputs.expectedOmissions.toList()..sort(),
-        // `visibleToModel` is not decoration. The corpus here is ground
-        // truth, and it is rendered only inside the capture context — so on a
-        // wake without a capture the model was shown none of it. A judge
-        // reading blockedBy and concluding the model ignored a dependency it
-        // never received would draw exactly the wrong lesson.
+        // Two different visibilities, and conflating them is how a judge gets
+        // misled. `corpusRowShown` is whether this row — its status, estimate
+        // and blockedBy — was rendered at all; the corpus appears only inside
+        // the capture context, so a capture-less wake sees none of it.
+        // `taskIdReferenceable` is the weaker fact that the model could name
+        // the id, which a decided task satisfies through its own projection
+        // even when its corpus row was never shown. Reporting the second as
+        // if it were the first would print `blockedBy` next to "the model saw
+        // this", inviting exactly the wrong conclusion.
+        'corpusRowsShown': inputs.visibleTaskIds == null,
         'corpus': [
           for (final task in inputs.corpus)
             {
@@ -500,18 +516,28 @@ class EvalReport {
               'status': task.status,
               'estimateMinutes': task.estimateMinutes,
               'blockedBy': task.blockedBy,
-              'visibleToModel': inputs.referenceableTaskIds.contains(
+              'corpusRowShown': inputs.visibleTaskIds == null,
+              'taskIdReferenceable': inputs.referenceableTaskIds.contains(
                 task.taskId,
               ),
             },
         ],
         'captureTranscript': scenario.captureTranscript,
       },
-      'prompts': {
-        'system': result.systemPrompt,
-        'user': result.userPrompts,
-        'forcedDraftRetry': result.forcedDraftRetry,
-      },
+      // Every conversation, not just the last. A durable retry opens a fresh
+      // one, and the entry's tool calls, attempts and cost already cover the
+      // whole cell — showing one prompt beside all of them leaves a judge
+      // unable to reconcile what it is reading.
+      'wakes': [
+        for (final wake in result.wakes)
+          {
+            'conversationId': wake.conversationId,
+            'system': wake.systemPrompt,
+            'user': wake.userMessages,
+            'forcedRetry': wake.forcedRetry,
+          },
+      ],
+      'forcedDraftRetry': result.forcedDraftRetry,
       'toolCalls': [
         for (final call in result.outcome.toolCalls)
           {
@@ -639,18 +665,14 @@ class EvalReport {
       )
       ..writeln('| --- | ---: | ---: | ---: | ---: |');
     for (final standing in standings) {
-      final runs = results.where(
-        (r) => r.request.modelId == standing.modelId,
-      );
-      final stable = _stablePrefixBytes(runs);
-      final mean = _mean(
-        runs.map((r) => utf8.encode(r.systemPrompt ?? '').length),
-      );
+      final prompts = _systemPromptsFor(results, standing.modelId);
+      final stable = _stablePrefixBytes(prompts);
+      final mean = _mean(prompts.map((prompt) => utf8.encode(prompt).length));
       final fraction = mean == 0
           ? '—'
           : '${(stable / mean * 100).toStringAsFixed(0)}%';
       buffer.writeln(
-        '| `${standing.modelId}` | ${runs.length} | $mean | $stable | '
+        '| `${standing.modelId}` | ${prompts.length} | $mean | $stable | '
         '$fraction |',
       );
     }
@@ -700,14 +722,34 @@ class EvalReport {
   ///
   /// With a single run this is the whole prompt, which is honest: nothing
   /// varied, so nothing has been shown to be unstable.
-  static int _stablePrefixBytes(Iterable<EvalRunResult> results) {
-    final prompts = [
-      for (final result in results)
-        if (result.systemPrompt != null) result.systemPrompt!,
-    ];
-    if (prompts.isEmpty) return 0;
-    var prefix = prompts.first;
-    for (final prompt in prompts.skip(1)) {
+  /// Every system prompt actually sent for [modelId], one per conversation.
+  ///
+  /// Per *wake*, not per cell: a durable job retry opens a fresh conversation
+  /// with its own prompt, and reading only the final one would drop the
+  /// earlier attempts from a stability figure that claims to cover every wake.
+  /// A cell that never reached the model contributes nothing rather than an
+  /// empty string — counting a zero-length prompt in the mean while excluding
+  /// it from the prefix can put the "stable" fraction above 100%.
+  static List<String> _systemPromptsFor(
+    List<EvalRunResult> results,
+    String modelId,
+  ) => [
+    for (final result in results)
+      if (result.request.modelId == modelId)
+        for (final wake in result.wakes)
+          if (wake.systemPrompt != null) wake.systemPrompt!,
+  ];
+
+  /// Bytes shared by every prompt in [prompts] — the portion a provider could
+  /// cache across wakes.
+  ///
+  /// With a single wake this is the whole prompt, which is honest: nothing
+  /// varied, so nothing has been shown to be unstable.
+  static int _stablePrefixBytes(Iterable<String> prompts) {
+    final list = prompts.toList();
+    if (list.isEmpty) return 0;
+    var prefix = list.first;
+    for (final prompt in list.skip(1)) {
       var i = 0;
       while (i < prefix.length && i < prompt.length && prefix[i] == prompt[i]) {
         i++;
@@ -751,19 +793,35 @@ class EvalReport {
 class EvalReportPaths {
   const EvalReportPaths({required this.jsonPath, required this.markdownPath});
 
+  /// Resolves the paths for one run.
+  ///
+  /// The default basename carries [timestamp], because the documented promise
+  /// is that runs accumulate and can be diffed — with a fixed basename each
+  /// invocation silently overwrote the last, so there was never anything to
+  /// diff against. An explicit env path still wins and stays fixed, which is
+  /// what a caller wanting "the latest report" at a stable location needs.
   factory EvalReportPaths.fromEnvironment({
+    required DateTime timestamp,
     Map<String, String>? environment,
     String defaultDirectory = 'tmp/day-planning-eval',
   }) {
     final env = environment ?? Platform.environment;
     final directory = env['DAY_PLANNING_EVAL_DIR'] ?? defaultDirectory;
+    final stamp = _stamp(timestamp);
     return EvalReportPaths(
       jsonPath:
-          env['DAY_PLANNING_EVAL_JSON'] ?? '$directory/day-planning-eval.json',
+          env['DAY_PLANNING_EVAL_JSON'] ??
+          '$directory/day-planning-eval-$stamp.json',
       markdownPath:
           env['DAY_PLANNING_EVAL_MARKDOWN'] ??
-          '$directory/day-planning-eval.md',
+          '$directory/day-planning-eval-$stamp.md',
     );
+  }
+
+  static String _stamp(DateTime at) {
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${at.year}${two(at.month)}${two(at.day)}-'
+        '${two(at.hour)}${two(at.minute)}${two(at.second)}';
   }
 
   final String jsonPath;
@@ -775,7 +833,9 @@ class EvalReportPaths {
 /// Returns the paths written, so a caller can point at them from a failure
 /// message.
 EvalReportPaths writeEvalReport(EvalReport report, {EvalReportPaths? paths}) {
-  final target = paths ?? EvalReportPaths.fromEnvironment();
+  // Stamped from the report itself, so the filename matches the run it holds.
+  final target =
+      paths ?? EvalReportPaths.fromEnvironment(timestamp: report.generatedAt);
   (File(target.jsonPath)..parent.createSync(recursive: true)).writeAsStringSync(
     const JsonEncoder.withIndent('  ').convert(report.toJson()),
   );

--- a/test/features/daily_os_next/eval/framework/eval_report_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report_test.dart
@@ -1,0 +1,554 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
+
+import 'eval_constraints.dart';
+import 'eval_models.dart';
+import 'eval_report.dart';
+import 'eval_runner.dart';
+import 'eval_scenario.dart';
+import 'eval_variant.dart';
+
+/// The report is where "not applicable is a third result" either survives or
+/// quietly becomes a pass. Every aggregation here is tested for that
+/// specifically, because a rate that counts inapplicable results as passes
+/// makes the laziest model look like the best one — and the number would look
+/// perfectly reasonable while doing it.
+void main() {
+  final generatedAt = DateTime(2026, 7, 25, 12);
+  final planDate = DateTime(2026, 7, 26);
+
+  const scenario = EvalScenario(
+    id: 'crowded',
+    intent: 'Does it prioritise?',
+    tasks: [
+      EvalTaskSpec(
+        id: 'task-1',
+        title: 'Send the overdue invoice',
+        estimateMinutes: 30,
+      ),
+    ],
+    captureTranscript: 'Busy day.',
+  );
+
+  EvalRunRequest request({
+    String modelId = 'model-a',
+    int sample = 1,
+    EvalVariant variant = evalBaselineVariant,
+    EvalScenario forScenario = scenario,
+  }) => EvalRunRequest(
+    scenario: forScenario,
+    variant: variant,
+    modelId: modelId,
+    sample: sample,
+    planDate: planDate,
+  );
+
+  PlannedBlock block({String id = 'b1', String? taskId}) => PlannedBlock(
+    id: id,
+    categoryId: 'cat-work',
+    startTime: DateTime(2026, 7, 26, 10),
+    endTime: DateTime(2026, 7, 26, 11),
+    title: 'Focus',
+    taskId: taskId,
+    reason: 'because',
+  );
+
+  EvalRunResult result({
+    required List<EvalConstraintResult> constraints,
+    EvalRunRequest? forRequest,
+    List<PlannedBlock> blocks = const [],
+    List<EvalToolCall> toolCalls = const [],
+    String? systemPrompt = 'system prompt',
+    List<String> userPrompts = const ['user prompt'],
+    Duration latency = const Duration(milliseconds: 100),
+    String? error,
+    String? jobStatus = 'succeeded',
+  }) {
+    final req = forRequest ?? request();
+    return EvalRunResult(
+      request: req,
+      outcome: EvalRunOutcome(
+        inputs: req.scenario.inputsFor(req.planDate),
+        blocks: blocks,
+        toolCalls: toolCalls,
+        planPersisted: blocks.isNotEmpty,
+      ),
+      constraints: constraints,
+      latency: latency,
+      wakes: [
+        EvalWakeTranscript(
+          conversationId: 'c1',
+          systemPrompt: systemPrompt,
+          userMessages: userPrompts,
+        ),
+      ],
+      jobStatus: jobStatus,
+      jobAttempts: 0,
+      consumption: const [],
+      error: error,
+    );
+  }
+
+  EvalConstraintResult pass(String id) =>
+      EvalConstraintResult(id: id, passed: true, detail: 'fine');
+  EvalConstraintResult fail(String id, [String detail = 'broken']) =>
+      EvalConstraintResult(id: id, passed: false, detail: detail);
+  EvalConstraintResult na(String id) =>
+      EvalConstraintResult.notApplicable(id, 'nothing exercised it');
+
+  group('rates', () {
+    test('inapplicable results are excluded from the denominator', () {
+      // The whole point: 1 pass and 2 not-applicable is 100%, not 33%. Both
+      // wrong answers are plausible-looking numbers.
+      final report = EvalReport.fromResults([
+        result(
+          constraints: [
+            pass(EvalConstraintIds.noOverlappingBlocks),
+            na(EvalConstraintIds.withinCapacity),
+            na(EvalConstraintIds.decidedTasksPlaced),
+          ],
+        ),
+      ], generatedAt: generatedAt);
+
+      final standing = report.standings.single;
+      expect(standing.overall.passed, 1);
+      expect(standing.overall.applicable, 1);
+      expect(standing.overall.rate, 1.0);
+    });
+
+    test(
+      'a constraint nothing exercised reports no rate, not a perfect one',
+      () {
+        final report = EvalReport.fromResults([
+          result(constraints: [na(EvalConstraintIds.blockerBeforeBlocked)]),
+        ], generatedAt: generatedAt);
+
+        final rate = report.standings.single.byConstraint.firstWhere(
+          (r) => r.constraintId == EvalConstraintIds.blockerBeforeBlocked,
+        );
+        expect(rate.rate, isNull);
+        expect(rate.label, '—');
+      },
+    );
+
+    test('mixes passes and failures into a real rate', () {
+      final report = EvalReport.fromResults([
+        result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+        result(
+          forRequest: request(sample: 2),
+          constraints: [fail(EvalConstraintIds.withinCapacity)],
+        ),
+        result(
+          forRequest: request(sample: 3),
+          constraints: [na(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final rate = report.standings.single.byConstraint.firstWhere(
+        (r) => r.constraintId == EvalConstraintIds.withinCapacity,
+      );
+      expect(rate.passed, 1);
+      expect(rate.applicable, 2);
+      expect(rate.label, '50% (1/2)');
+    });
+  });
+
+  group('leaderboard', () {
+    test('sorts by pass rate, best first', () {
+      final report = EvalReport.fromResults([
+        result(
+          forRequest: request(modelId: 'weak'),
+          constraints: [fail(EvalConstraintIds.withinCapacity)],
+        ),
+        result(
+          forRequest: request(modelId: 'strong'),
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      expect(report.standings.map((s) => s.modelId), ['strong', 'weak']);
+    });
+
+    test('breaks ties deterministically', () {
+      // Without a tiebreak the leaderboard reorders itself between runs that
+      // measured exactly the same thing, and a diff of two reports is noise.
+      final report = EvalReport.fromResults([
+        result(
+          forRequest: request(modelId: 'zeta'),
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+        result(
+          forRequest: request(modelId: 'alpha'),
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      expect(report.standings.map((s) => s.modelId), ['alpha', 'zeta']);
+    });
+
+    test('a model with no applicable results sorts last, not first', () {
+      final report = EvalReport.fromResults([
+        result(
+          forRequest: request(modelId: 'unmeasured'),
+          constraints: [na(EvalConstraintIds.withinCapacity)],
+        ),
+        result(
+          forRequest: request(modelId: 'measured'),
+          constraints: [fail(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      expect(
+        report.standings.map((s) => s.modelId),
+        ['measured', 'unmeasured'],
+        reason:
+            'a model that demonstrated nothing must not outrank one that was '
+            'measured and failed',
+      );
+    });
+
+    test('counts failed runs separately from constraint outcomes', () {
+      final report = EvalReport.fromResults([
+        result(
+          constraints: [na(EvalConstraintIds.withinCapacity)],
+          error: 'provider unreachable',
+          jobStatus: null,
+        ),
+      ], generatedAt: generatedAt);
+
+      expect(report.standings.single.failedRuns, 1);
+      expect(report.standings.single.runs, 1);
+    });
+  });
+
+  group('variant delta', () {
+    test('compares a variant against the baseline within one model', () {
+      const variant = EvalVariant(id: 'tighter', rationale: 'x');
+      final report = EvalReport.fromResults([
+        result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+        result(
+          forRequest: request(variant: variant),
+          constraints: [fail(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final delta =
+          (report.toJson()['variantDelta']! as Map)['model-a']!
+              as Map<String, Object?>;
+      final tighter = delta['tighter']! as Map<String, Object?>;
+      expect(tighter[EvalConstraintIds.withinCapacity], -1.0);
+    });
+
+    test(
+      'reports no delta when either side never exercised the constraint',
+      () {
+        // A delta against nothing is not zero — zero would read as "the variant
+        // changed nothing", which is a claim the data cannot support.
+        const variant = EvalVariant(id: 'tighter', rationale: 'x');
+        final report = EvalReport.fromResults([
+          result(constraints: [na(EvalConstraintIds.withinCapacity)]),
+          result(
+            forRequest: request(variant: variant),
+            constraints: [pass(EvalConstraintIds.withinCapacity)],
+          ),
+        ], generatedAt: generatedAt);
+
+        final delta =
+            (report.toJson()['variantDelta']! as Map)['model-a']!
+                as Map<String, Object?>;
+        final tighter = delta['tighter']! as Map<String, Object?>;
+        expect(tighter[EvalConstraintIds.withinCapacity], isNull);
+      },
+    );
+  });
+
+  group('judge bundle', () {
+    test(
+      'is bounded, keeps the newest samples, and states what it dropped',
+      () {
+        final report = EvalReport.fromResults(
+          [
+            for (var sample = 1; sample <= 5; sample++)
+              result(
+                forRequest: request(sample: sample),
+                constraints: [pass(EvalConstraintIds.withinCapacity)],
+              ),
+          ],
+          generatedAt: generatedAt,
+          // ignore: avoid_redundant_argument_values — the cap is the subject
+          bundleSamplesPerCell: 2,
+        );
+
+        final bundle = report.judgeBundle();
+        expect(bundle, hasLength(2));
+        expect(
+          bundle.map((entry) => entry['cell']),
+          ['crowded/model-a/baseline#5', 'crowded/model-a/baseline#4'],
+        );
+        expect(report.droppedSamples, 3);
+        expect(
+          report.toMarkdown(),
+          contains('3 sample(s) excluded'),
+          reason:
+              'a truncated bundle that does not say so reads as complete, and '
+              'a judge would draw conclusions from a partial view',
+        );
+      },
+    );
+
+    test('says nothing about exclusions when nothing was excluded', () {
+      final report = EvalReport.fromResults([
+        result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+      ], generatedAt: generatedAt);
+
+      expect(report.droppedSamples, 0);
+      expect(report.toMarkdown(), isNot(contains('excluded by that cap')));
+    });
+
+    test('carries everything needed to judge without re-running', () {
+      final report = EvalReport.fromResults([
+        result(
+          blocks: [block(taskId: 'task-1')],
+          toolCalls: const [
+            EvalToolCall(
+              name: 'draft_day_plan',
+              accepted: false,
+              rejectionMessage: 'blocks must stay within the planDate day',
+            ),
+            EvalToolCall(name: 'draft_day_plan', accepted: true),
+          ],
+          constraints: [
+            pass(EvalConstraintIds.withinCapacity),
+            fail(EvalConstraintIds.requiredWorkPlaced, 'not placed: task-1'),
+          ],
+        ),
+      ], generatedAt: generatedAt);
+
+      final entry = report.judgeBundle().single;
+      final scenarioJson = entry['scenario']! as Map<String, Object?>;
+      expect(
+        scenarioJson['intent'],
+        'Does it prioritise?',
+        reason: 'a judge cannot assess an answer without knowing the question',
+      );
+      expect(
+        (scenarioJson['corpus']! as List).single,
+        containsPair('taskId', 'task-1'),
+      );
+      expect(scenarioJson['captureTranscript'], 'Busy day.');
+      expect(
+        (scenarioJson['corpus']! as List).single,
+        containsPair('visibleToModel', true),
+      );
+      expect(
+        (entry['prompts']! as Map<String, Object?>)['system'],
+        'system prompt',
+      );
+      expect(
+        (entry['toolCalls']! as List).first,
+        containsPair(
+          'rejectionMessage',
+          'blocks must stay within the planDate day',
+        ),
+        reason:
+            'the rejection text is the only record that the first attempt was '
+            'illegal — the persisted plan is legal either way',
+      );
+      expect((entry['plan']! as List).single, containsPair('taskId', 'task-1'));
+      expect(
+        (entry['constraints']! as Map)[EvalConstraintIds.requiredWorkPlaced],
+        containsPair('detail', 'not placed: task-1'),
+      );
+    });
+
+    test('marks corpus the model was never shown as invisible', () {
+      // The no-capture scenarios keep the corpus as ground truth while the
+      // model sees only its decided tasks. Without this flag a judge would
+      // read blockedBy and blame the model for ignoring a dependency it was
+      // never given.
+      const hidden = EvalScenario(
+        id: 'hidden',
+        intent: 'the rule arrives, the data does not',
+        tasks: [
+          EvalTaskSpec(id: 'task-unseen', title: 'Unseen work'),
+        ],
+        includeCapture: false,
+      );
+      final report = EvalReport.fromResults([
+        result(
+          forRequest: request(forScenario: hidden),
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final corpus =
+          (report.judgeBundle().single['scenario']! as Map)['corpus']! as List;
+      expect(corpus.single, containsPair('visibleToModel', false));
+    });
+
+    test('rejects a cap below one', () {
+      expect(
+        () => EvalReport.fromResults(
+          [
+            result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+          ],
+          generatedAt: generatedAt,
+          bundleSamplesPerCell: 0,
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+  });
+
+  group('cost', () {
+    test('measures the stable prefix across every wake, not within one', () {
+      // What a provider could cache. Measured per model across scenarios: a
+      // per-cell figure would compare a prompt against itself and just
+      // restate the prompt size, which is what the first generated report
+      // showed before this was fixed.
+      const other = EvalScenario(
+        id: 'other',
+        intent: 'x',
+        tasks: [],
+        captureTranscript: 'x',
+      );
+      final report = EvalReport.fromResults([
+        result(
+          systemPrompt: 'SHARED HEAD then alpha',
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+        result(
+          forRequest: request(forScenario: other),
+          systemPrompt: 'SHARED HEAD then bravo',
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final stability =
+          (report.toJson()['promptStability']! as List).single
+              as Map<String, Object?>;
+      expect(stability['stablePrefixBytes'], 'SHARED HEAD then '.length);
+      expect(stability['wakes'], 2);
+      expect(
+        stability['stableFraction'],
+        closeTo(
+          'SHARED HEAD then '.length / 'SHARED HEAD then alpha'.length,
+          0.001,
+        ),
+      );
+      expect(report.toMarkdown(), contains('## Prompt stability'));
+    });
+
+    test('reports no stable fraction when no prompt was captured', () {
+      final report = EvalReport.fromResults([
+        result(
+          systemPrompt: null,
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final stability =
+          (report.toJson()['promptStability']! as List).single
+              as Map<String, Object?>;
+      expect(stability['stableFraction'], isNull);
+    });
+
+    test('counts prompt bytes including every user message', () {
+      final report = EvalReport.fromResults([
+        result(
+          systemPrompt: 'abc',
+          userPrompts: const ['de', 'f'],
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final cost =
+          (report.toJson()['cost']! as List).single as Map<String, Object?>;
+      expect(cost['meanPromptBytes'], 6);
+    });
+  });
+
+  group('failures', () {
+    test('carry the scorer detail and the rejection text', () {
+      final report = EvalReport.fromResults([
+        result(
+          toolCalls: const [
+            EvalToolCall(
+              name: 'draft_day_plan',
+              accepted: false,
+              rejectionMessage: 'must not start before current time',
+            ),
+          ],
+          constraints: [
+            fail(EvalConstraintIds.withinWorkingHours, 'starts 08:00'),
+          ],
+        ),
+      ], generatedAt: generatedAt);
+
+      final failure = report.failures.single;
+      expect(failure.detail, 'starts 08:00');
+      expect(failure.rejections.single, contains('must not start before'));
+      expect(report.toMarkdown(), contains('starts 08:00'));
+    });
+
+    test('a clean report says so rather than showing an empty section', () {
+      final report = EvalReport.fromResults([
+        result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+      ], generatedAt: generatedAt);
+
+      expect(report.failures, isEmpty);
+      expect(report.toMarkdown(), contains('None.'));
+    });
+  });
+
+  group('writeEvalReport', () {
+    test('writes JSON and Markdown, creating the directory', () {
+      final directory = Directory.systemTemp.createTempSync('eval-report-');
+      addTearDown(() => directory.deleteSync(recursive: true));
+      final paths = EvalReportPaths(
+        jsonPath: '${directory.path}/nested/report.json',
+        markdownPath: '${directory.path}/nested/report.md',
+      );
+      final report = EvalReport.fromResults([
+        result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+      ], generatedAt: generatedAt);
+
+      final written = writeEvalReport(report, paths: paths);
+
+      final decoded =
+          jsonDecode(File(written.jsonPath).readAsStringSync())
+              as Map<String, Object?>;
+      expect(decoded['kind'], 'lotti.dayPlanningEvalReport');
+      expect(decoded['runs'], 1);
+      expect(
+        File(written.markdownPath).readAsStringSync(),
+        contains('# Day-planning eval'),
+      );
+    });
+
+    test('defaults under a git-ignored directory and honours overrides', () {
+      expect(
+        EvalReportPaths.fromEnvironment(environment: const {}).jsonPath,
+        startsWith('tmp/'),
+        reason:
+            'runs accumulate across invocations, so the default must not be '
+            'somewhere a stray commit could pick it up',
+      );
+      expect(
+        EvalReportPaths.fromEnvironment(
+          environment: const {'DAY_PLANNING_EVAL_DIR': '/somewhere'},
+        ).markdownPath,
+        '/somewhere/day-planning-eval.md',
+      );
+      expect(
+        EvalReportPaths.fromEnvironment(
+          environment: const {'DAY_PLANNING_EVAL_JSON': '/exact/path.json'},
+        ).jsonPath,
+        '/exact/path.json',
+      );
+    });
+  });
+}

--- a/test/features/daily_os_next/eval/framework/eval_report_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report_test.dart
@@ -63,6 +63,7 @@ void main() {
     List<EvalToolCall> toolCalls = const [],
     String? systemPrompt = 'system prompt',
     List<String> userPrompts = const ['user prompt'],
+    List<EvalWakeTranscript>? wakes,
     Duration latency = const Duration(milliseconds: 100),
     String? error,
     String? jobStatus = 'succeeded',
@@ -78,13 +79,15 @@ void main() {
       ),
       constraints: constraints,
       latency: latency,
-      wakes: [
-        EvalWakeTranscript(
-          conversationId: 'c1',
-          systemPrompt: systemPrompt,
-          userMessages: userPrompts,
-        ),
-      ],
+      wakes:
+          wakes ??
+          [
+            EvalWakeTranscript(
+              conversationId: 'c1',
+              systemPrompt: systemPrompt,
+              userMessages: userPrompts,
+            ),
+          ],
       jobStatus: jobStatus,
       jobAttempts: 0,
       consumption: const [],
@@ -224,6 +227,34 @@ void main() {
     });
   });
 
+  group('scenario matrix', () {
+    test('keeps variants apart instead of pooling them', () {
+      // A baseline pass and a variant failure averaged into one 50% cell
+      // would hide which planning contract produced the outcome, which is the
+      // entire reason the matrix has a variant axis.
+      const variant = EvalVariant(id: 'tighter', rationale: 'x');
+      final report = EvalReport.fromResults([
+        result(constraints: [pass(EvalConstraintIds.withinCapacity)]),
+        result(
+          forRequest: request(variant: variant),
+          constraints: [fail(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final matrix =
+          (report.toJson()['scenarioMatrix']! as Map)['model-a']!
+              as Map<String, Object?>;
+      final baseline =
+          (matrix[evalBaselineVariantId]! as Map)['crowded']!
+              as Map<String, Object?>;
+      final tighter =
+          (matrix['tighter']! as Map)['crowded']! as Map<String, Object?>;
+
+      expect(baseline[EvalConstraintIds.withinCapacity], 1.0);
+      expect(tighter[EvalConstraintIds.withinCapacity], 0.0);
+    });
+  });
+
   group('variant delta', () {
     test('compares a variant against the baseline within one model', () {
       const variant = EvalVariant(id: 'tighter', rationale: 'x');
@@ -341,10 +372,10 @@ void main() {
       expect(scenarioJson['captureTranscript'], 'Busy day.');
       expect(
         (scenarioJson['corpus']! as List).single,
-        containsPair('visibleToModel', true),
+        containsPair('corpusRowShown', true),
       );
       expect(
-        (entry['prompts']! as Map<String, Object?>)['system'],
+        ((entry['wakes']! as List).single as Map)['system'],
         'system prompt',
       );
       expect(
@@ -364,17 +395,20 @@ void main() {
       );
     });
 
-    test('marks corpus the model was never shown as invisible', () {
-      // The no-capture scenarios keep the corpus as ground truth while the
-      // model sees only its decided tasks. Without this flag a judge would
-      // read blockedBy and blame the model for ignoring a dependency it was
-      // never given.
+    test('separates corpus visibility from decided-task referenceability', () {
+      // The trap: in a capture-less scenario a *decided* task is still
+      // referenceable through its own projection, so keying the flag on
+      // referenceability would print `blockedBy` beside "the model saw this"
+      // for a row that was never rendered — the exact wrong conclusion the
+      // flag exists to prevent.
       const hidden = EvalScenario(
         id: 'hidden',
         intent: 'the rule arrives, the data does not',
         tasks: [
+          EvalTaskSpec(id: 'task-decided', title: 'Decided work'),
           EvalTaskSpec(id: 'task-unseen', title: 'Unseen work'),
         ],
+        decidedTaskIds: ['task-decided'],
         includeCapture: false,
       );
       final report = EvalReport.fromResults([
@@ -384,10 +418,60 @@ void main() {
         ),
       ], generatedAt: generatedAt);
 
-      final corpus =
-          (report.judgeBundle().single['scenario']! as Map)['corpus']! as List;
-      expect(corpus.single, containsPair('visibleToModel', false));
+      final scenarioJson =
+          report.judgeBundle().single['scenario']! as Map<String, Object?>;
+      expect(scenarioJson['corpusRowsShown'], false);
+      final rows = (scenarioJson['corpus']! as List)
+          .cast<Map<String, Object?>>();
+      final decided = rows.firstWhere((r) => r['taskId'] == 'task-decided');
+      final unseen = rows.firstWhere((r) => r['taskId'] == 'task-unseen');
+
+      expect(
+        decided['taskIdReferenceable'],
+        isTrue,
+        reason: 'a decided task is named to the model through its projection',
+      );
+      expect(
+        decided['corpusRowShown'],
+        isFalse,
+        reason:
+            'its status, estimate and blockedBy were never rendered, so a '
+            'judge must not read them as something the model ignored',
+      );
+      expect(unseen['taskIdReferenceable'], isFalse);
+      expect(unseen['corpusRowShown'], isFalse);
     });
+
+    test(
+      'serialises every wake so the entry reconciles with its own totals',
+      () {
+        // The entry's tool calls, attempts and cost cover the whole cell, so
+        // showing one prompt beside all of them leaves a judge unable to
+        // reconcile what it is reading.
+        final report = EvalReport.fromResults([
+          result(
+            wakes: const [
+              EvalWakeTranscript(
+                conversationId: 'c1',
+                systemPrompt: 'first attempt',
+                userMessages: ['u1'],
+              ),
+              EvalWakeTranscript(
+                conversationId: 'c2',
+                systemPrompt: 'retry',
+                userMessages: ['u2', 'forced follow-up'],
+              ),
+            ],
+            constraints: [pass(EvalConstraintIds.withinCapacity)],
+          ),
+        ], generatedAt: generatedAt);
+
+        final wakes = report.judgeBundle().single['wakes']! as List;
+        expect(wakes, hasLength(2));
+        expect((wakes.first as Map)['system'], 'first attempt');
+        expect((wakes.last as Map)['forcedRetry'], isTrue);
+      },
+    );
 
     test('rejects a cap below one', () {
       expect(
@@ -455,6 +539,62 @@ void main() {
               as Map<String, Object?>;
       expect(stability['stableFraction'], isNull);
     });
+
+    test('counts every retry wake, not just the last', () {
+      // A durable job retry opens a fresh conversation with its own prompt.
+      // Reading only the final one drops the earlier attempts from a figure
+      // that claims to cover every wake.
+      final report = EvalReport.fromResults([
+        result(
+          wakes: const [
+            EvalWakeTranscript(
+              conversationId: 'c1',
+              systemPrompt: 'SHARED then one',
+              userMessages: ['u'],
+            ),
+            EvalWakeTranscript(
+              conversationId: 'c2',
+              systemPrompt: 'SHARED then two',
+              userMessages: ['u'],
+            ),
+          ],
+          constraints: [pass(EvalConstraintIds.withinCapacity)],
+        ),
+      ], generatedAt: generatedAt);
+
+      final stability =
+          (report.toJson()['promptStability']! as List).single
+              as Map<String, Object?>;
+      expect(stability['wakes'], 2, reason: 'wakes, not cells');
+      expect(stability['stablePrefixBytes'], 'SHARED then '.length);
+    });
+
+    test(
+      'a cell that never reached the model cannot push stability over 100%',
+      () {
+        // The failed cell contributes no prompt. Counting it as a zero-length
+        // prompt in the mean while excluding it from the prefix produced a
+        // "stable fraction" above 1 — a number that cannot mean anything.
+        final report = EvalReport.fromResults([
+          result(
+            systemPrompt: 'a stable system prompt',
+            constraints: [pass(EvalConstraintIds.withinCapacity)],
+          ),
+          result(
+            forRequest: request(sample: 2),
+            wakes: const [],
+            constraints: [na(EvalConstraintIds.withinCapacity)],
+            error: 'provider unreachable',
+          ),
+        ], generatedAt: generatedAt);
+
+        final stability =
+            (report.toJson()['promptStability']! as List).single
+                as Map<String, Object?>;
+        expect(stability['wakes'], 1);
+        expect(stability['stableFraction'], 1.0);
+      },
+    );
 
     test('counts prompt bytes including every user message', () {
       final report = EvalReport.fromResults([
@@ -531,7 +671,10 @@ void main() {
 
     test('defaults under a git-ignored directory and honours overrides', () {
       expect(
-        EvalReportPaths.fromEnvironment(environment: const {}).jsonPath,
+        EvalReportPaths.fromEnvironment(
+          timestamp: generatedAt,
+          environment: const {},
+        ).jsonPath,
         startsWith('tmp/'),
         reason:
             'runs accumulate across invocations, so the default must not be '
@@ -539,15 +682,33 @@ void main() {
       );
       expect(
         EvalReportPaths.fromEnvironment(
+          timestamp: generatedAt,
           environment: const {'DAY_PLANNING_EVAL_DIR': '/somewhere'},
         ).markdownPath,
-        '/somewhere/day-planning-eval.md',
+        '/somewhere/day-planning-eval-20260725-120000.md',
+        reason:
+            'a fixed basename overwrites the previous run, so there is never '
+            'anything to diff against',
       );
       expect(
         EvalReportPaths.fromEnvironment(
+          timestamp: generatedAt,
           environment: const {'DAY_PLANNING_EVAL_JSON': '/exact/path.json'},
         ).jsonPath,
         '/exact/path.json',
+        reason: 'an explicit override stays fixed',
+      );
+      expect(
+        EvalReportPaths.fromEnvironment(
+          timestamp: DateTime(2026, 7, 25, 12, 0, 1),
+          environment: const {},
+        ).jsonPath,
+        isNot(
+          EvalReportPaths.fromEnvironment(
+            timestamp: generatedAt,
+            environment: const {},
+          ).jsonPath,
+        ),
       );
     });
   });


### PR DESCRIPTION
Aggregates matrix results into JSON + Markdown, and into a bundle plan *quality* can be judged from without re-running. Closes `lotti3-anb.4`. Test-only; the sole `lib/` change is the feature README.

Output goes to the git-ignored `tmp/day-planning-eval/`, env-overridable via `DAY_PLANNING_EVAL_DIR` (or per-file with `DAY_PLANNING_EVAL_JSON` / `DAY_PLANNING_EVAL_MARKDOWN`), so runs accumulate and can be diffed.

## Rates are over *applicable* results only

This is the property the whole report stands on, and both ways of getting it wrong produce a number that looks perfectly reasonable:

- counting not-applicable as a **pass** makes the laziest model look best — a plan with nothing in it satisfies "no overlaps, nothing fabricated, every omission honoured"
- counting it as a **fail** punishes a scenario for not exercising a dimension

So a constraint nothing exercised reports `—`, never 100%, and the leaderboard sorts models with no applicable results *last* rather than first. Ties break deterministically, or diffing two reports of the same run is noise.

## What reading a generated report actually caught

I generated one end to end from a scripted matrix run before finishing, which is acceptance criterion 4. Two things fell out that no unit test would have:

**Stable-prefix was measured in the wrong place.** It was per (model, scenario), where there is normally one run — so it compared a prompt against itself and printed an identical figure for every scenario, silently restating the system prompt size. It is now per model across scenarios, which answers the question that matters: how much of the prompt a provider could cache. On the current prompt that is **the entire 7.7 KB system message**, with all variation in the user message. That is `lotti3-hkb.16` delivered as a by-product, as its bead anticipated.

**The bundle could mislead a judge.** Corpus rows carried `blockedBy` but nothing said whether the model was *shown* them. The corpus is ground truth and is rendered only inside the capture context, so on a capture-less wake (`blockedWithoutCorpus` exists precisely to test that) the model saw none of it. A judge reading `blockedBy` would have blamed the model for ignoring a dependency it never received. Rows now carry `visibleToModel`.

## The judge bundle

Plan quality — is this a sensible day, is the ordering right, is it realistic rather than overpacked-but-legal — is judged from artifacts by a person or by Opus 5 reading the repo, not by an in-harness LLM judge that would bake scoring noise and cost into every run while saying little you can act on.

So each bundle entry is self-sufficient: the scenario **and its intent** (a judge cannot assess an answer without the question), the exact prompts, every tool call including rejections and their text, the persisted plan, and that run's constraint results and cost. It is bounded to the newest samples per cell and **states what it dropped** — a truncated bundle that stays silent reads as complete.

## Verification

- `fvm dart analyze` clean.
- 175 tests in the eval framework, 21 of them new. Every aggregation is tested against the not-applicable trap specifically: 1 pass + 2 n/a is 100%, a model that demonstrated nothing sorts below one that was measured and failed, and a variant delta against a side that never exercised the constraint is `null` rather than zero — zero would read as "the variant changed nothing", a claim the data cannot support.
- A real report was generated from a scripted two-scenario matrix and read end to end, which is how both issues above were found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added day-planning evaluation reporting that aggregates run results into JSON and Markdown.
  - Reports include per-model standings, per-constraint applicable/pass rates, cost summaries, prompt stability metrics, and failure excerpts.
  - Generated “judge bundle” samples (with capped sampling) for transparent replay and analysis.
  - Output location can be configured via environment variables, with timestamped defaults.

- **Documentation**
  - Expanded README guidance with a full walkthrough of report sections and metrics.

- **Tests**
  - Added end-to-end coverage for aggregation rules, ranking logic, variant comparisons, stability/cost computations, bundle capping, and report writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->