### PR TITLE
fix(manual): assert the transcript model line via its localized template

### DIFF
--- a/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
+++ b/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
@@ -993,7 +993,11 @@ void main() {
         expect(find.byType(SpeechModalContent), findsOneWidget);
         expect(find.byType(TranscriptListItem), findsNWidgets(2));
         expect(
-          find.text('Model: Mistral, voxtral-mini-latest'),
+          find.text(
+            _messages(
+              tester,
+            ).transcriptModelLabel('Mistral', 'voxtral-mini-latest'),
+          ),
           findsOneWidget,
         );
         await captureScreenshot(


### PR DESCRIPTION
The first localized capture run after the pipeline revival (run 30585413745) failed in the German loop: the journal harness asserts the English literal `Model: Mistral, voxtral-mini-latest`, but German renders `Modell: …` via the translated `transcriptModelLabel` (French and Spanish translate it too; Czech and Romanian only pass by coincidence of prefix). The English loop passes, which is exactly what local verification covered — the gap only shows on localized runs.

The expectation is now built from `messages.transcriptModelLabel('Mistral', 'voxtral-mini-latest')`, so every locale asserts the string it actually renders. Verified locally: the full journal harness passes under `LOTTI_MANUAL_LOCALE=de` (36 tests).

Merging this unblocks the first R2 media publish — the currently running capture on main will fail the same way, and the next push/nightly run after this lands should go through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated transcript review screenshot coverage to use localized model labels.
  * Preserved existing modal content, transcript list, and screenshot validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->