### PR TITLE
fix: support compact phone layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never lowered again. Lotti now asks for iOS 15.8, the last iOS 15 release, so
   those devices are supported once more as long as they are fully up to date.
 
+### Changed
+- **Core screens now fit the smallest supported phones.** Agent wake rows, AI
+  usage figures, Daily OS planning and refinement, speech transcripts, session
+  ratings, and What's New no longer overflow or cut off their controls at the
+  original iPhone SE's 320 × 568 layout size. Short forms and planning panels
+  scroll when necessary, while compact rows wrap or shorten safely.
+
 ## [0.9.1071]
 ### Added
 - **Encryption keys are never shared with unverified devices — and sync never

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -38,6 +38,7 @@
     <release version="0.9.1072" date="2026-07-29">
       <description>
         <p>Fixed: Lotti installs on older iPhones and iPads again. The app had come to require iOS 17, which left devices that cannot be updated past iOS 15 — the iPhone 6s and the first-generation iPhone SE among them — unable to install it at all. Nothing in the app actually needed iOS 17: the requirement arrived with a speech feature that was removed from iOS shortly afterwards, and was never lowered again. Lotti now asks for iOS 15.8, the last iOS 15 release, so those devices are supported once more as long as they are fully up to date.</p>
+        <p>Changed: core screens now fit the smallest supported phones. Agent wake rows, AI usage figures, Daily OS planning and refinement, speech transcripts, session ratings, and What's New no longer overflow or cut off their controls at the original iPhone SE's 320 × 568 layout size. Short forms and planning panels scroll when necessary, while compact rows wrap or shorten safely.</p>
       </description>
     </release>
     <release version="0.9.1071" date="2026-07-26">

--- a/knowledge/features/daily_os_next/ui-surfaces.md
+++ b/knowledge/features/daily_os_next/ui-surfaces.md
@@ -5,13 +5,13 @@ description: The Day page, the anchored voice template, timeline editing, the ca
 resource: ../../../lib/features/daily_os_next/ui
 tags: [daily-os, ui, voice, timeline, onboarding]
 status: stable
-generated: { by: codex/5, at: 2026-07-28T23:33:17+02:00 }
+generated: { by: codex/5, at: 2026-07-29T19:06:26+02:00 }
 stale_after: 2026-10-26
 sources:
   - id: ui
     resource: ../../../lib/features/daily_os_next/ui
     title: Daily OS widgets and pages
-    last_modified: 2026-07-25
+    last_modified: 2026-07-29
   - id: typography
     resource: ../../../lib/features/design_system/theme/typography_helpers.dart
     title: Calm typography helpers
@@ -50,7 +50,8 @@ sticky glass action bar          ← never empty; all actions live here
 just above it inside the bounded middle zone (bottom-pinned, reverse-scrolled,
 top fade); the editable transcript takes the same zone after capture; Refine's
 idle zone shows read-only current-plan rows. On viewports shorter than the
-template's minimum the body scrolls rather than overflowing.
+template's minimum the body scrolls from a bottom anchor rather than overflowing,
+so the orb, caption and sticky actions remain reachable.
 
 `CaptureState` keeps two live audio signals while the mic is open: normalized
 `amplitudes` for the compact waveform bars and raw `dbfs` for the shader voice
@@ -156,6 +157,12 @@ The timeline toolbar's **Arrange** action expands folded regions and enables
 direct manipulation on planned non-calendar blocks: drag the body to move, or the
 top/bottom handles to resize. Preview motion is optimistic and snaps to
 fifteen-minute increments within the plan day.
