### PR TITLE
fix: let held ciphertext clamp the sync marker

### DIFF
--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -5,7 +5,7 @@ description: The Drift-backed inbound queue, the anchored catch-up bridge, per-r
 resource: ../../../lib/features/sync/queue
 tags: [sync, inbound-queue, catch-up, matrix]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T15:42:59Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T16:45:44Z }
 stale_after: 2026-11-02
 sources:
   - id: queue

--- a/lib/features/sync/queue/inbound_event_queue.dart
+++ b/lib/features/sync/queue/inbound_event_queue.dart
@@ -44,7 +44,20 @@ class InboundQueue {
   late final QueueDepthEmitter _depthEmitter = QueueDepthEmitter(
     loadStats: _depthStats,
   );
-  late final QueueMarkerAdvancer _markerAdvancer = QueueMarkerAdvancer(_db);
+
+  /// Reports the oldest received-but-unapplied event for a room that has no
+  /// queue row — ciphertext held in `PendingDecryptionPen`. Set by
+  /// `QueuePipelineCoordinator` once both collaborators exist; the queue
+  /// cannot own the pen, because the pen enqueues *into* the queue.
+  ///
+  /// Without it the marker can advance past held ciphertext, which the next
+  /// startup's strictly-forward bridge then never re-fetches.
+  int? Function(String roomId)? unqueuedFloorTs;
+
+  late final QueueMarkerAdvancer _markerAdvancer = QueueMarkerAdvancer(
+    _db,
+    unqueuedFloorTs: (roomId) => unqueuedFloorTs?.call(roomId),
+  );
   late final InboundQueueResurrection _resurrection = InboundQueueResurrection(
     db: _db,
     logging: _logging,

--- a/lib/features/sync/queue/pending_decryption_pen.dart
+++ b/lib/features/sync/queue/pending_decryption_pen.dart
@@ -88,6 +88,24 @@ class PendingDecryptionPen {
 
   int get size => _held.length;
 
+  /// Oldest `origin_server_ts` still held for [roomId], or null when the pen
+  /// holds nothing for that room.
+  ///
+  /// The marker clamp needs this. A held entry is received-but-not-applied,
+  /// exactly like a row sitting in `enqueued`/`leased`/`retrying` — but it has
+  /// no row, so `QueueMarkerAdvancer` cannot see it in the queue table. Left
+  /// invisible, a newer event applying moves `last_applied_ts` past the held
+  /// one, and the next startup's strictly-forward bridge never re-fetches it.
+  int? oldestHeldOriginTs(String roomId) {
+    int? oldest;
+    for (final held in _held.values) {
+      if (held.event.roomId != roomId) continue;
+      final ts = held.event.originServerTs.millisecondsSinceEpoch;
+      if (oldest == null || ts < oldest) oldest = ts;
+    }
+    return oldest;
+  }
+
   /// Starts the internal sweep timer if [sweepInterval] was provided.
   /// Optional — the `InboundWorker` can drive [flushInto] by calling
   /// it directly.

--- a/lib/features/sync/queue/queue_marker_advancer.dart
+++ b/lib/features/sync/queue/queue_marker_advancer.dart
@@ -10,9 +10,22 @@ import 'package:lotti/features/sync/queue/inbound_queue_models.dart';
 /// (drift transactions are zone-based, so this class participates in
 /// the caller's ambient transaction through the shared [SyncDatabase]).
 class QueueMarkerAdvancer {
-  QueueMarkerAdvancer(this._db);
+  QueueMarkerAdvancer(this._db, {this.unqueuedFloorTs});
 
   final SyncDatabase _db;
+
+  /// Oldest `origin_ts` for a room that is received-but-not-applied yet has
+  /// no queue row — today that means ciphertext parked in
+  /// `PendingDecryptionPen`.
+  ///
+  /// The clamp below is what keeps the marker from stepping over work that is
+  /// still outstanding, but it can only see the queue table. A penned event is
+  /// deliberately absent from it, so without this hook a newer event applying
+  /// advances `last_applied_ts` past the penned one, and the next startup's
+  /// strictly-forward bridge (`collectForwardForBootstrap` — "only events that
+  /// sort strictly after the anchor") never fetches it again. The event is
+  /// then gone with no row, no ledger entry and no counter to notice.
+  final int? Function(String roomId)? unqueuedFloorTs;
 
   /// Advances `queue_markers` for [entry]'s room if the candidate
   /// timestamp — clamped against any still-active queue rows for the
@@ -26,8 +39,9 @@ class QueueMarkerAdvancer {
   /// from regressing `lastAppliedTs` (F2).
   ///
   /// The clamp: an older row still in `enqueued`/`leased`/`retrying`
-  /// for the same room pins the candidate marker at `oldestActive −
-  /// 1`. This is what makes bounded retries safe under the ledger
+  /// for the same room — or an older event held by [unqueuedFloorTs],
+  /// which has no row at all — pins the candidate marker at
+  /// `oldestActive − 1`. This is what makes bounded retries safe under the ledger
   /// model — a poison row held as `abandoned` *does not* pin the
   /// marker (it is out of the active set by design), but the same
   /// event is still visible in the ledger for diagnostics and can be
@@ -43,10 +57,19 @@ class QueueMarkerAdvancer {
     // Probe the oldest still-active row for this room, excluding the
     // row we're about to transition out of the active set (commit or
     // abandon — caller is responsible for the status flip already).
-    final oldestActive = await _oldestActiveOriginTs(
+    final oldestActiveRow = await _oldestActiveOriginTs(
       roomId: entry.roomId,
       excludeQueueId: entry.queueId,
     );
+    // Rows and penned ciphertext are the same thing for this purpose: work
+    // that has arrived and has not been applied. Take the older of the two.
+    final oldestUnqueued = unqueuedFloorTs?.call(entry.roomId);
+    final oldestActive = switch ((oldestActiveRow, oldestUnqueued)) {
+      (null, null) => null,
+      (final int row, null) => row,
+      (null, final int held) => held,
+      (final int row, final int held) => row < held ? row : held,
+    };
     final clampedCandidateTs = oldestActive == null
         ? entry.originTs
         : (entry.originTs < oldestActive ? entry.originTs : oldestActive - 1);

--- a/lib/features/sync/queue/queue_pipeline_coordinator.dart
+++ b/lib/features/sync/queue/queue_pipeline_coordinator.dart
@@ -94,6 +94,17 @@ class QueuePipelineCoordinator {
          journalDb: journalDb,
          logging: logging,
        ) {
+    // Held ciphertext has no queue row, so the marker advancer cannot see it
+    // in the table. Give it the pen's floor, or a newer event applying will
+    // step the marker past ciphertext that the next startup's
+    // strictly-forward bridge then never re-fetches.
+
+    // Held ciphertext has no queue row, so the marker advancer cannot see it
+    // in the table. Give it the pen's floor, or a newer event applying will
+    // step the marker past ciphertext that the next startup's
+    // strictly-forward bridge then never re-fetches.
+    _queue.unqueuedFloorTs = _pen.oldestHeldOriginTs;
+
     _worker =
         workerOverride ??
         InboundWorker(

--- a/test/features/sync/queue/pending_decryption_pen_test.dart
+++ b/test/features/sync/queue/pending_decryption_pen_test.dart
@@ -241,6 +241,44 @@ void main() {
     },
   );
 
+  test('reports the oldest held timestamp per room', () async {
+    // This is what keeps the sync marker from stepping over held ciphertext.
+    final pen = PendingDecryptionPen(logging: logging);
+    expect(pen.oldestHeldOriginTs(roomId), isNull);
+
+    pen
+      ..hold(
+        buildEvent(
+          eventId: r'$mid',
+          roomId: roomId,
+          originTsMs: 5000,
+          type: EventTypes.Encrypted,
+        ),
+      )
+      ..hold(
+        buildEvent(
+          eventId: r'$old',
+          roomId: roomId,
+          originTsMs: 2000,
+          type: EventTypes.Encrypted,
+        ),
+      )
+      ..hold(
+        buildEvent(
+          eventId: r'$elsewhere',
+          roomId: '!other:example.org',
+          originTsMs: 100,
+          type: EventTypes.Encrypted,
+        ),
+      );
+
+    // Oldest, not most recently held — and scoped to the room, so one room's
+    // backlog cannot pin another room's marker.
+    expect(pen.oldestHeldOriginTs(roomId), 2000);
+    expect(pen.oldestHeldOriginTs('!other:example.org'), 100);
+    expect(pen.oldestHeldOriginTs('!empty:example.org'), isNull);
+  });
+
   test('capacity eviction drops the oldest entry', () async {
     final pen = PendingDecryptionPen(logging: logging, capacity: 2);
     final a = buildEvent(

--- a/test/features/sync/queue/queue_marker_advancer_test.dart
+++ b/test/features/sync/queue/queue_marker_advancer_test.dart
@@ -102,6 +102,83 @@ void main() {
     });
 
     test(
+      'older unqueued work clamps the marker exactly like an active row',
+      () async {
+        // Ciphertext in the pen is received-but-not-applied, but it has no
+        // row — that is the whole point of the pen. Invisible to the clamp, a
+        // newer event applying would step the marker past it, and the next
+        // startup's strictly-forward bridge ("only events that sort strictly
+        // after the anchor") would never fetch it again: gone, with no row,
+        // no ledger entry and no counter to notice.
+        final penned = QueueMarkerAdvancer(
+          db,
+          unqueuedFloorTs: (roomId) => roomId == _roomA ? 6000 : null,
+        );
+        final committingId = await insertRow(eventId: r'$c', originTs: 8000);
+
+        final advanced = await penned.advanceIfNewer(
+          _entry(queueId: committingId, eventId: r'$c', originTs: 8000),
+        );
+
+        expect(advanced, isTrue);
+        final marker = await readMarker();
+        expect(
+          marker?.lastAppliedTs,
+          5999,
+          reason: 'the marker stops just below the held event',
+        );
+        expect(
+          marker?.lastAppliedEventId,
+          isNull,
+          reason: 'a clamped marker names no specific event',
+        );
+      },
+    );
+
+    test(
+      'the floor only applies to its own room',
+      () async {
+        final penned = QueueMarkerAdvancer(
+          db,
+          unqueuedFloorTs: (roomId) =>
+              roomId == '!other:example.org' ? 1000 : null,
+        );
+        final committingId = await insertRow(eventId: r'$c', originTs: 8000);
+
+        await penned.advanceIfNewer(
+          _entry(queueId: committingId, eventId: r'$c', originTs: 8000),
+        );
+
+        final marker = await readMarker();
+        expect(marker?.lastAppliedTs, 8000);
+        expect(marker?.lastAppliedEventId, r'$c');
+      },
+    );
+
+    test(
+      'the older of a queue row and held ciphertext wins the clamp',
+      () async {
+        final penned = QueueMarkerAdvancer(
+          db,
+          unqueuedFloorTs: (_) => 7000,
+        );
+        await insertRow(eventId: r'$older-active', originTs: 6000);
+        final committingId = await insertRow(eventId: r'$c', originTs: 8000);
+
+        await penned.advanceIfNewer(
+          _entry(queueId: committingId, eventId: r'$c', originTs: 8000),
+        );
+
+        final marker = await readMarker();
+        expect(
+          marker?.lastAppliedTs,
+          5999,
+          reason: 'the row at 6000 is older than the held event at 7000',
+        );
+      },
+    );
+
+    test(
       'older active row in the same room clamps the marker to '
       'oldestActive - 1 and leaves the event id slot null',
       () async {

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -1729,6 +1729,30 @@ void main() {
     );
 
     test(
+      'the queue is given the pen as its unqueued marker floor',
+      () async {
+        // Without this wiring the two halves of the fix are inert: the pen
+        // can report its oldest held event and the advancer can clamp on a
+        // floor, but nothing connects them, so the marker still steps over
+        // held ciphertext. Deleting the assignment leaves every other test in
+        // this change passing, so it needs its own.
+        build();
+
+        final assigned =
+            verify(
+                  () => queue.unqueuedFloorTs = captureAny(),
+                ).captured.last
+                as int? Function(String);
+
+        when(
+          () => pen.oldestHeldOriginTs('!roomA:example.org'),
+        ).thenReturn(4242);
+        expect(assigned('!roomA:example.org'), 4242);
+        verify(() => pen.oldestHeldOriginTs('!roomA:example.org')).called(1);
+      },
+    );
+
+    test(
       'drainUntilEmpty stops waiting on a pen that cannot produce',
       () async {
         // Ciphertext whose key has not arrived is not a stranded row: it has


### PR DESCRIPTION
Closes `lotti3-21u`. Raised by the Codex reviewer on #3608; verified step by
step before accepting it, and it holds.

**Stacked on #3608** — the diff shown here includes that branch until it
merges. Base it on `main` after #3608 lands.

## The hole

`QueueMarkerAdvancer` exists to stop the sync marker stepping over work that
has arrived but not applied: it clamps the candidate timestamp against the
oldest still-active queue row for the room. But it can only see the queue
table, and a penned event is deliberately *not* in it — writing pre-decryption
ciphertext into `raw_json` would lose the payload on the next
`Event.fromJson` round-trip.

So held ciphertext could not clamp:

1. `_oldestActiveOriginTs` selects only rows in `enqueued`/`leased`/`retrying`.
   A penned event has no row, so it contributes nothing.
2. A newer event applies and moves `last_applied_ts` past the held one.
3. The pen is in memory; teardown discards it.
4. Next startup runs `collectForwardForBootstrap`, documented as **"Only
   events that sort strictly after the anchor"**. The held event is behind the
   anchor and is never re-fetched.

It is then simply gone from that device — no queue row, no ledger entry, no
counter, nothing to retry and nothing to notice. `collectHistory` (the
backward sweep) would find it, but that is an explicit user action, not part
of ordinary startup.

## The fix

- `PendingDecryptionPen.oldestHeldOriginTs(roomId)` — the pen reports its
  floor, scoped per room so one room's backlog cannot pin another's marker.
- `QueueMarkerAdvancer` takes the older of that floor and the oldest active
  row. Held ciphertext and an active row are the same thing for this purpose:
  received, not applied.
- `QueuePipelineCoordinator` connects them.

## The wiring needed its own test

With the coordinator assignment deleted, **every other test in this change
still passed.** The pen could report a floor, the advancer could clamp on one,
and nothing joined them — the fix would have been inert while looking well
covered. The new test captures the assigned callback and proves it delegates
to the pen; against the deleted line it reports `No matching calls (actually,
no calls at all)`.

## Why this is stacked rather than independent

Until #3608, backfill discarded ciphertext outright instead of penning it, so
on that path no penned event ever existed for the marker to step over. Fixing
the drop is precisely what makes this clamp necessary. The two belong in this
order.

## Verification

- `flutter test test/features/sync/` — **2942 passed, 1 skipped, 0 failed.**
- `test/features/sync/queue/` — 305 passing, up from 301: the floor clamps like
  a row, the floor is room-scoped, the older of row-vs-pen wins, the pen
  reports oldest-not-latest, and the coordinator wiring is pinned.
- `dart analyze lib test` — no issues.
- No version bump; no user-visible behaviour beyond the data loss it prevents,
  which is covered by the CHANGELOG entry already in #3608.
