### PR TITLE
fix: keep backfill from overflowing, understating, or stalling the pen

### DIFF
--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -5,7 +5,7 @@ description: The Drift-backed inbound queue, the anchored catch-up bridge, per-r
 resource: ../../../lib/features/sync/queue
 tags: [sync, inbound-queue, catch-up, matrix]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T16:45:44Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T17:15:56Z }
 stale_after: 2026-11-02
 sources:
   - id: queue
@@ -190,6 +190,34 @@ timestamp **strictly** beats the stored one, with the durable `event_id` as a
 tiebreak only when both sides are durable. The candidate is clamped against the
 oldest still-active row for the room, so the marker never crosses an unapplied
 gap.
+
+**Held ciphertext clamps it too.** A `PendingDecryptionPen` entry is
+received-but-not-applied — exactly what the clamp exists for — but it has no
+queue row by design, so the table-based probe cannot see it. Left invisible, a
+newer event applying moves the marker past it, the pen is discarded at
+teardown, and the next start's strictly-forward walk
+(`collectForwardForBootstrap`: "only events that sort strictly after the
+anchor") never re-fetches it: gone, with no row, no ledger entry and no
+counter. `QueueMarkerAdvancer.unqueuedFloorTs` therefore takes the older of the
+oldest active row and the pen's oldest held event for that room.
+
+**Backfill stops at pen capacity rather than evicting.** Ciphertext produces no
+queue rows, so the depth-based back-pressure in `QueueBootstrapSink` applies
+nothing to an all-encrypted run, while a forward walk emits up to 50 pages of
+200 and manual history collection is unbounded against a fixed 256-entry LRU.
+The sink admits only what fits — checked *before* holding, because `hold`
+enforces capacity by evicting — and returns false once a page needs more room
+than remains. Stopping is safe only because of the clamp above: the marker
+cannot pass what the pen holds, so the next run resumes from the right anchor
+instead of skipping the gap.
+
+One limit of that resume story is worth knowing: the clamp prevents the marker
+*advancing* past held work, but it cannot pull the marker *back*. Ciphertext
+penned by a backward or manual history walk is already behind the anchor, and
+the monotonic guard rejects a candidate below the stored timestamp — so if the
+pen is discarded before those entries decrypt, the forward walk will not
+revisit them. Closing that needs a persisted resume floor rather than an
+in-memory one.
 
 It deliberately does **not** use `TimelineEventOrdering.isNewer`, because
 `isNewer` treats a null stored event id as "no marker" even when the marker

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -5,7 +5,7 @@ description: The Drift-backed inbound queue, the anchored catch-up bridge, per-r
 resource: ../../../lib/features/sync/queue
 tags: [sync, inbound-queue, catch-up, matrix]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T17:15:56Z }
+generated: { by: claude-code/opus-5, at: 2026-07-26T18:27:07Z }
 stale_after: 2026-11-02
 sources:
   - id: queue
@@ -74,8 +74,8 @@ mid-drain simply re-leases the same rows on restart.
 `QueuePipelineCoordinator` subscribes to `MatrixSessionManager.timelineEvents`.
 Live events are routed through `PendingDecryptionPen` first, so
 **pre-decryption ciphertext never lands in `inbound_event_queue.raw_json`**. The
-worker re-resolves penned events via `room.getEventById` on every drain
-iteration; only fully-decrypted events reach `raw_json`.
+worker sweeps the pen at the top of every drain iteration and only
+fully-decrypted events reach `raw_json`.
 
 **The pen's give-up budget is measured in time, not in sweeps.** An entry that
 never decrypts is eventually dropped, and a dropped entry is gone — its
@@ -191,6 +191,22 @@ tiebreak only when both sides are durable. The candidate is clamped against the
 oldest still-active row for the room, so the marker never crosses an unapplied
 gap.
 
+**The room lookup has its own, shorter cadence.** A sweep does not re-query
+every held entry: `room.getEventById` is the expensive half, the worker sweeps
+before every batch, and `SyncTuning.inboundWorkerBatchSize` is 1 — draining 10k
+rows against a full 256-entry pen would otherwise issue ~2.5M sequential
+lookups. That load used to be self-limiting only because entries were dropped
+after 20 sweeps; holding them for ten real minutes makes it persist. So an
+entry is re-queried at most once per `lookupInterval` (1s), which bounds the
+cost while keeping detection within about a second of the key landing. It is a
+real, if small, latency: a key that arrives inside an entry's interval is
+noticed by the next eligible sweep, not the next sweep.
+
+Callers that give up after N unproductive sweeps must count only sweeps that
+actually looked. `drainUntilEmptyImpl` polls every 200ms, faster than the
+lookup interval, so counting throttled sweeps would spend its whole allowance
+inside one interval and tear the pen down without ever having queried the room.
+
 **Held ciphertext clamps it too.** A `PendingDecryptionPen` entry is
 received-but-not-applied — exactly what the clamp exists for — but it has no
 queue row by design, so the table-based probe cannot see it. Left invisible, a
@@ -207,7 +223,16 @@ nothing to an all-encrypted run, while a forward walk emits up to 50 pages of
 200 and manual history collection is unbounded against a fixed 256-entry LRU.
 The sink admits only what fits — checked *before* holding, because `hold`
 enforces capacity by evicting — and returns false once a page needs more room
-than remains. Stopping is safe only because of the clamp above: the marker
+than remains.
+
+That budget is **per room**, and the difference matters: capacity and LRU are
+global, `onRoomChanged` prunes queue rows but not the pen, and the worker only
+ever sweeps the current room. Measured globally, ciphertext left behind by a
+room the user switched away from would occupy every slot and stop the active
+room's bootstrap without admitting anything. Measured per room, the active
+room is admitted and the global LRU reclaims the stale entries — so backfill
+does not evict *within* a room, but it will evict *across* one. That is the
+intended trade: the displaced entries belong to a room nothing is sweeping. Stopping is safe only because of the clamp above: the marker
 cannot pass what the pen holds, so the next run resumes from the right anchor
 instead of skipping the gap.
 

