### PR TITLE
feat(manual): publish versioned release manuals with a live version selector

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -67,11 +67,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      ref: ${{ steps.version.outputs.ref }}
     steps:
       - name: Validate requested version
         id: version
         env:
           REQUESTED_VERSION: ${{ inputs.manual_version }}
+          REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           set -euo pipefail
           VERSION="${REQUESTED_VERSION:-development}"
@@ -81,6 +83,24 @@ jobs:
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # A release manual builds from the app tag that shipped it. Tags
+          # carry a build number (X.Y.Z+NNNN); the newest tag of the requested
+          # marketing version wins. Development builds from the triggering
+          # commit (empty ref = actions/checkout default).
+          if [[ "$VERSION" == "development" ]]; then
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          else
+            TAG=$(git ls-remote --tags "$REPOSITORY_URL" \
+                "refs/tags/${VERSION}" "refs/tags/${VERSION}+*" \
+              | awk '{print $2}' | grep -v '\^{}$' \
+              | sed 's#^refs/tags/##' | sort -V | tail -1)
+            if [[ -z "$TAG" ]]; then
+              echo "No app tag found for manual version ${VERSION}" >&2
+              exit 1
+            fi
+            echo "Resolved ${VERSION} to tag ${TAG}"
+            echo "ref=refs/tags/${TAG}" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Validate and build
@@ -89,14 +109,13 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pages: write
-      id-token: write
     steps:
       - name: Checkout Lotti
         uses: actions/checkout@v5
         with:
           path: lotti
           fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -130,37 +149,54 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Configure GitHub Pages
+      # Each manual version's built site lives in R2 under
+      # manual-site/<version>/. The deploy job mirrors that store into one
+      # GitHub Pages tree, so a version becomes selectable the moment its
+      # snapshot lands. 'development' is mutable; release snapshots are
+      # immutable. The .snapshot.json marker is uploaded last — the deploy
+      # refuses to publish a version without it.
+      - name: Publish site snapshot to R2
         if: >-
           github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.deploy &&
-           needs.metadata.outputs.version == 'development')
-        uses: actions/configure-pages@v5
-
-      - name: Assemble versioned GitHub Pages snapshot
-        if: >-
-          github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.deploy &&
-           needs.metadata.outputs.version == 'development')
-        working-directory: lotti/docs-site
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && inputs.deploy)
         env:
