### PR TITLE
fix: render every diagram under docs/, and gate the whole tree

### DIFF
--- a/.github/workflows/okf-validate.yml
+++ b/.github/workflows/okf-validate.yml
@@ -50,9 +50,9 @@ jobs:
           cache-dependency-path: tool/okf/package-lock.json
       # The Dart validator cannot parse mermaid — there is no Dart parser — so a
       # diagram that renders as an error box is invisible to `make okf_check`.
-      # Three shipped that way. This runs mermaid itself under jsdom, over the
-      # knowledge bundle, the ADRs and the architecture docs: the ADRs were
-      # ungated until two of their diagrams turned out not to render.
+      # Three shipped that way. This runs mermaid itself under jsdom over both
+      # knowledge/ and docs/: every tree left ungated accumulated broken
+      # diagrams, so the gate now covers anything a reader might open.
       - name: Install check dependencies
         run: npm ci
         working-directory: tool/okf

--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,12 @@ analyze:
 okf_check:
 	$(DART_CMD) run tool/okf/validate.dart knowledge
 
-# Parses every mermaid diagram in the knowledge bundle, the ADRs and the
-# architecture docs with mermaid itself. Separate from okf_check because there is
-# no Dart mermaid parser — a diagram that renders as an error box is invisible to
-# the Dart validator, and three shipped that way. The ADRs are gated for the same
-# reason: two of theirs rendered as error boxes while this watched knowledge/
-# alone. Implementation plans are deliberately out of scope — they are working
-# notes, not the durable map.
+# Parses every mermaid diagram under knowledge/ and docs/ with mermaid itself.
+# Separate from okf_check because there is no Dart mermaid parser — a diagram that
+# renders as an error box is invisible to the Dart validator, and three shipped
+# that way. Everything a reader might open is gated, because every tree left
+# outside this accumulated broken diagrams while it watched knowledge/ alone:
+# two in the ADRs, twelve across docs/.
 .PHONY: mermaid_check
 mermaid_check:
 	cd tool/okf && npm ci --silent && npm test --silent && npm run --silent check

--- a/docs/daily_os_ai_runtime_architecture.md
+++ b/docs/daily_os_ai_runtime_architecture.md
@@ -122,7 +122,7 @@ sequenceDiagram
   Log-->>Planner: projection updates with open requests
   Planner->>Verify: candidate DayPlan vs hard constraints
   Verify-->>Planner: violations (if any)
-  Planner->>Planner: rank by utility; compute VOI
+  Planner->>Planner: rank by utility, compute VOI
   alt VOI > interruption cost
     Planner->>User: ChangeSet (proposed schedule / conflict)
     User-->>Log: ChangeDecision (accept / reject)
@@ -159,7 +159,7 @@ stateDiagram-v2
   Appending --> CompactionCheck: tail beyond budget?
   CompactionCheck --> Compacting: yes
   CompactionCheck --> Idle: no
-  Compacting --> Idle: append checkpoint event; projection selects active checkpoint
+  Compacting --> Idle: append checkpoint event, projection selects active checkpoint
 ```
 
 This compaction is also what makes the **on-device prefix cache** pay off (§7): the rolling summary is a long-lived stable prefix, the recent tail is the volatile suffix.

--- a/docs/implementation_plans/2026-02-17_explicit_agents_foundation_layer_formal_model.md
+++ b/docs/implementation_plans/2026-02-17_explicit_agents_foundation_layer_formal_model.md
@@ -192,9 +192,9 @@ flowchart TD
 ```mermaid
 flowchart TD
   A["Two AgentState snapshots S1 and S2 arrive"] --> B["Compare vector clocks vc1 and vc2"]
-  B -->| "vc1 < vc2" | C["Select S2"]
-  B -->| "vc2 < vc1" | D["Select S1"]
-  B -->| "vc1 || vc2" | E["Run deterministic field-level concurrent merge"]
+  B -->|"vc1 < vc2"| C["Select S2"]
+  B -->|"vc2 < vc1"| D["Select S1"]
+  B -->|"vc1 || vc2"| E["Run deterministic field-level concurrent merge"]
   E --> F["Merge processed counters by max"]
   E --> G["Merge lifecycle by precedence order"]
   E --> H["Merge pointers by ancestry then deterministic tie-break"]
