### PR TITLE
fix: close out the review findings left open on #3664

### DIFF
--- a/docs/adr/0046-sync-actor-isolate-removed-and-how-to-rebuild.md
+++ b/docs/adr/0046-sync-actor-isolate-removed-and-how-to-rebuild.md
@@ -85,11 +85,13 @@ lines was the design, not the code.
 - ~7400 lines leave the repo; future sync changes stop needing a second,
   unreachable implementation.
 - Existing installs carry a stale `enable_sync_actor` row. Flags are seeded
-  with `insertFlagIfNotExists`, which never deletes, and the settings page
-  lists whatever rows the table holds — so removing the seed alone would leave
-  a live toggle wired to nothing. `initConfigFlags` now ends by deleting every
-  name in `retiredConfigFlags`, which is the mechanism to use whenever a flag
-  is retired.
+  with `insertFlagIfNotExists`, which never deletes, so removing the seed
+  alone leaves the row in every upgraded install forever — stored, emitted by
+  `watchConfigFlags`, and readable by name. It was never a *visible* toggle:
+  `FlagsBody` renders only the names in its `defaultDisplayedItems` whitelist,
+  and `enable_sync_actor` was never on it. `initConfigFlags` now ends by
+  deleting every name in `retiredConfigFlags` — storage cleanup, and the
+  mechanism to use whenever a flag is retired.
 - If jank appears later, the rebuild starts from this document rather than
   from a stale branch.
 
@@ -109,12 +111,20 @@ Establish that the remaining cost is still a render-thread problem.
 
 ### What proved sound
 
-**Direct DB writes, no apply/ack protocol.** The actor opens its own
-connections to the same `db.sqlite` and `settings.sqlite` files and writes
-through them. SQLite handles this: WAL mode, `busy_timeout = 5000` and
-`synchronous = NORMAL` are set in `_setupDatabase()`, so readers do not block
-writers. This removed an entire class of complexity from the original design
-and should be kept.
+**Direct DB writes, no apply/ack protocol.** The design was for the actor to
+open its own connections to the same SQLite files as the main isolate and
+write through them, rather than shipping every change back over a port. SQLite
+handles this: WAL mode, `busy_timeout = 5000` and `synchronous = NORMAL` are
+set in `_setupDatabase()`, so readers do not block writers. This removed an
+entire class of complexity from the original design and should be kept.
+
+Be precise about how far this was actually proven, because a rebuild will
+inherit the gap. **The only database the actor ever opened was
+`SyncDatabase`** — `SyncActorCommandHandler` constructed it through a
+`SyncDatabaseFactory`, and `OutboundQueue` claimed and updated outbox rows
+through it directly. `JournalDb` and `SettingsDb` from a second isolate is
+plan phase 4, which never landed (see above). So cross-isolate writes are
+demonstrated for the outbox and *inferred* for the journal.
 
 **Notification-driven UI refresh.** All sync-affected Drift `watch()` calls
 were replaced with `notificationDrivenStream()` fed by `UpdateNotifications`
@@ -131,11 +141,32 @@ Wire format detail worth keeping: send `List<String>`, not `Set`, because
 **A flat command/event protocol over `SendPort`.** Commands carry
 `{command, requestId, replyTo, ...payload}`; responses carry
 `{ok, requestId, error?, errorCode?, ...result}`; events carry
-`{event, ...payload}`. No priority queues or QoS. A linear state model —
-`uninitialized → initializing → idle → syncing → stopping → disposed` — with
+`{event, ...payload}`. No priority queues or QoS. A small state model with
 out-of-state commands answered `errorCode: 'INVALID_STATE'`. This was enough
 for login, room join, SAS verification and send/receive, and did not need to
 grow.
+
+The states were `uninitialized`, `initializing`, `idle`, `syncing`,
+`stopping`, `disposed`, but they were **not** a single linear chain, and a
+rebuild that assumes one will get the valid-command table wrong:
+
+```mermaid
+stateDiagram-v2
+  [*] --> uninitialized
+  uninitialized --> initializing: init
+  initializing --> syncing: init completes, background sync started
+  initializing --> uninitialized: init fails
+  syncing --> idle: stopSync
+  idle --> syncing: startSync
+  syncing --> stopping: dispose
+  idle --> stopping: dispose
+  stopping --> disposed
+  disposed --> [*]
+```
+
+`init` went straight to `syncing` — it started background sync as part of
+initialization — so `idle` was reachable **only** by an explicit `stopSync`,
+and `startSync` was rejected unless the actor was already `idle`.
 
 **Integration-test-driven development.** The docker-backed two-client test was
 the specification, and each phase extended it. That kept the actor honest
