### PR TITLE
test: score auditable partial task placements

### DIFF
--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T09:08:16+02:00 }
+generated: { by: codex/5, at: 2026-07-28T09:21:04+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -174,7 +174,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   full-day capacity. Scheduled non-task blocks retain their written duration in
   that charge while estimated task allocations are replaced by their estimate
   or audited-partial value, so buffers and calendar blocks cannot disappear
-  from effective capacity. A late-start scenario therefore cannot silently
+  from effective capacity. An allocation longer than its estimate retains its
+  actual duration and cannot cancel another task's estimate shortfall. A
+  late-start scenario therefore cannot silently
   compress work into the remaining window. Every structurally shortened decided task counts
   as deferred work for `surfacedConflict`, whether or not its disclosure earns
   audited partial credit, so a plan that represents every task only partially
@@ -205,7 +207,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   remains a meeting claim; copula modifiers do not change that head, so `the
   meeting was only partial` is rejected too.
   Ordinary possessive verbs retain their head subject as well, so
-  `the meeting has 60 minutes remaining` cannot supply the task's remainder.
+  `the meeting has 60 minutes remaining` cannot supply the task's remainder;
+  remainder-producing verbs such as `the meeting leaves 60 minutes remaining`
+  retain the meeting subject too.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required. Likewise, `left

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -76,10 +76,15 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   duration may replace the full estimate only when its reason gives concrete
   minute arithmetic (`60m of 120m`, or `partial` plus `60m remain`) that agrees
   with both the summed duration of that task's blocks and the corpus estimate.
-  Vague “partial” prose, silence, or contradictory numbers are charged at the
-  full estimate. The constraint detail records every credited partial and every
-  shortening denied credit, so the judge bundle preserves the accounting
-  evidence rather than only the final pass/fail.
+  Every concrete split and remainder in the task's disclosure must agree; one
+  matching fragment cannot override a contradictory remainder elsewhere in the
+  same disclosure. Vague “partial” prose, silence, or contradictory numbers are
+  charged at the full estimate. An audited partial remainder also counts as
+  deferred work for `surfacedConflict`, so a plan that represents every task
+  only partially must still name the trade or escalate it. The constraint
+  detail records every credited partial and every shortening denied credit, so
+  the judge bundle preserves the accounting evidence rather than only the
+  final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T10:19:08+02:00 }
+generated: { by: codex/5, at: 2026-07-28T10:37:50+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -93,8 +93,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   wanted, expected, proposed, attempted, tried, failed, refused, or declined
   actions are likewise not affirmative. Neither are inability complements such
   as `was unable to schedule`, `was not able to schedule`, or `was incapable of
-  scheduling`, nor actions the prose says were avoided or prevented. A later
-  action describing “the rest” cannot validate earlier omitted arithmetic.
+  scheduling`, nor actions the prose says were avoided or prevented, including
+  passive `was prevented from being scheduled` wording. A selected allocation
+  action must govern the numeric split; an earlier action with intervening
+  object prose, such as scheduling a meeting before reviewing `60 of 120`
+  recording minutes, cannot supply task-allocation context. A later action
+  describing “the rest” cannot validate earlier omitted arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -247,9 +251,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `no conflict` explicitly deny the trade, while `without conflict` and
   `conflict-free` are denials rather than disclosures. Modal dispositions such
   as `might be omitted` or `could be deferred` are speculative, not actual
-  trades. Avoidance and prevention complements are denials too: `task-c avoided
-  being omitted` does not assert an omission. An affirmative claim plus denial
-  of that same
+  trades. Avoidance and prevention complements are denials too: neither
+  `task-c avoided being omitted` nor `task-c avoided getting omitted` asserts an
+  omission. An affirmative claim plus denial of that same
   disposition receives no credit in either order or across two task-named
   fields. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T11:58:49+02:00 }
+generated: { by: codex/5, at: 2026-07-28T12:13:58+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -107,8 +107,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   qualifier such as `were unsuccessfully scheduled` does not. Obligation alone
   is not evidence that placement happened: `must schedule`, `needs to
   schedule`, and `is required to schedule` cannot validate allocation
-  arithmetic. A later action describing “the rest” cannot validate earlier
-  omitted arithmetic.
+  arithmetic. Failure qualifiers are rejected on either side of the action, so
+  neither `unsuccessfully scheduled 60 of 120 minutes` nor
+  `failed scheduling 60 of 120 minutes` is allocation evidence. A later action
+  describing “the rest” cannot validate earlier omitted arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -277,12 +279,17 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   modal complement length and a coordinated predicate such as `may need to be
   shortened and ultimately deferred` do not make the disposition affirmative.
   Modal scope ends only when the conjunction begins an independently asserted
-  clause. Avoidance
-  and prevention complements are denials too: neither
-  `task-c avoided being omitted` nor `task-c avoided getting omitted` asserts an
-  omission. An affirmative claim plus denial of that same
+  clause. Attempt and failure complements are likewise not actual
+  dispositions: neither `attempted to be omitted` nor `failed to be omitted`
+  surfaces a trade. Avoidance and prevention complements are denials too:
+  neither `task-c avoided being omitted` nor
+  `task-c avoided getting omitted` asserts an omission. An affirmative claim
+  plus denial of that same
   disposition receives no credit in either order or across two task-named
-  fields. Denials do not cancel a different asserted disposition:
+  fields. A task-bound full-completion claim retracts every trade
+  disposition, including across reason and note fields; `was omitted, but it
+  was fully scheduled after all` is contradictory rather than a surfaced
+  casualty. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the
   actual deferral.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T16:33:33+02:00 }
+generated: { by: codex/5, at: 2026-07-28T16:50:50+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -118,8 +118,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `scheduled for 60 of 120 minutes` or
   `scheduled exactly 60 of 120 minutes`, may bridge the action to its
   arithmetic without admitting arbitrary intervening object prose, while a
-  failure qualifier such as
-  `were unsuccessfully scheduled` does not. Obligation alone
+  failure qualifier such as `were unsuccessfully scheduled` or the trailing
+  equivalent `were scheduled unsuccessfully` does not. Obligation alone
   is not evidence that placement happened: `must schedule`, `needs to
   schedule`, and `is required to schedule` cannot validate allocation
   arithmetic. Failure qualifiers are rejected on either side of the action, so
@@ -366,11 +366,17 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   casualty. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the
   actual deferral.
+  Correlative negation covers both dispositions, so
+  `task-c was neither omitted nor deferred` asserts neither trade.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
   disclosures, including label-bound forms such as `task-c: Cannot fit today`.
   A causal explanation does not retract that disclosure:
   `task-c cannot be scheduled because no time remains` still names the omitted
   task even though its explanation contains `no`.
+  `Postponed` is normalized as a deferral alongside moved, deferred, and
+  carried-over work. Coordinated task subjects may use comma-separated and
+  Oxford-comma lists; every corpus task in
+  `task-a, task-b, and task-c were omitted` is a named casualty.
   A bare conflict object is not: `task-c resolves conflict` describes subject
   matter rather than a scheduling casualty, while the task-bound predicate
   `task-c has a scheduling conflict` does disclose one. An explicit omission

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T07:04:19+02:00 }
+generated: { by: codex/5, at: 2026-07-28T07:15:39+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -74,9 +74,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   the cheapest way to make an impossible day fit is to claim each task is shorter
   than it is. The one exception is an auditable partial placement: the block
   duration may replace the full estimate only when its reason gives concrete
-  minute arithmetic (`60m of 120m scheduled`, or an affirmative `partial` plus
-  a task-bound remainder such as `60m remain for later`, `Remaining 60m move to
-  tomorrow`, `60m still remain`, `60m will still remain`, or
+  minute arithmetic (`60m of 120m scheduled`, `60m out of 120m scheduled`, or
+  an affirmative `partial` plus a task-bound remainder such as
+  `60m remain for later`, `Remaining 60m move to tomorrow`,
+  `60m still remain`, `60m will still remain`, or
   `Remaining 60m are carried over`) that agrees with both the summed duration
   of that task's work blocks and the corpus estimate. A numeric
   completed/estimate split must describe task allocation,
@@ -124,8 +125,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   affirmative arithmetic. Likewise, `60 of 120 are scheduled and no more`
   remains affirmative because the later `no` follows the allocation action
   instead of negating it; `not only` is likewise affirmative emphasis rather
-  than negation, and leading `no more than` is an exact quantitative cap. A
-  negative fit quantifier that explains the partial, such as
+  than negation, and leading `no more than` is an exact quantitative cap.
+  Likewise, `60 minutes remain and no more fits today` leaves the concrete
+  remainder affirmative because the later limit explains the capacity trade
+  instead of denying that unfinished work exists. A negative fit quantifier
+  that explains the partial, such as
   `not all work fits so 60 of 120 are scheduled`, also leaves the concrete
   allocation affirmative. `Partial`, `partially`, and `partly` are accepted
   disclosure forms. Bare `partial` must be a standalone label or explanation,
@@ -178,7 +182,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   omit/defer/shorten/conflict disposition, is required. Likewise, `left
   unchanged` and moving a block to another clock slot are continuity or
   rescheduling, while `left unfinished` and moving work to tomorrow are actual
-  remainder dispositions.
+  remainder dispositions. A disposition word must govern the task or unfinished
+  work: domain language such as `task-c documents deferred revenue` does not
+  disclose that task-c itself was deferred.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
   than a disclosure, and an affirmative claim plus its denial receives no

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T15:23:37+02:00 }
+generated: { by: codex/5, at: 2026-07-28T15:40:36+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -81,7 +81,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `60m still remain`, `60 more minutes remain`,
   `60 additional minutes remain`, `60m will still remain`, or
   `Remaining 60m are carried over`) that agrees with both the summed duration
-  of that task's work blocks and the corpus estimate. A numeric
+  of that task's work blocks and the corpus estimate. Numeric evidence must
+  start at a complete numeric token, so a thousands or decimal suffix such as
+  the `060` in `1,060 minutes remain` cannot restart a match. A numeric
   completed/estimate split must describe task allocation,
   not omitted/deferred arithmetic or coincidentally equal workday capacity, so
   the surrounding clause must include an affirmative scheduled, allocated,
@@ -97,7 +99,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   forms such as
   `was supposed to schedule`, `was meant to schedule`, or
   `was going to schedule`, nor interrogative clauses such as
-  `Was task-c omitted?`. Inability complements such as
+  `Was task-c omitted?`. A later comma-delimited rhetorical question does not
+  make an earlier declarative allocation clause interrogative. Inability
+  complements such as
   `was unable to schedule`, `was not able to schedule`, or
   `was incapable of scheduling`, nor actions the prose says were avoided or
   prevented, including passive `was prevented from being scheduled` wording. A
@@ -230,7 +234,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   audited, because a contradictory note must not be hidden from matching
   arithmetic in the reason. Numeric continuity such as `60 minutes remain
   scheduled` is not a remainder claim.
-  Negated or vague “partial” prose, silence,
+  Outer falsehoods such as `It is false that task-c scheduled 60 of 120
+  minutes` negate numeric split or remainder evidence and therefore veto
+  otherwise matching partial credit. Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
   are charged at the full estimate or receive no placement score. Estimated

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T12:28:46+02:00 }
+generated: { by: codex/5, at: 2026-07-28T15:52:34+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -259,9 +259,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required. Likewise, `left
   unchanged` and moving a block to another clock slot are continuity or
-  rescheduling, while `left unfinished` and moving work to tomorrow are actual
-  remainder dispositions. A disposition word must govern the task or unfinished
-  work: domain language such as `task-c documents deferred revenue` or
+  rescheduling, while `left unfinished`, `left some work unfinished`, and moving
+  work to tomorrow are actual remainder dispositions. A quantitative complement
+  such as `shortened by 60 minutes` also remains a task-bound disposition. A
+  disposition word must govern the task or unfinished work: domain language
+  such as `task-c documents deferred revenue` or
   `task-c documents unscheduled maintenance`, and purpose phrases such as
   `formats notes for later reference` or terminal `formats notes for later`, do
   not disclose that task-c itself was deferred or left unscheduled. A
@@ -286,8 +288,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   shortened and ultimately deferred` do not make the disposition affirmative.
   Modal scope ends only when the conjunction begins an independently asserted
   clause. Attempt and failure complements are likewise not actual
-  dispositions: neither `attempted to be omitted` nor `failed to be omitted`
-  surfaces a trade. Avoidance and prevention complements are denials too:
+  dispositions: neither `attempted to be omitted`, `failed to be omitted`, nor
+  the direct requirement `requires deferring` surfaces a trade. Avoidance and
+  prevention complements are denials too:
   neither `task-c avoided being omitted` nor
   `task-c avoided getting omitted` asserts an omission. An affirmative claim
   plus denial of that same
@@ -299,9 +302,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the
   actual deferral.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
-  disclosures, including label-bound forms such as `task-c: Cannot fit today`,
-  as is an explicit omission such as `task-c was not scheduled due to
-  capacity`. Inability forms such as `cannot be scheduled`, `can't be
+  disclosures, including label-bound forms such as `task-c: Cannot fit today`.
+  A bare conflict object is not: `task-c resolves conflict` describes subject
+  matter rather than a scheduling casualty. An explicit omission such as
+  `task-c was not scheduled due to capacity` is affirmative too. Inability
+  forms such as `cannot be scheduled`, `can't be
   scheduled`, or `was unable to be scheduled` disclose the same omission,
   unless an outer falsehood construction such as `not true that task-c cannot
   fit` or `not true that task-c was not scheduled` denies the whole claim.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T15:04:54+02:00 }
+generated: { by: codex/5, at: 2026-07-28T15:23:37+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -96,7 +96,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   or declined actions are likewise not affirmative. Neither are expectation
   forms such as
   `was supposed to schedule`, `was meant to schedule`, or
-  `was going to schedule`, inability complements such as
+  `was going to schedule`, nor interrogative clauses such as
+  `Was task-c omitted?`. Inability complements such as
   `was unable to schedule`, `was not able to schedule`, or
   `was incapable of scheduling`, nor actions the prose says were avoided or
   prevented, including passive `was prevented from being scheduled` wording. A
@@ -125,9 +126,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Explicit trailing historical scope is rejected too:
   `scheduled 60 of 120 minutes yesterday` and the equivalent `last week`
-  describe prior allocation rather than the current block. Unbound splits are
-  ignored before their values are checked, and allocation explicitly scoped to
-  another subject or another
+  describe prior allocation rather than the current block. The same scope rule
+  applies to full-allocation retractions, so a note claiming `fully scheduled
+  yesterday` cannot veto current partial evidence. Unbound splits are ignored
+  before their values are checked, and allocation explicitly scoped to another
+  subject or another
   corpus task, named by id or full title, cannot earn credit for the placed
   task. Explicit current-task scope wins over a later temporal meeting modifier,
   such as `during the meeting`, but not over an explicit allocation destination:
@@ -334,8 +337,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `was going to schedule 60 of 120 minutes`. Avoidance and prevention
   complements are denials too:
   neither `task-c avoided being omitted` nor
-  `task-c avoided getting omitted` asserts an omission. An affirmative claim
-  plus denial of that same
+  `task-c avoided getting omitted` asserts an omission.
+  Long negated complements retain their negation as well:
+  `never actually got around to omitting` does not assert an omission merely
+  because more than three words separate the negator from the disposition.
+  An affirmative claim plus denial of that same
   disposition receives no credit in either order or across two task-named
   fields. A task-bound full-completion claim retracts every trade
   disposition, including across reason and note fields; `was omitted, but it

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T15:54:50+02:00 }
+generated: { by: codex/5, at: 2026-07-28T16:15:24+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -83,7 +83,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `Remaining 60m are carried over`) that agrees with both the summed duration
   of that task's work blocks and the corpus estimate. Numeric evidence must
   start at a complete numeric token, so a thousands or decimal suffix such as
-  the `060` in `1,060 minutes remain` cannot restart a match. A numeric
+  the `060` in `1,060 minutes remain`, or digits after a positive or negative
+  sign such as the `60` in `-60 minutes remain`, cannot restart a match. A numeric
   completed/estimate split must describe task allocation,
   not omitted/deferred arithmetic or coincidentally equal workday capacity, so
   the surrounding clause must include an affirmative scheduled, allocated,
@@ -308,7 +309,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   such as `task-c documents deferred revenue` or
   `task-c documents unscheduled maintenance`, and purpose phrases such as
   `formats notes for later reference` or terminal `formats notes for later`, do
-  not disclose that task-c itself was deferred or left unscheduled. A
+  not disclose that task-c itself was deferred or left unscheduled. Active
+  dispositions may govern a token-bounded task id or full title directly, so
+  `We omitted task-c due to capacity` and `We omitted Core due to capacity`
+  name the casualty when those references identify the current task. A
   `for later` disposition must be governed by a scheduling, movement, copula,
   or remainder predicate. The same object binding rejects domain phrases
   such as `reviews trade policy`, `evaluates a trade`, and `carries over

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T13:56:16+02:00 }
+generated: { by: codex/5, at: 2026-07-28T14:02:56+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -127,6 +127,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   such as `during the meeting`, but not over an explicit allocation destination:
   `task-c: 60 of 120 minutes are scheduled for the meeting` remains
   meeting-scoped evidence.
+  Allocation-action words that occur inside the current task's id or full title
+  are references, not predicates: `task-fit 60 of 120 minutes` contains no
+  assertion that the work was placed. A possessive task reference also retains
+  its following head noun, so `task-c's meeting has 60 of 120 minutes
+  scheduled` remains meeting evidence rather than task-c allocation.
   The block's task is the default arithmetic subject; a corpus reference
   overrides it when it is comma-led, adjacent, linked by an allocation action
   (including postpositive `allocated to Task D`), possessive, attached by `for`
@@ -152,16 +157,19 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   either order: both `the allocation failed` and a later `failed to allocate
   the task` invalidate earlier split arithmetic. An affirmative task-bound
   claim such as `task-c was fully scheduled after all` still contradicts and
-  vetoes partial accounting. A full-allocation adjective phrase with an
-  explicit non-task noun head, such as `Fully planned day`, does not describe
-  the attached task and cannot veto its partial evidence. A denial or
-  full-completion claim explicitly naming another corpus task does not retract
-  the enclosing task's arithmetic, while qualified non-completion such as `not
-  fully scheduled` describes a partial placement rather than no allocation. A
-  prepositional non-task phrase such as `Fully planned for the day` is likewise
-  about the day. Subjectless attached denials such as `Not completed after all`
-  default to the block's task after non-task and other-task subjects have been
-  excluded.
+  vetoes partial accounting. An outer falsehood such as
+  `It is false that task-c was fully scheduled` denies that completion and
+  therefore cannot veto valid partial evidence. A full-allocation adjective
+  phrase with an explicit non-task noun head, such as `Fully planned day` or
+  `Fully planned our day`, does not describe the attached task and cannot veto
+  its partial evidence; ordinary possessive determiners are accepted before
+  those full-plan heads. A denial or full-completion claim explicitly naming
+  another corpus task does not retract the enclosing task's arithmetic, while
+  qualified non-completion such as `not fully scheduled` describes a partial
+  placement rather than no allocation. A prepositional non-task phrase such as
+  `Fully planned for the day` is likewise about the day. Subjectless attached
+  denials such as `Not completed after all` default to the block's task after
+  non-task and other-task subjects have been excluded.
   The
   partial mention cannot be borrowed from a claim attributed to
   another corpus task or an explicit non-task subject. Unrelated meeting/workday

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T05:15:43+02:00 }
+generated: { by: codex/5, at: 2026-07-28T05:25:11+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -118,7 +118,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   letting a later explanation that the full task `cannot fit` invalidate
   affirmative arithmetic. Likewise, `60 of 120 are scheduled and no more`
   remains affirmative because the later `no` follows the allocation action
-  instead of negating it. A `partial` keyword is negated only by a preceding
+  instead of negating it; `not only` is likewise affirmative emphasis rather
+  than negation. A `partial` keyword is negated only by a preceding
   negator, so `partial because not all work fits` remains affirmative. Split
   syntax cannot provide its own task context: an allocation word or task
   reference must appear outside the matched numbers. Explicit other-subject
@@ -143,7 +144,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Trade language in the same reason is attributed to its nearest corpus task,
   so one task's deferred disposition cannot disclose another task's shortening.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
-  arithmetic or an actual omit/defer/shorten/conflict disposition is required.
+  arithmetic matching the structural remainder, or an actual
+  omit/defer/shorten/conflict disposition, is required.
   It must also be affirmative: `not partial` and `no conflict` explicitly deny
   the trade and receive no credit, while `cannot fit` is itself an affirmative
   disclosure of the constraint. The constraint detail records every credited

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -79,8 +79,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   that task's work blocks and the corpus estimate. Every concrete split and
   remainder in the task's disclosure must agree; one matching fragment cannot
   override a contradictory remainder elsewhere in the same disclosure.
-  Negated or vague “partial” prose, silence, contradictory numbers, buffer or
-  calendar blocks carrying a task id, and allocations below 10% of the estimate
+  Negated arithmetic clauses, negated or vague “partial” prose, silence,
+  contradictory numbers, buffer or calendar blocks carrying a task id,
+  allocations below 10% of the estimate, and overlapping blocks for one task
   are charged at the full estimate or receive no placement score. An audited
   partial remainder also counts as deferred work for `surfacedConflict`, so a
   plan that represents every task only partially must still name the trade or

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T11:10:07+02:00 }
+generated: { by: codex/5, at: 2026-07-28T11:24:37+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -102,7 +102,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `60 of 120` recording minutes, cannot supply task-allocation context, nor can
   later meeting scheduling borrow an earlier `60 of 120` recording count. A
   grammatical auxiliary/adverb bridge such as `were successfully scheduled`
-  remains affirmative. A later action describing “the rest” cannot validate
+  remains affirmative, while a failure qualifier such as `were unsuccessfully
+  scheduled` does not. A later action describing “the rest” cannot validate
   earlier omitted arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
@@ -136,7 +137,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   context. Speculative denials such as `this task might not be scheduled after
   all` do not retract an affirmative placement. An affirmative task-bound claim
   such as `task-c was fully scheduled after all` still contradicts and vetoes
-  partial accounting. A denial or
+  partial accounting. A full-allocation adjective phrase with an explicit
+  non-task noun head, such as `Fully planned day`, does not describe the
+  attached task and cannot veto its partial evidence. A denial or
   full-completion claim explicitly naming another corpus task does not retract
   the enclosing task's arithmetic, while qualified non-completion such as `not
   fully scheduled` describes a partial placement rather than no allocation.
@@ -209,7 +212,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   positive structural placement to shorten; it must instead name an actual
   omission, deferral, or other applicable trade.
   Numeric remainder claims for a fully omitted estimated task must equal its
-  full estimate; omission does not make arbitrary positive arithmetic valid.
+  full estimate and be affirmative; `task-c may leave a remainder: 120
+  minutes` is hypothetical rather than an actual disclosed trade. Omission does
+  not make arbitrary positive arithmetic valid.
   Hyphenated task ids also remain whole tokens: a title such as `Report` is not
   named merely because another task id contains `weekly-report`.
   The scorer does not combine a task name in one field with unbound trade prose

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T04:29:47+02:00 }
+generated: { by: codex/5, at: 2026-07-28T04:40:54+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -81,21 +81,23 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   estimate. A numeric completed/estimate split must describe task allocation,
   not omitted/deferred arithmetic or coincidentally equal workday capacity, so
   the surrounding clause must include an affirmative scheduled, allocated,
-  completed, planned, placed, or fitting action. Unbound splits are ignored
-  before their values are checked, and allocation explicitly scoped to another
-  subject or another corpus task, named by id or full title, cannot earn credit
-  for the placed task. The block's task is the default arithmetic subject; a
-  corpus reference overrides it only when it is adjacent, linked by an
-  allocation action (including postpositive `allocated to Task D`), possessive,
-  or attached by `for` or `of`. Distinct task ids retain distinct identities
-  even when their titles collide; an explicit id can therefore attribute
-  arithmetic to the other task, while an ambiguous shared title is handled
-  conservatively. This allows one clause to audit the current split and name a
-  deferred casualty before or after it. The same attribution applies to
-  remainder evidence. The partial mention and task-bound remainder must occur
-  in the same block reason, and the partial mention cannot be borrowed from a
-  claim attributed to another corpus task; unrelated workday-capacity prose
-  cannot supply the remainder.
+  completed, planned, placed, or fitting action that is nearer to the numbers
+  than any omitted/deferred predicate in the same comma-delimited clause. A
+  later action describing “the rest” cannot validate earlier omitted
+  arithmetic. Unbound splits are ignored before their values are checked, and
+  allocation explicitly scoped to another subject or another corpus task, named
+  by id or full title, cannot earn credit for the placed task. The block's task
+  is the default arithmetic subject; a corpus reference overrides it only when
+  it is adjacent, linked by an allocation action (including postpositive
+  `allocated to Task D`), possessive, or attached by `for` or `of`. Distinct
+  task ids retain distinct identities even when their titles collide; an
+  explicit id can therefore attribute arithmetic to the other task, while an
+  ambiguous shared title is handled conservatively. This allows one clause to
+  audit the current split and name a deferred casualty before or after it. The
+  same attribution applies to remainder evidence. The partial mention and
+  task-bound remainder must occur in the same block reason, and the partial
+  mention cannot be borrowed from a claim attributed to another corpus task;
+  unrelated workday-capacity prose cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -129,9 +131,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   that names the task by token-bounded id or full title. A name occurring only
   inside another task id or word, task-binding grammar such as `for this task`,
   and trade wording in unrelated plan prose cannot satisfy that disclosure.
-  The constraint detail records every credited partial and every shortening
-  denied credit, so the judge bundle preserves the accounting evidence rather
-  than only the final pass/fail.
+  Trade language must also be affirmative: `not partial` and `no conflict`
+  explicitly deny the trade and receive no credit, while `cannot fit` is itself
+  an affirmative disclosure of the constraint. The constraint detail records
+  every credited partial and every shortening denied credit, so the judge
+  bundle preserves the accounting evidence rather than only the final
+  pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T17:10:59+02:00 }
+generated: { by: codex/5, at: 2026-07-28T17:30:47+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -127,6 +127,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `failed scheduling 60 of 120 minutes` is allocation evidence. A standalone
   task-bound failure predicate retracts earlier arithmetic too:
   `scheduled 60 of 120 minutes, but the allocation failed` is not credit. A
+  failure explicitly scoped to a non-task subject does not retract the task:
+  `the allocation failed for the meeting` is meeting evidence even when the
+  non-task head follows the failure predicate. A
   later action describing “the rest” cannot validate earlier omitted
   arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
@@ -317,7 +320,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   not disclose that task-c itself was deferred or left unscheduled. Active
   dispositions may govern a token-bounded task id or full title directly, so
   `We omitted task-c due to capacity` and `We omitted Core due to capacity`
-  name the casualty when those references identify the current task. A
+  name the casualty when those references identify the current task.
+  Conjunction-delimited objects retain each governed task, so
+  `We omitted task-a and task-c` names task-c too. A
   `for later` disposition must be governed by a scheduling, movement, copula,
   or remainder predicate. The same object binding rejects domain phrases
   such as `reviews trade policy`, `evaluates a trade`, and `carries over
@@ -365,7 +370,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   was fully scheduled after all` is contradictory rather than a surfaced
   casualty. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the
-  actual deferral.
+  actual deferral. A contrastive replacement predicate is the same boundary:
+  `task-c was not dropped but deferred to a later day` denies only the drop.
   Correlative negation covers both dispositions, so
   `task-c was neither omitted nor deferred` asserts neither trade.
   Necessity idioms are affirmative rather than negated: `We had no choice but

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T12:13:58+02:00 }
+generated: { by: codex/5, at: 2026-07-28T12:28:46+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -102,15 +102,19 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `60 of 120` recording minutes, cannot supply task-allocation context, nor can
   later meeting scheduling borrow an earlier `60 of 120` recording count. A
   grammatical auxiliary/adverb bridge such as `were successfully scheduled`
-  remains affirmative, and exact quantity modifiers such as `scheduled exactly
-  60 of 120 minutes` may bridge the action to its arithmetic, while a failure
-  qualifier such as `were unsuccessfully scheduled` does not. Obligation alone
+  or `60 of 120 minutes do fit` remains affirmative, and exact quantity
+  modifiers such as `scheduled exactly 60 of 120 minutes` may bridge the action
+  to its arithmetic, while a failure qualifier such as
+  `were unsuccessfully scheduled` does not. Obligation alone
   is not evidence that placement happened: `must schedule`, `needs to
   schedule`, and `is required to schedule` cannot validate allocation
   arithmetic. Failure qualifiers are rejected on either side of the action, so
   neither `unsuccessfully scheduled 60 of 120 minutes` nor
-  `failed scheduling 60 of 120 minutes` is allocation evidence. A later action
-  describing “the rest” cannot validate earlier omitted arithmetic.
+  `failed scheduling 60 of 120 minutes` is allocation evidence. A standalone
+  task-bound failure predicate retracts earlier arithmetic too:
+  `scheduled 60 of 120 minutes, but the allocation failed` is not credit. A
+  later action describing “the rest” cannot validate earlier omitted
+  arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -259,8 +263,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   remainder dispositions. A disposition word must govern the task or unfinished
   work: domain language such as `task-c documents deferred revenue` or
   `task-c documents unscheduled maintenance`, and purpose phrases such as
-  `formats notes for later reference`, do not disclose that task-c itself was
-  deferred or left unscheduled. The same object binding rejects domain phrases
+  `formats notes for later reference` or terminal `formats notes for later`, do
+  not disclose that task-c itself was deferred or left unscheduled. A
+  `for later` disposition must be governed by a scheduling, movement, copula,
+  or remainder predicate. The same object binding rejects domain phrases
   such as `reviews trade policy` and `carries over balances`. Negative-fit
   evidence is subject-bound too: `task-c doesn't fit` remains affirmative, but
   `task-c validates that the payload cannot fit in memory` describes the
@@ -295,9 +301,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
   disclosures, including label-bound forms such as `task-c: Cannot fit today`,
   as is an explicit omission such as `task-c was not scheduled due to
-  capacity`, unless an outer falsehood construction such as `not true that
-  task-c cannot fit` or `not true that task-c was not scheduled` denies the
-  whole claim.
+  capacity`. Inability forms such as `cannot be scheduled`, `can't be
+  scheduled`, or `was unable to be scheduled` disclose the same omission,
+  unless an outer falsehood construction such as `not true that task-c cannot
+  fit` or `not true that task-c was not scheduled` denies the whole claim.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T13:41:50+02:00 }
+generated: { by: codex/5, at: 2026-07-28T13:56:16+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -94,8 +94,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   qualify or contradict a placement. Intended, planned, aimed, hoped,
   wanted, expected, proposed, attempted, tried, failed, refused, or declined
   actions are likewise not affirmative. Neither are expectation forms such as
-  `was supposed to schedule` or `was meant to schedule`, inability complements
-  such as `was unable to schedule`, `was not able to schedule`, or
+  `was supposed to schedule`, `was meant to schedule`, or
+  `was going to schedule`, inability complements such as
+  `was unable to schedule`, `was not able to schedule`, or
   `was incapable of scheduling`, nor actions the prose says were avoided or
   prevented, including passive `was prevented from being scheduled` wording. A
   selected allocation action must govern the numeric split on either side; an
@@ -291,8 +292,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   was not scheduled` does not retract task-c's affirmative deferral.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, while `without conflict` and
-  `conflict-free` are denials rather than disclosures. Modal dispositions such
-  as `might be omitted`, `could be deferred`, or
+  `conflict-free` are denials rather than disclosures. Outer falsehoods deny
+  positive dispositions too: `It is false that task-c conflicts` cannot surface
+  a trade. Modal dispositions such as `might be omitted`, `could be deferred`,
+  or
   `may ultimately need to be deferred` are speculative, not actual trades;
   modal complement length and a coordinated predicate such as `may need to be
   shortened and ultimately deferred` do not make the disposition affirmative.
@@ -300,11 +303,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   clause. Attempt and failure complements are likewise not actual
   dispositions: neither `attempted to be omitted`, `failed to be omitted`, the
   near miss `was almost omitted`, expectations such as `was supposed to be
-  omitted` or `was meant to be omitted`, nor the direct requirement
-  `requires deferring` surfaces a trade. The same rules reject allocation prose
-  such as `almost scheduled 60 of 120 minutes`,
-  `was supposed to schedule 60 of 120 minutes`, and
-  `was meant to schedule 60 of 120 minutes`. Avoidance and prevention
+  omitted`, `was meant to be omitted`, or `was going to be omitted`, nor the
+  direct requirement `requires deferring` surfaces a trade. The same rules
+  reject allocation prose such as `almost scheduled 60 of 120 minutes`,
+  `was supposed to schedule 60 of 120 minutes`,
+  `was meant to schedule 60 of 120 minutes`, and
+  `was going to schedule 60 of 120 minutes`. Avoidance and prevention
   complements are denials too:
   neither `task-c avoided being omitted` nor
   `task-c avoided getting omitted` asserts an omission. An affirmative claim

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T06:51:25+02:00 }
+generated: { by: codex/5, at: 2026-07-28T07:04:19+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -76,9 +76,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   duration may replace the full estimate only when its reason gives concrete
   minute arithmetic (`60m of 120m scheduled`, or an affirmative `partial` plus
   a task-bound remainder such as `60m remain for later`, `Remaining 60m move to
-  tomorrow`, `60m will remain`, or `Remaining 60m are carried over`) that agrees
-  with both the summed duration of that task's work blocks and the corpus
-  estimate. A numeric completed/estimate split must describe task allocation,
+  tomorrow`, `60m still remain`, `60m will still remain`, or
+  `Remaining 60m are carried over`) that agrees with both the summed duration
+  of that task's work blocks and the corpus estimate. A numeric
+  completed/estimate split must describe task allocation,
   not omitted/deferred arithmetic or coincidentally equal workday capacity, so
   the surrounding clause must include an affirmative scheduled, allocated,
   completed, planned, placed, or fitting action that is nearer to the numbers
@@ -127,15 +128,18 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   negative fit quantifier that explains the partial, such as
   `not all work fits so 60 of 120 are scheduled`, also leaves the concrete
   allocation affirmative. `Partial`, `partially`, and `partly` are accepted
-  disclosure forms. A partial keyword is negated only by a preceding negator,
-  so `partial because not all work fits` remains affirmative. Split
-  syntax cannot provide its own allocation context: an affirmative allocation
-  action must appear outside the matched numbers. A task reference can
-  attribute that action, but cannot replace it. Explicit other-subject scope
-  also outranks a nearby `partial` keyword, so `remain for`, `before`, or `until`
-  a meeting cannot earn task remainder credit while `partial for today` remains
-  valid. Bare numeric remainders in another field of the same task block are
-  still audited, because a contradictory note must not be hidden from matching
+  disclosure forms. Bare `partial` must be a standalone label or explanation,
+  follow a copula, or modify a placement noun such as task, work, placement, or
+  block; a task-owned noun phrase such as `task-c's partial index` is not
+  placement evidence. A partial keyword is negated only by a preceding negator,
+  so `partial because not all work fits` remains affirmative. Split syntax
+  cannot provide its own allocation context: an affirmative allocation action
+  must appear outside the matched numbers. A task reference can attribute that
+  action, but cannot replace it. Explicit other-subject scope also outranks a
+  nearby `partial` keyword, so `remain for`, `before`, or `until` a meeting
+  cannot earn task remainder credit while `partial for today` remains valid.
+  Bare numeric remainders in another field of the same task block are still
+  audited, because a contradictory note must not be hidden from matching
   arithmetic in the reason. Numeric continuity such as `60 minutes remain
   scheduled` is not a remainder claim.
   Negated or vague “partial” prose, silence,

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T14:02:56+02:00 }
+generated: { by: codex/5, at: 2026-07-28T14:36:12+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -105,9 +105,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   context, nor can later meeting scheduling borrow an earlier `60 of 120`
   recording count. A grammatical auxiliary/adverb bridge such as
   `were successfully scheduled` or `60 of 120 minutes do fit` remains
-  affirmative, and exact quantity
-  modifiers such as `scheduled exactly 60 of 120 minutes` may bridge the action
-  to its arithmetic, while a failure qualifier such as
+  affirmative. A direct quantity preposition or exact quantity modifier, such as
+  `scheduled for 60 of 120 minutes` or
+  `scheduled exactly 60 of 120 minutes`, may bridge the action to its
+  arithmetic without admitting arbitrary intervening object prose, while a
+  failure qualifier such as
   `were unsuccessfully scheduled` does not. Obligation alone
   is not evidence that placement happened: `must schedule`, `needs to
   schedule`, and `is required to schedule` cannot validate allocation
@@ -277,7 +279,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   omit/defer/shorten/conflict disposition, is required. Likewise, `left
   unchanged` and moving a block to another clock slot are continuity or
   rescheduling, while `left unfinished`, `left some work unfinished`, and moving
-  work to tomorrow are actual remainder dispositions. A quantitative complement
+  work to tomorrow are actual remainder dispositions. Unfinished work remains
+  distinct from full omission, so `not left out; left unfinished` still
+  discloses the unfinished remainder. A quantitative complement
   such as `shortened by 60 minutes` also remains a task-bound disposition. A
   disposition word must govern the task or unfinished work: domain language
   such as `task-c documents deferred revenue` or

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T14:36:12+02:00 }
+generated: { by: codex/5, at: 2026-07-28T15:04:54+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -92,8 +92,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c might be partially scheduled`. Modal remainder arithmetic such as
   `task-c might have 60 minutes remaining` is likewise hypothetical and cannot
   qualify or contradict a placement. Intended, planned, aimed, hoped,
-  wanted, expected, proposed, attempted, tried, failed, refused, or declined
-  actions are likewise not affirmative. Neither are expectation forms such as
+  wanted, expected, proposed, considered, attempted, tried, failed, refused,
+  or declined actions are likewise not affirmative. Neither are expectation
+  forms such as
   `was supposed to schedule`, `was meant to schedule`, or
   `was going to schedule`, inability complements such as
   `was unable to schedule`, `was not able to schedule`, or
@@ -122,8 +123,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
-  earlier valid task split. Unbound splits are ignored before their values are
-  checked, and allocation explicitly scoped to another subject or another
+  earlier valid task split. Explicit trailing historical scope is rejected too:
+  `scheduled 60 of 120 minutes yesterday` and the equivalent `last week`
+  describe prior allocation rather than the current block. Unbound splits are
+  ignored before their values are checked, and allocation explicitly scoped to
+  another subject or another
   corpus task, named by id or full title, cannot earn credit for the placed
   task. Explicit current-task scope wins over a later temporal meeting modifier,
   such as `during the meeting`, but not over an explicit allocation destination:
@@ -150,7 +154,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   partial mention and task-bound remainder must occur in the same block reason,
   as required by the model-facing prompt. Notes cannot earn partial credit, but
   their concrete arithmetic and denials remain audit evidence that can veto a
-  reason. A task-bound standalone allocation denial such as
+  reason. An explicitly task-named note is routed to that task across every
+  scheduled block, including notes on another task or a buffer; an unbound note
+  remains attached to its enclosing work block. A task-bound standalone
+  allocation denial such as
   `task-c was not scheduled after all` therefore retracts reason-field partial
   arithmetic even when the note contains no split or remainder of its own; the
   same applies to `not completed` because completion can supply allocation
@@ -255,6 +262,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   plan prose cannot satisfy that disclosure.
   Trade language in the same reason is attributed to its nearest corpus task,
   so one task's deferred disposition cannot disclose another task's shortening.
+  A coordinated subject made entirely of corpus task references is attributed
+  to every named task, so `task-c and task-d were omitted` surfaces both
+  casualties without admitting a mixed subject such as a meeting and a task.
   Label punctuation binds too, so `Partial: task-d` remains owned by `task-d`
   rather than the task attached to the enclosing block.
   Trade-shaped words inside the task's own id or full-title span are only
@@ -315,8 +325,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   clause. Attempt and failure complements are likewise not actual
   dispositions: neither `attempted to be omitted`, `failed to be omitted`, the
   near miss `was almost omitted`, expectations such as `was supposed to be
-  omitted`, `was meant to be omitted`, or `was going to be omitted`, nor the
-  direct requirement `requires deferring` surfaces a trade. The same rules
+  omitted`, `was meant to be omitted`, or `was going to be omitted`,
+  consideration such as `considered deferring`, nor the direct requirement
+  `requires deferring` surfaces a trade. The same rules
   reject allocation prose such as `almost scheduled 60 of 120 minutes`,
   `was supposed to schedule 60 of 120 minutes`,
   `was meant to schedule 60 of 120 minutes`, and
@@ -335,10 +346,13 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
   disclosures, including label-bound forms such as `task-c: Cannot fit today`.
   A bare conflict object is not: `task-c resolves conflict` describes subject
-  matter rather than a scheduling casualty. An explicit omission such as
+  matter rather than a scheduling casualty, while the task-bound predicate
+  `task-c has a scheduling conflict` does disclose one. An explicit omission
+  such as
   `task-c was not scheduled due to capacity` is affirmative too. Inability
   forms such as `cannot be scheduled`, `can't be
-  scheduled`, or `was unable to be scheduled` disclose the same omission,
+  scheduled`, `could not be scheduled`, `will not be scheduled`, or
+  `was unable to be scheduled` disclose the same omission,
   unless an outer falsehood construction such as `not true that task-c cannot
   fit` or `not true that task-c was not scheduled` denies the whole claim. All
   equivalent negative-scheduling forms, including `unable` wording without a

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T06:25:06+02:00 }
+generated: { by: codex/5, at: 2026-07-28T06:35:52+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -131,7 +131,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   a meeting cannot earn task remainder credit while `partial for today` remains
   valid. Bare numeric remainders in another field of the same task block are
   still audited, because a contradictory note must not be hidden from matching
-  arithmetic in the reason.
+  arithmetic in the reason. Numeric continuity such as `60 minutes remain
+  scheduled` is not a remainder claim.
   Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
@@ -154,11 +155,14 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Label punctuation binds too, so `Partial: task-d` remains owned by `task-d`
   rather than the task attached to the enclosing block.
   Trade-shaped words inside the task's own id or full-title span are only
-  naming evidence, not a separate disclosure.
+  naming evidence, not a separate disclosure in either capacity or conflict
+  scoring.
   An explicit non-task subject is rejected too: `the meeting is deferred`
   cannot disclose the shortening merely because the same reason names a task,
   and neither can `the meeting is scheduled for later`; `the remainder is
-  deferred` remains task-trade evidence.
+  deferred` remains task-trade evidence. A task reference inside a modifier
+  does not replace the head subject, so `the meeting for task-c is partial`
+  remains a meeting claim.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required. Likewise, `left
@@ -166,8 +170,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   rescheduling, while `left unfinished` and moving work to tomorrow are actual
   remainder dispositions.
   It must also be affirmative and internally consistent: `not partial` and
-  `no conflict` explicitly deny the trade, and an affirmative claim plus its
-  denial receives no credit in either order or across two task-named fields.
+  `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
+  than a disclosure, and an affirmative claim plus its denial receives no
+  credit in either order or across two task-named fields.
   `Cannot fit`, `conflicts`, and `conflicting` are affirmative disclosures.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T04:40:54+02:00 }
+generated: { by: codex/5, at: 2026-07-28T04:53:14+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -84,20 +84,24 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   completed, planned, placed, or fitting action that is nearer to the numbers
   than any omitted/deferred predicate in the same comma-delimited clause. A
   later action describing “the rest” cannot validate earlier omitted
-  arithmetic. Unbound splits are ignored before their values are checked, and
-  allocation explicitly scoped to another subject or another corpus task, named
-  by id or full title, cannot earn credit for the placed task. The block's task
-  is the default arithmetic subject; a corpus reference overrides it only when
-  it is adjacent, linked by an allocation action (including postpositive
-  `allocated to Task D`), possessive, or attached by `for` or `of`. Distinct
-  task ids retain distinct identities even when their titles collide; an
-  explicit id can therefore attribute arithmetic to the other task, while an
-  ambiguous shared title is handled conservatively. This allows one clause to
-  audit the current split and name a deferred casualty before or after it. The
-  same attribution applies to remainder evidence. The partial mention and
-  task-bound remainder must occur in the same block reason, and the partial
-  mention cannot be borrowed from a claim attributed to another corpus task;
-  unrelated workday-capacity prose cannot supply the remainder.
+  arithmetic. Unrelated meeting/workday scope is likewise associated with its
+  nearest allocation action, so later meeting arithmetic does not poison an
+  earlier valid task split. Unbound splits are ignored before their values are
+  checked, and allocation explicitly scoped to another subject or another
+  corpus task, named by id or full title, cannot earn credit for the placed
+  task. The block's task is the default arithmetic subject; a corpus reference
+  overrides it only when it is adjacent, linked by an allocation action
+  (including postpositive `allocated to Task D`), possessive, or attached by
+  `for` or `of`. Distinct task ids retain distinct identities even when their
+  titles collide; an explicit id can therefore attribute arithmetic to the
+  other task, while an ambiguous shared title is handled conservatively. This
+  allows one clause to audit the current split and name a deferred casualty
+  before or after it. The same attribution applies to remainder evidence. The
+  partial mention and task-bound remainder must occur in the same block reason,
+  and the partial mention cannot be borrowed from a claim attributed to another
+  corpus task; unrelated meeting/workday remainder scope is rejected before a
+  later disposition can bind it, and unrelated workday-capacity prose cannot
+  supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -131,12 +135,13 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   that names the task by token-bounded id or full title. A name occurring only
   inside another task id or word, task-binding grammar such as `for this task`,
   and trade wording in unrelated plan prose cannot satisfy that disclosure.
-  Trade language must also be affirmative: `not partial` and `no conflict`
-  explicitly deny the trade and receive no credit, while `cannot fit` is itself
-  an affirmative disclosure of the constraint. The constraint detail records
-  every credited partial and every shortening denied credit, so the judge
-  bundle preserves the accounting evidence rather than only the final
-  pass/fail.
+  Trade language in the same reason is attributed to its nearest corpus task,
+  so one task's deferred disposition cannot disclose another task's shortening.
+  It must also be affirmative: `not partial` and `no conflict` explicitly deny
+  the trade and receive no credit, while `cannot fit` is itself an affirmative
+  disclosure of the constraint. The constraint detail records every credited
+  partial and every shortening denied credit, so the judge bundle preserves the
+  accounting evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T07:48:40+02:00 }
+generated: { by: codex/5, at: 2026-07-28T08:05:22+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -45,8 +45,8 @@ always legal, and inspecting it alone measures the guards rather than the model.
 
 | Scored on | Constraints |
 |-----------|-------------|
-| Objective structure in the persisted plan | overlap, capacity (as written *and* as estimated), working hours, estimate fidelity, decided tasks placed, required work placed, expected omissions honoured, blocker ordering, fabricated task ids, fabricated calendar blocks, fabricated history, invented work, task-work typing, duplicate ids |
-| Weak semantic evidence in plan prose and accepted status/diff calls | conflict surfaced, blocker-bypass justification, directive honoured — visible per constraint, but excluded from ranking |
+| Objective structure in the persisted plan | overlap, capacity as written, estimated-capacity failures and passes that do not need partial-prose credit, working hours, estimate fidelity, decided tasks placed, required work placed, expected omissions honoured, blocker ordering, fabricated task ids, fabricated calendar blocks, fabricated history, invented work, task-work typing, duplicate ids |
+| Weak semantic evidence in plan prose and accepted status/diff calls | estimated-capacity passes that depend on audited partial prose, conflict surfaced, blocker-bypass justification, directive honoured — visible per constraint, but excluded from ranking |
 | The rejection count | whether the model complied without being corrected |
 
 A run that never attempted `draft_day_plan` is **inapplicable** for the rejection
@@ -87,7 +87,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   completed, planned, placed, or fitting action that is nearer to the numbers
   than any omitted/deferred predicate in the same comma-delimited clause. A
   merely possible action such as `task-c might schedule 60 of 120 minutes` is
-  not an affirmative allocation. A later action describing “the rest” cannot
+  not an affirmative allocation, and neither is
+  `task-c might be partially scheduled`. A later action describing “the rest” cannot
   validate earlier omitted
   arithmetic. Unrelated meeting/workday scope is likewise associated with its
   nearest allocation action, so later meeting arithmetic does not poison an
@@ -158,8 +159,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   allocations below 10% of the estimate, and overlapping blocks for one task
   are charged at the full estimate or receive no placement score. Estimated
   charges are compared with the clock-bounded `plannableMinutes`, not nominal
-  full-day capacity, so a late-start scenario cannot silently compress work
-  into the remaining window. Every structurally shortened decided task counts
+  full-day capacity. Scheduled non-task blocks retain their written duration in
+  that charge while estimated task allocations are replaced by their estimate
+  or audited-partial value, so buffers and calendar blocks cannot disappear
+  from effective capacity. A late-start scenario therefore cannot silently
+  compress work into the remaining window. Every structurally shortened decided task counts
   as deferred work for `surfacedConflict`, whether or not its disclosure earns
   audited partial credit, so a plan that represents every task only partially
   must still name the trade or escalate it. Merely repeating a shortened task's
@@ -197,7 +201,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   work: domain language such as `task-c documents deferred revenue` or
   `task-c documents unscheduled maintenance`, and purpose phrases such as
   `formats notes for later reference`, do not disclose that task-c itself was
-  deferred or left unscheduled. Contracted negative-fit forms such as
+  deferred or left unscheduled. The same object binding rejects domain phrases
+  such as `reviews trade policy` and `carries over balances`. Contracted negative-fit forms such as
   `task-c doesn't fit` remain affirmative conflict disclosures.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T07:33:30+02:00 }
+generated: { by: codex/5, at: 2026-07-28T07:48:40+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -168,6 +168,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   reason or note field that names the task by token-bounded id or full title.
   The same disclosure requirement applies to fully omitted tasks; mentioning an
   omitted task only as context for retained work does not surface the omission.
+  Numeric remainder claims for a fully omitted estimated task must equal its
+  full estimate; omission does not make arbitrary positive arithmetic valid.
   The scorer does not combine a task name in one field with unbound trade prose
   in the other. A name occurring only inside another task id or word,
   task-binding grammar such as `for this task`, and trade wording in unrelated
@@ -193,8 +195,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   rescheduling, while `left unfinished` and moving work to tomorrow are actual
   remainder dispositions. A disposition word must govern the task or unfinished
   work: domain language such as `task-c documents deferred revenue` or
-  `task-c documents unscheduled maintenance` does not disclose that task-c
-  itself was deferred or left unscheduled.
+  `task-c documents unscheduled maintenance`, and purpose phrases such as
+  `formats notes for later reference`, do not disclose that task-c itself was
+  deferred or left unscheduled. Contracted negative-fit forms such as
+  `task-c doesn't fit` remain affirmative conflict disclosures.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
   than a disclosure, and an affirmative claim plus its denial receives no

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T03:55:33+02:00 }
+generated: { by: codex/5, at: 2026-07-28T04:06:55+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -84,11 +84,14 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   subject or another corpus task, named by id or full title, cannot earn credit
   for the placed task. The block's task is the default arithmetic subject; a
   corpus reference overrides it only when it is adjacent, linked by an
-  allocation action, possessive, or attached by `for` or `of`. This allows one
-  clause to audit the current split and name a deferred casualty before or after
-  it. The same attribution applies to remainder evidence. The partial mention
-  and task-bound remainder must occur in the same block reason; unrelated
-  workday-capacity prose cannot supply the remainder.
+  allocation action, possessive, or attached by `for` or `of`. Distinct task ids
+  retain distinct identities even when their titles collide; an explicit id can
+  therefore attribute arithmetic to the other task, while an ambiguous shared
+  title is handled conservatively. This allows one clause to audit the current
+  split and name a deferred casualty before or after it. The same attribution
+  applies to remainder evidence. The partial mention and task-bound remainder
+  must occur in the same block reason; unrelated workday-capacity prose cannot
+  supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -118,9 +121,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   audited partial credit, so a plan that represents every task only partially
   must still name the trade or escalate it. Merely repeating a shortened task's
   title is not a trade: the prose must also disclose partial, deferred, omitted,
-  remaining, shortened, or conflicting work. The constraint detail records
-  every credited partial and every shortening denied credit, so the judge
-  bundle preserves the accounting
+  remaining, shortened, or conflicting work in the same block reason or note
+  that names the task. Trade wording in unrelated plan prose cannot satisfy that
+  disclosure. The constraint detail records every credited partial and every
+  shortening denied credit, so the judge bundle preserves the accounting
   evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T05:25:11+02:00 }
+generated: { by: codex/5, at: 2026-07-28T05:38:35+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -119,7 +119,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   affirmative arithmetic. Likewise, `60 of 120 are scheduled and no more`
   remains affirmative because the later `no` follows the allocation action
   instead of negating it; `not only` is likewise affirmative emphasis rather
-  than negation. A `partial` keyword is negated only by a preceding
+  than negation. A negative fit quantifier that explains the partial, such as
+  `not all work fits so 60 of 120 are scheduled`, also leaves the concrete
+  allocation affirmative. A `partial` keyword is negated only by a preceding
   negator, so `partial because not all work fits` remains affirmative. Split
   syntax cannot provide its own task context: an allocation word or task
   reference must appear outside the matched numbers. Explicit other-subject
@@ -143,6 +145,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   and trade wording in unrelated plan prose cannot satisfy that disclosure.
   Trade language in the same reason is attributed to its nearest corpus task,
   so one task's deferred disposition cannot disclose another task's shortening.
+  An explicit non-task subject is rejected too: `the meeting is deferred`
+  cannot disclose the shortening merely because the same reason names a task,
+  while `the remainder is deferred` remains task-trade evidence.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T22:03:45+02:00 }
+generated: { by: codex/5, at: 2026-07-28T22:12:29+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -221,9 +221,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
   to another subject such as a meeting or workday is ignored. The same applies
   to an object-owned quantity such as `reviews a recording with 60 minutes
-  remaining`; mentioning the task before the object does not transfer that
-  remainder to the task. Every concrete task-bound split and remainder across
-  the block reason and note must agree; one matching fragment cannot override a
+  remaining`, or subject-owned arithmetic such as `the battery shows 60 minutes
+  remaining`; a nearby placement claim does not transfer either remainder to
+  the task. Every concrete task-bound split and remainder across the block
+  reason and note must agree; one matching fragment cannot override a
   contradictory remainder elsewhere in the task's disclosure. Consequently,
   `30 of 120 minutes remain` cannot be credited as 30 completed minutes.
   Negation binds to nearby evidence and to the allocation action leading into
@@ -255,6 +256,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   action, but cannot replace it. Explicit other-subject scope also outranks a
   nearby `partial` keyword, so `remain for`, `before`, or `until` a meeting
   cannot earn task remainder credit while `partial for today` remains valid.
+  Future allocation scope cannot earn current-day partial credit. `Tomorrow`
+  is future scope when the evaluator has a same-day `now`, but remains the
+  current plan day for a future-day fixture whose `now` is absent.
   Bare numeric remainders in another field of the same task block are still
   audited, because a contradictory note must not be hidden from matching
   arithmetic in the reason. Numeric continuity such as `60 minutes remain
@@ -410,9 +414,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   carried-over work. Coordinated task subjects may use comma-separated and
   Oxford-comma lists; every corpus task in
   `task-a, task-b, and task-c were omitted` is a named casualty.
-  A bare conflict object is not: `task-c resolves conflict` describes subject
-  matter rather than a scheduling casualty, while the task-bound predicate
-  `task-c has a scheduling conflict` does disclose one. An explicit omission
+  A bare conflict object is not: `task-c resolves conflict` and `task-c
+  resolves conflicts` describe subject matter rather than a scheduling
+  casualty, while the task-bound predicate `task-c has a scheduling conflict`
+  does disclose one. An explicit omission
   such as
   `task-c was not scheduled due to capacity` is affirmative too. Inability
   forms such as `cannot be scheduled`, `can't be
@@ -423,6 +428,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   equivalent negative-scheduling forms, including `unable` wording without a
   lexical negation token, share one disposition identity, so an affirmative
   spelling in one field is retracted by an equivalent denial in another.
+  Omission synonyms (`omitted`, `dropped`, `unscheduled`, and `left out`) share
+  an identity as well; deferral and unfinished-work dispositions remain
+  distinct.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -74,15 +74,18 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   the cheapest way to make an impossible day fit is to claim each task is shorter
   than it is. The one exception is an auditable partial placement: the block
   duration may replace the full estimate only when its reason gives concrete
-  minute arithmetic (`60m of 120m`, or an affirmative `partial` plus either
-  `60m remain` or `Remaining 60m`) that agrees with both the summed duration of
-  that task's work blocks and the corpus estimate. Every concrete split and
-  remainder in the task's disclosure must agree; one matching fragment cannot
-  override a contradictory remainder elsewhere in the same disclosure.
-  Negated arithmetic clauses, negated or vague “partial” prose, silence,
-  contradictory numbers, buffer or calendar blocks carrying a task id,
-  allocations below 10% of the estimate, and overlapping blocks for one task
-  are charged at the full estimate or receive no placement score. An audited
+  minute arithmetic (`60m of 120m`, or an affirmative `partial` plus a
+  task-bound remainder such as `60m remain for later` or `Remaining 60m move to
+  tomorrow`) that agrees with both the summed duration of that task's work
+  blocks and the corpus estimate. The partial mention and task-bound remainder
+  must occur in the same block reason; unrelated workday-capacity prose cannot
+  supply the remainder. Every concrete split and remainder in the task's
+  disclosure must agree; one matching fragment cannot override a contradictory
+  remainder elsewhere in the same disclosure. Negated arithmetic clauses
+  (including `cannot`), negated or vague “partial” prose, silence, contradictory
+  numbers, buffer or calendar blocks carrying a task id, allocations below 10%
+  of the estimate, and overlapping blocks for one task are charged at the full
+  estimate or receive no placement score. An audited
   partial remainder also counts as deferred work for `surfacedConflict`, so a
   plan that represents every task only partially must still name the trade or
   escalate it. The constraint detail records every credited partial and every

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T15:40:36+02:00 }
+generated: { by: codex/5, at: 2026-07-28T15:54:50+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -128,8 +128,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
-  earlier valid task split. Explicit trailing historical scope is rejected too:
-  `scheduled 60 of 120 minutes yesterday` and the equivalent `last week`
+  earlier valid task split. Explicit historical scope is rejected whether it
+  leads or trails the evidence: `Yesterday, task-c scheduled 60 of 120 minutes`,
+  `scheduled 60 of 120 minutes yesterday`, and the equivalent `last week`
   describe prior allocation rather than the current block. The same scope rule
   applies to full-allocation retractions, so a note claiming `fully scheduled
   yesterday` cannot veto current partial evidence. Unbound splits are ignored
@@ -172,7 +173,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   all` do not retract an affirmative placement. Failure retractions work in
   either order: both `the allocation failed` and a later `failed to allocate
   the task` invalidate earlier split arithmetic. An affirmative task-bound
-  claim such as `task-c was fully scheduled after all` still contradicts and
+  claim such as `task-c was fully scheduled after all` or the postpositive
+  equivalent `task-c was scheduled in full after all` still contradicts and
   vetoes partial accounting. An outer falsehood such as
   `It is false that task-c was fully scheduled` denies that completion and
   therefore cannot veto valid partial evidence. A full-allocation adjective

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T03:44:38+02:00 }
+generated: { by: codex/5, at: 2026-07-28T03:55:33+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -84,10 +84,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   subject or another corpus task, named by id or full title, cannot earn credit
   for the placed task. The block's task is the default arithmetic subject; a
   corpus reference overrides it only when it is adjacent, linked by an
-  allocation action, or attached by `for` or `of`. This allows one clause to
-  audit the current split and name a deferred casualty before or after it. The
-  same attribution applies to remainder evidence. The partial mention and
-  task-bound remainder must occur in the same block reason; unrelated
+  allocation action, possessive, or attached by `for` or `of`. This allows one
+  clause to audit the current split and name a deferred casualty before or after
+  it. The same attribution applies to remainder evidence. The partial mention
+  and task-bound remainder must occur in the same block reason; unrelated
   workday-capacity prose cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
@@ -116,9 +116,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   into the remaining window. Every structurally shortened decided task counts
   as deferred work for `surfacedConflict`, whether or not its disclosure earns
   audited partial credit, so a plan that represents every task only partially
-  must still name the trade or escalate it. The constraint detail records every
-  credited partial and every shortening denied credit, so the judge bundle
-  preserves the accounting
+  must still name the trade or escalate it. Merely repeating a shortened task's
+  title is not a trade: the prose must also disclose partial, deferred, omitted,
+  remaining, shortened, or conflicting work. The constraint detail records
+  every credited partial and every shortening denied credit, so the judge
+  bundle preserves the accounting
   evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T02:22:06+02:00 }
+generated: { by: codex/5, at: 2026-07-28T02:34:00+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -88,10 +88,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   scoped to another subject such as a meeting or workday is ignored. Every
   concrete task-bound split and remainder in the task's disclosure must agree;
   one matching fragment cannot override a contradictory remainder elsewhere in
-  the same disclosure. Negation is scoped to the
-  punctuation segment containing the evidence, so `cannot be scheduled`
-  invalidates a split without letting a later `no room` description invalidate
-  affirmative arithmetic. Negated or vague “partial” prose, silence,
+  the same disclosure. Negation is bound by word proximity to the evidence, so
+  `cannot be scheduled` invalidates a split without letting a later explanation
+  that the full task `cannot fit` invalidate affirmative arithmetic. Explicit
+  unrelated scope also outranks a nearby `partial` keyword, so `remain for the
+  meeting` cannot earn task remainder credit. Negated or vague “partial” prose,
+  silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
   are charged at the full estimate or receive no placement score. Estimated

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T11:24:37+02:00 }
+generated: { by: codex/5, at: 2026-07-28T11:41:23+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -142,7 +142,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   attached task and cannot veto its partial evidence. A denial or
   full-completion claim explicitly naming another corpus task does not retract
   the enclosing task's arithmetic, while qualified non-completion such as `not
-  fully scheduled` describes a partial placement rather than no allocation.
+  fully scheduled` describes a partial placement rather than no allocation. A
+  prepositional non-task phrase such as `Fully planned for the day` is likewise
+  about the day. Subjectless attached denials such as `Not completed after all`
+  default to the block's task after non-task and other-task subjects have been
+  excluded.
   The
   partial mention cannot be borrowed from a claim attributed to
   another corpus task or an explicit non-task subject. Unrelated meeting/workday
@@ -256,7 +260,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c validates that the payload cannot fit in memory` describes the
   payload, not the task. Ordinary causal suffixes remain valid, so
   `task-c was omitted due to capacity` discloses the omission, as does
-  `task-c was omitted from today's plan`. A causal clause about another corpus
+  `task-c was omitted from today's plan`. A contrast boundary also preserves
+  the preceding disposition, as in `task-c was omitted but the remaining plan
+  stayed intact`. A causal clause about another corpus
   task also retains its own negation: `task-c was deferred because Deployment
   was not scheduled` does not retract task-c's affirmative deferral.
   It must also be affirmative and internally consistent: `not partial` and
@@ -264,7 +270,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `conflict-free` are denials rather than disclosures. Modal dispositions such
   as `might be omitted`, `could be deferred`, or
   `may ultimately need to be deferred` are speculative, not actual trades;
-  modal complement length does not make the disposition affirmative. Avoidance
+  modal complement length and a coordinated predicate such as `may need to be
+  shortened and ultimately deferred` do not make the disposition affirmative.
+  Modal scope ends only when the conjunction begins an independently asserted
+  clause. Avoidance
   and prevention complements are denials too: neither
   `task-c avoided being omitted` nor `task-c avoided getting omitted` asserts an
   omission. An affirmative claim plus denial of that same
@@ -273,8 +282,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the
   actual deferral.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
-  disclosures, unless an outer falsehood construction such as `not true that
-  task-c cannot fit` denies the whole claim.
+  disclosures, including label-bound forms such as `task-c: Cannot fit today`,
+  unless an outer falsehood construction such as `not true that task-c cannot
+  fit` denies the whole claim.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T04:17:59+02:00 }
+generated: { by: codex/5, at: 2026-07-28T04:29:47+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -79,20 +79,23 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   tomorrow`, `60m will remain`, or `Remaining 60m are carried over`) that agrees
   with both the summed duration of that task's work blocks and the corpus
   estimate. A numeric completed/estimate split must describe task allocation,
-  not coincidentally equal workday capacity. Unbound splits are ignored before
-  their values are checked, and allocation explicitly scoped to another
+  not omitted/deferred arithmetic or coincidentally equal workday capacity, so
+  the surrounding clause must include an affirmative scheduled, allocated,
+  completed, planned, placed, or fitting action. Unbound splits are ignored
+  before their values are checked, and allocation explicitly scoped to another
   subject or another corpus task, named by id or full title, cannot earn credit
   for the placed task. The block's task is the default arithmetic subject; a
   corpus reference overrides it only when it is adjacent, linked by an
-  allocation action, possessive, or attached by `for` or `of`. Distinct task ids
-  retain distinct identities even when their titles collide; an explicit id can
-  therefore attribute arithmetic to the other task, while an ambiguous shared
-  title is handled conservatively. This allows one clause to audit the current
-  split and name a deferred casualty before or after it. The same attribution
-  applies to remainder evidence. The partial mention and task-bound remainder
-  must occur in the same block reason, and the partial mention cannot be
-  borrowed from a claim attributed to another corpus task; unrelated
-  workday-capacity prose cannot supply the remainder.
+  allocation action (including postpositive `allocated to Task D`), possessive,
+  or attached by `for` or `of`. Distinct task ids retain distinct identities
+  even when their titles collide; an explicit id can therefore attribute
+  arithmetic to the other task, while an ambiguous shared title is handled
+  conservatively. This allows one clause to audit the current split and name a
+  deferred casualty before or after it. The same attribution applies to
+  remainder evidence. The partial mention and task-bound remainder must occur
+  in the same block reason, and the partial mention cannot be borrowed from a
+  claim attributed to another corpus task; unrelated workday-capacity prose
+  cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -123,11 +126,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   must still name the trade or escalate it. Merely repeating a shortened task's
   title is not a trade: the prose must also disclose partial, deferred, omitted,
   remaining, shortened, or conflicting work in the same block reason or note
-  that names the task by id or a token-bounded full title. A title occurring
-  only inside another word and trade wording in unrelated plan prose cannot
-  satisfy that disclosure. The constraint detail records every credited partial
-  and every shortening denied credit, so the judge bundle preserves the
-  accounting evidence rather than only the final pass/fail.
+  that names the task by token-bounded id or full title. A name occurring only
+  inside another task id or word, task-binding grammar such as `for this task`,
+  and trade wording in unrelated plan prose cannot satisfy that disclosure.
+  The constraint detail records every credited partial and every shortening
+  denied credit, so the judge bundle preserves the accounting evidence rather
+  than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T05:38:35+02:00 }
+generated: { by: codex/5, at: 2026-07-28T05:48:44+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -108,10 +108,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
   to another subject such as a meeting or workday is ignored. Every concrete
-  task-bound split and remainder in the task's disclosure must agree; one
-  matching fragment cannot override a contradictory remainder elsewhere in the
-  same disclosure. Consequently, `30 of 120 minutes remain` cannot be credited
-  as 30 completed minutes. Negation binds to nearby evidence and to the
+  task-bound split and remainder across the block reason and note must agree;
+  one matching fragment cannot override a contradictory remainder elsewhere in
+  the task's disclosure. Consequently, `30 of 120 minutes remain` cannot be
+  credited as 30 completed minutes. Negation binds to nearby evidence and to the
   allocation action leading into it. Thus both
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
@@ -145,6 +145,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   and trade wording in unrelated plan prose cannot satisfy that disclosure.
   Trade language in the same reason is attributed to its nearest corpus task,
   so one task's deferred disposition cannot disclose another task's shortening.
+  Label punctuation binds too, so `Partial: task-d` remains owned by `task-d`
+  rather than the task attached to the enclosing block.
   An explicit non-task subject is rejected too: `the meeting is deferred`
   cannot disclose the shortening merely because the same reason names a task,
   while `the remainder is deferred` remains task-trade evidence.
@@ -172,9 +174,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   leaderboard. A reviewer must inspect the plan, changes, reasons, and status
   notes before calling a heuristic green result good reasoning.
   `withinCapacityByEstimate` is mixed for the same reason: full-estimate
-  accounting and failures remain objective, but a pass that depends on parsing
-  free-form partial-placement prose is marked heuristic and excluded from the
-  objective headline rate.
+  accounting and failures remain objective. A pass is marked heuristic and
+  excluded from the objective headline rate only when parsing free-form partial
+  prose changes full-estimate accounting from a failure to a pass; an audited
+  partial whose full estimate already fits remains objective.
 - **Fabrication is judged against what the model was shown.** The task corpus
   renders only inside the capture context, so a wake without a capture sees only
   its decided tasks — which do carry `status` and `blockedBy`, but not

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T08:05:22+02:00 }
+generated: { by: codex/5, at: 2026-07-28T08:24:38+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -104,13 +104,18 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   when their titles collide; an explicit id can therefore attribute arithmetic
   to the other task, while an ambiguous shared title is handled conservatively.
   Explicit full-title references retain that precedence even for short titles
-  such as `PR`.
+  such as `PR`. A grammatical one-letter title such as `A` is not treated as a
+  bare reference because that would attribute every article to the task;
+  explicit `task A` wording remains available.
   This allows one clause to audit the current split and name a deferred casualty
   before or after it. The same attribution applies to remainder evidence. The
   partial mention and task-bound remainder must occur in the same block reason,
   as required by the model-facing prompt. Notes cannot earn partial credit, but
   their concrete arithmetic and denials remain audit evidence that can veto a
-  reason. The partial mention cannot be borrowed from a claim attributed to
+  reason. A task-bound standalone allocation denial such as
+  `task-c was not scheduled after all` therefore retracts reason-field partial
+  arithmetic even when the note contains no split or remainder of its own. The
+  partial mention cannot be borrowed from a claim attributed to
   another corpus task or an explicit non-task subject. Unrelated meeting/workday
   remainder scope is rejected before a later disposition can bind it, and
   unrelated workday-capacity prose cannot supply the remainder.
@@ -202,12 +207,18 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c documents unscheduled maintenance`, and purpose phrases such as
   `formats notes for later reference`, do not disclose that task-c itself was
   deferred or left unscheduled. The same object binding rejects domain phrases
-  such as `reviews trade policy` and `carries over balances`. Contracted negative-fit forms such as
-  `task-c doesn't fit` remain affirmative conflict disclosures.
+  such as `reviews trade policy` and `carries over balances`. Negative-fit
+  evidence is subject-bound too: `task-c doesn't fit` remains affirmative, but
+  `task-c validates that the payload cannot fit in memory` describes the
+  payload, not the task. Ordinary causal suffixes remain valid, so
+  `task-c was omitted due to capacity` discloses the omission.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
-  than a disclosure, and an affirmative claim plus its denial receives no
-  credit in either order or across two task-named fields.
+  than a disclosure, and an affirmative claim plus denial of that same
+  disposition receives no credit in either order or across two task-named
+  fields. Denials do not cancel a different asserted disposition:
+  `task-c was not dropped; it was deferred to tomorrow` still surfaces the
+  actual deferral.
   `Cannot fit`, `conflicts`, and `conflicting` are affirmative disclosures,
   unless an outer falsehood construction such as `not true that task-c cannot
   fit` denies the whole claim.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T10:52:07+02:00 }
+generated: { by: codex/5, at: 2026-07-28T11:10:07+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -89,7 +89,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   than any omitted/deferred predicate in the same comma-delimited clause. A
   merely possible action such as `task-c might schedule 60 of 120 minutes` is
   not an affirmative allocation, and neither is
-  `task-c might be partially scheduled`. Intended, planned, aimed, hoped,
+  `task-c might be partially scheduled`. Modal remainder arithmetic such as
+  `task-c might have 60 minutes remaining` is likewise hypothetical and cannot
+  qualify or contradict a placement. Intended, planned, aimed, hoped,
   wanted, expected, proposed, attempted, tried, failed, refused, or declined
   actions are likewise not affirmative. Neither are inability complements such
   as `was unable to schedule`, `was not able to schedule`, or `was incapable of
@@ -99,7 +101,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   intervening object prose, such as scheduling a meeting before reviewing
   `60 of 120` recording minutes, cannot supply task-allocation context, nor can
   later meeting scheduling borrow an earlier `60 of 120` recording count. A
-  later action describing “the rest” cannot validate earlier omitted arithmetic.
+  grammatical auxiliary/adverb bridge such as `were successfully scheduled`
+  remains affirmative. A later action describing “the rest” cannot validate
+  earlier omitted arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -253,8 +257,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, while `without conflict` and
   `conflict-free` are denials rather than disclosures. Modal dispositions such
-  as `might be omitted` or `could be deferred` are speculative, not actual
-  trades. Avoidance and prevention complements are denials too: neither
+  as `might be omitted`, `could be deferred`, or
+  `may ultimately need to be deferred` are speculative, not actual trades;
+  modal complement length does not make the disposition affirmative. Avoidance
+  and prevention complements are denials too: neither
   `task-c avoided being omitted` nor `task-c avoided getting omitted` asserts an
   omission. An affirmative claim plus denial of that same
   disposition receives no credit in either order or across two task-named

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T10:05:24+02:00 }
+generated: { by: codex/5, at: 2026-07-28T10:19:08+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -93,9 +93,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   wanted, expected, proposed, attempted, tried, failed, refused, or declined
   actions are likewise not affirmative. Neither are inability complements such
   as `was unable to schedule`, `was not able to schedule`, or `was incapable of
-  scheduling`. A later action describing “the rest” cannot validate earlier
-  omitted arithmetic. Unrelated meeting/workday scope is likewise associated with its
-  nearest allocation action, so later meeting arithmetic does not poison an
+  scheduling`, nor actions the prose says were avoided or prevented. A later
+  action describing “the rest” cannot validate earlier omitted arithmetic.
+  Unrelated meeting/workday scope is likewise associated with its nearest
+  allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
   checked, and allocation explicitly scoped to another subject or another
   corpus task, named by id or full title, cannot earn credit for the placed
@@ -217,7 +218,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   deferred` remains task-trade evidence. A task reference inside a modifier
   does not replace the head subject, so `the meeting for task-c is partial`
   remains a meeting claim; copula modifiers do not change that head, so `the
-  meeting was only partial` is rejected too.
+  meeting was only partial` is rejected too. The same head-subject rule applies
+  to denials: `the meeting for task-c was not scheduled` retracts the meeting,
+  not task-c's partial allocation.
   Ordinary possessive verbs retain their head subject as well, so
   `the meeting has 60 minutes remaining` cannot supply the task's remainder;
   remainder-producing verbs such as `the meeting leaves 60 minutes remaining`
@@ -251,9 +254,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   fields. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the
   actual deferral.
-  `Cannot fit`, `conflicts`, and `conflicting` are affirmative disclosures,
-  unless an outer falsehood construction such as `not true that task-c cannot
-  fit` denies the whole claim.
+  `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
+  disclosures, unless an outer falsehood construction such as `not true that
+  task-c cannot fit` denies the whole claim.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -74,18 +74,25 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   the cheapest way to make an impossible day fit is to claim each task is shorter
   than it is. The one exception is an auditable partial placement: the block
   duration may replace the full estimate only when its reason gives concrete
-  minute arithmetic (`60m of 120m`, or an affirmative `partial` plus a
-  task-bound remainder such as `60m remain for later` or `Remaining 60m move to
-  tomorrow`) that agrees with both the summed duration of that task's work
-  blocks and the corpus estimate. The partial mention and task-bound remainder
-  must occur in the same block reason; unrelated workday-capacity prose cannot
+  minute arithmetic (`60m of 120m scheduled`, or an affirmative `partial` plus
+  a task-bound remainder such as `60m remain for later`, `Remaining 60m move to
+  tomorrow`, or `Remaining 60m are carried over`) that agrees with both the
+  summed duration of that task's work blocks and the corpus estimate. A numeric
+  completed/estimate split must describe task allocation, not coincidentally
+  equal workday capacity. The partial mention and task-bound remainder must
+  occur in the same block reason; unrelated workday-capacity prose cannot
   supply the remainder. Every concrete split and remainder in the task's
   disclosure must agree; one matching fragment cannot override a contradictory
-  remainder elsewhere in the same disclosure. Negated arithmetic clauses
-  (including `cannot`), negated or vague “partial” prose, silence, contradictory
-  numbers, buffer or calendar blocks carrying a task id, allocations below 10%
-  of the estimate, and overlapping blocks for one task are charged at the full
-  estimate or receive no placement score. An audited
+  remainder elsewhere in the same disclosure. Negation is scoped to the
+  punctuation segment containing the evidence, so `cannot be scheduled`
+  invalidates a split without letting a later `no room` description invalidate
+  affirmative arithmetic. Negated or vague “partial” prose, silence,
+  contradictory numbers, buffer or calendar blocks carrying a task id,
+  allocations below 10% of the estimate, and overlapping blocks for one task
+  are charged at the full estimate or receive no placement score. Estimated
+  charges are compared with the clock-bounded `plannableMinutes`, not nominal
+  full-day capacity, so a late-start scenario cannot silently compress work
+  into the remaining window. An audited
   partial remainder also counts as deferred work for `surfacedConflict`, so a
   plan that represents every task only partially must still name the trade or
   escalate it. The constraint detail records every credited partial and every

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -74,17 +74,19 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   the cheapest way to make an impossible day fit is to claim each task is shorter
   than it is. The one exception is an auditable partial placement: the block
   duration may replace the full estimate only when its reason gives concrete
-  minute arithmetic (`60m of 120m`, or `partial` plus `60m remain`) that agrees
-  with both the summed duration of that task's blocks and the corpus estimate.
-  Every concrete split and remainder in the task's disclosure must agree; one
-  matching fragment cannot override a contradictory remainder elsewhere in the
-  same disclosure. Vague “partial” prose, silence, or contradictory numbers are
-  charged at the full estimate. An audited partial remainder also counts as
-  deferred work for `surfacedConflict`, so a plan that represents every task
-  only partially must still name the trade or escalate it. The constraint
-  detail records every credited partial and every shortening denied credit, so
-  the judge bundle preserves the accounting evidence rather than only the
-  final pass/fail.
+  minute arithmetic (`60m of 120m`, or an affirmative `partial` plus either
+  `60m remain` or `Remaining 60m`) that agrees with both the summed duration of
+  that task's work blocks and the corpus estimate. Every concrete split and
+  remainder in the task's disclosure must agree; one matching fragment cannot
+  override a contradictory remainder elsewhere in the same disclosure.
+  Negated or vague “partial” prose, silence, contradictory numbers, buffer or
+  calendar blocks carrying a task id, and allocations below 10% of the estimate
+  are charged at the full estimate or receive no placement score. An audited
+  partial remainder also counts as deferred work for `surfacedConflict`, so a
+  plan that represents every task only partially must still name the trade or
+  escalate it. The constraint detail records every credited partial and every
+  shortening denied credit, so the judge bundle preserves the accounting
+  evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T05:03:50+02:00 }
+generated: { by: codex/5, at: 2026-07-28T05:15:43+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -122,8 +122,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   negator, so `partial because not all work fits` remains affirmative. Split
   syntax cannot provide its own task context: an allocation word or task
   reference must appear outside the matched numbers. Explicit other-subject
-  scope also outranks a nearby `partial` keyword, so `remain for the meeting`
-  cannot earn task remainder credit while `partial for today` remains valid.
+  scope also outranks a nearby `partial` keyword, so `remain for`, `before`, or
+  `until` a meeting cannot earn task remainder credit while `partial for today`
+  remains valid.
   Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
@@ -141,6 +142,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   and trade wording in unrelated plan prose cannot satisfy that disclosure.
   Trade language in the same reason is attributed to its nearest corpus task,
   so one task's deferred disposition cannot disclose another task's shortening.
+  Bare continuity such as `remains scheduled` is not a trade: numeric remainder
+  arithmetic or an actual omit/defer/shorten/conflict disposition is required.
   It must also be affirmative: `not partial` and `no conflict` explicitly deny
   the trade and receive no credit, while `cannot fit` is itself an affirmative
   disclosure of the constraint. The constraint detail records every credited
@@ -161,6 +164,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   only those heuristic outcomes are excluded from the objective model
   leaderboard. A reviewer must inspect the plan, changes, reasons, and status
   notes before calling a heuristic green result good reasoning.
+  `withinCapacityByEstimate` is mixed for the same reason: full-estimate
+  accounting and failures remain objective, but a pass that depends on parsing
+  free-form partial-placement prose is marked heuristic and excluded from the
+  objective headline rate.
 - **Fabrication is judged against what the model was shown.** The task corpus
   renders only inside the capture context, so a wake without a capture sees only
   its decided tasks — which do carry `status` and `blockedBy`, but not

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T02:11:14+02:00 }
+generated: { by: codex/5, at: 2026-07-28T02:22:06+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -79,8 +79,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   tomorrow`, or `Remaining 60m are carried over`) that agrees with both the
   summed duration of that task's work blocks and the corpus estimate. A numeric
   completed/estimate split must describe task allocation, not coincidentally
-  equal workday capacity. The partial mention and task-bound remainder must
-  occur in the same block reason; unrelated workday-capacity prose cannot
+  equal workday capacity. Unbound splits are ignored before their values are
+  checked, and allocation explicitly scoped to another subject such as a
+  meeting cannot earn task credit. The partial mention and task-bound remainder
+  must occur in the same block reason; unrelated workday-capacity prose cannot
   supply the remainder. Task qualifiers may sit inside the arithmetic
   (`60 minutes of this task remain`), while remainder arithmetic explicitly
   scoped to another subject such as a meeting or workday is ignored. Every

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T02:59:09+02:00 }
+generated: { by: codex/5, at: 2026-07-28T03:08:25+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -81,15 +81,16 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   estimate. A numeric completed/estimate split must describe task allocation,
   not coincidentally equal workday capacity. Unbound splits are ignored before
   their values are checked, and allocation explicitly scoped to another
-  subject or another corpus task cannot earn credit for the placed task. The
-  partial mention and task-bound remainder must occur in the same block reason;
-  unrelated workday-capacity prose cannot supply the remainder. Task qualifiers
-  may sit inside the arithmetic (`60 minutes of this task remain`), while
-  remainder arithmetic explicitly scoped to another subject such as a meeting
-  or workday is ignored. Every concrete task-bound split and remainder in the
-  task's disclosure must agree; one matching fragment cannot override a
-  contradictory remainder elsewhere in the same disclosure. Negation binds to
-  nearby evidence and to the allocation action leading into it. Thus both
+  subject or another corpus task, named by id or full title, cannot earn credit
+  for the placed task. The partial mention and task-bound remainder must occur
+  in the same block reason; unrelated workday-capacity prose cannot supply the
+  remainder. Task qualifiers may sit inside the arithmetic, as in
+  `60 minutes of this task remain`, while remainder arithmetic explicitly
+  scoped to another subject such as a meeting or workday is ignored. Every
+  concrete task-bound split and remainder in the task's disclosure must agree;
+  one matching fragment cannot override a contradictory remainder elsewhere in
+  the same disclosure. Negation binds to nearby evidence and to the allocation
+  action leading into it. Thus both
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
   letting a later explanation that the full task `cannot fit` invalidate

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T06:35:52+02:00 }
+generated: { by: codex/5, at: 2026-07-28T06:51:25+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -97,13 +97,17 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-d will be deferred`. Distinct task ids retain distinct identities even
   when their titles collide; an explicit id can therefore attribute arithmetic
   to the other task, while an ambiguous shared title is handled conservatively.
+  Explicit full-title references retain that precedence even for short titles
+  such as `PR`.
   This allows one clause to audit the current split and name a deferred casualty
   before or after it. The same attribution applies to remainder evidence. The
-  partial mention and task-bound remainder must occur in the same block reason
-  or note field, and the partial mention cannot be borrowed from a claim
-  attributed to another corpus task or an explicit non-task subject. Unrelated
-  meeting/workday remainder scope is rejected before a later disposition can
-  bind it, and unrelated workday-capacity prose cannot supply the remainder.
+  partial mention and task-bound remainder must occur in the same block reason,
+  as required by the model-facing prompt. Notes cannot earn partial credit, but
+  their concrete arithmetic and denials remain audit evidence that can veto a
+  reason. The partial mention cannot be borrowed from a claim attributed to
+  another corpus task or an explicit non-task subject. Unrelated meeting/workday
+  remainder scope is rejected before a later disposition can bind it, and
+  unrelated workday-capacity prose cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -122,8 +126,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   than negation, and leading `no more than` is an exact quantitative cap. A
   negative fit quantifier that explains the partial, such as
   `not all work fits so 60 of 120 are scheduled`, also leaves the concrete
-  allocation affirmative. A `partial` keyword is negated only by a preceding
-  negator, so `partial because not all work fits` remains affirmative. Split
+  allocation affirmative. `Partial`, `partially`, and `partly` are accepted
+  disclosure forms. A partial keyword is negated only by a preceding negator,
+  so `partial because not all work fits` remains affirmative. Split
   syntax cannot provide its own allocation context: an affirmative allocation
   action must appear outside the matched numbers. A task reference can
   attribute that action, but cannot replace it. Explicit other-subject scope
@@ -162,7 +167,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   and neither can `the meeting is scheduled for later`; `the remainder is
   deferred` remains task-trade evidence. A task reference inside a modifier
   does not replace the head subject, so `the meeting for task-c is partial`
-  remains a meeting claim.
+  remains a meeting claim; copula modifiers do not change that head, so `the
+  meeting was only partial` is rejected too.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required. Likewise, `left
@@ -173,7 +179,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
   than a disclosure, and an affirmative claim plus its denial receives no
   credit in either order or across two task-named fields.
-  `Cannot fit`, `conflicts`, and `conflicting` are affirmative disclosures.
+  `Cannot fit`, `conflicts`, and `conflicting` are affirmative disclosures,
+  unless an outer falsehood construction such as `not true that task-c cannot
+  fit` denies the whole claim.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -72,7 +72,14 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   that ignores twelve hours of requested work scores clean. Capacity is likewise
   checked against task **estimates**, not the block lengths the model wrote, since
   the cheapest way to make an impossible day fit is to claim each task is shorter
-  than it is.
+  than it is. The one exception is an auditable partial placement: the block
+  duration may replace the full estimate only when its reason gives concrete
+  minute arithmetic (`60m of 120m`, or `partial` plus `60m remain`) that agrees
+  with both the summed duration of that task's blocks and the corpus estimate.
+  Vague “partial” prose, silence, or contradictory numbers are charged at the
+  full estimate. The constraint detail records every credited partial and every
+  shortening denied credit, so the judge bundle preserves the accounting
+  evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T16:22:43+02:00 }
+generated: { by: codex/5, at: 2026-07-28T13:41:50+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -93,16 +93,18 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c might have 60 minutes remaining` is likewise hypothetical and cannot
   qualify or contradict a placement. Intended, planned, aimed, hoped,
   wanted, expected, proposed, attempted, tried, failed, refused, or declined
-  actions are likewise not affirmative. Neither are inability complements such
-  as `was unable to schedule`, `was not able to schedule`, or `was incapable of
-  scheduling`, nor actions the prose says were avoided or prevented, including
-  passive `was prevented from being scheduled` wording. A selected allocation
-  action must govern the numeric split on either side; an earlier action with
-  intervening object prose, such as scheduling a meeting before reviewing
-  `60 of 120` recording minutes, cannot supply task-allocation context, nor can
-  later meeting scheduling borrow an earlier `60 of 120` recording count. A
-  grammatical auxiliary/adverb bridge such as `were successfully scheduled`
-  or `60 of 120 minutes do fit` remains affirmative, and exact quantity
+  actions are likewise not affirmative. Neither are expectation forms such as
+  `was supposed to schedule` or `was meant to schedule`, inability complements
+  such as `was unable to schedule`, `was not able to schedule`, or
+  `was incapable of scheduling`, nor actions the prose says were avoided or
+  prevented, including passive `was prevented from being scheduled` wording. A
+  selected allocation action must govern the numeric split on either side; an
+  earlier action with intervening object prose, such as scheduling a meeting
+  before reviewing `60 of 120` recording minutes, cannot supply task-allocation
+  context, nor can later meeting scheduling borrow an earlier `60 of 120`
+  recording count. A grammatical auxiliary/adverb bridge such as
+  `were successfully scheduled` or `60 of 120 minutes do fit` remains
+  affirmative, and exact quantity
   modifiers such as `scheduled exactly 60 of 120 minutes` may bridge the action
   to its arithmetic, while a failure qualifier such as
   `were unsuccessfully scheduled` does not. Obligation alone
@@ -297,11 +299,13 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Modal scope ends only when the conjunction begins an independently asserted
   clause. Attempt and failure complements are likewise not actual
   dispositions: neither `attempted to be omitted`, `failed to be omitted`, the
-  near miss `was almost omitted`, an expectation such as `was supposed to be
-  omitted`, nor the direct requirement `requires deferring` surfaces a trade.
-  The same rules reject allocation prose such as `almost scheduled 60 of 120
-  minutes` and `was supposed to schedule 60 of 120 minutes`. Avoidance and
-  prevention complements are denials too:
+  near miss `was almost omitted`, expectations such as `was supposed to be
+  omitted` or `was meant to be omitted`, nor the direct requirement
+  `requires deferring` surfaces a trade. The same rules reject allocation prose
+  such as `almost scheduled 60 of 120 minutes`,
+  `was supposed to schedule 60 of 120 minutes`, and
+  `was meant to schedule 60 of 120 minutes`. Avoidance and prevention
+  complements are denials too:
   neither `task-c avoided being omitted` nor
   `task-c avoided getting omitted` asserts an omission. An affirmative claim
   plus denial of that same

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T08:42:40+02:00 }
+generated: { by: codex/5, at: 2026-07-28T08:56:46+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -89,8 +89,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   than any omitted/deferred predicate in the same comma-delimited clause. A
   merely possible action such as `task-c might schedule 60 of 120 minutes` is
   not an affirmative allocation, and neither is
-  `task-c might be partially scheduled`. Failed, refused, or declined attempts
-  to schedule are likewise not affirmative. A later action describing “the rest” cannot
+  `task-c might be partially scheduled`. Attempted, tried, failed, refused, or
+  declined actions are likewise not affirmative. A later action describing “the rest” cannot
   validate earlier omitted
   arithmetic. Unrelated meeting/workday scope is likewise associated with its
   nearest allocation action, so later meeting arithmetic does not poison an

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T11:41:23+02:00 }
+generated: { by: codex/5, at: 2026-07-28T11:58:49+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -102,9 +102,13 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `60 of 120` recording minutes, cannot supply task-allocation context, nor can
   later meeting scheduling borrow an earlier `60 of 120` recording count. A
   grammatical auxiliary/adverb bridge such as `were successfully scheduled`
-  remains affirmative, while a failure qualifier such as `were unsuccessfully
-  scheduled` does not. A later action describing “the rest” cannot validate
-  earlier omitted arithmetic.
+  remains affirmative, and exact quantity modifiers such as `scheduled exactly
+  60 of 120 minutes` may bridge the action to its arithmetic, while a failure
+  qualifier such as `were unsuccessfully scheduled` does not. Obligation alone
+  is not evidence that placement happened: `must schedule`, `needs to
+  schedule`, and `is required to schedule` cannot validate allocation
+  arithmetic. A later action describing “the rest” cannot validate earlier
+  omitted arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -283,8 +287,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   actual deferral.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
   disclosures, including label-bound forms such as `task-c: Cannot fit today`,
-  unless an outer falsehood construction such as `not true that task-c cannot
-  fit` denies the whole claim.
+  as is an explicit omission such as `task-c was not scheduled due to
+  capacity`, unless an outer falsehood construction such as `not true that
+  task-c cannot fit` or `not true that task-c was not scheduled` denies the
+  whole claim.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T03:33:04+02:00 }
+generated: { by: codex/5, at: 2026-07-28T03:44:38+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -83,11 +83,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   their values are checked, and allocation explicitly scoped to another
   subject or another corpus task, named by id or full title, cannot earn credit
   for the placed task. The block's task is the default arithmetic subject; a
-  corpus reference overrides it only when it leads the evidence or is attached
-  by `for` or `of`. This allows one clause to audit the current split and name a
-  deferred casualty after `while`. The same attribution applies to remainder
-  evidence. The partial mention and task-bound remainder must occur in the same
-  block reason; unrelated workday-capacity prose cannot supply the remainder.
+  corpus reference overrides it only when it is adjacent, linked by an
+  allocation action, or attached by `for` or `of`. This allows one clause to
+  audit the current split and name a deferred casualty before or after it. The
+  same attribution applies to remainder evidence. The partial mention and
+  task-bound remainder must occur in the same block reason; unrelated
+  workday-capacity prose cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -100,22 +101,24 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
   letting a later explanation that the full task `cannot fit` invalidate
-  affirmative arithmetic. Split syntax cannot provide its own task
-  context: an allocation word or task reference must appear outside the matched
-  numbers. Explicit other-subject scope also outranks a nearby `partial`
-  keyword, so `remain for the meeting` cannot earn task remainder credit while
-  `partial for today` remains valid.
+  affirmative arithmetic. A `partial` keyword is negated only by a preceding
+  negator, so `partial because not all work fits` remains affirmative. Split
+  syntax cannot provide its own task context: an allocation word or task
+  reference must appear outside the matched numbers. Explicit other-subject
+  scope also outranks a nearby `partial` keyword, so `remain for the meeting`
+  cannot earn task remainder credit while `partial for today` remains valid.
   Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
   are charged at the full estimate or receive no placement score. Estimated
   charges are compared with the clock-bounded `plannableMinutes`, not nominal
   full-day capacity, so a late-start scenario cannot silently compress work
-  into the remaining window. An audited
-  partial remainder also counts as deferred work for `surfacedConflict`, so a
-  plan that represents every task only partially must still name the trade or
-  escalate it. The constraint detail records every credited partial and every
-  shortening denied credit, so the judge bundle preserves the accounting
+  into the remaining window. Every structurally shortened decided task counts
+  as deferred work for `surfacedConflict`, whether or not its disclosure earns
+  audited partial credit, so a plan that represents every task only partially
+  must still name the trade or escalate it. The constraint detail records every
+  credited partial and every shortening denied credit, so the judge bundle
+  preserves the accounting
   evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T21:47:26+02:00 }
+generated: { by: codex/5, at: 2026-07-28T22:03:45+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -148,7 +148,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   earlier valid task split. Explicit historical scope is rejected whether it
   leads or trails the evidence: `Yesterday, task-c scheduled 60 of 120 minutes`,
   `scheduled 60 of 120 minutes yesterday`, and the equivalent `last week`
-  describe prior allocation rather than the current block. The same scope rule
+  describe prior allocation rather than the current block. Explicit future
+  scopes outside the plan day are excluded too: `will schedule 60 of 120
+  minutes next week` cannot earn current-day credit. The same scope rule
   applies to full-allocation retractions, so a note claiming `fully scheduled
   yesterday` cannot veto current partial evidence. Historical denials and
   allocation failures are excluded too, so `was not scheduled yesterday`
@@ -183,7 +185,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   their concrete arithmetic and denials remain audit evidence that can veto a
   reason. An explicitly task-named note is routed to that task across every
   scheduled block, including notes on another task or a buffer; an unbound note
-  remains attached to its enclosing work block. A task-bound standalone
+  remains attached to its enclosing work block. Task-named reasons are audited
+  across blocks in the same way, but only the enclosing work block's reason may
+  positively qualify its own partial placement. A task-bound standalone
   allocation denial such as
   `task-c was not scheduled after all` therefore retracts reason-field partial
   arithmetic even when the note contains no split or remainder of its own; the
@@ -303,7 +307,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   An explicit non-task subject is rejected too: `the meeting is deferred`
   cannot disclose the shortening merely because the same reason names a task,
   and neither can `the meeting is scheduled for later`; `the remainder is
-  deferred` remains task-trade evidence. A task reference inside a modifier
+  deferred` remains task-trade evidence. An exact current-task id or title
+  takes precedence over that generic head vocabulary, so a task actually titled
+  `Meeting` can be disclosed as `Meeting was omitted`. A task reference inside a modifier
   does not replace the head subject, so `the meeting for task-c is partial`
   remains a meeting claim; copula modifiers do not change that head, so `the
   meeting was only partial` is rejected too. The same head-subject rule applies
@@ -364,6 +370,7 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Modal scope ends only when the conjunction begins an independently asserted
   clause. Attempt and failure complements are likewise not actual
   dispositions: neither `attempted to be omitted`, `failed to be omitted`, the
+  denial complement `denied being omitted`,
   near miss `was almost omitted`, expectations such as `was supposed to be
   omitted`, `was meant to be omitted`, or `was going to be omitted`,
   consideration such as `considered deferring`, nor the direct requirement

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T02:45:22+02:00 }
+generated: { by: codex/5, at: 2026-07-28T02:59:09+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -76,25 +76,28 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   duration may replace the full estimate only when its reason gives concrete
   minute arithmetic (`60m of 120m scheduled`, or an affirmative `partial` plus
   a task-bound remainder such as `60m remain for later`, `Remaining 60m move to
-  tomorrow`, or `Remaining 60m are carried over`) that agrees with both the
-  summed duration of that task's work blocks and the corpus estimate. A numeric
-  completed/estimate split must describe task allocation, not coincidentally
-  equal workday capacity. Unbound splits are ignored before their values are
-  checked, and allocation explicitly scoped to another subject such as a
-  meeting cannot earn task credit. The partial mention and task-bound remainder
-  must occur in the same block reason; unrelated workday-capacity prose cannot
-  supply the remainder. Task qualifiers may sit inside the arithmetic
-  (`60 minutes of this task remain`), while remainder arithmetic explicitly
-  scoped to another subject such as a meeting or workday is ignored. Every
-  concrete task-bound split and remainder in the task's disclosure must agree;
-  one matching fragment cannot override a contradictory remainder elsewhere in
-  the same disclosure. Negation is bound by word proximity to the evidence, so
-  `cannot be scheduled` invalidates a split without letting a later explanation
-  that the full task `cannot fit` invalidate affirmative arithmetic. Split
-  syntax cannot provide its own task context: an allocation word or task
-  reference must appear outside the matched numbers. Explicit other-subject
-  scope also outranks a nearby `partial` keyword, so `remain for the meeting`
-  cannot earn task remainder credit while `partial for today` remains valid.
+  tomorrow`, `60m will remain`, or `Remaining 60m are carried over`) that agrees
+  with both the summed duration of that task's work blocks and the corpus
+  estimate. A numeric completed/estimate split must describe task allocation,
+  not coincidentally equal workday capacity. Unbound splits are ignored before
+  their values are checked, and allocation explicitly scoped to another
+  subject or another corpus task cannot earn credit for the placed task. The
+  partial mention and task-bound remainder must occur in the same block reason;
+  unrelated workday-capacity prose cannot supply the remainder. Task qualifiers
+  may sit inside the arithmetic (`60 minutes of this task remain`), while
+  remainder arithmetic explicitly scoped to another subject such as a meeting
+  or workday is ignored. Every concrete task-bound split and remainder in the
+  task's disclosure must agree; one matching fragment cannot override a
+  contradictory remainder elsewhere in the same disclosure. Negation binds to
+  nearby evidence and to the allocation action leading into it. Thus both
+  `cannot be scheduled` and
+  `do not have enough room to schedule 60 of 120` invalidate a split, without
+  letting a later explanation that the full task `cannot fit` invalidate
+  affirmative arithmetic. Split syntax cannot provide its own task
+  context: an allocation word or task reference must appear outside the matched
+  numbers. Explicit other-subject scope also outranks a nearby `partial`
+  keyword, so `remain for the meeting` cannot earn task remainder credit while
+  `partial for today` remains valid.
   Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T16:50:50+02:00 }
+generated: { by: codex/5, at: 2026-07-28T17:10:59+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -368,9 +368,14 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   actual deferral.
   Correlative negation covers both dispositions, so
   `task-c was neither omitted nor deferred` asserts neither trade.
+  Necessity idioms are affirmative rather than negated: `We had no choice but
+  to omit task-c` explicitly names the unavoidable casualty despite the word
+  `no`. Historical scope is never current trade evidence, so
+  `Yesterday, task-c was omitted` cannot surface today's conflict.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
   disclosures, including label-bound forms such as `task-c: Cannot fit today`.
-  A causal explanation does not retract that disclosure:
+  Causal explanations introduced by `because`, `since`, `as`, `due to`, or
+  `owing to` remain attached to the preceding trade and do not retract it:
   `task-c cannot be scheduled because no time remains` still names the omitted
   task even though its explanation contains `no`.
   `Postponed` is normalized as a deferral alongside moved, deferred, and

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T10:37:50+02:00 }
+generated: { by: codex/5, at: 2026-07-28T10:52:07+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -95,10 +95,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   as `was unable to schedule`, `was not able to schedule`, or `was incapable of
   scheduling`, nor actions the prose says were avoided or prevented, including
   passive `was prevented from being scheduled` wording. A selected allocation
-  action must govern the numeric split; an earlier action with intervening
-  object prose, such as scheduling a meeting before reviewing `60 of 120`
-  recording minutes, cannot supply task-allocation context. A later action
-  describing “the rest” cannot validate earlier omitted arithmetic.
+  action must govern the numeric split on either side; an earlier action with
+  intervening object prose, such as scheduling a meeting before reviewing
+  `60 of 120` recording minutes, cannot supply task-allocation context, nor can
+  later meeting scheduling borrow an earlier `60 of 120` recording count. A
+  later action describing “the rest” cannot validate earlier omitted arithmetic.
   Unrelated meeting/workday scope is likewise associated with its nearest
   allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -128,8 +129,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c was not scheduled after all` therefore retracts reason-field partial
   arithmetic even when the note contains no split or remainder of its own; the
   same applies to `not completed` because completion can supply allocation
-  context. An affirmative task-bound claim such as `task-c was fully scheduled
-  after all` also contradicts and vetoes partial accounting. A denial or
+  context. Speculative denials such as `this task might not be scheduled after
+  all` do not retract an affirmative placement. An affirmative task-bound claim
+  such as `task-c was fully scheduled after all` still contradicts and vetoes
+  partial accounting. A denial or
   full-completion claim explicitly naming another corpus task does not retract
   the enclosing task's arithmetic, while qualified non-completion such as `not
   fully scheduled` describes a partial placement rather than no allocation.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T16:08:50+02:00 }
+generated: { by: codex/5, at: 2026-07-28T16:22:43+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -145,11 +145,13 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   arithmetic even when the note contains no split or remainder of its own; the
   same applies to `not completed` because completion can supply allocation
   context. Speculative denials such as `this task might not be scheduled after
-  all` do not retract an affirmative placement. An affirmative task-bound claim
-  such as `task-c was fully scheduled after all` still contradicts and vetoes
-  partial accounting. A full-allocation adjective phrase with an explicit
-  non-task noun head, such as `Fully planned day`, does not describe the
-  attached task and cannot veto its partial evidence. A denial or
+  all` do not retract an affirmative placement. Failure retractions work in
+  either order: both `the allocation failed` and a later `failed to allocate
+  the task` invalidate earlier split arithmetic. An affirmative task-bound
+  claim such as `task-c was fully scheduled after all` still contradicts and
+  vetoes partial accounting. A full-allocation adjective phrase with an
+  explicit non-task noun head, such as `Fully planned day`, does not describe
+  the attached task and cannot veto its partial evidence. A denial or
   full-completion claim explicitly naming another corpus task does not retract
   the enclosing task's arithmetic, while qualified non-completion such as `not
   fully scheduled` describes a partial placement rather than no allocation. A
@@ -165,12 +167,15 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
-  to another subject such as a meeting or workday is ignored. Every concrete
-  task-bound split and remainder across the block reason and note must agree;
-  one matching fragment cannot override a contradictory remainder elsewhere in
-  the task's disclosure. Consequently, `30 of 120 minutes remain` cannot be
-  credited as 30 completed minutes. Negation binds to nearby evidence and to the
-  allocation action leading into it. Thus both
+  to another subject such as a meeting or workday is ignored. The same applies
+  to an object-owned quantity such as `reviews a recording with 60 minutes
+  remaining`; mentioning the task before the object does not transfer that
+  remainder to the task. Every concrete task-bound split and remainder across
+  the block reason and note must agree; one matching fragment cannot override a
+  contradictory remainder elsewhere in the task's disclosure. Consequently,
+  `30 of 120 minutes remain` cannot be credited as 30 completed minutes.
+  Negation binds to nearby evidence and to the allocation action leading into
+  it. Thus both
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
   letting a later explanation that the full task `cannot fit` invalidate
@@ -250,7 +255,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   remains a meeting claim; copula modifiers do not change that head, so `the
   meeting was only partial` is rejected too. The same head-subject rule applies
   to denials: `the meeting for task-c was not scheduled` retracts the meeting,
-  not task-c's partial allocation.
+  not task-c's partial allocation, including future forms such as `task-c notes
+  that the meeting will not be scheduled`.
   Ordinary possessive verbs retain their head subject as well, so
   `the meeting has 60 minutes remaining` cannot supply the task's remainder;
   remainder-producing verbs such as `the meeting leaves 60 minutes remaining`
@@ -275,9 +281,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c validates that the payload cannot fit in memory` describes the
   payload, not the task. Ordinary causal suffixes remain valid, so
   `task-c was omitted due to capacity` discloses the omission, as does
-  `task-c was omitted from today's plan`. A contrast boundary also preserves
-  the preceding disposition, as in `task-c was omitted but the remaining plan
-  stayed intact`. A causal clause about another corpus
+  `task-c was omitted from today's plan`; bounded affirmative modifiers remain
+  valid too, as in `task-c was omitted entirely due to capacity`. A contrast
+  boundary also preserves the preceding disposition, as in `task-c was omitted
+  but the remaining plan stayed intact`. A causal clause about another corpus
   task also retains its own negation: `task-c was deferred because Deployment
   was not scheduled` does not retract task-c's affirmative deferral.
   It must also be affirmative and internally consistent: `not partial` and
@@ -290,10 +297,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Modal scope ends only when the conjunction begins an independently asserted
   clause. Attempt and failure complements are likewise not actual
   dispositions: neither `attempted to be omitted`, `failed to be omitted`, the
-  near miss `was almost omitted`, nor the direct requirement `requires
-  deferring` surfaces a trade. The same near-miss rule rejects allocation prose
-  such as `almost scheduled 60 of 120 minutes`. Avoidance and prevention
-  complements are denials too:
+  near miss `was almost omitted`, an expectation such as `was supposed to be
+  omitted`, nor the direct requirement `requires deferring` surfaces a trade.
+  The same rules reject allocation prose such as `almost scheduled 60 of 120
+  minutes` and `was supposed to schedule 60 of 120 minutes`. Avoidance and
+  prevention complements are denials too:
   neither `task-c avoided being omitted` nor
   `task-c avoided getting omitted` asserts an omission. An affirmative claim
   plus denial of that same
@@ -313,9 +321,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   scheduled`, or `was unable to be scheduled` disclose the same omission,
   unless an outer falsehood construction such as `not true that task-c cannot
   fit` or `not true that task-c was not scheduled` denies the whole claim. All
-  equivalent negative-scheduling forms share one disposition identity, so an
-  affirmative spelling in one field is retracted by an equivalent denial in
-  another.
+  equivalent negative-scheduling forms, including `unable` wording without a
+  lexical negation token, share one disposition identity, so an affirmative
+  spelling in one field is retracted by an equivalent denial in another.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T17:48:06+02:00 }
+generated: { by: codex/5, at: 2026-07-28T21:47:26+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -99,6 +99,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   Conditional and subjunctive clauses are counterfactual rather than evidence:
   `If task-c were scheduled for 60 of 120 minutes` cannot earn partial credit,
   even when a comma separates its later denial.
+  Commands are not assertions either: `Schedule for 60 of 120 minutes` does
+  not say that the allocation occurred.
   Intended, planned, aimed, hoped,
   wanted, expected, proposed, considered, attempted, tried, failed, refused,
   or declined actions are likewise not affirmative. Neither are expectation
@@ -118,7 +120,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   earlier action with intervening object prose, such as scheduling a meeting
   before reviewing `60 of 120` recording minutes, cannot supply task-allocation
   context, nor can later meeting scheduling borrow an earlier `60 of 120`
-  recording count. A grammatical auxiliary/adverb bridge such as
+  recording count. Object complements are excluded in the same way:
+  `task-c reviews a meeting with 60 of 120 minutes scheduled` describes the
+  meeting's arithmetic, not task-c's allocation. A grammatical
+  auxiliary/adverb bridge such as
   `were successfully scheduled` or `60 of 120 minutes do fit` remains
   affirmative. A direct quantity preposition or exact quantity modifier, such as
   `scheduled for 60 of 120 minutes` or
@@ -145,7 +150,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `scheduled 60 of 120 minutes yesterday`, and the equivalent `last week`
   describe prior allocation rather than the current block. The same scope rule
   applies to full-allocation retractions, so a note claiming `fully scheduled
-  yesterday` cannot veto current partial evidence. Unbound splits are ignored
+  yesterday` cannot veto current partial evidence. Historical denials and
+  allocation failures are excluded too, so `was not scheduled yesterday`
+  cannot retract today's valid split. Unbound splits are ignored
   before their values are checked, and allocation explicitly scoped to another
   subject or another
   corpus task, named by id or full title, cannot earn credit for the placed
@@ -343,6 +350,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   but the remaining plan stayed intact`. A causal clause about another corpus
   task also retains its own negation: `task-c was deferred because Deployment
   was not scheduled` does not retract task-c's affirmative deferral.
+  Imperative wording such as `Omit task-c due to capacity` requests a trade but
+  does not assert that one happened.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, while `without conflict` and
   `conflict-free` are denials rather than disclosures. Outer falsehoods deny

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T06:07:12+02:00 }
+generated: { by: codex/5, at: 2026-07-28T06:25:06+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -124,11 +124,14 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `not all work fits so 60 of 120 are scheduled`, also leaves the concrete
   allocation affirmative. A `partial` keyword is negated only by a preceding
   negator, so `partial because not all work fits` remains affirmative. Split
-  syntax cannot provide its own task context: an allocation word or task
-  reference must appear outside the matched numbers. Explicit other-subject
-  scope also outranks a nearby `partial` keyword, so `remain for`, `before`, or
-  `until` a meeting cannot earn task remainder credit while `partial for today`
-  remains valid.
+  syntax cannot provide its own allocation context: an affirmative allocation
+  action must appear outside the matched numbers. A task reference can
+  attribute that action, but cannot replace it. Explicit other-subject scope
+  also outranks a nearby `partial` keyword, so `remain for`, `before`, or `until`
+  a meeting cannot earn task remainder credit while `partial for today` remains
+  valid. Bare numeric remainders in another field of the same task block are
+  still audited, because a contradictory note must not be hidden from matching
+  arithmetic in the reason.
   Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
@@ -150,13 +153,18 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   so one task's deferred disposition cannot disclose another task's shortening.
   Label punctuation binds too, so `Partial: task-d` remains owned by `task-d`
   rather than the task attached to the enclosing block.
+  Trade-shaped words inside the task's own id or full-title span are only
+  naming evidence, not a separate disclosure.
   An explicit non-task subject is rejected too: `the meeting is deferred`
   cannot disclose the shortening merely because the same reason names a task,
   and neither can `the meeting is scheduled for later`; `the remainder is
   deferred` remains task-trade evidence.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
-  omit/defer/shorten/conflict disposition, is required.
+  omit/defer/shorten/conflict disposition, is required. Likewise, `left
+  unchanged` and moving a block to another clock slot are continuity or
+  rescheduling, while `left unfinished` and moving work to tomorrow are actual
+  remainder dispositions.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, and an affirmative claim plus its
   denial receives no credit in either order or across two task-named fields.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,13 +5,13 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-27T15:38:00+02:00 }
+generated: { by: codex/5, at: 2026-07-28T02:11:14+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
     resource: ../../../test/features/daily_os_next/eval
     title: Day-planning eval framework and live runner
-    last_modified: 2026-07-27
+    last_modified: 2026-07-28
   - id: integration
     resource: ../../../test/features/daily_os_next/integration
     title: Full durable multi-agent integration fixtures
@@ -81,9 +81,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   completed/estimate split must describe task allocation, not coincidentally
   equal workday capacity. The partial mention and task-bound remainder must
   occur in the same block reason; unrelated workday-capacity prose cannot
-  supply the remainder. Every concrete split and remainder in the task's
-  disclosure must agree; one matching fragment cannot override a contradictory
-  remainder elsewhere in the same disclosure. Negation is scoped to the
+  supply the remainder. Task qualifiers may sit inside the arithmetic
+  (`60 minutes of this task remain`), while remainder arithmetic explicitly
+  scoped to another subject such as a meeting or workday is ignored. Every
+  concrete task-bound split and remainder in the task's disclosure must agree;
+  one matching fragment cannot override a contradictory remainder elsewhere in
+  the same disclosure. Negation is scoped to the
   punctuation segment containing the evidence, so `cannot be scheduled`
   invalidates a split without letting a later `no room` description invalidate
   affirmative arithmetic. Negated or vague “partial” prose, silence,

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T07:15:39+02:00 }
+generated: { by: codex/5, at: 2026-07-28T07:33:30+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -74,8 +74,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   the cheapest way to make an impossible day fit is to claim each task is shorter
   than it is. The one exception is an auditable partial placement: the block
   duration may replace the full estimate only when its reason gives concrete
-  minute arithmetic (`60m of 120m scheduled`, `60m out of 120m scheduled`, or
-  an affirmative `partial` plus a task-bound remainder such as
+  minute arithmetic (`60m of 120m scheduled`,
+  `60m of an estimated 120m scheduled`, `60m out of 120m scheduled`, or an
+  affirmative `partial` plus a task-bound remainder such as
   `60m remain for later`, `Remaining 60m move to tomorrow`,
   `60m still remain`, `60m will still remain`, or
   `Remaining 60m are carried over`) that agrees with both the summed duration
@@ -85,7 +86,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   the surrounding clause must include an affirmative scheduled, allocated,
   completed, planned, placed, or fitting action that is nearer to the numbers
   than any omitted/deferred predicate in the same comma-delimited clause. A
-  later action describing “the rest” cannot validate earlier omitted
+  merely possible action such as `task-c might schedule 60 of 120 minutes` is
+  not an affirmative allocation. A later action describing “the rest” cannot
+  validate earlier omitted
   arithmetic. Unrelated meeting/workday scope is likewise associated with its
   nearest allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
@@ -135,7 +138,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   disclosure forms. Bare `partial` must be a standalone label or explanation,
   follow a copula, or modify a placement noun such as task, work, placement, or
   block; a task-owned noun phrase such as `task-c's partial index` is not
-  placement evidence. A partial keyword is negated only by a preceding negator,
+  placement evidence. Inflected forms must modify a placement action, so
+  `partially scheduled` qualifies while `partially dependent on the API` does
+  not. Progressive copulas remain subject-bearing: `the meeting is being
+  partially scheduled` is still a meeting claim, not task evidence. A partial
+  keyword is negated only by a preceding negator,
   so `partial because not all work fits` remains affirmative. Split syntax
   cannot provide its own allocation context: an affirmative allocation action
   must appear outside the matched numbers. A task reference can attribute that
@@ -159,6 +166,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   title is not a trade: the prose must also disclose partial, deferred, omitted,
   remaining, shortened, or conflicting work in the same individual block
   reason or note field that names the task by token-bounded id or full title.
+  The same disclosure requirement applies to fully omitted tasks; mentioning an
+  omitted task only as context for retained work does not surface the omission.
   The scorer does not combine a task name in one field with unbound trade prose
   in the other. A name occurring only inside another task id or word,
   task-binding grammar such as `for this task`, and trade wording in unrelated
@@ -183,8 +192,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   unchanged` and moving a block to another clock slot are continuity or
   rescheduling, while `left unfinished` and moving work to tomorrow are actual
   remainder dispositions. A disposition word must govern the task or unfinished
-  work: domain language such as `task-c documents deferred revenue` does not
-  disclose that task-c itself was deferred.
+  work: domain language such as `task-c documents deferred revenue` or
+  `task-c documents unscheduled maintenance` does not disclose that task-c
+  itself was deferred or left unscheduled.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
   than a disclosure, and an affirmative claim plus its denial receives no

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T16:15:24+02:00 }
+generated: { by: codex/5, at: 2026-07-28T16:33:33+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -94,7 +94,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   not an affirmative allocation, and neither is
   `task-c might be partially scheduled`. Modal remainder arithmetic such as
   `task-c might have 60 minutes remaining` is likewise hypothetical and cannot
-  qualify or contradict a placement. Intended, planned, aimed, hoped,
+  qualify or contradict a placement. Probabilistic complements such as
+  `task-c is likely to schedule 60 of 120 minutes` are non-asserted too.
+  Intended, planned, aimed, hoped,
   wanted, expected, proposed, considered, attempted, tried, failed, refused,
   or declined actions are likewise not affirmative. Neither are expectation
   forms such as
@@ -301,7 +303,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   omit/defer/shorten/conflict disposition, is required. Likewise, `left
   unchanged` and moving a block to another clock slot are continuity or
   rescheduling, while `left unfinished`, `left some work unfinished`, and moving
-  work to tomorrow are actual remainder dispositions. Unfinished work remains
+  work to tomorrow are actual remainder dispositions on a same-day plan. On a
+  future-day run, `tomorrow` names the day currently being planned, so
+  `scheduled for tomorrow` or `moved to tomorrow` alone cannot surface a
+  deferral. Unfinished work remains
   distinct from full omission, so `not left out; left unfinished` still
   discloses the unfinished remainder. A quantitative complement
   such as `shortened by 60 minutes` also remains a task-bound disposition. A
@@ -363,6 +368,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   actual deferral.
   `Cannot fit`, `will not fit`, `conflicts`, and `conflicting` are affirmative
   disclosures, including label-bound forms such as `task-c: Cannot fit today`.
+  A causal explanation does not retract that disclosure:
+  `task-c cannot be scheduled because no time remains` still names the omitted
+  task even though its explanation contains `no`.
   A bare conflict object is not: `task-c resolves conflict` describes subject
   matter rather than a scheduling casualty, while the task-bound predicate
   `task-c has a scheduling conflict` does disclose one. An explicit omission

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T09:34:43+02:00 }
+generated: { by: codex/5, at: 2026-07-28T09:52:34+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -98,7 +98,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   earlier valid task split. Unbound splits are ignored before their values are
   checked, and allocation explicitly scoped to another subject or another
   corpus task, named by id or full title, cannot earn credit for the placed
-  task. Explicit current-task scope wins over a later temporal meeting modifier.
+  task. Explicit current-task scope wins over a later temporal meeting modifier,
+  such as `during the meeting`, but not over an explicit allocation destination:
+  `task-c: 60 of 120 minutes are scheduled for the meeting` remains
+  meeting-scoped evidence.
   The block's task is the default arithmetic subject; a corpus reference
   overrides it when it is comma-led, adjacent, linked by an allocation action
   (including postpositive `allocated to Task D`), possessive, attached by `for`
@@ -187,6 +190,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   reason or note field that names the task by token-bounded id or full title.
   The same disclosure requirement applies to fully omitted tasks; mentioning an
   omitted task only as context for retained work does not surface the omission.
+  A `partial` claim cannot disclose a fully omitted task because there is no
+  positive structural placement to shorten; it must instead name an actual
+  omission, deferral, or other applicable trade.
   Numeric remainder claims for a fully omitted estimated task must equal its
   full estimate; omission does not make arbitrary positive arithmetic valid.
   Hyphenated task ids also remain whole tokens: a title such as `Report` is not
@@ -228,7 +234,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c validates that the payload cannot fit in memory` describes the
   payload, not the task. Ordinary causal suffixes remain valid, so
   `task-c was omitted due to capacity` discloses the omission, as does
-  `task-c was omitted from today's plan`.
+  `task-c was omitted from today's plan`. A causal clause about another corpus
+  task also retains its own negation: `task-c was deferred because Deployment
+  was not scheduled` does not retract task-c's affirmative deferral.
   It must also be affirmative and internally consistent: `not partial` and
   `no conflict` explicitly deny the trade, while `without conflict` and
   `conflict-free` are denials rather than disclosures. Modal dispositions such

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T09:21:04+02:00 }
+generated: { by: codex/5, at: 2026-07-28T09:34:43+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -89,8 +89,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   than any omitted/deferred predicate in the same comma-delimited clause. A
   merely possible action such as `task-c might schedule 60 of 120 minutes` is
   not an affirmative allocation, and neither is
-  `task-c might be partially scheduled`. Attempted, tried, failed, refused, or
-  declined actions are likewise not affirmative. A later action describing “the rest” cannot
+  `task-c might be partially scheduled`. Intended, planned, aimed, hoped,
+  wanted, expected, proposed, attempted, tried, failed, refused, or declined
+  actions are likewise not affirmative. A later action describing “the rest” cannot
   validate earlier omitted
   arithmetic. Unrelated meeting/workday scope is likewise associated with its
   nearest allocation action, so later meeting arithmetic does not poison an
@@ -188,6 +189,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   omitted task only as context for retained work does not surface the omission.
   Numeric remainder claims for a fully omitted estimated task must equal its
   full estimate; omission does not make arbitrary positive arithmetic valid.
+  Hyphenated task ids also remain whole tokens: a title such as `Report` is not
+  named merely because another task id contains `weekly-report`.
   The scorer does not combine a task name in one field with unbound trade prose
   in the other. A name occurring only inside another task id or word,
   task-binding grammar such as `for this task`, and trade wording in unrelated

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T05:48:44+02:00 }
+generated: { by: codex/5, at: 2026-07-28T06:07:12+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -99,11 +99,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   to the other task, while an ambiguous shared title is handled conservatively.
   This allows one clause to audit the current split and name a deferred casualty
   before or after it. The same attribution applies to remainder evidence. The
-  partial mention and task-bound remainder must occur in the same block reason,
-  and the partial mention cannot be borrowed from a claim attributed to another
-  corpus task; unrelated meeting/workday remainder scope is rejected before a
-  later disposition can bind it, and unrelated workday-capacity prose cannot
-  supply the remainder.
+  partial mention and task-bound remainder must occur in the same block reason
+  or note field, and the partial mention cannot be borrowed from a claim
+  attributed to another corpus task or an explicit non-task subject. Unrelated
+  meeting/workday remainder scope is rejected before a later disposition can
+  bind it, and unrelated workday-capacity prose cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -119,7 +119,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   affirmative arithmetic. Likewise, `60 of 120 are scheduled and no more`
   remains affirmative because the later `no` follows the allocation action
   instead of negating it; `not only` is likewise affirmative emphasis rather
-  than negation. A negative fit quantifier that explains the partial, such as
+  than negation, and leading `no more than` is an exact quantitative cap. A
+  negative fit quantifier that explains the partial, such as
   `not all work fits so 60 of 120 are scheduled`, also leaves the concrete
   allocation affirmative. A `partial` keyword is negated only by a preceding
   negator, so `partial because not all work fits` remains affirmative. Split
@@ -139,23 +140,28 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   audited partial credit, so a plan that represents every task only partially
   must still name the trade or escalate it. Merely repeating a shortened task's
   title is not a trade: the prose must also disclose partial, deferred, omitted,
-  remaining, shortened, or conflicting work in the same block reason or note
-  that names the task by token-bounded id or full title. A name occurring only
-  inside another task id or word, task-binding grammar such as `for this task`,
-  and trade wording in unrelated plan prose cannot satisfy that disclosure.
+  remaining, shortened, or conflicting work in the same individual block
+  reason or note field that names the task by token-bounded id or full title.
+  The scorer does not combine a task name in one field with unbound trade prose
+  in the other. A name occurring only inside another task id or word,
+  task-binding grammar such as `for this task`, and trade wording in unrelated
+  plan prose cannot satisfy that disclosure.
   Trade language in the same reason is attributed to its nearest corpus task,
   so one task's deferred disposition cannot disclose another task's shortening.
   Label punctuation binds too, so `Partial: task-d` remains owned by `task-d`
   rather than the task attached to the enclosing block.
   An explicit non-task subject is rejected too: `the meeting is deferred`
   cannot disclose the shortening merely because the same reason names a task,
-  while `the remainder is deferred` remains task-trade evidence.
+  and neither can `the meeting is scheduled for later`; `the remainder is
+  deferred` remains task-trade evidence.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required.
-  It must also be affirmative: `not partial` and `no conflict` explicitly deny
-  the trade and receive no credit, while `cannot fit` is itself an affirmative
-  disclosure of the constraint. The constraint detail records every credited
+  It must also be affirmative and internally consistent: `not partial` and
+  `no conflict` explicitly deny the trade, and an affirmative claim plus its
+  denial receives no credit in either order or across two task-named fields.
+  `Cannot fit`, `conflicts`, and `conflicting` are affirmative disclosures.
+  The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
@@ -178,6 +184,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   excluded from the objective headline rate only when parsing free-form partial
   prose changes full-estimate accounting from a failure to a pass; an audited
   partial whose full estimate already fits remains objective.
+  Markdown reports name both mixed constraints and the judge bundle serializes
+  every scored block reason and note, so reviewers can inspect the evidence
+  behind an excluded heuristic pass.
 - **Fabrication is judged against what the model was shown.** The task corpus
   renders only inside the capture context, so a wake without a capture sees only
   its decided tasks — which do carry `status` and `blockedBy`, but not
@@ -309,8 +318,9 @@ on.
 
 So the report emits a **judge bundle**: one self-sufficient JSON object per
 (scenario, model, variant, sample) carrying the scenario and its intent, the exact
-prompts, every tool call including rejections and their text, the persisted plan,
-and that run's constraint results and cost. Each constraint result is labelled
+prompts, every tool call including rejections and their text, the persisted plan
+including each block reason and note, and that run's constraint results and cost.
+Each constraint result is labelled
 `objective` or `heuristic`; heuristic entries repeat their caveat beside the
 evidence so a detached bundle cannot make a string match look like a semantic
 judgement.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T04:06:55+02:00 }
+generated: { by: codex/5, at: 2026-07-28T04:17:59+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -90,8 +90,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   title is handled conservatively. This allows one clause to audit the current
   split and name a deferred casualty before or after it. The same attribution
   applies to remainder evidence. The partial mention and task-bound remainder
-  must occur in the same block reason; unrelated workday-capacity prose cannot
-  supply the remainder.
+  must occur in the same block reason, and the partial mention cannot be
+  borrowed from a claim attributed to another corpus task; unrelated
+  workday-capacity prose cannot supply the remainder.
   Task qualifiers may sit inside the arithmetic, as in
   `60 minutes of this task remain`; leading forms may also qualify the noun, as
   in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
@@ -122,10 +123,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   must still name the trade or escalate it. Merely repeating a shortened task's
   title is not a trade: the prose must also disclose partial, deferred, omitted,
   remaining, shortened, or conflicting work in the same block reason or note
-  that names the task. Trade wording in unrelated plan prose cannot satisfy that
-  disclosure. The constraint detail records every credited partial and every
-  shortening denied credit, so the judge bundle preserves the accounting
-  evidence rather than only the final pass/fail.
+  that names the task by id or a token-bounded full title. A title occurring
+  only inside another word and trade wording in unrelated plan prose cannot
+  satisfy that disclosure. The constraint detail records every credited partial
+  and every shortening denied credit, so the judge bundle preserves the
+  accounting evidence rather than only the final pass/fail.
 - **Weak semantic outcomes are not ranking evidence.** `surfacedConflict`
   passes either when an accepted `attentionNeeded`
   escalation uses an allowed typed conflict reason or when block prose names

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T04:53:14+02:00 }
+generated: { by: codex/5, at: 2026-07-28T05:03:50+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -89,13 +89,15 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   earlier valid task split. Unbound splits are ignored before their values are
   checked, and allocation explicitly scoped to another subject or another
   corpus task, named by id or full title, cannot earn credit for the placed
-  task. The block's task is the default arithmetic subject; a corpus reference
-  overrides it only when it is adjacent, linked by an allocation action
-  (including postpositive `allocated to Task D`), possessive, or attached by
-  `for` or `of`. Distinct task ids retain distinct identities even when their
-  titles collide; an explicit id can therefore attribute arithmetic to the
-  other task, while an ambiguous shared title is handled conservatively. This
-  allows one clause to audit the current split and name a deferred casualty
+  task. Explicit current-task scope wins over a later temporal meeting modifier.
+  The block's task is the default arithmetic subject; a corpus reference
+  overrides it when it is comma-led, adjacent, linked by an allocation action
+  (including postpositive `allocated to Task D`), possessive, attached by `for`
+  or `of`, or connected through ordinary copula/future grammar such as
+  `task-d will be deferred`. Distinct task ids retain distinct identities even
+  when their titles collide; an explicit id can therefore attribute arithmetic
+  to the other task, while an ambiguous shared title is handled conservatively.
+  This allows one clause to audit the current split and name a deferred casualty
   before or after it. The same attribution applies to remainder evidence. The
   partial mention and task-bound remainder must occur in the same block reason,
   and the partial mention cannot be borrowed from a claim attributed to another
@@ -114,7 +116,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
   letting a later explanation that the full task `cannot fit` invalidate
-  affirmative arithmetic. A `partial` keyword is negated only by a preceding
+  affirmative arithmetic. Likewise, `60 of 120 are scheduled and no more`
+  remains affirmative because the later `no` follows the allocation action
+  instead of negating it. A `partial` keyword is negated only by a preceding
   negator, so `partial because not all work fits` remains affirmative. Split
   syntax cannot provide its own task context: an allocation word or task
   reference must appear outside the matched numbers. Explicit other-subject

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T15:52:34+02:00 }
+generated: { by: codex/5, at: 2026-07-28T16:08:50+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -269,8 +269,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   not disclose that task-c itself was deferred or left unscheduled. A
   `for later` disposition must be governed by a scheduling, movement, copula,
   or remainder predicate. The same object binding rejects domain phrases
-  such as `reviews trade policy` and `carries over balances`. Negative-fit
-  evidence is subject-bound too: `task-c doesn't fit` remains affirmative, but
+  such as `reviews trade policy`, `evaluates a trade`, and `carries over
+  balances`. Negative-fit evidence is subject-bound too: `task-c doesn't fit`
+  remains affirmative, but
   `task-c validates that the payload cannot fit in memory` describes the
   payload, not the task. Ordinary causal suffixes remain valid, so
   `task-c was omitted due to capacity` discloses the omission, as does
@@ -288,9 +289,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   shortened and ultimately deferred` do not make the disposition affirmative.
   Modal scope ends only when the conjunction begins an independently asserted
   clause. Attempt and failure complements are likewise not actual
-  dispositions: neither `attempted to be omitted`, `failed to be omitted`, nor
-  the direct requirement `requires deferring` surfaces a trade. Avoidance and
-  prevention complements are denials too:
+  dispositions: neither `attempted to be omitted`, `failed to be omitted`, the
+  near miss `was almost omitted`, nor the direct requirement `requires
+  deferring` surfaces a trade. The same near-miss rule rejects allocation prose
+  such as `almost scheduled 60 of 120 minutes`. Avoidance and prevention
+  complements are denials too:
   neither `task-c avoided being omitted` nor
   `task-c avoided getting omitted` asserts an omission. An affirmative claim
   plus denial of that same
@@ -309,7 +312,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   forms such as `cannot be scheduled`, `can't be
   scheduled`, or `was unable to be scheduled` disclose the same omission,
   unless an outer falsehood construction such as `not true that task-c cannot
-  fit` or `not true that task-c was not scheduled` denies the whole claim.
+  fit` or `not true that task-c was not scheduled` denies the whole claim. All
+  equivalent negative-scheduling forms share one disposition identity, so an
+  affirmative spelling in one field is retracted by an equivalent denial in
+  another.
   The detail records every credited
   partial and every shortening denied credit, so the judge bundle preserves the
   accounting evidence rather than only the final pass/fail.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T17:30:47+02:00 }
+generated: { by: codex/5, at: 2026-07-28T17:48:06+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -96,6 +96,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c might have 60 minutes remaining` is likewise hypothetical and cannot
   qualify or contradict a placement. Probabilistic complements such as
   `task-c is likely to schedule 60 of 120 minutes` are non-asserted too.
+  Conditional and subjunctive clauses are counterfactual rather than evidence:
+  `If task-c were scheduled for 60 of 120 minutes` cannot earn partial credit,
+  even when a comma separates its later denial.
   Intended, planned, aimed, hoped,
   wanted, expected, proposed, considered, attempted, tried, failed, refused,
   or declined actions are likewise not affirmative. Neither are expectation
@@ -106,8 +109,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   make an earlier declarative allocation clause interrogative. Inability
   complements such as
   `was unable to schedule`, `was not able to schedule`, or
-  `was incapable of scheduling`, nor actions the prose says were avoided or
-  prevented, including passive `was prevented from being scheduled` wording. A
+  `was incapable of scheduling` are not affirmative, nor are actions the prose
+  says were avoided or prevented, including passive
+  `was prevented from being scheduled` wording. Negation words inside the
+  current task id or title are names, not clause operators, so
+  `No-code prototype scheduled 60 of 120 minutes` remains affirmative. A
   selected allocation action must govern the numeric split on either side; an
   earlier action with intervening object prose, such as scheduling a meeting
   before reviewing `60 of 120` recording minutes, cannot supply task-allocation

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T08:56:46+02:00 }
+generated: { by: codex/5, at: 2026-07-28T09:08:16+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -118,7 +118,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c was not scheduled after all` therefore retracts reason-field partial
   arithmetic even when the note contains no split or remainder of its own; the
   same applies to `not completed` because completion can supply allocation
-  context. The
+  context. A denial explicitly naming another corpus task does not retract the
+  enclosing task's arithmetic, while qualified non-completion such as
+  `not fully scheduled` describes a partial placement rather than no allocation.
+  The
   partial mention cannot be borrowed from a claim attributed to
   another corpus task or an explicit non-task subject. Unrelated meeting/workday
   remainder scope is rejected before a later disposition can bind it, and
@@ -201,6 +204,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   does not replace the head subject, so `the meeting for task-c is partial`
   remains a meeting claim; copula modifiers do not change that head, so `the
   meeting was only partial` is rejected too.
+  Ordinary possessive verbs retain their head subject as well, so
+  `the meeting has 60 minutes remaining` cannot supply the task's remainder.
   Bare continuity such as `remains scheduled` is not a trade: numeric remainder
   arithmetic matching the structural remainder, or an actual
   omit/defer/shorten/conflict disposition, is required. Likewise, `left

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T02:34:00+02:00 }
+generated: { by: codex/5, at: 2026-07-28T02:45:22+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -90,10 +90,12 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   one matching fragment cannot override a contradictory remainder elsewhere in
   the same disclosure. Negation is bound by word proximity to the evidence, so
   `cannot be scheduled` invalidates a split without letting a later explanation
-  that the full task `cannot fit` invalidate affirmative arithmetic. Explicit
-  unrelated scope also outranks a nearby `partial` keyword, so `remain for the
-  meeting` cannot earn task remainder credit. Negated or vague “partial” prose,
-  silence,
+  that the full task `cannot fit` invalidate affirmative arithmetic. Split
+  syntax cannot provide its own task context: an allocation word or task
+  reference must appear outside the matched numbers. Explicit other-subject
+  scope also outranks a nearby `partial` keyword, so `remain for the meeting`
+  cannot earn task remainder credit while `partial for today` remains valid.
+  Negated or vague “partial” prose, silence,
   contradictory numbers, buffer or calendar blocks carrying a task id,
   allocations below 10% of the estimate, and overlapping blocks for one task
   are charged at the full estimate or receive no placement score. Estimated

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T03:08:25+02:00 }
+generated: { by: codex/5, at: 2026-07-28T03:20:29+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -82,15 +82,19 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   not coincidentally equal workday capacity. Unbound splits are ignored before
   their values are checked, and allocation explicitly scoped to another
   subject or another corpus task, named by id or full title, cannot earn credit
-  for the placed task. The partial mention and task-bound remainder must occur
-  in the same block reason; unrelated workday-capacity prose cannot supply the
-  remainder. Task qualifiers may sit inside the arithmetic, as in
-  `60 minutes of this task remain`, while remainder arithmetic explicitly
-  scoped to another subject such as a meeting or workday is ignored. Every
-  concrete task-bound split and remainder in the task's disclosure must agree;
-  one matching fragment cannot override a contradictory remainder elsewhere in
-  the same disclosure. Negation binds to nearby evidence and to the allocation
-  action leading into it. Thus both
+  for the placed task. When current and deferred task names share a clause, the
+  corpus reference nearest the arithmetic determines its subject, allowing the
+  reason to audit the current split and name its casualty together. The same
+  attribution applies to remainder evidence. The partial mention and task-bound
+  remainder must occur in the same block reason; unrelated workday-capacity
+  prose cannot supply the remainder. Task qualifiers may sit inside the
+  arithmetic, as in `60 minutes of this task remain`, while remainder arithmetic
+  explicitly scoped to another subject such as a meeting or workday is ignored.
+  Every concrete task-bound split and remainder in the task's disclosure must
+  agree; one matching fragment cannot override a contradictory remainder
+  elsewhere in the same disclosure. Consequently, `30 of 120 minutes remain`
+  cannot be credited as 30 completed minutes. Negation binds to nearby evidence
+  and to the allocation action leading into it. Thus both
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
   letting a later explanation that the full task `cannot fit` invalidate

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T09:52:34+02:00 }
+generated: { by: codex/5, at: 2026-07-28T10:05:24+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -91,9 +91,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   not an affirmative allocation, and neither is
   `task-c might be partially scheduled`. Intended, planned, aimed, hoped,
   wanted, expected, proposed, attempted, tried, failed, refused, or declined
-  actions are likewise not affirmative. A later action describing “the rest” cannot
-  validate earlier omitted
-  arithmetic. Unrelated meeting/workday scope is likewise associated with its
+  actions are likewise not affirmative. Neither are inability complements such
+  as `was unable to schedule`, `was not able to schedule`, or `was incapable of
+  scheduling`. A later action describing “the rest” cannot validate earlier
+  omitted arithmetic. Unrelated meeting/workday scope is likewise associated with its
   nearest allocation action, so later meeting arithmetic does not poison an
   earlier valid task split. Unbound splits are ignored before their values are
   checked, and allocation explicitly scoped to another subject or another
@@ -122,9 +123,11 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `task-c was not scheduled after all` therefore retracts reason-field partial
   arithmetic even when the note contains no split or remainder of its own; the
   same applies to `not completed` because completion can supply allocation
-  context. A denial explicitly naming another corpus task does not retract the
-  enclosing task's arithmetic, while qualified non-completion such as
-  `not fully scheduled` describes a partial placement rather than no allocation.
+  context. An affirmative task-bound claim such as `task-c was fully scheduled
+  after all` also contradicts and vetoes partial accounting. A denial or
+  full-completion claim explicitly naming another corpus task does not retract
+  the enclosing task's arithmetic, while qualified non-completion such as `not
+  fully scheduled` describes a partial placement rather than no allocation.
   The
   partial mention cannot be borrowed from a claim attributed to
   another corpus task or an explicit non-task subject. Unrelated meeting/workday
@@ -241,7 +244,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `no conflict` explicitly deny the trade, while `without conflict` and
   `conflict-free` are denials rather than disclosures. Modal dispositions such
   as `might be omitted` or `could be deferred` are speculative, not actual
-  trades. An affirmative claim plus denial of that same
+  trades. Avoidance and prevention complements are denials too: `task-c avoided
+  being omitted` does not assert an omission. An affirmative claim plus denial
+  of that same
   disposition receives no credit in either order or across two task-named
   fields. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T08:24:38+02:00 }
+generated: { by: codex/5, at: 2026-07-28T08:42:40+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -78,7 +78,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `60m of an estimated 120m scheduled`, `60m out of 120m scheduled`, or an
   affirmative `partial` plus a task-bound remainder such as
   `60m remain for later`, `Remaining 60m move to tomorrow`,
-  `60m still remain`, `60m will still remain`, or
+  `60m still remain`, `60 more minutes remain`,
+  `60 additional minutes remain`, `60m will still remain`, or
   `Remaining 60m are carried over`) that agrees with both the summed duration
   of that task's work blocks and the corpus estimate. A numeric
   completed/estimate split must describe task allocation,
@@ -88,7 +89,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   than any omitted/deferred predicate in the same comma-delimited clause. A
   merely possible action such as `task-c might schedule 60 of 120 minutes` is
   not an affirmative allocation, and neither is
-  `task-c might be partially scheduled`. A later action describing “the rest” cannot
+  `task-c might be partially scheduled`. Failed, refused, or declined attempts
+  to schedule are likewise not affirmative. A later action describing “the rest” cannot
   validate earlier omitted
   arithmetic. Unrelated meeting/workday scope is likewise associated with its
   nearest allocation action, so later meeting arithmetic does not poison an
@@ -114,7 +116,9 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   their concrete arithmetic and denials remain audit evidence that can veto a
   reason. A task-bound standalone allocation denial such as
   `task-c was not scheduled after all` therefore retracts reason-field partial
-  arithmetic even when the note contains no split or remainder of its own. The
+  arithmetic even when the note contains no split or remainder of its own; the
+  same applies to `not completed` because completion can supply allocation
+  context. The
   partial mention cannot be borrowed from a claim attributed to
   another corpus task or an explicit non-task subject. Unrelated meeting/workday
   remainder scope is rejected before a later disposition can bind it, and
@@ -211,10 +215,13 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   evidence is subject-bound too: `task-c doesn't fit` remains affirmative, but
   `task-c validates that the payload cannot fit in memory` describes the
   payload, not the task. Ordinary causal suffixes remain valid, so
-  `task-c was omitted due to capacity` discloses the omission.
+  `task-c was omitted due to capacity` discloses the omission, as does
+  `task-c was omitted from today's plan`.
   It must also be affirmative and internally consistent: `not partial` and
-  `no conflict` explicitly deny the trade, `conflict-free` is an antonym rather
-  than a disclosure, and an affirmative claim plus denial of that same
+  `no conflict` explicitly deny the trade, while `without conflict` and
+  `conflict-free` are denials rather than disclosures. Modal dispositions such
+  as `might be omitted` or `could be deferred` are speculative, not actual
+  trades. An affirmative claim plus denial of that same
   disposition receives no credit in either order or across two task-named
   fields. Denials do not cancel a different asserted disposition:
   `task-c was not dropped; it was deferred to tomorrow` still surfaces the

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T03:20:29+02:00 }
+generated: { by: codex/5, at: 2026-07-28T03:33:04+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -82,19 +82,21 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   not coincidentally equal workday capacity. Unbound splits are ignored before
   their values are checked, and allocation explicitly scoped to another
   subject or another corpus task, named by id or full title, cannot earn credit
-  for the placed task. When current and deferred task names share a clause, the
-  corpus reference nearest the arithmetic determines its subject, allowing the
-  reason to audit the current split and name its casualty together. The same
-  attribution applies to remainder evidence. The partial mention and task-bound
-  remainder must occur in the same block reason; unrelated workday-capacity
-  prose cannot supply the remainder. Task qualifiers may sit inside the
-  arithmetic, as in `60 minutes of this task remain`, while remainder arithmetic
-  explicitly scoped to another subject such as a meeting or workday is ignored.
-  Every concrete task-bound split and remainder in the task's disclosure must
-  agree; one matching fragment cannot override a contradictory remainder
-  elsewhere in the same disclosure. Consequently, `30 of 120 minutes remain`
-  cannot be credited as 30 completed minutes. Negation binds to nearby evidence
-  and to the allocation action leading into it. Thus both
+  for the placed task. The block's task is the default arithmetic subject; a
+  corpus reference overrides it only when it leads the evidence or is attached
+  by `for` or `of`. This allows one clause to audit the current split and name a
+  deferred casualty after `while`. The same attribution applies to remainder
+  evidence. The partial mention and task-bound remainder must occur in the same
+  block reason; unrelated workday-capacity prose cannot supply the remainder.
+  Task qualifiers may sit inside the arithmetic, as in
+  `60 minutes of this task remain`; leading forms may also qualify the noun, as
+  in `the remaining work is 60 minutes`. Remainder arithmetic explicitly scoped
+  to another subject such as a meeting or workday is ignored. Every concrete
+  task-bound split and remainder in the task's disclosure must agree; one
+  matching fragment cannot override a contradictory remainder elsewhere in the
+  same disclosure. Consequently, `30 of 120 minutes remain` cannot be credited
+  as 30 completed minutes. Negation binds to nearby evidence and to the
+  allocation action leading into it. Thus both
   `cannot be scheduled` and
   `do not have enough room to schedule 60 of 120` invalidate a split, without
   letting a later explanation that the full task `cannot fit` invalidate

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -893,6 +893,15 @@ bool _hasAuditablePartialDisclosure({
       hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
+      if (_evidenceNamesAnotherTask(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        continue;
+      }
       if (!_remainderIsRelatedToTask(reason, match)) continue;
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
@@ -902,6 +911,15 @@ bool _hasAuditablePartialDisclosure({
       }
     }
     for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
+      if (_evidenceNamesAnotherTask(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        continue;
+      }
       if (!_remainderIsRelatedToTask(reason, match)) continue;
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
@@ -948,47 +966,90 @@ bool _splitIsTaskBound(
   final context = _matchClauseExcludingMatch(reason, match);
   return _taskAllocationContextPattern.hasMatch(context) &&
       !_unrelatedSplitScopePattern.hasMatch(clause) &&
-      !_namesAnotherTask(
-        clause,
+      !_evidenceNamesAnotherTask(
+        reason,
+        match,
         taskId: taskId,
         taskTitle: taskTitle,
         corpus: corpus,
       );
 }
 
-bool _namesAnotherTask(
-  String clause, {
+bool _evidenceNamesAnotherTask(
+  String reason,
+  Match evidence, {
   required String taskId,
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
 }) {
+  final range = _matchClauseRange(reason, evidence, boundaries: '.;!?\n');
+  final currentDistance = _nearestTaskReferenceDistance(
+    reason,
+    evidence,
+    range: range,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
+  int? nearestOtherDistance;
   for (final task in corpus) {
     if (task.taskId == taskId ||
         task.title.trim().toLowerCase() == taskTitle.trim().toLowerCase()) {
       continue;
     }
-    final idPattern = RegExp(
-      r'(?:^|[^\w-])' + RegExp.escape(task.taskId) + r'(?=$|[^\w-])',
-      caseSensitive: false,
+    final distance = _nearestTaskReferenceDistance(
+      reason,
+      evidence,
+      range: range,
+      taskId: task.taskId,
+      taskTitle: task.title,
     );
-    final title = task.title.trim();
-    final titlePattern = RegExp(
-      r'\btask\s+' + RegExp.escape(title) + r'\b',
-      caseSensitive: false,
-    );
-    final bareTitlePattern = title.length >= 4
-        ? RegExp(
-            r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
-            caseSensitive: false,
-          )
-        : null;
-    if (idPattern.hasMatch(clause) ||
-        titlePattern.hasMatch(clause) ||
-        (bareTitlePattern?.hasMatch(clause) ?? false)) {
-      return true;
+    if (distance != null &&
+        (nearestOtherDistance == null || distance < nearestOtherDistance)) {
+      nearestOtherDistance = distance;
     }
   }
-  return false;
+  return nearestOtherDistance != null &&
+      (currentDistance == null || nearestOtherDistance <= currentDistance);
+}
+
+int? _nearestTaskReferenceDistance(
+  String reason,
+  Match evidence, {
+  required ({int start, int end}) range,
+  required String taskId,
+  required String taskTitle,
+}) {
+  final clause = reason.substring(range.start, range.end);
+  final title = taskTitle.trim();
+  final patterns = [
+    RegExp(
+      r'(?:^|[^\w-])' + RegExp.escape(taskId) + r'(?=$|[^\w-])',
+      caseSensitive: false,
+    ),
+    RegExp(
+      r'\btask\s+' + RegExp.escape(title) + r'\b',
+      caseSensitive: false,
+    ),
+    if (title.length >= 4)
+      RegExp(
+        r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
+        caseSensitive: false,
+      ),
+  ];
+  int? nearest;
+  for (final pattern in patterns) {
+    for (final reference in pattern.allMatches(clause)) {
+      final referenceStart = range.start + reference.start;
+      final referenceEnd = range.start + reference.end;
+      final distance = referenceEnd <= evidence.start
+          ? evidence.start - referenceEnd
+          : referenceStart >= evidence.end
+          ? referenceStart - evidence.end
+          : 0;
+      if (nearest == null || distance < nearest) nearest = distance;
+    }
+  }
+  return nearest;
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -796,7 +796,12 @@ final _unrelatedRemainderScopePattern = RegExp(
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
   r'left\s+(?:out|unfinished|incomplete|unscheduled)|'
-  r'(?:(?:is|are|was|were|be|been|being)\s+)?not\s+'
+  r'(?:(?:(?:is|are|was|were|be|been|being)\s+)?not|'
+  r'(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)'
+  r'(?:\s+be)?|'
+  r'(?:(?:is|are|was|were)\s+unable\s+to|'
+  r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)'
+  r'(?:\s+be)?)\s+'
   'schedul(?:e|ed|ing)|'
   r'trade|conflict(?:s|ed|ing)?(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
@@ -1194,6 +1199,21 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
 
 bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final wording = (match.group(0) ?? '').toLowerCase();
+  if (wording.startsWith('for ')) {
+    final prefix = prose.substring(range.start, match.start);
+    if (!RegExp(
+      r'\b(?:is|are|was|were|remain(?:s|ed|ing)?|left|'
+      'schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+      'plan(?:s|ned|ning)?|plac(?:e|ed|ing)|'
+      'defer(?:s|red|ring)?|omit(?:s|ted|ting)?|'
+      'drop(?:s|ped|ping)?|move(?:s|d|ing)?|'
+      r'roll(?:s|ed|ing)?|carr(?:y|ies|ied|ying))\s*$',
+      caseSensitive: false,
+    ).hasMatch(prefix)) {
+      return false;
+    }
+  }
   final suffix = prose.substring(match.end, range.end);
   if (!RegExp(r'^\s+\w').hasMatch(suffix)) return true;
   return RegExp(
@@ -1289,6 +1309,48 @@ bool _hasTaskBoundAllocationDenial(
       continue;
     }
     return true;
+  }
+  final allocationFailurePattern = RegExp(
+    r'\b(?:(?:the|this|that)\s+)?'
+    r'(?:allocation|placement|scheduling|completion)\s+'
+    r'(?:(?:has|had)\s+)?fail(?:s|ed|ing)?\b',
+    caseSensitive: false,
+  );
+  for (final failure in allocationFailurePattern.allMatches(prose)) {
+    if (_evidenceIsSpeculative(prose, failure) ||
+        _tradeEvidenceHasExplicitNonTaskSubject(
+          prose,
+          failure,
+          taskId: taskId,
+          taskTitle: taskTitle,
+        ) ||
+        _evidenceNamesAnotherTask(
+          prose,
+          failure,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        )) {
+      continue;
+    }
+    final range = _matchClauseRange(
+      prose,
+      failure,
+      boundaries: ',.;!?\n',
+    );
+    final prefix = prose.substring(range.start, failure.start);
+    if (RegExp(
+      r'\b(?:meeting|workday|calendar|appointment|event|session)\s*$',
+      caseSensitive: false,
+    ).hasMatch(prefix)) {
+      continue;
+    }
+    if (RegExp(
+      r'^\s*(?:(?:and|but|yet|so)\s+)?$',
+      caseSensitive: false,
+    ).hasMatch(prefix)) {
+      return true;
+    }
   }
   return false;
 }
@@ -1619,6 +1681,7 @@ bool _splitHasUnrelatedScope(
     } else if (start >= evidence.end &&
         !RegExp(
           r'^\s*(?:(?:is|are|was|were|will|be|been|being|has|have|had|'
+          'do|does|did|'
           'only|just|merely|already|actually|currently|now|'
           'estimate|estimated|successfully|explicitly|deliberately|'
           r'intentionally|firmly|definitively|concretely)\s+)*$',

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -706,7 +706,7 @@ final _partialOfEstimatePattern = RegExp(
 );
 
 final _partialRemainingPattern = RegExp(
-  r'\b(\d+)\s*(?:m|mins?|minutes?)\s+'
+  r'\b(\d+)\s*(?:(?:more|additional)\s+)?(?:m|mins?|minutes?)\s+'
   r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
   r'(?:(?:still|yet)\s+)?'
   r'(?:(?:is|are|will(?:\s+be)?)\s+)?'
@@ -717,7 +717,7 @@ final _partialRemainingPattern = RegExp(
 final _partialLeadingRemainingPattern = RegExp(
   r'\b(?:remaining(?:\s+(?:task|work))?|remainder)\s*:?\s*'
   r'(?:(?:is|are)\s+)?'
-  r'(\d+)\s*(?:m|mins?|minutes?)\b',
+  r'(\d+)\s*(?:(?:more|additional)\s+)?(?:m|mins?|minutes?)\b',
   caseSensitive: false,
 );
 
@@ -949,7 +949,7 @@ bool _hasAuditablePartialDisclosure({
         continue;
       }
       if (!_partialMentionDescribesPlacement(reason, match)) continue;
-      if (_partialMentionIsSpeculative(reason, match)) continue;
+      if (_evidenceIsSpeculative(reason, match)) continue;
       if (_partialMentionIsNegated(reason, match)) return false;
       if (disclosure.canQualify) reasonMentionsPartial = true;
     }
@@ -1118,6 +1118,11 @@ bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
         r'^\s+(?:to|until|for|because|due\s+to|owing\s+to|after|before|so|and|'
         r'with|against|over)\b',
         caseSensitive: false,
+      ).hasMatch(suffix) ||
+      RegExp(
+        r'^\s+from\s+(?:(?:today[\x27’]s|the|this|our|my|your|their)\s+)?'
+        r'(?:plan|schedule|day)\b',
+        caseSensitive: false,
       ).hasMatch(suffix);
 }
 
@@ -1148,7 +1153,7 @@ bool _hasTaskBoundAllocationDenial(
 }) {
   final placementActionPattern = RegExp(
     r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-    r'plan(?:ned|ning)?|plac(?:e|ed|ing))\b',
+    r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))\b',
     caseSensitive: false,
   );
   for (final action in placementActionPattern.allMatches(prose)) {
@@ -1188,7 +1193,7 @@ bool _allocationActionIsDirectlyDenied(String prose, Match action) {
   return false;
 }
 
-bool _partialMentionIsSpeculative(String prose, Match match) {
+bool _evidenceIsSpeculative(String prose, Match match) {
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final prefix = prose.substring(range.start, match.start);
   return RegExp(
@@ -1217,6 +1222,13 @@ bool _negationQualifiesRatherThanNegates(Match negation, String between) {
 
 bool _matchClauseIsNegated(String reason, Match match) {
   final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
+  final prefix = reason.substring(range.start, match.start);
+  if (RegExp(
+    r'\b(?:(?:without)(?:\s+any)?|free\s+of)\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix)) {
+    return true;
+  }
   final segment = reason.substring(range.start, range.end);
   for (final negation in _negationWordPattern.allMatches(segment)) {
     final negationStart = range.start + negation.start;
@@ -1347,10 +1359,15 @@ bool _allocationActionIsAsserted(
   }
   final prefix = prose.substring(clauseStart, action.start);
   return !RegExp(
-    r'\b(?:might|may|could|would|should|can)'
-    r'(?:\s+\w+){0,2}\s*$',
-    caseSensitive: false,
-  ).hasMatch(prefix);
+        r'\b(?:might|may|could|would|should|can)'
+        r'(?:\s+\w+){0,2}\s*$',
+        caseSensitive: false,
+      ).hasMatch(prefix) &&
+      !RegExp(
+        r'\b(?:fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
+        r'declin(?:e|es|ed|ing))\s+to\s*$',
+        caseSensitive: false,
+      ).hasMatch(prefix);
 }
 
 bool _splitHasUnrelatedScope(
@@ -2176,7 +2193,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   for (final match in _partialMentionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
         !_partialMentionDescribesPlacement(prose, match) ||
-        _partialMentionIsSpeculative(prose, match)) {
+        _evidenceIsSpeculative(prose, match)) {
       continue;
     }
     if (_partialMentionIsNegated(prose, match)) {
@@ -2187,7 +2204,8 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
-        !_tradeEvidenceDescribesTaskOrWork(prose, match)) {
+        !_tradeEvidenceDescribesTaskOrWork(prose, match) ||
+        _evidenceIsSpeculative(prose, match)) {
       continue;
     }
     if (_matchClauseIsNegated(prose, match)) {
@@ -2226,7 +2244,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
     }
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
-    if (!belongsToTask(match)) continue;
+    if (!belongsToTask(match) || _evidenceIsSpeculative(prose, match)) continue;
     final matchedTrade = match.group(0) ?? '';
     final negativeFitDisclosure =
         _negationWordPattern.hasMatch(matchedTrade) &&

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -705,15 +705,16 @@ final _partialLeadingRemainingPattern = RegExp(
 
 final _partialMentionPattern = RegExp(r'\bpartial\b', caseSensitive: false);
 
-final _negatedPartialPattern = RegExp(
-  r"\b(?:not|no|never|isn['’]?t|wasn['’]?t)\b"
-  r'(?:\s+\w+){0,3}\s+\bpartial\b',
+final _negationWordPattern = RegExp(
+  r'\b(?:not|no|never|(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
+  r'won|wouldn|shouldn|hasn|haven|hadn)[\x27’]?t)\b',
   caseSensitive: false,
 );
 
 typedef _EstimatedTaskPlacement = ({
   int allocatedMinutes,
   int estimateMinutes,
+  bool hasOverlappingBlocks,
   List<String> reasons,
 });
 
@@ -726,6 +727,7 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
   EvalRunOutcome outcome,
 ) {
   final allocatedByTask = <String, int>{};
+  final blocksByTask = <String, List<PlannedBlock>>{};
   final reasonsByTask = <String, List<String>>{};
   for (final block in _scheduled(outcome)) {
     if (block.type != PlannedBlockType.ai &&
@@ -740,6 +742,7 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
           minutes + block.endTime.difference(block.startTime).inMinutes,
       ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
     );
+    blocksByTask.putIfAbsent(taskId, () => []).add(block);
     final reason = block.reason?.trim();
     if (reason != null && reason.isNotEmpty) {
       reasonsByTask.putIfAbsent(taskId, () => []).add(reason);
@@ -752,9 +755,24 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
         entry.key: (
           allocatedMinutes: entry.value,
           estimateMinutes: estimate,
+          hasOverlappingBlocks: _hasOverlappingIntervals(
+            blocksByTask[entry.key] ?? const [],
+          ),
           reasons: reasonsByTask[entry.key] ?? const [],
         ),
   };
+}
+
+bool _hasOverlappingIntervals(List<PlannedBlock> blocks) {
+  if (blocks.length < 2) return false;
+  final ordered = [...blocks]
+    ..sort((a, b) => a.startTime.compareTo(b.startTime));
+  var latestEnd = ordered.first.endTime;
+  for (final block in ordered.skip(1)) {
+    if (block.startTime.isBefore(latestEnd)) return true;
+    if (block.endTime.isAfter(latestEnd)) latestEnd = block.endTime;
+  }
+  return false;
 }
 
 /// Whether a placement is substantial and its partial arithmetic is auditable.
@@ -762,10 +780,13 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
 /// The 10% floor matches the token-placement boundary used by
 /// [scoreRespectsEstimates]. Keeping it here prevents capacity and conflict
 /// scoring from treating a one-minute task marker as genuine partial work.
+/// Overlapping blocks are likewise ineligible because summed intervals can
+/// manufacture represented minutes without adding wall-clock work.
 bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
     placement.allocatedMinutes > 0 &&
     placement.allocatedMinutes < placement.estimateMinutes &&
     placement.allocatedMinutes * 10 >= placement.estimateMinutes &&
+    !placement.hasOverlappingBlocks &&
     _hasAuditablePartialDisclosure(
       reasons: placement.reasons,
       allocatedMinutes: placement.allocatedMinutes,
@@ -786,12 +807,16 @@ bool _hasAuditablePartialDisclosure({
   required int estimateMinutes,
 }) {
   final remainingMinutes = estimateMinutes - allocatedMinutes;
-  if (reasons.any(_negatedPartialPattern.hasMatch)) return false;
-  final mentionsPartial = reasons.any(_partialMentionPattern.hasMatch);
+  var mentionsPartial = false;
   var hasMatchingSplit = false;
   var hasMatchingRemainder = false;
   for (final reason in reasons) {
+    for (final match in _partialMentionPattern.allMatches(reason)) {
+      if (_matchClauseIsNegated(reason, match)) return false;
+      mentionsPartial = true;
+    }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
+      if (_matchClauseIsNegated(reason, match)) return false;
       final declaredAllocated = int.tryParse(match.group(1) ?? '');
       final declaredEstimate = int.tryParse(match.group(2) ?? '');
       if (declaredAllocated != allocatedMinutes ||
@@ -801,17 +826,40 @@ bool _hasAuditablePartialDisclosure({
       hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
+      if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
       hasMatchingRemainder = true;
     }
     for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
+      if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
       hasMatchingRemainder = true;
     }
   }
   return hasMatchingSplit || (mentionsPartial && hasMatchingRemainder);
+}
+
+bool _matchClauseIsNegated(String reason, Match match) {
+  const boundaries = '.;!?\n';
+  var clauseStart = 0;
+  for (var i = match.start - 1; i >= 0; i--) {
+    if (boundaries.contains(reason[i])) {
+      clauseStart = i + 1;
+      break;
+    }
+  }
+  var clauseEnd = reason.length;
+  for (var i = match.end; i < reason.length; i++) {
+    if (boundaries.contains(reason[i])) {
+      clauseEnd = i;
+      break;
+    }
+  }
+  return _negationWordPattern.hasMatch(
+    reason.substring(clauseStart, clauseEnd),
+  );
 }
 
 /// Work the scenario says any competent plan must include.

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -975,12 +975,22 @@ bool _partialMentionIsNegated(String reason, Match match) {
     final negationEnd = range.start + negation.end;
     if (negationEnd > match.start) continue;
     final between = reason.substring(negationEnd, match.start);
-    if (RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between)) {
+    if (_negationQualifiesRatherThanNegates(negation, between)) {
       continue;
     }
     if (_wordPattern.allMatches(between).length <= 3) return true;
   }
   return false;
+}
+
+bool _negationQualifiesRatherThanNegates(Match negation, String between) {
+  if ((negation.group(0) ?? '').toLowerCase() != 'not') return false;
+  return RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between) ||
+      RegExp(
+        r'^\s*all\b.*\bfit(?:s|ting)?\b\s+'
+        r'(?:so|therefore|thus|but)\s*$',
+        caseSensitive: false,
+      ).hasMatch(between);
 }
 
 bool _matchClauseIsNegated(String reason, Match match) {
@@ -995,7 +1005,7 @@ bool _matchClauseIsNegated(String reason, Match match) {
         ? reason.substring(match.end, negationStart)
         : '';
     if (negationEnd <= match.start &&
-        RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between)) {
+        _negationQualifiesRatherThanNegates(negation, between)) {
       continue;
     }
     if (negationStart >= match.end &&
@@ -1792,6 +1802,14 @@ bool _hasAffirmativeTradeDisclosure(
       ? null
       : placement.estimateMinutes - placement.allocatedMinutes;
   for (final match in _partialMentionPattern.allMatches(prose)) {
+    if (_tradeEvidenceHasExplicitNonTaskSubject(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+    )) {
+      continue;
+    }
     if (_evidenceNamesAnotherTask(
       prose,
       match,
@@ -1804,6 +1822,14 @@ bool _hasAffirmativeTradeDisclosure(
     if (!_partialMentionIsNegated(prose, match)) return true;
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
+    if (_tradeEvidenceHasExplicitNonTaskSubject(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+    )) {
+      continue;
+    }
     if (_evidenceNamesAnotherTask(
       prose,
       match,
@@ -1820,6 +1846,17 @@ bool _hasAffirmativeTradeDisclosure(
     _partialLeadingRemainingPattern,
   ]) {
     for (final match in pattern.allMatches(prose)) {
+      if (_tradeEvidenceHasExplicitNonTaskSubject(
+            prose,
+            match,
+            taskId: taskId,
+            taskTitle: task.title,
+          ) ||
+          _unrelatedRemainderScopePattern.hasMatch(
+            _matchClause(prose, match),
+          )) {
+        continue;
+      }
       if (_evidenceNamesAnotherTask(
         prose,
         match,
@@ -1840,6 +1877,14 @@ bool _hasAffirmativeTradeDisclosure(
     }
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
+    if (_tradeEvidenceHasExplicitNonTaskSubject(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+    )) {
+      continue;
+    }
     if (_evidenceNamesAnotherTask(
       prose,
       match,
@@ -1858,6 +1903,37 @@ bool _hasAffirmativeTradeDisclosure(
     }
   }
   return false;
+}
+
+bool _tradeEvidenceHasExplicitNonTaskSubject(
+  String prose,
+  Match evidence, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+  final currentTaskDistance = _nearestTaskReferenceDistance(
+    prose,
+    evidence,
+    range: range,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
+  if (currentTaskDistance != null) return false;
+  final prefix = prose.substring(range.start, evidence.start).trim();
+  final subjectMatch = RegExp(
+    r'^(.*?)\s+(?:is|are|was|were|has\s+been|have\s+been|had\s+been|'
+    r'will\s+be)\s*$',
+    caseSensitive: false,
+  ).firstMatch(prefix);
+  if (subjectMatch == null) return false;
+  final subject = subjectMatch.group(1)?.trim() ?? '';
+  return !RegExp(
+    r'^(?:(?:the|this|that|its)\s+)?'
+    r'(?:task|work|placement|block|remainder|remaining\s+(?:task|work)|'
+    r'rest|portion|part|it)$',
+    caseSensitive: false,
+  ).hasMatch(subject);
 }
 
 bool _taskTradeIsNamed(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -771,7 +771,8 @@ final _unrelatedRemainderScopePattern = RegExp(
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
   r'left\s+(?:out|unfinished|incomplete|unscheduled)|'
-  'trade|conflict(?:s|ed|ing)?|shorten(?:s|ed|ing)?|'
+  r'trade|conflict(?:s|ed|ing)?(?![-\s]+free\b)|'
+  'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
   r'(?:do|does|did)\s+not)\s+fit)\b',
   caseSensitive: false,
@@ -896,12 +897,18 @@ bool _hasAuditablePartialDisclosure({
     var reasonMentionsPartial = false;
     var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
-      if (_tradeEvidenceHasExplicitNonTaskSubject(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-      )) {
+      if (_evidenceFallsInsideTaskReference(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          _tradeEvidenceHasExplicitNonTaskSubject(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          )) {
         continue;
       }
       if (_evidenceNamesAnotherTask(
@@ -917,7 +924,13 @@ bool _hasAuditablePartialDisclosure({
       reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
-      if (_tradeEvidenceHasExplicitNonTaskSubject(
+      if (_evidenceFallsInsideTaskReference(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          _tradeEvidenceHasExplicitNonTaskSubject(
             reason,
             match,
             taskId: taskId,
@@ -942,12 +955,19 @@ bool _hasAuditablePartialDisclosure({
       hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
-      if (_tradeEvidenceHasExplicitNonTaskSubject(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-      )) {
+      if (_evidenceFallsInsideTaskReference(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          _tradeEvidenceHasExplicitNonTaskSubject(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          _remainderDescribesContinuity(reason, match)) {
         continue;
       }
       if (_evidenceNamesAnotherTask(
@@ -968,12 +988,19 @@ bool _hasAuditablePartialDisclosure({
       }
     }
     for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
-      if (_tradeEvidenceHasExplicitNonTaskSubject(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-      )) {
+      if (_evidenceFallsInsideTaskReference(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          _tradeEvidenceHasExplicitNonTaskSubject(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          _remainderDescribesContinuity(reason, match)) {
         continue;
       }
       if (_evidenceNamesAnotherTask(
@@ -1303,6 +1330,18 @@ bool _remainderIsTaskBound(String reason, Match match) {
 bool _remainderIsRelatedToTask(String reason, Match match) {
   if (_remainderIsTaskBound(reason, match)) return true;
   return !_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match));
+}
+
+bool _remainderDescribesContinuity(String reason, Match match) {
+  final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
+  final suffix = reason.substring(match.end, range.end);
+  return RegExp(
+    r'^\s+(?:(?:is|are|was|were|will\s+be)\s+)?'
+    '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+    'plan(?:ned|ning)?|plac(?:e|ed|ing)|book(?:ed|ing)|'
+    r'unchanged|intact|available|open)\b',
+    caseSensitive: false,
+  ).hasMatch(suffix);
 }
 
 String _matchClause(
@@ -1902,6 +1941,7 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   ]) {
     for (final match in pattern.allMatches(prose)) {
       if (!belongsToTask(match) ||
+          _remainderDescribesContinuity(prose, match) ||
           _unrelatedRemainderScopePattern.hasMatch(
             _matchClause(prose, match),
           )) {
@@ -1949,14 +1989,6 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   required String taskTitle,
 }) {
   final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
-  final currentTaskDistance = _nearestTaskReferenceDistance(
-    prose,
-    evidence,
-    range: range,
-    taskId: taskId,
-    taskTitle: taskTitle,
-  );
-  if (currentTaskDistance != null) return false;
   final prefix = prose.substring(range.start, evidence.start).trim();
   if (RegExp(
     r'^not\s+only\s+(?:is|are|was|were)$',
@@ -1974,12 +2006,43 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   ).firstMatch(prefix);
   if (subjectMatch == null) return false;
   final subject = subjectMatch.group(1)?.trim() ?? '';
-  return !RegExp(
+  if (RegExp(
     r'^(?:(?:the|this|that|its)\s+)?'
     r'(?:task|work|placement|block|remainder|remaining\s+(?:task|work)|'
-    r'rest|portion|part|it)$',
+    r'rest|portion|part|it)\b',
     caseSensitive: false,
-  ).hasMatch(subject);
+  ).hasMatch(subject)) {
+    return false;
+  }
+  return !_subjectStartsWithTaskReference(
+    subject,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
+}
+
+bool _subjectStartsWithTaskReference(
+  String subject, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  const prefix = r'^(?:(?:the|this|that|its)\s+)?';
+  const suffix =
+      r'(?=$|[\x27’]s\b|\s+(?:task|work|placement|block|remainder|rest|'
+      r'portion|part)\b)';
+  final title = taskTitle.trim();
+  return RegExp(
+        prefix + RegExp.escape(taskId) + suffix,
+        caseSensitive: false,
+      ).hasMatch(subject) ||
+      RegExp(
+        prefix + r'task\s+' + RegExp.escape(title) + suffix,
+        caseSensitive: false,
+      ).hasMatch(subject) ||
+      RegExp(
+        prefix + RegExp.escape(title) + suffix,
+        caseSensitive: false,
+      ).hasMatch(subject);
 }
 
 bool _taskTradeIsNamed(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -706,8 +706,16 @@ final _partialLeadingRemainingPattern = RegExp(
 final _partialMentionPattern = RegExp(r'\bpartial\b', caseSensitive: false);
 
 final _negationWordPattern = RegExp(
-  r'\b(?:not|no|never|(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
+  r'\b(?:not|no|never|cannot|(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
   r'won|wouldn|shouldn|hasn|haven|hadn)[\x27’]?t)\b',
+  caseSensitive: false,
+);
+
+final _partialRemainderDispositionPattern = RegExp(
+  r'\b(?:for\s+(?:later|tomorrow|another\s+day|a\s+(?:later|future)\s+day)|'
+  r'(?:roll|move|carry)(?:s|d|ed|ing)?\s+(?:over|to)\b|'
+  r'defer(?:s|red|ring)?\b|unscheduled\b|'
+  r'(?:of|for)\s+(?:this|the)\s+(?:task|work)\b)',
   caseSensitive: false,
 );
 
@@ -798,22 +806,23 @@ bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
 /// Block duration remains the authority. A reason earns partial accounting
 /// only when its concrete minute arithmetic agrees with both that duration and
 /// the corpus estimate. This accepts either an explicit `60m of 120m` split or
-/// the prompt's `partial` plus `60m remain` form; vague prose and contradictory
-/// numbers anywhere in the task's disclosure keep the conservative
-/// full-estimate charge.
+/// the prompt's `partial` plus a task-bound `60m remain for later` form. Vague
+/// prose, unrelated day-capacity arithmetic, and contradictory numbers anywhere
+/// in the task's disclosure keep the conservative full-estimate charge.
 bool _hasAuditablePartialDisclosure({
   required List<String> reasons,
   required int allocatedMinutes,
   required int estimateMinutes,
 }) {
   final remainingMinutes = estimateMinutes - allocatedMinutes;
-  var mentionsPartial = false;
   var hasMatchingSplit = false;
-  var hasMatchingRemainder = false;
+  var hasBoundPartialRemainder = false;
   for (final reason in reasons) {
+    var reasonMentionsPartial = false;
+    var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
       if (_matchClauseIsNegated(reason, match)) return false;
-      mentionsPartial = true;
+      reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
       if (_matchClauseIsNegated(reason, match)) return false;
@@ -829,19 +838,36 @@ bool _hasAuditablePartialDisclosure({
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
-      hasMatchingRemainder = true;
+      if (_remainderIsTaskBound(reason, match)) {
+        reasonHasBoundRemainder = true;
+      }
     }
     for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
-      hasMatchingRemainder = true;
+      if (_remainderIsTaskBound(reason, match)) {
+        reasonHasBoundRemainder = true;
+      }
+    }
+    if (reasonMentionsPartial && reasonHasBoundRemainder) {
+      hasBoundPartialRemainder = true;
     }
   }
-  return hasMatchingSplit || (mentionsPartial && hasMatchingRemainder);
+  return hasMatchingSplit || hasBoundPartialRemainder;
 }
 
 bool _matchClauseIsNegated(String reason, Match match) {
+  return _negationWordPattern.hasMatch(_matchClause(reason, match));
+}
+
+bool _remainderIsTaskBound(String reason, Match match) {
+  final clause = _matchClause(reason, match);
+  return _partialMentionPattern.hasMatch(clause) ||
+      _partialRemainderDispositionPattern.hasMatch(clause);
+}
+
+String _matchClause(String reason, Match match) {
   const boundaries = '.;!?\n';
   var clauseStart = 0;
   for (var i = match.start - 1; i >= 0; i--) {
@@ -857,9 +883,7 @@ bool _matchClauseIsNegated(String reason, Match match) {
       break;
     }
   }
-  return _negationWordPattern.hasMatch(
-    reason.substring(clauseStart, clauseEnd),
-  );
+  return reason.substring(clauseStart, clauseEnd);
 }
 
 /// Work the scenario says any competent plan must include.

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -693,6 +693,7 @@ final _partialOfEstimatePattern = RegExp(
 
 final _partialRemainingPattern = RegExp(
   r'\b(\d+)\s*(?:m|mins?|minutes?)\s+'
+  r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
   r'(?:(?:is|are)\s+)?(?:left|remain(?:s|ing)?)\b',
   caseSensitive: false,
 );
@@ -716,7 +717,7 @@ final _partialRemainderDispositionPattern = RegExp(
   r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
   r'(?:over|to)\b|'
   r'defer(?:s|red|ring)?\b|unscheduled\b|'
-  r'(?:of|for)\s+(?:this|the)\s+(?:task|work)\b)',
+  r'(?:of|for|in)\s+(?:this|the)\s+(?:task|work)\b)',
   caseSensitive: false,
 );
 
@@ -724,6 +725,11 @@ final _taskAllocationContextPattern = RegExp(
   r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
   'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
   r'fit(?:s|ting)?|estimate(?:d)?|task)\b',
+  caseSensitive: false,
+);
+
+final _unrelatedRemainderScopePattern = RegExp(
+  r'\b(?:in|during|for)\s+(?!(?:this|the)\s+(?:task|work)\b)',
   caseSensitive: false,
 );
 
@@ -845,6 +851,7 @@ bool _hasAuditablePartialDisclosure({
       }
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
+      if (!_remainderIsRelatedToTask(reason, match)) continue;
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
@@ -853,6 +860,7 @@ bool _hasAuditablePartialDisclosure({
       }
     }
     for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
+      if (!_remainderIsRelatedToTask(reason, match)) continue;
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
@@ -881,6 +889,15 @@ bool _remainderIsTaskBound(String reason, Match match) {
   final clause = _matchClause(reason, match);
   return _partialMentionPattern.hasMatch(clause) ||
       _partialRemainderDispositionPattern.hasMatch(clause);
+}
+
+bool _remainderIsRelatedToTask(String reason, Match match) {
+  if (_remainderIsTaskBound(reason, match)) return true;
+  if (_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match))) {
+    return false;
+  }
+  return _partialMentionPattern.hasMatch(reason) ||
+      _taskAllocationContextPattern.hasMatch(reason);
 }
 
 String _matchClause(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -795,7 +795,9 @@ final _unrelatedRemainderScopePattern = RegExp(
 
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
-  r'left\s+(?:out|unfinished|incomplete|unscheduled)|'
+  r'left\s+(?:(?:(?:some|the|this|that|its|our|my|your|their|remaining)\s+)*'
+  r'(?:task|work|remainder|rest|portion|part)\s+)?'
+  '(?:out|unfinished|incomplete|unscheduled)|'
   r'(?:(?:(?:is|are|was|were|be|been|being)\s+)?not|'
   r'(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)'
   r'(?:\s+be)?|'
@@ -803,7 +805,7 @@ final _conflictTradePattern = RegExp(
   r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)'
   r'(?:\s+be)?)\s+'
   'schedul(?:e|ed|ing)|'
-  r'trade|conflict(?:s|ed|ing)?(?![-\s]+free\b)|'
+  r'trade|conflict(?:s|ed|ing)(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
   r'(?:do|does|did|will|shall)\s+not|'
@@ -1227,6 +1229,12 @@ bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
+        r'^\s+by\s+(?:'
+        r'\d+(?:[.,]\d+)?\s*(?:%|percent|minutes?|hours?)|'
+        r'(?:an?|half\s+an)\s+hour)\b',
+        caseSensitive: false,
+      ).hasMatch(suffix) ||
+      RegExp(
         r'^\s+from\s+(?:(?:today[\x27’]s|the|this|our|my|your|their)\s+)?'
         r'(?:plan|schedule|day)\b',
         caseSensitive: false,
@@ -1588,7 +1596,8 @@ bool _evidenceActionIsAsserted(
       !RegExp(
         r'\b(?:must|need(?:s|ed)?\s+to|'
         r'(?:has|have|had)\s+to|(?:is|are|was|were)\s+required\s+to|'
-        r'ought\s+to)(?:\s+(?:be|being|get|getting))?\s*$',
+        r'ought\s+to|requir(?:e|es|ed|ing)(?:\s+to)?)'
+        r'(?:\s+(?:be|being|get|getting))?\s*$',
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !RegExp(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -733,6 +733,12 @@ final _negationWordPattern = RegExp(
   caseSensitive: false,
 );
 
+final _longNegatedComplementPattern = RegExp(
+  r'^\s*(?:(?:actually|really)\s+)?'
+  r'(?:get|gets|got|getting)\s+around\s+to\s*$',
+  caseSensitive: false,
+);
+
 final _avoidanceComplementPattern = RegExp(
   r'\b(?:avoid(?:s|ed|ing)?(?:\s+(?:being|getting))?|'
   'prevent(?:s|ed|ing)?|'
@@ -1159,6 +1165,7 @@ bool _hasTaskBoundFullAllocationClaim(
           taskTitle: taskTitle,
           corpus: corpus,
         ) ||
+        _evidenceHasTrailingHistoricalScope(prose, match) ||
         !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match) ||
         _matchClauseIsNegated(
@@ -1519,6 +1526,10 @@ bool _matchClauseIsNegated(
         _negationQualifiesRatherThanNegates(negation, between)) {
       continue;
     }
+    if (negationEnd <= match.start &&
+        _longNegatedComplementPattern.hasMatch(between)) {
+      return true;
+    }
     if (negationStart >= match.end &&
         _followingNegationExplainsCapacityLimit(
           reason,
@@ -1646,7 +1657,8 @@ bool _evidenceActionIsAsserted(
     }
   }
   final prefix = prose.substring(clauseStart, actionStart);
-  return !_evidenceStartIsSpeculative(prose, actionStart) &&
+  return !_evidenceClauseIsInterrogative(prose, actionStart) &&
+      !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
         r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
         r'(?:(?:is|are|was|were)\s+)?(?:supposed|meant|going)\s+to'
@@ -1678,6 +1690,14 @@ bool _evidenceActionIsAsserted(
       !_avoidanceComplementPattern.hasMatch(prefix);
 }
 
+bool _evidenceClauseIsInterrogative(String prose, int evidenceStart) {
+  for (var i = evidenceStart; i < prose.length; i++) {
+    if (prose[i] == '?') return true;
+    if ('.;!\n'.contains(prose[i])) return false;
+  }
+  return false;
+}
+
 bool _splitHasUnrelatedScope(
   String reason,
   Match evidence, {
@@ -1695,8 +1715,10 @@ bool _splitHasUnrelatedScope(
   final scopeEnd = evidence.end > evidenceAction.end
       ? evidence.end
       : evidenceAction.end;
-  if (_historicalAllocationScopePattern.hasMatch(
-    reason.substring(scopeEnd, range.end),
+  if (_evidenceHasTrailingHistoricalScope(
+    reason,
+    evidence,
+    evidenceEnd: scopeEnd,
   )) {
     return true;
   }
@@ -1725,6 +1747,17 @@ bool _splitHasUnrelatedScope(
     }
   }
   return false;
+}
+
+bool _evidenceHasTrailingHistoricalScope(
+  String prose,
+  Match evidence, {
+  int? evidenceEnd,
+}) {
+  final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+  return _historicalAllocationScopePattern.hasMatch(
+    prose.substring(evidenceEnd ?? evidence.end, range.end),
+  );
 }
 
 ({int start, int end, int distance})? _nearestPatternMatch(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1225,6 +1225,7 @@ bool _hasTaskBoundAllocationDenial(
   );
   for (final action in placementActionPattern.allMatches(prose)) {
     if (!_allocationActionIsDirectlyDenied(prose, action)) continue;
+    if (_evidenceIsSpeculative(prose, action)) continue;
     if (_tradeEvidenceHasExplicitNonTaskSubject(
       prose,
       action,
@@ -1564,11 +1565,20 @@ bool _splitHasUnrelatedScope(
   for (final match in _taskAllocationActionPattern.allMatches(clause)) {
     final start = range.start + match.start;
     final end = range.start + match.end;
-    if (end <= evidence.start &&
+    if (end <= evidence.start) {
+      if (!RegExp(
+        r'^\s*(?:(?:only|just|merely|about|approximately|roughly)\s+)?$',
+        caseSensitive: false,
+      ).hasMatch(reason.substring(end, evidence.start))) {
+        continue;
+      }
+    } else if (start >= evidence.end &&
         !RegExp(
-          r'^\s*(?:(?:only|just|merely|about|approximately|roughly)\s+)?$',
+          r'^\s*(?:(?:is|are|was|were|will|be|been|being|has|have|had|'
+          'only|just|merely|already|actually|currently|now|'
+          r'estimate|estimated)\s+)*$',
           caseSensitive: false,
-        ).hasMatch(reason.substring(end, evidence.start))) {
+        ).hasMatch(reason.substring(evidence.end, start))) {
       continue;
     }
     final distance = end <= evidence.start

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1390,7 +1390,10 @@ bool _allocationActionIsAsserted(
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !RegExp(
-        r'\b(?:attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
+        r'\b(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
+        'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
+        'propos(?:e|es|ed|ing)|plan(?:s|ned|ning)?|'
+        'attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
         'fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
         r'declin(?:e|es|ed|ing))\s+to\s*$',
         caseSensitive: false,
@@ -2152,7 +2155,7 @@ bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
   }
   return _allowsBareTaskTitle(title) &&
       RegExp(
-        r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
+        r'(?:^|[^\w-])' + RegExp.escape(title) + r'(?=$|[^\w-])',
         caseSensitive: false,
       ).hasMatch(prose);
 }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1103,6 +1103,7 @@ bool _hasTaskBoundFullAllocationClaim(
           taskId: taskId,
           taskTitle: taskTitle,
         ) ||
+        _fullAllocationClaimHasExplicitNonTaskHead(prose, match) ||
         _evidenceNamesAnotherTask(
           prose,
           match,
@@ -1123,6 +1124,20 @@ bool _hasTaskBoundFullAllocationClaim(
     return true;
   }
   return false;
+}
+
+bool _fullAllocationClaimHasExplicitNonTaskHead(
+  String prose,
+  Match match,
+) {
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final suffix = prose.substring(match.end, range.end);
+  return RegExp(
+    r'^\s+(?:(?:the|a|an|this|that)\s+)?'
+    '(?:day|meeting|workday|calendar|appointment|break|event|agenda|'
+    r'schedule|session)\b',
+    caseSensitive: false,
+  ).hasMatch(suffix);
 }
 
 bool _partialMentionIsNegated(String reason, Match match) {
@@ -1592,7 +1607,8 @@ bool _splitHasUnrelatedScope(
         !RegExp(
           r'^\s*(?:(?:is|are|was|were|will|be|been|being|has|have|had|'
           'only|just|merely|already|actually|currently|now|'
-          r'estimate|estimated|[a-z]+ly)\s+)*$',
+          'estimate|estimated|successfully|explicitly|deliberately|'
+          r'intentionally|firmly|definitively|concretely)\s+)*$',
           caseSensitive: false,
         ).hasMatch(reason.substring(evidence.end, start))) {
       continue;
@@ -2413,6 +2429,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
     for (final match in pattern.allMatches(prose)) {
       if (!belongsToTask(match) ||
           _remainderDescribesContinuity(prose, match) ||
+          _evidenceIsSpeculative(prose, match) ||
           _unrelatedRemainderScopePattern.hasMatch(
             _matchClause(prose, match),
           )) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -668,7 +668,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
       }
     }
   }
-  final capacity = outcome.inputs.capacityMinutes;
+  final capacity = outcome.inputs.plannableMinutes;
   final evidence = [
     if (partials.isNotEmpty) 'audited partials: ${partials.join(', ')}',
     if (undisclosedShortenings.isNotEmpty)
@@ -713,9 +713,17 @@ final _negationWordPattern = RegExp(
 
 final _partialRemainderDispositionPattern = RegExp(
   r'\b(?:for\s+(?:later|tomorrow|another\s+day|a\s+(?:later|future)\s+day)|'
-  r'(?:roll|move|carry)(?:s|d|ed|ing)?\s+(?:over|to)\b|'
+  r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
+  r'(?:over|to)\b|'
   r'defer(?:s|red|ring)?\b|unscheduled\b|'
   r'(?:of|for)\s+(?:this|the)\s+(?:task|work)\b)',
+  caseSensitive: false,
+);
+
+final _taskAllocationContextPattern = RegExp(
+  r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
+  r'fit(?:s|ting)?|estimate(?:d)?|task)\b',
   caseSensitive: false,
 );
 
@@ -832,7 +840,9 @@ bool _hasAuditablePartialDisclosure({
           declaredEstimate != estimateMinutes) {
         return false;
       }
-      hasMatchingSplit = true;
+      if (_splitIsTaskBound(reason, match)) {
+        hasMatchingSplit = true;
+      }
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
       if (_matchClauseIsNegated(reason, match)) return false;
@@ -858,7 +868,13 @@ bool _hasAuditablePartialDisclosure({
 }
 
 bool _matchClauseIsNegated(String reason, Match match) {
-  return _negationWordPattern.hasMatch(_matchClause(reason, match));
+  return _negationWordPattern.hasMatch(
+    _matchClause(reason, match, boundaries: ',.;!?\n'),
+  );
+}
+
+bool _splitIsTaskBound(String reason, Match match) {
+  return _taskAllocationContextPattern.hasMatch(_matchClause(reason, match));
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {
@@ -867,8 +883,11 @@ bool _remainderIsTaskBound(String reason, Match match) {
       _partialRemainderDispositionPattern.hasMatch(clause);
 }
 
-String _matchClause(String reason, Match match) {
-  const boundaries = '.;!?\n';
+String _matchClause(
+  String reason,
+  Match match, {
+  String boundaries = '.;!?\n',
+}) {
   var clauseStart = 0;
   for (var i = match.start - 1; i >= 0; i--) {
     if (boundaries.contains(reason[i])) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1725,7 +1725,7 @@ bool _splitHasUnrelatedScope(
     }
     if (end <= evidence.start) {
       if (!RegExp(
-        r'^\s*(?:(?:only|just|merely|about|approximately|roughly|'
+        r'^\s*(?:for\s+)?(?:(?:only|just|merely|about|approximately|roughly|'
         r'exactly|precisely)\s+)?$',
         caseSensitive: false,
       ).hasMatch(reason.substring(end, evidence.start))) {
@@ -2690,6 +2690,7 @@ String _tradeDispositionKey(Match match) {
   if (wording.contains('unscheduled')) return 'unscheduled';
   if (wording.contains('omit')) return 'omitted';
   if (wording.contains('drop')) return 'dropped';
+  if (wording.contains('unfinished')) return 'unfinished';
   if (wording.contains('left')) return 'left-out';
   if (wording.contains('conflict')) return 'conflict';
   if (wording.contains('shorten')) return 'shortened';

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -83,6 +83,7 @@ abstract final class EvalConstraintSignals {
 
   static const mixedIds = <String>{
     EvalConstraintIds.blockerBeforeBlocked,
+    EvalConstraintIds.withinCapacityByEstimate,
   };
 
   static const caveats = <String, String>{
@@ -91,6 +92,10 @@ abstract final class EvalConstraintSignals {
         'on a reason naming the blocker is heuristic: the match does not prove '
         'that the model understood the dependency or justified bypassing it; '
         'inspect the plan and reason in the judge bundle.',
+    EvalConstraintIds.withinCapacityByEstimate:
+        'Full-estimate accounting is objective. A pass that instead relies on '
+        'interpreting free-form partial-placement prose is heuristic; inspect '
+        'the reason and arithmetic in the judge bundle.',
     EvalConstraintIds.surfacedConflict:
         'Checks whether the output names omitted work or uses an accepted '
         'escalation reason. A match does not prove that the model understood '
@@ -677,6 +682,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   return EvalConstraintResult(
     id: id,
     passed: chargedMinutes <= capacity,
+    heuristic: chargedMinutes <= capacity && partials.isNotEmpty,
     detail:
         '${placements.length} placed task(s) charged at ${chargedMinutes}min against '
         '${capacity}min capacity'
@@ -757,14 +763,14 @@ final _omittedAllocationPattern = RegExp(
 );
 
 final _unrelatedRemainderScopePattern = RegExp(
-  r'\b(?:in|during|for)\s+'
+  r'\b(?:in|during|for|before|until)\s+'
   r'(?:(?:the|a|an|my|our|their|your)\s+)?'
   r'(?:meeting|workday|calendar|appointment|break)\b',
   caseSensitive: false,
 );
 
 final _conflictTradePattern = RegExp(
-  r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|left|remain(?:s|ed|ing)?|'
+  r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|left|'
   'trade|conflict|shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
   r'(?:do|does|did)\s+not)\s+fit)\b',
@@ -1797,6 +1803,23 @@ bool _hasAffirmativeTradeDisclosure(
       continue;
     }
     if (!_matchClauseIsNegated(prose, match)) return true;
+  }
+  for (final pattern in [
+    _partialRemainingPattern,
+    _partialLeadingRemainingPattern,
+  ]) {
+    for (final match in pattern.allMatches(prose)) {
+      if (_evidenceNamesAnotherTask(
+        prose,
+        match,
+        taskId: taskId,
+        taskTitle: task.title,
+        corpus: outcome.inputs.corpus,
+      )) {
+        continue;
+      }
+      if (!_matchClauseIsNegated(prose, match)) return true;
+    }
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
     if (_evidenceNamesAnotherTask(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -825,6 +825,21 @@ final _leadingHistoricalAllocationScopePattern = RegExp(
   caseSensitive: false,
 );
 
+final _futureAllocationScopePattern = RegExp(
+  r'^\s*(?:next\s+(?:week|month|year)|'
+  r'in\s+\d+\s+(?:days?|weeks?|months?|years?))'
+  r'\s*(?=$|because\b|due\s+to\b|owing\s+to\b)',
+  caseSensitive: false,
+);
+
+final _leadingFutureAllocationScopePattern = RegExp(
+  r'(?:^|[.;!?\n])\s*'
+  r'(?:next\s+(?:week|month|year)|'
+  r'in\s+\d+\s+(?:days?|weeks?|months?|years?))'
+  r'\s*,\s*$',
+  caseSensitive: false,
+);
+
 final _tradeSubjectPrefixPattern = RegExp(
   r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
   r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
@@ -895,6 +910,19 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
   }
 
   for (final block in _scheduled(outcome)) {
+    final isWorkBlock =
+        block.type == PlannedBlockType.ai ||
+        block.type == PlannedBlockType.manual;
+    final reason = block.reason?.trim();
+    if (reason != null && reason.isNotEmpty) {
+      for (final task in outcome.inputs.corpus) {
+        if ((!isWorkBlock || block.taskId != task.taskId) &&
+            (_taskIdNamed(task.taskId, reason) ||
+                _titleNamed(outcome, task.taskId, reason))) {
+          addDisclosure(task.taskId, canQualify: false, prose: reason);
+        }
+      }
+    }
     final note = block.note?.trim();
     final noteTaskIds = <String>{
       if (note != null && note.isNotEmpty)
@@ -908,10 +936,7 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
         addDisclosure(taskId, canQualify: false, prose: note);
       }
     }
-    if (block.type != PlannedBlockType.ai &&
-        block.type != PlannedBlockType.manual) {
-      continue;
-    }
+    if (!isWorkBlock) continue;
     final taskId = block.taskId;
     if (taskId == null) continue;
     allocatedByTask.update(
@@ -921,7 +946,6 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
       ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
     );
     blocksByTask.putIfAbsent(taskId, () => []).add(block);
-    final reason = block.reason?.trim();
     if (reason != null && reason.isNotEmpty) {
       addDisclosure(taskId, canQualify: true, prose: reason);
     }
@@ -1208,7 +1232,7 @@ bool _hasTaskBoundFullAllocationClaim(
           taskTitle: taskTitle,
           corpus: corpus,
         ) ||
-        _evidenceHasHistoricalScope(prose, match) ||
+        _evidenceHasNonCurrentAllocationScope(prose, match) ||
         !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match) ||
         _matchClauseIsNegated(
@@ -1382,7 +1406,7 @@ bool _hasTaskBoundAllocationDenial(
     caseSensitive: false,
   );
   for (final action in placementActionPattern.allMatches(prose)) {
-    if (_evidenceHasHistoricalScope(prose, action) ||
+    if (_evidenceHasNonCurrentAllocationScope(prose, action) ||
         !_allocationActionIsDirectlyDenied(
           prose,
           action,
@@ -1442,7 +1466,7 @@ bool _hasTaskBoundAllocationDenial(
     caseSensitive: false,
   );
   for (final failure in allocationFailurePattern.allMatches(prose)) {
-    if (_evidenceHasHistoricalScope(prose, failure) ||
+    if (_evidenceHasNonCurrentAllocationScope(prose, failure) ||
         _evidenceIsSpeculative(prose, failure) ||
         _tradeEvidenceHasExplicitNonTaskSubject(
           prose,
@@ -1806,7 +1830,8 @@ bool _evidenceActionIsAsserted(
         'propos(?:e|es|ed|ing)|plan(?:s|ned|ning)?|'
         'consider(?:s|ed|ing)?|'
         'attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
-        'fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
+        'fail(?:s|ed|ing)?|den(?:y|ies|ied|ying)|'
+        'refus(?:e|es|ed|ing)|'
         r'declin(?:e|es|ed|ing))(?:\s+to)?'
         r'(?:\s+(?:be|being|get|getting))?))\s*$',
         caseSensitive: false,
@@ -1878,7 +1903,7 @@ bool _splitHasUnrelatedScope(
   final scopeEnd = evidence.end > evidenceAction.end
       ? evidence.end
       : evidenceAction.end;
-  if (_evidenceHasHistoricalScope(
+  if (_evidenceHasNonCurrentAllocationScope(
     reason,
     evidence,
     evidenceEnd: scopeEnd,
@@ -1924,6 +1949,29 @@ bool _evidenceHasHistoricalScope(
     return true;
   }
   return _leadingHistoricalAllocationScopePattern.hasMatch(
+    prose.substring(0, range.start),
+  );
+}
+
+bool _evidenceHasNonCurrentAllocationScope(
+  String prose,
+  Match evidence, {
+  int? evidenceEnd,
+}) {
+  if (_evidenceHasHistoricalScope(
+    prose,
+    evidence,
+    evidenceEnd: evidenceEnd,
+  )) {
+    return true;
+  }
+  final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+  if (_futureAllocationScopePattern.hasMatch(
+    prose.substring(evidenceEnd ?? evidence.end, range.end),
+  )) {
+    return true;
+  }
+  return _leadingFutureAllocationScopePattern.hasMatch(
     prose.substring(0, range.start),
   );
 }
@@ -3018,11 +3066,10 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   ).allMatches(prefix)) {
     rawSubject = prefix.substring(complementizer.end).trim();
   }
-  if (_subjectStartsWithExplicitNonTaskHead(rawSubject)) {
-    return true;
-  }
   final subjectMatch = _tradeSubjectPrefixPattern.firstMatch(prefix);
-  if (subjectMatch == null) return false;
+  if (subjectMatch == null) {
+    return _subjectStartsWithExplicitNonTaskHead(rawSubject);
+  }
   final subject = subjectMatch.group(1)?.trim() ?? '';
   if (RegExp(
     r'^(?:(?:and|but|yet|so)\s+)?'

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -787,9 +787,12 @@ final _taskAllocationActionPattern = RegExp(
 );
 
 final _fullAllocationPattern = RegExp(
-  r'\b(?:fully|entirely|completely)\s+'
+  r'\b(?:(?:fully|entirely|completely)\s+'
   '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))\b',
+  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))|'
+  '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))\s+'
+  r'in\s+full)\b',
   caseSensitive: false,
 );
 
@@ -810,6 +813,14 @@ final _historicalAllocationScopePattern = RegExp(
   r'^\s*(?:yesterday|previously|earlier(?:\s+today)?|last\s+'
   '(?:week|month|year|(?:mon|tues|wednes|thurs|fri|satur|sun)day))'
   r'\s*(?=$|because\b|due\s+to\b|owing\s+to\b)',
+  caseSensitive: false,
+);
+
+final _leadingHistoricalAllocationScopePattern = RegExp(
+  r'(?:^|[.;!?\n])\s*'
+  r'(?:yesterday|previously|earlier(?:\s+today)?|last\s+'
+  '(?:week|month|year|(?:mon|tues|wednes|thurs|fri|satur|sun)day))'
+  r'\s*,\s*$',
   caseSensitive: false,
 );
 
@@ -1172,7 +1183,7 @@ bool _hasTaskBoundFullAllocationClaim(
           taskTitle: taskTitle,
           corpus: corpus,
         ) ||
-        _evidenceHasTrailingHistoricalScope(prose, match) ||
+        _evidenceHasHistoricalScope(prose, match) ||
         !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match) ||
         _matchClauseIsNegated(
@@ -1722,7 +1733,7 @@ bool _splitHasUnrelatedScope(
   final scopeEnd = evidence.end > evidenceAction.end
       ? evidence.end
       : evidenceAction.end;
-  if (_evidenceHasTrailingHistoricalScope(
+  if (_evidenceHasHistoricalScope(
     reason,
     evidence,
     evidenceEnd: scopeEnd,
@@ -1756,14 +1767,19 @@ bool _splitHasUnrelatedScope(
   return false;
 }
 
-bool _evidenceHasTrailingHistoricalScope(
+bool _evidenceHasHistoricalScope(
   String prose,
   Match evidence, {
   int? evidenceEnd,
 }) {
   final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
-  return _historicalAllocationScopePattern.hasMatch(
+  if (_historicalAllocationScopePattern.hasMatch(
     prose.substring(evidenceEnd ?? evidence.end, range.end),
+  )) {
+    return true;
+  }
+  return _leadingHistoricalAllocationScopePattern.hasMatch(
+    prose.substring(0, range.start),
   );
 }
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -730,7 +730,8 @@ final _partialMentionPattern = RegExp(
 );
 
 final _negationWordPattern = RegExp(
-  r'\b(?:not|no|never|cannot|(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
+  r'\b(?:not|no|never|neither|nor|cannot|'
+  '(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
   r'won|wouldn|shouldn|hasn|haven|hadn)[\x27’]?t)\b',
   caseSensitive: false,
 );
@@ -762,7 +763,7 @@ const _partialTradeDispositionSource =
     r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
     r'(?:over|to\s+(?:later|tomorrow|another\s+day|'
     r'a\s+(?:later|future)\s+day))\b|'
-    r'defer(?:s|red|ring)?\b|unscheduled\b';
+    r'defer(?:s|red|ring)?\b|postpon(?:e|es|ed|ing)\b|unscheduled\b';
 
 final _partialTradeDispositionPattern = RegExp(
   r'\b(?:'
@@ -1683,6 +1684,12 @@ bool _evidenceActionIsAsserted(
   String prose,
   int actionStart,
 ) {
+  if (RegExp(
+    r'^\w+\s+unsuccessfully\b',
+    caseSensitive: false,
+  ).hasMatch(prose.substring(actionStart))) {
+    return false;
+  }
   var clauseStart = 0;
   for (var i = actionStart - 1; i >= 0; i--) {
     if (',.;!?\n'.contains(prose[i])) {
@@ -2656,6 +2663,15 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   }
 
   bool belongsToTask(Match match) {
+    if (_tradeEvidenceHasCoordinatedTaskSubject(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    )) {
+      return true;
+    }
     if (_evidenceFallsInsideTaskReference(
           prose,
           match,
@@ -2670,15 +2686,6 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
           corpus: outcome.inputs.corpus,
         )) {
       return false;
-    }
-    if (_tradeEvidenceHasCoordinatedTaskSubject(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-      corpus: outcome.inputs.corpus,
-    )) {
-      return true;
     }
     return !_evidenceNamesAnotherTask(
       prose,
@@ -2843,7 +2850,9 @@ String _tradeDispositionKey(Match match) {
   if (wording.contains('partial') || wording.contains('partly')) {
     return 'partial';
   }
-  if (wording.contains('defer')) return 'deferred';
+  if (wording.contains('defer') || wording.contains('postpon')) {
+    return 'deferred';
+  }
   if (wording.contains('unscheduled')) return 'unscheduled';
   if (wording.contains('omit')) return 'omitted';
   if (wording.contains('drop')) return 'dropped';
@@ -2865,7 +2874,7 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   required String taskTitle,
   List<EvalCorpusTask> corpus = const [],
 }) {
-  final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+  final range = _matchClauseRange(prose, evidence, boundaries: '.;!?\n');
   final prefix = prose.substring(range.start, evidence.start).trim();
   if (RegExp(
     r'^not\s+only\s+(?:is|are|was|were)$',
@@ -2934,7 +2943,7 @@ bool _tradeEvidenceHasCoordinatedTaskSubject(
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
 }) {
-  final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+  final range = _matchClauseRange(prose, evidence, boundaries: '.;!?\n');
   final prefix = prose.substring(range.start, evidence.start).trim();
   final subjectMatch = _tradeSubjectPrefixPattern.firstMatch(prefix);
   final subject = subjectMatch?.group(1)?.trim();
@@ -2953,7 +2962,10 @@ bool _subjectIsOnlyCorpusTaskReferences(
   List<EvalCorpusTask> corpus,
 ) {
   final conjuncts = subject.split(
-    RegExp(r'\s+(?:and|&)\s+', caseSensitive: false),
+    RegExp(
+      r'\s*(?:,\s*(?:and\s+)?|\s+(?:and|&)\s+)',
+      caseSensitive: false,
+    ),
   );
   if (conjuncts.length < 2) return false;
   return conjuncts.every((conjunct) {
@@ -2972,15 +2984,20 @@ bool _subjectContainsTaskReference(
   required String taskId,
   required String taskTitle,
 }) {
-  return subject.split(RegExp(r'\s+(?:and|&)\s+', caseSensitive: false)).any((
-    conjunct,
-  ) {
-    return _subjectMatchesTaskReference(
-      conjunct,
-      taskId: taskId,
-      taskTitle: taskTitle,
-    );
-  });
+  return subject
+      .split(
+        RegExp(
+          r'\s*(?:,\s*(?:and\s+)?|\s+(?:and|&)\s+)',
+          caseSensitive: false,
+        ),
+      )
+      .any((conjunct) {
+        return _subjectMatchesTaskReference(
+          conjunct,
+          taskId: taskId,
+          taskTitle: taskTitle,
+        );
+      });
 }
 
 bool _subjectMatchesTaskReference(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -915,6 +915,13 @@ bool _hasAuditablePartialDisclosure({
   var hasBoundPartialRemainder = false;
   for (final disclosure in disclosures) {
     final reason = disclosure.prose;
+    if (_hasTaskBoundAllocationDenial(
+      reason,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    )) {
+      return false;
+    }
     var reasonMentionsPartial = false;
     var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
@@ -1108,9 +1115,77 @@ bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
-        r'^\s+(?:to|until|for|because|after|before|so|and|with|against|over)\b',
+        r'^\s+(?:to|until|for|because|due\s+to|owing\s+to|after|before|so|and|'
+        r'with|against|over)\b',
         caseSensitive: false,
       ).hasMatch(suffix);
+}
+
+bool _negativeFitEvidenceDescribesTaskOrWork(
+  String prose,
+  Match match, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final prefix = prose.substring(range.start, match.start).trimRight();
+  for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
+    for (final reference in pattern.allMatches(prefix)) {
+      if (reference.end == prefix.length) return true;
+    }
+  }
+  return RegExp(
+    r'\b(?:(?:the|this|that|its|our|my|your|their|full|remaining)\s+)*'
+    r'(?:task|work|remainder|rest|portion|part|it)\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
+}
+
+bool _hasTaskBoundAllocationDenial(
+  String prose, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  final placementActionPattern = RegExp(
+    r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+    r'plan(?:ned|ning)?|plac(?:e|ed|ing))\b',
+    caseSensitive: false,
+  );
+  for (final action in placementActionPattern.allMatches(prose)) {
+    if (!_allocationActionIsDirectlyDenied(prose, action)) continue;
+    final range = _matchClauseRange(prose, action, boundaries: ',.;!?\n');
+    if (_nearestTaskReferenceDistance(
+          prose,
+          action,
+          range: range,
+          taskId: taskId,
+          taskTitle: taskTitle,
+        ) !=
+        null) {
+      return true;
+    }
+    final prefix = prose.substring(range.start, action.start);
+    if (RegExp(
+      r'\b(?:(?:the|this|that|its)\s+)?'
+      r'(?:task|work|placement|block|it)\b',
+      caseSensitive: false,
+    ).hasMatch(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _allocationActionIsDirectlyDenied(String prose, Match action) {
+  final range = _matchClauseRange(prose, action, boundaries: ',.;!?\n');
+  final clause = prose.substring(range.start, action.start);
+  for (final negation in _negationWordPattern.allMatches(clause)) {
+    final negationEnd = range.start + negation.end;
+    final between = prose.substring(negationEnd, action.start);
+    if (_negationQualifiesRatherThanNegates(negation, between)) continue;
+    if (_wordPattern.allMatches(between).length <= 3) return true;
+  }
+  return false;
 }
 
 bool _partialMentionIsSpeculative(String prose, Match match) {
@@ -1415,11 +1490,17 @@ List<RegExp> _taskReferencePatterns(String taskId, String taskTitle) {
       r'\btask\s+' + RegExp.escape(title) + r'\b',
       caseSensitive: false,
     ),
-    RegExp(
-      r'(?:^|[^\w-])' + RegExp.escape(title) + r'(?=$|[^\w-])',
-      caseSensitive: false,
-    ),
+    if (_allowsBareTaskTitle(title))
+      RegExp(
+        r'(?:^|[^\w-])' + RegExp.escape(title) + r'(?=$|[^\w-])',
+        caseSensitive: false,
+      ),
   ];
+}
+
+bool _allowsBareTaskTitle(String title) {
+  final normalized = title.trim().toLowerCase();
+  return normalized != 'a' && normalized != 'i';
 }
 
 bool _evidenceFallsInsideTaskReference(
@@ -2018,8 +2099,14 @@ Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
 /// Whether [prose] mentions the title of [taskId].
 bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
   final title = outcome.inputs.taskById(taskId)?.title.trim();
-  return title != null &&
-      title.isNotEmpty &&
+  if (title == null || title.isEmpty) return false;
+  if (RegExp(
+    r'\btask\s+' + RegExp.escape(title) + r'\b',
+    caseSensitive: false,
+  ).hasMatch(prose)) {
+    return true;
+  }
+  return _allowsBareTaskTitle(title) &&
       RegExp(
         r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
         caseSensitive: false,
@@ -2031,19 +2118,39 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   caseSensitive: false,
 ).hasMatch(prose);
 
-({bool affirmative, bool denied}) _tradeDisclosureEvidence(
+typedef _TradeDisclosureEvidence = ({
+  Set<String> affirmative,
+  Set<String> denied,
+});
+
+_TradeDisclosureEvidence _tradeDisclosureEvidence(
   EvalRunOutcome outcome,
   String taskId,
   String prose,
 ) {
   final task = outcome.inputs.taskById(taskId);
-  if (task == null) return (affirmative: false, denied: false);
+  if (task == null) return (affirmative: <String>{}, denied: <String>{});
   final placement = _estimatedTaskPlacements(outcome)[taskId];
   final structuralRemainder = placement == null
       ? task.estimateMinutes
       : placement.estimateMinutes - placement.allocatedMinutes;
-  var hasAffirmativeEvidence = false;
-  var hasDeniedEvidence = false;
+  final affirmativeEvidence = <String>{};
+  final deniedEvidence = <String>{};
+
+  void record(String disposition, {required bool denied}) {
+    (denied ? deniedEvidence : affirmativeEvidence).add(disposition);
+  }
+
+  void denyAttachedDispositions(Match evidence) {
+    final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+    for (final disposition in _partialTradeDispositionPattern.allMatches(
+      prose,
+    )) {
+      if (disposition.start >= range.start && disposition.end <= range.end) {
+        record(_tradeDispositionKey(disposition), denied: true);
+      }
+    }
+  }
 
   bool belongsToTask(Match match) =>
       !_evidenceFallsInsideTaskReference(
@@ -2073,9 +2180,9 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
       continue;
     }
     if (_partialMentionIsNegated(prose, match)) {
-      hasDeniedEvidence = true;
+      record('partial', denied: true);
     } else {
-      hasAffirmativeEvidence = true;
+      record('partial', denied: false);
     }
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
@@ -2084,9 +2191,9 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
       continue;
     }
     if (_matchClauseIsNegated(prose, match)) {
-      hasDeniedEvidence = true;
+      record(_tradeDispositionKey(match), denied: true);
     } else {
-      hasAffirmativeEvidence = true;
+      record(_tradeDispositionKey(match), denied: false);
     }
   }
   for (final pattern in [
@@ -2106,13 +2213,15 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
           declaredRemainder <= 0 ||
           structuralRemainder != null &&
               declaredRemainder != structuralRemainder) {
-        hasDeniedEvidence = true;
+        record('remainder', denied: true);
+        denyAttachedDispositions(match);
         continue;
       }
       if (_matchClauseIsNegated(prose, match)) {
-        hasDeniedEvidence = true;
+        record('remainder', denied: true);
+        denyAttachedDispositions(match);
       } else {
-        hasAffirmativeEvidence = true;
+        record('remainder', denied: false);
       }
     }
   }
@@ -2123,23 +2232,51 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
         _negationWordPattern.hasMatch(matchedTrade) &&
         RegExp(r'\bfit\b', caseSensitive: false).hasMatch(matchedTrade);
     if (negativeFitDisclosure) {
+      if (!_negativeFitEvidenceDescribesTaskOrWork(
+        prose,
+        match,
+        taskId: taskId,
+        taskTitle: task.title,
+      )) {
+        continue;
+      }
       if (_negativeFitDisclosureIsDenied(prose, match)) {
-        hasDeniedEvidence = true;
+        record('negative-fit', denied: true);
       } else {
-        hasAffirmativeEvidence = true;
+        record('negative-fit', denied: false);
       }
     } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
       continue;
     } else if (_matchClauseIsNegated(prose, match)) {
-      hasDeniedEvidence = true;
+      record(_tradeDispositionKey(match), denied: true);
     } else {
-      hasAffirmativeEvidence = true;
+      record(_tradeDispositionKey(match), denied: false);
     }
   }
   return (
-    affirmative: hasAffirmativeEvidence,
-    denied: hasDeniedEvidence,
+    affirmative: affirmativeEvidence,
+    denied: deniedEvidence,
   );
+}
+
+String _tradeDispositionKey(Match match) {
+  final wording = (match.group(0) ?? '').toLowerCase();
+  if (wording.contains('partial') || wording.contains('partly')) {
+    return 'partial';
+  }
+  if (wording.contains('defer')) return 'deferred';
+  if (wording.contains('unscheduled')) return 'unscheduled';
+  if (wording.contains('omit')) return 'omitted';
+  if (wording.contains('drop')) return 'dropped';
+  if (wording.contains('left')) return 'left-out';
+  if (wording.contains('conflict')) return 'conflict';
+  if (wording.contains('shorten')) return 'shortened';
+  if (wording.contains('trade')) return 'trade';
+  if (wording.contains('roll')) return 'rolled-over';
+  if (wording.contains('carr')) return 'carried-over';
+  if (wording.contains('move')) return 'moved';
+  if (wording.startsWith('for ')) return 'for-later';
+  return wording;
 }
 
 bool _tradeEvidenceHasExplicitNonTaskSubject(
@@ -2211,8 +2348,8 @@ bool _taskTradeIsNamed(
   EvalRunOutcome outcome,
   String taskId,
 ) {
-  var hasAffirmativeNamedDisclosure = false;
-  var hasDeniedNamedDisclosure = false;
+  final affirmativeNamedDispositions = <String>{};
+  final deniedNamedDispositions = <String>{};
   for (final block in outcome.blocks) {
     for (final disclosure in [block.reason, block.note]) {
       final prose = disclosure?.trim().toLowerCase();
@@ -2221,11 +2358,13 @@ bool _taskTradeIsNamed(
           _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
       if (!namesTask) continue;
       final evidence = _tradeDisclosureEvidence(outcome, taskId, prose);
-      hasAffirmativeNamedDisclosure |= evidence.affirmative;
-      hasDeniedNamedDisclosure |= evidence.denied;
+      affirmativeNamedDispositions.addAll(evidence.affirmative);
+      deniedNamedDispositions.addAll(evidence.denied);
     }
   }
-  return hasAffirmativeNamedDisclosure && !hasDeniedNamedDisclosure;
+  return affirmativeNamedDispositions
+      .difference(deniedNamedDispositions)
+      .isNotEmpty;
 }
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1229,6 +1229,13 @@ bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
+        r'^\s+(?:entirely|completely|fully|actually|definitely|explicitly|'
+        'ultimately|finally|temporarily)'
+        r'(?:\s*$|\s+(?:to|until|for|because|due\s+to|owing\s+to|after|'
+        r'before|so|and|but|yet|with|against|over)\b)',
+        caseSensitive: false,
+      ).hasMatch(suffix) ||
+      RegExp(
         r'^\s+by\s+(?:'
         r'\d+(?:[.,]\d+)?\s*(?:%|percent|minutes?|hours?)|'
         r'(?:an?|half\s+an)\s+hour)\b',
@@ -1319,9 +1326,12 @@ bool _hasTaskBoundAllocationDenial(
     return true;
   }
   final allocationFailurePattern = RegExp(
-    r'\b(?:(?:the|this|that)\s+)?'
+    r'\b(?:(?:(?:the|this|that)\s+)?'
     r'(?:allocation|placement|scheduling|completion)\s+'
-    r'(?:(?:has|had)\s+)?fail(?:s|ed|ing)?\b',
+    r'(?:(?:has|had)\s+)?fail(?:s|ed|ing)?|'
+    r'fail(?:s|ed|ing)?\s+to\s+(?:be\s+)?'
+    '(?:schedul(?:e|ed)|allocat(?:e|ed)|complet(?:e|ed)|'
+    r'plan(?:ned)?|plac(?:e|ed)))\b',
     caseSensitive: false,
   );
   for (final failure in allocationFailurePattern.allMatches(prose)) {
@@ -1584,6 +1594,8 @@ bool _evidenceActionIsAsserted(
   return !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
         r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
+        r'(?:(?:is|are|was|were)\s+)?supposed\s+to'
+        r'(?:\s+(?:be|being|get|getting))?|'
         '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
         'propos(?:e|es|ed|ing)|plan(?:s|ned|ning)?|'
@@ -1851,6 +1863,7 @@ bool _referenceAttributesEvidence(
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {
+  if (_remainderHasExplicitNonTaskObject(reason, match)) return false;
   final clause = _matchClause(reason, match);
   if (_unrelatedRemainderScopePattern.hasMatch(clause)) return false;
   if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
@@ -1858,8 +1871,20 @@ bool _remainderIsTaskBound(String reason, Match match) {
 }
 
 bool _remainderIsRelatedToTask(String reason, Match match) {
+  if (_remainderHasExplicitNonTaskObject(reason, match)) return false;
   if (_remainderIsTaskBound(reason, match)) return true;
   return !_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match));
+}
+
+bool _remainderHasExplicitNonTaskObject(String reason, Match match) {
+  final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
+  final prefix = reason.substring(range.start, match.start);
+  return RegExp(
+    r'\b(?:a|an|the|this|that)\s+'
+    r'(?!(?:task|work|placement|block|remainder|rest|portion|part)\b)'
+    r'[\w-]+(?:\s+[\w-]+){0,3}\s+with\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
 }
 
 bool _remainderDescribesContinuity(String reason, Match match) {
@@ -2522,6 +2547,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
     for (final match in pattern.allMatches(prose)) {
       if (!belongsToTask(match) ||
           _remainderDescribesContinuity(prose, match) ||
+          !_remainderIsRelatedToTask(prose, match) ||
           _evidenceIsSpeculative(prose, match) ||
           _unrelatedRemainderScopePattern.hasMatch(
             _matchClause(prose, match),
@@ -2557,11 +2583,15 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
         hasEmbeddedNegation &&
         RegExp(r'\bfit\b', caseSensitive: false).hasMatch(matchedTrade);
     final negativeSchedulingDisclosure =
-        hasEmbeddedNegation &&
         RegExp(
           r'\bschedul(?:e|ed|ing)\b',
           caseSensitive: false,
-        ).hasMatch(matchedTrade);
+        ).hasMatch(matchedTrade) &&
+        (hasEmbeddedNegation ||
+            RegExp(
+              r'\bunable\s+to\b',
+              caseSensitive: false,
+            ).hasMatch(matchedTrade));
     if (negativeFitDisclosure) {
       if (!_negativeFitEvidenceDescribesTaskOrWork(
         prose,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1616,6 +1616,13 @@ bool _negativeTradeDisclosureIsDenied(String prose, Match match) {
         : start >= match.end
         ? prose.substring(match.end, start)
         : '';
+    if (start >= match.end &&
+        RegExp(
+          r'^\s*(?:because|since|as|due\s+to|owing\s+to)\s*$',
+          caseSensitive: false,
+        ).hasMatch(between)) {
+      continue;
+    }
     if (_wordPattern.allMatches(between).length <= 3) return true;
   }
   return false;
@@ -1688,6 +1695,8 @@ bool _evidenceActionIsAsserted(
       !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
         r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
+        r'(?:(?:is|are|was|were)\s+)?(?:likely|unlikely)\s+to'
+        r'(?:\s+(?:be|being|get|getting))?|'
         r'(?:(?:is|are|was|were)\s+)?(?:supposed|meant|going)\s+to'
         r'(?:\s+(?:be|being|get|getting))?|'
         '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
@@ -2703,6 +2712,11 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
+        outcome.inputs.now == null &&
+            RegExp(
+              r'\btomorrow\b',
+              caseSensitive: false,
+            ).hasMatch(match.group(0) ?? '') ||
         !_tradeEvidenceDescribesTaskOrWork(
           prose,
           match,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -712,6 +712,8 @@ final _negationWordPattern = RegExp(
   caseSensitive: false,
 );
 
+final _wordPattern = RegExp(r'\b\w+\b');
+
 final _partialRemainderDispositionPattern = RegExp(
   r'\b(?:for\s+(?:later|tomorrow|another\s+day|a\s+(?:later|future)\s+day)|'
   r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
@@ -884,9 +886,19 @@ bool _hasAuditablePartialDisclosure({
 }
 
 bool _matchClauseIsNegated(String reason, Match match) {
-  return _negationWordPattern.hasMatch(
-    _matchClause(reason, match, boundaries: ',.;!?\n'),
-  );
+  final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
+  final segment = reason.substring(range.start, range.end);
+  for (final negation in _negationWordPattern.allMatches(segment)) {
+    final negationStart = range.start + negation.start;
+    final negationEnd = range.start + negation.end;
+    final between = negationEnd <= match.start
+        ? reason.substring(negationEnd, match.start)
+        : negationStart >= match.end
+        ? reason.substring(match.end, negationStart)
+        : '';
+    if (_wordPattern.allMatches(between).length <= 3) return true;
+  }
+  return false;
 }
 
 bool _splitIsTaskBound(String reason, Match match) {
@@ -897,8 +909,9 @@ bool _splitIsTaskBound(String reason, Match match) {
 
 bool _remainderIsTaskBound(String reason, Match match) {
   final clause = _matchClause(reason, match);
-  return _partialMentionPattern.hasMatch(clause) ||
-      _partialRemainderDispositionPattern.hasMatch(clause);
+  if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
+  if (_unrelatedRemainderScopePattern.hasMatch(clause)) return false;
+  return _partialMentionPattern.hasMatch(clause);
 }
 
 bool _remainderIsRelatedToTask(String reason, Match match) {
@@ -915,6 +928,15 @@ String _matchClause(
   Match match, {
   String boundaries = '.;!?\n',
 }) {
+  final range = _matchClauseRange(reason, match, boundaries: boundaries);
+  return reason.substring(range.start, range.end);
+}
+
+({int start, int end}) _matchClauseRange(
+  String reason,
+  Match match, {
+  required String boundaries,
+}) {
   var clauseStart = 0;
   for (var i = match.start - 1; i >= 0; i--) {
     if (boundaries.contains(reason[i])) {
@@ -929,7 +951,7 @@ String _matchClause(
       break;
     }
   }
-  return reason.substring(clauseStart, clauseEnd);
+  return (start: clauseStart, end: clauseEnd);
 }
 
 /// Work the scenario says any competent plan must include.

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -694,7 +694,7 @@ final _partialOfEstimatePattern = RegExp(
 final _partialRemainingPattern = RegExp(
   r'\b(\d+)\s*(?:m|mins?|minutes?)\s+'
   r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
-  r'(?:(?:is|are)\s+)?(?:left|remain(?:s|ing)?)\b',
+  r'(?:(?:is|are|will)\s+)?(?:left|remain(?:s|ing)?)\b',
   caseSensitive: false,
 );
 
@@ -730,6 +730,13 @@ final _taskAllocationContextPattern = RegExp(
   caseSensitive: false,
 );
 
+final _taskAllocationActionPattern = RegExp(
+  r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
+  r'fit(?:s|ting)?)\b',
+  caseSensitive: false,
+);
+
 final _unrelatedRemainderScopePattern = RegExp(
   r'\b(?:in|during|for)\s+'
   r'(?:(?:the|a|an|my|our|their|your)\s+)?'
@@ -747,10 +754,13 @@ final _unrelatedSplitScopePattern = RegExp(
 );
 
 typedef _EstimatedTaskPlacement = ({
+  List<EvalCorpusTask> corpus,
   int allocatedMinutes,
   int estimateMinutes,
   bool hasOverlappingBlocks,
   List<String> reasons,
+  String taskId,
+  String taskTitle,
 });
 
 /// Estimated scheduled work grouped by task, with all disclosure prose.
@@ -785,15 +795,21 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
   }
   return {
     for (final entry in allocatedByTask.entries)
-      if (outcome.inputs.taskById(entry.key)?.estimateMinutes
-          case final int estimate when estimate > 0)
+      if (outcome.inputs.taskById(entry.key) case EvalCorpusTask(
+        :final taskId,
+        title: final taskTitle,
+        estimateMinutes: final int estimate,
+      ) when estimate > 0)
         entry.key: (
+          corpus: outcome.inputs.corpus,
           allocatedMinutes: entry.value,
           estimateMinutes: estimate,
           hasOverlappingBlocks: _hasOverlappingIntervals(
             blocksByTask[entry.key] ?? const [],
           ),
           reasons: reasonsByTask[entry.key] ?? const [],
+          taskId: taskId,
+          taskTitle: taskTitle,
         ),
   };
 }
@@ -826,6 +842,9 @@ bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
       reasons: placement.reasons,
       allocatedMinutes: placement.allocatedMinutes,
       estimateMinutes: placement.estimateMinutes,
+      taskId: placement.taskId,
+      taskTitle: placement.taskTitle,
+      corpus: placement.corpus,
     );
 
 /// Whether prose makes a shortened placement safe to charge as partial.
@@ -840,6 +859,9 @@ bool _hasAuditablePartialDisclosure({
   required List<String> reasons,
   required int allocatedMinutes,
   required int estimateMinutes,
+  required String taskId,
+  required String taskTitle,
+  required List<EvalCorpusTask> corpus,
 }) {
   final remainingMinutes = estimateMinutes - allocatedMinutes;
   var hasMatchingSplit = false;
@@ -852,7 +874,15 @@ bool _hasAuditablePartialDisclosure({
       reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
-      if (!_splitIsTaskBound(reason, match)) continue;
+      if (!_splitIsTaskBound(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        continue;
+      }
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredAllocated = int.tryParse(match.group(1) ?? '');
       final declaredEstimate = int.tryParse(match.group(2) ?? '');
@@ -898,23 +928,65 @@ bool _matchClauseIsNegated(String reason, Match match) {
         : negationStart >= match.end
         ? reason.substring(match.end, negationStart)
         : '';
-    if (_wordPattern.allMatches(between).length <= 3) return true;
+    if (_wordPattern.allMatches(between).length <= 3 ||
+        negationEnd <= match.start &&
+            _taskAllocationActionPattern.hasMatch(between)) {
+      return true;
+    }
   }
   return false;
 }
 
-bool _splitIsTaskBound(String reason, Match match) {
+bool _splitIsTaskBound(
+  String reason,
+  Match match, {
+  required String taskId,
+  required String taskTitle,
+  required List<EvalCorpusTask> corpus,
+}) {
   final clause = _matchClause(reason, match);
   final context = _matchClauseExcludingMatch(reason, match);
   return _taskAllocationContextPattern.hasMatch(context) &&
-      !_unrelatedSplitScopePattern.hasMatch(clause);
+      !_unrelatedSplitScopePattern.hasMatch(clause) &&
+      !_namesAnotherTask(
+        clause,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      );
+}
+
+bool _namesAnotherTask(
+  String clause, {
+  required String taskId,
+  required String taskTitle,
+  required List<EvalCorpusTask> corpus,
+}) {
+  for (final task in corpus) {
+    if (task.taskId == taskId ||
+        task.title.trim().toLowerCase() == taskTitle.trim().toLowerCase()) {
+      continue;
+    }
+    final idPattern = RegExp(
+      r'(?:^|[^\w-])' + RegExp.escape(task.taskId) + r'(?=$|[^\w-])',
+      caseSensitive: false,
+    );
+    final titlePattern = RegExp(
+      r'\btask\s+' + RegExp.escape(task.title.trim()) + r'\b',
+      caseSensitive: false,
+    );
+    if (idPattern.hasMatch(clause) || titlePattern.hasMatch(clause)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {
   final clause = _matchClause(reason, match);
   if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
   if (_unrelatedRemainderScopePattern.hasMatch(clause)) return false;
-  return _partialMentionPattern.hasMatch(clause);
+  return _partialMentionPattern.hasMatch(reason);
 }
 
 bool _remainderIsRelatedToTask(String reason, Match match) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -793,18 +793,39 @@ final _unrelatedRemainderScopePattern = RegExp(
   caseSensitive: false,
 );
 
+final _historicalAllocationScopePattern = RegExp(
+  r'^\s*(?:yesterday|previously|earlier(?:\s+today)?|last\s+'
+  '(?:week|month|year|(?:mon|tues|wednes|thurs|fri|satur|sun)day))'
+  r'\s*(?=$|because\b|due\s+to\b|owing\s+to\b)',
+  caseSensitive: false,
+);
+
+final _tradeSubjectPrefixPattern = RegExp(
+  r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
+  r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
+  r'(?:\s+(?:not|only|merely|just|still))?'
+  r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
+  '(?:has|have|had|leave(?:s|d|ing)?|left)|'
+  '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',
+  caseSensitive: false,
+);
+
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
   r'left\s+(?:(?:(?:some|the|this|that|its|our|my|your|their|remaining)\s+)*'
   r'(?:task|work|remainder|rest|portion|part)\s+)?'
   '(?:out|unfinished|incomplete|unscheduled)|'
   r'(?:(?:(?:is|are|was|were|be|been|being)\s+)?not|'
+  r'(?:can|could|will|shall)\s+not(?:\s+be)?|'
   r'(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)'
   r'(?:\s+be)?|'
   r'(?:(?:is|are|was|were)\s+unable\s+to|'
   r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)'
   r'(?:\s+be)?)\s+'
   'schedul(?:e|ed|ing)|'
+  r'(?:has|have|had)\s+(?:(?:a|the)\s+)?scheduling\s+conflict|'
   r'conflict(?:s|ed|ing)(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
@@ -836,7 +857,32 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
   final allocatedByTask = <String, int>{};
   final blocksByTask = <String, List<PlannedBlock>>{};
   final disclosuresByTask = <String, List<_PlacementDisclosure>>{};
+
+  void addDisclosure(
+    String taskId, {
+    required bool canQualify,
+    required String prose,
+  }) {
+    disclosuresByTask.putIfAbsent(taskId, () => []).add((
+      canQualify: canQualify,
+      prose: prose,
+    ));
+  }
+
   for (final block in _scheduled(outcome)) {
+    final note = block.note?.trim();
+    final noteTaskIds = <String>{
+      if (note != null && note.isNotEmpty)
+        for (final task in outcome.inputs.corpus)
+          if (_taskIdNamed(task.taskId, note) ||
+              _titleNamed(outcome, task.taskId, note))
+            task.taskId,
+    };
+    if (note != null && note.isNotEmpty) {
+      for (final taskId in noteTaskIds) {
+        addDisclosure(taskId, canQualify: false, prose: note);
+      }
+    }
     if (block.type != PlannedBlockType.ai &&
         block.type != PlannedBlockType.manual) {
       continue;
@@ -852,17 +898,10 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
     blocksByTask.putIfAbsent(taskId, () => []).add(block);
     final reason = block.reason?.trim();
     if (reason != null && reason.isNotEmpty) {
-      disclosuresByTask.putIfAbsent(taskId, () => []).add((
-        canQualify: true,
-        prose: reason,
-      ));
+      addDisclosure(taskId, canQualify: true, prose: reason);
     }
-    final note = block.note?.trim();
-    if (note != null && note.isNotEmpty) {
-      disclosuresByTask.putIfAbsent(taskId, () => []).add((
-        canQualify: false,
-        prose: note,
-      ));
+    if (note != null && note.isNotEmpty && noteTaskIds.isEmpty) {
+      addDisclosure(taskId, canQualify: false, prose: note);
     }
   }
   return {
@@ -1615,6 +1654,7 @@ bool _evidenceActionIsAsserted(
         '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
         'propos(?:e|es|ed|ing)|plan(?:s|ned|ning)?|'
+        'consider(?:s|ed|ing)?|'
         'attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
         'fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
         r'declin(?:e|es|ed|ing))(?:\s+to)?'
@@ -1652,6 +1692,14 @@ bool _splitHasUnrelatedScope(
   );
   if (evidenceAction == null) return false;
   final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
+  final scopeEnd = evidence.end > evidenceAction.end
+      ? evidence.end
+      : evidenceAction.end;
+  if (_historicalAllocationScopePattern.hasMatch(
+    reason.substring(scopeEnd, range.end),
+  )) {
+    return true;
+  }
   final currentTaskDistance = _nearestTaskReferenceDistance(
     reason,
     evidence,
@@ -2533,26 +2581,39 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
     }
   }
 
-  bool belongsToTask(Match match) =>
-      !_evidenceFallsInsideTaskReference(
-        prose,
-        match,
-        taskId: taskId,
-        taskTitle: task.title,
-      ) &&
-      !_tradeEvidenceHasExplicitNonTaskSubject(
-        prose,
-        match,
-        taskId: taskId,
-        taskTitle: task.title,
-      ) &&
-      !_evidenceNamesAnotherTask(
-        prose,
-        match,
-        taskId: taskId,
-        taskTitle: task.title,
-        corpus: outcome.inputs.corpus,
-      );
+  bool belongsToTask(Match match) {
+    if (_evidenceFallsInsideTaskReference(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: task.title,
+        ) ||
+        _tradeEvidenceHasExplicitNonTaskSubject(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: task.title,
+          corpus: outcome.inputs.corpus,
+        )) {
+      return false;
+    }
+    if (_tradeEvidenceHasCoordinatedTaskSubject(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    )) {
+      return true;
+    }
+    return !_evidenceNamesAnotherTask(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    );
+  }
 
   bool clauseIsNegated(Match match) => _matchClauseIsNegated(
     prose,
@@ -2706,6 +2767,7 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   Match evidence, {
   required String taskId,
   required String taskTitle,
+  List<EvalCorpusTask> corpus = const [],
 }) {
   final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
   final prefix = prose.substring(range.start, evidence.start).trim();
@@ -2722,17 +2784,17 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   )) {
     return true;
   }
-  final subjectMatch = RegExp(
-    r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
-    r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
-    r'(?:\s+(?:not|only|merely|just|still))?'
-    r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-    'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
-    '(?:has|have|had|leave(?:s|d|ing)?|left)|'
-    '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-    r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',
+  var rawSubject = prefix;
+  for (final complementizer in RegExp(
+    r'\bthat\s+',
     caseSensitive: false,
-  ).firstMatch(prefix);
+  ).allMatches(prefix)) {
+    rawSubject = prefix.substring(complementizer.end).trim();
+  }
+  if (_subjectStartsWithExplicitNonTaskHead(rawSubject)) {
+    return true;
+  }
+  final subjectMatch = _tradeSubjectPrefixPattern.firstMatch(prefix);
   if (subjectMatch == null) return false;
   final subject = subjectMatch.group(1)?.trim() ?? '';
   if (RegExp(
@@ -2751,11 +2813,101 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   )) {
     return true;
   }
+  if (_subjectIsOnlyCorpusTaskReferences(subject, corpus)) {
+    return false;
+  }
   return !_subjectStartsWithTaskReference(
     subject,
     taskId: taskId,
     taskTitle: taskTitle,
   );
+}
+
+bool _subjectStartsWithExplicitNonTaskHead(String subject) => RegExp(
+  r'^(?:(?:and|but|yet|so)\s+)?'
+  r'(?:(?:the|this|that|a|an|its|our|my|your|their)\s+)?'
+  '(?:day|meeting|workday|calendar|appointment|break|event|agenda|'
+  r'schedule|session)\b',
+  caseSensitive: false,
+).hasMatch(subject);
+
+bool _tradeEvidenceHasCoordinatedTaskSubject(
+  String prose,
+  Match evidence, {
+  required String taskId,
+  required String taskTitle,
+  required List<EvalCorpusTask> corpus,
+}) {
+  final range = _matchClauseRange(prose, evidence, boundaries: ',.;!?\n');
+  final prefix = prose.substring(range.start, evidence.start).trim();
+  final subjectMatch = _tradeSubjectPrefixPattern.firstMatch(prefix);
+  final subject = subjectMatch?.group(1)?.trim();
+  if (subject == null || !_subjectIsOnlyCorpusTaskReferences(subject, corpus)) {
+    return false;
+  }
+  return _subjectContainsTaskReference(
+    subject,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
+}
+
+bool _subjectIsOnlyCorpusTaskReferences(
+  String subject,
+  List<EvalCorpusTask> corpus,
+) {
+  final conjuncts = subject.split(
+    RegExp(r'\s+(?:and|&)\s+', caseSensitive: false),
+  );
+  if (conjuncts.length < 2) return false;
+  return conjuncts.every((conjunct) {
+    return corpus.any(
+      (task) => _subjectMatchesTaskReference(
+        conjunct,
+        taskId: task.taskId,
+        taskTitle: task.title,
+      ),
+    );
+  });
+}
+
+bool _subjectContainsTaskReference(
+  String subject, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  return subject.split(RegExp(r'\s+(?:and|&)\s+', caseSensitive: false)).any((
+    conjunct,
+  ) {
+    return _subjectMatchesTaskReference(
+      conjunct,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    );
+  });
+}
+
+bool _subjectMatchesTaskReference(
+  String subject, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  final normalized = subject.trim();
+  final title = taskTitle.trim();
+  const prefix = r'^(?:(?:the|this|that|its)\s+)?';
+  return RegExp(
+        prefix + RegExp.escape(taskId) + r'$',
+        caseSensitive: false,
+      ).hasMatch(normalized) ||
+      RegExp(
+        prefix + r'task\s+' + RegExp.escape(title) + r'$',
+        caseSensitive: false,
+      ).hasMatch(normalized) ||
+      _allowsBareTaskTitle(title) &&
+          RegExp(
+            prefix + RegExp.escape(title) + r'$',
+            caseSensitive: false,
+          ).hasMatch(normalized);
 }
 
 bool _subjectStartsWithPossessiveTaskReferenceToNonTaskHead(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -639,36 +639,18 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.withinCapacityByEstimate;
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
-  final allocatedByTask = <String, int>{};
-  final reasonsByTask = <String, List<String>>{};
-  for (final block in _scheduled(outcome)) {
-    final taskId = block.taskId;
-    if (taskId == null) continue;
-    allocatedByTask.update(
-      taskId,
-      (minutes) =>
-          minutes + block.endTime.difference(block.startTime).inMinutes,
-      ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
-    );
-    final reason = block.reason?.trim();
-    if (reason != null && reason.isNotEmpty) {
-      reasonsByTask.putIfAbsent(taskId, () => []).add(reason);
-    }
-  }
+  final placements = _estimatedTaskPlacements(outcome);
   var chargedMinutes = 0;
-  var counted = 0;
   final partials = <String>[];
   final undisclosedShortenings = <String>[];
-  for (final entry in allocatedByTask.entries) {
+  for (final entry in placements.entries) {
     final taskId = entry.key;
-    final estimate = outcome.inputs.taskById(taskId)?.estimateMinutes;
-    if (estimate == null || estimate <= 0) continue;
-    counted++;
-    final allocated = entry.value;
+    final allocated = entry.value.allocatedMinutes;
+    final estimate = entry.value.estimateMinutes;
     if (allocated > 0 &&
         allocated < estimate &&
         _hasAuditablePartialDisclosure(
-          reasons: reasonsByTask[taskId] ?? const [],
+          reasons: entry.value.reasons,
           allocatedMinutes: allocated,
           estimateMinutes: estimate,
         )) {
@@ -686,7 +668,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
       }
     }
   }
-  if (counted == 0) {
+  if (placements.isEmpty) {
     return const EvalConstraintResult.notApplicable(
       id,
       'no placed task carries an estimate',
@@ -702,7 +684,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
     id: id,
     passed: chargedMinutes <= capacity,
     detail:
-        '$counted placed task(s) charged at ${chargedMinutes}min against '
+        '${placements.length} placed task(s) charged at ${chargedMinutes}min against '
         '${capacity}min capacity'
         '${chargedMinutes > capacity ? ' (over by ${chargedMinutes - capacity})' : ''}'
         '${evidence.isEmpty ? '' : '; ${evidence.join('; ')}'}',
@@ -721,37 +703,84 @@ final _partialRemainingPattern = RegExp(
   caseSensitive: false,
 );
 
+typedef _EstimatedTaskPlacement = ({
+  int allocatedMinutes,
+  int estimateMinutes,
+  List<String> reasons,
+});
+
+/// Estimated scheduled work grouped by task, with all disclosure prose.
+///
+/// Both capacity accounting and conflict surfacing use this view so a partial
+/// cannot be credited by one constraint while its deferred remainder is
+/// invisible to the other.
+Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
+  EvalRunOutcome outcome,
+) {
+  final allocatedByTask = <String, int>{};
+  final reasonsByTask = <String, List<String>>{};
+  for (final block in _scheduled(outcome)) {
+    final taskId = block.taskId;
+    if (taskId == null) continue;
+    allocatedByTask.update(
+      taskId,
+      (minutes) =>
+          minutes + block.endTime.difference(block.startTime).inMinutes,
+      ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
+    );
+    final reason = block.reason?.trim();
+    if (reason != null && reason.isNotEmpty) {
+      reasonsByTask.putIfAbsent(taskId, () => []).add(reason);
+    }
+  }
+  return {
+    for (final entry in allocatedByTask.entries)
+      if (outcome.inputs.taskById(entry.key)?.estimateMinutes
+          case final int estimate when estimate > 0)
+        entry.key: (
+          allocatedMinutes: entry.value,
+          estimateMinutes: estimate,
+          reasons: reasonsByTask[entry.key] ?? const [],
+        ),
+  };
+}
+
 /// Whether prose makes a shortened placement safe to charge as partial.
 ///
 /// Block duration remains the authority. A reason earns partial accounting
 /// only when its concrete minute arithmetic agrees with both that duration and
 /// the corpus estimate. This accepts either an explicit `60m of 120m` split or
 /// the prompt's `partial` plus `60m remain` form; vague prose and contradictory
-/// numbers keep the conservative full-estimate charge.
+/// numbers anywhere in the task's disclosure keep the conservative
+/// full-estimate charge.
 bool _hasAuditablePartialDisclosure({
   required List<String> reasons,
   required int allocatedMinutes,
   required int estimateMinutes,
 }) {
   final remainingMinutes = estimateMinutes - allocatedMinutes;
+  final mentionsPartial = reasons.any(
+    (reason) => reason.toLowerCase().contains('partial'),
+  );
+  var hasMatchingSplit = false;
+  var hasMatchingRemainder = false;
   for (final reason in reasons) {
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
       final declaredAllocated = int.tryParse(match.group(1) ?? '');
       final declaredEstimate = int.tryParse(match.group(2) ?? '');
-      if (declaredAllocated == allocatedMinutes &&
-          declaredEstimate == estimateMinutes) {
-        return true;
+      if (declaredAllocated != allocatedMinutes ||
+          declaredEstimate != estimateMinutes) {
+        return false;
       }
+      hasMatchingSplit = true;
     }
-    if (!reason.toLowerCase().contains('partial')) continue;
     for (final match in _partialRemainingPattern.allMatches(reason)) {
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
-      if (declaredRemaining == remainingMinutes) {
-        return true;
-      }
+      if (declaredRemaining != remainingMinutes) return false;
+      hasMatchingRemainder = true;
     }
   }
-  return false;
+  return hasMatchingSplit || (mentionsPartial && hasMatchingRemainder);
 }
 
 /// Work the scenario says any competent plan must include.
@@ -823,16 +852,28 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   // The prompt asks for "which commitments collide and what trade would make
   // it fit", so a bare "Deferred" is not surfacing anything — it names no
   // casualty and gives the user nothing to act on. Require the text to
-  // identify at least one piece of work that was actually left out.
+  // identify at least one piece of work that was actually left out or only
+  // partially represented.
   final placed = _placedTaskIds(outcome);
-  final omitted = [
+  final auditedPartials = {
+    for (final entry in _estimatedTaskPlacements(outcome).entries)
+      if (entry.value.allocatedMinutes > 0 &&
+          entry.value.allocatedMinutes < entry.value.estimateMinutes &&
+          _hasAuditablePartialDisclosure(
+            reasons: entry.value.reasons,
+            allocatedMinutes: entry.value.allocatedMinutes,
+            estimateMinutes: entry.value.estimateMinutes,
+          ))
+        entry.key,
+  };
+  final deferred = [
     for (final taskId in outcome.inputs.decidedTaskIds)
-      if (!placed.contains(taskId)) taskId,
+      if (!placed.contains(taskId) || auditedPartials.contains(taskId)) taskId,
   ];
-  if (omitted.isEmpty) {
+  if (deferred.isEmpty) {
     return const EvalConstraintResult.notApplicable(
       id,
-      'nothing was left out, so there is no trade to name',
+      'nothing was left out or partially deferred, so there is no trade to name',
     );
   }
   final prose = [
@@ -840,7 +881,7 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
       '${block.reason ?? ''} ${block.note ?? ''}',
   ].join(' ').toLowerCase();
   final namedCasualties = [
-    for (final taskId in omitted)
+    for (final taskId in deferred)
       if (prose.contains(taskId.toLowerCase()) ||
           _titleNamed(outcome, taskId, prose))
         taskId,
@@ -849,9 +890,10 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
     id: id,
     passed: namedCasualties.isNotEmpty,
     detail: namedCasualties.isNotEmpty
-        ? 'named what it left out: ${namedCasualties.join(', ')}'
+        ? 'named deferred work: ${namedCasualties.join(', ')}'
         : 'absorbed an impossible day without naming a casualty — '
-              '${omitted.length} decided task(s) dropped in silence',
+              '${deferred.length} decided task(s) dropped or partially '
+              'deferred in silence',
   );
 }
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -790,7 +790,8 @@ final _conflictTradePattern = RegExp(
   r'trade|conflict(?:s|ed|ing)?(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
-  r'(?:do|does|did)\s+not|(?:don|doesn|didn)[\x27’]?t)\s+fit)\b',
+  r'(?:do|does|did|will|shall)\s+not|'
+  r'(?:don|doesn|didn)[\x27’]?t)\s+fit)\b',
   caseSensitive: false,
 );
 
@@ -1215,6 +1216,14 @@ bool _hasTaskBoundAllocationDenial(
   );
   for (final action in placementActionPattern.allMatches(prose)) {
     if (!_allocationActionIsDirectlyDenied(prose, action)) continue;
+    if (_tradeEvidenceHasExplicitNonTaskSubject(
+      prose,
+      action,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    )) {
+      continue;
+    }
     final range = _matchClauseRange(prose, action, boundaries: ',.;!?\n');
     if (_nearestTaskReferenceDistance(
           prose,
@@ -1248,7 +1257,7 @@ bool _hasTaskBoundAllocationDenial(
     final prefix = prose.substring(range.start, action.start);
     if (RegExp(
       r'\b(?:(?:the|this|that|its)\s+)?'
-      r'(?:task|work|placement|block|it)\b',
+      r'(?:task(?!-)|work|placement|block|it)\b',
       caseSensitive: false,
     ).hasMatch(prefix)) {
       return true;
@@ -1482,6 +1491,10 @@ bool _allocationActionIsAsserted(
         r'(?:unable\s+to|not\s+able\s+to|incapable\s+of)|'
         r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)\s*$',
         caseSensitive: false,
+      ).hasMatch(prefix) &&
+      !RegExp(
+        r'\b(?:avoid(?:s|ed|ing)?|prevent(?:s|ed|ing)?)\s*$',
+        caseSensitive: false,
       ).hasMatch(prefix);
 }
 
@@ -1666,7 +1679,7 @@ bool _referenceAttributesEvidence(
     return trimmed.isEmpty ||
         _taskAllocationActionPattern.hasMatch(between) ||
         RegExp(
-          r'^(?:is|are|was|were|has|have|had|will\s+be)$',
+          r'^(?:is|are|was|were|has|have|had|will\s+be)(?:\s+not)?$',
           caseSensitive: false,
         ).hasMatch(trimmed) ||
         RegExp(r'^[\x27’]s$', caseSensitive: false).hasMatch(trimmed) ||
@@ -2445,7 +2458,7 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   final subjectMatch = RegExp(
     r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
     r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
-    r'(?:\s+(?:only|merely|just|still))?'
+    r'(?:\s+(?:not|only|merely|just|still))?'
     r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
     '(?:has|have|had|leave(?:s|d|ing)?|left)|'

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1431,13 +1431,10 @@ bool _hasTaskBoundAllocationDenial(
       failure,
       boundaries: ',.;!?\n',
     );
-    final prefix = prose.substring(range.start, failure.start);
-    if (RegExp(
-      r'\b(?:meeting|workday|calendar|appointment|event|session)\s*$',
-      caseSensitive: false,
-    ).hasMatch(prefix)) {
+    if (_allocationFailureHasExplicitNonTaskScope(prose, failure, range)) {
       continue;
     }
+    final prefix = prose.substring(range.start, failure.start);
     if (RegExp(
       r'^\s*(?:(?:and|but|yet|so)\s+)?$',
       caseSensitive: false,
@@ -1446,6 +1443,26 @@ bool _hasTaskBoundAllocationDenial(
     }
   }
   return false;
+}
+
+bool _allocationFailureHasExplicitNonTaskScope(
+  String prose,
+  Match failure,
+  ({int start, int end}) range,
+) {
+  const nonTaskHead = '(?:meeting|workday|calendar|appointment|event|session)';
+  final prefix = prose.substring(range.start, failure.start);
+  if (RegExp(
+    '$nonTaskHead\\s*\$',
+    caseSensitive: false,
+  ).hasMatch(prefix)) {
+    return true;
+  }
+  final suffix = prose.substring(failure.end, range.end);
+  return RegExp(
+    r'^\s+for\s+(?:(?:the|this|that|a|an)\s+)?' + nonTaskHead + r'\b',
+    caseSensitive: false,
+  ).hasMatch(suffix);
 }
 
 bool _allocationActionIsDirectlyDenied(String prose, Match action) {
@@ -1558,6 +1575,10 @@ bool _matchClauseIsNegated(
       continue;
     }
     if (negationEnd <= match.start &&
+        _negationEndsAtContrastiveTradePredicate(between)) {
+      continue;
+    }
+    if (negationEnd <= match.start &&
         _longNegatedComplementPattern.hasMatch(between)) {
       return true;
     }
@@ -1621,6 +1642,10 @@ bool _negativeTradeDisclosureIsDenied(String prose, Match match) {
         _negationQualifiesRatherThanNegates(negation, between)) {
       continue;
     }
+    if (end <= match.start &&
+        _negationEndsAtContrastiveTradePredicate(between)) {
+      continue;
+    }
     if (start >= match.end &&
         RegExp(
           r'^\s*(?:because|since|as|due\s+to|owing\s+to)\s*$',
@@ -1631,6 +1656,17 @@ bool _negativeTradeDisclosureIsDenied(String prose, Match match) {
     if (_wordPattern.allMatches(between).length <= 3) return true;
   }
   return false;
+}
+
+bool _negationEndsAtContrastiveTradePredicate(String between) {
+  final contrast = RegExp(
+    r'\bbut\s*$',
+    caseSensitive: false,
+  ).firstMatch(between);
+  if (contrast == null) return false;
+  final deniedPredicate = between.substring(0, contrast.start);
+  return _partialTradeDispositionPattern.hasMatch(deniedPredicate) ||
+      _conflictTradePattern.hasMatch(deniedPredicate);
 }
 
 bool _splitIsTaskBound(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -733,6 +733,15 @@ final _negationWordPattern = RegExp(
   caseSensitive: false,
 );
 
+final _avoidanceComplementPattern = RegExp(
+  r'\b(?:avoid(?:s|ed|ing)?(?:\s+(?:being|getting))?|'
+  'prevent(?:s|ed|ing)?|'
+  r'(?:(?:is|are|was|were|be|been|being)\s+)?'
+  r'prevent(?:s|ed|ing)?(?:\s+[\w-]+){0,2}\s+from'
+  r'(?:\s+(?:being|getting))?)\s*$',
+  caseSensitive: false,
+);
+
 final _wordPattern = RegExp(r'\b\w+\b');
 
 const _partialTradeDispositionSource =
@@ -1324,12 +1333,7 @@ bool _matchClauseIsNegated(
   ).hasMatch(prefix)) {
     return true;
   }
-  if (RegExp(
-    r'\b(?:avoid(?:s|ed|ing)?(?:\s+being)?|'
-    r'(?:(?:is|are|was|were|be|been|being)\s+)?'
-    r'prevent(?:s|ed|ing)?(?:\s+\w+){0,2}\s+from(?:\s+being)?)\s*$',
-    caseSensitive: false,
-  ).hasMatch(prefix)) {
+  if (_avoidanceComplementPattern.hasMatch(prefix)) {
     return true;
   }
   for (final negation in _negationWordPattern.allMatches(reason, range.start)) {
@@ -1444,11 +1448,7 @@ bool _splitIsTaskBound(
 }
 
 bool _splitHasAffirmativeAllocation(String reason, Match match) {
-  final action = _nearestPatternMatch(
-    reason,
-    match,
-    _taskAllocationActionPattern,
-  );
+  final action = _nearestAllocationActionMatch(reason, match);
   if (action == null || !_allocationActionIsAsserted(reason, action)) {
     return false;
   }
@@ -1492,10 +1492,7 @@ bool _allocationActionIsAsserted(
         r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)\s*$',
         caseSensitive: false,
       ).hasMatch(prefix) &&
-      !RegExp(
-        r'\b(?:avoid(?:s|ed|ing)?|prevent(?:s|ed|ing)?)\s*$',
-        caseSensitive: false,
-      ).hasMatch(prefix);
+      !_avoidanceComplementPattern.hasMatch(prefix);
 }
 
 bool _splitHasUnrelatedScope(
@@ -1504,11 +1501,7 @@ bool _splitHasUnrelatedScope(
   required String taskId,
   required String taskTitle,
 }) {
-  final evidenceAction = _nearestPatternMatch(
-    reason,
-    evidence,
-    _taskAllocationActionPattern,
-  );
+  final evidenceAction = _nearestAllocationActionMatch(reason, evidence);
   if (evidenceAction == null) return false;
   final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
   final currentTaskDistance = _nearestTaskReferenceDistance(
@@ -1549,6 +1542,35 @@ bool _splitHasUnrelatedScope(
   for (final match in pattern.allMatches(clause)) {
     final start = range.start + match.start;
     final end = range.start + match.end;
+    final distance = end <= evidence.start
+        ? evidence.start - end
+        : start >= evidence.end
+        ? start - evidence.end
+        : 0;
+    if (nearest == null || distance < nearest.distance) {
+      nearest = (start: start, end: end, distance: distance);
+    }
+  }
+  return nearest;
+}
+
+({int start, int end, int distance})? _nearestAllocationActionMatch(
+  String reason,
+  Match evidence,
+) {
+  final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
+  final clause = reason.substring(range.start, range.end);
+  ({int start, int end, int distance})? nearest;
+  for (final match in _taskAllocationActionPattern.allMatches(clause)) {
+    final start = range.start + match.start;
+    final end = range.start + match.end;
+    if (end <= evidence.start &&
+        !RegExp(
+          r'^\s*(?:(?:only|just|merely|about|approximately|roughly)\s+)?$',
+          caseSensitive: false,
+        ).hasMatch(reason.substring(end, evidence.start))) {
+      continue;
+    }
     final distance = end <= evidence.start
         ? evidence.start - end
         : start >= evidence.end

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -776,7 +776,7 @@ final _unrelatedRemainderScopePattern = RegExp(
 
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|left|'
-  'trade|conflict|shorten(?:s|ed|ing)?|'
+  'trade|conflict(?:s|ed|ing)?|shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
   r'(?:do|does|did)\s+not)\s+fit)\b',
   caseSensitive: false,
@@ -901,6 +901,14 @@ bool _hasAuditablePartialDisclosure({
     var reasonMentionsPartial = false;
     var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
+      if (_tradeEvidenceHasExplicitNonTaskSubject(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+      )) {
+        continue;
+      }
       if (_evidenceNamesAnotherTask(
         reason,
         match,
@@ -914,13 +922,19 @@ bool _hasAuditablePartialDisclosure({
       reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
-      if (!_splitIsTaskBound(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-        corpus: corpus,
-      )) {
+      if (_tradeEvidenceHasExplicitNonTaskSubject(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+          ) ||
+          !_splitIsTaskBound(
+            reason,
+            match,
+            taskId: taskId,
+            taskTitle: taskTitle,
+            corpus: corpus,
+          )) {
         continue;
       }
       if (_matchClauseIsNegated(reason, match)) return false;
@@ -933,6 +947,14 @@ bool _hasAuditablePartialDisclosure({
       hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
+      if (_tradeEvidenceHasExplicitNonTaskSubject(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+      )) {
+        continue;
+      }
       if (_evidenceNamesAnotherTask(
         reason,
         match,
@@ -951,6 +973,14 @@ bool _hasAuditablePartialDisclosure({
       }
     }
     for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
+      if (_tradeEvidenceHasExplicitNonTaskSubject(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+      )) {
+        continue;
+      }
       if (_evidenceNamesAnotherTask(
         reason,
         match,
@@ -991,7 +1021,14 @@ bool _partialMentionIsNegated(String reason, Match match) {
 }
 
 bool _negationQualifiesRatherThanNegates(Match negation, String between) {
-  if ((negation.group(0) ?? '').toLowerCase() != 'not') return false;
+  final negator = (negation.group(0) ?? '').toLowerCase();
+  if (negator == 'no') {
+    return RegExp(
+      r'^\s*more\s+than\b',
+      caseSensitive: false,
+    ).hasMatch(between);
+  }
+  if (negator != 'not') return false;
   return RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between) ||
       RegExp(
         r'^\s*all\b.*\bfit(?:s|ting)?\b\s+'
@@ -1798,80 +1835,60 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   caseSensitive: false,
 ).hasMatch(prose);
 
-bool _hasAffirmativeTradeDisclosure(
+({bool affirmative, bool denied}) _tradeDisclosureEvidence(
   EvalRunOutcome outcome,
   String taskId,
   String prose,
 ) {
   final task = outcome.inputs.taskById(taskId);
-  if (task == null) return false;
+  if (task == null) return (affirmative: false, denied: false);
   final placement = _estimatedTaskPlacements(outcome)[taskId];
   final structuralRemainder = placement == null
       ? null
       : placement.estimateMinutes - placement.allocatedMinutes;
+  var hasAffirmativeEvidence = false;
+  var hasDeniedEvidence = false;
+
+  bool belongsToTask(Match match) =>
+      !_tradeEvidenceHasExplicitNonTaskSubject(
+        prose,
+        match,
+        taskId: taskId,
+        taskTitle: task.title,
+      ) &&
+      !_evidenceNamesAnotherTask(
+        prose,
+        match,
+        taskId: taskId,
+        taskTitle: task.title,
+        corpus: outcome.inputs.corpus,
+      );
+
   for (final match in _partialMentionPattern.allMatches(prose)) {
-    if (_tradeEvidenceHasExplicitNonTaskSubject(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-    )) {
-      continue;
+    if (!belongsToTask(match)) continue;
+    if (_partialMentionIsNegated(prose, match)) {
+      hasDeniedEvidence = true;
+    } else {
+      hasAffirmativeEvidence = true;
     }
-    if (_evidenceNamesAnotherTask(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-      corpus: outcome.inputs.corpus,
-    )) {
-      continue;
-    }
-    if (!_partialMentionIsNegated(prose, match)) return true;
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
-    if (_tradeEvidenceHasExplicitNonTaskSubject(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-    )) {
-      continue;
+    if (!belongsToTask(match)) continue;
+    if (_matchClauseIsNegated(prose, match)) {
+      hasDeniedEvidence = true;
+    } else {
+      hasAffirmativeEvidence = true;
     }
-    if (_evidenceNamesAnotherTask(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-      corpus: outcome.inputs.corpus,
-    )) {
-      continue;
-    }
-    if (!_matchClauseIsNegated(prose, match)) return true;
   }
   for (final pattern in [
     _partialRemainingPattern,
     _partialLeadingRemainingPattern,
   ]) {
     for (final match in pattern.allMatches(prose)) {
-      if (_tradeEvidenceHasExplicitNonTaskSubject(
-            prose,
-            match,
-            taskId: taskId,
-            taskTitle: task.title,
-          ) ||
+      if (!belongsToTask(match) ||
           _unrelatedRemainderScopePattern.hasMatch(
             _matchClause(prose, match),
           )) {
-        continue;
-      }
-      if (_evidenceNamesAnotherTask(
-        prose,
-        match,
-        taskId: taskId,
-        taskTitle: task.title,
-        corpus: outcome.inputs.corpus,
-      )) {
         continue;
       }
       final declaredRemainder = int.tryParse(match.group(1) ?? '');
@@ -1879,38 +1896,34 @@ bool _hasAffirmativeTradeDisclosure(
           declaredRemainder <= 0 ||
           structuralRemainder != null &&
               declaredRemainder != structuralRemainder) {
+        hasDeniedEvidence = true;
         continue;
       }
-      if (!_matchClauseIsNegated(prose, match)) return true;
+      if (_matchClauseIsNegated(prose, match)) {
+        hasDeniedEvidence = true;
+      } else {
+        hasAffirmativeEvidence = true;
+      }
     }
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
-    if (_tradeEvidenceHasExplicitNonTaskSubject(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-    )) {
-      continue;
-    }
-    if (_evidenceNamesAnotherTask(
-      prose,
-      match,
-      taskId: taskId,
-      taskTitle: task.title,
-      corpus: outcome.inputs.corpus,
-    )) {
-      continue;
-    }
+    if (!belongsToTask(match)) continue;
     final matchedTrade = match.group(0) ?? '';
     final negativeFitDisclosure =
         _negationWordPattern.hasMatch(matchedTrade) &&
         RegExp(r'\bfit\b', caseSensitive: false).hasMatch(matchedTrade);
-    if (negativeFitDisclosure || !_matchClauseIsNegated(prose, match)) {
-      return true;
+    if (negativeFitDisclosure) {
+      hasAffirmativeEvidence = true;
+    } else if (_matchClauseIsNegated(prose, match)) {
+      hasDeniedEvidence = true;
+    } else {
+      hasAffirmativeEvidence = true;
     }
   }
-  return false;
+  return (
+    affirmative: hasAffirmativeEvidence,
+    denied: hasDeniedEvidence,
+  );
 }
 
 bool _tradeEvidenceHasExplicitNonTaskSubject(
@@ -1929,9 +1942,18 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   );
   if (currentTaskDistance != null) return false;
   final prefix = prose.substring(range.start, evidence.start).trim();
+  if (RegExp(
+    r'^not\s+only\s+(?:is|are|was|were)$',
+    caseSensitive: false,
+  ).hasMatch(prefix)) {
+    return false;
+  }
   final subjectMatch = RegExp(
-    r'^(.*?)\s+(?:is|are|was|were|has\s+been|have\s+been|had\s+been|'
-    r'will\s+be)\s*$',
+    r'^(.*?)\s+(?:(?:is|are|was|were|has\s+been|have\s+been|had\s+been|'
+    r'will\s+be)(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+    'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
+    '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+    r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',
     caseSensitive: false,
   ).firstMatch(prefix);
   if (subjectMatch == null) return false;
@@ -1949,17 +1971,22 @@ bool _taskTradeIsNamed(
   String taskId, {
   required bool requireTradeDisclosure,
 }) {
+  var hasAffirmativeNamedDisclosure = false;
+  var hasDeniedNamedDisclosure = false;
   for (final block in outcome.blocks) {
-    final prose = '${block.reason ?? ''} ${block.note ?? ''}'.toLowerCase();
-    final namesTask =
-        _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
-    if (!namesTask) continue;
-    if (!requireTradeDisclosure ||
-        _hasAffirmativeTradeDisclosure(outcome, taskId, prose)) {
-      return true;
+    for (final disclosure in [block.reason, block.note]) {
+      final prose = disclosure?.trim().toLowerCase();
+      if (prose == null || prose.isEmpty) continue;
+      final namesTask =
+          _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
+      if (!namesTask) continue;
+      if (!requireTradeDisclosure) return true;
+      final evidence = _tradeDisclosureEvidence(outcome, taskId, prose);
+      hasAffirmativeNamedDisclosure |= evidence.affirmative;
+      hasDeniedNamedDisclosure |= evidence.denied;
     }
   }
-  return false;
+  return hasAffirmativeNamedDisclosure && !hasDeniedNamedDisclosure;
 }
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1128,7 +1128,8 @@ bool _hasTaskBoundFullAllocationClaim(
           taskId: taskId,
           taskTitle: taskTitle,
           corpus: corpus,
-        )) {
+        ) ||
+        _negativeTradeDisclosureIsDenied(prose, match)) {
       continue;
     }
     return true;
@@ -1144,7 +1145,7 @@ bool _fullAllocationClaimHasExplicitNonTaskHead(
   final suffix = prose.substring(match.end, range.end);
   return RegExp(
     r'^\s+(?:(?:for|throughout)\s+)?'
-    r'(?:(?:the|a|an|this|that)\s+)?'
+    r'(?:(?:the|a|an|this|that|my|your|his|her|its|our|their)\s+)?'
     '(?:day|meeting|workday|calendar|appointment|break|event|agenda|'
     r'schedule|session)\b',
     caseSensitive: false,
@@ -1550,7 +1551,12 @@ bool _splitIsTaskBound(
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
 }) {
-  return _splitHasAffirmativeAllocation(reason, match) &&
+  return _splitHasAffirmativeAllocation(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+      ) &&
       !_splitHasUnrelatedScope(
         reason,
         match,
@@ -1566,8 +1572,18 @@ bool _splitIsTaskBound(
       );
 }
 
-bool _splitHasAffirmativeAllocation(String reason, Match match) {
-  final action = _nearestAllocationActionMatch(reason, match);
+bool _splitHasAffirmativeAllocation(
+  String reason,
+  Match match, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  final action = _nearestAllocationActionMatch(
+    reason,
+    match,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
   if (action == null || !_evidenceActionIsAsserted(reason, action.start)) {
     return false;
   }
@@ -1628,7 +1644,12 @@ bool _splitHasUnrelatedScope(
   required String taskId,
   required String taskTitle,
 }) {
-  final evidenceAction = _nearestAllocationActionMatch(reason, evidence);
+  final evidenceAction = _nearestAllocationActionMatch(
+    reason,
+    evidence,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
   if (evidenceAction == null) return false;
   final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
   final currentTaskDistance = _nearestTaskReferenceDistance(
@@ -1683,14 +1704,25 @@ bool _splitHasUnrelatedScope(
 
 ({int start, int end, int distance})? _nearestAllocationActionMatch(
   String reason,
-  Match evidence,
-) {
+  Match evidence, {
+  required String taskId,
+  required String taskTitle,
+}) {
   final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
   final clause = reason.substring(range.start, range.end);
   ({int start, int end, int distance})? nearest;
   for (final match in _taskAllocationActionPattern.allMatches(clause)) {
     final start = range.start + match.start;
     final end = range.start + match.end;
+    if (_rangeFallsInsideTaskReference(
+      reason,
+      start: start,
+      end: end,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    )) {
+      continue;
+    }
     if (end <= evidence.start) {
       if (!RegExp(
         r'^\s*(?:(?:only|just|merely|about|approximately|roughly|'
@@ -1818,9 +1850,25 @@ bool _evidenceFallsInsideTaskReference(
   required String taskId,
   required String taskTitle,
 }) {
+  return _rangeFallsInsideTaskReference(
+    prose,
+    start: evidence.start,
+    end: evidence.end,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
+}
+
+bool _rangeFallsInsideTaskReference(
+  String prose, {
+  required int start,
+  required int end,
+  required String taskId,
+  required String taskTitle,
+}) {
   for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
     for (final reference in pattern.allMatches(prose)) {
-      if (reference.start <= evidence.start && reference.end >= evidence.end) {
+      if (reference.start <= start && reference.end >= end) {
         return true;
       }
     }
@@ -2666,6 +2714,13 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   ).hasMatch(prefix)) {
     return false;
   }
+  if (_subjectStartsWithPossessiveTaskReferenceToNonTaskHead(
+    prefix,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  )) {
+    return true;
+  }
   final subjectMatch = RegExp(
     r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
     r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
@@ -2688,11 +2743,44 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   ).hasMatch(subject)) {
     return false;
   }
+  if (_subjectStartsWithPossessiveTaskReferenceToNonTaskHead(
+    subject,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  )) {
+    return true;
+  }
   return !_subjectStartsWithTaskReference(
     subject,
     taskId: taskId,
     taskTitle: taskTitle,
   );
+}
+
+bool _subjectStartsWithPossessiveTaskReferenceToNonTaskHead(
+  String subject, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  final title = taskTitle.trim();
+  final taskReferences = [
+    RegExp.escape(taskId),
+    r'task\s+' + RegExp.escape(title),
+    if (_allowsBareTaskTitle(title)) RegExp.escape(title),
+  ];
+  for (final taskReference in taskReferences) {
+    if (RegExp(
+      r'^(?:(?:the|this|that|its)\s+)?'
+      '$taskReference'
+      r'[\x27’]s\s+'
+      '(?:day|meeting|workday|calendar|appointment|break|event|'
+      r'agenda|schedule|session)\b',
+      caseSensitive: false,
+    ).hasMatch(subject)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool _subjectStartsWithTaskReference(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -700,14 +700,16 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
 }
 
 final _partialOfEstimatePattern = RegExp(
-  r'\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+(?:out\s+)?of\s+'
+  r'(?<![\d.,])\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+'
+  r'(?:out\s+)?of\s+'
   r'(?:(?:an?|the)\s+)?(?:estimated\s+)?'
   r'(\d+)(?:\s+estimated)?\s*[-–—]?\s*(?:m|mins?|minutes?)\b',
   caseSensitive: false,
 );
 
 final _partialRemainingPattern = RegExp(
-  r'\b(\d+)\s*(?:(?:more|additional)\s+)?(?:m|mins?|minutes?)\s+'
+  r'(?<![\d.,])\b(\d+)\s*'
+  r'(?:(?:more|additional)\s+)?(?:m|mins?|minutes?)\s+'
   r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
   r'(?:(?:still|yet)\s+)?'
   r'(?:(?:is|are|will(?:\s+be)?)\s+)?'
@@ -730,6 +732,11 @@ final _partialMentionPattern = RegExp(
 final _negationWordPattern = RegExp(
   r'\b(?:not|no|never|cannot|(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
   r'won|wouldn|shouldn|hasn|haven|hadn)[\x27’]?t)\b',
+  caseSensitive: false,
+);
+
+final _outerFalsehoodPattern = RegExp(
+  r'\b(?:not\s+(?:actually\s+)?true|false)\s+that\b',
   caseSensitive: false,
 );
 
@@ -1493,6 +1500,9 @@ bool _matchClauseIsNegated(
 }) {
   final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
   final prefix = reason.substring(range.start, match.start);
+  if (_outerFalsehoodPattern.hasMatch(prefix)) {
+    return true;
+  }
   if (RegExp(
     r'\b(?:(?:without)(?:\s+any)?|free\s+of)\s*$',
     caseSensitive: false,
@@ -1573,10 +1583,7 @@ bool _followingNegationExplainsCapacityLimit(
 bool _negativeTradeDisclosureIsDenied(String prose, Match match) {
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final prefix = prose.substring(range.start, match.start);
-  if (RegExp(
-    r'\b(?:not\s+(?:actually\s+)?true|false)\s+that\b',
-    caseSensitive: false,
-  ).hasMatch(prefix)) {
+  if (_outerFalsehoodPattern.hasMatch(prefix)) {
     return true;
   }
   final clause = prose.substring(range.start, range.end);
@@ -1693,7 +1700,7 @@ bool _evidenceActionIsAsserted(
 bool _evidenceClauseIsInterrogative(String prose, int evidenceStart) {
   for (var i = evidenceStart; i < prose.length; i++) {
     if (prose[i] == '?') return true;
-    if ('.;!\n'.contains(prose[i])) return false;
+    if (',.;!\n'.contains(prose[i])) return false;
   }
   return false;
 }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -729,7 +729,8 @@ final _wordPattern = RegExp(r'\b\w+\b');
 const _partialTradeDispositionSource =
     r'for\s+(?:later|tomorrow|another\s+day|a\s+(?:later|future)\s+day)|'
     r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
-    r'(?:over|to)\b|'
+    r'(?:over|to\s+(?:later|tomorrow|another\s+day|'
+    r'a\s+(?:later|future)\s+day))\b|'
     r'defer(?:s|red|ring)?\b|unscheduled\b';
 
 final _partialTradeDispositionPattern = RegExp(
@@ -744,13 +745,6 @@ final _partialRemainderDispositionPattern = RegExp(
   '$_partialTradeDispositionSource'
   r')\b|'
   r'(?:of|for|in)\s+(?:this|the)\s+(?:task|work)\b)',
-  caseSensitive: false,
-);
-
-final _taskAllocationContextPattern = RegExp(
-  r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
-  r'fit(?:s|ting)?|estimate(?:d)?|task)\b',
   caseSensitive: false,
 );
 
@@ -775,7 +769,8 @@ final _unrelatedRemainderScopePattern = RegExp(
 );
 
 final _conflictTradePattern = RegExp(
-  r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|left|'
+  r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
+  r'left\s+(?:out|unfinished|incomplete|unscheduled)|'
   'trade|conflict(?:s|ed|ing)?|shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
   r'(?:do|does|did)\s+not)\s+fit)\b',
@@ -1205,24 +1200,8 @@ int? _nearestTaskReferenceDistance(
   required String taskTitle,
 }) {
   final clause = reason.substring(range.start, range.end);
-  final title = taskTitle.trim();
-  final patterns = [
-    RegExp(
-      r'(?:^|[^\w-])' + RegExp.escape(taskId) + r'(?=$|[^\w-])',
-      caseSensitive: false,
-    ),
-    RegExp(
-      r'\btask\s+' + RegExp.escape(title) + r'\b',
-      caseSensitive: false,
-    ),
-    if (title.length >= 4)
-      RegExp(
-        r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
-        caseSensitive: false,
-      ),
-  ];
   int? nearest;
-  for (final pattern in patterns) {
+  for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
     for (final reference in pattern.allMatches(clause)) {
       final referenceStart = range.start + reference.start;
       final referenceEnd = range.start + reference.end;
@@ -1243,6 +1222,41 @@ int? _nearestTaskReferenceDistance(
     }
   }
   return nearest;
+}
+
+List<RegExp> _taskReferencePatterns(String taskId, String taskTitle) {
+  final title = taskTitle.trim();
+  return [
+    RegExp(
+      r'(?:^|[^\w-])' + RegExp.escape(taskId) + r'(?=$|[^\w-])',
+      caseSensitive: false,
+    ),
+    RegExp(
+      r'\btask\s+' + RegExp.escape(title) + r'\b',
+      caseSensitive: false,
+    ),
+    if (title.length >= 4)
+      RegExp(
+        r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
+        caseSensitive: false,
+      ),
+  ];
+}
+
+bool _evidenceFallsInsideTaskReference(
+  String prose,
+  Match evidence, {
+  required String taskId,
+  required String taskTitle,
+}) {
+  for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
+    for (final reference in pattern.allMatches(prose)) {
+      if (reference.start <= evidence.start && reference.end >= evidence.end) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 bool _referenceAttributesEvidence(
@@ -1288,11 +1302,7 @@ bool _remainderIsTaskBound(String reason, Match match) {
 
 bool _remainderIsRelatedToTask(String reason, Match match) {
   if (_remainderIsTaskBound(reason, match)) return true;
-  if (_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match))) {
-    return false;
-  }
-  return _partialMentionPattern.hasMatch(reason) ||
-      _taskAllocationContextPattern.hasMatch(reason);
+  return !_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match));
 }
 
 String _matchClause(
@@ -1850,6 +1860,12 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   var hasDeniedEvidence = false;
 
   bool belongsToTask(Match match) =>
+      !_evidenceFallsInsideTaskReference(
+        prose,
+        match,
+        taskId: taskId,
+        taskTitle: task.title,
+      ) &&
       !_tradeEvidenceHasExplicitNonTaskSubject(
         prose,
         match,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -665,14 +665,15 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
     final taskId = entry.key;
     final allocated = entry.value.allocatedMinutes;
     final estimate = entry.value.estimateMinutes;
-    fullEstimateMinutes += estimate - allocated;
+    final estimateShortfall = estimate > allocated ? estimate - allocated : 0;
+    fullEstimateMinutes += estimateShortfall;
     if (_isAuditedPartial(entry.value)) {
       partials.add(
         '$taskId ${allocated}min partial of ${estimate}min '
         '(${estimate - allocated}min remain)',
       );
     } else {
-      chargedMinutes += estimate - allocated;
+      chargedMinutes += estimateShortfall;
       if (allocated > 0 && allocated < estimate) {
         undisclosedShortenings.add(
           '$taskId allocated ${allocated}min of ${estimate}min',
@@ -2343,7 +2344,7 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
     r'(?:\s+(?:only|merely|just|still))?'
     r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
-    '(?:has|have|had)|'
+    '(?:has|have|had|leave(?:s|d|ing)?|left)|'
     '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',
     caseSensitive: false,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -796,6 +796,8 @@ final _unrelatedRemainderScopePattern = RegExp(
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
   r'left\s+(?:out|unfinished|incomplete|unscheduled)|'
+  r'(?:(?:is|are|was|were|be|been|being)\s+)?not\s+'
+  'schedul(?:e|ed|ing)|'
   r'trade|conflict(?:s|ed|ing)?(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
@@ -1436,7 +1438,7 @@ bool _followingNegationExplainsCapacityLimit(
   ).hasMatch(suffix);
 }
 
-bool _negativeFitDisclosureIsDenied(String prose, Match match) {
+bool _negativeTradeDisclosureIsDenied(String prose, Match match) {
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final prefix = prose.substring(range.start, match.start);
   if (RegExp(
@@ -1519,6 +1521,12 @@ bool _allocationActionIsAsserted(
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !RegExp(
+        r'\b(?:must|need(?:s|ed)?\s+to|'
+        r'(?:has|have|had)\s+to|(?:is|are|was|were)\s+required\s+to|'
+        r'ought\s+to)\s*$',
+        caseSensitive: false,
+      ).hasMatch(prefix) &&
+      !RegExp(
         r'\b(?:(?:(?:is|are|was|were|be|been|being)\s+)?'
         r'(?:unable\s+to|not\s+able\s+to|incapable\s+of)|'
         r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)\s*$',
@@ -1598,7 +1606,8 @@ bool _splitHasUnrelatedScope(
     final end = range.start + match.end;
     if (end <= evidence.start) {
       if (!RegExp(
-        r'^\s*(?:(?:only|just|merely|about|approximately|roughly)\s+)?$',
+        r'^\s*(?:(?:only|just|merely|about|approximately|roughly|'
+        r'exactly|precisely)\s+)?$',
         caseSensitive: false,
       ).hasMatch(reason.substring(end, evidence.start))) {
         continue;
@@ -2455,9 +2464,16 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   for (final match in _conflictTradePattern.allMatches(prose)) {
     if (!belongsToTask(match) || _evidenceIsSpeculative(prose, match)) continue;
     final matchedTrade = match.group(0) ?? '';
+    final hasEmbeddedNegation = _negationWordPattern.hasMatch(matchedTrade);
     final negativeFitDisclosure =
-        _negationWordPattern.hasMatch(matchedTrade) &&
+        hasEmbeddedNegation &&
         RegExp(r'\bfit\b', caseSensitive: false).hasMatch(matchedTrade);
+    final negativeSchedulingDisclosure =
+        hasEmbeddedNegation &&
+        RegExp(
+          r'\bschedul(?:e|ed|ing)\b',
+          caseSensitive: false,
+        ).hasMatch(matchedTrade);
     if (negativeFitDisclosure) {
       if (!_negativeFitEvidenceDescribesTaskOrWork(
         prose,
@@ -2467,11 +2483,17 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
       )) {
         continue;
       }
-      if (_negativeFitDisclosureIsDenied(prose, match)) {
+      if (_negativeTradeDisclosureIsDenied(prose, match)) {
         record('negative-fit', denied: true);
       } else {
         record('negative-fit', denied: false);
       }
+    } else if (negativeSchedulingDisclosure) {
+      if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) continue;
+      record(
+        _tradeDispositionKey(match),
+        denied: _negativeTradeDisclosureIsDenied(prose, match),
+      );
     } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
       continue;
     } else if (clauseIsNegated(match)) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1073,7 +1073,15 @@ bool _hasAuditablePartialDisclosure({
           )) {
         continue;
       }
-      if (_matchClauseIsNegated(reason, match)) return false;
+      if (_matchClauseIsNegated(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        return false;
+      }
       final declaredAllocated = int.tryParse(match.group(1) ?? '');
       final declaredEstimate = int.tryParse(match.group(2) ?? '');
       if (declaredAllocated != allocatedMinutes ||
@@ -1109,7 +1117,15 @@ bool _hasAuditablePartialDisclosure({
         continue;
       }
       if (!_remainderIsRelatedToTask(reason, match)) continue;
-      if (_matchClauseIsNegated(reason, match)) return false;
+      if (_matchClauseIsNegated(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        return false;
+      }
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
       if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
@@ -1143,7 +1159,15 @@ bool _hasAuditablePartialDisclosure({
         continue;
       }
       if (!_remainderIsRelatedToTask(reason, match)) continue;
-      if (_matchClauseIsNegated(reason, match)) return false;
+      if (_matchClauseIsNegated(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        return false;
+      }
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
       if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
@@ -1358,7 +1382,14 @@ bool _hasTaskBoundAllocationDenial(
     caseSensitive: false,
   );
   for (final action in placementActionPattern.allMatches(prose)) {
-    if (!_allocationActionIsDirectlyDenied(prose, action)) continue;
+    if (!_allocationActionIsDirectlyDenied(
+      prose,
+      action,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    )) {
+      continue;
+    }
     if (_evidenceIsSpeculative(prose, action)) continue;
     if (_tradeEvidenceHasExplicitNonTaskSubject(
       prose,
@@ -1465,10 +1496,23 @@ bool _allocationFailureHasExplicitNonTaskScope(
   ).hasMatch(suffix);
 }
 
-bool _allocationActionIsDirectlyDenied(String prose, Match action) {
+bool _allocationActionIsDirectlyDenied(
+  String prose,
+  Match action, {
+  required String taskId,
+  required String taskTitle,
+}) {
   final range = _matchClauseRange(prose, action, boundaries: ',.;!?\n');
   final clause = prose.substring(range.start, action.start);
   for (final negation in _negationWordPattern.allMatches(clause)) {
+    if (_evidenceFallsInsideTaskReference(
+      clause,
+      negation,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    )) {
+      continue;
+    }
     final negationEnd = range.start + negation.end;
     final between = prose.substring(negationEnd, action.start);
     if (_negationQualifiesRatherThanNegates(negation, between)) continue;
@@ -1556,13 +1600,19 @@ bool _matchClauseIsNegated(
     final negationEnd = negation.end;
     if (taskId != null &&
         taskTitle != null &&
-        _evidenceNamesAnotherTask(
-          reason,
-          negation,
-          taskId: taskId,
-          taskTitle: taskTitle,
-          corpus: corpus,
-        )) {
+        (_evidenceFallsInsideTaskReference(
+              reason,
+              negation,
+              taskId: taskId,
+              taskTitle: taskTitle,
+            ) ||
+            _evidenceNamesAnotherTask(
+              reason,
+              negation,
+              taskId: taskId,
+              taskTitle: taskTitle,
+              corpus: corpus,
+            ))) {
       continue;
     }
     final between = negationEnd <= match.start
@@ -1739,6 +1789,7 @@ bool _evidenceActionIsAsserted(
   }
   final prefix = prose.substring(clauseStart, actionStart);
   return !_evidenceClauseIsInterrogative(prose, actionStart) &&
+      !_evidenceStartsInConditionalClause(prefix) &&
       !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
         r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
@@ -1772,6 +1823,16 @@ bool _evidenceActionIsAsserted(
       ).hasMatch(prefix) &&
       !_avoidanceComplementPattern.hasMatch(prefix);
 }
+
+bool _evidenceStartsInConditionalClause(String prefix) =>
+    RegExp(
+      r'^\s*(?:(?:even\s+)?if|unless)\b',
+      caseSensitive: false,
+    ).hasMatch(prefix) ||
+    RegExp(
+      r'^\s*(?:were|had)\b',
+      caseSensitive: false,
+    ).hasMatch(prefix);
 
 bool _evidenceClauseIsInterrogative(String prose, int evidenceStart) {
   for (var i = evidenceStart; i < prose.length; i++) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -699,7 +699,8 @@ final _partialRemainingPattern = RegExp(
 );
 
 final _partialLeadingRemainingPattern = RegExp(
-  r'\b(?:remaining|remainder(?:\s+is)?)\s*:?\s*'
+  r'\b(?:remaining(?:\s+(?:task|work))?|remainder)\s*:?\s*'
+  r'(?:(?:is|are)\s+)?'
   r'(\d+)\s*(?:m|mins?|minutes?)\b',
   caseSensitive: false,
 );
@@ -1041,6 +1042,14 @@ int? _nearestTaskReferenceDistance(
     for (final reference in pattern.allMatches(clause)) {
       final referenceStart = range.start + reference.start;
       final referenceEnd = range.start + reference.end;
+      if (!_referenceAttributesEvidence(
+        reason,
+        evidence,
+        referenceStart: referenceStart,
+        referenceEnd: referenceEnd,
+      )) {
+        continue;
+      }
       final distance = referenceEnd <= evidence.start
           ? evidence.start - referenceEnd
           : referenceStart >= evidence.end
@@ -1050,6 +1059,20 @@ int? _nearestTaskReferenceDistance(
     }
   }
   return nearest;
+}
+
+bool _referenceAttributesEvidence(
+  String reason,
+  Match evidence, {
+  required int referenceStart,
+  required int referenceEnd,
+}) {
+  if (referenceStart < evidence.end) return true;
+  final between = reason.substring(evidence.end, referenceStart);
+  return RegExp(
+    r'\b(?:for|of)\s*(?:the\s+)?$',
+    caseSensitive: false,
+  ).hasMatch(between);
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1246,7 +1246,13 @@ bool _negationQualifiesRatherThanNegates(Match negation, String between) {
       ).hasMatch(between);
 }
 
-bool _matchClauseIsNegated(String reason, Match match) {
+bool _matchClauseIsNegated(
+  String reason,
+  Match match, {
+  String? taskId,
+  String? taskTitle,
+  List<EvalCorpusTask> corpus = const [],
+}) {
   final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
   final prefix = reason.substring(range.start, match.start);
   if (RegExp(
@@ -1255,10 +1261,21 @@ bool _matchClauseIsNegated(String reason, Match match) {
   ).hasMatch(prefix)) {
     return true;
   }
-  final segment = reason.substring(range.start, range.end);
-  for (final negation in _negationWordPattern.allMatches(segment)) {
-    final negationStart = range.start + negation.start;
-    final negationEnd = range.start + negation.end;
+  for (final negation in _negationWordPattern.allMatches(reason, range.start)) {
+    if (negation.start >= range.end) break;
+    final negationStart = negation.start;
+    final negationEnd = negation.end;
+    if (taskId != null &&
+        taskTitle != null &&
+        _evidenceNamesAnotherTask(
+          reason,
+          negation,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        )) {
+      continue;
+    }
     final between = negationEnd <= match.start
         ? reason.substring(negationEnd, match.start)
         : negationStart >= match.end
@@ -1420,7 +1437,6 @@ bool _splitHasUnrelatedScope(
     taskId: taskId,
     taskTitle: taskTitle,
   );
-  if (currentTaskDistance != null) return false;
   for (final scope in _unrelatedRemainderScopePattern.allMatches(reason)) {
     if (scope.start < range.start || scope.end > range.end) continue;
     final scopeAction = _nearestPatternMatch(
@@ -1431,7 +1447,11 @@ bool _splitHasUnrelatedScope(
     if (scopeAction != null &&
         scopeAction.start == evidenceAction.start &&
         scopeAction.end == evidenceAction.end) {
-      return true;
+      final explicitlyAllocatedToScope = RegExp(
+        r'^for\b',
+        caseSensitive: false,
+      ).hasMatch(scope.group(0) ?? '');
+      return currentTaskDistance == null || explicitlyAllocatedToScope;
     }
   }
   return false;
@@ -2181,6 +2201,10 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   final structuralRemainder = placement == null
       ? task.estimateMinutes
       : placement.estimateMinutes - placement.allocatedMinutes;
+  final hasStructuralPartial =
+      placement != null &&
+      placement.allocatedMinutes > 0 &&
+      placement.allocatedMinutes < placement.estimateMinutes;
   final affirmativeEvidence = <String>{};
   final deniedEvidence = <String>{};
 
@@ -2220,8 +2244,17 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
         corpus: outcome.inputs.corpus,
       );
 
+  bool clauseIsNegated(Match match) => _matchClauseIsNegated(
+    prose,
+    match,
+    taskId: taskId,
+    taskTitle: task.title,
+    corpus: outcome.inputs.corpus,
+  );
+
   for (final match in _partialMentionPattern.allMatches(prose)) {
-    if (!belongsToTask(match) ||
+    if (!hasStructuralPartial ||
+        !belongsToTask(match) ||
         !_partialMentionDescribesPlacement(prose, match) ||
         _evidenceIsSpeculative(prose, match)) {
       continue;
@@ -2238,7 +2271,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
         _evidenceIsSpeculative(prose, match)) {
       continue;
     }
-    if (_matchClauseIsNegated(prose, match)) {
+    if (clauseIsNegated(match)) {
       record(_tradeDispositionKey(match), denied: true);
     } else {
       record(_tradeDispositionKey(match), denied: false);
@@ -2265,7 +2298,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
         denyAttachedDispositions(match);
         continue;
       }
-      if (_matchClauseIsNegated(prose, match)) {
+      if (clauseIsNegated(match)) {
         record('remainder', denied: true);
         denyAttachedDispositions(match);
       } else {
@@ -2295,7 +2328,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
       }
     } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
       continue;
-    } else if (_matchClauseIsNegated(prose, match)) {
+    } else if (clauseIsNegated(match)) {
       record(_tradeDispositionKey(match), denied: true);
     } else {
       record(_tradeDispositionKey(match), denied: false);

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -624,28 +624,67 @@ EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
   );
 }
 
-/// Placed work must fit the day at its *estimated* length, not its written
-/// one.
+/// Placed work must fit the day at its *estimated* length, except for an
+/// explicitly auditable partial placement.
 ///
 /// The per-task [scoreRespectsEstimates] check cannot catch a coordinated
 /// shrink: 240/180/120/180-minute tasks written as 160/120/80/120 all clear a
 /// per-task ratio while summing to exactly the 480-minute capacity. Summing
 /// estimates instead makes the arithmetic honest — 720 minutes of work does
-/// not fit in 480 however the blocks are labelled.
+/// not fit in 480 however the blocks are labelled. A shortened task is charged
+/// at its represented minutes only when its reason gives concrete minute
+/// arithmetic that agrees with both the block duration and corpus estimate;
+/// vague or contradictory partial prose keeps the full-estimate charge.
 EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.withinCapacityByEstimate;
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
-  var estimated = 0;
-  var counted = 0;
-  final seen = <String>{};
+  final allocatedByTask = <String, int>{};
+  final reasonsByTask = <String, List<String>>{};
   for (final block in _scheduled(outcome)) {
     final taskId = block.taskId;
-    if (taskId == null || !seen.add(taskId)) continue;
+    if (taskId == null) continue;
+    allocatedByTask.update(
+      taskId,
+      (minutes) =>
+          minutes + block.endTime.difference(block.startTime).inMinutes,
+      ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
+    );
+    final reason = block.reason?.trim();
+    if (reason != null && reason.isNotEmpty) {
+      reasonsByTask.putIfAbsent(taskId, () => []).add(reason);
+    }
+  }
+  var chargedMinutes = 0;
+  var counted = 0;
+  final partials = <String>[];
+  final undisclosedShortenings = <String>[];
+  for (final entry in allocatedByTask.entries) {
+    final taskId = entry.key;
     final estimate = outcome.inputs.taskById(taskId)?.estimateMinutes;
     if (estimate == null || estimate <= 0) continue;
-    estimated += estimate;
     counted++;
+    final allocated = entry.value;
+    if (allocated > 0 &&
+        allocated < estimate &&
+        _hasAuditablePartialDisclosure(
+          reasons: reasonsByTask[taskId] ?? const [],
+          allocatedMinutes: allocated,
+          estimateMinutes: estimate,
+        )) {
+      chargedMinutes += allocated;
+      partials.add(
+        '$taskId ${allocated}min partial of ${estimate}min '
+        '(${estimate - allocated}min remain)',
+      );
+    } else {
+      chargedMinutes += estimate;
+      if (allocated > 0 && allocated < estimate) {
+        undisclosedShortenings.add(
+          '$taskId allocated ${allocated}min of ${estimate}min',
+        );
+      }
+    }
   }
   if (counted == 0) {
     return const EvalConstraintResult.notApplicable(
@@ -654,14 +693,65 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
     );
   }
   final capacity = outcome.inputs.capacityMinutes;
+  final evidence = [
+    if (partials.isNotEmpty) 'audited partials: ${partials.join(', ')}',
+    if (undisclosedShortenings.isNotEmpty)
+      'charged at full estimate without a matching concrete partial disclosure: ${undisclosedShortenings.join(', ')}',
+  ];
   return EvalConstraintResult(
     id: id,
-    passed: estimated <= capacity,
+    passed: chargedMinutes <= capacity,
     detail:
-        '$counted placed task(s) estimated at ${estimated}min against '
+        '$counted placed task(s) charged at ${chargedMinutes}min against '
         '${capacity}min capacity'
-        '${estimated > capacity ? ' (over by ${estimated - capacity})' : ''}',
+        '${chargedMinutes > capacity ? ' (over by ${chargedMinutes - capacity})' : ''}'
+        '${evidence.isEmpty ? '' : '; ${evidence.join('; ')}'}',
   );
+}
+
+final _partialOfEstimatePattern = RegExp(
+  r'\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+of\s+(?:the\s+)?'
+  r'(\d+)(?:\s+estimated)?\s*[-–—]?\s*(?:m|mins?|minutes?)\b',
+  caseSensitive: false,
+);
+
+final _partialRemainingPattern = RegExp(
+  r'\b(\d+)\s*(?:m|mins?|minutes?)\s+'
+  r'(?:(?:is|are)\s+)?(?:left|remain(?:s|ing)?)\b',
+  caseSensitive: false,
+);
+
+/// Whether prose makes a shortened placement safe to charge as partial.
+///
+/// Block duration remains the authority. A reason earns partial accounting
+/// only when its concrete minute arithmetic agrees with both that duration and
+/// the corpus estimate. This accepts either an explicit `60m of 120m` split or
+/// the prompt's `partial` plus `60m remain` form; vague prose and contradictory
+/// numbers keep the conservative full-estimate charge.
+bool _hasAuditablePartialDisclosure({
+  required List<String> reasons,
+  required int allocatedMinutes,
+  required int estimateMinutes,
+}) {
+  final remainingMinutes = estimateMinutes - allocatedMinutes;
+  for (final reason in reasons) {
+    for (final match in _partialOfEstimatePattern.allMatches(reason)) {
+      final declaredAllocated = int.tryParse(match.group(1) ?? '');
+      final declaredEstimate = int.tryParse(match.group(2) ?? '');
+      if (declaredAllocated == allocatedMinutes &&
+          declaredEstimate == estimateMinutes) {
+        return true;
+      }
+    }
+    if (!reason.toLowerCase().contains('partial')) continue;
+    for (final match in _partialRemainingPattern.allMatches(reason)) {
+      final declaredRemaining = int.tryParse(match.group(1) ?? '');
+      if (declaredRemaining == remainingMinutes) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /// Work the scenario says any competent plan must include.

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -750,6 +750,12 @@ final _taskAllocationActionPattern = RegExp(
   caseSensitive: false,
 );
 
+final _omittedAllocationPattern = RegExp(
+  r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
+  r'defer(?:s|red|ring)?|unscheduled|left\s+out)\b',
+  caseSensitive: false,
+);
+
 final _unrelatedRemainderScopePattern = RegExp(
   r'\b(?:in|during|for)\s+'
   r'(?:(?:the|a|an|my|our|their|your)\s+)?'
@@ -1005,8 +1011,7 @@ bool _splitIsTaskBound(
   required List<EvalCorpusTask> corpus,
 }) {
   final clause = _matchClause(reason, match);
-  final context = _matchClauseExcludingMatch(reason, match);
-  return _taskAllocationActionPattern.hasMatch(context) &&
+  return _splitHasAffirmativeAllocation(reason, match) &&
       !_unrelatedSplitScopePattern.hasMatch(clause) &&
       !_evidenceNamesAnotherTask(
         reason,
@@ -1015,6 +1020,42 @@ bool _splitIsTaskBound(
         taskTitle: taskTitle,
         corpus: corpus,
       );
+}
+
+bool _splitHasAffirmativeAllocation(String reason, Match match) {
+  final actionDistance = _nearestPatternDistance(
+    reason,
+    match,
+    _taskAllocationActionPattern,
+  );
+  if (actionDistance == null) return false;
+  final omissionDistance = _nearestPatternDistance(
+    reason,
+    match,
+    _omittedAllocationPattern,
+  );
+  return omissionDistance == null || actionDistance < omissionDistance;
+}
+
+int? _nearestPatternDistance(
+  String reason,
+  Match evidence,
+  RegExp pattern,
+) {
+  final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
+  final clause = reason.substring(range.start, range.end);
+  int? nearest;
+  for (final match in pattern.allMatches(clause)) {
+    final start = range.start + match.start;
+    final end = range.start + match.end;
+    final distance = end <= evidence.start
+        ? evidence.start - end
+        : start >= evidence.end
+        ? start - evidence.end
+        : 0;
+    if (nearest == null || distance < nearest) nearest = distance;
+  }
+  return nearest;
 }
 
 bool _evidenceNamesAnotherTask(
@@ -1155,12 +1196,6 @@ String _matchClause(
 }) {
   final range = _matchClauseRange(reason, match, boundaries: boundaries);
   return reason.substring(range.start, range.end);
-}
-
-String _matchClauseExcludingMatch(String reason, Match match) {
-  final range = _matchClauseRange(reason, match, boundaries: '.;!?\n');
-  return '${reason.substring(range.start, match.start)} '
-      '${reason.substring(match.end, range.end)}';
 }
 
 ({int start, int end}) _matchClauseRange(
@@ -1694,6 +1729,25 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   caseSensitive: false,
 ).hasMatch(prose);
 
+bool _hasAffirmativeTradeDisclosure(String prose) {
+  for (final match in _partialMentionPattern.allMatches(prose)) {
+    if (!_partialMentionIsNegated(prose, match)) return true;
+  }
+  for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
+    if (!_matchClauseIsNegated(prose, match)) return true;
+  }
+  for (final match in _conflictTradePattern.allMatches(prose)) {
+    final matchedTrade = match.group(0) ?? '';
+    final negativeFitDisclosure =
+        _negationWordPattern.hasMatch(matchedTrade) &&
+        RegExp(r'\bfit\b', caseSensitive: false).hasMatch(matchedTrade);
+    if (negativeFitDisclosure || !_matchClauseIsNegated(prose, match)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool _taskTradeIsNamed(
   EvalRunOutcome outcome,
   String taskId, {
@@ -1704,10 +1758,7 @@ bool _taskTradeIsNamed(
     final namesTask =
         _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
     if (!namesTask) continue;
-    if (!requireTradeDisclosure ||
-        _partialMentionPattern.hasMatch(prose) ||
-        _partialTradeDispositionPattern.hasMatch(prose) ||
-        _conflictTradePattern.hasMatch(prose)) {
+    if (!requireTradeDisclosure || _hasAffirmativeTradeDisclosure(prose)) {
       return true;
     }
   }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1113,6 +1113,7 @@ bool _hasTaskBoundFullAllocationClaim(
           taskTitle: taskTitle,
           corpus: corpus,
         ) ||
+        !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match) ||
         _matchClauseIsNegated(
           prose,
@@ -1487,7 +1488,7 @@ bool _splitIsTaskBound(
 
 bool _splitHasAffirmativeAllocation(String reason, Match match) {
   final action = _nearestAllocationActionMatch(reason, match);
-  if (action == null || !_allocationActionIsAsserted(reason, action)) {
+  if (action == null || !_evidenceActionIsAsserted(reason, action.start)) {
     return false;
   }
   final omission = _nearestPatternMatch(
@@ -1498,38 +1499,41 @@ bool _splitHasAffirmativeAllocation(String reason, Match match) {
   return omission == null || action.distance < omission.distance;
 }
 
-bool _allocationActionIsAsserted(
+bool _evidenceActionIsAsserted(
   String prose,
-  ({int start, int end, int distance}) action,
+  int actionStart,
 ) {
   var clauseStart = 0;
-  for (var i = action.start - 1; i >= 0; i--) {
+  for (var i = actionStart - 1; i >= 0; i--) {
     if (',.;!?\n'.contains(prose[i])) {
       clauseStart = i + 1;
       break;
     }
   }
-  final prefix = prose.substring(clauseStart, action.start);
-  return !_evidenceStartIsSpeculative(prose, action.start) &&
+  final prefix = prose.substring(clauseStart, actionStart);
+  return !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
-        r'\b(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
+        r'\b(?:unsuccessfully|'
+        '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
         'propos(?:e|es|ed|ing)|plan(?:s|ned|ning)?|'
         'attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
         'fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
-        r'declin(?:e|es|ed|ing))\s+to\s*$',
+        r'declin(?:e|es|ed|ing))(?:\s+to)?'
+        r'(?:\s+(?:be|being|get|getting))?))\s*$',
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !RegExp(
         r'\b(?:must|need(?:s|ed)?\s+to|'
         r'(?:has|have|had)\s+to|(?:is|are|was|were)\s+required\s+to|'
-        r'ought\s+to)\s*$',
+        r'ought\s+to)(?:\s+(?:be|being|get|getting))?\s*$',
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !RegExp(
         r'\b(?:(?:(?:is|are|was|were|be|been|being)\s+)?'
         r'(?:unable\s+to|not\s+able\s+to|incapable\s+of)|'
-        r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)\s*$',
+        r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)'
+        r'(?:\s+(?:be|being|get|getting))?\s*$',
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !_avoidanceComplementPattern.hasMatch(prefix);
@@ -2342,6 +2346,7 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
 typedef _TradeDisclosureEvidence = ({
   Set<String> affirmative,
   Set<String> denied,
+  bool retractsAll,
 });
 
 _TradeDisclosureEvidence _tradeDisclosureEvidence(
@@ -2350,7 +2355,13 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   String prose,
 ) {
   final task = outcome.inputs.taskById(taskId);
-  if (task == null) return (affirmative: <String>{}, denied: <String>{});
+  if (task == null) {
+    return (
+      affirmative: <String>{},
+      denied: <String>{},
+      retractsAll: false,
+    );
+  }
   final placement = _estimatedTaskPlacements(outcome)[taskId];
   final structuralRemainder = placement == null
       ? task.estimateMinutes
@@ -2422,6 +2433,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
         !_tradeEvidenceDescribesTaskOrWork(prose, match) ||
+        !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match)) {
       continue;
     }
@@ -2462,7 +2474,11 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
     }
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
-    if (!belongsToTask(match) || _evidenceIsSpeculative(prose, match)) continue;
+    if (!belongsToTask(match) ||
+        !_evidenceActionIsAsserted(prose, match.start) ||
+        _evidenceIsSpeculative(prose, match)) {
+      continue;
+    }
     final matchedTrade = match.group(0) ?? '';
     final hasEmbeddedNegation = _negationWordPattern.hasMatch(matchedTrade);
     final negativeFitDisclosure =
@@ -2505,6 +2521,12 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   return (
     affirmative: affirmativeEvidence,
     denied: deniedEvidence,
+    retractsAll: _hasTaskBoundFullAllocationClaim(
+      prose,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    ),
   );
 }
 
@@ -2556,7 +2578,8 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   if (subjectMatch == null) return false;
   final subject = subjectMatch.group(1)?.trim() ?? '';
   if (RegExp(
-    r'^(?:(?:the|this|that|its)\s+)?'
+    r'^(?:(?:and|but|yet|so)\s+)?'
+    r'(?:(?:the|this|that|its)\s+)?'
     r'(?:task|work|placement|block|remainder|remaining\s+(?:task|work)|'
     r'rest|portion|part|it)\b',
     caseSensitive: false,
@@ -2600,6 +2623,7 @@ bool _taskTradeIsNamed(
 ) {
   final affirmativeNamedDispositions = <String>{};
   final deniedNamedDispositions = <String>{};
+  var retractsAllDispositions = false;
   for (final block in outcome.blocks) {
     for (final disclosure in [block.reason, block.note]) {
       final prose = disclosure?.trim().toLowerCase();
@@ -2610,11 +2634,13 @@ bool _taskTradeIsNamed(
       final evidence = _tradeDisclosureEvidence(outcome, taskId, prose);
       affirmativeNamedDispositions.addAll(evidence.affirmative);
       deniedNamedDispositions.addAll(evidence.denied);
+      retractsAllDispositions |= evidence.retractsAll;
     }
   }
-  return affirmativeNamedDispositions
-      .difference(deniedNamedDispositions)
-      .isNotEmpty;
+  return !retractsAllDispositions &&
+      affirmativeNamedDispositions
+          .difference(deniedNamedDispositions)
+          .isNotEmpty;
 }
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -637,9 +637,10 @@ EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
 /// per-task ratio while summing to exactly the 480-minute capacity. Summing
 /// estimates instead makes the arithmetic honest — 720 minutes of work does
 /// not fit in 480 however the blocks are labelled. A shortened task is charged
-/// at its represented minutes only when its reason gives concrete minute
-/// arithmetic that agrees with both the block duration and corpus estimate;
-/// vague or contradictory partial prose keeps the full-estimate charge.
+/// at its represented minutes only when its reason or note gives concrete
+/// minute arithmetic that agrees with both the block duration and corpus
+/// estimate; vague or contradictory partial prose keeps the full-estimate
+/// charge.
 EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.withinCapacityByEstimate;
   final noPlan = _requirePlan(outcome, id);
@@ -651,6 +652,10 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
       'no placed task carries an estimate',
     );
   }
+  final fullEstimateMinutes = placements.values.fold(
+    0,
+    (total, placement) => total + placement.estimateMinutes,
+  );
   var chargedMinutes = 0;
   final partials = <String>[];
   final undisclosedShortenings = <String>[];
@@ -682,7 +687,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   return EvalConstraintResult(
     id: id,
     passed: chargedMinutes <= capacity,
-    heuristic: chargedMinutes <= capacity && partials.isNotEmpty,
+    heuristic: chargedMinutes <= capacity && fullEstimateMinutes > capacity,
     detail:
         '${placements.length} placed task(s) charged at ${chargedMinutes}min against '
         '${capacity}min capacity'
@@ -812,9 +817,11 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
       ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
     );
     blocksByTask.putIfAbsent(taskId, () => []).add(block);
-    final reason = block.reason?.trim();
-    if (reason != null && reason.isNotEmpty) {
-      reasonsByTask.putIfAbsent(taskId, () => []).add(reason);
+    for (final disclosure in [block.reason, block.note]) {
+      final prose = disclosure?.trim();
+      if (prose != null && prose.isNotEmpty) {
+        reasonsByTask.putIfAbsent(taskId, () => []).add(prose);
+      }
     }
   }
   return {
@@ -1231,7 +1238,8 @@ bool _referenceAttributesEvidence(
         r'\bto\s*(?:the\s+)?$',
         caseSensitive: false,
       ).hasMatch(between);
-  return prepositionAttaches || allocationToAttaches;
+  final labelAttaches = RegExp(r'^\s*[:–—-]\s*$').hasMatch(between);
+  return prepositionAttaches || allocationToAttaches || labelAttaches;
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -637,10 +637,11 @@ EvalConstraintResult scoreRespectsEstimates(EvalRunOutcome outcome) {
 /// per-task ratio while summing to exactly the 480-minute capacity. Summing
 /// estimates instead makes the arithmetic honest — 720 minutes of work does
 /// not fit in 480 however the blocks are labelled. A shortened task is charged
-/// at its represented minutes only when its reason or note gives concrete
-/// minute arithmetic that agrees with both the block duration and corpus
-/// estimate; vague or contradictory partial prose keeps the full-estimate
-/// charge.
+/// at its represented minutes only when its reason gives concrete minute
+/// arithmetic that agrees with both the block duration and corpus estimate.
+/// Notes remain audit evidence and can veto a reason with contradictory
+/// arithmetic, but cannot earn partial credit; vague or contradictory partial
+/// prose keeps the full-estimate charge.
 EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.withinCapacityByEstimate;
   final noPlan = _requirePlan(outcome, id);
@@ -716,7 +717,10 @@ final _partialLeadingRemainingPattern = RegExp(
   caseSensitive: false,
 );
 
-final _partialMentionPattern = RegExp(r'\bpartial\b', caseSensitive: false);
+final _partialMentionPattern = RegExp(
+  r'\b(?:partial(?:ly)?|partly)\b',
+  caseSensitive: false,
+);
 
 final _negationWordPattern = RegExp(
   r'\b(?:not|no|never|cannot|(?:isn|wasn|weren|aren|doesn|don|didn|can|couldn|'
@@ -778,12 +782,14 @@ final _conflictTradePattern = RegExp(
   caseSensitive: false,
 );
 
+typedef _PlacementDisclosure = ({bool canQualify, String prose});
+
 typedef _EstimatedTaskPlacement = ({
   List<EvalCorpusTask> corpus,
   int allocatedMinutes,
+  List<_PlacementDisclosure> disclosures,
   int estimateMinutes,
   bool hasOverlappingBlocks,
-  List<String> reasons,
   String taskId,
   String taskTitle,
 });
@@ -798,7 +804,7 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
 ) {
   final allocatedByTask = <String, int>{};
   final blocksByTask = <String, List<PlannedBlock>>{};
-  final reasonsByTask = <String, List<String>>{};
+  final disclosuresByTask = <String, List<_PlacementDisclosure>>{};
   for (final block in _scheduled(outcome)) {
     if (block.type != PlannedBlockType.ai &&
         block.type != PlannedBlockType.manual) {
@@ -813,11 +819,19 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
       ifAbsent: () => block.endTime.difference(block.startTime).inMinutes,
     );
     blocksByTask.putIfAbsent(taskId, () => []).add(block);
-    for (final disclosure in [block.reason, block.note]) {
-      final prose = disclosure?.trim();
-      if (prose != null && prose.isNotEmpty) {
-        reasonsByTask.putIfAbsent(taskId, () => []).add(prose);
-      }
+    final reason = block.reason?.trim();
+    if (reason != null && reason.isNotEmpty) {
+      disclosuresByTask.putIfAbsent(taskId, () => []).add((
+        canQualify: true,
+        prose: reason,
+      ));
+    }
+    final note = block.note?.trim();
+    if (note != null && note.isNotEmpty) {
+      disclosuresByTask.putIfAbsent(taskId, () => []).add((
+        canQualify: false,
+        prose: note,
+      ));
     }
   }
   return {
@@ -830,11 +844,11 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
         entry.key: (
           corpus: outcome.inputs.corpus,
           allocatedMinutes: entry.value,
+          disclosures: disclosuresByTask[entry.key] ?? const [],
           estimateMinutes: estimate,
           hasOverlappingBlocks: _hasOverlappingIntervals(
             blocksByTask[entry.key] ?? const [],
           ),
-          reasons: reasonsByTask[entry.key] ?? const [],
           taskId: taskId,
           taskTitle: taskTitle,
         ),
@@ -866,7 +880,7 @@ bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
     placement.allocatedMinutes * 10 >= placement.estimateMinutes &&
     !placement.hasOverlappingBlocks &&
     _hasAuditablePartialDisclosure(
-      reasons: placement.reasons,
+      disclosures: placement.disclosures,
       allocatedMinutes: placement.allocatedMinutes,
       estimateMinutes: placement.estimateMinutes,
       taskId: placement.taskId,
@@ -880,10 +894,12 @@ bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
 /// only when its concrete minute arithmetic agrees with both that duration and
 /// the corpus estimate. This accepts either an explicit `60m of 120m` split or
 /// the prompt's `partial` plus a task-bound `60m remain for later` form. Vague
-/// prose, unrelated day-capacity arithmetic, and contradictory numbers anywhere
-/// in the task's disclosure keep the conservative full-estimate charge.
+/// prose, unrelated day-capacity arithmetic, and contradictory numbers in
+/// either the reason or note keep the conservative full-estimate charge. Notes
+/// are audit evidence only: they can veto credit but cannot satisfy the prompt's
+/// reason-field disclosure contract.
 bool _hasAuditablePartialDisclosure({
-  required List<String> reasons,
+  required List<_PlacementDisclosure> disclosures,
   required int allocatedMinutes,
   required int estimateMinutes,
   required String taskId,
@@ -893,7 +909,8 @@ bool _hasAuditablePartialDisclosure({
   final remainingMinutes = estimateMinutes - allocatedMinutes;
   var hasMatchingSplit = false;
   var hasBoundPartialRemainder = false;
-  for (final reason in reasons) {
+  for (final disclosure in disclosures) {
+    final reason = disclosure.prose;
     var reasonMentionsPartial = false;
     var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
@@ -921,7 +938,7 @@ bool _hasAuditablePartialDisclosure({
         continue;
       }
       if (_partialMentionIsNegated(reason, match)) return false;
-      reasonMentionsPartial = true;
+      if (disclosure.canQualify) reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
       if (_evidenceFallsInsideTaskReference(
@@ -952,7 +969,7 @@ bool _hasAuditablePartialDisclosure({
           declaredEstimate != estimateMinutes) {
         return false;
       }
-      hasMatchingSplit = true;
+      if (disclosure.canQualify) hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
       if (_evidenceFallsInsideTaskReference(
@@ -983,7 +1000,7 @@ bool _hasAuditablePartialDisclosure({
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
-      if (_remainderIsTaskBound(reason, match)) {
+      if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
         reasonHasBoundRemainder = true;
       }
     }
@@ -1016,7 +1033,7 @@ bool _hasAuditablePartialDisclosure({
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
-      if (_remainderIsTaskBound(reason, match)) {
+      if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
         reasonHasBoundRemainder = true;
       }
     }
@@ -1083,6 +1100,30 @@ bool _matchClauseIsNegated(String reason, Match match) {
             _taskAllocationActionPattern.hasMatch(between)) {
       return true;
     }
+  }
+  return false;
+}
+
+bool _negativeFitDisclosureIsDenied(String prose, Match match) {
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final prefix = prose.substring(range.start, match.start);
+  if (RegExp(
+    r'\b(?:not\s+(?:actually\s+)?true|false)\s+that\b',
+    caseSensitive: false,
+  ).hasMatch(prefix)) {
+    return true;
+  }
+  final clause = prose.substring(range.start, range.end);
+  for (final negation in _negationWordPattern.allMatches(clause)) {
+    final start = range.start + negation.start;
+    final end = range.start + negation.end;
+    if (start >= match.start && end <= match.end) continue;
+    final between = end <= match.start
+        ? prose.substring(end, match.start)
+        : start >= match.end
+        ? prose.substring(match.end, start)
+        : '';
+    if (_wordPattern.allMatches(between).length <= 3) return true;
   }
   return false;
 }
@@ -1262,11 +1303,10 @@ List<RegExp> _taskReferencePatterns(String taskId, String taskTitle) {
       r'\btask\s+' + RegExp.escape(title) + r'\b',
       caseSensitive: false,
     ),
-    if (title.length >= 4)
-      RegExp(
-        r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
-        caseSensitive: false,
-      ),
+    RegExp(
+      r'(?:^|[^\w-])' + RegExp.escape(title) + r'(?=$|[^\w-])',
+      caseSensitive: false,
+    ),
   ];
 }
 
@@ -1969,7 +2009,11 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
         _negationWordPattern.hasMatch(matchedTrade) &&
         RegExp(r'\bfit\b', caseSensitive: false).hasMatch(matchedTrade);
     if (negativeFitDisclosure) {
-      hasAffirmativeEvidence = true;
+      if (_negativeFitDisclosureIsDenied(prose, match)) {
+        hasDeniedEvidence = true;
+      } else {
+        hasAffirmativeEvidence = true;
+      }
     } else if (_matchClauseIsNegated(prose, match)) {
       hasDeniedEvidence = true;
     } else {
@@ -1998,7 +2042,8 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
   }
   final subjectMatch = RegExp(
     r'^(.*?)\s+(?:(?:is|are|was|were|has\s+been|have\s+been|had\s+been|'
-    r'will\s+be)(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+    r'will\s+be)(?:\s+(?:only|merely|just|still))?'
+    r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
     '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -805,7 +805,7 @@ final _conflictTradePattern = RegExp(
   r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)'
   r'(?:\s+be)?)\s+'
   'schedul(?:e|ed|ing)|'
-  r'trade|conflict(?:s|ed|ing)(?![-\s]+free\b)|'
+  r'conflict(?:s|ed|ing)(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
   r'(?:do|does|did|will|shall)\s+not|'
@@ -1583,7 +1583,7 @@ bool _evidenceActionIsAsserted(
   final prefix = prose.substring(clauseStart, actionStart);
   return !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
-        r'\b(?:unsuccessfully|'
+        r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
         '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
         'propos(?:e|es|ed|ing)|plan(?:s|ned|ning)?|'
@@ -2579,7 +2579,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
     } else if (negativeSchedulingDisclosure) {
       if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) continue;
       record(
-        _tradeDispositionKey(match),
+        'not-scheduled',
         denied: _negativeTradeDisclosureIsDenied(prose, match),
       );
     } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
@@ -2614,7 +2614,6 @@ String _tradeDispositionKey(Match match) {
   if (wording.contains('left')) return 'left-out';
   if (wording.contains('conflict')) return 'conflict';
   if (wording.contains('shorten')) return 'shortened';
-  if (wording.contains('trade')) return 'trade';
   if (wording.contains('roll')) return 'rolled-over';
   if (wording.contains('carr')) return 'carried-over';
   if (wording.contains('move')) return 'moved';

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1594,7 +1594,7 @@ bool _evidenceActionIsAsserted(
   return !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
         r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
-        r'(?:(?:is|are|was|were)\s+)?(?:supposed|meant)\s+to'
+        r'(?:(?:is|are|was|were)\s+)?(?:supposed|meant|going)\s+to'
         r'(?:\s+(?:be|being|get|getting))?|'
         '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
@@ -2614,7 +2614,8 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
       );
     } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
       continue;
-    } else if (clauseIsNegated(match)) {
+    } else if (clauseIsNegated(match) ||
+        _negativeTradeDisclosureIsDenied(prose, match)) {
       record(_tradeDispositionKey(match), denied: true);
     } else {
       record(_tradeDispositionKey(match), denied: false);

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1594,7 +1594,7 @@ bool _evidenceActionIsAsserted(
   return !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
         r'\b(?:almost|nearly|not\s+quite|unsuccessfully|'
-        r'(?:(?:is|are|was|were)\s+)?supposed\s+to'
+        r'(?:(?:is|are|was|were)\s+)?(?:supposed|meant)\s+to'
         r'(?:\s+(?:be|being|get|getting))?|'
         '(?:(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -971,11 +971,20 @@ bool _namesAnotherTask(
       r'(?:^|[^\w-])' + RegExp.escape(task.taskId) + r'(?=$|[^\w-])',
       caseSensitive: false,
     );
+    final title = task.title.trim();
     final titlePattern = RegExp(
-      r'\btask\s+' + RegExp.escape(task.title.trim()) + r'\b',
+      r'\btask\s+' + RegExp.escape(title) + r'\b',
       caseSensitive: false,
     );
-    if (idPattern.hasMatch(clause) || titlePattern.hasMatch(clause)) {
+    final bareTitlePattern = title.length >= 4
+        ? RegExp(
+            r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
+            caseSensitive: false,
+          )
+        : null;
+    if (idPattern.hasMatch(clause) ||
+        titlePattern.hasMatch(clause) ||
+        (bareTitlePattern?.hasMatch(clause) ?? false)) {
       return true;
     }
   }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -715,11 +715,23 @@ final _negationWordPattern = RegExp(
 
 final _wordPattern = RegExp(r'\b\w+\b');
 
+const _partialTradeDispositionSource =
+    r'for\s+(?:later|tomorrow|another\s+day|a\s+(?:later|future)\s+day)|'
+    r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
+    r'(?:over|to)\b|'
+    r'defer(?:s|red|ring)?\b|unscheduled\b';
+
+final _partialTradeDispositionPattern = RegExp(
+  r'\b(?:'
+  '$_partialTradeDispositionSource'
+  r')\b',
+  caseSensitive: false,
+);
+
 final _partialRemainderDispositionPattern = RegExp(
-  r'\b(?:for\s+(?:later|tomorrow|another\s+day|a\s+(?:later|future)\s+day)|'
-  r'(?:roll(?:s|ed|ing)?|move(?:s|d|ing)?|carr(?:y|ies|ied|ying))\s+'
-  r'(?:over|to)\b|'
-  r'defer(?:s|red|ring)?\b|unscheduled\b|'
+  r'\b(?:(?:'
+  '$_partialTradeDispositionSource'
+  r')\b|'
   r'(?:of|for|in)\s+(?:this|the)\s+(?:task|work)\b)',
   caseSensitive: false,
 );
@@ -994,7 +1006,7 @@ bool _splitIsTaskBound(
 }) {
   final clause = _matchClause(reason, match);
   final context = _matchClauseExcludingMatch(reason, match);
-  return _taskAllocationContextPattern.hasMatch(context) &&
+  return _taskAllocationActionPattern.hasMatch(context) &&
       !_unrelatedSplitScopePattern.hasMatch(clause) &&
       !_evidenceNamesAnotherTask(
         reason,
@@ -1107,10 +1119,17 @@ bool _referenceAttributesEvidence(
   }
   if (referenceStart < evidence.end) return true;
   final between = reason.substring(evidence.end, referenceStart);
-  return RegExp(
+  final prepositionAttaches = RegExp(
     r'\b(?:for|of)\s*(?:the\s+)?$',
     caseSensitive: false,
   ).hasMatch(between);
+  final allocationToAttaches =
+      _taskAllocationActionPattern.hasMatch(between) &&
+      RegExp(
+        r'\bto\s*(?:the\s+)?$',
+        caseSensitive: false,
+      ).hasMatch(between);
+  return prepositionAttaches || allocationToAttaches;
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {
@@ -1670,6 +1689,11 @@ bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
       ).hasMatch(prose);
 }
 
+bool _taskIdNamed(String taskId, String prose) => RegExp(
+  r'(?:^|[^\w-])' + RegExp.escape(taskId) + r'(?=$|[^\w-])',
+  caseSensitive: false,
+).hasMatch(prose);
+
 bool _taskTradeIsNamed(
   EvalRunOutcome outcome,
   String taskId, {
@@ -1678,12 +1702,11 @@ bool _taskTradeIsNamed(
   for (final block in outcome.blocks) {
     final prose = '${block.reason ?? ''} ${block.note ?? ''}'.toLowerCase();
     final namesTask =
-        prose.contains(taskId.toLowerCase()) ||
-        _titleNamed(outcome, taskId, prose);
+        _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
     if (!namesTask) continue;
     if (!requireTradeDisclosure ||
         _partialMentionPattern.hasMatch(prose) ||
-        _partialRemainderDispositionPattern.hasMatch(prose) ||
+        _partialTradeDispositionPattern.hasMatch(prose) ||
         _conflictTradePattern.hasMatch(prose)) {
       return true;
     }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1382,12 +1382,13 @@ bool _hasTaskBoundAllocationDenial(
     caseSensitive: false,
   );
   for (final action in placementActionPattern.allMatches(prose)) {
-    if (!_allocationActionIsDirectlyDenied(
-      prose,
-      action,
-      taskId: taskId,
-      taskTitle: taskTitle,
-    )) {
+    if (_evidenceHasHistoricalScope(prose, action) ||
+        !_allocationActionIsDirectlyDenied(
+          prose,
+          action,
+          taskId: taskId,
+          taskTitle: taskTitle,
+        )) {
       continue;
     }
     if (_evidenceIsSpeculative(prose, action)) continue;
@@ -1441,7 +1442,8 @@ bool _hasTaskBoundAllocationDenial(
     caseSensitive: false,
   );
   for (final failure in allocationFailurePattern.allMatches(prose)) {
-    if (_evidenceIsSpeculative(prose, failure) ||
+    if (_evidenceHasHistoricalScope(prose, failure) ||
+        _evidenceIsSpeculative(prose, failure) ||
         _tradeEvidenceHasExplicitNonTaskSubject(
           prose,
           failure,
@@ -1726,7 +1728,8 @@ bool _splitIsTaskBound(
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
 }) {
-  return _splitHasAffirmativeAllocation(
+  return !_evidenceHasExplicitNonTaskObject(reason, match) &&
+      _splitHasAffirmativeAllocation(
         reason,
         match,
         taskId: taskId,
@@ -1789,6 +1792,7 @@ bool _evidenceActionIsAsserted(
   }
   final prefix = prose.substring(clauseStart, actionStart);
   return !_evidenceClauseIsInterrogative(prose, actionStart) &&
+      !_evidenceActionIsImperative(prose, actionStart, prefix) &&
       !_evidenceStartsInConditionalClause(prefix) &&
       !_evidenceStartIsSpeculative(prose, actionStart) &&
       !RegExp(
@@ -1823,6 +1827,21 @@ bool _evidenceActionIsAsserted(
       ).hasMatch(prefix) &&
       !_avoidanceComplementPattern.hasMatch(prefix);
 }
+
+bool _evidenceActionIsImperative(
+  String prose,
+  int actionStart,
+  String prefix,
+) =>
+    RegExp(
+      r'^\s*(?:please\s+)?$',
+      caseSensitive: false,
+    ).hasMatch(prefix) &&
+    RegExp(
+      '^(?:schedule|allocate|complete|plan|place|fit|omit|drop|defer|'
+      r'postpone|shorten|roll|move|carry|leave)\b',
+      caseSensitive: false,
+    ).hasMatch(prose.substring(actionStart));
 
 bool _evidenceStartsInConditionalClause(String prefix) =>
     RegExp(
@@ -2141,7 +2160,7 @@ bool _referenceAttributesEvidence(
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {
-  if (_remainderHasExplicitNonTaskObject(reason, match)) return false;
+  if (_evidenceHasExplicitNonTaskObject(reason, match)) return false;
   final clause = _matchClause(reason, match);
   if (_unrelatedRemainderScopePattern.hasMatch(clause)) return false;
   if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
@@ -2149,12 +2168,12 @@ bool _remainderIsTaskBound(String reason, Match match) {
 }
 
 bool _remainderIsRelatedToTask(String reason, Match match) {
-  if (_remainderHasExplicitNonTaskObject(reason, match)) return false;
+  if (_evidenceHasExplicitNonTaskObject(reason, match)) return false;
   if (_remainderIsTaskBound(reason, match)) return true;
   return !_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match));
 }
 
-bool _remainderHasExplicitNonTaskObject(String reason, Match match) {
+bool _evidenceHasExplicitNonTaskObject(String reason, Match match) {
   final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
   final prefix = reason.substring(range.start, match.start);
   return RegExp(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -698,7 +698,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
 }
 
 final _partialOfEstimatePattern = RegExp(
-  r'\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+of\s+(?:the\s+)?'
+  r'\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+(?:out\s+)?of\s+(?:the\s+)?'
   r'(\d+)(?:\s+estimated)?\s*[-–—]?\s*(?:m|mins?|minutes?)\b',
   caseSensitive: false,
 );
@@ -1087,6 +1087,24 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
       isStandaloneLabelOrExplanation;
 }
 
+bool _tradeDispositionDescribesTaskOrWork(String prose, Match match) {
+  final wording = (match.group(0) ?? '').toLowerCase();
+  if (!wording.startsWith('defer')) return true;
+
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final suffix = prose.substring(match.end, range.end);
+  if (!RegExp(r'^\s+\w').hasMatch(suffix)) return true;
+  return RegExp(
+        r'^\s+(?:(?:the|this|that|their|our|my|your)\s+)?'
+        r'(?:task|work|remainder|rest|portion|part)\b',
+        caseSensitive: false,
+      ).hasMatch(suffix) ||
+      RegExp(
+        r'^\s+(?:to|until|for|because|after|before|so|and)\b',
+        caseSensitive: false,
+      ).hasMatch(suffix);
+}
+
 bool _negationQualifiesRatherThanNegates(Match negation, String between) {
   final negator = (negation.group(0) ?? '').toLowerCase();
   if (negator == 'no') {
@@ -1120,6 +1138,14 @@ bool _matchClauseIsNegated(String reason, Match match) {
       continue;
     }
     if (negationStart >= match.end &&
+        _followingNegationExplainsCapacityLimit(
+          reason,
+          negationStart: negationStart,
+          clauseEnd: range.end,
+        )) {
+      continue;
+    }
+    if (negationStart >= match.end &&
         _taskAllocationActionPattern.hasMatch(between)) {
       continue;
     }
@@ -1130,6 +1156,20 @@ bool _matchClauseIsNegated(String reason, Match match) {
     }
   }
   return false;
+}
+
+bool _followingNegationExplainsCapacityLimit(
+  String prose, {
+  required int negationStart,
+  required int clauseEnd,
+}) {
+  final suffix = prose.substring(negationStart, clauseEnd);
+  return RegExp(
+    r'^no\s+more'
+    r'(?:\s+(?:of\s+(?:this|the)\s+)?(?:task|work))?\s+'
+    r'(?:(?:can|will)\s+)?fit(?:s|ting)?\b',
+    caseSensitive: false,
+  ).hasMatch(suffix);
 }
 
 bool _negativeFitDisclosureIsDenied(String prose, Match match) {
@@ -1999,7 +2039,10 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
     }
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
-    if (!belongsToTask(match)) continue;
+    if (!belongsToTask(match) ||
+        !_tradeDispositionDescribesTaskOrWork(prose, match)) {
+      continue;
+    }
     if (_matchClauseIsNegated(prose, match)) {
       hasDeniedEvidence = true;
     } else {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -781,7 +781,7 @@ final _conflictTradePattern = RegExp(
   r'trade|conflict(?:s|ed|ing)?(?![-\s]+free\b)|'
   'shorten(?:s|ed|ing)?|'
   r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
-  r'(?:do|does|did)\s+not)\s+fit)\b',
+  r'(?:do|does|did)\s+not|(?:don|doesn|didn)[\x27’]?t)\s+fit)\b',
   caseSensitive: false,
 );
 
@@ -1098,7 +1098,11 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
 
 bool _tradeDispositionDescribesTaskOrWork(String prose, Match match) {
   final wording = (match.group(0) ?? '').toLowerCase();
-  if (!wording.startsWith('defer') && wording != 'unscheduled') return true;
+  if (!wording.startsWith('defer') &&
+      wording != 'unscheduled' &&
+      !wording.startsWith('for later')) {
+    return true;
+  }
 
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final suffix = prose.substring(match.end, range.end);
@@ -1154,7 +1158,9 @@ bool _matchClauseIsNegated(String reason, Match match) {
         )) {
       continue;
     }
-    if (negationStart >= match.end && RegExp('[–—]').hasMatch(between)) {
+    if (negationStart >= match.end &&
+        RegExp('[–—]').hasMatch(between) &&
+        _wordPattern.hasMatch(between)) {
       continue;
     }
     if (negationStart >= match.end &&
@@ -2029,7 +2035,7 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   if (task == null) return (affirmative: false, denied: false);
   final placement = _estimatedTaskPlacements(outcome)[taskId];
   final structuralRemainder = placement == null
-      ? null
+      ? task.estimateMinutes
       : placement.estimateMinutes - placement.allocatedMinutes;
   var hasAffirmativeEvidence = false;
   var hasDeniedEvidence = false;

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -871,7 +871,7 @@ bool _hasAuditablePartialDisclosure({
     var reasonMentionsPartial = false;
     var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
-      if (_matchClauseIsNegated(reason, match)) return false;
+      if (_partialMentionIsNegated(reason, match)) return false;
       reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
@@ -934,6 +934,18 @@ bool _hasAuditablePartialDisclosure({
     }
   }
   return hasMatchingSplit || hasBoundPartialRemainder;
+}
+
+bool _partialMentionIsNegated(String reason, Match match) {
+  final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
+  final segment = reason.substring(range.start, range.end);
+  for (final negation in _negationWordPattern.allMatches(segment)) {
+    final negationEnd = range.start + negation.end;
+    if (negationEnd > match.start) continue;
+    final between = reason.substring(negationEnd, match.start);
+    if (_wordPattern.allMatches(between).length <= 3) return true;
+  }
+  return false;
 }
 
 bool _matchClauseIsNegated(String reason, Match match) {
@@ -1067,6 +1079,13 @@ bool _referenceAttributesEvidence(
   required int referenceStart,
   required int referenceEnd,
 }) {
+  if (referenceEnd <= evidence.start) {
+    final between = reason.substring(referenceEnd, evidence.start);
+    final trimmed = between.trim();
+    return trimmed.isEmpty ||
+        _taskAllocationActionPattern.hasMatch(between) ||
+        RegExp(r'^[:–—-]+$').hasMatch(trimmed);
+  }
   if (referenceStart < evidence.end) return true;
   final between = reason.substring(evidence.end, referenceStart);
   return RegExp(
@@ -1200,13 +1219,13 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   // identify at least one piece of work that was actually left out or only
   // partially represented.
   final placed = _placedTaskIds(outcome);
-  final auditedPartials = {
+  final shortenedTasks = {
     for (final entry in _estimatedTaskPlacements(outcome).entries)
-      if (_isAuditedPartial(entry.value)) entry.key,
+      if (entry.value.allocatedMinutes < entry.value.estimateMinutes) entry.key,
   };
   final deferred = [
     for (final taskId in outcome.inputs.decidedTaskIds)
-      if (!placed.contains(taskId) || auditedPartials.contains(taskId)) taskId,
+      if (!placed.contains(taskId) || shortenedTasks.contains(taskId)) taskId,
   ];
   if (deferred.isEmpty) {
     return const EvalConstraintResult.notApplicable(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -700,7 +700,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
 }
 
 final _partialOfEstimatePattern = RegExp(
-  r'(?<![\d.,])\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+'
+  r'(?<![\d.,+−-])\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+'
   r'(?:out\s+)?of\s+'
   r'(?:(?:an?|the)\s+)?(?:estimated\s+)?'
   r'(\d+)(?:\s+estimated)?\s*[-–—]?\s*(?:m|mins?|minutes?)\b',
@@ -708,7 +708,7 @@ final _partialOfEstimatePattern = RegExp(
 );
 
 final _partialRemainingPattern = RegExp(
-  r'(?<![\d.,])\b(\d+)\s*'
+  r'(?<![\d.,+−-])\b(\d+)\s*'
   r'(?:(?:more|additional)\s+)?(?:m|mins?|minutes?)\s+'
   r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
   r'(?:(?:still|yet)\s+)?'
@@ -1264,7 +1264,12 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
       isStandaloneLabelOrExplanation;
 }
 
-bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
+bool _tradeEvidenceDescribesTaskOrWork(
+  String prose,
+  Match match, {
+  required String taskId,
+  required String taskTitle,
+}) {
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final wording = (match.group(0) ?? '').toLowerCase();
   if (wording.startsWith('for ')) {
@@ -1283,6 +1288,10 @@ bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
   }
   final suffix = prose.substring(match.end, range.end);
   if (!RegExp(r'^\s+\w').hasMatch(suffix)) return true;
+  for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
+    final reference = pattern.firstMatch(suffix);
+    if (reference != null && reference.start == 0) return true;
+  }
   return RegExp(
         r'^\s+(?:(?:the|this|that|their|our|my|your)\s+)?'
         r'(?:task|work|remainder|rest|portion|part)\b',
@@ -2694,7 +2703,12 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
-        !_tradeEvidenceDescribesTaskOrWork(prose, match) ||
+        !_tradeEvidenceDescribesTaskOrWork(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: task.title,
+        ) ||
         !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match)) {
       continue;
@@ -2772,12 +2786,24 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
         record('negative-fit', denied: false);
       }
     } else if (negativeSchedulingDisclosure) {
-      if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) continue;
+      if (!_tradeEvidenceDescribesTaskOrWork(
+        prose,
+        match,
+        taskId: taskId,
+        taskTitle: task.title,
+      )) {
+        continue;
+      }
       record(
         'not-scheduled',
         denied: _negativeTradeDisclosureIsDenied(prose, match),
       );
-    } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
+    } else if (!_tradeEvidenceDescribesTaskOrWork(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+    )) {
       continue;
     } else if (clauseIsNegated(match) ||
         _negativeTradeDisclosureIsDenied(prose, match)) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -640,6 +640,12 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
   final placements = _estimatedTaskPlacements(outcome);
+  if (placements.isEmpty) {
+    return const EvalConstraintResult.notApplicable(
+      id,
+      'no placed task carries an estimate',
+    );
+  }
   var chargedMinutes = 0;
   final partials = <String>[];
   final undisclosedShortenings = <String>[];
@@ -647,13 +653,7 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
     final taskId = entry.key;
     final allocated = entry.value.allocatedMinutes;
     final estimate = entry.value.estimateMinutes;
-    if (allocated > 0 &&
-        allocated < estimate &&
-        _hasAuditablePartialDisclosure(
-          reasons: entry.value.reasons,
-          allocatedMinutes: allocated,
-          estimateMinutes: estimate,
-        )) {
+    if (_isAuditedPartial(entry.value)) {
       chargedMinutes += allocated;
       partials.add(
         '$taskId ${allocated}min partial of ${estimate}min '
@@ -667,12 +667,6 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
         );
       }
     }
-  }
-  if (placements.isEmpty) {
-    return const EvalConstraintResult.notApplicable(
-      id,
-      'no placed task carries an estimate',
-    );
   }
   final capacity = outcome.inputs.capacityMinutes;
   final evidence = [
@@ -703,6 +697,20 @@ final _partialRemainingPattern = RegExp(
   caseSensitive: false,
 );
 
+final _partialLeadingRemainingPattern = RegExp(
+  r'\b(?:remaining|remainder(?:\s+is)?)\s*:?\s*'
+  r'(\d+)\s*(?:m|mins?|minutes?)\b',
+  caseSensitive: false,
+);
+
+final _partialMentionPattern = RegExp(r'\bpartial\b', caseSensitive: false);
+
+final _negatedPartialPattern = RegExp(
+  r"\b(?:not|no|never|isn['’]?t|wasn['’]?t)\b"
+  r'(?:\s+\w+){0,3}\s+\bpartial\b',
+  caseSensitive: false,
+);
+
 typedef _EstimatedTaskPlacement = ({
   int allocatedMinutes,
   int estimateMinutes,
@@ -720,6 +728,10 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
   final allocatedByTask = <String, int>{};
   final reasonsByTask = <String, List<String>>{};
   for (final block in _scheduled(outcome)) {
+    if (block.type != PlannedBlockType.ai &&
+        block.type != PlannedBlockType.manual) {
+      continue;
+    }
     final taskId = block.taskId;
     if (taskId == null) continue;
     allocatedByTask.update(
@@ -745,6 +757,21 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
   };
 }
 
+/// Whether a placement is substantial and its partial arithmetic is auditable.
+///
+/// The 10% floor matches the token-placement boundary used by
+/// [scoreRespectsEstimates]. Keeping it here prevents capacity and conflict
+/// scoring from treating a one-minute task marker as genuine partial work.
+bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
+    placement.allocatedMinutes > 0 &&
+    placement.allocatedMinutes < placement.estimateMinutes &&
+    placement.allocatedMinutes * 10 >= placement.estimateMinutes &&
+    _hasAuditablePartialDisclosure(
+      reasons: placement.reasons,
+      allocatedMinutes: placement.allocatedMinutes,
+      estimateMinutes: placement.estimateMinutes,
+    );
+
 /// Whether prose makes a shortened placement safe to charge as partial.
 ///
 /// Block duration remains the authority. A reason earns partial accounting
@@ -759,9 +786,8 @@ bool _hasAuditablePartialDisclosure({
   required int estimateMinutes,
 }) {
   final remainingMinutes = estimateMinutes - allocatedMinutes;
-  final mentionsPartial = reasons.any(
-    (reason) => reason.toLowerCase().contains('partial'),
-  );
+  if (reasons.any(_negatedPartialPattern.hasMatch)) return false;
+  final mentionsPartial = reasons.any(_partialMentionPattern.hasMatch);
   var hasMatchingSplit = false;
   var hasMatchingRemainder = false;
   for (final reason in reasons) {
@@ -775,6 +801,11 @@ bool _hasAuditablePartialDisclosure({
       hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
+      final declaredRemaining = int.tryParse(match.group(1) ?? '');
+      if (declaredRemaining != remainingMinutes) return false;
+      hasMatchingRemainder = true;
+    }
+    for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
       final declaredRemaining = int.tryParse(match.group(1) ?? '');
       if (declaredRemaining != remainingMinutes) return false;
       hasMatchingRemainder = true;
@@ -857,14 +888,7 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   final placed = _placedTaskIds(outcome);
   final auditedPartials = {
     for (final entry in _estimatedTaskPlacements(outcome).entries)
-      if (entry.value.allocatedMinutes > 0 &&
-          entry.value.allocatedMinutes < entry.value.estimateMinutes &&
-          _hasAuditablePartialDisclosure(
-            reasons: entry.value.reasons,
-            allocatedMinutes: entry.value.allocatedMinutes,
-            estimateMinutes: entry.value.estimateMinutes,
-          ))
-        entry.key,
+      if (_isAuditedPartial(entry.value)) entry.key,
   };
   final deferred = [
     for (final taskId in outcome.inputs.decidedTaskIds)

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1364,7 +1364,8 @@ bool _allocationActionIsAsserted(
         caseSensitive: false,
       ).hasMatch(prefix) &&
       !RegExp(
-        r'\b(?:fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
+        r'\b(?:attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
+        'fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
         r'declin(?:e|es|ed|ing))\s+to\s*$',
         caseSensitive: false,
       ).hasMatch(prefix);

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -879,6 +879,15 @@ bool _hasAuditablePartialDisclosure({
     var reasonMentionsPartial = false;
     var reasonHasBoundRemainder = false;
     for (final match in _partialMentionPattern.allMatches(reason)) {
+      if (_evidenceNamesAnotherTask(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+        corpus: corpus,
+      )) {
+        continue;
+      }
       if (_partialMentionIsNegated(reason, match)) return false;
       reasonMentionsPartial = true;
     }
@@ -1089,6 +1098,10 @@ bool _referenceAttributesEvidence(
     final trimmed = between.trim();
     return trimmed.isEmpty ||
         _taskAllocationActionPattern.hasMatch(between) ||
+        RegExp(
+          r'^(?:is|are|was|were)$',
+          caseSensitive: false,
+        ).hasMatch(trimmed) ||
         RegExp(r'^[\x27’]s$', caseSensitive: false).hasMatch(trimmed) ||
         RegExp(r'^[:–—-]+$').hasMatch(trimmed);
   }
@@ -1648,8 +1661,13 @@ Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
 
 /// Whether [prose] mentions the title of [taskId].
 bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
-  final title = outcome.inputs.taskById(taskId)?.title.toLowerCase();
-  return title != null && title.isNotEmpty && prose.contains(title);
+  final title = outcome.inputs.taskById(taskId)?.title.trim();
+  return title != null &&
+      title.isNotEmpty &&
+      RegExp(
+        r'(?:^|[^\w])' + RegExp.escape(title) + r'(?=$|[^\w])',
+        caseSensitive: false,
+      ).hasMatch(prose);
 }
 
 bool _taskTradeIsNamed(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1299,15 +1299,15 @@ bool _tradeEvidenceDescribesTaskOrWork(
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
-        r'^\s+(?:to|until|for|because|due\s+to|owing\s+to|after|before|so|and|'
-        r'but|yet|with|against|over)\b',
+        r'^\s+(?:to|until|for|because|since|as|due\s+to|owing\s+to|after|'
+        r'before|so|and|but|yet|with|against|over)\b',
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
         r'^\s+(?:entirely|completely|fully|actually|definitely|explicitly|'
         'ultimately|finally|temporarily)'
-        r'(?:\s*$|\s+(?:to|until|for|because|due\s+to|owing\s+to|after|'
-        r'before|so|and|but|yet|with|against|over)\b)',
+        r'(?:\s*$|\s+(?:to|until|for|because|since|as|due\s+to|owing\s+to|'
+        r'after|before|so|and|but|yet|with|against|over)\b)',
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
@@ -1495,7 +1495,7 @@ bool _negationQualifiesRatherThanNegates(Match negation, String between) {
   final negator = (negation.group(0) ?? '').toLowerCase();
   if (negator == 'no') {
     return RegExp(
-      r'^\s*more\s+than\b',
+      r'^\s*(?:more\s+than|(?:choice|option|alternative)\s+but\s+to)\b',
       caseSensitive: false,
     ).hasMatch(between);
   }
@@ -1617,6 +1617,10 @@ bool _negativeTradeDisclosureIsDenied(String prose, Match match) {
         : start >= match.end
         ? prose.substring(match.end, start)
         : '';
+    if (end <= match.start &&
+        _negationQualifiesRatherThanNegates(negation, between)) {
+      continue;
+    }
     if (start >= match.end &&
         RegExp(
           r'^\s*(?:because|since|as|due\s+to|owing\s+to)\s*$',
@@ -2724,6 +2728,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
               r'\btomorrow\b',
               caseSensitive: false,
             ).hasMatch(match.group(0) ?? '') ||
+        _evidenceHasHistoricalScope(prose, match) ||
         !_tradeEvidenceDescribesTaskOrWork(
           prose,
           match,
@@ -2773,6 +2778,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
+        _evidenceHasHistoricalScope(prose, match) ||
         !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match)) {
       continue;

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1133,7 +1133,8 @@ bool _fullAllocationClaimHasExplicitNonTaskHead(
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final suffix = prose.substring(match.end, range.end);
   return RegExp(
-    r'^\s+(?:(?:the|a|an|this|that)\s+)?'
+    r'^\s+(?:(?:for|throughout)\s+)?'
+    r'(?:(?:the|a|an|this|that)\s+)?'
     '(?:day|meeting|workday|calendar|appointment|break|event|agenda|'
     r'schedule|session)\b',
     caseSensitive: false,
@@ -1199,7 +1200,7 @@ bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
       ).hasMatch(suffix) ||
       RegExp(
         r'^\s+(?:to|until|for|because|due\s+to|owing\s+to|after|before|so|and|'
-        r'with|against|over)\b',
+        r'but|yet|with|against|over)\b',
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
@@ -1219,7 +1220,10 @@ bool _negativeFitEvidenceDescribesTaskOrWork(
   final prefix = prose.substring(range.start, match.start).trimRight();
   for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
     for (final reference in pattern.allMatches(prefix)) {
-      if (reference.end == prefix.length) return true;
+      final separator = prefix.substring(reference.end);
+      if (RegExp(r'^\s*(?:[:\-–—]\s*)?$').hasMatch(separator)) {
+        return true;
+      }
     }
   }
   return RegExp(
@@ -1281,14 +1285,7 @@ bool _hasTaskBoundAllocationDenial(
     )) {
       continue;
     }
-    final prefix = prose.substring(range.start, action.start);
-    if (RegExp(
-      r'\b(?:(?:the|this|that|its)\s+)?'
-      r'(?:task(?!-)|work|placement|block|it)\b',
-      caseSensitive: false,
-    ).hasMatch(prefix)) {
-      return true;
-    }
+    return true;
   }
   return false;
 }
@@ -1324,7 +1321,10 @@ bool _evidenceStartIsSpeculative(String prose, int evidenceStart) {
   ).allMatches(prefix)) {
     final complement = prefix.substring(modal.end);
     if (!RegExp(
-      r'\b(?:and|but|yet|however|while|although|though|so|therefore|then)\b',
+      r'\b(?:so|therefore)\b|'
+      r'\b(?:and|but|yet|while|although|though)\s+'
+      r'(?:(?:the|this|that|a|an)\s+)?[\w-]+\s+'
+      r'(?:is|are|was|were|has|have|had|will|does|do|did)\b',
       caseSensitive: false,
     ).hasMatch(complement)) {
       return true;

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -731,7 +731,9 @@ final _taskAllocationContextPattern = RegExp(
 );
 
 final _unrelatedRemainderScopePattern = RegExp(
-  r'\b(?:in|during|for)\s+(?!(?:this|the)\s+(?:task|work)\b)',
+  r'\b(?:in|during|for)\s+'
+  r'(?:(?:the|a|an|my|our|their|your)\s+)?'
+  r'(?:meeting|workday|calendar|appointment|break)\b',
   caseSensitive: false,
 );
 
@@ -903,7 +905,8 @@ bool _matchClauseIsNegated(String reason, Match match) {
 
 bool _splitIsTaskBound(String reason, Match match) {
   final clause = _matchClause(reason, match);
-  return _taskAllocationContextPattern.hasMatch(clause) &&
+  final context = _matchClauseExcludingMatch(reason, match);
+  return _taskAllocationContextPattern.hasMatch(context) &&
       !_unrelatedSplitScopePattern.hasMatch(clause);
 }
 
@@ -930,6 +933,12 @@ String _matchClause(
 }) {
   final range = _matchClauseRange(reason, match, boundaries: boundaries);
   return reason.substring(range.start, range.end);
+}
+
+String _matchClauseExcludingMatch(String reason, Match match) {
+  final range = _matchClauseRange(reason, match, boundaries: '.;!?\n');
+  return '${reason.substring(range.start, match.start)} '
+      '${reason.substring(match.end, range.end)}';
 }
 
 ({int start, int end}) _matchClauseRange(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -700,7 +700,7 @@ final _partialOfEstimatePattern = RegExp(
 final _partialRemainingPattern = RegExp(
   r'\b(\d+)\s*(?:m|mins?|minutes?)\s+'
   r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
-  r'(?:(?:is|are|will)\s+)?(?:left|remain(?:s|ing)?)\b',
+  r'(?:(?:is|are|will(?:\s+be)?)\s+)?(?:left|remain(?:s|ing)?)\b',
   caseSensitive: false,
 );
 
@@ -975,6 +975,9 @@ bool _partialMentionIsNegated(String reason, Match match) {
     final negationEnd = range.start + negation.end;
     if (negationEnd > match.start) continue;
     final between = reason.substring(negationEnd, match.start);
+    if (RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between)) {
+      continue;
+    }
     if (_wordPattern.allMatches(between).length <= 3) return true;
   }
   return false;
@@ -991,6 +994,10 @@ bool _matchClauseIsNegated(String reason, Match match) {
         : negationStart >= match.end
         ? reason.substring(match.end, negationStart)
         : '';
+    if (negationEnd <= match.start &&
+        RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between)) {
+      continue;
+    }
     if (negationStart >= match.end &&
         _taskAllocationActionPattern.hasMatch(between)) {
       continue;
@@ -1196,7 +1203,7 @@ bool _referenceAttributesEvidence(
     return trimmed.isEmpty ||
         _taskAllocationActionPattern.hasMatch(between) ||
         RegExp(
-          r'^(?:is|are|was|were|will\s+be)$',
+          r'^(?:is|are|was|were|has|have|had|will\s+be)$',
           caseSensitive: false,
         ).hasMatch(trimmed) ||
         RegExp(r'^[\x27’]s$', caseSensitive: false).hasMatch(trimmed) ||
@@ -1780,6 +1787,10 @@ bool _hasAffirmativeTradeDisclosure(
 ) {
   final task = outcome.inputs.taskById(taskId);
   if (task == null) return false;
+  final placement = _estimatedTaskPlacements(outcome)[taskId];
+  final structuralRemainder = placement == null
+      ? null
+      : placement.estimateMinutes - placement.allocatedMinutes;
   for (final match in _partialMentionPattern.allMatches(prose)) {
     if (_evidenceNamesAnotherTask(
       prose,
@@ -1816,6 +1827,13 @@ bool _hasAffirmativeTradeDisclosure(
         taskTitle: task.title,
         corpus: outcome.inputs.corpus,
       )) {
+        continue;
+      }
+      final declaredRemainder = int.tryParse(match.group(1) ?? '');
+      if (declaredRemainder == null ||
+          declaredRemainder <= 0 ||
+          structuralRemainder != null &&
+              declaredRemainder != structuralRemainder) {
         continue;
       }
       if (!_matchClauseIsNegated(prose, match)) return true;

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -840,6 +840,16 @@ final _leadingFutureAllocationScopePattern = RegExp(
   caseSensitive: false,
 );
 
+final _tomorrowAllocationScopePattern = RegExp(
+  r'^\s*tomorrow\s*(?=$|because\b|due\s+to\b|owing\s+to\b)',
+  caseSensitive: false,
+);
+
+final _leadingTomorrowAllocationScopePattern = RegExp(
+  r'(?:^|[.;!?\n])\s*tomorrow\s*,\s*$',
+  caseSensitive: false,
+);
+
 final _tradeSubjectPrefixPattern = RegExp(
   r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
   r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
@@ -882,6 +892,7 @@ typedef _EstimatedTaskPlacement = ({
   List<_PlacementDisclosure> disclosures,
   int estimateMinutes,
   bool hasOverlappingBlocks,
+  DateTime? now,
   String taskId,
   String taskTitle,
 });
@@ -968,6 +979,7 @@ Map<String, _EstimatedTaskPlacement> _estimatedTaskPlacements(
           hasOverlappingBlocks: _hasOverlappingIntervals(
             blocksByTask[entry.key] ?? const [],
           ),
+          now: outcome.inputs.now,
           taskId: taskId,
           taskTitle: taskTitle,
         ),
@@ -1005,6 +1017,7 @@ bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
       taskId: placement.taskId,
       taskTitle: placement.taskTitle,
       corpus: placement.corpus,
+      now: placement.now,
     );
 
 /// Whether prose makes a shortened placement safe to charge as partial.
@@ -1024,6 +1037,7 @@ bool _hasAuditablePartialDisclosure({
   required String taskId,
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
+  required DateTime? now,
 }) {
   final remainingMinutes = estimateMinutes - allocatedMinutes;
   var hasMatchingSplit = false;
@@ -1094,6 +1108,7 @@ bool _hasAuditablePartialDisclosure({
             taskId: taskId,
             taskTitle: taskTitle,
             corpus: corpus,
+            tomorrowIsFuture: now != null,
           )) {
         continue;
       }
@@ -1751,6 +1766,7 @@ bool _splitIsTaskBound(
   required String taskId,
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
+  required bool tomorrowIsFuture,
 }) {
   return !_evidenceHasExplicitNonTaskObject(reason, match) &&
       _splitHasAffirmativeAllocation(
@@ -1764,6 +1780,7 @@ bool _splitIsTaskBound(
         match,
         taskId: taskId,
         taskTitle: taskTitle,
+        tomorrowIsFuture: tomorrowIsFuture,
       ) &&
       !_evidenceNamesAnotherTask(
         reason,
@@ -1891,6 +1908,7 @@ bool _splitHasUnrelatedScope(
   Match evidence, {
   required String taskId,
   required String taskTitle,
+  required bool tomorrowIsFuture,
 }) {
   final evidenceAction = _nearestAllocationActionMatch(
     reason,
@@ -1907,6 +1925,7 @@ bool _splitHasUnrelatedScope(
     reason,
     evidence,
     evidenceEnd: scopeEnd,
+    tomorrowIsFuture: tomorrowIsFuture,
   )) {
     return true;
   }
@@ -1957,6 +1976,7 @@ bool _evidenceHasNonCurrentAllocationScope(
   String prose,
   Match evidence, {
   int? evidenceEnd,
+  bool tomorrowIsFuture = false,
 }) {
   if (_evidenceHasHistoricalScope(
     prose,
@@ -1971,9 +1991,15 @@ bool _evidenceHasNonCurrentAllocationScope(
   )) {
     return true;
   }
-  return _leadingFutureAllocationScopePattern.hasMatch(
-    prose.substring(0, range.start),
-  );
+  final leadingScope = prose.substring(0, range.start);
+  if (_leadingFutureAllocationScopePattern.hasMatch(leadingScope)) {
+    return true;
+  }
+  if (!tomorrowIsFuture) return false;
+  return _tomorrowAllocationScopePattern.hasMatch(
+        prose.substring(evidenceEnd ?? evidence.end, range.end),
+      ) ||
+      _leadingTomorrowAllocationScopePattern.hasMatch(leadingScope);
 }
 
 ({int start, int end, int distance})? _nearestPatternMatch(
@@ -2208,7 +2234,10 @@ bool _referenceAttributesEvidence(
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {
-  if (_evidenceHasExplicitNonTaskObject(reason, match)) return false;
+  if (_evidenceHasExplicitNonTaskObject(reason, match) ||
+      _remainderHasExplicitNonTaskSubject(reason, match)) {
+    return false;
+  }
   final clause = _matchClause(reason, match);
   if (_unrelatedRemainderScopePattern.hasMatch(clause)) return false;
   if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
@@ -2216,9 +2245,25 @@ bool _remainderIsTaskBound(String reason, Match match) {
 }
 
 bool _remainderIsRelatedToTask(String reason, Match match) {
-  if (_evidenceHasExplicitNonTaskObject(reason, match)) return false;
+  if (_evidenceHasExplicitNonTaskObject(reason, match) ||
+      _remainderHasExplicitNonTaskSubject(reason, match)) {
+    return false;
+  }
   if (_remainderIsTaskBound(reason, match)) return true;
   return !_unrelatedRemainderScopePattern.hasMatch(_matchClause(reason, match));
+}
+
+bool _remainderHasExplicitNonTaskSubject(String reason, Match match) {
+  final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
+  final prefix = reason.substring(range.start, match.start);
+  return RegExp(
+    r'^\s*(?:(?:and|but|yet|so)\s+)?'
+    r'(?:(?:the|a|an|this|that|its)\s+)?'
+    r'(?!(?:task|work|placement|block|remainder|remaining|rest|portion|part)\b)'
+    r'[\w-]+(?:\s+[\w-]+){0,3}\s+'
+    r'(?:shows?|reports?|displays?|reads?|has|have|had)\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
 }
 
 bool _evidenceHasExplicitNonTaskObject(String reason, Match match) {
@@ -2943,6 +2988,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
   for (final match in _conflictTradePattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
         _evidenceHasHistoricalScope(prose, match) ||
+        _conflictEvidenceIsObject(prose, match) ||
         !_evidenceActionIsAsserted(prose, match.start) ||
         _evidenceIsSpeculative(prose, match)) {
       continue;
@@ -3023,11 +3069,13 @@ String _tradeDispositionKey(Match match) {
   if (wording.contains('defer') || wording.contains('postpon')) {
     return 'deferred';
   }
-  if (wording.contains('unscheduled')) return 'unscheduled';
-  if (wording.contains('omit')) return 'omitted';
-  if (wording.contains('drop')) return 'dropped';
   if (wording.contains('unfinished')) return 'unfinished';
-  if (wording.contains('left')) return 'left-out';
+  if (wording.contains('unscheduled') ||
+      wording.contains('omit') ||
+      wording.contains('drop') ||
+      wording.contains('left')) {
+    return 'omitted';
+  }
   if (wording.contains('conflict')) return 'conflict';
   if (wording.contains('shorten')) return 'shortened';
   if (wording.contains('roll')) return 'rolled-over';
@@ -3035,6 +3083,24 @@ String _tradeDispositionKey(Match match) {
   if (wording.contains('move')) return 'moved';
   if (wording.startsWith('for ')) return 'for-later';
   return wording;
+}
+
+bool _conflictEvidenceIsObject(String prose, Match match) {
+  if (!RegExp(
+    r'^conflicts$',
+    caseSensitive: false,
+  ).hasMatch(match.group(0) ?? '')) {
+    return false;
+  }
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final prefix = prose.substring(range.start, match.start);
+  return RegExp(
+    r'\b(?:address(?:es|ed|ing)?|describe(?:s|d|ing)?|'
+    'discuss(?:es|ed|ing)?|document(?:s|ed|ing)?|'
+    'handle(?:s|d|ing)?|list(?:s|ed|ing)?|mention(?:s|ed|ing)?|'
+    r'resolve(?:s|d|ing)?|review(?:s|ed|ing)?|track(?:s|ed|ing)?)\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
 }
 
 bool _tradeEvidenceHasExplicitNonTaskSubject(

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -754,6 +754,14 @@ final _unrelatedSplitScopePattern = RegExp(
   caseSensitive: false,
 );
 
+final _conflictTradePattern = RegExp(
+  r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|left|remain(?:s|ed|ing)?|'
+  'trade|conflict|shorten(?:s|ed|ing)?|'
+  r'(?:(?:cannot|can[\x27’]?t|couldn[\x27’]?t|won[\x27’]?t)|'
+  r'(?:do|does|did)\s+not)\s+fit)\b',
+  caseSensitive: false,
+);
+
 typedef _EstimatedTaskPlacement = ({
   List<EvalCorpusTask> corpus,
   int allocatedMinutes,
@@ -1084,6 +1092,7 @@ bool _referenceAttributesEvidence(
     final trimmed = between.trim();
     return trimmed.isEmpty ||
         _taskAllocationActionPattern.hasMatch(between) ||
+        RegExp(r'^[\x27’]s$', caseSensitive: false).hasMatch(trimmed) ||
         RegExp(r'^[:–—-]+$').hasMatch(trimmed);
   }
   if (referenceStart < evidence.end) return true;
@@ -1237,11 +1246,15 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
     for (final block in outcome.blocks)
       '${block.reason ?? ''} ${block.note ?? ''}',
   ].join(' ').toLowerCase();
+  final hasTradeDisclosure =
+      _partialMentionPattern.hasMatch(prose) ||
+      _partialRemainderDispositionPattern.hasMatch(prose) ||
+      _conflictTradePattern.hasMatch(prose);
   final namedCasualties = [
     for (final taskId in deferred)
       if (prose.contains(taskId.toLowerCase()) ||
           _titleNamed(outcome, taskId, prose))
-        taskId,
+        if (!shortenedTasks.contains(taskId) || hasTradeDisclosure) taskId,
   ];
   return EvalConstraintResult(
     id: id,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -764,6 +764,13 @@ final _taskAllocationActionPattern = RegExp(
   caseSensitive: false,
 );
 
+final _fullAllocationPattern = RegExp(
+  r'\b(?:fully|entirely|completely)\s+'
+  '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))\b',
+  caseSensitive: false,
+);
+
 final _omittedAllocationPattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|'
   r'defer(?:s|red|ring)?|unscheduled|left\s+out)\b',
@@ -916,12 +923,18 @@ bool _hasAuditablePartialDisclosure({
   var hasBoundPartialRemainder = false;
   for (final disclosure in disclosures) {
     final reason = disclosure.prose;
-    if (_hasTaskBoundAllocationDenial(
-      reason,
-      taskId: taskId,
-      taskTitle: taskTitle,
-      corpus: corpus,
-    )) {
+    if (_hasTaskBoundFullAllocationClaim(
+          reason,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        ) ||
+        _hasTaskBoundAllocationDenial(
+          reason,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        )) {
       return false;
     }
     var reasonMentionsPartial = false;
@@ -1057,6 +1070,47 @@ bool _hasAuditablePartialDisclosure({
     }
   }
   return hasMatchingSplit || hasBoundPartialRemainder;
+}
+
+bool _hasTaskBoundFullAllocationClaim(
+  String prose, {
+  required String taskId,
+  required String taskTitle,
+  required List<EvalCorpusTask> corpus,
+}) {
+  for (final match in _fullAllocationPattern.allMatches(prose)) {
+    if (_evidenceFallsInsideTaskReference(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: taskTitle,
+        ) ||
+        _tradeEvidenceHasExplicitNonTaskSubject(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: taskTitle,
+        ) ||
+        _evidenceNamesAnotherTask(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        ) ||
+        _evidenceIsSpeculative(prose, match) ||
+        _matchClauseIsNegated(
+          prose,
+          match,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        )) {
+      continue;
+    }
+    return true;
+  }
+  return false;
 }
 
 bool _partialMentionIsNegated(String reason, Match match) {
@@ -1261,6 +1315,14 @@ bool _matchClauseIsNegated(
   ).hasMatch(prefix)) {
     return true;
   }
+  if (RegExp(
+    r'\b(?:avoid(?:s|ed|ing)?(?:\s+being)?|'
+    r'(?:(?:is|are|was|were|be|been|being)\s+)?'
+    r'prevent(?:s|ed|ing)?(?:\s+\w+){0,2}\s+from(?:\s+being)?)\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix)) {
+    return true;
+  }
   for (final negation in _negationWordPattern.allMatches(reason, range.start)) {
     if (negation.start >= range.end) break;
     final negationStart = negation.start;
@@ -1413,6 +1475,12 @@ bool _allocationActionIsAsserted(
         'attempt(?:s|ed|ing)?|tr(?:y|ies|ied|ying)|'
         'fail(?:s|ed|ing)?|refus(?:e|es|ed|ing)|'
         r'declin(?:e|es|ed|ing))\s+to\s*$',
+        caseSensitive: false,
+      ).hasMatch(prefix) &&
+      !RegExp(
+        r'\b(?:(?:(?:is|are|was|were|be|been|being)\s+)?'
+        r'(?:unable\s+to|not\s+able\s+to|incapable\s+of)|'
+        r'(?:isn|aren|wasn|weren)[\x27’]?t\s+able\s+to)\s*$',
         caseSensitive: false,
       ).hasMatch(prefix);
 }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -698,7 +698,8 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
 }
 
 final _partialOfEstimatePattern = RegExp(
-  r'\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+(?:out\s+)?of\s+(?:the\s+)?'
+  r'\b(\d+)(?:\s*(?:m|mins?|minutes?))?\s+(?:out\s+)?of\s+'
+  r'(?:(?:an?|the)\s+)?(?:estimated\s+)?'
   r'(\d+)(?:\s+estimated)?\s*[-–—]?\s*(?:m|mins?|minutes?)\b',
   caseSensitive: false,
 );
@@ -1064,13 +1065,21 @@ bool _partialMentionIsNegated(String reason, Match match) {
 
 bool _partialMentionDescribesPlacement(String prose, Match match) {
   final wording = (match.group(0) ?? '').toLowerCase();
-  if (wording == 'partially' || wording == 'partly') return true;
-
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final prefix = prose.substring(range.start, match.start);
   final suffix = prose.substring(match.end, range.end);
+  if (wording == 'partially' || wording == 'partly') {
+    return RegExp(
+      r'^\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+      'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
+      r'fit(?:s|ting)?|defer(?:s|red|ring)?|done|unfinished)\b',
+      caseSensitive: false,
+    ).hasMatch(suffix);
+  }
+
   final followsCopula = RegExp(
-    r'\b(?:is|are|was|were|has\s+been|have\s+been|had\s+been|will\s+be)'
+    r'\b(?:(?:is|are|was|were)(?:\s+being)?|'
+    r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
     r'(?:\s+(?:only|merely|just|still))?\s*$',
     caseSensitive: false,
   ).hasMatch(prefix);
@@ -1089,7 +1098,7 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
 
 bool _tradeDispositionDescribesTaskOrWork(String prose, Match match) {
   final wording = (match.group(0) ?? '').toLowerCase();
-  if (!wording.startsWith('defer')) return true;
+  if (!wording.startsWith('defer') && wording != 'unscheduled') return true;
 
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final suffix = prose.substring(match.end, range.end);
@@ -1143,6 +1152,9 @@ bool _matchClauseIsNegated(String reason, Match match) {
           negationStart: negationStart,
           clauseEnd: range.end,
         )) {
+      continue;
+    }
+    if (negationStart >= match.end && RegExp('[–—]').hasMatch(between)) {
       continue;
     }
     if (negationStart >= match.end &&
@@ -1225,13 +1237,34 @@ bool _splitHasAffirmativeAllocation(String reason, Match match) {
     match,
     _taskAllocationActionPattern,
   );
-  if (action == null) return false;
+  if (action == null || !_allocationActionIsAsserted(reason, action)) {
+    return false;
+  }
   final omission = _nearestPatternMatch(
     reason,
     match,
     _omittedAllocationPattern,
   );
   return omission == null || action.distance < omission.distance;
+}
+
+bool _allocationActionIsAsserted(
+  String prose,
+  ({int start, int end, int distance}) action,
+) {
+  var clauseStart = 0;
+  for (var i = action.start - 1; i >= 0; i--) {
+    if (',.;!?\n'.contains(prose[i])) {
+      clauseStart = i + 1;
+      break;
+    }
+  }
+  final prefix = prose.substring(clauseStart, action.start);
+  return !RegExp(
+    r'\b(?:might|may|could|would|should|can)'
+    r'(?:\s+\w+){0,2}\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
 }
 
 bool _splitHasUnrelatedScope(
@@ -1571,12 +1604,7 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   }
   final namedCasualties = [
     for (final taskId in deferred)
-      if (_taskTradeIsNamed(
-        outcome,
-        taskId,
-        requireTradeDisclosure: shortenedTasks.contains(taskId),
-      ))
-        taskId,
+      if (_taskTradeIsNamed(outcome, taskId)) taskId,
   ];
   return EvalConstraintResult(
     id: id,
@@ -2115,8 +2143,9 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
     return false;
   }
   final subjectMatch = RegExp(
-    r'^(.*?)\s+(?:(?:is|are|was|were|has\s+been|have\s+been|had\s+been|'
-    r'will\s+be)(?:\s+(?:only|merely|just|still))?'
+    r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
+    r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
+    r'(?:\s+(?:only|merely|just|still))?'
     r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
     '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
@@ -2166,9 +2195,8 @@ bool _subjectStartsWithTaskReference(
 
 bool _taskTradeIsNamed(
   EvalRunOutcome outcome,
-  String taskId, {
-  required bool requireTradeDisclosure,
-}) {
+  String taskId,
+) {
   var hasAffirmativeNamedDisclosure = false;
   var hasDeniedNamedDisclosure = false;
   for (final block in outcome.blocks) {
@@ -2178,7 +2206,6 @@ bool _taskTradeIsNamed(
       final namesTask =
           _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
       if (!namesTask) continue;
-      if (!requireTradeDisclosure) return true;
       final evidence = _tradeDisclosureEvidence(outcome, taskId, prose);
       hasAffirmativeNamedDisclosure |= evidence.affirmative;
       hasDeniedNamedDisclosure |= evidence.denied;

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -706,7 +706,9 @@ final _partialOfEstimatePattern = RegExp(
 final _partialRemainingPattern = RegExp(
   r'\b(\d+)\s*(?:m|mins?|minutes?)\s+'
   r'(?:(?:of|for)\s+(?:this|the)\s+(?:task|work)\s+)?'
-  r'(?:(?:is|are|will(?:\s+be)?)\s+)?(?:left|remain(?:s|ing)?)\b',
+  r'(?:(?:still|yet)\s+)?'
+  r'(?:(?:is|are|will(?:\s+be)?)\s+)?'
+  r'(?:(?:still|yet)\s+)?(?:left|remain(?:s|ing)?)\b',
   caseSensitive: false,
 );
 
@@ -894,10 +896,10 @@ bool _isAuditedPartial(_EstimatedTaskPlacement placement) =>
 /// only when its concrete minute arithmetic agrees with both that duration and
 /// the corpus estimate. This accepts either an explicit `60m of 120m` split or
 /// the prompt's `partial` plus a task-bound `60m remain for later` form. Vague
-/// prose, unrelated day-capacity arithmetic, and contradictory numbers in
-/// either the reason or note keep the conservative full-estimate charge. Notes
-/// are audit evidence only: they can veto credit but cannot satisfy the prompt's
-/// reason-field disclosure contract.
+/// prose, `partial` used as an unrelated noun modifier, unrelated day-capacity
+/// arithmetic, and contradictory numbers in either the reason or note keep the
+/// conservative full-estimate charge. Notes are audit evidence only: they can
+/// veto credit but cannot satisfy the prompt's reason-field disclosure contract.
 bool _hasAuditablePartialDisclosure({
   required List<_PlacementDisclosure> disclosures,
   required int allocatedMinutes,
@@ -937,6 +939,7 @@ bool _hasAuditablePartialDisclosure({
       )) {
         continue;
       }
+      if (!_partialMentionDescribesPlacement(reason, match)) continue;
       if (_partialMentionIsNegated(reason, match)) return false;
       if (disclosure.canQualify) reasonMentionsPartial = true;
     }
@@ -1057,6 +1060,31 @@ bool _partialMentionIsNegated(String reason, Match match) {
     if (_wordPattern.allMatches(between).length <= 3) return true;
   }
   return false;
+}
+
+bool _partialMentionDescribesPlacement(String prose, Match match) {
+  final wording = (match.group(0) ?? '').toLowerCase();
+  if (wording == 'partially' || wording == 'partly') return true;
+
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final prefix = prose.substring(range.start, match.start);
+  final suffix = prose.substring(match.end, range.end);
+  final followsCopula = RegExp(
+    r'\b(?:is|are|was|were|has\s+been|have\s+been|had\s+been|will\s+be)'
+    r'(?:\s+(?:only|merely|just|still))?\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
+  final modifiesPlacementNoun = RegExp(
+    r'^\s+(?:task|work|placement|block|portion|part)\b',
+    caseSensitive: false,
+  ).hasMatch(suffix);
+  final isStandaloneLabelOrExplanation = RegExp(
+    r'^\s*(?:$|[:;,.\-–—!?]|(?:for|because|due\s+to|with|and)\b)',
+    caseSensitive: false,
+  ).hasMatch(suffix);
+  return followsCopula ||
+      modifiesPlacementNoun ||
+      isStandaloneLabelOrExplanation;
 }
 
 bool _negationQualifiesRatherThanNegates(Match negation, String between) {
@@ -1960,7 +1988,10 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
       );
 
   for (final match in _partialMentionPattern.allMatches(prose)) {
-    if (!belongsToTask(match)) continue;
+    if (!belongsToTask(match) ||
+        !_partialMentionDescribesPlacement(prose, match)) {
+      continue;
+    }
     if (_partialMentionIsNegated(prose, match)) {
       hasDeniedEvidence = true;
     } else {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1022,7 +1022,8 @@ bool _hasAuditablePartialDisclosure({
             taskId: taskId,
             taskTitle: taskTitle,
           ) ||
-          _remainderDescribesContinuity(reason, match)) {
+          _remainderDescribesContinuity(reason, match) ||
+          _evidenceIsSpeculative(reason, match)) {
         continue;
       }
       if (_evidenceNamesAnotherTask(
@@ -1055,7 +1056,8 @@ bool _hasAuditablePartialDisclosure({
             taskId: taskId,
             taskTitle: taskTitle,
           ) ||
-          _remainderDescribesContinuity(reason, match)) {
+          _remainderDescribesContinuity(reason, match) ||
+          _evidenceIsSpeculative(reason, match)) {
         continue;
       }
       if (_evidenceNamesAnotherTask(
@@ -1289,13 +1291,31 @@ bool _allocationActionIsDirectlyDenied(String prose, Match action) {
 }
 
 bool _evidenceIsSpeculative(String prose, Match match) {
-  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
-  final prefix = prose.substring(range.start, match.start);
-  return RegExp(
-    r'\b(?:might|may|could|would|should|can)'
-    r'(?:\s+\w+){0,2}\s*$',
+  return _evidenceStartIsSpeculative(prose, match.start);
+}
+
+bool _evidenceStartIsSpeculative(String prose, int evidenceStart) {
+  var clauseStart = 0;
+  for (var i = evidenceStart - 1; i >= 0; i--) {
+    if (',.;!?\n'.contains(prose[i])) {
+      clauseStart = i + 1;
+      break;
+    }
+  }
+  final prefix = prose.substring(clauseStart, evidenceStart);
+  for (final modal in RegExp(
+    r'\b(?:might|may|could|would|should|can)\b',
     caseSensitive: false,
-  ).hasMatch(prefix);
+  ).allMatches(prefix)) {
+    final complement = prefix.substring(modal.end);
+    if (!RegExp(
+      r'\b(?:and|but|yet|however|while|although|though|so|therefore|then)\b',
+      caseSensitive: false,
+    ).hasMatch(complement)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool _negationQualifiesRatherThanNegates(Match negation, String between) {
@@ -1473,11 +1493,7 @@ bool _allocationActionIsAsserted(
     }
   }
   final prefix = prose.substring(clauseStart, action.start);
-  return !RegExp(
-        r'\b(?:might|may|could|would|should|can)'
-        r'(?:\s+\w+){0,2}\s*$',
-        caseSensitive: false,
-      ).hasMatch(prefix) &&
+  return !_evidenceStartIsSpeculative(prose, action.start) &&
       !RegExp(
         r'\b(?:intend(?:s|ed|ing)?|aim(?:s|ed|ing)?|'
         'hop(?:e|es|ed|ing)|want(?:s|ed|ing)?|expect(?:s|ed|ing)?|'
@@ -1576,7 +1592,7 @@ bool _splitHasUnrelatedScope(
         !RegExp(
           r'^\s*(?:(?:is|are|was|were|will|be|been|being|has|have|had|'
           'only|just|merely|already|actually|currently|now|'
-          r'estimate|estimated)\s+)*$',
+          r'estimate|estimated|[a-z]+ly)\s+)*$',
           caseSensitive: false,
         ).hasMatch(reason.substring(evidence.end, start))) {
       continue;

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -919,6 +919,7 @@ bool _hasAuditablePartialDisclosure({
       reason,
       taskId: taskId,
       taskTitle: taskTitle,
+      corpus: corpus,
     )) {
       return false;
     }
@@ -1150,6 +1151,7 @@ bool _hasTaskBoundAllocationDenial(
   String prose, {
   required String taskId,
   required String taskTitle,
+  required List<EvalCorpusTask> corpus,
 }) {
   final placementActionPattern = RegExp(
     r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
@@ -1168,6 +1170,25 @@ bool _hasTaskBoundAllocationDenial(
         ) !=
         null) {
       return true;
+    }
+    final clause = prose.substring(range.start, range.end);
+    final explicitlyNamesOtherTask = corpus
+        .where((task) => task.taskId != taskId)
+        .any(
+          (task) => _taskReferencePatterns(
+            task.taskId,
+            task.title,
+          ).any((pattern) => pattern.hasMatch(clause)),
+        );
+    if (explicitlyNamesOtherTask) continue;
+    if (_evidenceNamesAnotherTask(
+      prose,
+      action,
+      taskId: taskId,
+      taskTitle: taskTitle,
+      corpus: corpus,
+    )) {
+      continue;
     }
     final prefix = prose.substring(range.start, action.start);
     if (RegExp(
@@ -1213,6 +1234,10 @@ bool _negationQualifiesRatherThanNegates(Match negation, String between) {
   }
   if (negator != 'not') return false;
   return RegExp(r'^\s*only\b', caseSensitive: false).hasMatch(between) ||
+      RegExp(
+        r'^\s*(?:fully|entirely|completely)\b',
+        caseSensitive: false,
+      ).hasMatch(between) ||
       RegExp(
         r'^\s*all\b.*\bfit(?:s|ting)?\b\s+'
         r'(?:so|therefore|thus|but)\s*$',
@@ -2318,6 +2343,7 @@ bool _tradeEvidenceHasExplicitNonTaskSubject(
     r'(?:\s+(?:only|merely|just|still))?'
     r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
+    '(?:has|have|had)|'
     '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
     r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',
     caseSensitive: false,

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -1013,10 +1013,7 @@ bool _evidenceNamesAnotherTask(
   );
   int? nearestOtherDistance;
   for (final task in corpus) {
-    if (task.taskId == taskId ||
-        task.title.trim().toLowerCase() == taskTitle.trim().toLowerCase()) {
-      continue;
-    }
+    if (task.taskId == taskId) continue;
     final distance = _nearestTaskReferenceDistance(
       reason,
       evidence,
@@ -1242,19 +1239,14 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
       'nothing was left out or partially deferred, so there is no trade to name',
     );
   }
-  final prose = [
-    for (final block in outcome.blocks)
-      '${block.reason ?? ''} ${block.note ?? ''}',
-  ].join(' ').toLowerCase();
-  final hasTradeDisclosure =
-      _partialMentionPattern.hasMatch(prose) ||
-      _partialRemainderDispositionPattern.hasMatch(prose) ||
-      _conflictTradePattern.hasMatch(prose);
   final namedCasualties = [
     for (final taskId in deferred)
-      if (prose.contains(taskId.toLowerCase()) ||
-          _titleNamed(outcome, taskId, prose))
-        if (!shortenedTasks.contains(taskId) || hasTradeDisclosure) taskId,
+      if (_taskTradeIsNamed(
+        outcome,
+        taskId,
+        requireTradeDisclosure: shortenedTasks.contains(taskId),
+      ))
+        taskId,
   ];
   return EvalConstraintResult(
     id: id,
@@ -1658,6 +1650,27 @@ Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
 bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
   final title = outcome.inputs.taskById(taskId)?.title.toLowerCase();
   return title != null && title.isNotEmpty && prose.contains(title);
+}
+
+bool _taskTradeIsNamed(
+  EvalRunOutcome outcome,
+  String taskId, {
+  required bool requireTradeDisclosure,
+}) {
+  for (final block in outcome.blocks) {
+    final prose = '${block.reason ?? ''} ${block.note ?? ''}'.toLowerCase();
+    final namesTask =
+        prose.contains(taskId.toLowerCase()) ||
+        _titleNamed(outcome, taskId, prose);
+    if (!namesTask) continue;
+    if (!requireTradeDisclosure ||
+        _partialMentionPattern.hasMatch(prose) ||
+        _partialRemainderDispositionPattern.hasMatch(prose) ||
+        _conflictTradePattern.hasMatch(prose)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// Blocks that consume capacity — `dropped` ones are recorded but not

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -985,6 +985,10 @@ bool _matchClauseIsNegated(String reason, Match match) {
         : negationStart >= match.end
         ? reason.substring(match.end, negationStart)
         : '';
+    if (negationStart >= match.end &&
+        _taskAllocationActionPattern.hasMatch(between)) {
+      continue;
+    }
     if (_wordPattern.allMatches(between).length <= 3 ||
         negationEnd <= match.start &&
             _taskAllocationActionPattern.hasMatch(between)) {
@@ -1002,7 +1006,12 @@ bool _splitIsTaskBound(
   required List<EvalCorpusTask> corpus,
 }) {
   return _splitHasAffirmativeAllocation(reason, match) &&
-      !_splitHasUnrelatedScope(reason, match) &&
+      !_splitHasUnrelatedScope(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+      ) &&
       !_evidenceNamesAnotherTask(
         reason,
         match,
@@ -1027,7 +1036,12 @@ bool _splitHasAffirmativeAllocation(String reason, Match match) {
   return omission == null || action.distance < omission.distance;
 }
 
-bool _splitHasUnrelatedScope(String reason, Match evidence) {
+bool _splitHasUnrelatedScope(
+  String reason,
+  Match evidence, {
+  required String taskId,
+  required String taskTitle,
+}) {
   final evidenceAction = _nearestPatternMatch(
     reason,
     evidence,
@@ -1035,6 +1049,14 @@ bool _splitHasUnrelatedScope(String reason, Match evidence) {
   );
   if (evidenceAction == null) return false;
   final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
+  final currentTaskDistance = _nearestTaskReferenceDistance(
+    reason,
+    evidence,
+    range: range,
+    taskId: taskId,
+    taskTitle: taskTitle,
+  );
+  if (currentTaskDistance != null) return false;
   for (final scope in _unrelatedRemainderScopePattern.allMatches(reason)) {
     if (scope.start < range.start || scope.end > range.end) continue;
     final scopeAction = _nearestPatternMatch(
@@ -1168,11 +1190,11 @@ bool _referenceAttributesEvidence(
     return trimmed.isEmpty ||
         _taskAllocationActionPattern.hasMatch(between) ||
         RegExp(
-          r'^(?:is|are|was|were)$',
+          r'^(?:is|are|was|were|will\s+be)$',
           caseSensitive: false,
         ).hasMatch(trimmed) ||
         RegExp(r'^[\x27’]s$', caseSensitive: false).hasMatch(trimmed) ||
-        RegExp(r'^[:–—-]+$').hasMatch(trimmed);
+        RegExp(r'^[,:–—-]+$').hasMatch(trimmed);
   }
   if (referenceStart < evidence.end) return true;
   final between = reason.substring(evidence.end, referenceStart);

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -763,15 +763,6 @@ final _unrelatedRemainderScopePattern = RegExp(
   caseSensitive: false,
 );
 
-final _unrelatedSplitScopePattern = RegExp(
-  r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))'
-  r'\b[^,.;!?]*\b(?:for|in|during)\s+'
-  r'(?:(?:the|a|an|my|our|their|your)\s+)?'
-  r'(?:meeting|workday|calendar|appointment|break)\b',
-  caseSensitive: false,
-);
-
 final _conflictTradePattern = RegExp(
   r'\b(?:omit(?:s|ted|ting)?|drop(?:s|ped|ping)?|left|remain(?:s|ed|ing)?|'
   'trade|conflict|shorten(?:s|ed|ing)?|'
@@ -1010,9 +1001,8 @@ bool _splitIsTaskBound(
   required String taskTitle,
   required List<EvalCorpusTask> corpus,
 }) {
-  final clause = _matchClause(reason, match);
   return _splitHasAffirmativeAllocation(reason, match) &&
-      !_unrelatedSplitScopePattern.hasMatch(clause) &&
+      !_splitHasUnrelatedScope(reason, match) &&
       !_evidenceNamesAnotherTask(
         reason,
         match,
@@ -1023,28 +1013,52 @@ bool _splitIsTaskBound(
 }
 
 bool _splitHasAffirmativeAllocation(String reason, Match match) {
-  final actionDistance = _nearestPatternDistance(
+  final action = _nearestPatternMatch(
     reason,
     match,
     _taskAllocationActionPattern,
   );
-  if (actionDistance == null) return false;
-  final omissionDistance = _nearestPatternDistance(
+  if (action == null) return false;
+  final omission = _nearestPatternMatch(
     reason,
     match,
     _omittedAllocationPattern,
   );
-  return omissionDistance == null || actionDistance < omissionDistance;
+  return omission == null || action.distance < omission.distance;
 }
 
-int? _nearestPatternDistance(
+bool _splitHasUnrelatedScope(String reason, Match evidence) {
+  final evidenceAction = _nearestPatternMatch(
+    reason,
+    evidence,
+    _taskAllocationActionPattern,
+  );
+  if (evidenceAction == null) return false;
+  final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
+  for (final scope in _unrelatedRemainderScopePattern.allMatches(reason)) {
+    if (scope.start < range.start || scope.end > range.end) continue;
+    final scopeAction = _nearestPatternMatch(
+      reason,
+      scope,
+      _taskAllocationActionPattern,
+    );
+    if (scopeAction != null &&
+        scopeAction.start == evidenceAction.start &&
+        scopeAction.end == evidenceAction.end) {
+      return true;
+    }
+  }
+  return false;
+}
+
+({int start, int end, int distance})? _nearestPatternMatch(
   String reason,
   Match evidence,
   RegExp pattern,
 ) {
   final range = _matchClauseRange(reason, evidence, boundaries: ',.;!?\n');
   final clause = reason.substring(range.start, range.end);
-  int? nearest;
+  ({int start, int end, int distance})? nearest;
   for (final match in pattern.allMatches(clause)) {
     final start = range.start + match.start;
     final end = range.start + match.end;
@@ -1053,7 +1067,9 @@ int? _nearestPatternDistance(
         : start >= evidence.end
         ? start - evidence.end
         : 0;
-    if (nearest == null || distance < nearest) nearest = distance;
+    if (nearest == null || distance < nearest.distance) {
+      nearest = (start: start, end: end, distance: distance);
+    }
   }
   return nearest;
 }
@@ -1175,8 +1191,8 @@ bool _referenceAttributesEvidence(
 
 bool _remainderIsTaskBound(String reason, Match match) {
   final clause = _matchClause(reason, match);
-  if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
   if (_unrelatedRemainderScopePattern.hasMatch(clause)) return false;
+  if (_partialRemainderDispositionPattern.hasMatch(clause)) return true;
   return _partialMentionPattern.hasMatch(reason);
 }
 
@@ -1729,14 +1745,47 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   caseSensitive: false,
 ).hasMatch(prose);
 
-bool _hasAffirmativeTradeDisclosure(String prose) {
+bool _hasAffirmativeTradeDisclosure(
+  EvalRunOutcome outcome,
+  String taskId,
+  String prose,
+) {
+  final task = outcome.inputs.taskById(taskId);
+  if (task == null) return false;
   for (final match in _partialMentionPattern.allMatches(prose)) {
+    if (_evidenceNamesAnotherTask(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    )) {
+      continue;
+    }
     if (!_partialMentionIsNegated(prose, match)) return true;
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
+    if (_evidenceNamesAnotherTask(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    )) {
+      continue;
+    }
     if (!_matchClauseIsNegated(prose, match)) return true;
   }
   for (final match in _conflictTradePattern.allMatches(prose)) {
+    if (_evidenceNamesAnotherTask(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+      corpus: outcome.inputs.corpus,
+    )) {
+      continue;
+    }
     final matchedTrade = match.group(0) ?? '';
     final negativeFitDisclosure =
         _negationWordPattern.hasMatch(matchedTrade) &&
@@ -1758,7 +1807,8 @@ bool _taskTradeIsNamed(
     final namesTask =
         _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
     if (!namesTask) continue;
-    if (!requireTradeDisclosure || _hasAffirmativeTradeDisclosure(prose)) {
+    if (!requireTradeDisclosure ||
+        _hasAffirmativeTradeDisclosure(outcome, taskId, prose)) {
       return true;
     }
   }

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -733,6 +733,15 @@ final _unrelatedRemainderScopePattern = RegExp(
   caseSensitive: false,
 );
 
+final _unrelatedSplitScopePattern = RegExp(
+  r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
+  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))'
+  r'\b[^,.;!?]*\b(?:for|in|during)\s+'
+  r'(?:(?:the|a|an|my|our|their|your)\s+)?'
+  r'(?:meeting|workday|calendar|appointment|break)\b',
+  caseSensitive: false,
+);
+
 typedef _EstimatedTaskPlacement = ({
   int allocatedMinutes,
   int estimateMinutes,
@@ -839,6 +848,7 @@ bool _hasAuditablePartialDisclosure({
       reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
+      if (!_splitIsTaskBound(reason, match)) continue;
       if (_matchClauseIsNegated(reason, match)) return false;
       final declaredAllocated = int.tryParse(match.group(1) ?? '');
       final declaredEstimate = int.tryParse(match.group(2) ?? '');
@@ -846,9 +856,7 @@ bool _hasAuditablePartialDisclosure({
           declaredEstimate != estimateMinutes) {
         return false;
       }
-      if (_splitIsTaskBound(reason, match)) {
-        hasMatchingSplit = true;
-      }
+      hasMatchingSplit = true;
     }
     for (final match in _partialRemainingPattern.allMatches(reason)) {
       if (!_remainderIsRelatedToTask(reason, match)) continue;
@@ -882,7 +890,9 @@ bool _matchClauseIsNegated(String reason, Match match) {
 }
 
 bool _splitIsTaskBound(String reason, Match match) {
-  return _taskAllocationContextPattern.hasMatch(_matchClause(reason, match));
+  final clause = _matchClause(reason, match);
+  return _taskAllocationContextPattern.hasMatch(clause) &&
+      !_unrelatedSplitScopePattern.hasMatch(clause);
 }
 
 bool _remainderIsTaskBound(String reason, Match match) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -653,25 +653,26 @@ EvalConstraintResult scoreWithinCapacityByEstimate(EvalRunOutcome outcome) {
       'no placed task carries an estimate',
     );
   }
-  final fullEstimateMinutes = placements.values.fold(
+  final scheduledMinutes = _scheduled(outcome).fold(
     0,
-    (total, placement) => total + placement.estimateMinutes,
+    (total, block) => total + block.duration.inMinutes,
   );
-  var chargedMinutes = 0;
+  var fullEstimateMinutes = scheduledMinutes;
+  var chargedMinutes = scheduledMinutes;
   final partials = <String>[];
   final undisclosedShortenings = <String>[];
   for (final entry in placements.entries) {
     final taskId = entry.key;
     final allocated = entry.value.allocatedMinutes;
     final estimate = entry.value.estimateMinutes;
+    fullEstimateMinutes += estimate - allocated;
     if (_isAuditedPartial(entry.value)) {
-      chargedMinutes += allocated;
       partials.add(
         '$taskId ${allocated}min partial of ${estimate}min '
         '(${estimate - allocated}min remain)',
       );
     } else {
-      chargedMinutes += estimate;
+      chargedMinutes += estimate - allocated;
       if (allocated > 0 && allocated < estimate) {
         undisclosedShortenings.add(
           '$taskId allocated ${allocated}min of ${estimate}min',
@@ -941,6 +942,7 @@ bool _hasAuditablePartialDisclosure({
         continue;
       }
       if (!_partialMentionDescribesPlacement(reason, match)) continue;
+      if (_partialMentionIsSpeculative(reason, match)) continue;
       if (_partialMentionIsNegated(reason, match)) return false;
       if (disclosure.canQualify) reasonMentionsPartial = true;
     }
@@ -1096,14 +1098,7 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
       isStandaloneLabelOrExplanation;
 }
 
-bool _tradeDispositionDescribesTaskOrWork(String prose, Match match) {
-  final wording = (match.group(0) ?? '').toLowerCase();
-  if (!wording.startsWith('defer') &&
-      wording != 'unscheduled' &&
-      !wording.startsWith('for later')) {
-    return true;
-  }
-
+bool _tradeEvidenceDescribesTaskOrWork(String prose, Match match) {
   final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
   final suffix = prose.substring(match.end, range.end);
   if (!RegExp(r'^\s+\w').hasMatch(suffix)) return true;
@@ -1113,9 +1108,19 @@ bool _tradeDispositionDescribesTaskOrWork(String prose, Match match) {
         caseSensitive: false,
       ).hasMatch(suffix) ||
       RegExp(
-        r'^\s+(?:to|until|for|because|after|before|so|and)\b',
+        r'^\s+(?:to|until|for|because|after|before|so|and|with|against|over)\b',
         caseSensitive: false,
       ).hasMatch(suffix);
+}
+
+bool _partialMentionIsSpeculative(String prose, Match match) {
+  final range = _matchClauseRange(prose, match, boundaries: ',.;!?\n');
+  final prefix = prose.substring(range.start, match.start);
+  return RegExp(
+    r'\b(?:might|may|could|would|should|can)'
+    r'(?:\s+\w+){0,2}\s*$',
+    caseSensitive: false,
+  ).hasMatch(prefix);
 }
 
 bool _negationQualifiesRatherThanNegates(Match negation, String between) {
@@ -2063,7 +2068,8 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
 
   for (final match in _partialMentionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
-        !_partialMentionDescribesPlacement(prose, match)) {
+        !_partialMentionDescribesPlacement(prose, match) ||
+        _partialMentionIsSpeculative(prose, match)) {
       continue;
     }
     if (_partialMentionIsNegated(prose, match)) {
@@ -2074,7 +2080,7 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
   }
   for (final match in _partialTradeDispositionPattern.allMatches(prose)) {
     if (!belongsToTask(match) ||
-        !_tradeDispositionDescribesTaskOrWork(prose, match)) {
+        !_tradeEvidenceDescribesTaskOrWork(prose, match)) {
       continue;
     }
     if (_matchClauseIsNegated(prose, match)) {
@@ -2122,6 +2128,8 @@ bool _taskIdNamed(String taskId, String prose) => RegExp(
       } else {
         hasAffirmativeEvidence = true;
       }
+    } else if (!_tradeEvidenceDescribesTaskOrWork(prose, match)) {
+      continue;
     } else if (_matchClauseIsNegated(prose, match)) {
       hasDeniedEvidence = true;
     } else {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2821,6 +2821,79 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('another task denial does not veto partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'task-d was not scheduled after all.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(taskId: 'task-d', title: 'Dependency'),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('qualified non-completion preserves partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c was not fully scheduled; '
+                  '60 of 120 minutes are scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+    });
+
+    test('a possessive meeting remainder cannot earn partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c is partial; '
+                  'the meeting has 60 minutes remaining.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test(
       'a standalone completion denial vetoes reason-field partial credit',
       () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1882,6 +1882,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a supposed-to allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was supposed to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final failedAction in [
       'unsuccessfully scheduled',
       'failed scheduling',
@@ -1920,6 +1941,29 @@ void main() {
               reason:
                   'task-c scheduled 60 of 120 minutes, but the allocation '
                   'failed.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects a failed action after the allocation arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c scheduled 60 of 120 minutes, but failed to '
+                  'allocate the task.',
             ),
           ],
           corpus: tasks,
@@ -3105,6 +3149,29 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a numeric remainder owned by an object complement', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial; task-c reviews a recording with '
+                  '60 minutes remaining.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('does not borrow a postpositive task partial label', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4140,6 +4207,27 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts an affirmative adverb after an omitted disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was omitted entirely due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     test('keeps a deferral despite another task causal negation', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4323,6 +4411,7 @@ void main() {
       'task-c failed to be omitted.',
       'task-c requires deferring.',
       'task-c was almost omitted.',
+      'task-c was supposed to be omitted.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -4774,6 +4863,33 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('rejects a fully omitted remainder owned by an object complement', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c reviews a recording with 120 minutes remaining.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
     test('accepts a contracted negative-fit disclosure', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -5096,6 +5212,28 @@ void main() {
               endHour: 10,
               reason: 'task-c cannot be scheduled.',
               note: "It is false that task-c can't be scheduled.",
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('normalizes equivalent inability scheduling denials', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was unable to be scheduled.',
+              note: 'It is false that task-c was unable to be scheduled.',
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
@@ -5605,6 +5743,34 @@ void main() {
               reason:
                   'Focused work on task-c; '
                   'the meeting is scheduled for later.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not borrow a future meeting scheduling denial', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c notes that the meeting will not be scheduled.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1443,6 +1443,12 @@ void main() {
             'Partial: 90 minutes of the 120-minute task are scheduled; '
             '30 minutes remain.',
       ),
+      (
+        name: 'matching split with a contradictory remainder',
+        reason:
+            'Partial: 60 minutes of the 120-minute task are scheduled; '
+            '30 minutes remain.',
+      ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {
         final result = scoreWithinCapacityByEstimate(
@@ -1667,6 +1673,66 @@ void main() {
       );
 
       expect(result.isApplicable, isFalse);
+    });
+
+    test('counts an audited partial remainder as deferred work', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason:
+                  'Partial: 60 minutes of the 120-minute Prepare the board '
+                  'deck estimate fit; 60 minutes remain for tomorrow.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-deck'));
+    });
+
+    test('an unnamed audited partial remainder does not surface the trade', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason:
+                  'Partial: 60 of 120 estimated minutes fit; '
+                  '60 minutes remain.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('passes when the escalation actually names the conflict', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1903,6 +1903,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a meant-to allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was meant to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final failedAction in [
       'unsuccessfully scheduled',
       'failed scheduling',
@@ -4412,6 +4433,7 @@ void main() {
       'task-c requires deferring.',
       'task-c was almost omitted.',
       'task-c was supposed to be omitted.',
+      'task-c was meant to be omitted.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1385,6 +1385,49 @@ void main() {
       expect(result.detail, contains('over by 120'));
     });
 
+    test('charges non-task blocks alongside estimated task work', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'primary',
+              startHour: 9,
+              endHour: 15,
+              taskId: 'task-primary',
+            ),
+            block(
+              id: 'partial',
+              startHour: 15,
+              endHour: 16,
+              taskId: 'task-c',
+              reason: 'Partial: 60 of 120 minutes are scheduled.',
+            ),
+            block(
+              id: 'buffer',
+              startHour: 16,
+              endHour: 17,
+              type: PlannedBlockType.buffer,
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-primary',
+              title: 'Primary',
+              estimateMinutes: 420,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('540min'));
+    });
+
     test(
       'charges an explicit partial placement at its represented minutes',
       () {
@@ -1525,6 +1568,29 @@ void main() {
               taskId: 'task-c',
               reason:
                   'task-c is partially dependent on the API; '
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects a modal partial-and-remainder claim', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c might be partially scheduled; '
                   '60 minutes remain for later.',
             ),
           ],
@@ -3526,6 +3592,39 @@ void main() {
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
     });
+
+    for (final reason in [
+      'task-c reviews trade policy.',
+      'task-c carries over balances from the old ledger.',
+    ]) {
+      test('does not treat domain prose as trade evidence: $reason', () {
+        final result = scoreSurfacedConflict(
+          outcome(
+            blocks: [
+              block(
+                id: 'task-c-block',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: reason,
+              ),
+            ],
+            corpus: const [
+              EvalCorpusTask(
+                taskId: 'task-c',
+                title: 'C',
+                estimateMinutes: 120,
+              ),
+            ],
+            decidedTaskIds: const ['task-c'],
+            requiresConflictSurfaced: true,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('without naming a casualty'));
+      });
+    }
 
     test('validates a fully omitted task remainder against its estimate', () {
       final result = scoreSurfacedConflict(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1834,6 +1834,29 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('charges a split allocated to another task', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are allocated to Task D; '
+                  'Task C is deferred.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('charges a remainder explicitly naming another task', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1863,6 +1886,27 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('charges omitted split arithmetic at the full estimate', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '30 of 120 minutes are unscheduled for this task.',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 9, 30)),
+          ],
+          corpus: tasks,
+          capacityMinutes: 30,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 30min of 120min'));
     });
 
     test('does not borrow another task partial mention', () {
@@ -2484,6 +2528,67 @@ void main() {
               endHour: 10,
               taskId: 'task-deck',
               reason: 'Focused work on Prepare the board deck.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not find a casualty id inside another task id', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c2 is deferred.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-c2',
+              title: 'C2',
+              estimateMinutes: 60,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('task binding prose alone does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'deck',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason: 'Focused work on task-deck for this task.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2263,6 +2263,28 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('rejects a task-labelled split allocated to a meeting', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c: 60 of 120 minutes are scheduled for the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('accepts a task qualifier before the remainder verb', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3647,6 +3669,40 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('keeps a deferral despite another task causal negation', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c was deferred because Deployment was not scheduled.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-d',
+              title: 'Deployment',
+              estimateMinutes: 60,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     test('accepts an omission from the day plan', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4511,6 +4567,34 @@ void main() {
             EvalCorpusTask(taskId: 'task-report', title: 'Report'),
           ],
           decidedTaskIds: const ['task-deck', 'task-report'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('a partial claim does not disclose a fully omitted task', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              type: PlannedBlockType.buffer,
+              reason: 'task-c is partial.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2621,6 +2621,27 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts for directly introducing allocation arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was scheduled for 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('rejects arithmetic not governing a later allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -5512,6 +5533,36 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c was left unfinished.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('denied left-out does not cancel left-unfinished', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c was not left out; '
+                  'task-c was left unfinished.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -4671,6 +4671,27 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts since after an omitted task disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was omitted since the day was full.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     test('accepts a postponed task as a deferred casualty', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4690,6 +4711,27 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, allOf(contains('task-c'), contains('deferred')));
+    });
+
+    test('accepts an unavoidable-choice omission', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'We had no choice but to omit task-c due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('accepts a task id as an active omission object', () {
@@ -4861,6 +4903,27 @@ void main() {
         result.detail,
         allOf(contains('task-a'), contains('task-b'), contains('task-c')),
       );
+    });
+
+    test('rejects a historical omitted-task disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'Yesterday, task-c was omitted due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('accepts an explicit not-scheduled trade', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1767,6 +1767,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects imperative allocation evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Schedule for 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('ignores a negator inside the current task title', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3511,6 +3532,29 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects split arithmetic owned by an object complement', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c reviews a meeting with '
+                  '60 of 120 minutes scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('does not borrow a postpositive task partial label', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3804,6 +3848,28 @@ void main() {
               taskId: 'task-c',
               reason: 'task-c scheduled 60 of 120 minutes.',
               note: 'task-c was fully scheduled yesterday.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('a historical allocation denial preserves current partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c scheduled 60 of 120 minutes.',
+              note: 'task-c was not scheduled yesterday.',
             ),
           ],
           corpus: tasks,
@@ -4827,6 +4893,27 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c'));
+    });
+
+    test('rejects an imperative omission object', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'Omit task-c due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('accepts a task id in a coordinated active omission object', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1503,6 +1503,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('allows a partial remainder qualified for today', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial for today: '
+                  '60 minutes remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts an inflected carry disposition for the remainder', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1700,6 +1723,10 @@ void main() {
         reason:
             '60 of the 120 minutes are scheduled for the meeting; '
             'this task is deferred.',
+      ),
+      (
+        name: 'unrelated estimated meeting arithmetic',
+        reason: 'The meeting used 60 of 120 estimated minutes.',
       ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1518,6 +1518,27 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('rejects a numeric suffix inside a formatted remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial: 1,060 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final modifier in ['more', 'additional']) {
       test('accepts a $modifier-minutes remainder modifier', () {
         final result = scoreWithinCapacityByEstimate(
@@ -2663,6 +2684,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('keeps declarative evidence before a trailing question', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c scheduled 60 of 120 minutes, '
+                  'but why force the rest?',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     for (final historicalScope in ['yesterday', 'last week']) {
       test('rejects allocation arithmetic scoped to $historicalScope', () {
         final result = scoreWithinCapacityByEstimate(
@@ -3427,6 +3471,28 @@ void main() {
               taskId: 'task-c',
               reason: '60 of 120 minutes are scheduled.',
               note: 'task-c was not scheduled after all.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('an outer falsehood split note vetoes partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c scheduled 60 of 120 minutes.',
+              note: 'It is false that task-c scheduled 60 of 120 minutes.',
             ),
           ],
           corpus: tasks,

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2320,6 +2320,50 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('audits a bare contradictory remainder in the note', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: '90 minutes remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('accepts a matching bare remainder in the note', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: '60 minutes remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts matching partial arithmetic in the note', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2960,6 +3004,62 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('does not treat a trade word inside the task title as evidence', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'migration',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-migration',
+              reason: 'Focused work on Partial index migration.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-migration',
+              title: 'Partial index migration',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-migration'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('accepts a trade outside a task title containing a trade word', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'migration',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-migration',
+              reason: 'Partial: Partial index migration.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-migration',
+              title: 'Partial index migration',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-migration'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-migration'));
+    });
+
     test('does not combine task naming and trade across fields', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -3134,6 +3234,118 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('left-unchanged continuity does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was left unchanged.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('left-unfinished disposition discloses a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was left unfinished.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('moving a block to a clock slot does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c moved to the 10:00 slot.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('moving a task to tomorrow discloses a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c moved to tomorrow.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('zero remainder does not disclose a shortening', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1589,6 +1589,27 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('rejects speculative remainder arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial; task-c might have 60 minutes remaining.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final wording in ['partially', 'partly']) {
       test('accepts $wording scheduled work with a matching remainder', () {
         final result = scoreWithinCapacityByEstimate(
@@ -2394,6 +2415,27 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('accepts an affirmative adverb in a trailing allocation bridge', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c: 60 of 120 minutes were successfully scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     test('accepts a task qualifier before the remainder verb', () {
@@ -3904,6 +3946,7 @@ void main() {
     for (final reason in [
       'task-c might be omitted.',
       'task-c could be deferred.',
+      'task-c may ultimately need to be deferred.',
     ]) {
       test('rejects a speculative trade disposition: $reason', () {
         final result = scoreSurfacedConflict(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1723,6 +1723,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a likely-to allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c is likely to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('rejects a progressive non-task partial subject', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4599,6 +4620,7 @@ void main() {
           corpus: dropped,
           decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
+          now: DateTime(2026, 7, 18, 8),
         ),
       );
 
@@ -4790,6 +4812,27 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('preserves a scheduling omission before causal negation', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c cannot be scheduled because no time remains.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     for (final inability in [
       'cannot be scheduled',
       "can't be scheduled",
@@ -4903,6 +4946,7 @@ void main() {
       'task-c was meant to be omitted.',
       'task-c was going to be omitted.',
       'task-c considered deferring.',
+      'task-c is likely to be omitted.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -5334,6 +5378,27 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c'));
+    });
+
+    test('tomorrow is not a deferral on a future-day plan', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c is scheduled for tomorrow.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('does not treat a trade object as a trade disposition', () {
@@ -6087,6 +6152,7 @@ void main() {
           ],
           decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
+          now: DateTime(2026, 7, 18, 8),
         ),
       );
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1443,6 +1443,31 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    for (final wording in ['partially', 'partly']) {
+      test('accepts $wording scheduled work with a matching remainder', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason:
+                    'task-c is $wording scheduled; '
+                    '60 minutes remain for later.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c 60min partial of 120min'));
+      });
+    }
+
     test('an objectively fitting partial remains objective', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2311,6 +2336,29 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects an adverbial partial claim owned by a meeting', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'The meeting was only partial; '
+                  '60 minutes remain for task-c.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('does not borrow a postpositive task partial label', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2419,29 +2467,32 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
-    test('accepts matching partial arithmetic in the note', () {
-      final result = scoreWithinCapacityByEstimate(
-        outcome(
-          blocks: [
-            block(
-              id: 'partial',
-              startHour: 9,
-              endHour: 10,
-              taskId: 'task-c',
-              reason: 'Focused work on task-c.',
-              note:
-                  'Partial: 60 of 120 minutes are scheduled; '
-                  '60 minutes remain for later.',
-            ),
-          ],
-          corpus: tasks,
-          capacityMinutes: 60,
-        ),
-      );
+    test(
+      'note-only partial arithmetic does not satisfy the reason contract',
+      () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: 'Focused work on task-c.',
+                note:
+                    'Partial: 60 of 120 minutes are scheduled; '
+                    '60 minutes remain for later.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
 
-      expect(result.passed, isTrue);
-      expect(result.detail, contains('task-c 60min partial of 120min'));
-    });
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-c allocated 60min of 120min'));
+      },
+    );
 
     test('preserves distinct task ids when titles collide', () {
       final result = scoreWithinCapacityByEstimate(
@@ -2665,6 +2716,38 @@ void main() {
         expect(result.detail, contains('over by 60'));
       });
     }
+
+    test('attributes arithmetic to another task with a short title', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'PR has 60 of 120 minutes scheduled.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-pr',
+              title: 'PR',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
 
     for (final estimate in <int?>[null, 0]) {
       test('is not applicable for a placed task with estimate $estimate', () {
@@ -3805,6 +3888,62 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('outer negation denies a cannot-fit disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'It is not true that task-c cannot fit.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('an unqualified cannot-fit disclosure surfaces the shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c cannot fit.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('does not find a casualty title inside another word', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1855,6 +1855,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects an inability-only allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was unable to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('preserves a scheduling denial after dash punctuation', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2885,6 +2906,28 @@ void main() {
               taskId: 'task-c',
               reason: '60 of 120 minutes are scheduled.',
               note: 'task-c was not scheduled after all.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('a full-completion note vetoes reason-field partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'task-c was fully scheduled after all.',
             ),
           ],
           corpus: tasks,
@@ -4585,6 +4628,34 @@ void main() {
               endHour: 10,
               type: PlannedBlockType.buffer,
               reason: 'task-c is partial.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('an avoided disposition does not disclose a fully omitted task', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              type: PlannedBlockType.buffer,
+              reason: 'task-c avoided being omitted.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1327,6 +1327,62 @@ void main() {
       expect(result.passed, isTrue);
     });
 
+    test('uses the clock-bounded planning window after a late start', () {
+      const lateTasks = [
+        EvalCorpusTask(
+          taskId: 'invoice',
+          title: 'Send invoice',
+          estimateMinutes: 30,
+        ),
+        EvalCorpusTask(
+          taskId: 'reply',
+          title: 'Reply to client',
+          estimateMinutes: 25,
+        ),
+        EvalCorpusTask(
+          taskId: 'migration',
+          title: 'Finish migration',
+          estimateMinutes: 180,
+        ),
+      ];
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'invoice',
+              startHour: 15,
+              endHour: 16,
+              taskId: 'invoice',
+            ).copyWith(
+              startTime: DateTime(2026, 7, 18, 15, 5),
+              endTime: DateTime(2026, 7, 18, 15, 35),
+            ),
+            block(
+              id: 'reply',
+              startHour: 15,
+              endHour: 16,
+              taskId: 'reply',
+            ).copyWith(
+              startTime: DateTime(2026, 7, 18, 15, 35),
+              endTime: DateTime(2026, 7, 18, 16),
+            ),
+            block(
+              id: 'migration',
+              startHour: 16,
+              endHour: 17,
+              taskId: 'migration',
+            ),
+          ],
+          corpus: lateTasks,
+          now: DateTime(2026, 7, 18, 15),
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('235min against 115min'));
+      expect(result.detail, contains('over by 120'));
+    });
+
     test(
       'charges an explicit partial placement at its represented minutes',
       () {
@@ -1390,6 +1446,52 @@ void main() {
               reason:
                   'Partial placement: 60 of 120 estimated minutes. '
                   'Remaining 60 min roll to a future day.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('allows unrelated negation outside the partial arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 60 of 120 minutes are scheduled, '
+                  'with no room for the remaining work.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts an inflected carry disposition for the remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial. '
+                  'Remaining 60 minutes are carried over to tomorrow.',
             ),
           ],
           corpus: tasks,
@@ -1488,6 +1590,12 @@ void main() {
         reason:
             'Partial progress is recorded; '
             '60 minutes remain in the workday.',
+      ),
+      (
+        name: 'an unrelated workday completed-estimate split',
+        reason:
+            'Only 60 of the 120 minutes are available in the workday; '
+            'this task is deferred.',
       ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2373,6 +2373,29 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects arithmetic not governing a later allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c reviewed 60 of 120 minutes of recordings '
+                  'before scheduling the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('accepts a task qualifier before the remainder verb', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2982,6 +3005,28 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('a speculative note denial does not veto partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'this task might not be scheduled after all.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     test('a full-completion note vetoes reason-field partial credit', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1781,6 +1781,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects an attempted allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c attempted to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('preserves a scheduling denial after dash punctuation', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2894,6 +2915,27 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: '30 of the 120 minutes remain for this task.',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 9, 30)),
+          ],
+          corpus: tasks,
+          capacityMinutes: 30,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 30min of 120min'));
+    });
+
+    test('does not treat a trailing schedule as completed allocation', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c: 30 of 120 minutes remain to be scheduled.',
             ).copyWith(endTime: DateTime(2026, 7, 18, 9, 30)),
           ],
           corpus: tasks,

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1486,6 +1486,31 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    for (final modifier in ['more', 'additional']) {
+      test('accepts a $modifier-minutes remainder modifier', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason:
+                    'This placement is partial; '
+                    '60 $modifier minutes remain for later.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c 60min partial of 120min'));
+      });
+    }
+
     test('accepts a still-remaining modifier in partial arithmetic', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1724,6 +1749,27 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c might schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects a failed allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c failed to schedule 60 of 120 minutes.',
             ),
           ],
           corpus: tasks,
@@ -2755,6 +2801,31 @@ void main() {
     });
 
     test(
+      'a standalone completion denial vetoes reason-field partial credit',
+      () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: '60 of 120 minutes are completed.',
+                note: 'task-c was not completed after all.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-c allocated 60min of 120min'));
+      },
+    );
+
+    test(
       'note-only partial arithmetic does not satisfy the reason contract',
       () {
         final result = scoreWithinCapacityByEstimate(
@@ -3384,6 +3455,53 @@ void main() {
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c'));
     });
+
+    test('accepts an omission from the day plan', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: "task-c was omitted from today's plan.",
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    for (final reason in [
+      'task-c might be omitted.',
+      'task-c could be deferred.',
+    ]) {
+      test('rejects a speculative trade disposition: $reason', () {
+        final result = scoreSurfacedConflict(
+          outcome(
+            blocks: [
+              block(
+                id: 'context',
+                startHour: 9,
+                endHour: 10,
+                reason: reason,
+              ),
+            ],
+            corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+            decidedTaskIds: const ['task-c'],
+            requiresConflictSurfaced: true,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('without naming a casualty'));
+      });
+    }
 
     test('is not applicable when nothing was actually left out', () {
       final result = scoreSurfacedConflict(
@@ -4495,6 +4613,34 @@ void main() {
             EvalCorpusTask(
               taskId: 'task-c',
               title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('without-conflict wording does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c proceeds without conflict.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
               estimateMinutes: 120,
             ),
           ],

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1531,6 +1531,27 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts a split after a negative fit quantifier', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Not all work fits so 60 of 120 minutes are scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('allows a later explanation that the full task cannot fit', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2928,6 +2949,62 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not borrow a meeting disposition in the same reason', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work on task-c; the meeting is deferred.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('accepts a remainder-subject disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work on task-c; the remainder is deferred.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('does not borrow another task future-tense trade', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1767,6 +1767,28 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects future-dated allocation evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c will schedule 60 of 120 minutes next week.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+          now: DateTime(2026, 7, 18, 8),
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('rejects imperative allocation evidence', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3771,6 +3793,45 @@ void main() {
       );
     }
 
+    test('a task-named reason on another block vetoes partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c scheduled 60 of 120 minutes.',
+            ),
+            block(
+              id: 'other-task',
+              startHour: 10,
+              endHour: 11,
+              taskId: 'task-d',
+              reason: 'task-c was fully scheduled after all.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-d',
+              title: 'Dependency',
+              estimateMinutes: 60,
+            ),
+          ],
+          capacityMinutes: 120,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('a speculative note denial does not veto partial credit', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4961,6 +5022,27 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts an exact task title that is also a non-task head', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'Meeting was omitted due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Meeting')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     test('accepts an affirmative adverb after an omitted disposition', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -5281,6 +5363,7 @@ void main() {
     for (final reason in [
       'task-c attempted to be omitted.',
       'task-c failed to be omitted.',
+      'task-c denied being omitted.',
       'task-c requires deferring.',
       'task-c was almost omitted.',
       'task-c was supposed to be omitted.',

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/day_plan.dart';
 
 import 'eval_constraints.dart';
@@ -1315,6 +1316,7 @@ void main() {
           blocks: [
             block(id: '1', startHour: 9, endHour: 13, taskId: 'task-a'),
             block(id: '2', startHour: 13, endHour: 16, taskId: 'task-b'),
+            block(id: 'break', startHour: 16, endHour: 17),
           ],
           corpus: tasks,
         ),
@@ -1322,6 +1324,231 @@ void main() {
 
       expect(result.passed, isTrue);
     });
+
+    test(
+      'charges an explicit partial placement at its represented minutes',
+      () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(id: '1', startHour: 9, endHour: 13, taskId: 'task-a'),
+              block(id: '2', startHour: 13, endHour: 16, taskId: 'task-b'),
+              block(
+                id: '3',
+                startHour: 16,
+                endHour: 17,
+                taskId: 'task-c',
+                reason:
+                    'Only 60m of the 120m estimate fits in the remaining slot. '
+                    'One candidate interview can be completed; the second and '
+                    'Task D are deferred.',
+              ),
+            ],
+            corpus: tasks,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c'));
+        expect(result.detail, contains('60min partial'));
+        expect(result.detail, contains('480min'));
+      },
+    );
+
+    test('accepts the prompt contract of partial plus concrete remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'This placement is partial; 60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts compact completed-of-estimate minute arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial placement: 60 of 120 estimated minutes. '
+                  'Remaining 60 min roll to a future day.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('audits a partial task across all of its scheduled blocks', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial-1',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 9, 30)),
+            block(
+              id: 'partial-2',
+              startHour: 10,
+              endHour: 11,
+              taskId: 'task-c',
+              reason: 'Only 60 minutes of the 120-minute estimate fit.',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 10, 30)),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    for (final badDisclosure in <({String name, String? reason})>[
+      (
+        name: 'vague partial prose',
+        reason: 'Partial interview work; finish the rest later.',
+      ),
+      (name: 'silent compression', reason: null),
+      (name: 'blank disclosure', reason: '   '),
+      (
+        name: 'concrete duration without a partial split',
+        reason: 'Scheduled 60 minutes for the interview task.',
+      ),
+      (
+        name: 'numbers that contradict the block',
+        reason:
+            'Partial: 90 minutes of the 120-minute task are scheduled; '
+            '30 minutes remain.',
+      ),
+    ]) {
+      test('charges ${badDisclosure.name} at the full estimate', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(id: '1', startHour: 9, endHour: 13, taskId: 'task-a'),
+              block(id: '2', startHour: 13, endHour: 16, taskId: 'task-b'),
+              block(
+                id: '3',
+                startHour: 16,
+                endHour: 17,
+                taskId: 'task-c',
+                reason: badDisclosure.reason,
+              ),
+            ],
+            corpus: tasks,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('540min'));
+        expect(result.detail, contains('over by 60'));
+      });
+    }
+
+    for (final estimate in <int?>[null, 0]) {
+      test('is not applicable for a placed task with estimate $estimate', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(id: 'unknown', startHour: 9, endHour: 10, taskId: 'task-x'),
+            ],
+            corpus: [
+              EvalCorpusTask(
+                taskId: 'task-x',
+                title: 'X',
+                estimateMinutes: estimate,
+              ),
+            ],
+          ),
+        );
+
+        expect(result.isApplicable, isFalse);
+        expect(result.detail, contains('no placed task carries an estimate'));
+      });
+    }
+
+    test('a zero-duration placeholder never earns partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'zero',
+              startHour: 9,
+              endHour: 9,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 0 minutes of the 120-minute task are scheduled; '
+                  '120 minutes remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 0,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('charged at 120min'));
+      expect(result.detail, isNot(contains('audited partials')));
+    });
+
+    glados.Glados<int>(
+      glados.any.intInRange(15, 106),
+      glados.ExploreConfig(numRuns: 120),
+    ).test('matching partial disclosures preserve capacity arithmetic', (
+      allocated,
+    ) {
+      const estimate = 120;
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial: $allocated minutes of the $estimate-minute task '
+                  'are scheduled; ${estimate - allocated} minutes remain.',
+            ).copyWith(
+              endTime: DateTime(2026, 7, 18, 9).add(
+                Duration(minutes: allocated),
+              ),
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: allocated,
+        ),
+      );
+
+      expect(
+        result.passed,
+        isTrue,
+        reason: 'allocated=$allocated, estimate=$estimate',
+      );
+    }, tags: 'glados');
   });
 
   group('requiredWorkPlaced', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1744,6 +1744,57 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects counterfactual allocation evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'If task-c were scheduled for 60 of 120 minutes, '
+                  'but it was not.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('ignores a negator inside the current task title', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'No-code prototype scheduled 60 of 120 minutes for today.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'No-code prototype',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('rejects a progressive non-task partial subject', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1526,6 +1526,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('ignores unrelated completed-estimate arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are scheduled for this task. '
+                  'The meeting used 15 of 30 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts a task qualifier before the remainder verb', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1641,6 +1664,12 @@ void main() {
         name: 'an unrelated workday completed-estimate split',
         reason:
             'Only 60 of the 120 minutes are available in the workday; '
+            'this task is deferred.',
+      ),
+      (
+        name: 'a completed-estimate split scheduled for a meeting',
+        reason:
+            '60 of the 120 minutes are scheduled for the meeting; '
             'this task is deferred.',
       ),
     ]) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1789,6 +1789,49 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects tomorrow-dated allocation evidence on a same-day run', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c will schedule 60 of 120 minutes tomorrow.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+          now: DateTime(2026, 7, 18, 8),
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('accepts tomorrow allocation evidence on a future-day run', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c will schedule 60 of 120 minutes tomorrow.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('rejects imperative allocation evidence', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3543,6 +3586,29 @@ void main() {
               reason:
                   'Partial; task-c reviews a recording with '
                   '60 minutes remaining.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects a numeric remainder owned by an unrelated subject', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  'the battery shows 60 minutes remaining.',
             ),
           ],
           corpus: tasks,
@@ -5776,6 +5842,34 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('does not treat plural conflict objects as trade dispositions', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c resolves conflicts.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
     test('accepts a task-bound scheduling-conflict noun', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -6261,6 +6355,28 @@ void main() {
               endHour: 10,
               reason: 'task-c was omitted due to capacity.',
               note: 'task-c was fully scheduled after all.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('normalizes synonymous cross-field omission denials', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was omitted due to capacity.',
+              note: 'task-c was not left out after all.',
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -3122,6 +3122,33 @@ void main() {
       );
     });
 
+    test('does not treat an allocation verb inside a task id as evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-fit',
+              reason: 'task-fit 60 of 120 minutes.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-fit',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-fit allocated 60min of 120min'));
+    });
+
     test('does not treat a partial index as capacity evidence', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3388,6 +3415,31 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test(
+      'an outer falsehood full-completion note preserves partial credit',
+      () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: '60 of 120 minutes are scheduled.',
+                note: 'It is false that task-c was fully scheduled.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c 60min partial of 120min'));
+      },
+    );
+
     test('a fully planned day note preserves task partial credit', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3399,6 +3451,28 @@ void main() {
               taskId: 'task-c',
               reason: '60 of 120 minutes are scheduled.',
               note: 'Fully planned day.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('a fully planned possessive day note preserves partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'Fully planned our day.',
             ),
           ],
           corpus: tasks,
@@ -3539,6 +3613,27 @@ void main() {
               reason:
                   'task-c is partial; '
                   'the meeting leaves 60 minutes remaining.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('a possessive task meeting cannot own allocation arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: "task-c's meeting has 60 of 120 minutes scheduled.",
             ),
           ],
           corpus: tasks,

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1909,6 +1909,32 @@ void main() {
       expect(result.detail, contains('task-c allocated 30min of 120min'));
     });
 
+    test(
+      'does not borrow a later allocation action for omitted arithmetic',
+      () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason:
+                    '30 of 120 minutes are omitted while the rest is '
+                    'scheduled for this task.',
+              ).copyWith(endTime: DateTime(2026, 7, 18, 9, 30)),
+            ],
+            corpus: tasks,
+            capacityMinutes: 30,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-c allocated 30min of 120min'));
+      },
+    );
+
     test('does not borrow another task partial mention', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2599,6 +2625,62 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('negated partial does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c is not partial.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('denied conflict does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'There is no conflict for task-c.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1477,6 +1477,18 @@ void main() {
             '60 of the 120 minutes are not scheduled; '
             'this block is only a placeholder.',
       ),
+      (
+        name: 'an uncontracted cannot-negated split',
+        reason:
+            '60 of the 120 minutes cannot be scheduled; '
+            'this block is only a placeholder.',
+      ),
+      (
+        name: 'an unrelated workday remainder',
+        reason:
+            'Partial progress is recorded; '
+            '60 minutes remain in the workday.',
+      ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {
         final result = scoreWithinCapacityByEstimate(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1865,6 +1865,38 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('preserves distinct task ids when titles collide', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: "task-d's 60 of 120 minutes are scheduled.",
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Review',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-d',
+              title: 'Review',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('charges remaining-of-estimate prose at the full estimate', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2431,6 +2463,41 @@ void main() {
               endHour: 10,
               taskId: 'task-deck',
               reason: 'Focused work on Prepare the board deck.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('unrelated trade prose does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'deck',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason: 'Focused work on Prepare the board deck.',
+            ),
+            block(
+              id: 'buffer',
+              startHour: 10,
+              endHour: 11,
+              type: PlannedBlockType.buffer,
+              reason: 'Keep the remaining hour open for email.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2438,6 +2438,28 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('rejects a negative adverb in a trailing allocation bridge', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c: 60 of 120 minutes were unsuccessfully scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('accepts a task qualifier before the remainder verb', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3091,6 +3113,28 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('a fully planned day note preserves task partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'Fully planned day.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     test('another task denial does not veto partial credit', () {
@@ -4333,6 +4377,33 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c'));
+    });
+
+    test('rejects a speculative fully omitted task remainder', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c may leave a remainder: 120 minutes.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('accepts a future-tense negative-fit disclosure', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1508,6 +1508,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts affirmative not-only allocation wording', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Not only are 60 of 120 minutes scheduled; '
+                  'the remainder is deferred.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('allows a later explanation that the full task cannot fit', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1589,6 +1612,29 @@ void main() {
               reason:
                   'This placement is partial; '
                   '60 minutes will remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts a future passive partial remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  '60 minutes will be left for tomorrow.',
             ),
           ],
           corpus: tasks,
@@ -1964,6 +2010,27 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'For task-d, 60 of 120 minutes are scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('charges a has-linked split to the named task', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-d has 60 of 120 minutes scheduled.',
             ),
           ],
           corpus: tasks,
@@ -2784,6 +2851,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c remains scheduled as planned.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('zero remainder does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c: 0 minutes remain; everything is complete.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1514,6 +1514,52 @@ void main() {
       });
     }
 
+    test('does not treat partial dependency as placement evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c is partially dependent on the API; '
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects a progressive non-task partial subject', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'The meeting is being partially scheduled; '
+                  '60 minutes remain for task-c.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('an objectively fitting partial remains objective', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1579,6 +1625,48 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts a prepositive estimate qualifier', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 minutes of an estimated 120 minutes are scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('rejects speculative partial arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c might schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
     test('allows unrelated negation outside the partial arithmetic', () {
@@ -3362,6 +3450,34 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('does not treat unscheduled maintenance as trade evidence', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c documents unscheduled maintenance.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
     test('accepts a trade outside a task title containing a trade word', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -3731,6 +3847,33 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('a bare mention does not disclose a fully omitted task', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-deck-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason:
+                  'Focused on task-deck after reviewing '
+                  'task-report requirements.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(taskId: 'task-deck', title: 'Deck'),
+            EvalCorpusTask(taskId: 'task-report', title: 'Report'),
+          ],
+          decidedTaskIds: const ['task-deck', 'task-report'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -3137,6 +3137,28 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('a fully planned-for-day note preserves task partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'Fully planned for the day.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('another task denial does not veto partial credit', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3279,6 +3301,28 @@ void main() {
         expect(result.detail, contains('task-c allocated 60min of 120min'));
       },
     );
+
+    test('a subjectless completion denial vetoes partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are completed.',
+              note: 'Not completed after all.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
 
     test(
       'note-only partial arithmetic does not satisfy the reason contract',
@@ -3987,10 +4031,33 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts an omission before a contrast predicate', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason:
+                  'task-c was omitted but the remaining plan stayed intact.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     for (final reason in [
       'task-c might be omitted.',
       'task-c could be deferred.',
       'task-c may ultimately need to be deferred.',
+      'task-c may need to be shortened and ultimately deferred.',
     ]) {
       test('rejects a speculative trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -4367,6 +4434,27 @@ void main() {
               startHour: 9,
               endHour: 10,
               reason: "task-c doesn't fit today.",
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'C')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('accepts label punctuation before negative-fit disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c: Cannot fit today.',
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'C')],

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1876,6 +1876,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects an avoided allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c avoided scheduling 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('preserves a scheduling denial after dash punctuation', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2965,6 +2986,28 @@ void main() {
       );
 
       expect(result.passed, isTrue);
+    });
+
+    test('a meeting denial with a task modifier does not veto credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'The meeting for task-c was not scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     test('qualified non-completion preserves partial credit', () {
@@ -4149,6 +4192,34 @@ void main() {
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'C')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('accepts a future-tense negative-fit disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              type: PlannedBlockType.buffer,
+              reason: 'task-c will not fit today.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
           decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1897,6 +1897,29 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a passively prevented allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c was prevented from being scheduled '
+                  'for 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('preserves a scheduling denial after dash punctuation', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2316,6 +2339,29 @@ void main() {
               taskId: 'task-c',
               reason:
                   'task-c: 60 of 120 minutes are scheduled for the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects arithmetic not governed by the allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c scheduled the meeting after reviewing '
+                  '60 of 120 minutes of recordings.',
             ),
           ],
           corpus: tasks,
@@ -4727,6 +4773,34 @@ void main() {
               endHour: 10,
               type: PlannedBlockType.buffer,
               reason: 'task-c avoided being omitted.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('an avoided getting-complement does not disclose an omission', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              type: PlannedBlockType.buffer,
+              reason: 'task-c avoided getting omitted.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1641,6 +1641,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('keeps a valid split beside separate meeting allocation', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are scheduled for this task while '
+                  '30 minutes are scheduled for the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts a task qualifier before the remainder verb', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1934,6 +1957,29 @@ void main() {
         expect(result.detail, contains('task-c allocated 30min of 120min'));
       },
     );
+
+    test('does not bind a meeting remainder through a later disposition', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial; 60 minutes remain for the meeting while '
+                  'task-c is deferred.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
 
     test('does not borrow another task partial mention', () {
       final result = scoreWithinCapacityByEstimate(
@@ -2625,6 +2671,39 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not borrow another task trade in the same reason', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work on task-c; task-d is deferred.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-d',
+              title: 'D',
+              estimateMinutes: 60,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1539,6 +1539,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a positive match inside a negative remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial: -60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final modifier in ['more', 'additional']) {
       test('accepts a $modifier-minutes remainder modifier', () {
         final result = scoreWithinCapacityByEstimate(
@@ -4594,6 +4615,48 @@ void main() {
               startHour: 9,
               endHour: 10,
               reason: 'task-c was omitted due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('accepts a task id as an active omission object', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'We omitted task-c due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('accepts a full task title as an active omission object', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'We omitted Core due to capacity.',
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1887,6 +1887,52 @@ void main() {
       });
     }
 
+    test('rejects an allocation failure after the arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c scheduled 60 of 120 minutes, but the allocation '
+                  'failed.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('ignores a non-task allocation failure after arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c scheduled 60 of 120 minutes, but the meeting '
+                  'allocation failed.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('rejects an attempted allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2511,6 +2557,29 @@ void main() {
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
+
+    for (final auxiliary in ['do', 'does', 'did']) {
+      test('accepts an emphatic $auxiliary allocation bridge', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: 'task-c: 60 of 120 minutes $auxiliary fit.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c 60min partial of 120min'));
+      });
+    }
 
     test('rejects a negative adverb in a trailing allocation bridge', () {
       final result = scoreWithinCapacityByEstimate(
@@ -4126,6 +4195,35 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    for (final inability in [
+      'cannot be scheduled',
+      "can't be scheduled",
+      "couldn't be scheduled",
+      'was unable to be scheduled',
+      "wasn't able to be scheduled",
+    ]) {
+      test('accepts an inability-based scheduling omission: $inability', () {
+        final result = scoreSurfacedConflict(
+          outcome(
+            blocks: [
+              block(
+                id: 'context',
+                startHour: 9,
+                endHour: 10,
+                reason: 'task-c $inability due to capacity.',
+              ),
+            ],
+            corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+            decidedTaskIds: const ['task-c'],
+            requiresConflictSurfaced: true,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c'));
+      });
+    }
+
     test('rejects a denial of an explicit not-scheduled trade', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4491,6 +4589,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c formats notes for later reference.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not treat a terminal purpose phrase as trade evidence', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c formats notes for later.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1533,6 +1533,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts a leading exact-cap allocation', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'No more than 60 of 120 minutes are scheduled; '
+                  '60 minutes remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts affirmative not-only allocation wording', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1736,6 +1759,29 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('rejects a partial claim owned by a meeting', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'The meeting is partial. '
+                  '60 minutes remain for task-c.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
     test('charges a countdown before a meeting at the full estimate', () {
@@ -2914,6 +2960,93 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('does not combine task naming and trade across fields', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work on task-c.',
+              note: 'Partial attendance only.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('accepts a task-named trade in the note', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work.',
+              note: 'task-c is partial.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('rejects contradictory task-named claims across fields', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c is partial.',
+              note: 'task-c is not partial.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
     test('does not find a casualty id inside another task id', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -3092,6 +3225,36 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('does not borrow a scheduled meeting disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Focused work on task-c; '
+                  'the meeting is scheduled for later.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
     test('accepts a remainder-subject disposition', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -3180,6 +3343,72 @@ void main() {
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
     });
+
+    for (final reason in [
+      'task-c is partial; task-c is not partial.',
+      'task-c is not partial; task-c is partial.',
+    ]) {
+      test('contradictory partial claims do not disclose: $reason', () {
+        final result = scoreSurfacedConflict(
+          outcome(
+            blocks: [
+              block(
+                id: 'task-c-block',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: reason,
+              ),
+            ],
+            corpus: const [
+              EvalCorpusTask(
+                taskId: 'task-c',
+                title: 'C',
+                estimateMinutes: 120,
+              ),
+            ],
+            decidedTaskIds: const ['task-c'],
+            requiresConflictSurfaced: true,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('without naming a casualty'));
+      });
+    }
+
+    for (final reason in [
+      'task-c conflicts with the client meeting.',
+      'task-c is conflicting with the meeting.',
+    ]) {
+      test('accepts an inflected conflict disclosure: $reason', () {
+        final result = scoreSurfacedConflict(
+          outcome(
+            blocks: [
+              block(
+                id: 'task-c-block',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: reason,
+              ),
+            ],
+            corpus: const [
+              EvalCorpusTask(
+                taskId: 'task-c',
+                title: 'C',
+                estimateMinutes: 120,
+              ),
+            ],
+            decidedTaskIds: const ['task-c'],
+            requiresConflictSurfaced: true,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c'));
+      });
+    }
 
     test('denied conflict does not disclose a shortening', () {
       final result = scoreSurfacedConflict(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1329,6 +1329,38 @@ void main() {
       expect(result.passed, isTrue);
     });
 
+    test('an overlong allocation cannot cancel another estimate shortfall', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(id: 'long', startHour: 9, endHour: 13, taskId: 'task-long'),
+            block(
+              id: 'short',
+              startHour: 13,
+              endHour: 17,
+              taskId: 'task-short',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-long',
+              title: 'Long allocation',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-short',
+              title: 'Short allocation',
+              estimateMinutes: 360,
+            ),
+          ],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('600min'));
+      expect(result.detail, contains('over by 120'));
+    });
+
     test('uses the clock-bounded planning window after a late start', () {
       const lateTasks = [
         EvalCorpusTask(
@@ -2883,6 +2915,29 @@ void main() {
               reason:
                   'task-c is partial; '
                   'the meeting has 60 minutes remaining.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('a meeting that leaves a remainder cannot earn partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c is partial; '
+                  'the meeting leaves 60 minutes remaining.',
             ),
           ],
           corpus: tasks,

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1526,6 +1526,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts a future-tense partial remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  '60 minutes will remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts an inflected carry disposition for the remainder', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1701,6 +1724,12 @@ void main() {
             'this block is only a placeholder.',
       ),
       (
+        name: 'a long-form negated completed-estimate split',
+        reason:
+            'We do not have enough room to schedule '
+            '60 of the 120 minutes for this task.',
+      ),
+      (
         name: 'an unrelated workday remainder',
         reason:
             'Partial progress is recorded; '
@@ -1727,6 +1756,12 @@ void main() {
       (
         name: 'unrelated estimated meeting arithmetic',
         reason: 'The meeting used 60 of 120 estimated minutes.',
+      ),
+      (
+        name: 'another task completed-estimate split',
+        reason:
+            'Task D completed 60 of 120 minutes; '
+            'Task C is deferred.',
       ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1503,6 +1503,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('allows a partial explanation with a negative quantifier', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial because not all work fits; '
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('allows a partial remainder qualified for today', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1683,6 +1706,36 @@ void main() {
               reason:
                   '60 of 120 minutes are scheduled while '
                   'Prepare the board deck is deferred.',
+            ),
+          ],
+          corpus: const [
+            ...tasks,
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('keeps ownership when a deferred casualty appears first', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Although Prepare the board deck is deferred, '
+                  '60 of 120 minutes are scheduled for this task.',
             ),
           ],
           corpus: const [
@@ -2319,6 +2372,47 @@ void main() {
         ),
       );
 
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('an undisclosed shortening still requires a named casualty', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'deck',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason: 'Focused work.',
+            ),
+            block(
+              id: 'report',
+              startHour: 10,
+              endHour: 11,
+              taskId: 'task-report',
+              reason: 'Focused work.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-report',
+              title: 'Close the quarterly',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-deck', 'task-report'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.isApplicable, isTrue);
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
     });

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -3546,6 +3546,28 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('a historical full-completion note preserves partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c scheduled 60 of 120 minutes.',
+              note: 'task-c was fully scheduled yesterday.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test(
       'an outer falsehood full-completion note preserves partial credit',
       () {
@@ -4731,6 +4753,48 @@ void main() {
         expect(result.detail, contains('without naming a casualty'));
       });
     }
+
+    test('rejects a long-form negated trade complement', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c never actually got around to omitting the task.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('rejects an interrogative trade disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'Was task-c omitted?',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
 
     test('is not applicable when nothing was actually left out', () {
       final result = scoreSurfacedConflict(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2732,6 +2732,28 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('a standalone note denial vetoes reason-field partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled.',
+              note: 'task-c was not scheduled after all.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test(
       'note-only partial arithmetic does not satisfy the reason contract',
       () {
@@ -3012,6 +3034,39 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('does not treat an article as a one-letter task title', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 60 minutes of a 120-minute estimate are scheduled.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-a',
+              title: 'A',
+              estimateMinutes: 60,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     for (final estimate in <int?>[null, 0]) {
@@ -3307,6 +3362,27 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-deck'));
+    });
+
+    test('accepts a causal qualifier after an omitted task disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was omitted due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('is not applicable when nothing was actually left out', () {
@@ -3665,6 +3741,62 @@ void main() {
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'C')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('does not bind a payload negative-fit claim to the named task', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c validates that the payload cannot fit in memory.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('a denied disposition does not cancel a different asserted one', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was not dropped; it was deferred to tomorrow.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'Core',
+              estimateMinutes: 120,
+            ),
+          ],
           decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -17,6 +17,7 @@ void main() {
     required int startHour,
     required int endHour,
     String? taskId,
+    String? note,
     String? reason,
     String? title,
     PlannedBlockType type = PlannedBlockType.ai,
@@ -27,6 +28,7 @@ void main() {
     startTime: DateTime(2026, 7, 18, startHour),
     endTime: DateTime(2026, 7, 18, endHour),
     taskId: taskId,
+    note: note,
     reason: reason,
     title: title ?? id,
     type: type,
@@ -1441,6 +1443,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('an objectively fitting partial remains objective', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 60 of 120 minutes are scheduled; '
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.heuristic, isFalse);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts compact completed-of-estimate minute arithmetic', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2183,6 +2208,94 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('does not borrow a postpositive task partial label', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial: task-d; 60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('accepts a postpositive current-task partial label', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial: task-c; 60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('audits contradictory remainder arithmetic in the note', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial: 60 of 120 minutes are scheduled.',
+              note: '90 minutes remain for this task.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('accepts matching partial arithmetic in the note', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work on task-c.',
+              note:
+                  'Partial: 60 of 120 minutes are scheduled; '
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     test('preserves distinct task ids when titles collide', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2125,6 +2125,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('ignores a postpositive non-task allocation failure', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c scheduled 60 of 120 minutes, but the allocation '
+                  'failed for the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('rejects an attempted allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4755,6 +4778,30 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts a task id in a coordinated active omission object', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'We omitted task-a and task-c due to capacity.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(taskId: 'task-a', title: 'Alpha'),
+            EvalCorpusTask(taskId: 'task-c', title: 'Core'),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
     test('accepts a full task title as an active omission object', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -5816,6 +5863,27 @@ void main() {
               estimateMinutes: 120,
             ),
           ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('ends negation at a contrastive replacement disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was not dropped but deferred to a later day.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
           decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -19,6 +19,7 @@ void main() {
     String? taskId,
     String? reason,
     String? title,
+    PlannedBlockType type = PlannedBlockType.ai,
     PlannedBlockState state = PlannedBlockState.drafted,
   }) => PlannedBlock(
     id: id,
@@ -28,6 +29,7 @@ void main() {
     taskId: taskId,
     reason: reason,
     title: title ?? id,
+    type: type,
     state: state,
   );
 
@@ -1449,6 +1451,20 @@ void main() {
             'Partial: 60 minutes of the 120-minute task are scheduled; '
             '30 minutes remain.',
       ),
+      (
+        name: 'matching split with a contradictory prefix remainder',
+        reason:
+            'Partial: 60 of 120 estimated minutes are scheduled. '
+            'Remaining 30 min move to tomorrow.',
+      ),
+      (
+        name: 'a negated partial disclosure',
+        reason: 'This is not a partial placement; 60 minutes remain for later.',
+      ),
+      (
+        name: 'a contracted negated partial disclosure',
+        reason: "This isn't a partial placement; 60 minutes remain for later.",
+      ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {
         final result = scoreWithinCapacityByEstimate(
@@ -1519,6 +1535,90 @@ void main() {
       expect(result.detail, contains('charged at 120min'));
       expect(result.detail, isNot(contains('audited partials')));
     });
+
+    test('a token placement never earns partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(id: 'a', startHour: 9, endHour: 13, taskId: 'task-a'),
+            block(id: 'b', startHour: 13, endHour: 16, taskId: 'task-b'),
+            block(
+              id: 'token',
+              startHour: 16,
+              endHour: 17,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 1 minute of the 120-minute task is scheduled; '
+                  '119 minutes remain.',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 16, 1)),
+            block(
+              id: 'substantive',
+              startHour: 16,
+              endHour: 17,
+              taskId: 'task-d',
+              reason:
+                  'Partial: 59 minutes of the 180-minute task are scheduled; '
+                  '121 minutes remain.',
+            ).copyWith(
+              startTime: DateTime(2026, 7, 18, 16, 1),
+            ),
+          ],
+          corpus: tasks,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 1min of 120min'));
+    });
+
+    test('the 10 percent boundary is a substantive partial placement', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'boundary',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 12 minutes of the 120-minute task are scheduled; '
+                  '108 minutes remain.',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 9, 12)),
+          ],
+          corpus: tasks,
+          capacityMinutes: 12,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 12min partial of 120min'));
+    });
+
+    for (final type in [PlannedBlockType.buffer, PlannedBlockType.cal]) {
+      test('${type.name} blocks do not count as estimated task placements', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'non-work',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason:
+                    'Partial: 60 minutes of the 120-minute task are scheduled; '
+                    '60 minutes remain.',
+                type: type,
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.isApplicable, isFalse);
+        expect(result.detail, contains('no placed task carries an estimate'));
+      });
+    }
 
     glados.Glados<int>(
       glados.any.intInRange(15, 106),

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1981,6 +1981,10 @@ void main() {
             'Task D completed 60 of 120 minutes; '
             'Task C is deferred.',
       ),
+      (
+        name: 'another task possessive completed-estimate split',
+        reason: "task-d's 60 of 120 minutes are scheduled.",
+      ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {
         final result = scoreWithinCapacityByEstimate(
@@ -2413,6 +2417,34 @@ void main() {
       );
 
       expect(result.isApplicable, isTrue);
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('naming shortened work without a trade does not surface it', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'deck',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-deck',
+              reason: 'Focused work on Prepare the board deck.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
     });

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2034,6 +2034,28 @@ void main() {
       });
     }
 
+    test('rejects a trailing allocation failure qualifier', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c: 60 of 120 minutes were scheduled unsuccessfully.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('rejects an allocation failure after the arithmetic', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4649,6 +4671,27 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts a postponed task as a deferred casualty', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was postponed due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, allOf(contains('task-c'), contains('deferred')));
+    });
+
     test('accepts a task id as an active omission object', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4791,6 +4834,35 @@ void main() {
       expect(result.detail, allOf(contains('task-c'), contains('task-d')));
     });
 
+    test('accepts an Oxford-comma task omission subject', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason:
+                  'task-a, task-b, and task-c were omitted due to capacity.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(taskId: 'task-a', title: 'Alpha'),
+            EvalCorpusTask(taskId: 'task-b', title: 'Beta'),
+            EvalCorpusTask(taskId: 'task-c', title: 'Core'),
+          ],
+          decidedTaskIds: const ['task-a', 'task-b', 'task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(
+        result.detail,
+        allOf(contains('task-a'), contains('task-b'), contains('task-c')),
+      );
+    });
+
     test('accepts an explicit not-scheduled trade', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4875,6 +4947,27 @@ void main() {
               reason:
                   'It is not true that task-c was not scheduled due to '
                   'capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('rejects neither-nor trade dispositions', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was neither omitted nor deferred.',
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1924,6 +1924,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a going-to allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was going to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final failedAction in [
       'unsuccessfully scheduled',
       'failed scheduling',
@@ -4434,6 +4455,7 @@ void main() {
       'task-c was almost omitted.',
       'task-c was supposed to be omitted.',
       'task-c was meant to be omitted.',
+      'task-c was going to be omitted.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -5976,6 +5998,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'There is no conflict for task-c.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('outer falsehood denies a positive conflict disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'It is false that task-c conflicts.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1503,6 +1503,52 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('ignores unrelated remainder arithmetic in another subject', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are scheduled for this task. '
+                  '15 minutes remain in the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts a task qualifier before the remainder verb', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  '60 minutes of this task remain for tomorrow.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('audits a partial task across all of its scheduled blocks', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1813,6 +1813,33 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    for (final obligation in [
+      'must schedule',
+      'needs to schedule',
+      'is required to schedule',
+    ]) {
+      test('rejects obligation-only allocation: $obligation', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: 'task-c $obligation 60 of 120 minutes.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-c allocated 60min of 120min'));
+      });
+    }
+
     test('rejects a failed allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2392,6 +2419,27 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('accepts an exact modifier before allocation arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c scheduled exactly 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
     test('rejects arithmetic not governing a later allocation action', () {
@@ -4029,6 +4077,50 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c'));
+    });
+
+    test('accepts an explicit not-scheduled trade', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was not scheduled due to capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('rejects a denial of an explicit not-scheduled trade', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason:
+                  'It is not true that task-c was not scheduled due to '
+                  'capacity.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('accepts an omission before a contrast predicate', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1465,6 +1465,18 @@ void main() {
         name: 'a contracted negated partial disclosure',
         reason: "This isn't a partial placement; 60 minutes remain for later.",
       ),
+      (
+        name: 'a negated completed-estimate split',
+        reason:
+            'This block does not schedule 60 of the 120 minutes; '
+            'it is only a placeholder.',
+      ),
+      (
+        name: 'a completed-estimate split followed by negation',
+        reason:
+            '60 of the 120 minutes are not scheduled; '
+            'this block is only a placeholder.',
+      ),
     ]) {
       test('charges ${badDisclosure.name} at the full estimate', () {
         final result = scoreWithinCapacityByEstimate(
@@ -1592,6 +1604,31 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c 12min partial of 120min'));
+    });
+
+    test('overlapping blocks cannot manufacture a substantive partial', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            for (var i = 0; i < 12; i++)
+              block(
+                id: 'overlap-$i',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: i == 0
+                    ? 'Partial: 12 minutes of the 120-minute task are '
+                          'scheduled; 108 minutes remain.'
+                    : null,
+              ).copyWith(endTime: DateTime(2026, 7, 18, 9, 1)),
+          ],
+          corpus: tasks,
+          capacityMinutes: 12,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 12min of 120min'));
     });
 
     for (final type in [PlannedBlockType.buffer, PlannedBlockType.cal]) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1669,6 +1669,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('preserves a scheduling denial after dash punctuation', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes — not scheduled.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('allows unrelated negation outside the partial arithmetic', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3476,6 +3497,82 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not treat later reference as trade evidence', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c formats notes for later reference.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('validates a fully omitted task remainder against its estimate', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c: 5 minutes remain for later.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('accepts a contracted negative-fit disclosure', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: "task-c doesn't fit today.",
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'C')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('accepts a trade outside a task title containing a trade word', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1668,6 +1668,36 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('charges a split naming another task by its bare title', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Prepare the board deck completed 60 of 120 minutes; '
+                  'Current work is deferred.',
+            ),
+          ],
+          corpus: const [
+            ...tasks,
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final badDisclosure in <({String name, String? reason})>[
       (
         name: 'vague partial prose',

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1480,6 +1480,27 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts affirmative exact-cap wording', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '60 of 120 minutes are scheduled and no more.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('allows a later explanation that the full task cannot fit', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1653,6 +1674,29 @@ void main() {
               reason:
                   '60 of 120 minutes are scheduled for this task while '
                   '30 minutes are scheduled for the meeting.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('keeps an explicit task split during a meeting', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are scheduled for task-c '
+                  'during the meeting.',
             ),
           ],
           corpus: tasks,
@@ -1869,6 +1913,27 @@ void main() {
               reason:
                   '60 of 120 minutes are allocated to Task D; '
                   'Task C is deferred.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('charges a comma-scoped leading task split to that task', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'For task-d, 60 of 120 minutes are scheduled.',
             ),
           ],
           corpus: tasks,
@@ -2689,6 +2754,39 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'Focused work on task-c; task-d is deferred.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+            EvalCorpusTask(
+              taskId: 'task-d',
+              title: 'D',
+              estimateMinutes: 60,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not borrow another task future-tense trade', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Focused work on task-c; task-d will be deferred.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1443,6 +1443,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts a still-remaining modifier in partial arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  '60 minutes still remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     for (final wording in ['partially', 'partly']) {
       test('accepts $wording scheduled work with a matching remainder', () {
         final result = scoreWithinCapacityByEstimate(
@@ -2311,6 +2334,29 @@ void main() {
         result.detail,
         contains('task-migration allocated 60min of 120min'),
       );
+    });
+
+    test('does not treat a partial index as capacity evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  "Focused work on task-c's partial index; "
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
     test('rejects a partial claim owned by a meeting with a task modifier', () {
@@ -3208,6 +3254,34 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-migration'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not treat a partial index as trade evidence', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: "Focused work on task-c's partial index.",
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2732,6 +2732,27 @@ void main() {
       });
     }
 
+    test('rejects a leading historical allocation scope', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Yesterday, task-c scheduled 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('rejects arithmetic not governing a later allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -3601,6 +3622,28 @@ void main() {
               taskId: 'task-c',
               reason: '60 of 120 minutes are scheduled.',
               note: 'task-c was fully scheduled after all.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('a postpositive full-completion note vetoes partial credit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c scheduled 60 of 120 minutes.',
+              note: 'task-c was scheduled in full after all.',
             ),
           ],
           corpus: tasks,

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2256,6 +2256,61 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('does not treat partial inside a task title as capacity evidence', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-migration',
+              reason:
+                  'Focused work on Partial index migration; '
+                  '60 minutes remain for later.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-migration',
+              title: 'Partial index migration',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(
+        result.detail,
+        contains('task-migration allocated 60min of 120min'),
+      );
+    });
+
+    test('rejects a partial claim owned by a meeting with a task modifier', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'The meeting for task-c is partial; '
+                  '60 minutes remain for task-c.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('does not borrow a postpositive task partial label', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2439,6 +2494,52 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 30min of 120min'));
+    });
+
+    test('does not treat remaining scheduled time as unfinished work', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  "task-c's placement is partial; "
+                  '60 minutes remain scheduled as planned.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('rejects task-bound numeric continuity as unfinished work', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'task-c is partial; '
+                  '60 minutes remain scheduled as planned.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
     for (final badDisclosure in <({String name, String? reason})>[
@@ -3437,6 +3538,34 @@ void main() {
       expect(result.detail, contains('without naming a casualty'));
     });
 
+    test('does not borrow a meeting claim with a task modifier', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'The meeting for task-c is partial.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
     test('does not borrow a scheduled meeting disposition', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -3632,6 +3761,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'There is no conflict for task-c.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('conflict-free wording does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c uses a conflict-free schedule.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -4300,6 +4300,7 @@ void main() {
     for (final reason in [
       'task-c attempted to be omitted.',
       'task-c failed to be omitted.',
+      'task-c requires deferring.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -4617,6 +4618,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c formats notes for later.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not treat a conflict object as a trade disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c resolves conflict.',
             ),
           ],
           corpus: const [
@@ -5134,6 +5163,62 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c was left unfinished.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('transitive left-unfinished disposition discloses a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c left some work unfinished.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
+    });
+
+    test('quantified shortening discloses a trade', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c was shortened by 60 minutes.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -2082,6 +2082,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a considered allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c considered scheduling 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('rejects an inability-only allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2641,6 +2662,31 @@ void main() {
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
+
+    for (final historicalScope in ['yesterday', 'last week']) {
+      test('rejects allocation arithmetic scoped to $historicalScope', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason:
+                    'task-c was scheduled 60 of 120 minutes '
+                    '$historicalScope.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-c allocated 60min of 120min'));
+      });
+    }
 
     test('rejects arithmetic not governing a later allocation action', () {
       final result = scoreWithinCapacityByEstimate(
@@ -3391,6 +3437,70 @@ void main() {
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
+
+    for (final auditBlock
+        in <
+          ({
+            String label,
+            PlannedBlockType type,
+            String? taskId,
+          })
+        >[
+          (
+            label: 'another task',
+            type: PlannedBlockType.ai,
+            taskId: 'task-d',
+          ),
+          (
+            label: 'a buffer',
+            type: PlannedBlockType.buffer,
+            taskId: null,
+          ),
+        ]) {
+      test(
+        'a task-named note on ${auditBlock.label} vetoes partial credit',
+        () {
+          final result = scoreWithinCapacityByEstimate(
+            outcome(
+              blocks: [
+                block(
+                  id: 'partial',
+                  startHour: 9,
+                  endHour: 10,
+                  taskId: 'task-c',
+                  reason: 'task-c scheduled 60 of 120 minutes.',
+                ),
+                block(
+                  id: 'audit-block',
+                  startHour: 10,
+                  endHour: 11,
+                  type: auditBlock.type,
+                  taskId: auditBlock.taskId,
+                  reason: 'Plan context.',
+                  note: 'task-c was not scheduled after all.',
+                ),
+              ],
+              corpus: const [
+                EvalCorpusTask(
+                  taskId: 'task-c',
+                  title: 'Core',
+                  estimateMinutes: 120,
+                ),
+                EvalCorpusTask(
+                  taskId: 'task-d',
+                  title: 'Dependency',
+                  estimateMinutes: 60,
+                ),
+              ],
+              capacityMinutes: 120,
+            ),
+          );
+
+          expect(result.passed, isFalse);
+          expect(result.detail, contains('task-c allocated 60min of 120min'));
+        },
+      );
+    }
 
     test('a speculative note denial does not veto partial credit', () {
       final result = scoreWithinCapacityByEstimate(
@@ -4441,6 +4551,30 @@ void main() {
       expect(result.detail, contains('task-c'));
     });
 
+    test('accepts coordinated task omission subjects', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c and task-d were omitted due to capacity.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(taskId: 'task-c', title: 'Core'),
+            EvalCorpusTask(taskId: 'task-d', title: 'Dependency'),
+          ],
+          decidedTaskIds: const ['task-c', 'task-d'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, allOf(contains('task-c'), contains('task-d')));
+    });
+
     test('accepts an explicit not-scheduled trade', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4466,6 +4600,8 @@ void main() {
       'cannot be scheduled',
       "can't be scheduled",
       "couldn't be scheduled",
+      'could not be scheduled',
+      'will not be scheduled',
       'was unable to be scheduled',
       "wasn't able to be scheduled",
     ]) {
@@ -4572,6 +4708,7 @@ void main() {
       'task-c was supposed to be omitted.',
       'task-c was meant to be omitted.',
       'task-c was going to be omitted.',
+      'task-c considered deferring.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -4933,6 +5070,34 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('accepts a task-bound scheduling-conflict noun', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c has a scheduling conflict with the meeting.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c'));
     });
 
     test('does not treat a trade object as a trade disposition', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1641,6 +1641,36 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('allows a current-task split beside a deferred casualty', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are scheduled for task-c while '
+                  'Prepare the board deck is deferred.',
+            ),
+          ],
+          corpus: const [
+            ...tasks,
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('audits a partial task across all of its scheduled blocks', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1696,6 +1726,58 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('charges a remainder explicitly naming another task', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial. '
+                  'Remaining 60 minutes of Prepare the board deck '
+                  'are deferred.',
+            ),
+          ],
+          corpus: const [
+            ...tasks,
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
+    test('charges remaining-of-estimate prose at the full estimate', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: '30 of the 120 minutes remain for this task.',
+            ).copyWith(endTime: DateTime(2026, 7, 18, 9, 30)),
+          ],
+          corpus: tasks,
+          capacityMinutes: 30,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 30min of 120min'));
     });
 
     for (final badDisclosure in <({String name, String? reason})>[

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1861,6 +1861,32 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    for (final failedAction in [
+      'unsuccessfully scheduled',
+      'failed scheduling',
+    ]) {
+      test('rejects a leading failure qualifier: $failedAction', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason: 'task-c $failedAction 60 of 120 minutes.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('task-c allocated 60min of 120min'));
+      });
+    }
+
     test('rejects an attempted allocation action', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4173,6 +4199,32 @@ void main() {
       });
     }
 
+    for (final reason in [
+      'task-c attempted to be omitted.',
+      'task-c failed to be omitted.',
+    ]) {
+      test('rejects a non-asserted trade disposition: $reason', () {
+        final result = scoreSurfacedConflict(
+          outcome(
+            blocks: [
+              block(
+                id: 'context',
+                startHour: 9,
+                endHour: 10,
+                reason: reason,
+              ),
+            ],
+            corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+            decidedTaskIds: const ['task-c'],
+            requiresConflictSurfaced: true,
+          ),
+        );
+
+        expect(result.passed, isFalse);
+        expect(result.detail, contains('without naming a casualty'));
+      });
+    }
+
     test('is not applicable when nothing was actually left out', () {
       final result = scoreSurfacedConflict(
         outcome(
@@ -4776,6 +4828,50 @@ void main() {
               estimateMinutes: 120,
             ),
           ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('rejects a trade retracted by full completion', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason:
+                  'task-c was omitted, but it was fully scheduled after all.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('rejects a cross-field full-completion retraction', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c was omitted due to capacity.',
+              note: 'task-c was fully scheduled after all.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
           decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1480,6 +1480,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('allows a later explanation that the full task cannot fit', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'Partial: 60 of 120 minutes are scheduled because '
+                  'the full task cannot fit today.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('accepts an inflected carry disposition for the remainder', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1659,6 +1682,12 @@ void main() {
         reason:
             'Partial progress is recorded; '
             '60 minutes remain in the workday.',
+      ),
+      (
+        name: 'a nearby partial with a meeting remainder',
+        reason:
+            'This placement is partial, '
+            '60 minutes remain for the meeting.',
       ),
       (
         name: 'an unrelated workday completed-estimate split',

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1834,6 +1834,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects an intention-only allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c intended to schedule 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('preserves a scheduling denial after dash punctuation', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -4899,6 +4920,31 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-review'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not find a casualty title inside a hyphenated task id', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'weekly',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'weekly-report',
+              reason: 'Reviewed weekly-report. Deferred.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(taskId: 'task-report', title: 'Report'),
+            EvalCorpusTask(taskId: 'weekly-report', title: 'Weekly'),
+          ],
+          decidedTaskIds: const ['task-report'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1410,6 +1410,13 @@ void main() {
         expect(result.detail, contains('task-c'));
         expect(result.detail, contains('60min partial'));
         expect(result.detail, contains('480min'));
+        expect(result.heuristic, isTrue);
+        expect(
+          EvalConstraintSignals.kindFor(
+            EvalConstraintIds.withinCapacityByEstimate,
+          ),
+          'mixed',
+        );
       },
     );
 
@@ -1637,6 +1644,29 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('charges a countdown before a meeting at the full estimate', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  '60 minutes remain before the meeting starts.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
     test('ignores unrelated completed-estimate arithmetic', () {
@@ -2736,6 +2766,34 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('continuity prose does not disclose a shortening', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c remains scheduled as planned.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1466,6 +1466,29 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('accepts a remainder followed by a negative-fit explanation', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  '60 minutes remain and no more fits today.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     for (final wording in ['partially', 'partly']) {
       test('accepts $wording scheduled work with a matching remainder', () {
         final result = scoreWithinCapacityByEstimate(
@@ -1526,6 +1549,27 @@ void main() {
               reason:
                   'Partial placement: 60 of 120 estimated minutes. '
                   'Remaining 60 min roll to a future day.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts explicit out-of partial arithmetic', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Partial: 60 minutes out of 120 minutes are scheduled.',
             ),
           ],
           corpus: tasks,
@@ -3272,6 +3316,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: "Focused work on task-c's partial index.",
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not treat deferred revenue as trade evidence', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c documents deferred revenue.',
             ),
           ],
           corpus: const [

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1865,6 +1865,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('does not borrow another task partial mention', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'Task D is partial. 60 minutes remain.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     test('preserves distinct task ids when titles collide', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -2473,6 +2494,34 @@ void main() {
             ),
           ],
           decidedTaskIds: const ['task-deck'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not find a casualty title inside another word', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'review',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-review',
+              reason: 'Partial preview of the material; 60 minutes remain.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-review',
+              title: 'Review',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-review'],
           requiresConflictSurfaced: true,
         ),
       );

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1671,6 +1671,59 @@ void main() {
       expect(result.detail, contains('task-c 60min partial of 120min'));
     });
 
+    test('keeps the owning task implicit beside a deferred casualty', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  '60 of 120 minutes are scheduled while '
+                  'Prepare the board deck is deferred.',
+            ),
+          ],
+          corpus: const [
+            ...tasks,
+            EvalCorpusTask(
+              taskId: 'task-deck',
+              title: 'Prepare the board deck',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('accepts a noun-qualified leading remainder', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'This placement is partial; '
+                  'the remaining work is 60 minutes and will be deferred.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
     test('audits a partial task across all of its scheduled blocks', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1861,6 +1861,27 @@ void main() {
       expect(result.detail, contains('task-c allocated 60min of 120min'));
     });
 
+    test('rejects a near-miss allocation action', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c almost scheduled 60 of 120 minutes.',
+            ),
+          ],
+          corpus: tasks,
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('task-c allocated 60min of 120min'));
+    });
+
     for (final failedAction in [
       'unsuccessfully scheduled',
       'failed scheduling',
@@ -4301,6 +4322,7 @@ void main() {
       'task-c attempted to be omitted.',
       'task-c failed to be omitted.',
       'task-c requires deferring.',
+      'task-c was almost omitted.',
     ]) {
       test('rejects a non-asserted trade disposition: $reason', () {
         final result = scoreSurfacedConflict(
@@ -4646,6 +4668,34 @@ void main() {
               endHour: 10,
               taskId: 'task-c',
               reason: 'task-c resolves conflict.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'C',
+              estimateMinutes: 120,
+            ),
+          ],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('does not treat a trade object as a trade disposition', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'task-c-block',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason: 'task-c evaluates a trade.',
             ),
           ],
           corpus: const [
@@ -5024,6 +5074,28 @@ void main() {
               endHour: 10,
               reason: 'task-c was omitted due to capacity.',
               note: 'task-c was fully scheduled after all.',
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
+    });
+
+    test('normalizes equivalent cross-field scheduling denials', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: 'task-c cannot be scheduled.',
+              note: "It is false that task-c can't be scheduled.",
             ),
           ],
           corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],

--- a/test/features/daily_os_next/eval/framework/eval_report.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report.dart
@@ -621,6 +621,7 @@ class EvalReport {
     'end': block.endTime.toIso8601String(),
     'taskId': block.taskId,
     'reason': block.reason,
+    'note': block.note,
   };
 
   String toMarkdown() {
@@ -655,7 +656,10 @@ class EvalReport {
         'understood the trade. `surfacedConflict` and `directiveHonoured` are '
         'heuristic throughout. `blockerBeforeBlocked` is mixed: an actual '
         'ordering pass or unexcused failure is objective, while a pass through '
-        'its prose bypass is heuristic. Inspect the judge bundle before '
+        'its prose bypass is heuristic. `withinCapacityByEstimate` is also '
+        'mixed: full-estimate outcomes are objective, while a pass that depends '
+        'on free-form partial arithmetic is heuristic. Inspect the judge bundle '
+        'before '
         'treating a heuristic green as reasoning quality. Heuristic outcomes '
         'remain visible below but are excluded from the objective leaderboard.',
       )

--- a/test/features/daily_os_next/eval/framework/eval_report_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report_test.dart
@@ -46,15 +46,17 @@ void main() {
     planDate: planDate,
   );
 
-  PlannedBlock block({String id = 'b1', String? taskId}) => PlannedBlock(
-    id: id,
-    categoryId: 'cat-work',
-    startTime: DateTime(2026, 7, 26, 10),
-    endTime: DateTime(2026, 7, 26, 11),
-    title: 'Focus',
-    taskId: taskId,
-    reason: 'because',
-  );
+  PlannedBlock block({String id = 'b1', String? taskId, String? note}) =>
+      PlannedBlock(
+        id: id,
+        categoryId: 'cat-work',
+        startTime: DateTime(2026, 7, 26, 10),
+        endTime: DateTime(2026, 7, 26, 11),
+        title: 'Focus',
+        taskId: taskId,
+        reason: 'because',
+        note: note,
+      );
 
   EvalRunResult result({
     required List<EvalConstraintResult> constraints,
@@ -481,6 +483,13 @@ void main() {
       expect(markdown, contains('Inspect the judge bundle'));
       expect(
         markdown,
+        contains(
+          '`withinCapacityByEstimate` is also mixed: full-estimate outcomes '
+          'are objective',
+        ),
+      );
+      expect(
+        markdown,
         contains('| surfacedConflict | heuristic · inspect |'),
       );
       expect(
@@ -496,7 +505,7 @@ void main() {
     test('carries everything needed to judge without re-running', () {
       final report = EvalReport.fromResults([
         result(
-          blocks: [block(taskId: 'task-1')],
+          blocks: [block(taskId: 'task-1', note: 'Partial: 30m remain.')],
           toolCalls: const [
             EvalToolCall(
               name: 'draft_day_plan',
@@ -543,6 +552,10 @@ void main() {
             'illegal — the persisted plan is legal either way',
       );
       expect((entry['plan']! as List).single, containsPair('taskId', 'task-1'));
+      expect(
+        (entry['plan']! as List).single,
+        containsPair('note', 'Partial: 30m remain.'),
+      );
       expect(
         (entry['constraints']! as Map)[EvalConstraintIds.requiredWorkPlaced],
         containsPair('detail', 'not placed: task-1'),

--- a/test/features/daily_os_next/eval/framework/eval_scenario.dart
+++ b/test/features/daily_os_next/eval/framework/eval_scenario.dart
@@ -489,9 +489,9 @@ const _lateStart = EvalScenario(
   // and the scenario would read as covering a check it cannot perform. That is
   // worse than an acknowledged gap.
   //
-  // What actually needs checking is whether a *truncated* task was declared
-  // partial, which no scorer reads today (lotti3-qip). `respectsEstimates`
-  // holds the line meanwhile by requiring the plan to fill the time it has.
+  // `withinCapacityByEstimate` now audits whether a truncated task declares
+  // concrete partial arithmetic. `respectsEstimates` independently holds the
+  // line by requiring the plan to fill the time it has.
   startHour: 15,
   captureTranscript: 'Late start, only the afternoon left.',
 );


### PR DESCRIPTION
## Summary

- charge explicitly partial task placements at their represented minutes when the block reasons contain auditable minute arithmetic
- keep the conservative full-estimate charge for vague, silent, zero-duration, or contradictory shortenings
- preserve the per-task accounting evidence in the constraint detail and judge bundle
- document the partial-placement scoring contract

## Root cause

`withinCapacityByEstimate` counted each placed task's full corpus estimate exactly once. That correctly caught coordinated estimate compression, but it also marked an honest plan as over capacity when the model placed 60 of a 120-minute task and explicitly named the remaining work.

The scorer now sums scheduled duration per task and grants partial credit only when the reason's concrete arithmetic agrees with both that duration and the corpus estimate. Supported evidence includes forms such as `60m of 120m`, `60 of 120 estimated minutes`, and `partial` plus `60m remain`. Anything ambiguous remains charged at the full estimate.

## Verification

- `fvm dart analyze test/features/daily_os_next/eval/framework/eval_constraints.dart test/features/daily_os_next/eval/framework/eval_constraints_test.dart`
- `fvm flutter test test/features/daily_os_next/eval/framework/eval_constraints_test.dart` — 117 tests passed, including a 120-input tagged Glados property
- regression proof: the measured 60/120-minute case and the compact live-model wording both fail with the scorer fix reverted
- `make knowledge_check` — 89 concepts and 135 Mermaid blocks passed
- final live Melious overcommitted matrix: `withinCapacityByEstimate` passed 3/3 for GLM 5.2 and 3/3 for Qwen 3.5 397B

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in ten shards. This is evaluation-only behavior, so no user-facing changelog entry is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capacity/estimate scoring by charging minutes from explicit, auditable partial-placement disclosures and enforcing stricter minute-level consistency.
  * Clarified how audited partial remainders and deferred casualties affect surfaced-conflict outcomes, including updated failure wording.
* **Tests**
  * Expanded unit and randomized coverage for partial-placement auditing and surfaced-conflict casualty handling, including additional edge cases and 10% boundary scenarios.
* **Documentation**
  * Updated evaluation guidance and “Three load-bearing semantics” wording for the partial-placement exception, tightening validity and reconciliation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->