### PR TITLE
fix: bound Daily OS planning retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing when there is nothing on the clipboard to paste.
 
 ### Changed
+- **Daily OS planning now abandons silent AI requests quickly and retries
+  cleanly.** A provider that returned nothing could hold a plan for about two
+  minutes before the app tried again, and a retry could repeat the same
+  overcommit warning. Drafts and refinements now detect a silent response in
+  30 seconds, cancel it before late tool calls can land, and keep each planning
+  step focused on only the instructions and tools it can actually use.
 - **The "Enable Sync Actor" setting is gone.** The advanced-settings toggle
   never did anything — the isolate-based sync it was meant to switch on was
   never finished or connected — so it is removed rather than left as a switch

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
   <releases>
     <release version="0.9.1071" date="2026-07-26">
       <description>
+        <p>Changed: Daily OS planning now abandons silent AI requests quickly and retries cleanly. A provider that returned nothing could hold a plan for about two minutes before the app tried again, and a retry could repeat the same overcommit warning. Drafts and refinements now detect a silent response in 30 seconds, cancel it before late tool calls can land, and keep each planning step focused on only the instructions and tools it can actually use.</p>
         <p>Changed: Daily OS is opt-in again while its planning quality is improved. Existing installs that had enabled it keep that choice, while new installs start without the Daily OS navigation entry. It can be enabled explicitly from Settings → Advanced → Config flags.</p>
         <p>Fixed: the bottom navigation bar no longer collides with Android's system buttons. On phones that show the recents/home/back bar at the bottom — Samsung devices among them — the app's own bar sat partly underneath it, so its labels were crowded and taps near the bottom went to the system bar instead of the app. The bar now keeps clear of the whole system area.</p>
         <p>Changed: the "Enable Sync Actor" setting is gone. The advanced-settings toggle never did anything — the isolate-based sync it was meant to switch on was never finished or connected — so it is removed rather than left as a switch with nothing behind it.</p>

--- a/knowledge/features/daily_os_next/capture-and-planning.md
+++ b/knowledge/features/daily_os_next/capture-and-planning.md
@@ -15,11 +15,11 @@ sources:
   - id: prompt-builder
     resource: ../../../lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
     title: Day-agent prompt builder
-    last_modified: 2026-07-27
+    last_modified: 2026-07-29
   - id: workflow
     resource: ../../../lib/features/daily_os_next/agents/workflow
     title: Day-agent workflow and terminal-tool strategy
-    last_modified: 2026-07-27
+    last_modified: 2026-07-29
   - id: processing-runtime
     resource: ../../../lib/features/daily_os_next/services/day_processing_runtime.dart
     title: Durable processing runtime
@@ -80,7 +80,8 @@ Each user-facing wake now has a narrow tool surface:
 |---|---|
 | Capture submitted | `parse_capture_to_items` only |
 | Drafting | `create_task_from_phrase`, `raise_day_status`, `draft_day_plan` |
-| Refine | Normal day-agent tools except `parse_capture_to_items` and `draft_day_plan`; the plan mutation is `propose_plan_diff` |
+| Refine | `create_task_from_phrase`, `propose_plan_diff`, durable knowledge/recall, `write_day_summary`, and `raise_day_status` |
+| Coordinator digest | Durable knowledge/recall, summaries, directives, status, and optional pre-warm scheduling — never capture or plan mutation |
 
 The parser and drafter tools are **terminal artifacts only in their owning wake
 mode**. Once either one is accepted there, `DayAgentStrategy` completes that
@@ -94,6 +95,20 @@ drafting wake can re-parse, triage, search and summarize before it plans, and
 continuing after the final write adds another provider call after the requested
 artifact already exists. Refine never exposes the full-draft writer, so it
 cannot overwrite its baseline instead of producing a reviewable diff.
+
+The prose is narrowed with the schema, not merely the tool definitions. Capture
+wakes see only capture rules and their worked example; drafting wakes see only
+planning/drafting rules and their overcommit example; refine and digest each see
+their own contract. This prevents a draft model from following an advertised
+capture instruction for a tool that is intentionally absent.
+
+Inference also has a mode-specific **total** bound: 20 seconds for capture,
+30 seconds for draft/refine, and 60 seconds for a general wake. Streamed
+reasoning does not extend the deadline: reasoning that never reaches the
+terminal artifact is still user-visible waiting. Crossing the bound cancels the
+provider stream inside the conversation. This is distinct from the
+orchestrator's outer hard timeout: cancellation at the inference edge prevents
+a late tool batch from mutating after the outbox has started a retry.
 
 Durable scheduling has a matching no-lost-signal invariant. When an outbox
 change arrives while `DayProcessingRuntime` is already draining, the runtime

--- a/knowledge/features/daily_os_next/processing-outbox.md
+++ b/knowledge/features/daily_os_next/processing-outbox.md
@@ -15,11 +15,15 @@ sources:
   - id: repo
     resource: ../../../lib/features/daily_os_next/services/day_processing_outbox_repository.dart
     title: DayProcessingOutboxRepository
-    last_modified: 2026-07-25
+    last_modified: 2026-07-29
   - id: executor
     resource: ../../../lib/features/daily_os_next/services/day_agent_job_executor.dart
     title: DayAgentJobExecutor
     last_modified: 2026-07-25
+  - id: job-wiring
+    resource: ../../../lib/features/daily_os_next/state/day_agent_job_wiring.dart
+    title: Durable job wake tokens
+    last_modified: 2026-07-29
   - id: adr-0044
     resource: ../../../docs/adr/0044-day-processing-outbox-storage.md
     title: ADR 0044 — Day processing outbox storage
@@ -158,6 +162,19 @@ sequenceDiagram
   more attempt) and caps retries (`maxAttempts`, default 5) by downgrading to
   `deterministic` — because unlike transcription's free backoff, **every agent
   retry spends model tokens**.
+
+Every agent-job wake also carries `processing_job:<jobId>`. The per-attempt
+`runKey` remains the provenance key for plans and diffs, while the durable job
+id scopes side effects that may happen before the terminal artifact. In
+particular, `raise_day_status` upserts
+`day_status:<dayId>:job:<jobId>`: a retry can revise the status from its failed
+attempt, but cannot append a duplicate escalation.
+
+The outbox retains `last_failure_class` and `last_error` when a retry later
+succeeds. `attempts` still counts failed provider requests, and a new user
+request that re-arms the deterministic job clears all three fields. This makes
+a successful eval row explain that it recovered from a classified timeout
+instead of hiding the first attempt.
 
 ## Two independent drain lanes
 

--- a/knowledge/features/daily_os_next/wake-prompt.md
+++ b/knowledge/features/daily_os_next/wake-prompt.md
@@ -8,6 +8,10 @@ status: stable
 generated: { by: claude-code/opus-5, at: 2026-07-26T21:00:00Z }
 stale_after: 2026-10-26
 sources:
+  - id: system-prompt
+    resource: ../../../lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
+    title: Mode-specific system prompt and tool gating
+    last_modified: 2026-07-29
   - id: sections
     resource: ../../../lib/features/daily_os_next/agents/prompt/day_agent_prompt_sections.dart
     title: Prompt section tags
@@ -29,6 +33,32 @@ sources:
     title: ADR 0026 — Author-time memory links
     last_modified: 2026-06-09
 ---
+
+# The system prompt matches the wake mode
+
+The tool capability list is generated from the same `_isToolEnabled` decision
+that builds the API tool schema. A wake is therefore never told about a tool it
+cannot call.
+
+Mode-specific behavioral prose follows the same boundary:
+
+| Wake | System-prompt contract |
+|---|---|
+| Capture submitted | Capture matching rules, the dense-capture example, and the terminal `parse_capture_to_items` rule |
+| Drafting | Planning and drafting rules, the overcommit example, and the terminal `draft_day_plan` rule |
+| Refine | Planning and refine rules; no capture or full-draft contract |
+| Coordinator digest | Digest, week-context, and memory rules; no capture or plan-mutation contract |
+| General planning | Planning plus the configured week/memory capabilities |
+
+Capture and drafting intentionally omit memory prose and planning defaults when
+those tools or values cannot affect their single terminal artifact. This is
+both a correctness boundary and a latency boundary: an instruction-dense draft
+wake no longer spends turns on capture parsing, reconcile, pattern summaries,
+or memory work that its schema does not expose.
+
+The durable outbox's internal `processing_job:<jobId>` trigger participates in
+wake context and idempotency but is filtered out of `<trigger_tokens>` before
+the user message is rendered. It is workflow provenance, not model context.
 
 # The payload is tagged plaintext, not JSON
 

--- a/lib/features/daily_os_next/agents/domain/daily_os_planner_wake_context.dart
+++ b/lib/features/daily_os_next/agents/domain/daily_os_planner_wake_context.dart
@@ -17,6 +17,7 @@ class DailyOsPlannerWakeContext {
     this.captureIds = const [],
     this.decidedTaskIds = const [],
     this.decidedCaptureItemIds = const [],
+    this.processingJobId,
   });
 
   /// Builds a context from [triggerTokens] for a [dayId] the caller has
