### PR TITLE
fix(manual): shard the screenshot capture so it can finish

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -70,7 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      ref: ${{ steps.version.outputs.ref }}
+      commit: ${{ steps.commit.outputs.sha }}
+      locales: ${{ steps.locales.outputs.locales }}
     steps:
       - name: Validate requested version
         id: version
@@ -105,6 +106,33 @@ jobs:
             echo "ref=refs/tags/${TAG}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout Lotti
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.version.outputs.ref }}
+
+      # Every downstream job checks out this exact commit rather than the ref,
+      # so one run's site, screenshots and snapshot marker can never describe
+      # different commits — main moving mid-run, or a new build tag landing on
+      # the same marketing version, would otherwise split them.
+      - name: Record the commit under build
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # The capture matrix comes from the registry, so adding a manual locale
+      # cannot silently leave that locale uncaptured.
+      - name: Resolve the capture locales
+        id: locales
+        run: |
+          set -euo pipefail
+          LOCALES=$(jq -c '.locales' docs-site/metadata/screenshot-cases.json)
+          if [[ -z "$LOCALES" || "$LOCALES" == 'null' || "$LOCALES" == '[]' ]]; then
+            echo "::error::The screenshot registry declares no locales."
+            exit 1
+          fi
+          echo "locales=$LOCALES" >> "$GITHUB_OUTPUT"
+          echo "Capture locales: $LOCALES"
+
   build:
     name: Validate and build
     needs: metadata
@@ -112,21 +140,15 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    outputs:
-      commit: ${{ steps.commit.outputs.sha }}
     steps:
+      # For a release this is the tag's commit, not the commit that triggered
+      # the dispatch — the snapshot marker records what was actually built.
       - name: Checkout Lotti
         uses: actions/checkout@v5
         with:
           path: lotti
           fetch-depth: 0
-          ref: ${{ needs.metadata.outputs.ref }}
-
-      # For a release this is the tag's commit, not the commit that triggered
-      # the dispatch — the snapshot marker records what was actually built.
-      - name: Record built commit
-        id: commit
-        run: echo "sha=$(git -C lotti rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          ref: ${{ needs.metadata.outputs.commit }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -171,7 +193,7 @@ jobs:
            github.event_name == 'schedule' ||
            (github.event_name == 'workflow_dispatch' && inputs.deploy))
         env:
