### PR TITLE
test(sync): cover image and audio peer repair over Matrix

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -30,6 +30,8 @@ import 'package:lotti/features/sync/matrix/sent_event_registry.dart';
 import 'package:lotti/features/sync/matrix/session_manager.dart';
 import 'package:lotti/features/sync/matrix/sync_event_processor.dart';
 import 'package:lotti/features/sync/matrix/sync_room_manager.dart';
+import 'package:lotti/features/sync/media/media_repair_service.dart';
+import 'package:lotti/features/sync/media/media_request_handler.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_processor.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -63,6 +65,10 @@ import '../test/utils/utils.dart';
 import 'matrix_test_room.dart';
 
 const _uuid = Uuid();
+
+final _eventProcessors = Expando<SyncEventProcessor>(
+  'matrixIntegrationEventProcessor',
+);
 
 int _messageEntryCount(SyncMessage message) =>
     message is SyncOutboxBundle ? message.children.length : 1;
@@ -172,6 +178,62 @@ class _DeviceOutbox {
   }
 }
 
+/// Installs both halves of media self-healing on one simulated device.
+///
+/// Production wires these collaborators in `get_it.dart`. The Matrix
+/// integration harness constructs each device manually, so it must reproduce
+/// that wiring explicitly or a missing-media signal is observed and dropped.
+class _DeviceMediaRepair {
+  _DeviceMediaRepair._({
+    required this._eventProcessor,
+    required this._repairService,
+  });
+
+  factory _DeviceMediaRepair.wire({
+    required MatrixService matrixService,
+    required OutboxService outboxService,
+    required JournalDb journalDb,
+    required VectorClockService vectorClockService,
+    required Directory documentsDirectory,
+    required DomainLogger loggingService,
+    required Duration debounce,
+  }) {
+    final eventProcessor = _eventProcessors[matrixService];
+    if (eventProcessor == null) {
+      throw StateError('Matrix integration event processor was not recorded');
+    }
+    final repairService = MediaRepairService(
+      outboxService: outboxService,
+      vectorClockService: vectorClockService,
+      loggingService: loggingService,
+      debounce: debounce,
+    );
+    eventProcessor
+      ..missingMediaListener = repairService.reportMissing
+      ..mediaRequestHandler = MediaRequestHandler(
+        journalDb: journalDb,
+        outboxService: outboxService,
+        vectorClockService: vectorClockService,
+        documentsDirectory: documentsDirectory,
+        loggingService: loggingService,
+      );
+    return _DeviceMediaRepair._(
+      eventProcessor: eventProcessor,
+      repairService: repairService,
+    );
+  }
+
+  final SyncEventProcessor _eventProcessor;
+  final MediaRepairService _repairService;
+
+  void dispose() {
+    _eventProcessor
+      ..missingMediaListener = null
+      ..mediaRequestHandler = null;
+    _repairService.dispose();
+  }
+}
+
 Future<MatrixService> _createMatrixService({
   required MatrixConfig config,
   required MatrixSyncGateway gateway,
@@ -275,7 +337,7 @@ Future<MatrixService> _createMatrixService({
     queueCoordinator = onCoordinatorBuilt(queueCoordinator);
   }
 
-  return MatrixService(
+  final service = MatrixService(
     matrixConfig: config,
     gateway: gateway,
     loggingService: loggingService,
@@ -291,6 +353,8 @@ Future<MatrixService> _createMatrixService({
     sessionManager: sessionManager,
     queueCoordinator: queueCoordinator,
   );
+  _eventProcessors[service] = eventProcessor;
+  return service;
 }
 
 /// Domain logger that echoes sync-pipeline lines to test stdout.
@@ -321,6 +385,8 @@ class _EchoDomainLogger extends DomainLogger {
     'queue.bootstrap',
     'queue.coordinator',
     'bootstrap',
+    'mediaRepair',
+    'mediaRequest',
     'saveRoom',
   ];
 
@@ -1630,6 +1696,204 @@ void main() {
       timeout: const Timeout(Duration(minutes: 30)),
       skip: skipReason ?? false,
     );
+
+    test(
+      'Missing image and audio files self-heal through peer requests after '
+      'Bob restarts',
+      () async {
+        const repairTimeout = Duration(minutes: 5);
+        final imageId = const Uuid().v1();
+        final audioId = const Uuid().v1();
+        final imageTimestamp = DateTime.utc(2025, 2, 1, 14);
+        final audioTimestamp = DateTime.utc(2025, 2, 1, 15);
+        final image = JournalImage(
+          meta: _nextMediaMetadata(
+            device: aliceOutbox,
+            id: imageId,
+            timestamp: imageTimestamp,
+          ),
+          data: ImageData(
+            capturedAt: imageTimestamp,
+            imageId: imageId,
+            imageFile: '$imageId.png',
+            imageDirectory: '/images/2025-02-01/',
+          ),
+          entryText: const EntryText(
+            plainText: 'Peer-repair Matrix image fixture',
+          ),
+        );
+        final audio = JournalAudio(
+          meta: _nextMediaMetadata(
+            device: aliceOutbox,
+            id: audioId,
+            timestamp: audioTimestamp,
+          ),
+          data: AudioData(
+            dateFrom: audioTimestamp,
+            dateTo: audioTimestamp.add(const Duration(seconds: 1)),
+            audioFile: '$audioId.wav',
+            audioDirectory: '/audio/2025-02-01/',
+            duration: const Duration(seconds: 1),
+            language: 'en',
+          ),
+          entryText: const EntryText(
+            plainText: 'Peer-repair Matrix audio fixture',
+          ),
+        );
+        final imageBytes = base64Decode(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
+          'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+        );
+        final audioBytes = base64Decode(TestAudioData.shortSilenceWav);
+
+        if (!bobOutboxInitialized) {
+          bobOutbox = await _DeviceOutbox.create(
+            matrixService: bob,
+            journalDb: bobDb,
+            syncDb: bobSyncDb,
+            documentsDirectory: bobDocumentsDirectory,
+            userActivityService: sharedUserActivityService,
+            loggingService: getIt<DomainLogger>(),
+            vectorClockService: bobVectorClockService,
+            deviceName: 'bobDeviceV2',
+          );
+          bobOutboxInitialized = true;
+        }
+        await _sendMediaEntity(
+          entity: image,
+          bytes: imageBytes,
+          sender: aliceOutbox,
+          receiver: bobOutbox,
+          receiverService: bob,
+          timeout: repairTimeout,
+        );
+        await _sendMediaEntity(
+          entity: audio,
+          bytes: audioBytes,
+          sender: aliceOutbox,
+          receiver: bobOutbox,
+          receiverService: bob,
+          timeout: repairTimeout,
+        );
+
+        final bobImageFile = _mediaFileFor(bobOutbox, image);
+        final bobAudioFile = _mediaFileFor(bobOutbox, audio);
+        await bobOutbox.service.dispose();
+        bobOutboxInitialized = false;
+        await bob.dispose();
+        bobInitialized = false;
+        await bobImageFile.delete();
+        await bobAudioFile.delete();
+
+        // Recreate the receiving app so its process-local AttachmentIndex no
+        // longer contains either original descriptor. Marker-anchored startup
+        // catch-up begins after those historical events and cannot repair the
+        // files by replaying them.
+        bob = await _createBobService(
+          documentsDirectory: bobDocumentsDirectory,
+          config: config2,
+          loggingService: getIt<DomainLogger>(),
+          journalDb: bobDb,
+          settingsDb: bobSettingsDb,
+          secureStorage: secureStorageMock,
+          activityService: sharedUserActivityService,
+          updateNotifications: mockUpdateNotifications,
+          aiConfigRepository: sharedAiConfigRepository,
+          singleInstance: false,
+          syncDb: bobSyncDb,
+          vectorClockService: bobVectorClockService,
+        );
+        bobInitialized = true;
+        await bob.init();
+        expect(bob.debugPipeline, isNotNull);
+        await bob.queueCoordinator.triggerBridge();
+        expect(bobImageFile.existsSync(), isFalse);
+        expect(bobAudioFile.existsSync(), isFalse);
+
+        bobOutbox = await _DeviceOutbox.create(
+          matrixService: bob,
+          journalDb: bobDb,
+          syncDb: bobSyncDb,
+          documentsDirectory: bobDocumentsDirectory,
+          userActivityService: sharedUserActivityService,
+          loggingService: getIt<DomainLogger>(),
+          vectorClockService: bobVectorClockService,
+          deviceName: 'bobDeviceV2',
+        );
+        bobOutboxInitialized = true;
+
+        final repairWiring = <_DeviceMediaRepair>[];
+        addTearDown(() {
+          for (final wiring in repairWiring.reversed) {
+            wiring.dispose();
+          }
+        });
+        // Debounce timing has deterministic fake-time unit coverage. Keep the
+        // real-network regression focused on the encrypted request/response
+        // and exact-byte ingestion path rather than paying the production
+        // 20-second batching window on every Matrix CI lane.
+        const integrationDebounce = Duration(milliseconds: 200);
+        repairWiring
+          ..add(
+            _DeviceMediaRepair.wire(
+              matrixService: alice,
+              outboxService: aliceOutbox.service,
+              journalDb: aliceDb,
+              vectorClockService: aliceVectorClockService,
+              documentsDirectory: aliceDocumentsDirectory,
+              loggingService: getIt<DomainLogger>(),
+              debounce: integrationDebounce,
+            ),
+          )
+          ..add(
+            _DeviceMediaRepair.wire(
+              matrixService: bob,
+              outboxService: bobOutbox.service,
+              journalDb: bobDb,
+              vectorClockService: bobVectorClockService,
+              documentsDirectory: bobDocumentsDirectory,
+              loggingService: getIt<DomainLogger>(),
+              debounce: integrationDebounce,
+            ),
+          );
+
+        final updated = await _sendMediaMetadataUpdates(
+          entities: [image, audio],
+          sender: aliceOutbox,
+          timeout: repairTimeout,
+        );
+        await waitUntilAsync(
+          () async {
+            final updatedImage = await bobDb.journalEntityById(imageId);
+            final updatedAudio = await bobDb.journalEntityById(audioId);
+            final repaired =
+                updatedImage?.meta.vectorClock == updated[0].meta.vectorClock &&
+                updatedAudio?.meta.vectorClock == updated[1].meta.vectorClock &&
+                bobImageFile.existsSync() &&
+                bobAudioFile.existsSync();
+            if (!repaired) {
+              await aliceOutbox.service.enqueueNextSendRequest(
+                delay: Duration.zero,
+              );
+              await bobOutbox.service.enqueueNextSendRequest(
+                delay: Duration.zero,
+              );
+              await alice.forceRescan();
+              await bob.forceRescan();
+              await alice.retryNow();
+              await bob.retryNow();
+            }
+            return repaired;
+          },
+          timeout: repairTimeout,
+        );
+
+        expect(await bobImageFile.readAsBytes(), orderedEquals(imageBytes));
+        expect(await bobAudioFile.readAsBytes(), orderedEquals(audioBytes));
+      },
+      timeout: const Timeout(Duration(minutes: 15)),
+      skip: skipReason ?? false,
+    );
   });
 }
 
@@ -1825,6 +2089,80 @@ Future<JournalEntity> _sendMediaEntity({
     reason: 'Matrix must transfer the exact media payload between sandboxes',
   );
   return received!;
+}
+
+Future<List<JournalEntity>> _sendMediaMetadataUpdates({
+  required List<JournalEntity> entities,
+  required _DeviceOutbox sender,
+  required Duration timeout,
+}) async {
+  await _setMatrixSyncEnabled(sender.journalDb, enabled: false);
+  final updated = <JournalEntity>[];
+  try {
+    final actionableBefore = await sender.syncDb.getOutboxItems(
+      limit: entities.length + 1,
+      statuses: const [
+        OutboxStatus.pending,
+        OutboxStatus.sending,
+        OutboxStatus.error,
+      ],
+    );
+    expect(
+      actionableBefore,
+      isEmpty,
+      reason: '${sender.deviceName} outbox must start drained',
+    );
+
+    for (final entity in entities) {
+      final counter = sender.nextCounter++;
+      final metadata = entity.meta.copyWith(
+        updatedAt: entity.meta.updatedAt.add(Duration(minutes: counter)),
+        vectorClock: VectorClock({sender.deviceName: counter}),
+      );
+      final next = switch (entity) {
+        JournalImage() => entity.copyWith(meta: metadata),
+        JournalAudio() => entity.copyWith(meta: metadata),
+        _ => throw ArgumentError.value(
+          entity,
+          'entity',
+          'Expected JournalImage or JournalAudio',
+        ),
+      };
+      updated.add(next);
+
+      await saveJournalEntityJson(
+        next,
+        documentsDirectory: sender.documentsDirectory,
+      );
+      await sender.journalDb.updateJournalEntity(next);
+      await sender.service.enqueueMessage(
+        SyncMessage.journalEntity(
+          id: next.meta.id,
+          status: SyncEntryStatus.update,
+          vectorClock: next.meta.vectorClock,
+          jsonPath: relativeEntityPath(next),
+          originatingHostId: sender.deviceName,
+        ),
+      );
+    }
+
+    final pending = await sender.syncDb.getOutboxItems(
+      limit: entities.length + 1,
+      statuses: const [OutboxStatus.pending],
+    );
+    expect(pending, hasLength(entities.length));
+    expect(
+      pending.every((row) => row.filePath == null),
+      isTrue,
+      reason: 'ordinary metadata edits must not resend immutable media blobs',
+    );
+  } finally {
+    await _setMatrixSyncEnabled(sender.journalDb, enabled: true);
+  }
+
+  await sender.service.enqueueNextSendRequest(delay: Duration.zero);
+  await _waitForOutboxDrain(sender, timeout: timeout);
+  return updated;
 }
 
 Future<void> _stageTestMessages(int n, {required _DeviceOutbox device}) async {

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -65,6 +65,9 @@ import '../test/utils/utils.dart';
 import 'matrix_test_room.dart';
 
 const _uuid = Uuid();
+const _onePixelPngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
+    'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
 final _eventProcessors = Expando<SyncEventProcessor>(
   'matrixIntegrationEventProcessor',
@@ -225,6 +228,11 @@ class _DeviceMediaRepair {
 
   final SyncEventProcessor _eventProcessor;
   final MediaRepairService _repairService;
+
+  Set<String> get pendingEntryIds => _repairService.debugPending;
+
+  Future<void> flushPendingForTesting() =>
+      _repairService.flushPendingForTesting();
 
   void dispose() {
     _eventProcessor
@@ -947,10 +955,7 @@ void main() {
           ),
           entryText: const EntryText(plainText: 'Matrix image fixture'),
         );
-        final bytes = base64Decode(
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
-          'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-        );
+        final bytes = base64Decode(_onePixelPngBase64);
 
         final received = await _sendMediaEntity(
           entity: image,
@@ -1740,10 +1745,7 @@ void main() {
             plainText: 'Peer-repair Matrix audio fixture',
           ),
         );
-        final imageBytes = base64Decode(
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
-          'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-        );
+        final imageBytes = base64Decode(_onePixelPngBase64);
         final audioBytes = base64Decode(TestAudioData.shortSilenceWav);
 
         if (!bobOutboxInitialized) {
@@ -1780,6 +1782,11 @@ void main() {
         final bobAudioFile = _mediaFileFor(bobOutbox, audio);
         await bobOutbox.service.dispose();
         bobOutboxInitialized = false;
+        expect(
+          bobImageFile.existsSync() && bobAudioFile.existsSync(),
+          isTrue,
+          reason: 'both blobs must reach Bob before the repair scenario starts',
+        );
         await bob.dispose();
         bobInitialized = false;
         await bobImageFile.delete();
@@ -1807,6 +1814,7 @@ void main() {
         await bob.init();
         expect(bob.debugPipeline, isNotNull);
         await bob.queueCoordinator.triggerBridge();
+        await bob.queueCoordinator.drainBootstrapAttachmentWorkForTesting();
         expect(bobImageFile.existsSync(), isFalse);
         expect(bobAudioFile.existsSync(), isFalse);
 
@@ -1828,40 +1836,54 @@ void main() {
             wiring.dispose();
           }
         });
-        // Debounce timing has deterministic fake-time unit coverage. Keep the
-        // real-network regression focused on the encrypted request/response
-        // and exact-byte ingestion path rather than paying the production
-        // 20-second batching window on every Matrix CI lane.
-        const integrationDebounce = Duration(milliseconds: 200);
+        // Debounce timing has deterministic fake-time unit coverage. Arm a
+        // window that cannot race this test, then flush explicitly once both
+        // missing-entry signals have been observed.
+        const integrationDebounce = Duration(days: 1);
+        final aliceRepair = _DeviceMediaRepair.wire(
+          matrixService: alice,
+          outboxService: aliceOutbox.service,
+          journalDb: aliceDb,
+          vectorClockService: aliceVectorClockService,
+          documentsDirectory: aliceDocumentsDirectory,
+          loggingService: getIt<DomainLogger>(),
+          debounce: integrationDebounce,
+        );
+        final bobRepair = _DeviceMediaRepair.wire(
+          matrixService: bob,
+          outboxService: bobOutbox.service,
+          journalDb: bobDb,
+          vectorClockService: bobVectorClockService,
+          documentsDirectory: bobDocumentsDirectory,
+          loggingService: getIt<DomainLogger>(),
+          debounce: integrationDebounce,
+        );
         repairWiring
-          ..add(
-            _DeviceMediaRepair.wire(
-              matrixService: alice,
-              outboxService: aliceOutbox.service,
-              journalDb: aliceDb,
-              vectorClockService: aliceVectorClockService,
-              documentsDirectory: aliceDocumentsDirectory,
-              loggingService: getIt<DomainLogger>(),
-              debounce: integrationDebounce,
-            ),
-          )
-          ..add(
-            _DeviceMediaRepair.wire(
-              matrixService: bob,
-              outboxService: bobOutbox.service,
-              journalDb: bobDb,
-              vectorClockService: bobVectorClockService,
-              documentsDirectory: bobDocumentsDirectory,
-              loggingService: getIt<DomainLogger>(),
-              debounce: integrationDebounce,
-            ),
-          );
+          ..add(aliceRepair)
+          ..add(bobRepair);
 
         final updated = await _sendMediaMetadataUpdates(
           entities: [image, audio],
           sender: aliceOutbox,
           timeout: repairTimeout,
         );
+        final missingEntryIds = {imageId, audioId};
+        await waitUntilAsync(
+          () async {
+            final observed = bobRepair.pendingEntryIds.containsAll(
+              missingEntryIds,
+            );
+            if (!observed) {
+              await bob.forceRescan();
+              await bob.retryNow();
+            }
+            return observed;
+          },
+          timeout: repairTimeout,
+        );
+        expect(bobRepair.pendingEntryIds, missingEntryIds);
+        await bobRepair.flushPendingForTesting();
+        await bobOutbox.service.enqueueNextSendRequest(delay: Duration.zero);
         await waitUntilAsync(
           () async {
             final updatedImage = await bobDb.journalEntityById(imageId);

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -76,6 +76,16 @@ final _eventProcessors = Expando<SyncEventProcessor>(
 int _messageEntryCount(SyncMessage message) =>
     message is SyncOutboxBundle ? message.children.length : 1;
 
+Iterable<SyncMessage> _flattenMessages(Iterable<SyncMessage> messages) sync* {
+  for (final message in messages) {
+    if (message is SyncOutboxBundle) {
+      yield* _flattenMessages(message.children);
+    } else {
+      yield message;
+    }
+  }
+}
+
 /// Observes the production outbox sender without changing its send semantics.
 ///
 /// The mid-rejoin scenario uses [beforeSend] to pause *between* bundles. There
@@ -93,6 +103,7 @@ class _ObservedOutboxMessageSender implements OutboxMessageSender {
   int sentEvents = 0;
   int sentEntries = 0;
   final List<int> bundleSizes = [];
+  final List<SyncMessage> sentMessages = [];
 
   @override
   Future<bool> send(SyncMessage message) async {
@@ -103,6 +114,7 @@ class _ObservedOutboxMessageSender implements OutboxMessageSender {
       final entryCount = _messageEntryCount(message);
       sentEntries += entryCount;
       bundleSizes.add(entryCount);
+      sentMessages.add(message);
     }
     return sent;
   }
@@ -1862,6 +1874,8 @@ void main() {
           ..add(aliceRepair)
           ..add(bobRepair);
 
+        final bobSentBeforeRepair = bobOutbox.sender.sentMessages.length;
+        final aliceSentBeforeRepair = aliceOutbox.sender.sentMessages.length;
         final updated = await _sendMediaMetadataUpdates(
           entities: [image, audio],
           sender: aliceOutbox,
@@ -1910,6 +1924,28 @@ void main() {
           timeout: repairTimeout,
         );
 
+        final repairRequests = _flattenMessages(
+          bobOutbox.sender.sentMessages.skip(bobSentBeforeRepair),
+        ).whereType<SyncMediaRequest>().toList();
+        expect(repairRequests, hasLength(1));
+        expect(repairRequests.single.entryIds.toSet(), missingEntryIds);
+
+        final repairResponses =
+            _flattenMessages(
+                  aliceOutbox.sender.sentMessages.skip(aliceSentBeforeRepair),
+                )
+                .whereType<SyncJournalEntity>()
+                .where(
+                  (message) =>
+                      message.includeAttachments == true &&
+                      missingEntryIds.contains(message.id),
+                )
+                .toList();
+        expect(
+          repairResponses.map((message) => message.id).toSet(),
+          missingEntryIds,
+          reason: 'Alice must answer both requested entries with attachments',
+        );
         expect(await bobImageFile.readAsBytes(), orderedEquals(imageBytes));
         expect(await bobAudioFile.readAsBytes(), orderedEquals(audioBytes));
       },

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -11,7 +11,7 @@ sources:
   - id: queue
     resource: ../../../lib/features/sync/queue
     title: Inbound queue pipeline
-    last_modified: 2026-07-27
+    last_modified: 2026-07-29
   - id: processor
     resource: ../../../lib/features/sync/matrix/sync_event_processor.dart
     title: SyncEventProcessor
@@ -105,6 +105,11 @@ This has no fixed capacity and no attempt timer.
 On coordinator startup, an explicit room save, a manual rescan, or a joined-room
 `timeline.limited == true`, `BridgeCoordinator` runs a catch-up walk anchored on
 the per-room `last_applied_event_id` marker.
+
+Catch-up is single-flight. Organic sync triggers that arrive during a walk
+coalesce into one rerun. Explicit `bridgeNow()` callers await that entire rerun
+cascade, so returning from a manual rescan is a reliable synchronisation point
+for the bridge itself; attachment downloads remain independently queued.
 
 The preferred path is an **anchored forward walk**
 (`CatchUpStrategy.collectForwardForBootstrap`): force a server

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,10 @@
 # Knowledge Bundle Update Log
 
+## 2026-07-29
+* **Removal**: Removed the Character animation concept after its unused
+  implementation was deleted, so the bundle no longer describes or links to a
+  feature that is absent from the repository.
+
 ## 2026-07-26
 * **Enforcement**: The metadata that makes drift detectable now fails the build
   instead of being reported and ignored — a missing or empty `title`,

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -4,6 +4,9 @@
 * **Removal**: Removed the Character animation concept after its unused
   implementation was deleted, so the bundle no longer describes or links to a
   feature that is absent from the repository.
+* **Correction**: Clarified that explicit sync bridge calls await every
+  single-flight rerun coalesced onto the active pass, while attachment downloads
+  retain their independent queue and drain point.
 
 ## 2026-07-26
 * **Enforcement**: The metadata that makes drift detectable now fails the build

--- a/lib/features/sync/media/media_repair_service.dart
+++ b/lib/features/sync/media/media_repair_service.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/vector_clock_service.dart';
+import 'package:meta/meta.dart';
 
 /// Requester half of media self-healing: turns "this entry's blob is missing
 /// locally" into a broadcast [SyncMediaRequest] that peers answer with the
@@ -74,6 +75,17 @@ class MediaRepairService {
 
   /// Entry ids currently waiting for their next request — test seam.
   Set<String> get debugPending => Set.unmodifiable(_pending);
+
+  /// Cancels the debounce and sends the currently pending batch.
+  ///
+  /// Integration tests use this seam after observing the expected missing
+  /// entries so their network assertions do not depend on a real timer.
+  @visibleForTesting
+  Future<void> flushPendingForTesting() {
+    _timer?.cancel();
+    _timer = null;
+    return _flush();
+  }
 
   /// Records that [entryId]'s media file is missing locally and schedules a
   /// request for it. Safe to call repeatedly for the same entry: duplicates

--- a/lib/features/sync/queue/bridge_coordinator.dart
+++ b/lib/features/sync/queue/bridge_coordinator.dart
@@ -175,10 +175,24 @@ class BridgeCoordinator {
     }
   }
 
-  /// Runs a bridge pass explicitly, bypassing the onSync listener.
-  /// Used by `MatrixService.forceRescan(includeCatchUp: true)` and by
-  /// tests.
-  Future<void> bridgeNow() => _bridge(_currentRoomId());
+  /// Runs a bridge pass explicitly, bypassing the onSync listener, and waits
+  /// for any single-flight rerun coalesced onto that pass.
+  ///
+  /// Used by `MatrixService.forceRescan(includeCatchUp: true)` and by tests.
+  /// A completed future means the current bridge cascade is idle; bounded
+  /// retries scheduled for a later timeout remain asynchronous.
+  Future<void> bridgeNow() async {
+    await _bridge(_currentRoomId());
+    await _waitUntilIdle();
+  }
+
+  Future<void> _waitUntilIdle() async {
+    while (true) {
+      final inFlight = _inFlightBridge;
+      if (inFlight == null) return;
+      await inFlight;
+    }
+  }
 
   void _handle(SyncUpdate sync) {
     if (_stopped) return;

--- a/lib/features/sync/queue/queue_gap_recovery.dart
+++ b/lib/features/sync/queue/queue_gap_recovery.dart
@@ -160,20 +160,25 @@ extension QueueGapRecovery on QueuePipelineCoordinator {
       logging: _logging,
       decryptEvent: _decryptBootstrapEvent,
     );
-    final innerSink = _attachmentIngestor == null
-        ? queueSink
+    final attachmentSink = _attachmentIngestor == null
+        ? null
         : AttachmentAwareBootstrapSink(
-                inner: queueSink,
-                processAttachment: _processAttachment,
-              )
-              as BootstrapSink;
+            inner: queueSink,
+            processAttachment: _processAttachment,
+          );
+    final innerSink = attachmentSink ?? queueSink;
     final countingSink = TotalAcceptedCountingSink(innerSink);
-    final result = await CatchUpStrategy.collectForwardForBootstrap(
-      room: room,
-      sink: countingSink,
-      logging: _logging,
-      anchorEventId: anchorEventId,
-    );
+    late final BootstrapResult result;
+    try {
+      result = await CatchUpStrategy.collectForwardForBootstrap(
+        room: room,
+        sink: countingSink,
+        logging: _logging,
+        anchorEventId: anchorEventId,
+      );
+    } finally {
+      _trackBootstrapAttachmentSink(attachmentSink);
+    }
     _logging.log(
       LogDomain.sync,
       'queue.bootstrap.forward.done '
@@ -226,24 +231,29 @@ extension QueueGapRecovery on QueuePipelineCoordinator {
       logging: _logging,
       decryptEvent: _decryptBootstrapEvent,
     );
-    final innerSink = _attachmentIngestor == null
-        ? queueSink
+    final attachmentSink = _attachmentIngestor == null
+        ? null
         : AttachmentAwareBootstrapSink(
-                inner: queueSink,
-                processAttachment: _processAttachment,
-              )
-              as BootstrapSink;
+            inner: queueSink,
+            processAttachment: _processAttachment,
+          );
+    final innerSink = attachmentSink ?? queueSink;
     // Count accepted events across every page so we can detect the
     // "boundaryReached with totalAccepted==0" case that marks the
     // bridge barren — the gap-recovery trigger reads this flag.
     final countingSink = TotalAcceptedCountingSink(innerSink);
-    final result = await CatchUpStrategy.collectHistoryForBootstrap(
-      room: room,
-      sink: countingSink,
-      logging: _logging,
-      untilTimestamp: untilTimestamp,
-      overallTimeout: SyncTuning.backwardWalkTimeout,
-    );
+    late final BootstrapResult result;
+    try {
+      result = await CatchUpStrategy.collectHistoryForBootstrap(
+        room: room,
+        sink: countingSink,
+        logging: _logging,
+        untilTimestamp: untilTimestamp,
+        overallTimeout: SyncTuning.backwardWalkTimeout,
+      );
+    } finally {
+      _trackBootstrapAttachmentSink(attachmentSink);
+    }
     _updateBarrenBridgeFlag(
       untilTimestamp: untilTimestamp,
       result: result,

--- a/lib/features/sync/queue/queue_pipeline_coordinator.dart
+++ b/lib/features/sync/queue/queue_pipeline_coordinator.dart
@@ -224,6 +224,14 @@ class QueuePipelineCoordinator {
   /// so we only pay the DB load cost once per room.
   final Set<String> _postLoadedRoomIds = <String>{};
 
+  /// Attachment-aware sinks whose bootstrap page workers have not finished.
+  ///
+  /// Pagination intentionally does not await these workers. Keeping the
+  /// active sinks observable lets integration tests establish that no
+  /// historical attachment can still land before testing peer repair.
+  final Set<AttachmentAwareBootstrapSink> _activeBootstrapAttachmentSinks =
+      <AttachmentAwareBootstrapSink>{};
+
   InboundQueue get queue => _queue;
 
   bool get isRunning => _started;
@@ -233,6 +241,31 @@ class QueuePipelineCoordinator {
   /// Settings UI can force a /messages walk back to the stored
   /// marker without waiting for the next organic `limited=true`.
   Future<void> triggerBridge() => _bridge.bridgeNow();
+
+  /// Waits until bootstrap attachment workers and their queued downloads are
+  /// idle. This is a test synchronisation seam; production bootstrap remains
+  /// fire-and-forget relative to attachment ingestion.
+  @visibleForTesting
+  Future<void> drainBootstrapAttachmentWorkForTesting() async {
+    while (_activeBootstrapAttachmentSinks.isNotEmpty) {
+      await Future.wait(
+        _activeBootstrapAttachmentSinks.map((sink) => sink.drain()).toList(),
+      );
+    }
+    await _attachmentIngestor?.whenIdle();
+  }
+
+  void _trackBootstrapAttachmentSink(
+    AttachmentAwareBootstrapSink? sink,
+  ) {
+    if (sink == null) return;
+    _activeBootstrapAttachmentSinks.add(sink);
+    unawaited(
+      sink.drain().whenComplete(
+        () => _activeBootstrapAttachmentSinks.remove(sink),
+      ),
+    );
+  }
 
   /// True while the bridge coordinator is mid-walk (forward-reading
   /// new timeline events from the last applied event id). Exposed so

--- a/test/features/sync/media/media_repair_service_test.dart
+++ b/test/features/sync/media/media_repair_service_test.dart
@@ -90,6 +90,23 @@ void main() {
     });
   });
 
+  test('flushes pending misses without waiting for the debounce', () async {
+    final service = buildService();
+    addTearDown(service.dispose);
+
+    service
+      ..reportMissing(entryId: 'image-1', relativePath: '/images/1')
+      ..reportMissing(entryId: 'audio-1', relativePath: '/audio/1');
+
+    expect(requests, isEmpty);
+
+    await service.flushPendingForTesting();
+
+    expect(requests, hasLength(1));
+    expect(requests.single.entryIds, ['image-1', 'audio-1']);
+    expect(service.debugPending, isEmpty);
+  });
+
   test('splits a backlog across successive requests at the batch cap', () {
     fakeAsync((async) {
       final service = buildService(maxBatchSize: 2);

--- a/test/features/sync/queue/bridge_coordinator_test.dart
+++ b/test/features/sync/queue/bridge_coordinator_test.dart
@@ -625,42 +625,51 @@ void main() {
 
   test(
     'a second trigger that lands while a bridge is in-flight is coalesced '
-    'into exactly one rerun after the in-flight pass completes',
+    'into exactly one rerun and both explicit callers await the full cascade',
     () async {
       final room = MockRoom();
       when(() => room.id).thenReturn(roomId);
       final firstCallGate = Completer<void>();
+      final firstCallStarted = Completer<void>();
+      final rerunGate = Completer<void>();
+      final rerunStarted = Completer<void>();
+      var callCount = 0;
       final runner = _RecordingRunner()
         ..override = (Room r, BridgeMarker m) async {
-          if (r.id == roomId && !firstCallGate.isCompleted) {
-            // First call: wait for the gate.
-            // Second and later calls resolve immediately.
+          callCount++;
+          if (callCount == 1) {
+            firstCallStarted.complete();
+            await firstCallGate.future;
+          } else {
+            rerunStarted.complete();
+            await rerunGate.future;
           }
           return true;
         };
-      // Override the override: first call gated, subsequent immediate.
-      var callCount = 0;
-      runner.override = (Room r, BridgeMarker m) async {
-        callCount++;
-        if (callCount == 1) await firstCallGate.future;
-        return true;
-      };
       final coordinator = buildCoordinator(
         resolveRoom: () async => room,
         runner: runner,
       );
       final firstBridge = coordinator.bridgeNow();
-      await Future<void>.delayed(Duration.zero);
-      unawaited(coordinator.bridgeNow());
-      await Future<void>.delayed(Duration.zero);
+      await firstCallStarted.future;
+      var coalescedCallCompleted = false;
+      final coalescedBridge = coordinator.bridgeNow().then(
+        (_) => coalescedCallCompleted = true,
+      );
       expect(callCount, 1);
+
       firstCallGate.complete();
-      await firstBridge;
-      for (var i = 0; i < 20; i++) {
-        await Future<void>.delayed(Duration.zero);
-        if (callCount >= 2) break;
-      }
+      await rerunStarted.future;
       expect(callCount, 2);
+      expect(
+        coalescedCallCompleted,
+        isFalse,
+        reason: 'the coalesced caller must not outrun its scheduled rerun',
+      );
+
+      rerunGate.complete();
+      await Future.wait([firstBridge, coalescedBridge]);
+      expect(coalescedCallCompleted, isTrue);
     },
   );
 

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -91,6 +91,9 @@ class _FakeAttachmentIngestor implements AttachmentIngestor {
   }
 
   @override
+  Future<void> whenIdle() => Future<void>.value();
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
@@ -4362,8 +4365,10 @@ void main() {
         final realQueue = InboundQueue(db: syncDb, logging: logging);
         addTearDown(realQueue.dispose);
         final firstProcessed = Completer<Event>();
+        final processGate = Completer<void>();
         final ingestor = _FakeAttachmentIngestor(
           firstProcessed: firstProcessed,
+          processGate: processGate.future,
         );
 
         final coordinator = QueuePipelineCoordinator(
@@ -4428,6 +4433,19 @@ void main() {
         // The forward walk emitted page [e1] (anchor itself is
         // filtered) → ingestor.process must have fired for that event.
         expect(await firstProcessed.future, same(e1));
+        var drainCompleted = false;
+        final drain = coordinator.drainBootstrapAttachmentWorkForTesting().then(
+          (_) => drainCompleted = true,
+        );
+        await Future<void>.value();
+        expect(
+          drainCompleted,
+          isFalse,
+          reason: 'the test seam must wait for fire-and-forget page workers',
+        );
+        processGate.complete();
+        await drain;
+        expect(drainCompleted, isTrue);
         expect(ingestor.processCalls, hasLength(1));
         expect(ingestor.processCalls.single[#event], same(e1));
       },


### PR DESCRIPTION
## Summary

- wire the media-repair requester and responder into the two-device Matrix integration harness
- add a real Dendrite regression for missing image and audio repair after the receiving device restarts
- assert metadata-only updates do not carry attachments, then verify the peer request/response path restores the exact PNG and WAV bytes
- make the regression deterministic by explicitly flushing the repair batch and draining bootstrap attachment work before asserting stable absence
- make explicit bridge calls await the complete single-flight rerun cascade, so a manual rescan is a reliable bridge synchronization point
- record successful integration-harness traffic and require one two-ID repair request plus both attachment-bearing responses
- remove the stale Character knowledge concept left behind when #3660 deleted that implementation, restoring the OKF bundle on current `main`

## Why

PR #3648 added peer-assisted media repair, with requester and responder behavior covered separately by unit tests. The retained Matrix integration suite covered initial media transfer, but not the full encrypted round trip after a receiver loses blobs and restarts with a marker beyond the original attachment events.

This regression creates and transfers image and audio entries, restarts Bob to clear the process-local `AttachmentIndex`, deletes Bob's copies, proves normal marker catch-up does not restore them, and then exercises the production `SyncMediaRequest` / attachment response path. Explicit bridge calls now wait for reruns coalesced onto an already-active startup pass, preventing the absence check from racing a later bootstrap sink.

After rebasing onto #3660, the OKF validator also exposed that `knowledge/features/character.md` still referenced the deleted `lib/features/character` module. The documentation-only follow-up removes that obsolete concept, its index entry, and records the structural removal in the knowledge log.

## Verification

- `fvm dart format` on touched Dart files
- scoped `fvm dart analyze` on the integration and affected sync production/test files — zero issues
- targeted unit tests for bridge coordination, media repair, and queue coordination — 126 passed
- full normal Matrix integration file on Linux — 7/7 passed in 2m31s
- full degraded Matrix integration file through Toxiproxy — 7/7 passed in 1m28s
- repaired-media traffic asserts exactly one Bob request containing both missing IDs and Alice attachment responses for both IDs
- non-vacuous mutation check: removing the missing-media listener makes the regression time out with both files absent; restoring the wiring makes it pass
- `make knowledge_check` — 88 concepts, zero errors/warnings; 136 Mermaid blocks parsed
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved media self-healing so missing image and audio files can be restored from connected devices after a restart.
  - Added support for repairing media when metadata changes trigger synchronization.

- **Documentation**
  - Removed outdated documentation and exploratory listings for the Character animation feature.
  - Updated the knowledge log to reflect the feature’s removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->