@@ -148,25 +179,33 @@ behind a flag is not a matter of skipping `MatrixService.init()`:
 
 - `OutboxService`'s *constructor* calls `_startRunner()` (creating a
   `ClientRunner` and a watchdog timer) and subscribes to connectivity, login
-  state, and `watchOutboxCount()`. Constructing it starts sending.
-- `MatrixService`'s *constructor* builds the `MatrixStreamConsumer` pipeline,
-  schedules an unawaited startup `forceRescan()`, and subscribes to
-  connectivity.
+  state, and `watchOutboxCount()`. **Constructing it starts sending.**
+- `MatrixService`'s *constructor* subscribes to connectivity and builds the
+  `MatrixStreamConsumer` pipeline object. It does **not** start that pipeline
+  and does not kick off a rescan: `init()` does, via `_startQueuePipeline()`,
+  and `get_it_helpers.dart` calls `init()` separately.
 
 The invariant is: **when actor mode is active there must be exactly zero
 legacy sync producers running**, and the actor is sole owner of the Matrix
-client, sync loop and outbound sends. That requires preventing *construction*,
-not just initialization — which in turn breaks every consumer that resolves
-those singletons unconditionally (`main.dart`'s provider override, the
+client, sync loop and outbound sends. The two services need different
+treatment to get there, and conflating them is what makes the problem look
+harder than it is. For `MatrixService`, skipping `init()` is sufficient to
+keep it inert — construction leaves an idle pipeline object and a
+connectivity listener, neither of which sends or syncs. For `OutboxService`,
+only preventing *construction* works, and that is what breaks consumers
+resolving the singleton unconditionally (`main.dart`'s provider override, the
 `beamer_app` login-gate toast, sync maintenance, and the room/stats
-providers). Each needs a no-op stub or a conditional. Any rebuild should
-extract a `startSyncServices()` seam first and test that the flag-on path
-completes startup without constructing either service.
+providers). Any rebuild should extract a `startSyncServices()` seam first and
+test that the flag-on path completes startup without constructing
+`OutboxService` or calling `MatrixService.init()`.
 
 Read-only consumers of `SyncDatabase` and `JournalDb` may keep running. The
-outbox monitor page writes (`updateOutboxItem`, `deleteOutboxItemById`), which
-is safe only as long as the actor does not touch `SyncDatabase` — the original
-plan deliberately kept it out of scope, and a rebuild should too.
+outbox monitor page also writes (`updateOutboxItem`, `deleteOutboxItemById`),
+and that is the one genuine conflict: the actor's own `OutboundQueue` claimed
+and updated the same outbox rows. Ownership of `SyncDatabase` has to be
+settled explicitly in a rebuild — either the actor owns the outbox and the
+monitor page becomes read-only, or the monitor keeps its writes and the two
+coordinate through row claims. It cannot be left implicit as it was.
 
 ### What has changed since, and must be decided up front
 

--- a/docs/implementation_plans/2026-02-13_drift_wal_read_pools.md
+++ b/docs/implementation_plans/2026-02-13_drift_wal_read_pools.md
@@ -2,7 +2,13 @@
 
 ## Context
 
-We are preparing for the Actor-Based Sync Isolate (see `docs/implementation_plans/2026-02-12_actor_based_sync_isolate_plan.md`). The sync actor will open its own `JournalDb` and `SettingsDb` connections to the same SQLite files as the main isolate. Without WAL mode, this causes "Database is Locked" errors. Additionally, read pools offload heavy reads to background isolates, keeping the UI thread responsive during sync.
+**Historical note (2026-07-29):** the actor isolate this plan was written for has
+since been removed, and its plan file with it — see
+[ADR 0046](../adr/0046-sync-actor-isolate-removed-and-how-to-rebuild.md) for what
+was kept of that design. WAL mode and read pools were adopted on their own
+merits and remain in place; the motivation below is recorded as it stood.
+
+We were preparing for the Actor-Based Sync Isolate. The sync actor would open its own `JournalDb` and `SettingsDb` connections to the same SQLite files as the main isolate. Without WAL mode, this causes "Database is Locked" errors. Additionally, read pools offload heavy reads to background isolates, keeping the UI thread responsive during sync.
 
 **Current state**: `openDbConnection()` in `common.dart` calls `NativeDatabase.createInBackground(file)` with no setup callback, no WAL, and no read pools. Drift 2.21.0 is declared (supports `readPool`, introduced in 2.20.0).
 

--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -194,13 +194,16 @@ Future<void> initConfigFlags(
   }
 }
 
