### PR TITLE
ci: read the Windows Flutter version from .fvmrc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.44.7"
+  "dart.flutterSdkPath": ".fvm/flutter_sdk"
 }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -4,7 +4,13 @@ workflows:
     instance_type: windows_x2
     max_build_duration: 90
     environment:
-      flutter: 3.41.4
+      # `fvm` makes Codemagic read the version from .fvmrc — the same pin the
+      # GitHub Actions lanes read — so this file needs no edit on a Flutter
+      # bump. Codemagic fails the build if .fvmrc is missing. A literal
+      # version here silently rots: it sat at 3.41.4 (Dart 3.11.1) long after
+      # the SDK floor moved to 3.12.0, and every Windows release failed in
+      # `pub get` with a version-solving error.
+      flutter: fvm
       groups:
         - windows_signing
     triggering:

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -24,6 +24,10 @@ sources:
     resource: ../../.fvmrc
     title: Pinned Flutter version
     last_modified: 2026-07-22
+  - id: codemagic
+    resource: ../../codemagic.yaml
+    title: Windows release pipeline
+    last_modified: 2026-07-30
 ---
 
 # One codebase, five targets
@@ -37,11 +41,31 @@ sources:
 | Windows | MSIX |
 
 The Flutter SDK is **pinned in `.fvmrc`** (currently 3.44.7) and every command
-is expected to run through FVM — `fvm flutter …`, `fvm dart …`. CI reads the
-same file via `kuhnroyal/flutter-fvm-config-action`, so a local build and a CI
-build use the same SDK by construction rather than by convention.
+is expected to run through FVM — `fvm flutter …`, `fvm dart …`.
 
 Dart SDK constraint: `>=3.12.0 <4.0.0`; Flutter `>=3.44.0`.
+
+## Bumping the Flutter version
+
+`.fvmrc` is the source of truth, but it is not the only place the version is
+written down. Most consumers follow it automatically; one does not:
+
+| Consumer | Follows `.fvmrc`? |
+|----------|-------------------|
+| GitHub Actions lanes | Yes — `kuhnroyal/flutter-fvm-config-action` reads it |
+| Codemagic Windows release | Yes — `environment.flutter: fvm` reads it |
+| [`flatpak/com.matthiasn.lotti.flatpak-flutter.yml`](../../flatpak/com.matthiasn.lotti.flatpak-flutter.yml) | **No — hand-edit the Flutter `tag:`** |
+
+So a Flutter bump is `.fvmrc` **plus** the Flatpak manifest's Flutter `tag:`.
+That tag currently reads 3.44.0 against a 3.44.7 pin; it still resolves because
+the constraint floor is `>=3.44.0`, which is precisely why the drift is easy to
+miss.
+
+A stale pin does not announce itself. It surfaces one layer down, as
+`pub get` failing version solving — "the current Dart SDK version is X, because
+lotti requires SDK version >=3.12.0 <4.0.0, version solving failed" — which
+reads like a dependency problem rather than a toolchain one. The Windows lane
+sat broken this way across a dozen consecutive release tags.
 
 # Continuous integration
 
@@ -74,7 +98,8 @@ written is in [testing conventions](../conventions/testing.md).
 # Release
 
 Release is triggered by **pushing a git tag whose name is the `pubspec.yaml`
-version**. Seven workflows listen on `push: tags: ['**']` and fan out:
+version**. Seven GitHub workflows listen on `push: tags: ['**']`, and Windows
+fans out from the same tag on a different provider:
 
 ```mermaid
 flowchart TD
@@ -86,7 +111,15 @@ flowchart TD
   Tag --> E["flutter-linux-release.yml"]
   Tag --> F["flathub-release-pr.yml"]
   Tag --> G["python-services-release.yml"]
+  Tag --> H["codemagic.yaml — Windows MSIX"]
 ```
+
+**Windows is the one target not built on GitHub Actions.** It runs on
+[Codemagic](../../codemagic.yaml), on a `windows_x2` instance, triggered by the
+same `*.*.*+*` tag pattern, and it reports back as a `Windows Release` check on
+the tagged commit. Because it lives outside `.github/workflows/`, it is easy to
+overlook when auditing CI — its failures show up only on tag commits and in the
+build-notification email, never on a pull request.
 
 `flathub-release-pr.yml` also accepts `workflow_dispatch` with an explicit
 commit SHA and version override, for re-cutting a Flathub PR without moving the
@@ -127,6 +160,7 @@ generated-code rules live.
 | Concern | File |
 |---------|------|
 | CI and release pipelines | [`.github/workflows/`](../../.github/workflows) |
+| Windows release (Codemagic) | [`codemagic.yaml`](../../codemagic.yaml) |
 | Buildkite lanes | [`.buildkite/`](../../.buildkite) |
 | Build, test, packaging targets | [`Makefile`](../../Makefile) |
 | Flatpak manifest and metainfo | [`flatpak/`](../../flatpak) |

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -5,8 +5,8 @@ description: Five platform targets from one codebase, the checks every branch ru
 resource: ../..
 tags: [architecture, ci, release, platforms, build]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T16:00:00Z }
