### PR TITLE
fix: notify on sync-room clears, and stop clearing state during build

### DIFF
--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -271,10 +271,11 @@ reach the wrong device or none at all:
   while its sheet is open, so every rebuild would consume another peer and
   leave a newly paired device with nothing once the lock freed.
 - Clearing that record once nothing is unverified is **deferred to a
-  post-frame callback**. Riverpod rejects a provider write during widget
-  construction, and this branch is reached by the *successful* verification of
-  the last device — so clearing inline turned the normal end of the flow into
-  an exception.
+  post-frame callback**, because Riverpod rejects a provider write during
+  widget construction. The empty-list branch runs on initial mount too, but it
+  only writes when the set is non-empty — which is the *successful*
+  verification of the last pending device. Clearing inline was therefore silent
+  in the common case and threw at the normal end of the flow.
 
 Whether the settings surface shows the roster or the pairing setup card is
 `syncConfiguredProvider` (`state/sync_configured_provider.dart`): logged in

--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -270,6 +270,23 @@ reach the wrong device or none at all:
   ceremony holding the lock invalidates the unverified provider repeatedly
   while its sheet is open, so every rebuild would consume another peer and
   leave a newly paired device with nothing once the lock freed.
+- Clearing that record once nothing is unverified is **deferred to a
+  post-frame callback**. Riverpod rejects a provider write during widget
+  construction, and this branch is reached by the *successful* verification of
+  the last device — so clearing inline turned the normal end of the flow into
+  an exception.
+
+Whether the settings surface shows the roster or the pairing setup card is
+`syncConfiguredProvider` (`state/sync_configured_provider.dart`): logged in
+**and** holding a room id. Neither half notifies on its own —
+`MatrixService.syncRoomId` is a plain read through to a plain field — so the
+provider watches three signals and then reads the service once for the current
+truth. Login state alone is not enough, and the gap is not theoretical:
+`SyncSessionManager.connect()` drops a persisted room the account can no longer
+join (`M_FORBIDDEN`/`M_NOT_FOUND`) *after* the login event has already fired,
+leaving the roster on screen for a room that no longer exists.
+`SyncRoomManager.roomIdChanges` closes that — every mutation of the room id
+goes through one private setter, so no path can change it without emitting.
 
 `matrixVerificationRelaunchProvider` is what "show the emoji again" bumps. It
 releases only the identity that launcher last showed, deliberately rather than

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -235,6 +235,11 @@ class MatrixService {
   MatrixConfig? get matrixConfig => _sessionManager.matrixConfig;
 
   String? get syncRoomId => _roomManager.currentRoomId;
+
+  /// The sync room id on every change, null when cleared — for UI that gates
+  /// on whether sync is configured. [syncRoomId] is a plain read and cannot
+  /// notify on its own.
+  Stream<String?> get syncRoomIdChanges => _roomManager.roomIdChanges;
   Room? get syncRoom => _roomManager.currentRoom;
   Stream<SyncRoomInvite> get inviteRequests => _roomManager.inviteRequests;
 

--- a/lib/features/sync/matrix/sync_room_manager.dart
+++ b/lib/features/sync/matrix/sync_room_manager.dart
@@ -48,6 +48,17 @@ class SyncRoomManager {
   final StreamController<SyncRoomInvite> _inviteController =
       StreamController<SyncRoomInvite>.broadcast();
 
+  /// Emits whenever the sync room changes, including when it is cleared.
+  ///
+  /// `currentRoomId` is a plain field, so UI that gates on "is sync
+  /// configured" had nothing to rebuild on. That matters most for the clear
+  /// path: `SyncSessionManager.connect()` drops a persisted room the account
+  /// can no longer join *after* the login event has already fired, so a
+  /// login-only signal leaves the device roster on screen for a room that no
+  /// longer exists.
+  final StreamController<String?> _roomIdController =
+      StreamController<String?>.broadcast();
+
   StreamSubscription<RoomInviteEvent>? _inviteSubscription;
   Room? _currentRoom;
   String? _currentRoomId;
@@ -61,6 +72,17 @@ class SyncRoomManager {
   /// Emits invite requests that passed validation. The UI is expected to prompt
   /// the user and explicitly call [acceptInvite] when appropriate.
   Stream<SyncRoomInvite> get inviteRequests => _inviteController.stream;
+
+  /// The sync room id on every change, null when cleared.
+  Stream<String?> get roomIdChanges => _roomIdController.stream;
+
+  /// Single write point for [currentRoomId] so no mutation can skip the
+  /// notification. Silent when the value is unchanged.
+  void _setCurrentRoomId(String? roomId) {
+    if (_currentRoomId == roomId) return;
+    _currentRoomId = roomId;
+    if (!_roomIdController.isClosed) _roomIdController.add(roomId);
+  }
 
   /// Discovers existing Lotti sync rooms that this user is a member of.
   ///
@@ -161,7 +183,7 @@ class SyncRoomManager {
       await _gateway.leaveRoom(roomId);
       await _settingsDb.removeSettingsItem(matrixRoomKey);
       _currentRoom = null;
-      _currentRoomId = null;
+      _setCurrentRoomId(null);
 
       _loggingService.log(
         LogDomain.sync,
@@ -188,7 +210,7 @@ class SyncRoomManager {
         try {
           await _settingsDb.removeSettingsItem(matrixRoomKey);
           _currentRoom = null;
-          _currentRoomId = null;
+          _setCurrentRoomId(null);
           _loggingService.log(
             LogDomain.sync,
             'Cleared persisted state for $roomId (server says not in room).',
@@ -227,7 +249,7 @@ class SyncRoomManager {
     final previous = _currentRoomId;
     await _settingsDb.removeSettingsItem(matrixRoomKey);
     _currentRoom = null;
-    _currentRoomId = null;
+    _setCurrentRoomId(null);
     _loggingService.log(
       LogDomain.sync,
       'Cleared persisted sync room (was: ${previous ?? 'none'}).',
@@ -244,7 +266,7 @@ class SyncRoomManager {
 
     final savedRoomId = await _settingsDb.itemByKey(matrixRoomKey);
     if (savedRoomId != null) {
-      _currentRoomId = savedRoomId;
+      _setCurrentRoomId(savedRoomId);
     }
     return savedRoomId;
   }
@@ -332,10 +354,11 @@ class SyncRoomManager {
   Future<void> dispose() async {
     await _inviteSubscription?.cancel();
     await _inviteController.close();
+    await _roomIdController.close();
   }
 
   Room? _updateCurrentRoom(String roomId) {
-    _currentRoomId = roomId;
+    _setCurrentRoomId(roomId);
     _currentRoom = _gateway.getRoomById(roomId);
 
     if (_currentRoom == null) {
@@ -396,7 +419,7 @@ class SyncRoomManager {
     }
 
     _currentRoom = room;
-    _currentRoomId = roomId;
+    _setCurrentRoomId(roomId);
     return room;
   }
 }

--- a/lib/features/sync/state/sync_configured_provider.dart
+++ b/lib/features/sync/state/sync_configured_provider.dart
@@ -16,15 +16,19 @@ import 'package:lotti/providers/service_providers.dart';
 /// [provisioningControllerProvider] does not rescue it either — it stays
 /// `initial` for a session that was restored rather than freshly paired.
 ///
-/// [loginStateStreamProvider] is the missing signal: its transitions drive the
-/// rebuild, and the service is then read for the current truth.
+/// Login state alone is not enough either, and the gap is not theoretical:
+/// `SyncSessionManager.connect()` drops a persisted room the account can no
+/// longer join (`M_FORBIDDEN`/`M_NOT_FOUND`) *after* the login event has
+/// fired, so a login-only signal leaves the device roster on screen for a room
+/// that no longer exists. [syncRoomChangesProvider] closes that.
 final Provider<bool> syncConfiguredProvider = Provider.autoDispose<bool>(
   (ref) {
-    // Rebuild triggers. The values are deliberately not used directly: login
-    // state alone does not tell us about the room, and provisioning state
-    // tells us only about a pairing run in this session.
+    // Rebuild triggers. The values are deliberately not used directly: each
+    // signal covers a different transition, and the service is then read once
+    // for the current truth.
     ref
       ..watch(loginStateStreamProvider)
+      ..watch(syncRoomChangesProvider)
       ..watch(provisioningControllerProvider);
 
     final service = ref.watch(matrixServiceProvider);
@@ -32,3 +36,10 @@ final Provider<bool> syncConfiguredProvider = Provider.autoDispose<bool>(
   },
   name: 'syncConfiguredProvider',
 );
+
+/// Sync-room transitions, including clears.
+final StreamProvider<String?> syncRoomChangesProvider =
+    StreamProvider.autoDispose<String?>(
+      (ref) => ref.watch(matrixServiceProvider).syncRoomIdChanges,
+      name: 'syncRoomChangesProvider',
+    );

--- a/lib/features/sync/ui/widgets/matrix/auto_verification_launcher.dart
+++ b/lib/features/sync/ui/widgets/matrix/auto_verification_launcher.dart
@@ -105,7 +105,15 @@ class _AutoVerificationLauncherState
 
     if (unverifiedDevices.isEmpty) {
       _lastOffered = null;
-      ref.read(matrixVerificationHandledProvider.notifier).clear();
+      // Deferred: this branch is reached by the *successful* verification of
+      // the last pending device, and Riverpod rejects a provider write during
+      // widget construction — so clearing inline turned the normal success
+      // transition into a provider-modification exception.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          ref.read(matrixVerificationHandledProvider.notifier).clear();
+        }
+      });
       return const SizedBox.shrink();
     }
 

--- a/lib/features/sync/ui/widgets/matrix/auto_verification_launcher.dart
+++ b/lib/features/sync/ui/widgets/matrix/auto_verification_launcher.dart
@@ -105,10 +105,12 @@ class _AutoVerificationLauncherState
 
     if (unverifiedDevices.isEmpty) {
       _lastOffered = null;
-      // Deferred: this branch is reached by the *successful* verification of
-      // the last pending device, and Riverpod rejects a provider write during
-      // widget construction — so clearing inline turned the normal success
-      // transition into a provider-modification exception.
+      // Deferred because Riverpod rejects a provider write during widget
+      // construction. This branch runs on any empty list — including initial
+      // mount — but only writes when the set is non-empty, which is reached by
+      // the *successful* verification of the last pending device. Clearing
+      // inline therefore left the common case silent and turned the normal
+      // success transition into a provider-modification exception.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           ref.read(matrixVerificationHandledProvider.notifier).clear();

--- a/test/features/sync/matrix/matrix_service_test.dart
+++ b/test/features/sync/matrix/matrix_service_test.dart
@@ -157,6 +157,17 @@ void main() {
       expect(service.syncRoomId, '!room:s');
     });
 
+    test('syncRoomIdChanges forwards the room manager stream', () async {
+      // The UI gate for "is sync configured" hangs off this; a getter that
+      // returned a fresh empty stream would leave the roster stale forever.
+      final changes = Stream<String?>.fromIterable(['!room:s', null]);
+      when(() => roomManager.roomIdChanges).thenAnswer((_) => changes);
+
+      final service = createService();
+
+      expect(await service.syncRoomIdChanges.toList(), ['!room:s', null]);
+    });
+
     test('isLoggedIn delegates to session manager', () {
       when(() => sessionManager.isLoggedIn()).thenReturn(true);
 

--- a/test/features/sync/matrix/sync_room_manager_test.dart
+++ b/test/features/sync/matrix/sync_room_manager_test.dart
@@ -1019,4 +1019,60 @@ void main() {
       ).called(1);
     });
   });
+
+  group('roomIdChanges', () {
+    test('emits on join and on clear, so UI can gate on configured', () async {
+      // `currentRoomId` is a plain field. Without this stream the device
+      // roster stays on screen for a room the account can no longer join,
+      // because the clear happens after the login event has already fired.
+      when(
+        () => settingsDb.saveSettingsItem(matrixRoomKey, '!room:server'),
+      ).thenAnswer((_) async => 1);
+      when(() => gateway.getRoomById('!room:server')).thenReturn(MockRoom());
+
+      final seen = <String?>[];
+      final sub = manager.roomIdChanges.listen(seen.add);
+      addTearDown(sub.cancel);
+
+      await manager.saveRoomId('!room:server');
+      await manager.clearPersistedRoom();
+      await pumpEventQueue();
+
+      expect(seen, ['!room:server', null]);
+    });
+
+    test(
+      'stays silent when the id is set to the value it already has',
+      () async {
+        when(
+          () => settingsDb.saveSettingsItem(matrixRoomKey, '!room:server'),
+        ).thenAnswer((_) async => 1);
+        when(() => gateway.getRoomById('!room:server')).thenReturn(MockRoom());
+
+        final seen = <String?>[];
+        final sub = manager.roomIdChanges.listen(seen.add);
+        addTearDown(sub.cancel);
+
+        await manager.saveRoomId('!room:server');
+        await manager.saveRoomId('!room:server');
+        await pumpEventQueue();
+
+        // A re-save on every sync tick would otherwise rebuild the roster
+        // repeatedly for no change.
+        expect(seen, ['!room:server']);
+      },
+    );
+
+    test(
+      'a clear after dispose does not throw on the closed controller',
+      () async {
+        await manager.dispose();
+
+        // dispose() is racy by nature: teardown can land while a leave is still
+        // in flight, and an add on a closed controller would surface as an
+        // unhandled error rather than a no-op.
+        await expectLater(manager.clearPersistedRoom(), completes);
+      },
+    );
+  });
 }

--- a/test/features/sync/state/sync_configured_provider_test.dart
+++ b/test/features/sync/state/sync_configured_provider_test.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/sync/state/matrix_login_controller.dart';
+import 'package:lotti/features/sync/state/sync_configured_provider.dart';
+import 'package:lotti/providers/service_providers.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  late MockMatrixService service;
+  late StreamController<LoginState> loginStates;
+  late StreamController<String?> roomIds;
+
+  /// Mutable backing values so a test can change what the service reports and
+  /// then push the signal that is supposed to make the provider notice.
+  late bool loggedIn;
+  late String? roomId;
+
+  setUp(() {
+    service = MockMatrixService();
+    loginStates = StreamController<LoginState>.broadcast();
+    roomIds = StreamController<String?>.broadcast();
+    loggedIn = true;
+    roomId = '!room:server';
+
+    when(service.isLoggedIn).thenAnswer((_) => loggedIn);
+    when(() => service.syncRoomId).thenAnswer((_) => roomId);
+    when(() => service.syncRoomIdChanges).thenAnswer((_) => roomIds.stream);
+  });
+
+  tearDown(() async {
+    await loginStates.close();
+    await roomIds.close();
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        matrixServiceProvider.overrideWithValue(service),
+        // Overridden rather than stubbed through the Matrix client: the real
+        // provider reads `service.client.onLoginStateChanged`, which is not
+        // what this composition is about.
+        loginStateStreamProvider.overrideWith((_) => loginStates.stream),
+      ],
+    );
+    addTearDown(container.dispose);
+    // autoDispose providers need a listener to stay alive between reads.
+    container.listen(syncConfiguredProvider, (_, _) {});
+    return container;
+  }
+
+  group('syncConfiguredProvider', () {
+    test('is true only when logged in with a room', () {
+      expect(makeContainer().read(syncConfiguredProvider), isTrue);
+    });
+
+    test('is false when logged in without a room', () {
+      roomId = null;
+      expect(makeContainer().read(syncConfiguredProvider), isFalse);
+    });
+
+    test('is false when a room is persisted but the session is logged out', () {
+      loggedIn = false;
+      expect(makeContainer().read(syncConfiguredProvider), isFalse);
+    });
+
+    test('flips to false when the room is cleared after login', () async {
+      // The regression this exists for: `SyncSessionManager.connect()` drops a
+      // room the account can no longer join *after* the login event has
+      // fired, so a login-only signal left the device roster on screen for a
+      // room that no longer exists.
+      final container = makeContainer();
+      expect(container.read(syncConfiguredProvider), isTrue);
+
+      roomId = null;
+      roomIds.add(null);
+      await pumpEventQueue();
+
+      expect(container.read(syncConfiguredProvider), isFalse);
+    });
+
+    test(
+      'flips to true when a room arrives on an already-logged-in session',
+      () async {
+        // Pairing completes mid-session: login state does not change, only the
+        // room does.
+        roomId = null;
+        final container = makeContainer();
+        expect(container.read(syncConfiguredProvider), isFalse);
+
+        roomId = '!fresh:server';
+        roomIds.add('!fresh:server');
+        await pumpEventQueue();
+
+        expect(container.read(syncConfiguredProvider), isTrue);
+      },
+    );
+
+    test(
+      'flips to false when the session logs out with the room intact',
+      () async {
+        final container = makeContainer();
+        expect(container.read(syncConfiguredProvider), isTrue);
+
+        loggedIn = false;
+        loginStates.add(LoginState.loggedOut);
+        await pumpEventQueue();
+
+        expect(container.read(syncConfiguredProvider), isFalse);
+      },
+    );
+  });
+
+  group('syncRoomChangesProvider', () {
+    test('forwards the service stream, including the clear', () async {
+      final container = makeContainer();
+      final seen = <String?>[];
+      container.listen(
+        syncRoomChangesProvider,
+        (_, next) {
+          if (next case AsyncData(:final value)) seen.add(value);
+        },
+        fireImmediately: true,
+      );
+
+      roomIds
+        ..add('!room:server')
+        ..add(null);
+      await pumpEventQueue();
+
+      expect(seen, ['!room:server', null]);
+    });
+  });
+}

--- a/test/features/sync/ui/provisioned_sync_page_test.dart
+++ b/test/features/sync/ui/provisioned_sync_page_test.dart
@@ -106,8 +106,16 @@ void main() {
       // never notifies when login and room hydration complete. Init runs
       // unawaited at bootstrap, so a route opened mid-startup used to keep the
       // setup card until the user navigated away and back.
-      final loginState = StreamController<LoginState>.broadcast();
-      addTearDown(loginState.close);
+      // A finite stream rather than a controller closed at teardown: the page
+      // stays subscribed through `loginStateStreamProvider`, and closing a
+      // broadcast controller during async widget teardown can race the
+      // listener under the bundled runner (see test/README.md).
+      final loginGate = Completer<void>();
+      Stream<LoginState> loginStates() async* {
+        await loginGate.future;
+        yield LoginState.loggedIn;
+      }
+
       var configured = false;
       when(mockMatrixService.isLoggedIn).thenAnswer((_) => configured);
       when(
@@ -128,7 +136,7 @@ void main() {
         RiverpodWidgetTestBench(
           overrides: [
             matrixServiceProvider.overrideWithValue(mockMatrixService),
-            loginStateStreamProvider.overrideWith((_) => loginState.stream),
+            loginStateStreamProvider.overrideWith((_) => loginStates()),
           ],
           child: const ProvisionedSyncPage(),
         ),
@@ -140,12 +148,17 @@ void main() {
       // Startup completes: the login stream is the signal that gets the page
       // to re-evaluate.
       configured = true;
-      loginState.add(LoginState.loggedIn);
+      loginGate.complete();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(find.byType(ProvisionedStatusWidget), findsOneWidget);
       expect(find.byType(ProvisionedSyncSettingsCard), findsNothing);
+
+      // Unmount inside the test body so the stream's subscription is torn
+      // down here rather than racing teardown.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
     },
   );
 

--- a/test/features/sync/ui/widgets/matrix/auto_verification_launcher_test.dart
+++ b/test/features/sync/ui/widgets/matrix/auto_verification_launcher_test.dart
@@ -11,11 +11,23 @@ import 'package:lotti/features/sync/ui/widgets/matrix/auto_verification_launcher
 import 'package:lotti/features/sync/ui/widgets/matrix/verification_modal.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/providers/service_providers.dart';
+import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../../mocks/mocks.dart';
 import '../../../../../widget_test_utils.dart';
 import '../../provisioned/provisioned_status_page_test_helpers.dart';
+
+/// Reads its list on every build so a test can change what is unverified and
+/// invalidate, the way a completed ceremony does in production.
+class _MutableUnverifiedController extends MatrixUnverifiedController {
+  _MutableUnverifiedController(this.source);
+
+  final List<DeviceKeys> Function() source;
+
+  @override
+  Future<List<DeviceKeys>> build() async => source();
+}
 
 /// Stands in for a manual or incoming ceremony already owning the lock.
 class _HeldLock extends MatrixVerificationModalLock {
@@ -54,6 +66,7 @@ void main() {
     WidgetTester tester,
     List<MockDeviceKeys> unverified, {
     List<Override> extraOverrides = const [],
+    MatrixUnverifiedController Function()? unverifiedController,
   }) async {
     late ProviderContainer container;
     await tester.pumpWidget(
@@ -61,7 +74,8 @@ void main() {
         overrides: [
           matrixServiceProvider.overrideWithValue(mockMatrixService),
           matrixUnverifiedControllerProvider.overrideWith(
-            () => FakeMatrixUnverifiedController(unverified),
+            unverifiedController ??
+                () => FakeMatrixUnverifiedController(unverified),
           ),
           syncDevicesControllerProvider.overrideWith(
             () => FakeSyncDevicesController(const []),
@@ -122,34 +136,73 @@ void main() {
       );
     });
 
-    testWidgets('show-again re-offers the last device, not the first', (
+    testWidgets('show-again reopens the device last shown, not the first', (
       tester,
     ) async {
-      // Clearing the whole set restarts selection at the head of the list, so
-      // a stale peer sorting first would be reopened instead of the ceremony
-      // the user just dismissed.
-      final container = await pumpLauncher(tester, [
-        deviceNamed('Stale', 'STALE'),
-        deviceNamed('New phone', 'NEWPHONE'),
-      ]);
-      // Simulate the traversal having reached the newly paired device.
-      container
-          .read(matrixVerificationHandledProvider.notifier)
-          .markShown('@alice:example.com/NEWPHONE');
-      expect(container.read(matrixVerificationHandledProvider), hasLength(2));
+      // Drives the real traversal rather than poking the shared set: the
+      // launcher's `_lastOffered` is private, so a test that marks a device
+      // handled by hand releases the *wrong* identity and still passes.
+      final stale = deviceNamed('Stale', 'STALE');
+      final fresh = deviceNamed('New phone', 'NEWPHONE');
+      final container = await pumpLauncher(tester, [stale, fresh]);
+
+      Future<void> dismiss() async {
+        await tester.tap(find.byIcon(Icons.close_rounded));
+        await tester.pumpAndSettle();
+      }
+
+      DeviceKeys shownDevice() => tester
+          .widget<VerificationModal>(find.byType(VerificationModal))
+          .deviceKeys;
+
+      // First traversal takes the head of the list.
+      expect(shownDevice(), same(stale));
+      await dismiss();
+      // Dismissing invalidates the providers, so the next unshown device is
+      // offered on the rebuild.
+      await tester.pumpAndSettle();
+      expect(shownDevice(), same(fresh));
+      await dismiss();
+      expect(find.byType(VerificationModal), findsNothing);
 
       container.read(matrixVerificationRelaunchProvider.notifier).request();
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      // Only the last-shown identity became eligible again.
-      expect(
-        container.read(matrixVerificationHandledProvider),
-        contains('@alice:example.com/NEWPHONE'),
+      // The one the user was actually looking at — not the stale peer at the
+      // head of the list, which is what a full reset would have reopened.
+      expect(find.byType(VerificationModal), findsOneWidget);
+      expect(shownDevice(), same(fresh));
+    });
+  });
+
+  group('AutoVerificationLauncher handled-set lifecycle', () {
+    testWidgets('clears the handled set when the last device gets verified', (
+      tester,
+    ) async {
+      // The clear runs on the *success* path, so writing the provider inline
+      // in build() turned the normal end of verification into a provider
+      // modification exception — and the all-verified test could not catch it,
+      // because an already-empty set makes clear() a no-op.
+      var devices = <DeviceKeys>[deviceNamed('Old laptop', 'OLD')];
+      final container = await pumpLauncher(
+        tester,
+        const [],
+        unverifiedController: () => _MutableUnverifiedController(() => devices),
       );
-      expect(
-        container.read(matrixVerificationHandledProvider),
-        isNot(contains('@alice:example.com/STALE')),
-      );
+
+      expect(find.byType(VerificationModal), findsOneWidget);
+      expect(container.read(matrixVerificationHandledProvider), isNotEmpty);
+
+      await tester.tap(find.byIcon(Icons.close_rounded));
+      await tester.pumpAndSettle();
+
+      // The ceremony succeeded: nothing is unverified any more.
+      devices = [];
+      container.invalidate(matrixUnverifiedControllerProvider);
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(container.read(matrixVerificationHandledProvider), isEmpty);
     });
   });
 


### PR DESCRIPTION
Four findings from the post-merge review of #3634. Each is covered by a test
verified to fail with the fix reverted.

## The room id changed without telling anyone

`SyncRoomManager.currentRoomId` was a plain field, so `syncConfiguredProvider`
— the gate that chooses between the device roster and the pairing setup card —
had nothing to rebuild on. Login state alone does not cover it, and the gap is
not theoretical: `SyncSessionManager.connect()` drops a persisted room the
account can no longer join (`M_FORBIDDEN`/`M_NOT_FOUND`) *after* the login
event has already fired, so a login-only signal leaves the roster on screen for
a room that no longer exists.

All six mutations now go through one private setter that emits on change (and
is silent when the value is unchanged, so a re-save on every sync tick does not
churn the roster). `MatrixService.syncRoomIdChanges` exposes it and
`syncConfiguredProvider` watches it alongside login and provisioning state.

## The success path threw

`AutoVerificationLauncher` cleared `matrixVerificationHandledProvider` inline
in `build()`. Riverpod rejects a provider write during widget construction, and
that branch is reached by the *successful* verification of the last pending
device — the normal end of the flow. Deferred to a post-frame callback.

The existing "every device is verified" test could not catch it: it starts with
an empty set, and `clear()` short-circuits when the set is already empty. The
new test drives a device through being shown and then verified.

## Two tests proved nothing

- **`auto_verification_launcher_test.dart`** — the relaunch test marked a
  device handled by hand, which does not move the launcher's private
  `_lastOffered`. The request therefore released the *wrong* identity, and the
  in-flight guard blocked any second ceremony, so the assertions passed without
  the launcher ever re-offering anything. It now drives the real traversal,
  dismisses through to the second device, and asserts the reopened
  `VerificationModal.deviceKeys`. Reverted against the "release only
  `_lastOffered`" fix, it reopens the stale peer and fails.
- **`provisioned_sync_page_test.dart`** — closed a broadcast controller at
  teardown while the page was still subscribed through
  `loginStateStreamProvider`. Now a finite stream, with the widget unmounted
  inside the test body.

## Checks

- `fvm flutter analyze` — no issues found.
- `make knowledge_check` — 89 concepts, 0 errors; 134 Mermaid blocks parsed.
- 145 tests green across the five touched files.

No CHANGELOG entry: all four defects are in code merged for the add-device flow
but not yet released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync settings now update immediately as the active sync room is added, changed, or removed (including cleared-room transitions).
  * Fixed a potential issue that could prevent verification state from clearing after all devices are verified.
  * Improved verification prompts so previously handled devices can be shown again appropriately.
* **Documentation**
  * Expanded sync setup documentation with clearer guidance on room availability and how settings react to room changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->