### PR TITLE
test: cover media sync across device sandboxes

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -48,8 +48,10 @@ import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
+import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/file_utils.dart';
+import 'package:lotti/utils/image_utils.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
@@ -1701,8 +1703,8 @@ Metadata _nextMediaMetadata({
 
 String _relativeMediaPath(JournalEntity entity) {
   return switch (entity) {
-    JournalImage(:final data) => '${data.imageDirectory}${data.imageFile}',
-    JournalAudio(:final data) => '${data.audioDirectory}${data.audioFile}',
+    JournalImage() => getRelativeImagePath(entity),
+    JournalAudio() => AudioUtils.getRelativeAudioPath(entity),
     _ => throw ArgumentError.value(
       entity,
       'entity',

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -55,6 +56,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:uuid/uuid.dart';
 
 import '../test/mocks/mocks.dart';
+import '../test/test_resources/test_audio_data.dart';
 import '../test/utils/utils.dart';
 
 const _uuid = Uuid();
@@ -114,6 +116,7 @@ class _DeviceOutbox {
     required this.sender,
     required this.journalDb,
     required this.syncDb,
+    required this.documentsDirectory,
     required this.deviceName,
   });
 
@@ -121,6 +124,7 @@ class _DeviceOutbox {
   final _ObservedOutboxMessageSender sender;
   final JournalDb journalDb;
   final SyncDatabase syncDb;
+  final Directory documentsDirectory;
   final String deviceName;
   int nextCounter = 1;
 
@@ -159,6 +163,7 @@ class _DeviceOutbox {
       sender: sender,
       journalDb: journalDb,
       syncDb: syncDb,
+      documentsDirectory: documentsDirectory,
       deviceName: deviceName,
     );
   }
@@ -225,6 +230,12 @@ Future<MatrixService> _createMatrixService({
       SavedTaskFiltersPersistence(settingsDb),
       updateNotifications,
     ),
+    journalEntityLoader: SmartJournalEntityLoader(
+      attachmentIndex: sharedAttachmentIndex,
+      loggingService: loggingService,
+      documentsDirectory: documentsDirectory,
+    ),
+    documentsDirectory: documentsDirectory,
     attachmentIndex: sharedAttachmentIndex,
     sequenceLogService: sequenceLogService,
     journalDb: journalDb,
@@ -447,7 +458,9 @@ void main() {
     final mockUpdateNotifications = MockUpdateNotifications();
     late LoggingService sharedLoggingService;
     late UserActivityService sharedUserActivityService;
-    late Directory sharedDocumentsDirectory;
+    late Directory harnessDocumentsRoot;
+    late Directory aliceDocumentsDirectory;
+    late Directory bobDocumentsDirectory;
     late AiConfigRepository sharedAiConfigRepository;
 
     when(() => mockUpdateNotifications.updateStream).thenAnswer(
@@ -554,7 +567,13 @@ void main() {
         'lotti_matrix_${_uuid.v1()}_',
       );
       debugPrint('Created temporary docDir ${docDir.path}');
-      sharedDocumentsDirectory = docDir;
+      harnessDocumentsRoot = docDir;
+      aliceDocumentsDirectory = await Directory(
+        '${docDir.path}/alice',
+      ).create();
+      bobDocumentsDirectory = await Directory(
+        '${docDir.path}/bob',
+      ).create();
 
       aiConfigDb = AiConfigDb(inMemoryDatabase: true);
       sharedAiConfigRepository = AiConfigRepository(aiConfigDb);
@@ -564,7 +583,7 @@ void main() {
 
       // Register essential dependencies
       getIt
-        ..registerSingleton<Directory>(sharedDocumentsDirectory)
+        ..registerSingleton<Directory>(harnessDocumentsRoot)
         ..registerSingleton<LoggingService>(sharedLoggingService)
         ..registerSingleton<DomainLogger>(
           _EchoDomainLogger(loggingService: sharedLoggingService),
@@ -616,6 +635,11 @@ void main() {
       } catch (e) {
         debugPrint('Error during database cleanup: $e');
       }
+      try {
+        await harnessDocumentsRoot.delete(recursive: true);
+      } catch (e) {
+        debugPrint('Error deleting temporary documents: $e');
+      }
     });
 
     tearDown(() async {
@@ -638,7 +662,7 @@ void main() {
         ]);
 
         final aliceClient = await createMatrixClient(
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: aliceDocumentsDirectory,
           dbName: 'AliceV2',
         );
         final aliceRegistry = SentEventRegistry();
@@ -657,7 +681,7 @@ void main() {
           secureStorage: secureStorageMock,
           deviceName: 'AliceV2',
           activityService: sharedUserActivityService,
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: aliceDocumentsDirectory,
           updateNotifications: mockUpdateNotifications,
           aiConfigRepository: sharedAiConfigRepository,
           sentEventRegistry: aliceRegistry,
@@ -689,7 +713,7 @@ void main() {
 
         debugPrint('\n--- Bob goes live');
         bob = await _createBobService(
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: bobDocumentsDirectory,
           config: config2,
           loggingService: getIt<DomainLogger>(),
           journalDb: bobDb,
@@ -732,7 +756,7 @@ void main() {
           matrixService: alice,
           journalDb: aliceDb,
           syncDb: aliceSyncDb,
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: aliceDocumentsDirectory,
           userActivityService: sharedUserActivityService,
           loggingService: getIt<DomainLogger>(),
           vectorClockService: aliceVectorClockService,
@@ -743,7 +767,7 @@ void main() {
           matrixService: bob,
           journalDb: bobDb,
           syncDb: bobSyncDb,
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: bobDocumentsDirectory,
           userActivityService: sharedUserActivityService,
           loggingService: getIt<DomainLogger>(),
           vectorClockService: bobVectorClockService,
@@ -835,6 +859,93 @@ void main() {
     );
 
     test(
+      'Image sync transfers metadata and exact file bytes to Bob',
+      () async {
+        const mediaTimeout = Duration(minutes: 3);
+        final id = const Uuid().v1();
+        final timestamp = DateTime.utc(2025, 2, 1, 12);
+        final image = JournalImage(
+          meta: _nextMediaMetadata(
+            device: aliceOutbox,
+            id: id,
+            timestamp: timestamp,
+          ),
+          data: ImageData(
+            capturedAt: timestamp,
+            imageId: id,
+            imageFile: '$id.png',
+            imageDirectory: '/images/2025-02-01/',
+          ),
+          entryText: const EntryText(plainText: 'Matrix image fixture'),
+        );
+        final bytes = base64Decode(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
+          'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+        );
+
+        final received = await _sendMediaEntity(
+          entity: image,
+          bytes: bytes,
+          sender: aliceOutbox,
+          receiver: bobOutbox,
+          receiverService: bob,
+          timeout: mediaTimeout,
+        );
+
+        expect(received, isA<JournalImage>());
+        final receivedImage = received as JournalImage;
+        expect(receivedImage.meta, image.meta);
+        expect(receivedImage.data, image.data);
+        expect(receivedImage.entryText, image.entryText);
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+      skip: skipReason ?? false,
+    );
+
+    test(
+      'Audio sync transfers metadata and exact file bytes to Alice',
+      () async {
+        const mediaTimeout = Duration(minutes: 3);
+        final id = const Uuid().v1();
+        final timestamp = DateTime.utc(2025, 2, 1, 13);
+        final audio = JournalAudio(
+          meta: _nextMediaMetadata(
+            device: bobOutbox,
+            id: id,
+            timestamp: timestamp,
+          ),
+          data: AudioData(
+            dateFrom: timestamp,
+            dateTo: timestamp.add(const Duration(seconds: 1)),
+            audioFile: '$id.wav',
+            audioDirectory: '/audio/2025-02-01/',
+            duration: const Duration(seconds: 1),
+            language: 'en',
+          ),
+          entryText: const EntryText(plainText: 'Matrix audio fixture'),
+        );
+        final bytes = base64Decode(TestAudioData.shortSilenceWav);
+
+        final received = await _sendMediaEntity(
+          entity: audio,
+          bytes: bytes,
+          sender: bobOutbox,
+          receiver: aliceOutbox,
+          receiverService: alice,
+          timeout: mediaTimeout,
+        );
+
+        expect(received, isA<JournalAudio>());
+        final receivedAudio = received as JournalAudio;
+        expect(receivedAudio.meta, audio.meta);
+        expect(receivedAudio.data, audio.data);
+        expect(receivedAudio.entryText, audio.entryText);
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+      skip: skipReason ?? false,
+    );
+
+    test(
       'Late Megolm key survives Bob restart and clears the durable floor',
       () async {
         const lateKeyTimeout = Duration(minutes: 3);
@@ -889,7 +1000,7 @@ void main() {
           expect(persistedMarker.resumeFloorTs, floorBeforeRestart);
 
           bob = await _createBobService(
-            documentsDirectory: sharedDocumentsDirectory,
+            documentsDirectory: bobDocumentsDirectory,
             config: config2,
             loggingService: getIt<DomainLogger>(),
             journalDb: bobDb,
@@ -988,7 +1099,7 @@ void main() {
             matrixService: bob,
             journalDb: bobDb,
             syncDb: bobSyncDb,
-            documentsDirectory: sharedDocumentsDirectory,
+            documentsDirectory: bobDocumentsDirectory,
             userActivityService: sharedUserActivityService,
             loggingService: getIt<DomainLogger>(),
             vectorClockService: bobVectorClockService,
@@ -1086,7 +1197,7 @@ void main() {
         // Use singleInstance: false to avoid sqflite connection-cache
         // contention with the disposed first client's cached handle.
         bob = await _createBobService(
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: bobDocumentsDirectory,
           config: config2,
           loggingService: getIt<DomainLogger>(),
           journalDb: bobDb,
@@ -1358,7 +1469,7 @@ void main() {
         debugPrint('\n--- Phase 4: Bob cold-starts mid-burst');
         final catchupStopwatch = Stopwatch()..start();
         bob = await _createBobService(
-          documentsDirectory: sharedDocumentsDirectory,
+          documentsDirectory: bobDocumentsDirectory,
           config: config2,
           loggingService: getIt<DomainLogger>(),
           journalDb: bobDb,
@@ -1571,6 +1682,146 @@ Future<void> _setMatrixSyncEnabled(JournalDb db, {required bool enabled}) {
   );
 }
 
+Metadata _nextMediaMetadata({
+  required _DeviceOutbox device,
+  required String id,
+  required DateTime timestamp,
+}) {
+  final counter = device.nextCounter++;
+  return Metadata(
+    id: id,
+    createdAt: timestamp,
+    dateFrom: timestamp,
+    dateTo: timestamp,
+    updatedAt: timestamp,
+    starred: true,
+    vectorClock: VectorClock({device.deviceName: counter}),
+  );
+}
+
+String _relativeMediaPath(JournalEntity entity) {
+  return switch (entity) {
+    JournalImage(:final data) => '${data.imageDirectory}${data.imageFile}',
+    JournalAudio(:final data) => '${data.audioDirectory}${data.audioFile}',
+    _ => throw ArgumentError.value(
+      entity,
+      'entity',
+      'Expected JournalImage or JournalAudio',
+    ),
+  };
+}
+
+File _mediaFileFor(_DeviceOutbox device, JournalEntity entity) {
+  return File('${device.documentsDirectory.path}${_relativeMediaPath(entity)}');
+}
+
+Future<JournalEntity> _sendMediaEntity({
+  required JournalEntity entity,
+  required List<int> bytes,
+  required _DeviceOutbox sender,
+  required _DeviceOutbox receiver,
+  required MatrixService receiverService,
+  required Duration timeout,
+}) async {
+  final sourceFile = _mediaFileFor(sender, entity);
+  final receiverFile = _mediaFileFor(receiver, entity);
+  expect(
+    sourceFile.absolute.path,
+    isNot(receiverFile.absolute.path),
+    reason: 'simulated devices must use independent app sandboxes',
+  );
+  expect(
+    receiverFile.existsSync(),
+    isFalse,
+    reason: 'the receiver must not start with the sender media file',
+  );
+
+  await _setMatrixSyncEnabled(sender.journalDb, enabled: false);
+  try {
+    final actionableBefore = await sender.syncDb.getOutboxItems(
+      limit: 2,
+      statuses: const [
+        OutboxStatus.pending,
+        OutboxStatus.sending,
+        OutboxStatus.error,
+      ],
+    );
+    expect(
+      actionableBefore,
+      isEmpty,
+      reason: '${sender.deviceName} outbox must start drained',
+    );
+
+    await sourceFile.parent.create(recursive: true);
+    await sourceFile.writeAsBytes(bytes, flush: true);
+    await saveJournalEntityJson(
+      entity,
+      documentsDirectory: sender.documentsDirectory,
+    );
+    await sender.journalDb.updateJournalEntity(entity);
+    await sender.service.enqueueMessage(
+      SyncMessage.journalEntity(
+        id: entity.meta.id,
+        status: SyncEntryStatus.initial,
+        vectorClock: entity.meta.vectorClock,
+        jsonPath: relativeEntityPath(entity),
+        originatingHostId: sender.deviceName,
+      ),
+    );
+
+    final pending = await sender.syncDb.getOutboxItems(
+      limit: 2,
+      statuses: const [OutboxStatus.pending],
+    );
+    expect(pending, hasLength(1));
+    expect(
+      pending.single.filePath,
+      isNotNull,
+      reason: 'production outbox must classify media as an attachment row',
+    );
+  } finally {
+    await _setMatrixSyncEnabled(sender.journalDb, enabled: true);
+  }
+
+  final sentEventsBefore = sender.sender.sentEvents;
+  final sentEntriesBefore = sender.sender.sentEntries;
+  final bundleCountBefore = sender.sender.bundleSizes.length;
+  await sender.service.enqueueNextSendRequest(delay: Duration.zero);
+  await _waitForOutboxDrain(sender, timeout: timeout);
+
+  expect(sender.sender.sentEvents - sentEventsBefore, 1);
+  expect(sender.sender.sentEntries - sentEntriesBefore, 1);
+  expect(
+    sender.sender.bundleSizes.sublist(bundleCountBefore),
+    [1],
+    reason: 'media rows must travel alone rather than in an outbox bundle',
+  );
+
+  JournalEntity? received;
+  await waitUntilAsync(
+    () async {
+      received = await receiver.journalDb.journalEntityById(entity.meta.id);
+      if (received != null &&
+          receiverFile.existsSync() &&
+          receiverFile.lengthSync() == bytes.length) {
+        return true;
+      }
+      await receiverService.forceRescan();
+      await receiverService.retryNow();
+      return false;
+    },
+    timeout: timeout,
+  );
+
+  expect(received, isNotNull);
+  expect(
+    await receiverFile.readAsBytes(),
+    orderedEquals(bytes),
+    reason: 'Matrix must transfer the exact media payload between sandboxes',
+  );
+  return received!;
+}
+
 Future<void> _stageTestMessages(int n, {required _DeviceOutbox device}) async {
   await _setMatrixSyncEnabled(device.journalDb, enabled: false);
 
@@ -1615,7 +1866,10 @@ Future<void> _stageTestMessages(int n, {required _DeviceOutbox device}) async {
 
     final jsonPath = relativeEntityPath(entity);
 
-    await saveJournalEntityJson(entity);
+    await saveJournalEntityJson(
+      entity,
+      documentsDirectory: device.documentsDirectory,
+    );
     await device.journalDb.updateJournalEntity(entity);
     await device.service.enqueueMessage(
       SyncMessage.journalEntity(

--- a/lib/features/sync/matrix/smart_journal_entity_loader.dart
+++ b/lib/features/sync/matrix/smart_journal_entity_loader.dart
@@ -25,10 +25,9 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
   SmartJournalEntityLoader({
     required this._attachmentIndex,
     required DomainLogger loggingService,
-    Directory? documentsDirectory,
+    this.documentsDirectory,
     void Function()? onCachePurge,
   }) : _logging = loggingService,
-       _documentsDirectory = documentsDirectory,
        _fileLoader = FileSyncJournalEntityLoader(
          documentsDirectory: documentsDirectory,
        ) {
@@ -44,7 +43,8 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
 
   final AttachmentIndex _attachmentIndex;
   final DomainLogger _logging;
-  final Directory? _documentsDirectory;
+  @override
+  final Directory? documentsDirectory;
   final FileSyncJournalEntityLoader _fileLoader;
   late final VectorClockValidator _vectorClockValidator;
   late final DescriptorDownloader _descriptorDownloader;
@@ -298,7 +298,7 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
   }
 
   File _resolveCandidateFile(String relativePath) {
-    final documentsDirectory = _documentsDirectory;
+    final documentsDirectory = this.documentsDirectory;
     return documentsDirectory == null
         ? resolveJsonCandidateFile(relativePath)
         : resolveJsonCandidateFileInDirectory(

--- a/lib/features/sync/matrix/smart_journal_entity_loader.dart
+++ b/lib/features/sync/matrix/smart_journal_entity_loader.dart
@@ -25,8 +25,13 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
   SmartJournalEntityLoader({
     required this._attachmentIndex,
     required DomainLogger loggingService,
+    Directory? documentsDirectory,
     void Function()? onCachePurge,
-  }) : _logging = loggingService {
+  }) : _logging = loggingService,
+       _documentsDirectory = documentsDirectory,
+       _fileLoader = FileSyncJournalEntityLoader(
+         documentsDirectory: documentsDirectory,
+       ) {
     _vectorClockValidator = VectorClockValidator(
       loggingService: loggingService,
     );
@@ -39,6 +44,8 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
 
   final AttachmentIndex _attachmentIndex;
   final DomainLogger _logging;
+  final Directory? _documentsDirectory;
+  final FileSyncJournalEntityLoader _fileLoader;
   late final VectorClockValidator _vectorClockValidator;
   late final DescriptorDownloader _descriptorDownloader;
 
@@ -57,7 +64,7 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
     required String jsonPath,
     VectorClock? incomingVectorClock,
   }) async {
-    final targetFile = resolveJsonCandidateFile(jsonPath);
+    final targetFile = _resolveCandidateFile(jsonPath);
     // Build a canonical index key once and reuse it to avoid inconsistencies
     // across platforms (Windows vs. POSIX). The key always uses forward slashes
     // and has a single leading '/'. Any leading '/' or '\\' characters are trimmed.
@@ -65,7 +72,7 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
     // If we have an incoming vector clock, decide whether a fetch is needed.
     if (incomingVectorClock != null) {
       try {
-        final local = await const FileSyncJournalEntityLoader().load(
+        final local = await _fileLoader.load(
           jsonPath: jsonPath,
         );
         final localVc = local.meta.vectorClock;
@@ -190,7 +197,7 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
     }
 
     // Read and return the entity from disk (either pre-existing or freshly written).
-    final entity = await const FileSyncJournalEntityLoader().load(
+    final entity = await _fileLoader.load(
       jsonPath: jsonPath,
     );
 
@@ -223,7 +230,7 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
   }) async {
     final rp = relativePath;
     // Centralized resolution + sandbox enforcement (rejects path traversal).
-    final f = resolveJsonCandidateFile(rp);
+    final f = _resolveCandidateFile(rp);
     final fp = f.path;
     try {
       if (f.existsSync()) {
@@ -288,6 +295,16 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
       );
       _onMissingDescriptorPath?.call(descriptorKey);
     }
+  }
+
+  File _resolveCandidateFile(String relativePath) {
+    final documentsDirectory = _documentsDirectory;
+    return documentsDirectory == null
+        ? resolveJsonCandidateFile(relativePath)
+        : resolveJsonCandidateFileInDirectory(
+            relativePath,
+            documentsDirectory,
+          );
   }
 
   Future<bool> _maybePurgeCachedAttachment(Event event, String path) async {

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -109,7 +109,8 @@ class SyncEventProcessor {
     this._notificationsDb,
     this._notificationScheduler,
     this._syncNodeProfileRepository,
-  }) : _documentsDirectory = documentsDirectory,
+  }) : _documentsDirectory =
+           journalEntityLoader?.documentsDirectory ?? documentsDirectory,
        _journalEntityLoader =
            journalEntityLoader ??
            FileSyncJournalEntityLoader(

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -101,6 +101,7 @@ class SyncEventProcessor {
     required this._settingsDb,
     this._domainLogger,
     SyncJournalEntityLoader? journalEntityLoader,
+    Directory? documentsDirectory,
     this._sequenceLogService,
     this._attachmentIndex,
     this._journalDb,
@@ -108,8 +109,12 @@ class SyncEventProcessor {
     this._notificationsDb,
     this._notificationScheduler,
     this._syncNodeProfileRepository,
-  }) : _journalEntityLoader =
-           journalEntityLoader ?? const FileSyncJournalEntityLoader();
+  }) : _documentsDirectory = documentsDirectory,
+       _journalEntityLoader =
+           journalEntityLoader ??
+           FileSyncJournalEntityLoader(
+             documentsDirectory: documentsDirectory,
+           );
 
   final DomainLogger _loggingService;
   final DomainLogger? _domainLogger;
@@ -117,6 +122,7 @@ class SyncEventProcessor {
   final AiConfigRepository _aiConfigRepository;
   final SavedTaskFiltersRepository _savedTaskFiltersRepository;
   final SettingsDb _settingsDb;
+  final Directory? _documentsDirectory;
   final SyncJournalEntityLoader _journalEntityLoader;
   final SyncSequenceLogService? _sequenceLogService;
   final AttachmentIndex? _attachmentIndex;
@@ -158,6 +164,16 @@ class SyncEventProcessor {
   // path still gets its own fetch.
   final Map<String, Future<String?>> _inFlightDescriptorFetches =
       <String, Future<String?>>{};
+
+  File _resolveJsonCandidateFile(String jsonPath) {
+    final documentsDirectory = _documentsDirectory;
+    return documentsDirectory == null
+        ? resolveJsonCandidateFile(jsonPath)
+        : resolveJsonCandidateFileInDirectory(
+            jsonPath,
+            documentsDirectory,
+          );
+  }
 
   /// Backfill response handler. Set exactly once during DI boot via the
   /// public setter (declared `late final` so reads before assignment throw

--- a/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
+++ b/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
@@ -70,7 +70,7 @@ extension _AgentHandlers on SyncEventProcessor {
     // This is a permanent error (malformed jsonPath), so catch and skip.
     final File file;
     try {
-      file = resolveJsonCandidateFile(jp);
+      file = _resolveJsonCandidateFile(jp);
     } on FileSystemException catch (e, st) {
       _loggingService.error(
         LogDomain.sync,
@@ -575,7 +575,7 @@ extension _AgentHandlers on SyncEventProcessor {
   }) async {
     if (jsonPath == null) return;
     try {
-      final file = resolveJsonCandidateFile(jsonPath);
+      final file = _resolveJsonCandidateFile(jsonPath);
       await saveJson(file.path, jsonString);
     } on FileSystemException catch (e, st) {
       _loggingService.error(

--- a/lib/features/sync/matrix/sync_event_processor_outbox_bundle.dart
+++ b/lib/features/sync/matrix/sync_event_processor_outbox_bundle.dart
@@ -55,7 +55,7 @@ extension _OutboxBundleHandler on SyncEventProcessor {
 
     final File targetFile;
     try {
-      targetFile = resolveJsonCandidateFile(jp);
+      targetFile = _resolveJsonCandidateFile(jp);
     } on FileSystemException catch (e, st) {
       _loggingService.error(
         LogDomain.sync,
@@ -252,7 +252,7 @@ extension _OutboxBundleHandler on SyncEventProcessor {
 
         final File entityFile;
         try {
-          entityFile = resolveJsonCandidateFile(envelope.jsonPath);
+          entityFile = _resolveJsonCandidateFile(envelope.jsonPath);
         } on FileSystemException catch (e, st) {
           _loggingService.error(
             LogDomain.sync,

--- a/lib/features/sync/matrix/sync_journal_entity_loader.dart
+++ b/lib/features/sync/matrix/sync_journal_entity_loader.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: one_member_abstracts
-
 import 'dart:convert';
 import 'dart:io';
 
@@ -10,6 +8,8 @@ import 'package:lotti/utils/file_utils.dart';
 /// Abstraction for loading journal entities and related attachments when
 /// processing sync messages.
 abstract class SyncJournalEntityLoader {
+  Directory? get documentsDirectory;
+
   Future<JournalEntity> load({
     required String jsonPath,
     VectorClock? incomingVectorClock,
@@ -20,6 +20,7 @@ abstract class SyncJournalEntityLoader {
 class FileSyncJournalEntityLoader implements SyncJournalEntityLoader {
   const FileSyncJournalEntityLoader({this.documentsDirectory});
 
+  @override
   final Directory? documentsDirectory;
 
   @override

--- a/lib/features/sync/matrix/sync_journal_entity_loader.dart
+++ b/lib/features/sync/matrix/sync_journal_entity_loader.dart
@@ -1,9 +1,11 @@
 // ignore_for_file: one_member_abstracts
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/utils/file_utils.dart';
-import 'package:path/path.dart' as path;
 
 /// Abstraction for loading journal entities and related attachments when
 /// processing sync messages.
@@ -16,16 +18,24 @@ abstract class SyncJournalEntityLoader {
 
 /// Loads journal entities from the documents directory on disk.
 class FileSyncJournalEntityLoader implements SyncJournalEntityLoader {
-  const FileSyncJournalEntityLoader();
+  const FileSyncJournalEntityLoader({this.documentsDirectory});
+
+  final Directory? documentsDirectory;
 
   @override
   Future<JournalEntity> load({
     required String jsonPath,
     VectorClock? incomingVectorClock,
   }) async {
-    final candidateFile = resolveJsonCandidateFile(jsonPath);
-    final docPath = path.normalize(getDocumentsDirectory().path);
-    final jsonRelative = path.relative(candidateFile.path, from: docPath);
-    return readEntityFromJson(jsonRelative);
+    final documentsDirectory =
+        this.documentsDirectory ?? getDocumentsDirectory();
+    final candidateFile = resolveJsonCandidateFileInDirectory(
+      jsonPath,
+      documentsDirectory,
+    );
+    final jsonString = await candidateFile.readAsString();
+    return JournalEntity.fromJson(
+      jsonDecode(jsonString) as Map<String, dynamic>,
+    );
   }
 }

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -92,13 +92,27 @@ Future<void> saveJournalEntityJson(
 /// normalized candidate path or throws [FileSystemException] if the resolved
 /// path is outside the documents directory.
 File resolveJsonCandidateFile(String jsonPath) {
-  final docDir = getDocumentsDirectory();
+  return resolveJsonCandidateFileInDirectory(
+    jsonPath,
+    getDocumentsDirectory(),
+  );
+}
+
+/// Resolves [jsonPath] against an explicit [documentsDirectory].
+///
+/// Production callers normally use [resolveJsonCandidateFile]. The explicit
+/// variant supports multi-sandbox integration harnesses while preserving the
+/// same traversal guard.
+File resolveJsonCandidateFileInDirectory(
+  String jsonPath,
+  Directory documentsDirectory,
+) {
   final normalized = normalize(jsonPath);
   final relative = normalized.startsWith(separator)
       ? normalized.substring(1)
       : normalized;
-  final candidate = normalize(join(docDir.path, relative));
-  final docPath = normalize(docDir.path);
+  final candidate = normalize(join(documentsDirectory.path, relative));
+  final docPath = normalize(documentsDirectory.path);
   if (!isWithin(docPath, candidate) && docPath != candidate) {
     throw FileSystemException(
       'jsonPath resolves outside documents directory',

--- a/test/features/sync/matrix/smart_journal_entity_loader_test.dart
+++ b/test/features/sync/matrix/smart_journal_entity_loader_test.dart
@@ -80,6 +80,9 @@ void main() {
       'fetches JSON when no VC and file missing via AttachmentIndex',
       () async {
         const relJson = '/text_entries/2024-01-01/abc.text.json';
+        final explicitDir = Directory(
+          path.join(rootTempDir.path, 'explicit_$caseIndex'),
+        )..createSync();
         final index = AttachmentIndex();
         final ev = MockEvent();
         when(() => ev.attachmentMimetype).thenReturn('application/json');
@@ -106,6 +109,7 @@ void main() {
         final loader = SmartJournalEntityLoader(
           attachmentIndex: index,
           loggingService: loggingService,
+          documentsDirectory: explicitDir,
         );
 
         final loaded = await loader.load(jsonPath: relJson);
@@ -117,11 +121,14 @@ void main() {
           'hello',
         );
 
-        final docDir = getIt<Directory>().path;
         final normalized = stripLeadingSlashes(relJson);
-        final f = File(path.join(docDir, normalized));
+        final f = File(path.join(explicitDir.path, normalized));
         expect(f.existsSync(), isTrue);
         expect(f.lengthSync(), greaterThan(0));
+        expect(
+          File(path.join(getIt<Directory>().path, normalized)).existsSync(),
+          isFalse,
+        );
       },
     );
 

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -2525,6 +2525,22 @@ void main() {
     group('descriptor-only resolution (jsonPath)', () {
       late Directory tempDir;
 
+      SyncEventProcessor processorForExplicitDirectory(
+        Directory explicitDirectory,
+      ) {
+        return SyncEventProcessor(
+          loggingService: loggingService,
+          updateNotifications: updateNotifications,
+          aiConfigRepository: aiConfigRepository,
+          savedTaskFiltersRepository: savedTaskFiltersRepository,
+          settingsDb: settingsDb,
+          journalEntityLoader: FileSyncJournalEntityLoader(
+            documentsDirectory: explicitDirectory,
+          ),
+          documentsDirectory: tempDir,
+        )..agentRepository = mockAgentRepo;
+      }
+
       setUp(() {
         tempDir = Directory.systemTemp.createTempSync(
           'agent_resolve_test',
@@ -2576,6 +2592,56 @@ void main() {
       });
 
       test(
+        'derives the agent payload sandbox from the injected loader',
+        () async {
+          final explicitDirectory = await Directory(
+            path.join(tempDir.path, 'explicit-device'),
+          ).create();
+          final explicitProcessor = processorForExplicitDirectory(
+            explicitDirectory,
+          );
+          final entity = AgentDomainEntity.agent(
+            id: 'agent-explicit',
+            agentId: 'agent-explicit',
+            kind: 'task_agent',
+            displayName: 'Explicit Agent',
+            lifecycle: AgentLifecycle.active,
+            mode: AgentInteractionMode.autonomous,
+            allowedCategoryIds: const {},
+            currentStateId: 'state-1',
+            config: const AgentConfig(),
+            createdAt: DateTime(2024, 3, 15),
+            updatedAt: DateTime(2024, 3, 15),
+            vectorClock: null,
+          );
+          const relativePath = '/agent_entities/agent-explicit.json';
+          final explicitFile = File(
+            path.join(
+              explicitDirectory.path,
+              stripLeadingSlashes(relativePath),
+            ),
+          )..parent.createSync(recursive: true);
+          explicitFile.writeAsStringSync(jsonEncode(entity.toJson()));
+
+          const message = SyncMessage.agentEntity(
+            status: SyncEntryStatus.update,
+            jsonPath: relativePath,
+          );
+          when(() => event.text).thenReturn(encodeMessage(message));
+
+          await explicitProcessor.process(event: event, journalDb: journalDb);
+
+          verify(() => mockAgentRepo.upsertEntity(entity)).called(1);
+          expect(
+            File(
+              path.join(tempDir.path, stripLeadingSlashes(relativePath)),
+            ).existsSync(),
+            isFalse,
+          );
+        },
+      );
+
+      test(
         'keeps dominant local agent entity cache when jsonPath payload is stale',
         () async {
           const localVc = VectorClock({'host-A': 2});
@@ -2621,6 +2687,70 @@ void main() {
           expect(
             restored.mapOrNull(agentState: (entity) => entity.revision),
             2,
+          );
+        },
+      );
+
+      test(
+        'restores a dominant agent cache inside the injected loader sandbox',
+        () async {
+          final explicitDirectory = await Directory(
+            path.join(tempDir.path, 'explicit-restore-device'),
+          ).create();
+          final explicitProcessor = processorForExplicitDirectory(
+            explicitDirectory,
+          );
+          const localVc = VectorClock({'host-A': 2});
+          const incomingVc = VectorClock({'host-A': 1});
+          final local = AgentDomainEntity.agentState(
+            id: 'state-explicit-cache',
+            agentId: 'agent-1',
+            revision: 2,
+            slots: const AgentSlots(),
+            updatedAt: DateTime(2024, 3, 16),
+            vectorClock: localVc,
+          );
+          final stale = AgentDomainEntity.agentState(
+            id: 'state-explicit-cache',
+            agentId: 'agent-1',
+            revision: 1,
+            slots: const AgentSlots(),
+            updatedAt: DateTime(2024, 3, 15),
+            vectorClock: incomingVc,
+          );
+          when(
+            () => mockAgentRepo.getEntity('state-explicit-cache'),
+          ).thenAnswer((_) async => local);
+
+          const relativePath = '/agent_entities/state-explicit-cache.json';
+          final explicitFile = File(
+            path.join(
+              explicitDirectory.path,
+              stripLeadingSlashes(relativePath),
+            ),
+          )..parent.createSync(recursive: true);
+          explicitFile.writeAsStringSync(jsonEncode(stale.toJson()));
+          const message = SyncMessage.agentEntity(
+            status: SyncEntryStatus.update,
+            jsonPath: relativePath,
+          );
+          when(() => event.text).thenReturn(encodeMessage(message));
+
+          await explicitProcessor.process(event: event, journalDb: journalDb);
+
+          verifyNever(() => mockAgentRepo.upsertEntity(any()));
+          final restored = AgentDomainEntity.fromJson(
+            jsonDecode(explicitFile.readAsStringSync()) as Map<String, dynamic>,
+          );
+          expect(
+            restored.mapOrNull(agentState: (entity) => entity.revision),
+            2,
+          );
+          expect(
+            File(
+              path.join(tempDir.path, stripLeadingSlashes(relativePath)),
+            ).existsSync(),
+            isFalse,
           );
         },
       );

--- a/test/features/sync/matrix/sync_event_processor_outbox_bundle_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_outbox_bundle_test.dart
@@ -165,6 +165,76 @@ void main() {
       );
 
       test(
+        'uses the injected documents directory for the bundle and its '
+        'materialized journal payloads',
+        () async {
+          final explicitDirectory = await Directory(
+            path.join(tempDir.path, 'device'),
+          ).create();
+          final explicitProcessor = SyncEventProcessor(
+            loggingService: loggingService,
+            updateNotifications: updateNotifications,
+            aiConfigRepository: aiConfigRepository,
+            savedTaskFiltersRepository: savedTaskFiltersRepository,
+            settingsDb: settingsDb,
+            journalEntityLoader: journalEntityLoader,
+            documentsDirectory: explicitDirectory,
+          );
+          final entity = JournalEntry(
+            meta: Metadata(
+              id: 'isolated-entry',
+              createdAt: DateTime.utc(2026, 4, 25),
+              updatedAt: DateTime.utc(2026, 4, 25),
+              dateFrom: DateTime.utc(2026, 4, 25),
+              dateTo: DateTime.utc(2026, 4, 25),
+              vectorClock: const VectorClock({'isolated-host': 1}),
+            ),
+            entryText: const EntryText(plainText: 'isolated payload'),
+          );
+          const entityRelativePath =
+              '/journal/2026-04-25/isolated-entry.entry.json';
+          const bundleRelativePath = '/outbox_bundles/isolated-bundle.json';
+          final manifest = <String, dynamic>{
+            'version': 1,
+            'entries': [
+              <String, dynamic>{
+                'envelope': const SyncMessage.journalEntity(
+                  id: 'isolated-entry',
+                  jsonPath: entityRelativePath,
+                  vectorClock: VectorClock({'isolated-host': 1}),
+                  status: SyncEntryStatus.update,
+                ).toJson(),
+                'payload': entity.toJson(),
+              },
+            ],
+          };
+          final manifestFile = File(
+            path.join(
+              explicitDirectory.path,
+              stripLeadingSlashes(bundleRelativePath),
+            ),
+          )..parent.createSync(recursive: true);
+          manifestFile.writeAsStringSync(json.encode(manifest));
+
+          final resolved = await explicitProcessor
+              .resolveOutboxBundleManifestForTesting(bundleRelativePath);
+
+          expect(resolved?.children, hasLength(1));
+          final explicitPayload = File(
+            path.join(
+              explicitDirectory.path,
+              stripLeadingSlashes(entityRelativePath),
+            ),
+          );
+          final globalPayload = File(
+            path.join(tempDir.path, stripLeadingSlashes(entityRelativePath)),
+          );
+          expect(explicitPayload.existsSync(), isTrue);
+          expect(globalPayload.existsSync(), isFalse);
+        },
+      );
+
+      test(
         'returns null when the bundle jsonPath itself escapes the documents '
         'sandbox — resolveJsonCandidateFile throws FileSystemException for '
         'the bundle path and the resolver logs invalidPath then bails before '

--- a/test/features/sync/matrix/sync_journal_entity_loader_test.dart
+++ b/test/features/sync/matrix/sync_journal_entity_loader_test.dart
@@ -52,6 +52,29 @@ void main() {
       expect(entity.meta.id, fallbackJournalEntity.meta.id);
     });
 
+    test('loads from an explicit documents directory', () async {
+      final explicitDir = await Directory.systemTemp.createTemp(
+        'sync_loader_explicit',
+      );
+      addTearDown(() => explicitDir.delete(recursive: true));
+      final file = File(path.join(explicitDir.path, 'entity.json'));
+      await file.writeAsString(
+        jsonEncode(fallbackJournalEntity.toJson()),
+        flush: true,
+      );
+      final loader = FileSyncJournalEntityLoader(
+        documentsDirectory: explicitDir,
+      );
+
+      final entity = await loader.load(jsonPath: '/entity.json');
+
+      expect(entity.meta.id, fallbackJournalEntity.meta.id);
+      expect(
+        File(path.join(tempDir.path, 'entity.json')).existsSync(),
+        isFalse,
+      );
+    });
+
     test('rejects path traversal attempts', () async {
       // Create a file outside the documents directory to ensure it's not read.
       final externalDir = await Directory.systemTemp.createTemp(

--- a/test/utils/file_utils_test.dart
+++ b/test/utils/file_utils_test.dart
@@ -322,7 +322,9 @@ void main() {
     test(
       'resolveJsonCandidateFileInDirectory uses the explicit sandbox',
       () {
-        final explicitDir = Directory('${docDir.path}/explicit')..createSync();
+        final explicitDir = Directory(
+          '${docDir.path}/explicit',
+        )..createSync(recursive: true);
         final file = resolveJsonCandidateFileInDirectory(
           '/images/test.png',
           explicitDir,

--- a/test/utils/file_utils_test.dart
+++ b/test/utils/file_utils_test.dart
@@ -319,6 +319,26 @@ void main() {
       );
     });
 
+    test(
+      'resolveJsonCandidateFileInDirectory uses the explicit sandbox',
+      () {
+        final explicitDir = Directory('${docDir.path}/explicit')..createSync();
+        final file = resolveJsonCandidateFileInDirectory(
+          '/images/test.png',
+          explicitDir,
+        );
+
+        expect(file.path, '${explicitDir.path}/images/test.png');
+        expect(
+          () => resolveJsonCandidateFileInDirectory(
+            '../../../outside',
+            explicitDir,
+          ),
+          throwsA(isA<FileSystemException>()),
+        );
+      },
+    );
+
     // Properties: (a) any generated non-traversal relative path resolves to
     // a file inside docDir; (b) any '../'-prefixed path throws.
     glados.Glados2(


### PR DESCRIPTION
## Summary

- give Alice and Bob independent application-document sandboxes in the Matrix integration harness
- add image sync coverage from Alice to Bob and audio sync coverage from Bob to Alice
- assert journal metadata and exact transferred media bytes on the receiving device
- allow file loaders and outbox-bundle materialization to resolve against an explicitly injected documents directory while preserving the existing production default

## Why

The integration harness previously registered one process-global documents directory for both simulated devices. That made attachment checks vacuous: the receiver could observe the sender's file without Matrix transferring it.

Isolating the sandboxes exposed a second harness mismatch in the app's real bundled send path. `SyncEventProcessor` materialized outbox bundle manifests and child payloads through the process-global directory while the injected smart loader read from the device directory. The processor and loaders now use the same optional directory seam; normal production construction remains unchanged.

## Validation

- `fvm flutter analyze` — no issues
- targeted unit tests — 66 passed:
  - `test/utils/file_utils_test.dart`
  - `test/features/sync/matrix/sync_journal_entity_loader_test.dart`
  - `test/features/sync/matrix/smart_journal_entity_loader_test.dart`
  - `test/features/sync/matrix/sync_event_processor_outbox_bundle_test.dart`
- targeted real-Dendrite integration prefix — 3 passed in 33s:
  - 200-entry bundled baseline
  - image metadata and exact bytes, Alice → Bob
  - audio metadata and exact bytes, Bob → Alice
- non-vacuous check: temporarily deleting the receiver media file made the image integration test fail at its receiver-file wait; restoring the test made the same prefix pass

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved media synchronization to preserve journal metadata and exact transferred image/audio bytes.
  - Ensured media and related sync artifacts are sandboxed per device across restarts and rejoin scenarios.
  - Updated on-disk sync handling to honor an explicitly configured documents directory and prevent candidate-path traversal outside it.
- **Tests**
  - Added integration tests validating image/audio byte-level integrity and per-device sandbox isolation.
  - Added unit/widget tests for documents-directory–scoped journal loading and outbox manifest resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->