### PR TITLE
docs: document the add-device flow, and repair the sync captures

### DIFF
--- a/docs-site/docs/sync-and-data/add-device.mdx
+++ b/docs-site/docs/sync-and-data/add-device.mdx
@@ -11,11 +11,12 @@ short **check code** you compare before connecting, and an **emoji
 verification** afterwards.
 
 They do different jobs. The check code tells you the two screens are talking
-about the same account — it catches a stale or wrong code, which is the
-mistake people actually make. It is derived from public identifiers, so it is a
-recognition aid, not proof of who is on the other end. The emoji verification
-that follows is the step that authenticates the device, and until it completes
-the new device cannot read anything.
+about the same account, room and server — it catches a code from somewhere
+else, which is the mistake people actually make. It is derived from those
+identifiers only, not from the password, so it says nothing about whether the
+credentials inside are still current, and nothing about who is on the other
+end. The emoji verification that follows is the step that authenticates the
+device, and until it completes the new device cannot read anything.
 
 You need both devices in front of you. Start on one that is already connected —
 any of them, phone or desktop. There is no "main" device.
@@ -98,10 +99,9 @@ Leave both apps open until the first synchronization finishes.
 
 ## If something goes wrong
 
-- **The check codes differ.** Do not connect. You are not looking at your own
-  device's code. Note that reopening the sheet does not help by itself: the
-  same account, room and server always produce the same code, so a mismatch
-  means the two screens do not describe the same pairing.
+- **The check codes differ.** Do not connect. Reopening the sheet does not help
+  by itself: the same account, room and server always produce the same code, so
+  a mismatch means the two screens do not describe the same pairing.
 - **The code will not decode.** Copy it again on the first device rather than
   editing what you pasted; the encoded value is not meant to be hand-corrected.
   If the app reports a version mismatch, the two devices are on different Lotti

--- a/docs-site/docs/sync-and-data/add-device.mdx
+++ b/docs-site/docs/sync-and-data/add-device.mdx
@@ -66,8 +66,9 @@ what you are about to join, led by the pairing check code.
 />
 
 Look at the check code here and the one on the first device. **They must be
-identical.** If they differ, stop and discard the code — it belongs to a
-different account, and reopening the sheet will not change that.
+identical.** If they differ, stop and discard the code — the two screens do not
+describe the same account, room and server, and reopening the sheet will not
+change that.
 
 The account and server below the code are context rather than things to
 compare — they do not appear on the other device. When everything matches,
@@ -99,8 +100,8 @@ Leave both apps open until the first synchronization finishes.
 
 - **The check codes differ.** Do not connect. You are not looking at your own
   device's code. Note that reopening the sheet does not help by itself: the
-  same account produces the same code every time, so a mismatch means the two
-  screens belong to different accounts.
+  same account, room and server always produce the same code, so a mismatch
+  means the two screens do not describe the same pairing.
 - **The code will not decode.** Copy it again on the first device rather than
   editing what you pasted; the encoded value is not meant to be hand-corrected.
   If the app reports a version mismatch, the two devices are on different Lotti

--- a/docs-site/docs/sync-and-data/add-device.mdx
+++ b/docs-site/docs/sync-and-data/add-device.mdx
@@ -31,9 +31,11 @@ Open **Settings → Sync Settings → Devices** and choose **Add device**.
 />
 
 Treat what is on this screen the way you would treat your password, because
-that is what it contains. Anyone who scans or photographs the QR code can join
-your sync account and read your entries. Show it only to a device you own, and
-never send it through a chat, a screenshot or a shared screen.
+that is what it contains. Anyone who scans or photographs the QR code can sign
+in to your sync account: they cannot decrypt your entries without also being
+emoji-verified from one of your devices, but they can take over the account —
+including changing its password and locking you out. Show it only to a device
+you own, and never send it through a chat, a screenshot or a shared screen.
 
 **Closing the sheet hides the code; it does not revoke it.** The code encodes
 your current account password, so a photograph of it stays usable for as long

