### PR TITLE
fix: make the switch row's enlarged target real for assistive tech

### DIFF
--- a/knowledge/features/agents/ui-surfaces.md
+++ b/knowledge/features/agents/ui-surfaces.md
@@ -112,13 +112,16 @@ every glyph lands on `spacing.cardPadding`, sharing one leading edge with the
 summary prose and proposal rows, while interactive rows still get ink that
 breathes around their content.
 
-**Vertically the band declares no gaps at all, and that is the contract.** Every
-row here is a touch-target box taller than the ink inside it — all of them on
-one `spacing.step8` minimum — so each already contributes ~10 logical px of air
-above and below the text a reader can see. Declared gaps stack on top of that
-and the band pays twice: `step5` between two stacked rows rendered as ~34px of
-visible space, and the settings zone grew to a third of the card on a phone.
-Space the row boxes, not the text inside them.
+**Vertically the band declares no gaps at all, and that is the contract.** Its
+*interactive* rows — the trigger, the switch row, the identity rows — are
+touch-target boxes taller than the ink inside them, on one `spacing.step8`
+minimum, so each contributes ~10 logical px of air above and below the text a
+reader sees. The schedule line is the exception and stays a bare text row
+(`_ScheduleLabel` reserves width, never height); it needs no target of its own,
+and the boxes above and below it space it. Declared gaps stack on top of all
+that and the band pays twice: `step5` between two stacked rows rendered as
+~34px of visible space, and the settings zone grew to a third of the card on a
+phone. Space the row boxes, not the text inside them.
 
 The switch row earns its height rather than reserving it. An earlier revision
 wrapped the 40×24 switch in a `step9` box "for a full-size interaction target",
@@ -182,7 +185,7 @@ flowchart TD
   T1 -->|yes| W1["one line, short sentence"]
   T1 -->|no| T2{"...with '1:30'?"}
   T2 -->|yes| W2["one line, value only"]
-  T2 -->|no| S["stack: state / schedule / switch<br/>(no declared gaps; each row is<br/>a step8 box that spaces itself)"]
+  T2 -->|no| S["stack: state / schedule / switch<br/>(no declared gaps; the step8 target<br/>boxes space themselves)"]
   S --> S1{"freshness + trigger<br/>fit one line?"}
   S1 -->|no| S2["freshness above the trigger"]
   S --> S3{"countdown + 'Skip once'<br/>fit one line?"}

