### PR TITLE
feat(manual): publish screenshot media to R2 under versioned prefixes

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -44,7 +44,7 @@ on:
         default: true
         type: boolean
       publish_media:
-        description: 'Commit generated media to lotti-docs/main'
+        description: 'Upload generated media to the R2 bucket'
         required: true
         default: false
         type: boolean
@@ -178,18 +178,6 @@ jobs:
           path: lotti
           fetch-depth: 0
 
-      # lotti-docs is public, so the default token is enough to read it.
-      # LOTTI_DOCS_TOKEN (a PAT with contents:write on matthiasn/lotti-docs)
-      # is only required to push refreshed media back; without it the commit
-      # step below skips with a warning instead of failing the whole job.
-      - name: Checkout media repository
-        uses: actions/checkout@v5
-        with:
-          repository: matthiasn/lotti-docs
-          ref: main
-          path: lotti-docs
-          token: ${{ secrets.LOTTI_DOCS_TOKEN || github.token }}
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -222,45 +210,63 @@ jobs:
         run: >-
           make manual_screenshots
           MANUAL_VERSION="${{ needs.metadata.outputs.version }}"
-          LOTTI_DOCS_DIR="${{ github.workspace }}/lotti-docs"
+          MANUAL_MEDIA_DIR="${{ runner.temp }}/lotti-manual-media"
           MANUAL_CAPTURE_DIR="${{ runner.temp }}/lotti-manual-capture/${{ needs.metadata.outputs.version }}"
 
       - name: Upload generated media for review
         uses: actions/upload-artifact@v4
         with:
           name: lotti-manual-media-${{ needs.metadata.outputs.version }}
-          path: lotti-docs/manual/screenshots/${{ needs.metadata.outputs.version }}
+          path: ${{ runner.temp }}/lotti-manual-media/${{ needs.metadata.outputs.version }}
           if-no-files-found: error
           retention-days: 14
 
-      - name: Commit media to lotti-docs/main
+      # The manual's screenshots are served from the Cloudflare R2 bucket that
+      # also hosts the tutorial videos, under a versioned prefix per manual
+      # version. `development` is mutable and synced with deletion so retired
+      # cases disappear; release versions are immutable — publishing refuses
+      # to overwrite an existing manifest.
+      - name: Publish media to R2
         if: >-
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.publish_media)
-        working-directory: lotti-docs
         env:
           MANUAL_VERSION: ${{ needs.metadata.outputs.version }}
