### PR TITLE
fix: gate the ADRs' mermaid diagrams, and fix the two that never rendered

### DIFF
--- a/.github/workflows/okf-validate.yml
+++ b/.github/workflows/okf-validate.yml
@@ -50,7 +50,9 @@ jobs:
           cache-dependency-path: tool/okf/package-lock.json
       # The Dart validator cannot parse mermaid — there is no Dart parser — so a
       # diagram that renders as an error box is invisible to `make okf_check`.
-      # Three shipped that way. This runs mermaid itself under jsdom.
+      # Three shipped that way. This runs mermaid itself under jsdom, over the
+      # knowledge bundle, the ADRs and the architecture docs: the ADRs were
+      # ungated until two of their diagrams turned out not to render.
       - name: Install check dependencies
         run: npm ci
         working-directory: tool/okf

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,13 @@ analyze:
 okf_check:
 	$(DART_CMD) run tool/okf/validate.dart knowledge
 
-# Parses every mermaid diagram in the bundle with mermaid itself. Separate from
-# okf_check because there is no Dart mermaid parser — a diagram that renders as
-# an error box is invisible to the Dart validator, and three shipped that way.
+# Parses every mermaid diagram in the knowledge bundle, the ADRs and the
+# architecture docs with mermaid itself. Separate from okf_check because there is
+# no Dart mermaid parser — a diagram that renders as an error box is invisible to
+# the Dart validator, and three shipped that way. The ADRs are gated for the same
+# reason: two of theirs rendered as error boxes while this watched knowledge/
+# alone. Implementation plans are deliberately out of scope — they are working
+# notes, not the durable map.
 .PHONY: mermaid_check
 mermaid_check:
 	cd tool/okf && npm ci --silent && npm test --silent && npm run --silent check

--- a/docs/adr/0017-deterministic-log-compaction.md
+++ b/docs/adr/0017-deterministic-log-compaction.md
@@ -92,7 +92,7 @@ stateDiagram-v2
   Appending --> CompactionCheck: tail beyond budget?
   CompactionCheck --> Compacting: yes
   CompactionCheck --> Idle: no
-  Compacting --> Idle: append checkpoint event; projection selects active checkpoint
+  Compacting --> Idle: append checkpoint event, projection selects active checkpoint
 ```
 
 ## Consequences

--- a/docs/adr/0019-attention-negotiation-protocol.md
+++ b/docs/adr/0019-attention-negotiation-protocol.md
@@ -81,7 +81,7 @@ sequenceDiagram
   Agent->>Planner: attention_request (impact, deadline-slack, energy-fit)
   Planner->>Verify: candidate DayPlan vs hard constraints
   Verify-->>Planner: violations
-  Planner->>Planner: rank by utility; compute VOI
+  Planner->>Planner: rank by utility, compute VOI
   alt VOI > interruption cost
     Planner->>User: ChangeSet
     User-->>Planner: ChangeDecision

--- a/knowledge/conventions/knowledge-bundle.md
+++ b/knowledge/conventions/knowledge-bundle.md
@@ -5,7 +5,7 @@ description: The README/knowledge/ADR split, the frontmatter every concept carri
 resource: ../../knowledge
 tags: [convention, documentation, okf, process]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T23:00:00Z }
+generated: { by: claude-code/fable-5, at: 2026-07-29T01:20:00Z }
 stale_after: 2027-01-18
 sources:
   - id: okf-spec
@@ -16,6 +16,10 @@ sources:
     resource: ../../tool/okf/okf_validator.dart
     title: Conformance validator
     last_modified: 2026-07-26
+  - id: mermaid-gate
+    resource: ../../tool/okf/check_mermaid.mjs
+    title: Mermaid parse gate
+    last_modified: 2026-07-29
   - id: agents-md
     resource: ../../AGENTS.md
     title: Repository guidelines
@@ -309,11 +313,16 @@ diagram rather than reporting one:
   spaces inside a list item reads as an indented code block, so keep diagrams at the
   top level of a document.
 
-**The gate covers `knowledge/` only.** `check_mermaid.mjs` takes a directory, and
-pointing it at `docs/` currently reports 14 broken diagrams across the ADRs, the
-implementation plans and one architecture note — 8 parse failures and 5 phantom-node
-splits. Those are outside this bundle's contract and are not fixed here; widening
-the gate means fixing them first.
+**The gate covers `knowledge/`, `docs/adr/` and `docs/architecture/`.**
+`check_mermaid.mjs` takes any number of roots, and `npm run check` passes all
+three — 185 blocks. The ADRs were added once two of their diagrams turned out
+not to render: concepts cite ADRs rather than restating their decisions, so a
+decision record nobody can read is the same defect as a broken concept.
+
+**Implementation plans stay outside it**, and 10 of their diagrams do not
+render today. They are working notes rather than the durable map, and some are
+historical by design. Widening the gate to `docs/` means fixing those first —
+tracked separately, not assumed.
 
 **`make knowledge_check` is the one target to run after touching `knowledge/`.**
 It runs the Dart validator and the Mermaid parse together, because two targets

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -13,7 +13,10 @@
 // `dedupe payload by contentDigest; append messagePayload link; retract
 // vanished sources` — parsed clean and produced six nodes instead of one.
 //
