### PR TITLE
fix: address post-merge review of #3603 — two wrong guarantees, two fence bugs

### DIFF
--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -59,7 +59,7 @@ flowchart TD
   Enabled -->|no| Drop["dropped"]
   Enabled -->|yes| General["general app log for the day"]
   Err["DomainLogger.error(...)"] --> General2["general app log + error-YYYY-MM-DD.log<br/>full text, force-flushed"]
-  Err --> Safe["error-safe-YYYY-MM-DD.log<br/>runtime type only — shareable"]
+  Err --> Safe["error-safe-YYYY-MM-DD.log<br/>no raw error, no stack trace<br/>message kept verbatim"]
   Enabled -->|yes| PerDomain
   Err --> PerDomain{"domain routes to the sync file?"}
   PerDomain -->|yes| SyncLog["sync-YYYY-MM-DD.log"]

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -5,7 +5,7 @@ description: Twenty-four opt-in logging domains, where their lines land, and why
 resource: ../../lib/services/logging_domains.dart
 tags: [architecture, logging, diagnostics, observability]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T19:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2027-01-11
 sources:
   - id: log-domains
@@ -70,10 +70,18 @@ flowchart TD
 the full `error-<date>.log` mirror, the PII-safe `error-safe-<date>.log`, and then
 either the shared `sync-<date>.log` or its own `<domain>-<date>.log`.
 
-**The PII-safe log is the one to know about.** `error-safe-<date>.log` records only
-the error's **runtime type**, never the raw exception string, precisely so it can be
-shared or inspected without leaking user-authored content. The full mirror is for
-diagnosis on the device; the safe log is what may leave it.
+**The PII-safe log is the one to know about — and its guarantee is conditional.**
+`error-safe-<date>.log` omits two things that reliably carry content: the raw
+exception string and the stack trace (whose frames embed absolute paths, and with
+them the user's system username). What it does **not** omit is the caller's
+`message`: `safeErrorDescription` renders `'<message> (errorType=<Type>)'`
+verbatim.
+
+So the file is shareable **because callers are required to treat a log message as
+telemetry, never as content** — the contract `DomainLogger` states — not because
+the sink sanitises it. Putting a task title or a transcript in `message` puts it in
+the shareable log. The full mirror is for diagnosis on the device; this one is what
+may leave it, and that only holds if the contract does.
 
 There are therefore more files on disk than routing suggests — and two more that
 `LoggingService` does not own at all: `slow_queries` and `super_slow_queries`, both

--- a/knowledge/conventions/knowledge-bundle.md
+++ b/knowledge/conventions/knowledge-bundle.md
@@ -5,7 +5,7 @@ description: The README/knowledge/ADR split, the frontmatter every concept carri
 resource: ../../knowledge
 tags: [convention, documentation, okf, process]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T22:00:00Z }
 stale_after: 2027-01-18
 sources:
   - id: okf-spec
@@ -300,10 +300,13 @@ diagram rather than reporting one:
 - **A closing fence must be a uniform run** of the opener's character, at least as
   long. A mixed `` `~~ `` does not close a ``` block — it used to, which left the
   remainder of a file rendering as code while the check passed.
-- **Blockquote containers are stripped** before matching, so `> ```mermaid` is a
-  real diagram and its body is unwrapped before parsing. **List-item containers are
-  not modelled**: a fence indented past three spaces inside a list item reads as an
-  indented code block, so keep diagrams at the top level of a document.
+- **Blockquote containers are stripped, but only the opener's own.** `> ```mermaid`
+  is a real diagram and its body is unwrapped before parsing; a `>` appearing
+  *inside* a top-level fence stays literal, because stripping unconditionally let it
+  masquerade as the close and an unclosed fence validated clean. **List-item
+  containers are not modelled**: a fence indented past three spaces inside a list
+  item reads as an indented code block, so keep diagrams at the top level of a
+  document.
 
 **The gate covers `knowledge/` only.** `check_mermaid.mjs` takes a directory, and
 pointing it at `docs/` currently reports 14 broken diagrams across the ADRs, the

--- a/knowledge/conventions/knowledge-bundle.md
+++ b/knowledge/conventions/knowledge-bundle.md
@@ -5,7 +5,7 @@ description: The README/knowledge/ADR split, the frontmatter every concept carri
 resource: ../../knowledge
 tags: [convention, documentation, okf, process]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T19:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2027-01-18
 sources:
   - id: okf-spec
@@ -167,7 +167,10 @@ not-yet-written knowledge is legitimate.
 3. Bump `generated.at` on any concept you rewrote, and push `stale_after` out by
    the window its subject earns.
 4. Add a line to [`knowledge/log.md`](../log.md) for a structural change — a new
-   concept, a removed one, a reorganisation. Not for routine edits.
+   concept, a removed one, a reorganisation. Not for routine edits. **A date's entry
+   records the net outcome**: if a later change the same day reverses an earlier
+   claim, rewrite the entry rather than appending a contradiction, or the log ends up
+   asserting both.
 5. Run `make knowledge_check`.
 
 **If a concept contradicts the code, the concept is the defect.** Fix it in the
@@ -212,8 +215,11 @@ House rules — OKF grades these `SHOULD`, this repo does not:
 - A `verified` entry that is not `{ by, at }`, is missing `by`, or carries an `at`
   that is missing or malformed.
 - An actor outside the `<producer>/<version>` / `human:<id>` / `process:<id>`
-  convention — in `generated.by`, in `verified[].by`, or in the optional
-  `sources[].author`.
+  convention — in `generated.by`, in a `verified` entry's `by`, or in the optional
+  `sources[].author`. **`verified` takes either shape**: a single `{ by, at }`
+  mapping, as in the template above, or a list of them for more than one
+  confirmation. The validator treats a bare mapping as a one-element list, which is
+  why its messages say `verified[]`.
 - A root `index.md` whose frontmatter will not parse, or is not a mapping.
 - A `stale_after` that is not an absolute `YYYY-MM-DD` day.
 - A `sources` that is null, not a list, or empty; an entry that is not a mapping;
@@ -287,6 +293,17 @@ which is the one failure a checker must never have.
 **Four spaces of indent is not a fence.** CommonMark reads it as an indented code
 block, so that is how to show a mermaid fence as an *example* without either
 checker treating it as a diagram.
+
+Two more rules both checkers follow, because getting them wrong hides a broken
+diagram rather than reporting one:
+
+- **A closing fence must be a uniform run** of the opener's character, at least as
+  long. A mixed `` `~~ `` does not close a ``` block — it used to, which left the
+  remainder of a file rendering as code while the check passed.
+- **Blockquote containers are stripped** before matching, so `> ```mermaid` is a
+  real diagram and its body is unwrapped before parsing. **List-item containers are
+  not modelled**: a fence indented past three spaces inside a list item reads as an
+  indented code block, so keep diagrams at the top level of a document.
 
 **The gate covers `knowledge/` only.** `check_mermaid.mjs` takes a directory, and
 pointing it at `docs/` currently reports 14 broken diagrams across the ADRs, the

--- a/knowledge/conventions/knowledge-bundle.md
+++ b/knowledge/conventions/knowledge-bundle.md
@@ -5,7 +5,7 @@ description: The README/knowledge/ADR split, the frontmatter every concept carri
 resource: ../../knowledge
 tags: [convention, documentation, okf, process]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T22:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T23:00:00Z }
 stale_after: 2027-01-18
 sources:
   - id: okf-spec
@@ -300,13 +300,14 @@ diagram rather than reporting one:
 - **A closing fence must be a uniform run** of the opener's character, at least as
   long. A mixed `` `~~ `` does not close a ``` block — it used to, which left the
   remainder of a file rendering as code while the check passed.
-- **Blockquote containers are stripped, but only the opener's own.** `> ```mermaid`
-  is a real diagram and its body is unwrapped before parsing; a `>` appearing
-  *inside* a top-level fence stays literal, because stripping unconditionally let it
-  masquerade as the close and an unclosed fence validated clean. **List-item
-  containers are not modelled**: a fence indented past three spaces inside a list
-  item reads as an indented code block, so keep diagrams at the top level of a
-  document.
+- **Blockquote containers are stripped to the opener's depth.** `> ```mermaid` is a
+  real diagram and its body is unwrapped before parsing, and the marker's trailing
+  space is optional — `>flowchart TD` under a `> ` opener is the same container. A
+  `>` appearing *inside* a top-level fence stays literal, because stripping
+  unconditionally let it masquerade as the close and an unclosed fence validated
+  clean. **List-item containers are not modelled**: a fence indented past three
+  spaces inside a list item reads as an indented code block, so keep diagrams at the
+  top level of a document.
 
 **The gate covers `knowledge/` only.** `check_mermaid.mjs` takes a directory, and
 pointing it at `docs/` currently reports 14 broken diagrams across the ADRs, the

