### PR TITLE
fix(ai): record cost and impact for Melious transcriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   card into Manage mode.
 
 ### Fixed
+- **Transcription now counts towards your AI usage figures.** When a recording
+  was transcribed by a Melious speech model, the cost and the energy, carbon and
+  water it used were reported by the provider and then thrown away — so the AI
+  usage charts showed transcription as free, and every total that included it
+  was short. Those figures are now recorded like any other AI call.
 - **The app no longer asks for the microphone the moment it starts.** On a fresh
   install, Lotti asked to record audio while you were still looking at your task
   list, before you had asked it to record anything — which reasonably raises the

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
   <releases>
     <release version="0.9.1071" date="2026-07-26">
       <description>
+        <p>Fixed: transcription now counts towards your AI usage figures. When a recording was transcribed by a Melious speech model, the cost and the energy, carbon and water it used were reported by the provider and then thrown away — so the AI usage charts showed transcription as free, and every total that included it was short. Those figures are now recorded like any other AI call.</p>
         <p>Changed: sync filters now match the rest of the app. The Waiting, Failed, Sent, Unresolved, and Resolved controls on Sync Outbox and Sync Conflicts now use the shared design-system chip and count treatments, with consistent selected, hover, pressed, light, and dark states.</p>
         <p>Changed: the "More" menu at the bottom of the phone screen is no longer cramped. Its rows were sized to the bare minimum a finger needs, so the destinations stacked up against each other with the icons almost filling each row. Each row now has room around it, and the list keeps an even rhythm from top to bottom.</p>
         <p>Fixed: the app no longer asks for the microphone the moment it starts. On a fresh install, Lotti asked to record audio while you were still looking at your task list, before you had asked it to record anything. The app was checking whether it already had the permission, purely to write the answer to its log, and on Android and iOS that check is the request. The check is gone: the microphone is only ever asked for when you start a recording.</p>

--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -103,6 +103,31 @@ model default.
 **Reference-image generation is rejected explicitly** rather than silently
 ignored, because Melious currently documents only text-to-image generation.
 
+## Melious reports cost and impact only off the streaming path
+
+Alone among the providers, Melious returns per-call billing and environmental
+figures — `billing_cost` and `environment_impact` at the top level of the
+response body. They are **absent from streamed responses**, which carry only
+token `usage`, so they cannot ride the typed stream. They travel out of band
+instead: the caller passes an `InferenceImpactCollector` down the call, and
+whichever repository buffers the response parses `MeliousCallImpact` into it.
+
+That makes the collector's reach a per-endpoint property, and each buffered
+endpoint has to opt in:
+
+| Endpoint | How it buffers | Impact captured |
+|----------|----------------|-----------------|
+| `POST /chat/completions` | `_nonStreamingChat` when a collector is supplied — deliberately forfeiting incremental deltas, since Melious reports impact only when not streaming | Yes |
+| `POST /audio/transcriptions` (whisper-class ids) | Always one buffered POST | Yes, via `executeTranscription`'s `onSuccessResponse` hook |
+| `POST /chat/completions` with temporary-MP3 audio (Voxtral ids) | Always buffered | Yes |
+| `POST /images/generations` | Always buffered | Yes |
+
+A collector reaching `generateWithAudio` is routed by model id, so an endpoint
+that ignores the parameter silently records nothing — the call still succeeds
+and the transcript still arrives, which is why the gap is invisible until the
+consumption charts come up short. Fields Melious omits leave the collector
+untouched rather than writing zeros.
+
 A small curated static catalog exists for immediate setup before live-catalog
 rows are installed: `deepseek-v4-pro`, `glm-5.2`, `gemma-4-26b-a4b`,
 `minimax-m2.7`, `mistral-small-4-119b-instruct`, `qwen3.5-122b-a10b`,

--- a/lib/features/ai/repository/cloud_inference_generate_more.dart
+++ b/lib/features/ai/repository/cloud_inference_generate_more.dart
@@ -213,6 +213,7 @@ class CloudInferenceGenerateMore {
         baseUrl: baseUrl,
         apiKey: apiKey,
         contextBiasTerms: speechDictionaryTerms,
+        impactCollector: impactCollector,
       );
     }
 

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -583,6 +583,12 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   /// OpenAI-standard `prompt` form field to bias recognition toward names and
   /// domain vocabulary — honored by context-aware models such as Voxtral and
   /// safely ignored by models without prompt biasing.
