### PR TITLE
test: fail fast on a stalled sync, and make the pipeline visible at all

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/classes/config.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/ai/database/ai_config_db.dart';
@@ -163,6 +164,143 @@ Future<MatrixService> _createMatrixService({
   );
 }
 
+/// Domain logger that echoes sync-pipeline lines to test stdout.
+///
+/// The pipeline is silent under test for two independent reasons, and both
+/// have to be defeated to see anything:
+///
+///  * `DomainLogger.enabledDomains` starts empty, so every
+///    `log(LogDomain.sync, ...)` is a no-op unless a domain is added;
+///  * `LoggingService._enableLogging` is `!isTestEnv`, so `captureEvent`
+///    returns early under `FLUTTER_TEST` even when a domain is enabled.
+///
+/// The consequence is that the catch-up bridge — its mode, its page counts,
+/// its give-up ladder, and the exceptions `saveRoom.bootstrap` swallows —
+/// leaves no trace in an integration run. A failing test then shows only that
+/// nothing arrived, with no way to tell "never ran" from "ran and found
+/// nothing" from "threw". This class closes that gap without touching
+/// production logging.
+class _EchoDomainLogger extends DomainLogger {
+  _EchoDomainLogger({required super.loggingService}) {
+    enabledDomains.add(LogDomain.sync);
+  }
+
+  /// Sub-domains worth echoing. Everything in the sync domain would drown the
+  /// per-message traffic of a 250-event burst.
+  static const _interesting = <String>[
+    'queue.bridge',
+    'queue.bootstrap',
+    'queue.coordinator',
+    'bootstrap',
+    'saveRoom',
+  ];
+
+  bool _wanted(String? subDomain) =>
+      subDomain != null && _interesting.any(subDomain.startsWith);
+
+  @override
+  void log(
+    LogDomain domain,
+    String message, {
+    String? subDomain,
+    InsightLevel level = InsightLevel.info,
+  }) {
+    if (domain == LogDomain.sync && _wanted(subDomain)) {
+      debugPrint('[sync] $subDomain :: $message');
+    }
+    super.log(domain, message, subDomain: subDomain, level: level);
+  }
+
+  @override
+  void error(
+    LogDomain domain,
+    Object error, {
+    StackTrace? stackTrace,
+    String? subDomain,
+    String? message,
+  }) {
+    // Errors always echo. `saveRoom.bootstrap` and `queue.bridge.*` swallow
+    // exceptions into this method, so a silenced logger turns a thrown
+    // bootstrap into an indistinguishable no-op.
+    debugPrint('[sync][ERROR] ${subDomain ?? '-'} :: $error');
+    super.error(
+      domain,
+      error,
+      stackTrace: stackTrace,
+      subDomain: subDomain,
+      message: message,
+    );
+  }
+}
+
+/// Thrown when a convergence wait detects that nothing can still be in
+/// progress, so waiting out the full timeout would only burn CI time.
+class _SyncStalledException implements Exception {
+  _SyncStalledException(this.message);
+  final String message;
+  @override
+  String toString() => 'SyncStalled: $message';
+}
+
+/// Fails fast when sync has demonstrably stopped rather than merely being slow.
+///
+/// A device that is catching up always has *something* outstanding: rows in
+/// the inbound queue, or a bridge walk in flight. When the journal count has
+/// not moved for [stallWindow] AND the queue is empty AND no bridge is
+/// running, nothing is going to arrive — the remaining wait is dead time.
+///
+/// The degraded-network job used to spend the full 15-minute convergence
+/// timeout in exactly that state, on every branch, turning a ~6 minute suite
+/// into a ~21 minute one. Detecting the stall keeps the failure (it is a real
+/// bug) while returning the diagnosis in seconds.
+Future<void> throwIfStalled({
+  required MatrixService device,
+  required int currentCount,
+  required int lastCount,
+  required Stopwatch sinceLastProgress,
+  Duration stallWindow = const Duration(seconds: 90),
+  Duration warnWindow = const Duration(seconds: 20),
+}) async {
+  if (currentCount != lastCount) {
+    sinceLastProgress
+      ..reset()
+      ..start();
+    return;
+  }
+  if (sinceLastProgress.elapsed < warnWindow) return;
+
+  final coord = device.queueCoordinator;
+  final stats = await coord.queue.stats();
+  final quiet = stats.total == 0 && !coord.isBridgeInFlight;
+
+  // Below the failing threshold, report rather than fail. Healthy degraded
+  // runs have been measured going 62s without the journal count moving, so
+  // the window cannot be tightened on elapsed time alone — what decides it is
+  // whether the queue is also empty during those gaps. These lines answer
+  // that from real runs, so the threshold can be lowered on evidence.
+  if (sinceLastProgress.elapsed < stallWindow) {
+    debugPrint(
+      '[stall-probe] no progress for '
+      '${sinceLastProgress.elapsed.inSeconds}s at $currentCount entries; '
+      'quiet=$quiet queue[total=${stats.total} ready=${stats.readyNow}] '
+      'bridgeInFlight=${coord.isBridgeInFlight}',
+    );
+    return;
+  }
+
+  if (!quiet) return;
+
+  throw _SyncStalledException(
+    'no progress for ${sinceLastProgress.elapsed.inSeconds}s at '
+    '$currentCount entries, with an empty inbound queue and no bridge in '
+    'flight. Nothing is outstanding, so the remaining wait cannot help. '
+    'queue[total=${stats.total} ready=${stats.readyNow} '
+    'byProducer=${stats.byProducer}] '
+    'bridgeInFlight=${coord.isBridgeInFlight} '
+    'currentRoomId=${device.syncRoomId}',
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -286,7 +424,7 @@ void main() {
         ..registerSingleton<Directory>(sharedDocumentsDirectory)
         ..registerSingleton<LoggingService>(sharedLoggingService)
         ..registerSingleton<DomainLogger>(
-          DomainLogger(loggingService: sharedLoggingService),
+          _EchoDomainLogger(loggingService: sharedLoggingService),
         )
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<UserActivityService>(sharedUserActivityService)
@@ -635,6 +773,20 @@ void main() {
         // catch-up pagination time for the backlog)
         await Future<void>.delayed(const Duration(seconds: 5));
 
+        // Count real bridge completions. The metrics block printed below is
+        // NOT a substitute: `catchupBatches`, `processed`, `skipped`,
+        // `failures`, `flushes`, `retriesScheduled` and `circuitOpens` all
+        // have zero call sites in lib/ — they are structurally zero whatever
+        // sync does, and reading one as evidence is how this failure was
+        // misdiagnosed. Only `dbApplied` is wired.
+        var bridgeCompletions = 0;
+        final priorOnBridgeCompleted = bob.queueCoordinator.onBridgeCompleted;
+        bob.queueCoordinator.onBridgeCompleted = () {
+          bridgeCompletions++;
+          debugPrint('[probe] bridge completed #$bridgeCompletions');
+          priorOnBridgeCompleted?.call();
+        };
+
         Future<String> queueSnapshot() async {
           final coord = bob.queueCoordinator;
           final stats = await coord.queue.stats();
@@ -642,6 +794,8 @@ void main() {
               'byProducer=${stats.byProducer} '
               'oldestEnqueuedAt=${stats.oldestEnqueuedAt}] '
               'coord.running=${coord.isRunning} '
+              'bridgeInFlight=${coord.isBridgeInFlight} '
+              'bridgeCompletions=$bridgeCompletions '
               'currentRoomId=${bob.syncRoomId} '
               'syncRoom=${bob.syncRoom != null}';
         }
@@ -653,6 +807,8 @@ void main() {
         debugPrint('Bob ${await queueSnapshot()}');
 
         var lastBobCount = -1;
+        var stallProbeLastCount = -1;
+        final sinceLastProgress = Stopwatch()..start();
         await waitUntilAsync(
           () async {
             final currentCount = await bobDb.getJournalCount();
@@ -667,6 +823,13 @@ void main() {
             }
             // No manual forceRescan/retryNow — the pipeline must
             // self-drive catch-up through its signal-driven architecture.
+            await throwIfStalled(
+              device: bob,
+              currentCount: currentCount,
+              lastCount: stallProbeLastCount,
+              sinceLastProgress: sinceLastProgress,
+            );
+            stallProbeLastCount = currentCount;
             if (currentCount < expectedTotal) {
               // Log metrics every ~30s to diagnose stalls
               final elapsed = catchupStopwatch.elapsed.inSeconds;
@@ -907,6 +1070,8 @@ void main() {
         debugPrint('\n--- Phase 6: waiting for Bob to converge to $n new');
         final expectedTotal = bobCountBefore + n;
         var lastBobCount = -1;
+        var stallProbeLastCount = -1;
+        final sinceLastProgress = Stopwatch()..start();
         await waitUntilAsync(
           () async {
             final currentCount = await bobDb.getJournalCount();
@@ -918,6 +1083,13 @@ void main() {
               );
               lastBobCount = currentCount;
             }
+            await throwIfStalled(
+              device: bob,
+              currentCount: currentCount,
+              lastCount: stallProbeLastCount,
+              sinceLastProgress: sinceLastProgress,
+            );
+            stallProbeLastCount = currentCount;
             if (currentCount < expectedTotal) {
               final elapsed = catchupStopwatch.elapsed.inSeconds;
               if (elapsed > 0 && elapsed % 30 == 0) {

--- a/lib/features/sync/matrix/pipeline/bootstrap_forward_strategy.dart
+++ b/lib/features/sync/matrix/pipeline/bootstrap_forward_strategy.dart
@@ -110,6 +110,34 @@ Future<BootstrapResult> collectForwardForBootstrapImpl({
   }
   final anchorTs = TimelineEventOrdering.timestamp(anchor);
 
+  // What the context actually returned. A forward walk that emits nothing is
+  // indistinguishable from a healthy "already at the tip" unless we can see
+  // whether the server gave us events after the anchor at all, and whether it
+  // handed back a forward token. `anchorTs == newestTs` is the signature of a
+  // genuinely caught-up device; a missing forward window is not.
+  //
+  // Unguarded on purpose. Dart builds the message eagerly, so this scan runs
+  // even when the sync domain is disabled — but the list is one `/context`
+  // window (`Room.defaultHistoryCount` is 30) and we have just paid for the
+  // network round trip that produced it, so the cost is noise. Guarding on
+  // `DomainLogger.enabledDomains` would couple this to logger internals and
+  // trade real cost for none.
+  num? newestTs;
+  for (final event in timeline.events) {
+    final ts = TimelineEventOrdering.timestamp(event);
+    if (newestTs == null || ts > newestTs) newestTs = ts;
+  }
+  logging.log(
+    LogDomain.sync,
+    'bootstrap.forward.context '
+    'anchor=$anchorEventId '
+    'events=${timeline.events.length} '
+    'canRequestFuture=${timeline.canRequestFuture} '
+    'anchorTs=$anchorTs '
+    'newestTs=$newestTs',
+    subDomain: 'bootstrap.forward',
+  );
+
   var pageIndex = 0;
   var totalEventsSoFar = 0;
   num? newestTsSoFar;


### PR DESCRIPTION
The degraded-network job wastes **~13.5 minutes per stalled run, on every
branch**, and produces nothing usable when it does. This fixes the waste and
the blindness. It does not fix the underlying race — see the end.

## The waste

Both convergence tests wait up to 15 minutes for a device to catch up. When the
device is stuck they wait the entire 15 minutes and then fail with a bare
`TimeoutException`. Measured locally against dendrite + toxiproxy: the
cold-restart test started at **03:51 and gave up at 18:58**. When it passes, it
takes ~7 seconds.

A device that is genuinely catching up always has something outstanding: rows
in the inbound queue, or a bridge walk in flight. When the journal count has
not moved for 90s **and** the queue is empty **and** no bridge is running,
nothing is going to arrive and the rest of the wait is dead time.

Both waits now detect that and fail immediately with the diagnosis attached.

**Demonstrated**, on a run where both convergence tests hit the stall:

```
SyncStalled: no progress for 90s at 30 entries, with an empty inbound queue
and no bridge in flight. queue[total=0 ready=0 byProducer={}]
bridgeInFlight=false currentRoomId=!S9sWjKXC1ZCnHIL7:localhost

SyncStalled: no progress for 90s at 130 entries, ...

08:56 +1 -2: Some tests failed.
```

Caught at 90s each instead of 15 minutes each; whole suite **8:56 instead of
~30+**. A healthy run is unaffected — progress resets the timer, and the suite
still completes in ~6 minutes.

The failures are real and stay red. This changes how long they take to report,
not whether they report.

## The blindness

Sync has been **completely invisible in integration tests**, which is why this
stall survived undiagnosed. Two independent gates, either sufficient:

- `DomainLogger.enabledDomains` starts empty, so every
  `log(LogDomain.sync, ...)` is a no-op;
- `LoggingService._enableLogging` is `!isTestEnv`, so `captureEvent` returns
  early under `FLUTTER_TEST`.

Every `queue.bridge.*` line and every exception swallowed by
`saveRoom.bootstrap` has been discarded on every integration run this project
has ever done. A test-side echoing `DomainLogger` enables the sync domain,
prints the bridge/bootstrap/coordinator subdomains, and **always** prints
errors — a thrown bootstrap was previously indistinguishable from a no-op.

It works: the bridge is legible for the first time.

```
queue.bridge.start mode=reconnect.forward lastAppliedTs=... lastAppliedEventId=$s-x4D8...
queue.bootstrap.forward.done anchor=$s-x4D8... pages=0 events=0 accepted=0 stopReason=serverExhausted
queue.bridge.done completed=true
```

The walk runs, finds nothing, and reports success — so the 3×10s retry ladder
never engages and the backward fallback never runs (it needs `errorNoProgress`).

## The one production change

A single log line on the forward-walk context path: event count,
`canRequestFuture`, `anchorTs`, `newestTs`. That tuple separates a genuinely
caught-up device (`anchorTs == newestTs`, as seen on healthy runs) from one
that could not see the forward window — the distinction the whole question
turns on.

Left unguarded deliberately. Dart builds the message eagerly, but the list is
one `/context` window (`Room.defaultHistoryCount` = 30) and it follows the
network round trip that produced it. An earlier revision guarded it on
`DomainLogger.enabledDomains`; that coupled production code to logger
internals and broke 15 tests via an unstubbed mock getter, to save a cost that
is noise.

## Dead metrics

The cold-restart test gains a bridge-completion probe and a comment recording
that the metrics block printed beside it is **structurally zero**:
`catchupBatches`, `processed`, `skipped`, `failures`, `flushes`,
`retriesScheduled` and `circuitOpens` have no call sites anywhere in `lib/`.
Reading `catchupBatches: 0` as evidence is how this bug was first misdiagnosed.
Tracked separately as `lotti3-3xc` — they are also shown to users in the sync
metrics panel, where they read as "nothing is happening".

## What this does not fix

`lotti3-30b` (the race) stays open at P0. Its title is now known to be wrong
twice over: not "the bridge never runs" (that was the dead counter), and not
deterministic either — the suite passed in 5:51 with the cold-restart test
converging in 7s, then failed twice on the next run.

Fixing it needs one more piece of evidence: whether the forward walk's
`/context` returns an empty `events_after`, or returns events our
strictly-after filter rejects. A tempting fix — treat a zero-event walk as
incomplete — is **wrong as stated**, because a genuinely caught-up device emits
`pages=0 events=0 serverExhausted` too, and every idle bridge would then fire
three retries forever.

This PR is what produces that evidence: the next CI failure arrives in 90
seconds carrying the queue state, the bridge state and the context tuple,
instead of a bare timeout fifteen minutes late.

## Verification

- `flutter test test/features/sync/` — **3010 passed, 1 skipped**.
- `dart analyze lib integration_test` — no issues.
- Integration suite run twice: once healthy (5:51, all three pass), once with
  both convergence tests stalling (8:56, caught at 90s each).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics & Reliability**
  * Improved sync integration-test diagnostics with clearer progress tracking and stall detection.
  * Added visibility into sync-domain activity and bridge completions during convergence checks.
  * Enhanced bootstrap diagnostics by recording context timeline timestamps and pagination details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->