### PR TITLE
fix(manual): capture desktop task detail in its real layout

### DIFF
--- a/docs-site/docs/getting-started/first-task.mdx
+++ b/docs-site/docs/getting-started/first-task.mdx
@@ -67,7 +67,7 @@ assistant—understand the next action later.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Task detail for inspecting the orbital penguin habitat with due date, category, labels, AI summary, description, time records, and cover art"
+  alt="Task detail for inspecting the orbital penguin habitat with due date, category, labels, AI summary, checklist, logged time, and cover art"
 />
 
 ## Make it actionable

--- a/docs-site/docs/index.mdx
+++ b/docs-site/docs/index.mdx
@@ -19,7 +19,7 @@ description: Learn how to plan, capture, organize, and reflect with Lotti.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Lotti task page for the Project Waddle orbital penguin habitat, with task context, cover art, checklist, and time records"
+  alt="Lotti task page for the Project Waddle orbital penguin habitat, with task context, cover art, checklist, and logged time"
   caption="A task is a living record: the outcome, its context, its next moves, and the evidence of the work all travel together."
 />
 

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -70,7 +70,7 @@ pochopit další krok.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Podrobnosti úkolu o kontrole orbitálního obydlí tučňáků s termínem, kategorií, štítky, shrnutím AI, popisem, časovými záznamy a titulním obrázkem"
+  alt="Podrobnosti úkolu o kontrole orbitálního obydlí tučňáků s termínem, kategorií, štítky, shrnutím AI, kontrolním seznamem, zaznamenaným časem a titulním obrázkem"
 />
 
 ## Udělej z něj proveditelný úkol

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Nauč se s Lotti plánovat, zaznamenávat, organizovat a vyhodnocov
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Stránka úkolu Lotti pro orbitální tučňáčí habitat Project Waddle s kontextem, titulním obrázkem, kontrolním seznamem a časovými záznamy"
+  alt="Stránka úkolu Lotti pro orbitální tučňáčí habitat Project Waddle s kontextem, titulním obrázkem, kontrolním seznamem a zaznamenaným časem"
   caption="Úkol je živý záznam: výsledek, jeho souvislosti, další kroky i doklady o práci cestují spolu."
 />
 

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -67,7 +67,7 @@ Assistent—forstå næste handling senere.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Task detail for inspecting the orbital penguin habitat with due date, category, labels, AI summary, description, time records, and cover art"
+  alt="Task detail for inspecting the orbital penguin habitat with due date, category, labels, AI summary, checklist, logged time, and cover art"
 />
 
 ## Gør det handlingsorienteret

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Lær at planlægge, fange, organisere og reflektere sammen med Lott
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Lotti-opgaveside for Project Waddles orbitale pingvinhabitat med opgavekontekst, omslagskunst, tjekliste og tidsregistreringer"
+  alt="Lotti-opgaveside for Project Waddles orbitale pingvinhabitat med opgavekontekst, omslagskunst, tjekliste og registreret tid"
   caption="En opgave er en levende optegnelse: resultatet, konteksten, de næste skridt og dokumentationen for arbejdet følges ad."
 />
 

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -68,7 +68,7 @@ oder einem KI-Assistenten – später beim nächsten Schritt hilft.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Aufgabendetails zur Inspektion des orbitalen Pinguin-Habitats mit Fälligkeit, Kategorie, Labels, KI-Zusammenfassung, Beschreibung, Zeiteinträgen und Titelgrafik"
+  alt="Aufgabendetails zur Inspektion des orbitalen Pinguin-Habitats mit Fälligkeit, Kategorie, Labels, KI-Zusammenfassung, Checkliste, erfasster Zeit und Titelgrafik"
 />
 
 ## Die Aufgabe umsetzbar machen

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Erfahre, wie du mit Lotti planst, festhältst, organisierst und ref
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Lotti-Aufgabenseite für das Orbit-Habitat von Project Waddle mit Kontext, Titelbild, Checkliste und Zeiteinträgen"
+  alt="Lotti-Aufgabenseite für das Orbit-Habitat von Project Waddle mit Kontext, Titelbild, Checkliste und erfasster Zeit"
   caption="Eine Aufgabe ist ein lebender Eintrag: Ergebnis, Kontext, nächste Schritte und Arbeitsbelege reisen zusammen."
 />
 

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -58,7 +58,7 @@ Abre la tarea y usa su acción para añadir una nota, grabación, imagen u otra 
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Detalle de la tarea para inspeccionar el hábitat orbital de los pingüinos, con fecha límite, categoría, etiquetas, resumen de IA, descripción, registros de tiempo y portada"
+  alt="Detalle de la tarea para inspeccionar el hábitat orbital de los pingüinos, con fecha límite, categoría, etiquetas, resumen de IA, lista de comprobación, tiempo registrado y portada"
 />
 
 ## Haz que se pueda llevar a cabo

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Aprende a planificar, capturar, organizar y reflexionar con Lotti.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Página de tarea de Lotti para el hábitat orbital de pingüinos de Project Waddle, con contexto de la tarea, arte de portada, lista de comprobación y registros de tiempo"
+  alt="Página de tarea de Lotti para el hábitat orbital de pingüinos de Project Waddle, con contexto de la tarea, arte de portada, lista de comprobación y tiempo registrado"
   caption="Una tarea es un registro vivo: el resultado, su contexto, sus próximos pasos y las pruebas del trabajo viajan juntos."
 />
 

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -71,7 +71,7 @@ action plus tard.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Détail de tâche pour l’inspection de l’habitat orbital des manchots, avec échéance, catégorie, étiquettes, résumé IA, description, relevés de temps et illustration de couverture"
+  alt="Détail de tâche pour l’inspection de l’habitat orbital des manchots, avec échéance, catégorie, étiquettes, résumé IA, liste de contrôle, temps enregistré et illustration de couverture"
 />
 
 ## Rends-la concrète

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Découvre comment planifier, capturer, organiser et prendre du recu
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Page de tâche Lotti pour l’habitat orbital des manchots du Projet Waddle, avec contexte, illustration de couverture, liste de contrôle et relevés de temps"
+  alt="Page de tâche Lotti pour l’habitat orbital des manchots du Projet Waddle, avec contexte, illustration de couverture, liste de contrôle et temps enregistré"
   caption="Une tâche est une trace vivante : le résultat, son contexte, les prochaines étapes et les preuves du travail avancent ensemble."
 />
 

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -67,7 +67,7 @@ assistente—sostituire l'azione successiva più tardi.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Dettaglio compito per ispezionare l'habitat del pinguino orbitale con data, categoria, etichette, Riepilogo AI, descrizione, record di tempo, e coprire l'arte"
+  alt="Dettaglio compito per ispezionare l'habitat del pinguino orbitale con data, categoria, etichette, riepilogo AI, lista di controllo, tempo registrato e immagine di copertina"
 />
 
 ## Rendere l'azione

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Scopri come pianificare, catturare, organizzare e riflettere con Lo
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Pagina delle attività Lotti per l'habitat del pinguino orbitale del progetto Waddle, con il contesto di attività, l'arte di copertura, la lista di controllo e i record del tempo"
+  alt="Pagina delle attività Lotti per l'habitat del pinguino orbitale del progetto Waddle, con il contesto di attività, l'arte di copertura, la lista di controllo e il tempo registrato"
   caption="Un compito è un record vivente: il risultato, il suo contesto, le sue prossime mosse, e la prova del lavoro tutti viaggiano insieme."
 />
 

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -67,7 +67,7 @@ assistent - begrijp later de volgende actie.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Taak detail voor het inspecteren van de orbitale pinguïn habitat met de vervaldatum, categorie, labels, AI samenvatting, beschrijving, tijd records, en cover art"
+  alt="Taak detail voor het inspecteren van de orbitale pinguïn habitat met de vervaldatum, categorie, labels, AI-samenvatting, checklist, geregistreerde tijd en omslagafbeelding"
 />
 
 ## Maak het uitvoerbaar

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Leer hoe u kunt plannen, vastleggen, organiseren en reflecteren met
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Lotti taak pagina voor de Project Waddle baan pinguïn habitat, met taak context, cover kunst, checklist, en tijd records"
+  alt="Lotti taak pagina voor de Project Waddle baan pinguïn habitat, met taak context, cover kunst, checklist en geregistreerde tijd"
   caption="Een taak is een levend record: de uitkomst, de context, de volgende bewegingen en het bewijs van het werk reizen allemaal samen."
 />
 

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -69,7 +69,7 @@ você – ou um assistente de IA – a entender a próxima ação mais tarde.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Detalhe da tarefa para inspecionar o habitat orbital do pinguim com data de vencimento, categoria, rótulos, resumo de IA, descrição, registros de tempo e capa"
+  alt="Detalhe da tarefa para inspecionar o habitat orbital do pinguim com data de vencimento, categoria, rótulos, resumo de IA, lista de verificação, tempo registrado e capa"
 />
 
 ## Torne-o acionável

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Aprenda como planejar, capturar, organizar e refletir com Lotti.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Página de tarefa do Lotti para o habitat orbital de pinguins do Project Waddle, com contexto da tarefa, arte de capa, lista de verificação e registros de tempo"
+  alt="Página de tarefa do Lotti para o habitat orbital de pinguins do Project Waddle, com contexto da tarefa, arte de capa, lista de verificação e tempo registrado"
   caption="Uma tarefa é um registro vivo: o resultado, seu contexto, os próximos passos e as evidências do trabalho caminham juntos."
 />
 

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -58,7 +58,7 @@ Deschideți sarcina și folosiți acțiunea de adăugare pentru a atașa o notă
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Detaliul sarcinii pentru inspectarea habitatului orbital al pinguinilor, cu termen, categorie, etichete, rezumat AI, descriere, înregistrări de timp și copertă"
+  alt="Detaliul sarcinii pentru inspectarea habitatului orbital al pinguinilor, cu termen, categorie, etichete, rezumat AI, listă de verificare, timp înregistrat și copertă"
 />
 
 ## Faceți-o acționabilă

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -67,7 +67,7 @@ Assistent—förstå nästa åtgärd senare.
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Task detail for inspecting the orbital penguin habitat with due date, category, labels, AI summary, description, time records, and cover art"
+  alt="Task detail for inspecting the orbital penguin habitat with due date, category, labels, AI summary, checklist, logged time, and cover art"
 />
 
 ## Gör det handlingsbart

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/index.mdx
@@ -19,7 +19,7 @@ description: Lär dig att planera, fånga, organisera och reflektera tillsammans
 
 <ManualScreenshot
   caseId="tasks/detail"