@@ -227,16 +227,16 @@ flowchart TD
 ```mermaid
 flowchart TD
   A["Requested tool or model operation"] --> B["Check category and capability scope"]
-  B -->| "fail" | X["Reject: out_of_scope"]
-  B -->| "pass" | C["If inference, check provider and model allowlist"]
-  C -->| "fail" | Y["Reject: disallowed_provider_model"]
-  C -->| "pass" | D["Check privacy confirmation receipt for current policyVersion"]
-  D -->| "fail" | Z["Reject: privacy_confirmation_required"]
-  D -->| "pass" | E["Resolve secretRefId from secure store"]
-  E -->| "fail" | W["Reject: secret_unavailable"]
-  E -->| "pass" | F["Apply NEED_TO_KNOW payload projection"]
-  F -->| "overshared" | V["Reject: overshared_payload_blocked"]
-  F -->| "valid" | G["Execute operation and persist result"]
+  B -->|"fail"| X["Reject: out_of_scope"]
+  B -->|"pass"| C["If inference, check provider and model allowlist"]
+  C -->|"fail"| Y["Reject: disallowed_provider_model"]
+  C -->|"pass"| D["Check privacy confirmation receipt for current policyVersion"]
+  D -->|"fail"| Z["Reject: privacy_confirmation_required"]
+  D -->|"pass"| E["Resolve secretRefId from secure store"]
+  E -->|"fail"| W["Reject: secret_unavailable"]
+  E -->|"pass"| F["Apply NEED_TO_KNOW payload projection"]
+  F -->|"overshared"| V["Reject: overshared_payload_blocked"]
+  F -->|"valid"| G["Execute operation and persist result"]
 ```
 
 ## 1. System Model

--- a/docs/implementation_plans/2026-02-26_agent_refinement_throttle_tools_reporting.md
+++ b/docs/implementation_plans/2026-02-26_agent_refinement_throttle_tools_reporting.md
@@ -294,7 +294,7 @@ flowchart LR
         L
     end
 
-    subgraph Handled by AgentToolExecutor → TaskAgentWorkflow
+    subgraph executor["Handled by AgentToolExecutor → TaskAgentWorkflow"]
         C
         D
         E