-// Usage: node tool/okf/check_mermaid.mjs [bundle-dir]
+// Usage: node tool/okf/check_mermaid.mjs [dir...]
+// Defaults to `knowledge`. Several roots can be given, because the same trap is
+// invisible in any markdown the build does not parse: two broken ADR diagrams
+// shipped while this gate watched only the knowledge bundle.
 // Exits 0 when every block parses and renders the nodes it declares, 1 otherwise.
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
@@ -37,7 +40,8 @@ Object.defineProperty(globalThis, 'navigator', {
 const { default: mermaid } = await import('mermaid');
 mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
 
-const root = process.argv[2] ?? 'knowledge';
+const roots = process.argv.slice(2);
+if (roots.length === 0) roots.push('knowledge');
 
 function markdownFiles(dir) {
   return readdirSync(dir).flatMap((entry) => {
@@ -116,7 +120,7 @@ function stripDepth(line, depth) {
 
 const blocks = [];
 let unclosed = 0;
-for (const file of markdownFiles(root)) {
+for (const file of roots.flatMap((dir) => markdownFiles(dir))) {
   const lines = readFileSync(file, 'utf8').split('\n');
   let opener = null;
   let openedAt = 0;
@@ -217,7 +221,8 @@ for (const block of blocks) {
 }
 
 console.log(
-  `\nmermaid: parsed ${blocks.length} block(s) in ${root}/ — ` +
+  `\nmermaid: parsed ${blocks.length} block(s) in ` +
+    `${roots.map((dir) => `${dir}/`).join(', ')} — ` +
     `${failed} failed, ${unclosed} unclosed`,
 );
 process.exit(failed + unclosed === 0 ? 0 : 1);

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -169,6 +169,49 @@ test('a semicolon inside a note body is safe', () => {
   assert.ok(r.ok, r.output);
 });
 
+test('every root given is scanned, not just the first', () => {
+  // The gate watched only `knowledge/` while two ADR diagrams rendered as
+  // error boxes. Taking several roots is what closes that gap, so a second
+  // root being silently ignored would reopen it.
+  const first = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
+  const second = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
+  try {
+    writeFileSync(join(first, 'ok.md'), good);
+    writeFileSync(
+      join(second, 'broken.md'),
+      '```mermaid\nflowchart TD\n  A -->\n```\n',
+    );
+    assert.throws(
+      () =>
+        execFileSync('node', [script, first, second], {
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      'a broken diagram under the second root must fail the run',
+    );
+  } finally {
+    rmSync(first, { recursive: true, force: true });
+    rmSync(second, { recursive: true, force: true });
+  }
+});
+
+test('the block count spans every root', () => {
+  const first = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
+  const second = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
+  try {
+    writeFileSync(join(first, 'a.md'), good);
+    writeFileSync(join(second, 'b.md'), good);
+    const output = execFileSync('node', [script, first, second], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    assert.match(output, /parsed 2 block\(s\)/);
+  } finally {
+    rmSync(first, { recursive: true, force: true });
+    rmSync(second, { recursive: true, force: true });
+  }
+});
+
 test('markdown files in subdirectories are scanned', () => {
   const dir = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
   try {

--- a/tool/okf/package.json
+++ b/tool/okf/package.json
@@ -2,10 +2,10 @@
   "name": "lotti-okf-mermaid-check",
   "private": true,
   "version": "1.0.0",
-  "description": "Parses the knowledge bundle's mermaid diagrams with mermaid itself, which the Dart validator cannot do.",
+  "description": "Parses the mermaid diagrams in the knowledge bundle, the ADRs and the architecture docs with mermaid itself, which the Dart validator cannot do.",
   "type": "module",
   "scripts": {
-    "check": "node check_mermaid.mjs ../../knowledge",
+    "check": "node check_mermaid.mjs ../../knowledge ../../docs/adr ../../docs/architecture",
     "test": "node --test"
   },
   "dependencies": {


### PR DESCRIPTION
Closes `lotti3-29n`. Found while doing the #3664 follow-up (#3666).

## The gap

The mermaid gate exists because the Dart validator cannot parse mermaid, so a diagram that renders as an error box is invisible to `make okf_check` — three shipped that way before the gate was written. But the gate only ever watched `knowledge/`, which left the same class of bug free to land in any other markdown. It had: **two ADR diagrams did not render**, and nothing was ever going to notice.

That matters more for ADRs than for most docs. Concepts cite them rather than restating their decisions, and #3666 just leaned on ADR 0046 as a rebuild specification — a decision record whose diagram silently doesn't render is a decision nobody can read.

## The two broken diagrams

Both were the exact trap the checker already documents in its own header: **`;` terminates a mermaid statement**, so a semicolon inside a label ends the statement there.

- **ADR 0017** (`stateDiagram-v2`): `append checkpoint event; projection selects active checkpoint`. This one *parses* — it renders a phantom `;` node — which is why the checker inspects the built diagram rather than trusting parse success alone.
- **ADR 0019** (`sequenceDiagram`): `rank by utility; compute VOI`. Ending that message statement meant the following `alt VOI > interruption cost` line was reparsed as a new statement expecting an arrow, so the whole diagram failed.

Both are now commas, which is what the checker's own error message tells you to do.

## The gate

`check_mermaid.mjs` took a single root; it now takes any number, defaulting to `knowledge` as before. The check runs over `knowledge/`, `docs/adr/` and `docs/architecture/` — **185 blocks, up from 137**.

Implementation plans are deliberately excluded. They are working notes rather than the durable map, and ten of their diagrams currently do not render; folding that cleanup in here would bury a CI fix under a doc sweep. Filed as `lotti3-qg9` with the full file list, including the question of whether plans are worth gating at all.

## Verification

- `make knowledge_check` passes: 185 blocks, 0 failed, 0 unclosed.
- The checker's own suite is 22 tests, up from 20. The two new ones cover multi-root scanning, because a second root silently ignored would reopen precisely the gap this closes. **Both were confirmed to fail** when the scan is reverted to only the first root.
- End-to-end, not just unit: re-breaking ADR 0017's diagram and running `make mermaid_check` fails the target with the phantom-node message, so the wiring — Makefile through npm script through CI step — actually catches an ADR regression.