+
+On phone layouts the drafted-plan footer folds its three refinement shortcuts
+into one **Adjust** menu. At large accessibility text sizes it also omits the
+explanatory reason rows, preserving the plan projection and primary actions.
+When the timeline itself receives less height than its toolbar requires, the
+toolbar yields and the scrollable timeline takes the available space.
 
 ```mermaid
 sequenceDiagram

--- a/lib/features/agents/ui/listing/widgets/agent_list_row.dart
+++ b/lib/features/agents/ui/listing/widgets/agent_list_row.dart
@@ -94,22 +94,39 @@ class AgentListRow extends StatelessWidget {
         SizedBox(height: tokens.spacing.step3),
         Row(
           children: [
-            for (var i = 0; i < data.pills.length; i++) ...[
-              if (i > 0) SizedBox(width: tokens.spacing.step3),
-              _Pill(pill: data.pills[i]),
-            ],
-            const Spacer(),
-            if (data.metaRight != null)
-              Text(data.metaRight!, style: monoMetaStyle(tokens, colors)),
-            if (data.trailing != null) ...[
+            Expanded(
+              child: Wrap(
+                spacing: tokens.spacing.step3,
+                runSpacing: tokens.spacing.step2,
+                children: [
+                  for (final pill in data.pills) _Pill(pill: pill),
+                ],
+              ),
+            ),
+            if (data.metaRight != null ||
+                data.trailing != null ||
+                data.onTap != null) ...[
               SizedBox(width: tokens.spacing.step3),
-              data.trailing!(context),
-            ] else if (data.onTap != null) ...[
-              SizedBox(width: tokens.spacing.step3),
-              Icon(
-                Icons.chevron_right,
-                size: 16,
-                color: colors.text.lowEmphasis,
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (data.metaRight != null)
+                    Text(
+                      data.metaRight!,
+                      style: monoMetaStyle(tokens, colors),
+                    ),
+                  if (data.trailing != null) ...[
+                    SizedBox(width: tokens.spacing.step3),
+                    data.trailing!(context),
+                  ] else if (data.onTap != null) ...[
+                    SizedBox(width: tokens.spacing.step3),
+                    Icon(
+                      Icons.chevron_right,
+                      size: 16,
+                      color: colors.text.lowEmphasis,
+                    ),
+                  ],
+                ],
               ),
             ],
           ],
@@ -218,6 +235,8 @@ class _Pill extends StatelessWidget {
       ),
       child: Text(
         pill.label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: tokens.typography.styles.others.caption.copyWith(
           color: fg,
           fontWeight: tokens.typography.weight.semiBold,

--- a/lib/features/agents/ui/listing/widgets/agent_list_row.dart
+++ b/lib/features/agents/ui/listing/widgets/agent_list_row.dart
@@ -107,26 +107,32 @@ class AgentListRow extends StatelessWidget {
                 data.trailing != null ||
                 data.onTap != null) ...[
               SizedBox(width: tokens.spacing.step3),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (data.metaRight != null)
-                    Text(
-                      data.metaRight!,
-                      style: monoMetaStyle(tokens, colors),
-                    ),
-                  if (data.trailing != null) ...[
-                    SizedBox(width: tokens.spacing.step3),
-                    data.trailing!(context),
-                  ] else if (data.onTap != null) ...[
-                    SizedBox(width: tokens.spacing.step3),
-                    Icon(
-                      Icons.chevron_right,
-                      size: 16,
-                      color: colors.text.lowEmphasis,
-                    ),
+              Flexible(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (data.metaRight != null)
+                      Flexible(
+                        child: Text(
+                          data.metaRight!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: monoMetaStyle(tokens, colors),
+                        ),
+                      ),
+                    if (data.trailing != null) ...[
+                      SizedBox(width: tokens.spacing.step3),
+                      data.trailing!(context),
+                    ] else if (data.onTap != null) ...[
+                      SizedBox(width: tokens.spacing.step3),
+                      Icon(
+                        Icons.chevron_right,
+                        size: 16,
+                        color: colors.text.lowEmphasis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
             ],
           ],

--- a/lib/features/ai_consumption/ui/widgets/impact_kpi_row.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_kpi_row.dart
@@ -290,7 +290,7 @@ class _DeltaLine extends StatelessWidget {
     return Row(
       children: [
         Flexible(
-          flex: 3,
+          flex: 2,
           child: InsightsDeltaChip(
             current: (current * _kDeltaScale).round(),
             previous: (previous * _kDeltaScale).round(),
@@ -301,7 +301,6 @@ class _DeltaLine extends StatelessWidget {
         if (previousLabel != null) ...[
           SizedBox(width: tokens.spacing.step2),
           Expanded(
-            flex: 2,
             child: Text(
               context.messages.aiImpactKpiDeltaBaseline(previousLabel!),
               style: tokens.typography.styles.others.caption.copyWith(

--- a/lib/features/ai_consumption/ui/widgets/impact_kpi_row.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_kpi_row.dart
@@ -289,17 +289,15 @@ class _DeltaLine extends StatelessWidget {
     final tokens = context.designTokens;
     return Row(
       children: [
-        Flexible(
-          child: InsightsDeltaChip(
-            current: (current * _kDeltaScale).round(),
-            previous: (previous * _kDeltaScale).round(),
-            valence: valence,
-            prominent: prominent,
-          ),
+        InsightsDeltaChip(
+          current: (current * _kDeltaScale).round(),
+          previous: (previous * _kDeltaScale).round(),
+          valence: valence,
+          prominent: prominent,
         ),
         if (previousLabel != null) ...[
           SizedBox(width: tokens.spacing.step2),
-          Flexible(
+          Expanded(
             child: Text(
               context.messages.aiImpactKpiDeltaBaseline(previousLabel!),
               style: tokens.typography.styles.others.caption.copyWith(

--- a/lib/features/ai_consumption/ui/widgets/impact_kpi_row.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_kpi_row.dart
@@ -289,15 +289,19 @@ class _DeltaLine extends StatelessWidget {
     final tokens = context.designTokens;
     return Row(
       children: [
-        InsightsDeltaChip(
-          current: (current * _kDeltaScale).round(),
-          previous: (previous * _kDeltaScale).round(),
-          valence: valence,
-          prominent: prominent,
+        Flexible(
+          flex: 3,
+          child: InsightsDeltaChip(
+            current: (current * _kDeltaScale).round(),
+            previous: (previous * _kDeltaScale).round(),
+            valence: valence,
+            prominent: prominent,
+          ),
         ),
         if (previousLabel != null) ...[
           SizedBox(width: tokens.spacing.step2),
           Expanded(
+            flex: 2,
             child: Text(
               context.messages.aiImpactKpiDeltaBaseline(previousLabel!),
               style: tokens.typography.styles.others.caption.copyWith(

--- a/lib/features/daily_os_next/ui/pages/day_page.dart
+++ b/lib/features/daily_os_next/ui/pages/day_page.dart
@@ -610,9 +610,12 @@ class _PlanReviewStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final reasons = _planReasons(draft);
+    final textScale = dailyOsTextScaleOf(context);
+    final reasons = textScale < kDailyOsHideCoachingScale
+        ? _planReasons(draft)
+        : const <String>[];
     final compactActions =
-        dailyOsTextScaleOf(context) >= kDailyOsHideCoachingScale;
+        !isDesktopLayout(context) || textScale >= kDailyOsHideCoachingScale;
     return Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 760),

--- a/lib/features/daily_os_next/ui/pages/refine_page.dart
+++ b/lib/features/daily_os_next/ui/pages/refine_page.dart
@@ -94,6 +94,47 @@ class _RefineModalContentState extends ConsumerState<RefineModalContent> {
     );
     listenCaptureForRefine(ref, widget.draft);
 
+    final body = Column(
+      children: [
+        if (dailyOsTextScaleOf(context) < kDailyOsHideHeaderScale) ...[
+          // Reserved eyebrow slot mirrors the capture header anatomy
+          // so the headline baseline sits at the same height on
+          // every step.
+          Text(' ', style: calmGreetingStyle(tokens)),
+          SizedBox(height: tokens.spacing.step3),
+          _RefineHeadline(phase: state.phase),
+          SizedBox(height: tokens.spacing.step4),
+        ],
+        Expanded(
+          child: _RefineZone(draft: widget.draft, state: state),
+        ),
+        SizedBox(height: tokens.spacing.step4),
+        Consumer(
+          builder: (context, ref, _) {
+            final (amplitudes, dbfs) = ref.watch(
+              captureControllerProvider.select(
+                (s) => (s.amplitudes, s.dbfs),
+              ),
+            );
+            return VoiceOrbZone(
+              phase: refineOrbPhaseFor(state.phase, capturePhase),
+              caption: _caption(context, state.phase),
+              captionColor: _captionColor(tokens, state.phase),
+              semanticLabel: refineVoiceLabel(context, state.phase),
+              amplitudes: amplitudes,
+              dbfs: dbfs,
+              onTap: () => handleRefineVoiceTap(
+                refineState: state,
+                refineNotifier: notifier,
+                captureNotifier: captureNotifier,
+                planDate: widget.draft.dayDate,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+
     return Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 560),
@@ -104,45 +145,18 @@ class _RefineModalContentState extends ConsumerState<RefineModalContent> {
             tokens.spacing.step5,
             tokens.spacing.step5,
           ),
-          child: Column(
-            children: [
-              if (dailyOsTextScaleOf(context) < kDailyOsHideHeaderScale) ...[
-                // Reserved eyebrow slot mirrors the capture header anatomy
-                // so the headline baseline sits at the same height on
-                // every step.
-                Text(' ', style: calmGreetingStyle(tokens)),
-                SizedBox(height: tokens.spacing.step3),
-                _RefineHeadline(phase: state.phase),
-                SizedBox(height: tokens.spacing.step4),
-              ],
-              Expanded(
-                child: _RefineZone(draft: widget.draft, state: state),
-              ),
-              SizedBox(height: tokens.spacing.step4),
-              Consumer(
-                builder: (context, ref, _) {
-                  final (amplitudes, dbfs) = ref.watch(
-                    captureControllerProvider.select(
-                      (s) => (s.amplitudes, s.dbfs),
-                    ),
-                  );
-                  return VoiceOrbZone(
-                    phase: refineOrbPhaseFor(state.phase, capturePhase),
-                    caption: _caption(context, state.phase),
-                    captionColor: _captionColor(tokens, state.phase),
-                    semanticLabel: refineVoiceLabel(context, state.phase),
-                    amplitudes: amplitudes,
-                    dbfs: dbfs,
-                    onTap: () => handleRefineVoiceTap(
-                      refineState: state,
-                      refineNotifier: notifier,
-                      captureNotifier: captureNotifier,
-                      planDate: widget.draft.dayDate,
-                    ),
-                  );
-                },
-              ),
-            ],
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                reverse: true,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: constraints.maxHeight,
+                  ),
+                  child: IntrinsicHeight(child: body),
+                ),
+              );
+            },
           ),
         ),
       ),

--- a/lib/features/daily_os_next/ui/pages/shutdown_page.dart
+++ b/lib/features/daily_os_next/ui/pages/shutdown_page.dart
@@ -328,7 +328,7 @@ class _CarryoverRow extends StatelessWidget {
                   ),
                 ),
                 SizedBox(width: tokens.spacing.step3),
-                CategoryChip(category: item.category),
+                Flexible(child: CategoryChip(category: item.category)),
               ],
             ),
             SizedBox(height: tokens.spacing.step2),

--- a/lib/features/daily_os_next/ui/widgets/category_chip.dart
+++ b/lib/features/daily_os_next/ui/widgets/category_chip.dart
@@ -40,10 +40,14 @@ class CategoryChip extends StatelessWidget {
             ),
           ),
           SizedBox(width: tokens.spacing.step2),
-          Text(
-            category.name,
-            style: tokens.typography.styles.others.caption.copyWith(
-              color: tokens.colors.text.mediumEmphasis,
+          Flexible(
+            child: Text(
+              category.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: tokens.colors.text.mediumEmphasis,
+              ),
             ),
           ),
         ],

--- a/lib/features/daily_os_next/ui/widgets/day_timeline.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline.dart
@@ -268,17 +268,20 @@ class _DayTimelineState extends State<DayTimeline> {
     return LayoutBuilder(
       builder: (context, constraints) {
         final comparisonMode = _comparisonModeForWidth(constraints.maxWidth);
+        final toolbarHeight = tokens.spacing.step9 + tokens.spacing.step3;
+        final showToolbar = constraints.maxHeight >= toolbarHeight;
         return Column(
           children: [
-            _TimelineToolbar(
-              mode: comparisonMode,
-              arrangeMode: _arrangeMode,
-              showHint: widget.showGestureHint,
-              onToggleMode: _toggleComparisonMode,
-              onToggleArrange: widget.onRescheduleBlock == null
-                  ? null
-                  : _toggleArrangeMode,
-            ),
+            if (showToolbar)
+              _TimelineToolbar(
+                mode: comparisonMode,
+                arrangeMode: _arrangeMode,
+                showHint: widget.showGestureHint,
+                onToggleMode: _toggleComparisonMode,
+                onToggleArrange: widget.onRescheduleBlock == null
+                    ? null
+                    : _toggleArrangeMode,
+              ),
             Expanded(
               child: Listener(
                 onPointerDown: _handlePointerDown,

--- a/lib/features/daily_os_next/ui/widgets/diff_row.dart
+++ b/lib/features/daily_os_next/ui/widgets/diff_row.dart
@@ -49,7 +49,7 @@ class DiffRow extends StatelessWidget {
               children: [
                 _ChangeBadge(change: change),
                 SizedBox(width: tokens.spacing.step3),
-                CategoryChip(category: change.category),
+                Flexible(child: CategoryChip(category: change.category)),
               ],
             ),
             SizedBox(height: tokens.spacing.step3),

--- a/lib/features/daily_os_next/ui/widgets/learning_cards.dart
+++ b/lib/features/daily_os_next/ui/widgets/learning_cards.dart
@@ -149,7 +149,9 @@ class _GentleNudgeCard extends StatelessWidget {
             ),
           ),
           SizedBox(height: tokens.spacing.step4),
-          Row(
+          Wrap(
+            spacing: tokens.spacing.step3,
+            runSpacing: tokens.spacing.step2,
             children: [
               // Disabled until the day-agent layer wires the
               // accept/decline round-trip; a no-op handler would imply
@@ -172,7 +174,6 @@ class _GentleNudgeCard extends StatelessWidget {
                   context.messages.dailyOsNextDraftingNudgeAccept,
                 ),
               ),
-              SizedBox(width: tokens.spacing.step3),
               TextButton(
                 onPressed: null,
                 style: TextButton.styleFrom(

--- a/lib/features/insights/ui/widgets/insights_delta_chip.dart
+++ b/lib/features/insights/ui/widgets/insights_delta_chip.dart
@@ -126,7 +126,7 @@ class InsightsDeltaChip extends StatelessWidget {
       children: [
         Icon(glyph, size: glyphSize, color: color),
         SizedBox(width: tokens.spacing.step1),
-        label,
+        Flexible(child: label),
       ],
     );
   }

--- a/lib/features/ratings/ui/session_rating_modal.dart
+++ b/lib/features/ratings/ui/session_rating_modal.dart
@@ -183,91 +183,80 @@ class _RatingModalState extends ConsumerState<RatingModal> {
     BuildContext context,
     List<RatingQuestion> catalog,
   ) {
-    return Padding(
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-      ),
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(AppTheme.spacingLarge),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _dragHandle(context),
-            const SizedBox(height: AppTheme.spacingLarge),
-            Text(
-              context.messages.sessionRatingTitle,
-              style: context.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 24),
+    return _buildScrollableSheet(
+      context,
+      children: [
+        Text(
+          context.messages.sessionRatingTitle,
+          style: context.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 24),
 
-            // Dynamic questions from catalog
-            for (final question in catalog) ...[
-              if (question.inputType == 'segmented' && question.options != null)
-                RatingSegmentedInput(
-                  label: question.question,
-                  segments: [
-                    for (final opt in question.options!)
-                      (label: opt.label, value: opt.value),
-                  ],
-                  value: _answers[question.key],
-                  onChanged: (v) => setState(() => _answers[question.key] = v),
-                )
-              else
-                _buildTapBarRow(question),
-              const SizedBox(height: AppTheme.spacingLarge),
-            ],
-
-            // Note field
-            TextField(
-              controller: _noteController,
-              decoration: InputDecoration(
-                hintText: context.messages.sessionRatingNoteHint,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: AppTheme.spacingMedium,
-                  vertical: AppTheme.spacingSmall,
-                ),
-              ),
-              maxLines: 2,
-              textInputAction: TextInputAction.done,
-            ),
-            const SizedBox(height: 24),
-
-            // Actions
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: _close,
-                    child: Text(context.messages.sessionRatingSkipButton),
-                  ),
-                ),
-                const SizedBox(width: AppTheme.spacingMedium),
-                Expanded(
-                  child: FilledButton(
-                    onPressed: _canSubmit(catalog) && !_isSubmitting
-                        ? _submit
-                        : null,
-                    child: _isSubmitting
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Text(context.messages.sessionRatingSaveButton),
-                  ),
-                ),
+        // Dynamic questions from catalog
+        for (final question in catalog) ...[
+          if (question.inputType == 'segmented' && question.options != null)
+            RatingSegmentedInput(
+              label: question.question,
+              segments: [
+                for (final opt in question.options!)
+                  (label: opt.label, value: opt.value),
               ],
+              value: _answers[question.key],
+              onChanged: (v) => setState(() => _answers[question.key] = v),
+            )
+          else
+            _buildTapBarRow(question),
+          const SizedBox(height: AppTheme.spacingLarge),
+        ],
+
+        // Note field
+        TextField(
+          controller: _noteController,
+          decoration: InputDecoration(
+            hintText: context.messages.sessionRatingNoteHint,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
             ),
-            const SizedBox(height: AppTheme.spacingSmall),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: AppTheme.spacingMedium,
+              vertical: AppTheme.spacingSmall,
+            ),
+          ),
+          maxLines: 2,
+          textInputAction: TextInputAction.done,
+        ),
+        const SizedBox(height: 24),
+
+        // Actions
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: _close,
+                child: Text(context.messages.sessionRatingSkipButton),
+              ),
+            ),
+            const SizedBox(width: AppTheme.spacingMedium),
+            Expanded(
+              child: FilledButton(
+                onPressed: _canSubmit(catalog) && !_isSubmitting
+                    ? _submit
+                    : null,
+                child: _isSubmitting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(context.messages.sessionRatingSaveButton),
+              ),
+            ),
           ],
         ),
-      ),
+        const SizedBox(height: AppTheme.spacingSmall),
+      ],
     );
   }
 
@@ -306,55 +295,77 @@ class _RatingModalState extends ConsumerState<RatingModal> {
         ? existing.data.dimensions
         : <RatingDimension>[];
 
+    return _buildScrollableSheet(
+      context,
+      children: [
+        Text(
+          widget.catalogId,
+          style: context.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 24),
+
+        // Show each stored dimension read-only
+        for (final dim in dimensions) ...[
+          _ReadOnlyDimensionRow(dimension: dim),
+          const SizedBox(height: AppTheme.spacingSmall),
+        ],
+
+        // Note
+        if (existing is RatingEntry &&
+            existing.data.note != null &&
+            existing.data.note!.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppTheme.spacingSmall),
+            child: Text(
+              existing.data.note!,
+              style: context.textTheme.bodyMedium,
+            ),
+          ),
+
+        const SizedBox(height: 24),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton(
+            onPressed: _close,
+            child: Text(context.messages.sessionRatingSkipButton),
+          ),
+        ),
+        const SizedBox(height: AppTheme.spacingSmall),
+      ],
+    );
+  }
+
+  Widget _buildScrollableSheet(
+    BuildContext context, {
+    required List<Widget> children,
+  }) {
     return Padding(
       padding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(AppTheme.spacingLarge),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _dragHandle(context),
-            const SizedBox(height: AppTheme.spacingLarge),
-            Text(
-              widget.catalogId,
-              style: context.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.w600,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.only(top: AppTheme.spacingLarge),
+              child: _dragHandle(context),
+            ),
+          ),
+          Flexible(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(AppTheme.spacingLarge),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: children,
               ),
             ),
-            const SizedBox(height: 24),
-
-            // Show each stored dimension read-only
-            for (final dim in dimensions) ...[
-              _ReadOnlyDimensionRow(dimension: dim),
-              const SizedBox(height: AppTheme.spacingSmall),
-            ],
-
-            // Note
-            if (existing is RatingEntry &&
-                existing.data.note != null &&
-                existing.data.note!.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(bottom: AppTheme.spacingSmall),
-                child: Text(
-                  existing.data.note!,
-                  style: context.textTheme.bodyMedium,
-                ),
-              ),
-
-            const SizedBox(height: 24),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton(
-                onPressed: _close,
-                child: Text(context.messages.sessionRatingSkipButton),
-              ),
-            ),
-            const SizedBox(height: AppTheme.spacingSmall),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/ratings/ui/session_rating_modal.dart
+++ b/lib/features/ratings/ui/session_rating_modal.dart
@@ -187,7 +187,7 @@ class _RatingModalState extends ConsumerState<RatingModal> {
       padding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
-      child: Container(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(AppTheme.spacingLarge),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -310,7 +310,7 @@ class _RatingModalState extends ConsumerState<RatingModal> {
       padding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
-      child: Container(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(AppTheme.spacingLarge),
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/features/speech/ui/widgets/speech_modal/transcripts_list_item.dart
+++ b/lib/features/speech/ui/widgets/speech_modal/transcripts_list_item.dart
@@ -114,13 +114,14 @@ class _TranscriptListItemState extends State<TranscriptListItem> {
       title: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
+          Wrap(
+            spacing: tokens.spacing.step3,
+            runSpacing: tokens.spacing.step1,
             children: [
               Text(
                 dfShorter.format(widget.transcript.created),
                 style: titleStyle,
               ),
-              SizedBox(width: tokens.spacing.step3),
               if (processingTime != null)
                 Text(
                   '⏳${formatMmSs(processingTime)}',

--- a/lib/features/whats_new/ui/whats_new_navigation_footer.dart
+++ b/lib/features/whats_new/ui/whats_new_navigation_footer.dart
@@ -194,33 +194,36 @@ class _IndicatorDots extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: List.generate(total, (index) {
-        final isActive = index == current;
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(total, (index) {
+          final isActive = index == current;
 
-        return AnimatedContainer(
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeOutQuart,
-          margin: const EdgeInsets.symmetric(horizontal: 4),
-          width: isActive ? 28 : 8,
-          height: 8,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(4),
-            color: isActive
-                ? colorScheme.primary
-                : colorScheme.outline.withValues(alpha: 0.3),
-            boxShadow: isActive
-                ? [
-                    BoxShadow(
-                      color: colorScheme.primary.withValues(alpha: 0.4),
-                      blurRadius: 8,
-                    ),
-                  ]
-                : null,
-          ),
-        );
-      }),
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOutQuart,
+            margin: const EdgeInsets.symmetric(horizontal: 4),
+            width: isActive ? 28 : 8,
+            height: 8,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(4),
+              color: isActive
+                  ? colorScheme.primary
+                  : colorScheme.outline.withValues(alpha: 0.3),
+              boxShadow: isActive
+                  ? [
+                      BoxShadow(
+                        color: colorScheme.primary.withValues(alpha: 0.4),
+                        blurRadius: 8,
+                      ),
+                    ]
+                  : null,
+            ),
+          );
+        }),
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1072+4271
+version: 0.9.1072+4272
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/ui/listing/widgets/agent_list_row_test.dart
+++ b/test/features/agents/ui/listing/widgets/agent_list_row_test.dart
@@ -172,6 +172,30 @@ void main() {
       expect(find.text('pill'), findsOneWidget);
     });
 
+    testWidgets('compact metadata wraps without overflowing at phone width', (
+      tester,
+    ) async {
+      await _pumpRow(
+        tester,
+        _row(
+          pills: const [
+            AgentListPill(label: 'pending'),
+            AgentListPill(label: 'scheduled'),
+          ],
+          metaRight: '12:45',
+          onTap: () {},
+        ),
+        // Agent list cards have 280 logical pixels at a 320px viewport,
+        // leaving 248px after the row's horizontal padding.
+        width: 280,
+      );
+
+      expect(find.text('pending'), findsOneWidget);
+      expect(find.text('scheduled'), findsOneWidget);
+      expect(find.text('12:45'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     // Pill-rendering invariant: every label in `pills` must appear in the
     // rendered output, regardless of list length, tone mix, or layout. The
     // repo keeps Glados `.test()` bodies for pure (synchronous) logic only —

--- a/test/features/agents/ui/listing/widgets/agent_list_row_test.dart
+++ b/test/features/agents/ui/listing/widgets/agent_list_row_test.dart
@@ -196,6 +196,26 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('compact metadata yields to a trailing action at phone width', (
+      tester,
+    ) async {
+      const metadata = 'Wednesday, 29 July 2026 at 19:45';
+      await _pumpRow(
+        tester,
+        _row(
+          pills: const [AgentListPill(label: 'scheduled')],
+          metaRight: metadata,
+          trailing: (_) => const Icon(Icons.star),
+        ),
+        width: 280,
+      );
+
+      final text = tester.widget<Text>(find.text(metadata));
+      expect(text.overflow, TextOverflow.ellipsis);
+      expect(find.byIcon(Icons.star), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     // Pill-rendering invariant: every label in `pills` must appear in the
     // rendered output, regardless of list length, tone mix, or layout. The
     // repo keeps Glados `.test()` bodies for pure (synchronous) logic only —

--- a/test/features/agents/ui/listing/widgets/agent_list_row_test.dart
+++ b/test/features/agents/ui/listing/widgets/agent_list_row_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/ui/listing/agent_list_data.dart';
 import 'package:lotti/features/agents/ui/listing/widgets/agent_list_row.dart';
@@ -212,8 +213,14 @@ void main() {
 
       final text = tester.widget<Text>(find.text(metadata));
       expect(text.overflow, TextOverflow.ellipsis);
-      expect(find.byIcon(Icons.star), findsOneWidget);
-      expect(tester.takeException(), isNull);
+      final paragraph = tester.renderObject<RenderParagraph>(
+        find.text(metadata),
+      );
+      expect(paragraph.didExceedMaxLines, isTrue);
+      expect(
+        tester.getRect(find.text(metadata)).right,
+        lessThanOrEqualTo(tester.getRect(find.byIcon(Icons.star)).left),
+      );
     });
 
     // Pill-rendering invariant: every label in `pills` must appear in the

--- a/test/features/ai_consumption/ui/widgets/impact_kpi_row_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_kpi_row_test.dart
@@ -179,7 +179,7 @@ void main() {
       surface: const Size(320, 568),
       previousTotals: const ConsumptionMetrics(
         callCount: 4,
-        totalTokens: 10000,
+        totalTokens: 9000,
         credits: 1,
         energyKwh: 0.25,
         carbonGCo2: 200,
@@ -187,7 +187,22 @@ void main() {
       previousLabel: 'May',
     );
 
-    expect(find.text('+23%'), findsWidgets);
+    expect(find.text('+23%'), findsOneWidget);
+    expect(find.text('vs May'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('extreme selected delta stays bounded at iPhone SE width', (
+    tester,
+  ) async {
+    await pumpRow(
+      tester,
+      surface: const Size(320, 568),
+      previousTotals: const ConsumptionMetrics(credits: 0.000001),
+      previousLabel: 'May',
+    );
+
+    expect(find.text('+122999900%'), findsOneWidget);
     expect(find.text('vs May'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });

--- a/test/features/ai_consumption/ui/widgets/impact_kpi_row_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_kpi_row_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai_consumption/logic/consumption_formatting.dart';
 import 'package:lotti/features/ai_consumption/model/consumption_aggregation_models.dart';
@@ -6,6 +7,13 @@ import 'package:lotti/features/ai_consumption/model/impact_dashboard_models.dart
 import 'package:lotti/features/ai_consumption/ui/widgets/impact_kpi_row.dart';
 
 import '../../../../widget_test_utils.dart';
+
+Rect _selectedTileRect(WidgetTester tester) {
+  final selectedTile = tester
+      .widgetList<Semantics>(find.byType(Semantics))
+      .singleWhere((semantics) => semantics.properties.selected ?? false);
+  return tester.getRect(find.byWidget(selectedTile));
+}
 
 void main() {
   const totals = ConsumptionMetrics(
@@ -189,7 +197,15 @@ void main() {
 
     expect(find.text('+23%'), findsOneWidget);
     expect(find.text('vs May'), findsOneWidget);
-    expect(tester.takeException(), isNull);
+    final tileRect = _selectedTileRect(tester);
+    final deltaRect = tester.getRect(find.text('+23%'));
+    final baselineRect = tester.getRect(find.text('vs May'));
+    expect(deltaRect.left, greaterThanOrEqualTo(tileRect.left));
+    expect(
+      deltaRect.right,
+      lessThanOrEqualTo(baselineRect.left),
+    );
+    expect(baselineRect.right, lessThanOrEqualTo(tileRect.right));
   });
 
   testWidgets('extreme selected delta stays bounded at iPhone SE width', (
@@ -204,7 +220,19 @@ void main() {
 
     expect(find.text('+122999900%'), findsOneWidget);
     expect(find.text('vs May'), findsOneWidget);
-    expect(tester.takeException(), isNull);
+    final delta = tester.renderObject<RenderParagraph>(
+      find.text('+122999900%'),
+    );
+    expect(delta.didExceedMaxLines, isTrue);
+    final tileRect = _selectedTileRect(tester);
+    final deltaRect = tester.getRect(find.text('+122999900%'));
+    final baselineRect = tester.getRect(find.text('vs May'));
+    expect(deltaRect.left, greaterThanOrEqualTo(tileRect.left));
+    expect(
+      deltaRect.right,
+      lessThanOrEqualTo(baselineRect.left),
+    );
+    expect(baselineRect.right, lessThanOrEqualTo(tileRect.right));
   });
 
   testWidgets('omits the delta when there is no previous period', (

--- a/test/features/ai_consumption/ui/widgets/impact_kpi_row_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_kpi_row_test.dart
@@ -171,6 +171,27 @@ void main() {
     expect(find.text('vs May'), findsOneWidget);
   });
 
+  testWidgets('selected delta and baseline fit an iPhone SE width', (
+    tester,
+  ) async {
+    await pumpRow(
+      tester,
+      surface: const Size(320, 568),
+      previousTotals: const ConsumptionMetrics(
+        callCount: 4,
+        totalTokens: 10000,
+        credits: 1,
+        energyKwh: 0.25,
+        carbonGCo2: 200,
+      ),
+      previousLabel: 'May',
+    );
+
+    expect(find.text('+23%'), findsWidgets);
+    expect(find.text('vs May'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('omits the delta when there is no previous period', (
     tester,
   ) async {

--- a/test/features/daily_os_next/ui/pages/day_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_test.dart
@@ -1278,6 +1278,48 @@ void main() {
       },
     );
 
+    testWidgets('drafted review footer fits an iPhone SE viewport', (
+      tester,
+    ) async {
+      const size = Size(320, 568);
+      _setSurfaceSize(tester, size);
+      await tester.pumpWidget(
+        _wrap(
+          DayPage(draft: _draftedWithReasons()),
+          size: size,
+        ),
+      );
+      await tester.pump();
+
+      final messages = tester.element(find.byType(DayPage)).messages;
+      expect(find.text(messages.dailyOsNextReviewLooksGood), findsOneWidget);
+      expect(find.text(messages.dailyOsNextReviewAdjust), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('large text hides review reasons on an iPhone SE viewport', (
+      tester,
+    ) async {
+      const size = Size(320, 568);
+      final mediaQueryData = phoneMediaQueryData.copyWith(
+        size: size,
+        textScaler: const TextScaler.linear(2),
+      );
+      _setSurfaceSize(tester, size);
+      await tester.pumpWidget(
+        _wrap(
+          DayPage(draft: _draftedWithReasons()),
+          mediaQueryData: mediaQueryData,
+        ),
+      );
+      await tester.pump();
+
+      final messages = tester.element(find.byType(DayPage)).messages;
+      expect(find.text(messages.dailyOsNextReviewAdjust), findsOneWidget);
+      expect(find.text(messages.dailyOsNextReviewWhyTitle), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('committed footer swaps Lock In for Wrap up', (tester) async {
       _setSurface(tester);
       await tester.pumpWidget(

--- a/test/features/daily_os_next/ui/pages/refine_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/refine_page_test.dart
@@ -771,6 +771,29 @@ void main() {
   });
 
   group('RefineModalContent', () {
+    testWidgets('scrolls instead of overflowing a short phone modal', (
+      tester,
+    ) async {
+      final draft = _emptyPlan();
+      await tester.pumpWidget(
+        _wrap(
+          Scaffold(
+            body: SizedBox(
+              width: 320,
+              height: 326,
+              child: RefineModalContent(draft: draft),
+            ),
+          ),
+          size: const Size(320, 568),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(RefineModalContent), findsOneWidget);
+      expect(find.byType(SingleChildScrollView), findsWidgets);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('submits an initial transcript when opened with one', (
       tester,
     ) async {

--- a/test/features/daily_os_next/ui/pages/shutdown_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/shutdown_page_test.dart
@@ -71,6 +71,54 @@ class _TomorrowNoteAgent extends MockDayAgent {
   }) async => note;
 }
 
+class _LongCarryoverCategoryAgent extends MockDayAgent {
+  _LongCarryoverCategoryAgent()
+    : super(
+        parseLatency: Duration.zero,
+        pendingLatency: Duration.zero,
+        triageLatency: Duration.zero,
+        draftLatency: Duration.zero,
+        summarizeLatency: Duration.zero,
+        clock: () => DateTime(2026, 5, 25, 9),
+      );
+
+  static const categoryName =
+      'A category name that is much wider than a compact phone card';
+
+  @override
+  Future<
+    ({
+      List<CompletedItem> completed,
+      List<CarryoverItem> carryover,
+      ShutdownMetrics metrics,
+    })
+  >
+  surfaceShutdownData({required DateTime forDate}) async => (
+    completed: const <CompletedItem>[],
+    carryover: const [
+      CarryoverItem(
+        taskId: 'long-category-task',
+        title: 'Carry this task forward',
+        category: DayAgentCategory(
+          id: 'cat-long',
+          name: categoryName,
+          colorHex: '3366CC',
+        ),
+        reason: 'The task needs another day.',
+        suggestedTarget: '→ tomorrow morning',
+      ),
+    ],
+    metrics: const ShutdownMetrics(
+      focusMinutes: 0,
+      flowSessions: 0,
+      contextSwitches: 0,
+      contextSwitchesWeekAvg: 0,
+      energyScore: 0,
+      energyDeltaVsWeek: 0,
+    ),
+  );
+}
+
 void main() {
   group('ShutdownPage', () {
     testWidgets('renders completed + carryover + tomorrow content', (
@@ -129,6 +177,30 @@ void main() {
         expect(bounds.left, greaterThanOrEqualTo(0));
         expect(bounds.right, lessThanOrEqualTo(size.width));
       }
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('long carryover category stays bounded on a compact phone', (
+      tester,
+    ) async {
+      const size = Size(360, 640);
+      _setView(tester, size: size);
+
+      await tester.pumpWidget(
+        _wrap(
+          ShutdownPage(forDate: DateTime(2026, 5, 25)),
+          overrides: [
+            dayAgentProvider.overrideWithValue(_LongCarryoverCategoryAgent()),
+          ],
+          size: size,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.text(_LongCarryoverCategoryAgent.categoryName),
+        findsOneWidget,
+      );
       expect(tester.takeException(), isNull);
     });
 

--- a/test/features/daily_os_next/ui/widgets/category_chip_test.dart
+++ b/test/features/daily_os_next/ui/widgets/category_chip_test.dart
@@ -64,4 +64,35 @@ void main() {
     expect(hasGreySwatch, isTrue);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('long category label fits narrow cards at large text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: Size(320, 568),
+          textScaler: TextScaler.linear(2),
+        ),
+        child: makeTestableWidgetNoScroll(
+          const Scaffold(
+            body: SizedBox(
+              width: 100,
+              child: CategoryChip(
+                category: DayAgentCategory(
+                  id: 'c3',
+                  name: 'Very long category',
+                  colorHex: '#4285F4',
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Very long category'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
@@ -173,6 +173,32 @@ void main() {
   tearDown(() => beamToNamedOverride = null);
 
   group('DayTimeline', () {
+    testWidgets('short viewport prioritizes scrollable timeline over toolbar', (
+      tester,
+    ) async {
+      const size = Size(320, 39);
+      _setView(tester, size);
+
+      await tester.pumpWidget(
+        _wrap(
+          SizedBox(
+            width: size.width,
+            height: size.height,
+            child: DayTimeline(
+              draft: _draft(),
+              clock: () => DateTime(2026, 5, 25, 9, 15),
+            ),
+          ),
+          size: size,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const Key('daily_os_timeline_scroll')), findsOneWidget);
+      expect(find.byIcon(Icons.view_week_outlined), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('renders each block from the draft without band label text', (
       tester,
     ) async {

--- a/test/features/daily_os_next/ui/widgets/diff_row_test.dart
+++ b/test/features/daily_os_next/ui/widgets/diff_row_test.dart
@@ -120,6 +120,43 @@ void main() {
       expect(find.text(messages.changeSetSwipeReject), findsNothing);
     });
 
+    testWidgets('long category stays bounded by the production header row', (
+      tester,
+    ) async {
+      const categoryName =
+          'A category name that is much wider than a compact phone card';
+      const change = PlanDiffChange(
+        id: 'diff_long_category',
+        kind: PlanDiffChangeKind.added,
+        title: 'Task title',
+        category: DayAgentCategory(
+          id: 'cat-long',
+          name: categoryName,
+          colorHex: '3366CC',
+        ),
+        reason: 'Some reason.',
+        affectedBlockId: 'block-1',
+      );
+
+      await tester.pumpWidget(
+        _wrap(
+          SizedBox(
+            width: 280,
+            child: DiffRow(
+              change: change,
+              decision: PlanDiffChangeDecision.pending,
+              onAccept: () {},
+              onReject: () {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(categoryName), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     group('badge label per diff kind', () {
       // Covers _overlineFor branches for all three kinds
       for (final kind in PlanDiffChangeKind.values) {

--- a/test/features/daily_os_next/ui/widgets/learning_cards_test.dart
+++ b/test/features/daily_os_next/ui/widgets/learning_cards_test.dart
@@ -110,6 +110,37 @@ void main() {
       expect(find.byIcon(Icons.arrow_forward_rounded), findsNothing);
     });
 
+    testWidgets('nudge actions wrap without overflowing a narrow card', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              // 294px card width leaves the same 254px action-row width
+              // observed in the 320px day-planning modal.
+              width: 294,
+              child: LearningCardsColumn(cards: [_nudge()]),
+            ),
+          ),
+        ),
+      );
+
+      final messages = tester
+          .element(find.byType(LearningCardsColumn))
+          .messages;
+      expect(
+        find.text(messages.dailyOsNextDraftingNudgeAccept),
+        findsOneWidget,
+      );
+      expect(
+        find.text(messages.dailyOsNextDraftingNudgeDecline),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('mixed list keeps standard + nudge variants distinct', (
       tester,
     ) async {

--- a/test/features/insights/ui/widgets/insights_delta_chip_test.dart
+++ b/test/features/insights/ui/widgets/insights_delta_chip_test.dart
@@ -54,6 +54,24 @@ void main() {
       expect(find.text('-12%'), findsOneWidget);
     });
 
+    testWidgets('ellipsizes an extreme delta inside a narrow constraint', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const SizedBox(
+            width: 60,
+            child: InsightsDeltaChip(current: 1230000, previous: 1),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final label = tester.widget<Text>(find.text('+122999900%'));
+      expect(label.overflow, TextOverflow.ellipsis);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('shows "new" when there is no previous time', (tester) async {
       await pump(tester, current: 60, previous: 0);
       expect(find.text('new'), findsOneWidget);

--- a/test/features/insights/ui/widgets/insights_delta_chip_test.dart
+++ b/test/features/insights/ui/widgets/insights_delta_chip_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/insights/ui/widgets/insights_delta_chip.dart';
@@ -69,7 +70,11 @@ void main() {
 
       final label = tester.widget<Text>(find.text('+122999900%'));
       expect(label.overflow, TextOverflow.ellipsis);
-      expect(tester.takeException(), isNull);
+      final paragraph = tester.renderObject<RenderParagraph>(
+        find.text('+122999900%'),
+      );
+      expect(paragraph.didExceedMaxLines, isTrue);
+      expect(paragraph.size.width, lessThan(60));
     });
 
     testWidgets('shows "new" when there is no previous time', (tester) async {

--- a/test/features/ratings/ui/session_rating_modal_test.dart
+++ b/test/features/ratings/ui/session_rating_modal_test.dart
@@ -37,6 +37,7 @@ void main() {
   Widget buildSubject({
     String catalogId = 'session',
     List<Override> overrides = const [],
+    MediaQueryData? mediaQueryData,
   }) {
     return makeTestableWidgetWithScaffold(
       RatingModal(targetId: testTimeEntryId, catalogId: catalogId),
@@ -44,6 +45,7 @@ void main() {
         ratingRepositoryProvider.overrideWithValue(mockRepository),
         ...overrides,
       ],
+      mediaQueryData: mediaQueryData,
     );
   }
 
@@ -135,6 +137,33 @@ void main() {
 
       expect(find.text('Skip'), findsOneWidget);
       expect(find.text('Save'), findsOneWidget);
+    });
+
+    testWidgets('rating form scrolls instead of overflowing iPhone SE', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(320, 568)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const Scaffold(
+            body: RatingModal(targetId: testTimeEntryId),
+          ),
+          overrides: [
+            ratingRepositoryProvider.overrideWithValue(mockRepository),
+          ],
+          mediaQueryData: const MediaQueryData(size: Size(320, 568)),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(SingleChildScrollView), findsWidgets);
+      expect(find.text('Rate this session'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('Save button is disabled when not all dimensions are set', (

--- a/test/features/ratings/ui/session_rating_modal_test.dart
+++ b/test/features/ratings/ui/session_rating_modal_test.dart
@@ -10,6 +10,16 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
+Finder _dragHandle() => find.byWidgetPredicate(
+  (widget) =>
+      widget is Container &&
+      widget.constraints ==
+          const BoxConstraints.tightFor(width: 40, height: 4) &&
+      widget.decoration is BoxDecoration &&
+      (widget.decoration! as BoxDecoration).borderRadius ==
+          BorderRadius.circular(2),
+);
+
 void main() {
   late MockRatingRepository mockRepository;
 
@@ -226,17 +236,58 @@ void main() {
       await tester.pump();
 
       // The drag handle is a 40x4 rounded Container at the top of the sheet.
-      final handle = find.byWidgetPredicate(
-        (widget) =>
-            widget is Container &&
-            widget.constraints ==
-                const BoxConstraints.tightFor(width: 40, height: 4) &&
-            widget.decoration is BoxDecoration &&
-            (widget.decoration! as BoxDecoration).borderRadius ==
-                BorderRadius.circular(2),
-      );
+      final handle = _dragHandle();
       expect(handle, findsOneWidget);
       expect(tester.getSize(handle), const Size(40, 4));
+      final sheetScroll = find.descendant(
+        of: find.byType(RatingModal),
+        matching: find.byType(SingleChildScrollView),
+      );
+      expect(sheetScroll, findsOneWidget);
+      expect(
+        find.descendant(
+          of: sheetScroll,
+          matching: handle,
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('swiping the handle dismisses the scrollable bottom sheet', (
+      tester,
+    ) async {
+      const size = Size(320, 568);
+      tester.view
+        ..physicalSize = size
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                await RatingModal.show(context, testTimeEntryId);
+              },
+              child: const Text('open rating'),
+            ),
+          ),
+          overrides: [
+            ratingRepositoryProvider.overrideWithValue(mockRepository),
+          ],
+          mediaQueryData: const MediaQueryData(size: size),
+        ),
+      );
+
+      await tester.tap(find.text('open rating'));
+      await tester.pumpAndSettle();
+      expect(find.byType(RatingModal), findsOneWidget);
+
+      await tester.fling(_dragHandle(), const Offset(0, 300), 1000);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RatingModal), findsNothing);
+      expect(find.text('open rating'), findsOneWidget);
     });
 
     testWidgets('submit calls repository when all dimensions set', (
@@ -426,9 +477,7 @@ void main() {
                 onPressed: () => Navigator.of(context).push(
                   MaterialPageRoute<void>(
                     builder: (_) => const Scaffold(
-                      body: SingleChildScrollView(
-                        child: RatingModal(targetId: testTimeEntryId),
-                      ),
+                      body: RatingModal(targetId: testTimeEntryId),
                     ),
                   ),
                 ),

--- a/test/features/speech/ui/widgets/speech_modal/transcripts_list_item_test.dart
+++ b/test/features/speech/ui/widgets/speech_modal/transcripts_list_item_test.dart
@@ -131,6 +131,22 @@ void main() {
       );
     });
 
+    testWidgets('date and processing time wrap at iPhone SE width', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(320, 568)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(makeTestableWidget(testTranscript));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('⏳'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('has correct horizontal padding', (tester) async {
       await tester.pumpWidget(makeTestableWidget(testTranscript));
       await tester.pump();
@@ -177,8 +193,10 @@ void main() {
       // Check that the Column has CrossAxisAlignment.start
       expect(column.crossAxisAlignment, CrossAxisAlignment.start);
 
-      // Check that the Column has 2 Row children (timestamp + processing time, lang + model)
-      expect(column.children.whereType<Row>().length, 2);
+      // Timestamp + processing time use a Wrap so they can flow on narrow
+      // phones; language + model remain on one Row.
+      expect(column.children.whereType<Wrap>(), hasLength(1));
+      expect(column.children.whereType<Row>(), hasLength(1));
     });
 
     testWidgets('displays processing time when available', (tester) async {
@@ -415,8 +433,8 @@ void main() {
       final column = expansionTile.title as Column;
       final rows = column.children.whereType<Row>().toList();
 
-      // Second row should contain both language and model info
-      expect(rows[1].children.length, greaterThan(1));
+      // The remaining Row contains both language and model info.
+      expect(rows.single.children.length, greaterThan(1));
 
       // Find Text widgets in the second row
       final textWidgets = <Text>[];
@@ -430,7 +448,7 @@ void main() {
         }
       }
 
-      findTextWidgets(rows[1]);
+      findTextWidgets(rows.single);
 
       // Should have at least 2 text widgets (lang and model)
       expect(textWidgets.length, greaterThanOrEqualTo(2));

--- a/test/features/whats_new/ui/whats_new_navigation_footer_test.dart
+++ b/test/features/whats_new/ui/whats_new_navigation_footer_test.dart
@@ -5,6 +5,35 @@ import 'package:lotti/features/whats_new/ui/whats_new_navigation_footer.dart';
 import '../../../widget_test_utils.dart';
 
 void main() {
+  testWidgets('two release indicators fit an iPhone SE footer', (
+    tester,
+  ) async {
+    tester.view
+      ..physicalSize = const Size(320, 568)
+      ..devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) => NavigationFooter(
+            totalReleases: 2,
+            currentRelease: 1,
+            colorScheme: Theme.of(context).colorScheme,
+            onNavigate: (_) {},
+            onMarkAllSeen: () {},
+          ),
+        ),
+        mediaQueryData: phoneMediaQueryData.copyWith(
+          size: const Size(320, 568),
+        ),
+      ),
+    );
+
+    expect(find.text('Done'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('German skip action fits and marks releases as seen', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

The iOS 15.8 deployment target makes the original iPhone SE installable again, but its 320 × 568 logical-pixel viewport exposed ten concrete layout failures across core flows. This PR fixes those overflows without redesigning otherwise usable surfaces.

- makes Daily OS planning/refinement, session rating, and other short forms scroll when height is constrained
- lets compact metadata/actions wrap or yield safely in agent wakes, AI Impact, transcripts, learning nudges, category chips, and What's New
- adds focused widget regressions at the failing viewport, including 2× text scale cases
- updates the Daily OS UI knowledge map and the 0.9.1072 release notes

## Audit

The screenshot catalog produced **296 baseline screenshots from 135 phone scenarios** covering Daily OS, tasks/projects, journal and recordings, agents, AI settings/impact, app settings and sync, insights, events, onboarding, and What's New. Ten reproducible defects were confirmed: four high severity and six medium severity. Every affected surface was re-rendered after the fix at **320 × 568 logical pixels**.

### Before / after

| Before | After |
| --- | --- |
| **Daily OS day view — vertical overflow**<br>![Daily OS day view before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/day_mini_02_timeline_dark.png) | **Compact review controls and yielding timeline**<br>![Daily OS day view after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/day_mini_02_timeline_dark.png) |
| **Daily OS refine — fixed template overflow**<br>![Daily OS refine before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/mini_09_refine_dark.png) | **Fill-or-scroll layout with reachable actions**<br>![Daily OS refine after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/mini_09_refine_dark.png) |
| **Session rating — form clipped below sheet**<br>![Session rating before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/session_rating_mobile_dark.png) | **Scrollable form keeps questions/actions reachable**<br>![Session rating after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/session_rating_mobile_dark.png) |
| **Transcript review — metadata row overflow**<br>![Transcript review before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/recording_transcripts_mobile_dark.png) | **Metadata wraps while preserving both values**<br>![Transcript review after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/recording_transcripts_mobile_dark.png) |

<details>
<summary>Six additional before/after pairs</summary>

| Before | After |
| --- | --- |
| **Agent pending wakes — competing fixed row**<br>![Pending wakes before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/agents_pending_wakes_mobile_dark.png) | **Status pills wrap in a flexible area**<br>![Pending wakes after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/agents_pending_wakes_mobile_dark.png) |
| **AI Impact — selected delta chip crushed**<br>![AI Impact before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/ai_usage_mobile_dark.png) | **Chip keeps intrinsic width**<br>![AI Impact after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/ai_usage_mobile_dark.png) |
| **Learning nudge — localized actions overflow**<br>![Learning nudge before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/learning_nudge_mobile_dark.png) | **Actions wrap cleanly**<br>![Learning nudge after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/learning_nudge_mobile_dark.png) |
| **What's New — release dots exceed center slot**<br>![What's New before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/whats_new_past_release_mobile_dark.png) | **Indicator scales to available width**<br>![What's New after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/whats_new_past_release_mobile_dark.png) |
| **Daily OS at 2× text — review/chip overflow**<br>![Daily OS large text before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/day_mini_08_timeline_dark_ts20.png) | **Compact reasons and ellipsized category**<br>![Daily OS large text after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/day_mini_08_timeline_dark_ts20.png) |
| **Refine at 2× text — controls unreachable**<br>![Refine large text before](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/before/mini_22_refine_dark_ts20.png) | **Bottom-anchored scroll fallback**<br>![Refine large text after](https://raw.githubusercontent.com/matthiasn/lotti-docs/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen/after/mini_22_refine_dark_ts20.png) |

</details>

The durable screenshot inventory is in [`lotti-docs`](https://github.com/matthiasn/lotti-docs/tree/dda23ea3ac7eb99909e1506136f1094123df2e63/pr-screenshots/ios-se-small-screen).

## Verification

- `fvm dart format .` — 4,163 files checked, no changes
- `fvm flutter analyze` — no issues
- 197 focused widget tests across the ten touched test files — all pass
- `make knowledge_check` — 88 concepts and 447 Mermaid blocks pass
- affected screenshot scenarios re-rendered at 320 × 568; no RenderFlex overflow stripes remain

The full ~27k-test suite and patch coverage are delegated to the repository's ten-shard CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved small-phone (iPhone SE) responsiveness across key screens so content no longer overflows or clips; pills/categories now wrap or ellipsize safely.
  * Refine, session rating, and learning/transcripts layouts now better adapt to short viewports (including safe scrolling and conditional toolbar/compact controls).
* **Documentation**
  * Updated UI behavior notes for short viewports and refinement/timeline action behavior.
* **Tests**
  * Added/expanded widget tests for iPhone SE and very short viewports to verify scrolling/truncation and prevent render exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->