-stale_after: 2027-01-11
+generated: { by: claude-code/opus-5, at: 2026-07-30T21:16:11Z }
+stale_after: 2027-01-30
 sources:
   - id: workflows
     resource: ../../.github/workflows
@@ -40,8 +40,11 @@ sources:
 | Linux | Flatpak (Flathub) and tarball |
 | Windows | MSIX |
 
-The Flutter SDK is **pinned in `.fvmrc`** (currently 3.44.7) and every command
-is expected to run through FVM — `fvm flutter …`, `fvm dart …`.
+The Flutter SDK is **pinned in `.fvmrc`** (currently 3.44.7). *Locally*, every
+command is expected to run through FVM — `fvm flutter …`, `fvm dart …`. CI does
+not use that prefix: each provider selects the pinned SDK for the build machine
+and then invokes bare `flutter` and `dart`. The pin is honoured by SDK
+selection there, not by the command prefix.
 
 Dart SDK constraint: `>=3.12.0 <4.0.0`; Flutter `>=3.44.0`.
 
@@ -54,6 +57,7 @@ written down. Most consumers follow it automatically; one does not:
 |----------|-------------------|
 | GitHub Actions lanes | Yes — `kuhnroyal/flutter-fvm-config-action` reads it |
 | Codemagic Windows release | Yes — `environment.flutter: fvm` reads it |
+| [`.vscode/settings.json`](../../.vscode/settings.json) | Yes — points at the `.fvm/flutter_sdk` symlink, which `fvm use` repoints |
 | [`flatpak/com.matthiasn.lotti.flatpak-flutter.yml`](../../flatpak/com.matthiasn.lotti.flatpak-flutter.yml) | **No — hand-edit the Flutter `tag:`** |
 
 So a Flutter bump is `.fvmrc` **plus** the Flatpak manifest's Flutter `tag:`.


### PR DESCRIPTION
## Problem

The `Windows Release` build on Codemagic has been failing on **every one of the last twelve release tags**, back through `0.9.1071+4261`. No Windows MSIX has been produced in a long while.

`codemagic.yaml` pinned `flutter: 3.41.4`, which ships **Dart 3.11.1**. `pubspec.yaml` requires `sdk: '>=3.12.0 <4.0.0'`, a floor that moved in 901c25a87. So step 5 died immediately and every step after it was skipped:

```
Resolving dependencies...
The current Dart SDK version is 3.11.1.

Because lotti requires SDK version >=3.12.0 <4.0.0, version solving failed.
```

The pin had been touched twice since the file was added, while `.fvmrc` moved five times. Nothing connected the two.

## Fix

Codemagic accepts `fvm` as the value of `environment.flutter` and reads `.fvmrc` directly ([docs](https://docs.codemagic.io/yaml-basic-configuration/yaml-getting-started/)). Since FVM v3 that is the `.fvmrc` file, which this repo has at its root, and this is not a monorepo, so the plain form applies.

The Windows lane now resolves its SDK from the same pin as the GitHub Actions lanes, and this file needs no edit on a future Flutter bump.

## Documentation

`knowledge/architecture/platform-and-release.md` gains a **"Bumping the Flutter version"** section stating which consumers follow `.fvmrc` automatically and which do not. With Codemagic on `fvm`, the one remaining hand-maintained pin is `flatpak/com.matthiasn.lotti.flatpak-flutter.yml`, whose Flutter `tag:` reads `3.44.0` against a `3.44.7` pin — it resolves today only because the constraint floor is exactly `>=3.44.0`, which is what makes that drift easy to miss.

The concept also had **no mention of the Windows lane at all** — it lists "seven workflows" and a tag fan-out diagram with no Codemagic node, since it is not a GitHub workflow. That is plausibly why this rotted unnoticed for a dozen tags. Codemagic is now in the diagram, the release prose, the "Where to look" table, and the frontmatter sources.

## Verification

- Flutter 3.44.7 reports `dartSdkVersion: 3.12.2`, clearing the constraint.
- `make knowledge_check` passes — 88 concepts, 0 errors/warnings; 447 mermaid blocks, 0 failures.

**What this PR cannot prove:** steps 6–10 (`analyze`, `build windows --release`, signing, MSIX, zip) have not run on any recent commit, so fixing `pub get` may expose a further failure. `flutter analyze` is green on main. The Windows build pulls in the vendored `third_party/flutter_onnxruntime`, which does ship a `windows/` implementation but has never been built at this Flutter version. Only the next release tag will tell.

One residual risk: the Codemagic docs do not explicitly confirm `flutter: fvm` on `windows_x2` instances. If machine prep rejects it, the fallback is a literal `3.44.7` in that field.

No CHANGELOG entry: CI tweaks are in the skip list and nothing regressed in a shipped release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows release builds by ensuring they use the project’s configured Flutter SDK version, reducing failures caused by outdated version settings.

- **Documentation**
  - Updated platform and release documentation with clearer Flutter version bump guidance, including how CI selects the pinned SDK and how to address pin drift.
  - Documented Windows release triggering, where failures appear, and added the Codemagic-based Windows release workflow details.
  - Updated release guidance to reflect the latest CI/release setup and release diagram.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->