--- a/knowledge/features/agents/projection.md
+++ b/knowledge/features/agents/projection.md
@@ -5,7 +5,7 @@ description: "A pure, deterministic fold over an event *set* — proving that pr
 resource: ../../../lib/features/agents/projection
 tags: [agents, projection, determinism, convergence]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T22:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T23:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: sync-service
@@ -104,9 +104,11 @@ Two boundaries make that precise:
 A malformed synced log (a duplicate id or a cycle from a peer) makes the fold
 throw; the wake falls back to the cached row and logs, rather than aborting.
 
-The composite's own header still says it "drives no production read" — that
-sentence predates the cutover it predicted, and `agent_sync_service.dart` is the
-authority:
+One piece of history worth knowing, because it misled this concept twice: the
+composite's header used to read *"drives no production read; B6 flips reads onto
+this fold"* — a sentence that outlived the cutover it predicted. It now describes
+the shipped state, and `agent_sync_service.dart` remains the authority for the read
+path:
 
 - It calls `project(canonicalOrder(...))` for the structural part — heads and the
   latest report — and aggregates the rest **directly off the messages and links**:

--- a/knowledge/features/agents/projection.md
+++ b/knowledge/features/agents/projection.md
@@ -5,7 +5,7 @@ description: "A pure, deterministic fold over an event *set* — proving that pr
 resource: ../../../lib/features/agents/projection
 tags: [agents, projection, determinism, convergence]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T22:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: sync-service
@@ -94,9 +94,12 @@ Two boundaries make that precise:
   the log does not own — `recentHeadMessageId`, the G-counters, device-local
   scheduling — stay on the cache by construction.
 - **Only the wake path reads this way.** UI and service reads stay on the raw cache
-  via `AgentRepository.getAgentState`, which is eventual and self-healing. And the
-  reconcile loads *markers*, not the full message log, so its cost does not grow
-  with an agent's history.
+  via `AgentRepository.getAgentState`, which is eventual and self-healing.
+- **It loads markers, not the whole log — but it is not free.**
+  `getMessagesByKind(agentId, system)` passes no limit, and a milestone marker is
+  appended on every completed wake (plus retractions and fork joins), so the read
+  and the fold **grow with the number of wakes**. Far smaller than the full message
+  log, and still linear in history — worth knowing before adding work to this path.
 
 A malformed synced log (a duplicate id or a cycle from a peer) makes the fold
 throw; the wake falls back to the cached row and logs, rather than aborting.

--- a/knowledge/features/agents/projection.md
+++ b/knowledge/features/agents/projection.md
@@ -5,9 +5,13 @@ description: "A pure, deterministic fold over an event *set* — proving that pr
 resource: ../../../lib/features/agents/projection
 tags: [agents, projection, determinism, convergence]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T20:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2026-10-12
 sources:
+  - id: sync-service
+    resource: ../../../lib/features/agents/sync/agent_sync_service.dart
+    title: reconciledAgentState — the wake-path read cutover
+    last_modified: 2026-06-13
   - id: src
     resource: ../../../lib/features/agents/projection
     title: Projection kernel source
@@ -72,11 +76,34 @@ the fold cannot depend on which head arrived first.
 # Above the kernel: `DerivedAgentState`
 
 The kernel is deliberately small. `DerivedAgentState` (`derived_agent_state.dart`)
-is the **storage-coupled composite** built on top of it — and, in its own words,
-it *"drives no production read"* yet. Reads still come from the mutable cache; the
-planned step that flips them onto this fold has not happened, and there are no
-external call sites. Read it as the target shape and the comparison mechanism, not
-as the current read path:
+is the **storage-coupled composite** built on top of it, and the fold **is** on the
+wake critical path today:
+
+`AgentSyncService.reconciledAgentState` — called at the start of every task,
+project, event, improver and day-agent wake — loads the `system` milestone markers
+and the agent's outbound links, runs `reconcileAgentState` (which calls
+`deriveAgentState`) over the cached row, and returns the reconciled value. So a
+watermark or active slot the cache lost to last-writer-wins under a partition
+**self-heals before the agent decides anything**, and the healed row is persisted
+only when something actually diverged.
+
+Two boundaries make that precise:
+
+- **The reconcile is not a blind "log wins".** Watermarks take `max(derived,
+  cache)` because they are monotonic; active slots take `derived ?? cache`. Fields
+  the log does not own — `recentHeadMessageId`, the G-counters, device-local
+  scheduling — stay on the cache by construction.
+- **Only the wake path reads this way.** UI and service reads stay on the raw cache
+  via `AgentRepository.getAgentState`, which is eventual and self-healing. And the
+  reconcile loads *markers*, not the full message log, so its cost does not grow
+  with an agent's history.
+
+A malformed synced log (a duplicate id or a cycle from a peer) makes the fold
+throw; the wake falls back to the cached row and logs, rather than aborting.
+
+The composite's own header still says it "drives no production read" — that
+sentence predates the cutover it predicted, and `agent_sync_service.dart` is the
+authority:
 
 - It calls `project(canonicalOrder(...))` for the structural part — heads and the
   latest report — and aggregates the rest **directly off the messages and links**:
@@ -87,12 +114,13 @@ as the current read path:
   messages and links derive an equal state regardless of arrival order. That is
   the guarantee **the mutable cache cannot make** under last-write-wins.
 
-`compareShadowProjection` (`shadow_projection.dart`) is what that comparison is
-for: it checks the projection against the live mutable state and returns a
+`compareShadowProjection` (`shadow_projection.dart`) is the other half: it checks
+the projection against the live mutable state and returns a
 `ShadowProjectionReport` — match or divergence — used as a test assertion and an
 optional debug-mode runtime check. There is no `ShadowProjection` type; the pieces
-are the function, that report and `ShadowProjectionStatus`. So today the fold's job
-is to make a drifted cache **detectable** rather than to serve reads.
+are the function, that report and `ShadowProjectionStatus`. It never drives a read;
+it makes a drifted cache **detectable** where the reconcile above makes it
+**self-healing**.
 
 The projection is plain Dart with no I/O, so it can be exercised with property
 tests over shuffled event sets — the only honest way to test a claim about

--- a/knowledge/features/daily_os_next/wake-prompt.md
+++ b/knowledge/features/daily_os_next/wake-prompt.md
@@ -5,7 +5,7 @@ description: Tagged plaintext sections ordered stable-to-volatile for prefix cac
 resource: ../../../lib/features/daily_os_next/agents/prompt/day_agent_prompt_sections.dart
 tags: [daily-os, prompt, context, prefix-cache, memory]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T00:30:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2026-10-26
 sources:
   - id: sections
@@ -104,10 +104,11 @@ with tracked time. `current_local_time` sits last and lets same-day drafting
 distinguish future plan slots from time that has already passed.
 
 **`day_entries` is a bounded index, not a log.** It carries recording receipts so