--- a/lib/features/sync/queue/bootstrap_sink.dart
+++ b/lib/features/sync/queue/bootstrap_sink.dart
@@ -75,6 +75,7 @@ class QueueBootstrapSink implements BootstrapSink {
     // `hold` returns false for anything already decrypted, so this only
     // diverts the events the queue would otherwise refuse.
     final heldIn = pen;
+    final penSizeBefore = heldIn?.size ?? 0;
     final forQueue = heldIn == null
         ? events
         : [
@@ -82,9 +83,24 @@ class QueueBootstrapSink implements BootstrapSink {
               if (!heldIn.hold(event)) event,
           ];
     final penned = events.length - forQueue.length;
+    // `hold` returns true for a re-hold as well as a first hold, so count by
+    // the pen's own growth: only entries it did not already have are new.
+    final newlyPenned = (heldIn?.size ?? 0) - penSizeBefore;
 
     final enqueue = await _queue.appendBootstrapPage(forQueue);
-    _lastAcceptedCount = enqueue.accepted;
+
+    // Retained ciphertext counts as accepted. `collectHistoryForBootstrapImpl`
+    // reads `lastAcceptedCount == 0` as a stale-cache signal and pulls up to
+    // five more pages past the boundary; on an all-encrypted page that would
+    // be a lie, and those extra pages are exactly what pushes the pen over
+    // capacity and evicts the boundary events we were trying to keep.
+    _lastAcceptedCount = enqueue.accepted + newlyPenned;
+
+    if (newlyPenned > 0) {
+      // No rows means no depth signal, so an idle worker would not look at
+      // the pen until its 60s empty-queue tick.
+      _queue.signalPendingWork();
+    }
 
     _logging.log(
       LogDomain.sync,
@@ -95,6 +111,7 @@ class QueueBootstrapSink implements BootstrapSink {
       'dupes=${enqueue.duplicatesDropped} '
       'filteredOutByType=${enqueue.filteredOutByType} '
       'penned=$penned '
+      'newlyPenned=$newlyPenned '
       'deferredPendingDecryption=${enqueue.deferredPendingDecryption} '
       'totalEventsSoFar=${info.totalEventsSoFar} '
       'oldestTs=${info.oldestTimestampSoFar} '
@@ -102,6 +119,30 @@ class QueueBootstrapSink implements BootstrapSink {
       'elapsedMs=${info.elapsed.inMilliseconds}',
       subDomain: _logSub,
     );
+
+    // Ciphertext creates no queue rows, so `_waitForDrain` — which watches
+    // queue depth — applies no back-pressure to an all-encrypted run at all.
+    // A forward walk emits up to 50 pages of 200, and manual history
+    // collection is unbounded, against a 256-entry LRU pen: without this the
+    // walk silently evicts the oldest ciphertext long before it finishes,
+    // recreating exactly the loss this sink was changed to prevent.
+    //
+    // Stopping is safe now that held events clamp the sync marker: the marker
+    // cannot advance past what the pen is holding, so the next run resumes
+    // from the right anchor instead of skipping the gap. Evicting is not
+    // safe, so prefer the bounded stop.
+    final holding = heldIn?.size ?? 0;
+    if (heldIn != null && holding >= heldIn.capacity) {
+      _logging.log(
+        LogDomain.sync,
+        'queue.bootstrap.penFull '
+        'page=${info.pageIndex} '
+        'penSize=$holding '
+        'capacity=${heldIn.capacity}',
+        subDomain: _logSub,
+      );
+      return false;
+    }
 
     try {
       await _waitForDrain();

--- a/lib/features/sync/queue/bootstrap_sink.dart
+++ b/lib/features/sync/queue/bootstrap_sink.dart
@@ -89,17 +89,25 @@ class QueueBootstrapSink implements BootstrapSink {
     if (heldIn == null) {
       forQueue.addAll(events);
     } else {
-      final available = heldIn.capacity - heldIn.size;
       for (final event in events) {
         if (event.type != EventTypes.Encrypted) {
           forQueue.add(event);
           continue;
         }
-        // A re-hold of something already held costs no slot, so only growth
-        // counts against the budget.
-        if (!heldIn.holds(event.eventId) && newlyPenned >= available) {
+        // Budget per room, not globally. The pen's capacity and LRU are
+        // global, so ciphertext left over from a room the user switched away
+        // from would otherwise eat the whole budget and stop the active
+        // room's bootstrap without admitting a single event.
+        final roomId = event.roomId ?? '';
+        // A re-hold of something already held costs no slot.
+        if (!heldIn.holds(event.eventId) &&
+            heldIn.sizeForRoom(roomId) >= heldIn.capacity) {
+          // Note it and keep scanning. Breaking here would discard the rest
+          // of a page that has already been fetched — later plaintext and
+          // already-held events included — and the manual "Fetch all history"
+          // path has no automatic retry to pick them up afterwards.
           penExhausted = true;
-          break;
+          continue;
         }
         final sizeBefore = heldIn.size;
         heldIn.hold(event);
@@ -117,9 +125,15 @@ class QueueBootstrapSink implements BootstrapSink {
     // capacity and evicts the boundary events we were trying to keep.
     _lastAcceptedCount = enqueue.accepted + newlyPenned;
 
-    if (newlyPenned > 0) {
+    if (newlyPenned > 0 || penExhausted) {
       // No rows means no depth signal, so an idle worker would not look at
       // the pen until its 60s empty-queue tick.
+      //
+      // Exhaustion signals too, and that case matters more: a page that adds
+      // nothing new is exactly the one where the pen is stuck, and
+      // `BridgeCoordinator` gives up after ~10s of retries — well inside that
+      // idle tick. Without a nudge every retry meets the same full pen and
+      // the bridge abandons the walk even if a key landed seconds earlier.
       _queue.signalPendingWork();
     }
 

--- a/lib/features/sync/queue/bootstrap_sink.dart
+++ b/lib/features/sync/queue/bootstrap_sink.dart
@@ -102,12 +102,20 @@ class QueueBootstrapSink implements BootstrapSink {
         // A re-hold of something already held costs no slot.
         if (!heldIn.holds(event.eventId) &&
             heldIn.sizeForRoom(roomId) >= heldIn.capacity) {
-          // Note it and keep scanning. Breaking here would discard the rest
-          // of a page that has already been fetched — later plaintext and
-          // already-held events included — and the manual "Fetch all history"
-          // path has no automatic retry to pick them up afterwards.
+          // Stop the page here. Nothing after this point may be queued:
+          // this event has no row, no pen entry and therefore no marker
+          // clamp, so a later plaintext event from the same page would
+          // advance the marker straight past it and the incomplete-bootstrap
+          // retry would then anchor after the gap.
+          //
+          // This does discard the remainder of a page that has already been
+          // fetched, which is a real cost on the manual "Fetch all history"
+          // path since nothing retries it automatically. That is the better
+          // side of the trade: re-fetching is free, and losing an event
+          // behind an advanced marker is permanent. Admitting past the gap
+          // safely needs the persisted resume floor tracked as lotti3-0i2.
           penExhausted = true;
-          continue;
+          break;
         }
         final sizeBefore = heldIn.size;
         heldIn.hold(event);

--- a/lib/features/sync/queue/bootstrap_sink.dart
+++ b/lib/features/sync/queue/bootstrap_sink.dart
@@ -74,18 +74,39 @@ class QueueBootstrapSink implements BootstrapSink {
     // Pen first, enqueue second — the same order the live producer uses.
     // `hold` returns false for anything already decrypted, so this only
     // diverts the events the queue would otherwise refuse.
+    //
+    // Admission is checked per event and *before* holding, never after.
+    // `hold` enforces capacity itself by evicting the oldest entry, so a
+    // page that overshoots has already destroyed something by the time any
+    // after-the-fact size check runs: a 255-entry pen taking two new events
+    // evicts one, then reports 256 to a guard that thinks it stopped in time.
     final heldIn = pen;
-    final penSizeBefore = heldIn?.size ?? 0;
-    final forQueue = heldIn == null
-        ? events
-        : [
-            for (final event in events)
-              if (!heldIn.hold(event)) event,
-          ];
-    final penned = events.length - forQueue.length;
-    // `hold` returns true for a re-hold as well as a first hold, so count by
-    // the pen's own growth: only entries it did not already have are new.
-    final newlyPenned = (heldIn?.size ?? 0) - penSizeBefore;
+    final forQueue = <Event>[];
+    var penned = 0;
+    var newlyPenned = 0;
+    var penExhausted = false;
+
+    if (heldIn == null) {
+      forQueue.addAll(events);
+    } else {
+      final available = heldIn.capacity - heldIn.size;
+      for (final event in events) {
+        if (event.type != EventTypes.Encrypted) {
+          forQueue.add(event);
+          continue;
+        }
+        // A re-hold of something already held costs no slot, so only growth
+        // counts against the budget.
+        if (!heldIn.holds(event.eventId) && newlyPenned >= available) {
+          penExhausted = true;
+          break;
+        }
+        final sizeBefore = heldIn.size;
+        heldIn.hold(event);
+        penned++;
+        if (heldIn.size > sizeBefore) newlyPenned++;
+      }
+    }
 
     final enqueue = await _queue.appendBootstrapPage(forQueue);
 
@@ -131,14 +152,13 @@ class QueueBootstrapSink implements BootstrapSink {
     // cannot advance past what the pen is holding, so the next run resumes
     // from the right anchor instead of skipping the gap. Evicting is not
     // safe, so prefer the bounded stop.
-    final holding = heldIn?.size ?? 0;
-    if (heldIn != null && holding >= heldIn.capacity) {
+    if (penExhausted) {
       _logging.log(
         LogDomain.sync,
         'queue.bootstrap.penFull '
         'page=${info.pageIndex} '
-        'penSize=$holding '
-        'capacity=${heldIn.capacity}',
+        'penSize=${heldIn?.size} '
+        'capacity=${heldIn?.capacity}',
         subDomain: _logSub,
       );
       return false;

--- a/lib/features/sync/queue/inbound_event_queue.dart
+++ b/lib/features/sync/queue/inbound_event_queue.dart
@@ -64,6 +64,16 @@ class InboundQueue {
     onDepthChanged: _depthEmitter.schedule,
   );
 
+  /// Nudges [depthChanges] without an enqueue.
+  ///
+  /// Work can become available to the worker without any row appearing —
+  /// ciphertext landing in `PendingDecryptionPen` is the case that matters,
+  /// since the worker sweeps the pen at the top of each drain iteration but
+  /// only wakes on a depth signal or its idle tick. With an empty queue that
+  /// tick is `_idleTick * 12` (60s), so without this a key arriving right
+  /// after a penned page would sit unused for up to a minute.
+  void signalPendingWork() => _depthEmitter.schedule();
+
   Stream<QueueDepthSignal> get depthChanges => _depthEmitter.changes;
 
   Future<void> dispose() => _depthEmitter.dispose();

--- a/lib/features/sync/queue/pending_decryption_pen.dart
+++ b/lib/features/sync/queue/pending_decryption_pen.dart
@@ -234,11 +234,13 @@ class PendingDecryptionPen {
         enqueued: 0,
         stillEncrypted: 0,
         dropped: 0,
+        lookups: 0,
       );
     }
 
     var stillEncrypted = 0;
     var dropped = 0;
+    var lookups = 0;
     final decrypted = <({String id, Event event})>[];
 
     final ids = _held.keys.toList(growable: false);
@@ -255,6 +257,7 @@ class PendingDecryptionPen {
         continue;
       }
       held.lastLookupAtMs = nowMs;
+      lookups++;
 
       final latest = await _fetchLatest(room, id);
       final candidate = latest ?? held.event;
@@ -305,6 +308,7 @@ class PendingDecryptionPen {
       enqueued: decrypted.length,
       stillEncrypted: stillEncrypted,
       dropped: dropped,
+      lookups: lookups,
     );
   }
 
@@ -343,9 +347,19 @@ class PenFlushOutcome {
     required this.enqueued,
     required this.stillEncrypted,
     required this.dropped,
+    required this.lookups,
   });
 
   final int enqueued;
   final int stillEncrypted;
   final int dropped;
+
+  /// How many entries were actually re-queried this sweep.
+  ///
+  /// Zero means every held entry was inside its [PendingDecryptionPen
+  /// .lookupInterval] and the sweep could not have discovered a decryption
+  /// even if one had happened. Callers that give up after N unproductive
+  /// sweeps must not count those, or a caller whose own cadence is faster
+  /// than the lookup interval gives up without ever having looked.
+  final int lookups;
 }

--- a/lib/features/sync/queue/pending_decryption_pen.dart
+++ b/lib/features/sync/queue/pending_decryption_pen.dart
@@ -110,6 +110,10 @@ class PendingDecryptionPen {
 
   int get size => _held.length;
 
+  /// Whether [eventId] is already held. A re-hold costs no capacity, so
+  /// admission checks must not count one against the remaining slots.
+  bool holds(String eventId) => _held.containsKey(eventId);
+
   /// Oldest `origin_server_ts` still held for [roomId], or null when the pen
   /// holds nothing for that room.
   ///

--- a/lib/features/sync/queue/pending_decryption_pen.dart
+++ b/lib/features/sync/queue/pending_decryption_pen.dart
@@ -114,6 +114,24 @@ class PendingDecryptionPen {
   /// admission checks must not count one against the remaining slots.
   bool holds(String eventId) => _held.containsKey(eventId);
 
+  /// How many entries are held for [roomId].
+  ///
+  /// Admission budgets are per room. The pen's capacity is global and its
+  /// eviction is global LRU, so entries left over from a room the user has
+  /// switched away from would otherwise consume the whole budget and stop the
+  /// active room's bootstrap without admitting anything — `onRoomChanged`
+  /// prunes queue rows but not the pen, and the worker only ever sweeps the
+  /// current room, so those entries linger until their attempt budget runs
+  /// out. Measuring the active room's own occupancy lets its events in, and
+  /// the LRU then reclaims the stale ones, which is the right trade.
+  int sizeForRoom(String roomId) {
+    var count = 0;
+    for (final held in _held.values) {
+      if (held.event.roomId == roomId) count++;
+    }
+    return count;
+  }
+
   /// Oldest `origin_server_ts` still held for [roomId], or null when the pen
   /// holds nothing for that room.
   ///

--- a/lib/features/sync/queue/pending_decryption_pen.dart
+++ b/lib/features/sync/queue/pending_decryption_pen.dart
@@ -201,6 +201,7 @@ class PendingDecryptionPen {
   /// decrypted and the caller should proceed with normal enqueue.
   bool hold(Event event) {
     if (event.type != EventTypes.Encrypted) return false;
+    _protectedRoomId = event.roomId;
 
     final id = event.eventId;
     final existing = _held.remove(id);
@@ -326,9 +327,13 @@ class PendingDecryptionPen {
     }
   }
 
+  /// The room whose entry was most recently held. Eviction prefers any other
+  /// room's entry over this one.
+  String? _protectedRoomId;
+
   void _enforceCapacity() {
     while (_held.length > capacity) {
-      final victim = _held.keys.first;
+      final victim = _pickVictim();
       _held.remove(victim);
       _logging.log(
         LogDomain.sync,
@@ -336,6 +341,25 @@ class PendingDecryptionPen {
         subDomain: _logSub,
       );
     }
+  }
+
+  /// Oldest entry belonging to a room other than the one being held for, or
+  /// the oldest entry overall when every entry belongs to it.
+  ///
+  /// Plain LRU is wrong once admission is budgeted per room. Switching
+  /// A → B → A can leave an A entry as the global oldest while a B entry is
+  /// newer; the per-room budget then admits another A event and LRU evicts
+  /// the *active* room's ciphertext — losing both the event and the marker
+  /// clamp that protects it, so later A commits advance straight past it. The
+  /// inactive room's entry is the right victim: nothing is sweeping it.
+  String _pickVictim() {
+    final protectedRoom = _protectedRoomId;
+    if (protectedRoom != null) {
+      for (final entry in _held.entries) {
+        if (entry.value.event.roomId != protectedRoom) return entry.key;
+      }
+    }
+    return _held.keys.first;
   }
 }
 

--- a/lib/features/sync/queue/pending_decryption_pen.dart
+++ b/lib/features/sync/queue/pending_decryption_pen.dart
@@ -15,6 +15,10 @@ class _HeldEvent {
   Event event;
   int heldAtMs;
 
+  /// When this entry was last looked up against the room. Zero means never,
+  /// so the first sweep after holding always looks.
+  int lastLookupAtMs = 0;
+
   /// When this entry last *spent* an attempt. Distinct from the sweep that
   /// merely looked at it: sweeps are as frequent as the worker's drain loop,
   /// attempts are meant to be spaced in real time.
@@ -45,9 +49,11 @@ class _HeldEvent {
 /// attempts in ~2ms — dropping ciphertext whose Megolm key was still in
 /// flight, on exactly the slow links where keys take longest to arrive.
 ///
-/// The spacing costs nothing in recovery latency: every sweep still asks
-/// the room for a decrypted copy and enqueues it the moment one exists.
-/// Only the countdown to giving up is rate-limited.
+/// Spacing the countdown costs almost nothing in recovery latency: the room
+/// is still polled for a decrypted copy on its own, much shorter
+/// [lookupInterval], and the event is enqueued the moment one exists. Both
+/// cadences are needed — one bounds how long ciphertext is kept, the other
+/// bounds how much work keeping it costs.
 ///
 /// The window is per session, not absolute: the pen is in memory, so a
 /// teardown discards whatever it still holds. That is not a loss path —
@@ -66,6 +72,7 @@ class PendingDecryptionPen {
     this.capacity = 256,
     this.maxAttempts = 20,
     this.attemptInterval = const Duration(seconds: 30),
+    this.lookupInterval = const Duration(seconds: 1),
     this.sweepInterval,
   });
 
@@ -77,6 +84,21 @@ class PendingDecryptionPen {
   /// [Duration.zero] to make every sweep count, which is only useful for
   /// tests that model the budget directly.
   final Duration attemptInterval;
+
+  /// Minimum real time between two `room.getEventById` lookups for the same
+  /// entry.
+  ///
+  /// The lookup is the expensive half of a sweep, and sweeps are frequent:
+  /// `InboundWorker` flushes the whole pen before every batch and
+  /// `SyncTuning.inboundWorkerBatchSize` is 1, so draining 10k rows with a
+  /// full 256-entry pen would otherwise issue ~2.5M sequential lookups. That
+  /// used to be self-limiting only because entries were dropped after 20
+  /// sweeps; holding them for a real ten minutes makes the load persist, so
+  /// the lookup needs its own cadence rather than inheriting the sweep's.
+  ///
+  /// Kept far shorter than [attemptInterval] so decryption is still noticed
+  /// within about a second of the key landing.
+  final Duration lookupInterval;
 
   final Duration? sweepInterval;
 
@@ -202,6 +224,16 @@ class PendingDecryptionPen {
       final held = _held[id];
       if (held == null) continue;
 
+      // Rate-limit the lookup itself, not just the countdown it feeds. An
+      // entry that was checked a moment ago cannot have decrypted since
+      // without the SDK having done work we would see on the next tick.
+      final nowMs = clock.now().millisecondsSinceEpoch;
+      if (nowMs - held.lastLookupAtMs < lookupInterval.inMilliseconds) {
+        stillEncrypted++;
+        continue;
+      }
+      held.lastLookupAtMs = nowMs;
+
       final latest = await _fetchLatest(room, id);
       final candidate = latest ?? held.event;
 
@@ -213,10 +245,8 @@ class PendingDecryptionPen {
         continue;
       }
 
-      // Sweeps are unbounded in frequency; attempts are not. Looking again
-      // costs nothing, so an entry only pays when `attemptInterval` has
-      // elapsed since it last paid.
-      final nowMs = clock.now().millisecondsSinceEpoch;
+      // Sweeps are unbounded in frequency; attempts are not. An entry only
+      // pays when `attemptInterval` has elapsed since it last paid.
       if (nowMs - held.lastAttemptAtMs < attemptInterval.inMilliseconds) {
         stillEncrypted++;
         continue;

--- a/lib/features/sync/queue/queue_lifecycle.dart
+++ b/lib/features/sync/queue/queue_lifecycle.dart
@@ -203,6 +203,12 @@ extension QueueLifecycle on QueuePipelineCoordinator {
       final room = await _resolveRoom();
       var penEnqueued = 0;
       var penLookups = 0;
+      // No room means no lookup is possible at all — after logout or room
+      // removal the pen can never drain, so a pass with no room counts as
+      // stalled. Without this the eligible-lookup rule below never fires and
+      // teardown polls the whole 30s deadline, blocking the user-visible
+      // flag-off and logout paths.
+      final penCanProgress = room != null;
       if (room != null) {
         try {
           final outcome = await _pen.flushInto(queue: _queue, room: room);
@@ -232,7 +238,7 @@ extension QueueLifecycle on QueuePipelineCoordinator {
 
       if (penEnqueued > 0) {
         unproductivePenFlushes = 0;
-      } else if (_pen.size > 0 && penLookups > 0) {
+      } else if (_pen.size > 0 && (penLookups > 0 || !penCanProgress)) {
         // Only a sweep that actually re-queried the room counts. The pen
         // throttles its own lookups, and this loop polls faster than that
         // interval — counting throttled sweeps would let shutdown exhaust its

--- a/lib/features/sync/queue/queue_lifecycle.dart
+++ b/lib/features/sync/queue/queue_lifecycle.dart
@@ -168,11 +168,13 @@ extension QueueLifecycle on QueuePipelineCoordinator {
     );
   }
 
-  /// How many consecutive pen flushes may produce nothing before
-  /// [drainUntilEmptyImpl] stops waiting on it. At the loop's 200ms back-off
-  /// this is ~1s — long enough for the SDK to finish a decryption already in
-  /// progress, short enough that ciphertext whose key has not arrived does not
-  /// hold teardown open for the whole timeout.
+  /// How many consecutive pen flushes that actually re-queried the room may
+  /// produce nothing before [drainUntilEmptyImpl] stops waiting on it.
+  ///
+  /// Counted in *eligible* sweeps, not wall-clock ticks: the pen throttles
+  /// lookups on its own cadence and this loop polls faster than that, so
+  /// counting throttled sweeps would burn the whole allowance inside a single
+  /// lookup interval and tear down without ever having looked.
   static const int _penStallFlushes = 5;
 
   /// Implementation of [QueuePipelineCoordinator.drainUntilEmpty]; see [QueueLifecycle].
@@ -200,10 +202,12 @@ extension QueueLifecycle on QueuePipelineCoordinator {
       //    while held events are waiting to enter it.
       final room = await _resolveRoom();
       var penEnqueued = 0;
+      var penLookups = 0;
       if (room != null) {
         try {
           final outcome = await _pen.flushInto(queue: _queue, room: room);
           penEnqueued = outcome.enqueued;
+          penLookups = outcome.lookups;
         } catch (error, stackTrace) {
           _logging.error(
             LogDomain.sync,
@@ -228,7 +232,12 @@ extension QueueLifecycle on QueuePipelineCoordinator {
 
       if (penEnqueued > 0) {
         unproductivePenFlushes = 0;
-      } else if (_pen.size > 0) {
+      } else if (_pen.size > 0 && penLookups > 0) {
+        // Only a sweep that actually re-queried the room counts. The pen
+        // throttles its own lookups, and this loop polls faster than that
+        // interval — counting throttled sweeps would let shutdown exhaust its
+        // allowance without ever having looked once, discarding a key that
+        // landed in the gap.
         unproductivePenFlushes++;
       }
 

--- a/test/features/sync/queue/bootstrap_sink_test.dart
+++ b/test/features/sync/queue/bootstrap_sink_test.dart
@@ -367,6 +367,87 @@ void main() {
     },
   );
 
+  test(
+    'a full pen does not discard the rest of an already-fetched page',
+    () async {
+      // Breaking out of the scan throws away work that has already crossed
+      // the network — later plaintext and already-held events included — and
+      // the manual "Fetch all history" path has no automatic retry to pick
+      // them up afterwards.
+      final pen = PendingDecryptionPen(logging: logging, capacity: 1);
+      final sink = QueueBootstrapSink(
+        queue: queue,
+        logging: logging,
+        pen: pen,
+      );
+
+      final cont = await sink.onPage([
+        _buildEvent(
+          eventId: r'$sealedA',
+          originTsMs: 1,
+          type: EventTypes.Encrypted,
+        ),
+        // No slot left for this one...
+        _buildEvent(
+          eventId: r'$sealedB',
+          originTsMs: 2,
+          type: EventTypes.Encrypted,
+        ),
+        // ...but this one needs no slot and must still be queued.
+        _buildEvent(eventId: r'$plain', originTsMs: 3),
+      ], info(0, 3));
+
+      expect(cont, isFalse, reason: 'pagination still stops');
+      expect(pen.size, 1, reason: 'capacity respected, nothing evicted');
+      expect(pen.holds(r'$sealedA'), isTrue);
+      final stats = await queue.stats();
+      expect(
+        stats.total,
+        1,
+        reason: 'the plaintext after the boundary still reaches the queue',
+      );
+    },
+  );
+
+  test(
+    'capacity is budgeted per room, not across the whole pen',
+    () async {
+      // The pen's capacity and LRU are global. Ciphertext left over from a
+      // room the user switched away from would otherwise consume the entire
+      // budget and stop the active room's bootstrap dead — `onRoomChanged`
+      // prunes queue rows but not the pen.
+      final pen = PendingDecryptionPen(logging: logging, capacity: 1)
+        ..hold(
+          _buildEvent(
+            eventId: r'$stale',
+            originTsMs: 1,
+            roomId: '!oldRoom:example.org',
+            type: EventTypes.Encrypted,
+          ),
+        );
+
+      final sink = QueueBootstrapSink(
+        queue: queue,
+        logging: logging,
+        pen: pen,
+      );
+      final cont = await sink.onPage([
+        _buildEvent(
+          eventId: r'$fresh',
+          originTsMs: 2,
+          type: EventTypes.Encrypted,
+        ),
+      ], info(0, 1));
+
+      expect(
+        cont,
+        isTrue,
+        reason: 'the active room has its own budget and is not blocked',
+      );
+      expect(pen.holds(r'$fresh'), isTrue);
+    },
+  );
+
   test('cancelSignal stops pagination between pages', () async {
     // Make the pre-cancel queue contain >highWater entries so the sink
     // awaits drain when the next onPage fires.

--- a/test/features/sync/queue/bootstrap_sink_test.dart
+++ b/test/features/sync/queue/bootstrap_sink_test.dart
@@ -274,6 +274,49 @@ void main() {
     },
   );
 
+  test(
+    'a full pen stops pagination instead of evicting the oldest ciphertext',
+    () async {
+      // A forward walk emits up to 50 pages of 200 and manual history
+      // collection is unbounded, while the pen is a fixed LRU. Ciphertext
+      // creates no queue rows, so the depth-based back-pressure never fires —
+      // the walk would run the pen's oldest entries straight off the end,
+      // recreating the loss this sink exists to prevent. Stopping is safe:
+      // held events clamp the sync marker, so the next run resumes from the
+      // right anchor rather than skipping the gap.
+      final pen = PendingDecryptionPen(logging: logging, capacity: 2);
+      final sink = QueueBootstrapSink(
+        queue: queue,
+        logging: logging,
+        pen: pen,
+      );
+
+      final page = [
+        for (var i = 0; i < 2; i++)
+          _buildEvent(
+            eventId: '\$sealed$i',
+            originTsMs: i + 1,
+            type: EventTypes.Encrypted,
+          ),
+      ];
+      final cont = await sink.onPage(page, info(0, page.length));
+
+      expect(pen.size, 2);
+      expect(
+        cont,
+        isFalse,
+        reason: 'pagination halts at capacity rather than overflowing it',
+      );
+      expect(
+        sink.lastAcceptedCount,
+        2,
+        reason:
+            'retained ciphertext counts as accepted, so the caller does '
+            'not read this page as a stale-cache miss',
+      );
+    },
+  );
+
   test('cancelSignal stops pagination between pages', () async {
     // Make the pre-cancel queue contain >highWater entries so the sink
     // awaits drain when the next onPage fires.

--- a/test/features/sync/queue/bootstrap_sink_test.dart
+++ b/test/features/sync/queue/bootstrap_sink_test.dart
@@ -304,8 +304,10 @@ void main() {
       expect(pen.size, 2);
       expect(
         cont,
-        isFalse,
-        reason: 'pagination halts at capacity rather than overflowing it',
+        isTrue,
+        reason:
+            'a page that fits exactly is admitted whole; the stop comes '
+            'when the next page has nowhere to go',
       );
       expect(
         sink.lastAcceptedCount,
@@ -313,6 +315,54 @@ void main() {
         reason:
             'retained ciphertext counts as accepted, so the caller does '
             'not read this page as a stale-cache miss',
+      );
+    },
+  );
+
+  test(
+    'admission is checked before holding, so nothing is evicted',
+    () async {
+      // `hold` enforces capacity itself by evicting the oldest entry, so a
+      // guard that runs after the page has been held has already destroyed
+      // something: a nearly-full pen taking two new events evicts one, then
+      // reports a size that looks like it stopped in time.
+      final pen = PendingDecryptionPen(logging: logging, capacity: 2);
+      final sink = QueueBootstrapSink(
+        queue: queue,
+        logging: logging,
+        pen: pen,
+      );
+
+      // Fill one slot, leaving exactly one free.
+      await sink.onPage([
+        _buildEvent(
+          eventId: r'$first',
+          originTsMs: 1,
+          type: EventTypes.Encrypted,
+        ),
+      ], info(0, 1));
+      expect(pen.size, 1);
+
+      // Two more new events against one free slot.
+      final cont = await sink.onPage([
+        _buildEvent(
+          eventId: r'$second',
+          originTsMs: 2,
+          type: EventTypes.Encrypted,
+        ),
+        _buildEvent(
+          eventId: r'$third',
+          originTsMs: 3,
+          type: EventTypes.Encrypted,
+        ),
+      ], info(1, 2));
+
+      expect(cont, isFalse, reason: 'pagination stops at the boundary');
+      expect(pen.size, 2, reason: 'filled exactly, never overflowed');
+      expect(
+        pen.holds(r'$first'),
+        isTrue,
+        reason: 'the oldest entry must not have been evicted to make room',
       );
     },
   );

--- a/test/features/sync/queue/bootstrap_sink_test.dart
+++ b/test/features/sync/queue/bootstrap_sink_test.dart
@@ -368,7 +368,7 @@ void main() {
   );
 
   test(
-    'a full pen does not discard the rest of an already-fetched page',
+    'a full pen stops the page at the gap rather than queueing past it',
     () async {
       // Breaking out of the scan throws away work that has already crossed
       // the network — later plaintext and already-held events included — and
@@ -403,8 +403,11 @@ void main() {
       final stats = await queue.stats();
       expect(
         stats.total,
-        1,
-        reason: 'the plaintext after the boundary still reaches the queue',
+        0,
+        reason:
+            'nothing past the gap may be queued: the overflow event has '
+            'no row and no pen entry, so it has no marker clamp, and a later '
+            'event from the same page would advance the marker past it',
       );
     },
   );

--- a/test/features/sync/queue/pending_decryption_pen_test.dart
+++ b/test/features/sync/queue/pending_decryption_pen_test.dart
@@ -334,6 +334,44 @@ void main() {
     },
   );
 
+  test(
+    'eviction prefers an inactive room over the room being held for',
+    () async {
+      // Plain LRU is wrong once admission is budgeted per room. Switching
+      // A -> B -> A can leave an A entry as the global oldest while a B entry
+      // is newer; evicting the A entry would cost the active room both the
+      // ciphertext and the marker clamp that protects it, so later A commits
+      // would advance straight past it.
+      final pen = PendingDecryptionPen(logging: logging, capacity: 2);
+      Event sealed(String id, String room, int ts) => buildEvent(
+        eventId: id,
+        roomId: room,
+        originTsMs: ts,
+        type: EventTypes.Encrypted,
+      );
+
+      pen
+        ..hold(sealed(r'$oldestA', roomId, 1))
+        ..hold(sealed(r'$newerB', '!roomB:example.org', 2))
+        // Room A again, over capacity: the B entry is the right victim even
+        // though the A entry is older.
+        ..hold(sealed(r'$freshA', roomId, 3));
+
+      expect(pen.size, 2);
+      expect(
+        pen.holds(r'$oldestA'),
+        isTrue,
+        reason: 'the active room keeps its ciphertext and its marker clamp',
+      );
+      expect(pen.holds(r'$freshA'), isTrue);
+      expect(
+        pen.holds(r'$newerB'),
+        isFalse,
+        reason: 'nothing is sweeping the inactive room, so it yields first',
+      );
+    },
+  );
+
   test('capacity eviction drops the oldest entry', () async {
     final pen = PendingDecryptionPen(logging: logging, capacity: 2);
     final a = buildEvent(

--- a/test/features/sync/queue/pending_decryption_pen_test.dart
+++ b/test/features/sync/queue/pending_decryption_pen_test.dart
@@ -116,7 +116,9 @@ void main() {
       final pen = PendingDecryptionPen(
         logging: logging,
         maxAttempts: 2,
+        // Models per-sweep semantics, so both cadences are disabled.
         attemptInterval: Duration.zero,
+        lookupInterval: Duration.zero,
       );
       final encrypted = buildEvent(
         eventId: r'$doomed',
@@ -278,6 +280,59 @@ void main() {
     expect(pen.oldestHeldOriginTs('!other:example.org'), 100);
     expect(pen.oldestHeldOriginTs('!empty:example.org'), isNull);
   });
+
+  test(
+    'a fast drain loop does not re-query the room for every sweep',
+    () async {
+      // The lookup is the expensive half of a sweep, and the worker flushes
+      // the whole pen before every batch with `inboundWorkerBatchSize == 1`.
+      // Draining 10k rows against a full pen would issue millions of
+      // sequential `getEventById` calls. That was self-limiting only while
+      // entries were dropped after 20 sweeps; holding them for ten real
+      // minutes makes the load persist, so the lookup needs its own cadence.
+      final pen = PendingDecryptionPen(logging: logging);
+      final encrypted = buildEvent(
+        eventId: r'$sealed',
+        roomId: roomId,
+        originTsMs: 1,
+        type: EventTypes.Encrypted,
+      );
+      final held = DateTime.utc(2026, 7, 26, 12);
+      await withClock(Clock.fixed(held), () async => pen.hold(encrypted));
+
+      var lookups = 0;
+      when(() => room.getEventById(r'$sealed')).thenAnswer((_) async {
+        lookups++;
+        return encrypted;
+      });
+
+      // 100 sweeps inside one instant — what a burst drain does.
+      await withClock(
+        Clock.fixed(held.add(const Duration(seconds: 5))),
+        () async {
+          for (var i = 0; i < 100; i++) {
+            await pen.flushInto(queue: queue, room: room);
+          }
+        },
+      );
+      expect(
+        lookups,
+        1,
+        reason: 'one lookup per entry per lookupInterval, not per sweep',
+      );
+
+      // A later sweep, past the interval, looks again — so a key that lands
+      // is still noticed promptly.
+      await withClock(
+        Clock.fixed(held.add(const Duration(seconds: 7))),
+        () async {
+          await pen.flushInto(queue: queue, room: room);
+        },
+      );
+      expect(lookups, 2);
+      expect(pen.size, 1, reason: 'still held, still encrypted');
+    },
+  );
 
   test('capacity eviction drops the oldest entry', () async {
     final pen = PendingDecryptionPen(logging: logging, capacity: 2);
@@ -452,9 +507,10 @@ void main() {
           logging: localLogging,
           capacity: scenario.capacity,
           maxAttempts: scenario.maxAttempts,
-          // The model counts one attempt per flush, so this scenario opts
-          // out of the real-time spacing production uses.
+          // The model counts one attempt per flush and one lookup per sweep,
+          // so this scenario opts out of both real-time cadences.
           attemptInterval: Duration.zero,
+          lookupInterval: Duration.zero,
         );
         final expected = ExpectedPenModel(
           capacity: scenario.capacity,

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -1757,6 +1757,62 @@ void main() {
     );
 
     test(
+      'a lookup-throttled sweep does not count toward the stall limit',
+      () async {
+        // The pen throttles its own `room.getEventById` calls, and this loop
+        // polls faster than that interval. Counting throttled sweeps burned
+        // the whole allowance inside a single interval, so shutdown could
+        // tear the pen down without ever having looked once — discarding a
+        // key that landed in the gap.
+        when(() => queue.stats()).thenAnswer(
+          (_) async => const QueueStats(
+            total: 0,
+            byProducer: {},
+            readyNow: 0,
+            oldestEnqueuedAt: null,
+          ),
+        );
+        when(() => queue.earliestReadyAt()).thenAnswer((_) async => null);
+        final room = MockRoom();
+        when(() => roomManager.currentRoom).thenReturn(room);
+        when(() => pen.size).thenReturn(1);
+        // Every sweep is throttled: nothing enqueued, and no lookup made.
+        when(() => pen.flushInto(queue: queue, room: room)).thenAnswer(
+          (_) async => const PenFlushOutcome(
+            enqueued: 0,
+            stillEncrypted: 1,
+            dropped: 0,
+            lookups: 0,
+          ),
+        );
+
+        final coordinator = build();
+        fakeAsync((async) {
+          var completed = false;
+          withClock(Clock(() => DateTime.utc(2026).add(async.elapsed)), () {
+            unawaited(
+              coordinator
+                  .drainUntilEmpty(timeout: const Duration(seconds: 30))
+                  .then<void>((_) => completed = true),
+            );
+          });
+
+          // Past where five 200ms polls would have exhausted the allowance.
+          async.elapse(const Duration(seconds: 3));
+          expect(
+            completed,
+            isFalse,
+            reason: 'throttled sweeps must not spend the stall allowance',
+          );
+
+          // It still ends, at the timeout, rather than hanging forever.
+          async.elapse(const Duration(seconds: 30));
+          expect(completed, isTrue);
+        });
+      },
+    );
+
+    test(
       'drainUntilEmpty stops waiting on a pen that cannot produce',
       () async {
         // Ciphertext whose key has not arrived is not a stranded row: it has
@@ -1777,8 +1833,12 @@ void main() {
         when(() => roomManager.currentRoom).thenReturn(room);
         when(() => pen.size).thenReturn(3);
         when(() => pen.flushInto(queue: queue, room: room)).thenAnswer(
-          (_) async =>
-              const PenFlushOutcome(enqueued: 0, stillEncrypted: 3, dropped: 0),
+          (_) async => const PenFlushOutcome(
+            enqueued: 0,
+            stillEncrypted: 3,
+            dropped: 0,
+            lookups: 3,
+          ),
         );
 
         final coordinator = build();
@@ -1858,8 +1918,12 @@ void main() {
         final room = MockRoom();
         when(() => roomManager.currentRoom).thenReturn(room);
         when(() => pen.flushInto(queue: queue, room: room)).thenAnswer(
-          (_) async =>
-              const PenFlushOutcome(enqueued: 0, stillEncrypted: 0, dropped: 0),
+          (_) async => const PenFlushOutcome(
+            enqueued: 0,
+            stillEncrypted: 0,
+            dropped: 0,
+            lookups: 0,
+          ),
         );
 
         final coordinator = build();
@@ -1909,6 +1973,7 @@ void main() {
             enqueued: 0,
             stillEncrypted: 0,
             dropped: 0,
+            lookups: 0,
           );
         });
         when(bench.queue.stats).thenAnswer((_) async {

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -594,6 +594,9 @@ class _GladosBench {
     AttachmentIndex? attachmentIndex,
     UpdateNotifications? updateNotifications,
   }) {
+    // `capacity` is a non-nullable int the bootstrap sink reads to decide
+    // whether it may keep paginating; an unstubbed mock getter yields null.
+    when(() => pen.capacity).thenReturn(256);
     return QueuePipelineCoordinator(
       syncDb: syncDb,
       settingsDb: settingsDb,
@@ -735,6 +738,7 @@ void main() {
     worker = _MockWorker();
     bridge = _MockBridge();
     pen = _MockPen();
+    when(() => pen.capacity).thenReturn(256);
     seeder = _MockSeeder();
     timelineCtl = StreamController<Event>.broadcast(sync: true);
     syncCtl = CachedStreamController<SyncUpdate>();

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -1813,6 +1813,48 @@ void main() {
     );
 
     test(
+      'a pen with no room to resolve counts as stalled straight away',
+      () async {
+        // After logout or room removal the pen can never drain: no room means
+        // no lookup, so the eligible-lookup rule would never fire and
+        // teardown would poll the whole 30s deadline — on the user-visible
+        // flag-off and logout paths.
+        when(() => queue.stats()).thenAnswer(
+          (_) async => const QueueStats(
+            total: 0,
+            byProducer: {},
+            readyNow: 0,
+            oldestEnqueuedAt: null,
+          ),
+        );
+        when(() => queue.earliestReadyAt()).thenAnswer((_) async => null);
+        when(() => roomManager.currentRoom).thenReturn(null);
+        when(() => pen.size).thenReturn(2);
+
+        final coordinator = build();
+        fakeAsync((async) {
+          var completed = false;
+          withClock(Clock(() => DateTime.utc(2026).add(async.elapsed)), () {
+            unawaited(
+              coordinator
+                  .drainUntilEmpty(timeout: const Duration(seconds: 30))
+                  .then<void>((_) => completed = true),
+            );
+          });
+
+          async.elapse(const Duration(seconds: 5));
+          expect(
+            completed,
+            isTrue,
+            reason:
+                'teardown must not wait out the deadline for a pen that '
+                'has no room to drain into',
+          );
+        });
+      },
+    );
+
+    test(
       'drainUntilEmpty stops waiting on a pen that cannot produce',
       () async {
         // Ciphertext whose key has not arrived is not a stranded row: it has


### PR DESCRIPTION
Three review findings from #3608, all consequences of that change diverting
ciphertext out of the queue and into the pen. Depends on #3611 (marker clamp)
for the first one to be safe.

## P1 — backfill could overflow the pen and silently evict

A forward walk emits up to 50 pages of 200, and manual history collection is
unbounded, against a fixed 256-entry LRU pen. Ciphertext produces no queue
rows, so `_waitForDrain` — which watches queue *depth* — applies no
back-pressure to an all-encrypted run whatsoever. The walk would run the pen's
oldest entries off the end long before finishing, recreating precisely the data
loss #3608 was written to stop.

The sink now halts pagination once the pen is at capacity, logging
`queue.bootstrap.penFull`.

**Stopping is only safe because of #3611.** Held events clamp the sync marker
there, so the marker cannot advance past what the pen holds and the next run
resumes from the correct anchor rather than skipping the gap. Without that,
halting would strand the same events by a different route. Evicting is never
safe, so the bounded stop is the right trade.

## P2 — retained ciphertext read as "accepted zero"

`collectHistoryForBootstrapImpl` treats `lastAcceptedCount == 0` as a
stale-cache signal and requests up to five further pages past the boundary. On
a page that was entirely ciphertext, the sink *had* retained the page, so that
reading was false — and those extra pages are exactly what pushes the pen over
capacity and evicts the boundary events being preserved.

Newly penned events now count toward the accepted total. Measured by the pen's
own growth rather than `hold`'s return value, because `hold` returns true for a
re-hold as well as a first hold.

## P2 — penning did not wake the worker

`appendBootstrapPage([])` emits no `depthChanges` signal, so an idle worker
would not inspect the pen until its empty-queue tick — `_idleTick * 12`, 60
seconds. A key that became available immediately after a penned page sat unused
for up to a minute unless an unrelated plain event happened to arrive.
`InboundQueue.signalPendingWork()` nudges the depth stream without an enqueue.

## A break this caught

`capacity` is a non-nullable `int` the sink now reads, and `_MockPen` did not
stub it — an unstubbed mocktail getter returns null, which took out **15 tests**
in `queue_pipeline_coordinator_test` that merely construct a coordinator.
`bootstrap_sink_test.dart` stayed green throughout; only running the full sync
suite surfaced it.

## Verification

- `flutter test test/features/sync/` — **2943 passed, 1 skipped, 0 failed.**
- `dart analyze lib test` — no issues.
- New test: a full pen halts pagination rather than overflowing, and reports the
  retained page as accepted.

## Not included

The fourth late P1 on #3608 — attachment descriptors bypassing ingestion after
pen decryption — is untouched here. It is a different subsystem (the
`AttachmentAwareBootstrapSink` wrapper versus the pen's direct
`enqueueBatch` path) and deserves its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved encrypted-event synchronization by buffering pending ciphertext per room without displacing active-room work.
  - Added capacity-aware pagination that stops safely when buffering limits are reached.
  - Reduced repeated room lookups during decryption retries.
  - Improved worker responsiveness when buffered work becomes available.
  - Refined progress tracking to avoid treating throttled or unavailable work as stalled.

- **Documentation**
  - Expanded synchronization documentation covering decryption buffering, marker advancement, lookup pacing, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update — rebased on merged #3611, plus a third P1 from its review

`5606020b3` (#3611) is in main, so the capacity stop below is now safe as
described. Rebased to a clean two commits.

### The pen's room lookup needed its own cadence

Raised on #3611 and valid — a cost this series introduced.

Spacing the give-up countdown left `_fetchLatest` running for *every* held
entry on *every* sweep. The docstring I wrote even claimed "looking again costs
nothing." It does not: `InboundWorker` flushes the whole pen before every
batch and `SyncTuning.inboundWorkerBatchSize` is **1**, so draining 10k rows
against a full 256-entry pen issues on the order of **2.5 million** sequential
`room.getEventById` calls.

That load used to be self-limiting, and only by accident — entries were dropped
after 20 sweeps, so the pen emptied within seconds. Holding ciphertext for a
real ten minutes, which was the entire point of the earlier fix, is what makes
it persist. It can stall the drain the change was meant to protect.

The lookup now has its own, much shorter cadence (1s), independent of the 30s
attempt interval:

- one bounds **how long** ciphertext is kept,
- the other bounds **what keeping it costs**.

Decryption is still noticed within about a second of the key landing, so
recovery latency is unchanged in practice. New test: 100 sweeps in a single
instant produce **one** lookup, and a sweep past the interval looks again.

Two existing tests broke, correctly. Both model per-sweep semantics and already
disabled `attemptInterval`; they now disable `lookupInterval` too.

### Verification after the rebase

- `flutter test test/features/sync/` — **2944 passed, 1 skipped, 0 failed.**
- `dart analyze lib test` — no issues.