-  alt="Lotti task page for the Project Waddle orbital penguin habitat, with task context, cover art, checklist, and time records"
+  alt="Lotti task page for the Project Waddle orbital penguin habitat, with task context, cover art, checklist, and logged time"
   caption="A task is a living record: the outcome, its context, its next moves, and the evidence of the work all travel together."
 />
 

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -38,6 +38,7 @@ import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/journal/state/linked_entries_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/create/create_entry_action_modal.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details_widget.dart';
 import 'package:lotti/features/tasks/state/task_live_data_provider.dart';
@@ -48,6 +49,7 @@ import 'package:lotti/features/tasks/ui/linked_tasks/relationship_type_selector.
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_root_page.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
+import 'package:lotti/features/tasks/ui/task_form.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -74,6 +76,17 @@ import '../pages/task_details_page_test_helpers.dart';
 class _ManualRunningInferenceController extends InferenceStatusController {
   @override
   InferenceStatus build() => InferenceStatus.running;
+}
+
+/// Serves a fixed link list so the task's below-card entries render without a
+/// Drift-level link graph behind them.
+class _ManualLinkedEntriesController extends LinkedEntriesController {
+  _ManualLinkedEntriesController(this._links);
+
+  final List<EntryLink> _links;
+
+  @override
+  Future<List<EntryLink>> build() async => _links;
 }
 
 const _manualTaskAgentId = 'agent-habitat-watcher';
