### PR TITLE
fix: stop the stall detector failing a device that is waiting on a key

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -271,7 +271,13 @@ Future<void> throwIfStalled({
 
   final coord = device.queueCoordinator;
   final stats = await coord.queue.stats();
-  final quiet = stats.total == 0 && !coord.isBridgeInFlight;
+  // Held ciphertext counts as outstanding. A `PendingDecryptionPen` entry has
+  // no queue row by design, so depth reads zero while the device is legitimately
+  // waiting for a Megolm key — for up to the pen's full retry window. Treating
+  // depth plus bridge state as exhaustive would turn a recoverable
+  // degraded-network run into a false failure.
+  final held = coord.heldCiphertextCount;
+  final quiet = stats.total == 0 && held == 0 && !coord.isBridgeInFlight;
 
   // Below the failing threshold, report rather than fail. Healthy degraded
   // runs have been measured going 62s without the journal count moving, so
@@ -283,6 +289,7 @@ Future<void> throwIfStalled({
       '[stall-probe] no progress for '
       '${sinceLastProgress.elapsed.inSeconds}s at $currentCount entries; '
       'quiet=$quiet queue[total=${stats.total} ready=${stats.readyNow}] '
+      'heldCiphertext=$held '
       'bridgeInFlight=${coord.isBridgeInFlight}',
     );
     return;
@@ -293,9 +300,11 @@ Future<void> throwIfStalled({
   throw _SyncStalledException(
     'no progress for ${sinceLastProgress.elapsed.inSeconds}s at '
     '$currentCount entries, with an empty inbound queue and no bridge in '
-    'flight. Nothing is outstanding, so the remaining wait cannot help. '
+    'flight, and no ciphertext awaiting a key. Nothing is outstanding, so the '
+    'remaining wait cannot help. '
     'queue[total=${stats.total} ready=${stats.readyNow} '
     'byProducer=${stats.byProducer}] '
+    'heldCiphertext=$held '
     'bridgeInFlight=${coord.isBridgeInFlight} '
     'currentRoomId=${device.syncRoomId}',
   );
@@ -765,20 +774,19 @@ void main() {
 
         // Join the existing room (the new client needs to re-join)
         await bob.joinRoom(roomId);
-        // Save room so pipeline attaches to it (triggers start + forceRescan)
-        await bob.saveRoom(roomId);
-        debugPrint('Bob re-joined room $roomId');
 
-        // Allow startup catch-up to run (sync wait is up to 30s, plus
-        // catch-up pagination time for the backlog)
-        await Future<void>.delayed(const Duration(seconds: 5));
-
-        // Count real bridge completions. The metrics block printed below is
-        // NOT a substitute: `catchupBatches`, `processed`, `skipped`,
-        // `failures`, `flushes`, `retriesScheduled` and `circuitOpens` all
-        // have zero call sites in lib/ — they are structurally zero whatever
-        // sync does, and reading one as evidence is how this failure was
-        // misdiagnosed. Only `dbApplied` is wired.
+        // Attach BEFORE saveRoom. saveRoom kicks the bootstrap asynchronously,
+        // so a probe installed afterwards can miss a bridge that has already
+        // finished — leaving a zero count that reads exactly like the "never
+        // ran" diagnosis this instrumentation exists to disprove. (It did, on
+        // the first instrumented run.)
+        //
+        // The metrics block printed later is not a substitute:
+        // `catchupBatches`, `processed`, `skipped`, `failures`, `flushes`,
+        // `retriesScheduled` and `circuitOpens` have zero call sites in lib/,
+        // so they are structurally zero whatever sync does. Only `dbApplied`
+        // is wired. Reading one of them as evidence is how this bug was first
+        // misdiagnosed.
         var bridgeCompletions = 0;
         final priorOnBridgeCompleted = bob.queueCoordinator.onBridgeCompleted;
         bob.queueCoordinator.onBridgeCompleted = () {
@@ -786,6 +794,14 @@ void main() {
           debugPrint('[probe] bridge completed #$bridgeCompletions');
           priorOnBridgeCompleted?.call();
         };
+
+        // Save room so pipeline attaches to it (triggers start + forceRescan)
+        await bob.saveRoom(roomId);
+        debugPrint('Bob re-joined room $roomId');
+
+        // Allow startup catch-up to run (sync wait is up to 30s, plus
+        // catch-up pagination time for the backlog)
+        await Future<void>.delayed(const Duration(seconds: 5));
 
         Future<String> queueSnapshot() async {
           final coord = bob.queueCoordinator;

--- a/lib/features/sync/matrix/pipeline/bootstrap_forward_strategy.dart
+++ b/lib/features/sync/matrix/pipeline/bootstrap_forward_strategy.dart
@@ -116,25 +116,50 @@ Future<BootstrapResult> collectForwardForBootstrapImpl({
   // handed back a forward token. `anchorTs == newestTs` is the signature of a
   // genuinely caught-up device; a missing forward window is not.
   //
-  // Unguarded on purpose. Dart builds the message eagerly, so this scan runs
-  // even when the sync domain is disabled — but the list is one `/context`
-  // window (`Room.defaultHistoryCount` is 30) and we have just paid for the
-  // network round trip that produced it, so the cost is noise. Guarding on
-  // `DomainLogger.enabledDomains` would couple this to logger internals and
-  // trade real cost for none.
+  // What the context actually returned, so an empty walk can be told apart
+  // from a healthy one.
+  //
+  // `strictlyAfter` is the load-bearing number, not `newestTs`. Ordering here
+  // is by `(timestamp, eventId)`, so a burst can put later events on the same
+  // millisecond as the anchor — and then `newestTs == anchorTs` even though
+  // events genuinely sort after it. Reporting timestamps alone would show the
+  // "caught up" signature for precisely the missing-forward-window case this
+  // exists to identify. Counting through the same predicate the page filter
+  // uses cannot drift from it.
+  //
+  // Unguarded on purpose: Dart builds the message eagerly, but the list is one
+  // `/context` window (`Room.defaultHistoryCount` is 30) and it follows the
+  // network round trip that produced it, so the cost is noise.
   num? newestTs;
+  String? newestEventId;
+  var strictlyAfter = 0;
   for (final event in timeline.events) {
     final ts = TimelineEventOrdering.timestamp(event);
-    if (newestTs == null || ts > newestTs) newestTs = ts;
+    if (newestTs == null ||
+        ts > newestTs ||
+        (ts == newestTs &&
+            (newestEventId == null ||
+                event.eventId.compareTo(newestEventId) > 0))) {
+      newestTs = ts;
+      newestEventId = event.eventId;
+    }
+    if (CatchUpStrategy.isStrictlyAfter(
+      event,
+      anchorTs: anchorTs,
+      anchorEventId: anchorEventId,
+    )) {
+      strictlyAfter++;
+    }
   }
   logging.log(
     LogDomain.sync,
     'bootstrap.forward.context '
     'anchor=$anchorEventId '
     'events=${timeline.events.length} '
+    'strictlyAfter=$strictlyAfter '
     'canRequestFuture=${timeline.canRequestFuture} '
     'anchorTs=$anchorTs '
-    'newestTs=$newestTs',
+    'newestTs=$newestTs newestEventId=$newestEventId',
     subDomain: 'bootstrap.forward',
   );
 

--- a/lib/features/sync/queue/queue_pipeline_coordinator.dart
+++ b/lib/features/sync/queue/queue_pipeline_coordinator.dart
@@ -248,6 +248,15 @@ class QueuePipelineCoordinator {
   /// events still in the pipe.
   bool get isBridgeInFlight => _bridge.isBridgeInFlight;
 
+  /// How many encrypted events are held awaiting their Megolm key.
+  ///
+  /// Part of "is anything still outstanding?", and invisible without this: a
+  /// penned event deliberately has no queue row, so queue depth reads zero
+  /// while the work is very much in progress. A caller that treats depth plus
+  /// bridge state as exhaustive will mistake a device waiting on a key for a
+  /// device that has stopped.
+  int get heldCiphertextCount => _pen.size;
+
   /// Callback that fires once per terminal bridge pass. Intended for
   /// the backfill request service to be nudged the moment the walk
   /// settles, so it can dispatch requests for any entries still


### PR DESCRIPTION
Follow-up to #3620, addressing its three review findings. Two of them would
have made the instrumentation worse than what it replaced.

## The stall detector could fail a healthy device

It treated "empty inbound queue + idle bridge" as proof that nothing was
outstanding. It is not.

A `PendingDecryptionPen` entry has **no queue row by design** — that is the
entire point, since pre-decryption ciphertext must never reach `raw_json`,
where an `Event.fromJson` round trip re-materialises it undecrypted and the
payload is lost. So queue depth reads zero while the device is legitimately
waiting for a Megolm key, for up to the pen's full retry window.

A degraded-network run that would have recovered would instead have failed
after 90 seconds. **A flaky red costs more than the slow red it replaced**, so
this matters more than the 13.5 minutes #3620 saved.

The quiet check now counts held ciphertext, via a read-only
`heldCiphertextCount` on `QueuePipelineCoordinator`. The failure message and
the 20s `[stall-probe]` line both report it.

## The context diagnostic was broken in exactly its intended case

Ordering here is by `(timestamp, eventId)`, not timestamp alone. A burst can
put later events on the *same millisecond* as the anchor — so `newestTs ==
anchorTs` holds even though those events genuinely sort after it.

That is the documented "genuinely caught up" signature. The diagnostic would
therefore have reported *caught up* for precisely the missing-forward-window
failure it was added to identify.

It now reports **`strictlyAfter`** — the count of events that pass
`CatchUpStrategy.isStrictlyAfter`, the same predicate the page filter uses, so
the diagnostic cannot drift from the behaviour it describes — plus the newest
`(ts, eventId)` pair rather than a bare timestamp.

## The probe attached too late

`saveRoom` kicks the bootstrap asynchronously, so a fast bridge could finish
before the completion probe existed.

Not hypothetical: the first instrumented run reported `bridgeCompletions=0` for
exactly this reason, recreating the "never ran" reading the probe was added to
disprove. It now attaches before `saveRoom`, with a comment recording why.

## Verification

- `flutter test test/features/sync/` — **3010 passed, 1 skipped, 0 failed**.
- `dart analyze lib integration_test` — no issues.
- Production surface is one new read-only getter plus two extra fields on an
  existing log line.

## Still open

`lotti3-30b` — the underlying race — remains P0 and unfixed. #3620 plus this
PR are what will produce the evidence to close it: a failing CI run now reports
in ~90s carrying queue depth, held-ciphertext count, bridge state and the
`strictlyAfter` count, instead of a bare `TimeoutException` fifteen minutes
late.
