### PR TITLE
fix: unify planning allocation grammar

### DIFF
--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -5,7 +5,7 @@ description: Measuring what the model plans (not what the guards enforce), and p
 resource: ../../../test/features/daily_os_next/eval
 tags: [daily-os, evaluation, benchmark, testing]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T22:39:29+02:00 }
+generated: { by: codex/5, at: 2026-07-28T23:19:59+02:00 }
 stale_after: 2026-10-27
 sources:
   - id: eval
@@ -118,7 +118,10 @@ fabricated, every omission honoured" and hand a failed run a clean sweep.
   `No-code prototype scheduled 60 of 120 minutes` remains affirmative, as does
   the partial label in `No-code prototype is partial`. Allocation predicates
   accept ordinary third-person present forms such as `schedules`, `allocates`,
-  `completes`, `plans`, and `places`. A
+  `completes`, `plans`, and `places`. One shared grammar applies those forms to
+  affirmative splits, full-allocation and direct-denial vetoes, and subject
+  extraction; `The coordinator schedules 60 of 120 minutes` therefore remains
+  coordinator-owned instead of defaulting to the block task. A
   selected allocation action must govern the numeric split on either side; an
   earlier action with intervening object prose, such as scheduling a meeting
   before reviewing `60 of 120` recording minutes, cannot supply task-allocation

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -780,19 +780,24 @@ final _partialRemainderDispositionPattern = RegExp(
   caseSensitive: false,
 );
 
+const _placementActionSource =
+    'schedul(?:e|es|ed|ing)|'
+    'allocat(?:e|es|ed|ing)|'
+    'complet(?:e|es|ed|ing)|'
+    'plan(?:s|ned|ning)?|'
+    'plac(?:e|es|ed|ing)';
+
 final _taskAllocationActionPattern = RegExp(
-  r'\b(?:schedul(?:e|es|ed|ing)|allocat(?:e|es|ed|ing)|'
-  'complet(?:e|es|ed|ing)|plan(?:s|ned|ning)?|plac(?:e|es|ed|ing)|'
+  r'\b(?:'
+  '$_placementActionSource|'
   r'fit(?:s|ting)?)\b',
   caseSensitive: false,
 );
 
 final _fullAllocationPattern = RegExp(
   r'\b(?:(?:fully|entirely|completely)\s+'
-  '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))|'
-  '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))\s+'
+  '(?:$_placementActionSource)|'
+  '(?:$_placementActionSource)\\s+'
   r'in\s+full)\b',
   caseSensitive: false,
 );
@@ -854,11 +859,9 @@ final _tradeSubjectPrefixPattern = RegExp(
   r'^(.*?)\s+(?:(?:(?:is|are|was|were)(?:\s+being)?|'
   r'(?:has|have|had)\s+been(?:\s+being)?|will\s+be(?:\s+being)?)'
   r'(?:\s+(?:not|only|merely|just|still))?'
-  r'(?:\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))?|'
+  '(?:\\s+(?:$_placementActionSource))?|'
   '(?:has|have|had|leave(?:s|d|ing)?|left)|'
-  '(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-  r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)))\s*$',
+  '(?:$_placementActionSource))\\s*\$',
   caseSensitive: false,
 );
 
