### PR TITLE
fix(tasks): inset the no-results empty state from the screen edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the one control naming your current filter showed a bare number. The
   save affordance now yields its label first.
 
+### Fixed
+- **The "no tasks match" message no longer sticks to the screen edge.** When
+  the Tasks list's empty-state message wrapped to a second line — a longer
+  language such as German, or a larger system text size — it was laid out
+  across the full width of the screen, flush against the left edge with no
+  margin. It now uses the same centered, inset empty-state treatment as the
+  Logbook, with the tasks glyph above it.
+
 ## [0.9.1073]
 ### Added
 - **The manual keeps every released version readable.** The manual's version

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -44,6 +44,7 @@
         <p>Changed: the saved-views button is called Views. It opens saved views, but it was labelled "Filters" — sitting directly beside the funnel that opens the actual filters, so the two most-used controls in the header shared a name and led to different places.</p>
         <p>Changed: colour in the filter chips means what the chip means. Every active filter chip sat on the same tinted plate regardless of what it stood for, so a red P0 priority chip was drawn on a green background. The plate is now neutral and the chip's own colour carries the meaning.</p>
         <p>Fixed: an ad-hoc filter keeps its name on a narrow screen. On a 375-point phone the "Custom" pill was squeezed until only its task count was left, so the one control naming your current filter showed a bare number. The save affordance now yields its label first.</p>
+        <p>Fixed: the "no tasks match" message no longer sticks to the screen edge. When the Tasks list's empty-state message wrapped to a second line — a longer language such as German, or a larger system text size — it was laid out across the full width of the screen, flush against the left edge with no margin. It now uses the same centered, inset empty-state treatment as the Logbook, with the tasks glyph above it.</p>
       </description>
     </release>
     <release version="0.9.1073" date="2026-07-29">

--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/chips/active_filter_chip.dart';
 import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
+import 'package:lotti/features/design_system/components/empty_states/design_system_empty_state.dart';
 import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
 import 'package:lotti/features/design_system/components/layout/detail_content_width.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
@@ -548,17 +549,24 @@ class _TasksTabPageBodyState extends ConsumerState<_TasksTabPageBody> {
                                                 CircularProgressIndicator.adaptive(),
                                           ),
                                         ),
-                                    noItemsFoundIndicatorBuilder: (_) =>
+                                    // The sliver has no horizontal inset, so
+                                    // this indicator must bring its own — a
+                                    // message long enough to wrap (long
+                                    // locale, large text scale) otherwise
+                                    // renders flush against the screen edge.
+                                    noItemsFoundIndicatorBuilder: (context) =>
                                         Padding(
-                                          padding: const EdgeInsets.only(
-                                            top: 48,
+                                          padding: EdgeInsets.only(
+                                            top: context
+                                                .designTokens
+                                                .spacing
+                                                .step9,
                                           ),
-                                          child: Center(
-                                            child: Text(
-                                              context
-                                                  .messages
-                                                  .taskShowcaseNoResults,
-                                            ),
+                                          child: DesignSystemEmptyState(
+                                            icon: Icons.list_outlined,
+                                            title: context
+                                                .messages
+                                                .taskShowcaseNoResults,
                                           ),
                                         ),
                                     itemBuilder: (context, item, index) {

--- a/lib/features/tasks/ui/widgets/task_list_pane.dart
+++ b/lib/features/tasks/ui/widgets/task_list_pane.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
+import 'package:lotti/features/design_system/components/empty_states/design_system_empty_state.dart';
 import 'package:lotti/features/design_system/components/scrollbars/design_system_scrollbar.dart';
 import 'package:lotti/features/design_system/components/search/design_system_search.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_task_filter_sheet.dart';
@@ -16,7 +17,7 @@ import 'package:lotti/features/tasks/ui/widgets/task_showcase_shared_widgets.dar
 import 'package:lotti/l10n/app_localizations_context.dart';
 
 /// Left pane of the task showcase: a search header, the active-filter chip
-/// row (when filters are applied), and either [TaskShowcaseEmptyResults] or a
+/// row (when filters are applied), and either a [DesignSystemEmptyState] or a
 /// [TaskListSectionsList] of the visible sections. Search/filter/selection
 /// interactions are forwarded to the supplied callbacks.
 class TaskListPane extends StatelessWidget {
@@ -58,8 +59,9 @@ class TaskListPane extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16, 0, 16, 120),
               child: state.visibleSections.isEmpty
-                  ? TaskShowcaseEmptyResults(
-                      message: context.messages.taskShowcaseNoResults,
+                  ? DesignSystemEmptyState(
+                      icon: Icons.list_outlined,
+                      title: context.messages.taskShowcaseNoResults,
                     )
                   : TaskListSectionsList(
                       sections: state.visibleSections,
@@ -403,24 +405,6 @@ class _TaskListSearchHeader extends StatelessWidget {
           ),
           const SizedBox(height: 12),
         ],
-      ),
-    );
-  }
-}
-
-/// Centered placeholder shown when no tasks match the current search/filters.
-class TaskShowcaseEmptyResults extends StatelessWidget {
-  const TaskShowcaseEmptyResults({required this.message, super.key});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text(
-        message,
-        style: context.designTokens.typography.styles.subtitle.subtitle1
-            .copyWith(color: TaskShowcasePalette.mediumText(context)),
       ),
     );
   }