-          PAGES_PREFIX: ${{ github.event.repository.name }}
-          VERSION: ${{ needs.metadata.outputs.version }}
-        run: >-
-          npm run pages:assemble --
-          --build-root build
-          --output-root "${RUNNER_TEMP}/lotti-manual-pages"
-          --pages-prefix "$PAGES_PREFIX"
-          --version "$VERSION"
-
-      - name: Upload GitHub Pages artifact
-        if: >-
-          github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.deploy &&
-           needs.metadata.outputs.version == 'development')
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: ${{ runner.temp }}/lotti-manual-pages
+          MANUAL_VERSION: ${{ needs.metadata.outputs.version }}
+          LOTTI_COMMIT: ${{ github.sha }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          set -euo pipefail
+          if [[ -z "$R2_ACCOUNT_ID" || -z "$R2_BUCKET_NAME" || \
+                -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+            echo "::warning::R2 credentials are not configured; skipping the" \
+              "site snapshot publish. The build is still available as the" \
+              "run artifact."
+            exit 0
+          fi
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          KEY_PREFIX="manual-site/${MANUAL_VERSION}"
+          DEST="s3://${R2_BUCKET_NAME}/${KEY_PREFIX}"
+          if [[ "$MANUAL_VERSION" != 'development' ]]; then
+            if aws s3api head-object --endpoint-url "$ENDPOINT" \
+                --bucket "$R2_BUCKET_NAME" \
+                --key "${KEY_PREFIX}/.snapshot.json" >/dev/null 2>&1; then
+              echo "::error::Manual site ${MANUAL_VERSION} is already" \
+                "published and immutable; refusing to overwrite it."
+              exit 1
+            fi
+          fi
+          aws s3 sync lotti/docs-site/build "$DEST" \
+            --endpoint-url "$ENDPOINT" \
+            --exclude '.snapshot.json' --delete --no-progress
+          printf '{"version":"%s","appCommit":"%s","generatedAt":"%s"}\n' \
+            "$MANUAL_VERSION" "$LOTTI_COMMIT" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${RUNNER_TEMP}/.snapshot.json"
+          aws s3 cp "${RUNNER_TEMP}/.snapshot.json" "$DEST/.snapshot.json" \
+            --endpoint-url "$ENDPOINT"
 
   screenshots:
     name: Capture screenshot catalog
@@ -274,8 +310,7 @@ jobs:
     if: >-
       needs.build.result == 'success' &&
       (github.event_name == 'push' ||
-       (github.event_name == 'workflow_dispatch' && inputs.deploy &&
-        needs.metadata.outputs.version == 'development'))
+       (github.event_name == 'workflow_dispatch' && inputs.deploy))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -289,6 +324,59 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # The Pages tree is composed from the R2 site-snapshot store, not from
+      # this run's build alone — that is what keeps every published manual
+      # version selectable after any single-version deploy. The finalize
+      # script runs from the default branch, so release snapshots built from
+      # old tags are composed with current publishing logic.
+      - name: Checkout Lotti
+        uses: actions/checkout@v5
+        with:
+          path: lotti
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Mirror site snapshots from R2
+        id: mirror
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          set -euo pipefail
+          if [[ -z "$R2_ACCOUNT_ID" || -z "$R2_BUCKET_NAME" || \
+                -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+            echo "::warning::R2 credentials are not configured; skipping the" \
+              "Pages deploy — there is no site-snapshot store to publish."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          aws s3 sync "s3://${R2_BUCKET_NAME}/manual-site" \
+            "${RUNNER_TEMP}/lotti-manual-pages/manual" \
+            --endpoint-url "$ENDPOINT" --no-progress
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Finalize Pages tree
+        if: steps.mirror.outputs.ready == 'true'
+        env:
+          PAGES_PREFIX: ${{ github.event.repository.name }}
+        run: >-
+          node lotti/docs-site/scripts/assemble-pages-site.mjs
+          --finalize
+          --output-root "${RUNNER_TEMP}/lotti-manual-pages"
+          --pages-prefix "$PAGES_PREFIX"
+
+      - name: Upload GitHub Pages artifact
+        if: steps.mirror.outputs.ready == 'true'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ${{ runner.temp }}/lotti-manual-pages
+
       - name: Deploy artifact to GitHub Pages
+        if: steps.mirror.outputs.ready == 'true'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -48,16 +48,22 @@ The published development manual lives at:
 
 `https://matthiasn.github.io/lotti/manual/development/`
 
-The repository root and `/lotti/manual/` redirect to that version. On every
-matching push to `main`, GitHub Actions validates and builds the site, assembles
-the repo-prefixed Pages tree, uploads it as a Pages artifact, and deploys it.
-Generated Docusaurus output is never committed: it exists only in the Actions
-runner and the immutable Pages deployment artifact.
+The repository root and `/lotti/manual/` redirect to the latest published
+release, or to `development` before the first one. On every matching push to
+`main`, GitHub Actions validates and builds the site, uploads the built tree
+to the R2 site-snapshot store (`manual-site/<version>/`), mirrors the whole
+store into one repo-prefixed Pages tree, and deploys it. Generated Docusaurus
+output is never committed: it exists only in the Actions runner, the R2
+store, and the Pages deployment artifact.
 
-The initial Pages deployment publishes `development`. Version promotion will
-assemble immutable release artifacts into the same Pages snapshot; manually
-building another version already works, but it does not replace the live
-development snapshot during this first publishing phase.
+Publishing a release manual is a `workflow_dispatch` of the Manual workflow
+with `manual_version: X.Y.Z` and `deploy: true`: the run resolves the newest
+app tag of that marketing version, builds the site and screenshot catalog
+from that tag, uploads both to their immutable R2 prefixes (existing release
+snapshots are never overwritten), and redeploys Pages with every version side
+by side. Each deploy also writes a live `manual/releases.json` next to the
+version directories; the version dropdown fetches it at runtime, so even old
+immutable snapshots list releases published after them.
 
 Run the same production build locally with:
 
@@ -175,9 +181,7 @@ MANUAL_BASE_URL=/lotti/manual/1.0.0/ \
 npm run build
 ```
 
-`metadata/releases.json` drives cross-version links and records which publicly
-distributed App Store version should receive the `latest` alias. The current
-GitHub Pages workflow publishes the development snapshot; the first App Store
-release needs the companion tagged-release job to assemble the immutable
-versioned Pages snapshot and media catalog. No `versioned_docs` directory is
-allowed.
+`metadata/releases.json` is only the build-time fallback catalog baked into
+each snapshot; the authoritative list is derived from the R2 site-snapshot
+store on every deploy and served as `manual/releases.json`, which the version
+dropdown fetches at runtime. No `versioned_docs` directory is allowed.

--- a/docs-site/docs/reference/manual-maintenance.mdx
+++ b/docs-site/docs/reference/manual-maintenance.mdx
@@ -81,6 +81,10 @@ tabs.
 ## Publish a release
 
 Manual source is not copied for every app version. The app release tag already
-preserves its exact source. CI checks out that tag, builds with
-`MANUAL_VERSION=<version>`, and publishes an immutable static directory. The
-release dropdown is a small manifest of those directories.
+preserves its exact source. Publishing is a manual workflow run with the
+marketing version and deploy enabled: CI resolves the newest app tag of that
+version, builds the site and its screenshot catalog from the tag, uploads
+both to immutable versioned storage, and redeploys the site with every
+version side by side. Release snapshots are never overwritten. The version
+dropdown reads a live catalog written on every deploy, so older manuals also
+list the releases that came after them.

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -77,5 +77,9 @@ otevřenými kartami příručky.
 ## Publikuj vydání
 
 Zdroj příručky se nekopíruje pro každou verzi aplikace. Tag vydání už uchovává
-přesný zdroj. CI tento tag načte, sestaví s `MANUAL_VERSION=<verze>` a publikuje
-neměnný statický adresář. Výběr vydání je malý manifest těchto adresářů.
+přesný zdroj. Publikace je ruční spuštění workflow s marketingovou verzí a
+zapnutým nasazením: CI najde nejnovější tag aplikace dané verze, sestaví z něj
+web i jeho katalog snímků obrazovky, nahraje obojí do neměnného verzovaného
+úložiště a znovu nasadí web se všemi verzemi vedle sebe. Snapshoty vydání se
+nikdy nepřepisují. Výběr verzí čte živý katalog zapisovaný při každém nasazení,
+takže i starší příručky uvádějí vydání, která přišla po nich.

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -79,6 +79,10 @@ skærmbilleder straks, og valget bevares på tværs af sider og åbne manualfane
 ## Publish a release
 
 Manualkilden kopieres ikke for hver appversion. Appens udgivelsestag bevarer
-allerede den præcise kilde. CI tjekker dette tag ud, bygger med
-`MANUAL_VERSION=<version>` og udgiver en uforanderlig statisk mappe.
-Udgivelsesdropdownen er et lille manifest over disse mapper.
+allerede den præcise kilde. Udgivelse sker som en manuelt startet
+workflow-kørsel med marketingversionen og deploy slået til: CI finder det
+nyeste app-tag for den version, bygger sitet og dets screenshot-katalog fra
+tagget, uploader begge dele til uforanderligt versioneret lager og gendeployer
+sitet med alle versioner side om side. Udgivelsessnapshots overskrives aldrig.
+Versionsdropdownen læser et live-katalog, der skrives ved hvert deploy, så
+ældre manualer også viser de udgivelser, der kom efter dem.

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -82,6 +82,11 @@ hinweg erhalten.
 ## Ein Release veröffentlichen
 
 Der Quelltext wird nicht für jede App-Version kopiert. Das App-Release-Tag
-bewahrt bereits den exakten Stand. CI checkt dieses Tag aus, baut mit
-`MANUAL_VERSION=<version>` und veröffentlicht ein unveränderliches statisches
-Verzeichnis. Das Versionsmenü ist ein kleines Manifest dieser Verzeichnisse.
+bewahrt bereits den exakten Stand. Veröffentlicht wird über einen manuell
+gestarteten Workflow-Lauf mit der Marketing-Version und aktiviertem Deploy:
+CI ermittelt das neueste App-Tag dieser Version, baut die Seite und ihren
+Screenshot-Katalog aus dem Tag, lädt beides in unveränderlichen versionierten
+Speicher hoch und deployt die Seite mit allen Versionen nebeneinander neu.
+Release-Snapshots werden nie überschrieben. Das Versionsmenü liest einen
+Live-Katalog, der bei jedem Deploy geschrieben wird, sodass ältere Handbücher
+auch die Releases auflisten, die nach ihnen erschienen sind.

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -85,7 +85,12 @@ páginas y pestañas abiertas del manual.
 ## Publica una versión
 
 El código fuente del manual no se copia para cada versión de la aplicación. La
-etiqueta de versión de la aplicación ya conserva su código exacto. CI consulta
-esa etiqueta, compila con `MANUAL_VERSION=<version>` y publica un directorio
-estático inmutable. El menú desplegable de versiones es un manifiesto pequeño de
-esos directorios.
+etiqueta de versión de la aplicación ya conserva su código exacto. Publicar es
+una ejecución manual del workflow con la versión de marketing y el despliegue
+activado: CI resuelve la etiqueta de aplicación más reciente de esa versión,
+compila el sitio y su catálogo de capturas a partir de la etiqueta, sube ambos
+a un almacenamiento versionado inmutable y vuelve a desplegar el sitio con
+todas las versiones lado a lado. Las instantáneas de versión nunca se
+sobrescriben. El menú desplegable de versiones lee un catálogo en vivo que se
+escribe en cada despliegue, así que los manuales antiguos también listan las
+versiones que llegaron después.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -86,6 +86,12 @@ pages et les onglets de manuel ouverts.
 ## Publier une version
 
 La source du manuel n’est pas copiée pour chaque version de l’application. Le
-tag de version conserve déjà sa source exacte. L’intégration continue récupère
-ce tag, construit avec `MANUAL_VERSION=<version>` et publie un répertoire statique
-immuable. Le menu des versions est un petit manifeste de ces répertoires.
+tag de version conserve déjà sa source exacte. La publication est un lancement
+manuel du workflow avec la version marketing et le déploiement activé :
+l’intégration continue résout le tag d’application le plus récent de cette
+version, construit le site et son catalogue de captures à partir du tag,
+téléverse les deux vers un stockage versionné immuable, puis redéploie le site
+avec toutes les versions côte à côte. Les instantanés de version ne sont jamais
+écrasés. Le menu des versions lit un catalogue en direct écrit à chaque
+déploiement, si bien que les anciens manuels listent aussi les versions parues
+après eux.

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -80,7 +80,13 @@ Tavole.
 
 ## Pubblica un rilascio
 
-La sorgente manuale non viene copiata per ogni versione dell'app.
-conserva la sua fonte esatta. CI controlla il tag, si costruisce con
-`MANUAL_VERSION=<version>`, e pubblica una directory statica immutabile.
-Il dropdown del rilascio è un piccolo manifesto di quelle directory.
+La sorgente del manuale non viene copiata per ogni versione dell'app. Il tag di
+rilascio dell'app conserva già la sua sorgente esatta. La pubblicazione è
+un'esecuzione manuale del workflow con la versione di marketing e il deploy
+abilitato: la CI risolve il tag dell'app più recente di quella versione,
+costruisce il sito e il suo catalogo di screenshot dal tag, carica entrambi in
+uno storage versionato immutabile e ridistribuisce il sito con tutte le
+versioni fianco a fianco. Gli snapshot di rilascio non vengono mai
+sovrascritti. Il dropdown delle versioni legge un catalogo live scritto a ogni
+deploy, quindi anche i manuali più vecchi elencano i rilasci arrivati dopo di
+loro.

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -82,7 +82,12 @@ tabbladen.
 
 ## Publiceer een release
 
-De handmatige bron wordt niet voor elke app-versie gekopieerd. De app-releasetag al
-behoudt de exacte bron. CI controleert die tag en bouwt ermee
-`MANUAL_VERSION=<version>`, en publiceert een onveranderlijke statische map. De
-release dropdown is een klein manifest van die mappen.
+De bron van de handleiding wordt niet voor elke app-versie gekopieerd. De
+app-releasetag behoudt de exacte bron al. Publiceren is een handmatig gestarte
+workflow-run met de marketingversie en deploy ingeschakeld: CI zoekt de nieuwste
+app-tag van die versie op, bouwt de site en de bijbehorende screenshotcatalogus
+vanaf de tag, uploadt beide naar onveranderlijke geversioneerde opslag en
+deployt de site opnieuw met alle versies naast elkaar. Release-snapshots worden
+nooit overschreven. De versiedropdown leest een live catalogus die bij elke
+deploy wordt geschreven, dus oudere handleidingen tonen ook de releases die na
+hen verschenen.

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -87,7 +87,11 @@ entre páginas e abas abertas do manual.
 ## Publicar um lançamento
 
 O código-fonte do manual não é copiado para cada versão do aplicativo. A tag
-de lançamento do aplicativo já preserva sua origem exata. O CI faz checkout
-dessa tag, compila com `MANUAL_VERSION=<version>` e publica um diretório
-estático imutável. O menu suspenso de versões é um pequeno manifesto desses
-diretórios.
+de lançamento do aplicativo já preserva sua origem exata. A publicação é uma
+execução manual do workflow com a versão de marketing e o deploy habilitado: o
+CI resolve a tag de aplicativo mais recente daquela versão, compila o site e
+seu catálogo de capturas de tela a partir da tag, envia ambos para um
+armazenamento versionado imutável e reimplanta o site com todas as versões
+lado a lado. Os snapshots de lançamento nunca são sobrescritos. O menu
+suspenso de versões lê um catálogo ao vivo gravado a cada deploy, então
+manuais mais antigos também listam os lançamentos que vieram depois deles.

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -46,4 +46,4 @@ Fiecare caz automatizat trebuie să ofere variante mobil-luminos, mobil-întunec
 
 ## Publicați o lansare
 
-Sursa manualului nu este copiată pentru fiecare versiune a aplicației. Eticheta de lansare a aplicației păstrează deja sursa exactă. CI verifică acea etichetă, construiește cu `MANUAL_VERSION=<version>` și publică un director static imuabil. Selectorul de lansări este un manifest mic al acelor directoare.
+Sursa manualului nu este copiată pentru fiecare versiune a aplicației. Eticheta de lansare a aplicației păstrează deja sursa exactă. Publicarea este o rulare manuală a fluxului de lucru, cu versiunea de marketing și cu implementarea activată: CI determină cea mai recentă etichetă de aplicație a acelei versiuni, construiește site-ul și catalogul său de capturi de ecran din etichetă, încarcă ambele într-un spațiu de stocare versionat imuabil și reimplementează site-ul cu toate versiunile una lângă alta. Instantaneele de lansare nu sunt niciodată suprascrise. Selectorul de versiuni citește un catalog live scris la fiecare implementare, astfel încât manualele mai vechi listează și lansările apărute după ele.

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -79,6 +79,10 @@ alla skärmdumpar direkt, och valet bevaras mellan sidor och öppna manualflikar
 ## Publish a release
 
 Manualkällan kopieras inte för varje appversion. Appens utgåvetagg bevarar
-redan exakt källa. CI checkar ut den taggen, bygger med
-`MANUAL_VERSION=<version>` och publicerar en oföränderlig statisk katalog.
-Utgåverullistan är ett litet manifest över dessa kataloger.
+redan exakt källa. Publicering är en manuellt startad workflow-körning med
+marknadsföringsversionen och deploy aktiverat: CI tar fram den senaste
+apptaggen för den versionen, bygger sajten och dess skärmdumpskatalog från
+taggen, laddar upp båda till oföränderlig versionerad lagring och deployar om
+sajten med alla versioner sida vid sida. Utgåvesnapshots skrivs aldrig över.
+Utgåverullistan läser en livekatalog som skrivs vid varje deploy, så äldre
+manualer listar även de utgåvor som kom efter dem.

--- a/docs-site/scripts/assemble-pages-site.mjs
+++ b/docs-site/scripts/assemble-pages-site.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import {cp, mkdir, rm, writeFile} from 'node:fs/promises';
+import {access, cp, mkdir, readdir, rm, writeFile} from 'node:fs/promises';
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -82,19 +82,124 @@ export async function assemblePagesSite({
   return {targetUrl};
 }
 
+/**
+ * Order two manual versions. `development` sorts after every release;
+ * releases compare by their numeric `major.minor.patch` triple, and a
+ * suffixed build (`1.2.3-rc.1`) sorts before the plain release it precedes.
+ */
+export function compareManualVersions(a, b) {
+  if (a === b) return 0;
+  if (a === 'development') return 1;
+  if (b === 'development') return -1;
+  const parse = (value) => {
+    const triple = value.match(/^\d+\.\d+\.\d+/)?.[0] ?? '0.0.0';
+    return {
+      numbers: triple.split('.').map(Number),
+      suffix: value.slice(triple.length),
+    };
+  };
+  const left = parse(a);
+  const right = parse(b);
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (left.numbers[i] ?? 0) - (right.numbers[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  if (left.suffix === right.suffix) return 0;
+  if (left.suffix === '') return 1;
+  if (right.suffix === '') return -1;
+  return left.suffix < right.suffix ? -1 : 1;
+}
+
+/**
+ * Finalize a Pages tree whose `manual/<version>/` directories were already
+ * mirrored from the site-snapshot store: keep only complete snapshots (the
+ * `.snapshot.json` marker is uploaded last), write the live release catalog
+ * the version dropdown fetches at runtime, and point the root redirects at
+ * the latest published release — or at `development` before the first one.
+ */
+export async function finalizePagesSite({outputRoot, pagesPrefix}) {
+  const normalizedPrefix = normalizePagesPrefix(pagesPrefix);
+  const manualRoot = resolve(outputRoot, 'manual');
+  const entries = await readdir(manualRoot, {withFileTypes: true});
+  const versions = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    validateManualVersion(entry.name);
+    const marker = resolve(manualRoot, entry.name, '.snapshot.json');
+    try {
+      await access(marker);
+    } catch {
+      throw new Error(
+        `Manual version ${entry.name} has no .snapshot.json marker; ` +
+          'refusing to publish an incomplete site snapshot.',
+      );
+    }
+    versions.push(entry.name);
+  }
+  if (versions.length === 0) {
+    throw new Error('No manual site snapshots found to publish.');
+  }
+  versions.sort(compareManualVersions).reverse();
+
+  const published = versions.filter((version) => version !== 'development');
+  const latestPublished = published[0] ?? null;
+  const catalog = {
+    schemaVersion: 1,
+    latestPublished,
+    versions: [
+      ...(versions.includes('development')
+        ? [
+            {
+              version: 'development',
+              label: 'Development',
+              status: 'development',
+            },
+          ]
+        : []),
+      ...published.map((version) => ({
+        version,
+        label: version,
+        status: 'published',
+      })),
+    ],
+  };
+  await writeFile(
+    resolve(manualRoot, 'releases.json'),
+    `${JSON.stringify(catalog, null, 2)}\n`,
+  );
+
+  const targetVersion = latestPublished ?? 'development';
+  const targetUrl = `${normalizedPrefix}/manual/${targetVersion}/`;
+  const redirect = redirectDocument(targetUrl);
+  await writeFile(resolve(outputRoot, '.nojekyll'), '');
+  await writeFile(resolve(outputRoot, 'index.html'), redirect);
+  await writeFile(resolve(manualRoot, 'index.html'), redirect);
+
+  return {targetUrl, latestPublished, versions};
+}
+
 async function main() {
   const options = parseNamedArguments(process.argv.slice(2));
-  const version = String(options.version ?? 'development');
-  const buildRoot = resolve(
-    siteDirectory,
-    String(options['build-root'] ?? 'build'),
-  );
   const outputRoot = resolve(
     siteDirectory,
     String(options['output-root'] ?? 'pages-build'),
   );
   const pagesPrefix = String(options['pages-prefix'] ?? 'lotti');
 
+  if (options.finalize === true) {
+    const result = await finalizePagesSite({outputRoot, pagesPrefix});
+    console.log(
+      `GitHub Pages tree finalized: versions ${result.versions.join(', ')}; ` +
+        `root redirects to ${result.targetUrl}`,
+    );
+    return;
+  }
+
+  const version = String(options.version ?? 'development');
+  const buildRoot = resolve(
+    siteDirectory,
+    String(options['build-root'] ?? 'build'),
+  );
   const result = await assemblePagesSite({
     buildRoot,
     outputRoot,

--- a/docs-site/src/components/ManualVersionNavbarItem/index.tsx
+++ b/docs-site/src/components/ManualVersionNavbarItem/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {translate} from '@docusaurus/Translate';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
@@ -19,6 +19,14 @@ type Props = Omit<
   'items' | 'label'
 >;
 
+function isCatalog(value: unknown): value is ReleaseCatalog {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as ReleaseCatalog).versions)
+  );
+}
+
 export default function ManualVersionNavbarItem(
   props: Props,
 ): React.JSX.Element {
@@ -32,15 +40,36 @@ export default function ManualVersionNavbarItem(
   const manualRootPath = String(
     siteConfig.customFields?.manualRootPath ?? '/manual',
   ).replace(/\/$/, '');
-  const catalog = siteConfig.customFields?.manualReleases as ReleaseCatalog;
+  const bakedCatalog = siteConfig.customFields?.manualReleases as ReleaseCatalog;
+  // The baked catalog only knows the releases that existed when this version
+  // was built; an immutable release snapshot would otherwise never list the
+  // versions published after it. Every Pages deploy writes a live catalog
+  // next to the version directories, so prefer that and fall back to the
+  // baked list when it is unreachable (local dev server, offline).
+  const [catalog, setCatalog] = useState<ReleaseCatalog>(bakedCatalog);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${manualRootPath}/releases.json`)
+      .then((response) => (response.ok ? response.json() : null))
+      .then((live: unknown) => {
+        if (!cancelled && isCatalog(live)) {
+          setCatalog(live);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [manualRootPath]);
+
   const localeSuffix = currentLocale === defaultLocale ? '' : `/${currentLocale}`;
   const items = catalog.versions.map((release) => ({
     label:
       release.status === 'development'
-        ? `${translate({
+        ? translate({
             id: 'manual.version.development',
             message: 'Development',
-          })} (${String(siteConfig.customFields?.sourceAppVersion)})`
+          })
         : release.label,
     href: `${manualRootPath}/${release.version}${localeSuffix}/`,
   }));
@@ -51,10 +80,10 @@ export default function ManualVersionNavbarItem(
       items={items}
       label={
         currentVersion === 'development'
-          ? translate({
+          ? `${translate({
               id: 'manual.version.development',
               message: 'Development',
-            })
+            })} (${String(siteConfig.customFields?.sourceAppVersion)})`
           : currentVersion
       }
     />

--- a/docs-site/tests/pages-artifact.test.mjs
+++ b/docs-site/tests/pages-artifact.test.mjs
@@ -6,6 +6,8 @@ import test from 'node:test';
 
 import {
   assemblePagesSite,
+  compareManualVersions,
+  finalizePagesSite,
   normalizePagesPrefix,
 } from '../scripts/assemble-pages-site.mjs';
 
@@ -13,6 +15,80 @@ test('normalizes safe repository URL prefixes', () => {
   assert.equal(normalizePagesPrefix('lotti'), '/lotti');
   assert.equal(normalizePagesPrefix('/lotti/'), '/lotti');
   assert.throws(() => normalizePagesPrefix('../lotti'), /Invalid/);
+});
+
+test('orders manual versions with development last', () => {
+  const versions = ['0.9.1073', 'development', '0.10.0', '0.9.1073-rc.1'];
+  versions.sort(compareManualVersions);
+  assert.deepEqual(versions, [
+    '0.9.1073-rc.1',
+    '0.9.1073',
+    '0.10.0',
+    'development',
+  ]);
+});
+
+test('finalizes a mirrored tree: catalog, latest redirect, marker guard', async () => {
+  const root = await mkdtemp(resolve(tmpdir(), 'lotti-pages-'));
+  const outputRoot = resolve(root, 'pages');
+  const manualRoot = resolve(outputRoot, 'manual');
+  const addSnapshot = async (version, {complete = true} = {}) => {
+    await mkdir(resolve(manualRoot, version), {recursive: true});
+    await writeFile(resolve(manualRoot, version, 'index.html'), '<h1>x</h1>');
+    if (complete) {
+      await writeFile(resolve(manualRoot, version, '.snapshot.json'), '{}');
+    }
+  };
+
+  try {
+    await addSnapshot('development');
+    await addSnapshot('0.9.1073');
+    await addSnapshot('0.10.0');
+
+    const result = await finalizePagesSite({outputRoot, pagesPrefix: 'lotti'});
+    assert.equal(result.latestPublished, '0.10.0');
+    assert.equal(result.targetUrl, '/lotti/manual/0.10.0/');
+
+    const catalog = JSON.parse(
+      await readFile(resolve(manualRoot, 'releases.json'), 'utf8'),
+    );
+    assert.equal(catalog.latestPublished, '0.10.0');
+    assert.deepEqual(
+      catalog.versions.map((release) => `${release.version}:${release.status}`),
+      ['development:development', '0.10.0:published', '0.9.1073:published'],
+    );
+    assert.match(
+      await readFile(resolve(outputRoot, 'index.html'), 'utf8'),
+      /\/lotti\/manual\/0\.10\.0\//,
+    );
+
+    await addSnapshot('0.10.1', {complete: false});
+    await assert.rejects(
+      finalizePagesSite({outputRoot, pagesPrefix: 'lotti'}),
+      /no \.snapshot\.json marker/,
+    );
+  } finally {
+    await rm(root, {force: true, recursive: true});
+  }
+});
+
+test('finalize redirects to development before the first release', async () => {
+  const root = await mkdtemp(resolve(tmpdir(), 'lotti-pages-'));
+  const outputRoot = resolve(root, 'pages');
+  try {
+    await mkdir(resolve(outputRoot, 'manual', 'development'), {
+      recursive: true,
+    });
+    await writeFile(
+      resolve(outputRoot, 'manual', 'development', '.snapshot.json'),
+      '{}',
+    );
+    const result = await finalizePagesSite({outputRoot, pagesPrefix: 'lotti'});
+    assert.equal(result.latestPublished, null);
+    assert.equal(result.targetUrl, '/lotti/manual/development/');
+  } finally {
+    await rm(root, {force: true, recursive: true});
+  }
 });
 
 test('assembles a versioned Pages snapshot with root redirects', async () => {


### PR DESCRIPTION
## Why

The version dropdown existed but had nothing real to select. The Pages tree only ever contained the single version a run had just built, so deploying a release would have *replaced* the development manual rather than standing beside it — and an immutable release snapshot would forever list only the versions that existed when it was built.

## What

**Site snapshots move to the R2 store, mirroring the screenshot catalog:**
- The build job uploads each version's built site to `manual-site/<version>/` — `development` mutable (synced with `--delete`), releases immutable: a second publish of the same version is refused, and the `.snapshot.json` marker uploads last so a half-uploaded snapshot is never publishable.
- The deploy job composes the Pages tree by mirroring the whole store, then runs a new `--finalize` mode of the assemble script: it validates every snapshot's completeness marker, writes a live `manual/releases.json` derived from what is actually published, and points the root redirects at the latest published release (or `development` before the first one). Any single-version run therefore redeploys *all* versions side by side.
- The finalize script runs from the default branch even when the built version came from an old tag, so historic snapshots are always composed with current publishing logic.

**The dropdown reads a live catalog:**
- `ManualVersionNavbarItem` fetches `manual/releases.json` at runtime and falls back to the baked `metadata/releases.json` (local dev, offline). Old immutable snapshots therefore list releases published after them.

**Publishing a release** is a `workflow_dispatch` with `manual_version: X.Y.Z` and `deploy: true`: the metadata job resolves the newest app tag of that marketing version (tags carry `+build` numbers), the build checks out that tag, and site + screenshot catalog publish to their immutable prefixes.

Known limitation: tags that predate the R2 media migration would build with their old site config — versions tagged from here on are the supported case.

## Verification

- New unit tests: version ordering (suffix < release < development), finalize catalog/redirect generation, incomplete-snapshot refusal, pre-first-release redirect to development. Full `node --test` suite passes.
- `npm run check` (validate, typecheck, tests, 11-locale production build, built-site smoke): green.
- actionlint on the workflow: clean; TypeScript `tsc --noEmit`: clean.
- Manual-maintenance reference page updated in English and all ten translations; docs-site README describes the release flow.

First deploy after merge is a no-op behaviorally: the build publishes `manual-site/development/` before the deploy mirrors the store, so the composed tree contains exactly today's development manual until the first release is dispatched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual releases are now published as immutable, versioned snapshots and displayed side by side.
  * The release selector updates from a live catalog, including releases added after earlier manuals.
  * The site automatically redirects to the latest published release, with development used as a fallback.
  * Release publishing now validates source versions and prevents incomplete or accidental overwrites.

* **Documentation**
  * Updated publishing and release-model guidance across supported languages to reflect the new workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->