@@ -393,6 +406,12 @@ void main() {
       () => mocks.journalDb.journalEntityById(any()),
     ).thenAnswer((invocation) async {
       final id = invocation.positionalArguments.first as String;
+      // Yield a full event-loop turn rather than resolving on the next
+      // microtask. A real Drift lookup always crosses a timer boundary, and
+      // controllers that aggregate several of these (checklist completion
+      // counts) only settle correctly when their own build future has
+      // resolved first.
+      await Future<void>.delayed(Duration.zero);
       return world.entityById(id);
     });
     when(
@@ -415,12 +434,34 @@ void main() {
               : null,
       };
     });
+    // The habitat task is the one fixture that has logged time, so the manual
+    // screenshots show real progress ("1h 10m of 2h") instead of "0m of 2h".
     when(
       () => mocks.journalDb.getBulkLinkedTimeSpans(any()),
-    ).thenAnswer((_) async => <String, List<LinkedEntityTimeSpan>>{});
+    ).thenAnswer((invocation) async {
+      final fromIds = invocation.positionalArguments.first as Set<String>;
+      final record = world.habitatTimeRecord;
+      return {
+        for (final id in fromIds)
+          id: id == manualOrbitalHabitatTaskId
+              ? <LinkedEntityTimeSpan>[
+                  (
+                    id: record.meta.id,
+                    dateFrom: record.meta.dateFrom,
+                    dateTo: record.meta.dateTo,
+                  ),
+                ]
+              : <LinkedEntityTimeSpan>[],
+      };
+    });
     when(
       () => mocks.journalDb.getLinkedEntities(any()),
-    ).thenAnswer((_) async => <JournalEntity>[]);
+    ).thenAnswer((invocation) async {
+      final linkedFrom = invocation.positionalArguments.first as String;
+      return linkedFrom == manualOrbitalHabitatTaskId
+          ? <JournalEntity>[world.habitatTimeRecord]
+          : <JournalEntity>[];
+    });
     when(mocks.journalDb.watchConfigFlags).thenAnswer(
       (_) => const Stream.empty(),
     );