-          LOTTI_COMMIT: ${{ steps.commit.outputs.sha }}
+          LOTTI_COMMIT: ${{ needs.metadata.outputs.commit }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -205,14 +227,14 @@ jobs:
   # two-step release (capture+publish first, deploy later) is also valid.
   publish_site:
     name: Publish release site snapshot
-    needs: [metadata, build, screenshots]
+    needs: [metadata, build, screenshot_catalog]
     if: >-
       always() &&
       needs.build.result == 'success' &&
       github.event_name == 'workflow_dispatch' && inputs.deploy &&
       needs.metadata.outputs.version != 'development' &&
-      (needs.screenshots.result == 'success' ||
-       needs.screenshots.result == 'skipped')
+      (needs.screenshot_catalog.result == 'success' ||
+       needs.screenshot_catalog.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -225,7 +247,7 @@ jobs:
       - name: Publish site snapshot to R2
         env:
           MANUAL_VERSION: ${{ needs.metadata.outputs.version }}
-          LOTTI_COMMIT: ${{ needs.build.outputs.commit }}
+          LOTTI_COMMIT: ${{ needs.metadata.outputs.commit }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -283,15 +305,26 @@ jobs:
           aws s3 cp "${RUNNER_TEMP}/.snapshot.json" "$DEST/.snapshot.json" \
             --endpoint-url "$ENDPOINT"
 
+  # One job per manual locale. A locale takes roughly twelve minutes to
+  # capture, so the whole catalog needs over two hours in sequence — longer
+  # than a runner should hold, and the reason this job used to be killed at
+  # its timeout without ever publishing. Each shard converts its own locale to
+  # WebP and leaves the manifest to `screenshot_catalog`, which sees them all.
   screenshots:
-    name: Capture screenshot catalog
+    name: Capture ${{ matrix.locale }} screenshots
     needs: metadata
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.capture_screenshots)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 45
+    strategy:
+      # Report every broken locale in one run: a capture that only fails in,
+      # say, German is exactly the kind of defect a cancelled matrix hides.
+      fail-fast: false
+      matrix:
+        locale: ${{ fromJSON(needs.metadata.outputs.locales) }}
     steps:
       # A release captures from its resolved app tag, so the immutable media
       # prefix shows the UI that release actually shipped — not current main.
@@ -299,7 +332,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: lotti
-          ref: ${{ needs.metadata.outputs.ref }}
+          ref: ${{ needs.metadata.outputs.commit }}
           fetch-depth: 0
 
       - name: Set up Node
@@ -329,13 +362,79 @@ jobs:
         working-directory: lotti
         run: fvm flutter pub get --enforce-lockfile
 
-      - name: Capture and materialize registered screenshots
+      - name: Install manual dependencies
+        working-directory: lotti
+        run: make manual_deps
+
+      - name: Capture and materialize the ${{ matrix.locale }} screenshots
         working-directory: lotti
         run: >-
-          make manual_screenshots
+          make manual_screenshots_shard
+          MANUAL_LOCALE="${{ matrix.locale }}"
           MANUAL_VERSION="${{ needs.metadata.outputs.version }}"
           MANUAL_MEDIA_DIR="${{ runner.temp }}/lotti-manual-media"
           MANUAL_CAPTURE_DIR="${{ runner.temp }}/lotti-manual-capture/${{ needs.metadata.outputs.version }}"
+
+      - name: Upload the ${{ matrix.locale }} media slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: lotti-manual-media-${{ needs.metadata.outputs.version }}-${{ matrix.locale }}
+          path: ${{ runner.temp }}/lotti-manual-media/${{ needs.metadata.outputs.version }}
+          if-no-files-found: error
+          # Purely a hand-off to the job below; the reviewable artifact is the
+          # merged catalog it produces.
+          retention-days: 1
+
+  # Reassemble the sharded slices into one catalog. The manifest is written
+  # here rather than in a shard because it must describe every locale, and
+  # validation only means anything against the complete tree.
+  screenshot_catalog:
+    name: Publish screenshot catalog
+    needs: [metadata, screenshots]
+    if: needs.screenshots.result == 'success'
+    runs-on: ubuntu-latest
+    # Moves the whole catalog twice (download, then publish) and checksums
+    # every file in it, so it needs more than a trivial budget.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Lotti
+        uses: actions/checkout@v5
+        with:
+          path: lotti
+          ref: ${{ needs.metadata.outputs.commit }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: lotti/docs-site/package-lock.json
+
+      - name: Install manual dependencies
+        working-directory: lotti
+        run: make manual_deps
+
+      # The slices are disjoint — English at the root, every other locale
+      # under its own directory — so merging them cannot lose or clobber a
+      # file. `--delete` on the publish below then retires anything stale.
+      - name: Download every locale's media slice
+        uses: actions/download-artifact@v5
+        with:
+          pattern: lotti-manual-media-${{ needs.metadata.outputs.version }}-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/lotti-manual-media/${{ needs.metadata.outputs.version }}
+
+      # Fails when any registered case, locale or variant is missing, which is
+      # what makes an incomplete matrix impossible to publish.
+      - name: Write and validate the combined manifest
+        working-directory: lotti
+        env:
+          LOTTI_COMMIT: ${{ needs.metadata.outputs.commit }}
+        run: >-
+          make manual_screenshots_manifest
+          MANUAL_VERSION="${{ needs.metadata.outputs.version }}"
+          MANUAL_MEDIA_DIR="${{ runner.temp }}/lotti-manual-media"
 
       - name: Upload generated media for review
         uses: actions/upload-artifact@v4

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -119,6 +119,26 @@ jobs:
         id: commit
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      # A release builds from its tag, and the capture targets live in that
+      # tag's Makefile alongside the screenshot tests they invoke. Tags cut
+      # before the sharded pipeline cannot be captured this way — say so here,
+      # in seconds, rather than through eleven runners each failing on a
+      # missing target after twelve minutes of capture.
+      - name: Verify the resolved tree supports sharded capture
+        if: steps.version.outputs.version != 'development'
+        env:
+          MANUAL_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! make -n manual_screenshots_shard MANUAL_LOCALE=en \
+              >/dev/null 2>&1; then
+            echo "::error::The tag resolved for ${MANUAL_VERSION} predates the" \
+              "sharded screenshot pipeline and has no" \
+              "'manual_screenshots_shard' target, so its catalog cannot be" \
+              "captured. Publish a release manual from a tag that contains it."
+            exit 1
+          fi
+
       # The capture matrix comes from the registry, so adding a manual locale
       # cannot silently leave that locale uncaptured.
       - name: Resolve the capture locales

--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,27 @@ manual_check_media:
 .PHONY: manual_screenshots
 manual_screenshots: manual_deps
 	@set -e; for locale in $(MANUAL_LOCALES); do \
-		$(MAKE) manual_screenshots_locale \
-			MANUAL_LOCALE="$$locale" \
-			MANUAL_CAPTURE_DIR="$(MANUAL_CAPTURE_DIR)/$$locale"; \
+		$(MAKE) manual_screenshots_shard MANUAL_LOCALE="$$locale"; \
 	done
-	npm --prefix docs-site run manifest -- --capture-dir "$(MANUAL_CAPTURE_DIR)" --output-root "$(MANUAL_MEDIA_DIR)" --version "$(MANUAL_VERSION)" --locales "$(MANUAL_LOCALES)"
+	$(MAKE) manual_screenshots_manifest
+
+# One locale's slice of the catalog: capture its PNGs, then convert only that
+# locale to WebP and leave the manifest to a later pass over the merged tree.
+# CI fans these out across runners — capturing all $(words $(MANUAL_LOCALES))
+# locales in sequence takes over two hours, more than a single job can spend.
+.PHONY: manual_screenshots_shard
+manual_screenshots_shard:
+	$(MAKE) manual_screenshots_locale \
+		MANUAL_LOCALE="$(MANUAL_LOCALE)" \
+		MANUAL_CAPTURE_DIR="$(MANUAL_CAPTURE_DIR)/$(MANUAL_LOCALE)"
+	npm --prefix docs-site run manifest -- --capture-dir "$(MANUAL_CAPTURE_DIR)" --output-root "$(MANUAL_MEDIA_DIR)" --version "$(MANUAL_VERSION)" --locales "$(MANUAL_LOCALE)" --skip-manifest
+
+# Write and validate the manifest over an already-materialized media tree.
+# Every locale's WebP files must be present, whether one machine produced them
+# or eleven did.
+.PHONY: manual_screenshots_manifest
+manual_screenshots_manifest:
+	npm --prefix docs-site run manifest -- --output-root "$(MANUAL_MEDIA_DIR)" --version "$(MANUAL_VERSION)" --manifest-only
 	$(MAKE) manual_check_media MANUAL_VERSION="$(MANUAL_VERSION)" MANUAL_MEDIA_DIR="$(MANUAL_MEDIA_DIR)"
 
 .PHONY: manual_screenshots_locale

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,14 @@ fluttium_docs: manual_screenshots
 	@echo "fluttium_docs is deprecated; generated manual media is ready in $(MANUAL_MEDIA_DIR)."
 
 .PHONY: manual_deps
-manual_deps:
+manual_deps: docs-site/node_modules
+
+# A real file target, not a phony one: the screenshot targets below each need
+# these dependencies, and the eleven-locale loop would otherwise pay `npm ci`
+# eleven times. Reinstalls only when the lockfile is newer than the tree.
+docs-site/node_modules: docs-site/package-lock.json
 	npm --prefix docs-site ci
+	@touch $@
 
 .PHONY: manual_start
 manual_start:
@@ -196,7 +202,7 @@ manual_screenshots: manual_deps
 # CI fans these out across runners — capturing all $(words $(MANUAL_LOCALES))
 # locales in sequence takes over two hours, more than a single job can spend.
 .PHONY: manual_screenshots_shard
-manual_screenshots_shard:
+manual_screenshots_shard: docs-site/node_modules
 	$(MAKE) manual_screenshots_locale \
 		MANUAL_LOCALE="$(MANUAL_LOCALE)" \
 		MANUAL_CAPTURE_DIR="$(MANUAL_CAPTURE_DIR)/$(MANUAL_LOCALE)"
@@ -206,7 +212,7 @@ manual_screenshots_shard:
 # Every locale's WebP files must be present, whether one machine produced them
 # or eleven did.
 .PHONY: manual_screenshots_manifest
-manual_screenshots_manifest:
+manual_screenshots_manifest: docs-site/node_modules
 	npm --prefix docs-site run manifest -- --output-root "$(MANUAL_MEDIA_DIR)" --version "$(MANUAL_VERSION)" --manifest-only
 	$(MAKE) manual_check_media MANUAL_VERSION="$(MANUAL_VERSION)" MANUAL_MEDIA_DIR="$(MANUAL_MEDIA_DIR)"
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ I have tracked around 11,000 hours of my own work in it since 2022.
      point at the `development` channel and update when the manual regenerates;
      if a case id is ever renamed, these links need renaming with it. -->
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/tasks/workspace/desktop-dark.webp">
-  <img alt="The task workspace: a filtered task list beside an open task with its cover art, status, labels, and AI summary" src="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/tasks/workspace/desktop-light.webp">
+  <source media="(prefers-color-scheme: dark)" srcset="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/tasks/workspace/desktop-dark.webp">
+  <img alt="The task workspace: a filtered task list beside an open task with its cover art, status, labels, and AI summary" src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/tasks/workspace/desktop-light.webp">
 </picture>
 
 [Read the manual](https://matthiasn.github.io/lotti/manual/development/) ·
@@ -51,8 +51,8 @@ storage layout rather than by careful prompting — see
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/tasks/agent-suggestions/mobile-dark.webp">
-    <img alt="A task agent's report with two proposed changes, each with a dismiss and a confirm control, plus Confirm all and the automatic-updates toggle" src="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/tasks/agent-suggestions/mobile-light.webp" width="380">
+    <source media="(prefers-color-scheme: dark)" srcset="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/tasks/agent-suggestions/mobile-dark.webp">
+    <img alt="A task agent's report with two proposed changes, each with a dismiss and a confirm control, plus Confirm all and the automatic-updates toggle" src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/tasks/agent-suggestions/mobile-light.webp" width="380">
   </picture>
 </p>
 
@@ -69,8 +69,8 @@ Melious. Local inference is not measured at all, because the cost moves onto
 your own hardware and grid.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/ai/usage/desktop-dark.webp">
-  <img alt="Usage &amp; Impact: cost, energy, CO2e, tokens and requests for the month, with cost broken down per day and per category" src="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/ai/usage/desktop-light.webp">
+  <source media="(prefers-color-scheme: dark)" srcset="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/ai/usage/desktop-dark.webp">
+  <img alt="Usage &amp; Impact: cost, energy, CO2e, tokens and requests for the month, with cost broken down per day and per category" src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/ai/usage/desktop-light.webp">
 </picture>
 
 ---
@@ -112,8 +112,8 @@ your own hardware and grid.
 - **Time analysis** over categories, habits, and measurements.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/time-analysis/overview/desktop-dark.webp">
-  <img alt="Time Analysis: total, focused and other hours for the month, time per day stacked by category, and a per-category table with share and daily average" src="https://raw.githubusercontent.com/matthiasn/lotti-docs/main/manual/screenshots/development/time-analysis/overview/desktop-light.webp">
+  <source media="(prefers-color-scheme: dark)" srcset="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/time-analysis/overview/desktop-dark.webp">
+  <img alt="Time Analysis: total, focused and other hours for the month, time per day stacked by category, and a per-category table with share and daily average" src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/manual/screenshots/development/time-analysis/overview/desktop-light.webp">
 </picture>
 
 - **Categories and labels** to make the boundaries that your decisions

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -107,12 +107,23 @@ directory (`build/manual_capture/`), converts them to canonical WebP paths,
 and writes a checksum/dimension manifest under
 `build/manual_media/development/`.
 
-CI runs this same full pipeline on every manual-relevant push to `main`,
-nightly at 02:23 UTC, and on demand. Main-branch captures sync the materialized
-catalog to the R2 bucket (uploading `manifest.json` last, so readers never
-resolve cases whose media has not landed); pull requests only validate the
-site and never publish generated media. The site resolves media from the
-bucket's public URL; override it at build time with `MANUAL_MEDIA_BASE_URL`.
+CI runs the same pipeline on every manual-relevant push to `main`, nightly at
+02:23 UTC, and on demand — but **one job per locale**, because a locale takes
+about twelve minutes and the whole catalog does not fit in a single job. Each
+shard runs the two targets the loop above is made of:
+
+```bash
+make manual_screenshots_shard MANUAL_LOCALE=de   # capture + convert one locale
+make manual_screenshots_manifest                 # manifest over the merged tree
+```
+
+A following job merges every locale's slice, writes the manifest across all of
+them, and validates the complete matrix before publishing — so an incomplete
+capture cannot reach the bucket. Main-branch runs then sync the materialized
+catalog to R2 (uploading `manifest.json` last, so readers never resolve cases
+whose media has not landed); pull requests only validate the site and never
+publish generated media. The site resolves media from the bucket's public URL;
+override it at build time with `MANUAL_MEDIA_BASE_URL`.
 
 When only a new or changed case needs publishing, pass its IDs to the manifest
 builder so the existing catalog remains untouched. For example:

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -63,7 +63,10 @@ app tag of that marketing version, builds the site and screenshot catalog
 from that tag, uploads both to their immutable R2 prefixes (existing release
 snapshots are never overwritten, and a release site never deploys without a
 screenshot catalog captured from the same commit), and redeploys Pages with
-every version side by side. Each deploy also writes a live `manual/releases.json` next to the
+every version side by side. The capture targets live in the resolved tag's own
+Makefile, next to the screenshot tests they invoke, so a release manual can
+only be published from a tag that contains the sharded pipeline; the run says
+so immediately rather than failing once capture is under way. Each deploy also writes a live `manual/releases.json` next to the
 version directories; the version dropdown fetches it at runtime, so even old
 immutable snapshots list releases published after them.
 

--- a/docs-site/scripts/build-screenshot-manifest.mjs
+++ b/docs-site/scripts/build-screenshot-manifest.mjs
@@ -29,8 +29,12 @@ const outputRoot = resolve(
   String(options['output-root'] ?? '../build/manual_media'),
 );
 const outputDirectory = resolve(outputRoot, version);
+// Overridable so the shard/merge contract can be exercised against a small
+// synthetic registry instead of the real 134-case matrix.
 const registry = await readJson(
-  resolve(siteDirectory, 'metadata/screenshot-cases.json'),
+  resolve(
+    String(options.registry ?? resolve(siteDirectory, 'metadata/screenshot-cases.json')),
+  ),
 );
 
 validateManualVersion(version);

--- a/docs-site/tests/build-screenshot-manifest.test.mjs
+++ b/docs-site/tests/build-screenshot-manifest.test.mjs
@@ -1,0 +1,277 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, resolve} from 'node:path';
+import test from 'node:test';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+import sharp from 'sharp';
+
+const runScript = promisify(execFile);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../scripts/build-screenshot-manifest.mjs',
+);
+
+// A deliberately tiny stand-in for metadata/screenshot-cases.json: the real
+// 134-case matrix would make this test cost minutes for no extra coverage.
+const REGISTRY = {
+  schemaVersion: 2,
+  defaultLocale: 'en',
+  locales: ['en', 'de', 'fr'],
+  cases: [
+    {
+      id: 'tasks/workspace',
+      title: 'Task workspace',
+      sourceTest: 'test/features/tasks/ui/widgets/task_manual_screenshots_test.dart',
+      variants: {
+        'mobile-light': 'workspace_mobile_light.png',
+        'mobile-dark': 'workspace_mobile_dark.png',
+        'desktop-light': 'workspace_desktop_light.png',
+        'desktop-dark': 'workspace_desktop_dark.png',
+      },
+    },
+    {
+      id: 'ai/usage',
+      title: 'Usage and impact',
+      sourceTest: 'test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart',
+      variants: {
+        'mobile-light': 'usage_mobile_light.png',
+        'mobile-dark': 'usage_mobile_dark.png',
+        'desktop-light': 'usage_desktop_light.png',
+        'desktop-dark': 'usage_desktop_dark.png',
+      },
+    },
+  ],
+};
+
+/**
+ * Pin the manifest's provenance fields so two runs of the same catalog differ
+ * only where the code differs, never by wall clock or checked-out commit.
+ */
+const DETERMINISTIC_ENV = {
+  ...process.env,
+  LOTTI_COMMIT: '1234567890abcdef1234567890abcdef12345678',
+  SOURCE_DATE_EPOCH: '1750000000',
+};
+
+/**
+ * Write one distinguishable PNG per case, locale and variant, so a manifest
+ * that silently pointed at the wrong file would produce a different checksum.
+ */
+async function seedCaptureTree(captureDirectory, locales) {
+  for (const locale of locales) {
+    for (const screenshotCase of REGISTRY.cases) {
+      for (const [variant, fileName] of Object.entries(
+        screenshotCase.variants,
+      )) {
+        const width = variant.startsWith('mobile') ? 12 : 20;
+        const [r, g, b] = createHash('sha256')
+          .update(`${locale}/${screenshotCase.id}/${variant}`)
+          .digest();
+        const path = resolve(captureDirectory, locale, fileName);
+        await mkdir(dirname(path), {recursive: true});
+        await sharp({
+          create: {width, height: 8, channels: 3, background: {r, g, b}},
+        })
+          .png()
+          .toFile(path);
+      }
+    }
+  }
+}
+
+async function withWorkspace(run) {
+  const root = await mkdtemp(resolve(tmpdir(), 'lotti-manifest-'));
+  try {
+    const registryPath = resolve(root, 'registry.json');
+    await writeFile(registryPath, JSON.stringify(REGISTRY));
+    const captureDirectory = resolve(root, 'capture');
+    await seedCaptureTree(captureDirectory, REGISTRY.locales);
+    await run({root, registryPath, captureDirectory});
+  } finally {
+    await rm(root, {force: true, recursive: true});
+  }
+}
+
+const buildManifest = (registryPath, args) =>
+  runScript('node', [scriptPath, '--registry', registryPath, ...args], {
+    env: DETERMINISTIC_ENV,
+  });
+
+test('sharded per-locale conversion plus a merge pass equals one-shot output', async () => {
+  await withWorkspace(async ({root, registryPath, captureDirectory}) => {
+    const shardedRoot = resolve(root, 'media-sharded');
+    const oneShotRoot = resolve(root, 'media-one-shot');
+    const common = [
+      '--capture-dir',
+      captureDirectory,
+      '--version',
+      'development',
+    ];
+
+    // What CI now does: each locale converts alone, on its own machine.
+    for (const locale of REGISTRY.locales) {
+      const {stdout} = await buildManifest(registryPath, [
+        ...common,
+        '--output-root',
+        shardedRoot,
+        '--locales',
+        locale,
+        '--skip-manifest',
+      ]);
+      assert.match(stdout, new RegExp(`captured locales: ${locale}\\.`));
+    }
+
+    // A shard must not leave a manifest behind: a manifest that described one
+    // locale would advertise cases whose other locales had not been captured.
+    await assert.rejects(
+      readFile(resolve(shardedRoot, 'development/manifest.json')),
+      {code: 'ENOENT'},
+    );
+
+    await buildManifest(registryPath, [
+      '--output-root',
+      shardedRoot,
+      '--version',
+      'development',
+      '--manifest-only',
+    ]);
+    await buildManifest(registryPath, [
+      ...common,
+      '--output-root',
+      oneShotRoot,
+    ]);
+
+    const sharded = JSON.parse(
+      await readFile(resolve(shardedRoot, 'development/manifest.json'), 'utf8'),
+    );
+    const oneShot = JSON.parse(
+      await readFile(resolve(oneShotRoot, 'development/manifest.json'), 'utf8'),
+    );
+    assert.deepEqual(sharded, oneShot);
+
+    // The equality above is only worth something if the manifest is complete.
+    assert.deepEqual(
+      sharded.cases.map((entry) => entry.id).sort(),
+      ['ai/usage', 'tasks/workspace'],
+    );
+    for (const entry of sharded.cases) {
+      assert.deepEqual(Object.keys(entry.locales), REGISTRY.locales);
+      for (const locale of REGISTRY.locales) {
+        const variants = entry.locales[locale].variants;
+        assert.deepEqual(Object.keys(variants).sort(), [
+          'desktop-dark',
+          'desktop-light',
+          'mobile-dark',
+          'mobile-light',
+        ]);
+        for (const [variant, media] of Object.entries(variants)) {
+          const expectedPath =
+            locale === REGISTRY.defaultLocale
+              ? `${entry.id}/${variant}.webp`
+              : `${locale}/${entry.id}/${variant}.webp`;
+          assert.equal(media.path, expectedPath);
+          assert.equal(media.width, variant.startsWith('mobile') ? 12 : 20);
+          assert.ok(media.bytes > 0);
+          assert.match(media.sha256, /^[0-9a-f]{64}$/);
+        }
+      }
+    }
+
+    // Distinguishable inputs must stay distinguishable: identical checksums
+    // across locales would mean a shard overwrote another shard's media.
+    const checksums = sharded.cases.flatMap((entry) =>
+      REGISTRY.locales.map(
+        (locale) => entry.locales[locale].variants['desktop-light'].sha256,
+      ),
+    );
+    assert.equal(new Set(checksums).size, checksums.length);
+  });
+});
+
+test('the merge pass refuses a catalog with a locale still missing', async () => {
+  await withWorkspace(async ({root, registryPath, captureDirectory}) => {
+    const mediaRoot = resolve(root, 'media-partial');
+    for (const locale of ['en', 'de']) {
+      await buildManifest(registryPath, [
+        '--capture-dir',
+        captureDirectory,
+        '--output-root',
+        mediaRoot,
+        '--version',
+        'development',
+        '--locales',
+        locale,
+        '--skip-manifest',
+      ]);
+    }
+
+    // French never ran — the guard that keeps a half-finished capture matrix
+    // from being published as if it were whole.
+    await assert.rejects(
+      buildManifest(registryPath, [
+        '--output-root',
+        mediaRoot,
+        '--version',
+        'development',
+        '--manifest-only',
+      ]),
+      (error) => {
+        assert.match(error.stderr, /ENOENT/);
+        assert.match(error.stderr, /fr\/tasks\/workspace\/mobile-light\.webp/);
+        return true;
+      },
+    );
+  });
+});
+
+test('--skip-manifest and --manifest-only are mutually exclusive', async () => {
+  await withWorkspace(async ({root, registryPath}) => {
+    await assert.rejects(
+      buildManifest(registryPath, [
+        '--output-root',
+        resolve(root, 'media-conflict'),
+        '--version',
+        'development',
+        '--skip-manifest',
+        '--manifest-only',
+      ]),
+      (error) => {
+        assert.match(error.stderr, /Use either --skip-manifest or --manifest-only/);
+        return true;
+      },
+    );
+  });
+});
+
+test('a published release manifest is never rebuilt over', async () => {
+  await withWorkspace(async ({root, registryPath, captureDirectory}) => {
+    const mediaRoot = resolve(root, 'media-release');
+    const release = ['--version', '1.2.3'];
+    await buildManifest(registryPath, [
+      '--capture-dir',
+      captureDirectory,
+      '--output-root',
+      mediaRoot,
+      ...release,
+    ]);
+
+    await assert.rejects(
+      buildManifest(registryPath, [
+        '--capture-dir',
+        captureDirectory,
+        '--output-root',
+        mediaRoot,
+        ...release,
+      ]),
+      (error) => {
+        assert.match(error.stderr, /Release media 1\.2\.3 already exists/);
+        return true;
+      },
+    );
+  });
+});

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -110,6 +110,18 @@ tag**, and refuses to advertise a release whose screenshot catalog is not in
 the bucket. Pull requests only validate; nothing publishes without the `R2_*`
 repository secrets.
 
+The capture itself is **sharded one job per manual locale**, with the matrix
+read from the screenshot registry so a newly registered locale cannot go
+uncaptured. A locale takes roughly twelve minutes, so the eleven-locale
+catalog needs over two hours in sequence — as a single job it was killed at
+its timeout every night and published nothing. Each shard converts only its
+own locale to WebP (`make manual_screenshots_shard`); a following
+`screenshot_catalog` job merges the slices, writes the manifest across all of
+them and validates the complete matrix (`make manual_screenshots_manifest`)
+before anything reaches the bucket. All jobs check out one commit resolved
+once by the `metadata` job, so a run's site, screenshots and snapshot marker
+can never describe different commits.
+
 The ten-way shard belongs to `flutter-test-linux-faster.yml` above: it runs
 `very_good test` across a ten-job matrix. **Buildkite is not sharded** — the
 pipelines under `.buildkite/` run a bare `flutter test` for the Linux and Windows

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -55,13 +55,25 @@ Which home an image belongs in follows from who regenerates it:
 
 | Destination | Contents | Lifecycle |
 |-------------|----------|-----------|
-| R2 bucket, `manual/screenshots/<version>/<case-id>/` | The **generated** manual catalog — `mobile-light`, `mobile-dark`, `desktop-light`, `desktop-dark` per case, plus `manifest.json` | Produced by `make manual_screenshots` and published by the `manual.yml` CI lane; never hand-edited or renamed. `development/` is refreshed with deletion (retired cases disappear), numbered release prefixes are immutable — publishing refuses to overwrite an existing manifest |
+| R2 bucket, `manual/screenshots/<version>/<case-id>/` | The **generated** manual catalog — `mobile-light`, `mobile-dark`, `desktop-light`, `desktop-dark` per case, plus `manifest.json` | Produced by `make manual_screenshots` and published by the `manual.yml` CI lane; never hand-edited or renamed. `development/` is refreshed with deletion (retired cases disappear), numbered release prefixes are immutable — publishing refuses to overwrite an existing manifest. The app `README.md` embeds from this catalog too, so its screenshots age with the app rather than with whoever last remembered to retake them |
 | `lotti-docs`: `images/<app-version>/` | Hand-picked shots for release communication and the README | Written once per release, then left alone |
 | `lotti-docs`: `pr-screenshots/<topic-slug>/` | **Review evidence** for a pull request | Written by hand while the work is in review; kept afterwards as the record of what reviewers saw |
 
 `make manual_screenshots` stages captures and the materialized catalog under
 the gitignored `build/manual_capture/` and `build/manual_media/` directories;
 only the CI publish step talks to R2, using the `R2_*` repository secrets.
+
+It is a loop over two smaller targets, and CI uses those directly rather than
+the loop: `manual_screenshots_shard` captures **one** locale and converts only
+that locale to WebP, and `manual_screenshots_manifest` writes and validates the
+manifest over whatever complete media tree exists. CI runs one shard job per
+locale in parallel and merges them, because a locale takes about twelve
+minutes and the full catalog does not fit in a single job's timeout. Run a
+single locale the same way CI does when iterating on one language:
+
+```bash
+make manual_screenshots_shard MANUAL_LOCALE=de
+```
 
 # A UI pull request shows before *and* after
 

--- a/test/README.md
+++ b/test/README.md
@@ -582,22 +582,28 @@ tap that changes chart data, or captures show mid-lerp frames.
 ### Automated manual screenshot catalog
 
 Permanent manual media is a stricter use of the committed per-feature
-harnesses. The source test stays in `lotti`, but every generated image is
-written to the sibling `lotti-docs` repository. Never add generated manual
-PNGs or WebPs to this application repository.
+harnesses. The source test stays in `lotti`; every generated image is staged
+under the gitignored `build/manual_capture/` and `build/manual_media/`
+directories and published from CI to the Cloudflare R2 bucket. Never add
+generated manual PNGs or WebPs to this application repository.
 
 Run the current catalog from the repository root:
 
 ```bash
-make manual_screenshots
+make manual_screenshots                          # every registered locale
+make manual_screenshots_shard MANUAL_LOCALE=de   # just one, as CI does
 ```
+
+Prefer the single-locale form while iterating: the full catalog is eleven
+locales at roughly twelve minutes each, which is why CI fans the locales out
+across parallel jobs rather than looping.
 
 The case contract lives in `docs-site/metadata/screenshot-cases.json`. Each
 case must name a deterministic source test and provide all four inputs:
 mobile-light, mobile-dark, desktop-light, and desktop-dark. The build converts
 those PNGs to canonical WebP paths under
-`../lotti-docs/manual/screenshots/<version>/<case-id>/` and writes a manifest
-with dimensions, byte sizes, SHA-256 checksums, source test, and Lotti commit.
+`build/manual_media/<version>/<case-id>/` and writes a manifest with
+dimensions, byte sizes, SHA-256 checksums, source test, and Lotti commit.
 
 The Flutter source test must still make meaningful UI assertions before it
 captures. The media manifest validates the artifact contract; it does not


### PR DESCRIPTION
## The bug

The screenshot capture job has **never** completed. A locale takes about twelve minutes, so the eleven-locale catalog needs over two hours — against a `timeout-minutes: 60`.

From last night's scheduled run (`30602028907`), per-locale wall clock:

| locale | start | end |
|---|---|---|
| en | 03:40:10 | 03:52:04 |
| de | 03:52:13 | 04:04:07 |
| fr | 04:04:17 | 04:16:10 |
| it | 04:16:19 | 04:28:12 |
| es | 04:28:22 | **killed 04:37:25** |

Five locales in, the job hit its timeout. GitHub reports a timed-out job as `cancelled`, which is why the last several runs read as though somebody stopped them by hand.

The consequences are live: the bucket still serves a catalog captured before the last few UI changes, `sync/add-device` and `sync/paired` 404 on the published manual, and retired `agents/stats` / `theming/picker` media is still there because the `--delete` sync never runs.

## The fix

Capture is now **one job per manual locale**, with the matrix read from `screenshot-cases.json` so a newly registered locale cannot silently go uncaptured. Each shard converts only its own locale to WebP; a new `screenshot_catalog` job merges the slices, writes the manifest across all of them, and validates the complete matrix before anything reaches R2 — so an incomplete capture still cannot be published.

Wall clock goes from *never finishing* to roughly one shard's twenty minutes plus a short merge.

`make manual_screenshots` becomes a loop over the two targets CI calls directly (`manual_screenshots_shard`, `manual_screenshots_manifest`), so the local and CI paths cannot drift — and iterating on one language no longer means capturing eleven:

```bash
make manual_screenshots_shard MANUAL_LOCALE=de
```

## Also here

- **One commit per run.** `metadata` resolves the built commit once and every job checks out that exact SHA, so a run's site, screenshots and snapshot marker cannot describe different commits (main moving mid-run, or a new build tag landing on the same marketing version, would otherwise split them). This replaces `build`'s own `rev-parse`.
- **App README screenshots move to R2.** They were still served from the `lotti-docs` copy that stopped being regenerated at the migration — already going stale, and they would 404 outright once that dead tree is removed. All eight verified serving 200 from the bucket.

## Verification

- A **real English shard** run end to end locally: 540 PNGs captured, 536 WebP written (134 cases × 4 variants), no manifest left behind, 43 MB. Zero test failures — the harness fixes hold.
- The merge job's exact command run against a **full-scale 5,896-file tree**: manifest written and media validation passed in 4 s, giving 134 cases × 11 locales × 4 variants with correct canonical paths.
- New `docs-site/tests/build-screenshot-manifest.test.mjs` covers the shard→merge contract the pipeline now depends on: sharded output is byte-identical to one-shot, a shard leaves no partial manifest, a missing locale is refused, the two flags are mutually exclusive, and a published release manifest is never rebuilt over. Both mutations (a shard writing its own manifest; the merge tolerating missing media) were confirmed to fail the right tests.
- `npm run check` (typecheck, validate, 57 tests, 11-locale build, smoke), `make knowledge_check`, and `actionlint` all clean.

## Follow-up

Merging this triggers a capture run — that will be the first complete media publish since the migration, which should retire the orphaned cases and fix the two 404s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README screenshots to use hosted documentation assets.
  * Expanded screenshot-generation guidance with locale-specific commands, sharding, and artifact locations.
  * Documented the updated release and validation workflow.

* **Improvements**
  * Screenshot generation now supports parallel locale processing and complete catalog validation.
  * Releases verify consistent, immutable screenshot catalogs before publishing.
  * Media catalogs are assembled and published only when all locale captures are complete.

* **Tests**
  * Added coverage for complete locale and variant manifests, sharded captures, and invalid or incomplete catalogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->