+  ///
+  /// When [impactCollector] is provided, the cost and environmental impact
+  /// Melious reports alongside the transcript are written to it. Transcription
+  /// is a single buffered POST, so it always carries the impact fields a
+  /// streamed chat response would omit. Fields absent from the response leave
+  /// the collector untouched.
   Stream<CreateChatCompletionStreamResponse> transcribeAudio({
     required String model,
     required String audioBase64,
@@ -591,6 +597,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     String responseFormat = 'json',
     List<String>? contextBiasTerms,
     Duration? timeout,
+    InferenceImpactCollector? impactCollector,
   }) {
     final normalizedBaseUrl = baseUrl.trim();
     final normalizedApiKey = apiKey.trim();
@@ -612,6 +619,18 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       responseIdPrefix: 'melious-transcription-',
       audioLengthForLog: audioBase64.length,
       timeout: timeout,
+      onSuccessResponse: impactCollector == null
+          ? null
+          : (decoded, response) {
+              final impact = MeliousCallImpact.fromResponseJson(
+                decoded,
+                costCreditsDecimal:
+                    MeliousCallImpact.costDecimalFromResponseBody(
+                      response.body,
+                    ),
+              );
+              if (impact.hasData) impactCollector.impact = impact;
+            },
       sendRequest: (requestTimeout, timeoutErrorMessage) async {
         final uri = _buildEndpointUri(
           normalizedBaseUrl,

--- a/lib/features/ai/repository/transcription_repository.dart
+++ b/lib/features/ai/repository/transcription_repository.dart
@@ -40,6 +40,14 @@ class TranscriptionRepository {
   /// the raw response. It receives the computed timeout and a
   /// pre-formatted timeout error message so it can throw
   /// [TranscriptionException] from its own `onTimeout` callback.
+  ///
+  /// [onSuccessResponse] is invoked once, after a 200 response has been decoded
+  /// and validated, with both the decoded body and the raw [http.Response].
+  /// It exists for provider-specific fields this shared template does not
+  /// model — Melious' `environment_impact`/`billing_cost`, which a caller reads
+  /// into an impact collector. The raw response is passed alongside the decoded
+  /// map because recovering a provider's unmodified decimal digits requires the
+  /// body text, which `jsonDecode` has already lost.
   Stream<CreateChatCompletionStreamResponse> executeTranscription({
     required String providerName,
     required String responseIdPrefix,
@@ -50,6 +58,8 @@ class TranscriptionRepository {
     sendRequest,
     required int audioLengthForLog,
     Duration? timeout,
+    void Function(Map<String, dynamic> decoded, http.Response response)?
+    onSuccessResponse,
   }) {
     final requestTimeout =
         timeout ?? const Duration(seconds: whisperTranscriptionTimeoutSeconds);
@@ -108,6 +118,7 @@ class TranscriptionRepository {
 
           final text = result['text'] as String;
           final usage = parseCompletionUsage(result['usage']);
+          onSuccessResponse?.call(result, response);
 
           developer.log(
             'Successfully transcribed audio - '

--- a/test/features/ai/repository/cloud_inference_generate_more_test.dart
+++ b/test/features/ai/repository/cloud_inference_generate_more_test.dart
@@ -314,7 +314,40 @@ void main() {
             baseUrl: baseUrl,
             apiKey: 'key',
             contextBiasTerms: const ['Lotti', 'Voxtral'],
+            impactCollector: null,
           ),
+        );
+      },
+    );
+
+    test(
+      'hands the impact collector to Melious transcription models',
+      () async {
+        final meliousRepository = _FakeMeliousInferenceRepository();
+        final meliousGenerateMore = createGenerateMore(
+          meliousRepository: meliousRepository,
+        );
+        final meliousProvider = providerOfType(InferenceProviderType.melious);
+        final impactCollector = InferenceImpactCollector();
+
+        await meliousGenerateMore
+            .generateWithAudio(
+              prompt,
+              model: 'openai/whisper-large-v3',
+              audioBase64: 'melious-audio',
+              baseUrl: meliousProvider.baseUrl,
+              apiKey: meliousProvider.apiKey,
+              provider: meliousProvider,
+              impactCollector: impactCollector,
+            )
+            .drain<void>();
+
+        // Without this the collector reaches the router and is dropped on the
+        // transcription branch, so a transcription's cost and environmental
+        // impact are never recorded.
+        expect(
+          meliousRepository.audioCalls.single.impactCollector,
+          same(impactCollector),
         );
       },
     );
@@ -749,6 +782,7 @@ class _FakeMeliousInferenceRepository extends MeliousInferenceRepository {
           String baseUrl,
           String apiKey,
           List<String>? contextBiasTerms,
+          InferenceImpactCollector? impactCollector,
         })
       >[];
   final chatAudioCalls =
@@ -792,6 +826,7 @@ class _FakeMeliousInferenceRepository extends MeliousInferenceRepository {
     String responseFormat = 'json',
     List<String>? contextBiasTerms,
     Duration? timeout,
+    InferenceImpactCollector? impactCollector,
   }) {
     audioCalls.add(
       (
@@ -800,6 +835,7 @@ class _FakeMeliousInferenceRepository extends MeliousInferenceRepository {
         baseUrl: baseUrl,
         apiKey: apiKey,
         contextBiasTerms: contextBiasTerms,
+        impactCollector: impactCollector,
       ),
     );
     return Stream.value(

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -941,6 +941,95 @@ void main() {
     );
 
     test(
+      'transcribeAudio captures Melious billing and impact data',
+      () async {
+        final impactCollector = InferenceImpactCollector();
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient.streaming(
+            (_, _) async => http.StreamedResponse(
+              Stream.value(
+                utf8.encode(
+                  jsonEncode({
+                    'text': 'bonjour',
+                    'environment_impact': {
+                      'energy_kwh': 0.0031,
+                      'carbon_g_co2': 0.93,
+                      'water_liters': 0.12,
+                      'renewable_percent': 87.5,
+                      'pue': 1.2,
+                      'location': 'FI',
+                      'provider_id': 'upstream-whisper',
+                    },
+                    'billing_cost': {'credits': '0.0007'},
+                  }),
+                ),
+              ),
+              200,
+            ),
+          ),
+        );
+        addTearDown(repository.close);
+
+        await repository
+            .transcribeAudio(
+              model: 'openai/whisper-large-v3',
+              audioBase64: base64Encode([1, 2, 3]),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              impactCollector: impactCollector,
+            )
+            .drain<void>();
+
+        expect(
+          impactCollector.impact,
+          const MeliousCallImpact(
+            energyKwh: 0.0031,
+            carbonGCo2: 0.93,
+            waterLiters: 0.12,
+            renewablePercent: 87.5,
+            pue: 1.2,
+            dataCenter: 'FI',
+            providerId: 'upstream-whisper',
+            costCredits: 0.0007,
+            costCreditsDecimal: '0.0007',
+          ),
+        );
+      },
+    );
+
+    test(
+      'transcribeAudio leaves the collector empty when Melious reports no '
+      'impact',
+      () async {
+        final impactCollector = InferenceImpactCollector();
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient.streaming(
+            (_, _) async => http.StreamedResponse(
+              Stream.value(utf8.encode(jsonEncode({'text': 'bonjour'}))),
+              200,
+            ),
+          ),
+        );
+        addTearDown(repository.close);
+
+        final chunks = await repository
+            .transcribeAudio(
+              model: 'openai/whisper-large-v3',
+              audioBase64: base64Encode([1, 2, 3]),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              impactCollector: impactCollector,
+            )
+            .toList();
+
+        // The transcript still arrives — a response without impact fields is
+        // normal, not an error.
+        expect(chunks.single.choices?.single.delta?.content, 'bonjour');
+        expect(impactCollector.impact, isNull);
+      },
+    );
+
+    test(
       'transcribeChatAudio sends temporary MP3 and deletes it after success',
       () async {
         http.Request? captured;


### PR DESCRIPTION
## Problem

Transcribing a recording with a Melious speech model recorded **no** cost or environmental impact, so the AI consumption charts showed transcription as free and every total including it came up short.

## Cause

Melious returns `billing_cost` and `environment_impact` at the top level of a **buffered** response — they are absent from streamed ones, so they can't ride the typed stream and travel out of band through an `InferenceImpactCollector` instead.

`UnifiedAiInferenceRepository` does pass a collector for Melious audio (`unified_ai_inference_repository.dart:511`). But `generateWithAudio` routes by model id, and only the **chat-audio** branch forwarded it. For whisper-class ids — the `POST /audio/transcriptions` branch — the collector reached the router and was silently dropped. `MeliousInferenceRepository.transcribeAudio` had no such parameter at all.

Silent is the operative word: the call succeeds and the transcript arrives either way, so the gap only shows up as missing numbers in the charts.

## Change

- `TranscriptionRepository.executeTranscription` gains an optional `onSuccessResponse(decoded, response)` hook, invoked once after a 200 is decoded and validated. The shared template stays provider-agnostic — Melious-specific fields are parsed by Melious. The raw response goes along with the decoded map because recovering the provider's unmodified decimal digits needs the body text, which `jsonDecode` has already lost.
- `MeliousInferenceRepository.transcribeAudio` accepts an `impactCollector` and parses `MeliousCallImpact` through that hook.
- `CloudInferenceGenerateMore` forwards the collector on the transcription branch.

Absent fields leave the collector untouched, so a response without impact data behaves exactly as it does today.

## Tests

- `transcribeAudio captures Melious billing and impact data` — full round-trip through the multipart endpoint, asserting every parsed field including the preserved `costCreditsDecimal`.
- `transcribeAudio leaves the collector empty when Melious reports no impact` — transcript still arrives, collector stays null.
- `hands the impact collector to Melious transcription models` — the routing regression itself.

Each verified against the reverted fix: the routing test fails without the one-line forward, the parse tests fail without the hook. 209 tests green across the four affected repository test files; analyzer clean.

## Docs

`knowledge/features/ai/provider-routing.md` had nothing on the impact mechanism at all. Added a section covering why it travels out of band, and a per-endpoint table of which buffered endpoints capture it — the property that made this bug possible.