### PR TITLE
fix: keep automatic inference running past a hand-picked model, and show a new task's agent immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1070]
+### Fixed
+- **Choosing your own model no longer switches off automatic transcription and
+  image analysis.** Picking a model by hand for a task's assistant replaced the
+  whole AI setup, not just the thinking model, so the category's automatic
+  transcription and image analysis quietly stopped — and picking a different
+  model afterwards never brought them back. Each of them now falls back to the
+  profile the task inherits from its category, so they keep using the
+  category's transcription and image models while your chosen model handles the
+  thinking. A profile you picked for a task still wins every capability it
+  actually configures; only a missing one falls through. This also fixes tasks
+  created before their category had an AI profile, which never picked one up.
+- **A new task gets its assistant right away.** Creating a task in a category
+  with an agent template left the AI card empty for several seconds before the
+  assistant appeared, which looked like assignment had failed and led people to
+  add one by hand. The assistant was in fact created immediately — the card
+  just had no way of hearing about it until the first update finished running.
+  It now appears as the task opens.
+
 ## [0.9.1069]
 ### Fixed
 - **You can trigger an update at any time again.** While an automatic update was

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,12 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1070" date="2026-07-25">
+      <description>
+        <p>Fixed: choosing your own model no longer switches off automatic transcription and image analysis. Picking a model by hand for a task's assistant replaced the whole AI setup, not just the thinking model, so the category's automatic transcription and image analysis quietly stopped — and picking a different model afterwards never brought them back. Each of them now falls back to the profile the task inherits from its category, so they keep using the category's transcription and image models while your chosen model handles the thinking. A profile you picked for a task still wins every capability it actually configures; only a missing one falls through. This also fixes tasks created before their category had an AI profile, which never picked one up.</p>
+        <p>Fixed: a new task gets its assistant right away. Creating a task in a category with an agent template left the AI card empty for several seconds before the assistant appeared, which looked like assignment had failed and led people to add one by hand. The assistant was in fact created immediately — the card just had no way of hearing about it until the first update finished running. It now appears as the task opens.</p>
+      </description>
+    </release>
     <release version="0.9.1069" date="2026-07-25">
       <description>
         <p>Changed: the AI summary card's bottom section is simpler and works on a phone. The update controls no longer sit in a box inside a box, so the strip reads as one quiet band and stops running out of room on narrow screens or in longer languages. As space gets tight the countdown shortens its wording rather than cutting off the time itself.</p>

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -1120,11 +1120,36 @@ the write."
 3. creates the agent identity and state
 4. sets `slots.activeTaskId`
 5. creates `agent_task` and `template_assignment` links
-6. registers a task subscription
-7. enqueues a creation wake — callers can merge extra entity IDs into its
+6. announces the assignment on `UpdateNotifications` once the transaction has
+   committed (see below)
+7. registers a task subscription
+8. enqueues a creation wake — callers can merge extra entity IDs into its
    trigger tokens via `additionalWakeTokens` (the onboarding first-task flow
    passes the already-transcribed audio entry, so the first turn attends to
    the spoken capture like a `transcriptionComplete` wake would)
+
+### Assignment announcement
+
+`taskAgentProvider` — what the AI summary card watches — keys its refresh on
+the **task** id via `agentUpdateStreamProvider(taskId)`, and nothing in the
+agent write path emits that token: identity, state, and links all go through
+`AgentSyncService`, which does not notify at all. Callers make this worse by
+design, `unawaited`-ing `autoAssignCategoryAgent` and navigating immediately,
+so the provider's first read usually lands before the agent exists.
+
+The only notification that ever carried the task id was
+`_notifyWakeCompletion` (`state/agent_wiring.dart`), which fires when a wake
+*finishes* — a full inference round-trip after creation. The card therefore
+sat empty for seconds on a freshly created task, reading as "no agent was
+assigned" and pushing users to assign one by hand.
+
+`createTaskAgent` now calls `UpdateNotifications.notifyUiOnly({agentId,
+taskId, agentNotification})` immediately after the transaction commits and
+before the creation wake is enqueued. `notifyUiOnly` keeps it off
+`localUpdateStream`, so the wake orchestrator does not read the agent system's
+own write as task content changing and stack a second wake on the creation
+wake. The dependency is optional (`UpdateNotifications?`) so tests and non-UI
+composition roots can build the service without the notification bus.
 
 ### Wake Flow
 

--- a/lib/features/agents/service/task_agent_service.dart
+++ b/lib/features/agents/service/task_agent_service.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:uuid/uuid.dart';
 
@@ -31,6 +32,7 @@ class TaskAgentService {
     required this.repository,
     required this.orchestrator,
     required this.syncService,
+    this.updateNotifications,
     this.domainLogger,
   });
 
@@ -41,6 +43,19 @@ class TaskAgentService {
   /// Sync-aware write service. All entity/link writes go through this so
   /// they are automatically enqueued for cross-device sync.
   final AgentSyncService syncService;
+
+  /// Notifies UI providers that an agent now exists for a task.
+  ///
+  /// `taskAgentProvider` keys its refresh on the **task** id, and no agent
+  /// write emits that token: the identity, state, and agent↔task link all go
+  /// through [AgentSyncService], which does not notify at all. Without this,
+  /// a freshly assigned agent stays invisible until something unrelated
+  /// happens to notify with the task id — in practice the creation wake's
+  /// completion, a whole inference round-trip later.
+  ///
+  /// Optional so tests and non-UI callers can construct the service without
+  /// the notification bus.
+  final UpdateNotifications? updateNotifications;
 
   /// Optional domain logger for structured, PII-safe logging.
   final DomainLogger? domainLogger;
@@ -200,6 +215,12 @@ class TaskAgentService {
       return identity;
     });
 
+    // Announce the assignment before any wake work. The transaction has
+    // committed, so a provider that refetches now sees the agent — which is
+    // the whole point: the card must fill in as the task opens, not once the
+    // first wake returns.
+    _notifyTaskAgentAssigned(agentId: identity.agentId, taskId: taskId);
+
     final inferenceEnabled =
         identity.config.inferenceSetup?.mode !=
         AgentInferenceSetupMode.disabled;
@@ -235,6 +256,18 @@ class TaskAgentService {
     );
 
     return identity;
+  }
+
+  /// Tells UI providers keyed on [taskId] that [agentId] is now assigned.
+  ///
+  /// Deliberately `notifyUiOnly`: this is the agent system announcing its own
+  /// write, and the wake orchestrator must not treat it as task content
+  /// changing and schedule a wake on top of the creation wake.
+  void _notifyTaskAgentAssigned({
+    required String agentId,
+    required String taskId,
+  }) {
+    updateNotifications?.notifyUiOnly({agentId, taskId, agentNotification});
   }
 
   /// Find the Task Agent for [taskId], or `null` if none exists.