@@ -1324,8 +1327,8 @@ bool _partialMentionDescribesPlacement(String prose, Match match) {
   final suffix = prose.substring(match.end, range.end);
   if (wording == 'partially' || wording == 'partly') {
     return RegExp(
-      r'^\s+(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-      'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing)|'
+      r'^\s+(?:'
+      '$_placementActionSource|'
       r'fit(?:s|ting)?|defer(?:s|red|ring)?|done|unfinished)\b',
       caseSensitive: false,
     ).hasMatch(suffix);
@@ -1362,8 +1365,7 @@ bool _tradeEvidenceDescribesTaskOrWork(
     final prefix = prose.substring(range.start, match.start);
     if (!RegExp(
       r'\b(?:is|are|was|were|remain(?:s|ed|ing)?|left|'
-      'schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-      'plan(?:s|ned|ning)?|plac(?:e|ed|ing)|'
+      '$_placementActionSource|'
       'defer(?:s|red|ring)?|omit(?:s|ted|ting)?|'
       'drop(?:s|ped|ping)?|move(?:s|d|ing)?|'
       r'roll(?:s|ed|ing)?|carr(?:y|ies|ied|ying))\s*$',
@@ -1445,8 +1447,9 @@ bool _hasTaskBoundAllocationDenial(
   required List<EvalCorpusTask> corpus,
 }) {
   final placementActionPattern = RegExp(
-    r'\b(?:schedul(?:e|ed|ing)|allocat(?:e|ed|ing)|'
-    r'complet(?:e|ed|ing)|plan(?:ned|ning)?|plac(?:e|ed|ing))\b',
+    r'\b(?:'
+    '$_placementActionSource'
+    r')\b',
     caseSensitive: false,
   );
   for (final action in placementActionPattern.allMatches(prose)) {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test.dart
@@ -1497,13 +1497,14 @@ void main() {
       },
     );
 
-    for (final allocationPredicate in [
+    const thirdPersonAllocationPredicates = [
       'schedules',
       'allocates',
       'completes',
       'plans',
       'places',
-    ]) {
+    ];
+    for (final allocationPredicate in thirdPersonAllocationPredicates) {
       test('accepts third-person $allocationPredicate split evidence', () {
         final result = scoreWithinCapacityByEstimate(
           outcome(
@@ -1525,6 +1526,91 @@ void main() {
         expect(result.passed, isTrue);
         expect(result.detail, contains('task-c 60min partial of 120min'));
       });
+    }
+
+    for (final allocationPredicate in thirdPersonAllocationPredicates) {
+      test(
+        'rejects third-person $allocationPredicate with a full contradiction',
+        () {
+          final result = scoreWithinCapacityByEstimate(
+            outcome(
+              blocks: [
+                block(
+                  id: 'partial',
+                  startHour: 9,
+                  endHour: 10,
+                  taskId: 'task-c',
+                  reason:
+                      'task-c $allocationPredicate 60 of 120 minutes for today. '
+                      'task-c fully $allocationPredicate all 120 minutes '
+                      'after all.',
+                ),
+              ],
+              corpus: tasks,
+              capacityMinutes: 60,
+            ),
+          );
+
+          expect(result.passed, isFalse);
+          expect(result.detail, contains('task-c allocated 60min of 120min'));
+        },
+      );
+    }
+
+    for (final allocationPredicate in thirdPersonAllocationPredicates) {
+      test(
+        'rejects a directly denied third-person $allocationPredicate claim',
+        () {
+          final result = scoreWithinCapacityByEstimate(
+            outcome(
+              blocks: [
+                block(
+                  id: 'partial',
+                  startHour: 9,
+                  endHour: 10,
+                  taskId: 'task-c',
+                  reason:
+                      'task-c $allocationPredicate 60 of 120 minutes for today. '
+                      'task-c never $allocationPredicate the task after all.',
+                ),
+              ],
+              corpus: tasks,
+              capacityMinutes: 60,
+            ),
+          );
+
+          expect(result.passed, isFalse);
+          expect(result.detail, contains('task-c allocated 60min of 120min'));
+        },
+      );
+    }
+
+    for (final allocationPredicate in thirdPersonAllocationPredicates) {
+      test(
+        'rejects non-task subject $allocationPredicate split evidence',
+        () {
+          final result = scoreWithinCapacityByEstimate(
+            outcome(
+              blocks: [
+                block(
+                  id: 'partial',
+                  startHour: 9,
+                  endHour: 10,
+                  taskId: 'task-c',
+                  reason:
+                      'The coordinator $allocationPredicate '
+                      '60 of 120 minutes for today.',
+                ),
+              ],
+              corpus: tasks,
+              capacityMinutes: 60,
+            ),
+          );
+
+          expect(result.passed, isFalse);
+          expect(result.detail, contains('task-c allocated 60min of 120min'));
+        },
+      );
     }
 
     test('accepts the prompt contract of partial plus concrete remainder', () {


### PR DESCRIPTION
## Summary

- share one allocation-action grammar across affirmative split evidence, full-allocation contradictions, direct denials, and trade-subject extraction
- recognize ordinary third-person forms such as `schedules`, `allocates`, `completes`, `plans`, and `places` consistently
- prevent coordinator-owned allocation prose from being misattributed to the block task
- update the Daily OS evaluation knowledge map to document the invariant

## Why

Post-merge review of #3654 found two gaps: third-person allocation verbs could establish a partial split without being recognized by contradiction vetoes, and the same forms were absent from subject extraction. That could award partial-allocation credit to contradictory prose or to a non-task subject.

## Regression evidence

Added 15 focused regressions covering all five third-person verbs across:

- full-allocation contradictions
- direct allocation denials
- non-task subjects

All 15 failed against the merged #3654 implementation before the fix and pass with this change.

## Validation

- `fvm flutter test test/features/daily_os_next/eval/framework/eval_constraints_test.dart --reporter compact` — 409 tests passed
- `fvm dart analyze test/features/daily_os_next/eval/framework/eval_constraints.dart test/features/daily_os_next/eval/framework/eval_constraints_test.dart` — no issues
- `make knowledge_check` — 89 concepts valid, 20 validator tests passed, 136 Mermaid blocks parsed
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. CI and Codecov are the authoritative full-suite and patch-coverage results.