### PR TITLE
fix(tasks): tap the visible filter control in the manual capture

### DIFF
--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -33,6 +33,7 @@ import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
 import 'package:lotti/features/ai/ui/image_generation/cover_art_skill_modal.dart';
+import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
@@ -792,7 +793,17 @@ void main() {
           surface: const TasksRootPage(),
         );
 
-        await tester.tap(find.byIcon(Icons.filter_list_rounded).first);
+        // The collapsing header keeps both states in the tree at once, so the
+        // same filter icon exists twice: once in the expanded header a reader
+        // sees, once in the compact bar behind `IgnorePointer`. Scope to the
+        // expanded header and take no `.first` — an ambiguous finder here
+        // silently tapped the unhittable copy instead of failing.
+        await tester.tap(
+          find.descendant(
+            of: find.byType(TabSectionHeader),
+            matching: find.byIcon(Icons.filter_list_rounded),
+          ),
+        );
         await settleFrames(tester, 6);
         final messages = AppLocalizations.of(
           tester.element(find.byType(TasksRootPage)),


### PR DESCRIPTION
The nightly manual capture is currently broken on `main`. Run [30623473131](https://github.com/matthiasn/lotti/actions/runs/30623473131) failed **all eleven locale shards** — the first real failure the sharded pipeline has reported, and it caught a genuine regression rather than an infrastructure problem.

## Cause

`feat(tasks): collapse the task list header on scroll` (#3699) keeps both header states in the tree simultaneously, so `Icons.filter_list_rounded` now matches **twice**: once in the expanded header a reader sees, once in the compact bar sitting behind `IgnorePointer`/`AnimatedOpacity`.

The capture tapped `find.byIcon(Icons.filter_list_rounded).first`, which resolves to the unhittable copy. Flutter emitted a hit-test warning and carried on, so the modal never opened and the following assertion failed:

```
Expected: exactly one matching candidate
  Actual: _TextWidgetFinder:<Found 0 widgets with text "Filter tasks": []>
```

4 of 44 tests, × 11 locales.

## Fix

Scope the finder to the expanded header, and drop the `.first`:

```dart
await tester.tap(
  find.descendant(
    of: find.byType(TabSectionHeader),
    matching: find.byIcon(Icons.filter_list_rounded),
  ),
);
```

The `.first` is the part that mattered. The two other screenshot suites that open this same modal (`projects_manual_screenshots_test.dart`, `journal_manual_screenshots_test.dart`) match without it and were unaffected — they would have failed loudly on a second match. Here `.first` turned "two candidates" into a silent tap on the wrong one.

## Verification

- The 4 previously-failing cases pass, and the full file is 44/44.
- Confirmed the capture is actually **correct**, not merely passing: the rendered PNG shows the Filter tasks modal open over the task list, with sort, status, priority and agent controls. A green test here only proves the tap landed somewhere.
- `fvm flutter analyze` clean.

No CHANGELOG entry — test-only, no user-visible behavior change.

## Note

`main`'s published catalog is unaffected: it was last published by run 30609935274 from `f7ee284b8`, before #3699 landed. Without this fix the next nightly would fail and the catalog would simply go stale rather than regress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated task-filter screenshot coverage to target the filter control in the expanded section header.
  * Improved test reliability by avoiding an ambiguous duplicate filter icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->