### PR TITLE
ci: cache Matrix test dependencies

### DIFF
--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -127,7 +127,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries

--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Cache Pub Packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -44,6 +49,7 @@ jobs:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           cache: true
+          pub-cache: false
       - name: Get Flutter dependencies
         run: flutter pub get --offline --enforce-lockfile || flutter pub get --enforce-lockfile
       - uses: hoverkraft-tech/compose-action@v2.0.0
@@ -67,6 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Cache Pub Packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -91,6 +102,7 @@ jobs:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           cache: true
+          pub-cache: false
       - name: Get Flutter dependencies
         run: flutter pub get --offline --enforce-lockfile || flutter pub get --enforce-lockfile
       - uses: hoverkraft-tech/compose-action@v2.0.0
@@ -111,6 +123,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Cache Pub Packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -135,6 +152,7 @@ jobs:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           cache: true
+          pub-cache: false
       - name: Get Flutter dependencies
         run: flutter pub get --offline --enforce-lockfile || flutter pub get --enforce-lockfile
       - uses: hoverkraft-tech/compose-action@v2.0.0

--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          key: ${{ runner.os }}-pub-v1-${{ hashFiles('pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          key: ${{ runner.os }}-pub-v1-${{ hashFiles('pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
@@ -127,7 +127,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          key: ${{ runner.os }}-pub-v1-${{ hashFiles('pubspec.lock') }}
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries

--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          cache: true
+      - name: Get Flutter dependencies
+        run: flutter pub get --offline --enforce-lockfile || flutter pub get --enforce-lockfile
       - uses: hoverkraft-tech/compose-action@v2.0.0
         with:
           cwd: "integration_test/docker"
@@ -55,7 +58,7 @@ jobs:
           run: |
             chmod +x ./setup_toxiproxy_docker.sh ./run_matrix_tests.sh
             ./setup_toxiproxy_docker.sh
-            ./run_matrix_tests.sh
+            ./run_matrix_tests.sh --no-pub
 
   test_actor_isolate:
     name: Matrix Actor Isolate Test on Linux
@@ -87,6 +90,9 @@ jobs:
         with:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          cache: true
+      - name: Get Flutter dependencies
+        run: flutter pub get --offline --enforce-lockfile || flutter pub get --enforce-lockfile
       - uses: hoverkraft-tech/compose-action@v2.0.0
         with:
           cwd: "integration_test/docker"
@@ -96,7 +102,7 @@ jobs:
           working-directory: ./integration_test
           run: |
             chmod +x ./run_matrix_actor_isolate_test.sh
-            ./run_matrix_actor_isolate_test.sh
+            ./run_matrix_actor_isolate_test.sh --no-pub
 
   test_degraded_network:
     name: Matrix Test on Linux with degraded network
@@ -128,6 +134,9 @@ jobs:
         with:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          cache: true
+      - name: Get Flutter dependencies
+        run: flutter pub get --offline --enforce-lockfile || flutter pub get --enforce-lockfile
       - uses: hoverkraft-tech/compose-action@v2.0.0
         with:
           cwd: "integration_test/docker"
@@ -140,4 +149,4 @@ jobs:
           run: |
             chmod +x ./setup_toxiproxy_docker.sh ./run_matrix_tests.sh
             ./setup_toxiproxy_docker.sh
-            ./run_matrix_tests.sh
+            ./run_matrix_tests.sh --no-pub


### PR DESCRIPTION
## What

- cache the pinned Flutter SDK in all three Matrix integration jobs
- cache `~/.pub-cache` by the root `pubspec.lock`, with a versioned key for safe cache-schema changes
- resolve locked dependencies once before each test, preferring offline resolution on an exact hit and falling back online on a cold or incomplete cache
- pass `--no-pub` to each integration test runner so `flutter test` does not repeat dependency resolution
- avoid recursive `hashFiles('**/pubspec.lock')`, which traversed generated Flutter plugin symlinks and failed during post-job cache evaluation

## Baseline

Measured from [run 30235629159](https://github.com/matthiasn/lotti/actions/runs/30235629159):

| Job | Total | apt | Flutter setup | Implicit pub get | Linux build | Setup through built app |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Regular Matrix | 11:27 | 0:42 | 0:57 | 0:39 | 2:10 | 5:13 |
| Degraded Matrix | 10:24 | 0:51 | 1:00 | 0:46 | 2:06 | 5:35 |

`Setup through built app` is measured from job start through the `✓ Built build/linux/.../lotti` log line, immediately before the integration workload.

## Cold and warm results

The final workflow was exercised with a deliberately new `pub-v1` key in [cold attempt 1](https://github.com/matthiasn/lotti/actions/runs/30258467530/attempts/1), then rerun unchanged in [warm attempt 2](https://github.com/matthiasn/lotti/actions/runs/30258467530/attempts/2). Both attempts passed all three Matrix jobs, including post-cache teardown.

| Job | Baseline total | Cold total | Warm total | Baseline setup | Cold setup | Warm setup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Regular Matrix | 11:27 | 11:10 (-0:17) | 11:29 (+0:02) | 5:13 | 4:57 (-0:16) | 4:50 (-0:23) |
| Degraded Matrix | 10:24 | 8:56 (-1:28) | 8:29 (-1:55) | 5:35 | 4:15 (-1:20) | 3:47 (-1:48) |
| Actor isolate | — | 5:47 | 3:48 (-1:59 vs cold) | — | — | — |

The regular warm run's setup was 23 seconds faster, but its post-build test workload varied upward by about 25 seconds and masked that saving in the end-to-end total. The cold run shows a 17-second end-to-end reduction with nearly identical post-build workload. The degraded job improved end-to-end by 14% cold and 18% warm.

Cold-cache evidence:

- all three jobs logged `Cache not found` for the new Pub key
- online dependency resolution completed in 41–49 seconds
- the actor job saved a 533,729,966-byte Pub archive; the two concurrent jobs handled the existing-key race without failing

Warm-cache evidence:

- all three jobs restored the exact 533,729,966-byte Pub cache in 5–7 seconds
- locked offline dependency resolution completed in 6–7 seconds per GitHub step (about 2.5 seconds inside `flutter pub get`)
- Flutter SDK setup completed in 12–17 seconds, versus 57–60 seconds at baseline

## Cache choices

Docker image pulls were about five seconds in the baseline logs; compose startup including health checks was only 14–17 seconds. Caching image tarballs would add archive restore and unpack work for little potential gain, so this PR deliberately leaves Docker images uncached.

Apt setup remains variable because package installation is still required on every ephemeral runner. Caching downloaded `.deb` files would not eliminate unpack/configuration time and lacks evidence that transfer savings exceed cache overhead.

## Validation

- `actionlint` v1.7.12
- `git diff --check`
- local `fvm flutter analyze`: zero issues
- local locked offline dependency resolution
- cold and warm Matrix workflow attempts: all jobs pass
- after rebasing onto the latest `main`, [run 30259979115](https://github.com/matthiasn/lotti/actions/runs/30259979115) passes actor (4:14), degraded (5:09), and regular (6:20)
- full PR CI on the rebased head passes: Flutter analyzer, all ten unit/widget shards, Glados property tests, CodeQL, knowledge validation, and Matrix integration tests

No CHANGELOG or metainfo entry is included because this is an internal CI-only change with no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Flutter matrix test reliability by installing locked dependencies before test execution.
  * Added package caching to reduce setup time across test runs.
  * Updated integration tests to use preinstalled dependencies without fetching packages during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->