@@ -42,6 +43,7 @@ class DailyOsPlannerWakeContext {
       decidedCaptureItemIds: decidedCaptureItemIdsFromTriggerTokens(
         triggerTokens,
       ),
+      processingJobId: processingJobIdFromTriggerTokens(triggerTokens),
     );
   }
 
@@ -68,6 +70,13 @@ class DailyOsPlannerWakeContext {
 
   /// Decided parsed-capture-item IDs advertised on the wake.
   final List<String> decidedCaptureItemIds;
+
+  /// Durable outbox job whose attempt opened this wake, when present.
+  ///
+  /// Retries of the same job carry the same id while each wake has a new
+  /// [runKey]. Side effects that can occur before the terminal artifact use
+  /// this as their idempotency scope.
+  final String? processingJobId;
 
   /// Whether the wake requests drafting for this context's day workspace.
   bool get isDraftingWake => hasDraftingTokenForDay(triggerTokens, dayId);

--- a/lib/features/daily_os_next/agents/domain/day_agent_slots.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_slots.dart
@@ -55,6 +55,15 @@ const dayStatusEventIdPrefix = 'day_status:';
 String dayStatusEventId(String dayId, String suffix) =>
     '$dayStatusEventIdPrefix$dayId:$suffix';
 
+/// Stable day-status event ID for one durable processing job.
+///
+/// A draft attempt may raise status before its required plan artifact, then
+/// fail and retry under a fresh wake run key. Keying that status to the
+/// durable job makes each attempt upsert the same event instead of appending
+/// duplicate escalations.
+String dayStatusEventIdForProcessingJob(String dayId, String processingJobId) =>
+    dayStatusEventId(dayId, 'job:$processingJobId');
+
 /// Monday 00:00 local time of the calendar week containing [date].
 ///
 /// Weeks are ISO weeks (Monday-start), matching the digest's "recent weeks"

--- a/lib/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart
@@ -73,6 +73,13 @@ const dayAgentDecidedTaskPrefix = 'decided_task:';
 /// considers "decided" but which does not have a persisted task ID yet.
 const dayAgentDecidedCaptureItemPrefix = 'decided_capture_item:';
 
+/// Wake trigger token prefix carrying the durable outbox job behind a wake.
+///
+/// The job id is not model context. It gives retrying wakes one stable
+/// idempotency scope for side effects that may precede the terminal artifact,
+/// such as `raise_day_status`.
+const dayAgentProcessingJobPrefix = 'processing_job:';
+
 /// Creates the planning-day workspace trigger token for [dayId].
 String dayAgentPlanningDayToken(String dayId) {
   return '$dayAgentPlanningDayPrefix$dayId';
@@ -106,6 +113,11 @@ String dayAgentDecidedTaskToken(String taskId) {
 /// Creates the decided capture-item trigger token for [parsedItemId].
 String dayAgentDecidedCaptureItemToken(String parsedItemId) {
   return '$dayAgentDecidedCaptureItemPrefix$parsedItemId';
+}
+
+/// Creates the durable processing-job trigger token for [jobId].
+String dayAgentProcessingJobToken(String jobId) {
+  return '$dayAgentProcessingJobPrefix$jobId';
 }
 
 /// Whether [triggerTokens] requests a drafting wake for the [dayId]
@@ -153,6 +165,19 @@ List<String> decidedTaskIdsFromTriggerTokens(Set<String> triggerTokens) =>
 List<String> decidedCaptureItemIdsFromTriggerTokens(
   Set<String> triggerTokens,
 ) => _idsForPrefix(triggerTokens, dayAgentDecidedCaptureItemPrefix)..sort();
+
+/// Extracts the one durable processing-job id carried by a wake.
+///
+/// A wake created outside the outbox has no such id. Multiple distinct ids
+/// are invalid rather than arbitrarily selecting one: they would collapse
+/// unrelated intents into the same idempotency scope.
+String? processingJobIdFromTriggerTokens(Set<String> triggerTokens) {
+  final ids = _idsForPrefix(triggerTokens, dayAgentProcessingJobPrefix).toSet();
+  if (ids.length > 1) {
+    throw StateError('Ambiguous processing job ids: ${ids.toList()..sort()}');
+  }
+  return ids.isEmpty ? null : ids.first;
+}
 
 List<String> _idsForPrefix(Set<String> tokens, String prefix) {
   final out = <String>[];

--- a/lib/features/daily_os_next/agents/service/day_agent_directive_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_directive_service.dart
@@ -82,13 +82,15 @@ class DayAgentDirectiveService {
   ///
   /// [wakeDayId] is the wake's workspace day — `raise_day_status` may only
   /// target it (an agent cannot speak for another day). [runKey] scopes the
-  /// one-status-event-per-wake cap.
+  /// one-status-event-per-wake cap. [processingJobId] gives retries of one
+  /// durable intent a stable upsert key.
   Future<DayAgentDirectToolResult> executeTool({
     required String agentId,
     required String toolName,
     required Map<String, dynamic> args,
     String? wakeDayId,
     String? runKey,
+    String? processingJobId,
   }) async {
     try {
       final data = switch (toolName) {
@@ -98,6 +100,7 @@ class DayAgentDirectiveService {
           args,
           wakeDayId: wakeDayId,
           runKey: runKey,
+          processingJobId: processingJobId,
         ),
         _ => throw DayAgentDirectiveException('unknown tool "$toolName"'),
       };
@@ -235,6 +238,7 @@ class DayAgentDirectiveService {
     Map<String, dynamic> args, {
     String? wakeDayId,
     String? runKey,
+    String? processingJobId,
   }) async {
     final dayId = requiredStringArg(args, 'dayId');
     if (dateFromDayId(dayId) == null) {
@@ -278,6 +282,9 @@ class DayAgentDirectiveService {
       status: status,
       reasons: reasons,
       note: note,
+      eventId: processingJobId == null
+          ? null
+          : dayStatusEventIdForProcessingJob(dayId, processingJobId),
     );
     return {
       'id': event.id,
@@ -292,11 +299,12 @@ class DayAgentDirectiveService {
     required DayStatusKind status,
     List<DayStatusReason> reasons = const [],
     String note = '',
+    String? eventId,
   }) async {
     final now = clock.now();
     final event =
         AgentDomainEntity.dayStatusEvent(
-              id: dayStatusEventId(dayId, _uuid.v4()),
+              id: eventId ?? dayStatusEventId(dayId, _uuid.v4()),
               agentId: agentId,
               dayId: dayId,
               status: status,

--- a/lib/features/daily_os_next/agents/workflow/day_agent_context_builder.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_context_builder.dart
@@ -147,7 +147,12 @@ extension DayAgentContextBuilder on DayAgentWorkflow {
       // changing trigger set never evicts the large stable blocks above it.
       ..addJson(
         DayAgentPromptTags.triggerTokens,
-        triggerTokens.toList()..sort(),
+        triggerTokens
+            .where(
+              (token) => !token.startsWith(dayAgentProcessingJobPrefix),
+            )
+            .toList()
+          ..sort(),
       )
       // The day's planning floor, next to the wall-clock it is derived from.
       // Rendered for every wake that could place a block, not just drafting:

--- a/lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_prompt_builder.dart
@@ -28,8 +28,8 @@ const dayAgentOmissionRules = '''
 /// Public so source-mirrored tests can prevent the prompt from drifting back
 /// to abstract rules that do not demonstrate instruction retention.
 @visibleForTesting
-const dayAgentPlanningExamples = '''
-Worked examples:
+const dayAgentCaptureExample = '''
+Worked example:
 - Dense capture: "Keep 12:00-12:40 completely free for lunch; batch the three
   candidate replies into one 25-minute block; spend up to 30 minutes sketching
   onboarding ideas only if the vendor quote has arrived; reserve 45 minutes
@@ -37,6 +37,11 @@ Worked examples:
   as five separate items, preserving the protected interval, batching,
   conditional dependency, duration limit, and stop boundary. Do not collapse
   or discard any clause because the transcript is conversational.
+''';
+
+@visibleForTesting
+const dayAgentDraftExample = '''
+Worked example:
 - Overcommitted draft: 105 minutes remain, while three selected items total
   150 minutes. Place the 60-minute archive cleanup and 45-minute tax-form
   review, then use `raise_day_status` with `overCommitted` and name the
@@ -45,6 +50,11 @@ Worked examples:
   selected item is either placed, explicitly partial, or explicitly named as
   omitted or conflicting.
 ''';
+
+/// Combined fixture retained for source-mirrored prompt regression tests.
+@visibleForTesting
+const dayAgentPlanningExamples =
+    '$dayAgentCaptureExample\n$dayAgentDraftExample';
 
 @visibleForTesting
 const dayAgentCaptureTerminalRule = '''
@@ -65,49 +75,44 @@ const dayAgentDraftTerminalRule = '''
 /// definitions for [DayAgentWorkflow]. Split from the main workflow file for
 /// size; all members are library-private.
 extension DayAgentPromptBuilder on DayAgentWorkflow {
-  String _buildSystemPrompt(TemplateContext? ctx, {required String agentId}) {
-    const captureToolLines =
-        '- `submit_capture`: persist a user capture transcript and enqueue parsing.\n'
-        '- `parse_capture_to_items`: persist capture phrases parsed from the current capture-submitted wake.\n'
-        '- `match_to_corpus`: find existing task candidates for a phrase.\n'
-        '- `link_capture_phrase_to_task`: attach a parsed capture item to a task.\n'
-        "- `break_capture_link`: remove a parsed capture item's task link.\n"
-        '- `surface_pending_decisions`: list overdue, in-progress, missed recurring, and due-today tasks for reconcile.\n'
-        '- `apply_triage`: apply a reconcile action to a task.\n'
-        '- `create_task_from_phrase`: create a real task from a new capture phrase.';
-    const planToolLines =
-        '- `draft_day_plan`: persist a drafted day plan with blocks and reasons.\n'
-        '- `summarize_recent_patterns`: return learning cards from recent day drafts.';
-    const knowledgeToolLines =
-        '- `propose_knowledge`: durably remember how the user wants to be '
-        'planned. Use source "userStated" only when the user told you '
-        'directly; every entry awaits their confirmation in the panel.';
-    const weekContextToolLines =
-        '- `write_day_summary`: your contemporaneous note on a day (today or '
-        'yesterday only) — what happened and why, one paragraph, max 500 '
-        'characters.';
-    const directiveToolLines =
-        '- `issue_day_directive`: issue or revise your distilled directive '
-        'for one day — commitments, capacity budget, carry-over, '
-        'constraints, attention notes. Bounded facts only; never '
-        'transcripts.';
-    const statusToolLines =
-        "- `raise_day_status`: raise a typed status event for this wake's "
-        'day (the coordinator reads it at its next digest). '
-        '`attentionNeeded` needs typed reasons; silence already means fine. '
-        'At most one event per wake.';
-    final toolLines = <String>[
-      '- `record_observations`: private memory for learnings and uncertainty.',
-      '- `set_next_wake`: schedule the next useful pre-warm wake.',
-      '- `search_memory`: recall past detail folded out of the summary by keyword, or pass `ids` to pull up specific entries (e.g. to follow a [[relation:id]] link).',
-      if (captureService != null) captureToolLines,
-      if (planService != null) planToolLines,
-      if (knowledgeService != null) knowledgeToolLines,
-      if (weekContextService != null) weekContextToolLines,
-      if (directiveService != null && agentId == dailyOsPlannerAgentId)
-        directiveToolLines,
-      if (directiveService != null) statusToolLines,
-    ];
+  String _buildSystemPrompt(
+    TemplateContext? ctx, {
+    required String agentId,
+    required DailyOsPlannerWakeContext wakeContext,
+    required CaptureContext? captureContext,
+  }) {
+    final isCaptureWake = _requiresCaptureParse(
+      wakeContext: wakeContext,
+      captureContext: captureContext,
+    );
+    final isDraftWake = wakeContext.isDraftingWake;
+    final isRefineWake = wakeContext.isRefineWake;
+    final isDigestWake =
+        wakeContext.isDigestWake && agentId == dailyOsPlannerAgentId;
+    final isPlanningWake = !isCaptureWake && !isDigestWake;
+    final enabledToolNames = dayAgentTools
+        .where(
+          (tool) => _isToolEnabled(
+            tool.name,
+            agentId: agentId,
+            wakeContext: wakeContext,
+            captureContext: captureContext,
+          ),
+        )
+        .map((tool) => tool.name)
+        .toSet();
+    final toolLines = dayAgentTools
+        .where((tool) => enabledToolNames.contains(tool.name))
+        .map((tool) => '- `${tool.name}`: ${tool.description}')
+        .join('\n');
+    final hasMemoryTools = enabledToolNames.intersection(const {
+      DayAgentToolNames.recordObservations,
+      DayAgentToolNames.searchMemory,
+      DayAgentToolNames.proposeKnowledge,
+    }).isNotEmpty;
+    final hasWeekContextTool = enabledToolNames.contains(
+      DayAgentToolNames.writeDaySummary,
+    );
     final scaffold =
         '''
 You are the Daily OS planner: one durable agent that plans across days and
@@ -119,7 +124,8 @@ this wake targets.
 
 Tool capabilities (this wake receives only the relevant subset):
 
-${toolLines.join('\n')}
+${toolLines.isEmpty ? '- No tools are available for this wake.' : toolLines}
+${isCaptureWake ? '''
 
 Capture matching rules:
 - Use the embedded task corpus when parsing a submitted capture.
@@ -136,9 +142,11 @@ $dayAgentCaptureTerminalRule
   that existing task. When the evidence is ambiguous, prefer a low-confidence
   match or a new item so the user can choose instead of silently reviving old
   work.
+$dayAgentCaptureExample''' : ''}
+${isPlanningWake ? '''
 
-Drafting rules:
-- Every `ai` block passed to `draft_day_plan` must include a concrete reason.
+Planning rules:
+- Every generated `ai` block must include a concrete reason.
 - Keep blocks inside the local plan day and within the user's capacity.
 - `<planning_window>` governs where today's work may start, on every wake that
   can place a block — drafting, refine, or a scheduled planning wake alike.
@@ -186,6 +194,10 @@ $dayAgentOmissionRules
   instead of overpacking the plan.
 - Buffer and manual blocks may omit reasons when their purpose is
   self-evident.
+''' : ''}
+${isDraftWake ? '''
+
+Drafting rules:
 - When this wake's user message carries a `<drafting>` section (i.e. the trigger
   tokens include `drafting:<dayId>`), your priority is to call
   `draft_day_plan` once with the full updated block list — replacing or
@@ -203,7 +215,8 @@ $dayAgentOmissionRules
   wake; the complete planning context is already in this message.
 $dayAgentDraftTerminalRule
 
-$dayAgentPlanningExamples
+$dayAgentDraftExample''' : ''}
+${isRefineWake ? '''
 
 Refine rules:
 - When this wake's user message carries a `<refine>` section (i.e. the trigger
@@ -219,7 +232,8 @@ Refine rules:
   your own. After the user commits, the plan is in shepherding mode and
   further edits require an explicit refine.
 - Shutdown and agenda mutation tools are not available yet. Do not claim you
-  shut down a day.${dependencyResolver == null ? '' : '''
+  shut down a day.''' : ''}
+${isPlanningWake && dependencyResolver != null ? '''
 
 
 Blocked-work rules (ADR 0043):
@@ -234,7 +248,8 @@ Blocked-work rules (ADR 0043):
   that cannot start, and say why in another block's `reason`.
 - When a decided/committed task is blocked, prefer placing the blocker
   instead and say so in the block's reason — unless that blocker is itself
-  shown as blocked, in which case the rule above applies to it too.'''}${directiveService != null && agentId == dailyOsPlannerAgentId ? '''
+  shown as blocked, in which case the rule above applies to it too.''' : ''}
+${isDigestWake ? '''
 
 
 Digest rules (`<digest>` present — your coordinator ritual, ADR 0032):
@@ -258,7 +273,8 @@ Digest rules (`<digest>` present — your coordinator ritual, ADR 0032):
 - A directive commitment on a task blocked for planning should target its
   blocker instead, or name the blocker explicitly in an attention note so
   the per-day agent inherits the dependency context from the directive
-  itself.'''}''' : ''}${weekContextService == null ? '' : '''
+  itself.'''}''' : ''}
+${hasWeekContextTool ? '''
 
 
 Week context (`<recent_days>` / `<week_ahead>`):
@@ -275,7 +291,8 @@ Week context (`<recent_days>` / `<week_ahead>`):
   only. Do not restate the numbers — the facts line already carries them. If
   yesterday has no note yet, write it on any wake while it is still writable.
 - Your `Agent note:` lines in `<recent_days>` are your own past testimony; the
-  facts line next to them wins on any contradiction.'''}
+  facts line next to them wins on any contradiction.''' : ''}
+${hasMemoryTools ? '''
 
 Your memory (append-only — you add, never overwrite):
 - Keep each observation atomic: one idea per note, so it can be linked and
@@ -297,10 +314,12 @@ Your memory (append-only — you add, never overwrite):
 - Actually follow your links: when an entry cites `[[relation:id]]`, call
   `search_memory` with `ids` to pull those entries up before deciding.
 
-Record private observations and schedule one useful future wake when warranted.
+Record private observations and schedule one useful future wake when warranted.''' : ''}
 
+${isPlanningWake || isDigestWake ? '''
 Planning defaults:
-${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
+${const JsonEncoder.withIndent('  ').convert(config.toJson())}''' : ''}'''
+            .replaceAll(RegExp(r'\n{3,}'), '\n\n');
 
     if (ctx == null) return scaffold;
 
@@ -364,12 +383,32 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
         DayAgentToolNames.draftDayPlan,
       }.contains(toolName);
     }
-    if (wakeContext.isRefineWake &&
-        toolName == DayAgentToolNames.draftDayPlan) {
-      // Refine wakes edit an existing plan through `propose_plan_diff`.
-      // Re-exposing the full-draft writer lets a model overwrite the baseline
-      // before it proposes the reviewable diff the user requested.
-      return false;
+    if (wakeContext.isRefineWake) {
+      // Refine wakes have one reviewable artifact to produce. Keep only the
+      // tools needed to materialise newly requested work, explain a conflict,
+      // persist the diff, or retain genuinely durable context.
+      return const {
+        DayAgentToolNames.createTaskFromPhrase,
+        DayAgentToolNames.proposePlanDiff,
+        DayAgentToolNames.proposeKnowledge,
+        DayAgentToolNames.recordObservations,
+        DayAgentToolNames.searchMemory,
+        DayAgentToolNames.writeDaySummary,
+        DayAgentToolNames.raiseDayStatus,
+      }.contains(toolName);
+    }
+    if (wakeContext.isDigestWake && agentId == dailyOsPlannerAgentId) {
+      // A coordinator digest distils directives and summaries. Capture and
+      // plan mutation tools are both irrelevant and actively misleading.
+      return const {
+        DayAgentToolNames.recordObservations,
+        DayAgentToolNames.setNextWake,
+        DayAgentToolNames.searchMemory,
+        DayAgentToolNames.proposeKnowledge,
+        DayAgentToolNames.writeDaySummary,
+        DayAgentToolNames.issueDayDirective,
+        DayAgentToolNames.raiseDayStatus,
+      }.contains(toolName);
     }
     if (toolName == DayAgentToolNames.parseCaptureToItems) {
       return false;
@@ -425,7 +464,7 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     required String conversationId,
     required String modelId,
     required AiConfigInferenceProvider provider,
-    required CloudInferenceWrapper inferenceRepo,
+    required InferenceRepositoryInterface inferenceRepo,
     required List<ChatCompletionTool> tools,
     required DayAgentStrategy strategy,
     required String captureId,
@@ -478,7 +517,7 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     required String conversationId,
     required String modelId,
     required AiConfigInferenceProvider provider,
-    required CloudInferenceWrapper inferenceRepo,
+    required InferenceRepositoryInterface inferenceRepo,
     required List<ChatCompletionTool> tools,
     required DayAgentStrategy strategy,
     required String? consumptionAgentId,

--- a/lib/features/daily_os_next/agents/workflow/day_agent_tool_handlers.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_tool_handlers.dart
@@ -9,6 +9,7 @@ extension DayAgentToolHandlers on DayAgentWorkflow {
     required String threadId,
     required String runKey,
     required String dayId,
+    required String? processingJobId,
     required String toolName,
     required Map<String, dynamic> args,
   }) async {
@@ -57,6 +58,7 @@ extension DayAgentToolHandlers on DayAgentWorkflow {
         args: args,
         wakeDayId: dayId,
         runKey: runKey,
+        processingJobId: processingJobId,
       );
       return DayAgentToolResult(
         success: result.success,

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -22,6 +22,7 @@ import 'package:lotti/features/ai/model/inference_usage.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/ai/util/profile_resolver.dart';
 import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/daily_os_planner_wake_context.dart';
@@ -85,6 +86,7 @@ class DayAgentWorkflow {
     this.logSummarizer,
     this.compactionTailBudgetTokens = 50000,
     this.compactionTailRetainTokens = 20000,
+    this.inferenceTimeouts = const DayAgentInferenceTimeoutPolicy(),
   });
 
   /// Agent repository.
@@ -149,6 +151,9 @@ class DayAgentWorkflow {
   /// Compaction watermarks — see `TaskAgentWorkflow` for the rationale.
   final int compactionTailBudgetTokens;
   final int compactionTailRetainTokens;
+
+  /// Per-mode provider-stream total deadlines.
+  final DayAgentInferenceTimeoutPolicy inferenceTimeouts;
 
   static const minScheduledWakeLeadTime = Duration(minutes: 15);
   static const maxScheduledWakeWritesPerDay = 4;
@@ -366,7 +371,26 @@ class DayAgentWorkflow {
         ? await _weekContext(planDate: dayDate, now: now)
         : null;
     final dayAudioEntries = await _dayAudioEntries(resolvedDayId);
-    final systemPrompt = _buildSystemPrompt(templateCtx, agentId: agentId);
+    final requiresCaptureParse = _requiresCaptureParse(
+      wakeContext: wakeContext,
+      captureContext: captureContext,
+    );
+    final requiresDraftDayPlan = _requiresDraftDayPlan(
+      wakeContext: wakeContext,
+    );
+    final wakeKind = requiresCaptureParse
+        ? DayAgentWakeKind.capture
+        : requiresDraftDayPlan
+        ? DayAgentWakeKind.draft
+        : wakeContext.isRefineWake
+        ? DayAgentWakeKind.refine
+        : DayAgentWakeKind.general;
+    final systemPrompt = _buildSystemPrompt(
+      templateCtx,
+      agentId: agentId,
+      wakeContext: wakeContext,
+      captureContext: captureContext,
+    );
     final userMessage = _buildUserMessage(
       dayId: resolvedDayId,
       planDate: dayDate,
@@ -409,27 +433,28 @@ class DayAgentWorkflow {
         runKey: runKey,
         domainLogger: domainLogger,
         terminalToolNames: {
-          if (_requiresCaptureParse(
-            wakeContext: wakeContext,
-            captureContext: captureContext,
-          ))
-            DayAgentToolNames.parseCaptureToItems,
-          if (_requiresDraftDayPlan(wakeContext: wakeContext))
-            DayAgentToolNames.draftDayPlan,
+          if (requiresCaptureParse) DayAgentToolNames.parseCaptureToItems,
+          if (requiresDraftDayPlan) DayAgentToolNames.draftDayPlan,
         },
         executeToolHandler: (toolName, args, manager) => _executeToolHandler(
           agentId: agentId,
           threadId: threadId,
           runKey: runKey,
           dayId: resolvedDayId,
+          processingJobId: wakeContext.processingJobId,
           toolName: toolName,
           args: args,
         ),
       );
 
-      final inferenceRepo = CloudInferenceWrapper(
+      final cloudInferenceRepo = CloudInferenceWrapper(
         cloudRepository: cloudInferenceRepository,
         geminiThinkingMode: resolvedProfile.thinkingModel?.geminiThinkingMode,
+      );
+      final inferenceRepo = DayAgentTimeoutInferenceRepository(
+        delegate: cloudInferenceRepo,
+        wakeKind: wakeKind,
+        timeout: inferenceTimeouts.forKind(wakeKind),
       );
 
       if (templateCtx != null) {
@@ -465,10 +490,7 @@ class DayAgentWorkflow {
         rethrowInferenceErrors: true,
       );
 
-      if (_requiresCaptureParse(
-        wakeContext: wakeContext,
-        captureContext: captureContext,
-      )) {
+      if (requiresCaptureParse) {
         if (!strategy.didPersistCaptureParse) {
           // The resolved capture context is the single source of truth for
           // which capture this wake parses; re-extracting from the token set
@@ -495,7 +517,7 @@ class DayAgentWorkflow {
         }
       }
 
-      if (_requiresDraftDayPlan(wakeContext: wakeContext)) {
+      if (requiresDraftDayPlan) {
         if (!strategy.didPersistDraftDayPlan) {
           final retryUsage = await _forceDraftDayPlanIfMissing(
             conversationId: conversationId,

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
@@ -1,9 +1,176 @@
+import 'dart:async';
+
 import 'package:lotti/features/agents/memory/memory_links.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/ai/model/ai_call_impact.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/gemini_tool_call.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_directive_models.dart';
+import 'package:openai_dart/openai_dart.dart';
 import 'package:uuid/uuid.dart';
+
+/// Model-facing mode of one day-agent wake.
+enum DayAgentWakeKind { capture, draft, refine, general }
+
+/// Maximum provider-stream lifetime for each wake kind.
+///
+/// This deadline includes streamed reasoning. A model that keeps emitting
+/// thought chunks without producing the terminal artifact cannot extend the
+/// user's wait to the wake orchestrator's two-minute hard abort.
+class DayAgentInferenceTimeoutPolicy {
+  const DayAgentInferenceTimeoutPolicy({
+    this.capture = const Duration(seconds: 20),
+    this.draft = const Duration(seconds: 30),
+    this.refine = const Duration(seconds: 30),
+    this.general = const Duration(seconds: 60),
+  });
+
+  final Duration capture;
+  final Duration draft;
+  final Duration refine;
+  final Duration general;
+
+  Duration forKind(DayAgentWakeKind kind) => switch (kind) {
+    DayAgentWakeKind.capture => capture,
+    DayAgentWakeKind.draft => draft,
+    DayAgentWakeKind.refine => refine,
+    DayAgentWakeKind.general => general,
+  };
+}
+
+/// Classified provider deadline failure for one day-agent wake.
+class DayAgentInferenceTimedOutException extends TimeoutException {
+  DayAgentInferenceTimedOutException({
+    required this.wakeKind,
+    required Duration timeout,
+  }) : super(
+         '${wakeKind.name} inference exceeded its '
+         '${timeout.inSeconds}s deadline',
+         timeout,
+       );
+
+  final DayAgentWakeKind wakeKind;
+}
+
+/// Applies a mode-specific total deadline to day-agent inference streams.
+///
+/// The timer starts when the conversation listens and does not reset for
+/// streamed thought or content chunks. Crossing it cancels the upstream
+/// provider subscription before reporting the classified timeout, so a late
+/// tool batch cannot mutate after the outbox starts a retry.
+class DayAgentTimeoutInferenceRepository
+    implements InferenceRepositoryInterface {
+  DayAgentTimeoutInferenceRepository({
+    required this.delegate,
+    required this.wakeKind,
+    required this.timeout,
+  }) {
+    if (timeout <= Duration.zero) {
+      throw ArgumentError.value(
+        timeout,
+        'timeout',
+        'must be positive',
+      );
+    }
+  }
+
+  final InferenceRepositoryInterface delegate;
+  final DayAgentWakeKind wakeKind;
+  final Duration timeout;
+
+  Stream<CreateChatCompletionStreamResponse> _bound(
+    Stream<CreateChatCompletionStreamResponse> source,
+  ) {
+    late final StreamController<CreateChatCompletionStreamResponse> controller;
+    StreamSubscription<CreateChatCompletionStreamResponse>? subscription;
+    Timer? deadline;
+
+    controller = StreamController<CreateChatCompletionStreamResponse>(
+      sync: true,
+      onListen: () {
+        deadline = Timer(timeout, () {
+          final cancellation = subscription?.cancel();
+          if (cancellation != null) unawaited(cancellation);
+          controller.addError(
+            DayAgentInferenceTimedOutException(
+              wakeKind: wakeKind,
+              timeout: timeout,
+            ),
+          );
+          unawaited(controller.close());
+        });
+        subscription = source.listen(
+          controller.add,
+          onError: controller.addError,
+          onDone: () {
+            deadline?.cancel();
+            unawaited(controller.close());
+          },
+        );
+      },
+      onCancel: () async {
+        deadline?.cancel();
+        await subscription?.cancel();
+      },
+    );
+    return controller.stream;
+  }
+
+  @override
+  Stream<CreateChatCompletionStreamResponse> generateTextWithMessages({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    required double temperature,
+    required AiConfigInferenceProvider provider,
+    int? maxCompletionTokens,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+    Map<String, String>? thoughtSignatures,
+    ThoughtSignatureCollector? signatureCollector,
+    int? turnIndex,
+    InferenceImpactCollector? impactCollector,
+  }) => _bound(
+    delegate.generateTextWithMessages(
+      messages: messages,
+      model: model,
+      temperature: temperature,
+      provider: provider,
+      maxCompletionTokens: maxCompletionTokens,
+      tools: tools,
+      toolChoice: toolChoice,
+      thoughtSignatures: thoughtSignatures,
+      signatureCollector: signatureCollector,
+      turnIndex: turnIndex,
+      impactCollector: impactCollector,
+    ),
+  );
+
+  @override
+  Stream<CreateChatCompletionStreamResponse> generateText({
+    required String prompt,
+    required String model,
+    required double temperature,
+    required String? systemMessage,
+    required AiConfigInferenceProvider provider,
+    int? maxCompletionTokens,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+  }) => _bound(
+    delegate.generateText(
+      prompt: prompt,
+      model: model,
+      temperature: temperature,
+      systemMessage: systemMessage,
+      provider: provider,
+      maxCompletionTokens: maxCompletionTokens,
+      tools: tools,
+      toolChoice: toolChoice,
+    ),
+  );
+}
 
 /// Raised when a day-agent tool call fails (bad arguments, unknown tool, or a
 /// failed side effect). Carries a human-readable [message] surfaced back to the

--- a/lib/features/daily_os_next/services/day_processing_job.dart
+++ b/lib/features/daily_os_next/services/day_processing_job.dart
@@ -303,6 +303,11 @@ class DayProcessingJob {
   final String? claimToken;
   final DateTime? leaseUntil;
   final DateTime? retryNotBefore;
+
+  /// Most recent classified failure for this intent, retained after a later
+  /// successful retry so Activity and evaluation can explain [attempts].
+  ///
+  /// A fresh/re-armed intent clears both fields.
   final DayProcessingFailureClass? lastFailureClass;
   final String? lastError;
 

--- a/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
+++ b/lib/features/daily_os_next/services/day_processing_outbox_repository.dart
@@ -597,8 +597,7 @@ class DayProcessingOutboxRepository {
     final rows = await db.customWriteReturning(
       'UPDATE day_processing_jobs SET '
       "status = 'running', updated_at = ?1, generation = generation + 1, "
-      'claim_token = ?2, lease_until = ?3, '
-      'last_error = NULL, last_failure_class = NULL '
+      'claim_token = ?2, lease_until = ?3 '
       'WHERE id = ($selector) '
       'RETURNING $_columns',
       variables: variables,
@@ -620,8 +619,6 @@ class DayProcessingOutboxRepository {
       resultEntityId: resultEntityId,
       clearClaimToken: true,
       clearLeaseUntil: true,
-      clearLastError: true,
-      clearLastFailureClass: true,
     );
   });
 

--- a/lib/features/daily_os_next/state/day_agent_job_wiring.dart
+++ b/lib/features/daily_os_next/state/day_agent_job_wiring.dart
@@ -42,7 +42,10 @@ DayAgentJobExecutor buildDayAgentJobExecutor({
       final (reason, tokens) = switch (job.payload) {
         ParseCapturePayload(:final captureId) => (
           dayAgentCaptureSubmittedReason,
-          {dayAgentCaptureSubmittedToken(captureId)},
+          {
+            dayAgentCaptureSubmittedToken(captureId),
+            dayAgentProcessingJobToken(job.id),
+          },
         ),
         DraftPlanPayload(
           :final captureId,
@@ -61,6 +64,7 @@ DayAgentJobExecutor buildDayAgentJobExecutor({
               for (final id in decidedCaptureItemIds)
                 if (id.trim().isNotEmpty)
                   dayAgentDecidedCaptureItemToken(id.trim()),
+              dayAgentProcessingJobToken(job.id),
             },
           ),
         RefinePlanPayload(:final transcriptCaptureId) => (
@@ -71,6 +75,7 @@ DayAgentJobExecutor buildDayAgentJobExecutor({
             if (transcriptCaptureId != null &&
                 transcriptCaptureId.trim().isNotEmpty)
               dayAgentCaptureSubmittedToken(transcriptCaptureId.trim()),
+            dayAgentProcessingJobToken(job.id),
           },
         ),
         TranscribeAudioPayload() => throw StateError(

--- a/test/features/daily_os_next/agents/domain/daily_os_planner_wake_context_test.dart
+++ b/test/features/daily_os_next/agents/domain/daily_os_planner_wake_context_test.dart
@@ -23,11 +23,13 @@ void main() {
       dayAgentCaptureSubmittedToken('capture-a'),
       dayAgentDecidedTaskToken('task-1'),
       dayAgentDecidedCaptureItemToken('parsed-1'),
+      dayAgentProcessingJobToken('job-1'),
     });
 
     expect(ctx.captureIds, ['capture-a', 'capture-b']);
     expect(ctx.decidedTaskIds, contains('task-1'));
     expect(ctx.decidedCaptureItemIds, contains('parsed-1'));
+    expect(ctx.processingJobId, 'job-1');
     expect(ctx.isDraftingWake, isTrue);
     expect(ctx.isRefineWake, isFalse);
   });

--- a/test/features/daily_os_next/agents/domain/day_agent_slots_test.dart
+++ b/test/features/daily_os_next/agents/domain/day_agent_slots_test.dart
@@ -95,6 +95,16 @@ void main() {
         isNot(dayStatusEventId('dayplan-2026-05-25', 'b')),
       );
     });
+
+    test('durable retries share one processing-job-scoped event id', () {
+      expect(
+        dayStatusEventIdForProcessingJob(
+          'dayplan-2026-05-25',
+          'draft_dayplan-2026-05-25',
+        ),
+        'day_status:dayplan-2026-05-25:job:draft_dayplan-2026-05-25',
+      );
+    });
   });
 
   group('weekStartFor', () {

--- a/test/features/daily_os_next/agents/domain/day_agent_trigger_tokens_test.dart
+++ b/test/features/daily_os_next/agents/domain/day_agent_trigger_tokens_test.dart
@@ -44,6 +44,46 @@ void main() {
         '${dayAgentDecidedCaptureItemPrefix}parsed-abc',
       );
     });
+
+    test('processing-job token round-trips the durable job id', () {
+      const jobId = 'draft_dayplan-2026-05-25';
+      final token = dayAgentProcessingJobToken(jobId);
+
+      expect(token, '$dayAgentProcessingJobPrefix$jobId');
+      expect(processingJobIdFromTriggerTokens({token}), jobId);
+    });
+  });
+
+  group('processingJobIdFromTriggerTokens', () {
+    test('returns null when no durable job token is present', () {
+      expect(
+        processingJobIdFromTriggerTokens({
+          dayAgentDraftingToken('dayplan-2026-05-25'),
+        }),
+        isNull,
+      );
+    });
+
+    test('rejects ambiguous merged durable job tokens', () {
+      expect(
+        () => processingJobIdFromTriggerTokens({
+          dayAgentProcessingJobToken('job-a'),
+          dayAgentProcessingJobToken('job-b'),
+        }),
+        throwsStateError,
+      );
+    });
+
+    test('ignores empty job ids and trims the selected id', () {
+      expect(
+        processingJobIdFromTriggerTokens({
+          dayAgentProcessingJobPrefix,
+          '$dayAgentProcessingJobPrefix   ',
+          '$dayAgentProcessingJobPrefix  job-a  ',
+        }),
+        'job-a',
+      );
+    });
   });
 
   group('hasDraftingTokenForDay', () {

--- a/test/features/daily_os_next/agents/service/day_agent_directive_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_directive_service_test.dart
@@ -388,6 +388,7 @@ void main() {
       String agentId = perDayAgent,
       String? wakeDayId = dayId,
       String? runKey,
+      String? processingJobId,
     }) {
       return withClock(
         Clock.fixed(now),
@@ -397,6 +398,7 @@ void main() {
           args: args,
           wakeDayId: wakeDayId,
           runKey: runKey,
+          processingJobId: processingJobId,
         ),
       );
     }
@@ -422,6 +424,44 @@ void main() {
         ]);
         expect(event.raisedAt, now);
         expect(notifications, containsAll([dayId, event.id]));
+      },
+    );
+
+    test(
+      'durable-job retries upsert one status event instead of duplicating it',
+      () async {
+        const processingJobId = 'draft_dayplan-2026-07-23';
+        const args = <String, dynamic>{
+          'dayId': dayId,
+          'status': 'attentionNeeded',
+          'reasons': ['overCommitted'],
+          'note': 'The selected work does not fit.',
+        };
+
+        final first = await executeRaise(
+          args,
+          runKey: 'attempt-1',
+          processingJobId: processingJobId,
+        );
+        final retry = await executeRaise(
+          args,
+          runKey: 'attempt-2',
+          processingJobId: processingJobId,
+        );
+
+        expect(first.success, isTrue, reason: first.output);
+        expect(retry.success, isTrue, reason: retry.output);
+        final events = upserted.whereType<DayStatusEventEntity>().toList();
+        expect(
+          events,
+          hasLength(2),
+          reason: 'both attempts reached the writer',
+        );
+        expect(
+          events.map((event) => event.id).toSet(),
+          {'day_status:$dayId:job:$processingJobId'},
+          reason: 'the synced upsert key, not the wake run key, owns identity',
+        );
       },
     );
 

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_models_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_models_test.dart
@@ -1,9 +1,17 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/ai/model/ai_call_impact.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/gemini_tool_call.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_directive_models.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart';
+import 'package:openai_dart/openai_dart.dart';
 
-import '../../../agents/test_data/entity_factories.dart';
+import '../../../agents/test_utils.dart';
 
 // The rest of day_agent_workflow_models.dart (tool exceptions, observation
 // trimming, scheduled-wake carry-over, counter GC) is exercised through
@@ -149,4 +157,209 @@ void main() {
       );
     });
   });
+
+  group('day-agent inference timeout', () {
+    test('uses a materially shorter bound for drafting than general wakes', () {
+      const policy = DayAgentInferenceTimeoutPolicy();
+
+      expect(
+        policy.forKind(DayAgentWakeKind.capture),
+        const Duration(seconds: 20),
+      );
+      expect(
+        policy.forKind(DayAgentWakeKind.draft),
+        const Duration(seconds: 30),
+      );
+      expect(
+        policy.forKind(DayAgentWakeKind.refine),
+        const Duration(seconds: 30),
+      );
+      expect(
+        policy.forKind(DayAgentWakeKind.general),
+        const Duration(seconds: 60),
+      );
+    });
+
+    test('rejects a non-positive deadline', () {
+      expect(
+        () => DayAgentTimeoutInferenceRepository(
+          delegate: const _StreamInferenceRepository(Stream.empty()),
+          wakeKind: DayAgentWakeKind.draft,
+          timeout: Duration.zero,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('generateText cancels the deadline when the provider completes', () {
+      fakeAsync((async) {
+        final source = StreamController<CreateChatCompletionStreamResponse>(
+          sync: true,
+        );
+        final chunks = <CreateChatCompletionStreamResponse>[];
+        final errors = <Object>[];
+        final repository = DayAgentTimeoutInferenceRepository(
+          delegate: _StreamInferenceRepository(source.stream),
+          wakeKind: DayAgentWakeKind.capture,
+          timeout: const Duration(seconds: 20),
+        );
+
+        repository
+            .generateText(
+              prompt: 'capture',
+              model: 'glm-5.2',
+              temperature: 0.3,
+              systemMessage: null,
+              provider: testInferenceProvider(),
+            )
+            .listen(
+              chunks.add,
+              onError: errors.add,
+            );
+        source
+          ..add(_thinkingChunk('glm-5.2'))
+          ..close();
+        async
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 21))
+          ..flushMicrotasks();
+
+        expect(chunks, hasLength(1));
+        expect(errors, isEmpty);
+      });
+    });
+
+    test('classifies and cancels a provider stream at the total deadline', () {
+      fakeAsync((async) {
+        var upstreamCancelled = false;
+        final source = StreamController<CreateChatCompletionStreamResponse>(
+          sync: true,
+          onCancel: () {
+            upstreamCancelled = true;
+          },
+        );
+        final errors = <Object>[];
+        final repository = DayAgentTimeoutInferenceRepository(
+          delegate: _StreamInferenceRepository(source.stream),
+          wakeKind: DayAgentWakeKind.draft,
+          timeout: const Duration(seconds: 30),
+        );
+
+        final subscription = repository
+            .generateTextWithMessages(
+              messages: const [],
+              model: 'glm-5.2',
+              temperature: 0.3,
+              provider: testInferenceProvider(),
+            )
+            .listen((_) {}, onError: errors.add);
+
+        async
+          ..elapse(const Duration(seconds: 29))
+          ..flushMicrotasks();
+        expect(errors, isEmpty);
+
+        async
+          ..elapse(const Duration(seconds: 1))
+          ..flushMicrotasks();
+        expect(errors, hasLength(1));
+        expect(errors.single, isA<TimeoutException>());
+        expect(errors.single, isA<DayAgentInferenceTimedOutException>());
+        expect(errors.single.toString(), contains('draft'));
+        expect(errors.single.toString(), contains('30s'));
+        expect(
+          upstreamCancelled,
+          isTrue,
+          reason:
+              'The inner timeout must cancel the provider stream so a late '
+              'tool batch cannot mutate after the retry starts.',
+        );
+
+        unawaited(subscription.cancel());
+        unawaited(source.close());
+      });
+    });
+
+    test('stream activity does not extend the total deadline', () {
+      fakeAsync((async) {
+        var upstreamCancelled = false;
+        final source = StreamController<CreateChatCompletionStreamResponse>(
+          sync: true,
+          onCancel: () {
+            upstreamCancelled = true;
+          },
+        );
+        final errors = <Object>[];
+        final repository = DayAgentTimeoutInferenceRepository(
+          delegate: _StreamInferenceRepository(source.stream),
+          wakeKind: DayAgentWakeKind.draft,
+          timeout: const Duration(seconds: 30),
+        );
+
+        repository
+            .generateTextWithMessages(
+              messages: const [],
+              model: 'qwen3.5-397b-a17b',
+              temperature: 0.3,
+              provider: testInferenceProvider(),
+            )
+            .listen((_) {}, onError: errors.add);
+
+        for (var i = 0; i < 5; i++) {
+          async.elapse(const Duration(seconds: 5));
+          source.add(_thinkingChunk('qwen3.5-397b-a17b'));
+          async.flushMicrotasks();
+          expect(errors, isEmpty);
+        }
+        async
+          ..elapse(const Duration(seconds: 5))
+          ..flushMicrotasks();
+
+        expect(errors.single, isA<DayAgentInferenceTimedOutException>());
+        expect(upstreamCancelled, isTrue);
+        unawaited(source.close());
+      });
+    });
+  });
+}
+
+CreateChatCompletionStreamResponse _thinkingChunk(String model) =>
+    CreateChatCompletionStreamResponse(
+      id: 'thinking',
+      created: 0,
+      model: model,
+      choices: const [],
+    );
+
+class _StreamInferenceRepository implements InferenceRepositoryInterface {
+  const _StreamInferenceRepository(this.stream);
+
+  final Stream<CreateChatCompletionStreamResponse> stream;
+
+  @override
+  Stream<CreateChatCompletionStreamResponse> generateText({
+    required String prompt,
+    required String model,
+    required double temperature,
+    required String? systemMessage,
+    required AiConfigInferenceProvider provider,
+    int? maxCompletionTokens,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+  }) => stream;
+
+  @override
+  Stream<CreateChatCompletionStreamResponse> generateTextWithMessages({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    required double temperature,
+    required AiConfigInferenceProvider provider,
+    int? maxCompletionTokens,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+    Map<String, String>? thoughtSignatures,
+    ThoughtSignatureCollector? signatureCollector,
+    int? turnIndex,
+    InferenceImpactCollector? impactCollector,
+  }) => stream;
 }

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -31,6 +31,7 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_se
 import 'package:lotti/features/daily_os_next/agents/service/day_audio_entry_context_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
+import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart';
 import 'package:lotti/features/tasks/repository/task_dependency_resolver.dart';
 import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
@@ -1898,6 +1899,7 @@ void main() {
               args: any(named: 'args'),
               wakeDayId: any(named: 'wakeDayId'),
               runKey: any(named: 'runKey'),
+              processingJobId: any(named: 'processingJobId'),
             ),
           ).thenAnswer(
             (_) async => DayAgentDirectToolResult.success(
@@ -1949,6 +1951,7 @@ void main() {
               args: any(named: 'args'),
               wakeDayId: any(named: 'wakeDayId'),
               runKey: any(named: 'runKey'),
+              processingJobId: any(named: 'processingJobId'),
             ),
           ).thenAnswer(
             (_) async => DayAgentDirectToolResult.success(
@@ -1965,9 +1968,16 @@ void main() {
 
           final result = await execute(
             workflow(directiveService: directiveService),
+            triggerTokens: {
+              dayAgentPlanningDayToken(dayId),
+              dayAgentProcessingJobToken('job-1'),
+            },
           );
 
           expect(result.success, isTrue);
+          expect(sentPrompt().json('trigger_tokens'), [
+            dayAgentPlanningDayToken(dayId),
+          ]);
           verify(
             () => directiveService.executeTool(
               agentId: agentId,
@@ -1975,6 +1985,7 @@ void main() {
               args: {'dayId': dayId, 'status': 'dayClosed'},
               wakeDayId: dayId,
               runKey: runKey,
+              processingJobId: 'job-1',
             ),
           ).called(1);
         },
@@ -2827,8 +2838,12 @@ void main() {
         );
         final inferenceRepo =
             conversationRepository.sendMessageCalls.single.inferenceRepo;
-        expect(inferenceRepo, isA<CloudInferenceWrapper>());
-        final wrapper = inferenceRepo as CloudInferenceWrapper;
+        expect(inferenceRepo, isA<DayAgentTimeoutInferenceRepository>());
+        final bounded = inferenceRepo as DayAgentTimeoutInferenceRepository;
+        expect(bounded.wakeKind, DayAgentWakeKind.general);
+        expect(bounded.timeout, const Duration(seconds: 60));
+        expect(bounded.delegate, isA<CloudInferenceWrapper>());
+        final wrapper = bounded.delegate as CloudInferenceWrapper;
         // testAiModel defaults to AiConfigModel.geminiThinkingMode == low.
         expect(wrapper.geminiThinkingMode, GeminiThinkingMode.low);
 
@@ -2960,6 +2975,13 @@ void main() {
           'priority': 'P2',
         },
       ]);
+      final systemPrompt = conversationRepository.lastSystemMessage!;
+      expect(systemPrompt, contains('Capture matching rules:'));
+      expect(systemPrompt, contains('`parse_capture_to_items`'));
+      expect(systemPrompt, isNot(contains('Drafting rules:')));
+      expect(systemPrompt, isNot(contains('`draft_day_plan`')));
+      expect(systemPrompt, isNot(contains('Refine rules:')));
+      expect(systemPrompt, isNot(contains('Your memory (append-only')));
     });
 
     group('capture wake parse enforcement', () {
@@ -3023,6 +3045,14 @@ void main() {
 
           expect(result.success, isTrue);
           expect(conversationRepository.sendMessageCalls, hasLength(2));
+          final systemPrompt = conversationRepository.lastSystemMessage!;
+          expect(systemPrompt, contains('Capture matching rules:'));
+          expect(systemPrompt, contains('`parse_capture_to_items`'));
+          expect(systemPrompt, isNot(contains('Drafting rules:')));
+          expect(systemPrompt, isNot(contains('`draft_day_plan`')));
+          expect(systemPrompt, isNot(contains('Refine rules:')));
+          expect(systemPrompt, isNot(contains('`summarize_recent_patterns`')));
+          expect(systemPrompt, isNot(contains('Your memory (append-only')));
           expect(
             conversationRepository.sendMessageCalls.first.toolChoice,
             isNull,
@@ -3832,6 +3862,14 @@ void main() {
 
           expect(result.success, isTrue);
           expect(conversationRepository.sendMessageCalls, hasLength(2));
+          final systemPrompt = conversationRepository.lastSystemMessage!;
+          expect(systemPrompt, contains('Drafting rules:'));
+          expect(systemPrompt, contains('`draft_day_plan`'));
+          expect(systemPrompt, isNot(contains('Capture matching rules:')));
+          expect(systemPrompt, isNot(contains('`parse_capture_to_items`')));
+          expect(systemPrompt, isNot(contains('Refine rules:')));
+          expect(systemPrompt, isNot(contains('`summarize_recent_patterns`')));
+          expect(systemPrompt, isNot(contains('Your memory (append-only')));
           expect(
             conversationRepository.sendMessageCalls.first.toolChoice,
             isNull,
@@ -4099,6 +4137,16 @@ void main() {
         );
 
         expect(result.success, isTrue);
+        final systemPrompt = conversationRepository.lastSystemMessage!;
+        expect(systemPrompt, contains('Refine rules:'));
+        expect(systemPrompt, contains('`propose_plan_diff`'));
+        expect(systemPrompt, isNot(contains('Capture matching rules:')));
+        expect(systemPrompt, isNot(contains('`parse_capture_to_items`')));
+        expect(systemPrompt, isNot(contains('`draft_day_plan`')));
+        expect(
+          systemPrompt,
+          isNot(contains('On `drafting:<dayId>` wakes')),
+        );
         final refinePayload =
             sentPrompt().json('refine')! as Map<String, dynamic>;
         expect(refinePayload['requested'], isTrue);
@@ -5450,7 +5498,7 @@ void main() {
         // The gated block keeps exactly one blank line on each seam.
         expect(
           conversationRepository.lastSystemMessage,
-          contains('shut down a day.\n\nWeek context'),
+          contains('self-evident.\n\nWeek context'),
         );
         expect(
           conversationRepository.lastSystemMessage,
@@ -5469,7 +5517,7 @@ void main() {
         // No double blank line where the gated block collapsed to nothing.
         expect(
           conversationRepository.lastSystemMessage,
-          contains('shut down a day.\n\nYour memory'),
+          contains('self-evident.\n\nYour memory'),
         );
       });
     });
@@ -5536,7 +5584,7 @@ void main() {
           // The gated block keeps exactly one blank line on the seam.
           expect(
             conversationRepository.lastSystemMessage,
-            contains('shut down a day.\n\nBlocked-work rules'),
+            contains('self-evident.\n\nBlocked-work rules'),
           );
 
           await execute(workflow());

--- a/test/features/daily_os_next/eval/framework/eval_report.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report.dart
@@ -597,6 +597,8 @@ class EvalReport {
       'job': {
         'status': result.jobStatus,
         'attempts': result.jobAttempts,
+        'lastFailureClass': result.jobLastFailureClass,
+        'lastError': result.jobLastError,
         'latencyMs': result.latency.inMilliseconds,
         'error': result.error,
       },

--- a/test/features/daily_os_next/eval/framework/eval_report_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_report_test.dart
@@ -69,6 +69,8 @@ void main() {
     Duration latency = const Duration(milliseconds: 100),
     String? error,
     String? jobStatus = 'succeeded',
+    String? jobLastFailureClass,
+    String? jobLastError,
   }) {
     final req = forRequest ?? request();
     return EvalRunResult(
@@ -92,6 +94,8 @@ void main() {
           ],
       jobStatus: jobStatus,
       jobAttempts: 0,
+      jobLastFailureClass: jobLastFailureClass,
+      jobLastError: jobLastError,
       consumption: const [],
       error: error,
     );
@@ -518,6 +522,8 @@ void main() {
             pass(EvalConstraintIds.withinCapacity),
             fail(EvalConstraintIds.requiredWorkPlaced, 'not placed: task-1'),
           ],
+          jobLastFailureClass: 'timeout',
+          jobLastError: 'draft inference produced no stream activity for 30s',
         ),
       ], generatedAt: generatedAt);
 
@@ -559,6 +565,17 @@ void main() {
       expect(
         (entry['constraints']! as Map)[EvalConstraintIds.requiredWorkPlaced],
         containsPair('detail', 'not placed: task-1'),
+      );
+      expect(
+        entry['job'],
+        containsPair('lastFailureClass', 'timeout'),
+      );
+      expect(
+        entry['job'],
+        containsPair(
+          'lastError',
+          'draft inference produced no stream activity for 30s',
+        ),
       );
     });
 

--- a/test/features/daily_os_next/eval/framework/eval_runner.dart
+++ b/test/features/daily_os_next/eval/framework/eval_runner.dart
@@ -109,6 +109,8 @@ class EvalRunResult {
     required this.wakes,
     required this.jobStatus,
     required this.jobAttempts,
+    required this.jobLastFailureClass,
+    required this.jobLastError,
     required this.consumption,
     this.error,
   });
@@ -131,6 +133,10 @@ class EvalRunResult {
   /// Terminal status of the draft job, or null when no job was found.
   final String? jobStatus;
   final int? jobAttempts;
+
+  /// Most recent failed attempt, retained even when a later retry succeeded.
+  final String? jobLastFailureClass;
+  final String? jobLastError;
 
   /// Consumption events recorded during this run. Empty for scripted models,
   /// which never reach a provider.
@@ -458,6 +464,8 @@ Future<EvalRunResult> _runCell(
       wakes: recorder.wakes,
       jobStatus: job?.status.name,
       jobAttempts: job?.attempts,
+      jobLastFailureClass: job?.lastFailureClass?.name,
+      jobLastError: job?.lastError,
       consumption: List.unmodifiable(
         attribution?.recordedInteractions ?? const <AiConsumptionEvent>[],
       ),
@@ -503,6 +511,8 @@ EvalRunResult _failedResult(
     wakes: const [],
     jobStatus: null,
     jobAttempts: null,
+    jobLastFailureClass: null,
+    jobLastError: null,
     consumption: const [],
     error: error.toString(),
   );

--- a/test/features/daily_os_next/services/day_processing_outbox_processor_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_processor_test.dart
@@ -368,6 +368,53 @@ void main() {
     );
 
     test(
+      'a classified timeout retries immediately and a later success retains '
+      'the recovered cause',
+      () async {
+        var executorRuns = 0;
+        final processor = DayProcessingOutboxProcessor(
+          repository: repository,
+          transcribe: (_) async => 'unused',
+          attachTranscript: (_, _) async => true,
+          randomUnit: () => 0,
+          agentJobExecutor: (job) async {
+            executorRuns++;
+            return executorRuns == 1
+                ? const DayAgentJobFailed(
+                    failureClass: DayProcessingFailureClass.timeout,
+                    error: 'draft inference exceeded its 30s deadline',
+                  )
+                : const DayAgentJobSucceeded(resultEntityId: 'plan-1');
+          },
+        );
+        await enqueueParse();
+
+        expect(
+          await processor.processNext(
+            kinds: const {DayProcessingJobKind.parseCapture},
+          ),
+          DayProcessingRunResult.deferred,
+        );
+        expect(
+          await processor.processNext(
+            kinds: const {DayProcessingJobKind.parseCapture},
+          ),
+          DayProcessingRunResult.succeeded,
+        );
+
+        final saved = await repository.getById('parse_cap-1');
+        expect(executorRuns, 2);
+        expect(saved!.status, DayProcessingJobStatus.succeeded);
+        expect(saved.attempts, 1);
+        expect(saved.lastFailureClass, DayProcessingFailureClass.timeout);
+        expect(
+          saved.lastError,
+          'draft inference exceeded its 30s deadline',
+        );
+      },
+    );
+
+    test(
       'no registered executor fails the job instead of hanging silently',
       () async {
         final processor = DayProcessingOutboxProcessor(

--- a/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
+++ b/test/features/daily_os_next/services/day_processing_outbox_repository_test.dart
@@ -363,6 +363,32 @@ void main() {
     expect(await repository.claimNext(), isNotNull);
   });
 
+  test(
+    'a successful retry preserves the classified cause of the prior attempt',
+    () async {
+      await enqueue();
+      final firstClaim = await repository.claimNext();
+      await repository.markFailure(
+        jobId: firstClaim!.job.id,
+        claimToken: firstClaim.token,
+        failureClass: DayProcessingFailureClass.timeout,
+        error: 'draft inference stalled for 30s',
+        retryDelay: Duration.zero,
+      );
+
+      final retryClaim = await repository.claimNext();
+      final succeeded = await repository.markSucceeded(
+        jobId: retryClaim!.job.id,
+        claimToken: retryClaim.token,
+      );
+
+      expect(succeeded.status, DayProcessingJobStatus.succeeded);
+      expect(succeeded.attempts, 1);
+      expect(succeeded.lastFailureClass, DayProcessingFailureClass.timeout);
+      expect(succeeded.lastError, 'draft inference stalled for 30s');
+    },
+  );
+
   test('orders ready work by due time and then stable job id', () async {
     await enqueue();
     final claim = await repository.claimNext();

--- a/test/features/daily_os_next/state/day_agent_job_wiring_test.dart
+++ b/test/features/daily_os_next/state/day_agent_job_wiring_test.dart
@@ -120,7 +120,10 @@ void main() {
           ),
         ).captured;
         expect(captured[0], dayAgentCaptureSubmittedReason);
-        expect(captured[1], {dayAgentCaptureSubmittedToken('cap-1')});
+        expect(captured[1], {
+          dayAgentCaptureSubmittedToken('cap-1'),
+          dayAgentProcessingJobToken('job-1'),
+        });
       },
     );
 
@@ -166,6 +169,7 @@ void main() {
           dayAgentCaptureSubmittedToken('cap-1'),
           dayAgentDecidedTaskToken('task-1'),
           dayAgentDecidedCaptureItemToken('item-1'),
+          dayAgentProcessingJobToken('job-1'),
         });
       },
     );
@@ -202,6 +206,7 @@ void main() {
         expect(captured[1], {
           dayAgentPlanningDayToken('dayplan-2026-07-22'),
           dayAgentDraftingToken('dayplan-2026-07-22'),
+          dayAgentProcessingJobToken('job-1'),
         });
       },
     );
@@ -242,6 +247,7 @@ void main() {
           dayAgentPlanningDayToken('dayplan-2026-07-22'),
           dayAgentRefineToken('dayplan-2026-07-22'),
           dayAgentCaptureSubmittedToken('cap-refine'),
+          dayAgentProcessingJobToken('job-1'),
         });
       },
     );


### PR DESCRIPTION
## What changed

- add hard total inference deadlines by Day Agent wake kind: 20 seconds for capture, 30 seconds for draft/refine, and 60 seconds for general wakes
- cancel the upstream inference stream at the deadline even when the provider continues emitting reasoning tokens
- retain the classified timeout cause after a successful durable retry
- make retry-generated day-status events deterministic per processing job so a retry cannot duplicate an accepted status
- advertise only the instructions and tools available to the current wake mode; capture parser prose no longer appears in planning wakes
- hide internal processing-job tokens from model-visible context
- expose retained job failure context in eval reports
- update the Daily OS architecture knowledge, changelog, and Flatpak release metadata

## Why

A tool-less provider attempt could consume roughly two minutes before the durable planning job retried. Separately, draft prompts still described the capture parser even though that tool was unavailable, causing Qwen to spend turns attempting the wrong workflow. The outer timeout also did not prevent a late inference stream from continuing to mutate state.

This bounds the complete provider stream, preserves a useful classified cause for diagnosis, and makes retries idempotent while aligning each prompt with its actual tool surface.

## Validation

- `make analyze` — zero findings
- 384 focused tests across the touched Day Agent, outbox, and eval files — passed
- `make knowledge_check` — 88 concepts valid; all 135 Mermaid diagrams parse
- local changed-line coverage — 96/96 (100%)
- final live Melious `overCommitted` matrix, Qwen 3.5 397B A17B, 3 samples:
  - 3/3 executions succeeded
  - 10.1–24.7 seconds, 16.7-second mean
  - zero `parse_capture_to_items` attempts
  - 94% objective score (31/33); the two remaining misses were existing working-hours planning quality, with a block ending at 18:00

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. Codecov is the authoritative patch-coverage result.

No screenshots are required because this changes inference, retry, and prompt behavior without changing a visual surface.