### PR TITLE
fix: recognize planning evidence inflections

### DIFF
--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T22:12:29+02:00 }
+generated: { by: codex/5, at: 2026-07-28T22:39:29+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -115,7 +115,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   says were avoided or prevented, including passive
   `was prevented from being scheduled` wording. Negation words inside the
   current task id or title are names, not clause operators, so
-  `No-code prototype scheduled 60 of 120 minutes` remains affirmative. A
+  `No-code prototype scheduled 60 of 120 minutes` remains affirmative, as does
+  the partial label in `No-code prototype is partial`. Allocation predicates
+  accept ordinary third-person present forms such as `schedules`, `allocates`,
+  `completes`, `plans`, and `places`. A
   selected allocation action must govern the numeric split on either side; an
   earlier action with intervening object prose, such as scheduling a meeting
   before reviewing `60 of 120` recording minutes, cannot supply task-allocation
@@ -166,7 +169,8 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   are references, not predicates: `task-fit 60 of 120 minutes` contains no
   assertion that the work was placed. A possessive task reference also retains
   its following head noun, so `task-c's meeting has 60 of 120 minutes
-  scheduled` remains meeting evidence rather than task-c allocation.
+  scheduled` remains meeting evidence rather than task-c allocation, and
+  `omitted task-c's meeting` omits the meeting rather than task-c.
   The block's task is the default arithmetic subject; a corpus reference
   overrides it when it is comma-led, adjacent, linked by an allocation action
   (including postpositive `allocated to Task D`), possessive, attached by `for`

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -781,8 +781,8 @@ final _partialRemainderDispositionPattern = RegExp(
 );
 
 final _taskAllocationActionPattern = RegExp(
-  r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
+  r'\b(?:schedul(?:e|es|ed|ing)|allocat(?:e|es|ed|ing)|'
+  'complet(?:e|es|ed|ing)|plan(?:s|ned|ning)?|plac(?:e|es|ed|ing)|'
   r'fit(?:s|ting)?)\b',
   caseSensitive: false,
 );
@@ -1086,7 +1086,14 @@ bool _hasAuditablePartialDisclosure({
       }
       if (!_partialMentionDescribesPlacement(reason, match)) continue;
       if (_evidenceIsSpeculative(reason, match)) continue;
-      if (_partialMentionIsNegated(reason, match)) return false;
+      if (_partialMentionIsNegated(
+        reason,
+        match,
+        taskId: taskId,
+        taskTitle: taskTitle,
+      )) {
+        return false;
+      }
       if (disclosure.canQualify) reasonMentionsPartial = true;
     }
     for (final match in _partialOfEstimatePattern.allMatches(reason)) {
@@ -1280,12 +1287,27 @@ bool _fullAllocationClaimHasExplicitNonTaskHead(
   ).hasMatch(suffix);
 }
 
-bool _partialMentionIsNegated(String reason, Match match) {
+bool _partialMentionIsNegated(
+  String reason,
+  Match match, {
+  required String taskId,
+  required String taskTitle,
+}) {
   final range = _matchClauseRange(reason, match, boundaries: ',.;!?\n');
   final segment = reason.substring(range.start, range.end);
   for (final negation in _negationWordPattern.allMatches(segment)) {
+    final negationStart = range.start + negation.start;
     final negationEnd = range.start + negation.end;
     if (negationEnd > match.start) continue;
+    if (_rangeFallsInsideTaskReference(
+      reason,
+      start: negationStart,
+      end: negationEnd,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    )) {
+      continue;
+    }
     final between = reason.substring(negationEnd, match.start);
     if (_negationQualifiesRatherThanNegates(negation, between)) {
       continue;
@@ -1352,6 +1374,13 @@ bool _tradeEvidenceDescribesTaskOrWork(
   }
   final suffix = prose.substring(match.end, range.end);
   if (!RegExp(r'^\s+\w').hasMatch(suffix)) return true;
+  if (_subjectStartsWithPossessiveTaskReferenceToNonTaskHead(
+    suffix.trimLeft(),
+    taskId: taskId,
+    taskTitle: taskTitle,
+  )) {
+    return false;
+  }
   for (final pattern in _taskReferencePatterns(taskId, taskTitle)) {
     final reference = pattern.firstMatch(suffix);
     if (reference != null && reference.start == 0) return true;
@@ -2924,7 +2953,12 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
         _evidenceIsSpeculative(prose, match)) {
       continue;
     }
-    if (_partialMentionIsNegated(prose, match)) {
+    if (_partialMentionIsNegated(
+      prose,
+      match,
+      taskId: taskId,
+      taskTitle: task.title,
+    )) {
       record('partial', denied: true);
     } else {
       record('partial', denied: false);

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1497,6 +1497,36 @@ void main() {
       },
     );
 
+    for (final allocationPredicate in [
+      'schedules',
+      'allocates',
+      'completes',
+      'plans',
+      'places',
+    ]) {
+      test('accepts third-person $allocationPredicate split evidence', () {
+        final result = scoreWithinCapacityByEstimate(
+          outcome(
+            blocks: [
+              block(
+                id: 'partial',
+                startHour: 9,
+                endHour: 10,
+                taskId: 'task-c',
+                reason:
+                    'task-c $allocationPredicate 60 of 120 minutes for today.',
+              ),
+            ],
+            corpus: tasks,
+            capacityMinutes: 60,
+          ),
+        );
+
+        expect(result.passed, isTrue);
+        expect(result.detail, contains('task-c 60min partial of 120min'));
+      });
+    }
+
     test('accepts the prompt contract of partial plus concrete remainder', () {
       final result = scoreWithinCapacityByEstimate(
         outcome(
@@ -1864,6 +1894,35 @@ void main() {
               taskId: 'task-c',
               reason:
                   'No-code prototype scheduled 60 of 120 minutes for today.',
+            ),
+          ],
+          corpus: const [
+            EvalCorpusTask(
+              taskId: 'task-c',
+              title: 'No-code prototype',
+              estimateMinutes: 120,
+            ),
+          ],
+          capacityMinutes: 60,
+        ),
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.detail, contains('task-c 60min partial of 120min'));
+    });
+
+    test('ignores a title-contained negator for a partial label', () {
+      final result = scoreWithinCapacityByEstimate(
+        outcome(
+          blocks: [
+            block(
+              id: 'partial',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-c',
+              reason:
+                  'No-code prototype is partial; '
+                  '60 minutes remain for later.',
             ),
           ],
           corpus: const [
@@ -5020,6 +5079,27 @@ void main() {
 
       expect(result.passed, isTrue);
       expect(result.detail, contains('task-c'));
+    });
+
+    test('rejects a possessive non-task head as an omission object', () {
+      final result = scoreSurfacedConflict(
+        outcome(
+          blocks: [
+            block(
+              id: 'context',
+              startHour: 9,
+              endHour: 10,
+              reason: "We omitted task-c's meeting due to capacity.",
+            ),
+          ],
+          corpus: const [EvalCorpusTask(taskId: 'task-c', title: 'Core')],
+          decidedTaskIds: const ['task-c'],
+          requiresConflictSurfaced: true,
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(result.detail, contains('without naming a casualty'));
     });
 
     test('rejects an imperative omission object', () {


### PR DESCRIPTION
## Summary

Follow up on three late review findings that arrived just after #3647 merged:

- accept ordinary third-person allocation predicates (`schedules`, `allocates`, `completes`, `plans`, and `places`) as concrete partial-allocation evidence;
- ignore negators contained inside the exact current task title when evaluating a partial label;
- preserve explicit non-task heads after possessive task references, so `omitted task-c's meeting` does not surface task-c as the casualty.

## Regression evidence

All seven added cases failed against the merged #3647 head before the fix: five allocation-predicate variants plus the exact `No-code prototype is partial` and `task-c's meeting` examples. They pass on this branch.

## Validation

- `fvm flutter test test/features/daily_os_next/eval/framework/eval_constraints_test.dart --reporter compact` — 394/394 passed
- scoped `fvm dart analyze` — zero issues
- `make knowledge_check` — 89 concepts, 20 validator tests, and 136 Mermaid blocks passed
- formatter and diff checks clean

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified evaluation guidance for numeric allocation, partial-credit labels, acceptable wording, and meeting evidence.
  * Added examples covering possessive task references and omitted meeting descriptions.

* **Bug Fixes**
  * Improved recognition of common allocation and placement phrasing.
  * Reduced incorrect scoring when negation appears within a referenced task title.
  * Improved handling of possessive references that do not identify an actual task conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->