--- a/lib/features/tasks/ui/widgets/task_mobile_list_detail_showcase.dart
+++ b/lib/features/tasks/ui/widgets/task_mobile_list_detail_showcase.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
+import 'package:lotti/features/design_system/components/empty_states/design_system_empty_state.dart';
 import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/design_system_showcase_mobile_chrome.dart';
 import 'package:lotti/features/design_system/components/scrollbars/design_system_scrollbar.dart';
@@ -190,8 +191,9 @@ class _TaskMobileListScreen extends StatelessWidget {
                 child: Padding(
                   padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
                   child: state.visibleSections.isEmpty
-                      ? TaskShowcaseEmptyResults(
-                          message: context.messages.taskShowcaseNoResults,
+                      ? DesignSystemEmptyState(
+                          icon: Icons.list_outlined,
+                          title: context.messages.taskShowcaseNoResults,
                         )
                       : TaskListSectionsList(
                           sections: state.visibleSections,

--- a/test/features/tasks/ui/pages/tasks_tab_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_tab_page_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -11,7 +12,9 @@ import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/chips/active_filter_chip.dart';
 import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
+import 'package:lotti/features/design_system/components/empty_states/design_system_empty_state.dart';
 import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
@@ -1243,22 +1246,139 @@ void main() {
     });
   });
 
-  testWidgets(
-    'shows the noItemsFound indicator when the page is empty',
-    (tester) async {
+  group('no-results empty state', () {
+    const message = 'No tasks match your search.';
+
+    setUp(() {
       pagingController.value = PagingState<int, JournalEntity>(
         pages: const [<JournalEntity>[]],
         keys: const [0],
         hasNextPage: false,
       );
+    });
 
-      await tester.pumpWidget(buildSubject(state: state()));
+    Future<void> pumpEmpty(
+      WidgetTester tester, {
+      MediaQueryData? mediaQueryData,
+    }) async {
+      await tester.pumpWidget(
+        buildSubject(state: state(), mediaQueryData: mediaQueryData),
+      );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
+    }
 
-      expect(find.text('No tasks match your search.'), findsOneWidget);
-    },
-  );
+    testWidgets(
+      'composes the design-system empty state with the tasks glyph',
+      (tester) async {
+        await pumpEmpty(tester);
+
+        final emptyState = find.byType(DesignSystemEmptyState);
+        expect(emptyState, findsOneWidget);
+        expect(
+          tester.widget<DesignSystemEmptyState>(emptyState).icon,
+          Icons.list_outlined,
+        );
+        expect(
+          find.descendant(of: emptyState, matching: find.text(message)),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'the message is never laid out edge to edge on a phone-width pane',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(390, 844)
+          ..devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await pumpEmpty(
+          tester,
+          mediaQueryData: const MediaQueryData(size: Size(390, 844)),
+        );
+
+        final messageFinder = find.text(message);
+        final inset = tester.element(messageFinder).designTokens.spacing.step6;
+        final paragraph = tester.renderObject<RenderParagraph>(messageFinder);
+
+        // The layout contract, not the painted position: whatever width the
+        // rendered lines happen to take, the paragraph must never be OFFERED
+        // the full pane width — that is exactly the state in which a wrapping
+        // message painted flush against the screen edge.
+        expect(
+          paragraph.constraints.maxWidth,
+          lessThanOrEqualTo(390 - 2 * inset + 0.01),
+        );
+      },
+    );
+
+    testWidgets(
+      'a message wrapped by a large text scale keeps clear of both edges',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(390, 844)
+          ..devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await pumpEmpty(
+          tester,
+          mediaQueryData: const MediaQueryData(
+            size: Size(390, 844),
+            textScaler: TextScaler.linear(2),
+          ),
+        );
+
+        final messageFinder = find.text(message);
+        final inset = tester.element(messageFinder).designTokens.spacing.step6;
+        final paragraph = tester.renderObject<RenderParagraph>(messageFinder);
+
+        // Measure per word, not over the whole string: a wrapped line's
+        // trailing space glyph legitimately extends past the visual line
+        // edge, so its selection box would fail an edge assertion without
+        // any ink being rendered there.
+        final wordBoxes = <TextBox>[];
+        var searchStart = 0;
+        for (final word in message.split(' ')) {
+          final start = message.indexOf(word, searchStart);
+          searchStart = start + word.length;
+          wordBoxes.addAll(
+            paragraph.getBoxesForSelection(
+              TextSelection(baseOffset: start, extentOffset: searchStart),
+            ),
+          );
+        }
+
+        // Guard against a vacuous pass: the accessibility scale must
+        // actually wrap the message, since a single centered line kept
+        // clear of the edges even before the empty state carried an inset.
+        final lineTops = wordBoxes.map((box) => box.top).toSet();
+        expect(
+          lineTops.length,
+          greaterThan(1),
+          reason: 'the scaled message must wrap for this test to bite',
+        );
+
+        for (final box in wordBoxes) {
+          final left = paragraph.localToGlobal(Offset(box.left, box.top)).dx;
+          final right = paragraph.localToGlobal(Offset(box.right, box.top)).dx;
+          expect(
+            left,
+            greaterThanOrEqualTo(inset - 0.01),
+            reason: 'no rendered word may reach the left screen edge',
+          );
+          expect(
+            right,
+            lessThanOrEqualTo(390 - inset + 0.01),
+            reason: 'no rendered word may reach the right screen edge',
+          );
+        }
+      },
+    );
+  });
 
   testWidgets(
     'header filter is inactive for the default status set and no other facets',

--- a/test/features/tasks/ui/widgets/task_list_pane_test.dart
+++ b/test/features/tasks/ui/widgets/task_list_pane_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
+import 'package:lotti/features/design_system/components/empty_states/design_system_empty_state.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_task_filter_sheet.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -512,9 +513,9 @@ void main() {
   });
 
   group('TaskListPane chrome', () {
-    testWidgets('list pane paints background.level01 to match sidebar', (
-      tester,
-    ) async {
+    // A pane over zero tasks: every chrome test also implicitly renders the
+    // empty branch, and the empty-state test asserts on it directly.
+    Future<void> pumpEmptyPane(WidgetTester tester) async {
       final state = TaskListDetailState(
         data: TaskListData(
           categories: const [],
@@ -542,6 +543,12 @@ void main() {
         ),
       );
       await tester.pump();
+    }
+
+    testWidgets('list pane paints background.level01 to match sidebar', (
+      tester,
+    ) async {
+      await pumpEmptyPane(tester);
 
       final decoratedBox = tester.widget<DecoratedBox>(
         find
@@ -556,36 +563,31 @@ void main() {
     });
 
     testWidgets('filter icon is the Figma funnel glyph', (tester) async {
-      final state = TaskListDetailState(
-        data: TaskListData(
-          categories: const [],
-          tasks: const [],
-          currentTime: DateTime(2026, 4, 17),
-        ),
-        searchQuery: '',
-        selectedTaskId: '',
-        filterState: DesignSystemTaskFilterState(
-          title: 'Filters',
-          clearAllLabel: 'Clear',
-          applyLabel: 'Apply',
-        ),
-      );
-
-      await tester.pumpWidget(
-        wrap(
-          TaskListPane(
-            state: state,
-            onTaskSelected: (_) {},
-            onSearchChanged: (_) {},
-            onSearchCleared: () {},
-            onFilterPressed: () {},
-          ),
-        ),
-      );
-      await tester.pump();
+      await pumpEmptyPane(tester);
 
       expect(find.byIcon(Icons.filter_list_rounded), findsOneWidget);
       expect(find.byIcon(Icons.tune_rounded), findsNothing);
     });
+
+    testWidgets(
+      'no visible sections compose the design-system empty state',
+      (tester) async {
+        await pumpEmptyPane(tester);
+
+        final emptyState = find.byType(DesignSystemEmptyState);
+        expect(emptyState, findsOneWidget);
+        expect(
+          tester.widget<DesignSystemEmptyState>(emptyState).icon,
+          Icons.list_outlined,
+        );
+        expect(
+          find.descendant(
+            of: emptyState,
+            matching: find.text('No tasks match your search.'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
   });
 }

--- a/test/features/tasks/ui/widgets/task_mobile_list_detail_showcase_test.dart
+++ b/test/features/tasks/ui/widgets/task_mobile_list_detail_showcase_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
+import 'package:lotti/features/design_system/components/empty_states/design_system_empty_state.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/tasks/state/task_live_data_provider.dart';
 import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
@@ -381,14 +382,14 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.byType(TaskShowcaseEmptyResults), findsNothing);
+      expect(find.byType(DesignSystemEmptyState), findsNothing);
 
       // Enter a query that matches no task title, category, or project.
       final searchField = find.byType(TextField).first;
       await tester.enterText(searchField, 'zzznomatch999');
       await tester.pump();
 
-      expect(find.byType(TaskShowcaseEmptyResults), findsOneWidget);
+      expect(find.byType(DesignSystemEmptyState), findsOneWidget);
       expect(
         container
             .read(taskListDetailShowcaseControllerProvider)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Tasks empty state with centered, inset messaging and a tasks icon.
  * Prevented wrapped no-results text from reaching the screen edge, including at larger text sizes.

* **Documentation**
  * Added release notes for the updated Tasks empty-state layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->