--- a/lib/features/agents/ui/task_agent_automation_row.dart
+++ b/lib/features/agents/ui/task_agent_automation_row.dart
@@ -613,14 +613,18 @@ class _AutomationSetting extends StatelessWidget {
     final row = Row(
       children: [
         Expanded(
-          child: Text(
-            messages.taskAgentAutomaticUpdatesLabel,
-            // Wraps rather than truncates: "Automatische Aktualisierungen"
-            // cut to "Automatische Aktuali…" says less than the same words on
-            // two lines.
-            maxLines: 2,
-            style: tokens.typography.styles.others.caption.copyWith(
-              color: tokens.colors.aiCard.metaText,
+          // Silent: the toggle already publishes this exact string as its
+          // label, and the merged node below would otherwise say it twice.
+          child: ExcludeSemantics(
+            child: Text(
+              messages.taskAgentAutomaticUpdatesLabel,
+              // Wraps rather than truncates: "Automatische Aktualisierungen"
+              // cut to "Automatische Aktuali…" says less than the same words on
+              // two lines.
+              maxLines: 2,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: tokens.colors.aiCard.metaText,
+              ),
             ),
           ),
         ),
@@ -652,35 +656,43 @@ class _AutomationSetting extends StatelessWidget {
     // 48 minimum in its short dimension. The switch keeps its own ink for
     // direct hits; nested taps resolve to the innermost, so this cannot fire
     // twice.
-    return Material(
-      key: const ValueKey('taskAgentAutomationSetting'),
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: enabled ? () => onChanged(!value) : null,
-        borderRadius: BorderRadius.circular(tokens.radii.s),
-        // The enlarged target is for pointers and thumbs. The switch inside
-        // already publishes the accessible control — button, toggled state and
-        // label — so this row must not add a second, unlabelled button node
-        // beside it.
-        excludeFromSemantics: true,
-        // ...and it must not add a second *focus* stop either. Excluding
-        // semantics does nothing to focus traversal, so without this Tab lands
-        // twice on one setting — once on this wrapper, once on the switch —
-        // and both stops toggle it. The switch keeps the keyboard; the row is
-        // pointer-only.
-        canRequestFocus: false,
-        // ...and it must not add a second *focus* stop either. Excluding
-        // semantics does nothing to focus traversal, so without this Tab lands
-        // twice on one setting — once on this wrapper, once on the switch —
-        // and both stops toggle it. The switch keeps the keyboard; the row is
-        // pointer-only.
-        // One row box, on the same `step8` minimum as every other row in this
-        // band. It is 8px shorter than the slot it replaces and, unlike that
-        // slot, all of it is tappable.
-        child: ConstrainedBox(
-          key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
-          constraints: BoxConstraints(minHeight: tokens.spacing.step8),
-          child: row,
+    // `excludeFromSemantics` on the ink below stops the row publishing a
+    // second, unlabelled button — but on its own it also left the enlarged
+    // target invisible to assistive tech, since the only actionable node was
+    // the switch's own 40x24 track and the label beside it was inert. Merging
+    // makes the row one node: the switch's toggled state and tap action, over
+    // the union of their rects. Same shape as `SwitchListTile`.
+    return MergeSemantics(
+      child: Material(
+        key: const ValueKey('taskAgentAutomationSetting'),
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: enabled ? () => onChanged(!value) : null,
+          borderRadius: BorderRadius.circular(tokens.radii.s),
+          // The enlarged target is for pointers and thumbs. The switch inside
+          // already publishes the accessible control — button, toggled state and
+          // label — so this row must not add a second, unlabelled button node
+          // beside it.
+          excludeFromSemantics: true,
+          // ...and it must not add a second *focus* stop either. Excluding
+          // semantics does nothing to focus traversal, so without this Tab lands
+          // twice on one setting — once on this wrapper, once on the switch —
+          // and both stops toggle it. The switch keeps the keyboard; the row is
+          // pointer-only.
+          canRequestFocus: false,
+          // ...and it must not add a second *focus* stop either. Excluding
+          // semantics does nothing to focus traversal, so without this Tab lands
+          // twice on one setting — once on this wrapper, once on the switch —
+          // and both stops toggle it. The switch keeps the keyboard; the row is
+          // pointer-only.
+          // One row box, on the same `step8` minimum as every other row in this
+          // band. It is 8px shorter than the slot it replaces and, unlike that
+          // slot, all of it is tappable.
+          child: ConstrainedBox(
+            key: const ValueKey('taskAgentAutomaticUpdatesTarget'),
+            constraints: BoxConstraints(minHeight: tokens.spacing.step8),
+            child: row,
+          ),
         ),
       ),
     );

--- a/test/features/agents/ui/task_agent_automation_row_test.dart
+++ b/test/features/agents/ui/task_agent_automation_row_test.dart
@@ -1,5 +1,7 @@
+import 'dart:ui' show Tristate;
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/ui/task_agent_automation_row.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
@@ -219,6 +221,41 @@ void main() {
         1,
         reason: 'only the switch itself may take keyboard focus',
       );
+    });
+
+    testWidgets('the whole row is one actionable node for assistive tech', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      bool? changedTo;
+      await pumpRow(
+        tester,
+        subject(onAutomaticUpdatesChanged: (value) => changedTo = value),
+      );
+
+      // Enlarging the pointer target is not enough on its own: with the row's
+      // semantics excluded and the label inert, the only actionable node was
+      // the switch's own 40x24 track, so touch exploration never reached the
+      // advertised full-row target.
+      final node = tester.getSemantics(
+        find.byKey(const ValueKey('taskAgentAutomationSetting')),
+      );
+      final data = node.getSemanticsData();
+      expect(data.label, 'Automatic updates');
+      // A switch that is off: applicable, and currently false.
+      expect(data.flagsCollection.isToggled, Tristate.isFalse);
+      expect(data.hasAction(SemanticsAction.tap), isTrue);
+
+      // One node, not two: the label must not announce separately from the
+      // control it belongs to.
+      final rowRect = tester.getRect(
+        find.byKey(const ValueKey('taskAgentAutomaticUpdatesTarget')),
+      );
+      expect(node.rect.width, moreOrLessEquals(rowRect.width, epsilon: 1));
+
+      await tester.tap(find.text('Automatic updates'));
+      expect(changedTo, isTrue);
+      handle.dispose();
     });
 
     testWidgets('is disabled while an automation write is in flight', (


### PR DESCRIPTION
Post-merge review of #3604. Both findings were valid; both are verified rather
than taken on trust.

## The enlarged tap target never reached assistive tech

#3604 made the whole automatic-updates row tappable and documented it as a
full-row control. It was not one for screen-reader users.

With the row's semantics excluded (so it would not publish a second, unlabelled
button beside the switch) and the visible label inert, the only actionable node
was the switch's own 40×24 track. I confirmed this by running the new test
against that tree: the semantics node over the row reports **`label: ''`** and
no tap action. Touch exploration on the label found nothing.

`MergeSemantics` fixes it — the shape `SwitchListTile` uses. The row now
publishes **one** node carrying the switch's toggled state and tap action across
the union of their rects. The visible label is wrapped in `ExcludeSemantics`,
because the toggle already publishes that exact string and the merged node would
otherwise announce the setting twice.

The pointer wrapper keeps `canRequestFocus: false` from #3604, so the switch
still owns the keyboard and there is still exactly one focus stop — the two
concerns are independent and both hold.

The regression test asserts the merged node's label, its toggled state, its tap
action, and that its rect spans the row.

## The concept had gained a false invariant while losing another

#3604's prose claimed every stacked row is a `step8` box. It is not:
`_ScheduleLabel` returns `SizedBox(width: spec.reservedWidth, …)` — width only,
no minimum height — so the schedule line neither carries a target box nor
self-spaces.

Giving that row a `step8` minimum would have made the prose true by adding back
height the previous PR existed to remove, so the prose is what changed instead.
It now says the *interactive* rows (trigger, switch row, identity rows) are
`step8` targets that space themselves, and the schedule line is a bare text row
that needs no target and is spaced by the boxes above and below it. The flow
diagram's stack node is reworded to match.

## Not included

**No version bump.** `0.9.1070+4259` is tagged and contains #3604, so the
inaccessible target did ship — but bumping is a call I do not make unasked. Say
so and this becomes `+4260` with a CHANGELOG entry for the accessibility fix;
without a bump the CHANGELOG stays untouched, since the visible layout is
unchanged by this PR.

## Verification

- `dart analyze lib test` — no issues.
- `make okf_check` — 89 concepts, 0 errors, 0 warnings.
- `flutter test test/features/agents/ test/features/design_system/` —
  **6168 passed, 2 skipped, 0 failed** (one more than #3604: the new semantics
  test).
- No screenshots: this PR changes the semantics tree and one paragraph of prose.
  Nothing it does is visible in a pixel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the Automatic updates setting so assistive technologies recognize it as one actionable control.
  * Tapping the setting label now consistently toggles the control across the full row.

* **Documentation**
  * Clarified spacing, touch-target, and layout behavior for AI card controls and stacked rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->