### PR TITLE
ci(manual): capture screenshots nightly instead of on every push

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -330,11 +330,16 @@ jobs:
   # than a runner should hold, and the reason this job used to be killed at
   # its timeout without ever publishing. Each shard converts its own locale to
   # WebP and leaves the manifest to `screenshot_catalog`, which sees them all.
+  # Deliberately NOT on push. A capture costs eleven runners for around twenty
+  # minutes each, and almost nothing that lands on main changes a screenshot —
+  # the path filter admits prose edits under docs-site/, which cannot change
+  # one at all. Refreshing nightly keeps the catalog at most a day behind the
+  # UI for a fraction of the runner budget; a UI change that needs its media
+  # immediately can dispatch the workflow.
   screenshots:
     name: Capture ${{ matrix.locale }} screenshots
     needs: metadata
     if: >-
-      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.capture_screenshots)
     runs-on: ubuntu-latest
@@ -343,6 +348,9 @@ jobs:
       # Report every broken locale in one run: a capture that only fails in,
       # say, German is exactly the kind of defect a cancelled matrix hides.
       fail-fast: false
+      # Leave room for the ten-way test shards and everything else that shares
+      # this account's runner pool; the nightly has all night to finish.
+      max-parallel: 4
       matrix:
         locale: ${{ fromJSON(needs.metadata.outputs.locales) }}
     steps:
@@ -471,7 +479,6 @@ jobs:
       # to overwrite an existing manifest.
       - name: Publish media to R2
         if: >-
-          github.event_name == 'push' ||
           github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.publish_media)
         env:

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -110,10 +110,13 @@ directory (`build/manual_capture/`), converts them to canonical WebP paths,
 and writes a checksum/dimension manifest under
 `build/manual_media/development/`.
 
-CI runs the same pipeline on every manual-relevant push to `main`, nightly at
-02:23 UTC, and on demand — but **one job per locale**, because a locale takes
-about twelve minutes and the whole catalog does not fit in a single job. Each
-shard runs the two targets the loop above is made of:
+CI runs the same pipeline **nightly at 02:23 UTC and on demand — not on
+push** — as **one job per locale**, because a locale takes about twelve
+minutes and the whole catalog does not fit in a single job. Eleven runners for
+twenty minutes is too much to spend on every merge when almost nothing that
+lands changes a screenshot, so the catalog refreshes once a day and is at most
+a day behind the UI. Need it sooner after a UI change? Dispatch the workflow.
+Each shard runs the two targets the loop above is made of:
 
 ```bash
 make manual_screenshots_shard MANUAL_LOCALE=de   # capture + convert one locale
@@ -122,11 +125,12 @@ make manual_screenshots_manifest                 # manifest over the merged tree
 
 A following job merges every locale's slice, writes the manifest across all of
 them, and validates the complete matrix before publishing — so an incomplete
-capture cannot reach the bucket. Main-branch runs then sync the materialized
-catalog to R2 (uploading `manifest.json` last, so readers never resolve cases
-whose media has not landed); pull requests only validate the site and never
-publish generated media. The site resolves media from the bucket's public URL;
-override it at build time with `MANUAL_MEDIA_BASE_URL`.
+capture cannot reach the bucket. It then syncs the materialized catalog to R2
+(uploading `manifest.json` last, so readers never resolve cases whose media
+has not landed). The *site* still builds and deploys on every manual-relevant
+push, so prose fixes go live immediately; pull requests only validate and
+never publish. The site resolves media from the bucket's public URL; override
+it at build time with `MANUAL_MEDIA_BASE_URL`.
 
 When only a new or changed case needs publishing, pass its IDs to the manifest
 builder so the existing catalog remains untouched. For example:

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -114,7 +114,11 @@ The capture itself is **sharded one job per manual locale**, with the matrix
 read from the screenshot registry so a newly registered locale cannot go
 uncaptured. A locale takes roughly twelve minutes, so the eleven-locale
 catalog needs over two hours in sequence — as a single job it was killed at
-its timeout every night and published nothing. Each shard converts only its
+its timeout every night and published nothing. Capture runs **nightly and on
+dispatch, never on push**, at `max-parallel: 4`: eleven runners is too large a
+share of the pool to spend per merge when almost nothing that lands changes a
+screenshot. The site itself still builds and deploys per push, so the two
+cadences differ — prose is immediate, media is at most a day behind. Each shard converts only its
 own locale to WebP (`make manual_screenshots_shard`); a following
 `screenshot_catalog` job merges the slices, writes the manifest across all of
 them and validates the complete matrix (`make manual_screenshots_manifest`)

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -67,9 +67,13 @@ It is a loop over two smaller targets, and CI uses those directly rather than
 the loop: `manual_screenshots_shard` captures **one** locale and converts only
 that locale to WebP, and `manual_screenshots_manifest` writes and validates the
 manifest over whatever complete media tree exists. CI runs one shard job per
-locale in parallel and merges them, because a locale takes about twelve
-minutes and the full catalog does not fit in a single job's timeout. Run a
-single locale the same way CI does when iterating on one language:
+locale and merges them, because a locale takes about twelve minutes and the
+full catalog does not fit in a single job's timeout — nightly and on dispatch
+only, four at a time, because eleven runners per merge is more than a catalog
+that rarely changes is worth. **A UI change therefore ships before its manual
+media does**; dispatch the workflow when a screenshot needs to be current
+sooner. Run a single locale the same way CI does when iterating on one
+language:
 
 ```bash
 make manual_screenshots_shard MANUAL_LOCALE=de