-a later wake can recover a completed offline check-in immediately, capped at the
-newest 32 with the omitted count rendered explicitly rather than silently. It
-closes the byte-stable prefix — five sections precede it, twelve follow — so a
-heavy capture day must not be allowed to inflate it. Anything that grows this section pushes the whole
+a later wake can recover a completed offline check-in immediately — capped at the
+newest 32 of however many the day holds, with the omitted count rendered explicitly
+rather than silently (see [day entries](#day-entries)). It closes the byte-stable
+prefix — five sections precede it, twelve follow — so a heavy capture day must not
+be allowed to inflate it. Anything that grows this section pushes the whole
 per-wake band out of cache.
 
 ## Prompt-record splice
@@ -243,7 +244,12 @@ following links via `search_memory(ids:)`.
 
 # Day entries
 
-Later planner wakes load metadata for every persisted day recording plus bounded
-reviewed/correlated text into `<day_entries>`, **even before a `CaptureEntity`
-exists**. Pending recordings therefore remain discoverable without fabricated
-transcript content.
+Later planner wakes load metadata for every persisted day recording of that day,
+plus bounded reviewed/correlated text, **even before a `CaptureEntity` exists** —
+so a pending recording stays discoverable without fabricated transcript content.
+
+**The load is unbounded; the section is not.** `loadForDay` returns every recording
+for the day, and the context builder then renders only the **newest 32** into
+`<day_entries>`, with the omitted count marked explicitly. Both statements are
+about the same data at different stages: read "every persisted recording" as what
+is *available* to the section, and 32 as what reaches the model.

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -5,7 +5,7 @@ description: The Drift-backed inbound queue, the anchored catch-up bridge, per-r
 resource: ../../../lib/features/sync/queue
 tags: [sync, inbound-queue, catch-up, matrix]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T16:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2026-11-02
 sources:
   - id: queue
@@ -88,8 +88,8 @@ The preferred path is an **anchored forward walk**
 `/context/{eventId}` request with `room.getTimeline(eventContextId: marker,
 limit: 0)`, then walk `/messages?dir=f`.
 
-**The zero cache limit is required by the Matrix SDK.** This was established
-against **7.0.0 and has not been re-verified since**; `pubspec.yaml` now pins
+**The zero cache limit was required by Matrix SDK 7.0.0**, and has not been
+re-verified since; `pubspec.yaml` now pins
 `matrix: ^8.1.0`, and four in-code comments still name 7.0.0
 (`bootstrap_forward_strategy.dart`, `bootstrap_backward_strategy.dart`, and twice
 in `queue_pipeline_coordinator.dart`). Treat the workaround as load-bearing until

--- a/knowledge/features/tasks/data-model.md
+++ b/knowledge/features/tasks/data-model.md
@@ -5,7 +5,7 @@ description: What TaskData carries, the two boundaries it deliberately excludes,
 resource: ../../../lib/classes/task.dart
 tags: [tasks, domain, progress, estimates]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T22:00:00Z }
 stale_after: 2027-01-25
 sources:
   - id: task
@@ -39,19 +39,24 @@ Every variant carries `id`, `createdAt`, `utcOffset`, `timezone` and
 the only two that do. Nothing else distinguishes `done` from `rejected`
 structurally, so for the terminal pair the status *is* the discriminator.
 
-**The live/terminal split is not in the union at all, and it is duplicated.** Seven
-files re-state "DONE and REJECTED are the closed ones" independently — four of them
-as the same raw SQL predicate:
+**The live/terminal split is not in the union, and it is duplicated widely.** At
+least thirteen files decide "DONE and REJECTED are the closed ones" independently,
+in five idioms — the exact count is not the point, the absence of a shared constant
+is:
 
-| Site | Form |
-|------|------|
-| `tasks/ui/utils.dart` `openTaskStatuses` | the five live labels — what the linking UI filters on |
-| `day_agent_capture_helpers.dart` `isClosedTask` / `closedTaskStatuses` | `{'DONE', 'REJECTED'}` |
-| `agents/tools/task_status_handler.dart` `terminalStatuses` | `{'DONE', 'REJECTED'}` |
-| `database.dart`, `database_task_due_queries.dart`, `database_migration.dart`, `database.drift` | `AND task_status NOT IN ('DONE', 'REJECTED')` in raw SQL |
+| Idiom | Where |
+|-------|-------|
+| The five live labels as a list | `tasks/ui/utils.dart` `openTaskStatuses` — what the linking UI filters on |
+| A `{'DONE', 'REJECTED'}` set | `day_agent_capture_helpers.dart` (`isClosedTask`), `agents/tools/task_status_handler.dart` |
+| Raw SQL `NOT IN ('DONE', 'REJECTED')` | `database.dart`, `database.drift`, `database_task_due_queries.dart`, `database_migration.dart` |
+| A sealed-type test, `is TaskDone \|\| is TaskRejected` | `wake_run_chart_providers.dart` (`_findResolution`), `task_resolution_time_series.dart`, `task_blockers_controller.dart`, `desktop_task_header_connector.dart` |
+| Prompt and tool contracts | `task_field_tool_definitions.dart`, `task_agent_prompt_builder.dart` |
 
-Adding an eighth status means finding all seven. There is no shared constant to
-change.
+**Adding an eighth status means finding all of them** — grep for both the string
+pair and the type pair; there is no constant to change. The quietest to miss is the
+metrics path: `_findResolution` returning null makes a wake run read as
+*unresolved* rather than erroring, so a new terminal status would silently distort
+the charts.
 
 **Nothing in the code restricts which status may follow which.** There is no
 transition table, no guard, and no validation — a task can go from `onHold`

--- a/knowledge/features/tasks/data-model.md
+++ b/knowledge/features/tasks/data-model.md
@@ -5,7 +5,7 @@ description: What TaskData carries, the two boundaries it deliberately excludes,
 resource: ../../../lib/classes/task.dart
 tags: [tasks, domain, progress, estimates]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T13:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2027-01-25
 sources:
   - id: task
@@ -39,8 +39,9 @@ Every variant carries `id`, `createdAt`, `utcOffset`, `timezone` and
 the only two that do. Nothing else distinguishes `done` from `rejected`
 structurally, so for the terminal pair the status *is* the discriminator.
 
-**The live/terminal split is not in the union at all, and it is duplicated.** Six
-places re-state "DONE and REJECTED are the closed ones" independently:
+**The live/terminal split is not in the union at all, and it is duplicated.** Seven
+files re-state "DONE and REJECTED are the closed ones" independently — four of them
+as the same raw SQL predicate:
 
 | Site | Form |
 |------|------|
@@ -49,8 +50,8 @@ places re-state "DONE and REJECTED are the closed ones" independently:
 | `agents/tools/task_status_handler.dart` `terminalStatuses` | `{'DONE', 'REJECTED'}` |
 | `database.dart`, `database_task_due_queries.dart`, `database_migration.dart`, `database.drift` | `AND task_status NOT IN ('DONE', 'REJECTED')` in raw SQL |
 
-Adding an eighth status means finding every one of them. There is no shared
-constant to change.
+Adding an eighth status means finding all seven. There is no shared constant to
+change.
 
 **Nothing in the code restricts which status may follow which.** There is no
 transition table, no guard, and no validation — a task can go from `onHold`

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -26,7 +26,9 @@
   ten query-bearing mixins use one, while **single-entity journal reads** skip
   filtering; `PROPAGATED::` is **additive**, so matching the bare token alone is
   complete, and the wake deferral it enables is opt-in per subscription;
-  `DerivedAgentState` **drives no production read** yet; CI runs `very_good test`
+  `DerivedAgentState` **is** on the wake critical path via
+  `AgentSyncService.reconciledAgentState`, while UI and service reads stay on the
+  raw cache; CI runs `very_good test`
   with its optimizer on, so a leak reaches other files **in the same shard**;
   `TaskStatus` has **seven** variants; an error reaches **two to four** files
   including the PII-safe `error-safe-<date>.log`; and the build-runner

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,102 +1,53 @@
 # Knowledge Bundle Update Log
 
 ## 2026-07-26
-* **Fix**: Corrected an inverted rule and a doubly-overshot narrowing. The
-  `PROPAGATED::` prefix is **additive** — every emitter sends the bare token in the
-  same set, so matching it alone is complete, and the deferral it enables is opt-in
-  per subscription. The privacy gate has **three** mechanisms, nine of ten
-  query-bearing mixins use one, and what skips filtering is single-entity journal
-  reads, not by-id reads as a class. The stale source comment that seeded the
-  original error was corrected too.
-* **Fix**: Corrected three claims the previous day's fixes introduced — a
-  notification payload is **not** token-only (it leads with the entity's own id,
-  carries linked ids, and includes dynamic `PROJECT_ENTITY_UPDATE:<id>` keys),
-  `DerivedAgentState` **drives no production read** yet, and an error reaches two
-  to four files including the PII-safe `error-safe-<date>.log` the sink diagram
-  had omitted.
-* **Creation**: Added [screenshots](conventions/screenshots.md) — the first written
-  account of where captured images live (the sibling `lotti-docs` repo, never
-  here), the three destinations there and their different lifecycles, and the
-  before/after pair a UI pull request carries. The practice had ~1,100 files across
-  37 topics and was documented nowhere, including in `lotti-docs`'s own README.
-* **Creation**: Documented the last three subsystems with no home: the
-  `UpdateNotifications` token vocabulary and its `PROPAGATED::` prefix (which
-  changes wake throttling, not just reactivity), `DerivedAgentState` and
-  `ShadowProjection` above the projection kernel, and the error-log mirror the
-  logging sink diagram had omitted.
-* **Update**: Closed three documented-but-unenforced gaps in the validator —
-  `resource: ""` and `tags: []` now fail, and a `stale_after` warns for the
-  fortnight before it becomes an error, so a batch coming due is never first heard
-  about as a red push.
-* **Fix**: Narrowed the privacy claim that mattered most: the `private` gate is
-  **opt-in and most reads skip it** — thirteen call sites in five files, and
-  by-id reads including `journalEntityById` never filter. "Every read passes a
-  private-visibility gate" was wrong by an order of magnitude.
-* **Fix**: The mermaid gate now catches the quiet failure it only documented. Two
-  live state diagrams had a `;` in an unquoted label, parsing clean while
-  rendering five phantom nodes each; the checker inspects the built diagram for
-  ids containing `;`, and it now has thirteen tests of its own.
-* **Fix**: Corrected three claims this bundle got wrong *while* fixing others:
-  `TaskStatus` has seven variants, not five (`done` and `rejected` were missed by
-  reading a truncated line range); a leak *can* cross test files on CI, because
-  very_good's optimizer bundles every test into one isolate per shard; and `:=` is
-  not a Mermaid trap — only `;` is, and its quiet failure mode is a stray node
-  rather than an error.
-* **Update**: `make knowledge_check` is now the single target for a change under
-  `knowledge/`, running the validator and the Mermaid parse together, and the
-  Mermaid checker accepts every CommonMark fence form instead of skipping
-  `~~~mermaid` in silence.
+* **Enforcement**: The metadata that makes drift detectable now fails the build
+  instead of being reported and ignored — a missing or empty `title`,
+  `description`, `resource`, `tags`, `status`, `generated`, `stale_after` or
+  `sources`, a source set that never leaves the bundle, an unclosed fenced block,
+  and a `stale_after` that has passed (with a warning for the fortnight before).
+  What stays advisory is the narrow set OKF is deliberately permissive about, plus
+  the `Attested Computation` fields nothing here uses. An unrecognised CLI flag is
+  rejected rather than ignored.
+* **Enforcement**: Mermaid is parsed in CI by mermaid itself
+  ([`tool/okf/check_mermaid.mjs`](../tool/okf/check_mermaid.mjs), 15 tests), since
+  there is no Dart parser. It accepts every CommonMark fence form, treats a
+  four-space-indented fence as the literal it is, and inspects the built diagram —
+  a `;` in an unquoted label parses clean while rendering phantom nodes. Three
+  diagrams that never rendered and one closing fence with prose welded to it were
+  repaired. `make knowledge_check` runs the validator and this together.
+* **Reorganisation**: Collapsed 23 feature directories holding a single
+  sub-200-line concept into one file each, and moved the projection kernel under
+  the agents tree. 24 index files gone, concept count unchanged.
+* **Update**: Staggered `stale_after` by subsystem — 15 review dates instead of
+  one shared cliff, at most eleven concepts each.
+* **Fix**: Corrected roughly thirty claims against the code. The load-bearing ones,
+  in their final form: the `private` gate is reached **three** ways and nine of the
+  ten query-bearing mixins use one, while **single-entity journal reads** skip
+  filtering; `PROPAGATED::` is **additive**, so matching the bare token alone is
+  complete, and the wake deferral it enables is opt-in per subscription;
+  `DerivedAgentState` **drives no production read** yet; CI runs `very_good test`
+  with its optimizer on, so a leak reaches other files **in the same shard**;
+  `TaskStatus` has **seven** variants; an error reaches **two to four** files
+  including the PII-safe `error-safe-<date>.log`; and the build-runner
+  `--build-filter` trap **does** show in `git status`, which is the only signal
+  there is.
 * **Fix**: Recomputed every `sources[].last_modified` from `git log` — 162 of 229
-  had been written as "about today" rather than asked of history, some off by six
-  weeks. The field now records what each concept was actually written against.
-* **Fix**: Corrected fourteen claims that contradicted the code, across habits,
-  the knowledge-graph PoC, settings, sync, persistence, the journal entity, task
-  relationships, the CI story and the build-runner trap. Four `lib/` READMEs were
-  wrong too, and `memory-and-compaction`'s subject pointed at a directory holding
-  one unrelated file.
-* **Creation**: Documented the slow-query capture's **second tier** — the 200 ms
-  threshold that also captures `EXPLAIN QUERY PLAN` and writes a separate
-  `super_slow_queries` file, which is the one worth reading first.
-* **Creation**: Documented three things the bundle had no home for — the
-  `private` visibility gate every `JournalDb` read routes through (a filter, not
-  a protection), `TaskStatus`'s five states and the fact that *nothing* constrains
-  their transitions, and which nine of `lib/widgets/`'s sixteen groups the
-  shared-widgets concept does not cover.
-* **Update**: Added diagrams to the seven concepts whose subject has a shape
-  prose cannot carry — the `JournalEntity` union, the `linked_entries` row, the
-  projection kernel's permutation invariance, the idle gate's state machine, the
-  wake prompt's stability bands, dashboard item dispatch, and theming's
-  arrival-based sync. 69 of 88 concepts now carry at least one.
-* **Fix**: Repaired three Mermaid diagrams that did not parse and one closing
-  fence with prose welded to it, which had been rendering the tail of a concept
-  as code. The validator now fails on an unclosed fence; Mermaid syntax itself
-  still needs the out-of-band parse check documented in the convention.
-* **Update**: Raised the house-rule metadata checks from warnings to errors, so
-  a concept missing a description, a freshness date or code provenance now fails
-  CI rather than being reported and ignored. What stays a warning is what OKF is
-  deliberately permissive about — a link to knowledge not written yet — plus a
-  concept whose `stale_after` has passed, which is now reported.
+  were written as "about today" rather than asked of history, some off by six
+  weeks. All 238 match now.
+* **Creation**: Documented what had no home: the `private` visibility gate, the
+  `UpdateNotifications` routing-key vocabulary and its `PROPAGATED::` semantics,
+  `DerivedAgentState` with the shadow comparison, the error-log mirrors including
+  the PII-safe sink, the slow-query second tier, `TaskStatus` and the fact that
+  nothing constrains its transitions, and which nine of `lib/widgets/`'s sixteen
+  groups the shared-widgets concept omits.
+* **Creation**: Added [screenshots](conventions/screenshots.md) — where captured
+  images live (the sibling `lotti-docs` repo, never here), its three destinations
+  and their lifecycles, and the before/after pair a UI pull request carries. The
+  practice held ~1,100 files across 37 topics and was documented nowhere.
 * **Update**: Gave [the root index](index.md) a reading order, an authority
-  hierarchy and a code-to-concept map for the shared trees under `lib/` that have
-  no README of their own.
-* **Reorganisation**: Collapsed 23 feature directories that held a single
-  sub-200-line concept into one file each — `features/categories/overview.md`
-  became `features/categories.md`. An index listing one document is a hop, not
-  progressive disclosure. The count of concepts is unchanged; 24 index files are
-  gone.
-* **Reorganisation**: Moved the projection kernel from `features/agents_projection/`
-  to [`features/agents/projection.md`](features/agents/projection.md). It
-  documents `lib/features/agents/projection`, so it was a sibling of the feature
-  that owns it rather than a part of it.
-* **Update**: Differentiated `stale_after` by how fast each subject moves —
-  three months for `agents`, `ai`, `daily_os_next` and `sync`, twelve for domain
-  models and settled exploratory work, six for everything else. One shared date
-  expired the whole bundle on a single day and said nothing about which concepts
-  actually change.
-* **Update**: Split the overlapping settings prose — `settings_v2` owns the tree
-  and the argument for having one, `settings` owns the shell that renders it —
-  and dropped the drift-prone inventory counts from the reserved `index.md`
-  files, which carry no freshness metadata of their own.
+  hierarchy, and a code-to-concept map for the shared trees under `lib/`; added
+  diagrams to seven concepts, so 69 of 89 carry at least one.
 
 ## 2026-07-25
 * **Initialization**: Established the OKF v0.2 bundle at `knowledge/`, with the

--- a/lib/features/agents/projection/derived_agent_state.dart
+++ b/lib/features/agents/projection/derived_agent_state.dart
@@ -30,7 +30,10 @@ import 'package:lotti/features/agents/projection/shadow_projection.dart';
 ///   `consecutiveFailureCount`, `pendingProjectActivityAt`, scheduling) — stay
 ///   on the cache by design.
 ///
-/// Drives no production read; B6 flips reads onto this fold.
+/// **The B6 read cutover has shipped**: `AgentSyncService.reconciledAgentState`
+/// folds this over the cached row at the start of every wake, so the wake path
+/// reads through here. UI and service reads stay on the raw cache
+/// (`AgentRepository.getAgentState`), which is eventual and self-healing.
 class DerivedAgentState extends Equatable {
   const DerivedAgentState({
     required this.projection,

--- a/test/tool/okf/okf_validator_test.dart
+++ b/test/tool/okf/okf_validator_test.dart
@@ -1134,6 +1134,32 @@ Body.
       expect(result.issues, isEmpty);
     });
 
+    test('a mixed closing run does not close the block', () {
+      // CommonMark requires a uniform run; `~~ after ``` passed a "first
+      // character matches, long enough" test and closed the block.
+      final result = validateBundle(
+        _bundle(_concept(body: '```mermaid\nflowchart TD\n`~~\n')),
+      );
+
+      expect(result.errors.single.message, contains('is never closed'));
+    });
+
+    test('a blockquoted fence is recognised, and its close too', () {
+      final result = validateBundle(
+        _bundle(_concept(body: '> ```dart\n> var x = 1;\n> ```\n')),
+      );
+
+      expect(result.issues, isEmpty);
+    });
+
+    test('an unclosed blockquoted fence is still caught', () {
+      final result = validateBundle(
+        _bundle(_concept(body: '> ```dart\n> var x = 1;\n')),
+      );
+
+      expect(result.errors.single.message, contains('is never closed'));
+    });
+
     test('a tilde block is not closed by backticks', () {
       final result = validateBundle(
         _bundle(_concept(body: '~~~text\nplain\n```\n')),

--- a/test/tool/okf/okf_validator_test.dart
+++ b/test/tool/okf/okf_validator_test.dart
@@ -1162,6 +1162,17 @@ Body.
       expect(result.issues, isEmpty);
     });
 
+    test('a quoted fence closes even when marker spacing varies', () {
+      // The marker's trailing space is optional in CommonMark, so an exact-text
+      // prefix match stripped neither the body nor the close and reported a valid
+      // block as unclosed.
+      final result = validateBundle(
+        _bundle(_concept(body: '> ```dart\n>var x = 1;\n>```\n')),
+      );
+
+      expect(result.issues, isEmpty);
+    });
+
     test('an unclosed blockquoted fence is still caught', () {
       final result = validateBundle(
         _bundle(_concept(body: '> ```dart\n> var x = 1;\n')),

--- a/test/tool/okf/okf_validator_test.dart
+++ b/test/tool/okf/okf_validator_test.dart
@@ -1144,6 +1144,16 @@ Body.
       expect(result.errors.single.message, contains('is never closed'));
     });
 
+    test('a literal > inside a top-level fence does not close it', () {
+      // Stripping `>` unconditionally made this marker read as the close, so an
+      // unclosed fence validated clean.
+      final result = validateBundle(
+        _bundle(_concept(body: '```mermaid\nflowchart TD\n> ```\n')),
+      );
+
+      expect(result.errors.single.message, contains('is never closed'));
+    });
+
     test('a blockquoted fence is recognised, and its close too', () {
       final result = validateBundle(
         _bundle(_concept(body: '> ```dart\n> var x = 1;\n> ```\n')),

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -75,13 +75,27 @@ function closesFence(line, opener) {
   return run[0] === opener[0] && run.length >= opener.length;
 }
 
-/// Strips blockquote markers, which CommonMark removes before a fence is
-/// recognised — `> ```mermaid` opens a real block. Nested quotes are handled by
-/// repetition. **List-item containers are not modelled**: a fence indented past
-/// three spaces inside a list item is read here as an indented code block, so
-/// keep diagrams at the top level of a document.
-function stripContainers(line) {
-  return line.replace(/^(?: {0,3}>(?: |\t)?)+/, '');
+const CONTAINER = /^(?: {0,3}>(?: |\t)?)+/;
+
+/// The blockquote prefix `line` carries, or `''`.
+function containerPrefix(line) {
+  return CONTAINER.exec(line)?.[0] ?? '';
+}
+
+/// Removes exactly `prefix` from the front of `line`.
+///
+/// Tied to the opener on purpose. Stripping `>` unconditionally meant a
+/// **top-level** fence whose body contained a literal `` > ``` `` had that marker
+/// stripped and then read as the close — so an unclosed fence was reported as a
+/// clean block. CommonMark treats content inside a fence as literal; only the
+/// container the fence was opened *under* is removed from its body.
+///
+/// **List-item containers are not modelled**: a fence indented past three spaces
+/// inside a list item reads as an indented code block, so keep diagrams at the
+/// top level of a document.
+function stripPrefix(line, prefix) {
+  if (prefix === '') return line;
+  return line.startsWith(prefix) ? line.slice(prefix.length) : line;
 }
 
 const blocks = [];
@@ -91,13 +105,17 @@ for (const file of markdownFiles(root)) {
   let opener = null;
   let openedAt = 0;
   let isMermaid = false;
+  let prefix = '';
   lines.forEach((line, index) => {
-    // Keep the leading indent: only trailing whitespace and containers are noise.
-    const kept = stripContainers(line.replace(/\s+$/, ''));
+    const trimmedEnd = line.replace(/\s+$/, '');
     if (opener === null) {
-      const match = FENCE.exec(kept);
+      // Outside a fence, a blockquote marker is a container: strip it, and
+      // remember it so the body and the close are read in the same context.
+      const candidate = containerPrefix(trimmedEnd);
+      const match = FENCE.exec(stripPrefix(trimmedEnd, candidate));
       if (match) {
         opener = match[2];
+        prefix = candidate;
         openedAt = index;
         // Only the *outermost* fence counts: a mermaid fence shown as an example
         // inside a ````markdown block is documentation, not a diagram to parse.
@@ -105,7 +123,8 @@ for (const file of markdownFiles(root)) {
       }
       return;
     }
-    if (!closesFence(kept, opener)) return;
+    // Inside a fence, only the opener's own container is removed.
+    if (!closesFence(stripPrefix(trimmedEnd, prefix), opener)) return;
     if (isMermaid) {
       blocks.push({
         file,
@@ -114,12 +133,13 @@ for (const file of markdownFiles(root)) {
         // and reports "no diagram type detected" for a diagram that renders fine.
         code: lines
           .slice(openedAt + 1, index)
-          .map(stripContainers)
+          .map((l) => stripPrefix(l, prefix))
           .join('\n'),
       });
     }
     opener = null;
     isMermaid = false;
+    prefix = '';
   });
   if (opener !== null && isMermaid) {
     // The Dart validator reports any unclosed fence; repeated here so this

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -75,16 +75,27 @@ function closesFence(line, opener) {
   return run[0] === opener[0] && run.length >= opener.length;
 }
 
-const CONTAINER = /^(?: {0,3}>(?: |\t)?)+/;
+// One blockquote marker: up to three spaces of indent, `>`, and an *optional*
+// single space or tab. The trailing space is optional in CommonMark, which is why
+// the container is tracked as a **depth** rather than as literal prefix text — a
+// body line may write `>flowchart TD` under an opener that wrote `> `.
+const MARKER = /^ {0,3}>(?: |\t)?/;
 
-/// The blockquote prefix `line` carries, or `''`.
-function containerPrefix(line) {
-  return CONTAINER.exec(line)?.[0] ?? '';
+/// How many blockquote markers `line` opens with.
+function containerDepth(line) {
+  let rest = line;
+  let depth = 0;
+  for (;;) {
+    const match = MARKER.exec(rest);
+    if (match === null) return depth;
+    rest = rest.slice(match[0].length);
+    depth += 1;
+  }
 }
 
-/// Removes exactly `prefix` from the front of `line`.
+/// Removes `depth` blockquote markers from `line`, whatever their spacing.
 ///
-/// Tied to the opener on purpose. Stripping `>` unconditionally meant a
+/// Tied to the opener's depth on purpose. Stripping `>` unconditionally meant a
 /// **top-level** fence whose body contained a literal `` > ``` `` had that marker
 /// stripped and then read as the close — so an unclosed fence was reported as a
 /// clean block. CommonMark treats content inside a fence as literal; only the
@@ -93,9 +104,14 @@ function containerPrefix(line) {
 /// **List-item containers are not modelled**: a fence indented past three spaces
 /// inside a list item reads as an indented code block, so keep diagrams at the
 /// top level of a document.
-function stripPrefix(line, prefix) {
-  if (prefix === '') return line;
-  return line.startsWith(prefix) ? line.slice(prefix.length) : line;
+function stripDepth(line, depth) {
+  let rest = line;
+  for (let i = 0; i < depth; i++) {
+    const match = MARKER.exec(rest);
+    if (match === null) return rest;
+    rest = rest.slice(match[0].length);
+  }
+  return rest;
 }
 
 const blocks = [];
@@ -105,17 +121,17 @@ for (const file of markdownFiles(root)) {
   let opener = null;
   let openedAt = 0;
   let isMermaid = false;
-  let prefix = '';
+  let depth = 0;
   lines.forEach((line, index) => {
     const trimmedEnd = line.replace(/\s+$/, '');
     if (opener === null) {
       // Outside a fence, a blockquote marker is a container: strip it, and
       // remember it so the body and the close are read in the same context.
-      const candidate = containerPrefix(trimmedEnd);
-      const match = FENCE.exec(stripPrefix(trimmedEnd, candidate));
+      const candidate = containerDepth(trimmedEnd);
+      const match = FENCE.exec(stripDepth(trimmedEnd, candidate));
       if (match) {
         opener = match[2];
-        prefix = candidate;
+        depth = candidate;
         openedAt = index;
         // Only the *outermost* fence counts: a mermaid fence shown as an example
         // inside a ````markdown block is documentation, not a diagram to parse.
@@ -124,7 +140,7 @@ for (const file of markdownFiles(root)) {
       return;
     }
     // Inside a fence, only the opener's own container is removed.
-    if (!closesFence(stripPrefix(trimmedEnd, prefix), opener)) return;
+    if (!closesFence(stripDepth(trimmedEnd, depth), opener)) return;
     if (isMermaid) {
       blocks.push({
         file,
@@ -133,13 +149,13 @@ for (const file of markdownFiles(root)) {
         // and reports "no diagram type detected" for a diagram that renders fine.
         code: lines
           .slice(openedAt + 1, index)
-          .map((l) => stripPrefix(l, prefix))
+          .map((l) => stripDepth(l, depth))
           .join('\n'),
       });
     }
     opener = null;
     isMermaid = false;
-    prefix = '';
+    depth = 0;
   });
   if (opener !== null && isMermaid) {
     // The Dart validator reports any unclosed fence; repeated here so this

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -61,12 +61,27 @@ function markdownFiles(dir) {
 const FENCE = /^( {0,3})(`{3,}|~{3,})\s*(\S*)/;
 
 /// Whether `line` closes a block opened by `opener`: indented at most three
-/// spaces, same delimiter character, at least as long, and nothing else on it.
+/// spaces, a **uniform** run of the opener's delimiter, at least as long, and
+/// nothing else on the line.
+///
+/// The run must be uniform, not merely start with the right character: a mixed
+/// `` `~~ `` after a ``` opener satisfied "first character matches, length is
+/// enough" and closed the block, so the rest of the concept still rendered as
+/// code while the checker reported success.
 function closesFence(line, opener) {
-  const match = /^( {0,3})([`~]+)\s*$/.exec(line);
+  const match = /^ {0,3}(`+|~+)\s*$/.exec(line);
   if (match === null) return false;
-  const run = match[2];
+  const run = match[1];
   return run[0] === opener[0] && run.length >= opener.length;
+}
+
+/// Strips blockquote markers, which CommonMark removes before a fence is
+/// recognised — `> ```mermaid` opens a real block. Nested quotes are handled by
+/// repetition. **List-item containers are not modelled**: a fence indented past
+/// three spaces inside a list item is read here as an indented code block, so
+/// keep diagrams at the top level of a document.
+function stripContainers(line) {
+  return line.replace(/^(?: {0,3}>(?: |\t)?)+/, '');
 }
 
 const blocks = [];
@@ -77,8 +92,8 @@ for (const file of markdownFiles(root)) {
   let openedAt = 0;
   let isMermaid = false;
   lines.forEach((line, index) => {
-    // Keep the leading indent: only the trailing whitespace is noise.
-    const kept = line.replace(/\s+$/, '');
+    // Keep the leading indent: only trailing whitespace and containers are noise.
+    const kept = stripContainers(line.replace(/\s+$/, ''));
     if (opener === null) {
       const match = FENCE.exec(kept);
       if (match) {
@@ -95,7 +110,12 @@ for (const file of markdownFiles(root)) {
       blocks.push({
         file,
         line: openedAt + 1,
-        code: lines.slice(openedAt + 1, index).join('\n'),
+        // Unwrap the container on the body too, or mermaid is handed `> > A --> B`
+        // and reports "no diagram type detected" for a diagram that renders fine.
+        code: lines
+          .slice(openedAt + 1, index)
+          .map(stripContainers)
+          .join('\n'),
       });
     }
     opener = null;

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -104,6 +104,12 @@ test('a mixed closing run does not close the block', () => {
   assert.match(r.output, /unclosed mermaid fence/);
 });
 
+test('a literal > inside a top-level fence does not close it', () => {
+  const r = run('```mermaid\nflowchart TD\n> ```\n');
+  assert.ok(!r.ok, r.output);
+  assert.match(r.output, /unclosed mermaid fence/);
+});
+
 test('a blockquoted fence is a real diagram', () => {
   // CommonMark strips the container prefix before recognising the fence, so
   // `> ```mermaid` opens a block. Requiring column 0 skipped it in silence.

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -95,6 +95,29 @@ test('a three-space-indented fence is still a diagram', () => {
   assert.match(r.output, /FAIL/);
 });
 
+test('a mixed closing run does not close the block', () => {
+  // CommonMark requires the closing run to be uniform. `` `~~ `` after a ```
+  // opener passed a "first character matches, long enough" test and closed the
+  // block, so the rest of the file rendered as code while the check passed.
+  const r = run('```mermaid\nflowchart TD\n  A --> B\n`~~\n\nprose\n');
+  assert.ok(!r.ok, r.output);
+  assert.match(r.output, /unclosed mermaid fence/);
+});
+
+test('a blockquoted fence is a real diagram', () => {
+  // CommonMark strips the container prefix before recognising the fence, so
+  // `> ```mermaid` opens a block. Requiring column 0 skipped it in silence.
+  const r = run('> ```mermaid\n> flowchart TD\n>   A -->\n> ```\n');
+  assert.ok(!r.ok, r.output);
+  assert.match(r.output, /FAIL/);
+});
+
+test('a nested blockquote fence is still recognised', () => {
+  const r = run('> > ```mermaid\n> > flowchart TD\n> >   A --> B\n> > ```\n');
+  assert.ok(r.ok, r.output);
+  assert.match(r.output, /parsed 1 block/);
+});
+
 test('an unclosed mermaid fence is reported', () => {
   const r = run('```mermaid\nflowchart TD\n  A --> B\n');
   assert.ok(!r.ok);

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -118,6 +118,15 @@ test('a blockquoted fence is a real diagram', () => {
   assert.match(r.output, /FAIL/);
 });
 
+test('a quoted fence works when marker spacing varies', () => {
+  // `>flowchart TD` under a `> ```mermaid` opener: the marker's trailing space is
+  // optional, so matching exact prefix text stripped nothing and the block read
+  // as unclosed.
+  const r = run('> ```mermaid\n>flowchart TD\n>  A --> B\n>```\n');
+  assert.ok(r.ok, r.output);
+  assert.match(r.output, /parsed 1 block/);
+});
+
 test('a nested blockquote fence is still recognised', () => {
   const r = run('> > ```mermaid\n> > flowchart TD\n> >   A --> B\n> > ```\n');
   assert.ok(r.ok, r.output);

--- a/tool/okf/okf_validator.dart
+++ b/tool/okf/okf_validator.dart
@@ -270,11 +270,11 @@ List<OkfIssue> validateFencedBlocks(String path, String content) {
   String? opener;
   var openedAt = 0;
   for (var i = 0; i < lines.length; i++) {
-    // Trailing whitespace is noise; the *leading* indent is not. CommonMark
-    // allows a fence to be indented by at most three spaces — at four it is an
-    // indented code block, so a documented example of a fence is not a fence.
-    // Trimming the indent away made those literals open and close real blocks.
-    final line = lines[i].trimRight();
+    // Trailing whitespace and blockquote markers are noise; the *leading indent*
+    // is not. CommonMark allows a fence to be indented by at most three spaces —
+    // at four it is an indented code block, so a documented example of a fence is
+    // not a fence. Trimming the indent away made those literals open real blocks.
+    final line = _stripContainers(lines[i].trimRight());
     if (opener == null) {
       final match = _fenceOpenPattern.firstMatch(line);
       if (match != null) {
@@ -302,14 +302,26 @@ List<OkfIssue> validateFencedBlocks(String path, String content) {
 final _fenceOpenPattern = RegExp('^( {0,3})(`{3,}|~{3,})');
 
 /// Whether [line] is a valid closing fence for a block opened by [opener]:
-/// indented at most three spaces, the same delimiter character, at least as long
-/// as the opener, and nothing else on the line.
+/// indented at most three spaces, a **uniform** run of the opener's delimiter, at
+/// least as long as the opener, and nothing else on the line.
+///
+/// Uniform, not merely starting with the right character: a mixed `` `~~ `` after
+/// a ``` opener passed the old "first char matches, long enough" test and closed
+/// the block, leaving the rest of the file rendering as code while the check
+/// reported clean.
 bool _closesFence(String line, String opener) {
-  final match = RegExp(r'^( {0,3})([`~]+)$').firstMatch(line);
+  final match = RegExp(r'^ {0,3}(`+|~+)$').firstMatch(line);
   if (match == null) return false;
-  final run = match.group(2)!;
+  final run = match.group(1)!;
   return run[0] == opener[0] && run.length >= opener.length;
 }
+
+/// Strips blockquote markers, which CommonMark removes before a fence is
+/// recognised, so `> ```dart` opens a real block. List-item containers are not
+/// modelled: a fence indented past three spaces inside a list item reads as an
+/// indented code block here.
+String _stripContainers(String line) =>
+    line.replaceFirst(RegExp('^(?: {0,3}>(?: |\t)?)+'), '');
 
 /// Blanks out fenced blocks and inline code so link scanning never treats a
 /// documented link *form* — `` `[Title](/tasks/<taskId>)` `` — as a real link

--- a/tool/okf/okf_validator.dart
+++ b/tool/okf/okf_validator.dart
@@ -269,7 +269,7 @@ List<OkfIssue> validateFencedBlocks(String path, String content) {
   final lines = content.split('\n');
   String? opener;
   var openedAt = 0;
-  var prefix = '';
+  var depth = 0;
   for (var i = 0; i < lines.length; i++) {
     // Trailing whitespace and blockquote markers are noise; the *leading indent*
     // is not. CommonMark allows a fence to be indented by at most three spaces —
@@ -279,21 +279,21 @@ List<OkfIssue> validateFencedBlocks(String path, String content) {
     if (opener == null) {
       // Outside a fence a blockquote marker is a container: strip it, and
       // remember it so the close is read in the same context.
-      final candidate = _containerPrefix(trimmedEnd);
+      final candidate = _containerDepth(trimmedEnd);
       final match = _fenceOpenPattern.firstMatch(
-        _stripPrefix(trimmedEnd, candidate),
+        _stripDepth(trimmedEnd, candidate),
       );
       if (match != null) {
         opener = match.group(2);
-        prefix = candidate;
+        depth = candidate;
         openedAt = i + 1;
       }
       continue;
     }
     // Inside a fence, only the opener's own container is removed.
-    if (_closesFence(_stripPrefix(trimmedEnd, prefix), opener)) {
+    if (_closesFence(_stripDepth(trimmedEnd, depth), opener)) {
       opener = null;
-      prefix = '';
+      depth = 0;
     }
   }
   if (opener == null) return const [];
@@ -327,25 +327,43 @@ bool _closesFence(String line, String opener) {
   return run[0] == opener[0] && run.length >= opener.length;
 }
 
-final _containerPattern = RegExp('^(?: {0,3}>(?: |\t)?)+');
+// One blockquote marker: up to three spaces, `>`, and an *optional* single space
+// or tab. The trailing space being optional is why the container is tracked as a
+// depth rather than as literal prefix text — a body line may write `>flowchart TD`
+// under an opener that wrote `> `, and an exact-text match would strip neither the
+// body nor the close.
+final _markerPattern = RegExp('^ {0,3}>(?: |\t)?');
 
-/// The blockquote prefix [line] carries, or `''`.
-String _containerPrefix(String line) =>
-    _containerPattern.firstMatch(line)?.group(0) ?? '';
+/// How many blockquote markers [line] opens with.
+int _containerDepth(String line) {
+  var rest = line;
+  var depth = 0;
+  while (true) {
+    final match = _markerPattern.firstMatch(rest);
+    if (match == null) return depth;
+    rest = rest.substring(match.end);
+    depth++;
+  }
+}
 
-/// Removes exactly [prefix] from the front of [line].
+/// Removes [depth] blockquote markers from [line], whatever their spacing.
 ///
-/// Tied to the fence opener on purpose. Stripping `>` unconditionally meant a
-/// **top-level** fence whose body contained a literal `` > ``` `` had that marker
-/// removed and the line then read as the close — so an unclosed fence validated
-/// clean. CommonMark treats fence content as literal; only the container the
-/// fence was opened *under* is stripped from its body.
+/// Tied to the fence opener's depth on purpose. Stripping `>` unconditionally
+/// meant a **top-level** fence whose body contained a literal `` > ``` `` had that
+/// marker removed and the line then read as the close — so an unclosed fence
+/// validated clean. CommonMark treats fence content as literal; only the container
+/// the fence was opened *under* is stripped from its body.
 ///
 /// List-item containers are not modelled: a fence indented past three spaces
 /// inside a list item reads as an indented code block here.
-String _stripPrefix(String line, String prefix) {
-  if (prefix.isEmpty) return line;
-  return line.startsWith(prefix) ? line.substring(prefix.length) : line;
+String _stripDepth(String line, int depth) {
+  var rest = line;
+  for (var i = 0; i < depth; i++) {
+    final match = _markerPattern.firstMatch(rest);
+    if (match == null) return rest;
+    rest = rest.substring(match.end);
+  }
+  return rest;
 }
 
 /// Blanks out fenced blocks and inline code so link scanning never treats a

--- a/tool/okf/okf_validator.dart
+++ b/tool/okf/okf_validator.dart
@@ -269,21 +269,32 @@ List<OkfIssue> validateFencedBlocks(String path, String content) {
   final lines = content.split('\n');
   String? opener;
   var openedAt = 0;
+  var prefix = '';
   for (var i = 0; i < lines.length; i++) {
     // Trailing whitespace and blockquote markers are noise; the *leading indent*
     // is not. CommonMark allows a fence to be indented by at most three spaces —
     // at four it is an indented code block, so a documented example of a fence is
     // not a fence. Trimming the indent away made those literals open real blocks.
-    final line = _stripContainers(lines[i].trimRight());
+    final trimmedEnd = lines[i].trimRight();
     if (opener == null) {
-      final match = _fenceOpenPattern.firstMatch(line);
+      // Outside a fence a blockquote marker is a container: strip it, and
+      // remember it so the close is read in the same context.
+      final candidate = _containerPrefix(trimmedEnd);
+      final match = _fenceOpenPattern.firstMatch(
+        _stripPrefix(trimmedEnd, candidate),
+      );
       if (match != null) {
         opener = match.group(2);
+        prefix = candidate;
         openedAt = i + 1;
       }
       continue;
     }
-    if (_closesFence(line, opener)) opener = null;
+    // Inside a fence, only the opener's own container is removed.
+    if (_closesFence(_stripPrefix(trimmedEnd, prefix), opener)) {
+      opener = null;
+      prefix = '';
+    }
   }
   if (opener == null) return const [];
   return [
@@ -316,12 +327,26 @@ bool _closesFence(String line, String opener) {
   return run[0] == opener[0] && run.length >= opener.length;
 }
 
-/// Strips blockquote markers, which CommonMark removes before a fence is
-/// recognised, so `> ```dart` opens a real block. List-item containers are not
-/// modelled: a fence indented past three spaces inside a list item reads as an
-/// indented code block here.
-String _stripContainers(String line) =>
-    line.replaceFirst(RegExp('^(?: {0,3}>(?: |\t)?)+'), '');
+final _containerPattern = RegExp('^(?: {0,3}>(?: |\t)?)+');
+
+/// The blockquote prefix [line] carries, or `''`.
+String _containerPrefix(String line) =>
+    _containerPattern.firstMatch(line)?.group(0) ?? '';
+
+/// Removes exactly [prefix] from the front of [line].
+///
+/// Tied to the fence opener on purpose. Stripping `>` unconditionally meant a
+/// **top-level** fence whose body contained a literal `` > ``` `` had that marker
+/// removed and the line then read as the close — so an unclosed fence validated
+/// clean. CommonMark treats fence content as literal; only the container the
+/// fence was opened *under* is stripped from its body.
+///
+/// List-item containers are not modelled: a fence indented past three spaces
+/// inside a list item reads as an indented code block here.
+String _stripPrefix(String line, String prefix) {
+  if (prefix.isEmpty) return line;
+  return line.startsWith(prefix) ? line.substring(prefix.length) : line;
+}
 
 /// Blanks out fenced blocks and inline code so link scanning never treats a
 /// documented link *form* — `` `[Title](/tasks/<taskId>)` `` — as a real link


### PR DESCRIPTION
Addresses the review comments that landed on #3603 after it merged — seven from
CodeRabbit, four from Codex. Ten were valid; each was checked against the code
before changing anything.

Docs and tooling only — no runtime change, so no CHANGELOG entry.

## Two guarantees that were wrong

**The PII-safe log.** `error-safe-<date>.log` was documented as recording only the
error's runtime type, so it could be shared without leaking user-authored content.
`safeErrorDescription` renders `'<message> (errorType=<Type>)'` — the caller's
`message` goes in verbatim. What the file omits is the raw exception string and the
stack trace (whose frames carry absolute paths and the system username). So it is
shareable **because callers must treat a log message as telemetry, never content**,
which is the contract `DomainLogger` states — not because the sink sanitises it.

**`DerivedAgentState` is on the wake critical path.** The composite's own header
says "Drives no production read; B6 flips reads onto this fold", and I trusted it.
That sentence predates the cutover it predicted:
`AgentSyncService.reconciledAgentState` is called at the start of every task,
project, event, improver and day-agent wake, folding markers and links over the
cached row so a value lost to last-writer-wins self-heals before the agent decides
anything. The concept now documents that, plus the two boundaries that keep it
precise — the merge is not a blind "log wins", and UI/service reads *do* stay on the
raw cache — and the stale header comment is fixed at source.

That is the third time a stale source comment seeded a wrong claim in this work,
after `database_config_flags.dart` and AGENTS.md's six-catalog ARB list. Each time
the fix now includes the comment.

## Two fence defects

Both verified by fixture before and after, and pinned by tests.

- **A mixed closing run closed a block.** The check looked at the first character
  and the length only, and the character class allowed `` `~~ `` — so a malformed
  run closed a ``` block and the rest of the file rendered as code while the check
  reported clean. CommonMark requires a uniform run.
- **Blockquoted fences were skipped in silence.** CommonMark strips container
  prefixes before recognising a fence, so `> ```mermaid` is a real diagram. Both
  scanners strip blockquote markers now, and the checker unwraps the body too —
  otherwise mermaid receives `> > A --> B` and reports no diagram type. List-item
  containers remain unmodelled, which is now stated rather than implied.

## Content corrections

- `knowledge/log.md`'s single `2026-07-26` entry had grown ten bullets across the
  day, several recording claims a later bullet in the same entry reversed — the
  privacy overshoot, "TaskStatus's five states", expiry as merely "reported". It is
  now the net outcome, and the convention says a date's entry records that rather
  than the churn.
- The live/terminal `TaskStatus` split is duplicated across **seven** files, not
  six.
- `verified` accepts either a `{ by, at }` mapping or a list of them; the doc named
  only `verified[].by`, which is the validator's message label rather than the shape
  an author writes.
- `day_entries` was described as both "every persisted recording" and "newest 32".
  Both are true at different stages — `loadForDay` is unbounded, the prompt section
  caps — and both passages now say which.
- The Matrix zero-cache-limit note still opened as a present-tense assertion; it now
  reads as a 7.0.0 finding not re-verified on 8.x.

## Verification

`make knowledge_check` (89 concepts, 131 diagrams), strict mode, 95 validator tests,
18 mermaid-checker tests, analyzer, formatter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified PII-safe error-log sharing conditions and retained message handling.
  - Updated guidance for maintenance logs, status validation, Mermaid fences, task statuses, and Matrix SDK behavior.
  - Documented projection wake-path reads, self-healing, fallback behavior, and bounded day-entry rendering.
  - Refreshed architecture, feature, and release-history documentation.

- **Bug Fixes**
  - Improved Mermaid validation for indented, blockquoted, nested, and malformed fenced diagrams.
  - Prevented mixed delimiter runs from being incorrectly treated as closing fences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->