### PR TITLE
test: close the sync pairing patch-coverage gaps, fix the first-device guide

### DIFF
--- a/docs-site/docs/sync-and-data/first-device.mdx
+++ b/docs-site/docs/sync-and-data/first-device.mdx
@@ -22,10 +22,11 @@ Run by a homeserver admin, it:
 3. writes a **provisioning bundle** — the text Lotti accepts as a pairing
    code — to a file.
 
-The README next to the tool documents every argument and the safe ways to
+The README next to the tool documents the one-time setup, every argument and the safe ways to
 supply the admin password. A minimal run looks like:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -42,11 +43,13 @@ you with the care described below.
 On the device that should become your first, open **Settings → Sync
 Settings → Devices** and choose **Set up sync**. Paste the bundle's text
 into the code field — on a phone, where the camera opens first, choose
-**Paste the code instead** to get there. From that point the flow is the
-ordinary pairing journey: review what the code describes, connect, and
-[verify](./sync.mdx#verify-the-new-device).
+**Paste the code instead** to get there. Review what the code describes,
+then connect — and that is the whole journey for a first device. There is
+no emoji verification here: verification compares two of your devices, and
+you only have one. The ceremony makes its first appearance when you pair
+your second device with [Add a device](./add-device.mdx).
 
-One difference is worth knowing: consuming a fresh provisioning bundle
+Also worth knowing: consuming a fresh provisioning bundle
 **rotates the account password** as part of connecting. The bundle file is
 spent after its first use — the live credential then exists only on that
 device, and every further device pairs from an existing one with

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -22,10 +22,11 @@ Spuštěn adminem homeserveru:
 3. zapíše do souboru **provisioning bundle** — text, který Lotti přijímá
    jako párovací kód.
 
-README vedle nástroje dokumentuje každý argument i bezpečné způsoby předání
+README vedle nástroje dokumentuje jednorázové nastavení, každý argument i bezpečné způsoby předání
 administrátorského hesla. Minimální spuštění vypadá takto:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -42,10 +43,13 @@ zacházej s péčí popsanou níže.
 Na zařízení, které se má stát tvým prvním, otevři **Nastavení → Nastavení
 synchronizace → Zařízení** a zvol **Nastavit synchronizaci**. Vlož text
 bundlu do pole pro kód — na telefonu, kde se nejdřív otevře fotoaparát, se
-tam dostaneš přes **Raději kód vložit**. Odtud je to běžná párovací cesta:
-zkontrolovat, co kód popisuje, připojit se a [ověřit](./sync.mdx).
+tam dostaneš přes **Raději kód vložit**. Zkontroluj, co kód popisuje, a
+připoj se — u prvního zařízení tím cesta končí. Žádné ověření pomocí emoji
+tu není: ověření porovnává dvě tvá zařízení, a máš zatím jen jedno.
+Ceremonie se poprvé objeví, až budeš párovat druhé zařízení přes
+[Přidat zařízení](./add-device.mdx).
 
-Jeden rozdíl stojí za to znát: použití čerstvého provisioning bundlu
+Za vědění stojí i tohle: použití čerstvého provisioning bundlu
 **rotuje heslo účtu** v rámci připojení. Soubor s bundlem je po prvním
 použití vyčerpaný — platné přihlašovací údaje pak existují jen na tom
 zařízení a každé další zařízení se páruje z existujícího přes

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -22,10 +22,11 @@ Kørt af en homeserver-admin:
 3. skriver et **provisioneringsbundle** — den tekst, Lotti accepterer som
    parringskode — til en fil.
 
-README'en ved siden af værktøjet dokumenterer hvert argument og de sikre
+README'en ved siden af værktøjet dokumenterer engangsopsætningen, hvert argument og de sikre
 måder at levere admin-adgangskoden på. En minimal kørsel ser sådan ud:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -43,10 +44,12 @@ På den enhed, der skal være din første, åbn **Indstillinger →
 Synkroniseringsindstillinger → Enheder**, og vælg **Konfigurer
 synkronisering**. Indsæt bundlets tekst i kodefeltet — på en telefon, hvor
 kameraet åbner først, vælger du **Indsæt koden i stedet** for at komme
-derhen. Derfra er forløbet den almindelige parringsrejse: gennemgå hvad
-koden beskriver, forbind, og [verificér](./sync.mdx).
+derhen. Gennemgå hvad koden beskriver, og forbind — for en første enhed er
+det hele rejsen. Der er ingen emoji-verificering her: den sammenligner to
+af dine enheder, og du har kun én. Ceremonien dukker op første gang, når du
+parrer din anden enhed med [Tilføj en enhed](./add-device.mdx).
 
-Én forskel er værd at kende: at bruge et frisk provisioneringsbundle
+Også værd at vide: at bruge et frisk provisioneringsbundle
 **roterer kontoens adgangskode** som en del af forbindelsen. Bundlefilen er
 brugt op efter første anvendelse — den gyldige adgang findes derefter kun på
 den enhed, og hver følgende enhed parres fra en eksisterende med

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -24,10 +24,11 @@ Von einem Homeserver-Admin ausgeführt:
 3. schreibt ein **Provisionierungs-Bundle** — den Text, den Lotti als
    Pairing-Code akzeptiert — in eine Datei.
 
-Das README neben dem Werkzeug dokumentiert jedes Argument und die sicheren
+Das README neben dem Werkzeug dokumentiert die einmalige Einrichtung, jedes Argument und die sicheren
 Wege, das Admin-Passwort zu übergeben. Ein minimaler Aufruf sieht so aus:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -46,10 +47,13 @@ Sorgfalt.
 Synchronisierungseinstellungen → Geräte** und wähle **Sync einrichten**.
 Füge den Text des Bundles in das Codefeld ein — auf dem Telefon, wo sich
 zuerst die Kamera öffnet, kommst du mit **Code stattdessen einfügen**
-dorthin. Ab da ist der Ablauf die gewohnte Pairing-Reise: prüfen, was der
-Code beschreibt, verbinden und [verifizieren](./sync.mdx).
+dorthin. Prüfe, was der Code beschreibt, und verbinde — das ist für ein
+erstes Gerät bereits die ganze Reise. Eine Emoji-Verifizierung gibt es hier
+nicht: Sie vergleicht zwei deiner Geräte, und du hast erst eins. Die
+Zeremonie tritt zum ersten Mal auf, wenn du dein zweites Gerät über
+[Gerät hinzufügen](./add-device.mdx) koppelst.
 
-Ein Unterschied ist wissenswert: Das Einlösen eines frischen
+Ebenfalls wissenswert: Das Einlösen eines frischen
 Provisionierungs-Bundles **rotiert das Kontopasswort** beim Verbinden. Die
 Bundle-Datei ist nach dem ersten Gebrauch verbraucht — die gültigen
 Zugangsdaten existieren dann nur auf diesem Gerät, und jedes weitere Gerät

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -24,10 +24,11 @@ Ejecutada por un admin del homeserver:
 3. escribe en un archivo un **bundle de aprovisionamiento** — el texto que
    Lotti acepta como código de emparejamiento.
 
-El README junto a la herramienta documenta cada argumento y las formas
+El README junto a la herramienta documenta la puesta en marcha inicial, cada argumento y las formas
 seguras de pasar la contraseña de admin. Una ejecución mínima se ve así:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -44,11 +45,14 @@ llega con el cuidado descrito abajo.
 En el dispositivo que será tu primero, abre **Ajustes → Ajustes de
 sincronización → Dispositivos** y elige **Configurar sincronización**. Pega
 el texto del bundle en el campo de código — en el móvil, donde primero se
-abre la cámara, elige **Pegar el código en su lugar** para llegar ahí. A
-partir de ahí el flujo es el recorrido de emparejamiento normal: revisar lo
-que describe el código, conectar y [verificar](./sync.mdx).
+abre la cámara, elige **Pegar el código en su lugar** para llegar ahí. Revisa lo que
+describe el código y conecta — ese es ya todo el recorrido para un primer
+dispositivo. Aquí no hay verificación con emojis: la verificación compara
+dos de tus dispositivos, y solo tienes uno. La ceremonia aparece por primera
+vez al emparejar tu segundo dispositivo con
+[Añadir un dispositivo](./add-device.mdx).
 
-Merece la pena saber una diferencia: consumir un bundle de aprovisionamiento
+También merece la pena saberlo: consumir un bundle de aprovisionamiento
 nuevo **rota la contraseña de la cuenta** al conectar. El archivo del bundle
 queda gastado tras su primer uso — la credencial viva existe entonces solo
 en ese dispositivo, y cada dispositivo siguiente se empareja desde uno

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -48,9 +48,10 @@ synchronisation**. Colle le texte du bundle dans le champ de code — sur un
 téléphone, où la caméra s'ouvre d'abord, choisis **Coller le code à la
 place** pour y accéder. Vérifie ce que le code décrit, puis connecte-toi —
 c'est déjà tout le parcours pour un premier appareil. Il n'y a pas de
-vérification par emoji ici : elle compare deux de tes appareils, et tu n'en
-as qu'un. La cérémonie apparaît pour la première fois quand tu appaires ton
-deuxième appareil avec [Ajouter un appareil](./add-device.mdx).
+vérification par emoji ici : cette vérification compare deux de tes
+appareils, et tu n'en as qu'un. La cérémonie apparaît pour la première fois
+quand tu appaires ton deuxième appareil avec
+[Ajouter un appareil](./add-device.mdx).
 
 Bon à savoir aussi : consommer un bundle de provisionnement
 neuf **fait tourner le mot de passe du compte** au moment de la connexion.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -24,10 +24,11 @@ Exécutée par un admin du homeserver, elle :
 3. écrit dans un fichier un **bundle de provisionnement** — le texte que
    Lotti accepte comme code d'appairage.
 
-Le README à côté de l'outil documente chaque argument et les façons sûres de
+Le README à côté de l'outil documente l'installation initiale, chaque argument et les façons sûres de
 fournir le mot de passe admin. Une exécution minimale ressemble à :
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -45,11 +46,13 @@ Sur l'appareil qui doit devenir ton premier, ouvre **Paramètres →
 Paramètres de synchronisation → Appareils** et choisis **Configurer la
 synchronisation**. Colle le texte du bundle dans le champ de code — sur un
 téléphone, où la caméra s'ouvre d'abord, choisis **Coller le code à la
-place** pour y accéder. À partir de là, c'est le parcours d'appairage
-ordinaire : vérifier ce que le code décrit, se connecter, puis
-[vérifier l'appareil](./sync.mdx).
+place** pour y accéder. Vérifie ce que le code décrit, puis connecte-toi —
+c'est déjà tout le parcours pour un premier appareil. Il n'y a pas de
+vérification par emoji ici : elle compare deux de tes appareils, et tu n'en
+as qu'un. La cérémonie apparaît pour la première fois quand tu appaires ton
+deuxième appareil avec [Ajouter un appareil](./add-device.mdx).
 
-Une différence mérite d'être connue : consommer un bundle de provisionnement
+Bon à savoir aussi : consommer un bundle de provisionnement
 neuf **fait tourner le mot de passe du compte** au moment de la connexion.
 Le fichier du bundle est donc épuisé après sa première utilisation — les
 identifiants actifs n'existent alors que sur cet appareil, et chaque

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -24,10 +24,11 @@ Eseguita da un admin dell'homeserver:
 3. scrive in un file un **bundle di provisioning** — il testo che Lotti
    accetta come codice di associazione.
 
-Il README accanto allo strumento documenta ogni argomento e i modi sicuri di
+Il README accanto allo strumento documenta la configurazione iniziale, ogni argomento e i modi sicuri di
 fornire la password admin. Un'esecuzione minima è così:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -45,11 +46,13 @@ Sul dispositivo che diventerà il tuo primo, apri **Impostazioni →
 Impostazioni di sincronizzazione → Dispositivi** e scegli **Configura la
 sincronizzazione**. Incolla il testo del bundle nel campo del codice — su un
 telefono, dove prima si apre la fotocamera, scegli **Incolla invece il
-codice** per arrivarci. Da lì il flusso è il normale percorso di
-associazione: rivedere cosa descrive il codice, connettersi e
-[verificare](./sync.mdx).
+codice** per arrivarci. Rivedi cosa descrive il codice e connettiti — per
+un primo dispositivo il percorso finisce qui. Non c'è verifica con le
+emoji: la verifica confronta due dei tuoi dispositivi, e ne hai uno solo.
+La cerimonia compare per la prima volta quando associ il secondo
+dispositivo con [Aggiungere un dispositivo](./add-device.mdx).
 
-Vale la pena conoscere una differenza: consumare un bundle di provisioning
+Vale anche la pena sapere: consumare un bundle di provisioning
 fresco **ruota la password dell'account** al momento della connessione. Il
 file del bundle è quindi esaurito dopo il primo uso — la credenziale viva
 esiste solo su quel dispositivo, e ogni dispositivo successivo si associa da

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -23,11 +23,12 @@ Uitgevoerd door een homeserver-admin:
 3. schrijft het een **provisioningbundle** — de tekst die Lotti als
    koppelcode accepteert — naar een bestand.
 
-De README naast het gereedschap documenteert elk argument en de veilige
+De README naast het gereedschap documenteert de eenmalige installatie, elk argument en de veilige
 manieren om het admin-wachtwoord aan te leveren. Een minimale run ziet er zo
 uit:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -45,10 +46,13 @@ Open op het apparaat dat je eerste moet worden **Instellingen →
 Instellingen synchroniseren → Apparaten** en kies **Synchronisatie
 instellen**. Plak de tekst van de bundle in het codeveld — op een telefoon,
 waar eerst de camera opent, kom je daar via **Plak de code in plaats
-daarvan**. Vanaf dat punt is het de gewone koppelreis: nakijken wat de code
-beschrijft, verbinden en [verifiëren](./sync.mdx).
+daarvan**. Kijk na wat de code beschrijft en verbind — voor een eerste
+apparaat is dat meteen de hele reis. Emoji-verificatie is er hier niet: die
+vergelijkt twee van je apparaten, en je hebt er pas één. De ceremonie
+verschijnt voor het eerst wanneer je je tweede apparaat koppelt met
+[Een apparaat toevoegen](./add-device.mdx).
 
-Eén verschil is het weten waard: het gebruiken van een verse
+Ook goed om te weten: het gebruiken van een verse
 provisioningbundle **roteert het accountwachtwoord** tijdens het verbinden.
 Het bundlebestand is daarmee op na het eerste gebruik — het geldige
 inloggegeven bestaat dan alleen op dat apparaat, en elk volgend apparaat

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -24,10 +24,11 @@ Executada por um admin do homeserver:
 3. escreve num ficheiro um **bundle de provisionamento** — o texto que o
    Lotti aceita como código de emparelhamento.
 
-O README ao lado da ferramenta documenta cada argumento e as formas seguras
+O README ao lado da ferramenta documenta a configuração inicial, cada argumento e as formas seguras
 de fornecer a palavra-passe de admin. Uma execução mínima é assim:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -45,10 +46,13 @@ No dispositivo que vai ser o teu primeiro, abre **Definições →
 Configurações de sincronização → Dispositivos** e escolhe **Configurar
 sincronização**. Cola o texto do bundle no campo do código — num telemóvel,
 onde a câmara abre primeiro, escolhe **Colar o código em alternativa** para
-lá chegar. A partir daí o fluxo é o percurso normal de emparelhamento: rever
-o que o código descreve, ligar e [verificar](./sync.mdx).
+lá chegar. Revê o que o código descreve e liga — para um primeiro
+dispositivo, o percurso acaba aí. Não há verificação por emojis aqui: a
+verificação compara dois dos teus dispositivos, e só tens um. A cerimónia
+aparece pela primeira vez quando emparelhas o teu segundo dispositivo com
+[Adicionar um dispositivo](./add-device.mdx).
 
-Vale a pena conhecer uma diferença: consumir um bundle de provisionamento
+Também vale a pena saber: consumir um bundle de provisionamento
 fresco **roda a palavra-passe da conta** ao ligar. O ficheiro do bundle fica
 gasto após o primeiro uso — a credencial viva passa a existir apenas nesse
 dispositivo, e cada dispositivo seguinte emparelha a partir de um existente

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -24,10 +24,11 @@ Rulat de un administrator al homeserver-ului:
 3. scrie într-un fișier un **bundle de provizionare** — textul pe care
    Lotti îl acceptă drept cod de asociere.
 
-README-ul de lângă instrument documentează fiecare argument și modurile
+README-ul de lângă instrument documentează configurarea inițială, fiecare argument și modurile
 sigure de a furniza parola de administrator. O rulare minimă arată astfel:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -44,11 +45,14 @@ la dumneavoastră cu grija descrisă mai jos.
 Pe dispozitivul care urmează să devină primul, deschideți **Setări → Setări
 sincronizare → Dispozitive** și alegeți **Configurați sincronizarea**.
 Lipiți textul bundle-ului în câmpul pentru cod — pe telefon, unde se
-deschide întâi camera, ajungeți acolo prin **Lipiți codul în schimb**. De
-aici fluxul este parcursul obișnuit de asociere: verificați ce descrie
-codul, conectați-vă și [verificați dispozitivul](./sync.mdx).
+deschide întâi camera, ajungeți acolo prin **Lipiți codul în schimb**.
+Verificați ce descrie codul și conectați-vă — pentru primul dispozitiv,
+parcursul se încheie aici. Nu există verificare cu emoji: verificarea
+compară două dintre dispozitivele dumneavoastră, iar deocamdată aveți doar
+unul. Ceremonia apare prima dată când asociați al doilea dispozitiv prin
+[Adăugați un dispozitiv](./add-device.mdx).
 
-O diferență merită cunoscută: consumarea unui bundle de provizionare
+Tot util de știut: consumarea unui bundle de provizionare
 proaspăt **rotește parola contului** în cadrul conectării. Fișierul
 bundle-ului este epuizat după prima utilizare — datele de autentificare
 valabile există apoi doar pe acel dispozitiv, iar fiecare dispozitiv

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/sync-and-data/first-device.mdx
@@ -22,10 +22,11 @@ Körd av en homeserver-admin:
 3. skriver en **provisioneringsbundle** — texten Lotti godtar som
    parkopplingskod — till en fil.
 
-README-filen bredvid verktyget dokumenterar varje argument och de säkra
+README-filen bredvid verktyget dokumenterar engångsinstallationen, varje argument och de säkra
 sätten att ange admin-lösenordet. En minimal körning ser ut så här:
 
 ```bash
+cd tools/matrix_provisioner
 python provision.py \
   --homeserver https://matrix.example.com \
   --admin-user admin \
@@ -42,11 +43,13 @@ som beskrivs nedan.
 På enheten som ska bli din första, öppna **Inställningar →
 Synkroniseringsinställningar → Enheter** och välj **Konfigurera synk**.
 Klistra in bundlens text i kodfältet — på en telefon, där kameran öppnas
-först, väljer du **Klistra in koden i stället** för att komma dit. Därifrån
-är flödet den vanliga parkopplingsresan: granska vad koden beskriver, anslut
-och [verifiera](./sync.mdx).
+först, väljer du **Klistra in koden i stället** för att komma dit. Granska
+vad koden beskriver och anslut — för en första enhet är det hela resan. Här
+finns ingen emojiverifiering: den jämför två av dina enheter, och du har
+bara en. Ceremonin dyker upp första gången när du parkopplar din andra
+enhet med [Lägg till en enhet](./add-device.mdx).
 
-En skillnad är värd att känna till: att använda en färsk
+Också värt att veta: att använda en färsk
 provisioneringsbundle **roterar kontots lösenord** som en del av
 anslutningen. Bundlefilen är förbrukad efter första användningen — den
 gällande inloggningen finns då bara på den enheten, och varje följande enhet

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -615,8 +615,12 @@ class _ViewfinderBrackets extends StatelessWidget {
   }
 }
 
-/// Public for its repaint contract's unit test: the painter mounts under a
-/// `const` overlay, so no widget test can ever hand it a new delegate.
+/// `shouldRepaint` is the delegate-comparison contract the framework
+/// consults when a rebuild provides a new painter instance: it compares the
+/// visual fields (color, corner length, corner radius, stroke width, inset)
+/// against the previous delegate's and requests a redraw only when one
+/// differs. Public for that contract's unit test — the painter mounts under
+/// a `const` overlay, so no widget test can ever hand it a new delegate.
 @visibleForTesting
 class ViewfinderBracketsPainter extends CustomPainter {
   ViewfinderBracketsPainter({

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -604,7 +604,7 @@ class _ViewfinderBrackets extends StatelessWidget {
     final tokens = context.designTokens;
 
     return CustomPaint(
-      painter: _ViewfinderBracketsPainter(
+      painter: ViewfinderBracketsPainter(
         color: tokens.colors.interactive.enabled,
         cornerLength: tokens.spacing.step7,
         cornerRadius: tokens.radii.l,
@@ -615,8 +615,11 @@ class _ViewfinderBrackets extends StatelessWidget {
   }
 }
 
-class _ViewfinderBracketsPainter extends CustomPainter {
-  _ViewfinderBracketsPainter({
+/// Public for its repaint contract's unit test: the painter mounts under a
+/// `const` overlay, so no widget test can ever hand it a new delegate.
+@visibleForTesting
+class ViewfinderBracketsPainter extends CustomPainter {
+  ViewfinderBracketsPainter({
     required this.color,
     required this.cornerLength,
     required this.cornerRadius,
@@ -681,7 +684,7 @@ class _ViewfinderBracketsPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_ViewfinderBracketsPainter oldDelegate) =>
+  bool shouldRepaint(ViewfinderBracketsPainter oldDelegate) =>
       color != oldDelegate.color ||
       cornerLength != oldDelegate.cornerLength ||
       cornerRadius != oldDelegate.cornerRadius ||

--- a/test/features/sync/ui/provisioned/add_device_page_test.dart
+++ b/test/features/sync/ui/provisioned/add_device_page_test.dart
@@ -680,6 +680,29 @@ void main() {
       );
       expect(code.left, greaterThan(qr.right));
     });
+
+    testWidgets('reduced motion parks the timeline dot', (tester) async {
+      // The active stop's pulse must respect the OS animation veto — and
+      // actually stop its controller, or the "waiting" screen ticks forever.
+      useTallSurface(tester);
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const SingleChildScrollView(
+            child: AddDeviceView(pollInterval: Duration(days: 1)),
+          ),
+          overrides: overrides(calls: _Calls()),
+          mediaQueryData: phoneMediaQueryData.copyWith(
+            disableAnimations: true,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Settles only because the dot's controller is parked; a live
+      // repeat(reverse: true) would make this time out.
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('add_device_timeline')), findsOneWidget);
+    });
   });
 
   group('AddDeviceActionBar', () {
@@ -774,6 +797,43 @@ void main() {
       await tester.tap(find.byKey(const Key('add_device_poll_retry')));
       await tester.pump();
       expect(retries, 1);
+    });
+
+    testWidgets('the hand-off pair stacks below the wide-card width', (
+      tester,
+    ) async {
+      // Two large labeled buttons in one phone-width row ellipsize both
+      // labels; below the pairing card's breakpoint they stack, full width.
+      final signal = AddDeviceJoinSignal()..value = AddDeviceJoinState.waiting;
+      addTearDown(signal.dispose);
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          SizedBox(
+            width: kAddDeviceWideCard - 40,
+            child: AddDeviceActionBar(
+              signal: signal,
+              onSendMessages: (_) async {},
+              onSendSettings: (_) async {},
+            ),
+          ),
+          overrides: overrides(calls: _Calls(), devices: existing),
+        ),
+      );
+      await tester.pump();
+
+      final settings = tester.getRect(
+        find.byKey(const Key('add_device_send_settings')),
+      );
+      final messages = tester.getRect(
+        find.byKey(const Key('add_device_send_messages')),
+      );
+      expect(settings.bottom, lessThanOrEqualTo(messages.top));
+      expect(
+        settings.left,
+        messages.left,
+        reason: 'stacked and stretched, not side by side',
+      );
+      expect(settings.width, messages.width);
     });
 
     testWidgets('wears the lock while the hand-off is gated', (

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -127,6 +127,35 @@ void main() {
       );
     });
 
+    test('the viewfinder painter repaints only when its look changes', () {
+      // The overlay is const-mounted, so the framework consults this
+      // contract on theme changes; repainting on identical values would
+      // redraw the brackets every frame the camera preview ticks.
+      ViewfinderBracketsPainter make({
+        Color color = const Color(0xFF00FF00),
+        double cornerLength = 24,
+        double cornerRadius = 12,
+        double strokeWidth = 2,
+        double inset = 16,
+      }) => ViewfinderBracketsPainter(
+        color: color,
+        cornerLength: cornerLength,
+        cornerRadius: cornerRadius,
+        strokeWidth: strokeWidth,
+        inset: inset,
+      );
+
+      expect(make().shouldRepaint(make()), isFalse);
+      expect(
+        make(color: const Color(0xFFFF0000)).shouldRepaint(make()),
+        isTrue,
+      );
+      expect(make(cornerLength: 32).shouldRepaint(make()), isTrue);
+      expect(make(cornerRadius: 8).shouldRepaint(make()), isTrue);
+      expect(make(strokeWidth: 3).shouldRepaint(make()), isTrue);
+      expect(make(inset: 20).shouldRepaint(make()), isTrue);
+    });
+
     testWidgets('desktop stays on manual entry with no camera', (
       tester,
     ) async {

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -127,35 +127,6 @@ void main() {
       );
     });
 
-    test('the viewfinder painter repaints only when its look changes', () {
-      // The overlay is const-mounted, so the framework consults this
-      // contract on theme changes; repainting on identical values would
-      // redraw the brackets every frame the camera preview ticks.
-      ViewfinderBracketsPainter make({
-        Color color = const Color(0xFF00FF00),
-        double cornerLength = 24,
-        double cornerRadius = 12,
-        double strokeWidth = 2,
-        double inset = 16,
-      }) => ViewfinderBracketsPainter(
-        color: color,
-        cornerLength: cornerLength,
-        cornerRadius: cornerRadius,
-        strokeWidth: strokeWidth,
-        inset: inset,
-      );
-
-      expect(make().shouldRepaint(make()), isFalse);
-      expect(
-        make(color: const Color(0xFFFF0000)).shouldRepaint(make()),
-        isTrue,
-      );
-      expect(make(cornerLength: 32).shouldRepaint(make()), isTrue);
-      expect(make(cornerRadius: 8).shouldRepaint(make()), isTrue);
-      expect(make(strokeWidth: 3).shouldRepaint(make()), isTrue);
-      expect(make(inset: 20).shouldRepaint(make()), isTrue);
-    });
-
     testWidgets('desktop stays on manual entry with no camera', (
       tester,
     ) async {

--- a/test/features/sync/ui/provisioned/bundle_import_page_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_test.dart
@@ -17,6 +17,7 @@ import 'package:lotti/utils/platform.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import '../../../../helpers/fallbacks.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
@@ -41,6 +42,9 @@ void main() {
   );
 
   setUpAll(() {
+    registerAllFallbackValues();
+    // Not part of the shared inventory: a real instance of a config class
+    // only sync tests stub with `any()`.
     registerFallbackValue(
       const MatrixConfig(homeServer: '', user: '', password: ''),
     );
@@ -903,7 +907,6 @@ void main() {
       final originalInstance = UrlLauncherPlatform.instance;
       UrlLauncherPlatform.instance = mockUrlLauncher;
       addTearDown(() => UrlLauncherPlatform.instance = originalInstance);
-      registerFallbackValue(FakeLaunchOptions());
       when(
         () => mockUrlLauncher.launchUrl(any(), any()),
       ).thenAnswer((_) async => true);
@@ -921,6 +924,38 @@ void main() {
               ).captured.single
               as String;
       expect(url, endsWith('sync-and-data/first-device'));
+    });
+
+    test('the viewfinder painter compares its look fields for a new '
+        'delegate', () {
+      // The contract the framework consults when a rebuild hands the render
+      // object a new painter delegate: repaint when any of the visual
+      // fields (color, corner length, corner radius, stroke width, inset)
+      // differs from the previous delegate's, and skip the redraw when the
+      // two delegates would paint identically.
+      ViewfinderBracketsPainter make({
+        Color color = const Color(0xFF00FF00),
+        double cornerLength = 24,
+        double cornerRadius = 12,
+        double strokeWidth = 2,
+        double inset = 16,
+      }) => ViewfinderBracketsPainter(
+        color: color,
+        cornerLength: cornerLength,
+        cornerRadius: cornerRadius,
+        strokeWidth: strokeWidth,
+        inset: inset,
+      );
+
+      expect(make().shouldRepaint(make()), isFalse);
+      expect(
+        make(color: const Color(0xFFFF0000)).shouldRepaint(make()),
+        isTrue,
+      );
+      expect(make(cornerLength: 32).shouldRepaint(make()), isTrue);
+      expect(make(cornerRadius: 8).shouldRepaint(make()), isTrue);
+      expect(make(strokeWidth: 3).shouldRepaint(make()), isTrue);
+      expect(make(inset: 20).shouldRepaint(make()), isTrue);
     });
 
     testWidgets('a provisioning reset clears the stale decoded bundle', (

--- a/test/features/sync/ui/provisioned/bundle_import_page_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
@@ -424,6 +425,8 @@ void main() {
       // user review. A fixed label + right-aligned value row squeezed the
       // identifier into a sliver (or overflowed) once a long localized
       // label met an accessibility text scale; the pair must stack instead.
+      // French, because "Compte de synchronisation" at double scale is what
+      // actually exceeded a phone-width sheet.
       tester.view
         ..physicalSize = const Size(390, 2400)
         ..devicePixelRatio = 1.0;
@@ -442,6 +445,7 @@ void main() {
             ),
           ),
           overrides: defaultOverrides(),
+          locale: const Locale('fr'),
         ),
       );
       await tester.pump();
@@ -889,6 +893,34 @@ void main() {
       );
       expect(manual.label, context.messages.syncPairOpenManual);
       expect(manual.onPressed, isNotNull);
+    });
+
+    testWidgets('the manual button opens the first-device guide, not the '
+        'manual root', (tester) async {
+      // A root landing still left the user hunting for the one page that
+      // explains where a first code comes from.
+      final mockUrlLauncher = MockUrlLauncher();
+      final originalInstance = UrlLauncherPlatform.instance;
+      UrlLauncherPlatform.instance = mockUrlLauncher;
+      addTearDown(() => UrlLauncherPlatform.instance = originalInstance);
+      registerFallbackValue(FakeLaunchOptions());
+      when(
+        () => mockUrlLauncher.launchUrl(any(), any()),
+      ).thenAnswer((_) async => true);
+
+      await pumpImport(tester);
+      await tester.ensureVisible(
+        find.byKey(const Key('bundle_import_open_manual')),
+      );
+      await tester.tap(find.byKey(const Key('bundle_import_open_manual')));
+      await tester.pump();
+
+      final url =
+          verify(
+                () => mockUrlLauncher.launchUrl(captureAny(), any()),
+              ).captured.single
+              as String;
+      expect(url, endsWith('sync-and-data/first-device'));
     });
 
     testWidgets('a provisioning reset clears the stale decoded bundle', (

--- a/test/features/sync/ui/widgets/matrix/sync_devices_list_test.dart
+++ b/test/features/sync/ui/widgets/matrix/sync_devices_list_test.dart
@@ -9,8 +9,10 @@ import 'package:lotti/features/design_system/components/spinners/design_system_s
 import 'package:lotti/features/sync/models/sync_device_info.dart';
 import 'package:lotti/features/sync/state/sync_devices_provider.dart';
 import 'package:lotti/features/sync/ui/provisioned/add_device_page.dart';
+import 'package:lotti/features/sync/ui/re_sync_modal.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/device_card.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/sync_devices_list.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:mocktail/mocktail.dart';
@@ -841,6 +843,64 @@ void main() {
         find.byKey(const Key('sync_devices_send_messages')),
         findsOneWidget,
       );
+    });
+
+    testWidgets('Send settings opens the room-wide settings hand-off', (
+      tester,
+    ) async {
+      // The banner's whole point: the action that used to die with the
+      // Add-device sheet must actually open the hand-off from here.
+      final container = await pumpWithContainer(
+        tester,
+        initial: [currentDevice, joinedPhone],
+      );
+      container
+          .read(syncDevicesControllerProvider.notifier)
+          .state = const AsyncData<List<SyncDeviceInfo>>([
+        currentDevice,
+        verifiedPhone,
+      ]);
+      await tester.pump();
+      await tester.pump();
+
+      await tester.ensureVisible(
+        find.byKey(const Key('sync_devices_send_settings')),
+      );
+      await tester.tap(find.byKey(const Key('sync_devices_send_settings')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final context = tester.element(find.byType(SyncDevicesList));
+      expect(
+        find.text(context.messages.syncEntitiesConfirm),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Send message history opens the re-sync hand-off', (
+      tester,
+    ) async {
+      final container = await pumpWithContainer(
+        tester,
+        initial: [currentDevice, joinedPhone],
+      );
+      container
+          .read(syncDevicesControllerProvider.notifier)
+          .state = const AsyncData<List<SyncDeviceInfo>>([
+        currentDevice,
+        verifiedPhone,
+      ]);
+      await tester.pump();
+      await tester.pump();
+
+      await tester.ensureVisible(
+        find.byKey(const Key('sync_devices_send_messages')),
+      );
+      await tester.tap(find.byKey(const Key('sync_devices_send_messages')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byType(ReSyncModalContent), findsOneWidget);
     });
 
     testWidgets('stays away for a roster that was already verified', (

--- a/test/features/sync/ui/widgets/matrix/verification_ceremony_stages_test.dart
+++ b/test/features/sync/ui/widgets/matrix/verification_ceremony_stages_test.dart
@@ -155,6 +155,56 @@ void main() {
       expect(cancelled, 1);
     });
 
+    testWidgets('the decision pair stacks on a phone sheet, accent on top', (
+      tester,
+    ) async {
+      // Two spelled-out labels share a phone sheet's width badly: side by
+      // side they truncate into indistinguishability, which is exactly the
+      // distinction this pair exists to make.
+      var accepted = 0;
+      var cancelled = 0;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          SingleChildScrollView(
+            child: SizedBox(
+              width: kVerificationDecisionRowMinWidth - 60,
+              child: VerificationEmojiStage(
+                emojis: emojis,
+                awaitingOtherDevice: false,
+                onAccept: () => accepted++,
+                onCancel: () => cancelled++,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final context = tester.element(find.byType(VerificationEmojiStage));
+      final acceptFinder = find.widgetWithText(
+        DesignSystemButton,
+        context.messages.syncVerifyTheyMatch,
+      );
+      final cancelFinder = find.widgetWithText(
+        DesignSystemButton,
+        context.messages.syncVerifyTheyDiffer,
+      );
+      // Stacked, accent above the quiet way out — and both full width so
+      // neither label can ellipsize.
+      expect(
+        tester.getTopLeft(acceptFinder).dy,
+        lessThan(tester.getTopLeft(cancelFinder).dy),
+      );
+      expect(tester.widget<DesignSystemButton>(acceptFinder).fullWidth, isTrue);
+      expect(tester.widget<DesignSystemButton>(cancelFinder).fullWidth, isTrue);
+
+      await tester.ensureVisible(acceptFinder);
+      await tester.tap(acceptFinder);
+      await tester.ensureVisible(cancelFinder);
+      await tester.tap(cancelFinder);
+      expect(accepted, 1);
+      expect(cancelled, 1);
+    });
+
     testWidgets('waits on the peer with the accept disabled', (tester) async {
       var accepted = 0;
       await pumpStage(tester, awaiting: true, onAccept: () => accepted++);

--- a/test/features/sync/ui/widgets/sync_device_pair_motif_test.dart
+++ b/test/features/sync/ui/widgets/sync_device_pair_motif_test.dart
@@ -71,6 +71,23 @@ void main() {
       expect(after, isNot(equals(before)));
     });
 
+    testWidgets('the pulse stops when the connection completes', (
+      tester,
+    ) async {
+      // The repeating controller must not outlive the connecting state: a
+      // motif updated to linked keeps ticking invisibly otherwise, burning
+      // frames on a screen that reads as finished.
+      await pumpMotif(tester, SyncDevicePairMotifState.connecting);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      await pumpMotif(tester, SyncDevicePairMotifState.linked);
+      // Settles only if didUpdateWidget stopped the repeat — a live
+      // repeating controller would make this time out.
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.smartphone_rounded), findsOneWidget);
+    });
+
     testWidgets('reduced motion parks the stream at steady mid-strength', (
       tester,
     ) async {

--- a/test/widget_test_utils.dart
+++ b/test/widget_test_utils.dart
@@ -283,6 +283,7 @@ Widget makeTestableWidgetWithScaffold(
   List<Override> overrides = const [],
   ThemeData? theme,
   MediaQueryData? mediaQueryData,
+  Locale? locale,
 }) {
   final mq = mediaQueryData ?? phoneMediaQueryData;
 
@@ -300,6 +301,7 @@ Widget makeTestableWidgetWithScaffold(
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: AppLocalizations.supportedLocales,
+        locale: locale,
         home: Scaffold(
           body: SingleChildScrollView(
             child: ConstrainedBox(


### PR DESCRIPTION
Follow-up to #3650, which merged at 97.91% patch coverage (21 lines missing). This PR covers every one of those lines with behavioral tests and resolves the two review comments that were still open at merge time.

## Coverage

- **Just-joined banner hand-off** (`sync_devices_list.dart`): both banner actions are now tapped — Send settings must open the room-wide settings confirmation, Send message history must open the re-sync sheet. The hand-off the banner exists for is now proven to happen, not just rendered.
- **First-device manual button** (`bundle_import_page.dart`): tapped against a stubbed `url_launcher`; the launched URL must end in `sync-and-data/first-device`, not the manual root.
- **Pair motif** (`sync_device_pair_motif.dart`): the pulse controller must stop when the state leaves `connecting` — `pumpAndSettle` would time out on a still-repeating controller.
- **Emoji decision pair** (`verification_ceremony_stages.dart`): the stacked phone branch — accent above the quiet exit, both full width, both tappable.
- **Add-device bar** (`add_device_page.dart`): the stacked narrow branch, plus the timeline dot parking its controller under reduced motion.
- **Viewfinder painter** (`bundle_import_page.dart`): the repaint contract gets a direct unit test — repaint only when a visual input changes. The class is `@visibleForTesting`-public because its `const`-mounted overlay never hands the render object a new delegate in a widget test.
- **Context rows**: the large-text regression test now runs in French, where the overflow actually reproduced (verified failing against the pre-fix layout); the shared scaffold harness gained a `locale` parameter.

## Review items from #3650

- **First-device guide promised an impossible step** ([comment](https://github.com/matthiasn/lotti/pull/3650#discussion_r3664252077)): a first device routes `ready` → first-device ending with no emoji ceremony — there is no second device to compare with. The guide (all 11 languages) now ends the journey at connect and introduces the ceremony with the second device.
- **Provisioning command not runnable** ([comment](https://github.com/matthiasn/lotti/pull/3650#discussion_r3664252096)): the example now starts with `cd tools/matrix_provisioner`, and the README sentence mentions the one-time setup. All 11 languages; the docs site builds clean in every locale.

No CHANGELOG entry: test-only work plus corrections to manual content that has not shipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified first-device setup and provisioning instructions across supported languages.
  * Added guidance on secure administrator password handling and the minimal provisioning command.
  * Explained that emoji verification begins when pairing a second device, not the first.
  * Improved instructions for pasting and using a fresh provisioning bundle.
* **Bug Fixes**
  * Improved reliability of pairing and synchronization interface behavior across reduced-motion, narrow-screen, and large-text layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->