-          LOTTI_COMMIT: ${{ github.sha }}
-          HAS_DOCS_TOKEN: ${{ secrets.LOTTI_DOCS_TOKEN != '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
         run: |
           set -euo pipefail
-          if [[ "$HAS_DOCS_TOKEN" != 'true' ]]; then
-            echo "::warning::LOTTI_DOCS_TOKEN is not configured; skipping the" \
-              "media publish. Add a PAT with contents:write on" \
-              "matthiasn/lotti-docs to re-enable automatic publishing." \
-              "The capture is still available as the run artifact."
+          if [[ -z "$R2_ACCOUNT_ID" || -z "$R2_BUCKET_NAME" || \
+                -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+            echo "::warning::R2 credentials are not configured (R2_ACCOUNT_ID," \
+              "R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME);" \
+              "skipping the media publish. The capture is still available" \
+              "as the run artifact."
             exit 0
           fi
-          git config user.name 'Lotti Manual Bot'
-          git config user.email 'manual-bot@lotti.local'
-          git add "manual/screenshots/$MANUAL_VERSION"
-          if git diff --cached --quiet; then
-            echo "Screenshot catalog is already current."
-            exit 0
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          SRC="${RUNNER_TEMP}/lotti-manual-media/${MANUAL_VERSION}"
+          KEY_PREFIX="manual/screenshots/${MANUAL_VERSION}"
+          DEST="s3://${R2_BUCKET_NAME}/${KEY_PREFIX}"
+          if [[ "$MANUAL_VERSION" != 'development' ]]; then
+            if aws s3api head-object --endpoint-url "$ENDPOINT" \
+                --bucket "$R2_BUCKET_NAME" \
+                --key "${KEY_PREFIX}/manifest.json" >/dev/null 2>&1; then
+              echo "::error::Manual version ${MANUAL_VERSION} is already" \
+                "published and immutable; refusing to overwrite it."
+              exit 1
+            fi
           fi
-          git commit -m "docs: refresh $MANUAL_VERSION manual screenshots for ${LOTTI_COMMIT:0:12}"
-          git push origin HEAD:main
+          # The manifest goes up last so readers never resolve cases whose
+          # media has not landed yet.
+          aws s3 sync "$SRC" "$DEST" --endpoint-url "$ENDPOINT" \
+            --exclude 'manifest.json' --delete --no-progress
+          aws s3 cp "$SRC/manifest.json" "$DEST/manifest.json" \
+            --endpoint-url "$ENDPOINT"
 
   deploy:
     name: Publish GitHub Pages

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,10 @@ THRESH ?= 1000
 LOTTI_DOCS_DIR ?= $(abspath ../lotti-docs)
 MANUAL_VERSION ?= development
 MANUAL_LOCALES ?= en de fr it es cs nl ro pt da sv
-MANUAL_CAPTURE_DIR ?= $(LOTTI_DOCS_DIR)/manual/.staging/$(MANUAL_VERSION)
-MANUAL_MEDIA_DIR ?= $(LOTTI_DOCS_DIR)/manual/screenshots
+# Manual screenshots are staged and materialized locally (gitignored), then
+# published to the R2 bucket by CI — they no longer live in lotti-docs.
+MANUAL_CAPTURE_DIR ?= $(abspath build/manual_capture)/$(MANUAL_VERSION)
+MANUAL_MEDIA_DIR ?= $(abspath build/manual_media)
 
 .PHONY: test
 test:
@@ -190,7 +192,7 @@ manual_screenshots: manual_deps
 			MANUAL_CAPTURE_DIR="$(MANUAL_CAPTURE_DIR)/$$locale"; \
 	done
 	npm --prefix docs-site run manifest -- --capture-dir "$(MANUAL_CAPTURE_DIR)" --output-root "$(MANUAL_MEDIA_DIR)" --version "$(MANUAL_VERSION)" --locales "$(MANUAL_LOCALES)"
-	$(MAKE) manual_check_media MANUAL_VERSION="$(MANUAL_VERSION)" LOTTI_DOCS_DIR="$(LOTTI_DOCS_DIR)"
+	$(MAKE) manual_check_media MANUAL_VERSION="$(MANUAL_VERSION)" MANUAL_MEDIA_DIR="$(MANUAL_MEDIA_DIR)"
 
 .PHONY: manual_screenshots_locale
 manual_screenshots_locale:

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -81,24 +81,30 @@ npm run pages:assemble -- \
 
 ## Screenshot workflow
 
-Generated screenshots belong in the sibling `../lotti-docs` repository. The
-registry reuses deterministic feature screenshot harnesses:
+Generated screenshots are published to the Cloudflare R2 bucket that also
+hosts the tutorial videos, under one versioned prefix per manual version
+(`manual/screenshots/<version>/…`). The `development` prefix is mutable and
+synced with deletion so retired cases disappear; release prefixes are
+immutable — publishing refuses to overwrite an existing manifest. The registry
+reuses deterministic feature screenshot harnesses:
 
 ```bash
 make manual_screenshots
 ```
 
-That command captures all registered English, German, French, Italian, Spanish,
-Czech, Romanian, Portuguese, Danish, and Swedish mobile/desktop and light/dark
-PNG inputs into an ignored staging
-directory,
-converts them to canonical WebP paths, and writes a checksum/dimension manifest under
-`../lotti-docs/manual/screenshots/development/`.
+That command captures all registered locales (English, German, French,
+Italian, Spanish, Czech, Dutch, Romanian, Portuguese, Danish, and Swedish) at
+mobile/desktop sizes in light/dark as PNG inputs into a gitignored staging
+directory (`build/manual_capture/`), converts them to canonical WebP paths,
+and writes a checksum/dimension manifest under
+`build/manual_media/development/`.
 
-CI runs this same full pipeline on every manual-relevant push to `main`, nightly
-at 02:23 UTC, and on demand. Main-branch captures fast-forward a normal commit
-to `lotti-docs/main`; pull requests only validate the site and never publish
-generated media.
+CI runs this same full pipeline on every manual-relevant push to `main`,
+nightly at 02:23 UTC, and on demand. Main-branch captures sync the materialized
+catalog to the R2 bucket (uploading `manifest.json` last, so readers never
+resolve cases whose media has not landed); pull requests only validate the
+site and never publish generated media. The site resolves media from the
+bucket's public URL; override it at build time with `MANUAL_MEDIA_BASE_URL`.
 
 When only a new or changed case needs publishing, pass its IDs to the manifest
 builder so the existing catalog remains untouched. For example:

--- a/docs-site/docs/reference/manual-maintenance.mdx
+++ b/docs-site/docs/reference/manual-maintenance.mdx
@@ -6,8 +6,9 @@ description: The lightweight contribution workflow for manual content and screen
 # Maintain this manual
 
 The source lives in the application repository so a behavior change and its
-documentation can land together. Generated screenshots live in the sibling
-`lotti-docs` repository and are never committed to the application tree.
+documentation can land together. Generated screenshots are published to a
+Cloudflare R2 bucket under one versioned prefix per manual version and are
+never committed to the application tree.
 
 ## Edit prose
 
@@ -60,14 +61,16 @@ commits.
 3. Put visible fixture copy behind `manualScreenshotText(...)` for every
    supported locale when it is not already provided by the app localization
    files.
-4. Capture every locale into `../lotti-docs`; never into this repository.
+4. Capture every locale into the gitignored local staging directory
+   (`make manual_screenshots`); CI publishes the result to the R2 bucket.
 5. Generate and validate the media manifest.
 6. Reference the case with `<ManualScreenshot caseId="…" alt="…" />` on
    every language page.
 
 Every app screenshot in an authored page must use `ManualScreenshot`. Direct
-links to old `lotti-docs` images fail manual validation because they cannot
-follow the global Mobile/Desktop choice or the manual's light/dark theme.
+links to screenshot media — legacy `lotti-docs` images or the R2 bucket
+itself — fail manual validation because they cannot follow the global
+Mobile/Desktop choice or the manual's light/dark theme.
 
 Every automated case must provide mobile-light, mobile-dark, desktop-light,
 and desktop-dark variants in every published locale. The manual component

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -99,7 +99,7 @@ const config: Config = {
     manualRootPath,
     manualMediaBaseUrl:
       process.env.MANUAL_MEDIA_BASE_URL ??
-      'https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots',
+      'https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots',
     manualReleases: releases,
     tutorialVideoBaseUrl:
       (process.env.TUTORIAL_VIDEO_BASE_URL ?? '').trim() ||

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -6,8 +6,9 @@ description: Lehký postup přispívání do obsahu příručky a snímků obraz
 # Údržba této příručky
 
 Zdroj žije v repozitáři aplikace, aby změna chování a její dokumentace mohly
-přijít společně. Vygenerované snímky žijí v sousedním repozitáři `lotti-docs`
-a nikdy se necommitují do stromu aplikace.
+přijít společně. Vygenerované snímky se publikují do bucketu Cloudflare R2
+pod jedním verzovaným prefixem pro každou verzi příručky a nikdy se
+necommitují do stromu aplikace.
 
 ## Upravuj text
 
@@ -56,14 +57,16 @@ počty bez blokování tematických commitů.
    `docs-site/metadata/screenshot-cases.json`.
 3. Viditelný ukázkový text, který neposkytují lokalizační soubory aplikace,
    vlož za `manualScreenshotText(...)` pro každý podporovaný jazyk.
-4. Zachyť všechny jazyky do `../lotti-docs`, nikdy do tohoto repozitáře.
+4. Zachyť všechny jazyky do místního přípravného adresáře ignorovaného gitem
+   (`make manual_screenshots`); výsledek pak do bucketu R2 publikuje CI.
 5. Vygeneruj a ověř manifest médií.
 6. Na každé jazykové stránce odkazuj pomocí
    `<ManualScreenshot caseId="…" alt="…" />`.
 
 Každý snímek aplikace na psané stránce musí používat `ManualScreenshot`. Přímé
-odkazy na staré obrázky `lotti-docs` neprojdou validací, protože nemohou
-následovat globální volbu Mobil/Počítač ani světlý a tmavý motiv příručky.
+odkazy na média snímků — staré obrázky `lotti-docs` i samotný bucket R2 —
+neprojdou validací, protože nemohou následovat globální volbu Mobil/Počítač
+ani světlý a tmavý motiv příručky.
 
 Každý automatický případ musí poskytnout mobilní světlou, mobilní tmavou,
 počítačovou světlou a počítačovou tmavou variantu v každém publikovaném jazyce.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -6,8 +6,9 @@ description: Den lette bidragsarbejdsgang for manuelt indhold og skærmbilleder.
 # Vedligehold denne manual
 
 Kildekoden ligger i applikationsarkivet, så en adfærdsændring og dens
-dokumentation kan lande sammen. Genererede skærmbilleder ligger i søsterarkivet
-`lotti-docs` og bliver aldrig commit'et til applikationstræet.
+dokumentation kan lande sammen. Genererede skærmbilleder publiceres til en
+Cloudflare R2-bucket under ét versioneret præfiks pr. manualversion og bliver
+aldrig commit'et til applikationstræet.
 
 ## Rediger prosaen
 
@@ -59,14 +60,16 @@ emneforpligtelser.
    `docs-site/metadata/screenshot-cases.json`.
 3. Læg synlig fixturetekst bag `manualScreenshotText(...)` for hvert
    understøttet sprog, når den ikke allerede leveres af appens lokaliseringsfiler.
-4. Optag hvert sprog i `../lotti-docs`, aldrig i dette arkiv.
+4. Optag hvert sprog i den gitignorerede lokale staging-mappe
+   (`make manual_screenshots`); CI publicerer resultatet til R2-bucketen.
 5. Generer og valider mediemanifestet.
 6. Henvis til sagen med `<ManualScreenshot caseId="…" alt="…" />` på
    hver sprogsideside.
 
 Alle appskærmbilleder på en forfattet side skal bruge `ManualScreenshot`. Direkte
-links til gamle `lotti-docs`-billeder fejler manuel validering, fordi de ikke kan
-følge det globale Mobile/Desktop-valg eller manualens lyse/mørke tema.
+links til skærmbilledmedier — gamle `lotti-docs`-billeder eller selve
+R2-bucketen — fejler manualvalideringen, fordi de ikke kan følge det globale
+Mobile/Desktop-valg eller manualens lyse/mørke tema.
 
 Hver automatiseret sag skal levere mobile-light-, mobile-dark-, desktop-light-
 og desktop-dark-varianter på hvert udgivet sprog. Manual-komponenten vælger det

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -6,8 +6,9 @@ description: Der schlanke Beitragsablauf für Handbuchtexte, Übersetzungen und 
 # Dieses Handbuch pflegen
 
 Der Quelltext liegt im App-Repository, damit eine Verhaltensänderung gemeinsam
-mit ihrer Dokumentation landen kann. Erzeugte Screenshots liegen im
-Schwester-Repository `lotti-docs` und werden nie in den App-Baum eingecheckt.
+mit ihrer Dokumentation landen kann. Erzeugte Screenshots werden in einen
+Cloudflare-R2-Bucket unter einem versionierten Präfix pro Handbuchversion
+veröffentlicht und nie in den App-Baum eingecheckt.
 
 ## Texte bearbeiten
 
@@ -60,14 +61,16 @@ Commits zu blockieren.
 3. Hinterlege sichtbare Demo-Texte über `manualScreenshotText(...)` für jede
    unterstützte Sprache, wenn sie nicht bereits aus der App-Lokalisierung
    stammen.
-4. Erfasse mit `make manual_screenshots` alle Sprachen in `../lotti-docs` –
-   niemals in diesem Repository.
+4. Erfasse mit `make manual_screenshots` alle Sprachen in das lokale, per
+   Gitignore ausgeschlossene Staging-Verzeichnis; CI veröffentlicht das
+   Ergebnis in den R2-Bucket.
 5. Erzeuge und validiere das Medienmanifest.
 6. Referenziere den Fall mit `<ManualScreenshot caseId="…" alt="…" />` in
    jeder Sprachseite.
 
-Jeder App-Screenshot muss `ManualScreenshot` verwenden. Direkte Links auf alte
-`lotti-docs`-Bilder scheitern an der Validierung, weil sie weder der globalen
+Jeder App-Screenshot muss `ManualScreenshot` verwenden. Direkte Links auf
+Screenshot-Medien – alte `lotti-docs`-Bilder oder den R2-Bucket selbst –
+scheitern an der Validierung, weil sie weder der globalen
 Mobil/Desktop-Auswahl noch Hell/Dunkel oder der Dokumentsprache folgen.
 
 Jeder automatisierte Fall liefert Mobil-Hell, Mobil-Dunkel, Desktop-Hell und

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -7,8 +7,8 @@ description: El flujo de contribución ligero para el contenido y las capturas d
 
 El código fuente vive en el repositorio de la aplicación, para que un cambio de
 comportamiento y su documentación puedan publicarse juntos. Las capturas
-generadas viven en el repositorio hermano `lotti-docs` y nunca se confirman en
-el árbol de la aplicación.
+generadas se publican en un bucket de Cloudflare R2 bajo un prefijo versionado
+por cada versión del manual y nunca se confirman en el árbol de la aplicación.
 
 ## Edita el texto
 
@@ -64,14 +64,16 @@ recuentos restantes sin bloquear confirmaciones por tema.
 3. Sitúa el texto visible del conjunto tras `manualScreenshotText(...)` para cada
    idioma compatible cuando aún no lo proporcionen los archivos de localización
    de la aplicación.
-4. Captura cada idioma en `../lotti-docs`; nunca en este repositorio.
+4. Captura cada idioma en el directorio local de staging ignorado por git
+   (`make manual_screenshots`); CI publica el resultado en el bucket de R2.
 5. Genera y valida el manifiesto de medios.
 6. Haz referencia al caso con
    `<ManualScreenshot caseId="…" alt="…" />` en cada página de idioma.
 
 Cada captura de la aplicación de una página creada debe usar
-`ManualScreenshot`. Los enlaces directos a imágenes antiguas de `lotti-docs`
-no superan la validación del manual porque no pueden seguir la elección global
+`ManualScreenshot`. Los enlaces directos a los medios de capturas —ya sean
+imágenes antiguas de `lotti-docs` o el propio bucket de R2— no superan la
+validación del manual porque no pueden seguir la elección global
 Móvil/Escritorio ni el tema claro u oscuro del manual.
 
 Cada caso automatizado debe proporcionar variantes móvil-clara, móvil-oscura,

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -7,8 +7,9 @@ description: Le flux de contribution léger pour le contenu du manuel et les cap
 
 La source vit dans le dépôt de l’application afin qu’un changement de
 comportement et sa documentation puissent arriver ensemble. Les captures
-générées vivent dans le dépôt voisin `lotti-docs` et ne sont jamais ajoutées à
-l’arborescence de l’application.
+générées sont publiées dans un bucket Cloudflare R2, sous un préfixe versionné
+par version du manuel, et ne sont jamais ajoutées à l’arborescence de
+l’application.
 
 ## Modifier le texte
 
@@ -64,15 +65,17 @@ restant sans bloquer les commits par sujet.
 3. Place le texte de démonstration visible derrière `manualScreenshotText(...)`
    pour chaque langue prise en charge lorsqu’il n’est pas déjà fourni par les
    fichiers de localisation de l’application.
-4. Capture chaque langue dans `../lotti-docs`, jamais dans ce dépôt.
+4. Capture chaque langue dans le répertoire de staging local ignoré par Git
+   (`make manual_screenshots`) ; la CI publie le résultat dans le bucket R2.
 5. Génère et valide le manifeste média.
 6. Référence le cas avec `<ManualScreenshot caseId="…" alt="…" />` dans chaque
    page de langue.
 
 Chaque capture de l’application dans une page rédigée doit utiliser
-`ManualScreenshot`. Les liens directs vers d’anciennes images `lotti-docs`
-échouent à la validation du manuel, car ils ne peuvent pas suivre le choix
-global Mobile/Ordinateur ni le thème clair/sombre du manuel.
+`ManualScreenshot`. Les liens directs vers les médias de capture —
+anciennes images `lotti-docs` ou le bucket R2 lui-même — échouent à la
+validation du manuel, car ils ne peuvent pas suivre le choix global
+Mobile/Ordinateur ni le thème clair/sombre du manuel.
 
 Chaque cas automatisé doit fournir les variantes mobile clair, mobile sombre,
 ordinateur clair et ordinateur sombre dans chaque langue publiée. Le composant

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -6,8 +6,9 @@ description: Il flusso di lavoro del contributo leggero per contenuti e screensh
 # Mantenere questo manuale
 
 La fonte vive nel repository delle applicazioni in modo da un cambiamento di comportamento e la sua
-la documentazione può atterrare insieme. Gli screenshot generati vivono nel fratello
-`lotti-docs` repository e non sono mai impegnati nell'albero delle applicazioni.
+la documentazione può atterrare insieme. Gli screenshot generati vengono pubblicati
+in un bucket Cloudflare R2 sotto un prefisso versionato per ogni versione del
+manuale e non vengono mai committati nell'albero dell'applicazione.
 
 ## Modifica della prosa
 
@@ -60,13 +61,15 @@ commit.
 3. Metti la copia visibile dell'apparecchio dietro `manualScreenshotText(...)` per ogni
    supportato locale quando non è già fornito dalla localizzazione dell'app
    I file.
-4. Cattura ogni locale in `../lotti-docs`; mai in questo repository.
+4. Cattura ogni locale nella directory locale di staging ignorata da git
+   (`make manual_screenshots`); la CI pubblica il risultato nel bucket R2.
 5. Generare e convalidare il manifesto dei media.
 6. Riferimento del caso con `<ManualScreenshot caseId="…" alt="…" />` su
    ogni pagina di lingua.
 
-Ogni schermate di app in una pagina autorizzata deve usare `ManualScreenshot`. Direct
-link a vecchie immagini `lotti-docs` falliscono la validazione manuale perché non possono
+Ogni schermate di app in una pagina autorizzata deve usare `ManualScreenshot`.
+I link diretti ai media degli screenshot — vecchie immagini `lotti-docs` o il
+bucket R2 stesso — falliscono la validazione del manuale perché non possono
 seguire la scelta globale Mobile/Desktop o il tema light/dark del manuale.
 
 Ogni caso automatizzato deve fornire luce mobile, mobile-dark, desktop-light,

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -6,8 +6,10 @@ description: De lichtgewicht bijdrageworkflow voor handmatige inhoud en schermaf
 # Onderhoud deze handleiding
 
 De bron bevindt zich in de applicatierepository, dus een gedragsverandering en de bijbehorende
-documentatie kunnen samen worden ingediend. Gegenereerde schermafbeeldingen staan in de zuster-
-repository `lotti-docs` en worden nooit in de applicatiestructuur opgenomen.
+documentatie kunnen samen worden ingediend. Gegenereerde schermafbeeldingen
+worden gepubliceerd naar een Cloudflare R2-bucket onder één geversioneerd
+prefix per handleidingsversie en worden nooit in de applicatiestructuur
+opgenomen.
 
 ## Bewerk proza
 
@@ -60,14 +62,17 @@ pleegt.
 3. Plaats voor elk een zichtbare armatuurkopie achter `manualScreenshotText(...)`
    ondersteunde landinstelling wanneer deze nog niet wordt aangeboden door de app-lokalisatie
    bestanden.
-4. Leg elke landinstelling vast in `../lotti-docs`; nooit in deze repository.
+4. Leg elke landinstelling vast in de door git genegeerde lokale stagingmap
+   (`make manual_screenshots`); CI publiceert het resultaat naar de R2-bucket.
 5. Genereer en valideer het mediamanifest.
 6. Verwijs op elke taalpagina naar de case met
    `<ManualScreenshot caseId="…" alt="…" />`.
 
-Elke app-screenshot op een geschreven pagina moet `ManualScreenshot` gebruiken. Direct
-koppelingen naar oude `lotti-docs`-afbeeldingen mislukken handmatige validatie omdat dit niet mogelijk is
-volg de algemene Mobile/Desktop-keuze of het light/dark-thema van de handleiding.
+Elke app-screenshot op een geschreven pagina moet `ManualScreenshot` gebruiken.
+Directe koppelingen naar screenshotmedia — oude `lotti-docs`-afbeeldingen of
+de R2-bucket zelf — mislukken bij de validatie van de handleiding, omdat ze de
+algemene Mobile/Desktop-keuze of het light/dark-thema van de handleiding niet
+kunnen volgen.
 
 Elke geautomatiseerde behuizing moet mobiel-licht, mobiel-donker, desktop-licht,
 en desktop-donkere varianten in elke gepubliceerde landinstelling. Het handmatige onderdeel

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -7,8 +7,9 @@ description: O fluxo de contribuição leve para o conteúdo do manual e as capt
 
 O código-fonte fica no repositório do aplicativo, para que uma mudança de
 comportamento e sua documentação possam entrar juntas. As capturas de tela
-geradas ficam no repositório irmão `lotti-docs` e nunca são adicionadas à
-árvore do aplicativo.
+geradas são publicadas em um bucket do Cloudflare R2, sob um prefixo
+versionado para cada versão do manual, e nunca são adicionadas à árvore do
+aplicativo.
 
 ## Editar prosa
 
@@ -65,15 +66,17 @@ as contagens restantes sem bloquear commits do tamanho de um tópico.
 3. Coloque os textos visíveis do fixture atrás de `manualScreenshotText(...)`
    para cada localidade suportada quando eles ainda não forem fornecidos pelos
    arquivos de localização do aplicativo.
-4. Capture todas as localidades em `../lotti-docs`; nunca neste repositório.
+4. Capture todas as localidades no diretório local de staging ignorado pelo
+   git (`make manual_screenshots`); o CI publica o resultado no bucket R2.
 5. Gere e valide o manifesto de mídia.
 6. Referencie o caso com `<ManualScreenshot caseId="…" alt="…" />` em
    cada página de idioma.
 
 Toda captura de tela do aplicativo em uma página escrita deve usar
-`ManualScreenshot`. Links diretos para imagens antigas do `lotti-docs` falham
-na validação do manual porque não conseguem acompanhar a escolha global
-Mobile/Desktop nem o tema claro/escuro do manual.
+`ManualScreenshot`. Links diretos para as mídias de captura — imagens antigas
+do `lotti-docs` ou o próprio bucket R2 — falham na validação do manual porque
+não conseguem acompanhar a escolha global Mobile/Desktop nem o tema
+claro/escuro do manual.
 
 Todo caso automatizado deve fornecer as variantes mobile-light, mobile-dark,
 desktop-light e desktop-dark em cada localidade publicada. O componente do

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -5,7 +5,7 @@ description: Fluxul de contribuție simplu pentru conținutul manualului și cap
 
 # Întrețineți acest manual
 
-Sursa se află în depozitul aplicației, astfel încât o schimbare de comportament și documentația ei pot fi livrate împreună. Capturile de ecran generate se află în depozitul vecin `lotti-docs` și nu sunt niciodată incluse în arborele aplicației.
+Sursa se află în depozitul aplicației, astfel încât o schimbare de comportament și documentația ei pot fi livrate împreună. Capturile de ecran generate sunt publicate într-un bucket Cloudflare R2, sub câte un prefix versionat pentru fiecare versiune a manualului, și nu sunt niciodată incluse în arborele aplicației.
 
 ## Editați textul
 
@@ -36,11 +36,11 @@ Rulați `npm --prefix docs-site run coverage:complete` pentru pragul de lansare.
 1. Adăugați sau reutilizați un harness determinist Flutter pentru capturi de ecran.
 2. Înregistrați cazul și cele patru imagini-sursă în `docs-site/metadata/screenshot-cases.json`.
 3. Puneți textul fixture vizibil în spatele `manualScreenshotText(...)` pentru fiecare limbă acceptată, când nu este deja furnizat de fișierele ARB ale aplicației.
-4. Capturați fiecare limbă în `../lotti-docs`; niciodată în acest depozit.
+4. Capturați fiecare limbă în directorul local de pregătire ignorat de git (`make manual_screenshots`); CI publică rezultatul în bucketul R2.
 5. Generați și validați manifestul media.
 6. Referiți cazul prin `<ManualScreenshot caseId="…" alt="…" />` în fiecare pagină de limbă.
 
-Fiecare captură a aplicației într-o pagină creată trebuie să folosească `ManualScreenshot`. Legăturile directe către imagini vechi din `lotti-docs` eșuează validarea manualului, fiindcă nu pot urma alegerea globală Mobil/Desktop sau tema luminoasă/întunecată a manualului.
+Fiecare captură a aplicației într-o pagină creată trebuie să folosească `ManualScreenshot`. Legăturile directe către mediile capturilor de ecran — imagini vechi din `lotti-docs` sau chiar bucketul R2 — eșuează validarea manualului, fiindcă nu pot urma alegerea globală Mobil/Desktop sau tema luminoasă/întunecată a manualului.
 
 Fiecare caz automatizat trebuie să ofere variante mobil-luminos, mobil-întunecat, desktop-luminos și desktop-întunecat pentru fiecare limbă publicată. Componenta manualului alege limba și tema potrivite. Schimbarea Mobil/Desktop pentru orice imagine actualizează imediat toate capturile și persistă între pagini și file de manual deschise.
 

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -6,8 +6,9 @@ description: Det lätta bidragsflödet för manuellt innehåll och skärmdumpar.
 # Underhåll denna manual
 
 Källkoden finns i applikationsarkivet, så en beteendeförändring och dess
-dokumentation kan landa ihop. Genererade skärmdumpar finns i syskonarkivet
-`lotti-docs` och checkas aldrig in i applikationsträdet.
+dokumentation kan landa ihop. Genererade skärmdumpar publiceras till en
+Cloudflare R2-bucket under ett versionerat prefix per manualversion och
+checkas aldrig in i applikationsträdet.
 
 ## Redigera prosa
 
@@ -59,14 +60,16 @@ manualbyggen fortsätter att rapportera de återstående räkningarna utan att b
    `docs-site/metadata/screenshot-cases.json`.
 3. Lägg synlig fixturetext bakom `manualScreenshotText(...)` för varje
    språk som stöds när den inte redan tillhandahålls av applokaliseringsfilerna.
-4. Fånga varje språk i `../lotti-docs`, aldrig i detta arkiv.
+4. Fånga varje språk i den gitignorerade lokala staging-katalogen
+   (`make manual_screenshots`); CI publicerar resultatet till R2-bucketen.
 5. Skapa och validera mediemanifestet.
 6. Referera till fallet med `<ManualScreenshot caseId="…" alt="…" />` på
    varje språksida.
 
 Varje appskärmdump på en författad sida måste använda `ManualScreenshot`. Direkta
-länkar till gamla `lotti-docs`-bilder misslyckas vid manualvalidering eftersom de
-inte kan följa det globala Mobile/Desktop-valet eller manualens ljusa/mörka tema.
+länkar till skärmdumpsmedia — gamla `lotti-docs`-bilder eller själva
+R2-bucketen — misslyckas vid manualvalideringen eftersom de inte kan följa det
+globala Mobile/Desktop-valet eller manualens ljusa/mörka tema.
 
 Varje automatiserat fall måste ha mobile-light-, mobile-dark-, desktop-light-
 och desktop-dark-varianter för varje publicerat språk. Manualkomponenten väljer

--- a/docs-site/scripts/build-screenshot-manifest.mjs
+++ b/docs-site/scripts/build-screenshot-manifest.mjs
@@ -23,10 +23,10 @@ import {
 const options = parseNamedArguments(process.argv.slice(2));
 const version = String(options.version ?? 'development');
 const captureDirectory = resolve(
-  String(options['capture-dir'] ?? '../lotti-docs/manual/.staging'),
+  String(options['capture-dir'] ?? `../build/manual_capture/${version}`),
 );
 const outputRoot = resolve(
-  String(options['output-root'] ?? '../lotti-docs/manual/screenshots'),
+  String(options['output-root'] ?? '../build/manual_media'),
 );
 const outputDirectory = resolve(outputRoot, version);
 const registry = await readJson(

--- a/docs-site/scripts/manual-lib.mjs
+++ b/docs-site/scripts/manual-lib.mjs
@@ -145,9 +145,12 @@ export function findUnmanagedScreenshotReferences(source) {
   const authoringMarkup = source
     .replace(/```[\s\S]*?```/g, '')
     .replace(/`[^`\n]+`/g, '');
-  const lottiDocsMediaUrl =
-    /https:\/\/raw\.githubusercontent\.com\/matthiasn\/lotti-docs\/[^\s)'">]+/g;
-  return [...new Set(authoringMarkup.match(lottiDocsMediaUrl) ?? [])];
+  // Screenshots resolve through the ManualScreenshot component; a hard-coded
+  // URL — whether the legacy lotti-docs raw path or the R2 bucket itself —
+  // bypasses versioning, locale, and theme resolution.
+  const unmanagedMediaUrl =
+    /https:\/\/(?:raw\.githubusercontent\.com\/matthiasn\/lotti-docs|pub-[a-z0-9]+\.r2\.dev\/manual\/screenshots)\/[^\s)'">]+/g;
+  return [...new Set(authoringMarkup.match(unmanagedMediaUrl) ?? [])];
 }
 
 /** Find an import that points at a Widgetbook or showcase-only surface. */

--- a/docs-site/scripts/validate-manual.mjs
+++ b/docs-site/scripts/validate-manual.mjs
@@ -347,7 +347,7 @@ for (const docFile of localizedDocFiles) {
   }
   for (const url of findUnmanagedScreenshotReferences(source)) {
     errors.push(
-      `${docFile} embeds unmanaged lotti-docs media (${url}). ` +
+      `${docFile} embeds unmanaged screenshot media (${url}). ` +
         'App screenshots must use a registered ManualScreenshot case.',
     );
   }

--- a/docs-site/tests/manual-lib.test.mjs
+++ b/docs-site/tests/manual-lib.test.mjs
@@ -50,6 +50,19 @@ test('unmanaged lotti-docs images are rejected outside code examples', () => {
   assert.deepEqual(findUnmanagedScreenshotReferences(source), [legacyUrl]);
 });
 
+test('hard-coded R2 screenshot URLs are rejected too', () => {
+  const bucketUrl =
+    'https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/theming/preferences/mobile-dark.webp';
+  const videoUrl =
+    'https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/tutorial-videos/create_task_en.mp4';
+  const source = [
+    `![Screenshot](${bucketUrl})`,
+    `A video elsewhere: ${videoUrl}`,
+  ].join('\n');
+
+  assert.deepEqual(findUnmanagedScreenshotReferences(source), [bucketUrl]);
+});
+
 test('Widgetbook and showcase imports are rejected regardless of path style', () => {
   for (const importPath of [
     'package:lotti/features/widgetbook/task_showcase.dart',

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -14,8 +14,8 @@ sources:
     last_modified: 2026-06-16
   - id: makefile
     resource: ../../Makefile
-    title: manual_screenshots targets and LOTTI_DOCS_DIR
-    last_modified: 2026-07-26
+    title: manual_screenshots targets and their staging directories
+    last_modified: 2026-07-31
   - id: gitignore
     resource: ../../.gitignore
     title: The `screenshots` ignore rule
@@ -29,9 +29,12 @@ sources:
 # Images do not live in this repository
 
 `assets/` holds what the *app* ships — icons, tutorial media, design-system
-exports. **Everything captured for humans to look at goes to the sibling
-[`lotti-docs`](https://github.com/matthiasn/lotti-docs) repository instead**, and
-is referenced from here by raw URL:
+exports. **Everything captured for humans to look at leaves this repository.**
+The generated manual catalog is published to the Cloudflare R2 bucket that
+also hosts the tutorial videos; hand-picked release imagery and pull-request
+review evidence go to the sibling
+[`lotti-docs`](https://github.com/matthiasn/lotti-docs) repository and are
+referenced from here by raw URL:
 
 ```markdown
 ![Task details on macOS](https://raw.githubusercontent.com/matthiasn/lotti-docs/main/images/0.9.998/task_details_screenshot_macos.png)
@@ -48,18 +51,17 @@ be committed if you `git add` it.
 
 # Three destinations, three lifecycles
 
-`lotti-docs` is not one bucket. Which directory an image belongs in follows from
-who regenerates it:
+Which home an image belongs in follows from who regenerates it:
 
-| Directory | Contents | Lifecycle |
-|-----------|----------|-----------|
-| `manual/screenshots/<version>/<case-id>/` | The **generated** manual catalog — `mobile-light`, `mobile-dark`, `desktop-light`, `desktop-dark` per case, plus `manifest.json` | Produced by `make manual_screenshots` from this repo; never hand-edited or renamed. `development/` is refreshed, numbered release directories are immutable |
-| `images/<app-version>/` | Hand-picked shots for release communication and the README | Written once per release, then left alone |
-| `pr-screenshots/<topic-slug>/` | **Review evidence** for a pull request | Written by hand while the work is in review; kept afterwards as the record of what reviewers saw |
+| Destination | Contents | Lifecycle |
+|-------------|----------|-----------|
+| R2 bucket, `manual/screenshots/<version>/<case-id>/` | The **generated** manual catalog — `mobile-light`, `mobile-dark`, `desktop-light`, `desktop-dark` per case, plus `manifest.json` | Produced by `make manual_screenshots` and published by the `manual.yml` CI lane; never hand-edited or renamed. `development/` is refreshed with deletion (retired cases disappear), numbered release prefixes are immutable — publishing refuses to overwrite an existing manifest |
+| `lotti-docs`: `images/<app-version>/` | Hand-picked shots for release communication and the README | Written once per release, then left alone |
+| `lotti-docs`: `pr-screenshots/<topic-slug>/` | **Review evidence** for a pull request | Written by hand while the work is in review; kept afterwards as the record of what reviewers saw |
 
-`make manual_screenshots` writes through `LOTTI_DOCS_DIR`, which defaults to
-`../lotti-docs` — a sibling checkout, not a submodule. Nothing in CI enforces
-that the two repositories are in step.
+`make manual_screenshots` stages captures and the materialized catalog under
+the gitignored `build/manual_capture/` and `build/manual_media/` directories;
+only the CI publish step talks to R2, using the `R2_*` repository secrets.
 
 # A UI pull request shows before *and* after
 


### PR DESCRIPTION
## Why

The generated manual screenshot catalog (5,900 WebP files across 11 locales, ~1 GB per full refresh) lived in the lotti-docs git repository and was served through raw.githubusercontent. Three structural problems:

- WebP defeats git delta compression, so every catalog-wide refresh (theme rebuild, design-system migration) permanently grows the repo. It is already a 1.7 GB clone, which every CI capture run had to download just to diff.
- raw.githubusercontent is geo-blocked in some regions and serves with a fixed five-minute cache.
- The publish path required a lotti-docs PAT that was never created (#3692's root cause). 

The catalog now lives in the Cloudflare R2 bucket that already hosts the tutorial videos, under one versioned prefix per manual version (`manual/screenshots/<version>/…`) — free egress, nothing accreting in git history, one media store.

## What

- **`manual.yml`**: the capture job no longer checks out lotti-docs. It stages under `$RUNNER_TEMP` and syncs to R2 with the preinstalled AWS CLI: `development` is mutable and synced with `--delete` (retired cases such as `agents/stats` and `theming/picker` prune automatically); release prefixes are immutable — publishing refuses to overwrite an existing manifest. `manifest.json` uploads last so readers never resolve cases whose media has not landed. Without the `R2_*` secrets the step skips with a warning and the catalog is still uploaded as a run artifact.
- **Makefile**: staging and materialization move to the gitignored `build/manual_capture/` and `build/manual_media/`; the manual targets no longer depend on a sibling lotti-docs checkout.
- **Site**: the default `manualMediaBaseUrl` flips to the bucket's public URL; `MANUAL_MEDIA_BASE_URL` still overrides it at build time.
- **Validation**: the unmanaged-screenshot rule now also rejects hard-coded R2 screenshot URLs in prose (screenshots must go through `ManualScreenshot`), with a test.
- **Docs**: docs-site README, the manual-maintenance reference page in English and all ten translations, and `knowledge/conventions/screenshots.md` describe the new flow.

## Already done outside this diff

- The bucket is **seeded** with the current development catalog (all 11 locales), verified publicly served — so the base-URL flip cannot produce a 404 window on merge.
- The four `R2_*` repository secrets are set, so the first main-branch run after merging publishes a fresh catalog — including the `sync/add-device` and `sync/paired` media that currently 404 on the live manual.
- The `LOTTI_DOCS_TOKEN` PAT from #3692's follow-up is now unnecessary and should never be created.

## Verification

- `npm run check`: validate, unit tests (including the new R2-URL rejection test), typecheck, production build for all 11 locales, built-site smoke — green.
- `make knowledge_check`: green after the convention update.
- actionlint on the workflow: clean.
- Seeded media spot-checked over HTTP: manifest and locale variants serve 200 from the bucket's public URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated manual screenshots can now be published to Cloudflare R2 under versioned paths.
  * Release media is protected from accidental overwrites, while development media can be synchronized and cleaned up.
  * Screenshot workflows retain downloadable artifacts for review.

* **Documentation**
  * Updated screenshot maintenance guidance and translations to describe local staging, R2 publishing, and media validation.
  * Documented configurable media URLs and clarified supported screenshot display behavior.

* **Bug Fixes**
  * Validation now detects and rejects direct links to unmanaged screenshot media, including R2-hosted images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->