### PR TITLE
fix(sync): ingest freshly decrypted attachments

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -1032,10 +1032,31 @@ void main() {
     );
 
     test(
-      'Late Megolm key survives Bob restart and clears the durable floor',
+      'Late Megolm key restores a file-backed image after Bob restarts',
       () async {
         const lateKeyTimeout = Duration(minutes: 3);
         final bobCountBefore = await bobDb.getJournalCount();
+        final imageId = const Uuid().v1();
+        final imageTimestamp = DateTime.utc(2025, 2, 1, 14);
+        final image = JournalImage(
+          meta: _nextMediaMetadata(
+            device: aliceOutbox,
+            id: imageId,
+            timestamp: imageTimestamp,
+          ),
+          data: ImageData(
+            capturedAt: imageTimestamp,
+            imageId: imageId,
+            imageFile: '$imageId.png',
+            imageDirectory: '/images/2025-02-01/',
+          ),
+          entryText: const EntryText(
+            plainText: 'Late-key Matrix image fixture',
+          ),
+        );
+        final imageBytes = base64Decode(_onePixelPngBase64);
+        final bobImageFile = _mediaFileFor(bobOutbox, image);
+        expect(bobImageFile.existsSync(), isFalse);
         final bobDeviceId = bob.client.deviceID;
         expect(bobDeviceId, isNotNull);
 
@@ -1056,9 +1077,16 @@ void main() {
           await alice.client.encryption!.keyManager
               .clearOrUseOutboundGroupSession(roomId, wipe: true);
 
-          await _sendTestMessages(
-            1,
-            device: aliceOutbox,
+          await _stageMediaEntity(
+            entity: image,
+            bytes: imageBytes,
+            sender: aliceOutbox,
+          );
+          await aliceOutbox.service.enqueueNextSendRequest(
+            delay: Duration.zero,
+          );
+          await _waitForOutboxDrain(
+            aliceOutbox,
             timeout: lateKeyTimeout,
           );
 
@@ -1113,6 +1141,13 @@ void main() {
             floorBeforeRestart,
           );
 
+          // Pause Lotti's live receiver before importing the key. The Matrix
+          // SDK may retry cached timeline events as soon as a room key lands;
+          // the second cold restart below makes recovery belong to bootstrap
+          // rather than that live-event side effect.
+          await bob.queueCoordinator.stop();
+          expect(bob.queueCoordinator.isRunning, isFalse);
+
           await bobDevice.setVerified(true, false);
           final outboundSession = alice.client.encryption!.keyManager
               .getOutboundGroupSession(roomId)
@@ -1162,13 +1197,51 @@ void main() {
             isNotNull,
             reason: 'the restarted SDK must persist the real room key',
           );
+
+          expect(bobImageFile.existsSync(), isFalse);
+          await bob.dispose();
+          bobInitialized = false;
+          bob = await _createBobService(
+            documentsDirectory: bobDocumentsDirectory,
+            config: config2,
+            loggingService: getIt<DomainLogger>(),
+            journalDb: bobDb,
+            settingsDb: bobSettingsDb,
+            secureStorage: secureStorageMock,
+            activityService: sharedUserActivityService,
+            updateNotifications: mockUpdateNotifications,
+            aiConfigRepository: sharedAiConfigRepository,
+            singleInstance: false,
+            syncDb: bobSyncDb,
+            vectorClockService: bobVectorClockService,
+          );
+          bobInitialized = true;
+          await bob.init();
+          expect(bob.debugPipeline, isNotNull);
+          expect(bobImageFile.existsSync(), isFalse);
+
           await bob.queueCoordinator.triggerBridge();
 
           await waitUntilAsync(
-            () async =>
-                await bobDb.getJournalCount() == bobCountBefore + 1 &&
-                await bob.queueCoordinator.queue.resumeFloorTs(roomId) == null,
+            () async {
+              final received = await bobDb.journalEntityById(imageId);
+              return received is JournalImage &&
+                  bobImageFile.existsSync() &&
+                  bobImageFile.lengthSync() == imageBytes.length &&
+                  await bob.queueCoordinator.queue.resumeFloorTs(roomId) ==
+                      null;
+            },
             timeout: lateKeyTimeout,
+          );
+          final received = await bobDb.journalEntityById(imageId);
+          expect(received, isA<JournalImage>());
+          expect((received! as JournalImage).data, image.data);
+          expect(
+            await bobImageFile.readAsBytes(),
+            orderedEquals(imageBytes),
+            reason:
+                'cold-start bootstrap must hydrate the JSON and image before '
+                'the companion sync payload applies',
           );
           expect(
             await bob.queueCoordinator.queue.resumeFloorTs(roomId),
@@ -1930,7 +2003,7 @@ void main() {
         expect(repairRequests, hasLength(1));
         expect(repairRequests.single.entryIds.toSet(), missingEntryIds);
 
-        final repairResponses =
+        List<SyncJournalEntity> repairResponses() =>
             _flattenMessages(
                   aliceOutbox.sender.sentMessages.skip(aliceSentBeforeRepair),
                 )
@@ -1941,8 +2014,22 @@ void main() {
                       missingEntryIds.contains(message.id),
                 )
                 .toList();
+        await waitUntilAsync(
+          () async {
+            final responseIds = repairResponses()
+                .map((message) => message.id)
+                .toSet();
+            if (!responseIds.containsAll(missingEntryIds)) {
+              await aliceOutbox.service.enqueueNextSendRequest(
+                delay: Duration.zero,
+              );
+            }
+            return responseIds.containsAll(missingEntryIds);
+          },
+          timeout: repairTimeout,
+        );
         expect(
-          repairResponses.map((message) => message.id).toSet(),
+          repairResponses().map((message) => message.id).toSet(),
           missingEntryIds,
           reason: 'Alice must answer both requested entries with attachments',
         );
@@ -2063,6 +2150,57 @@ Future<JournalEntity> _sendMediaEntity({
     reason: 'the receiver must not start with the sender media file',
   );
 
+  await _stageMediaEntity(
+    entity: entity,
+    bytes: bytes,
+    sender: sender,
+  );
+
+  final sentEventsBefore = sender.sender.sentEvents;
+  final sentEntriesBefore = sender.sender.sentEntries;
+  final bundleCountBefore = sender.sender.bundleSizes.length;
+  await sender.service.enqueueNextSendRequest(delay: Duration.zero);
+  await _waitForOutboxDrain(sender, timeout: timeout);
+
+  expect(sender.sender.sentEvents - sentEventsBefore, 1);
+  expect(sender.sender.sentEntries - sentEntriesBefore, 1);
+  expect(
+    sender.sender.bundleSizes.sublist(bundleCountBefore),
+    [1],
+    reason: 'media rows must travel alone rather than in an outbox bundle',
+  );
+
+  JournalEntity? received;
+  await waitUntilAsync(
+    () async {
+      received = await receiver.journalDb.journalEntityById(entity.meta.id);
+      if (received != null &&
+          receiverFile.existsSync() &&
+          receiverFile.lengthSync() == bytes.length) {
+        return true;
+      }
+      await receiverService.forceRescan();
+      await receiverService.retryNow();
+      return false;
+    },
+    timeout: timeout,
+  );
+
+  expect(received, isNotNull);
+  expect(
+    await receiverFile.readAsBytes(),
+    orderedEquals(bytes),
+    reason: 'Matrix must transfer the exact media payload between sandboxes',
+  );
+  return received!;
+}
+
+Future<void> _stageMediaEntity({
+  required JournalEntity entity,
+  required List<int> bytes,
+  required _DeviceOutbox sender,
+}) async {
+  final sourceFile = _mediaFileFor(sender, entity);
   await _setMatrixSyncEnabled(sender.journalDb, enabled: false);
   try {
     final actionableBefore = await sender.syncDb.getOutboxItems(
@@ -2109,44 +2247,6 @@ Future<JournalEntity> _sendMediaEntity({
   } finally {
     await _setMatrixSyncEnabled(sender.journalDb, enabled: true);
   }
-
-  final sentEventsBefore = sender.sender.sentEvents;
-  final sentEntriesBefore = sender.sender.sentEntries;
-  final bundleCountBefore = sender.sender.bundleSizes.length;
-  await sender.service.enqueueNextSendRequest(delay: Duration.zero);
-  await _waitForOutboxDrain(sender, timeout: timeout);
-
-  expect(sender.sender.sentEvents - sentEventsBefore, 1);
-  expect(sender.sender.sentEntries - sentEntriesBefore, 1);
-  expect(
-    sender.sender.bundleSizes.sublist(bundleCountBefore),
-    [1],
-    reason: 'media rows must travel alone rather than in an outbox bundle',
-  );
-
-  JournalEntity? received;
-  await waitUntilAsync(
-    () async {
-      received = await receiver.journalDb.journalEntityById(entity.meta.id);
-      if (received != null &&
-          receiverFile.existsSync() &&
-          receiverFile.lengthSync() == bytes.length) {
-        return true;
-      }
-      await receiverService.forceRescan();
-      await receiverService.retryNow();
-      return false;
-    },
-    timeout: timeout,
-  );
-
-  expect(received, isNotNull);
-  expect(
-    await receiverFile.readAsBytes(),
-    orderedEquals(bytes),
-    reason: 'Matrix must transfer the exact media payload between sandboxes',
-  );
-  return received!;
 }
 
 Future<List<JournalEntity>> _sendMediaMetadataUpdates({

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -90,7 +90,13 @@ does not maintain a second retry cache. When any to-device traffic arrives
 while a durable floor exists, `BridgeCoordinator` reruns catch-up; pagination
 can still return a cached encrypted `Event`, so `QueueBootstrapSink` makes one
 fresh `decryptRoomEvent` attempt before classifying it. Successful plaintext is
-queued; ciphertext that remains unresolved keeps the floor.
+queued; ciphertext that remains unresolved keeps the floor. When that fresh
+attempt reveals an attachment descriptor, the queue sink synchronously hands
+the decrypted event to `AttachmentAwareBootstrapSink` before type
+classification. The descriptor then enters the same bounded attachment worker
+pool as plaintext page events, so its JSON can land and wake a companion payload
+from `pendingAttachment`; the descriptor itself remains excluded from the
+inbound event queue.
 
 The same rule applies to bootstrap pages. `QueueBootstrapSink` lowers each
 room's floor before appending later plaintext from that page, re-decrypts each

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -7,6 +7,9 @@
 * **Correction**: Clarified that explicit sync bridge calls await every
   single-flight rerun coalesced onto the active pass, while attachment downloads
   retain their independent queue and drain point.
+* **Correction**: Documented the bootstrap ordering contract for freshly
+  decrypted attachment descriptors: they enter the bounded attachment worker
+  pool before queue classification drops the non-payload event.
 
 ## 2026-07-26
 * **Enforcement**: The metadata that makes drift detectable now fails the build

--- a/lib/features/sync/queue/attachment_aware_bootstrap_sink.dart
+++ b/lib/features/sync/queue/attachment_aware_bootstrap_sink.dart
@@ -3,16 +3,23 @@ import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:lotti/features/sync/matrix/pipeline/catch_up_strategy.dart';
+import 'package:lotti/features/sync/queue/bootstrap_sink.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:matrix/matrix.dart';
 
-/// Bootstrap sink wrapper that funnels each paginated event through the
-/// coordinator's attachment ingestor *before* forwarding to the inner sink.
+/// Bootstrap sink wrapper that funnels each plaintext paginated event through
+/// the coordinator's attachment ingestor before forwarding to the inner sink.
 /// This is the catch-up equivalent of the live-stream `_handleLiveEvent`
 /// hook: every attachment descriptor observed during
 /// `collectHistoryForBootstrap` is recorded + downloaded so the companion
 /// sync-payload events that the inner sink enqueues have their JSON on disk
 /// by the time the worker applies them.
+///
+/// Encrypted page events are not useful to attachment ingestion and are
+/// skipped here. When the inner [QueueBootstrapSink] successfully re-decrypts
+/// one, its `onDecryptedEvent` callback must call [addDecryptedEvent] so the
+/// resulting plaintext enters this same bounded worker pool before queue
+/// classification.
 ///
 /// Attachment processing is fire-and-forget relative to pagination — the
 /// inner sink's return value flows through unchanged and the caller is not
@@ -46,13 +53,27 @@ class AttachmentAwareBootstrapSink implements BootstrapSink {
 
   @override
   Future<bool> onPage(List<Event> events, BootstrapPageInfo info) async {
-    // Enqueue the page and make sure we have workers draining it. Do this
-    // before delegating to the inner sink so attachment work for page N
-    // can overlap with the inner sink's work on page N and the network
-    // fetch for page N+1.
-    _pending.addAll(events);
-    _ensureWorkers();
+    for (final event in events) {
+      if (event.type != EventTypes.Encrypted) {
+        _add(event);
+      }
+    }
     return _inner.onPage(events, info);
+  }
+
+  /// Adds plaintext revealed by the inner sink's fresh decryption attempt.
+  ///
+  /// This is synchronous by design: the event is queued before the inner sink
+  /// classifies it, while the actual download remains asynchronous and bounded
+  /// by [_concurrency].
+  void addDecryptedEvent(Event event) {
+    assert(event.type != EventTypes.Encrypted, 'expected plaintext event');
+    _add(event);
+  }
+
+  void _add(Event event) {
+    _pending.add(event);
+    _ensureWorkers();
   }
 
   void _ensureWorkers() {

--- a/lib/features/sync/queue/bootstrap_sink.dart
+++ b/lib/features/sync/queue/bootstrap_sink.dart
@@ -8,6 +8,7 @@ import 'package:matrix/matrix.dart';
 const _logSub = 'queue.bootstrap';
 
 typedef BootstrapEventDecryptor = Future<Event> Function(Event event);
+typedef BootstrapDecryptedEventHandler = void Function(Event event);
 
 /// [BootstrapSink] implementation that forwards each paginated page to
 /// `InboundQueue.appendBootstrapPage` and awaits back-pressure
@@ -27,6 +28,7 @@ class QueueBootstrapSink implements BootstrapSink {
     this.backPressureTimeout = const Duration(seconds: 30),
     this._cancelSignal,
     this.decryptEvent,
+    this.onDecryptedEvent,
   }) {
     // Register the cancel handler eagerly so cancellation that lands
     // between pages (while `_waitForDrain` is not currently awaiting)
@@ -42,6 +44,7 @@ class QueueBootstrapSink implements BootstrapSink {
   final Duration backPressureTimeout;
   final Future<void>? _cancelSignal;
   final BootstrapEventDecryptor? decryptEvent;
+  final BootstrapDecryptedEventHandler? onDecryptedEvent;
 
   bool _cancelled = false;
   int _lastAcceptedCount = 0;
@@ -69,7 +72,8 @@ class QueueBootstrapSink implements BootstrapSink {
     var unresolvedCount = 0;
     for (final originalEvent in events) {
       var event = originalEvent;
-      if (event.type == EventTypes.Encrypted && decryptEvent != null) {
+      final wasEncrypted = event.type == EventTypes.Encrypted;
+      if (wasEncrypted && decryptEvent != null) {
         try {
           event = await decryptEvent!(event);
         } catch (error, stackTrace) {
@@ -82,6 +86,9 @@ class QueueBootstrapSink implements BootstrapSink {
         }
       }
       if (event.type != EventTypes.Encrypted) {
+        if (wasEncrypted) {
+          onDecryptedEvent?.call(event);
+        }
         forQueue.add(event);
         continue;
       }

--- a/lib/features/sync/queue/queue_gap_recovery.dart
+++ b/lib/features/sync/queue/queue_gap_recovery.dart
@@ -155,12 +155,14 @@ extension QueueGapRecovery on QueuePipelineCoordinator {
     required String anchorEventId,
   }) async {
     final walkStartedAtFloorRevision = _queue.resumeFloorRevision(room.id);
+    AttachmentAwareBootstrapSink? attachmentSink;
     final queueSink = QueueBootstrapSink(
       queue: _queue,
       logging: _logging,
       decryptEvent: _decryptBootstrapEvent,
+      onDecryptedEvent: (event) => attachmentSink?.addDecryptedEvent(event),
     );
-    final attachmentSink = _attachmentIngestor == null
+    attachmentSink = _attachmentIngestor == null
         ? null
         : AttachmentAwareBootstrapSink(
             inner: queueSink,
@@ -226,12 +228,14 @@ extension QueueGapRecovery on QueuePipelineCoordinator {
     // enqueue the sync-payload events while their descriptor
     // JSONs never land on disk, producing the pendingAttachment
     // skip cascade we just fixed.
+    AttachmentAwareBootstrapSink? attachmentSink;
     final queueSink = QueueBootstrapSink(
       queue: _queue,
       logging: _logging,
       decryptEvent: _decryptBootstrapEvent,
+      onDecryptedEvent: (event) => attachmentSink?.addDecryptedEvent(event),
     );
-    final attachmentSink = _attachmentIngestor == null
+    attachmentSink = _attachmentIngestor == null
         ? null
         : AttachmentAwareBootstrapSink(
             inner: queueSink,

--- a/test/features/sync/queue/attachment_aware_bootstrap_sink_test.dart
+++ b/test/features/sync/queue/attachment_aware_bootstrap_sink_test.dart
@@ -46,6 +46,7 @@ class _RecordingInnerSink implements BootstrapSink {
 Event _buildEvent(String id) {
   final event = MockEvent();
   when(() => event.eventId).thenReturn(id);
+  when(() => event.type).thenReturn(EventTypes.Message);
   return event;
 }
 
@@ -248,6 +249,27 @@ void main() {
 
         expect(processed, containsAll(<String>['a', 'b']));
         expect(processed.contains('bad'), isFalse);
+      },
+    );
+
+    test(
+      'skips ciphertext pages and accepts their later decrypted event',
+      () async {
+        final processed = <Event>[];
+        final sink = AttachmentAwareBootstrapSink(
+          inner: _RecordingInnerSink(),
+          processAttachment: (event) async => processed.add(event),
+        );
+        final encrypted = _buildEvent('encrypted');
+        final decrypted = _buildEvent('decrypted');
+        when(() => encrypted.type).thenReturn(EventTypes.Encrypted);
+        when(() => decrypted.type).thenReturn(EventTypes.Message);
+
+        await sink.onPage([encrypted], _pageInfo());
+        sink.addDecryptedEvent(decrypted);
+        await sink.drain();
+
+        expect(processed, [same(decrypted)]);
       },
     );
 

--- a/test/features/sync/queue/bootstrap_sink_test.dart
+++ b/test/features/sync/queue/bootstrap_sink_test.dart
@@ -242,6 +242,7 @@ void main() {
       );
       final decrypted = _buildEvent(eventId: r'$sealed', originTsMs: 2);
       final seen = <Event>[];
+      final decryptedEvents = <Event>[];
       final sink = QueueBootstrapSink(
         queue: queue,
         logging: logging,
@@ -249,12 +250,14 @@ void main() {
           seen.add(event);
           return decrypted;
         },
+        onDecryptedEvent: decryptedEvents.add,
       );
 
       final cont = await sink.onPage([encrypted], info(0, 1));
 
       expect(cont, isTrue);
       expect(seen, [same(encrypted)]);
+      expect(decryptedEvents, [same(decrypted)]);
       expect((await queue.stats()).total, 1);
       expect(await queue.resumeFloorTs('!roomA:example.org'), isNull);
       expect(sink.oldestUnresolvedTs, isNull);

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -4356,20 +4356,19 @@ void main() {
     );
 
     test(
-      'forward walk routes every paginated event through the '
-      'AttachmentIngestor — bootstrap catch-up on a room with '
-      'historical attachments must hydrate descriptor JSONs alongside '
-      'the queue enqueue, otherwise the companion sync-payload events '
-      'sit in pendingAttachment forever',
+      'forward walk sends a freshly-decrypted descriptor through the '
+      'AttachmentIngestor before queue classification',
       () async {
         final realQueue = InboundQueue(db: syncDb, logging: logging);
         addTearDown(realQueue.dispose);
+        final encryption = MockEncryption();
         final firstProcessed = Completer<Event>();
         final processGate = Completer<void>();
         final ingestor = _FakeAttachmentIngestor(
           firstProcessed: firstProcessed,
           processGate: processGate.future,
         );
+        when(() => client.encryption).thenReturn(encryption);
 
         final coordinator = QueuePipelineCoordinator(
           syncDb: syncDb,
@@ -4397,23 +4396,42 @@ void main() {
         when(
           () => anchor.originServerTs,
         ).thenReturn(DateTime.fromMillisecondsSinceEpoch(100));
-        final e1 = MockEvent();
-        when(() => e1.eventId).thenReturn(r'$e1');
+        final encrypted = MockEvent();
+        when(() => encrypted.eventId).thenReturn(r'$descriptor');
         when(
-          () => e1.originServerTs,
+          () => encrypted.originServerTs,
         ).thenReturn(DateTime.fromMillisecondsSinceEpoch(110));
-        when(() => e1.roomId).thenReturn(roomId);
-        when(() => e1.type).thenReturn(EventTypes.Message);
-        when(() => e1.content).thenReturn(<String, dynamic>{});
-        when(e1.toJson).thenReturn(<String, dynamic>{
-          'event_id': r'$e1',
+        when(() => encrypted.roomId).thenReturn(roomId);
+        when(() => encrypted.type).thenReturn(EventTypes.Encrypted);
+        when(() => encrypted.content).thenReturn(<String, dynamic>{
+          'ciphertext': <String, dynamic>{},
+        });
+        final decrypted = MockEvent();
+        when(() => decrypted.eventId).thenReturn(r'$descriptor');
+        when(
+          () => decrypted.originServerTs,
+        ).thenReturn(DateTime.fromMillisecondsSinceEpoch(110));
+        when(() => decrypted.roomId).thenReturn(roomId);
+        when(() => decrypted.type).thenReturn(EventTypes.Message);
+        when(() => decrypted.content).thenReturn(<String, dynamic>{
+          'msgtype': 'm.file',
+          'relativePath': '/journal/descriptor.json',
+        });
+        when(decrypted.toJson).thenReturn(<String, dynamic>{
+          'event_id': r'$descriptor',
           'room_id': roomId,
           'origin_server_ts': 110,
           'type': EventTypes.Message,
-          'content': <String, dynamic>{},
+          'content': <String, dynamic>{
+            'msgtype': 'm.file',
+            'relativePath': '/journal/descriptor.json',
+          },
         });
+        when(
+          () => encryption.decryptRoomEvent(encrypted),
+        ).thenAnswer((_) async => decrypted);
         final timeline = MockTimeline();
-        when(() => timeline.events).thenReturn(<Event>[anchor, e1]);
+        when(() => timeline.events).thenReturn(<Event>[anchor, encrypted]);
         when(() => timeline.canRequestFuture).thenReturn(false);
         when(timeline.cancelSubscriptions).thenAnswer((_) {});
         when(
@@ -4430,9 +4448,7 @@ void main() {
         );
         expect(completed, isTrue);
 
-        // The forward walk emitted page [e1] (anchor itself is
-        // filtered) → ingestor.process must have fired for that event.
-        expect(await firstProcessed.future, same(e1));
+        final processed = await firstProcessed.future;
         var drainCompleted = false;
         final drain = coordinator.drainBootstrapAttachmentWorkForTesting().then(
           (_) => drainCompleted = true,
@@ -4447,7 +4463,15 @@ void main() {
         await drain;
         expect(drainCompleted, isTrue);
         expect(ingestor.processCalls, hasLength(1));
-        expect(ingestor.processCalls.single[#event], same(e1));
+        expect(
+          processed,
+          same(decrypted),
+          reason:
+              'attachment descriptors revealed by the fresh decrypt must not '
+              'be ingested as their original ciphertext',
+        );
+        expect(ingestor.processCalls.single[#event], same(decrypted));
+        verify(() => encryption.decryptRoomEvent(encrypted)).called(1);
       },
     );
 

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -4476,16 +4476,17 @@ void main() {
     );
 
     test(
-      'backward walk with attachment ingestor routes every page event '
-      'through `AttachmentIngestor.process` — covers the ingestor-aware '
-      'branch for the fresh-client / anchor-unresolvable fallback',
+      'backward walk sends a freshly-decrypted descriptor through the '
+      'AttachmentIngestor before queue classification',
       () async {
         final realQueue = InboundQueue(db: syncDb, logging: logging);
         addTearDown(realQueue.dispose);
+        final encryption = MockEncryption();
         final firstProcessed = Completer<Event>();
         final ingestor = _FakeAttachmentIngestor(
           firstProcessed: firstProcessed,
         );
+        when(() => client.encryption).thenReturn(encryption);
 
         final coordinator = QueuePipelineCoordinator(
           syncDb: syncDb,
@@ -4508,23 +4509,42 @@ void main() {
 
         final room = MockRoom();
         when(() => room.id).thenReturn(roomId);
-        final e = MockEvent();
-        when(() => e.eventId).thenReturn(r'$e1');
+        final encrypted = MockEvent();
+        when(() => encrypted.eventId).thenReturn(r'$descriptor');
         when(
-          () => e.originServerTs,
+          () => encrypted.originServerTs,
         ).thenReturn(DateTime.fromMillisecondsSinceEpoch(200));
-        when(() => e.roomId).thenReturn(roomId);
-        when(() => e.type).thenReturn(EventTypes.Message);
-        when(() => e.content).thenReturn(<String, dynamic>{});
-        when(e.toJson).thenReturn(<String, dynamic>{
-          'event_id': r'$e1',
+        when(() => encrypted.roomId).thenReturn(roomId);
+        when(() => encrypted.type).thenReturn(EventTypes.Encrypted);
+        when(() => encrypted.content).thenReturn(<String, dynamic>{
+          'ciphertext': <String, dynamic>{},
+        });
+        final decrypted = MockEvent();
+        when(() => decrypted.eventId).thenReturn(r'$descriptor');
+        when(
+          () => decrypted.originServerTs,
+        ).thenReturn(DateTime.fromMillisecondsSinceEpoch(200));
+        when(() => decrypted.roomId).thenReturn(roomId);
+        when(() => decrypted.type).thenReturn(EventTypes.Message);
+        when(() => decrypted.content).thenReturn(<String, dynamic>{
+          'msgtype': 'm.file',
+          'relativePath': '/journal/descriptor.json',
+        });
+        when(decrypted.toJson).thenReturn(<String, dynamic>{
+          'event_id': r'$descriptor',
           'room_id': roomId,
           'origin_server_ts': 200,
           'type': EventTypes.Message,
-          'content': <String, dynamic>{},
+          'content': <String, dynamic>{
+            'msgtype': 'm.file',
+            'relativePath': '/journal/descriptor.json',
+          },
         });
+        when(
+          () => encryption.decryptRoomEvent(encrypted),
+        ).thenAnswer((_) async => decrypted);
         final tl = MockTimeline();
-        when(() => tl.events).thenReturn(<Event>[e]);
+        when(() => tl.events).thenReturn(<Event>[encrypted]);
         when(() => tl.canRequestHistory).thenReturn(false);
         when(tl.cancelSubscriptions).thenAnswer((_) {});
         when(
@@ -4535,9 +4555,10 @@ void main() {
         // No anchor id → backward walk runs.
         final completed = await coordinator.runBootstrapForTest(room: room);
         expect(completed, isTrue);
-        expect(await firstProcessed.future, same(e));
+        expect(await firstProcessed.future, same(decrypted));
         expect(ingestor.processCalls, hasLength(1));
-        expect(ingestor.processCalls.single[#event], same(e));
+        expect(ingestor.processCalls.single[#event], same(decrypted));
+        verify(() => encryption.decryptRoomEvent(encrypted)).called(1);
       },
     );
 


### PR DESCRIPTION
## Summary

- hand freshly decrypted bootstrap events to attachment ingestion before queue type classification drops descriptor events
- preserve the existing single decrypt attempt, durable floor accounting, and bounded attachment worker pool
- extend the real Matrix late-key scenario to a file-backed image with exact-byte verification across cold restarts
- make the existing peer-repair response assertion wait for both sender-side responses instead of racing the completed downloads
- document the receive-path ordering contract

## Regression proof

The coordinator regression supplies an encrypted history event whose SDK decryptor returns a new plaintext file descriptor. With the new handoff removed, the test fails because attachment ingestion receives the original ciphertext rather than the decrypted descriptor.

The real-server integration scenario additionally verifies that a late Megolm key persisted across restart recovers the journal image and exact PNG bytes through cold-start bootstrap. In the current SDK environment those cold-bootstrap descriptors are already plaintext, so this is end-to-end recovery coverage; the deterministic coordinator test is the proof for the cached-ciphertext branch.

## Verification

- scoped Dart analyzer: no issues
- 106 targeted queue tests: pass
- Matrix integration, regular network: 7/7 pass in 2m59s
- Matrix integration, degraded network: 7/7 pass in 1m29s
- `make knowledge_check`: 88 concepts and 135 Mermaid blocks pass
- formatting and `git diff --check`: clean