@@ -523,6 +564,12 @@ void main() {
       });
 
       testWidgets('$viewport task detail — $theme', (tester) async {
+        // Desktop never shows the task detail full-bleed: it lives in the
+        // right pane of [TasksRootPage]. Capturing the page standalone at
+        // 1440pt made the 16:9 cover art 810pt tall and pushed the entire
+        // record off screen, so the manual's lead screenshot was nothing but
+        // cover art. Capture the real layout instead, scrolled so the record
+        // — not the artwork — is what the reader sees.
         await _pumpTaskSurface(
           tester,
           device: device,
@@ -530,20 +577,30 @@ void main() {
           world: world,
           pageController: pageController,
           journalRepository: journalRepository,
-          surface: TaskDetailsPage(taskId: world.orbitalHabitatTask.meta.id),
+          surface: device.isPhone
+              ? TaskDetailsPage(taskId: world.orbitalHabitatTask.meta.id)
+              : const TasksRootPage(),
         );
+        if (!device.isPhone) {
+          await _focusTaskDetailBody(tester);
+        }
 
         expect(find.byType(TaskDetailsPage), findsOneWidget);
-        expect(
-          find.text(
-            _t(
-              'Inspect orbital penguin habitat',
-              'Pinguin-Habitat im Orbit inspizieren',
-            ),
-          ),
-          findsWidgets,
+        final title = _t(
+          'Inspect orbital penguin habitat',
+          'Pinguin-Habitat im Orbit inspizieren',
         );
+        expect(find.text(title), findsWidgets);
         expect(find.text(_manualTaskAgentName), findsOneWidget);
+        // The record itself has to be on screen, not merely in the tree.
+        _expectVisible(tester, device, find.text(title).last);
+        _expectVisible(
+          tester,
+          device,
+          find.text(
+            _t('Pre-launch checks', 'Checks vor dem Start'),
+          ),
+        );
         await captureScreenshot(
           tester,
           'task_detail_${viewport}_$theme',
@@ -1120,6 +1177,23 @@ Future<void> _pumpTaskSurface(
               id: world.orbitalHabitatTask.id,
               aiResponseType: AiResponseType.imageGeneration,
             )).overrideWith(_ManualRunningInferenceController.new),
+            // The habitat task's below-card list: one time record, resolved
+            // from memory rather than through the Drift link graph.
+            linkedEntriesControllerProvider(
+              manualOrbitalHabitatTaskId,
+            ).overrideWith(
+              () => _ManualLinkedEntriesController(<EntryLink>[
+                EntryLink.basic(
+                  id: 'link-habitat-time-record',
+                  fromId: manualOrbitalHabitatTaskId,
+                  toId: world.habitatTimeRecord.meta.id,
+                  createdAt: world.habitatTimeRecord.meta.createdAt,
+                  updatedAt: world.habitatTimeRecord.meta.updatedAt,
+                  vectorClock: null,
+                ),
+              ]),
+            ),
+            createEntryControllerOverride(world.habitatTimeRecord),
             for (final coverImage in world.coverImages)
               createEntryControllerOverride(coverImage),
             for (final task in world.taskBrowseTasks)
@@ -1146,6 +1220,50 @@ Future<void> _pumpTaskSurface(
     );
     await settleFrames(tester, 8);
   });
+}
+
+/// Scrolls the task detail pane so the task form sits just below a slim band
+/// of cover art, leaving the record — title, chips, notes, checklist, logged
+/// time — as the subject of the frame.
+Future<void> _focusTaskDetailBody(WidgetTester tester) async {
+  const coverBand = 70.0;
+  final scrollable = find
+      .descendant(
+        of: find.byType(TaskDetailsPage),
+        matching: find.byType(Scrollable),
+      )
+      .first;
+  final position = tester.state<ScrollableState>(scrollable).position;
+  final targetTop = tester.getTopLeft(find.byType(TaskForm)).dy;
+  position.jumpTo(
+    (position.pixels + targetTop - coverBand).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    ),
+  );
+  await settleFrames(tester, 4);
+}
+
+/// Fails when [finder]'s widget is laid out outside the captured viewport.
+///
+/// `find.text` matches widgets that are in the tree but scrolled far off
+/// screen, which is exactly how the desktop task-detail capture silently
+/// became a full-bleed cover art shot while its assertions stayed green.
+void _expectVisible(
+  WidgetTester tester,
+  ScreenshotDevice device,
+  Finder finder,
+) {
+  final viewport = Offset.zero & device.size;
+  final rect = tester.getRect(finder);
+  expect(
+    rect.overlaps(viewport),
+    isTrue,
+    reason:
+        'Expected ${finder.describeMatch(Plurality.one)} to be visible '
+        'within $viewport, '
+        'but it is laid out at $rect.',
+  );
 }
 
 Future<void> _focusTaskAgentCard(

--- a/test/helpers/manual_demo_world.dart
+++ b/test/helpers/manual_demo_world.dart
@@ -4,7 +4,10 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/checklist_data.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -42,6 +45,12 @@ const manualHabitatLocalProfileId = 'profile-habitat-local-first';
 const manualFishDiplomacyProfileId = 'profile-fish-diplomacy';
 
 const manualOrbitalHabitatTaskId = 'task-orbital-habitat';
+const manualHabitatChecklistId = 'manual-habitat-checklist';
+const manualHabitatSealsItemId = 'manual-habitat-item-seals';
+const manualHabitatRollCallItemId = 'manual-habitat-item-roll-call';
+const manualHabitatCargoItemId = 'manual-habitat-item-cargo';
+const manualHabitatClearanceItemId = 'manual-habitat-item-clearance';
+const manualHabitatTimeRecordId = 'manual-habitat-time-record';
 const manualRollCallTaskId = 'task-emperor-penguin-roll-call';
 const manualLaunchReviewTaskId = 'task-project-waddle-launch-review';
 const manualLunchTaskId = 'task-coffee-is-not-a-vegetable';
@@ -417,6 +426,9 @@ class ManualDemoWorld {
     required this.labels,
     required this.coverImages,
     required this.tasks,
+    required this.checklists,
+    required this.checklistItems,
+    required this.timeRecords,
   });
 
   factory ManualDemoWorld.penguinLogistics() {
@@ -480,6 +492,7 @@ class ManualDemoWorld {
       required String coverArtId,
       required List<String> labelIds,
       required Duration estimate,
+      List<String>? checklistIds,
     }) {
       final base = TestTaskFactory.create(
         id: id,
@@ -492,6 +505,7 @@ class ManualDemoWorld {
         statusHistory: [status],
         categoryId: manualDemoCategoryId,
         estimate: estimate,
+        checklistIds: checklistIds,
       );
       return base.copyWith(
         meta: base.meta.copyWith(labelIds: labelIds),
@@ -530,10 +544,115 @@ class ManualDemoWorld {
       utcOffset: 120,
     );
 
+    ChecklistItem checklistItem({
+      required String id,
+      required String title,
+      required bool isChecked,
+      required Duration checkedAgo,
+    }) {
+      return ChecklistItem(
+        meta: TestMetadataFactory.create(
+          id: id,
+          createdAt: manualDemoNow.subtract(const Duration(days: 1)),
+          categoryId: manualDemoCategoryId,
+        ),
+        data: ChecklistItemData(
+          id: id,
+          title: title,
+          isChecked: isChecked,
+          linkedChecklists: const [manualHabitatChecklistId],
+          checkedAt: isChecked ? manualDemoNow.subtract(checkedAgo) : null,
+        ),
+      );
+    }
+
+    // The habitat inspection is the task the manual follows end to end, so it
+    // is the one fixture that carries a checklist and a time record: the
+    // screenshots have to show a task as a *record of work*, not an empty
+    // shell.
+    final checklistItems = <ChecklistItem>[
+      checklistItem(
+        id: manualHabitatSealsItemId,
+        title: _t(
+          'Walk pressure seals A–F',
+          'Druckdichtungen A–F abgehen',
+        ),
+        isChecked: true,
+        checkedAgo: const Duration(hours: 1, minutes: 18),
+      ),
+      checklistItem(
+        id: manualHabitatRollCallItemId,
+        title: _t(
+          'Count all 37 emperor penguins',
+          'Alle 37 Kaiserpinguine zählen',
+        ),
+        isChecked: true,
+        checkedAgo: const Duration(minutes: 52),
+      ),
+      checklistItem(
+        id: manualHabitatCargoItemId,
+        title: _t(
+          'Route the sardine cargo pods',
+          'Sardinen-Frachtkapseln routen',
+        ),
+        isChecked: false,
+        checkedAgo: Duration.zero,
+      ),
+      checklistItem(
+        id: manualHabitatClearanceItemId,
+        title: _t(
+          'Request Mission Control clearance',
+          'Freigabe der Missionskontrolle anfordern',
+        ),
+        isChecked: false,
+        checkedAgo: Duration.zero,
+      ),
+    ];
+
+    final habitatChecklist = Checklist(
+      meta: TestMetadataFactory.create(
+        id: manualHabitatChecklistId,
+        createdAt: manualDemoNow.subtract(const Duration(days: 1)),
+        categoryId: manualDemoCategoryId,
+      ),
+      data: ChecklistData(
+        title: _t('Pre-launch checks', 'Checks vor dem Start'),
+        linkedChecklistItems: [
+          for (final item in checklistItems) item.meta.id,
+        ],
+        linkedTasks: const [manualOrbitalHabitatTaskId],
+      ),
+    );
+
+    final habitatTimeRecord = JournalEntry(
+      meta: TestMetadataFactory.create(
+        id: manualHabitatTimeRecordId,
+        createdAt: manualDemoNow.subtract(
+          const Duration(hours: 1, minutes: 18),
+        ),
+        dateFrom: manualDemoNow.subtract(const Duration(hours: 1, minutes: 18)),
+        dateTo: manualDemoNow.subtract(const Duration(minutes: 8)),
+        categoryId: manualDemoCategoryId,
+      ),
+      entryText: EntryText(
+        plainText: _t(
+          'Seal walk complete: A–F held at 101.3 kPa overnight. Roll call '
+              'confirmed all 37 penguins, including the one asleep in the '
+              'cargo netting.',
+          'Dichtungsrundgang abgeschlossen: A–F hielten über Nacht 101,3 kPa. '
+              'Der Zählappell bestätigte alle 37 Pinguine, auch den, der im '
+              'Frachtnetz schlief.',
+        ),
+      ),
+    );
+
     return ManualDemoWorld._(
       category: category,
       labels: labels,
       coverImages: coverImages,
+      checklists: [habitatChecklist],
+      checklistItems: checklistItems,
+      timeRecords: [habitatTimeRecord],
       tasks: [
         task(
           id: manualRollCallTaskId,
@@ -574,6 +693,7 @@ class ManualDemoWorld {
             manualDemoCriticalLabelId,
           ],
           estimate: const Duration(hours: 2),
+          checklistIds: const [manualHabitatChecklistId],
         ),
         task(
           id: manualLaunchReviewTaskId,
@@ -715,7 +835,28 @@ class ManualDemoWorld {
   final List<JournalImage> coverImages;
   final List<Task> tasks;
 
+  /// Checklists owned by tasks in this world, keyed into tasks through
+  /// `TaskData.checklistIds`.
+  final List<Checklist> checklists;
+
+  /// Every checklist item referenced by [checklists].
+  final List<ChecklistItem> checklistItems;
+
+  /// Text entries with a `dateFrom`/`dateTo` span, linked from a task so the
+  /// task shows logged time rather than `0m of 2h`.
+  final List<JournalEntry> timeRecords;
+
   Task get orbitalHabitatTask => taskById(manualOrbitalHabitatTaskId);
+
+  /// The single checklist attached to [orbitalHabitatTask].
+  Checklist get habitatChecklist => checklists.singleWhere(
+    (list) => list.meta.id == manualHabitatChecklistId,
+  );
+
+  /// The single time record linked from [orbitalHabitatTask].
+  JournalEntry get habitatTimeRecord => timeRecords.singleWhere(
+    (entry) => entry.meta.id == manualHabitatTimeRecordId,
+  );
   Task get fishFeederTask => taskById(manualFishFeederTaskId);
   Task get sardineCargoTask => taskById(manualSardineCargoTaskId);
   Task get penguinPassengerTask => taskById(manualPenguinPassengerTaskId);
@@ -742,6 +883,15 @@ class ManualDemoWorld {
     }
     for (final task in tasks) {
       if (task.meta.id == id) return task;
+    }
+    for (final checklist in checklists) {
+      if (checklist.meta.id == id) return checklist;
+    }
+    for (final item in checklistItems) {
+      if (item.meta.id == id) return item;
+    }
+    for (final entry in timeRecords) {
+      if (entry.meta.id == id) return entry;
     }
     return null;
   }


### PR DESCRIPTION
## Problem

The first desktop screenshot on the manual landing page ([/manual/development/](https://matthiasn.github.io/lotti/manual/development/)) shows nothing but cover art — no title, no chips, no checklist, just the penguin and the bottom toolbar.

The desktop variant of `tasks/detail` was captured by pumping `TaskDetailsPage` **standalone at 1440×900**. The cover art is a 16:9 `SliverAppBar` sized from available width (`lib/features/tasks/ui/task_expandable_app_bar.dart:46`), so 1440pt wide → **810pt of cover on a 900pt viewport**, and everything below it is off screen.

This is not an app bug. On desktop the task detail always renders in the right pane of `TasksRootPage` (`task_navigation.dart` → `pushDesktopTaskDetail`), where the pane is ~890pt wide and the cover lands at a sensible ~500pt. The full-bleed layout only ever existed inside the screenshot test.

## Changes

- **Capture the real layout.** Desktop `tasks/detail` now pumps `TasksRootPage` with the task selected, scrolled so the record sits under a slim band of cover art. Mobile keeps the standalone page — that *is* its real route.
- **Stop the assertions passing vacuously.** `find.text` matches widgets laid out 800pt off screen, which is exactly how this regressed unnoticed. New `_expectVisible` fails when the match falls outside the captured viewport. Verified by reverting the capture change: `Expected widget with text "Pre-launch checks" to be visible within Rect.fromLTRB(0.0, 0.0, 1440.0, …)` → fails.
- **Populate the fixture** so the shot shows a task as a record of work rather than an empty shell: a four-item checklist (two done) and a 1h 10m time record on the habitat task. The chip now reads **"1h 10m of 2h"** instead of "0m of 2h", and the checklist header **"2/4 done"**.
- **Fix the alt text** on the three pages using this case (`index`, `first-task`, `tasks`), across all 11 locales — it promised "time records" and a "description" the frame does not show.

## Note on the mock timing change

`journalEntityById` now yields a full event-loop turn instead of resolving on the next microtask. Without it, `ChecklistCompletionController` reported 0/4 permanently: its `build()` future resolves *after* the item controllers it subscribed to, so the stale build result overwrites their updates. A real Drift lookup always crosses a timer boundary, so the slower mock is the faithful one. The underlying lost-update race in that controller is real but latent in production for the same reason — not touched here.

## Test state

`task_manual_screenshots_test.dart` has **8 failures that pre-exist on main** (4 × `task agent manual updates`, 4 × `task link picker`); confirmed identical with these changes stashed. This PR adds none. `docs-site` `npm run validate` and `npm test` pass.

## Still open

The task description renders as the "Enter notes…" placeholder — `FakeEntryController` overrides `build()` without calling `setController()`, so Quill gets an empty document. Out of scope here; it touches a helper many suites share.

The staged PNGs in `lotti-docs` have not been regenerated yet — that is a separate capture-and-publish step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved screenshot alternative text across supported languages to accurately describe checklists and logged time.
  * Updated task detail and homepage accessibility descriptions to match the current interface.

* **Tests**
  * Improved task screenshot coverage and rendering reliability.
  * Added representative checklist and logged-time data to manual task demonstrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->