--- a/docs/implementation_plans/2026-02-26_template_evolution_agent_lifecycle.md
+++ b/docs/implementation_plans/2026-02-26_template_evolution_agent_lifecycle.md
@@ -190,7 +190,7 @@ erDiagram
     AgentTemplateEntity ||--o{ EvolutionNoteEntity : "notes (agentId = template ID)"
     AgentTemplateEntity ||--o{ TaskAgentIdentity : "template_assignment link"
 
-    AgentTemplateEntity ..o| EvolutionAgentIdentity : "Phase 2: evolution agent"
+    AgentTemplateEntity ||..o| EvolutionAgentIdentity : "Phase 2: evolution agent"
     EvolutionAgentIdentity ||--|| AgentStateEntity : "Phase 2: durable state (lastAcknowledgedAt)"
     EvolutionAgentIdentity ||--o{ AgentMessageEntity : "conversation messages"
 

--- a/docs/implementation_plans/2026-02-28_checklist_user_sovereignty.md
+++ b/docs/implementation_plans/2026-02-28_checklist_user_sovereignty.md
@@ -85,16 +85,10 @@ graph TB
 ```mermaid
 timeline
     title When can the agent override a user-checked item?
-    section 10:00 PM : User checks item "Done"
-        : checkedBy = user
-        : checkedAt = 22:00
-    section 10:05 PM : Agent wakes, sees no evidence
-        : ❌ CANNOT uncheck
-        : Absence of evidence ≠ evidence of absence
-    section 10:30 PM : User records "X isn't done yet"
-        : New evidence timestamped AFTER 22:00
-    section 10:35 PM : Agent wakes, sees post-dated evidence
-        : ✅ CAN uncheck (with reason citing the recording)
+    10.00 PM : User checks item "Done" : checkedBy = user : checkedAt = 22.00
+    10.05 PM : Agent wakes, sees no evidence : ❌ CANNOT uncheck : Absence of evidence ≠ evidence of absence
+    10.30 PM : User records "X isn't done yet" : New evidence timestamped AFTER 22.00
+    10.35 PM : Agent wakes, sees post-dated evidence : ✅ CAN uncheck (with reason citing the recording)
 ```
 
 ### Checklist Item State Machine — `isChecked` with Provenance

--- a/docs/implementation_plans/2026-06-01_input_capture_and_compaction_plan.md
+++ b/docs/implementation_plans/2026-06-01_input_capture_and_compaction_plan.md
@@ -56,14 +56,14 @@ So PR 5 delivers two wins from one mechanism:
 stateDiagram-v2
   [*] --> Idle
   Idle --> Capturing: wake fires
-  Capturing --> Capturing: per source — hash rendered text; dedupe payload by contentDigest; append messagePayload link (provenance + ordering); append retraction for deleted/unlinked sources
+  Capturing --> Capturing: per source — hash rendered text, dedupe payload by contentDigest, append messagePayload link (provenance + ordering), append retraction for deleted/unlinked sources
   Capturing --> Assembling: input frontier recorded on the wake message
   Assembling --> Running: stable prefix (soul → tools → active summary → uncovered tail, canonical order) + currentLocalTime last
   Running --> Appending: emit reasoning/report events to log
   Appending --> BudgetCheck: uncovered tail beyond model budget?
   BudgetCheck --> Compacting: yes
   BudgetCheck --> Idle: no
-  Compacting --> Idle: append summary checkpoint over the frontier; projection selects the active checkpoint
+  Compacting --> Idle: append summary checkpoint over the frontier, projection selects the active checkpoint
 ```
 
 ## Increments

--- a/docs/implementation_plans/2026-06-02_join_by_continuation_plan.md
+++ b/docs/implementation_plans/2026-06-02_join_by_continuation_plan.md
@@ -164,7 +164,7 @@ stateDiagram-v2
   SingleHead --> Forked: two devices append off the same head (concurrent messagePrev children)
   Forked --> Forked: local view still settling (dangling parent or pending join edges) — defer
   Forked --> Joining: a wake starts and observes ≥2 heads over a complete view
-  Joining --> SingleHead: append content-addressed join (messagePrev → all heads); head := joinId; prefix re-warms
+  Joining --> SingleHead: append content-addressed join (messagePrev → all heads), head := joinId, prefix re-warms
   Joining --> SingleHead: peer emitted the same join id concurrently → set-union merges to one node
 ```
 

--- a/docs/implementation_plans/2026-07-15_onboarding_rollout_wiring.md
+++ b/docs/implementation_plans/2026-07-15_onboarding_rollout_wiring.md
@@ -214,7 +214,7 @@ stateDiagram-v2
   DailyOS --> [*]: day plan created → both completed
 
   [*] --> ExistingConfigured
-  ExistingConfigured --> DailyOS2: B1 marks welcome completed; providerReady=true
+  ExistingConfigured --> DailyOS2: B1 marks welcome completed, providerReady=true
   DailyOS2 --> [*]: first day plan → completed
 
   [*] --> ExistingNoProvider

--- a/docs/implementation_plans/2026-07-18_ai_consumption_attribution_system.md
+++ b/docs/implementation_plans/2026-07-18_ai_consumption_attribution_system.md
@@ -751,16 +751,16 @@ No external service is required for v1. If one is added later, it must:
 stateDiagram-v2
   [*] --> Pending: mint attribution, interaction, and intended output ids
   Pending --> Calling: durably persist pending session before inference
-  Calling --> EvidenceDurable: provider completes; commit interaction, cost, and sanitized recovery capsule
+  Calling --> EvidenceDurable: provider completes, commit interaction, cost, and sanitized recovery capsule
   EvidenceDurable --> EvidencePublished: enqueue existing-compatible consumption envelope
   EvidencePublished --> PersistingOutput: publication barrier opens
   PersistingOutput --> Finalizing: output carrier stores terminal attribution envelope
-  Finalizing --> Succeeded: project attribution + links; clear pending session
+  Finalizing --> Succeeded: project attribution + links, clear pending session
   Calling --> Failed: persist failed terminal evidence + attribution
   Calling --> Cancelled: persist cancelled terminal evidence + attribution
   Pending --> Abandoned: recovery finds no provider completion
   EvidencePublished --> Partial: executor is permanently lost before output
-  PersistingOutput --> Repaired: output exists; idempotent projection repair runs
+  PersistingOutput --> Repaired: output exists, idempotent projection repair runs
   Repaired --> Succeeded
 ```
 

--- a/docs/implementation_plans/2026-07-21_tutorial_video_workbench.md
+++ b/docs/implementation_plans/2026-07-21_tutorial_video_workbench.md
@@ -180,7 +180,7 @@ sequenceDiagram
     O->>T: render narration + user_voice clips (locale)
     T-->>O: clips + durations manifest
     O->>X: start display, start capture
-    O->>A: fvm flutter drive -d linux --target=integration_test/tutorial/&lt;scenario&gt;_tutorial_test.dart (env: locale, manifest, timeline path)
+    O->>A: fvm flutter drive -d linux --target=integration_test/tutorial/{scenario}_tutorial_test.dart (env: locale, manifest, timeline path)
     A->>A: seed penguin world, open task
     A->>A: step "record": open modal, start recording
     A->>A: paplay user_voice clip into virtual mic, stop recording

--- a/knowledge/conventions/knowledge-bundle.md
+++ b/knowledge/conventions/knowledge-bundle.md
@@ -5,7 +5,7 @@ description: The README/knowledge/ADR split, the frontmatter every concept carri
 resource: ../../knowledge
 tags: [convention, documentation, okf, process]
 status: stable
-generated: { by: claude-code/fable-5, at: 2026-07-29T01:20:00Z }
+generated: { by: claude-code/fable-5, at: 2026-07-29T02:05:00Z }
 stale_after: 2027-01-18
 sources:
   - id: okf-spec
@@ -313,16 +313,19 @@ diagram rather than reporting one:
   spaces inside a list item reads as an indented code block, so keep diagrams at the
   top level of a document.
 
-**The gate covers `knowledge/`, `docs/adr/` and `docs/architecture/`.**
-`check_mermaid.mjs` takes any number of roots, and `npm run check` passes all
-three — 185 blocks. The ADRs were added once two of their diagrams turned out
-not to render: concepts cite ADRs rather than restating their decisions, so a
-decision record nobody can read is the same defect as a broken concept.
+**The gate covers `knowledge/` and `docs/`** — 447 blocks. `check_mermaid.mjs`
+takes any number of roots, and a path may be a file or a directory, so a single
+document can be checked while fixing it.
 
-**Implementation plans stay outside it**, and 10 of their diagrams do not
-render today. They are working notes rather than the durable map, and some are
-historical by design. Widening the gate to `docs/` means fixing those first —
-tracked separately, not assumed.
+It was not always this wide, and each narrowing cost something. While it
+watched `knowledge/` alone, two ADR diagrams rendered as error boxes — and
+concepts *cite* ADRs rather than restating their decisions, so an unreadable
+decision record is the same defect as a broken concept. Widening to the ADRs
+then exposed twelve more across `docs/`, ten of them in implementation plans,
+which is where most diagrams live. The lesson is the one this gate exists to
+teach: **an ungated tree accumulates broken diagrams silently**, so the
+boundary is now "anything a reader might open" rather than a judgement about
+which documents deserve to render.
 
 **`make knowledge_check` is the one target to run after touching `knowledge/`.**
 It runs the Dart validator and the Mermaid parse together, because two targets

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -13,10 +13,13 @@
 // `dedupe payload by contentDigest; append messagePayload link; retract
 // vanished sources` — parsed clean and produced six nodes instead of one.
 //
-// Usage: node tool/okf/check_mermaid.mjs [dir...]
-// Defaults to `knowledge`. Several roots can be given, because the same trap is
-// invisible in any markdown the build does not parse: two broken ADR diagrams
-// shipped while this gate watched only the knowledge bundle.
+// Usage: node tool/okf/check_mermaid.mjs [path...]
+// Defaults to `knowledge`. Each path is a directory to scan or a single `.md`
+// file to check; anything else is rejected rather than silently scanning
+// nothing. Several roots can be given, because the same trap is invisible in
+// any markdown the build does not parse: two broken ADR diagrams shipped while
+// this gate watched only the knowledge bundle, and twelve more sat under
+// `docs/`.
 // Exits 0 when every block parses and renders the nodes it declares, 1 otherwise.
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
@@ -49,7 +52,16 @@ if (roots.length === 0) roots.push('knowledge');
 /// what you want while fixing the diagrams it reports.
 function markdownFiles(target) {
   if (!statSync(target).isDirectory()) {
-    return target.endsWith('.md') ? [target] : [];
+    // Returning [] here would let `check_mermaid.mjs README.txt` report
+    // "0 blocks, 0 failed" and exit 0 — a false green in the one tool that
+    // exists to prevent them.
+    if (!target.endsWith('.md')) {
+      throw new Error(
+        `not a directory or a markdown file: ${target}\n` +
+          'Pass a directory to scan, or a .md file to check on its own.',
+      );
+    }
+    return [target];
   }
   return readdirSync(target).flatMap((entry) => {
     const path = join(target, entry);
@@ -125,9 +137,19 @@ function stripDepth(line, depth) {
   return rest;
 }
 
+// A bad root is a usage error, not a crash: report it the way every other
+// failure here is reported rather than as a raw Node stack trace.
+let targets;
+try {
+  targets = roots.flatMap((dir) => markdownFiles(dir));
+} catch (error) {
+  console.error(`\nmermaid: ${error.message}`);
+  process.exit(1);
+}
+
 const blocks = [];
 let unclosed = 0;
-for (const file of roots.flatMap((dir) => markdownFiles(dir))) {
+for (const file of targets) {
   const lines = readFileSync(file, 'utf8').split('\n');
   let opener = null;
   let openedAt = 0;

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -43,9 +43,16 @@ mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
 const roots = process.argv.slice(2);
 if (roots.length === 0) roots.push('knowledge');
 
-function markdownFiles(dir) {
-  return readdirSync(dir).flatMap((entry) => {
-    const path = join(dir, entry);
+/// Every markdown file under `target`, which may be a directory or a single
+/// file. The file form is not a convenience: handing this a path used to throw
+/// a raw ENOTDIR stack trace, and checking one document at a time is exactly
+/// what you want while fixing the diagrams it reports.
+function markdownFiles(target) {
+  if (!statSync(target).isDirectory()) {
+    return target.endsWith('.md') ? [target] : [];
+  }
+  return readdirSync(target).flatMap((entry) => {
+    const path = join(target, entry);
     return statSync(path).isDirectory()
       ? markdownFiles(path)
       : path.endsWith('.md')
@@ -221,8 +228,7 @@ for (const block of blocks) {
 }
 
 console.log(
-  `\nmermaid: parsed ${blocks.length} block(s) in ` +
-    `${roots.map((dir) => `${dir}/`).join(', ')} — ` +
+  `\nmermaid: parsed ${blocks.length} block(s) in ${roots.join(', ')} — ` +
     `${failed} failed, ${unclosed} unclosed`,
 );
 process.exit(failed + unclosed === 0 ? 0 : 1);

--- a/tool/okf/check_mermaid.mjs
+++ b/tool/okf/check_mermaid.mjs
@@ -190,10 +190,18 @@ for (const file of targets) {
     isMermaid = false;
     depth = 0;
   });
-  if (opener !== null && isMermaid) {
-    // The Dart validator reports any unclosed fence; repeated here so this
-    // script is honest about a block it could not extract rather than skipping.
-    console.error(`unclosed mermaid fence: ${file}:${openedAt + 1}`);
+  if (opener !== null) {
+    // **Every** unclosed fence is reported, not only a mermaid one. An
+    // unclosed ordinary fence swallows the rest of the file as literal code,
+    // so any diagram below it is never extracted — and reporting only mermaid
+    // openers meant that silently exited 0. That was survivable while the Dart
+    // validator (which flags any unclosed fence) covered the same tree, but it
+    // only runs over knowledge/, so docs/ had no such backstop.
+    const kind = isMermaid ? 'mermaid' : 'code';
+    console.error(
+      `unclosed ${kind} fence: ${file}:${openedAt + 1}` +
+        (isMermaid ? '' : ' — hides any diagram below it'),
+    );
     unclosed++;
   }
 }

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -169,6 +169,21 @@ test('a semicolon inside a note body is safe', () => {
   assert.ok(r.ok, r.output);
 });
 
+test('a root may be a single file', () => {
+  // Passing a file used to throw a raw ENOTDIR stack trace. Checking one
+  // document is what you want while fixing the diagrams it reports.
+  const dir = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
+  try {
+    const file = join(dir, 'one.md');
+    writeFileSync(file, '```mermaid\nflowchart TD\n  A -->\n```\n');
+    assert.throws(() =>
+      execFileSync('node', [script, file], { encoding: 'utf8', stdio: 'pipe' }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('every root given is scanned, not just the first', () => {
   // The gate watched only `knowledge/` while two ADR diagrams rendered as
   // error boxes. Taking several roots is what closes that gap, so a second

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -139,9 +139,13 @@ test('an unclosed mermaid fence is reported', () => {
   assert.match(r.output, /unclosed mermaid fence/);
 });
 
-test('an unclosed non-mermaid fence is left to the Dart validator', () => {
+test('an unclosed ordinary fence is reported too', () => {
+  // This used to be delegated to the Dart validator, which flags any unclosed
+  // fence — but that validator only runs over knowledge/, so once docs/ was
+  // gated here the delegation had no backstop.
   const r = run('```dart\nvar x = 1;\n');
-  assert.ok(r.ok, r.output);
+  assert.ok(!r.ok, r.output);
+  assert.match(r.output, /unclosed code fence/);
 });
 
 test('a semicolon that splits a statement fails even though it parses', () => {
@@ -198,6 +202,18 @@ test('a root may be a single file', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('an unclosed ordinary fence is reported, not silently swallowed', () => {
+  // It hides every diagram below it: the extractor reads the rest of the file
+  // as literal code. Reporting only unclosed *mermaid* openers meant a broken
+  // diagram underneath one exited 0 — and outside knowledge/ nothing else
+  // flags unclosed fences.
+  const r = run('```dart\nvar x = 1;\n\n```mermaid\nflowchart TD\n  A --> B\n');
+  assert.ok(!r.ok, r.output);
+  assert.match(r.output, /unclosed code fence/);
+  // The diagram below it was never extracted — that is the harm.
+  assert.match(r.output, /parsed 0 block\(s\)/);
 });
 
 test('a root that is neither a directory nor markdown is rejected', () => {

--- a/tool/okf/check_mermaid_test.mjs
+++ b/tool/okf/check_mermaid_test.mjs
@@ -170,15 +170,55 @@ test('a semicolon inside a note body is safe', () => {
 });
 
 test('a root may be a single file', () => {
-  // Passing a file used to throw a raw ENOTDIR stack trace. Checking one
-  // document is what you want while fixing the diagrams it reports.
+  // Passing a file used to throw a raw ENOTDIR stack trace. Asserting only
+  // that a *broken* file fails would not distinguish the fix from that crash,
+  // so this checks a valid file is read and counted, then that a broken one
+  // fails for a mermaid reason.
   const dir = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
   try {
-    const file = join(dir, 'one.md');
-    writeFileSync(file, '```mermaid\nflowchart TD\n  A -->\n```\n');
-    assert.throws(() =>
-      execFileSync('node', [script, file], { encoding: 'utf8', stdio: 'pipe' }),
-    );
+    const valid = join(dir, 'one.md');
+    writeFileSync(valid, good);
+    const output = execFileSync('node', [script, valid], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    assert.match(output, /parsed 1 block\(s\)/);
+
+    const broken = join(dir, 'two.md');
+    writeFileSync(broken, '```mermaid\nflowchart TD\n  A -->\n```\n');
+    try {
+      execFileSync('node', [script, broken], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      assert.fail('a broken diagram in a file root must fail the run');
+    } catch (error) {
+      assert.match(`${error.stdout ?? ''}${error.stderr ?? ''}`, /FAIL/);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a root that is neither a directory nor markdown is rejected', () => {
+  // Silently scanning nothing and exiting 0 is the failure mode this whole
+  // tool exists to prevent.
+  const dir = mkdtempSync(join(tmpdir(), 'mermaid-gate-'));
+  try {
+    const notMarkdown = join(dir, 'README.txt');
+    writeFileSync(notMarkdown, 'flowchart TD\n  A --> B\n');
+    try {
+      execFileSync('node', [script, notMarkdown], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      assert.fail('an unsupported root must not pass silently');
+    } catch (error) {
+      assert.match(
+        `${error.stdout ?? ''}${error.stderr ?? ''}`,
+        /not a directory or a markdown file/,
+      );
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tool/okf/package.json
+++ b/tool/okf/package.json
@@ -2,10 +2,10 @@
   "name": "lotti-okf-mermaid-check",
   "private": true,
   "version": "1.0.0",
-  "description": "Parses the mermaid diagrams in the knowledge bundle, the ADRs and the architecture docs with mermaid itself, which the Dart validator cannot do.",
+  "description": "Parses every mermaid diagram under knowledge/ and docs/ with mermaid itself, which the Dart validator cannot do.",
   "type": "module",
   "scripts": {
-    "check": "node check_mermaid.mjs ../../knowledge ../../docs/adr ../../docs/architecture",
+    "check": "node check_mermaid.mjs ../../knowledge ../../docs",
     "test": "node --test"
   },
   "dependencies": {


### PR DESCRIPTION
Closes `lotti3-qg9`, the last of the mermaid-gate thread (#3669 fixed the ADRs).

## The decision the issue left open

Whether implementation plans are worth gating at all, given they are working notes and some are historical. **They are.** 253 of the 312 mermaid blocks under `docs/` live in plans, so excluding them excludes where nearly all future breakage will happen — and a plan's diagram matters most precisely when someone reopens it to resume the work, which is exactly how ADR 0046 was used as a rebuild spec two PRs ago. Once the existing diagrams render, keeping the gate costs nothing.

So all twelve are fixed and the gate now covers `knowledge/` and `docs/` outright: **447 blocks**, up from 185.

## Five distinct faults, not one

Worth listing, because only the first was the already-known trap:

- **Seven semicolon splits** — a `;` in a label ends the statement, so the remainder is reparsed. Some render phantom `;` nodes while parsing clean, which is why the checker inspects the built diagram. Now commas.
- **`-->| "label" |`** — the quoted label has to sit flush against the pipes (`-->|"label"|`).
- **`subgraph Handled by AgentToolExecutor → TaskAgentWorkflow`** — an unquoted subgraph title cannot carry `→`. Now `subgraph executor["…"]`.
- **`AgentTemplateEntity ..o| EvolutionAgentIdentity`** — not a valid ER relationship; it is missing the left cardinality. The non-identifying "exactly one to zero-or-one" is `||..o|`.
- **A `timeline` separates period from event with `:`**, so `section 10:00 PM : …` ended the period at the timestamp and left the rest unparseable. Timestamps are now dotted (`10.00 PM`) and the `section` prefix is dropped — every event, emoji and symbol is preserved; I checked that `❌`, `✅` and `≠` all parse rather than quietly dropping them.
- **`&lt;scenario&gt;`** does not parse in a sequence message. `{scenario}` reads the same.

## Also

`check_mermaid.mjs` now accepts a file as well as a directory. It threw a raw `ENOTDIR` stack trace before — I hit it myself checking one document at a time while fixing these, which is exactly the workflow the tool's own output invites.

## Verification

- `make knowledge_check` passes: 447 blocks, 0 failed, 0 unclosed.
- Checker suite is 23 tests, up from 22; the new one covers the single-file root.
- End-to-end, not just unit: re-breaking a *plan* diagram (`2026-07-15_onboarding_rollout_wiring.md`) makes `make mermaid_check` fail. That is the specific thing this PR claims to newly catch, so it is the specific thing worth proving.

The convention doc's gate contract is updated again — it now records why the boundary is "anything a reader might open" rather than a judgement about which documents deserve to render, since each narrower boundary turned out to be hiding broken diagrams.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Mermaid diagrams, labels, and punctuation across architecture, implementation, and planning documents for clearer rendering and consistency.
  * Refreshed Mermaid “gate” documentation to reflect broader coverage in both `knowledge/` and `docs/`.
* **Bug Fixes**
  * Mermaid validation now correctly accepts either a directory or a single Markdown file path as the scan target.
* **Tests**
  * Added test coverage for single-file validation and for rejecting invalid (non-directory, non-Markdown) inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->