--- a/lib/features/agents/state/task_agent_providers.dart
+++ b/lib/features/agents/state/task_agent_providers.dart
@@ -15,6 +15,7 @@ TaskAgentService taskAgentService(Ref ref) {
     repository: ref.watch(agentRepositoryProvider),
     orchestrator: ref.watch(wakeOrchestratorProvider),
     syncService: ref.watch(agentSyncServiceProvider),
+    updateNotifications: ref.watch(maybeUpdateNotificationsProvider),
     domainLogger: ref.watch(domainLoggerProvider),
   );
 }

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -227,9 +227,15 @@ inference switched on?"}
   Gate -->|yes| Auto["ProfileAutomationService"]
 
   Auto --> Resolve["ProfileAutomationResolver.resolveForTask()"]
-  Resolve --> Match["Find exactly one automate=true skill assignment"]
+  Resolve --> Match["Find exactly one automate=true skill assignment
+with the matching model slot populated"]
   Match --> Runner["SkillInferenceRunner"]
-  Match -->|no match, transcription only| Fallback["Direct model fallback
+  Match -->|no match| Inherited["resolveAutomationFallbacks():
+task.profileId, then category.defaultProfileId"]
+  Inherited --> Match2["Same per-capability match"]
+  Match2 --> Runner
+  Match -->|ambiguous| Stop
+  Match2 -->|no match, transcription only| Fallback["Direct model fallback
 (also behind the gate)"]
   Fallback --> Runner
 
@@ -270,9 +276,37 @@ with no visible control to restore it.
 Past the gate, the automatic branch is intentionally strict:
 
 - it only handles a skill type when exactly one automated assignment matches
-- if multiple automated skills of the same type exist, the profile is treated as ambiguous and automation is skipped
+- if multiple automated skills of the same type exist, the profile is treated as ambiguous and automation is skipped — and that ends the walk below rather than moving on, because guessing between two deliberate assignments is worse than doing nothing
 - the resolved profile must expose the required model slot for that skill type
 - the per-recording `enableSpeechRecognition: false` opt-out still wins independently of the category switch
+
+#### The per-capability profile walk
+
+`resolveForTask` answers *which profile drives this task's agent*. That is the
+right question for the thinking route and the wrong one for automated
+capabilities, so `ProfileAutomationService` asks it per capability and walks
+further when the answer does not own the one it needs:
+
+1. `resolveForTask(taskId)` — the agent's profile.
+2. `resolveAutomationFallbacks(taskId)` — the task's own inherited
+   `profileId`, then the owning category's `defaultProfileId`, de-duplicated
+   by profile id and resolved lazily (only reached when step 1 produced no
+   match).
+
+Each candidate must both automate the skill type *and* have the matching model
+slot populated, so a profile deliberately chosen for a task still wins every
+capability it does own and only the missing one falls through.
+
+The walk exists because picking a **thinking model by hand** resolves the task
+to a bare model route: `ProfileResolver._resolveTypedSetup` returns a
+`ResolvedProfile` carrying a thinking model and nothing else — no capability
+slots, no `skillAssignments` — whenever `AgentInferenceSetup` has a
+`thinkingModelOverrideId` and no `baseProfileId`. Treating that as the last
+word switched the category's automatic transcription and image analysis off as
+a side effect of a model choice, and no later model change brought them back:
+`updateAgentThinkingModelOverride` copies the same null `baseProfileId`
+forward every time. The same hole opened for a task created before its
+category had a default profile, whose `task.data.profileId` is null.
 
 `SkillInferenceRunner` then persists results according to skill type:
 
@@ -307,10 +341,11 @@ already-prefetched legacy entries are used only where no usable report exists.
 
 ## Profile Resolution
 
-`ProfileResolver` is the shared resolution engine for agent wakes. `ProfileAutomationResolver` wraps it for skill execution and offers two entry points:
+`ProfileResolver` is the shared resolution engine for agent wakes. `ProfileAutomationResolver` wraps it for skill execution and offers three entry points:
 
 - `resolveForTask(taskId)` — task-linked execution. Tries the agent path, then falls back to the task's own `profileId`.
 - `resolveForCategory(categoryId)` — standalone entries (no parent task). Reads `CategoryDefinition.defaultProfileId` and resolves it directly through `ProfileResolver.resolveByProfileId`.
+- `resolveAutomationFallbacks(taskId)` — the ordered, de-duplicated profiles a task *inherits* (`task.data.profileId`, then the owning category's `defaultProfileId`). Only `ProfileAutomationService` uses it, to keep an automated capability running when the agent's own route does not own it. See [The per-capability profile walk](#the-per-capability-profile-walk).
 
 `triggerSkillProvider` selects between the two: when `linkedTaskId` is non-null it calls `resolveForTask`; otherwise it looks up the entry, reads its `categoryId`, and calls `resolveForCategory`. Skills whose `contextPolicy` is `fullTask` are filtered out of the popup for standalone entries (see [Skill Filtering](#skill-filtering) below), so the standalone branch only runs `dictionaryOnly` / `taskSummary` / `none` skills.
 

--- a/lib/features/ai/helpers/profile_automation_resolver.dart
+++ b/lib/features/ai/helpers/profile_automation_resolver.dart
@@ -14,6 +14,9 @@ typedef TaskProfileLookup = Future<String?> Function(String taskId);
 /// `null` when the category has none configured.
 typedef CategoryProfileLookup = Future<String?> Function(String categoryId);
 
+/// Callback that returns the `categoryId` owning a task, or `null`.
+typedef TaskCategoryLookup = Future<String?> Function(String taskId);
+
 /// Resolves the inference profile for a task's agent — or, for entries that
 /// have no parent task, for the entry's category.
 ///
@@ -30,6 +33,10 @@ typedef CategoryProfileLookup = Future<String?> Function(String categoryId);
 /// `defaultProfileId`.
 ///
 /// Returns `null` if no profile can be resolved through any path.
+///
+/// [resolveForTask] answers "which profile drives this task's agent". That is
+/// the right question for the thinking route and the wrong one for automated
+/// capabilities, which is what [resolveAutomationFallbacks] exists for.
 class ProfileAutomationResolver {
   const ProfileAutomationResolver({
     required this._taskAgentService,
@@ -37,6 +44,7 @@ class ProfileAutomationResolver {
     required this._profileResolver,
     this._taskProfileLookup,
     this._categoryProfileLookup,
+    this._taskCategoryLookup,
   });
 
   final TaskAgentService _taskAgentService;
@@ -44,6 +52,7 @@ class ProfileAutomationResolver {
   final ProfileResolver _profileResolver;
   final TaskProfileLookup? _taskProfileLookup;
   final CategoryProfileLookup? _categoryProfileLookup;
+  final TaskCategoryLookup? _taskCategoryLookup;
 
   /// Resolves the profile for the given [taskId]'s agent.
   ///
@@ -58,6 +67,57 @@ class ProfileAutomationResolver {
 
     // 2. Fall back to the task's own profileId (inherited from category).
     return _resolveViaTaskProfile(taskId);
+  }
+
+  /// Profiles that can supply an automated capability [resolveForTask] does
+  /// not own, most specific first and without duplicates.
+  ///
+  /// The agent's profile drives the *thinking* route, and picking a thinking
+  /// model by hand resolves to a bare model route — no capability slots, no
+  /// skill assignments at all. Treating that as the last word switches the
+  /// category's automatic transcription and image analysis off as a side
+  /// effect of a model choice, and no later model change brings them back.
+  /// The same hole opens for a task created before its category had a default
+  /// profile, and for a profile that carries a thinking model but not every
+  /// capability the category configured.
+  ///
+  /// Order:
+  /// 1. `task.data.profileId` (inherited from the category at creation).
+  /// 2. The owning category's current `defaultProfileId`.
+  ///
+  /// Callers walk this list *per capability* and take the first profile that
+  /// actually owns the slot they need, so a profile deliberately chosen for
+  /// this task still wins every capability it does own.
+  ///
+  /// Profiles that cannot be loaded are skipped rather than ending the walk.
+  Future<List<ResolvedProfile>> resolveAutomationFallbacks(
+    String taskId,
+  ) async {
+    final candidateProfileIds = <String>{};
+
+    final taskProfileId = await _taskProfileLookup?.call(taskId);
+    if (taskProfileId != null) candidateProfileIds.add(taskProfileId);
+
+    final categoryId = await _taskCategoryLookup?.call(taskId);
+    if (categoryId != null) {
+      final categoryProfileId = await _categoryProfileLookup?.call(categoryId);
+      if (categoryProfileId != null) candidateProfileIds.add(categoryProfileId);
+    }
+
+    final resolved = <ResolvedProfile>[];
+    for (final profileId in candidateProfileIds) {
+      final profile = await _profileResolver.resolveByProfileId(profileId);
+      if (profile == null) {
+        developer.log(
+          'Automation fallback profile $profileId for task $taskId could not '
+          'be resolved — skipping',
+          name: _logTag,
+        );
+        continue;
+      }
+      resolved.add(profile);
+    }
+    return resolved;
   }
 
   /// Returns the raw profile id for [taskId] using the same resolution chain

--- a/lib/features/ai/services/profile_automation_service.dart
+++ b/lib/features/ai/services/profile_automation_service.dart
@@ -22,6 +22,24 @@ typedef _TranscriptionFallbackCandidate = ({
   AiConfigInferenceProvider provider,
 });
 
+/// The automated skill a profile contributes for one requested skill type.
+typedef _AutomatedSkillMatch = ({
+  SkillAssignment assignment,
+  AiConfigSkill skill,
+});
+
+/// Outcome of inspecting a single profile for one skill type.
+///
+/// An ambiguous outcome is not "no match": it means the profile automates the
+/// same skill type more than once, and their context policies could differ
+/// silently. That ends the whole walk rather than moving to the next
+/// candidate — guessing which of two deliberate assignments the user meant is
+/// worse than doing nothing.
+typedef _SkillMatchOutcome = ({_AutomatedSkillMatch? match, bool ambiguous});
+
+const _SkillMatchOutcome _noSkillMatch = (match: null, ambiguous: false);
+const _SkillMatchOutcome _ambiguousSkillMatch = (match: null, ambiguous: true);
+
 /// Whether the category owning [taskId] has automatic inference switched on.
 ///
 /// Wired to `CategoryDefinition.automaticInferenceEnabledEffective`. An
@@ -169,22 +187,91 @@ class ProfileAutomationService {
     );
   }
 
-  /// Core resolution: find a matching skill assignment with `automate: true`
-  /// for the given [skillType] on the task's agent's profile.
+  /// Core resolution: find the profile that automates [skillType] for [taskId]
+  /// and the assignment that does it.
+  ///
+  /// Walks the task's profiles per capability, most specific first: the
+  /// profile driving the task's agent, then the profiles the task inherits
+  /// ([ProfileAutomationResolver.resolveAutomationFallbacks]). The first one
+  /// that both automates [skillType] and has the matching model slot
+  /// populated wins.
+  ///
+  /// The walk is what keeps a hand-picked thinking model from switching the
+  /// category's automation off: that choice resolves to a bare model route
+  /// carrying no capability slots and no skill assignments, so transcription
+  /// and image analysis fall through to the profile the task inherited from
+  /// its category instead of silently not running. Automation the agent's own
+  /// profile does own is unaffected — it matches on the first candidate and
+  /// the fallbacks are never consulted.
   Future<AutomationResult> _tryAutomateSkillType({
     required String taskId,
     required SkillType skillType,
   }) async {
-    // 1. Resolve the profile for the task's agent.
-    final resolvedProfile = await _resolver.resolveForTask(taskId);
-    if (resolvedProfile == null) {
-      return AutomationResult.notHandled;
+    final primaryProfile = await _resolver.resolveForTask(taskId);
+    if (primaryProfile != null) {
+      final outcome = await _matchAutomatedSkill(
+        profile: primaryProfile,
+        skillType: skillType,
+        taskId: taskId,
+      );
+      if (outcome.ambiguous) return AutomationResult.notHandled;
+      final match = outcome.match;
+      if (match != null) {
+        developer.log(
+          'Profile automation: using skill "${match.skill.name}" for '
+          '$skillType on task $taskId',
+          name: _logTag,
+        );
+        return AutomationResult(
+          handled: true,
+          resolvedProfile: primaryProfile,
+          skill: match.skill,
+          skillAssignment: match.assignment,
+        );
+      }
     }
 
-    // 2. Collect all automated skill assignments matching the requested type.
-    final matches = <({SkillAssignment assignment, AiConfigSkill skill})>[];
+    final fallbacks = await _resolver.resolveAutomationFallbacks(taskId);
+    for (final fallbackProfile in fallbacks) {
+      final outcome = await _matchAutomatedSkill(
+        profile: fallbackProfile,
+        skillType: skillType,
+        taskId: taskId,
+      );
+      if (outcome.ambiguous) return AutomationResult.notHandled;
+      final match = outcome.match;
+      if (match == null) continue;
 
-    for (final assignment in resolvedProfile.skillAssignments) {
+      developer.log(
+        'Profile automation: task $taskId does not own $skillType, falling '
+        'back to inherited profile skill "${match.skill.name}"',
+        name: _logTag,
+      );
+      return AutomationResult(
+        handled: true,
+        resolvedProfile: fallbackProfile,
+        skill: match.skill,
+        skillAssignment: match.assignment,
+      );
+    }
+
+    return AutomationResult.notHandled;
+  }
+
+  /// Inspects one [profile] for an automated skill of [skillType].
+  ///
+  /// A match requires all three: an assignment with `automate: true`, a skill
+  /// config of the requested type behind it, and the profile's matching model
+  /// slot populated — a profile that automates transcription without a
+  /// transcription model cannot run it.
+  Future<_SkillMatchOutcome> _matchAutomatedSkill({
+    required ResolvedProfile profile,
+    required SkillType skillType,
+    required String taskId,
+  }) async {
+    final matches = <_AutomatedSkillMatch>[];
+
+    for (final assignment in profile.skillAssignments) {
       if (!assignment.automate) continue;
 
       final skillConfig = await _aiConfigRepository.getConfigById(
@@ -200,8 +287,7 @@ class ProfileAutomationService {
 
       if (skillConfig.skillType != skillType) continue;
 
-      // Verify the profile has the required model slot populated.
-      if (!_hasModelSlotForSkillType(resolvedProfile, skillType)) {
+      if (!_hasModelSlotForSkillType(profile, skillType)) {
         developer.log(
           'Profile has no model slot for $skillType, skipping skill '
           '${skillConfig.name}',
@@ -213,32 +299,18 @@ class ProfileAutomationService {
       matches.add((assignment: assignment, skill: skillConfig));
     }
 
-    if (matches.isEmpty) return AutomationResult.notHandled;
+    if (matches.isEmpty) return _noSkillMatch;
 
-    // 3. Reject ambiguous profiles with multiple automated skills of the
-    //    same type — the context policy could differ silently.
     if (matches.length > 1) {
       developer.log(
         'Ambiguous profile: ${matches.length} automated $skillType '
         'skills found for task $taskId, treating as not handled',
         name: _logTag,
       );
-      return AutomationResult.notHandled;
+      return _ambiguousSkillMatch;
     }
 
-    final match = matches.first;
-    developer.log(
-      'Profile automation: using skill "${match.skill.name}" for '
-      '$skillType on task $taskId',
-      name: _logTag,
-    );
-
-    return AutomationResult(
-      handled: true,
-      resolvedProfile: resolvedProfile,
-      skill: match.skill,
-      skillAssignment: match.assignment,
-    );
+    return (match: matches.first, ambiguous: false);
   }
 
   /// Checks whether the given task has an automated skill of the given type.

--- a/lib/features/ai/state/profile_automation_providers.dart
+++ b/lib/features/ai/state/profile_automation_providers.dart
@@ -43,6 +43,12 @@ ProfileAutomationResolver profileAutomationResolver(Ref ref) {
           .getCategoryById(categoryId);
       return category?.defaultProfileId;
     },
+    taskCategoryLookup: (taskId) async {
+      final entity = await ref
+          .read(journalDbProvider)
+          .journalEntityById(taskId);
+      return entity?.meta.categoryId;
+    },
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1069+4255
+version: 0.9.1070+4256
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/service/task_agent_service_test.dart
+++ b/test/features/agents/service/task_agent_service_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/service/task_agent_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:mocktail/mocktail.dart';
@@ -200,6 +201,7 @@ void main() {
   late MockAgentRepository mockRepository;
   late MockWakeOrchestrator mockOrchestrator;
   late MockAgentSyncService mockSyncService;
+  late MockUpdateNotifications mockUpdateNotifications;
   late TaskAgentService service;
 
   AgentIdentityEntity makeIdentity({
@@ -269,11 +271,15 @@ void main() {
       () => mockRepository.getAgentStatesByAgentIds(any()),
     ).thenAnswer((_) async => const {});
 
+    mockUpdateNotifications = MockUpdateNotifications();
+    when(() => mockUpdateNotifications.notifyUiOnly(any())).thenReturn(null);
+
     service = TaskAgentService(
       agentService: mockAgentService,
       repository: mockRepository,
       orchestrator: mockOrchestrator,
       syncService: mockSyncService,
+      updateNotifications: mockUpdateNotifications,
       domainLogger: DomainLogger(loggingService: LoggingService())
         ..enabledDomains.add(LogDomain.agentRuntime),
     );
@@ -1012,6 +1018,143 @@ void main() {
           ).called(1);
         },
       );
+
+      // `taskAgentProvider` refreshes on the *task* id, and nothing in the
+      // agent write path emits it — the identity, state and agent↔task link
+      // all go through AgentSyncService, which does not notify. Without this
+      // announcement the card sits empty until the creation wake completes a
+      // full inference round-trip later, which reads as "no agent was
+      // assigned" and pushes users to assign one by hand.
+      group('assignment announcement', () {
+        Future<void> createAgentForTask(
+          String taskId, {
+          UpdateNotifications? notifications,
+        }) async {
+          final identity = makeIdentity();
+          when(
+            () => mockRepository.getLinksTo(taskId, type: 'agent_task'),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          ).thenAnswer((_) async => identity);
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => makeState());
+          when(() => mockOrchestrator.addSubscription(any())).thenReturn(null);
+          when(
+            () => mockOrchestrator.setAwaitingContent(
+              any(),
+              awaiting: any(named: 'awaiting'),
+            ),
+          ).thenReturn(null);
+
+          final target = notifications == null
+              ? service
+              : TaskAgentService(
+                  agentService: mockAgentService,
+                  repository: mockRepository,
+                  orchestrator: mockOrchestrator,
+                  syncService: mockSyncService,
+                  updateNotifications: notifications,
+                );
+
+          await target.createTaskAgent(
+            taskId: taskId,
+            templateId: kTestTemplateId,
+            allowedCategoryIds: const {},
+          );
+        }
+
+        test('announces the new agent against its task id', () async {
+          await createAgentForTask('task-announce');
+
+          final captured =
+              verify(
+                    () => mockUpdateNotifications.notifyUiOnly(captureAny()),
+                  ).captured.single
+                  as Set<String>;
+          expect(captured, contains('task-announce'));
+          expect(captured, contains('agent-1'));
+          expect(captured, contains(agentNotification));
+        });
+
+        // `notifyUiOnly` keeps the announcement off `localUpdateStream`, so
+        // the wake orchestrator does not read the agent system's own write as
+        // task content changing and stack a second wake on the creation wake.
+        test('never announces on the wake-triggering stream', () async {
+          await createAgentForTask('task-quiet');
+
+          verifyNever(() => mockUpdateNotifications.notify(any()));
+        });
+
+        test('announces before the creation wake is enqueued', () async {
+          final order = <String>[];
+          final orderedNotifications = MockUpdateNotifications();
+          when(() => orderedNotifications.notifyUiOnly(any())).thenAnswer((_) {
+            order.add('notify');
+          });
+          when(
+            () => mockOrchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          ).thenAnswer((_) {
+            order.add('wake');
+            return 'run-key-stub';
+          });
+
+          await createAgentForTask(
+            'task-order',
+            notifications: orderedNotifications,
+          );
+
+          expect(order, ['notify', 'wake']);
+        });
+
+        test('creation still succeeds without a notification bus', () async {
+          final unwired = TaskAgentService(
+            agentService: mockAgentService,
+            repository: mockRepository,
+            orchestrator: mockOrchestrator,
+            syncService: mockSyncService,
+          );
+          when(
+            () => mockRepository.getLinksTo('task-unwired', type: 'agent_task'),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          ).thenAnswer((_) async => makeIdentity());
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => makeState());
+          when(() => mockOrchestrator.addSubscription(any())).thenReturn(null);
+          when(
+            () => mockOrchestrator.setAwaitingContent(
+              any(),
+              awaiting: any(named: 'awaiting'),
+            ),
+          ).thenReturn(null);
+
+          final identity = await unwired.createTaskAgent(
+            taskId: 'task-unwired',
+            templateId: kTestTemplateId,
+            allowedCategoryIds: const {},
+          );
+
+          expect(identity.agentId, 'agent-1');
+        });
+      });
     });
 
     group('getTaskAgentForTask', () {

--- a/test/features/ai/helpers/profile_automation_resolver_test.dart
+++ b/test/features/ai/helpers/profile_automation_resolver_test.dart
@@ -451,4 +451,149 @@ void main() {
       tags: 'glados',
     );
   });
+
+  // `resolveForTask` answers which profile drives the task's agent. Once a
+  // thinking model is picked by hand that answer is a bare model route with no
+  // capability slots and no skill assignments, so automation needs the
+  // profiles the task inherits as well.
+  group('resolveAutomationFallbacks', () {
+    ProfileAutomationResolver makeResolver({
+      TaskProfileLookup? taskProfileLookup,
+      CategoryProfileLookup? categoryProfileLookup,
+      TaskCategoryLookup? taskCategoryLookup,
+    }) {
+      return ProfileAutomationResolver(
+        taskAgentService: mockTaskAgentService,
+        templateService: mockTemplateService,
+        profileResolver: mockProfileResolver,
+        taskProfileLookup: taskProfileLookup,
+        categoryProfileLookup: categoryProfileLookup,
+        taskCategoryLookup: taskCategoryLookup,
+      );
+    }
+
+    test(
+      'returns the task profile before the category default',
+      () async {
+        final taskProfile = makeResolvedProfile();
+        final categoryProfile = ResolvedProfile(
+          thinkingModelId: 'category-thinking',
+          thinkingProvider: testInferenceProvider(id: 'p-category'),
+        );
+        final fallbackResolver = makeResolver(
+          taskProfileLookup: (_) async => 'task-profile',
+          taskCategoryLookup: (_) async => 'cat-1',
+          categoryProfileLookup: (categoryId) async =>
+              categoryId == 'cat-1' ? 'category-profile' : null,
+        );
+        when(
+          () => mockProfileResolver.resolveByProfileId('task-profile'),
+        ).thenAnswer((_) async => taskProfile);
+        when(
+          () => mockProfileResolver.resolveByProfileId('category-profile'),
+        ).thenAnswer((_) async => categoryProfile);
+
+        final result = await fallbackResolver.resolveAutomationFallbacks(
+          'task-1',
+        );
+
+        expect(result, [taskProfile, categoryProfile]);
+        // The agent path belongs to `resolveForTask`; the fallback walk must
+        // not re-run it.
+        verifyNever(() => mockTaskAgentService.getTaskAgentForTask(any()));
+      },
+    );
+
+    test('resolves a shared profile id only once', () async {
+      final profile = makeResolvedProfile();
+      final fallbackResolver = makeResolver(
+        taskProfileLookup: (_) async => 'shared-profile',
+        taskCategoryLookup: (_) async => 'cat-1',
+        categoryProfileLookup: (_) async => 'shared-profile',
+      );
+      when(
+        () => mockProfileResolver.resolveByProfileId('shared-profile'),
+      ).thenAnswer((_) async => profile);
+
+      final result = await fallbackResolver.resolveAutomationFallbacks(
+        'task-1',
+      );
+
+      expect(result, [profile]);
+      verify(
+        () => mockProfileResolver.resolveByProfileId('shared-profile'),
+      ).called(1);
+    });
+
+    // A task created before its category had a default profile carries no
+    // `profileId` of its own — the category is the only thing left that can
+    // supply the capability.
+    test(
+      'falls through to the category when the task has no profile',
+      () async {
+        final categoryProfile = makeResolvedProfile();
+        final fallbackResolver = makeResolver(
+          taskProfileLookup: (_) async => null,
+          taskCategoryLookup: (_) async => 'cat-1',
+          categoryProfileLookup: (_) async => 'category-profile',
+        );
+        when(
+          () => mockProfileResolver.resolveByProfileId('category-profile'),
+        ).thenAnswer((_) async => categoryProfile);
+
+        final result = await fallbackResolver.resolveAutomationFallbacks(
+          'task-1',
+        );
+
+        expect(result, [categoryProfile]);
+      },
+    );
+
+    // A deleted or broken profile must not hide the one behind it.
+    test(
+      'skips a candidate that cannot be resolved and keeps walking',
+      () async {
+        final categoryProfile = makeResolvedProfile();
+        final fallbackResolver = makeResolver(
+          taskProfileLookup: (_) async => 'deleted-profile',
+          taskCategoryLookup: (_) async => 'cat-1',
+          categoryProfileLookup: (_) async => 'category-profile',
+        );
+        when(
+          () => mockProfileResolver.resolveByProfileId('deleted-profile'),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockProfileResolver.resolveByProfileId('category-profile'),
+        ).thenAnswer((_) async => categoryProfile);
+
+        final result = await fallbackResolver.resolveAutomationFallbacks(
+          'task-1',
+        );
+
+        expect(result, [categoryProfile]);
+      },
+    );
+
+    test('returns nothing when the entry has no category', () async {
+      final fallbackResolver = makeResolver(
+        taskProfileLookup: (_) async => null,
+        taskCategoryLookup: (_) async => null,
+        categoryProfileLookup: (_) async =>
+            fail('category profile must not be read without a category'),
+      );
+
+      final result = await fallbackResolver.resolveAutomationFallbacks(
+        'task-1',
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('returns nothing when no lookups are wired', () async {
+      final result = await resolver.resolveAutomationFallbacks('task-1');
+
+      expect(result, isEmpty);
+      verifyNever(() => mockProfileResolver.resolveByProfileId(any()));
+    });
+  });
 }

--- a/test/features/ai/services/profile_automation_service_test.dart
+++ b/test/features/ai/services/profile_automation_service_test.dart
@@ -286,6 +286,11 @@ void main() {
     when(
       () => mockAiConfig.getConfigsByType(AiConfigType.model),
     ).thenAnswer((_) async => const <AiConfig>[]);
+    // Default: the task inherits nothing beyond what `resolveForTask` returns.
+    // The `inherited profile fallback` group overrides this per test.
+    when(
+      () => mockResolver.resolveAutomationFallbacks(any()),
+    ).thenAnswer((_) async => const <ResolvedProfile>[]);
   });
 
   tearDown(() {
@@ -298,15 +303,20 @@ void main() {
     bool withTranscription = false,
     bool withImageRecognition = false,
     bool withImageGeneration = false,
+    String thinkingModelId = 'models/gemini-3-flash-preview',
+    String transcriptionModelId = 'whisper-1',
+    String imageRecognitionModelId = 'vision-model',
   }) {
     return ResolvedProfile(
-      thinkingModelId: 'models/gemini-3-flash-preview',
+      thinkingModelId: thinkingModelId,
       thinkingProvider: testInferenceProvider(),
-      transcriptionModelId: withTranscription ? 'whisper-1' : null,
+      transcriptionModelId: withTranscription ? transcriptionModelId : null,
       transcriptionProvider: withTranscription
           ? testInferenceProvider(id: 'p-audio')
           : null,
-      imageRecognitionModelId: withImageRecognition ? 'vision-model' : null,
+      imageRecognitionModelId: withImageRecognition
+          ? imageRecognitionModelId
+          : null,
       imageRecognitionProvider: withImageRecognition
           ? testInferenceProvider(id: 'p-vision')
           : null,
@@ -1145,6 +1155,302 @@ void main() {
       );
     });
 
+    // Picking a thinking model by hand resolves the task to a bare model
+    // route: no capability slots, no skill assignments. That must not switch
+    // the category's automatic transcription and image analysis off, and no
+    // later model change repairs it, because the agent keeps resolving to the
+    // same bare route.
+    group('inherited profile fallback', () {
+      /// What `resolveForTask` returns once a thinking model is picked by hand
+      /// and the agent has no base profile — thinking route only.
+      ResolvedProfile handPickedModelRoute() =>
+          makeProfile(thinkingModelId: 'glm-5.2');
+
+      /// The category's profile, inherited by the task, which owns the
+      /// capability slots and the automated assignments.
+      ResolvedProfile inheritedProfile({
+        required String skillId,
+        bool withTranscription = false,
+        bool withImageRecognition = false,
+      }) => makeProfile(
+        skillAssignments: [SkillAssignment(skillId: skillId, automate: true)],
+        withTranscription: withTranscription,
+        withImageRecognition: withImageRecognition,
+        transcriptionModelId: 'category-whisper',
+        imageRecognitionModelId: 'category-vision',
+      );
+
+      test(
+        'transcription runs on the inherited profile after a model was '
+        'picked by hand',
+        () async {
+          when(
+            () => mockResolver.resolveForTask('task-1'),
+          ).thenAnswer((_) async => handPickedModelRoute());
+          when(
+            () => mockResolver.resolveAutomationFallbacks('task-1'),
+          ).thenAnswer(
+            (_) async => [
+              inheritedProfile(
+                skillId: 'skill-transcribe',
+                withTranscription: true,
+              ),
+            ],
+          );
+          when(
+            () => mockAiConfig.getConfigById('skill-transcribe'),
+          ).thenAnswer((_) async => makeSkill(id: 'skill-transcribe'));
+
+          final result = await service.tryTranscribe(taskId: 'task-1');
+
+          expect(result.handled, isTrue);
+          expect(result.skill!.id, 'skill-transcribe');
+          // The run uses the category's transcription model, not the
+          // hand-picked thinking model.
+          expect(
+            result.resolvedProfile!.transcriptionModelId,
+            'category-whisper',
+          );
+        },
+      );
+
+      test(
+        'image analysis runs on the inherited profile after a model was '
+        'picked by hand',
+        () async {
+          when(
+            () => mockResolver.resolveForTask('task-1'),
+          ).thenAnswer((_) async => handPickedModelRoute());
+          when(
+            () => mockResolver.resolveAutomationFallbacks('task-1'),
+          ).thenAnswer(
+            (_) async => [
+              inheritedProfile(
+                skillId: 'skill-image',
+                withImageRecognition: true,
+              ),
+            ],
+          );
+          when(() => mockAiConfig.getConfigById('skill-image')).thenAnswer(
+            (_) async => makeSkill(
+              id: 'skill-image',
+              skillType: SkillType.imageAnalysis,
+            ),
+          );
+
+          final result = await service.tryAnalyzeImage(taskId: 'task-1');
+
+          expect(result.handled, isTrue);
+          expect(result.skill!.id, 'skill-image');
+          expect(
+            result.resolvedProfile!.imageRecognitionModelId,
+            'category-vision',
+          );
+        },
+      );
+
+      test(
+        'the task-linked profile wins and the inherited ones are never read',
+        () async {
+          when(() => mockResolver.resolveForTask('task-1')).thenAnswer(
+            (_) async => makeProfile(
+              skillAssignments: const [
+                SkillAssignment(skillId: 'skill-transcribe', automate: true),
+              ],
+              withTranscription: true,
+            ),
+          );
+          when(
+            () => mockAiConfig.getConfigById('skill-transcribe'),
+          ).thenAnswer((_) async => makeSkill(id: 'skill-transcribe'));
+
+          final result = await service.tryTranscribe(taskId: 'task-1');
+
+          expect(result.handled, isTrue);
+          expect(result.resolvedProfile!.transcriptionModelId, 'whisper-1');
+          verifyNever(() => mockResolver.resolveAutomationFallbacks(any()));
+        },
+      );
+
+      // The walk is per capability: a profile chosen for this task keeps every
+      // capability it does own, and only the missing one falls through.
+      test(
+        'only the capability the task-linked profile lacks falls back',
+        () async {
+          when(() => mockResolver.resolveForTask('task-1')).thenAnswer(
+            (_) async => makeProfile(
+              skillAssignments: const [
+                SkillAssignment(skillId: 'skill-image', automate: true),
+                SkillAssignment(skillId: 'skill-transcribe', automate: true),
+              ],
+              // Automates transcription, but has no transcription model.
+              withImageRecognition: true,
+            ),
+          );
+          when(
+            () => mockResolver.resolveAutomationFallbacks('task-1'),
+          ).thenAnswer(
+            (_) async => [
+              inheritedProfile(
+                skillId: 'skill-inherited-transcribe',
+                withTranscription: true,
+              ),
+            ],
+          );
+          when(() => mockAiConfig.getConfigById('skill-image')).thenAnswer(
+            (_) async => makeSkill(
+              id: 'skill-image',
+              skillType: SkillType.imageAnalysis,
+            ),
+          );
+          when(
+            () => mockAiConfig.getConfigById('skill-transcribe'),
+          ).thenAnswer((_) async => makeSkill(id: 'skill-transcribe'));
+          when(
+            () => mockAiConfig.getConfigById('skill-inherited-transcribe'),
+          ).thenAnswer(
+            (_) async => makeSkill(id: 'skill-inherited-transcribe'),
+          );
+
+          final imageResult = await service.tryAnalyzeImage(taskId: 'task-1');
+          final transcribeResult = await service.tryTranscribe(
+            taskId: 'task-1',
+          );
+
+          expect(imageResult.skill!.id, 'skill-image');
+          expect(
+            imageResult.resolvedProfile!.imageRecognitionModelId,
+            'vision-model',
+          );
+          expect(transcribeResult.skill!.id, 'skill-inherited-transcribe');
+          expect(
+            transcribeResult.resolvedProfile!.transcriptionModelId,
+            'category-whisper',
+          );
+        },
+      );
+
+      test('walks the inherited profiles in order', () async {
+        when(
+          () => mockResolver.resolveForTask('task-1'),
+        ).thenAnswer((_) async => handPickedModelRoute());
+        when(
+          () => mockResolver.resolveAutomationFallbacks('task-1'),
+        ).thenAnswer(
+          (_) async => [
+            // The task's own inherited profile automates nothing.
+            makeProfile(withTranscription: true),
+            inheritedProfile(
+              skillId: 'skill-transcribe',
+              withTranscription: true,
+            ),
+          ],
+        );
+        when(
+          () => mockAiConfig.getConfigById('skill-transcribe'),
+        ).thenAnswer((_) async => makeSkill(id: 'skill-transcribe'));
+
+        final result = await service.tryTranscribe(taskId: 'task-1');
+
+        expect(result.handled, isTrue);
+        expect(
+          result.resolvedProfile!.transcriptionModelId,
+          'category-whisper',
+        );
+      });
+
+      // Two deliberate assignments of the same type could carry different
+      // context policies. Guessing which one the user meant is worse than
+      // doing nothing, so ambiguity ends the walk instead of demoting the
+      // task to a profile it never selected.
+      test('an ambiguous task-linked profile ends the walk', () async {
+        when(() => mockResolver.resolveForTask('task-1')).thenAnswer(
+          (_) async => makeProfile(
+            skillAssignments: const [
+              SkillAssignment(skillId: 'skill-t1', automate: true),
+              SkillAssignment(skillId: 'skill-t2', automate: true),
+            ],
+            withTranscription: true,
+          ),
+        );
+        when(
+          () => mockAiConfig.getConfigById('skill-t1'),
+        ).thenAnswer((_) async => makeSkill(id: 'skill-t1'));
+        when(
+          () => mockAiConfig.getConfigById('skill-t2'),
+        ).thenAnswer((_) async => makeSkill(id: 'skill-t2'));
+
+        final result = await service.tryTranscribe(taskId: 'task-1');
+
+        expect(result.handled, isFalse);
+        verifyNever(() => mockResolver.resolveAutomationFallbacks(any()));
+      });
+
+      // The category switch is still the only consent to spend tokens without
+      // a gesture — the wider walk must not sneak past it.
+      test('the category gate short-circuits before the walk', () async {
+        categoryAllowsAutomation = false;
+
+        final result = await service.tryAnalyzeImage(taskId: 'task-1');
+
+        expect(result.handled, isFalse);
+        verifyNever(() => mockResolver.resolveAutomationFallbacks(any()));
+      });
+
+      test(
+        'the checkbox affordance reflects the inherited transcription skill',
+        () async {
+          when(
+            () => mockResolver.resolveForTask('task-1'),
+          ).thenAnswer((_) async => handPickedModelRoute());
+          when(
+            () => mockResolver.resolveAutomationFallbacks('task-1'),
+          ).thenAnswer(
+            (_) async => [
+              inheritedProfile(
+                skillId: 'skill-transcribe',
+                withTranscription: true,
+              ),
+            ],
+          );
+          when(
+            () => mockAiConfig.getConfigById('skill-transcribe'),
+          ).thenAnswer((_) async => makeSkill(id: 'skill-transcribe'));
+
+          final available = await service.hasAutomatedSkillType(
+            taskId: 'task-1',
+            skillType: SkillType.transcription,
+          );
+
+          expect(available, isTrue);
+        },
+      );
+
+      test(
+        'the direct transcription fallback still runs when nothing inherits '
+        'the capability',
+        () async {
+          when(
+            () => mockResolver.resolveForTask('task-1'),
+          ).thenAnswer((_) async => handPickedModelRoute());
+          when(
+            () => mockAiConfig.getConfigsByType(AiConfigType.model),
+          ).thenAnswer((_) async => [makeModel()]);
+          when(
+            () => mockAiConfig.getConfigById('provider-mlx'),
+          ).thenAnswer((_) async => makeProvider());
+
+          final result = await service.tryTranscribe(taskId: 'task-1');
+
+          expect(result.handled, isTrue);
+          expect(
+            result.resolvedProfile!.transcriptionModelId,
+            mlxAudioQwenAsr17B8BitModelId,
+          );
+        },
+      );
+    });
+
     glados.Glados(
       glados.any.automationServiceScenario,
       glados.ExploreConfig(numRuns: 180),
@@ -1189,6 +1495,9 @@ void main() {
           resolverCalls++;
           return scenario.profileMissing ? null : profile;
         });
+        when(
+          () => localResolver.resolveAutomationFallbacks(any()),
+        ).thenAnswer((_) async => const <ResolvedProfile>[]);
         when(
           () => localAiConfig.getConfigsByType(AiConfigType.model),
         ).thenAnswer((_) async => const <AiConfig>[]);
@@ -1291,6 +1600,9 @@ void main() {
         when(
           () => localResolver.resolveForTask('rank-task'),
         ).thenAnswer((_) async => null);
+        when(
+          () => localResolver.resolveAutomationFallbacks(any()),
+        ).thenAnswer((_) async => const <ResolvedProfile>[]);
         when(
           () => localAiConfig.getConfigsByType(AiConfigType.model),
         ).thenAnswer((_) async => models);

--- a/test/features/ai/state/profile_automation_providers_test.dart
+++ b/test/features/ai/state/profile_automation_providers_test.dart
@@ -360,6 +360,88 @@ void main() {
       expect(result, isNull);
     });
 
+    // The fallback walk needs the task's category, not just its profileId:
+    // a task created before its category had a default profile carries no
+    // profileId of its own.
+    group('taskCategoryLookup via resolveAutomationFallbacks', () {
+      JournalEntity taskWith({String? categoryId, String? profileId}) {
+        return JournalEntity.task(
+          meta: Metadata(
+            id: 'task-1',
+            createdAt: DateTime(2024),
+            updatedAt: DateTime(2024),
+            dateFrom: DateTime(2024),
+            dateTo: DateTime(2024),
+            categoryId: categoryId,
+          ),
+          data: TaskData(
+            status: TaskStatus.open(
+              id: 'status-1',
+              createdAt: DateTime(2024),
+              utcOffset: 0,
+            ),
+            title: 'Task',
+            statusHistory: const [],
+            dateFrom: DateTime(2024),
+            dateTo: DateTime(2024),
+            estimate: Duration.zero,
+            profileId: profileId,
+          ),
+        );
+      }
+
+      test('walks the task profile and then the category default', () async {
+        when(() => mockDb.journalEntityById('task-1')).thenAnswer(
+          (_) async => taskWith(categoryId: 'cat-1', profileId: 'profile-task'),
+        );
+        when(
+          () => mockDb.getCategoryById('cat-1'),
+        ).thenAnswer(
+          (_) async => makeCategory(defaultProfileId: 'profile-cat'),
+        );
+
+        final container = createContainer();
+        final resolver = container.read(profileAutomationResolverProvider);
+        // Both profile lookups return null (mockAiConfigRepo default), so the
+        // walk yields nothing — what matters is which ids it reached for.
+        final result = await resolver.resolveAutomationFallbacks('task-1');
+
+        expect(result, isEmpty);
+        verify(() => mockAiConfigRepo.getConfigById('profile-task')).called(1);
+        verify(() => mockAiConfigRepo.getConfigById('profile-cat')).called(1);
+      });
+
+      test('reaches the category default with no task profile', () async {
+        when(
+          () => mockDb.journalEntityById('task-1'),
+        ).thenAnswer((_) async => taskWith(categoryId: 'cat-1'));
+        when(
+          () => mockDb.getCategoryById('cat-1'),
+        ).thenAnswer(
+          (_) async => makeCategory(defaultProfileId: 'profile-cat'),
+        );
+
+        final container = createContainer();
+        final resolver = container.read(profileAutomationResolverProvider);
+        await resolver.resolveAutomationFallbacks('task-1');
+
+        verify(() => mockAiConfigRepo.getConfigById('profile-cat')).called(1);
+      });
+
+      test('reads no category when the entry is missing', () async {
+        when(
+          () => mockDb.journalEntityById('task-gone'),
+        ).thenAnswer((_) async => null);
+
+        final container = createContainer();
+        final resolver = container.read(profileAutomationResolverProvider);
+        final result = await resolver.resolveAutomationFallbacks('task-gone');
+
+        expect(result, isEmpty);
+        verifyNever(() => mockDb.getCategoryById(any()));
+      });
+    });
+
     // The gate the service applies before any automation: the entry's
     // category must have automatic inference switched on.
     group('categoryAutomationLookup', () {


### PR DESCRIPTION
## Problem

Two separate defects, both visible at task creation time.

### 1. A hand-picked model switched off automatic transcription and image analysis

`ProfileAutomationService` resolved exactly one profile — `ProfileAutomationResolver.resolveForTask` — and returned not-handled when it did not own the requested capability.

Picking a thinking model by hand takes the override branch in `ProfileResolver._resolveTypedSetup`. When the agent's `AgentInferenceSetup` has a `thinkingModelOverrideId` and **no** `baseProfileId`, that branch returns a bare `ResolvedProfile`: a thinking model and nothing else — no `transcriptionProvider`, no `imageRecognitionProvider`, `skillAssignments: []`. It is non-null, so:

- `_hasModelSlotForSkillType` fails, no assignment matches, nothing runs; and
- because the agent path "succeeded", `resolveForTask` never fell through to the task's inherited `profileId`.

`baseProfileId` is null exactly when the setup was `disabled` at the moment the model was picked — which `createTaskAgent` writes whenever the category had no default profile at task-creation time. **Switching to a different model afterwards never recovered**, because `updateAgentThinkingModelOverride` reads `current?.mode == configured ? current?.baseProfileId : identity.config.profileId` and copies the same null forward every time.

Two related holes closed by the same change: image analysis had no fallback at all (transcription at least had `_tryDirectTranscriptionFallback`), and a task created *before* its category got a default profile has `task.data.profileId == null` with no category-level fallback — the manual path in `skill_trigger_providers.dart` has one, the automatic path did not.

### 2. A new task's agent stayed invisible for seconds

`taskAgentProvider` — what the AI summary card watches — keys its refresh on the **task** id via `agentUpdateStreamProvider(taskId)`. Nothing in the agent write path emits that token: identity, state and the `agent_task` link all go through `AgentSyncService`, which does not notify at all. Callers `unawaited` `autoAssignCategoryAgent` and navigate immediately, so the provider's first read usually lands before the agent exists.

The only notification that ever carried the task id is `_notifyWakeCompletion` (`state/agent_wiring.dart`), which fires when a wake *finishes* — a full inference round-trip later. Hence the reported 5–10s of an empty card, which reads as "assignment failed" and pushes users to assign an agent by hand. Corroboration: the manual "Assign agent" CTA already had to call `ref.invalidate(taskAgentProvider(taskId))` explicitly, because the automatic path has no notification.

## Fix

**Per-capability profile walk.** `ProfileAutomationService._tryAutomateSkillType` now walks candidates and takes the first that both automates the skill type *and* has the matching model slot populated:

1. `resolveForTask(taskId)` — the agent's profile.
2. `resolveAutomationFallbacks(taskId)` (new) — the task's inherited `profileId`, then the category's `defaultProfileId`, de-duplicated by profile id and only reached when step 1 produced no match.

So a hand-picked model keeps handling the thinking while transcription and image analysis fall back to the category's models, and a profile deliberately chosen for a task still wins every capability it does own — only the missing one falls through. Ambiguity (two automated skills of the same type) ends the walk rather than demoting the task to a profile it never selected.

The change is scoped to the automation service: `resolveForTask` keeps its existing meaning for agent wakes, the manual skill triggers and the model pickers.

**Assignment announcement.** `createTaskAgent` calls `UpdateNotifications.notifyUiOnly({agentId, taskId, agentNotification})` once the transaction commits and before the creation wake is enqueued. `notifyUiOnly` keeps it off `localUpdateStream`, so the wake orchestrator does not read the agent system's own write as task content changing and stack a second wake on the creation wake. The dependency is optional so non-UI composition roots can build the service without the bus.

## Not changed

- **The category consent gate is intentional, not a regression.** `automaticInferenceEnabled ?? false` starts off for every category, including ones that already had a profile — shipped and documented in 0.9.1065. If that switch is off, nothing runs regardless of this fix. Worth checking on the affected category before concluding the fix did not take.
- **Image analysis still has no direct-model fallback.** Unlike transcription, there is no "any configured vision model" path. Inventing one would spend tokens on a model the user never chose, which is what the consent design avoids.
- **`EventAgentService.createEventAgent` and `ProjectAgentService.createProjectAgent` have the identical missing-notification defect** (`eventAgentProvider`/`projectAgentProvider` key on the event/project id). Left out as separate scope — happy to extend this PR or file a follow-up.

## Tests

- `profile_automation_service_test.dart` — new `inherited profile fallback` group: transcription and image analysis after a hand-picked model, task-linked profile wins and fallbacks are never read, only the missing capability falls through, walk order, ambiguity ends the walk, the consent gate still short-circuits first, checkbox affordance, direct transcription fallback still reachable. 5 of these fail without the production change.
- `profile_automation_resolver_test.dart` — new `resolveAutomationFallbacks` group: order, shared-id de-duplication, task-without-profile, unresolvable candidate skipped without ending the walk, no category, no lookups wired.
- `profile_automation_providers_test.dart` — new `taskCategoryLookup` group covering the new provider wiring.
- `task_agent_service_test.dart` — new `assignment announcement` group: token contents, `notifyUiOnly` only, ordered before the creation wake, and creation without a notification bus. 2 of these fail without the production change.

`fvm flutter analyze lib test` clean. 9936 tests pass across `test/features/agents`, `test/features/ai`, `test/features/speech`; adjacent suites (`onboarding`, `logic/create`, `journal` create widgets, `tasks` linked-tasks + tab page, `daily_os_next/agents`, synced-audio dispatcher) pass too.
