### PR TITLE
test: measure the binding day directive in the eval

### DIFF
--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -40,6 +40,7 @@ abstract final class EvalConstraintIds {
   static const noInventedWork = 'noInventedWork';
   static const taskWorkIsTyped = 'taskWorkIsTyped';
   static const noFabricatedCalendarBlocks = 'noFabricatedCalendarBlocks';
+  static const directiveHonoured = 'directiveHonoured';
 
   /// Guarded — scored on rejections rather than on the plan.
   static const compliedWithoutRejection = 'compliedWithoutRejection';
@@ -61,6 +62,7 @@ abstract final class EvalConstraintIds {
     noInventedWork,
     taskWorkIsTyped,
     noFabricatedCalendarBlocks,
+    directiveHonoured,
     compliedWithoutRejection,
   ];
 }
@@ -83,6 +85,7 @@ List<EvalConstraintResult> scoreAll(EvalRunOutcome outcome) => [
   scoreNoInventedWork(outcome),
   scoreTaskWorkIsTyped(outcome),
   scoreNoFabricatedCalendarBlocks(outcome),
+  scoreDirectiveHonoured(outcome),
   scoreCompliedWithoutRejection(outcome),
 ];
 
@@ -690,6 +693,92 @@ EvalConstraintResult scoreTaskWorkIsTyped(EvalRunOutcome outcome) {
     detail: mistyped.isEmpty
         ? 'task work is on work blocks'
         : mistyped.join('; '),
+  );
+}
+
+/// Every directive commitment is represented, traded away, or escalated —
+/// never silently dropped.
+///
+/// This is the strongest contract in the prompt. The directive is stated as
+/// "BINDING, not a hint", and the three legitimate responses are spelled out:
+/// represent the commitment in the plan, trade it away in a proposed diff
+/// whose reason names the colliding commitment, or escalate via
+/// `raise_day_status` with reason `directiveUnsatisfiable`. Nothing in the
+/// write path enforces any of it — the directive is prompt text and the plan
+/// writer never reads it back — so a model can drop a commitment the user
+/// asked for and the plan persists clean.
+///
+/// Escalation is directive-level: a model that says the directive cannot be
+/// satisfied has answered for every commitment it did not place, which is what
+/// the prompt asks of it. Trades are per-commitment and must name their
+/// casualty, because "traded something away" without saying what gives the
+/// user nothing to act on.
+EvalConstraintResult scoreDirectiveHonoured(EvalRunOutcome outcome) {
+  const id = EvalConstraintIds.directiveHonoured;
+  final directive = outcome.inputs.directive;
+  if (directive == null || directive.commitments.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'the wake was given no directive',
+    );
+  }
+  final escalated = outcome.toolCalls.any(
+    (call) =>
+        call.accepted &&
+        call.name.contains('raise_day_status') &&
+        call.arguments['status'] == 'attentionNeeded' &&
+        switch (call.arguments['reasons']) {
+          final List<Object?> list =>
+            list.map((r) => '$r').contains('directiveUnsatisfiable'),
+          _ => false,
+        },
+  );
+
+  // Prose the model attached to the plan, where a representation names its
+  // commitment.
+  final planProse = [
+    for (final block in _scheduled(outcome))
+      '${block.title ?? ''} ${block.reason ?? ''} ${block.note ?? ''}',
+  ].join(' ').toLowerCase();
+  // Reasons on any proposed diff, which is where the prompt puts a trade.
+  final tradeProse = [
+    for (final call in outcome.toolCalls)
+      if (call.accepted && call.name.contains('propose_plan_diff'))
+        switch (call.arguments['changes']) {
+          final List<Object?> changes => [
+            for (final change in changes)
+              if (change is Map) '${change['reason'] ?? ''}',
+          ].join(' '),
+          _ => '',
+        },
+  ].join(' ').toLowerCase();
+
+  final dispositions = <String>[];
+  final dropped = <String>[];
+  for (final commitment in directive.commitments) {
+    final title = commitment.title.toLowerCase();
+    final identifier = commitment.id.toLowerCase();
+    bool named(String prose) =>
+        (title.isNotEmpty && prose.contains(title)) ||
+        (identifier.isNotEmpty && prose.contains(identifier));
+    if (named(planProse)) {
+      dispositions.add('${commitment.id}: represented');
+    } else if (named(tradeProse)) {
+      dispositions.add('${commitment.id}: traded, naming the collision');
+    } else if (escalated) {
+      dispositions.add('${commitment.id}: escalated');
+    } else {
+      dispositions.add('${commitment.id}: SILENTLY DROPPED');
+      dropped.add(commitment.id);
+    }
+  }
+  return EvalConstraintResult(
+    id: id,
+    passed: dropped.isEmpty,
+    detail: dropped.isEmpty
+        ? 'every commitment answered for — ${dispositions.join('; ')}'
+        : 'dropped without a word: ${dropped.join(', ')} '
+              '(${dispositions.join('; ')})',
   );
 }
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -47,6 +47,7 @@ void main() {
     Set<String>? visibleTaskIds,
     List<EvalToolCall> toolCalls = const [],
     int capacityMinutes = 480,
+    EvalDirective? directive,
   }) => EvalRunOutcome(
     inputs: EvalFixtureInputs(
       dayId: 'dayplan-2026-07-18',
@@ -64,6 +65,7 @@ void main() {
       workingHoursStartHour: workingHoursStartHour,
       workingHoursEndHour: workingHoursEndHour,
       capacityMinutes: capacityMinutes,
+      directive: directive,
     ),
     blocks: blocks,
     toolCalls: toolCalls,
@@ -1455,6 +1457,231 @@ void main() {
         scoreNoFabricatedCalendarBlocks(subject).detail,
         isNot(contains('outside')),
       );
+    });
+  });
+
+  group('directiveHonoured', () {
+    const commitments = [
+      EvalDirectiveCommitment(
+        id: 'commit-deck',
+        title: 'Prepare the board deck',
+        minutes: 180,
+      ),
+      EvalDirectiveCommitment(
+        id: 'commit-1-1s',
+        title: 'Run the weekly 1:1s',
+        minutes: 90,
+      ),
+    ];
+    const directive = EvalDirective(
+      commitments: commitments,
+      availableMinutes: 240,
+    );
+
+    PlannedBlock titled(String title, {String? reason}) => PlannedBlock(
+      id: title,
+      categoryId: 'cat-1',
+      startTime: DateTime(2026, 7, 18, 9),
+      endTime: DateTime(2026, 7, 18, 12),
+      title: title,
+      reason: reason,
+    );
+
+    test('is not applicable when the wake was given no directive', () {
+      final result = scoreDirectiveHonoured(outcome());
+
+      expect(result.isApplicable, isFalse);
+      expect(result.detail, contains('no directive'));
+    });
+
+    test('fails when a commitment is dropped without a word', () {
+      // Nothing in the write path enforces the directive — it is prompt text
+      // and the plan writer never reads it back — so a dropped commitment
+      // persists a clean-looking plan.
+      final result = scoreDirectiveHonoured(
+        outcome(
+          blocks: [titled('Prepare the board deck')],
+          directive: directive,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('commit-1-1s'));
+      expect(
+        result.detail,
+        contains('dropped without a word'),
+        reason: 'the report has to say which commitment vanished',
+      );
+    });
+
+    test('passes when every commitment is represented in the plan', () {
+      final result = scoreDirectiveHonoured(
+        outcome(
+          blocks: [
+            titled('Prepare the board deck'),
+            titled('Run the weekly 1:1s'),
+          ],
+          directive: directive,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('represented'));
+    });
+
+    test('accepts a commitment named only in a block reason', () {
+      // A commitment can be honoured inside other work; the prompt asks for
+      // it to be represented, not to be its own titled block.
+      final result = scoreDirectiveHonoured(
+        outcome(
+          blocks: [
+            titled('Prepare the board deck'),
+            titled('Leadership block', reason: 'Covers commit-1-1s.'),
+          ],
+          directive: directive,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('escalation answers for every commitment left unplaced', () {
+      // Escalation is directive-level: a model that says the orders cannot be
+      // satisfied has answered for all of them, which is what the prompt asks.
+      final result = scoreDirectiveHonoured(
+        outcome(
+          blocks: [titled('Prepare the board deck')],
+          directive: directive,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'raise_day_status',
+              accepted: true,
+              arguments: {
+                'status': 'attentionNeeded',
+                'reasons': ['directiveUnsatisfiable'],
+              },
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('escalated'));
+    });
+
+    test('a rejected or unrelated escalation does not answer for anything', () {
+      for (final call in const [
+        EvalToolCall(
+          name: 'raise_day_status',
+          accepted: false,
+          arguments: {
+            'status': 'attentionNeeded',
+            'reasons': ['directiveUnsatisfiable'],
+          },
+        ),
+        EvalToolCall(
+          name: 'raise_day_status',
+          accepted: true,
+          arguments: {
+            'status': 'attentionNeeded',
+            'reasons': ['processingBlocked'],
+          },
+        ),
+        EvalToolCall(
+          name: 'raise_day_status',
+          accepted: true,
+          arguments: {
+            'status': 'onTrack',
+            'reasons': ['directiveUnsatisfiable'],
+          },
+        ),
+      ]) {
+        final result = scoreDirectiveHonoured(
+          outcome(
+            blocks: [titled('Prepare the board deck')],
+            directive: directive,
+            toolCalls: [call],
+          ),
+        );
+
+        expect(
+          result.passed,
+          isFalse,
+          reason:
+              'status=${call.arguments['status']} accepted=${call.accepted}',
+        );
+      }
+    });
+
+    test('a trade must name the commitment it collides with', () {
+      // The prompt says the diff's reason names the colliding commitment.
+      // "Traded something away" without saying what gives the user nothing.
+      final vague = scoreDirectiveHonoured(
+        outcome(
+          blocks: [titled('Prepare the board deck')],
+          directive: directive,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'propose_plan_diff',
+              accepted: true,
+              arguments: {
+                'changes': [
+                  {'action': 'dropped', 'reason': 'Something had to give.'},
+                ],
+              },
+            ),
+          ],
+        ),
+      );
+      final named = scoreDirectiveHonoured(
+        outcome(
+          blocks: [titled('Prepare the board deck')],
+          directive: directive,
+          toolCalls: const [
+            EvalToolCall(
+              name: 'propose_plan_diff',
+              accepted: true,
+              arguments: {
+                'changes': [
+                  {
+                    'action': 'dropped',
+                    'reason':
+                        'Run the weekly 1:1s collides with the board deck.',
+                  },
+                ],
+              },
+            ),
+          ],
+        ),
+      );
+
+      expect(vague.passed, isFalse);
+      expect(named.passed, isTrue);
+      expect(named.detail, contains('traded'));
+    });
+
+    test('a dropped block does not count as representing a commitment', () {
+      // Dropping is the model declining the work, which is the opposite of
+      // honouring the order.
+      final result = scoreDirectiveHonoured(
+        outcome(
+          blocks: [
+            PlannedBlock(
+              id: 'b1',
+              categoryId: 'cat-1',
+              startTime: DateTime(2026, 7, 18, 9),
+              endTime: DateTime(2026, 7, 18, 12),
+              title: 'Prepare the board deck',
+              state: PlannedBlockState.dropped,
+            ),
+            titled('Run the weekly 1:1s'),
+          ],
+          directive: directive,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('commit-deck'));
     });
   });
 

--- a/test/features/daily_os_next/eval/framework/eval_models.dart
+++ b/test/features/daily_os_next/eval/framework/eval_models.dart
@@ -44,6 +44,57 @@ class EvalCorpusTask {
       status.toUpperCase() == 'BLOCKED' || blockedBy.isNotEmpty;
 }
 
+/// One commitment the coordinator handed down for a day.
+///
+/// Directive commitments are not tasks: they carry their own ids and titles
+/// and never appear in the task corpus, so a scorer has to match them by what
+/// the plan says rather than by `taskId`.
+@immutable
+class EvalDirectiveCommitment {
+  const EvalDirectiveCommitment({
+    required this.id,
+    required this.title,
+    required this.minutes,
+  });
+
+  final String id;
+  final String title;
+  final int minutes;
+}
+
+/// The `<day_directive>` a scenario seeds.
+///
+/// The prompt calls this BINDING, not a hint, and names exactly three
+/// legitimate responses to a commitment: represent it in the plan, trade it
+/// away in a diff whose reason names the colliding commitment, or escalate via
+/// `raise_day_status` with reason `directiveUnsatisfiable`. Silently dropping
+/// one is the failure.
+@immutable
+class EvalDirective {
+  const EvalDirective({
+    required this.commitments,
+    required this.availableMinutes,
+    this.alreadyScheduledMinutes = 0,
+    this.attentionNotes = const [],
+  });
+
+  final List<EvalDirectiveCommitment> commitments;
+
+  /// `capacityBudget.availableMinutes` as the coordinator stated it.
+  final int availableMinutes;
+  final int alreadyScheduledMinutes;
+  final List<String> attentionNotes;
+
+  int get requestedMinutes =>
+      commitments.fold<int>(0, (sum, c) => sum + c.minutes);
+
+  /// What the prompt asks the model to reconcile against before drafting.
+  int get remainingMinutes => availableMinutes - alreadyScheduledMinutes;
+
+  /// Whether the directive can be honoured in full as stated.
+  bool get fits => requestedMinutes <= remainingMinutes;
+}
+
 /// The inputs a scenario handed the model, kept alongside the result so a
 /// scorer never has to re-derive what the model was asked to do.
 @immutable
@@ -63,6 +114,7 @@ class EvalFixtureInputs {
     this.capacityMinutes = 480,
     this.workingHoursStartHour = 9,
     this.workingHoursEndHour = 17,
+    this.directive,
     this.now,
   });
 
@@ -144,6 +196,9 @@ class EvalFixtureInputs {
   /// of 480 minutes and stays inside the calendar day, so every other
   /// constraint is satisfied while the plan is unusable.
   final int workingHoursEndHour;
+
+  /// The binding directive the wake was given, if any.
+  final EvalDirective? directive;
 
   /// Wall instant the draft ran at, for same-day scenarios. Null for a
   /// future-day draft, where "the past" has no meaning.

--- a/test/features/daily_os_next/eval/framework/eval_runner.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner.dart
@@ -1,5 +1,4 @@
 import 'package:clock/clock.dart';
-import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/ai/conversation/conversation_manager.dart';
@@ -10,6 +9,9 @@ import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/ai_consumption/model/ai_consumption_event.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_config.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_identity.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_directive_models.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:meta/meta.dart';
@@ -403,6 +405,9 @@ Future<EvalRunResult> _runCell(
     final captureId = scenario.includeCapture
         ? await _seedCapture(harness, scenario, planDate)
         : const CaptureId('');
+    if (scenario.directive != null) {
+      await _seedDirective(harness, scenario.directive!, planDate);
+    }
 
     stopwatch.start();
     try {
@@ -531,6 +536,50 @@ Future<CaptureId> _seedCapture(
           as CaptureEntity;
   await harness.syncService.upsertEntity(capture);
   return CaptureId(capture.id);
+}
+
+/// Writes the scenario's `<day_directive>` directly, without running a digest
+/// wake to issue it.
+///
+/// Production issues a directive from the coordinator's digest, which is a
+/// second model call with its own prompt and tool budget — the same reason the
+/// capture is seeded rather than submitted. What the drafting wake needs is
+/// the persisted [DayDirectiveEntity]: `directiveForDay` reads it by
+/// deterministic id and the prompt builder renders the real section from it.
+Future<void> _seedDirective(
+  DayAgentPipelineHarness harness,
+  EvalDirective directive,
+  DateTime planDate,
+) async {
+  final dayId = dayAgentIdForDate(planDate);
+  final now = clock.now();
+  await harness.syncService.upsertEntity(
+    AgentDomainEntity.dayDirective(
+      id: dayDirectiveEntityId(dayId),
+      agentId: dailyOsPlannerAgentId,
+      dayId: dayId,
+      planDate: planDate,
+      directiveRevisionId: 'eval-directive-1',
+      issuedAt: now,
+      createdAt: now,
+      updatedAt: now,
+      vectorClock: null,
+      commitments: [
+        for (final commitment in directive.commitments)
+          DayDirectiveCommitment(
+            id: commitment.id,
+            source: DayCommitmentSource.userCommitment,
+            title: commitment.title,
+            minutes: commitment.minutes,
+          ),
+      ],
+      capacityBudget: DayCapacityBudget(
+        availableMinutes: directive.availableMinutes,
+        alreadyScheduledMinutes: directive.alreadyScheduledMinutes,
+      ),
+      attentionNotes: directive.attentionNotes,
+    ),
+  );
 }
 
 /// Reconstructs the ordered tool-call log from the agent messages one wake

--- a/test/features/daily_os_next/eval/framework/eval_runner_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner_test.dart
@@ -619,6 +619,42 @@ void main() {
       },
     );
 
+    test('renders the seeded directive into the prompt', () async {
+      // The directive is seeded as a real entity and read back through
+      // `directiveForDay`, so this asserts the whole path — a scenario whose
+      // directive never reached the prompt would score the contract against a
+      // model that was never given it.
+      final scenario = evalScenarios.firstWhere(
+        (s) => s.id == 'bindingDirective',
+      );
+      final planDate = evalPlanDateFor(scenario, today);
+      final result = await runEvalCell(
+        request: requestFor(scenario),
+        model: scriptedTarget(
+          turns: [
+            [draftCall(planDate: planDate, blocks: legalBlocks(planDate))],
+          ],
+        ),
+      );
+
+      expect(result.userPrompts.single, contains('<day_directive>'));
+      expect(result.userPrompts.single, contains('commit-board-deck'));
+      expect(
+        result.userPrompts.single,
+        contains('Prepare the board deck'),
+        reason: 'the commitment title is what a plan block has to name',
+      );
+      expect(
+        result.constraints
+            .firstWhere((c) => c.id == EvalConstraintIds.directiveHonoured)
+            .passed,
+        isFalse,
+        reason:
+            'the scripted plan names no commitment, so all three were '
+            'silently dropped',
+      );
+    });
+
     test(
       'drafts a same-day scenario under a clock anchored to its start hour',
       () async {

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -72,6 +72,7 @@ class EvalScenario {
     this.startHour,
     this.includeCapture = true,
     this.captureTranscript,
+    this.directive,
   });
 
   final String id;
@@ -126,6 +127,12 @@ class EvalScenario {
   final bool includeCapture;
 
   final String? captureTranscript;
+
+  /// A binding `<day_directive>` the coordinator issued for this day.
+  ///
+  /// Seeded as a real `DayDirectiveEntity`, so the wake reads it through the
+  /// production path and renders the real prompt section.
+  final EvalDirective? directive;
 
   /// Blocker map for the fixture-backed resolver.
   Map<String, List<ResolvedBlocker>> get blockedStatus {
@@ -188,6 +195,7 @@ class EvalScenario {
       // the model can name are its decided ones. The corpus above stays as
       // ground truth for constraints that need to know what is actually true.
       visibleTaskIds: includeCapture ? null : {...decidedTaskIds},
+      directive: directive,
       capacityMinutes: effective.capacityMinutes,
       workingHoursStartHour: evalWholeHourOf(
         effective.workingHoursStart,
@@ -330,6 +338,7 @@ const List<EvalScenario> evalScenarios = [
   _blockedChain,
   _blockedWithoutCorpus,
   _staleDecidedTask,
+  _bindingDirective,
 ];
 
 /// Does it invent work when there is none to do?
@@ -596,6 +605,57 @@ const _staleDecidedTask = EvalScenario(
   captureTranscript:
       'I already sent that invoice last week, it is done. Today I need to get '
       'through the security questionnaire.',
+);
+
+/// Orders from the coordinator that do not fit the day.
+const _bindingDirective = EvalScenario(
+  id: 'bindingDirective',
+  intent:
+      'A directive the prompt calls BINDING asks for 390 minutes against a '
+      '240-minute budget. Does the planner represent what fits and answer for '
+      'the rest — trading with the collision named, or escalating as '
+      'directiveUnsatisfiable — or does it quietly drop a commitment the user '
+      'asked for?',
+  tasks: [
+    EvalTaskSpec(
+      id: 'task-inbox',
+      title: 'Clear the support inbox',
+      estimateMinutes: 45,
+    ),
+    EvalTaskSpec(
+      id: 'task-release-notes',
+      title: 'Write the release notes',
+      estimateMinutes: 60,
+      dueOffsetDays: 0,
+    ),
+  ],
+  // Deliberately over budget: 180 + 120 + 90 against 240 remaining. A day that
+  // fits would let a model honour everything by accident and prove nothing
+  // about the contract, which only bites when something has to give.
+  directive: EvalDirective(
+    commitments: [
+      EvalDirectiveCommitment(
+        id: 'commit-board-deck',
+        title: 'Prepare the board deck',
+        minutes: 180,
+      ),
+      EvalDirectiveCommitment(
+        id: 'commit-interviews',
+        title: 'Interview two candidates',
+        minutes: 120,
+      ),
+      EvalDirectiveCommitment(
+        id: 'commit-weekly-1-1s',
+        title: 'Run the weekly 1:1s',
+        minutes: 90,
+      ),
+    ],
+    availableMinutes: 300,
+    alreadyScheduledMinutes: 60,
+    attentionNotes: ['Board deck is the one that cannot slip.'],
+  ),
+  captureTranscript:
+      'The board deck has to land today. Not sure how the rest fits.',
 );
 
 /// Stubs the corpus reads on [journalDb] from [scenario].

--- a/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario_test.dart
@@ -397,6 +397,21 @@ void main() {
     expect(middle.data.status, isA<TaskBlocked>());
   });
 
+  test('the binding-directive scenario asks for more than the budget', () {
+    // A directive that fits would let a model honour everything by accident.
+    // The contract only bites when something has to give.
+    final directive = byId('bindingDirective').directive!;
+
+    expect(directive.commitments, hasLength(3));
+    expect(directive.requestedMinutes, 390);
+    expect(directive.remainingMinutes, 240);
+    expect(
+      directive.fits,
+      isFalse,
+      reason: 'a satisfiable directive measures nothing about the contract',
+    );
+  });
+
   test('every scenario claiming a capture can actually supply one', () {
     // A scenario with includeCapture but no transcript would silently become
     // its no-capture twin: the corpus would never be rendered while the


### PR DESCRIPTION
The prompt calls the day directive **"BINDING, not a hint"** and names exactly three legitimate responses to a commitment: represent it in the plan, trade it away in a diff whose reason names the colliding commitment, or escalate via `raise_day_status` with reason `directiveUnsatisfiable`. Nothing enforces any of it — the directive is prompt text and the plan writer never reads it back — so a model can drop a commitment the user asked for and the plan persists looking clean.

That was the strongest contract in the prompt and the only major one with no coverage at all. Stronger than ADR 0043's blocked-work rule, which does have a scenario. Closes `lotti3-anb.10`. Test-only.

## The scenario

`bindingDirective` seeds a real `DayDirectiveEntity`: three commitments totalling **390 minutes against a 240-minute remaining budget** (300 available, 60 already scheduled). Deliberately over budget — a directive that fits would let a model honour everything by accident and prove nothing, since the contract only bites when something has to give. A fixture test asserts the arithmetic, so a later edit cannot quietly make it satisfiable.

It is seeded directly rather than by running a digest wake, for the same reason the capture is: a digest is a second model call with its own prompt and tool budget, and the unit of measurement here is one drafting wake. `directiveForDay` reads it by deterministic id and the prompt builder renders the real section — a runner test asserts `<day_directive>`, the commitment id and its title all reach the prompt, so the scenario cannot silently stop testing anything.

## The scorer

`directiveHonoured` classifies each commitment as represented, traded, escalated, or **silently dropped**, and fails on the last. Details worth flagging:

- **A trade must name the commitment it collides with**, as the prompt specifies. "Something had to give" fails; naming the colliding commitment passes. Tested both ways.
- **Escalation is directive-level.** A model that says the orders cannot be satisfied has answered for every commitment it did not place — that is what the prompt asks. But a *rejected* escalation, a different status, or an unrelated reason (`processingBlocked`) answers for none; all three are tested.
- **A dropped block does not represent a commitment.** Dropping is the model declining the work, which is the opposite of honouring the order.
- Representation is matched on the commitment's title or id appearing in a block's title, reason or note. That is string matching, with the limits string matching has — but gaming it requires actually placing a block named after the commitment, and whether that block is real is what the capacity, estimate and working-hours scorers already measure.

## Verification

- `fvm dart analyze` clean; 164 tests in the eval framework, 11 new.
- The existing "drives every shipped scenario end to end" test now covers `bindingDirective`, so the seeding is exercised through the real pipeline.