-/// Flags the app no longer defines, removed from existing installs on start.
+/// Flags the app no longer defines, deleted from existing installs on start.
 ///
-/// Deleting a flag's `insertFlagIfNotExists` call only stops *new* installs
-/// from getting it. The settings page lists whatever rows `config_flags`
-/// holds, so without this an upgraded install keeps a toggle that no code
-/// reads. Entries can be dropped from this list once every install that could
-/// still carry the row has upgraded past it.
+/// This is storage cleanup, not a fix for a visible toggle: `FlagsBody`
+/// renders only the names in its `defaultDisplayedItems` whitelist, so a row
+/// the app has stopped defining is already invisible there. Deleting a flag's
+/// `insertFlagIfNotExists` call stops *new* installs from getting the row, but
+/// upgraded installs keep it forever — still stored, still emitted by
+/// `watchConfigFlags`, and still readable by name. Entries can be dropped from
+/// this list once every install that could still carry the row has upgraded
+/// past it.
 const retiredConfigFlags = <String>[
   // Removed with the sync actor isolate (ADR 0046). Never read by any code
   // path: the actor it would have gated was never wired into the app.

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -85,7 +85,6 @@ lib/features/sync/
 ├── sequence/    # (hostId, counter) accounting
 ├── backfill/    # gap requests and responses
 ├── media/       # self-healing fetch for missing image/audio blobs
-├── actor/       # isolate-based implementation (not the default path)
 ├── model/       # SyncMessage and node profiles
 ├── state/       # Riverpod controllers
 └── ui/          # settings, stats, conflicts, outbox monitor

--- a/lib/features/sync/matrix/client.dart
+++ b/lib/features/sync/matrix/client.dart
@@ -14,22 +14,16 @@ Future<Client> createMatrixClient({
 }) async {
   final name = dbName ?? 'lotti_sync';
   final path = '${documentsDirectory.path}/matrix/$name.db';
-  final isActorClient = name.startsWith('sync_actor_');
 
   sqfliteFfiInit();
-  final dbFactory = isActorClient
-      // Actor hosts already run inside spawned isolates. Avoid an additional
-      // FFI worker isolate hop for DB I/O here to reduce cross-isolate DB
-      // contention/misuse during crypto session reads.
-      ? databaseFactoryFfiNoIsolate
-      : createDatabaseFactoryFfi(ffiInit: sqfliteFfiInit);
+  final dbFactory = createDatabaseFactoryFfi(ffiInit: sqfliteFfiInit);
 
   final database = await MatrixSdkDatabase.init(
     name,
     database: await dbFactory.openDatabase(
       path,
       options: OpenDatabaseOptions(
-        singleInstance: singleInstance ?? !isActorClient,
+        singleInstance: singleInstance ?? true,
         onConfigure: (db) async {
           await db.execute('PRAGMA journal_mode = WAL');
           await db.execute('PRAGMA busy_timeout = 5000');

--- a/test/database/journal_db/config_flags_test.dart
+++ b/test/database/journal_db/config_flags_test.dart
@@ -184,20 +184,33 @@ void main() {
       expect(names, isNot(contains(retired)));
     });
 
-    test('every retired flag name is gone from the seeded set', () async {
-      // Guards the reverse mistake: a flag named in `retiredConfigFlags`
-      // while still being seeded would be deleted and re-inserted on every
-      // start, flapping the settings list.
+    test('a retired flag is never seeded, not even transiently', () async {
+      // Asserting the final table state cannot catch the mistake this guards:
+      // a flag left in the seed calls *and* listed as retired is inserted and
+      // then deleted within the same `initConfigFlags` run, so the table ends
+      // up correct while every start pays an insert, a delete and two stream
+      // emissions. Watch what the flag stream actually emits instead.
+      for (final retired in retiredConfigFlags) {
+        await db.deleteConfigFlag(retired);
+      }
+
+      final emitted = <String>{};
+      final subscription = db.watchConfigFlags().listen((flags) {
+        emitted.addAll(flags.map((flag) => flag.name));
+      });
+      addTearDown(subscription.cancel);
+      await pumpEventQueue();
+
       await initConfigFlags(db, inMemoryDatabase: true);
-      final names = (await db.watchConfigFlags().first)
-          .map((f) => f.name)
-          .toSet();
+      await pumpEventQueue();
 
       for (final retired in retiredConfigFlags) {
         expect(
-          names,
+          emitted,
           isNot(contains(retired)),
-          reason: '$retired is retired but still seeded by initConfigFlags',
+          reason:
+              '$retired is retired but still seeded by initConfigFlags, so '
+              'every start inserts and then deletes it again',
         );
       }
     });


### PR DESCRIPTION
Follow-up to #3664. Eight P2 review findings were filed on that PR and it merged with all eight threads unresolved and unanswered. I re-verified each against the merged tree (`472c26d51`) — **all eight still held** — and fixed them here. Each is answered on the original thread too.

## Code the removal should have taken with it

**`createMatrixClient` kept an unreachable actor branch.** It derived `isActorClient` from a `sync_actor_` database-name prefix, which selected `databaseFactoryFfiNoIsolate` and inverted the `singleInstance` default. With the actor gone, the only production caller (`get_it.dart`) passes no `dbName` and the tests pass `custom_db`, so the prefix can never match: both behaviours were dead. Removed.

The review also named `lottiSyncRoomStateType` as a residual — that one had already gone with the outbound queue, so there was nothing left to do.

## A mechanism justified by something that isn't true

`retiredConfigFlags` explained itself with *"the settings page lists whatever rows `config_flags` holds, so without this an upgraded install keeps a toggle that no code reads."* It doesn't: `FlagsBody` maps over its `defaultDisplayedItems` whitelist and looks each name up, so a row that isn't on the list is never rendered — and `enable_sync_actor` was never on it.

The mechanism is still worth keeping, but as what it actually is: storage cleanup for a row that would otherwise sit in every upgraded install forever, still emitted by `watchConfigFlags`. The docstring and the ADR consequence now say that instead of claiming a live toggle was left wired to nothing.

## A test that could not fail for its stated reason

`every retired flag name is gone from the seeded set` asserted the final table state. A flag both seeded *and* retired is inserted and then deleted inside the same `initConfigFlags` run, so the end state looks correct while every startup pays an insert, a delete and two stream emissions — the exact bug the test claimed to guard would have passed it.

It now watches what `watchConfigFlags` emits across the run rather than sampling the end state. Confirmed meaningful by adding a seeded flag (`enable_logging`) to `retiredConfigFlags`: the new test fails, the old one passed.

## ADR 0046 recorded a design the code never had

This one matters most, because the ADR is explicitly the specification for a future rebuild — an inaccuracy here is a bug someone will implement.

- **Database ownership.** It said the actor "opens its own connections to the same `db.sqlite` and `settings.sqlite` files". It never did: `SyncActorCommandHandler` constructed only a `SyncDatabase`, and `OutboundQueue` claimed and updated outbox rows through it. `JournalDb`/`SettingsDb` was plan phase 4, which the ADR itself says never landed. A later line then told a rebuild the actor must *not* touch `SyncDatabase` — contradicting the one database it actually used. Now states what was proven (outbox, cross-isolate) versus inferred (journal), and flags outbox ownership as something a rebuild must settle explicitly rather than inherit.
- **State model.** Recorded as a linear `uninitialized → initializing → idle → syncing → stopping → disposed`. `_handleInit` went `initializing → syncing` directly (it started background sync as part of init); `idle` was reachable only through `stopSync`, and `startSync` was rejected unless already `idle`. That changes which commands are valid straight after init, so the corrected model is now a diagram rather than prose.
- **Startup trap.** It claimed `MatrixService`'s constructor "schedules an unawaited startup `forceRescan()`" and concluded that *construction* of both services must be prevented — which is what made the rebuild look expensive, since every unconditional consumer would need a stub. The constructor subscribes to connectivity and builds the pipeline object, but does not start it and does not rescan; `init()` does, and `get_it_helpers.dart` calls it separately. `OutboxService` genuinely does self-start in its constructor (`_startRunner()`). Split accordingly: skipping `init()` is enough for `MatrixService`, and only `OutboxService` needs construction prevented.

## A dead pointer

`docs/implementation_plans/2026-02-13_drift_wal_read_pools.md` still sent readers to the deleted actor plan and described the actor as upcoming. It now carries a dated historical note pointing at ADR 0046, and keeps its original motivation in the past tense — WAL and read pools stand on their own merits and are still in place.

## Also removed

`lib/features/sync/README.md` still listed `actor/` in its code map, pointing at a directory that no longer exists.

## Testing

`fvm flutter analyze` clean across the repo. `make knowledge_check` passes, and the mermaid parser run against `docs/adr/` accepts the new state diagram.

Unrelated pre-existing finding, not touched here: that same run reports two ADR diagrams that do not parse — `0017-deterministic-log-compaction.md:86` and `0019-attention-negotiation-protocol.md:75`. CI only parses `knowledge/`, so nothing catches them. Tracked separately rather than mixed into this PR.