--- a/test/README.md
+++ b/test/README.md
@@ -596,7 +596,8 @@ make manual_screenshots_shard MANUAL_LOCALE=de   # just one, as CI does
 
 Prefer the single-locale form while iterating: the full catalog is eleven
 locales at roughly twelve minutes each, which is why CI fans the locales out
-across parallel jobs rather than looping.
+across parallel jobs rather than looping — and why it does so nightly rather
+than per push.
 
 The case contract lives in `docs-site/metadata/screenshot-cases.json`. Each
 case must name a deterministic source test and provide all four inputs:


### PR DESCRIPTION
Follow-up to #3700.

Sharding fixed a capture that could never finish, but left it costing **eleven runners for ~20 minutes each on every manual-relevant push to `main`** — a large share of the pool per merge, competing with the ten-way test shards.

And most of that spend buys nothing: the path filter admits prose edits under `docs-site/**`, which cannot change a single screenshot. Even a genuine UI change rarely alters more than a handful of the 134 cases, and there is no way to know which without capturing.

## Change

- **Capture runs nightly (02:23 UTC) and on dispatch only — not on push.**
- **`max-parallel: 4`**, so even the nightly leaves most of the pool free.
- Dropped the now-unreachable `push` clause from the media publish step rather than leaving a condition that can never be true.

Runner cost per day goes from *~220 runner-minutes × every manual-relevant merge* to *~220 runner-minutes once*, and peak occupancy from 11 concurrent jobs to 4.

## The trade-off

**A UI change now ships before its manual media does** — the catalog is at most a day behind. That is stated in the three places that describe the pipeline, along with the escape hatch: dispatch the workflow when a screenshot needs to be current sooner.

The *site* still builds and deploys on every manual-relevant push, so prose fixes remain immediate. Only the media cadence changes.

## Not changed

The `push`/`pull_request` path filters still list the Flutter screenshot-test paths. Those were there to trigger a capture, which no longer happens on either event, so a push touching only a screenshot test now runs a short site build for no reason. Left alone deliberately — it is one brief job, and trimming trigger paths is easy to get subtly wrong. Worth a separate look if it proves annoying.

## Verification

`actionlint` clean, `make okf_check` clean (88 concepts). Docs updated in `docs-site/README.md`, `knowledge/architecture/platform-and-release.md`, `knowledge/conventions/screenshots.md`, and `test/README.md`.

Merging this does **not** kick off a capture: the merge commit's workflow no longer captures on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
  - Screenshot and media publishing now run nightly or through manual requests instead of on every push.
  - Site builds and deployments continue to run for relevant changes.
  - Screenshot generation supports parallel locale processing, with published media potentially delayed by up to one day.

- **Documentation**
  - Updated guidance explains screenshot refresh timing, manual triggering, locale processing, and catalog validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->