--- a/docs-site/docs/sync-and-data/add-device.mdx
+++ b/docs-site/docs/sync-and-data/add-device.mdx
@@ -1,0 +1,97 @@
+---
+title: Add a device
+description: Pair a new device to your sync account with a QR code, check the pairing code matches, and finish the two steps that follow.
+---
+
+# Add a device
+
+All of your devices share one sync account. Adding a device means handing it
+the credentials for that account, which is why the flow asks you to compare a
+short code before anything connects: it is the only point at which you can tell
+your own device apart from someone else's.
+
+You need both devices in front of you. Start on one that is already connected —
+any of them, phone or desktop. There is no "main" device.
+
+## Show the code on a device you already use
+
+Open **Settings → Sync Settings → Devices** and choose **Add device**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Lotti Add device sheet showing a QR code, a lock-badged security note, and the pairing check code 2BD-EF4"
+  caption="The code is minted when you open this sheet and only while it is open. Note the check code underneath it — you will compare that in a moment."
+/>
+
+Treat what is on this screen the way you would treat your password, because
+that is what it contains. Anyone who scans or photographs the QR code can join
+your sync account and read your entries. Show it only to a device you own, and
+never send it through a chat, a screenshot or a shared screen.
+
+**Copy pairing code** is offered deliberately, for the case where the joining
+device has no camera — a desktop joining a desktop. It puts the same
+credentials on your clipboard, so paste them straight into the other device and
+nowhere else.
+
+## Scan it on the new device
+
+Install Lotti on the new device, then open **Settings → Sync Settings →
+Devices** there. On a phone the camera opens straight away; point it at the
+first device. On a desktop, or if the camera is unavailable, choose **enter
+manually** and paste the copied code.
+
+## Check the code matches before connecting
+
+Decoding the code does not connect anything. What appears first is a review of
+what you are about to join, led by the pairing check code.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Lotti pairing review showing the check code, the account that will be joined, and the sync server host"
+  caption="Both devices derive this code independently from the account, room and server. They never exchange it — which is what makes comparing it worth doing."
+/>
+
+Look at the check code here and the one on the first device. **They must be
+identical.** If they differ, stop: you are not looking at your own device's
+code. Discard it and start again from a freshly opened Add device sheet.
+
+The account and server below the code are context rather than things to
+compare — they do not appear on the other device. When everything matches,
+choose **Connect this device**.
+
+## Finish the two steps that follow
+
+Connecting joins the account. It does not yet give the new device the ability
+to read anything.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Lotti sync setup showing this device is connected, with emoji verification and Send settings still outstanding"
+  caption="Connected is the easy half. The card names what is still missing, and says plainly that until verification finishes this device cannot read your entries."
+/>
+
+1. **Compare the emoji.** A row of emoji appears on both devices. Check they
+   match and confirm on each. Until you do, the new device receives ciphertext
+   it cannot read — encryption keys are only shared with devices you have
+   verified. See [Verify the new device](./sync.mdx#verify-the-new-device).
+2. **Send settings.** Back on the first device, in the Add device sheet you
+   still have open, choose **Send settings** so your categories, habits,
+   dashboards and AI configuration arrive on the new device. If you already
+   closed the sheet, reopen **Settings → Sync Settings → Devices → Add device**.
+
+Leave both apps open until the first synchronization finishes.
+
+## If something goes wrong
+
+- **The check codes differ.** Do not connect. Close the sheet on the first
+  device, open a fresh one, and try again — the code is regenerated each time.
+- **The code will not decode.** Copy it again on the first device rather than
+  editing what you pasted; the encoded value is not meant to be hand-corrected.
+  If the app reports a version mismatch, the two devices are on different Lotti
+  builds and both need updating.
+- **The new device connected but stays empty.** That is the expected state
+  before verification. Finish the emoji comparison, then check
+  [Sync devices](./sync.mdx) for outbox and backfill status.
+
+Continue with [Sync devices](./sync.mdx) for everyday status, delivery health
+and recovery tools.

--- a/docs-site/docs/sync-and-data/add-device.mdx
+++ b/docs-site/docs/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Pair a new device to your sync account with a QR code, check the pa
 # Add a device
 
 All of your devices share one sync account. Adding a device means handing it
-the credentials for that account, which is why the flow asks you to compare a
-short code before anything connects: it is the only point at which you can tell
-your own device apart from someone else's.
+the credentials for that account, so the flow is built around two checks: a
+short **check code** you compare before connecting, and an **emoji
+verification** afterwards.
+
+They do different jobs. The check code tells you the two screens are talking
+about the same account — it catches a stale or wrong code, which is the
+mistake people actually make. It is derived from public identifiers, so it is a
+recognition aid, not proof of who is on the other end. The emoji verification
+that follows is the step that authenticates the device, and until it completes
+the new device cannot read anything.
 
 You need both devices in front of you. Start on one that is already connected —
 any of them, phone or desktop. There is no "main" device.
@@ -20,13 +27,18 @@ Open **Settings → Sync Settings → Devices** and choose **Add device**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Lotti Add device sheet showing a QR code, a lock-badged security note, and the pairing check code 2BD-EF4"
-  caption="The code is minted when you open this sheet and only while it is open. Note the check code underneath it — you will compare that in a moment."
+  caption="The code is shown only while this sheet is open. Note the check code underneath it — you will compare that in a moment."
 />
 
 Treat what is on this screen the way you would treat your password, because
 that is what it contains. Anyone who scans or photographs the QR code can join
 your sync account and read your entries. Show it only to a device you own, and
 never send it through a chat, a screenshot or a shared screen.
+
+**Closing the sheet hides the code; it does not revoke it.** The code encodes
+your current account password, so a photograph of it stays usable for as long
+as that password does. If you think someone captured it, treat it as a leaked
+password rather than as something that has since expired.
 
 **Copy pairing code** is offered deliberately, for the case where the joining
 device has no camera — a desktop joining a desktop. It puts the same
@@ -36,9 +48,9 @@ nowhere else.
 ## Scan it on the new device
 
 Install Lotti on the new device, then open **Settings → Sync Settings →
-Devices** there. On a phone the camera opens straight away; point it at the
-first device. On a desktop, or if the camera is unavailable, choose **enter
-manually** and paste the copied code.
+Devices** there and select the **Devices** card. On a phone the camera opens
+straight away; point it at the first device. On a desktop, or if the camera is
+unavailable, choose **Enter code manually** and paste the copied code.
 
 ## Check the code matches before connecting
 
@@ -52,8 +64,8 @@ what you are about to join, led by the pairing check code.
 />
 
 Look at the check code here and the one on the first device. **They must be
-identical.** If they differ, stop: you are not looking at your own device's
-code. Discard it and start again from a freshly opened Add device sheet.
+identical.** If they differ, stop and discard the code — it belongs to a
+different account, and reopening the sheet will not change that.
 
 The account and server below the code are context rather than things to
 compare — they do not appear on the other device. When everything matches,
@@ -83,8 +95,10 @@ Leave both apps open until the first synchronization finishes.
 
 ## If something goes wrong
 
-- **The check codes differ.** Do not connect. Close the sheet on the first
-  device, open a fresh one, and try again — the code is regenerated each time.
+- **The check codes differ.** Do not connect. You are not looking at your own
+  device's code. Note that reopening the sheet does not help by itself: the
+  same account produces the same code every time, so a mismatch means the two
+  screens belong to different accounts.
 - **The code will not decode.** Copy it again on the first device rather than
   editing what you pasted; the encoded value is not meant to be hand-corrected.
   If the app reports a version mismatch, the two devices are on different Lotti

--- a/docs-site/docs/sync-and-data/sync.mdx
+++ b/docs-site/docs/sync-and-data/sync.mdx
@@ -22,33 +22,31 @@ service yet.
   caption="The Sync hub keeps everyday status near diagnostics and recovery tools. Project Waddle currently has three outbox items to inspect."
 />
 
-## Pair another device
+## See your devices
 
-Start on a device that is already connected:
-
-1. Open **Settings → Sync → Provisioned Sync**.
-2. On desktop, show the handover QR code. Keep this screen private: the bundle
-   grants access to your sync account and room.
-3. On the new device, open the same page and scan the QR code or paste the
-   complete provisioning bundle.
-4. Review the decoded server, user, and room before selecting **Import**.
-5. Let the first synchronization finish before closing either app.
+**Settings → Sync Settings → Devices** lists every session on your sync
+account — not only the unverified ones.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Provisioned Sync status on mobile and the secure device handover QR code on desktop"
-  caption="Desktop can present the handover QR code; mobile shows the connected account and verification state. Treat the QR code like a password."
+  alt="Lotti Devices page listing the sessions on the sync account with verification state and when each was last seen"
+  caption="Each row shows whether the device is verified and when the server last saw it. An unverified device cannot read new entries, and the list says so."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Lotti provisioning import review showing the Project Waddle sync server, user, and room"
-  caption="Import only when every decoded value belongs to the sync account you intended to join."
-/>
+Sessions signed in with this account can be removed — except the one you are
+on. Devices paired the old way, each with its own account, can be verified but
+not removed.
 
-If the import reports an error, keep the original device connected, generate a
-fresh handover bundle, and retry with the full value. Do not manually edit the
-encoded bundle.
+## Pair another device
+
+Pairing is its own flow, with a code to compare and two steps that follow
+connecting. It has a page of its own: [Add a device](./add-device.mdx).
+
+In short: on a device that is already connected, open **Settings → Sync
+Settings → Devices → Add device** and show the code. On the new device, open
+the same page and scan it. Compare the pairing check code on both screens
+before connecting — the QR code carries your sync account credentials, so it
+goes to your own device and nowhere else.
 
 ## Verify the new device
 

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,94 @@
+---
+title: Přidat zařízení
+description: Spáruj nové zařízení se svým synchronizačním účtem pomocí QR kódu, ověř kontrolní kód a dokonči dva kroky, které následují.
+---
+
+# Přidat zařízení
+
+Všechna tvá zařízení sdílejí jeden synchronizační účet. Přidat zařízení znamená
+předat mu přihlašovací údaje k tomuto účtu — proto tě postup před jakýmkoli
+připojením žádá o porovnání krátkého kódu. Je to jediný okamžik, kdy poznáš své
+vlastní zařízení od cizího.
+
+Potřebuješ obě zařízení před sebou. Začni na tom, které už je připojené — na
+kterémkoli, telefonu i počítači. Žádné „hlavní“ zařízení neexistuje.
+
+## Zobraz kód na zařízení, které už používáš
+
+Otevři **Nastavení → Synchronizace → Zařízení** a zvol **Přidat zařízení**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Obrazovka Přidat zařízení v Lotti s QR kódem, bezpečnostním upozorněním se zámkem a kontrolním kódem 2BD-EF4"
+  caption="Kód vzniká při otevření této obrazovky a jen po dobu, kdy je otevřená. Všimni si kontrolního kódu pod ním — ten budeš za chvíli porovnávat."
+/>
+
+Zacházej s touto obrazovkou jako se svým heslem, protože přesně to obsahuje. Kdo
+naskenuje nebo vyfotí QR kód, může se připojit k tvému účtu a číst tvé záznamy.
+Ukazuj ho jen zařízení, které ti patří, a nikdy ho neposílej chatem, snímkem
+obrazovky ani sdílenou obrazovkou.
+
+**Kopírovat párovací kód** je tu záměrně pro případ, že připojované zařízení nemá
+fotoaparát — počítač připojující se k počítači. Vloží stejné údaje do schránky:
+vlož je přímo do druhého zařízení a nikam jinam.
+
+## Naskenuj ho na novém zařízení
+
+Nainstaluj Lotti na nové zařízení a otevři tam **Nastavení → Synchronizace →
+Zařízení**. Na telefonu se fotoaparát otevře hned; namiř ho na první zařízení. Na
+počítači, nebo když fotoaparát není dostupný, zvol **zadat ručně** a vlož
+zkopírovaný kód.
+
+## Před připojením ověř, že kód souhlasí
+
+Dekódování kódu nic nepřipojí. Nejdřív se objeví přehled toho, k čemu se
+chystáš připojit, v čele s kontrolním kódem.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Přehled párování v Lotti s kontrolním kódem, účtem k připojení a synchronizačním serverem"
+  caption="Obě zařízení odvozují tento kód nezávisle z účtu, místnosti a serveru. Nikdy si ho nevyměňují — proto má porovnání smysl."
+/>
+
+Podívej se na kontrolní kód tady a na ten na prvním zařízení. **Musí být
+totožné.** Pokud se liší, přestaň: nedíváš se na kód svého vlastního zařízení.
+Zahoď ho a začni znovu z čerstvě otevřené obrazovky Přidat zařízení.
+
+Účet a server pod kódem jsou kontext, ne věci k porovnávání — na druhém zařízení
+se neobjeví. Když všechno souhlasí, zvol **Připojit toto zařízení**.
+
+## Dokonči dva následující kroky
+
+Připojení tě přidá k účtu. Nové zařízení tím ještě nic nepřečte.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Nastavení synchronizace v Lotti: toto zařízení je připojeno, ověření emoji a Odeslat nastavení stále čekají"
+  caption="Připojeno je ta snadná polovina. Karta pojmenuje, co chybí, a jasně říká, že do ověření toto zařízení nic nepřečte."
+/>
+
+1. **Porovnej emoji.** Na obou zařízeních se objeví řada emoji. Zkontroluj, že
+   souhlasí, a potvrď na každém. Do té doby dostává nové zařízení jen šifru,
+   kterou nepřečte — klíče jdou výhradně ověřeným zařízením. Viz
+   [Synchronizace zařízení](./sync.mdx).
+2. **Odešli nastavení.** Na prvním zařízení, v stále otevřené obrazovce Přidat
+   zařízení, zvol **Odeslat nastavení**, aby dorazily kategorie, návyky,
+   nástěnky a konfigurace AI. Pokud jsi ji už zavřel, otevři znovu **Nastavení →
+   Synchronizace → Zařízení → Přidat zařízení**.
+
+Nech obě aplikace otevřené, dokud první synchronizace neskončí.
+
+## Když se něco pokazí
+
+- **Kontrolní kódy se liší.** Nepřipojuj. Zavři obrazovku na prvním zařízení,
+  otevři novou a zkus to znovu — kód se pokaždé vytvoří nový.
+- **Kód nejde dekódovat.** Zkopíruj ho na prvním zařízení znovu, místo abys
+  opravoval vložený text; zakódovaná hodnota není určená k ručním úpravám. Když
+  aplikace hlásí neshodu verzí, zařízení běží na různých sestaveních a obě
+  potřebují aktualizaci.
+- **Nové zařízení se připojilo, ale zůstává prázdné.** To je před ověřením
+  očekávaný stav. Dokonči porovnání emoji a pak zkontroluj
+  [Synchronizace zařízení](./sync.mdx) kvůli frontě odeslání a doplňování.
+
+Pokračuj na [Synchronizace zařízení](./sync.mdx) pro každodenní stav, kvalitu
+doručení a nástroje obnovy.

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,15 @@ description: Spáruj nové zařízení se svým synchronizačním účtem pomoc�
 # Přidat zařízení
 
 Všechna tvá zařízení sdílejí jeden synchronizační účet. Přidat zařízení znamená
-předat mu přihlašovací údaje k tomuto účtu — proto tě postup před jakýmkoli
-připojením žádá o porovnání krátkého kódu. Je to jediný okamžik, kdy poznáš své
-vlastní zařízení od cizího.
+předat mu přihlašovací údaje k tomuto účtu, a proto má postup dvě kontroly:
+krátký **kontrolní kód**, který porovnáš před připojením, a **ověření emoji**
+poté.
+
+Dělají různé věci. Kontrolní kód říká, že obě obrazovky mluví o témže účtu —
+zachytí zastaralý nebo špatný kód, tedy chybu, která se opravdu stává. Odvozuje
+se z veřejných identifikátorů, takže je to pomůcka k rozpoznání, ne důkaz, kdo je
+na druhé straně. Následné ověření emoji je krok, který zařízení autentizuje, a
+dokud neproběhne, nové zařízení nic nepřečte.
 
 Potřebuješ obě zařízení před sebou. Začni na tom, které už je připojené — na
 kterémkoli, telefonu i počítači. Žádné „hlavní“ zařízení neexistuje.
@@ -28,6 +34,11 @@ naskenuje nebo vyfotí QR kód, může se připojit k tvému účtu a číst tv�
 Ukazuj ho jen zařízení, které ti patří, a nikdy ho neposílej chatem, snímkem
 obrazovky ani sdílenou obrazovkou.
 
+**Zavření obrazovky kód skryje, ale nezneplatní ho.** Kód obsahuje aktuální
+heslo tvého účtu — fotka zůstane použitelná, dokud to heslo platí. Pokud máš
+podezření, že si ho někdo vyfotil, ber to jako uniklé heslo, ne jako něco, co
+mezitím vypršelo.
+
 **Kopírovat párovací kód** je tu záměrně pro případ, že připojované zařízení nemá
 fotoaparát — počítač připojující se k počítači. Vloží stejné údaje do schránky:
 vlož je přímo do druhého zařízení a nikam jinam.
@@ -35,8 +46,8 @@ vlož je přímo do druhého zařízení a nikam jinam.
 ## Naskenuj ho na novém zařízení
 
 Nainstaluj Lotti na nové zařízení a otevři tam **Nastavení → Synchronizace →
-Zařízení**. Na telefonu se fotoaparát otevře hned; namiř ho na první zařízení. Na
-počítači, nebo když fotoaparát není dostupný, zvol **zadat ručně** a vlož
+Zařízení** a vyber kartu **Zařízení**. Na telefonu se fotoaparát otevře hned; namiř ho na první zařízení. Na
+počítači, nebo když fotoaparát není dostupný, zvol **Zadat kód ručně** a vlož
 zkopírovaný kód.
 
 ## Před připojením ověř, že kód souhlasí
@@ -81,7 +92,8 @@ Nech obě aplikace otevřené, dokud první synchronizace neskončí.
 ## Když se něco pokazí
 
 - **Kontrolní kódy se liší.** Nepřipojuj. Zavři obrazovku na prvním zařízení,
-  otevři novou a zkus to znovu — kód se pokaždé vytvoří nový.
+  otevři novou a zkus to znovu — stejný účet vytvoří pokaždé stejný
+  kód, takže neshoda znamená, že obrazovky patří různým účtům.
 - **Kód nejde dekódovat.** Zkopíruj ho na prvním zařízení znovu, místo abys
   opravoval vložený text; zakódovaná hodnota není určená k ručním úpravám. Když
   aplikace hlásí neshodu verzí, zařízení běží na různých sestaveních a obě

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,9 @@ krátký **kontrolní kód**, který porovnáš před připojením, a **ověřen
 poté.
 
 Dělají různé věci. Kontrolní kód říká, že obě obrazovky mluví o témže účtu —
-zachytí zastaralý nebo špatný kód, tedy chybu, která se opravdu stává. Odvozuje
-se z veřejných identifikátorů, takže je to pomůcka k rozpoznání, ne důkaz, kdo je
-na druhé straně. Následné ověření emoji je krok, který zařízení autentizuje, a
+zachytí kód odjinud, tedy chybu, která se opravdu stává. Odvozuje
+se jen z těchto identifikátorů, ne z hesla — neříká tedy nic o tom, jestli jsou
+obsažené přihlašovací údaje ještě platné, ani kdo je na druhé straně. Následné ověření emoji je krok, který zařízení autentizuje, a
 dokud neproběhne, nové zařízení nic nepřečte.
 
 Potřebuješ obě zařízení před sebou. Začni na tom, které už je připojené — na
@@ -21,7 +21,7 @@ kterémkoli, telefonu i počítači. Žádné „hlavní“ zařízení neexistu
 
 ## Zobraz kód na zařízení, které už používáš
 
-Otevři **Nastavení → Synchronizace → Zařízení** a zvol **Přidat zařízení**.
+Otevři **Nastavení → Nastavení synchronizace → Zařízení** a zvol **Přidat zařízení**.
 
 <ManualScreenshot
   caseId="sync/add-device"
@@ -46,7 +46,7 @@ vlož je přímo do druhého zařízení a nikam jinam.
 
 ## Naskenuj ho na novém zařízení
 
-Nainstaluj Lotti na nové zařízení a otevři tam **Nastavení → Synchronizace →
+Nainstaluj Lotti na nové zařízení a otevři tam **Nastavení → Nastavení synchronizace →
 Zařízení** a vyber kartu **Zařízení**. Na telefonu se fotoaparát otevře hned; namiř ho na první zařízení. Na
 počítači, nebo když fotoaparát není dostupný, zvol **Zadat kód ručně** a vlož
 zkopírovaný kód.
@@ -63,8 +63,7 @@ chystáš připojit, v čele s kontrolním kódem.
 />
 
 Podívej se na kontrolní kód tady a na ten na prvním zařízení. **Musí být
-totožné.** Pokud se liší, přestaň: nedíváš se na kód svého vlastního zařízení.
-Zahoď ho: obě obrazovky nepopisují tentýž účet, místnost a server a znovu
+totožné.** Pokud se liší, přestaň a zahoď ho: obě obrazovky nepopisují tentýž účet, místnost a server a znovu
 otevřená obrazovka to nezmění.
 
 Účet a server pod kódem jsou kontext, ne věci k porovnávání — na druhém zařízení
@@ -87,7 +86,7 @@ Připojení tě přidá k účtu. Nové zařízení tím ještě nic nepřečte.
 2. **Odešli nastavení.** Na prvním zařízení, v stále otevřené obrazovce Přidat
    zařízení, zvol **Odeslat nastavení**, aby dorazily kategorie, návyky,
    nástěnky a konfigurace AI. Pokud jsi ji už zavřel, otevři znovu **Nastavení →
-   Synchronizace → Zařízení → Přidat zařízení**.
+   Nastavení synchronizace → Zařízení → Přidat zařízení**.
 
 Nech obě aplikace otevřené, dokud první synchronizace neskončí.
 

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -26,7 +26,7 @@ Otevři **Nastavení → Synchronizace → Zařízení** a zvol **Přidat zaří
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Obrazovka Přidat zařízení v Lotti s QR kódem, bezpečnostním upozorněním se zámkem a kontrolním kódem 2BD-EF4"
-  caption="Kód vzniká při otevření této obrazovky a jen po dobu, kdy je otevřená. Všimni si kontrolního kódu pod ním — ten budeš za chvíli porovnávat."
+  caption="Kód se zobrazuje jen po dobu, kdy je tato obrazovka otevřená. Všimni si kontrolního kódu pod ním — ten budeš za chvíli porovnávat."
 />
 
 Zacházej s touto obrazovkou jako se svým heslem, protože přesně to obsahuje. Kdo naskenuje nebo vyfotí QR kód, se může přihlásit k tvému účtu: tvé záznamy
@@ -92,9 +92,9 @@ Nech obě aplikace otevřené, dokud první synchronizace neskončí.
 
 ## Když se něco pokazí
 
-- **Kontrolní kódy se liší.** Nepřipojuj. Zavři obrazovku na prvním zařízení,
-  otevři novou a zkus to znovu — stejný účet vytvoří pokaždé stejný
-  kód, takže neshoda znamená, že obrazovky patří různým účtům.
+- **Kontrolní kódy se liší.** Nepřipojuj. Nedíváš se na kód svého
+  vlastního zařízení. Otevřít obrazovku znovu nepomůže: stejný účet vytvoří
+  pokaždé stejný kód, takže neshoda znamená, že obrazovky patří různým účtům.
 - **Kód nejde dekódovat.** Zkopíruj ho na prvním zařízení znovu, místo abys
   opravoval vložený text; zakódovaná hodnota není určená k ručním úpravám. Když
   aplikace hlásí neshodu verzí, zařízení běží na různých sestaveních a obě

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -29,8 +29,9 @@ Otevři **Nastavení → Synchronizace → Zařízení** a zvol **Přidat zaří
   caption="Kód vzniká při otevření této obrazovky a jen po dobu, kdy je otevřená. Všimni si kontrolního kódu pod ním — ten budeš za chvíli porovnávat."
 />
 
-Zacházej s touto obrazovkou jako se svým heslem, protože přesně to obsahuje. Kdo
-naskenuje nebo vyfotí QR kód, může se připojit k tvému účtu a číst tvé záznamy.
+Zacházej s touto obrazovkou jako se svým heslem, protože přesně to obsahuje. Kdo naskenuje nebo vyfotí QR kód, se může přihlásit k tvému účtu: tvé záznamy
+bez ověření emoji z některého tvého zařízení nedešifruje, ale účet může
+převzít — včetně změny hesla, která tě uzamkne.
 Ukazuj ho jen zařízení, které ti patří, a nikdy ho neposílej chatem, snímkem
 obrazovky ani sdílenou obrazovkou.
 

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -64,7 +64,8 @@ chystáš připojit, v čele s kontrolním kódem.
 
 Podívej se na kontrolní kód tady a na ten na prvním zařízení. **Musí být
 totožné.** Pokud se liší, přestaň: nedíváš se na kód svého vlastního zařízení.
-Zahoď ho a začni znovu z čerstvě otevřené obrazovky Přidat zařízení.
+Zahoď ho: obě obrazovky nepopisují tentýž účet, místnost a server a znovu
+otevřená obrazovka to nezmění.
 
 Účet a server pod kódem jsou kontext, ne věci k porovnávání — na druhém zařízení
 se neobjeví. Když všechno souhlasí, zvol **Připojit toto zařízení**.
@@ -94,7 +95,7 @@ Nech obě aplikace otevřené, dokud první synchronizace neskončí.
 
 - **Kontrolní kódy se liší.** Nepřipojuj. Nedíváš se na kód svého
   vlastního zařízení. Otevřít obrazovku znovu nepomůže: stejný účet vytvoří
-  pokaždé stejný kód, takže neshoda znamená, že obrazovky patří různým účtům.
+  pokaždé stejný kód, takže neshoda znamená, že obrazovky nepopisují totéž párování.
 - **Kód nejde dekódovat.** Zkopíruj ho na prvním zařízení znovu, místo abys
   opravoval vložený text; zakódovaná hodnota není určená k ručním úpravám. Když
   aplikace hlásí neshodu verzí, zařízení běží na různých sestaveních a obě

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -21,34 +21,31 @@ synchronizační službě.
   caption="Centrum Sync drží běžný stav vedle diagnostiky a nástrojů obnovy. Project Waddle má právě tři položky odchozí fronty ke kontrole."
 />
 
-## Spáruj další zařízení
+## Zobraz svá zařízení
 
-Začni na zařízení, které už je připojené:
-
-1. Otevři **Nastavení → Sync → Nastavení synchronizace**.
-2. Na počítači zobraz předávací QR kód. Udržuj tuto obrazovku soukromou: balíček
-   uděluje přístup k synchronizačnímu účtu a místnosti.
-3. Na novém zařízení otevři stejnou stránku a QR kód naskenuj nebo vlož celý
-   balíček nastavení.
-4. Před volbou **Importovat** zkontroluj dekódovaný server, uživatele a
-   místnost.
-5. Nech dokončit první synchronizaci, než některou aplikaci zavřeš.
+**Nastavení → Synchronizace → Zařízení** vypíše každou relaci tvého
+synchronizačního účtu — nejen ty neověřené.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Stav Nastavení synchronizace na mobilu a bezpečný párovací QR kód zařízení na počítači"
-  caption="Počítač může zobrazit předávací QR kód; mobil ukazuje připojený účet a stav ověření. S QR kódem zacházej jako s heslem."
+  alt="Stránka Zařízení v Lotti se seznamem relací synchronizačního účtu, stavem ověření a poslední aktivitou"
+  caption="Každý řádek ukazuje, zda je zařízení ověřené a kdy ho server naposledy viděl. Neověřené zařízení nepřečte nové záznamy a seznam to říká."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Kontrola importu nastavení Lotti se synchronizačním serverem, uživatelem a místností Project Waddle"
-  caption="Importuj jen tehdy, když všechny dekódované hodnoty patří k účtu, který jsi chtěl připojit."
-/>
+Relace přihlášené tímto účtem lze odebrat — kromě té, na které právě jsi.
+Zařízení spárovaná starým způsobem, s vlastním účtem, lze ověřit, ale ne
+odebrat.
 
-Pokud import hlásí chybu, ponech původní zařízení připojené, vytvoř nový
-předávací balíček a zopakuj postup s celou hodnotou. Zakódovaný balíček ručně
-neupravuj.
+## Spáruj další zařízení
+
+Párování je samostatný postup s kódem k porovnání a dvěma kroky po připojení.
+Má vlastní stránku: [Přidat zařízení](./add-device.mdx).
+
+Stručně: na už připojeném zařízení otevři **Nastavení → Synchronizace →
+Zařízení → Přidat zařízení** a zobraz kód. Na novém zařízení otevři stejnou
+stránku a naskenuj ho. Před připojením porovnej kontrolní kód na obou
+obrazovkách — QR kód nese přihlašovací údaje k tvému synchronizačnímu účtu
+a patří jen tvému vlastnímu zařízení.
 
 ## Ověř nové zařízení
 

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -23,7 +23,7 @@ synchronizační službě.
 
 ## Zobraz svá zařízení
 
-**Nastavení → Synchronizace → Zařízení** vypíše každou relaci tvého
+**Nastavení → Nastavení synchronizace → Zařízení** vypíše každou relaci tvého
 synchronizačního účtu — nejen ty neověřené.
 
 <ManualScreenshot
@@ -41,7 +41,7 @@ odebrat.
 Párování je samostatný postup s kódem k porovnání a dvěma kroky po připojení.
 Má vlastní stránku: [Přidat zařízení](./add-device.mdx).
 
-Stručně: na už připojeném zařízení otevři **Nastavení → Synchronizace →
+Stručně: na už připojeném zařízení otevři **Nastavení → Nastavení synchronizace →
 Zařízení → Přidat zařízení** a zobraz kód. Na novém zařízení otevři stejnou
 stránku a naskenuj ho. Před připojením porovnej kontrolní kód na obou
 obrazovkách — QR kód nese přihlašovací údaje k tvému synchronizačnímu účtu

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -64,8 +64,8 @@ det, du er ved at tilslutte dig, anført af kontrolkoden.
 />
 
 Se på kontrolkoden her og den på den første enhed. **De skal være identiske.**
-Er de forskellige, så stop: du ser ikke din egen enheds kode. Kassér den, og
-begynd forfra fra en nyåbnet Tilføj enhed-skærm.
+Er de forskellige, så stop: du ser ikke din egen enheds kode. Kassér den: de to skærme beskriver ikke den samme konto, det samme rum og den
+samme server, og at åbne skærmen igen ændrer ikke det.
 
 Kontoen og serveren under koden er kontekst, ikke noget at sammenligne — de vises
 ikke på den anden enhed. Når alt stemmer, vælg **Forbind denne enhed**.
@@ -96,7 +96,7 @@ Lad begge apps være åbne, indtil den første synkronisering er færdig.
 
 - **Kontrolkoderne er forskellige.** Forbind ikke. Du ser ikke din egen enheds
   kode. At åbne skærmen igen hjælper ikke: den samme konto giver den samme kode
-  hver gang, så en forskel betyder, at de to skærme hører til forskellige konti.
+  hver gang, så en forskel betyder, at de to skærme ikke beskriver den samme parring.
 - **Koden kan ikke afkodes.** Kopiér den igen på den første enhed i stedet for at
   rette i det, du indsatte; den kodede værdi er ikke beregnet til håndarbejde.
   Melder appen om forskellige versioner, kører enhederne på forskellige builds og

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ hvilken som helst, telefon eller computer. Der findes ingen «hovedenhed».
 
 ## Vis koden på en enhed, du allerede bruger
 
-Åbn **Indstillinger → Synkronisering → Enheder**, og vælg **Tilføj enhed**.
+Åbn **Indstillinger → Synkroniseringsindstillinger → Enheder**, og vælg **Tilføj enhed**.
 
 <ManualScreenshot
   caseId="sync/add-device"
@@ -30,9 +30,10 @@ hvilken som helst, telefon eller computer. Der findes ingen «hovedenhed».
   caption="Koden dannes, når du åbner denne skærm, og kun så længe den er åben. Læg mærke til kontrolkoden nedenunder — den sammenligner du om lidt."
 />
 
-Behandl denne skærm som din adgangskode, for det er det, den indeholder. Enhver,
-der scanner eller fotograferer QR-koden, kan tilslutte sig din konto og læse dine
-noter. Vis den kun til en enhed, du selv ejer, og send den aldrig via chat,
+Behandl denne skærm som din adgangskode, for det er det, den indeholder. Enhver, der scanner eller fotograferer QR-koden, kan logge ind på din konto:
+vedkommende kan ikke dekryptere dine noter uden også at være emoji-verificeret
+fra en af dine enheder, men kan overtage kontoen — inklusive at skifte
+adgangskoden og lukke dig ude. Vis den kun til en enhed, du selv ejer, og send den aldrig via chat,
 skærmbillede eller delt skærm.
 
 **At lukke skærmen skjuler koden, men tilbagekalder den ikke.** Koden
@@ -47,7 +48,7 @@ andet sted.
 
 ## Scan den på den nye enhed
 
-Installér Lotti på den nye enhed, og åbn der **Indstillinger → Synkronisering →
+Installér Lotti på den nye enhed, og åbn der **Indstillinger → Synkroniseringsindstillinger →
 Enheder**, og vælg kortet **Enheder**. På en telefon åbner kameraet med det samme; ret det mod den første
 enhed. På computer, eller hvis kameraet ikke er tilgængeligt, vælg **Indtast koden manuelt**, og indsæt den kopierede kode.
 
@@ -87,7 +88,7 @@ til at læse noget.
 2. **Send indstillingerne.** På den første enhed, i den stadig åbne Tilføj
    enhed-skærm, vælg **Send indstillinger**, så kategorier, vaner, dashboards og
    AI-opsætning når frem. Har du lukket den, åbn **Indstillinger →
-   Synkronisering → Enheder → Tilføj enhed** igen.
+   Synkroniseringsindstillinger → Enheder → Tilføj enhed** igen.
 
 Lad begge apps være åbne, indtil den første synkronisering er færdig.
 

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,96 @@
+---
+title: Tilføj en enhed
+description: Par en ny enhed med din synkroniseringskonto via en QR-kode, kontrollér kontrolkoden, og fuldfør de to trin bagefter.
+---
+
+# Tilføj en enhed
+
+Alle dine enheder deler én synkroniseringskonto. At tilføje en enhed betyder at
+give den loginoplysningerne til den konto — derfor beder forløbet dig sammenligne
+en kort kode, før noget forbindes. Det er det eneste tidspunkt, hvor du kan skelne
+din egen enhed fra en andens.
+
+Du skal have begge enheder foran dig. Start på en, der allerede er forbundet —
+hvilken som helst, telefon eller computer. Der findes ingen «hovedenhed».
+
+## Vis koden på en enhed, du allerede bruger
+
+Åbn **Indstillinger → Synkronisering → Enheder**, og vælg **Tilføj enhed**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Lottis skærm Tilføj enhed med QR-kode, sikkerhedsnote med hængelås og kontrolkoden 2BD-EF4"
+  caption="Koden dannes, når du åbner denne skærm, og kun så længe den er åben. Læg mærke til kontrolkoden nedenunder — den sammenligner du om lidt."
+/>
+
+Behandl denne skærm som din adgangskode, for det er det, den indeholder. Enhver,
+der scanner eller fotograferer QR-koden, kan tilslutte sig din konto og læse dine
+noter. Vis den kun til en enhed, du selv ejer, og send den aldrig via chat,
+skærmbillede eller delt skærm.
+
+**Kopiér parringskode** findes med vilje til de tilfælde, hvor den nye enhed ikke
+har kamera — en computer, der forbinder til en computer. Den lægger de samme
+oplysninger i udklipsholderen: indsæt dem direkte i den anden enhed og intet
+andet sted.
+
+## Scan den på den nye enhed
+
+Installér Lotti på den nye enhed, og åbn der **Indstillinger → Synkronisering →
+Enheder**. På en telefon åbner kameraet med det samme; ret det mod den første
+enhed. På computer, eller hvis kameraet ikke er tilgængeligt, vælg **indtast
+manuelt**, og indsæt den kopierede kode.
+
+## Kontrollér, at koden stemmer, før du forbinder
+
+At afkode koden forbinder ikke noget. Det første, der vises, er en oversigt over
+det, du er ved at tilslutte dig, anført af kontrolkoden.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Lottis parringsoversigt med kontrolkode, kontoen der tilsluttes, og synkroniseringsserveren"
+  caption="Begge enheder udleder denne kode uafhængigt af hinanden ud fra konto, rum og server. De udveksler den aldrig — derfor er sammenligningen værd at lave."
+/>
+
+Se på kontrolkoden her og den på den første enhed. **De skal være identiske.**
+Er de forskellige, så stop: du ser ikke din egen enheds kode. Kassér den, og
+begynd forfra fra en nyåbnet Tilføj enhed-skærm.
+
+Kontoen og serveren under koden er kontekst, ikke noget at sammenligne — de vises
+ikke på den anden enhed. Når alt stemmer, vælg **Forbind denne enhed**.
+
+## Fuldfør de to trin bagefter
+
+Forbindelsen tilslutter dig kontoen. Den giver endnu ikke den nye enhed adgang
+til at læse noget.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Lottis synkroniseringsopsætning: denne enhed er forbundet, emoji-verifikation og Send indstillinger mangler stadig"
+  caption="Forbundet er den nemme halvdel. Kortet siger, hvad der mangler, og gør klart, at enheden indtil verifikationen ikke kan læse noget."
+/>
+
+1. **Sammenlign emojierne.** En række emoji vises på begge enheder. Kontrollér,
+   at de stemmer, og bekræft på hver. Indtil da modtager den nye enhed kun
+   krypteret indhold, den ikke kan læse — nøgler går kun til verificerede
+   enheder. Se [Synkronisér enheder](./sync.mdx).
+2. **Send indstillingerne.** På den første enhed, i den stadig åbne Tilføj
+   enhed-skærm, vælg **Send indstillinger**, så kategorier, vaner, dashboards og
+   AI-opsætning når frem. Har du lukket den, åbn **Indstillinger →
+   Synkronisering → Enheder → Tilføj enhed** igen.
+
+Lad begge apps være åbne, indtil den første synkronisering er færdig.
+
+## Hvis noget går galt
+
+- **Kontrolkoderne er forskellige.** Forbind ikke. Luk skærmen på den første
+  enhed, åbn en ny, og prøv igen — koden dannes på ny hver gang.
+- **Koden kan ikke afkodes.** Kopiér den igen på den første enhed i stedet for at
+  rette i det, du indsatte; den kodede værdi er ikke beregnet til håndarbejde.
+  Melder appen om forskellige versioner, kører enhederne på forskellige builds og
+  skal begge opdateres.
+- **Den nye enhed er forbundet, men forbliver tom.** Det er den forventede
+  tilstand før verifikation. Afslut emoji-sammenligningen, og se derefter
+  [Synkronisér enheder](./sync.mdx) for udbakke og genopretning.
+
+Fortsæt med [Synkronisér enheder](./sync.mdx) for daglig status, leveringssundhed
+og genopretningsværktøjer.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -27,7 +27,7 @@ hvilken som helst, telefon eller computer. Der findes ingen «hovedenhed».
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Lottis skærm Tilføj enhed med QR-kode, sikkerhedsnote med hængelås og kontrolkoden 2BD-EF4"
-  caption="Koden dannes, når du åbner denne skærm, og kun så længe den er åben. Læg mærke til kontrolkoden nedenunder — den sammenligner du om lidt."
+  caption="Koden vises kun, så længe denne skærm er åben. Læg mærke til kontrolkoden nedenunder — den sammenligner du om lidt."
 />
 
 Behandl denne skærm som din adgangskode, for det er det, den indeholder. Enhver, der scanner eller fotograferer QR-koden, kan logge ind på din konto:
@@ -94,8 +94,8 @@ Lad begge apps være åbne, indtil den første synkronisering er færdig.
 
 ## Hvis noget går galt
 
-- **Kontrolkoderne er forskellige.** Forbind ikke. Luk skærmen på den første
-  enhed, åbn en ny, og prøv igen — den samme konto giver den samme kode
+- **Kontrolkoderne er forskellige.** Forbind ikke. Du ser ikke din egen enheds
+  kode. At åbne skærmen igen hjælper ikke: den samme konto giver den samme kode
   hver gang, så en forskel betyder, at de to skærme hører til forskellige konti.
 - **Koden kan ikke afkodes.** Kopiér den igen på den første enhed i stedet for at
   rette i det, du indsatte; den kodede værdi er ikke beregnet til håndarbejde.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Par en ny enhed med din synkroniseringskonto via en QR-kode, kontro
 # Tilføj en enhed
 
 Alle dine enheder deler én synkroniseringskonto. At tilføje en enhed betyder at
-give den loginoplysningerne til den konto — derfor beder forløbet dig sammenligne
-en kort kode, før noget forbindes. Det er det eneste tidspunkt, hvor du kan skelne
-din egen enhed fra en andens.
+give den loginoplysningerne til den konto, så forløbet har to kontroller: en kort
+**kontrolkode**, du sammenligner før du forbinder, og en **emoji-verifikation**
+bagefter.
+
+De gør hver sit. Kontrolkoden fortæller, at de to skærme taler om den samme
+konto — den fanger en forældet eller forkert kode, altså den fejl man faktisk
+begår. Den udledes af offentlige identifikatorer og er derfor en genkendelseshjælp,
+ikke et bevis for, hvem der er i den anden ende. Emoji-verifikationen bagefter er
+det trin, der autentificerer enheden, og indtil den er færdig kan den nye enhed
+ikke læse noget.
 
 Du skal have begge enheder foran dig. Start på en, der allerede er forbundet —
 hvilken som helst, telefon eller computer. Der findes ingen «hovedenhed».
@@ -28,6 +35,11 @@ der scanner eller fotograferer QR-koden, kan tilslutte sig din konto og læse di
 noter. Vis den kun til en enhed, du selv ejer, og send den aldrig via chat,
 skærmbillede eller delt skærm.
 
+**At lukke skærmen skjuler koden, men tilbagekalder den ikke.** Koden
+indeholder din kontos nuværende adgangskode: et foto kan bruges, så længe den
+adgangskode gælder. Tror du, at nogen har taget et billede af den, så behandl
+den som en lækket adgangskode og ikke som noget, der er udløbet.
+
 **Kopiér parringskode** findes med vilje til de tilfælde, hvor den nye enhed ikke
 har kamera — en computer, der forbinder til en computer. Den lægger de samme
 oplysninger i udklipsholderen: indsæt dem direkte i den anden enhed og intet
@@ -36,9 +48,8 @@ andet sted.
 ## Scan den på den nye enhed
 
 Installér Lotti på den nye enhed, og åbn der **Indstillinger → Synkronisering →
-Enheder**. På en telefon åbner kameraet med det samme; ret det mod den første
-enhed. På computer, eller hvis kameraet ikke er tilgængeligt, vælg **indtast
-manuelt**, og indsæt den kopierede kode.
+Enheder**, og vælg kortet **Enheder**. På en telefon åbner kameraet med det samme; ret det mod den første
+enhed. På computer, eller hvis kameraet ikke er tilgængeligt, vælg **Indtast koden manuelt**, og indsæt den kopierede kode.
 
 ## Kontrollér, at koden stemmer, før du forbinder
 
@@ -83,7 +94,8 @@ Lad begge apps være åbne, indtil den første synkronisering er færdig.
 ## Hvis noget går galt
 
 - **Kontrolkoderne er forskellige.** Forbind ikke. Luk skærmen på den første
-  enhed, åbn en ny, og prøv igen — koden dannes på ny hver gang.
+  enhed, åbn en ny, og prøv igen — den samme konto giver den samme kode
+  hver gang, så en forskel betyder, at de to skærme hører til forskellige konti.
 - **Koden kan ikke afkodes.** Kopiér den igen på den første enhed i stedet for at
   rette i det, du indsatte; den kodede værdi er ikke beregnet til håndarbejde.
   Melder appen om forskellige versioner, kører enhederne på forskellige builds og

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ give den loginoplysningerne til den konto, så forløbet har to kontroller: en k
 bagefter.
 
 De gør hver sit. Kontrolkoden fortæller, at de to skærme taler om den samme
-konto — den fanger en forældet eller forkert kode, altså den fejl man faktisk
-begår. Den udledes af offentlige identifikatorer og er derfor en genkendelseshjælp,
-ikke et bevis for, hvem der er i den anden ende. Emoji-verifikationen bagefter er
+konto — den fanger en kode fra et andet sted, altså den fejl man faktisk
+begår. Den udledes kun af de identifikatorer, ikke af adgangskoden — den siger
+derfor intet om, hvorvidt de indeholdte loginoplysninger stadig gælder, og
+intet om, hvem der er i den anden ende. Emoji-verifikationen bagefter er
 det trin, der autentificerer enheden, og indtil den er færdig kan den nye enhed
 ikke læse noget.
 
@@ -64,7 +65,7 @@ det, du er ved at tilslutte dig, anført af kontrolkoden.
 />
 
 Se på kontrolkoden her og den på den første enhed. **De skal være identiske.**
-Er de forskellige, så stop: du ser ikke din egen enheds kode. Kassér den: de to skærme beskriver ikke den samme konto, det samme rum og den
+Er de forskellige, så stop. Kassér den: de to skærme beskriver ikke den samme konto, det samme rum og den
 samme server, og at åbne skærmen igen ændrer ikke det.
 
 Kontoen og serveren under koden er kontekst, ikke noget at sammenligne — de vises

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -24,7 +24,7 @@ service endnu.
 
 ## Se dine enheder
 
-**Indstillinger → Synkronisering → Enheder** viser hver session på din
+**Indstillinger → Synkroniseringsindstillinger → Enheder** viser hver session på din
 synkroniseringskonto — ikke kun de ikke-verificerede.
 
 <ManualScreenshot
@@ -43,7 +43,7 @@ Parring er sit eget forløb, med en kode at sammenligne og to trin efter
 forbindelsen. Den har sin egen side: [Tilføj en enhed](./add-device.mdx).
 
 Kort fortalt: På en enhed, der allerede er forbundet, åbner du **Indstillinger →
-Synkronisering → Enheder → Tilføj enhed** og viser koden. På den nye enhed åbner
+Synkroniseringsindstillinger → Enheder → Tilføj enhed** og viser koden. På den nye enhed åbner
 du den samme side og scanner den. Sammenlign kontrolkoden på begge skærme, før du
 forbinder — QR-koden indeholder loginoplysningerne til din synkroniseringskonto
 og går kun til din egen enhed.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -22,33 +22,31 @@ service endnu.
   caption="The Sync hub keeps everyday status near diagnostics and recovery tools. Project Waddle currently has three outbox items to inspect."
 />
 
-## Parr en anden enhed
+## Se dine enheder
 
-Start på en enhed, der allerede er tilsluttet:
-
-1. Åbn **Indstillinger → Synkroniser → Provisioneret Synkronisering**.
-2. På skrivebordet viser du overdragelses-QR-koden. Hold denne skærm privat: pakken
-   Giver adgang til din Sync-konto og værelse.
-3. På den nye enhed skal du åbne samme side og scanne QR-koden eller indsætte
-   Komplet provisioning-pakke.
-4. Gennemgå den afkodede server, bruger og rum, før du vælger **Import**.
-5. Lad den første synkronisering være færdig, før du lukker en af appsene.
+**Indstillinger → Synkronisering → Enheder** viser hver session på din
+synkroniseringskonto — ikke kun de ikke-verificerede.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Provisioned Sync status on mobile and the secure device handover QR code on desktop"
-  caption="Desktop can present the handover QR code; mobile shows the connected account and verification state. Treat the QR code like a password."
+  alt="Lottis Enheder-side med sessionerne på synkroniseringskontoen, verifikationsstatus og sidst set"
+  caption="Hver række viser, om enheden er verificeret, og hvornår serveren sidst så den. En ikke-verificeret enhed kan ikke læse nye noter, og listen siger det."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Lotti provisioning import review showing the Project Waddle sync server, user, and room"
-  caption="Import only when every decoded value belongs to the sync account you intended to join."
-/>
+Sessioner, der er logget ind med denne konto, kan fjernes — undtagen den, du
+sidder på. Enheder, der er parret på den gamle måde med hver sin konto, kan
+verificeres, men ikke fjernes.
 
-Hvis importen rapporterer en fejl, behold den oprindelige enhed tilsluttet, generer en
-Frisk overdragelsesbund, og prøv igen med fuld værdi. Rediger ikke manuelt
-Kodet bundt.
+## Parr en anden enhed
+
+Parring er sit eget forløb, med en kode at sammenligne og to trin efter
+forbindelsen. Den har sin egen side: [Tilføj en enhed](./add-device.mdx).
+
+Kort fortalt: På en enhed, der allerede er forbundet, åbner du **Indstillinger →
+Synkronisering → Enheder → Tilføj enhed** og viser koden. På den nye enhed åbner
+du den samme side og scanner den. Sammenlign kontrolkoden på begge skærme, før du
+forbinder — QR-koden indeholder loginoplysningerne til din synkroniseringskonto
+og går kun til din egen enhed.
 
 ## Verificér den nye enhed
 

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -69,8 +69,9 @@ Das Entschlüsseln des Codes verbindet noch nichts. Zuerst erscheint eine
 
 Sieh dir den Prüfcode hier und den auf dem ersten Gerät an. **Sie müssen
 identisch sein.** Unterscheiden sie sich, brich ab: Dann siehst du nicht den
-Code deines eigenen Geräts. Verwirf ihn und beginne mit einem frisch geöffneten
-Bildschirm „Gerät hinzufügen“ neu.
+Code deines eigenen Geräts. Verwirf ihn: Die beiden Bildschirme
+beschreiben nicht dasselbe Konto, denselben Raum und denselben Server, und ein
+neu geöffneter Bildschirm ändert daran nichts.
 
 Konto und Server unter dem Code sind Kontext, nichts zum Vergleichen — sie
 erscheinen auf dem anderen Gerät nicht. Wenn alles passt, wähle **Dieses Gerät
@@ -105,7 +106,7 @@ Lass beide Apps offen, bis die erste Synchronisierung fertig ist.
 - **Die Prüfcodes unterscheiden sich.** Nicht verbinden. Du siehst nicht den Code
   deines eigenen Geräts. Ein neuer Bildschirm hilft nicht: Dasselbe Konto
   erzeugt jedes Mal denselben Code, eine Abweichung heißt also, dass die beiden
-  Bildschirme zu verschiedenen Konten gehören.
+  Bildschirme nicht dieselbe Kopplung beschreiben.
 - **Der Code lässt sich nicht lesen.** Kopiere ihn auf dem ersten Gerät erneut,
   statt das Eingefügte zu korrigieren; der kodierte Wert ist nicht für
   Handarbeit gedacht. Meldet die App eine Versionsabweichung, laufen die Geräte

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,102 @@
+---
+title: Gerät hinzufügen
+description: Koppele ein neues Gerät per QR-Code mit deinem Sync-Konto, prüfe den Vergleichscode und erledige die zwei Schritte danach.
+---
+
+# Gerät hinzufügen
+
+Alle deine Geräte teilen sich ein Sync-Konto. Ein Gerät hinzuzufügen heißt, ihm
+die Zugangsdaten dieses Kontos zu übergeben. Deshalb bittet dich der Ablauf,
+vorher einen kurzen Code zu vergleichen: Das ist der einzige Punkt, an dem du
+dein eigenes Gerät von einem fremden unterscheiden kannst.
+
+Du brauchst beide Geräte vor dir. Beginne auf einem, das bereits verbunden ist —
+egal welches, Telefon oder Desktop. Es gibt kein „Hauptgerät“.
+
+## Den Code auf einem bereits genutzten Gerät anzeigen
+
+Öffne **Einstellungen → Synchronisierung → Geräte** und wähle **Gerät
+hinzufügen**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Lottis Bildschirm „Gerät hinzufügen“ mit QR-Code, Sicherheitshinweis mit Schloss und dem Prüfcode 2BD-EF4"
+  caption="Der Code entsteht beim Öffnen dieses Bildschirms und nur solange er offen ist. Beachte den Prüfcode darunter — den vergleichst du gleich."
+/>
+
+Behandle diesen Bildschirm wie dein Passwort, denn genau das steckt darin. Wer
+den QR-Code scannt oder abfotografiert, kann deinem Sync-Konto beitreten und
+deine Einträge lesen. Zeige ihn nur einem Gerät, das dir gehört, und schicke ihn
+nie per Chat, Screenshot oder geteiltem Bildschirm.
+
+**Kopplungscode kopieren** gibt es bewusst für den Fall, dass das neue Gerät
+keine Kamera hat — ein Desktop, der einem Desktop beitritt. Es legt dieselben
+Zugangsdaten in die Zwischenablage: Füge sie direkt im anderen Gerät ein und
+sonst nirgends.
+
+## Auf dem neuen Gerät scannen
+
+Installiere Lotti auf dem neuen Gerät und öffne dort **Einstellungen →
+Synchronisierung → Geräte**. Auf dem Telefon öffnet sich die Kamera sofort;
+richte sie auf das erste Gerät. Auf dem Desktop, oder wenn keine Kamera
+verfügbar ist, wähle **manuell eingeben** und füge den kopierten Code ein.
+
+## Vor dem Verbinden den Code vergleichen
+
+Das Entschlüsseln des Codes verbindet noch nichts. Zuerst erscheint eine
+Übersicht dessen, dem du beitreten willst — angeführt vom Prüfcode.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Lottis Kopplungsübersicht mit Prüfcode, dem beizutretenden Konto und dem Sync-Server"
+  caption="Beide Geräte leiten diesen Code unabhängig aus Konto, Raum und Server ab. Sie tauschen ihn nie aus — deshalb lohnt der Vergleich."
+/>
+
+Sieh dir den Prüfcode hier und den auf dem ersten Gerät an. **Sie müssen
+identisch sein.** Unterscheiden sie sich, brich ab: Dann siehst du nicht den
+Code deines eigenen Geräts. Verwirf ihn und beginne mit einem frisch geöffneten
+Bildschirm „Gerät hinzufügen“ neu.
+
+Konto und Server unter dem Code sind Kontext, nichts zum Vergleichen — sie
+erscheinen auf dem anderen Gerät nicht. Wenn alles passt, wähle **Dieses Gerät
+verbinden**.
+
+## Die zwei Schritte danach abschließen
+
+Verbinden tritt dem Konto bei. Es erlaubt dem neuen Gerät noch nicht, etwas zu
+lesen.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Lottis Sync-Einrichtung: Dieses Gerät ist verbunden, Emoji-Verifizierung und Einstellungen senden stehen noch aus"
+  caption="Verbunden ist die leichte Hälfte. Die Karte benennt, was noch fehlt, und sagt klar, dass dieses Gerät bis zur Verifizierung nichts lesen kann."
+/>
+
+1. **Emoji vergleichen.** Auf beiden Geräten erscheint eine Reihe Emoji. Prüfe,
+   ob sie übereinstimmen, und bestätige auf beiden. Bis dahin erhält das neue
+   Gerät nur Chiffrat, das es nicht lesen kann — Schlüssel gehen ausschließlich
+   an verifizierte Geräte. Siehe
+   [Das neue Gerät verifizieren](./sync.mdx).
+2. **Einstellungen senden.** Wähle auf dem ersten Gerät im noch offenen
+   Bildschirm „Gerät hinzufügen“ **Einstellungen senden**, damit Kategorien,
+   Gewohnheiten, Dashboards und KI-Konfiguration ankommen. Hast du ihn schon
+   geschlossen, öffne **Einstellungen → Synchronisierung → Geräte → Gerät
+   hinzufügen** erneut.
+
+Lass beide Apps offen, bis die erste Synchronisierung fertig ist.
+
+## Wenn etwas schiefgeht
+
+- **Die Prüfcodes unterscheiden sich.** Nicht verbinden. Schließe den Bildschirm
+  auf dem ersten Gerät, öffne einen neuen und versuche es erneut — der Code wird
+  jedes Mal neu erzeugt.
+- **Der Code lässt sich nicht lesen.** Kopiere ihn auf dem ersten Gerät erneut,
+  statt das Eingefügte zu korrigieren; der kodierte Wert ist nicht für
+  Handarbeit gedacht. Meldet die App eine Versionsabweichung, laufen die Geräte
+  auf verschiedenen Lotti-Ständen und beide brauchen ein Update.
+- **Das neue Gerät ist verbunden, bleibt aber leer.** Das ist vor der
+  Verifizierung der erwartete Zustand. Schließe den Emoji-Vergleich ab und prüfe
+  dann unter [Geräte synchronisieren](./sync.mdx) Postausgang und Nachfüllung.
+
+Weiter mit [Geräte synchronisieren](./sync.mdx) für Alltagsstatus,
+Zustellqualität und Wiederherstellung.

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ egal welches, Telefon oder Desktop. Es gibt kein „Hauptgerät“.
 
 ## Den Code auf einem bereits genutzten Gerät anzeigen
 
-Öffne **Einstellungen → Synchronisierung → Geräte** und wähle **Gerät
+Öffne **Einstellungen → Synchronisierungseinstellungen → Geräte** und wähle **Gerät
 hinzufügen**.
 
 <ManualScreenshot
@@ -31,9 +31,11 @@ hinzufügen**.
   caption="Der Code entsteht beim Öffnen dieses Bildschirms und nur solange er offen ist. Beachte den Prüfcode darunter — den vergleichst du gleich."
 />
 
-Behandle diesen Bildschirm wie dein Passwort, denn genau das steckt darin. Wer
-den QR-Code scannt oder abfotografiert, kann deinem Sync-Konto beitreten und
-deine Einträge lesen. Zeige ihn nur einem Gerät, das dir gehört, und schicke ihn
+Behandle diesen Bildschirm wie dein Passwort, denn genau das steckt darin. Wer den
+QR-Code scannt oder abfotografiert, kann sich bei deinem Sync-Konto anmelden:
+Deine Einträge kann er ohne Emoji-Verifizierung von einem deiner Geräte nicht
+entschlüsseln, aber er kann das Konto übernehmen — inklusive Passwortwechsel,
+der dich aussperrt. Zeige ihn nur einem Gerät, das dir gehört, und schicke ihn
 nie per Chat, Screenshot oder geteiltem Bildschirm.
 
 **Das Schließen des Bildschirms blendet den Code aus, macht ihn aber nicht
@@ -50,7 +52,7 @@ sonst nirgends.
 ## Auf dem neuen Gerät scannen
 
 Installiere Lotti auf dem neuen Gerät und öffne dort **Einstellungen →
-Synchronisierung → Geräte** und wähle dort die Karte **Geräte**. Auf dem Telefon öffnet sich die Kamera sofort;
+Synchronisierungseinstellungen → Geräte** und wähle dort die Karte **Geräte**. Auf dem Telefon öffnet sich die Kamera sofort;
 richte sie auf das erste Gerät. Auf dem Desktop, oder wenn keine Kamera
 verfügbar ist, wähle **Code manuell eingeben** und füge den kopierten Code ein.
 
@@ -93,7 +95,7 @@ lesen.
 2. **Einstellungen senden.** Wähle auf dem ersten Gerät im noch offenen
    Bildschirm „Gerät hinzufügen“ **Einstellungen senden**, damit Kategorien,
    Gewohnheiten, Dashboards und KI-Konfiguration ankommen. Hast du ihn schon
-   geschlossen, öffne **Einstellungen → Synchronisierung → Geräte → Gerät
+   geschlossen, öffne **Einstellungen → Synchronisierungseinstellungen → Geräte → Gerät
    hinzufügen** erneut.
 
 Lass beide Apps offen, bis die erste Synchronisierung fertig ist.

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ Prüfungen: einen kurzen **Prüfcode**, den du vor dem Verbinden vergleichst, un
 danach eine **Emoji-Verifizierung**.
 
 Sie leisten Verschiedenes. Der Prüfcode zeigt, dass beide Bildschirme dasselbe
-Konto meinen — er fängt einen veralteten oder falschen Code ab, also den Fehler,
-den man tatsächlich macht. Er wird aus öffentlichen Kennungen abgeleitet und ist
-damit eine Wiedererkennungshilfe, kein Beweis, wer am anderen Ende sitzt. Die
+Konto meinen — er fängt einen Code von woanders ab, also den Fehler,
+den man tatsächlich macht. Er wird nur aus diesen Kennungen abgeleitet, nicht
+aus dem Passwort — er sagt also nichts darüber, ob die enthaltenen Zugangsdaten
+noch gültig sind, und nichts darüber, wer am anderen Ende sitzt. Die
 anschließende Emoji-Verifizierung ist der Schritt, der das Gerät authentifiziert,
 und bis sie abgeschlossen ist, kann das neue Gerät nichts lesen.
 
@@ -68,8 +69,7 @@ Das Entschlüsseln des Codes verbindet noch nichts. Zuerst erscheint eine
 />
 
 Sieh dir den Prüfcode hier und den auf dem ersten Gerät an. **Sie müssen
-identisch sein.** Unterscheiden sie sich, brich ab: Dann siehst du nicht den
-Code deines eigenen Geräts. Verwirf ihn: Die beiden Bildschirme
+identisch sein.** Unterscheiden sie sich, brich ab. Verwirf ihn: Die beiden Bildschirme
 beschreiben nicht dasselbe Konto, denselben Raum und denselben Server, und ein
 neu geöffneter Bildschirm ändert daran nichts.
 

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -28,7 +28,7 @@ hinzufügen**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Lottis Bildschirm „Gerät hinzufügen“ mit QR-Code, Sicherheitshinweis mit Schloss und dem Prüfcode 2BD-EF4"
-  caption="Der Code entsteht beim Öffnen dieses Bildschirms und nur solange er offen ist. Beachte den Prüfcode darunter — den vergleichst du gleich."
+  caption="Der Code wird nur angezeigt, solange dieser Bildschirm offen ist. Beachte den Prüfcode darunter — den vergleichst du gleich."
 />
 
 Behandle diesen Bildschirm wie dein Passwort, denn genau das steckt darin. Wer den
@@ -102,9 +102,9 @@ Lass beide Apps offen, bis die erste Synchronisierung fertig ist.
 
 ## Wenn etwas schiefgeht
 
-- **Die Prüfcodes unterscheiden sich.** Nicht verbinden. Schließe den Bildschirm
-  auf dem ersten Gerät, öffne einen neuen und versuche es erneut — dasselbe Konto erzeugt
-  jedes Mal denselben Code, eine Abweichung heißt also, dass die beiden
+- **Die Prüfcodes unterscheiden sich.** Nicht verbinden. Du siehst nicht den Code
+  deines eigenen Geräts. Ein neuer Bildschirm hilft nicht: Dasselbe Konto
+  erzeugt jedes Mal denselben Code, eine Abweichung heißt also, dass die beiden
   Bildschirme zu verschiedenen Konten gehören.
 - **Der Code lässt sich nicht lesen.** Kopiere ihn auf dem ersten Gerät erneut,
   statt das Eingefügte zu korrigieren; der kodierte Wert ist nicht für

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Koppele ein neues Gerät per QR-Code mit deinem Sync-Konto, prüfe 
 # Gerät hinzufügen
 
 Alle deine Geräte teilen sich ein Sync-Konto. Ein Gerät hinzuzufügen heißt, ihm
-die Zugangsdaten dieses Kontos zu übergeben. Deshalb bittet dich der Ablauf,
-vorher einen kurzen Code zu vergleichen: Das ist der einzige Punkt, an dem du
-dein eigenes Gerät von einem fremden unterscheiden kannst.
+die Zugangsdaten dieses Kontos zu übergeben. Deshalb hat der Ablauf zwei
+Prüfungen: einen kurzen **Prüfcode**, den du vor dem Verbinden vergleichst, und
+danach eine **Emoji-Verifizierung**.
+
+Sie leisten Verschiedenes. Der Prüfcode zeigt, dass beide Bildschirme dasselbe
+Konto meinen — er fängt einen veralteten oder falschen Code ab, also den Fehler,
+den man tatsächlich macht. Er wird aus öffentlichen Kennungen abgeleitet und ist
+damit eine Wiedererkennungshilfe, kein Beweis, wer am anderen Ende sitzt. Die
+anschließende Emoji-Verifizierung ist der Schritt, der das Gerät authentifiziert,
+und bis sie abgeschlossen ist, kann das neue Gerät nichts lesen.
 
 Du brauchst beide Geräte vor dir. Beginne auf einem, das bereits verbunden ist —
 egal welches, Telefon oder Desktop. Es gibt kein „Hauptgerät“.
@@ -29,6 +36,12 @@ den QR-Code scannt oder abfotografiert, kann deinem Sync-Konto beitreten und
 deine Einträge lesen. Zeige ihn nur einem Gerät, das dir gehört, und schicke ihn
 nie per Chat, Screenshot oder geteiltem Bildschirm.
 
+**Das Schließen des Bildschirms blendet den Code aus, macht ihn aber nicht
+ungültig.** Der Code enthält dein aktuelles Kontopasswort — ein Foto davon
+bleibt so lange nutzbar, wie dieses Passwort gilt. Wenn du vermutest, dass ihn
+jemand abfotografiert hat, behandle ihn wie ein geleaktes Passwort und nicht
+wie etwas, das inzwischen abgelaufen wäre.
+
 **Kopplungscode kopieren** gibt es bewusst für den Fall, dass das neue Gerät
 keine Kamera hat — ein Desktop, der einem Desktop beitritt. Es legt dieselben
 Zugangsdaten in die Zwischenablage: Füge sie direkt im anderen Gerät ein und
@@ -37,9 +50,9 @@ sonst nirgends.
 ## Auf dem neuen Gerät scannen
 
 Installiere Lotti auf dem neuen Gerät und öffne dort **Einstellungen →
-Synchronisierung → Geräte**. Auf dem Telefon öffnet sich die Kamera sofort;
+Synchronisierung → Geräte** und wähle dort die Karte **Geräte**. Auf dem Telefon öffnet sich die Kamera sofort;
 richte sie auf das erste Gerät. Auf dem Desktop, oder wenn keine Kamera
-verfügbar ist, wähle **manuell eingeben** und füge den kopierten Code ein.
+verfügbar ist, wähle **Code manuell eingeben** und füge den kopierten Code ein.
 
 ## Vor dem Verbinden den Code vergleichen
 
@@ -88,8 +101,9 @@ Lass beide Apps offen, bis die erste Synchronisierung fertig ist.
 ## Wenn etwas schiefgeht
 
 - **Die Prüfcodes unterscheiden sich.** Nicht verbinden. Schließe den Bildschirm
-  auf dem ersten Gerät, öffne einen neuen und versuche es erneut — der Code wird
-  jedes Mal neu erzeugt.
+  auf dem ersten Gerät, öffne einen neuen und versuche es erneut — dasselbe Konto erzeugt
+  jedes Mal denselben Code, eine Abweichung heißt also, dass die beiden
+  Bildschirme zu verschiedenen Konten gehören.
 - **Der Code lässt sich nicht lesen.** Kopiere ihn auf dem ersten Gerät erneut,
   statt das Eingefügte zu korrigieren; der kodierte Wert ist nicht für
   Handarbeit gedacht. Meldet die App eine Versionsabweichung, laufen die Geräte

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -24,7 +24,7 @@ Sync-Dienst noch nicht erreicht haben.
 
 ## Deine Geräte sehen
 
-**Einstellungen → Synchronisierung → Geräte** listet jede Sitzung deines
+**Einstellungen → Synchronisierungseinstellungen → Geräte** listet jede Sitzung deines
 Sync-Kontos — nicht nur die unverifizierten.
 
 <ManualScreenshot
@@ -44,7 +44,7 @@ Schritten nach dem Verbinden. Es hat eine eigene Seite:
 [Gerät hinzufügen](./add-device.mdx).
 
 Kurz gefasst: Öffne auf einem bereits verbundenen Gerät **Einstellungen →
-Synchronisierung → Geräte → Gerät hinzufügen** und zeige den Code. Öffne auf dem
+Synchronisierungseinstellungen → Geräte → Gerät hinzufügen** und zeige den Code. Öffne auf dem
 neuen Gerät dieselbe Seite und scanne ihn. Vergleiche den Prüfcode auf beiden
 Bildschirmen, bevor du verbindest — der QR-Code enthält die Zugangsdaten deines
 Sync-Kontos und geht nur an dein eigenes Gerät.

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -22,33 +22,32 @@ Sync-Dienst noch nicht erreicht haben.
   caption="Alltagsstatus steht neben Diagnose und Wiederherstellung. Project Waddle hat drei Elemente im Postausgang."
 />
 
-## Ein weiteres Gerät koppeln
+## Deine Geräte sehen
 
-Beginne auf einem bereits verbundenen Gerät:
-
-1. Öffne **Einstellungen → Synchronisierung → Bereitgestellte Synchronisierung**.
-2. Zeige auf dem Desktop den Übergabe-QR-Code. Halte ihn privat: Das Paket
-   gewährt Zugang zu Konto und Raum.
-3. Öffne auf dem neuen Gerät dieselbe Seite und scanne den QR-Code oder füge
-   das vollständige Bereitstellungspaket ein.
-4. Prüfe Server, Benutzer und Raum vor **Importieren**.
-5. Warte, bis die erste Synchronisierung abgeschlossen ist, bevor du eine App
-   schließt.
+**Einstellungen → Synchronisierung → Geräte** listet jede Sitzung deines
+Sync-Kontos — nicht nur die unverifizierten.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Status der bereitgestellten Synchronisierung mobil und sicherer Geräteübergabe-QR-Code auf Desktop"
-  caption="Desktop kann den QR-Code zeigen; mobil siehst du Konto und Verifizierung. Behandle den Code wie ein Passwort."
+  alt="Lottis Geräteseite mit den Sitzungen des Sync-Kontos, Verifizierungsstatus und letzter Sichtung"
+  caption="Jede Zeile zeigt, ob das Gerät verifiziert ist und wann der Server es zuletzt gesehen hat. Ein unverifiziertes Gerät kann neue Einträge nicht lesen, und die Liste sagt das."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Lottis Importprüfung mit Project-Waddle-Sync-Server, Benutzer und Raum"
-  caption="Importiere nur, wenn jeder dekodierte Wert zum gewünschten Konto gehört."
-/>
+Mit diesem Konto angemeldete Sitzungen lassen sich entfernen — außer der, auf der
+du gerade bist. Auf die alte Art gekoppelte Geräte mit eigenem Konto lassen sich
+verifizieren, aber nicht entfernen.
 
-Bei Fehlern halte das Originalgerät verbunden, erzeuge ein frisches Paket und
-versuche den vollständigen Wert erneut. Bearbeite die Kodierung nicht manuell.
+## Ein weiteres Gerät koppeln
+
+Das Koppeln ist ein eigener Ablauf, mit einem Code zum Vergleichen und zwei
+Schritten nach dem Verbinden. Es hat eine eigene Seite:
+[Gerät hinzufügen](./add-device.mdx).
+
+Kurz gefasst: Öffne auf einem bereits verbundenen Gerät **Einstellungen →
+Synchronisierung → Geräte → Gerät hinzufügen** und zeige den Code. Öffne auf dem
+neuen Gerät dieselbe Seite und scanne ihn. Vergleiche den Prüfcode auf beiden
+Bildschirmen, bevor du verbindest — der QR-Code enthält die Zugangsdaten deines
+Sync-Kontos und geht nur an dein eigenes Gerät.
 
 ## Das neue Gerät verifizieren
 

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ cualquiera, móvil u ordenador. No hay un dispositivo «principal».
 
 ## Muestra el código en un dispositivo que ya usas
 
-Abre **Ajustes → Sincronización → Dispositivos** y elige **Añadir dispositivo**.
+Abre **Ajustes → Ajustes de sincronización → Dispositivos** y elige **Añadir dispositivo**.
 
 <ManualScreenshot
   caseId="sync/add-device"
@@ -31,8 +31,10 @@ Abre **Ajustes → Sincronización → Dispositivos** y elige **Añadir disposit
 />
 
 Trata esta pantalla como tratarías tu contraseña, porque es lo que contiene.
-Quien escanee o fotografíe el código QR puede unirse a tu cuenta y leer tus
-entradas. Muéstralo solo a un dispositivo tuyo y nunca lo envíes por chat,
+Quien escanee o fotografíe el código QR puede iniciar sesión en tu cuenta: no
+puede descifrar tus entradas sin estar además verificado con emoji desde uno de
+tus dispositivos, pero sí puede apoderarse de la cuenta, contraseña incluida, y
+dejarte fuera. Muéstralo solo a un dispositivo tuyo y nunca lo envíes por chat,
 captura de pantalla o pantalla compartida.
 
 **Cerrar la pantalla oculta el código, pero no lo revoca.** El código
@@ -47,7 +49,7 @@ dispositivo y en ningún otro sitio.
 
 ## Escanéalo en el dispositivo nuevo
 
-Instala Lotti en el dispositivo nuevo y abre allí **Ajustes → Sincronización →
+Instala Lotti en el dispositivo nuevo y abre allí **Ajustes → Ajustes de sincronización →
 Dispositivos** y selecciona la tarjeta **Dispositivos**. En el móvil la cámara se abre enseguida; apunta al primer
 dispositivo. En ordenador, o si la cámara no está disponible, elige **Introducir el código manualmente** y pega el código copiado.
 
@@ -90,7 +92,7 @@ Conectar une a la cuenta. Todavía no permite al dispositivo nuevo leer nada.
 2. **Envía los ajustes.** En el primer dispositivo, en la pantalla Añadir
    dispositivo que sigue abierta, elige **Enviar ajustes** para que lleguen
    categorías, hábitos, paneles y la configuración de IA. Si ya la cerraste,
-   vuelve a abrir **Ajustes → Sincronización → Dispositivos → Añadir
+   vuelve a abrir **Ajustes → Ajustes de sincronización → Dispositivos → Añadir
    dispositivo**.
 
 Deja ambas apps abiertas hasta que termine la primera sincronización.

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -27,7 +27,7 @@ Abre **Ajustes → Ajustes de sincronización → Dispositivos** y elige **Añad
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Pantalla Añadir dispositivo de Lotti con código QR, aviso de seguridad con candado y el código de verificación 2BD-EF4"
-  caption="El código se genera al abrir esta pantalla y solo mientras siga abierta. Fíjate en el código de verificación de debajo: lo compararás enseguida."
+  caption="El código solo se muestra mientras esta pantalla siga abierta. Fíjate en el código de verificación de debajo: lo compararás enseguida."
 />
 
 Trata esta pantalla como tratarías tu contraseña, porque es lo que contiene.
@@ -99,10 +99,10 @@ Deja ambas apps abiertas hasta que termine la primera sincronización.
 
 ## Si algo va mal
 
-- **Los códigos de verificación difieren.** No conectes. Cierra la pantalla del
-  primer dispositivo, abre una nueva e inténtalo otra vez: la misma cuenta produce siempre el mismo
-  código, así que una diferencia significa que las dos pantallas pertenecen a
-  cuentas distintas.
+- **Los códigos de verificación difieren.** No conectes. No estás viendo el código de
+  tu propio dispositivo. Reabrir la pantalla no ayuda: la misma cuenta produce
+  siempre el mismo código, así que una diferencia significa que las dos
+  pantallas pertenecen a cuentas distintas.
 - **El código no se descodifica.** Cópialo de nuevo en el primer dispositivo en
   lugar de corregir lo que pegaste; el valor codificado no está pensado para
   arreglarse a mano. Si la app informa de versiones distintas, los dispositivos

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,101 @@
+---
+title: Añadir un dispositivo
+description: Empareja un dispositivo nuevo con tu cuenta de sincronización mediante un código QR, comprueba el código de verificación y completa los dos pasos siguientes.
+---
+
+# Añadir un dispositivo
+
+Todos tus dispositivos comparten una sola cuenta de sincronización. Añadir un
+dispositivo significa entregarle las credenciales de esa cuenta: por eso el flujo
+te pide comparar un código corto antes de conectar nada. Es el único momento en
+el que puedes distinguir tu dispositivo del de otra persona.
+
+Necesitas ambos dispositivos delante. Empieza en uno que ya esté conectado —
+cualquiera, móvil u ordenador. No hay un dispositivo «principal».
+
+## Muestra el código en un dispositivo que ya usas
+
+Abre **Ajustes → Sincronización → Dispositivos** y elige **Añadir dispositivo**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Pantalla Añadir dispositivo de Lotti con código QR, aviso de seguridad con candado y el código de verificación 2BD-EF4"
+  caption="El código se genera al abrir esta pantalla y solo mientras siga abierta. Fíjate en el código de verificación de debajo: lo compararás enseguida."
+/>
+
+Trata esta pantalla como tratarías tu contraseña, porque es lo que contiene.
+Quien escanee o fotografíe el código QR puede unirse a tu cuenta y leer tus
+entradas. Muéstralo solo a un dispositivo tuyo y nunca lo envíes por chat,
+captura de pantalla o pantalla compartida.
+
+**Copiar código de emparejamiento** existe a propósito para cuando el
+dispositivo que se une no tiene cámara — un ordenador uniéndose a otro. Pone las
+mismas credenciales en el portapapeles: pégalas directamente en el otro
+dispositivo y en ningún otro sitio.
+
+## Escanéalo en el dispositivo nuevo
+
+Instala Lotti en el dispositivo nuevo y abre allí **Ajustes → Sincronización →
+Dispositivos**. En el móvil la cámara se abre enseguida; apunta al primer
+dispositivo. En ordenador, o si la cámara no está disponible, elige **introducir
+manualmente** y pega el código copiado.
+
+## Comprueba que el código coincide antes de conectar
+
+Descodificar el código no conecta nada. Lo primero que aparece es un resumen de
+aquello a lo que estás a punto de unirte, encabezado por el código de
+verificación.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Resumen de emparejamiento de Lotti con el código de verificación, la cuenta a la que se unirá y el servidor de sincronización"
+  caption="Ambos dispositivos derivan este código de forma independiente a partir de cuenta, sala y servidor. Nunca se lo intercambian: por eso compararlo sirve."
+/>
+
+Mira el código de verificación aquí y el del primer dispositivo. **Deben ser
+idénticos.** Si difieren, para: no estás viendo el código de tu propio
+dispositivo. Descártalo y empieza de nuevo desde una pantalla Añadir dispositivo
+recién abierta.
+
+La cuenta y el servidor bajo el código son contexto, no cosas que comparar: no
+aparecen en el otro dispositivo. Cuando todo coincida, elige **Conectar este
+dispositivo**.
+
+## Completa los dos pasos siguientes
+
+Conectar une a la cuenta. Todavía no permite al dispositivo nuevo leer nada.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Configuración de sincronización de Lotti: este dispositivo está conectado, verificación con emoji y Enviar ajustes aún pendientes"
+  caption="Conectado es la mitad fácil. La tarjeta nombra lo que falta y dice claramente que sin verificación este dispositivo no puede leer nada."
+/>
+
+1. **Compara los emoji.** En ambos dispositivos aparece una fila de emoji.
+   Comprueba que coinciden y confirma en cada uno. Hasta entonces el dispositivo
+   nuevo solo recibe cifrado que no puede leer: las claves van únicamente a
+   dispositivos verificados. Consulta
+   [Sincronizar dispositivos](./sync.mdx).
+2. **Envía los ajustes.** En el primer dispositivo, en la pantalla Añadir
+   dispositivo que sigue abierta, elige **Enviar ajustes** para que lleguen
+   categorías, hábitos, paneles y la configuración de IA. Si ya la cerraste,
+   vuelve a abrir **Ajustes → Sincronización → Dispositivos → Añadir
+   dispositivo**.
+
+Deja ambas apps abiertas hasta que termine la primera sincronización.
+
+## Si algo va mal
+
+- **Los códigos de verificación difieren.** No conectes. Cierra la pantalla del
+  primer dispositivo, abre una nueva e inténtalo otra vez: el código se regenera
+  cada vez.
+- **El código no se descodifica.** Cópialo de nuevo en el primer dispositivo en
+  lugar de corregir lo que pegaste; el valor codificado no está pensado para
+  arreglarse a mano. Si la app informa de versiones distintas, los dispositivos
+  llevan compilaciones diferentes y ambos necesitan actualizarse.
+- **El dispositivo nuevo conecta pero sigue vacío.** Es el estado esperado antes
+  de la verificación. Termina la comparación de emoji y luego revisa
+  [Sincronizar dispositivos](./sync.mdx) para bandeja de salida y recuperación.
+
+Continúa con [Sincronizar dispositivos](./sync.mdx) para el estado diario, la
+salud de la entrega y las herramientas de recuperación.

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ tiene dos comprobaciones: un **código de verificación** corto que comparas ant
 de conectar y una **verificación con emoji** después.
 
 Hacen cosas distintas. El código de verificación indica que ambas pantallas
-hablan de la misma cuenta: detecta un código caducado o equivocado, que es el
-error que de verdad se comete. Se deriva de identificadores públicos, así que es
-una ayuda de reconocimiento, no una prueba de quién está al otro lado. La
+hablan de la misma cuenta: detecta un código venido de otro sitio, que es el
+error que de verdad se comete. Se deriva solo de esos identificadores, no de la
+contraseña: no dice nada sobre si las credenciales que lleva siguen siendo
+válidas, ni sobre quién está al otro lado. La
 verificación con emoji posterior es el paso que autentica el dispositivo, y hasta
 que termina el dispositivo nuevo no puede leer nada.
 
@@ -66,8 +67,7 @@ verificación.
 />
 
 Mira el código de verificación aquí y el del primer dispositivo. **Deben ser
-idénticos.** Si difieren, para: no estás viendo el código de tu propio
-dispositivo. Descártalo: las dos pantallas no describen la misma cuenta, sala y servidor, y
+idénticos.** Si difieren, para y descártalo: las dos pantallas no describen la misma cuenta, sala y servidor, y
 reabrir la pantalla no cambiará eso.
 
 La cuenta y el servidor bajo el código son contexto, no cosas que comparar: no

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Empareja un dispositivo nuevo con tu cuenta de sincronización medi
 # Añadir un dispositivo
 
 Todos tus dispositivos comparten una sola cuenta de sincronización. Añadir un
-dispositivo significa entregarle las credenciales de esa cuenta: por eso el flujo
-te pide comparar un código corto antes de conectar nada. Es el único momento en
-el que puedes distinguir tu dispositivo del de otra persona.
+dispositivo significa entregarle las credenciales de esa cuenta, así que el flujo
+tiene dos comprobaciones: un **código de verificación** corto que comparas antes
+de conectar y una **verificación con emoji** después.
+
+Hacen cosas distintas. El código de verificación indica que ambas pantallas
+hablan de la misma cuenta: detecta un código caducado o equivocado, que es el
+error que de verdad se comete. Se deriva de identificadores públicos, así que es
+una ayuda de reconocimiento, no una prueba de quién está al otro lado. La
+verificación con emoji posterior es el paso que autentica el dispositivo, y hasta
+que termina el dispositivo nuevo no puede leer nada.
 
 Necesitas ambos dispositivos delante. Empieza en uno que ya esté conectado —
 cualquiera, móvil u ordenador. No hay un dispositivo «principal».
@@ -28,6 +35,11 @@ Quien escanee o fotografíe el código QR puede unirse a tu cuenta y leer tus
 entradas. Muéstralo solo a un dispositivo tuyo y nunca lo envíes por chat,
 captura de pantalla o pantalla compartida.
 
+**Cerrar la pantalla oculta el código, pero no lo revoca.** El código
+contiene la contraseña actual de tu cuenta: una foto sigue siendo utilizable
+mientras esa contraseña siga vigente. Si crees que alguien la ha capturado,
+trátala como una contraseña filtrada, no como algo que haya caducado.
+
 **Copiar código de emparejamiento** existe a propósito para cuando el
 dispositivo que se une no tiene cámara — un ordenador uniéndose a otro. Pone las
 mismas credenciales en el portapapeles: pégalas directamente en el otro
@@ -36,9 +48,8 @@ dispositivo y en ningún otro sitio.
 ## Escanéalo en el dispositivo nuevo
 
 Instala Lotti en el dispositivo nuevo y abre allí **Ajustes → Sincronización →
-Dispositivos**. En el móvil la cámara se abre enseguida; apunta al primer
-dispositivo. En ordenador, o si la cámara no está disponible, elige **introducir
-manualmente** y pega el código copiado.
+Dispositivos** y selecciona la tarjeta **Dispositivos**. En el móvil la cámara se abre enseguida; apunta al primer
+dispositivo. En ordenador, o si la cámara no está disponible, elige **Introducir el código manualmente** y pega el código copiado.
 
 ## Comprueba que el código coincide antes de conectar
 
@@ -87,8 +98,9 @@ Deja ambas apps abiertas hasta que termine la primera sincronización.
 ## Si algo va mal
 
 - **Los códigos de verificación difieren.** No conectes. Cierra la pantalla del
-  primer dispositivo, abre una nueva e inténtalo otra vez: el código se regenera
-  cada vez.
+  primer dispositivo, abre una nueva e inténtalo otra vez: la misma cuenta produce siempre el mismo
+  código, así que una diferencia significa que las dos pantallas pertenecen a
+  cuentas distintas.
 - **El código no se descodifica.** Cópialo de nuevo en el primer dispositivo en
   lugar de corregir lo que pegaste; el valor codificado no está pensado para
   arreglarse a mano. Si la app informa de versiones distintas, los dispositivos

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -67,8 +67,8 @@ verificación.
 
 Mira el código de verificación aquí y el del primer dispositivo. **Deben ser
 idénticos.** Si difieren, para: no estás viendo el código de tu propio
-dispositivo. Descártalo y empieza de nuevo desde una pantalla Añadir dispositivo
-recién abierta.
+dispositivo. Descártalo: las dos pantallas no describen la misma cuenta, sala y servidor, y
+reabrir la pantalla no cambiará eso.
 
 La cuenta y el servidor bajo el código son contexto, no cosas que comparar: no
 aparecen en el otro dispositivo. Cuando todo coincida, elige **Conectar este
@@ -101,8 +101,8 @@ Deja ambas apps abiertas hasta que termine la primera sincronización.
 
 - **Los códigos de verificación difieren.** No conectes. No estás viendo el código de
   tu propio dispositivo. Reabrir la pantalla no ayuda: la misma cuenta produce
-  siempre el mismo código, así que una diferencia significa que las dos
-  pantallas pertenecen a cuentas distintas.
+  siempre el mismo código, así que una diferencia significa que las dos pantallas no
+  describen el mismo emparejamiento.
 - **El código no se descodifica.** Cópialo de nuevo en el primer dispositivo en
   lugar de corregir lo que pegaste; el valor codificado no está pensado para
   arreglarse a mano. Si la app informa de versiones distintas, los dispositivos

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -25,7 +25,7 @@ aún no ha llegado al servicio de sincronización.
 
 ## Ver tus dispositivos
 
-**Ajustes → Sincronización → Dispositivos** enumera cada sesión de tu cuenta de
+**Ajustes → Ajustes de sincronización → Dispositivos** enumera cada sesión de tu cuenta de
 sincronización, no solo las no verificadas.
 
 <ManualScreenshot
@@ -44,7 +44,7 @@ El emparejamiento es un flujo propio, con un código que comparar y dos pasos
 después de conectar. Tiene su propia página:
 [Añadir un dispositivo](./add-device.mdx).
 
-En resumen: en un dispositivo ya conectado abre **Ajustes → Sincronización →
+En resumen: en un dispositivo ya conectado abre **Ajustes → Ajustes de sincronización →
 Dispositivos → Añadir dispositivo** y muestra el código. En el dispositivo nuevo
 abre la misma página y escanéalo. Compara el código de comprobación en ambas
 pantallas antes de conectar: el código QR lleva las credenciales de tu cuenta de

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -23,35 +23,32 @@ aún no ha llegado al servicio de sincronización.
   caption="El centro de Sync mantiene el estado diario cerca de las herramientas de diagnóstico y recuperación. Project Waddle tiene actualmente tres elementos en la bandeja de salida que conviene inspeccionar."
 />
 
-## Empareja otro dispositivo
+## Ver tus dispositivos
 
-Empieza en un dispositivo que ya esté conectado:
-
-1. Abre **Ajustes → Sync → Provisioned Sync**.
-2. En el escritorio, muestra el código QR de transferencia. Mantén esta pantalla
-   privada: el paquete concede acceso a tu cuenta y sala de sincronización.
-3. En el dispositivo nuevo, abre la misma página y escanea el código QR o pega
-   el paquete de aprovisionamiento completo.
-4. Revisa el servidor, usuario y sala descodificados antes de seleccionar
-   **Importar**.
-5. Deja que termine la primera sincronización antes de cerrar cualquiera de las
-   dos aplicaciones.
+**Ajustes → Sincronización → Dispositivos** enumera cada sesión de tu cuenta de
+sincronización, no solo las no verificadas.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Estado de Provisioned Sync en móvil y código QR de transferencia segura entre dispositivos en escritorio"
-  caption="El escritorio puede mostrar el código QR de transferencia; el móvil muestra la cuenta conectada y el estado de verificación. Trata el código QR como una contraseña."
+  alt="Página Dispositivos de Lotti con las sesiones de la cuenta de sincronización, su estado de verificación y su última actividad"
+  caption="Cada fila muestra si el dispositivo está verificado y cuándo lo vio el servidor por última vez. Un dispositivo sin verificar no puede leer entradas nuevas, y la lista lo indica."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Revisión de la importación de aprovisionamiento de Lotti con el servidor, usuario y sala de sincronización de Project Waddle"
-  caption="Importa solo cuando cada valor descodificado pertenezca a la cuenta de sincronización a la que pretendías unirte."
-/>
+Las sesiones iniciadas con esta cuenta se pueden eliminar, salvo aquella en la
+que estás. Los dispositivos emparejados a la antigua, con su propia cuenta, se
+pueden verificar pero no eliminar.
 
-Si la importación informa de un error, mantén conectado el dispositivo original,
-genera un paquete de transferencia nuevo e inténtalo otra vez con el valor
-completo. No edites manualmente el paquete codificado.
+## Empareja otro dispositivo
+
+El emparejamiento es un flujo propio, con un código que comparar y dos pasos
+después de conectar. Tiene su propia página:
+[Añadir un dispositivo](./add-device.mdx).
+
+En resumen: en un dispositivo ya conectado abre **Ajustes → Sincronización →
+Dispositivos → Añadir dispositivo** y muestra el código. En el dispositivo nuevo
+abre la misma página y escanéalo. Compara el código de comprobación en ambas
+pantallas antes de conectar: el código QR lleva las credenciales de tu cuenta de
+sincronización y solo va a tu propio dispositivo.
 
 ## Verifica el dispositivo nuevo
 

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,103 @@
+---
+title: Ajouter un appareil
+description: Appaire un nouvel appareil à ton compte de synchronisation avec un QR code, vérifie le code de contrôle et termine les deux étapes qui suivent.
+---
+
+# Ajouter un appareil
+
+Tous tes appareils partagent un seul compte de synchronisation. Ajouter un
+appareil, c'est lui confier les identifiants de ce compte : c'est pourquoi le
+parcours te demande de comparer un code court avant toute connexion. C'est le
+seul moment où tu peux distinguer ton appareil de celui de quelqu'un d'autre.
+
+Il te faut les deux appareils devant toi. Commence sur un appareil déjà
+connecté — n'importe lequel, téléphone ou ordinateur. Il n'y a pas d'appareil
+« principal ».
+
+## Afficher le code sur un appareil déjà utilisé
+
+Ouvre **Paramètres → Synchronisation → Appareils** et choisis **Ajouter un
+appareil**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Écran Ajouter un appareil de Lotti avec un QR code, une note de sécurité avec cadenas et le code de contrôle 2BD-EF4"
+  caption="Le code est généré à l'ouverture de cet écran, et seulement tant qu'il reste ouvert. Note le code de contrôle en dessous : tu vas le comparer."
+/>
+
+Traite cet écran comme ton mot de passe, car c'est ce qu'il contient. Quiconque
+scanne ou photographie le QR code peut rejoindre ton compte et lire tes entrées.
+Ne le montre qu'à un appareil qui t'appartient, et ne l'envoie jamais par
+messagerie, capture d'écran ou partage d'écran.
+
+**Copier le code d'appairage** existe volontairement pour le cas où l'appareil
+qui rejoint n'a pas de caméra — un ordinateur rejoignant un ordinateur. Il place
+les mêmes identifiants dans ton presse-papiers : colle-les directement dans
+l'autre appareil et nulle part ailleurs.
+
+## Le scanner sur le nouvel appareil
+
+Installe Lotti sur le nouvel appareil, puis ouvres-y **Paramètres →
+Synchronisation → Appareils**. Sur un téléphone la caméra s'ouvre aussitôt ;
+vise le premier appareil. Sur un ordinateur, ou si la caméra est indisponible,
+choisis **saisir manuellement** et colle le code copié.
+
+## Vérifier que le code correspond avant de connecter
+
+Décoder le code ne connecte rien. Ce qui apparaît d'abord est un récapitulatif
+de ce que tu t'apprêtes à rejoindre, mené par le code de contrôle.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Récapitulatif d'appairage de Lotti avec le code de contrôle, le compte rejoint et le serveur de synchronisation"
+  caption="Les deux appareils dérivent ce code indépendamment du compte, du salon et du serveur. Ils ne l'échangent jamais — d'où l'intérêt de le comparer."
+/>
+
+Regarde le code de contrôle ici et celui du premier appareil. **Ils doivent être
+identiques.** S'ils diffèrent, arrête-toi : ce n'est pas le code de ton appareil.
+Écarte-le et recommence depuis un écran Ajouter un appareil fraîchement ouvert.
+
+Le compte et le serveur sous le code sont du contexte, pas des éléments à
+comparer — ils n'apparaissent pas sur l'autre appareil. Quand tout correspond,
+choisis **Connecter cet appareil**.
+
+## Terminer les deux étapes suivantes
+
+La connexion rejoint le compte. Elle ne permet pas encore au nouvel appareil de
+lire quoi que ce soit.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Configuration de synchronisation Lotti : cet appareil est connecté, vérification par emoji et Envoyer les réglages encore en attente"
+  caption="Connecté, c'est la moitié facile. La carte nomme ce qui manque et dit clairement que sans vérification l'appareil ne peut rien lire."
+/>
+
+1. **Compare les emoji.** Une rangée d'emoji apparaît sur les deux appareils.
+   Vérifie qu'ils correspondent et confirme sur chacun. Jusque-là, le nouvel
+   appareil ne reçoit que du chiffré illisible — les clés ne vont qu'aux
+   appareils vérifiés. Voir
+   [Vérifier le nouvel appareil](./sync.mdx).
+2. **Envoie les réglages.** Sur le premier appareil, dans l'écran Ajouter un
+   appareil encore ouvert, choisis **Envoyer les réglages** pour que catégories,
+   habitudes, tableaux de bord et configuration IA arrivent. Si tu l'as fermé,
+   rouvre **Paramètres → Synchronisation → Appareils → Ajouter un appareil**.
+
+Laisse les deux applications ouvertes jusqu'à la fin de la première
+synchronisation.
+
+## En cas de problème
+
+- **Les codes de contrôle diffèrent.** Ne connecte pas. Ferme l'écran sur le
+  premier appareil, ouvre-en un nouveau et réessaie — le code est régénéré à
+  chaque fois.
+- **Le code ne se décode pas.** Copie-le à nouveau sur le premier appareil
+  plutôt que de corriger ce que tu as collé ; la valeur encodée n'est pas faite
+  pour être retouchée. Si l'app signale une différence de version, les deux
+  appareils sont sur des builds différents et doivent être mis à jour.
+- **Le nouvel appareil est connecté mais reste vide.** C'est l'état attendu
+  avant vérification. Termine la comparaison des emoji, puis consulte
+  [Synchroniser les appareils](./sync.mdx) pour la file d'envoi et le
+  rattrapage.
+
+Poursuis avec [Synchroniser les appareils](./sync.mdx) pour l'état quotidien, la
+qualité de livraison et les outils de récupération.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ vérifications : un court **code de contrôle** que tu compares avant de
 connecter, et une **vérification par emoji** ensuite.
 
 Elles ne font pas la même chose. Le code de contrôle dit que les deux écrans
-parlent du même compte — il attrape un code périmé ou erroné, l'erreur que l'on
-commet réellement. Il dérive d'identifiants publics : c'est une aide à la
-reconnaissance, pas une preuve de qui se trouve en face. La vérification par
+parlent du même compte — il attrape un code venu d'ailleurs, l'erreur que l'on
+commet réellement. Il ne dérive que de ces identifiants, pas du mot de passe :
+il ne dit rien de la validité des identifiants qu'il contient, ni de qui se
+trouve en face. La vérification par
 emoji qui suit est l'étape qui authentifie l'appareil, et tant qu'elle n'est pas
 terminée le nouvel appareil ne peut rien lire.
 
@@ -70,8 +71,7 @@ de ce que tu t'apprêtes à rejoindre, mené par le code de contrôle.
 />
 
 Regarde le code de contrôle ici et celui du premier appareil. **Ils doivent être
-identiques.** S'ils diffèrent, arrête-toi : ce n'est pas le code de ton appareil.
-Écarte-le : les deux écrans ne décrivent pas le même compte, le même salon et
+identiques.** S'ils diffèrent, arrête-toi et écarte-le : les deux écrans ne décrivent pas le même compte, le même salon et
 le même serveur, et rouvrir l'écran n'y changera rien.
 
 Le compte et le serveur sous le code sont du contexte, pas des éléments à

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Appaire un nouvel appareil à ton compte de synchronisation avec un
 # Ajouter un appareil
 
 Tous tes appareils partagent un seul compte de synchronisation. Ajouter un
-appareil, c'est lui confier les identifiants de ce compte : c'est pourquoi le
-parcours te demande de comparer un code court avant toute connexion. C'est le
-seul moment où tu peux distinguer ton appareil de celui de quelqu'un d'autre.
+appareil, c'est lui confier les identifiants de ce compte, d'où deux
+vérifications : un court **code de contrôle** que tu compares avant de
+connecter, et une **vérification par emoji** ensuite.
+
+Elles ne font pas la même chose. Le code de contrôle dit que les deux écrans
+parlent du même compte — il attrape un code périmé ou erroné, l'erreur que l'on
+commet réellement. Il dérive d'identifiants publics : c'est une aide à la
+reconnaissance, pas une preuve de qui se trouve en face. La vérification par
+emoji qui suit est l'étape qui authentifie l'appareil, et tant qu'elle n'est pas
+terminée le nouvel appareil ne peut rien lire.
 
 Il te faut les deux appareils devant toi. Commence sur un appareil déjà
 connecté — n'importe lequel, téléphone ou ordinateur. Il n'y a pas d'appareil
@@ -30,6 +37,11 @@ scanne ou photographie le QR code peut rejoindre ton compte et lire tes entrées
 Ne le montre qu'à un appareil qui t'appartient, et ne l'envoie jamais par
 messagerie, capture d'écran ou partage d'écran.
 
+**Fermer l'écran masque le code, mais ne le révoque pas.** Le code contient
+le mot de passe actuel de ton compte : une photo reste utilisable aussi
+longtemps que ce mot de passe. Si tu penses que quelqu'un l'a capturé, traite-le
+comme un mot de passe divulgué, pas comme quelque chose qui aurait expiré.
+
 **Copier le code d'appairage** existe volontairement pour le cas où l'appareil
 qui rejoint n'a pas de caméra — un ordinateur rejoignant un ordinateur. Il place
 les mêmes identifiants dans ton presse-papiers : colle-les directement dans
@@ -38,9 +50,10 @@ l'autre appareil et nulle part ailleurs.
 ## Le scanner sur le nouvel appareil
 
 Installe Lotti sur le nouvel appareil, puis ouvres-y **Paramètres →
-Synchronisation → Appareils**. Sur un téléphone la caméra s'ouvre aussitôt ;
+Synchronisation → Appareils** et sélectionne la carte **Appareils**. Sur un
+téléphone la caméra s'ouvre aussitôt ;
 vise le premier appareil. Sur un ordinateur, ou si la caméra est indisponible,
-choisis **saisir manuellement** et colle le code copié.
+choisis **Saisir le code manuellement** et colle le code copié.
 
 ## Vérifier que le code correspond avant de connecter
 
@@ -88,8 +101,9 @@ synchronisation.
 ## En cas de problème
 
 - **Les codes de contrôle diffèrent.** Ne connecte pas. Ferme l'écran sur le
-  premier appareil, ouvre-en un nouveau et réessaie — le code est régénéré à
-  chaque fois.
+  premier appareil, ouvre-en un nouveau et réessaie — le même compte produit le même
+  code à chaque fois, donc un écart signifie que les deux écrans appartiennent à
+  des comptes différents.
 - **Le code ne se décode pas.** Copie-le à nouveau sur le premier appareil
   plutôt que de corriger ce que tu as collé ; la valeur encodée n'est pas faite
   pour être retouchée. Si l'app signale une différence de version, les deux

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -52,7 +52,7 @@ l'autre appareil et nulle part ailleurs.
 
 ## Le scanner sur le nouvel appareil
 
-Installe Lotti sur le nouvel appareil, puis ouvres-y **Paramètres →
+Installe Lotti sur le nouvel appareil, puis ouvre-y **Paramètres →
 Paramètres de synchronisation → Appareils** et sélectionne la carte **Appareils**. Sur un
 téléphone la caméra s'ouvre aussitôt ;
 vise le premier appareil. Sur un ordinateur, ou si la caméra est indisponible,
@@ -71,7 +71,8 @@ de ce que tu t'apprêtes à rejoindre, mené par le code de contrôle.
 
 Regarde le code de contrôle ici et celui du premier appareil. **Ils doivent être
 identiques.** S'ils diffèrent, arrête-toi : ce n'est pas le code de ton appareil.
-Écarte-le et recommence depuis un écran Ajouter un appareil fraîchement ouvert.
+Écarte-le : les deux écrans ne décrivent pas le même compte, le même salon et
+le même serveur, et rouvrir l'écran n'y changera rien.
 
 Le compte et le serveur sous le code sont du contexte, pas des éléments à
 comparer — ils n'apparaissent pas sur l'autre appareil. Quand tout correspond,
@@ -105,8 +106,8 @@ synchronisation.
 
 - **Les codes de contrôle diffèrent.** Ne connecte pas. Ce n'est pas le code de
   ton appareil. Rouvrir l'écran n'y changera rien : le même compte produit le
-  même code à chaque fois, donc un écart signifie que les deux écrans
-  appartiennent à des comptes différents.
+  même code à chaque fois, donc un écart signifie que les deux écrans ne
+  décrivent pas le même appairage.
 - **Le code ne se décode pas.** Copie-le à nouveau sur le premier appareil
   plutôt que de corriger ce que tu as collé ; la valeur encodée n'est pas faite
   pour être retouchée. Si l'app signale une différence de version, les deux

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -29,7 +29,7 @@ appareil**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Écran Ajouter un appareil de Lotti avec un QR code, une note de sécurité avec cadenas et le code de contrôle 2BD-EF4"
-  caption="Le code est généré à l'ouverture de cet écran, et seulement tant qu'il reste ouvert. Note le code de contrôle en dessous : tu vas le comparer."
+  caption="Le code n'est affiché que tant que cet écran reste ouvert. Note le code de contrôle en dessous : tu vas le comparer."
 />
 
 Traite cet écran comme ton mot de passe, car c'est ce qu'il contient. Quiconque scanne ou
@@ -103,10 +103,10 @@ synchronisation.
 
 ## En cas de problème
 
-- **Les codes de contrôle diffèrent.** Ne connecte pas. Ferme l'écran sur le
-  premier appareil, ouvre-en un nouveau et réessaie — le même compte produit le même
-  code à chaque fois, donc un écart signifie que les deux écrans appartiennent à
-  des comptes différents.
+- **Les codes de contrôle diffèrent.** Ne connecte pas. Ce n'est pas le code de
+  ton appareil. Rouvrir l'écran n'y changera rien : le même compte produit le
+  même code à chaque fois, donc un écart signifie que les deux écrans
+  appartiennent à des comptes différents.
 - **Le code ne se décode pas.** Copie-le à nouveau sur le premier appareil
   plutôt que de corriger ce que tu as collé ; la valeur encodée n'est pas faite
   pour être retouchée. Si l'app signale une différence de version, les deux

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -23,7 +23,7 @@ connecté — n'importe lequel, téléphone ou ordinateur. Il n'y a pas d'appare
 
 ## Afficher le code sur un appareil déjà utilisé
 
-Ouvre **Paramètres → Synchronisation → Appareils** et choisis **Ajouter un
+Ouvre **Paramètres → Paramètres de synchronisation → Appareils** et choisis **Ajouter un
 appareil**.
 
 <ManualScreenshot
@@ -32,8 +32,11 @@ appareil**.
   caption="Le code est généré à l'ouverture de cet écran, et seulement tant qu'il reste ouvert. Note le code de contrôle en dessous : tu vas le comparer."
 />
 
-Traite cet écran comme ton mot de passe, car c'est ce qu'il contient. Quiconque
-scanne ou photographie le QR code peut rejoindre ton compte et lire tes entrées.
+Traite cet écran comme ton mot de passe, car c'est ce qu'il contient. Quiconque scanne ou
+photographie le QR code peut se connecter à ton compte : il ne peut pas
+déchiffrer tes entrées sans être aussi vérifié par emoji depuis un de tes
+appareils, mais il peut prendre le contrôle du compte — y compris en changeant
+le mot de passe et en t'excluant.
 Ne le montre qu'à un appareil qui t'appartient, et ne l'envoie jamais par
 messagerie, capture d'écran ou partage d'écran.
 
@@ -42,7 +45,7 @@ le mot de passe actuel de ton compte : une photo reste utilisable aussi
 longtemps que ce mot de passe. Si tu penses que quelqu'un l'a capturé, traite-le
 comme un mot de passe divulgué, pas comme quelque chose qui aurait expiré.
 
-**Copier le code d'appairage** existe volontairement pour le cas où l'appareil
+**Copier le code d’appairage** existe volontairement pour le cas où l'appareil
 qui rejoint n'a pas de caméra — un ordinateur rejoignant un ordinateur. Il place
 les mêmes identifiants dans ton presse-papiers : colle-les directement dans
 l'autre appareil et nulle part ailleurs.
@@ -50,7 +53,7 @@ l'autre appareil et nulle part ailleurs.
 ## Le scanner sur le nouvel appareil
 
 Installe Lotti sur le nouvel appareil, puis ouvres-y **Paramètres →
-Synchronisation → Appareils** et sélectionne la carte **Appareils**. Sur un
+Paramètres de synchronisation → Appareils** et sélectionne la carte **Appareils**. Sur un
 téléphone la caméra s'ouvre aussitôt ;
 vise le premier appareil. Sur un ordinateur, ou si la caméra est indisponible,
 choisis **Saisir le code manuellement** et colle le code copié.
@@ -93,7 +96,7 @@ lire quoi que ce soit.
 2. **Envoie les réglages.** Sur le premier appareil, dans l'écran Ajouter un
    appareil encore ouvert, choisis **Envoyer les réglages** pour que catégories,
    habitudes, tableaux de bord et configuration IA arrivent. Si tu l'as fermé,
-   rouvre **Paramètres → Synchronisation → Appareils → Ajouter un appareil**.
+   rouvre **Paramètres → Paramètres de synchronisation → Appareils → Ajouter un appareil**.
 
 Laisse les deux applications ouvertes jusqu'à la fin de la première
 synchronisation.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -23,35 +23,32 @@ correspond au travail qui n’a pas encore atteint le service de synchronisation
   caption="Le centre de synchronisation maintient l’état courant près des outils de diagnostic et de récupération. Project Waddle contient actuellement trois éléments de boîte d’envoi à examiner."
 />
 
-## Appairer un autre appareil
+## Voir tes appareils
 
-Commence sur un appareil déjà connecté :
-
-1. Ouvre **Paramètres → Synchronisation → Synchronisation provisionnée**.
-2. Sur ordinateur, affiche le code QR de transfert. Garde cet écran privé : le
-   lot donne accès à ton compte et à ton salon de synchronisation.
-3. Sur le nouvel appareil, ouvre la même page et scanne le code QR ou colle le
-   lot de provisionnement complet.
-4. Examine le serveur, l’utilisateur et le salon décodés avant de sélectionner
-   **Importer**.
-5. Laisse la première synchronisation se terminer avant de fermer l’une ou
-   l’autre application.
+**Paramètres → Synchronisation → Appareils** liste chaque session de ton compte
+de synchronisation, pas seulement celles non vérifiées.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="État de synchronisation provisionnée sur mobile et code QR de transfert sécurisé d’appareil sur ordinateur"
-  caption="L’ordinateur peut présenter le code QR de transfert ; le mobile indique le compte connecté et l’état de vérification. Traite ce code QR comme un mot de passe."
+  alt="Page Appareils de Lotti listant les sessions du compte de synchronisation avec leur état de vérification et leur dernière activité"
+  caption="Chaque ligne indique si l'appareil est vérifié et quand le serveur l'a vu pour la dernière fois. Un appareil non vérifié ne peut pas lire les nouvelles entrées, et la liste le dit."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Revue d’import de provisionnement Lotti affichant le serveur de synchronisation, l’utilisateur et le salon Project Waddle"
-  caption="N’importe que lorsque chaque valeur décodée appartient au compte de synchronisation que tu voulais rejoindre."
-/>
+Les sessions connectées avec ce compte peuvent être supprimées — sauf celle que
+tu utilises. Les appareils appairés à l'ancienne, avec leur propre compte,
+peuvent être vérifiés mais pas supprimés.
 
-Si l’import signale une erreur, garde l’appareil d’origine connecté, génère un
-nouveau lot de transfert et réessaie avec la valeur complète. Ne modifie pas
-manuellement le lot encodé.
+## Appairer un autre appareil
+
+L'appairage est un parcours à part entière, avec un code à comparer et deux
+étapes après la connexion. Il a sa propre page :
+[Ajouter un appareil](./add-device.mdx).
+
+En bref : sur un appareil déjà connecté, ouvre **Paramètres → Synchronisation →
+Appareils → Ajouter un appareil** et affiche le code. Sur le nouvel appareil,
+ouvre la même page et scanne-le. Compare le code de vérification sur les deux
+écrans avant de connecter — le QR code contient les identifiants de ton compte
+de synchronisation et ne va qu'à ton propre appareil.
 
 ## Vérifier le nouvel appareil
 

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -25,7 +25,7 @@ correspond au travail qui n’a pas encore atteint le service de synchronisation
 
 ## Voir tes appareils
 
-**Paramètres → Synchronisation → Appareils** liste chaque session de ton compte
+**Paramètres → Paramètres de synchronisation → Appareils** liste chaque session de ton compte
 de synchronisation, pas seulement celles non vérifiées.
 
 <ManualScreenshot
@@ -44,7 +44,7 @@ L'appairage est un parcours à part entière, avec un code à comparer et deux
 étapes après la connexion. Il a sa propre page :
 [Ajouter un appareil](./add-device.mdx).
 
-En bref : sur un appareil déjà connecté, ouvre **Paramètres → Synchronisation →
+En bref : sur un appareil déjà connecté, ouvre **Paramètres → Paramètres de synchronisation →
 Appareils → Ajouter un appareil** et affiche le code. Sur le nouvel appareil,
 ouvre la même page et scanne-le. Compare le code de vérification sur les deux
 écrans avant de connecter — le QR code contient les identifiants de ton compte

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ qualsiasi, telefono o computer. Non esiste un dispositivo «principale».
 
 ## Mostra il codice su un dispositivo che già usi
 
-Apri **Impostazioni → Sincronizzazione → Dispositivi** e scegli **Aggiungi
+Apri **Impostazioni → Impostazioni di sincronizzazione → Dispositivi** e scegli **Aggiungi
 dispositivo**.
 
 <ManualScreenshot
@@ -32,8 +32,10 @@ dispositivo**.
 />
 
 Tratta questa schermata come tratteresti la tua password, perché è ciò che
-contiene. Chi scansiona o fotografa il codice QR può entrare nel tuo account e
-leggere le tue voci. Mostralo solo a un dispositivo tuo e non inviarlo mai via
+contiene. Chi scansiona o fotografa il codice QR può accedere al tuo
+account: non può decifrare le tue voci senza essere anche verificato con le
+emoji da un tuo dispositivo, ma può impadronirsi dell'account — password
+compresa, escludendoti. Mostralo solo a un dispositivo tuo e non inviarlo mai via
 chat, screenshot o schermo condiviso.
 
 **Chiudere la schermata nasconde il codice, non lo revoca.** Il codice
@@ -41,7 +43,7 @@ contiene la password attuale del tuo account: una foto resta utilizzabile
 finché quella password è valida. Se sospetti che qualcuno l'abbia catturata,
 trattala come una password trapelata, non come qualcosa di scaduto.
 
-**Copia codice di accoppiamento** esiste di proposito per quando il dispositivo
+**Copia codice di abbinamento** esiste di proposito per quando il dispositivo
 che si unisce non ha fotocamera — un computer che si unisce a un computer. Mette
 le stesse credenziali negli appunti: incollale direttamente nell'altro
 dispositivo e da nessuna altra parte.
@@ -49,7 +51,7 @@ dispositivo e da nessuna altra parte.
 ## Scansionalo sul nuovo dispositivo
 
 Installa Lotti sul nuovo dispositivo, poi apri lì **Impostazioni →
-Sincronizzazione → Dispositivi** e seleziona la scheda **Dispositivi**. Sul
+Impostazioni di sincronizzazione → Dispositivi** e seleziona la scheda **Dispositivi**. Sul
 telefono la fotocamera si apre subito:
 inquadra il primo dispositivo. Su computer, o se la fotocamera non è
 disponibile, scegli **Inserisci il codice manualmente** e incolla il codice copiato.
@@ -93,7 +95,7 @@ leggere alcunché.
 2. **Invia le impostazioni.** Sul primo dispositivo, nella schermata Aggiungi
    dispositivo ancora aperta, scegli **Invia impostazioni** perché categorie,
    abitudini, dashboard e configurazione IA arrivino. Se l'hai già chiusa,
-   riapri **Impostazioni → Sincronizzazione → Dispositivi → Aggiungi
+   riapri **Impostazioni → Impostazioni di sincronizzazione → Dispositivi → Aggiungi
    dispositivo**.
 
 Lascia aperte entrambe le app finché la prima sincronizzazione non è finita.

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ perciò il percorso prevede due controlli: un breve **codice di controllo** da
 confrontare prima di connettere e una **verifica con emoji** subito dopo.
 
 Fanno cose diverse. Il codice di controllo dice che i due schermi parlano dello
-stesso account — intercetta un codice vecchio o sbagliato, cioè l'errore che si
-commette davvero. Deriva da identificatori pubblici: è un aiuto al
-riconoscimento, non una prova di chi sta dall'altra parte. La verifica con emoji
+stesso account — intercetta un codice che viene da altrove, cioè l'errore che si
+commette davvero. Deriva solo da quegli identificatori, non dalla password:
+non dice nulla su quanto siano ancora valide le credenziali che contiene, né su
+chi sta dall'altra parte. La verifica con emoji
 che segue è il passaggio che autentica il dispositivo, e finché non è completata
 il nuovo dispositivo non può leggere nulla.
 
@@ -68,8 +69,7 @@ cui stai per unirti, guidato dal codice di controllo.
 />
 
 Guarda il codice di controllo qui e quello sul primo dispositivo. **Devono
-essere identici.** Se differiscono, fermati: non stai guardando il codice del tuo
-dispositivo. Scartalo: i due schermi non descrivono lo stesso account, la stessa stanza e lo
+essere identici.** Se differiscono, fermati e scartalo: i due schermi non descrivono lo stesso account, la stessa stanza e lo
 stesso server, e riaprire la schermata non cambia nulla.
 
 Account e server sotto il codice sono contesto, non elementi da confrontare: non
@@ -102,8 +102,7 @@ Lascia aperte entrambe le app finché la prima sincronizzazione non è finita.
 
 ## Se qualcosa va storto
 
-- **I codici di controllo differiscono.** Non connettere. Non stai guardando il
-  codice del tuo dispositivo. Riaprire la schermata non serve: lo stesso account
+- **I codici di controllo differiscono.** Non connettere. Riaprire la schermata non serve: lo stesso account
   produce sempre lo stesso codice, quindi una differenza significa che i due schermi non
   descrivono lo stesso abbinamento.
 - **Il codice non si decodifica.** Copialo di nuovo sul primo dispositivo invece

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,103 @@
+---
+title: Aggiungere un dispositivo
+description: Accoppia un nuovo dispositivo al tuo account di sincronizzazione con un codice QR, verifica il codice di controllo e completa i due passaggi successivi.
+---
+
+# Aggiungere un dispositivo
+
+Tutti i tuoi dispositivi condividono un unico account di sincronizzazione.
+Aggiungere un dispositivo significa consegnargli le credenziali di quell'account:
+per questo il percorso ti chiede di confrontare un codice breve prima di
+collegare qualcosa. È l'unico momento in cui puoi distinguere il tuo dispositivo
+da quello di qualcun altro.
+
+Ti servono entrambi i dispositivi davanti. Parti da uno già connesso — uno
+qualsiasi, telefono o computer. Non esiste un dispositivo «principale».
+
+## Mostra il codice su un dispositivo che già usi
+
+Apri **Impostazioni → Sincronizzazione → Dispositivi** e scegli **Aggiungi
+dispositivo**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Schermata Aggiungi dispositivo di Lotti con codice QR, avviso di sicurezza con lucchetto e codice di controllo 2BD-EF4"
+  caption="Il codice viene generato all'apertura di questa schermata e solo finché resta aperta. Nota il codice di controllo sotto: lo confronterai tra poco."
+/>
+
+Tratta questa schermata come tratteresti la tua password, perché è ciò che
+contiene. Chi scansiona o fotografa il codice QR può entrare nel tuo account e
+leggere le tue voci. Mostralo solo a un dispositivo tuo e non inviarlo mai via
+chat, screenshot o schermo condiviso.
+
+**Copia codice di accoppiamento** esiste di proposito per quando il dispositivo
+che si unisce non ha fotocamera — un computer che si unisce a un computer. Mette
+le stesse credenziali negli appunti: incollale direttamente nell'altro
+dispositivo e da nessuna altra parte.
+
+## Scansionalo sul nuovo dispositivo
+
+Installa Lotti sul nuovo dispositivo, poi apri lì **Impostazioni →
+Sincronizzazione → Dispositivi**. Sul telefono la fotocamera si apre subito:
+inquadra il primo dispositivo. Su computer, o se la fotocamera non è
+disponibile, scegli **inserisci manualmente** e incolla il codice copiato.
+
+## Controlla che il codice corrisponda prima di connettere
+
+Decodificare il codice non connette nulla. Compare prima un riepilogo di ciò a
+cui stai per unirti, guidato dal codice di controllo.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Riepilogo di accoppiamento di Lotti con codice di controllo, account da unire e server di sincronizzazione"
+  caption="Entrambi i dispositivi ricavano questo codice in modo indipendente da account, stanza e server. Non se lo scambiano mai: per questo confrontarlo ha senso."
+/>
+
+Guarda il codice di controllo qui e quello sul primo dispositivo. **Devono
+essere identici.** Se differiscono, fermati: non stai guardando il codice del tuo
+dispositivo. Scartalo e ricomincia da una schermata Aggiungi dispositivo appena
+aperta.
+
+Account e server sotto il codice sono contesto, non elementi da confrontare: non
+compaiono sull'altro dispositivo. Quando tutto corrisponde, scegli **Connetti
+questo dispositivo**.
+
+## Completa i due passaggi successivi
+
+Connettere unisce all'account. Non consente ancora al nuovo dispositivo di
+leggere alcunché.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Configurazione sync di Lotti: questo dispositivo è connesso, verifica con emoji e Invia impostazioni ancora in sospeso"
+  caption="Connesso è la metà facile. La scheda indica cosa manca e dice chiaramente che senza verifica il dispositivo non può leggere nulla."
+/>
+
+1. **Confronta le emoji.** Su entrambi i dispositivi compare una fila di emoji.
+   Controlla che coincidano e conferma su ciascuno. Fino ad allora il nuovo
+   dispositivo riceve solo cifrato illeggibile: le chiavi vanno solo ai
+   dispositivi verificati. Vedi
+   [Sincronizzare i dispositivi](./sync.mdx).
+2. **Invia le impostazioni.** Sul primo dispositivo, nella schermata Aggiungi
+   dispositivo ancora aperta, scegli **Invia impostazioni** perché categorie,
+   abitudini, dashboard e configurazione IA arrivino. Se l'hai già chiusa,
+   riapri **Impostazioni → Sincronizzazione → Dispositivi → Aggiungi
+   dispositivo**.
+
+Lascia aperte entrambe le app finché la prima sincronizzazione non è finita.
+
+## Se qualcosa va storto
+
+- **I codici di controllo differiscono.** Non connettere. Chiudi la schermata sul
+  primo dispositivo, aprine una nuova e riprova: il codice viene rigenerato ogni
+  volta.
+- **Il codice non si decodifica.** Copialo di nuovo sul primo dispositivo invece
+  di correggere ciò che hai incollato; il valore codificato non è pensato per
+  essere sistemato a mano. Se l'app segnala versioni diverse, i due dispositivi
+  hanno build differenti e vanno entrambi aggiornati.
+- **Il nuovo dispositivo è connesso ma resta vuoto.** È lo stato previsto prima
+  della verifica. Completa il confronto delle emoji, poi controlla
+  [Sincronizzare i dispositivi](./sync.mdx) per posta in uscita e recupero.
+
+Prosegui con [Sincronizzare i dispositivi](./sync.mdx) per stato quotidiano,
+qualità della consegna e strumenti di recupero.

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -28,7 +28,7 @@ dispositivo**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Schermata Aggiungi dispositivo di Lotti con codice QR, avviso di sicurezza con lucchetto e codice di controllo 2BD-EF4"
-  caption="Il codice viene generato all'apertura di questa schermata e solo finché resta aperta. Nota il codice di controllo sotto: lo confronterai tra poco."
+  caption="Il codice è mostrato solo finché questa schermata resta aperta. Nota il codice di controllo sotto: lo confronterai tra poco."
 />
 
 Tratta questa schermata come tratteresti la tua password, perché è ciò che
@@ -102,10 +102,10 @@ Lascia aperte entrambe le app finché la prima sincronizzazione non è finita.
 
 ## Se qualcosa va storto
 
-- **I codici di controllo differiscono.** Non connettere. Chiudi la schermata sul
-  primo dispositivo, aprine una nuova e riprova: lo stesso account produce sempre lo
-  stesso codice, quindi una differenza significa che i due schermi appartengono
-  ad account diversi.
+- **I codici di controllo differiscono.** Non connettere. Non stai guardando il
+  codice del tuo dispositivo. Riaprire la schermata non serve: lo stesso account
+  produce sempre lo stesso codice, quindi una differenza significa che i due
+  schermi appartengono ad account diversi.
 - **Il codice non si decodifica.** Copialo di nuovo sul primo dispositivo invece
   di correggere ciò che hai incollato; il valore codificato non è pensato per
   essere sistemato a mano. Se l'app segnala versioni diverse, i due dispositivi

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -69,8 +69,8 @@ cui stai per unirti, guidato dal codice di controllo.
 
 Guarda il codice di controllo qui e quello sul primo dispositivo. **Devono
 essere identici.** Se differiscono, fermati: non stai guardando il codice del tuo
-dispositivo. Scartalo e ricomincia da una schermata Aggiungi dispositivo appena
-aperta.
+dispositivo. Scartalo: i due schermi non descrivono lo stesso account, la stessa stanza e lo
+stesso server, e riaprire la schermata non cambia nulla.
 
 Account e server sotto il codice sono contesto, non elementi da confrontare: non
 compaiono sull'altro dispositivo. Quando tutto corrisponde, scegli **Connetti
@@ -104,8 +104,8 @@ Lascia aperte entrambe le app finché la prima sincronizzazione non è finita.
 
 - **I codici di controllo differiscono.** Non connettere. Non stai guardando il
   codice del tuo dispositivo. Riaprire la schermata non serve: lo stesso account
-  produce sempre lo stesso codice, quindi una differenza significa che i due
-  schermi appartengono ad account diversi.
+  produce sempre lo stesso codice, quindi una differenza significa che i due schermi non
+  descrivono lo stesso abbinamento.
 - **Il codice non si decodifica.** Copialo di nuovo sul primo dispositivo invece
   di correggere ciò che hai incollato; il valore codificato non è pensato per
   essere sistemato a mano. Se l'app segnala versioni diverse, i due dispositivi

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,10 +6,16 @@ description: Accoppia un nuovo dispositivo al tuo account di sincronizzazione co
 # Aggiungere un dispositivo
 
 Tutti i tuoi dispositivi condividono un unico account di sincronizzazione.
-Aggiungere un dispositivo significa consegnargli le credenziali di quell'account:
-per questo il percorso ti chiede di confrontare un codice breve prima di
-collegare qualcosa. È l'unico momento in cui puoi distinguere il tuo dispositivo
-da quello di qualcun altro.
+Aggiungere un dispositivo significa consegnargli le credenziali di quell'account,
+perciò il percorso prevede due controlli: un breve **codice di controllo** da
+confrontare prima di connettere e una **verifica con emoji** subito dopo.
+
+Fanno cose diverse. Il codice di controllo dice che i due schermi parlano dello
+stesso account — intercetta un codice vecchio o sbagliato, cioè l'errore che si
+commette davvero. Deriva da identificatori pubblici: è un aiuto al
+riconoscimento, non una prova di chi sta dall'altra parte. La verifica con emoji
+che segue è il passaggio che autentica il dispositivo, e finché non è completata
+il nuovo dispositivo non può leggere nulla.
 
 Ti servono entrambi i dispositivi davanti. Parti da uno già connesso — uno
 qualsiasi, telefono o computer. Non esiste un dispositivo «principale».
@@ -30,6 +36,11 @@ contiene. Chi scansiona o fotografa il codice QR può entrare nel tuo account e
 leggere le tue voci. Mostralo solo a un dispositivo tuo e non inviarlo mai via
 chat, screenshot o schermo condiviso.
 
+**Chiudere la schermata nasconde il codice, non lo revoca.** Il codice
+contiene la password attuale del tuo account: una foto resta utilizzabile
+finché quella password è valida. Se sospetti che qualcuno l'abbia catturata,
+trattala come una password trapelata, non come qualcosa di scaduto.
+
 **Copia codice di accoppiamento** esiste di proposito per quando il dispositivo
 che si unisce non ha fotocamera — un computer che si unisce a un computer. Mette
 le stesse credenziali negli appunti: incollale direttamente nell'altro
@@ -38,9 +49,10 @@ dispositivo e da nessuna altra parte.
 ## Scansionalo sul nuovo dispositivo
 
 Installa Lotti sul nuovo dispositivo, poi apri lì **Impostazioni →
-Sincronizzazione → Dispositivi**. Sul telefono la fotocamera si apre subito:
+Sincronizzazione → Dispositivi** e seleziona la scheda **Dispositivi**. Sul
+telefono la fotocamera si apre subito:
 inquadra il primo dispositivo. Su computer, o se la fotocamera non è
-disponibile, scegli **inserisci manualmente** e incolla il codice copiato.
+disponibile, scegli **Inserisci il codice manualmente** e incolla il codice copiato.
 
 ## Controlla che il codice corrisponda prima di connettere
 
@@ -89,8 +101,9 @@ Lascia aperte entrambe le app finché la prima sincronizzazione non è finita.
 ## Se qualcosa va storto
 
 - **I codici di controllo differiscono.** Non connettere. Chiudi la schermata sul
-  primo dispositivo, aprine una nuova e riprova: il codice viene rigenerato ogni
-  volta.
+  primo dispositivo, aprine una nuova e riprova: lo stesso account produce sempre lo
+  stesso codice, quindi una differenza significa che i due schermi appartengono
+  ad account diversi.
 - **Il codice non si decodifica.** Copialo di nuovo sul primo dispositivo invece
   di correggere ciò che hai incollato; il valore codificato non è pensato per
   essere sistemato a mano. Se l'app segnala versioni diverse, i due dispositivi

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -24,7 +24,7 @@ servizio ancora.
 
 ## Vedere i tuoi dispositivi
 
-**Impostazioni → Sincronizzazione → Dispositivi** elenca ogni sessione del tuo
+**Impostazioni → Impostazioni di sincronizzazione → Dispositivi** elenca ogni sessione del tuo
 account di sincronizzazione, non solo quelle non verificate.
 
 <ManualScreenshot
@@ -37,13 +37,13 @@ Le sessioni collegate con questo account si possono rimuovere — tranne quella 
 cui ti trovi. I dispositivi accoppiati alla vecchia maniera, con un account
 proprio, si possono verificare ma non rimuovere.
 
-## Coprire un altro dispositivo
+## Associare un altro dispositivo
 
 L'accoppiamento è un percorso a sé, con un codice da confrontare e due passaggi
 dopo la connessione. Ha una pagina dedicata:
 [Aggiungere un dispositivo](./add-device.mdx).
 
-In breve: su un dispositivo già connesso apri **Impostazioni → Sincronizzazione
+In breve: su un dispositivo già connesso apri **Impostazioni → Impostazioni di sincronizzazione
 → Dispositivi → Aggiungi dispositivo** e mostra il codice. Sul nuovo dispositivo
 apri la stessa pagina e scansionalo. Confronta il codice di controllo su entrambi
 gli schermi prima di connettere — il codice QR contiene le credenziali del tuo

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -22,33 +22,32 @@ servizio ancora.
   caption="Il hub Sync mantiene lo stato di tutti i giorni vicino a strumenti diagnostici e di recupero."
 />
 
-## Coprire un altro dispositivo
+## Vedere i tuoi dispositivi
 
-Avviare su un dispositivo già collegato:
-
-1. Aprire ** Impostazioni → Sync → Provisioned Sync**.
-2. Sul desktop, mostrare il codice QR di consegna. Tenere questa schermata privata: il bundle
-   garantisce l'accesso al tuo account di sincronizzazione e alla tua stanza.
-3. Sul nuovo dispositivo, aprire la stessa pagina e scansionare il codice QR o incollare il
-   pacchetto completo di provisioning.
-4. Verificare il server, l'utente e la stanza decodificato prima di selezionare **Import**.
-5. Lasciare la prima terminazione di sincronizzazione prima di chiudere entrambe le app.
+**Impostazioni → Sincronizzazione → Dispositivi** elenca ogni sessione del tuo
+account di sincronizzazione, non solo quelle non verificate.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Provisionato stato Sync su mobile e il dispositivo sicuro consegna codice QR sul desktop"
-  caption="Desktop può presentare il codice QR di consegna; mobile mostra l'account collegato e lo stato di verifica."
+  alt="Pagina Dispositivi di Lotti con le sessioni dell'account di sincronizzazione, stato di verifica e ultimo accesso"
+  caption="Ogni riga mostra se il dispositivo è verificato e quando il server lo ha visto l'ultima volta. Un dispositivo non verificato non può leggere le nuove voci, e l'elenco lo dice."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Lotti che fornisce l'importazione recensione che mostra il server di sincronizzazione Project Waddle, utente e camera"
-  caption="Importa solo quando ogni valore decodificato appartiene al conto di sincronizzazione che intendete aderire."
-/>
+Le sessioni collegate con questo account si possono rimuovere — tranne quella su
+cui ti trovi. I dispositivi accoppiati alla vecchia maniera, con un account
+proprio, si possono verificare ma non rimuovere.
 
-Se l'importazione segnala un errore, mantenere il dispositivo originale collegato, generare un
-nuovo fascio di consegna, e riprovare con il valore completo. Non modificare manualmente il
-fascio codificato.
+## Coprire un altro dispositivo
+
+L'accoppiamento è un percorso a sé, con un codice da confrontare e due passaggi
+dopo la connessione. Ha una pagina dedicata:
+[Aggiungere un dispositivo](./add-device.mdx).
+
+In breve: su un dispositivo già connesso apri **Impostazioni → Sincronizzazione
+→ Dispositivi → Aggiungi dispositivo** e mostra il codice. Sul nuovo dispositivo
+apri la stessa pagina e scansionalo. Confronta il codice di controllo su entrambi
+gli schermi prima di connettere — il codice QR contiene le credenziali del tuo
+account di sincronizzazione e va solo al tuo dispositivo.
 
 ## Verificare il nuovo dispositivo
 

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -28,7 +28,7 @@ toevoegen**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Scherm Apparaat toevoegen van Lotti met QR-code, beveiligingsmelding met slot en de controlecode 2BD-EF4"
-  caption="De code ontstaat bij het openen van dit scherm en alleen zolang het open is. Let op de controlecode eronder — die vergelijk je zo."
+  caption="De code wordt alleen getoond zolang dit scherm open is. Let op de controlecode eronder — die vergelijk je zo."
 />
 
 Behandel dit scherm zoals je je wachtwoord behandelt, want dat is wat erin zit.
@@ -100,10 +100,10 @@ Laat beide apps open tot de eerste synchronisatie klaar is.
 
 ## Als er iets misgaat
 
-- **De controlecodes verschillen.** Niet verbinden. Sluit het scherm op het
-  eerste apparaat, open een nieuw en probeer opnieuw — hetzelfde account levert elke keer
-  dezelfde code op, dus een verschil betekent dat de twee schermen bij
-  verschillende accounts horen.
+- **De controlecodes verschillen.** Niet verbinden. Je kijkt niet naar de code
+  van je eigen apparaat. Het scherm opnieuw openen helpt niet: hetzelfde account
+  levert elke keer dezelfde code op, dus een verschil betekent dat de twee
+  schermen bij verschillende accounts horen.
 - **De code laat zich niet decoderen.** Kopieer hem opnieuw op het eerste
   apparaat in plaats van te corrigeren wat je plakte; de gecodeerde waarde is
   niet bedoeld om met de hand bij te werken. Meldt de app verschillende versies,

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,101 @@
+---
+title: Een apparaat toevoegen
+description: Koppel een nieuw apparaat aan je synchronisatieaccount met een QR-code, controleer de controlecode en rond de twee stappen daarna af.
+---
+
+# Een apparaat toevoegen
+
+Al je apparaten delen één synchronisatieaccount. Een apparaat toevoegen betekent
+dat je het de inloggegevens van dat account geeft — daarom vraagt de stroom je om
+eerst een korte code te vergelijken. Dat is het enige moment waarop je je eigen
+apparaat van dat van iemand anders kunt onderscheiden.
+
+Je hebt beide apparaten voor je nodig. Begin op een apparaat dat al verbonden is
+— welk dan ook, telefoon of desktop. Er is geen «hoofdapparaat».
+
+## Toon de code op een apparaat dat je al gebruikt
+
+Open **Instellingen → Synchronisatie → Apparaten** en kies **Apparaat
+toevoegen**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Scherm Apparaat toevoegen van Lotti met QR-code, beveiligingsmelding met slot en de controlecode 2BD-EF4"
+  caption="De code ontstaat bij het openen van dit scherm en alleen zolang het open is. Let op de controlecode eronder — die vergelijk je zo."
+/>
+
+Behandel dit scherm zoals je je wachtwoord behandelt, want dat is wat erin zit.
+Wie de QR-code scant of fotografeert kan bij je synchronisatieaccount en je
+notities lezen. Toon hem alleen aan een apparaat dat van jou is, en stuur hem
+nooit via chat, schermafbeelding of gedeeld scherm.
+
+**Koppelcode kopiëren** bestaat bewust voor het geval het nieuwe apparaat geen
+camera heeft — een desktop die bij een desktop komt. Het zet dezelfde
+inloggegevens op je klembord: plak ze rechtstreeks in het andere apparaat en
+nergens anders.
+
+## Scan hem op het nieuwe apparaat
+
+Installeer Lotti op het nieuwe apparaat en open daar **Instellingen →
+Synchronisatie → Apparaten**. Op een telefoon opent de camera meteen; richt hem
+op het eerste apparaat. Op een desktop, of als de camera niet beschikbaar is,
+kies **handmatig invoeren** en plak de gekopieerde code.
+
+## Controleer of de code klopt voor je verbindt
+
+De code decoderen verbindt nog niets. Wat eerst verschijnt is een overzicht van
+waar je je bij gaat voegen, aangevoerd door de controlecode.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Koppeloverzicht van Lotti met de controlecode, het account waar je bij komt en de synchronisatieserver"
+  caption="Beide apparaten leiden deze code onafhankelijk af uit account, ruimte en server. Ze wisselen hem nooit uit — daarom is vergelijken zinvol."
+/>
+
+Kijk naar de controlecode hier en die op het eerste apparaat. **Ze moeten
+identiek zijn.** Verschillen ze, stop dan: je kijkt niet naar de code van je
+eigen apparaat. Gooi hem weg en begin opnieuw met een vers geopend scherm
+Apparaat toevoegen.
+
+Het account en de server onder de code zijn context, niets om te vergelijken —
+ze verschijnen niet op het andere apparaat. Klopt alles, kies dan **Dit apparaat
+verbinden**.
+
+## Rond de twee stappen daarna af
+
+Verbinden voegt je toe aan het account. Het geeft het nieuwe apparaat nog niet de
+mogelijkheid iets te lezen.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Lotti sync-instelling: dit apparaat is verbonden, emoji-verificatie en Instellingen versturen staan nog open"
+  caption="Verbonden is de makkelijke helft. De kaart benoemt wat er nog mist en zegt duidelijk dat dit apparaat tot de verificatie niets kan lezen."
+/>
+
+1. **Vergelijk de emoji.** Op beide apparaten verschijnt een rij emoji.
+   Controleer of ze overeenkomen en bevestig op allebei. Tot dan krijgt het
+   nieuwe apparaat alleen versleutelde tekst die het niet kan lezen — sleutels
+   gaan uitsluitend naar geverifieerde apparaten. Zie
+   [Apparaten synchroniseren](./sync.mdx).
+2. **Verstuur de instellingen.** Kies op het eerste apparaat, in het nog geopende
+   scherm Apparaat toevoegen, **Instellingen versturen** zodat categorieën,
+   gewoontes, dashboards en AI-configuratie aankomen. Al gesloten? Open
+   **Instellingen → Synchronisatie → Apparaten → Apparaat toevoegen** opnieuw.
+
+Laat beide apps open tot de eerste synchronisatie klaar is.
+
+## Als er iets misgaat
+
+- **De controlecodes verschillen.** Niet verbinden. Sluit het scherm op het
+  eerste apparaat, open een nieuw en probeer opnieuw — de code wordt elke keer
+  opnieuw aangemaakt.
+- **De code laat zich niet decoderen.** Kopieer hem opnieuw op het eerste
+  apparaat in plaats van te corrigeren wat je plakte; de gecodeerde waarde is
+  niet bedoeld om met de hand bij te werken. Meldt de app verschillende versies,
+  dan draaien de apparaten op verschillende builds en moeten beide bijgewerkt.
+- **Het nieuwe apparaat is verbonden maar blijft leeg.** Dat is de verwachte
+  toestand vóór verificatie. Rond de emoji-vergelijking af en bekijk daarna
+  [Apparaten synchroniseren](./sync.mdx) voor postvak uit en herstel.
+
+Ga verder met [Apparaten synchroniseren](./sync.mdx) voor dagelijkse status,
+bezorgkwaliteit en herstelgereedschap.

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Koppel een nieuw apparaat aan je synchronisatieaccount met een QR-c
 # Een apparaat toevoegen
 
 Al je apparaten delen één synchronisatieaccount. Een apparaat toevoegen betekent
-dat je het de inloggegevens van dat account geeft — daarom vraagt de stroom je om
-eerst een korte code te vergelijken. Dat is het enige moment waarop je je eigen
-apparaat van dat van iemand anders kunt onderscheiden.
+dat je het de inloggegevens van dat account geeft, dus de stroom kent twee
+controles: een korte **controlecode** die je vóór het verbinden vergelijkt, en
+daarna een **emoji-verificatie**.
+
+Ze doen iets verschillends. De controlecode zegt dat beide schermen over
+hetzelfde account gaan — hij vangt een verouderde of verkeerde code, de fout die
+mensen echt maken. Hij wordt afgeleid uit openbare identificatoren en is dus een
+herkenningshulp, geen bewijs van wie er aan de andere kant zit. De
+emoji-verificatie daarna is de stap die het apparaat authenticeert, en tot die
+klaar is kan het nieuwe apparaat niets lezen.
 
 Je hebt beide apparaten voor je nodig. Begin op een apparaat dat al verbonden is
 — welk dan ook, telefoon of desktop. Er is geen «hoofdapparaat».
@@ -29,6 +36,11 @@ Wie de QR-code scant of fotografeert kan bij je synchronisatieaccount en je
 notities lezen. Toon hem alleen aan een apparaat dat van jou is, en stuur hem
 nooit via chat, schermafbeelding of gedeeld scherm.
 
+**Het scherm sluiten verbergt de code, maar trekt hem niet in.** De code bevat
+het huidige wachtwoord van je account: een foto blijft bruikbaar zolang dat
+wachtwoord geldt. Denk je dat iemand hem heeft vastgelegd, behandel het dan als
+een gelekt wachtwoord en niet als iets dat inmiddels verlopen is.
+
 **Koppelcode kopiëren** bestaat bewust voor het geval het nieuwe apparaat geen
 camera heeft — een desktop die bij een desktop komt. Het zet dezelfde
 inloggegevens op je klembord: plak ze rechtstreeks in het andere apparaat en
@@ -37,9 +49,9 @@ nergens anders.
 ## Scan hem op het nieuwe apparaat
 
 Installeer Lotti op het nieuwe apparaat en open daar **Instellingen →
-Synchronisatie → Apparaten**. Op een telefoon opent de camera meteen; richt hem
+Synchronisatie → Apparaten** en kies de kaart **Apparaten**. Op een telefoon opent de camera meteen; richt hem
 op het eerste apparaat. Op een desktop, of als de camera niet beschikbaar is,
-kies **handmatig invoeren** en plak de gekopieerde code.
+kies **Code handmatig invoeren** en plak de gekopieerde code.
 
 ## Controleer of de code klopt voor je verbindt
 
@@ -87,8 +99,9 @@ Laat beide apps open tot de eerste synchronisatie klaar is.
 ## Als er iets misgaat
 
 - **De controlecodes verschillen.** Niet verbinden. Sluit het scherm op het
-  eerste apparaat, open een nieuw en probeer opnieuw — de code wordt elke keer
-  opnieuw aangemaakt.
+  eerste apparaat, open een nieuw en probeer opnieuw — hetzelfde account levert elke keer
+  dezelfde code op, dus een verschil betekent dat de twee schermen bij
+  verschillende accounts horen.
 - **De code laat zich niet decoderen.** Kopieer hem opnieuw op het eerste
   apparaat in plaats van te corrigeren wat je plakte; de gecodeerde waarde is
   niet bedoeld om met de hand bij te werken. Meldt de app verschillende versies,

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ controles: een korte **controlecode** die je vóór het verbinden vergelijkt, en
 daarna een **emoji-verificatie**.
 
 Ze doen iets verschillends. De controlecode zegt dat beide schermen over
-hetzelfde account gaan — hij vangt een verouderde of verkeerde code, de fout die
-mensen echt maken. Hij wordt afgeleid uit openbare identificatoren en is dus een
-herkenningshulp, geen bewijs van wie er aan de andere kant zit. De
+hetzelfde account gaan — hij vangt een code van elders, de fout die
+mensen echt maken. Hij wordt alleen uit die identificatoren afgeleid, niet uit
+het wachtwoord — hij zegt dus niets over of de inloggegevens erin nog geldig
+zijn, en niets over wie er aan de andere kant zit. De
 emoji-verificatie daarna is de stap die het apparaat authenticeert, en tot die
 klaar is kan het nieuwe apparaat niets lezen.
 
@@ -67,8 +68,7 @@ waar je je bij gaat voegen, aangevoerd door de controlecode.
 />
 
 Kijk naar de controlecode hier en die op het eerste apparaat. **Ze moeten
-identiek zijn.** Verschillen ze, stop dan: je kijkt niet naar de code van je
-eigen apparaat. Gooi hem weg: de twee schermen beschrijven niet hetzelfde account, dezelfde
+identiek zijn.** Verschillen ze, stop dan. Gooi hem weg: de twee schermen beschrijven niet hetzelfde account, dezelfde
 ruimte en dezelfde server, en het scherm opnieuw openen verandert dat niet.
 
 Het account en de server onder de code zijn context, niets om te vergelijken —
@@ -100,8 +100,7 @@ Laat beide apps open tot de eerste synchronisatie klaar is.
 
 ## Als er iets misgaat
 
-- **De controlecodes verschillen.** Niet verbinden. Je kijkt niet naar de code
-  van je eigen apparaat. Het scherm opnieuw openen helpt niet: hetzelfde account
+- **De controlecodes verschillen.** Niet verbinden. Het scherm opnieuw openen helpt niet: hetzelfde account
   levert elke keer dezelfde code op, dus een verschil betekent dat de twee schermen niet
   dezelfde koppeling beschrijven.
 - **De code laat zich niet decoderen.** Kopieer hem opnieuw op het eerste

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -68,8 +68,8 @@ waar je je bij gaat voegen, aangevoerd door de controlecode.
 
 Kijk naar de controlecode hier en die op het eerste apparaat. **Ze moeten
 identiek zijn.** Verschillen ze, stop dan: je kijkt niet naar de code van je
-eigen apparaat. Gooi hem weg en begin opnieuw met een vers geopend scherm
-Apparaat toevoegen.
+eigen apparaat. Gooi hem weg: de twee schermen beschrijven niet hetzelfde account, dezelfde
+ruimte en dezelfde server, en het scherm opnieuw openen verandert dat niet.
 
 Het account en de server onder de code zijn context, niets om te vergelijken —
 ze verschijnen niet op het andere apparaat. Klopt alles, kies dan **Dit apparaat
@@ -102,8 +102,8 @@ Laat beide apps open tot de eerste synchronisatie klaar is.
 
 - **De controlecodes verschillen.** Niet verbinden. Je kijkt niet naar de code
   van je eigen apparaat. Het scherm opnieuw openen helpt niet: hetzelfde account
-  levert elke keer dezelfde code op, dus een verschil betekent dat de twee
-  schermen bij verschillende accounts horen.
+  levert elke keer dezelfde code op, dus een verschil betekent dat de twee schermen niet
+  dezelfde koppeling beschrijven.
 - **De code laat zich niet decoderen.** Kopieer hem opnieuw op het eerste
   apparaat in plaats van te corrigeren wat je plakte; de gecodeerde waarde is
   niet bedoeld om met de hand bij te werken. Meldt de app verschillende versies,

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ Je hebt beide apparaten voor je nodig. Begin op een apparaat dat al verbonden is
 
 ## Toon de code op een apparaat dat je al gebruikt
 
-Open **Instellingen → Synchronisatie → Apparaten** en kies **Apparaat
+Open **Instellingen → Instellingen synchroniseren → Apparaten** en kies **Apparaat
 toevoegen**.
 
 <ManualScreenshot
@@ -32,8 +32,10 @@ toevoegen**.
 />
 
 Behandel dit scherm zoals je je wachtwoord behandelt, want dat is wat erin zit.
-Wie de QR-code scant of fotografeert kan bij je synchronisatieaccount en je
-notities lezen. Toon hem alleen aan een apparaat dat van jou is, en stuur hem
+Wie de QR-code scant of fotografeert kan zich aanmelden bij je
+synchronisatieaccount: je notities kan diegene niet ontsleutelen zonder ook via
+emoji geverifieerd te zijn vanaf een van je apparaten, maar het account
+overnemen kan wel — inclusief het wachtwoord wijzigen en jou buitensluiten. Toon hem alleen aan een apparaat dat van jou is, en stuur hem
 nooit via chat, schermafbeelding of gedeeld scherm.
 
 **Het scherm sluiten verbergt de code, maar trekt hem niet in.** De code bevat
@@ -49,7 +51,7 @@ nergens anders.
 ## Scan hem op het nieuwe apparaat
 
 Installeer Lotti op het nieuwe apparaat en open daar **Instellingen →
-Synchronisatie → Apparaten** en kies de kaart **Apparaten**. Op een telefoon opent de camera meteen; richt hem
+Instellingen synchroniseren → Apparaten** en kies de kaart **Apparaten**. Op een telefoon opent de camera meteen; richt hem
 op het eerste apparaat. Op een desktop, of als de camera niet beschikbaar is,
 kies **Code handmatig invoeren** en plak de gekopieerde code.
 
@@ -92,7 +94,7 @@ mogelijkheid iets te lezen.
 2. **Verstuur de instellingen.** Kies op het eerste apparaat, in het nog geopende
    scherm Apparaat toevoegen, **Instellingen versturen** zodat categorieën,
    gewoontes, dashboards en AI-configuratie aankomen. Al gesloten? Open
-   **Instellingen → Synchronisatie → Apparaten → Apparaat toevoegen** opnieuw.
+   **Instellingen → Instellingen synchroniseren → Apparaten → Apparaat toevoegen** opnieuw.
 
 Laat beide apps open tot de eerste synchronisatie klaar is.
 

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -24,7 +24,7 @@ nog dienst.
 
 ## Bekijk je apparaten
 
-**Instellingen → Synchronisatie → Apparaten** toont elke sessie op je
+**Instellingen → Instellingen synchroniseren → Apparaten** toont elke sessie op je
 synchronisatieaccount — niet alleen de niet-geverifieerde.
 
 <ManualScreenshot
@@ -43,7 +43,7 @@ Koppelen is een eigen stroom, met een code om te vergelijken en twee stappen na
 het verbinden. Het heeft een eigen pagina:
 [Een apparaat toevoegen](./add-device.mdx).
 
-Kort: open op een al verbonden apparaat **Instellingen → Synchronisatie →
+Kort: open op een al verbonden apparaat **Instellingen → Instellingen synchroniseren →
 Apparaten → Apparaat toevoegen** en toon de code. Open op het nieuwe apparaat
 dezelfde pagina en scan hem. Vergelijk de controlecode op beide schermen voordat
 je verbindt — de QR-code bevat de inloggegevens van je synchronisatieaccount en

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -22,33 +22,32 @@ nog dienst.
   caption="De Sync-hub houdt de dagelijkse status in de buurt van diagnoses en hersteltools. Project Waddle heeft momenteel drie outbox-items te inspecteren."
 />
 
-## Koppel een ander apparaat
+## Bekijk je apparaten
 
-Begin op een apparaat dat al is verbonden:
-
-1. Open **Instellingen → Synchronisatie → Ingerichte synchronisatie**.
-2. Toon op het bureaublad de QR-code voor de overdracht. Houd dit scherm privé: de bundel
-   geeft toegang tot uw synchronisatieaccount en kamer.
-3. Open op het nieuwe apparaat dezelfde pagina en scan de QR-code of plak de
-   volledige inrichtingsbundel.
-4. Controleer de gedecodeerde server, gebruiker en ruimte voordat u **Importeren** selecteert.
-5. Laat de eerste synchronisatie voltooien voordat u een van beide apps sluit.
+**Instellingen → Synchronisatie → Apparaten** toont elke sessie op je
+synchronisatieaccount — niet alleen de niet-geverifieerde.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Voorzien van Sync status op mobiel en de veilige apparaat overdracht QR code op bureaublad"
-  caption="Desktop kan de overdracht QR code; mobiel toont de aangesloten account en verificatie staat. Behandel de QR code als een wachtwoord."
+  alt="Lotti's pagina Apparaten met de sessies op het synchronisatieaccount, verificatiestatus en laatst gezien"
+  caption="Elke rij laat zien of het apparaat geverifieerd is en wanneer de server het voor het laatst zag. Een niet-geverifieerd apparaat kan nieuwe notities niet lezen, en de lijst zegt dat."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Lotti provisioning import review toont de project Waddle sync server, gebruiker en room"
-  caption="Importeer alleen wanneer elke gedecodeerde waarde behoort tot het synchronisatieaccount dat u wilde aansluiten."
-/>
+Sessies die met dit account zijn aangemeld kun je verwijderen — behalve die
+waarop je zit. Apparaten die op de oude manier zijn gekoppeld, elk met een eigen
+account, kun je wel verifiëren maar niet verwijderen.
 
-Als de import een fout meldt, laat het originele apparaat dan aangesloten, genereer een
-nieuwe overdrachtsbundel en probeer het opnieuw met de volledige waarde. Bewerk de
-gecodeerde bundel niet.
+## Koppel een ander apparaat
+
+Koppelen is een eigen stroom, met een code om te vergelijken en twee stappen na
+het verbinden. Het heeft een eigen pagina:
+[Een apparaat toevoegen](./add-device.mdx).
+
+Kort: open op een al verbonden apparaat **Instellingen → Synchronisatie →
+Apparaten → Apparaat toevoegen** en toon de code. Open op het nieuwe apparaat
+dezelfde pagina en scan hem. Vergelijk de controlecode op beide schermen voordat
+je verbindt — de QR-code bevat de inloggegevens van je synchronisatieaccount en
+gaat alleen naar je eigen apparaat.
 
 ## Controleer het nieuwe apparaat
 

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -68,8 +68,8 @@ a que estás prestes a juntar-te, encabeçado pelo código de verificação.
 
 Olha para o código de verificação aqui e para o do primeiro dispositivo. **Têm de
 ser idênticos.** Se forem diferentes, para: não estás a ver o código do teu
-próprio dispositivo. Descarta-o e recomeça a partir de um ecrã Adicionar
-dispositivo acabado de abrir.
+próprio dispositivo. Descarta-o: os dois ecrãs não descrevem a mesma conta, sala e servidor, e
+reabrir o ecrã não muda isso.
 
 A conta e o servidor por baixo do código são contexto, não coisas a comparar —
 não aparecem no outro dispositivo. Quando tudo coincidir, escolhe **Conectar este dispositivo**.
@@ -100,8 +100,8 @@ Deixa as duas aplicações abertas até a primeira sincronização terminar.
 
 - **Os códigos de verificação diferem.** Não ligues. Não estás a ver o código do teu
   próprio dispositivo. Reabrir o ecrã não ajuda: a mesma conta produz sempre o
-  mesmo código, por isso uma diferença significa que os dois ecrãs pertencem a
-  contas diferentes.
+  mesmo código, por isso uma diferença significa que os dois ecrãs não descrevem
+  o mesmo emparelhamento.
 - **O código não descodifica.** Copia-o outra vez no primeiro dispositivo em vez
   de corrigires o que colaste; o valor codificado não é para ser acertado à mão.
   Se a aplicação indicar versões diferentes, os dispositivos têm compilações

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ isso o processo tem duas verificações: um **código de verificação** curto q
 comparas antes de ligar e uma **verificação por emoji** a seguir.
 
 Fazem coisas diferentes. O código de verificação diz que os dois ecrãs falam da
-mesma conta — apanha um código antigo ou errado, que é o erro que de facto se
-comete. Deriva de identificadores públicos, por isso é uma ajuda ao
-reconhecimento, não uma prova de quem está do outro lado. A verificação por emoji
+mesma conta — apanha um código vindo de outro sítio, que é o erro que de facto se
+comete. Deriva apenas desses identificadores, não da palavra-passe — não diz
+nada sobre se as credenciais que leva ainda são válidas, nem sobre quem está do
+outro lado. A verificação por emoji
 que se segue é o passo que autentica o dispositivo e, até terminar, o dispositivo
 novo não consegue ler nada.
 
@@ -67,8 +68,7 @@ a que estás prestes a juntar-te, encabeçado pelo código de verificação.
 />
 
 Olha para o código de verificação aqui e para o do primeiro dispositivo. **Têm de
-ser idênticos.** Se forem diferentes, para: não estás a ver o código do teu
-próprio dispositivo. Descarta-o: os dois ecrãs não descrevem a mesma conta, sala e servidor, e
+ser idênticos.** Se forem diferentes, para. Descarta-o: os dois ecrãs não descrevem a mesma conta, sala e servidor, e
 reabrir o ecrã não muda isso.
 
 A conta e o servidor por baixo do código são contexto, não coisas a comparar —

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -28,7 +28,7 @@ dispositivo**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Ecrã Adicionar dispositivo do Lotti com código QR, aviso de segurança com cadeado e o código de verificação 2BD-EF4"
-  caption="O código é gerado ao abrir este ecrã e apenas enquanto ele estiver aberto. Repara no código de verificação por baixo: vais compará-lo já a seguir."
+  caption="O código só é mostrado enquanto este ecrã estiver aberto. Repara no código de verificação por baixo: vais compará-lo já a seguir."
 />
 
 Trata este ecrã como tratarias a tua palavra-passe, porque é isso que ele
@@ -98,10 +98,10 @@ Deixa as duas aplicações abertas até a primeira sincronização terminar.
 
 ## Se algo correr mal
 
-- **Os códigos de verificação diferem.** Não ligues. Fecha o ecrã no primeiro
-  dispositivo, abre um novo e tenta outra vez — a mesma conta produz sempre o mesmo
-  código, por isso uma diferença significa que os dois ecrãs pertencem a contas
-  diferentes.
+- **Os códigos de verificação diferem.** Não ligues. Não estás a ver o código do teu
+  próprio dispositivo. Reabrir o ecrã não ajuda: a mesma conta produz sempre o
+  mesmo código, por isso uma diferença significa que os dois ecrãs pertencem a
+  contas diferentes.
 - **O código não descodifica.** Copia-o outra vez no primeiro dispositivo em vez
   de corrigires o que colaste; o valor codificado não é para ser acertado à mão.
   Se a aplicação indicar versões diferentes, os dispositivos têm compilações

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ qualquer um, telemóvel ou computador. Não há dispositivo «principal».
 
 ## Mostra o código num dispositivo que já usas
 
-Abre **Definições → Sincronização → Dispositivos** e escolhe **Adicionar
+Abre **Definições → Configurações de sincronização → Dispositivos** e escolhe **Adicionar
 dispositivo**.
 
 <ManualScreenshot
@@ -32,8 +32,10 @@ dispositivo**.
 />
 
 Trata este ecrã como tratarias a tua palavra-passe, porque é isso que ele
-contém. Quem ler ou fotografar o código QR pode entrar na tua conta e ler as tuas
-entradas. Mostra-o apenas a um dispositivo teu e nunca o envies por conversa,
+contém. Quem ler ou fotografar o código QR pode iniciar sessão na tua conta: não
+consegue decifrar as tuas entradas sem estar também verificado por emoji a
+partir de um dos teus dispositivos, mas pode tomar conta da conta — incluindo
+mudar a palavra-passe e deixar-te de fora. Mostra-o apenas a um dispositivo teu e nunca o envies por conversa,
 captura de ecrã ou ecrã partilhado.
 
 **Fechar o ecrã esconde o código, mas não o revoga.** O código contém a
@@ -48,7 +50,7 @@ outro dispositivo e em mais lado nenhum.
 
 ## Lê o código no dispositivo novo
 
-Instala o Lotti no dispositivo novo e abre lá **Definições → Sincronização →
+Instala o Lotti no dispositivo novo e abre lá **Definições → Configurações de sincronização →
 Dispositivos** e seleciona o cartão **Dispositivos**. No telemóvel a câmara abre de imediato; aponta ao primeiro
 dispositivo. No computador, ou se a câmara não estiver disponível, escolhe
 **Digitar o código manualmente** e cola o código copiado.
@@ -90,7 +92,7 @@ que seja.
 2. **Envia as definições.** No primeiro dispositivo, no ecrã Adicionar
    dispositivo que ainda tens aberto, escolhe **Enviar configurações** para que
    categorias, hábitos, painéis e configuração de IA cheguem. Se já o fechaste,
-   reabre **Definições → Sincronização → Dispositivos → Adicionar dispositivo**.
+   reabre **Definições → Configurações de sincronização → Dispositivos → Adicionar dispositivo**.
 
 Deixa as duas aplicações abertas até a primeira sincronização terminar.
 

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,10 +6,16 @@ description: Pareia um novo dispositivo com a tua conta de sincronização atrav
 # Adicionar um dispositivo
 
 Todos os teus dispositivos partilham uma única conta de sincronização.
-Adicionar um dispositivo significa entregar-lhe as credenciais dessa conta — por
-isso o processo pede que compares um código curto antes de ligar seja o que for.
-É o único momento em que consegues distinguir o teu dispositivo do de outra
-pessoa.
+Adicionar um dispositivo significa entregar-lhe as credenciais dessa conta, por
+isso o processo tem duas verificações: um **código de verificação** curto que
+comparas antes de ligar e uma **verificação por emoji** a seguir.
+
+Fazem coisas diferentes. O código de verificação diz que os dois ecrãs falam da
+mesma conta — apanha um código antigo ou errado, que é o erro que de facto se
+comete. Deriva de identificadores públicos, por isso é uma ajuda ao
+reconhecimento, não uma prova de quem está do outro lado. A verificação por emoji
+que se segue é o passo que autentica o dispositivo e, até terminar, o dispositivo
+novo não consegue ler nada.
 
 Precisas dos dois dispositivos à frente. Começa num que já esteja ligado —
 qualquer um, telemóvel ou computador. Não há dispositivo «principal».
@@ -30,6 +36,11 @@ contém. Quem ler ou fotografar o código QR pode entrar na tua conta e ler as t
 entradas. Mostra-o apenas a um dispositivo teu e nunca o envies por conversa,
 captura de ecrã ou ecrã partilhado.
 
+**Fechar o ecrã esconde o código, mas não o revoga.** O código contém a
+palavra-passe atual da tua conta: uma fotografia continua utilizável enquanto
+essa palavra-passe for válida. Se achas que alguém a captou, trata-a como uma
+palavra-passe divulgada e não como algo que entretanto expirou.
+
 **Copiar código de emparelhamento** existe de propósito para quando o
 dispositivo que se junta não tem câmara — um computador a juntar-se a outro.
 Coloca as mesmas credenciais na área de transferência: cola-as diretamente no
@@ -38,9 +49,9 @@ outro dispositivo e em mais lado nenhum.
 ## Lê o código no dispositivo novo
 
 Instala o Lotti no dispositivo novo e abre lá **Definições → Sincronização →
-Dispositivos**. No telemóvel a câmara abre de imediato; aponta ao primeiro
+Dispositivos** e seleciona o cartão **Dispositivos**. No telemóvel a câmara abre de imediato; aponta ao primeiro
 dispositivo. No computador, ou se a câmara não estiver disponível, escolhe
-**introduzir manualmente** e cola o código copiado.
+**Digitar o código manualmente** e cola o código copiado.
 
 ## Confere que o código coincide antes de ligar
 
@@ -59,8 +70,7 @@ próprio dispositivo. Descarta-o e recomeça a partir de um ecrã Adicionar
 dispositivo acabado de abrir.
 
 A conta e o servidor por baixo do código são contexto, não coisas a comparar —
-não aparecem no outro dispositivo. Quando tudo coincidir, escolhe **Ligar este
-dispositivo**.
+não aparecem no outro dispositivo. Quando tudo coincidir, escolhe **Conectar este dispositivo**.
 
 ## Conclui os dois passos seguintes
 
@@ -69,7 +79,7 @@ que seja.
 
 <ManualScreenshot
   caseId="sync/paired"
-  alt="Configuração de sincronização do Lotti: este dispositivo está ligado, verificação por emoji e Enviar definições ainda pendentes"
+  alt="Configuração de sincronização do Lotti: este dispositivo está ligado, verificação por emoji e Enviar configurações ainda pendentes"
   caption="Ligado é a metade fácil. O cartão diz o que falta e afirma claramente que, até à verificação, este dispositivo não consegue ler nada."
 />
 
@@ -78,7 +88,7 @@ que seja.
    apenas cifra que não consegue ler — as chaves só vão para dispositivos
    verificados. Vê [Sincronizar dispositivos](./sync.mdx).
 2. **Envia as definições.** No primeiro dispositivo, no ecrã Adicionar
-   dispositivo que ainda tens aberto, escolhe **Enviar definições** para que
+   dispositivo que ainda tens aberto, escolhe **Enviar configurações** para que
    categorias, hábitos, painéis e configuração de IA cheguem. Se já o fechaste,
    reabre **Definições → Sincronização → Dispositivos → Adicionar dispositivo**.
 
@@ -87,8 +97,9 @@ Deixa as duas aplicações abertas até a primeira sincronização terminar.
 ## Se algo correr mal
 
 - **Os códigos de verificação diferem.** Não ligues. Fecha o ecrã no primeiro
-  dispositivo, abre um novo e tenta outra vez — o código é gerado de novo de cada
-  vez.
+  dispositivo, abre um novo e tenta outra vez — a mesma conta produz sempre o mesmo
+  código, por isso uma diferença significa que os dois ecrãs pertencem a contas
+  diferentes.
 - **O código não descodifica.** Copia-o outra vez no primeiro dispositivo em vez
   de corrigires o que colaste; o valor codificado não é para ser acertado à mão.
   Se a aplicação indicar versões diferentes, os dispositivos têm compilações

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,101 @@
+---
+title: Adicionar um dispositivo
+description: Pareia um novo dispositivo com a tua conta de sincronização através de um código QR, confere o código de verificação e conclui os dois passos seguintes.
+---
+
+# Adicionar um dispositivo
+
+Todos os teus dispositivos partilham uma única conta de sincronização.
+Adicionar um dispositivo significa entregar-lhe as credenciais dessa conta — por
+isso o processo pede que compares um código curto antes de ligar seja o que for.
+É o único momento em que consegues distinguir o teu dispositivo do de outra
+pessoa.
+
+Precisas dos dois dispositivos à frente. Começa num que já esteja ligado —
+qualquer um, telemóvel ou computador. Não há dispositivo «principal».
+
+## Mostra o código num dispositivo que já usas
+
+Abre **Definições → Sincronização → Dispositivos** e escolhe **Adicionar
+dispositivo**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Ecrã Adicionar dispositivo do Lotti com código QR, aviso de segurança com cadeado e o código de verificação 2BD-EF4"
+  caption="O código é gerado ao abrir este ecrã e apenas enquanto ele estiver aberto. Repara no código de verificação por baixo: vais compará-lo já a seguir."
+/>
+
+Trata este ecrã como tratarias a tua palavra-passe, porque é isso que ele
+contém. Quem ler ou fotografar o código QR pode entrar na tua conta e ler as tuas
+entradas. Mostra-o apenas a um dispositivo teu e nunca o envies por conversa,
+captura de ecrã ou ecrã partilhado.
+
+**Copiar código de emparelhamento** existe de propósito para quando o
+dispositivo que se junta não tem câmara — um computador a juntar-se a outro.
+Coloca as mesmas credenciais na área de transferência: cola-as diretamente no
+outro dispositivo e em mais lado nenhum.
+
+## Lê o código no dispositivo novo
+
+Instala o Lotti no dispositivo novo e abre lá **Definições → Sincronização →
+Dispositivos**. No telemóvel a câmara abre de imediato; aponta ao primeiro
+dispositivo. No computador, ou se a câmara não estiver disponível, escolhe
+**introduzir manualmente** e cola o código copiado.
+
+## Confere que o código coincide antes de ligar
+
+Descodificar o código não liga nada. O que aparece primeiro é um resumo daquilo
+a que estás prestes a juntar-te, encabeçado pelo código de verificação.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Resumo de emparelhamento do Lotti com o código de verificação, a conta a que se vai juntar e o servidor de sincronização"
+  caption="Ambos os dispositivos derivam este código de forma independente a partir da conta, da sala e do servidor. Nunca o trocam entre si — é isso que torna a comparação útil."
+/>
+
+Olha para o código de verificação aqui e para o do primeiro dispositivo. **Têm de
+ser idênticos.** Se forem diferentes, para: não estás a ver o código do teu
+próprio dispositivo. Descarta-o e recomeça a partir de um ecrã Adicionar
+dispositivo acabado de abrir.
+
+A conta e o servidor por baixo do código são contexto, não coisas a comparar —
+não aparecem no outro dispositivo. Quando tudo coincidir, escolhe **Ligar este
+dispositivo**.
+
+## Conclui os dois passos seguintes
+
+Ligar junta-te à conta. Ainda não permite que o dispositivo novo leia o que quer
+que seja.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Configuração de sincronização do Lotti: este dispositivo está ligado, verificação por emoji e Enviar definições ainda pendentes"
+  caption="Ligado é a metade fácil. O cartão diz o que falta e afirma claramente que, até à verificação, este dispositivo não consegue ler nada."
+/>
+
+1. **Compara os emojis.** Aparece uma fila de emojis nos dois dispositivos.
+   Confere que coincidem e confirma em cada um. Até lá, o dispositivo novo recebe
+   apenas cifra que não consegue ler — as chaves só vão para dispositivos
+   verificados. Vê [Sincronizar dispositivos](./sync.mdx).
+2. **Envia as definições.** No primeiro dispositivo, no ecrã Adicionar
+   dispositivo que ainda tens aberto, escolhe **Enviar definições** para que
+   categorias, hábitos, painéis e configuração de IA cheguem. Se já o fechaste,
+   reabre **Definições → Sincronização → Dispositivos → Adicionar dispositivo**.
+
+Deixa as duas aplicações abertas até a primeira sincronização terminar.
+
+## Se algo correr mal
+
+- **Os códigos de verificação diferem.** Não ligues. Fecha o ecrã no primeiro
+  dispositivo, abre um novo e tenta outra vez — o código é gerado de novo de cada
+  vez.
+- **O código não descodifica.** Copia-o outra vez no primeiro dispositivo em vez
+  de corrigires o que colaste; o valor codificado não é para ser acertado à mão.
+  Se a aplicação indicar versões diferentes, os dispositivos têm compilações
+  diferentes e ambos precisam de atualização.
+- **O dispositivo novo ligou mas continua vazio.** É o estado esperado antes da
+  verificação. Termina a comparação dos emojis e depois consulta
+  [Sincronizar dispositivos](./sync.mdx) para a fila de saída e a recuperação.
+
+Continua com [Sincronizar dispositivos](./sync.mdx) para estado diário, saúde da
+entrega e ferramentas de recuperação.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -25,7 +25,7 @@ saída** é o trabalho que ainda não chegou ao serviço de sincronização.
 
 ## Vê os teus dispositivos
 
-**Definições → Sincronização → Dispositivos** lista todas as sessões da tua
+**Definições → Configurações de sincronização → Dispositivos** lista todas as sessões da tua
 conta de sincronização — não apenas as não verificadas.
 
 <ManualScreenshot
@@ -44,7 +44,7 @@ O pareamento é um fluxo próprio, com um código para comparar e dois passos
 depois de conectar. Tem uma página própria:
 [Adicionar um dispositivo](./add-device.mdx).
 
-Em resumo: num dispositivo já conectado abre **Definições → Sincronização →
+Em resumo: num dispositivo já conectado abre **Definições → Configurações de sincronização →
 Dispositivos → Adicionar dispositivo** e mostra o código. No dispositivo novo
 abre a mesma página e faz a leitura. Compara o código de verificação nos dois
 ecrãs antes de conectar — o código QR leva as credenciais da tua conta de

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -23,33 +23,32 @@ saída** é o trabalho que ainda não chegou ao serviço de sincronização.
   caption="O hub de sincronização mantém o status do dia a dia perto das ferramentas de diagnóstico e recuperação. O Project Waddle atualmente tem três itens na caixa de saída para inspecionar."
 />
 
-## Parear outro dispositivo
+## Vê os teus dispositivos
 
-Comece em um dispositivo que já esteja conectado:
-
-1. Abra **Configurações → Sincronização → Sincronização Provisionada**.
-2. No desktop, mostre o código QR de transferência. Mantenha esta tela privada: o pacote
-   concede acesso à sua conta e sala de sincronização.
-3. No novo dispositivo, abra a mesma página e escaneie o código QR ou cole o
-   pacote completo de provisionamento.
-4. Revise o servidor, o usuário e a sala decodificados antes de selecionar **Importar**.
-5. Deixe a primeira sincronização terminar antes de fechar qualquer um dos aplicativos.
+**Definições → Sincronização → Dispositivos** lista todas as sessões da tua
+conta de sincronização — não apenas as não verificadas.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Status da Sincronização Provisionada no celular e o código QR seguro de transferência do dispositivo no desktop"
-  caption="O desktop pode apresentar o código QR de transferência; o celular mostra a conta conectada e o estado de verificação. Trate o código QR como uma senha."
+  alt="Página Dispositivos do Lotti com as sessões da conta de sincronização, estado de verificação e última atividade"
+  caption="Cada linha mostra se o dispositivo está verificado e quando o servidor o viu pela última vez. Um dispositivo não verificado não consegue ler entradas novas, e a lista di-lo."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Revisão de importação de provisionamento do Lotti mostrando o servidor de sincronização, o usuário e a sala do Project Waddle"
-  caption="Importe somente quando cada valor decodificado pertencer à conta de sincronização na qual você pretende ingressar."
-/>
+As sessões com sessão iniciada nesta conta podem ser removidas — exceto aquela
+em que estás. Os dispositivos emparelhados à maneira antiga, cada um com a sua
+conta, podem ser verificados mas não removidos.
 
-Se a importação reportar um erro, mantenha o dispositivo original conectado,
-gere um novo pacote de transferência e tente novamente com o valor completo.
-Não edite o pacote codificado manualmente.
+## Parear outro dispositivo
+
+O pareamento é um fluxo próprio, com um código para comparar e dois passos
+depois de conectar. Tem uma página própria:
+[Adicionar um dispositivo](./add-device.mdx).
+
+Em resumo: num dispositivo já conectado abre **Definições → Sincronização →
+Dispositivos → Adicionar dispositivo** e mostra o código. No dispositivo novo
+abre a mesma página e faz a leitura. Compara o código de verificação nos dois
+ecrãs antes de conectar — o código QR leva as credenciais da tua conta de
+sincronização e vai apenas para o teu próprio dispositivo.
 
 ## Verifique o novo dispositivo
 

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -28,7 +28,7 @@ dispozitiv**.
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Ecranul Adăugați dispozitiv din Lotti, cu cod QR, notă de securitate cu lacăt și codul de control 2BD-EF4"
-  caption="Codul este generat la deschiderea acestui ecran și doar cât timp rămâne deschis. Observați codul de control de dedesubt — pe acela îl veți compara."
+  caption="Codul este afișat doar cât timp acest ecran rămâne deschis. Observați codul de control de dedesubt — pe acela îl veți compara."
 />
 
 Tratați acest ecran așa cum v-ați trata parola, pentru că exact asta conține.
@@ -100,9 +100,9 @@ Lăsați ambele aplicații deschise până se termină prima sincronizare.
 
 ## Dacă ceva nu merge
 
-- **Codurile de control diferă.** Nu conectați. Închideți ecranul de pe primul
-  dispozitiv, deschideți unul nou și încercați din nou — același cont produce de fiecare dată
-  același cod, deci o nepotrivire înseamnă că cele două ecrane aparțin unor
+- **Codurile de control diferă.** Nu conectați. Nu priviți codul propriului
+  dispozitiv. Redeschiderea ecranului nu ajută: același cont produce de fiecare
+  dată același cod, deci o nepotrivire înseamnă că cele două ecrane aparțin unor
   conturi diferite.
 - **Codul nu se decodifică.** Copiați-l din nou pe primul dispozitiv în loc să
   corectați ce ați lipit; valoarea codificată nu este menită să fie ajustată

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -69,7 +69,8 @@ la care urmează să vă alăturați, condus de codul de control.
 
 Priviți codul de control de aici și pe cel de pe primul dispozitiv. **Trebuie să
 fie identice.** Dacă diferă, opriți-vă: nu priviți codul propriului dispozitiv.
-Renunțați la el și reluați dintr-un ecran Adăugați dispozitiv proaspăt deschis.
+Renunțați la el: cele două ecrane nu descriu același cont, aceeași cameră și
+același server, iar redeschiderea ecranului nu schimbă acest lucru.
 
 Contul și serverul de sub cod sunt context, nu elemente de comparat — ele nu apar
 pe celălalt dispozitiv. Când totul se potrivește, alegeți **Conectați acest
@@ -102,8 +103,8 @@ Lăsați ambele aplicații deschise până se termină prima sincronizare.
 
 - **Codurile de control diferă.** Nu conectați. Nu priviți codul propriului
   dispozitiv. Redeschiderea ecranului nu ajută: același cont produce de fiecare
-  dată același cod, deci o nepotrivire înseamnă că cele două ecrane aparțin unor
-  conturi diferite.
+  dată același cod, deci o nepotrivire înseamnă că cele două ecrane nu descriu
+  aceeași asociere.
 - **Codul nu se decodifică.** Copiați-l din nou pe primul dispozitiv în loc să
   corectați ce ați lipit; valoarea codificată nu este menită să fie ajustată
   manual. Dacă aplicația semnalează versiuni diferite, dispozitivele rulează

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ oricare, telefon sau calculator. Nu există un dispozitiv „principal”.
 
 ## Afișați codul pe un dispozitiv pe care îl folosiți deja
 
-Deschideți **Setări → Sincronizare → Dispozitive** și alegeți **Adăugați
+Deschideți **Setări → Setări sincronizare → Dispozitive** și alegeți **Adăugați
 dispozitiv**.
 
 <ManualScreenshot
@@ -32,8 +32,10 @@ dispozitiv**.
 />
 
 Tratați acest ecran așa cum v-ați trata parola, pentru că exact asta conține.
-Oricine scanează sau fotografiază codul QR se poate alătura contului
-dumneavoastră și vă poate citi însemnările. Arătați-l doar unui dispozitiv care
+Oricine scanează sau fotografiază codul QR se poate autentifica în contul
+dumneavoastră: nu vă poate decripta însemnările fără a fi și verificat prin
+emoji de pe unul dintre dispozitivele dumneavoastră, dar poate prelua contul —
+inclusiv schimbând parola și blocându-vă accesul. Arătați-l doar unui dispozitiv care
 vă aparține și nu îl trimiteți niciodată prin chat, captură de ecran sau ecran
 partajat.
 
@@ -50,7 +52,7 @@ dispozitiv și nicăieri altundeva.
 ## Scanați-l pe dispozitivul nou
 
 Instalați Lotti pe dispozitivul nou, apoi deschideți acolo **Setări →
-Sincronizare → Dispozitive** și selectați cardul **Dispozitive**. Pe telefon camera se deschide imediat; îndreptați-o
+Setări sincronizare → Dispozitive** și selectați cardul **Dispozitive**. Pe telefon camera se deschide imediat; îndreptați-o
 spre primul dispozitiv. Pe calculator, sau dacă nu există cameră, alegeți
 **Introduceți codul manual** și lipiți codul copiat.
 
@@ -92,7 +94,7 @@ ceva.
 2. **Trimiteți setările.** Pe primul dispozitiv, în ecranul Adăugați dispozitiv
    încă deschis, alegeți **Trimiteți setările**, pentru ca listele de categorii,
    obiceiuri, tablourile de bord și configurația AI să ajungă. Dacă l-ați închis,
-   redeschideți **Setări → Sincronizare → Dispozitive → Adăugați dispozitiv**.
+   redeschideți **Setări → Setări sincronizare → Dispozitive → Adăugați dispozitiv**.
 
 Lăsați ambele aplicații deschise până se termină prima sincronizare.
 

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ că fluxul are două verificări: un **cod de control** scurt, pe care îl compa
 înainte de conectare, și o **verificare prin emoji** după aceea.
 
 Ele fac lucruri diferite. Codul de control arată că ambele ecrane vorbesc despre
-același cont — prinde un cod vechi sau greșit, adică eroarea care chiar se
-întâmplă. Este derivat din identificatori publici, deci este un ajutor de
-recunoaștere, nu o dovadă a cine se află la celălalt capăt. Verificarea prin
+același cont — prinde un cod venit din altă parte, adică eroarea care chiar se
+întâmplă. Este derivat doar din acei identificatori, nu din parolă — deci nu
+spune nimic despre cât de valabile mai sunt datele de acces din el și nimic
+despre cine se află la celălalt capăt. Verificarea prin
 emoji care urmează este pasul care autentifică dispozitivul, iar până se încheie
 noul dispozitiv nu poate citi nimic.
 
@@ -68,8 +69,7 @@ la care urmează să vă alăturați, condus de codul de control.
 />
 
 Priviți codul de control de aici și pe cel de pe primul dispozitiv. **Trebuie să
-fie identice.** Dacă diferă, opriți-vă: nu priviți codul propriului dispozitiv.
-Renunțați la el: cele două ecrane nu descriu același cont, aceeași cameră și
+fie identice.** Dacă diferă, opriți-vă și renunțați la el: cele două ecrane nu descriu același cont, aceeași cameră și
 același server, iar redeschiderea ecranului nu schimbă acest lucru.
 
 Contul și serverul de sub cod sunt context, nu elemente de comparat — ele nu apar
@@ -101,8 +101,7 @@ Lăsați ambele aplicații deschise până se termină prima sincronizare.
 
 ## Dacă ceva nu merge
 
-- **Codurile de control diferă.** Nu conectați. Nu priviți codul propriului
-  dispozitiv. Redeschiderea ecranului nu ajută: același cont produce de fiecare
+- **Codurile de control diferă.** Nu conectați. Redeschiderea ecranului nu ajută: același cont produce de fiecare
   dată același cod, deci o nepotrivire înseamnă că cele două ecrane nu descriu
   aceeași asociere.
 - **Codul nu se decodifică.** Copiați-l din nou pe primul dispozitiv în loc să

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,102 @@
+---
+title: Adăugați un dispozitiv
+description: Asociați un dispozitiv nou contului dumneavoastră de sincronizare printr-un cod QR, verificați codul de control și încheiați cei doi pași care urmează.
+---
+
+# Adăugați un dispozitiv
+
+Toate dispozitivele dumneavoastră folosesc un singur cont de sincronizare. A
+adăuga un dispozitiv înseamnă a-i încredința datele de acces ale acelui cont — de
+aceea fluxul vă cere să comparați un cod scurt înainte de a conecta ceva. Este
+singurul moment în care puteți deosebi dispozitivul dumneavoastră de al altcuiva.
+
+Aveți nevoie de ambele dispozitive în față. Începeți de pe unul deja conectat —
+oricare, telefon sau calculator. Nu există un dispozitiv „principal”.
+
+## Afișați codul pe un dispozitiv pe care îl folosiți deja
+
+Deschideți **Setări → Sincronizare → Dispozitive** și alegeți **Adăugați
+dispozitiv**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Ecranul Adăugați dispozitiv din Lotti, cu cod QR, notă de securitate cu lacăt și codul de control 2BD-EF4"
+  caption="Codul este generat la deschiderea acestui ecran și doar cât timp rămâne deschis. Observați codul de control de dedesubt — pe acela îl veți compara."
+/>
+
+Tratați acest ecran așa cum v-ați trata parola, pentru că exact asta conține.
+Oricine scanează sau fotografiază codul QR se poate alătura contului
+dumneavoastră și vă poate citi însemnările. Arătați-l doar unui dispozitiv care
+vă aparține și nu îl trimiteți niciodată prin chat, captură de ecran sau ecran
+partajat.
+
+**Copiați codul de asociere** există intenționat pentru cazul în care
+dispozitivul care se alătură nu are cameră — un calculator care se alătură unui
+calculator. Pune aceleași date în clipboard: lipiți-le direct în celălalt
+dispozitiv și nicăieri altundeva.
+
+## Scanați-l pe dispozitivul nou
+
+Instalați Lotti pe dispozitivul nou, apoi deschideți acolo **Setări →
+Sincronizare → Dispozitive**. Pe telefon camera se deschide imediat; îndreptați-o
+spre primul dispozitiv. Pe calculator, sau dacă nu există cameră, alegeți
+**introduceți manual** și lipiți codul copiat.
+
+## Verificați că se potrivește codul înainte de conectare
+
+Decodificarea codului nu conectează nimic. Mai întâi apare un rezumat al lucrului
+la care urmează să vă alăturați, condus de codul de control.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Rezumatul asocierii din Lotti, cu codul de control, contul la care se alătură și serverul de sincronizare"
+  caption="Ambele dispozitive derivă acest cod independent, din cont, cameră și server. Nu îl schimbă niciodată între ele — de aceea compararea contează."
+/>
+
+Priviți codul de control de aici și pe cel de pe primul dispozitiv. **Trebuie să
+fie identice.** Dacă diferă, opriți-vă: nu priviți codul propriului dispozitiv.
+Renunțați la el și reluați dintr-un ecran Adăugați dispozitiv proaspăt deschis.
+
+Contul și serverul de sub cod sunt context, nu elemente de comparat — ele nu apar
+pe celălalt dispozitiv. Când totul se potrivește, alegeți **Conectați acest
+dispozitiv**.
+
+## Încheiați cei doi pași care urmează
+
+Conectarea vă alătură contului. Încă nu permite dispozitivului nou să citească
+ceva.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Configurarea sincronizării în Lotti: acest dispozitiv este conectat, verificarea prin emoji și Trimiteți setările sunt încă în așteptare"
+  caption="Conectat este jumătatea ușoară. Cardul numește ce lipsește și spune clar că, până la verificare, acest dispozitiv nu poate citi nimic."
+/>
+
+1. **Comparați emoji-urile.** Pe ambele dispozitive apare un rând de emoji.
+   Verificați că se potrivesc și confirmați pe fiecare. Până atunci, dispozitivul
+   nou primește doar text cifrat pe care nu îl poate citi — cheile merg exclusiv
+   către dispozitive verificate. Vedeți
+   [Sincronizarea dispozitivelor](./sync.mdx).
+2. **Trimiteți setările.** Pe primul dispozitiv, în ecranul Adăugați dispozitiv
+   încă deschis, alegeți **Trimiteți setările**, pentru ca listele de categorii,
+   obiceiuri, tablourile de bord și configurația AI să ajungă. Dacă l-ați închis,
+   redeschideți **Setări → Sincronizare → Dispozitive → Adăugați dispozitiv**.
+
+Lăsați ambele aplicații deschise până se termină prima sincronizare.
+
+## Dacă ceva nu merge
+
+- **Codurile de control diferă.** Nu conectați. Închideți ecranul de pe primul
+  dispozitiv, deschideți unul nou și încercați din nou — codul este regenerat de
+  fiecare dată.
+- **Codul nu se decodifică.** Copiați-l din nou pe primul dispozitiv în loc să
+  corectați ce ați lipit; valoarea codificată nu este menită să fie ajustată
+  manual. Dacă aplicația semnalează versiuni diferite, dispozitivele rulează
+  compilări diferite și ambele au nevoie de actualizare.
+- **Dispozitivul nou s-a conectat, dar rămâne gol.** Este starea așteptată
+  înainte de verificare. Încheiați compararea emoji-urilor, apoi consultați
+  [Sincronizarea dispozitivelor](./sync.mdx) pentru coada de trimitere și
+  recuperare.
+
+Continuați cu [Sincronizarea dispozitivelor](./sync.mdx) pentru starea zilnică,
+sănătatea livrării și instrumentele de recuperare.

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Asociați un dispozitiv nou contului dumneavoastră de sincronizare
 # Adăugați un dispozitiv
 
 Toate dispozitivele dumneavoastră folosesc un singur cont de sincronizare. A
-adăuga un dispozitiv înseamnă a-i încredința datele de acces ale acelui cont — de
-aceea fluxul vă cere să comparați un cod scurt înainte de a conecta ceva. Este
-singurul moment în care puteți deosebi dispozitivul dumneavoastră de al altcuiva.
+adăuga un dispozitiv înseamnă a-i încredința datele de acces ale acelui cont, așa
+că fluxul are două verificări: un **cod de control** scurt, pe care îl comparați
+înainte de conectare, și o **verificare prin emoji** după aceea.
+
+Ele fac lucruri diferite. Codul de control arată că ambele ecrane vorbesc despre
+același cont — prinde un cod vechi sau greșit, adică eroarea care chiar se
+întâmplă. Este derivat din identificatori publici, deci este un ajutor de
+recunoaștere, nu o dovadă a cine se află la celălalt capăt. Verificarea prin
+emoji care urmează este pasul care autentifică dispozitivul, iar până se încheie
+noul dispozitiv nu poate citi nimic.
 
 Aveți nevoie de ambele dispozitive în față. Începeți de pe unul deja conectat —
 oricare, telefon sau calculator. Nu există un dispozitiv „principal”.
@@ -30,6 +37,11 @@ dumneavoastră și vă poate citi însemnările. Arătați-l doar unui dispoziti
 vă aparține și nu îl trimiteți niciodată prin chat, captură de ecran sau ecran
 partajat.
 
+**Închiderea ecranului ascunde codul, dar nu îl revocă.** Codul conține parola
+actuală a contului dumneavoastră: o fotografie rămâne utilizabilă atât timp cât
+acea parolă este valabilă. Dacă bănuiți că cineva l-a capturat, tratați-l ca pe
+o parolă compromisă, nu ca pe ceva care între timp ar fi expirat.
+
 **Copiați codul de asociere** există intenționat pentru cazul în care
 dispozitivul care se alătură nu are cameră — un calculator care se alătură unui
 calculator. Pune aceleași date în clipboard: lipiți-le direct în celălalt
@@ -38,9 +50,9 @@ dispozitiv și nicăieri altundeva.
 ## Scanați-l pe dispozitivul nou
 
 Instalați Lotti pe dispozitivul nou, apoi deschideți acolo **Setări →
-Sincronizare → Dispozitive**. Pe telefon camera se deschide imediat; îndreptați-o
+Sincronizare → Dispozitive** și selectați cardul **Dispozitive**. Pe telefon camera se deschide imediat; îndreptați-o
 spre primul dispozitiv. Pe calculator, sau dacă nu există cameră, alegeți
-**introduceți manual** și lipiți codul copiat.
+**Introduceți codul manual** și lipiți codul copiat.
 
 ## Verificați că se potrivește codul înainte de conectare
 
@@ -87,8 +99,9 @@ Lăsați ambele aplicații deschise până se termină prima sincronizare.
 ## Dacă ceva nu merge
 
 - **Codurile de control diferă.** Nu conectați. Închideți ecranul de pe primul
-  dispozitiv, deschideți unul nou și încercați din nou — codul este regenerat de
-  fiecare dată.
+  dispozitiv, deschideți unul nou și încercați din nou — același cont produce de fiecare dată
+  același cod, deci o nepotrivire înseamnă că cele două ecrane aparțin unor
+  conturi diferite.
 - **Codul nu se decodifică.** Copiați-l din nou pe primul dispozitiv în loc să
   corectați ce ați lipit; valoarea codificată nu este menită să fie ajustată
   manual. Dacă aplicația semnalează versiuni diferite, dispozitivele rulează

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -13,7 +13,7 @@ Deschideți **Setări → Sincronizare** pentru a vedea paginile disponibile de 
 
 ## Vedeți dispozitivele dumneavoastră
 
-**Setări → Sincronizare → Dispozitive** enumeră fiecare sesiune a contului
+**Setări → Setări sincronizare → Dispozitive** enumeră fiecare sesiune a contului
 dumneavoastră de sincronizare, nu doar pe cele neverificate.
 
 <ManualScreenshot
@@ -31,7 +31,7 @@ pot fi verificate, dar nu eliminate.
 Asocierea este un flux separat, cu un cod de comparat și doi pași după
 conectare. Are o pagină proprie: [Adăugați un dispozitiv](./add-device.mdx).
 
-Pe scurt: pe un dispozitiv deja conectat deschideți **Setări → Sincronizare →
+Pe scurt: pe un dispozitiv deja conectat deschideți **Setări → Setări sincronizare →
 Dispozitive → Adăugați dispozitiv** și afișați codul. Pe noul dispozitiv
 deschideți aceeași pagină și scanați-l. Comparați codul de verificare pe ambele
 ecrane înainte de a conecta — codul QR conține datele de acces ale contului

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -11,21 +11,31 @@ Deschideți **Setări → Sincronizare** pentru a vedea paginile disponibile de 
 
 <ManualScreenshot caseId="sync/hub" alt="Setările Lotti Sync, cu Sincronizare aprovizionată, identitatea dispozitivului, recuperare, statistici, cutie de ieșire, conflicte și întreținere" caption="Centrul de sincronizare păstrează starea de zi cu zi aproape de instrumentele de diagnostic și recuperare. Project Waddle are în prezent trei elemente de inspectat în cutia de ieșire." />
 
+## Vedeți dispozitivele dumneavoastră
+
+**Setări → Sincronizare → Dispozitive** enumeră fiecare sesiune a contului
+dumneavoastră de sincronizare, nu doar pe cele neverificate.
+
+<ManualScreenshot
+  caseId="sync/status"
+  alt="Pagina Dispozitive din Lotti, cu sesiunile contului de sincronizare, starea verificării și ultima activitate"
+  caption="Fiecare rând arată dacă dispozitivul este verificat și când l-a văzut ultima dată serverul. Un dispozitiv neverificat nu poate citi însemnările noi, iar lista spune asta."
+/>
+
+Sesiunile autentificate cu acest cont pot fi eliminate — cu excepția celei pe
+care vă aflați. Dispozitivele asociate în modul vechi, fiecare cu propriul cont,
+pot fi verificate, dar nu eliminate.
+
 ## Asociați alt dispozitiv
 
-Începeți de pe un dispozitiv deja conectat:
+Asocierea este un flux separat, cu un cod de comparat și doi pași după
+conectare. Are o pagină proprie: [Adăugați un dispozitiv](./add-device.mdx).
 
-1. Deschideți **Setări → Sincronizare → Sincronizare aprovizionată**.
-2. Pe desktop, afișați codul QR de transfer. Păstrați acest ecran privat: pachetul acordă acces la contul și camera dvs. de sincronizare.
-3. Pe dispozitivul nou, deschideți aceeași pagină și scanați codul QR sau lipiți pachetul complet de aprovizionare.
-4. Examinați serverul, utilizatorul și camera decodate înainte de a selecta **Importați**.
-5. Lăsați prima sincronizare să se termine înainte de a închide oricare dintre aplicații.
-
-<ManualScreenshot caseId="sync/status" alt="Starea Sincronizare aprovizionată pe mobil și codul QR securizat de transfer al dispozitivului pe desktop" caption="Desktopul poate afișa codul QR de transfer; mobilul arată contul conectat și starea verificării. Tratați codul QR ca pe o parolă." />
-
-<ManualScreenshot caseId="sync/provisioned" alt="Revizuirea importului de aprovizionare Lotti, cu serverul de sincronizare, utilizatorul și camera Project Waddle" caption="Importați numai când fiecare valoare decodată aparține contului de sincronizare la care ați intenționat să vă alăturați." />
-
-Dacă importul raportează o eroare, păstrați conectat dispozitivul original, generați un pachet de transfer nou și încercați din nou cu valoarea completă. Nu editați manual pachetul codificat.
+Pe scurt: pe un dispozitiv deja conectat deschideți **Setări → Sincronizare →
+Dispozitive → Adăugați dispozitiv** și afișați codul. Pe noul dispozitiv
+deschideți aceeași pagină și scanați-l. Comparați codul de verificare pe ambele
+ecrane înainte de a conecta — codul QR conține datele de acces ale contului
+dumneavoastră de sincronizare și merge doar către propriul dispozitiv.
 
 ## Verificați noul dispozitiv
 

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -27,7 +27,7 @@ som helst, telefon eller dator. Det finns ingen «huvudenhet».
 <ManualScreenshot
   caseId="sync/add-device"
   alt="Lottis skärm Lägg till enhet med QR-kod, säkerhetsnotis med hänglås och kontrollkoden 2BD-EF4"
-  caption="Koden skapas när du öppnar den här skärmen och bara så länge den är öppen. Lägg märke till kontrollkoden under — den jämför du strax."
+  caption="Koden visas bara så länge den här skärmen är öppen. Lägg märke till kontrollkoden under — den jämför du strax."
 />
 
 Behandla den här skärmen som ditt lösenord, för det är vad den innehåller. Den som skannar eller fotograferar QR-koden kan logga in på ditt konto:
@@ -93,9 +93,9 @@ Låt båda apparna vara öppna tills den första synkroniseringen är klar.
 
 ## Om något går fel
 
-- **Kontrollkoderna skiljer sig åt.** Anslut inte. Stäng skärmen på den första
-  enheten, öppna en ny och försök igen — samma konto ger samma kod varje
-  gång, så en skillnad betyder att de två skärmarna hör till olika konton.
+- **Kontrollkoderna skiljer sig åt.** Anslut inte. Du tittar inte på din egen
+  enhets kod. Att öppna skärmen igen hjälper inte: samma konto ger samma kod
+  varje gång, så en skillnad betyder att de två skärmarna hör till olika konton.
 - **Koden går inte att avkoda.** Kopiera den igen på den första enheten i stället
   för att rätta det du klistrade in; det kodade värdet är inte tänkt att justeras
   för hand. Rapporterar appen olika versioner kör enheterna olika byggen och båda

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -11,9 +11,10 @@ kontroller: en kort **kontrollkod** som du jämför innan du ansluter, och en
 **emoji-verifiering** efteråt.
 
 De gör olika saker. Kontrollkoden säger att de två skärmarna talar om samma
-konto — den fångar en gammal eller felaktig kod, alltså det misstag man faktiskt
-gör. Den härleds ur offentliga identifierare och är därför ett igenkänningsstöd,
-inte ett bevis för vem som är i andra änden. Emoji-verifieringen som följer är
+konto — den fångar en kod från något annat håll, alltså det misstag man faktiskt
+gör. Den härleds bara ur de identifierarna, inte ur lösenordet — den säger
+därför ingenting om huruvida uppgifterna i den fortfarande gäller, och
+ingenting om vem som är i andra änden. Emoji-verifieringen som följer är
 steget som autentiserar enheten, och tills den är klar kan den nya enheten inte
 läsa något.
 
@@ -63,7 +64,7 @@ det du är på väg att gå med i, med kontrollkoden överst.
 />
 
 Titta på kontrollkoden här och den på den första enheten. **De måste vara
-identiska.** Skiljer de sig åt, sluta: du tittar inte på din egen enhets kod.
+identiska.** Skiljer de sig åt, sluta.
 Kasta den: de två skärmarna beskriver inte samma konto, rum och server, och att
 öppna skärmen igen ändrar inte det.
 

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -1,0 +1,95 @@
+---
+title: Lägg till en enhet
+description: Para ihop en ny enhet med ditt synkroniseringskonto via en QR-kod, kontrollera kontrollkoden och slutför de två stegen efteråt.
+---
+
+# Lägg till en enhet
+
+Alla dina enheter delar ett enda synkroniseringskonto. Att lägga till en enhet
+innebär att du ger den inloggningsuppgifterna till det kontot — därför ber flödet
+dig jämföra en kort kod innan något ansluts. Det är det enda tillfälle då du kan
+skilja din egen enhet från någon annans.
+
+Du behöver båda enheterna framför dig. Börja på en som redan är ansluten — vilken
+som helst, telefon eller dator. Det finns ingen «huvudenhet».
+
+## Visa koden på en enhet du redan använder
+
+Öppna **Inställningar → Synkronisering → Enheter** och välj **Lägg till enhet**.
+
+<ManualScreenshot
+  caseId="sync/add-device"
+  alt="Lottis skärm Lägg till enhet med QR-kod, säkerhetsnotis med hänglås och kontrollkoden 2BD-EF4"
+  caption="Koden skapas när du öppnar den här skärmen och bara så länge den är öppen. Lägg märke till kontrollkoden under — den jämför du strax."
+/>
+
+Behandla den här skärmen som ditt lösenord, för det är vad den innehåller. Den
+som skannar eller fotograferar QR-koden kan gå med i ditt konto och läsa dina
+anteckningar. Visa den bara för en enhet du själv äger, och skicka den aldrig via
+chatt, skärmbild eller delad skärm.
+
+**Kopiera ihopparningskod** finns medvetet för fallet där enheten som ansluter
+saknar kamera — en dator som ansluter till en dator. Den lägger samma uppgifter i
+urklipp: klistra in dem direkt i den andra enheten och ingen annanstans.
+
+## Skanna den på den nya enheten
+
+Installera Lotti på den nya enheten och öppna där **Inställningar →
+Synkronisering → Enheter**. På en telefon öppnas kameran direkt; rikta den mot
+den första enheten. På dator, eller om kameran inte är tillgänglig, välj **ange
+manuellt** och klistra in den kopierade koden.
+
+## Kontrollera att koden stämmer innan du ansluter
+
+Att avkoda koden ansluter ingenting. Det som visas först är en sammanfattning av
+det du är på väg att gå med i, med kontrollkoden överst.
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Lottis ihopparningssammanfattning med kontrollkod, kontot som ansluts och synkroniseringsservern"
+  caption="Båda enheterna härleder koden oberoende av varandra ur konto, rum och server. De utbyter den aldrig — det är därför jämförelsen är värd att göra."
+/>
+
+Titta på kontrollkoden här och den på den första enheten. **De måste vara
+identiska.** Skiljer de sig åt, sluta: du tittar inte på din egen enhets kod.
+Kasta den och börja om från en nyöppnad Lägg till enhet-skärm.
+
+Kontot och servern under koden är sammanhang, inte något att jämföra — de visas
+inte på den andra enheten. När allt stämmer väljer du **Anslut den här enheten**.
+
+## Slutför de två stegen efteråt
+
+Anslutningen ansluter dig till kontot. Den ger ännu inte den nya enheten
+möjlighet att läsa något.
+
+<ManualScreenshot
+  caseId="sync/paired"
+  alt="Lottis synkroniseringsinställning: den här enheten är ansluten, emoji-verifiering och Skicka inställningar återstår"
+  caption="Ansluten är den lätta halvan. Kortet namnger vad som saknas och säger tydligt att enheten fram till verifieringen inte kan läsa något."
+/>
+
+1. **Jämför emojierna.** En rad emoji visas på båda enheterna. Kontrollera att de
+   stämmer och bekräfta på var och en. Fram till dess får den nya enheten bara
+   krypterat innehåll den inte kan läsa — nycklar går enbart till verifierade
+   enheter. Se [Synkronisera enheter](./sync.mdx).
+2. **Skicka inställningarna.** På den första enheten, i den fortfarande öppna
+   Lägg till enhet-skärmen, välj **Skicka inställningar** så att kategorier,
+   vanor, instrumentpaneler och AI-konfiguration kommer fram. Har du stängt den,
+   öppna **Inställningar → Synkronisering → Enheter → Lägg till enhet** igen.
+
+Låt båda apparna vara öppna tills den första synkroniseringen är klar.
+
+## Om något går fel
+
+- **Kontrollkoderna skiljer sig åt.** Anslut inte. Stäng skärmen på den första
+  enheten, öppna en ny och försök igen — koden skapas på nytt varje gång.
+- **Koden går inte att avkoda.** Kopiera den igen på den första enheten i stället
+  för att rätta det du klistrade in; det kodade värdet är inte tänkt att justeras
+  för hand. Rapporterar appen olika versioner kör enheterna olika byggen och båda
+  behöver uppdateras.
+- **Den nya enheten är ansluten men förblir tom.** Det är det förväntade
+  tillståndet före verifiering. Slutför emoji-jämförelsen och kontrollera sedan
+  [Synkronisera enheter](./sync.mdx) för utkorg och återhämtning.
+
+Fortsätt med [Synkronisera enheter](./sync.mdx) för daglig status,
+leveranshälsa och återställningsverktyg.

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -6,9 +6,16 @@ description: Para ihop en ny enhet med ditt synkroniseringskonto via en QR-kod, 
 # Lägg till en enhet
 
 Alla dina enheter delar ett enda synkroniseringskonto. Att lägga till en enhet
-innebär att du ger den inloggningsuppgifterna till det kontot — därför ber flödet
-dig jämföra en kort kod innan något ansluts. Det är det enda tillfälle då du kan
-skilja din egen enhet från någon annans.
+innebär att du ger den inloggningsuppgifterna till det kontot, så flödet har två
+kontroller: en kort **kontrollkod** som du jämför innan du ansluter, och en
+**emoji-verifiering** efteråt.
+
+De gör olika saker. Kontrollkoden säger att de två skärmarna talar om samma
+konto — den fångar en gammal eller felaktig kod, alltså det misstag man faktiskt
+gör. Den härleds ur offentliga identifierare och är därför ett igenkänningsstöd,
+inte ett bevis för vem som är i andra änden. Emoji-verifieringen som följer är
+steget som autentiserar enheten, och tills den är klar kan den nya enheten inte
+läsa något.
 
 Du behöver båda enheterna framför dig. Börja på en som redan är ansluten — vilken
 som helst, telefon eller dator. Det finns ingen «huvudenhet».
@@ -28,6 +35,11 @@ som skannar eller fotograferar QR-koden kan gå med i ditt konto och läsa dina
 anteckningar. Visa den bara för en enhet du själv äger, och skicka den aldrig via
 chatt, skärmbild eller delad skärm.
 
+**Att stänga skärmen döljer koden, men återkallar den inte.** Koden innehåller
+ditt kontos nuvarande lösenord: ett foto går att använda så länge det lösenordet
+gäller. Tror du att någon har fångat den, behandla den som ett läckt lösenord och
+inte som något som hunnit gå ut.
+
 **Kopiera ihopparningskod** finns medvetet för fallet där enheten som ansluter
 saknar kamera — en dator som ansluter till en dator. Den lägger samma uppgifter i
 urklipp: klistra in dem direkt i den andra enheten och ingen annanstans.
@@ -35,9 +47,8 @@ urklipp: klistra in dem direkt i den andra enheten och ingen annanstans.
 ## Skanna den på den nya enheten
 
 Installera Lotti på den nya enheten och öppna där **Inställningar →
-Synkronisering → Enheter**. På en telefon öppnas kameran direkt; rikta den mot
-den första enheten. På dator, eller om kameran inte är tillgänglig, välj **ange
-manuellt** och klistra in den kopierade koden.
+Synkronisering → Enheter** och välj kortet **Enheter**. På en telefon öppnas kameran direkt; rikta den mot
+den första enheten. På dator, eller om kameran inte är tillgänglig, välj **Ange koden manuellt** och klistra in den kopierade koden.
 
 ## Kontrollera att koden stämmer innan du ansluter
 
@@ -82,7 +93,8 @@ Låt båda apparna vara öppna tills den första synkroniseringen är klar.
 ## Om något går fel
 
 - **Kontrollkoderna skiljer sig åt.** Anslut inte. Stäng skärmen på den första
-  enheten, öppna en ny och försök igen — koden skapas på nytt varje gång.
+  enheten, öppna en ny och försök igen — samma konto ger samma kod varje
+  gång, så en skillnad betyder att de två skärmarna hör till olika konton.
 - **Koden går inte att avkoda.** Kopiera den igen på den första enheten i stället
   för att rätta det du klistrade in; det kodade värdet är inte tänkt att justeras
   för hand. Rapporterar appen olika versioner kör enheterna olika byggen och båda

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -22,7 +22,7 @@ som helst, telefon eller dator. Det finns ingen «huvudenhet».
 
 ## Visa koden på en enhet du redan använder
 
-Öppna **Inställningar → Synkronisering → Enheter** och välj **Lägg till enhet**.
+Öppna **Inställningar → Synkroniseringsinställningar → Enheter** och välj **Lägg till enhet**.
 
 <ManualScreenshot
   caseId="sync/add-device"
@@ -30,9 +30,10 @@ som helst, telefon eller dator. Det finns ingen «huvudenhet».
   caption="Koden skapas när du öppnar den här skärmen och bara så länge den är öppen. Lägg märke till kontrollkoden under — den jämför du strax."
 />
 
-Behandla den här skärmen som ditt lösenord, för det är vad den innehåller. Den
-som skannar eller fotograferar QR-koden kan gå med i ditt konto och läsa dina
-anteckningar. Visa den bara för en enhet du själv äger, och skicka den aldrig via
+Behandla den här skärmen som ditt lösenord, för det är vad den innehåller. Den som skannar eller fotograferar QR-koden kan logga in på ditt konto:
+hen kan inte dekryptera dina anteckningar utan att också vara emoji-verifierad
+från en av dina enheter, men kan ta över kontot — inklusive att byta lösenord
+och stänga ute dig. Visa den bara för en enhet du själv äger, och skicka den aldrig via
 chatt, skärmbild eller delad skärm.
 
 **Att stänga skärmen döljer koden, men återkallar den inte.** Koden innehåller
@@ -40,14 +41,14 @@ ditt kontos nuvarande lösenord: ett foto går att använda så länge det löse
 gäller. Tror du att någon har fångat den, behandla den som ett läckt lösenord och
 inte som något som hunnit gå ut.
 
-**Kopiera ihopparningskod** finns medvetet för fallet där enheten som ansluter
+**Kopiera parkopplingskod** finns medvetet för fallet där enheten som ansluter
 saknar kamera — en dator som ansluter till en dator. Den lägger samma uppgifter i
 urklipp: klistra in dem direkt i den andra enheten och ingen annanstans.
 
 ## Skanna den på den nya enheten
 
 Installera Lotti på den nya enheten och öppna där **Inställningar →
-Synkronisering → Enheter** och välj kortet **Enheter**. På en telefon öppnas kameran direkt; rikta den mot
+Synkroniseringsinställningar → Enheter** och välj kortet **Enheter**. På en telefon öppnas kameran direkt; rikta den mot
 den första enheten. På dator, eller om kameran inte är tillgänglig, välj **Ange koden manuellt** och klistra in den kopierade koden.
 
 ## Kontrollera att koden stämmer innan du ansluter
@@ -86,7 +87,7 @@ möjlighet att läsa något.
 2. **Skicka inställningarna.** På den första enheten, i den fortfarande öppna
    Lägg till enhet-skärmen, välj **Skicka inställningar** så att kategorier,
    vanor, instrumentpaneler och AI-konfiguration kommer fram. Har du stängt den,
-   öppna **Inställningar → Synkronisering → Enheter → Lägg till enhet** igen.
+   öppna **Inställningar → Synkroniseringsinställningar → Enheter → Lägg till enhet** igen.
 
 Låt båda apparna vara öppna tills den första synkroniseringen är klar.
 

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/add-device.mdx
@@ -64,7 +64,8 @@ det du är på väg att gå med i, med kontrollkoden överst.
 
 Titta på kontrollkoden här och den på den första enheten. **De måste vara
 identiska.** Skiljer de sig åt, sluta: du tittar inte på din egen enhets kod.
-Kasta den och börja om från en nyöppnad Lägg till enhet-skärm.
+Kasta den: de två skärmarna beskriver inte samma konto, rum och server, och att
+öppna skärmen igen ändrar inte det.
 
 Kontot och servern under koden är sammanhang, inte något att jämföra — de visas
 inte på den andra enheten. När allt stämmer väljer du **Anslut den här enheten**.
@@ -95,7 +96,7 @@ Låt båda apparna vara öppna tills den första synkroniseringen är klar.
 
 - **Kontrollkoderna skiljer sig åt.** Anslut inte. Du tittar inte på din egen
   enhets kod. Att öppna skärmen igen hjälper inte: samma konto ger samma kod
-  varje gång, så en skillnad betyder att de två skärmarna hör till olika konton.
+  varje gång, så en skillnad betyder att de två skärmarna inte beskriver samma ihopparning.
 - **Koden går inte att avkoda.** Kopiera den igen på den första enheten i stället
   för att rätta det du klistrade in; det kodade värdet är inte tänkt att justeras
   för hand. Rapporterar appen olika versioner kör enheterna olika byggen och båda

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -22,33 +22,31 @@ service än.
   caption="The Sync hub keeps everyday status near diagnostics and recovery tools. Project Waddle currently has three outbox items to inspect."
 />
 
-## Para ihop en annan enhet
+## Se dina enheter
 
-Börja på en enhet som redan är ansluten:
-
-1. Öppna **Inställningar → Synkronisera → Provisionerad Synkronisering**.
-2. På datorn, visa QR-koden för överlämningen. Håll denna skärm privat: paketet
-   Ger tillgång till ditt Sync-konto och rum.
-3. På den nya enheten, öppna samma sida och skanna QR-koden eller klistra in
-   Komplett provisioneringspaket.
-4. Gå igenom den avkodade servern, användaren och rummet innan du väljer **Importera**.
-5. Låt den första synkroniseringen bli klar innan du stänger någon av apparna.
+**Inställningar → Synkronisering → Enheter** listar varje session på ditt
+synkroniseringskonto — inte bara de overifierade.
 
 <ManualScreenshot
   caseId="sync/status"
-  alt="Provisioned Sync status on mobile and the secure device handover QR code on desktop"
-  caption="Desktop can present the handover QR code; mobile shows the connected account and verification state. Treat the QR code like a password."
+  alt="Lottis Enheter-sida med sessionerna på synkroniseringskontot, verifieringsstatus och senast sedd"
+  caption="Varje rad visar om enheten är verifierad och när servern senast såg den. En overifierad enhet kan inte läsa nya anteckningar, och listan säger det."
 />
 
-<ManualScreenshot
-  caseId="sync/provisioned"
-  alt="Lotti provisioning import review showing the Project Waddle sync server, user, and room"
-  caption="Import only when every decoded value belongs to the sync account you intended to join."
-/>
+Sessioner som är inloggade med det här kontot kan tas bort — utom den du sitter
+på. Enheter som parats på det gamla sättet, var och en med eget konto, kan
+verifieras men inte tas bort.
 
-Om importen rapporterar ett fel, behåll den ursprungliga enheten ansluten, generera en
-Ny överlämning och försök igen med full värde. Redigera inte manuellt
-Kodad bunt.
+## Para ihop en annan enhet
+
+Ihopparning är ett eget flöde, med en kod att jämföra och två steg efter
+anslutningen. Den har en egen sida: [Lägg till en enhet](./add-device.mdx).
+
+Kort sagt: på en enhet som redan är ansluten öppnar du **Inställningar →
+Synkronisering → Enheter → Lägg till enhet** och visar koden. På den nya enheten
+öppnar du samma sida och skannar den. Jämför kontrollkoden på båda skärmarna
+innan du ansluter — QR-koden bär inloggningsuppgifterna till ditt
+synkroniseringskonto och går bara till din egen enhet.
 
 ## Verifiera den nya enheten
 

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -24,7 +24,7 @@ service än.
 
 ## Se dina enheter
 
-**Inställningar → Synkronisering → Enheter** listar varje session på ditt
+**Inställningar → Synkroniseringsinställningar → Enheter** listar varje session på ditt
 synkroniseringskonto — inte bara de overifierade.
 
 <ManualScreenshot
@@ -43,7 +43,7 @@ Ihopparning är ett eget flöde, med en kod att jämföra och två steg efter
 anslutningen. Den har en egen sida: [Lägg till en enhet](./add-device.mdx).
 
 Kort sagt: på en enhet som redan är ansluten öppnar du **Inställningar →
-Synkronisering → Enheter → Lägg till enhet** och visar koden. På den nya enheten
+Synkroniseringsinställningar → Enheter → Lägg till enhet** och visar koden. På den nya enheten
 öppnar du samma sida och skannar den. Jämför kontrollkoden på båda skärmarna
 innan du ansluter — QR-koden bär inloggningsuppgifterna till ditt
 synkroniseringskonto och går bara till din egen enhet.

--- a/docs-site/metadata/features.json
+++ b/docs-site/metadata/features.json
@@ -391,8 +391,7 @@
       "screenshotCases": [
         "sync/add-device",
         "sync/provisioned",
-        "sync/paired",
-        "sync/verification"
+        "sync/paired"
       ]
     },
     {
@@ -403,6 +402,7 @@
       "screenshotCases": [
         "sync/hub",
         "sync/status",
+        "sync/verification",
         "sync/node-profile",
         "sync/backfill",
         "sync/stats",

--- a/docs-site/metadata/features.json
+++ b/docs-site/metadata/features.json
@@ -384,15 +384,25 @@
       ]
     },
     {
+      "id": "add-device",
+      "title": "Add a device",
+      "page": "sync-and-data/add-device",
+      "status": "verified",
+      "screenshotCases": [
+        "sync/add-device",
+        "sync/provisioned",
+        "sync/paired",
+        "sync/verification"
+      ]
+    },
+    {
       "id": "sync",
       "title": "Sync and recovery",
       "page": "sync-and-data/sync",
       "status": "verified",
       "screenshotCases": [
         "sync/hub",
-        "sync/provisioned",
         "sync/status",
-        "sync/verification",
         "sync/node-profile",
         "sync/backfill",
         "sync/stats",

--- a/docs-site/metadata/screenshot-cases.json
+++ b/docs-site/metadata/screenshot-cases.json
@@ -1,7 +1,19 @@
 {
   "schemaVersion": 2,
   "defaultLocale": "en",
-  "locales": ["en", "de", "fr", "it", "es", "cs", "nl", "ro", "pt", "da", "sv"],
+  "locales": [
+    "en",
+    "de",
+    "fr",
+    "it",
+    "es",
+    "cs",
+    "nl",
+    "ro",
+    "pt",
+    "da",
+    "sv"
+  ],
   "cases": [
     {
       "id": "daily-os/agenda",
@@ -1354,6 +1366,28 @@
         "mobile-dark": "sync_provisioned_mobile_dark.png",
         "desktop-light": "sync_provisioned_desktop_light.png",
         "desktop-dark": "sync_provisioned_desktop_dark.png"
+      }
+    },
+    {
+      "id": "sync/add-device",
+      "title": "Add device handover code",
+      "sourceTest": "test/features/sync/ui/sync_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "sync_add_device_mobile_light.png",
+        "mobile-dark": "sync_add_device_mobile_dark.png",
+        "desktop-light": "sync_add_device_desktop_light.png",
+        "desktop-dark": "sync_add_device_desktop_dark.png"
+      }
+    },
+    {
+      "id": "sync/paired",
+      "title": "Device paired, remaining steps",
+      "sourceTest": "test/features/sync/ui/sync_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "sync_paired_mobile_light.png",
+        "mobile-dark": "sync_paired_mobile_dark.png",
+        "desktop-light": "sync_paired_desktop_light.png",
+        "desktop-dark": "sync_paired_desktop_dark.png"
       }
     },
     {

--- a/docs-site/metadata/surface-inventory.json
+++ b/docs-site/metadata/surface-inventory.json
@@ -5,109 +5,1239 @@
     "exclusions": "Simple confirmations, generic date/color/category pickers, transient loading/error states, and platform-owned permission prompts are documented inside their owning surface rather than counted separately."
   },
   "surfaces": [
-    {"id":"tasks-list","title":"Tasks list and workspace","kind":"route-page","source":"lib/beamer/locations/tasks_location.dart","sourcePattern":"'/tasks'","locator":"/tasks","routes":["/tasks"],"page":"organize-and-reflect/tasks","status":"verified"},
-    {"id":"task-detail","title":"Task detail","kind":"route-page","source":"lib/beamer/locations/tasks_location.dart","sourcePattern":"'/tasks/:taskId'","locator":"/tasks/:taskId","routes":["/tasks/:taskId"],"page":"organize-and-reflect/tasks","status":"verified"},
-    {"id":"daily-os-day","title":"Daily OS day","kind":"route-page","source":"lib/beamer/locations/calendar_location.dart","sourcePattern":"'/calendar'","locator":"/calendar","routes":["/calendar"],"page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"time-analysis","title":"Time analysis","kind":"route-page","source":"lib/beamer/locations/calendar_location.dart","sourcePattern":"'/calendar/time'","locator":"/calendar/time","routes":["/calendar/time"],"page":"organize-and-reflect/time-analysis","status":"verified"},
-    {"id":"daily-os-refine","title":"Daily OS refine","kind":"route-page","source":"lib/beamer/locations/calendar_location.dart","sourcePattern":"'/calendar/refine/:date'","locator":"/calendar/refine/:date","routes":["/calendar/refine/:date"],"page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"daily-os-commit","title":"Daily OS commit","kind":"route-page","source":"lib/beamer/locations/calendar_location.dart","sourcePattern":"'/calendar/commit/:date'","locator":"/calendar/commit/:date","routes":["/calendar/commit/:date"],"page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"daily-os-shutdown","title":"Daily OS shutdown","kind":"route-page","source":"lib/beamer/locations/calendar_location.dart","sourcePattern":"'/calendar/shutdown/:date'","locator":"/calendar/shutdown/:date","routes":["/calendar/shutdown/:date"],"page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"projects-list","title":"Projects list","kind":"route-page","source":"lib/beamer/locations/projects_location.dart","sourcePattern":"'/projects'","locator":"/projects","routes":["/projects"],"page":"organize-and-reflect/projects","status":"verified"},
-    {"id":"project-detail","title":"Project detail","kind":"route-page","source":"lib/beamer/locations/projects_location.dart","sourcePattern":"'/projects/:projectId'","locator":"/projects/:projectId","routes":["/projects/:projectId"],"page":"organize-and-reflect/projects","status":"verified"},
-    {"id":"events-list","title":"Events overview","kind":"route-page","source":"lib/beamer/locations/events_location.dart","sourcePattern":"'/events'","locator":"/events","routes":["/events"],"page":"organize-and-reflect/events","status":"verified"},
-    {"id":"event-detail","title":"Event detail","kind":"route-page","source":"lib/beamer/locations/events_location.dart","sourcePattern":"'/events/:eventId'","locator":"/events/:eventId","routes":["/events/:eventId"],"page":"organize-and-reflect/events","status":"verified"},
-    {"id":"habits-today","title":"Habits today","kind":"route-page","source":"lib/beamer/locations/habits_location.dart","sourcePattern":"'/habits'","locator":"/habits","routes":["/habits"],"page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"journal-list","title":"Journal","kind":"route-page","source":"lib/beamer/locations/journal_location.dart","sourcePattern":"'/journal'","locator":"/journal","routes":["/journal"],"page":"organize-and-reflect/journal","status":"verified"},
-    {"id":"journal-entry-detail","title":"Journal entry detail","kind":"route-page","source":"lib/beamer/locations/journal_location.dart","sourcePattern":"'/journal/:entryId'","locator":"/journal/:entryId","routes":["/journal/:entryId"],"page":"organize-and-reflect/journal","status":"verified"},
-    {"id":"survey-fill-route","title":"Survey deep-link fallback","kind":"route-page","source":"lib/beamer/locations/journal_location.dart","sourcePattern":"'/journal/fill_survey/:surveyType'","locator":"/journal/fill_survey/:surveyType","routes":["/journal/fill_survey/:surveyType"],"page":"plan-and-capture/surveys","status":"verified"},
-    {"id":"dashboards-list","title":"Dashboards list","kind":"route-page","source":"lib/beamer/locations/dashboards_location.dart","sourcePattern":"'/dashboards'","locator":"/dashboards","routes":["/dashboards"],"page":"organize-and-reflect/dashboards","status":"verified"},
-    {"id":"dashboard-view","title":"Dashboard view","kind":"route-page","source":"lib/beamer/locations/dashboards_location.dart","sourcePattern":"'/dashboards/:dashboardId'","locator":"/dashboards/:dashboardId","routes":["/dashboards/:dashboardId"],"page":"organize-and-reflect/dashboards","status":"verified"},
-    {"id":"ai-impact","title":"AI impact analysis","kind":"route-page","source":"lib/beamer/locations/dashboards_location.dart","sourcePattern":"'/dashboards/impact'","locator":"/dashboards/impact","routes":["/dashboards/impact"],"page":"ai-and-automation/usage","status":"verified"},
-
-    {"id":"settings-root","title":"Settings home","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings'","locator":"/settings","routes":["/settings"],"page":"reference/settings","status":"verified"},
-    {"id":"settings-whats-new","title":"What's New","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'whats-new'","locator":"settings:whats-new","page":"reference/whats-new","status":"verified"},
-    {"id":"settings-onboarding","title":"Onboarding settings","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'onboarding'","locator":"/settings/onboarding","routes":["/settings/onboarding"],"page":"getting-started/onboarding","status":"verified"},
-    {"id":"settings-ai-providers","title":"AI providers","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'ai/providers'","locator":"settings:ai/providers","routes":["/settings/ai"],"page":"ai-and-automation/provider-setup","status":"verified"},
-    {"id":"settings-ai-models","title":"AI models","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'ai/models'","locator":"settings:ai/models","page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"settings-ai-profiles","title":"AI profiles","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'ai/profiles'","locator":"settings:ai/profiles","page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"settings-ai-usage","title":"AI usage","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'ai/usage'","locator":"settings:ai/usage","page":"ai-and-automation/usage","status":"verified"},
-    {"id":"settings-ai-provider-detail","title":"AI provider detail","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/ai/provider/:providerId'","locator":"/settings/ai/provider/:providerId","routes":["/settings/ai/provider/:providerId"],"page":"ai-and-automation/provider-setup","status":"verified"},
-    {"id":"settings-ai-provider-editor","title":"AI provider editor","kind":"settings-page","source":"lib/features/ai/ui/settings/inference_provider_edit_page.dart","sourcePattern":"class InferenceProviderEditPage","locator":"AI provider detail → Edit","page":"ai-and-automation/provider-setup","status":"verified"},
-    {"id":"settings-ai-model-editor","title":"AI model editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/ai/model/:modelId'","locator":"/settings/ai/model/:modelId","routes":["/settings/ai/model/:modelId"],"page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"settings-ai-profile-editor","title":"AI profile editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/ai/profile/:profileId'","locator":"/settings/ai/profile/:profileId","routes":["/settings/ai/profile/:profileId"],"page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"settings-ai-legacy-profiles","title":"Legacy inference profiles","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/ai/profiles'","locator":"/settings/ai/profiles","routes":["/settings/ai/profiles"],"page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"settings-agent-templates","title":"Agent templates","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'agents/templates'","locator":"/settings/agents/templates","routes":["/settings/agents","/settings/agents/templates"],"page":"ai-and-automation/agent-blueprints","status":"verified"},
-    {"id":"settings-agent-instances","title":"Agent instances","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'agents/instances'","locator":"/settings/agents/instances","routes":["/settings/agents/instances"],"page":"ai-and-automation/agents","status":"verified"},
-    {"id":"settings-agent-souls","title":"Agent souls","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'agents/souls'","locator":"/settings/agents/souls","routes":["/settings/agents/souls"],"page":"ai-and-automation/agent-blueprints","status":"verified"},
-    {"id":"settings-agent-pending-wakes","title":"Agent pending wakes","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'agents/pending-wakes'","locator":"/settings/agents/pending-wakes","routes":["/settings/agents/pending-wakes"],"page":"ai-and-automation/agents","status":"verified"},
-    {"id":"settings-agent-template-editor","title":"Agent template editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/agents/templates/:templateId'","locator":"/settings/agents/templates/create or :templateId","routes":["/settings/agents/templates/create","/settings/agents/templates/:templateId"],"page":"ai-and-automation/agent-blueprints","status":"verified"},
-    {"id":"settings-agent-template-review","title":"Agent template evolution review","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/agents/templates/:templateId/review'","locator":"/settings/agents/templates/:templateId/review","routes":["/settings/agents/templates/:templateId/review"],"page":"ai-and-automation/agent-blueprints","status":"verified"},
-    {"id":"settings-agent-soul-editor","title":"Agent soul editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/agents/souls/:soulId'","locator":"/settings/agents/souls/create or :soulId","routes":["/settings/agents/souls/create","/settings/agents/souls/:soulId"],"page":"ai-and-automation/agent-blueprints","status":"verified"},
-    {"id":"settings-agent-soul-review","title":"Agent soul evolution review","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/agents/souls/:soulId/review'","locator":"/settings/agents/souls/:soulId/review","routes":["/settings/agents/souls/:soulId/review"],"page":"ai-and-automation/agent-blueprints","status":"verified"},
-    {"id":"settings-agent-instance-detail","title":"Agent instance detail","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/agents/instances/:agentId'","locator":"/settings/agents/instances/:agentId","routes":["/settings/agents/instances/:agentId"],"page":"ai-and-automation/agents","status":"verified"},
-    {"id":"settings-daily-os","title":"Daily OS settings","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'daily-os'","locator":"/settings/daily-os","routes":["/settings/daily-os"],"page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"settings-sync-hub","title":"Sync settings hub","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync'","locator":"/settings/sync","routes":["/settings/sync"],"page":"sync-and-data/sync","status":"verified"},
-    {"id":"settings-sync-provisioned","title":"Provisioned Sync","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/provisioned'","locator":"/settings/sync/provisioned","routes":["/settings/sync/provisioned"],"page":"sync-and-data/sync","status":"verified"},
-    {"id":"settings-sync-node-profile","title":"Sync node profile","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/node-profile'","locator":"/settings/sync/node-profile","routes":["/settings/sync/node-profile"],"page":"sync-and-data/sync","status":"verified"},
-    {"id":"settings-sync-backfill","title":"Sync backfill","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/backfill'","locator":"/settings/sync/backfill","routes":["/settings/sync/backfill"],"page":"sync-and-data/sync","status":"verified"},
-    {"id":"settings-sync-stats","title":"Sync statistics","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/stats'","locator":"/settings/sync/stats","routes":["/settings/sync/stats"],"page":"sync-and-data/sync","status":"verified"},
-    {"id":"settings-sync-outbox","title":"Sync outbox","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/outbox'","locator":"/settings/sync/outbox","routes":["/settings/sync/outbox"],"page":"sync-and-data/sync","status":"verified"},
-    {"id":"settings-sync-conflicts","title":"Sync conflicts","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/conflicts'","locator":"/settings/advanced/conflicts","routes":["/settings/advanced/conflicts"],"page":"sync-and-data/conflicts","status":"verified"},
-    {"id":"settings-sync-conflict-detail","title":"Sync conflict detail","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/advanced/conflicts/:conflictId'","locator":"/settings/advanced/conflicts/:conflictId","routes":["/settings/advanced/conflicts/:conflictId"],"page":"sync-and-data/conflicts","status":"verified"},
-    {"id":"settings-sync-conflict-editor","title":"Sync manual merge editor","kind":"settings-page","source":"lib/features/sync/ui/widgets/conflicts/conflict_resolution_view.dart","sourcePattern":"_buildCombining","locator":"Conflict detail → Combine","page":"sync-and-data/conflicts","status":"verified"},
-    {"id":"settings-sync-matrix-maintenance","title":"Matrix sync maintenance","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'sync/matrix-maintenance'","locator":"/settings/sync/matrix/maintenance","routes":["/settings/sync/matrix/maintenance"],"page":"sync-and-data/maintenance","status":"verified"},
-    {"id":"settings-definitions-hub","title":"Definitions hub","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'definitions'","locator":"/settings/definitions","routes":["/settings/definitions"],"page":"reference/settings","status":"verified"},
-    {"id":"settings-categories-list","title":"Category definitions","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'definitions/categories'","locator":"/settings/categories","routes":["/settings/categories"],"page":"organize-and-reflect/categories","status":"verified"},
-    {"id":"settings-category-editor","title":"Category editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/categories/:categoryId'","locator":"/settings/categories/create or :categoryId","routes":["/settings/categories/create","/settings/categories/:categoryId"],"page":"organize-and-reflect/categories","status":"verified"},
-    {"id":"settings-labels-list","title":"Label definitions","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'definitions/labels'","locator":"/settings/labels","routes":["/settings/labels"],"page":"organize-and-reflect/labels","status":"verified"},
-    {"id":"settings-label-editor","title":"Label editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/labels/:labelId'","locator":"/settings/labels/create or :labelId","routes":["/settings/labels/create","/settings/labels/:labelId"],"page":"organize-and-reflect/labels","status":"verified"},
-    {"id":"settings-habits-list","title":"Habit definitions","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'definitions/habits'","locator":"/settings/habits","routes":["/settings/habits","/settings/habits/search/:searchTerm"],"page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"settings-habit-editor","title":"Habit editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/habits/by_id/:habitId'","locator":"/settings/habits/create or by_id/:habitId","routes":["/settings/habits/create","/settings/habits/by_id/:habitId"],"page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"settings-dashboards-list","title":"Dashboard definitions","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'definitions/dashboards'","locator":"/settings/dashboards","routes":["/settings/dashboards"],"page":"organize-and-reflect/dashboards","status":"verified"},
-    {"id":"settings-dashboard-editor","title":"Dashboard editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/dashboards/:dashboardId'","locator":"/settings/dashboards/create or :dashboardId","routes":["/settings/dashboards/create","/settings/dashboards/:dashboardId"],"page":"organize-and-reflect/dashboards","status":"verified"},
-    {"id":"settings-measurables-list","title":"Measurable definitions","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'definitions/measurables'","locator":"/settings/measurables","routes":["/settings/measurables"],"page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"settings-measurable-editor","title":"Measurable editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/measurables/:measurableId'","locator":"/settings/measurables/create or :measurableId","routes":["/settings/measurables/create","/settings/measurables/:measurableId"],"page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"settings-project-editor","title":"Project settings editor","kind":"settings-page","source":"lib/beamer/locations/settings_location.dart","sourcePattern":"'/settings/projects/:projectId'","locator":"/settings/projects/:projectId","routes":["/settings/projects/:projectId"],"page":"organize-and-reflect/projects","status":"verified"},
-    {"id":"settings-recording-style","title":"Recording Style","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'recording-style'","locator":"/settings/recording-style","routes":["/settings/recording-style"],"page":"reference/recording-style","status":"verified"},
-    {"id":"settings-theming","title":"Theming","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'theming'","locator":"/settings/theming","routes":["/settings/theming"],"page":"reference/appearance","status":"verified"},
-    {"id":"settings-keyboard-shortcuts","title":"Keyboard shortcuts","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'keyboard-shortcuts'","locator":"/settings/keyboard-shortcuts","routes":["/settings/keyboard-shortcuts"],"page":"reference/keyboard-shortcuts","status":"verified"},
-    {"id":"settings-speech","title":"Speech and text-to-speech","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'speech'","locator":"/settings/speech","routes":["/settings/speech"],"page":"reference/speech","status":"verified"},
-    {"id":"settings-advanced-hub","title":"Advanced Settings hub","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced'","locator":"/settings/advanced","routes":["/settings/advanced"],"page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-flags","title":"Configuration flags","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/flags'","locator":"/settings/flags","routes":["/settings/flags"],"page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-animations","title":"Completion animations","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/animations'","locator":"/settings/advanced/animations","routes":["/settings/advanced/animations"],"page":"reference/completion-celebrations","status":"verified"},
-    {"id":"settings-manual-language","title":"Language","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/manual-language'","locator":"/settings/advanced/manual-language","routes":["/settings/advanced/manual-language"],"page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-celebration-playground","title":"Celebration style playground","kind":"settings-page","source":"lib/features/settings/ui/pages/advanced/celebration_playground_page.dart","sourcePattern":"class CelebrationPlaygroundPage","locator":"Animations → Customize style","page":"reference/completion-celebrations","status":"verified"},
-    {"id":"settings-logging","title":"Logging domains","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/logging'","locator":"/settings/advanced/logging_domains","routes":["/settings/advanced/logging_domains"],"page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-health-import","title":"Health import","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/health-import'","locator":"/settings/health_import","routes":["/settings/health_import"],"page":"sync-and-data/health-import","status":"verified"},
-    {"id":"settings-maintenance","title":"Maintenance","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/maintenance'","locator":"/settings/advanced/maintenance","routes":["/settings/advanced/maintenance","/settings/maintenance"],"page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-onboarding-metrics","title":"Onboarding metrics","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/onboarding-metrics'","locator":"/settings/advanced/onboarding_metrics","routes":["/settings/advanced/onboarding_metrics"],"page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-about","title":"About Lotti","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'advanced/about'","locator":"/settings/advanced/about","page":"reference/advanced-settings","status":"verified"},
-    {"id":"settings-manual","title":"Open the Manual","kind":"settings-page","source":"lib/features/settings_v2/domain/settings_tree_data.dart","sourcePattern":"'manual'","locator":"Settings → Manual or macOS Help → Manual","page":"reference/settings","status":"verified"},
-
-    {"id":"workflow-create-entry","title":"Create entry menu","kind":"workflow","source":"lib/features/journal/ui/widgets/create/create_entry_action_modal.dart","sourcePattern":"class CreateEntryModal","locator":"Global create action","page":"plan-and-capture/entries","status":"verified"},
-    {"id":"workflow-audio-recording","title":"Audio recording","kind":"workflow","source":"lib/features/speech/ui/widgets/recording/audio_recording_modal.dart","sourcePattern":"class AudioRecordingModal","locator":"Create audio recording","page":"plan-and-capture/recordings","status":"verified"},
-    {"id":"workflow-transcription-review","title":"Speech transcription review","kind":"workflow","source":"lib/features/speech/ui/widgets/speech_modal/speech_modal.dart","sourcePattern":"class SpeechModalContent","locator":"Open recording transcript","page":"plan-and-capture/recordings","status":"verified"},
-    {"id":"workflow-task-filters","title":"Task filters","kind":"workflow","source":"lib/features/tasks/ui/filtering/task_filter_modal.dart","sourcePattern":"showTaskFilterModal","locator":"Tasks → Filter","page":"organize-and-reflect/tasks","status":"verified"},
-    {"id":"workflow-task-cover-art","title":"Generate task cover art","kind":"workflow","source":"lib/features/ai/ui/image_generation/cover_art_skill_modal.dart","sourcePattern":"class CoverArtSkillModal","locator":"Task image generation","page":"organize-and-reflect/task-cover-art","status":"verified"},
-    {"id":"workflow-link-task","title":"Link another task","kind":"workflow","source":"lib/features/tasks/ui/linked_tasks/link_task_modal.dart","sourcePattern":"class LinkTaskModal","locator":"Task → Linked","page":"organize-and-reflect/tasks","status":"verified"},
-    {"id":"workflow-habit-completion","title":"Record habit completion","kind":"workflow","source":"lib/pages/create/complete_habit_dialog.dart","sourcePattern":"class HabitDialog","locator":"Habits → Record","page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"workflow-measurement-capture","title":"Record a measurement","kind":"workflow","source":"lib/pages/create/create_measurement_dialog.dart","sourcePattern":"class _MeasurementEditorPage","locator":"Create measurement","page":"organize-and-reflect/habits-and-measurables","status":"verified"},
-    {"id":"workflow-project-create","title":"Create project","kind":"workflow","source":"lib/features/projects/ui/widgets/project_create_modal.dart","sourcePattern":"showProjectCreateModal","locator":"Projects → Create","page":"organize-and-reflect/projects","status":"verified"},
-    {"id":"workflow-daily-os-planning","title":"Daily OS capture and reconciliation","kind":"workflow","source":"lib/features/daily_os_next/ui/pages/day_planning_modal.dart","sourcePattern":"showDayPlanningModal","locator":"Daily OS → Speak or type a check-in","page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"workflow-day-block-edit","title":"Edit a day block","kind":"workflow","source":"lib/features/daily_os_next/ui/widgets/day_block_edit_modal.dart","sourcePattern":"class DayBlockEditModal","locator":"Daily OS → Edit block","page":"plan-and-capture/daily-os","status":"verified"},
-    {"id":"workflow-command-palette","title":"Command palette","kind":"workflow","source":"lib/features/keyboard/ui/command_palette.dart","sourcePattern":"showAppCommandPalette","locator":"Primary + K","page":"reference/keyboard-shortcuts","status":"verified"},
-    {"id":"workflow-shortcut-overlay","title":"Keyboard shortcut overlay","kind":"workflow","source":"lib/features/keyboard/ui/keyboard_shortcuts_page.dart","sourcePattern":"showKeyboardShortcutsOverlay","locator":"F1 or Primary + ?","page":"reference/keyboard-shortcuts","status":"verified"},
-    {"id":"workflow-onboarding","title":"Welcome and first capture","kind":"workflow","source":"lib/features/onboarding/ui/onboarding_welcome_modal.dart","sourcePattern":"class OnboardingWelcomeModal","locator":"First run or Settings → Onboarding","page":"getting-started/onboarding","status":"verified"},
-    {"id":"workflow-whats-new","title":"What's New releases","kind":"workflow","source":"lib/features/whats_new/ui/whats_new_modal.dart","sourcePattern":"class WhatsNewModal","locator":"Settings → What's New","page":"reference/whats-new","status":"verified"},
-    {"id":"workflow-sync-pairing","title":"Pair a sync device","kind":"workflow","source":"lib/features/sync/ui/provisioned/provisioned_sync_modal.dart","sourcePattern":"class ProvisionedSyncSettingsCard","locator":"Provisioned Sync → Pair device","page":"sync-and-data/sync","status":"verified"},
-    {"id":"workflow-sync-verification","title":"Verify a sync device","kind":"workflow","source":"lib/features/sync/ui/widgets/matrix/verification_modal.dart","sourcePattern":"class VerificationModal","locator":"Sync verification request","page":"sync-and-data/sync","status":"verified"},
-    {"id":"workflow-ai-skills","title":"Run contextual AI skills","kind":"workflow","source":"lib/features/ai/ui/unified_ai_skills_modal.dart","sourcePattern":"class UnifiedAiModal","locator":"Generate…","page":"ai-and-automation/skills","status":"verified"},
-    {"id":"workflow-ai-profile-picker","title":"Choose an inference profile","kind":"workflow","source":"lib/features/ai/ui/widgets/inference_profile_picker_modal.dart","sourcePattern":"class InferenceProfilePickerList","locator":"Inference profile field","page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"workflow-ai-model-picker","title":"Choose a provider model","kind":"workflow","source":"lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart","sourcePattern":"class InferenceProviderModelPickerModal","locator":"Model field","page":"ai-and-automation/models-and-profiles","status":"verified"},
-    {"id":"workflow-session-rating","title":"Rate a recorded session","kind":"workflow","source":"lib/features/ratings/ui/session_rating_modal.dart","sourcePattern":"class RatingModal","locator":"Time record → Rating","page":"organize-and-reflect/time-tracking","status":"verified"},
-    {"id":"workflow-survey-fill","title":"Complete a survey","kind":"workflow","source":"lib/features/surveys/tools/run_surveys.dart","sourcePattern":"Future<void> runSurvey","locator":"Dashboard survey chart → Add","page":"plan-and-capture/surveys","status":"verified"},
-    {"id":"workflow-dashboard-charts","title":"Compose dashboard charts","kind":"workflow","source":"lib/features/settings/ui/pages/dashboards/dashboard_definition_page.dart","sourcePattern":"class DashboardDefinitionPage","locator":"Dashboard editor → Charts","page":"organize-and-reflect/dashboards","status":"verified"},
-    {"id":"workflow-entry-date-time","title":"Edit entry date and time","kind":"workflow","source":"lib/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal.dart","sourcePattern":"class EntryDateTimeMultiPageModal","locator":"Entry detail → Date and time","page":"organize-and-reflect/journal","status":"verified"},
-    {"id":"workflow-linked-entry-filter","title":"Filter linked entries","kind":"workflow","source":"lib/features/journal/ui/widgets/linked_entries_filter_modal.dart","sourcePattern":"showLinkedEntriesFilterModal","locator":"Entry detail → Linked entries filter","page":"organize-and-reflect/journal","status":"verified"}
+    {
+      "id": "tasks-list",
+      "title": "Tasks list and workspace",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/tasks_location.dart",
+      "sourcePattern": "'/tasks'",
+      "locator": "/tasks",
+      "routes": [
+        "/tasks"
+      ],
+      "page": "organize-and-reflect/tasks",
+      "status": "verified"
+    },
+    {
+      "id": "task-detail",
+      "title": "Task detail",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/tasks_location.dart",
+      "sourcePattern": "'/tasks/:taskId'",
+      "locator": "/tasks/:taskId",
+      "routes": [
+        "/tasks/:taskId"
+      ],
+      "page": "organize-and-reflect/tasks",
+      "status": "verified"
+    },
+    {
+      "id": "daily-os-day",
+      "title": "Daily OS day",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/calendar_location.dart",
+      "sourcePattern": "'/calendar'",
+      "locator": "/calendar",
+      "routes": [
+        "/calendar"
+      ],
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "time-analysis",
+      "title": "Time analysis",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/calendar_location.dart",
+      "sourcePattern": "'/calendar/time'",
+      "locator": "/calendar/time",
+      "routes": [
+        "/calendar/time"
+      ],
+      "page": "organize-and-reflect/time-analysis",
+      "status": "verified"
+    },
+    {
+      "id": "daily-os-refine",
+      "title": "Daily OS refine",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/calendar_location.dart",
+      "sourcePattern": "'/calendar/refine/:date'",
+      "locator": "/calendar/refine/:date",
+      "routes": [
+        "/calendar/refine/:date"
+      ],
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "daily-os-commit",
+      "title": "Daily OS commit",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/calendar_location.dart",
+      "sourcePattern": "'/calendar/commit/:date'",
+      "locator": "/calendar/commit/:date",
+      "routes": [
+        "/calendar/commit/:date"
+      ],
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "daily-os-shutdown",
+      "title": "Daily OS shutdown",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/calendar_location.dart",
+      "sourcePattern": "'/calendar/shutdown/:date'",
+      "locator": "/calendar/shutdown/:date",
+      "routes": [
+        "/calendar/shutdown/:date"
+      ],
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "projects-list",
+      "title": "Projects list",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/projects_location.dart",
+      "sourcePattern": "'/projects'",
+      "locator": "/projects",
+      "routes": [
+        "/projects"
+      ],
+      "page": "organize-and-reflect/projects",
+      "status": "verified"
+    },
+    {
+      "id": "project-detail",
+      "title": "Project detail",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/projects_location.dart",
+      "sourcePattern": "'/projects/:projectId'",
+      "locator": "/projects/:projectId",
+      "routes": [
+        "/projects/:projectId"
+      ],
+      "page": "organize-and-reflect/projects",
+      "status": "verified"
+    },
+    {
+      "id": "events-list",
+      "title": "Events overview",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/events_location.dart",
+      "sourcePattern": "'/events'",
+      "locator": "/events",
+      "routes": [
+        "/events"
+      ],
+      "page": "organize-and-reflect/events",
+      "status": "verified"
+    },
+    {
+      "id": "event-detail",
+      "title": "Event detail",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/events_location.dart",
+      "sourcePattern": "'/events/:eventId'",
+      "locator": "/events/:eventId",
+      "routes": [
+        "/events/:eventId"
+      ],
+      "page": "organize-and-reflect/events",
+      "status": "verified"
+    },
+    {
+      "id": "habits-today",
+      "title": "Habits today",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/habits_location.dart",
+      "sourcePattern": "'/habits'",
+      "locator": "/habits",
+      "routes": [
+        "/habits"
+      ],
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "journal-list",
+      "title": "Journal",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/journal_location.dart",
+      "sourcePattern": "'/journal'",
+      "locator": "/journal",
+      "routes": [
+        "/journal"
+      ],
+      "page": "organize-and-reflect/journal",
+      "status": "verified"
+    },
+    {
+      "id": "journal-entry-detail",
+      "title": "Journal entry detail",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/journal_location.dart",
+      "sourcePattern": "'/journal/:entryId'",
+      "locator": "/journal/:entryId",
+      "routes": [
+        "/journal/:entryId"
+      ],
+      "page": "organize-and-reflect/journal",
+      "status": "verified"
+    },
+    {
+      "id": "survey-fill-route",
+      "title": "Survey deep-link fallback",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/journal_location.dart",
+      "sourcePattern": "'/journal/fill_survey/:surveyType'",
+      "locator": "/journal/fill_survey/:surveyType",
+      "routes": [
+        "/journal/fill_survey/:surveyType"
+      ],
+      "page": "plan-and-capture/surveys",
+      "status": "verified"
+    },
+    {
+      "id": "dashboards-list",
+      "title": "Dashboards list",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/dashboards_location.dart",
+      "sourcePattern": "'/dashboards'",
+      "locator": "/dashboards",
+      "routes": [
+        "/dashboards"
+      ],
+      "page": "organize-and-reflect/dashboards",
+      "status": "verified"
+    },
+    {
+      "id": "dashboard-view",
+      "title": "Dashboard view",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/dashboards_location.dart",
+      "sourcePattern": "'/dashboards/:dashboardId'",
+      "locator": "/dashboards/:dashboardId",
+      "routes": [
+        "/dashboards/:dashboardId"
+      ],
+      "page": "organize-and-reflect/dashboards",
+      "status": "verified"
+    },
+    {
+      "id": "ai-impact",
+      "title": "AI impact analysis",
+      "kind": "route-page",
+      "source": "lib/beamer/locations/dashboards_location.dart",
+      "sourcePattern": "'/dashboards/impact'",
+      "locator": "/dashboards/impact",
+      "routes": [
+        "/dashboards/impact"
+      ],
+      "page": "ai-and-automation/usage",
+      "status": "verified"
+    },
+    {
+      "id": "settings-root",
+      "title": "Settings home",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings'",
+      "locator": "/settings",
+      "routes": [
+        "/settings"
+      ],
+      "page": "reference/settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-whats-new",
+      "title": "What's New",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'whats-new'",
+      "locator": "settings:whats-new",
+      "page": "reference/whats-new",
+      "status": "verified"
+    },
+    {
+      "id": "settings-onboarding",
+      "title": "Onboarding settings",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'onboarding'",
+      "locator": "/settings/onboarding",
+      "routes": [
+        "/settings/onboarding"
+      ],
+      "page": "getting-started/onboarding",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-providers",
+      "title": "AI providers",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'ai/providers'",
+      "locator": "settings:ai/providers",
+      "routes": [
+        "/settings/ai"
+      ],
+      "page": "ai-and-automation/provider-setup",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-models",
+      "title": "AI models",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'ai/models'",
+      "locator": "settings:ai/models",
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-profiles",
+      "title": "AI profiles",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'ai/profiles'",
+      "locator": "settings:ai/profiles",
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-usage",
+      "title": "AI usage",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'ai/usage'",
+      "locator": "settings:ai/usage",
+      "page": "ai-and-automation/usage",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-provider-detail",
+      "title": "AI provider detail",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/ai/provider/:providerId'",
+      "locator": "/settings/ai/provider/:providerId",
+      "routes": [
+        "/settings/ai/provider/:providerId"
+      ],
+      "page": "ai-and-automation/provider-setup",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-provider-editor",
+      "title": "AI provider editor",
+      "kind": "settings-page",
+      "source": "lib/features/ai/ui/settings/inference_provider_edit_page.dart",
+      "sourcePattern": "class InferenceProviderEditPage",
+      "locator": "AI provider detail → Edit",
+      "page": "ai-and-automation/provider-setup",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-model-editor",
+      "title": "AI model editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/ai/model/:modelId'",
+      "locator": "/settings/ai/model/:modelId",
+      "routes": [
+        "/settings/ai/model/:modelId"
+      ],
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-profile-editor",
+      "title": "AI profile editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/ai/profile/:profileId'",
+      "locator": "/settings/ai/profile/:profileId",
+      "routes": [
+        "/settings/ai/profile/:profileId"
+      ],
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "settings-ai-legacy-profiles",
+      "title": "Legacy inference profiles",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/ai/profiles'",
+      "locator": "/settings/ai/profiles",
+      "routes": [
+        "/settings/ai/profiles"
+      ],
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-templates",
+      "title": "Agent templates",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'agents/templates'",
+      "locator": "/settings/agents/templates",
+      "routes": [
+        "/settings/agents",
+        "/settings/agents/templates"
+      ],
+      "page": "ai-and-automation/agent-blueprints",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-instances",
+      "title": "Agent instances",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'agents/instances'",
+      "locator": "/settings/agents/instances",
+      "routes": [
+        "/settings/agents/instances"
+      ],
+      "page": "ai-and-automation/agents",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-souls",
+      "title": "Agent souls",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'agents/souls'",
+      "locator": "/settings/agents/souls",
+      "routes": [
+        "/settings/agents/souls"
+      ],
+      "page": "ai-and-automation/agent-blueprints",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-pending-wakes",
+      "title": "Agent pending wakes",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'agents/pending-wakes'",
+      "locator": "/settings/agents/pending-wakes",
+      "routes": [
+        "/settings/agents/pending-wakes"
+      ],
+      "page": "ai-and-automation/agents",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-template-editor",
+      "title": "Agent template editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/agents/templates/:templateId'",
+      "locator": "/settings/agents/templates/create or :templateId",
+      "routes": [
+        "/settings/agents/templates/create",
+        "/settings/agents/templates/:templateId"
+      ],
+      "page": "ai-and-automation/agent-blueprints",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-template-review",
+      "title": "Agent template evolution review",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/agents/templates/:templateId/review'",
+      "locator": "/settings/agents/templates/:templateId/review",
+      "routes": [
+        "/settings/agents/templates/:templateId/review"
+      ],
+      "page": "ai-and-automation/agent-blueprints",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-soul-editor",
+      "title": "Agent soul editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/agents/souls/:soulId'",
+      "locator": "/settings/agents/souls/create or :soulId",
+      "routes": [
+        "/settings/agents/souls/create",
+        "/settings/agents/souls/:soulId"
+      ],
+      "page": "ai-and-automation/agent-blueprints",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-soul-review",
+      "title": "Agent soul evolution review",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/agents/souls/:soulId/review'",
+      "locator": "/settings/agents/souls/:soulId/review",
+      "routes": [
+        "/settings/agents/souls/:soulId/review"
+      ],
+      "page": "ai-and-automation/agent-blueprints",
+      "status": "verified"
+    },
+    {
+      "id": "settings-agent-instance-detail",
+      "title": "Agent instance detail",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/agents/instances/:agentId'",
+      "locator": "/settings/agents/instances/:agentId",
+      "routes": [
+        "/settings/agents/instances/:agentId"
+      ],
+      "page": "ai-and-automation/agents",
+      "status": "verified"
+    },
+    {
+      "id": "settings-daily-os",
+      "title": "Daily OS settings",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'daily-os'",
+      "locator": "/settings/daily-os",
+      "routes": [
+        "/settings/daily-os"
+      ],
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-hub",
+      "title": "Sync settings hub",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync'",
+      "locator": "/settings/sync",
+      "routes": [
+        "/settings/sync"
+      ],
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-provisioned",
+      "title": "Provisioned Sync",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/provisioned'",
+      "locator": "/settings/sync/provisioned",
+      "routes": [
+        "/settings/sync/provisioned"
+      ],
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-node-profile",
+      "title": "Sync node profile",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/node-profile'",
+      "locator": "/settings/sync/node-profile",
+      "routes": [
+        "/settings/sync/node-profile"
+      ],
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-backfill",
+      "title": "Sync backfill",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/backfill'",
+      "locator": "/settings/sync/backfill",
+      "routes": [
+        "/settings/sync/backfill"
+      ],
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-stats",
+      "title": "Sync statistics",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/stats'",
+      "locator": "/settings/sync/stats",
+      "routes": [
+        "/settings/sync/stats"
+      ],
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-outbox",
+      "title": "Sync outbox",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/outbox'",
+      "locator": "/settings/sync/outbox",
+      "routes": [
+        "/settings/sync/outbox"
+      ],
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-conflicts",
+      "title": "Sync conflicts",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/conflicts'",
+      "locator": "/settings/advanced/conflicts",
+      "routes": [
+        "/settings/advanced/conflicts"
+      ],
+      "page": "sync-and-data/conflicts",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-conflict-detail",
+      "title": "Sync conflict detail",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/advanced/conflicts/:conflictId'",
+      "locator": "/settings/advanced/conflicts/:conflictId",
+      "routes": [
+        "/settings/advanced/conflicts/:conflictId"
+      ],
+      "page": "sync-and-data/conflicts",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-conflict-editor",
+      "title": "Sync manual merge editor",
+      "kind": "settings-page",
+      "source": "lib/features/sync/ui/widgets/conflicts/conflict_resolution_view.dart",
+      "sourcePattern": "_buildCombining",
+      "locator": "Conflict detail → Combine",
+      "page": "sync-and-data/conflicts",
+      "status": "verified"
+    },
+    {
+      "id": "settings-sync-matrix-maintenance",
+      "title": "Matrix sync maintenance",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'sync/matrix-maintenance'",
+      "locator": "/settings/sync/matrix/maintenance",
+      "routes": [
+        "/settings/sync/matrix/maintenance"
+      ],
+      "page": "sync-and-data/maintenance",
+      "status": "verified"
+    },
+    {
+      "id": "settings-definitions-hub",
+      "title": "Definitions hub",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'definitions'",
+      "locator": "/settings/definitions",
+      "routes": [
+        "/settings/definitions"
+      ],
+      "page": "reference/settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-categories-list",
+      "title": "Category definitions",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'definitions/categories'",
+      "locator": "/settings/categories",
+      "routes": [
+        "/settings/categories"
+      ],
+      "page": "organize-and-reflect/categories",
+      "status": "verified"
+    },
+    {
+      "id": "settings-category-editor",
+      "title": "Category editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/categories/:categoryId'",
+      "locator": "/settings/categories/create or :categoryId",
+      "routes": [
+        "/settings/categories/create",
+        "/settings/categories/:categoryId"
+      ],
+      "page": "organize-and-reflect/categories",
+      "status": "verified"
+    },
+    {
+      "id": "settings-labels-list",
+      "title": "Label definitions",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'definitions/labels'",
+      "locator": "/settings/labels",
+      "routes": [
+        "/settings/labels"
+      ],
+      "page": "organize-and-reflect/labels",
+      "status": "verified"
+    },
+    {
+      "id": "settings-label-editor",
+      "title": "Label editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/labels/:labelId'",
+      "locator": "/settings/labels/create or :labelId",
+      "routes": [
+        "/settings/labels/create",
+        "/settings/labels/:labelId"
+      ],
+      "page": "organize-and-reflect/labels",
+      "status": "verified"
+    },
+    {
+      "id": "settings-habits-list",
+      "title": "Habit definitions",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'definitions/habits'",
+      "locator": "/settings/habits",
+      "routes": [
+        "/settings/habits",
+        "/settings/habits/search/:searchTerm"
+      ],
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "settings-habit-editor",
+      "title": "Habit editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/habits/by_id/:habitId'",
+      "locator": "/settings/habits/create or by_id/:habitId",
+      "routes": [
+        "/settings/habits/create",
+        "/settings/habits/by_id/:habitId"
+      ],
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "settings-dashboards-list",
+      "title": "Dashboard definitions",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'definitions/dashboards'",
+      "locator": "/settings/dashboards",
+      "routes": [
+        "/settings/dashboards"
+      ],
+      "page": "organize-and-reflect/dashboards",
+      "status": "verified"
+    },
+    {
+      "id": "settings-dashboard-editor",
+      "title": "Dashboard editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/dashboards/:dashboardId'",
+      "locator": "/settings/dashboards/create or :dashboardId",
+      "routes": [
+        "/settings/dashboards/create",
+        "/settings/dashboards/:dashboardId"
+      ],
+      "page": "organize-and-reflect/dashboards",
+      "status": "verified"
+    },
+    {
+      "id": "settings-measurables-list",
+      "title": "Measurable definitions",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'definitions/measurables'",
+      "locator": "/settings/measurables",
+      "routes": [
+        "/settings/measurables"
+      ],
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "settings-measurable-editor",
+      "title": "Measurable editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/measurables/:measurableId'",
+      "locator": "/settings/measurables/create or :measurableId",
+      "routes": [
+        "/settings/measurables/create",
+        "/settings/measurables/:measurableId"
+      ],
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "settings-project-editor",
+      "title": "Project settings editor",
+      "kind": "settings-page",
+      "source": "lib/beamer/locations/settings_location.dart",
+      "sourcePattern": "'/settings/projects/:projectId'",
+      "locator": "/settings/projects/:projectId",
+      "routes": [
+        "/settings/projects/:projectId"
+      ],
+      "page": "organize-and-reflect/projects",
+      "status": "verified"
+    },
+    {
+      "id": "settings-recording-style",
+      "title": "Recording Style",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'recording-style'",
+      "locator": "/settings/recording-style",
+      "routes": [
+        "/settings/recording-style"
+      ],
+      "page": "reference/recording-style",
+      "status": "verified"
+    },
+    {
+      "id": "settings-theming",
+      "title": "Theming",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'theming'",
+      "locator": "/settings/theming",
+      "routes": [
+        "/settings/theming"
+      ],
+      "page": "reference/appearance",
+      "status": "verified"
+    },
+    {
+      "id": "settings-keyboard-shortcuts",
+      "title": "Keyboard shortcuts",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'keyboard-shortcuts'",
+      "locator": "/settings/keyboard-shortcuts",
+      "routes": [
+        "/settings/keyboard-shortcuts"
+      ],
+      "page": "reference/keyboard-shortcuts",
+      "status": "verified"
+    },
+    {
+      "id": "settings-speech",
+      "title": "Speech and text-to-speech",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'speech'",
+      "locator": "/settings/speech",
+      "routes": [
+        "/settings/speech"
+      ],
+      "page": "reference/speech",
+      "status": "verified"
+    },
+    {
+      "id": "settings-advanced-hub",
+      "title": "Advanced Settings hub",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced'",
+      "locator": "/settings/advanced",
+      "routes": [
+        "/settings/advanced"
+      ],
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-flags",
+      "title": "Configuration flags",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/flags'",
+      "locator": "/settings/flags",
+      "routes": [
+        "/settings/flags"
+      ],
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-animations",
+      "title": "Completion animations",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/animations'",
+      "locator": "/settings/advanced/animations",
+      "routes": [
+        "/settings/advanced/animations"
+      ],
+      "page": "reference/completion-celebrations",
+      "status": "verified"
+    },
+    {
+      "id": "settings-manual-language",
+      "title": "Language",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/manual-language'",
+      "locator": "/settings/advanced/manual-language",
+      "routes": [
+        "/settings/advanced/manual-language"
+      ],
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-celebration-playground",
+      "title": "Celebration style playground",
+      "kind": "settings-page",
+      "source": "lib/features/settings/ui/pages/advanced/celebration_playground_page.dart",
+      "sourcePattern": "class CelebrationPlaygroundPage",
+      "locator": "Animations → Customize style",
+      "page": "reference/completion-celebrations",
+      "status": "verified"
+    },
+    {
+      "id": "settings-logging",
+      "title": "Logging domains",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/logging'",
+      "locator": "/settings/advanced/logging_domains",
+      "routes": [
+        "/settings/advanced/logging_domains"
+      ],
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-health-import",
+      "title": "Health import",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/health-import'",
+      "locator": "/settings/health_import",
+      "routes": [
+        "/settings/health_import"
+      ],
+      "page": "sync-and-data/health-import",
+      "status": "verified"
+    },
+    {
+      "id": "settings-maintenance",
+      "title": "Maintenance",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/maintenance'",
+      "locator": "/settings/advanced/maintenance",
+      "routes": [
+        "/settings/advanced/maintenance",
+        "/settings/maintenance"
+      ],
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-onboarding-metrics",
+      "title": "Onboarding metrics",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/onboarding-metrics'",
+      "locator": "/settings/advanced/onboarding_metrics",
+      "routes": [
+        "/settings/advanced/onboarding_metrics"
+      ],
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-about",
+      "title": "About Lotti",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'advanced/about'",
+      "locator": "/settings/advanced/about",
+      "page": "reference/advanced-settings",
+      "status": "verified"
+    },
+    {
+      "id": "settings-manual",
+      "title": "Open the Manual",
+      "kind": "settings-page",
+      "source": "lib/features/settings_v2/domain/settings_tree_data.dart",
+      "sourcePattern": "'manual'",
+      "locator": "Settings → Manual or macOS Help → Manual",
+      "page": "reference/settings",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-create-entry",
+      "title": "Create entry menu",
+      "kind": "workflow",
+      "source": "lib/features/journal/ui/widgets/create/create_entry_action_modal.dart",
+      "sourcePattern": "class CreateEntryModal",
+      "locator": "Global create action",
+      "page": "plan-and-capture/entries",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-audio-recording",
+      "title": "Audio recording",
+      "kind": "workflow",
+      "source": "lib/features/speech/ui/widgets/recording/audio_recording_modal.dart",
+      "sourcePattern": "class AudioRecordingModal",
+      "locator": "Create audio recording",
+      "page": "plan-and-capture/recordings",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-transcription-review",
+      "title": "Speech transcription review",
+      "kind": "workflow",
+      "source": "lib/features/speech/ui/widgets/speech_modal/speech_modal.dart",
+      "sourcePattern": "class SpeechModalContent",
+      "locator": "Open recording transcript",
+      "page": "plan-and-capture/recordings",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-task-filters",
+      "title": "Task filters",
+      "kind": "workflow",
+      "source": "lib/features/tasks/ui/filtering/task_filter_modal.dart",
+      "sourcePattern": "showTaskFilterModal",
+      "locator": "Tasks → Filter",
+      "page": "organize-and-reflect/tasks",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-task-cover-art",
+      "title": "Generate task cover art",
+      "kind": "workflow",
+      "source": "lib/features/ai/ui/image_generation/cover_art_skill_modal.dart",
+      "sourcePattern": "class CoverArtSkillModal",
+      "locator": "Task image generation",
+      "page": "organize-and-reflect/task-cover-art",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-link-task",
+      "title": "Link another task",
+      "kind": "workflow",
+      "source": "lib/features/tasks/ui/linked_tasks/link_task_modal.dart",
+      "sourcePattern": "class LinkTaskModal",
+      "locator": "Task → Linked",
+      "page": "organize-and-reflect/tasks",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-habit-completion",
+      "title": "Record habit completion",
+      "kind": "workflow",
+      "source": "lib/pages/create/complete_habit_dialog.dart",
+      "sourcePattern": "class HabitDialog",
+      "locator": "Habits → Record",
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-measurement-capture",
+      "title": "Record a measurement",
+      "kind": "workflow",
+      "source": "lib/pages/create/create_measurement_dialog.dart",
+      "sourcePattern": "class _MeasurementEditorPage",
+      "locator": "Create measurement",
+      "page": "organize-and-reflect/habits-and-measurables",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-project-create",
+      "title": "Create project",
+      "kind": "workflow",
+      "source": "lib/features/projects/ui/widgets/project_create_modal.dart",
+      "sourcePattern": "showProjectCreateModal",
+      "locator": "Projects → Create",
+      "page": "organize-and-reflect/projects",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-daily-os-planning",
+      "title": "Daily OS capture and reconciliation",
+      "kind": "workflow",
+      "source": "lib/features/daily_os_next/ui/pages/day_planning_modal.dart",
+      "sourcePattern": "showDayPlanningModal",
+      "locator": "Daily OS → Speak or type a check-in",
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-day-block-edit",
+      "title": "Edit a day block",
+      "kind": "workflow",
+      "source": "lib/features/daily_os_next/ui/widgets/day_block_edit_modal.dart",
+      "sourcePattern": "class DayBlockEditModal",
+      "locator": "Daily OS → Edit block",
+      "page": "plan-and-capture/daily-os",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-command-palette",
+      "title": "Command palette",
+      "kind": "workflow",
+      "source": "lib/features/keyboard/ui/command_palette.dart",
+      "sourcePattern": "showAppCommandPalette",
+      "locator": "Primary + K",
+      "page": "reference/keyboard-shortcuts",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-shortcut-overlay",
+      "title": "Keyboard shortcut overlay",
+      "kind": "workflow",
+      "source": "lib/features/keyboard/ui/keyboard_shortcuts_page.dart",
+      "sourcePattern": "showKeyboardShortcutsOverlay",
+      "locator": "F1 or Primary + ?",
+      "page": "reference/keyboard-shortcuts",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-onboarding",
+      "title": "Welcome and first capture",
+      "kind": "workflow",
+      "source": "lib/features/onboarding/ui/onboarding_welcome_modal.dart",
+      "sourcePattern": "class OnboardingWelcomeModal",
+      "locator": "First run or Settings → Onboarding",
+      "page": "getting-started/onboarding",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-whats-new",
+      "title": "What's New releases",
+      "kind": "workflow",
+      "source": "lib/features/whats_new/ui/whats_new_modal.dart",
+      "sourcePattern": "class WhatsNewModal",
+      "locator": "Settings → What's New",
+      "page": "reference/whats-new",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-sync-pairing",
+      "title": "Pair a sync device",
+      "kind": "workflow",
+      "source": "lib/features/sync/ui/provisioned/provisioned_sync_modal.dart",
+      "sourcePattern": "class ProvisionedSyncSettingsCard",
+      "locator": "Sync Settings → Devices → Add device",
+      "page": "sync-and-data/add-device",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-sync-verification",
+      "title": "Verify a sync device",
+      "kind": "workflow",
+      "source": "lib/features/sync/ui/widgets/matrix/verification_modal.dart",
+      "sourcePattern": "class VerificationModal",
+      "locator": "Sync verification request",
+      "page": "sync-and-data/sync",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-ai-skills",
+      "title": "Run contextual AI skills",
+      "kind": "workflow",
+      "source": "lib/features/ai/ui/unified_ai_skills_modal.dart",
+      "sourcePattern": "class UnifiedAiModal",
+      "locator": "Generate…",
+      "page": "ai-and-automation/skills",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-ai-profile-picker",
+      "title": "Choose an inference profile",
+      "kind": "workflow",
+      "source": "lib/features/ai/ui/widgets/inference_profile_picker_modal.dart",
+      "sourcePattern": "class InferenceProfilePickerList",
+      "locator": "Inference profile field",
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-ai-model-picker",
+      "title": "Choose a provider model",
+      "kind": "workflow",
+      "source": "lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart",
+      "sourcePattern": "class InferenceProviderModelPickerModal",
+      "locator": "Model field",
+      "page": "ai-and-automation/models-and-profiles",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-session-rating",
+      "title": "Rate a recorded session",
+      "kind": "workflow",
+      "source": "lib/features/ratings/ui/session_rating_modal.dart",
+      "sourcePattern": "class RatingModal",
+      "locator": "Time record → Rating",
+      "page": "organize-and-reflect/time-tracking",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-survey-fill",
+      "title": "Complete a survey",
+      "kind": "workflow",
+      "source": "lib/features/surveys/tools/run_surveys.dart",
+      "sourcePattern": "Future<void> runSurvey",
+      "locator": "Dashboard survey chart → Add",
+      "page": "plan-and-capture/surveys",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-dashboard-charts",
+      "title": "Compose dashboard charts",
+      "kind": "workflow",
+      "source": "lib/features/settings/ui/pages/dashboards/dashboard_definition_page.dart",
+      "sourcePattern": "class DashboardDefinitionPage",
+      "locator": "Dashboard editor → Charts",
+      "page": "organize-and-reflect/dashboards",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-entry-date-time",
+      "title": "Edit entry date and time",
+      "kind": "workflow",
+      "source": "lib/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal.dart",
+      "sourcePattern": "class EntryDateTimeMultiPageModal",
+      "locator": "Entry detail → Date and time",
+      "page": "organize-and-reflect/journal",
+      "status": "verified"
+    },
+    {
+      "id": "workflow-linked-entry-filter",
+      "title": "Filter linked entries",
+      "kind": "workflow",
+      "source": "lib/features/journal/ui/widgets/linked_entries_filter_modal.dart",
+      "sourcePattern": "showLinkedEntriesFilterModal",
+      "locator": "Entry detail → Linked entries filter",
+      "page": "organize-and-reflect/journal",
+      "status": "verified"
+    }
   ]
 }

--- a/docs-site/scripts/smoke-built-site.mjs
+++ b/docs-site/scripts/smoke-built-site.mjs
@@ -266,12 +266,18 @@ for (const feature of features.features) {
   }
 }
 
+/// Strips the trailing `index.html` so a page is identified by its route.
+const routeOf = (path) => path.replace(/\/?index\.html$/, '');
+
 const translatedDocCounts = Object.fromEntries(
   translatedLocales.map((locale) => [locale, 0]),
 );
+const translatedDocIds = Object.fromEntries(
+  translatedLocales.map((locale) => [locale, new Set()]),
+);
 for (const locale of translatedLocales) {
   for (const path of buildFiles) {
-    if (!path.startsWith(`${locale}/`) || !path.endsWith('/index.html')) continue;
+    if (!path.startsWith(`${locale}/`) || !path.endsWith('index.html')) continue;
     const html = await readFile(resolve(buildDirectory, path), 'utf8');
     if (!html.includes('theme-doc-markdown')) continue;
     assert.equal(
@@ -282,23 +288,39 @@ for (const locale of translatedLocales) {
       `Translated document ${path} must render exactly one translation notice.`,
     );
     translatedDocCounts[locale] += 1;
+    translatedDocIds[locale].add(routeOf(path.slice(locale.length + 1)));
   }
 }
 
-// Compared across locales rather than against a pinned number. The invariant
-// worth holding is that no locale is missing a document, and a hard-coded
-// count instead fails on every page added — reporting it as a translation
-// problem rather than a stale constant.
-const [referenceLocale, ...otherLocales] = translatedLocales;
+// Measured against the English documents that were actually built, not against
+// a pinned number and not against another locale. Comparing locales to each
+// other only proves they agree — if every locale were missing the same page
+// they would agree on being wrong. A hard-coded count is no better: it fails
+// on every page added, and reports it as a translation problem rather than a
+// stale constant.
+const englishDocIds = new Set();
+for (const path of buildFiles) {
+  if (!path.endsWith('index.html')) continue;
+  const [head] = path.split('/');
+  if (translatedLocales.includes(head)) continue;
+  const html = await readFile(resolve(buildDirectory, path), 'utf8');
+  if (!html.includes('theme-doc-markdown')) continue;
+  englishDocIds.add(routeOf(path));
+}
+
 assert.ok(
-  translatedDocCounts[referenceLocale] > 0,
-  'The translation notice audit found no translated documents at all.',
+  englishDocIds.size > 0,
+  'The translation notice audit found no English documents to measure against.',
 );
-for (const locale of otherLocales) {
-  assert.equal(
-    translatedDocCounts[locale],
-    translatedDocCounts[referenceLocale],
-    `The translation notice audit must cover every ${locale} manual document.`,
+
+for (const locale of translatedLocales) {
+  const missing = [...englishDocIds].filter(
+    (id) => !translatedDocIds[locale].has(id),
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `The ${locale} manual is missing documents: ${missing.join(', ')}.`,
   );
 }
 

--- a/docs-site/scripts/smoke-built-site.mjs
+++ b/docs-site/scripts/smoke-built-site.mjs
@@ -283,9 +283,21 @@ for (const locale of translatedLocales) {
     );
     translatedDocCounts[locale] += 1;
   }
+}
+
+// Compared across locales rather than against a pinned number. The invariant
+// worth holding is that no locale is missing a document, and a hard-coded
+// count instead fails on every page added — reporting it as a translation
+// problem rather than a stale constant.
+const [referenceLocale, ...otherLocales] = translatedLocales;
+assert.ok(
+  translatedDocCounts[referenceLocale] > 0,
+  'The translation notice audit found no translated documents at all.',
+);
+for (const locale of otherLocales) {
   assert.equal(
     translatedDocCounts[locale],
-    40,
+    translatedDocCounts[referenceLocale],
     `The translation notice audit must cover every ${locale} manual document.`,
   );
 }

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Sync & data',
       items: [
+        'sync-and-data/add-device',
         'sync-and-data/sync',
         'sync-and-data/conflicts',
         'sync-and-data/maintenance',

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -442,7 +442,13 @@ class _ScannerViewState extends State<_ScannerView> {
     super.initState();
     // Nothing to start when the preview is a stand-in.
     if (scannerPreviewOverride == null) {
-      unawaited(_startCamera());
+      // After the first frame, not during initState: `MobileScanner` is a
+      // child, so it has not mounted or called `attach()` yet. Starting here
+      // would leave the controller waiting on its attachment timeout instead
+      // of a completed attach.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) unawaited(_startCamera());
+      });
     }
   }
 

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/sync/ui/widgets/matrix/pairing_check_code_view.da
 import 'package:lotti/features/sync/ui/widgets/matrix/sync_callout.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/sync_flow_section.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/dev_logger.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
@@ -465,8 +466,16 @@ class _ScannerViewState extends State<_ScannerView> {
   Future<void> _startCamera() async {
     try {
       await widget.controller.start();
-    } on Exception {
-      // Reported by errorBuilder, or moot because the page has gone.
+    } on Exception catch (error, stackTrace) {
+      // Logged rather than dropped: a camera the platform refuses already
+      // reaches the user through `errorBuilder`, but a start that fails for
+      // any other reason would otherwise leave no trace at all.
+      DevLogger.error(
+        name: 'BundleImport',
+        message: 'Camera start failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -77,8 +77,15 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
   /// widget caches its failed start otherwise.
   int _scannerGeneration = 0;
 
+  /// The camera is started by [_ScannerView] rather than by `MobileScanner`.
+  ///
+  /// With `autoStart` the package calls `start()` from an initializer it never
+  /// awaits, so a page torn down mid-initialisation resumes that call against
+  /// a disposed controller and the error surfaces as an unhandled async
+  /// failure nothing can catch. Starting it ourselves makes the same failure
+  /// catchable.
   MobileScannerController _ensureScannerController() {
-    return _scannerController ??= MobileScannerController();
+    return _scannerController ??= MobileScannerController(autoStart: false);
   }
 
   /// Recreates the camera after the user has granted permission elsewhere.
@@ -392,7 +399,19 @@ class _StepTitle extends StatelessWidget {
   }
 }
 
-class _ScannerView extends StatelessWidget {
+/// Replaces the live camera preview, for tests and manual screenshots.
+///
+/// A headless capture has no camera plugin: `MobileScanner` renders a black
+/// rectangle and the platform channel answers every call with
+/// `MissingPluginException`. Neither belongs in the manual, and a stand-in
+/// viewfinder documents the step better than an empty frame would.
+///
+/// Follows the same override pattern as `beamToNamedOverride`. Null in
+/// production, where the real scanner is always used.
+@visibleForTesting
+Widget Function(BuildContext context, double side)? scannerPreviewOverride;
+
+class _ScannerView extends StatefulWidget {
   const _ScannerView({
     required this.controller,
     required this.onDetect,
@@ -413,10 +432,49 @@ class _ScannerView extends StatelessWidget {
   final String? errorText;
 
   @override
+  State<_ScannerView> createState() => _ScannerViewState();
+}
+
+class _ScannerViewState extends State<_ScannerView> {
+  @override
+  void initState() {
+    super.initState();
+    // Nothing to start when the preview is a stand-in.
+    if (scannerPreviewOverride == null) {
+      unawaited(_startCamera());
+    }
+  }
+
+  @override
+  void dispose() {
+    // Best effort: the controller belongs to the page, which disposes it.
+    if (scannerPreviewOverride == null) {
+      unawaited(widget.controller.stop().catchError((Object _) {}));
+    }
+    super.dispose();
+  }
+
+  /// Starts the camera and swallows a failure to do so.
+  ///
+  /// The failure that matters is the page being torn down while this is in
+  /// flight: the controller is disposed and `start()` then rejects. With
+  /// `autoStart` that call lives inside `MobileScanner`'s own un-awaited
+  /// initializer, where nothing can catch it and it surfaces as an unhandled
+  /// async error. Owning the call is what makes it catchable — a camera that
+  /// cannot start is already reported through `errorBuilder`.
+  Future<void> _startCamera() async {
+    try {
+      await widget.controller.start();
+    } on Exception {
+      // Reported by errorBuilder, or moot because the page has gone.
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final error = errorText;
+    final error = widget.errorText;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -438,14 +496,16 @@ class _ScannerView extends StatelessWidget {
                 borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
                 child: SizedBox.square(
                   dimension: side,
-                  child: MobileScanner(
-                    controller: controller,
-                    onDetect: onDetect,
-                    errorBuilder: (context, error) => _CameraUnavailable(
-                      message: messages.syncPairCameraDenied,
-                      onRetry: onRetryCamera,
-                    ),
-                  ),
+                  child:
+                      scannerPreviewOverride?.call(context, side) ??
+                      MobileScanner(
+                        controller: widget.controller,
+                        onDetect: widget.onDetect,
+                        errorBuilder: (context, error) => _CameraUnavailable(
+                          message: messages.syncPairCameraDenied,
+                          onRetry: widget.onRetryCamera,
+                        ),
+                      ),
                 ),
               ),
             );
@@ -477,7 +537,7 @@ class _ScannerView extends StatelessWidget {
             key: const Key('bundle_import_enter_manually'),
             label: messages.syncPairEnterManually,
             variant: DesignSystemButtonVariant.outlined,
-            onPressed: onEnterManually,
+            onPressed: widget.onEnterManually,
           ),
         ),
       ],

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -383,6 +383,10 @@ void main() {
       );
       await tester.pump();
       expect(find.byType(MobileScanner), findsOneWidget);
+      // The camera really is mid-startup, so what follows is the race and not
+      // a page that never tried.
+      expect(gated.started, isTrue);
+      expect(gated.gate.isCompleted, isFalse);
 
       // The user moves on before the camera has finished coming up.
       await tester.pumpWidget(const SizedBox.shrink());
@@ -725,8 +729,13 @@ class _FailingStartScanner extends FakeMethodChannelMobileScanner {
 class _GatedStartScanner extends FakeMethodChannelMobileScanner {
   final Completer<void> gate = Completer<void>();
 
+  /// Whether the page ever asked for the camera. Without this the test would
+  /// pass just as happily if startup never began at all.
+  bool started = false;
+
   @override
   Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    started = true;
     await gate.future;
     return super.start(startOptions);
   }

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -361,6 +362,39 @@ void main() {
       );
     });
 
+    testWidgets('leaving the scanner mid-initialisation reports no error', (
+      tester,
+    ) async {
+      // The camera is started from an async call. If the page goes away while
+      // that is in flight, the controller is disposed underneath it and the
+      // start rejects. Left to `MobileScanner`'s own un-awaited initializer
+      // that lands as an unhandled async error nothing can catch, which is
+      // what broke every mobile manual capture (lotti3-82s).
+      setUpMobileScanner();
+      final gated = _GatedStartScanner();
+      MobileScannerPlatform.instance = gated;
+      addTearDown(gated.disposeControllers);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+          overrides: defaultOverrides(),
+        ),
+      );
+      await tester.pump();
+      expect(find.byType(MobileScanner), findsOneWidget);
+
+      // The user moves on before the camera has finished coming up.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      // ...and only now does the camera answer.
+      gated.gate.complete();
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('declining a scanned code lands on the field and stays there', (
       tester,
     ) async {
@@ -625,4 +659,16 @@ void main() {
       expect(find.text('@alice:example.com'), findsNothing);
     });
   });
+}
+
+/// A camera whose start hangs until released, so a test can tear the page down
+/// while initialisation is still in flight.
+class _GatedStartScanner extends FakeMethodChannelMobileScanner {
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    await gate.future;
+    return super.start(startOptions);
+  }
 }

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -395,6 +395,56 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('a camera that refuses to start leaves the page usable', (
+      tester,
+    ) async {
+      // The start now happens in a future this page owns, so its failure has
+      // to be handled here rather than escaping as an unhandled async error.
+      setUpMobileScanner();
+      final failing = _FailingStartScanner();
+      MobileScannerPlatform.instance = failing;
+      addTearDown(failing.disposeControllers);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+          overrides: defaultOverrides(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      // The way out of a dead camera stays on screen.
+      final context = tester.element(find.byType(BundleImportWidget));
+      expect(
+        find.text(context.messages.syncPairEnterManually),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('scannerPreviewOverride replaces the live camera', (
+      tester,
+    ) async {
+      // The seam the manual captures rely on: a headless run has no camera
+      // plugin, so the real scanner must not be mounted at all.
+      setUpMobileScanner();
+      scannerPreviewOverride = (context, side) =>
+          const ColoredBox(key: Key('stand_in'), color: Color(0xFF00FF00));
+      addTearDown(() => scannerPreviewOverride = null);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+          overrides: defaultOverrides(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('stand_in')), findsOneWidget);
+      expect(find.byType(MobileScanner), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('declining a scanned code lands on the field and stays there', (
       tester,
     ) async {
@@ -659,6 +709,15 @@ void main() {
       expect(find.text('@alice:example.com'), findsNothing);
     });
   });
+}
+
+/// A camera that refuses to start, standing in for a device where the platform
+/// rejects the request outright.
+class _FailingStartScanner extends FakeMethodChannelMobileScanner {
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    throw const FormatException('camera refused');
+  }
 }
 
 /// A camera whose start hangs until released, so a test can tear the page down

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -59,6 +59,7 @@ import 'package:lotti/features/sync/ui/pages/conflicts/conflict_detail_route.dar
 import 'package:lotti/features/sync/ui/pages/conflicts/conflicts_page.dart';
 import 'package:lotti/features/sync/ui/pages/outbox/outbox_monitor_page.dart';
 import 'package:lotti/features/sync/ui/pages/sync_node_profile_page.dart';
+import 'package:lotti/features/sync/ui/provisioned/add_device_page.dart';
 import 'package:lotti/features/sync/ui/provisioned/bundle_import_page.dart';
 import 'package:lotti/features/sync/ui/provisioned/provisioned_status_page.dart';
 import 'package:lotti/features/sync/ui/provisioned/provisioned_sync_modal.dart';
@@ -965,6 +966,39 @@ void main() {
     }
   }
 
+  /// Refuses to publish a QR code that encodes anything real.
+  ///
+  /// This capture ends up in a public docs repository and the payload is a
+  /// live credential by design — it carries the sync account's password.
+  ///
+  /// `QrImageView` keeps its payload private, so this guards the two things
+  /// that decide it instead: that the provisioning controller is still the
+  /// stubbed one (drop that override and the sheet mints a bundle from
+  /// whatever sync config the machine running the capture has), and that the
+  /// bundle it mints is demo data.
+  void expectQrCarriesOnlyDemoData(WidgetTester tester) {
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(AddDeviceView)),
+    );
+    expect(
+      container.read(provisioningControllerProvider.notifier),
+      isA<_ManualProvisioningController>(),
+      reason: "A real controller would mint this machine's sync credentials",
+    );
+
+    final bundle = SyncProvisioningBundle.fromJson(
+      jsonDecode(
+            utf8.decode(base64Url.decode(base64Url.normalize(_manualHandover))),
+          )
+          as Map<String, dynamic>,
+    );
+    expect(bundle.password, 'manual-demo-only');
+    expect(bundle.user, endsWith('.test'));
+    // `.test` is reserved by RFC 2606; it can never resolve.
+    expect(Uri.parse(bundle.homeServer).host, endsWith('.test'));
+    expect(bundle.roomId, endsWith('.test'));
+  }
+
   void expectSurface(WidgetTester tester, _SyncSurface surface) {
     final context = tester.element(find.byType(Scaffold).first);
     final messages = context.messages;
@@ -991,6 +1025,7 @@ void main() {
         // derive it independently and it must be compared before connecting.
         expect(find.byType(PairingCheckCodeView), findsOneWidget);
         expect(find.text(messages.syncAddDeviceIntro), findsWidgets);
+        expectQrCarriesOnlyDemoData(tester);
       case _SyncSurface.paired:
         // The quiet "connected" line plus the card that says what is still
         // outstanding — the point of the screen is the second half.

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -800,14 +800,14 @@ void main() {
           terminal: const ProvisioningState.done(),
         ),
       ),
-    if (surface == _SyncSurface.addDevice) ...[
+    if (surface == _SyncSurface.addDevice)
       provisioningControllerProvider.overrideWith(
         _ManualProvisioningController.new,
       ),
+    if (surface == _SyncSurface.addDevice || surface == _SyncSurface.status)
       syncDevicesControllerProvider.overrideWith(
         () => _ManualSyncDevicesController(_manualDevices),
       ),
-    ],
   ];
 
   /// Opens the setup modal and gets the decoded bundle on screen.
@@ -819,6 +819,7 @@ void main() {
   Future<void> openBundleImport(
     WidgetTester tester, {
     bool confirm = false,
+    String? bundleText,
   }) async {
     await tester.tap(find.byType(ProvisionedSyncSettingsCard));
     await settleFrames(tester, 10);
@@ -832,7 +833,10 @@ void main() {
       await settleFrames(tester, 8);
     }
 
-    await tester.enterText(find.byType(TextField), _provisioningBundleText);
+    await tester.enterText(
+      find.byType(TextField),
+      bundleText ?? _provisioningBundleText,
+    );
     await tester.pump();
 
     final context = tester.element(find.byType(BundleImportWidget));
@@ -868,7 +872,15 @@ void main() {
         await tester.tap(find.byKey(const Key('sync_devices_add_device')));
         await settleFrames(tester, 18);
       case _SyncSurface.paired:
-        await openBundleImport(tester, confirm: true);
+        // A handover bundle, not the provisioned one: production sends
+        // `provisioned` through password rotation to `ready` and the
+        // first-device view, and only a peer's `handover` reaches `done` and
+        // the paired steps this capture documents.
+        await openBundleImport(
+          tester,
+          confirm: true,
+          bundleText: _manualHandover,
+        );
         await settleFrames(tester, 18);
       case _SyncSurface.status:
         // A configured account renders the roster inline on the page; there is
@@ -944,6 +956,11 @@ void main() {
         expect(find.byType(SyncFlowSection), findsWidgets);
       case _SyncSurface.status:
         expect(find.byType(ProvisionedStatusWidget), findsOneWidget);
+        // The roster rows are the subject of this capture; asserting only the
+        // surrounding widget passed happily against an empty list.
+        for (final device in _manualDevices) {
+          expect(find.text(device.displayName!), findsWidgets);
+        }
         expect(
           find.text(messages.settingsMatrixDiagnosticShowButton),
           findsOneWidget,

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -39,6 +39,7 @@ import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/features/sync/matrix/pipeline/sync_metrics.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/model/sync_node_profile.dart';
+import 'package:lotti/features/sync/models/sync_device_info.dart';
 import 'package:lotti/features/sync/models/sync_models.dart';
 import 'package:lotti/features/sync/services/sync_node_profile_broadcaster.dart';
 import 'package:lotti/features/sync/state/backfill_config_controller.dart';
@@ -46,6 +47,8 @@ import 'package:lotti/features/sync/state/backfill_stats_controller.dart';
 import 'package:lotti/features/sync/state/matrix_stats_provider.dart';
 import 'package:lotti/features/sync/state/matrix_unverified_provider.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/features/sync/state/provisioning_controller.dart';
+import 'package:lotti/features/sync/state/sync_devices_provider.dart';
 import 'package:lotti/features/sync/state/sync_maintenance_controller.dart';
 import 'package:lotti/features/sync/state/synced_audio_inference_providers.dart';
 import 'package:lotti/features/sync/tuning.dart';
@@ -60,6 +63,8 @@ import 'package:lotti/features/sync/ui/provisioned/provisioned_status_page.dart'
 import 'package:lotti/features/sync/ui/provisioned/provisioned_sync_modal.dart';
 import 'package:lotti/features/sync/ui/provisioned_sync_page.dart';
 import 'package:lotti/features/sync/ui/sync_stats_page.dart';
+import 'package:lotti/features/sync/ui/widgets/matrix/pairing_check_code_view.dart';
+import 'package:lotti/features/sync/ui/widgets/matrix/sync_flow_section.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/verification_modal.dart';
 import 'package:lotti/features/sync/ui/widgets/outbox/outbox_message_card.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
@@ -348,6 +353,35 @@ final String _provisioningBundleText = base64UrlEncode(
   utf8.encode(jsonEncode(_provisioningBundle.toJson())),
 );
 
+/// What an already-paired device hands to a new one: same account and room,
+/// `handover` kind, so the joining device joins without rotating the password.
+final String _manualHandover = base64UrlEncode(
+  utf8.encode(
+    jsonEncode(
+      _provisioningBundle.copyWith(kind: SyncBundleKind.handover).toJson(),
+    ),
+  ),
+);
+
+/// The account as the Add device sheet finds it: this device, plus the peer
+/// that has already been verified.
+final List<SyncDeviceInfo> _manualDevices = [
+  SyncDeviceInfo(
+    deviceId: 'MISSIONCONTROL',
+    displayName: _t('Mission Control Mac', 'Mission-Control-Mac'),
+    isCurrentDevice: true,
+    verified: true,
+    lastSeen: _syncTime,
+  ),
+  SyncDeviceInfo(
+    deviceId: 'PEBBLEPHONE',
+    displayName: _t('Admiral Pebble\u2019s Phone', 'Admiral Pebbles Telefon'),
+    isCurrentDevice: false,
+    verified: true,
+    lastSeen: _syncTime.subtract(const Duration(minutes: 6)),
+  ),
+];
+
 class _ManualBackfillStatsController extends BackfillStatsController {
   @override
   BackfillStatsState build() => BackfillStatsState(stats: _backfillStats);
@@ -379,6 +413,44 @@ class _ManualUnverifiedController extends MatrixUnverifiedController {
   Future<List<DeviceKeys>> build() async => devices;
 }
 
+/// Holds the provisioning flow at a fixed point so the onboarding surfaces
+/// render deterministically: [terminal] is where importing lands, and the Add
+/// device sheet mints a fixed bundle instead of reading persisted config.
+class _ManualProvisioningController extends ProvisioningController {
+  _ManualProvisioningController({this.terminal});
+
+  /// Where the flow lands when the bundle is imported. Null keeps the real
+  /// progression, which no manual surface needs.
+  final ProvisioningState? terminal;
+
+  @override
+  ProvisioningState build() => const ProvisioningState.initial();
+
+  @override
+  Future<String?> regenerateHandover() async => _manualHandover;
+
+  /// The real call walks login, room join and password rotation against a
+  /// live homeserver. The manual wants the frame at the end of that, so this
+  /// jumps straight to it.
+  @override
+  Future<void> configureFromBundle(SyncProvisioningBundle bundle) async {
+    final target = terminal;
+    if (target != null) state = target;
+  }
+}
+
+class _ManualSyncDevicesController extends SyncDevicesController {
+  _ManualSyncDevicesController(this.devices);
+
+  final List<SyncDeviceInfo> devices;
+
+  @override
+  Future<List<SyncDeviceInfo>> build() async => devices;
+
+  @override
+  Future<bool> refresh() async => true;
+}
+
 class _ManualSyncMaintenanceController extends SyncMaintenanceController {
   @override
   SyncState build() => const SyncState();
@@ -387,6 +459,8 @@ class _ManualSyncMaintenanceController extends SyncMaintenanceController {
 enum _SyncSurface {
   hub,
   provisioned,
+  addDevice,
+  paired,
   status,
   verification,
   nodeProfile,
@@ -403,6 +477,8 @@ extension on _SyncSurface {
   String get id => switch (this) {
     _SyncSurface.hub => 'hub',
     _SyncSurface.provisioned => 'provisioned',
+    _SyncSurface.addDevice => 'add_device',
+    _SyncSurface.paired => 'paired',
     _SyncSurface.status => 'status',
     _SyncSurface.verification => 'verification',
     _SyncSurface.nodeProfile => 'node_profile',
@@ -418,6 +494,8 @@ extension on _SyncSurface {
   String get route => switch (this) {
     _SyncSurface.hub => '/settings/sync',
     _SyncSurface.provisioned => '/settings/sync/provisioned',
+    _SyncSurface.addDevice => '/settings/sync/provisioned',
+    _SyncSurface.paired => '/settings/sync/provisioned',
     _SyncSurface.status => '/settings/sync/provisioned',
     _SyncSurface.verification => '/settings/sync/provisioned',
     _SyncSurface.nodeProfile => '/settings/sync/node-profile',
@@ -439,6 +517,8 @@ extension on _SyncSurface {
   Widget mobilePage() => switch (this) {
     _SyncSurface.hub => const SettingsMobileBranchPage(branchId: 'sync'),
     _SyncSurface.provisioned => const ProvisionedSyncPage(),
+    _SyncSurface.addDevice => const ProvisionedSyncPage(),
+    _SyncSurface.paired => const ProvisionedSyncPage(),
     _SyncSurface.status => const ProvisionedSyncPage(),
     _SyncSurface.verification => const ProvisionedSyncPage(),
     _SyncSurface.nodeProfile => const SyncNodeProfilePage(),
@@ -711,7 +791,70 @@ void main() {
     syncControllerProvider.overrideWith(
       _ManualSyncMaintenanceController.new,
     ),
+    // Scoped to the two onboarding surfaces. Applied globally, these replace
+    // the controllers the older surfaces drive for real, and their captures
+    // stop reaching the states they assert on.
+    if (surface == _SyncSurface.paired)
+      provisioningControllerProvider.overrideWith(
+        () => _ManualProvisioningController(
+          terminal: const ProvisioningState.done(),
+        ),
+      ),
+    if (surface == _SyncSurface.addDevice) ...[
+      provisioningControllerProvider.overrideWith(
+        _ManualProvisioningController.new,
+      ),
+      syncDevicesControllerProvider.overrideWith(
+        () => _ManualSyncDevicesController(_manualDevices),
+      ),
+    ],
   ];
+
+  /// Opens the setup modal and gets the decoded bundle on screen.
+  ///
+  /// Since the add-device redesign the import page opens the camera on mobile,
+  /// so the paste field sits behind *enter manually* rather than being the
+  /// first thing rendered. Stops on the decoded review unless [confirm], which
+  /// carries on into the flow the way a user committing to the pairing does.
+  Future<void> openBundleImport(
+    WidgetTester tester, {
+    bool confirm = false,
+  }) async {
+    await tester.tap(find.byType(ProvisionedSyncSettingsCard));
+    await settleFrames(tester, 10);
+    expect(find.byType(BundleImportWidget), findsOneWidget);
+
+    final manual = find.byKey(const Key('bundle_import_enter_manually'));
+    if (manual.evaluate().isNotEmpty) {
+      await tester.ensureVisible(manual);
+      await tester.pump();
+      await tester.tap(manual, warnIfMissed: false);
+      await settleFrames(tester, 8);
+    }
+
+    await tester.enterText(find.byType(TextField), _provisioningBundleText);
+    await tester.pump();
+
+    final context = tester.element(find.byType(BundleImportWidget));
+    final importButton = find.text(
+      context.messages.provisionedSyncImportButton,
+    );
+    await tester.ensureVisible(importButton);
+    await tester.pump();
+    await tester.tap(importButton, warnIfMissed: false);
+    await settleFrames(tester, 8);
+
+    // Importing only decodes. What lands is a review — server, account, room
+    // and the pairing check code — and connecting is a separate, deliberate
+    // confirmation on top of it.
+    expect(find.byKey(const ValueKey('bundle_import_decoded')), findsOneWidget);
+    if (!confirm) return;
+
+    final connect = find.text(context.messages.syncPairConnectButton);
+    await tester.ensureVisible(connect);
+    await tester.pump();
+    await tester.tap(connect, warnIfMissed: false);
+  }
 
   Future<void> configureSurface(
     WidgetTester tester,
@@ -719,22 +862,22 @@ void main() {
   ) async {
     switch (surface) {
       case _SyncSurface.provisioned:
-        await tester.tap(find.byType(ProvisionedSyncSettingsCard));
-        await settleFrames(tester, 10);
-        expect(find.byType(BundleImportWidget), findsOneWidget);
-        await tester.enterText(find.byType(TextField), _provisioningBundleText);
-        await tester.pump();
-        final context = tester.element(find.byType(BundleImportWidget));
-        await tester.tap(
-          find.text(context.messages.provisionedSyncImportButton),
-        );
+        await openBundleImport(tester);
         await settleFrames(tester, 8);
+      case _SyncSurface.addDevice:
+        await tester.tap(find.byKey(const Key('sync_devices_add_device')));
+        await settleFrames(tester, 18);
+      case _SyncSurface.paired:
+        await openBundleImport(tester, confirm: true);
+        await settleFrames(tester, 18);
       case _SyncSurface.status:
-        await tester.tap(find.byType(ProvisionedSyncSettingsCard));
-        await settleFrames(tester, 18);
+        // A configured account renders the roster inline on the page; there is
+        // no settings card left to tap since the add-device redesign.
+        await settleFrames(tester, 8);
       case _SyncSurface.verification:
-        await tester.tap(find.byType(ProvisionedSyncSettingsCard));
-        await settleFrames(tester, 18);
+        // Same inline roster, and the embedded AutoVerificationLauncher opens
+        // the ceremony on its own once a device is unverified.
+        await settleFrames(tester, 8);
         expect(find.byType(VerificationModal), findsOneWidget);
         verificationStream.add(verificationRunner);
         await settleFrames(tester, 10);
@@ -773,8 +916,32 @@ void main() {
         expect(find.text(messages.provisionedSyncTitle), findsWidgets);
         expect(find.text(messages.settingsMaintenanceTitle), findsWidgets);
       case _SyncSurface.provisioned:
-        expect(find.text(_provisioningBundle.homeServer), findsOneWidget);
+        // The check code leads the review because it is the only value a
+        // person can compare against the inviting device; the server is shown
+        // as a host rather than a full URL.
+        expect(
+          find.byKey(const Key('bundle_import_check_code')),
+          findsOneWidget,
+        );
         expect(find.text(_provisioningBundle.user), findsOneWidget);
+        expect(
+          find.text(Uri.parse(_provisioningBundle.homeServer).host),
+          findsOneWidget,
+        );
+      case _SyncSurface.addDevice:
+        // The pairing check code is the point of the sheet: both devices
+        // derive it independently and it must be compared before connecting.
+        expect(find.byType(PairingCheckCodeView), findsOneWidget);
+        expect(find.text(messages.syncAddDeviceIntro), findsWidgets);
+      case _SyncSurface.paired:
+        // The quiet "connected" line plus the card that says what is still
+        // outstanding — the point of the screen is the second half.
+        // The quiet "connected" line plus the card that says what is still
+        // outstanding — the point of the screen is the second half.
+        // The quiet "connected" line plus the card that says what is still
+        // outstanding — the point of the screen is the second half.
+        expect(find.text(messages.provisionedSyncDone), findsOneWidget);
+        expect(find.byType(SyncFlowSection), findsWidgets);
       case _SyncSurface.status:
         expect(find.byType(ProvisionedStatusWidget), findsOneWidget);
         expect(
@@ -872,7 +1039,8 @@ void main() {
 
       final configured =
           surface == _SyncSurface.status ||
-          surface == _SyncSurface.verification;
+          surface == _SyncSurface.verification ||
+          surface == _SyncSurface.addDevice;
       when(matrixService.isLoggedIn).thenReturn(configured);
       when(
         () => matrixService.syncRoomId,

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -33,6 +33,7 @@ import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/agents/state/ritual_review_providers.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/settings_root_page.dart';
 import 'package:lotti/features/settings_v2/ui/mobile/settings_mobile_branch_page.dart';
 import 'package:lotti/features/sync/matrix.dart';
@@ -439,6 +440,46 @@ class _ManualProvisioningController extends ProvisioningController {
   }
 }
 
+/// The viewfinder as the manual should depict it: a framed target area, not
+/// the black rectangle a camera-less capture would otherwise produce.
+class _ViewfinderStandIn extends StatelessWidget {
+  const _ViewfinderStandIn({required this.side});
+
+  final double side;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tokens.colors.background.level02,
+        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+      ),
+      child: Center(
+        child: SizedBox.square(
+          dimension: side * 0.6,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: tokens.colors.text.mediumEmphasis,
+                width: tokens.spacing.step1,
+              ),
+              borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+            ),
+            child: Center(
+              child: Icon(
+                Icons.qr_code_2_rounded,
+                size: side * 0.3,
+                color: tokens.colors.text.lowEmphasis,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _ManualSyncDevicesController extends SyncDevicesController {
   _ManualSyncDevicesController(this.devices);
 
@@ -750,10 +791,15 @@ void main() {
       ..registerSingleton<NavService>(navService);
 
     beamToNamedOverride = (_) {};
+    // A capture has no camera plugin, so the real scanner is a black square
+    // and a stream of MissingPluginExceptions. This stands in for the
+    // viewfinder and makes the scanning step legible in the manual.
+    scannerPreviewOverride = (context, side) => _ViewfinderStandIn(side: side);
   });
 
   tearDown(() async {
     beamToNamedOverride = null;
+    scannerPreviewOverride = null;
     await verificationStream.close();
     await navService.dispose();
     await tearDownTestGetIt();


### PR DESCRIPTION
## The manual described a flow that no longer exists

`sync.mdx` still told people to open **Settings → Sync → Provisioned Sync** (the
node is **Devices** now), said only a desktop could show the handover QR code
(any paired device can), and never mentioned the pairing check code — the one
thing the flow asks the user to actually verify.

## And its screenshots could not be regenerated

**Twelve of the 48 sync captures fail on `main`** — every `provisioned`,
`status` and `verification` variant, both viewports, both themes. I confirmed
this by stashing my changes and running against a clean tree. Two causes, both
fallout from the add-device redesign:

- `status` and `verification` tap a `ProvisionedSyncSettingsCard` that no longer
  exists on the configured path — the roster renders inline now. The fix is to
  stop tapping anything; `verification` just waits for the embedded
  `AutoVerificationLauncher`.
- `provisioned` broke twice: the paste field now sits behind *enter manually*
  because the import page is camera-first, and the decoded review shows the
  homeserver as a bare host rather than a full URL. Its assertion now targets
  the check code, which is the point of that screen.

CI never caught this — `sync_manual_screenshots_test.dart` is opt-in via
`LOTTI_SCREENSHOT_DIR` and runs only in `manual.yml`, not the sharded suite.

**54 of 56 pass now**, including two new surfaces.

## A page of its own

The flow spans two devices and four surfaces, which is more than a section of an
already long page carries, so it becomes `sync-and-data/add-device.mdx`, first in
the Sync & data sidebar since pairing precedes everything else there. The old
section becomes a pointer.

A new **See your devices** section takes over `sync/status`, which the rewrite
would otherwise have orphaned — the validator catches exactly that.

All ten translated locales updated: the new page and the `sync.mdx` edits.
Informal register throughout, formal for Romanian per the localization
convention.

## Two things to look at

1. **`sync/paired` on mobile is still red.** `MobileScannerController` used after
   dispose on the real connect path — filed as `lotti3-82s` (P1). I did not work
   around it in the harness: desktop passes precisely because there is no scanner
   there, so this looks like a genuine defect on the path a phone takes when
   pairing for the first time. Happy to hold this PR until that lands if you'd
   rather not merge with a known-red capture.
2. **The translations are mine.** Ten locales of user-facing prose, written by me
   rather than a translator. Worth a look from someone who reads them before this
   ships.

## Checks

- `node docs-site/scripts/validate-manual.mjs` — passes: 37 features, 41 source
  pages across 11 locales, 135 screenshot cases.
- `fvm flutter analyze` — no issues found.
- Capture suite: 54/56 (was 36/48 on `main`).

No CHANGELOG entry — documentation only, no runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Add device” Sync guide (QR/manual pairing, security-code comparison, emoji verification, settings transfer, and troubleshooting for the “empty until verified” state).
  * Added localized translations and onboarding screenshot coverage for the new flow.
* **Documentation**
  * Updated the main Sync guide with a “See your devices” section and refreshed device pairing instructions.
* **Bug Fixes**
  * Improved camera-scanner startup/teardown handling for more reliable scanning.
* **Tests**
  * Expanded Sync screenshot harness and added widget tests for scanner lifecycle and the built-docs translation audit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->