### PR TITLE
fix(tasks): repair the agent-suggestion capture, and check captures before merge

### DIFF
--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -95,6 +95,14 @@ const _manualTaskAgentStateId = 'state-habitat-watcher';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
 final String _manualTaskAgentName = _t('Habitat Watcher', 'Habitatwächter');
+
+/// The proposed checklist item's title, shared by the fixture that supplies it
+/// and the assertion that looks for it — the rendered row wraps this in
+/// locale-specific quotation marks, so neither side may spell out the result.
+final String _manualTaskAgentAddItemTitle = _t(
+  'Run zero-gravity sardine feeder test',
+  'Schwerelos-Futterautomaten testen',
+);
 final String _manualTaskAgentTldr = _t(
   'All 37 emperor penguins are accounted for. Habitat pressure held at '
       '101.3 kPa overnight; the remaining launch risk is the zero-gravity '
@@ -271,12 +279,7 @@ List<PendingSuggestion> _manualTaskAgentSuggestions() {
     items: [
       ChangeItem(
         toolName: 'add_checklist_item',
-        args: {
-          'title': _t(
-            'Run zero-gravity sardine feeder test',
-            'Schwerelos-Futterautomaten testen',
-          ),
-        },
+        args: {'title': _manualTaskAgentAddItemTitle},
         humanSummary: _t(
           'Add: "Run zero-gravity sardine feeder test"',
           'Hinzufügen: "Schwerelos-Futterautomaten testen"',
@@ -717,17 +720,21 @@ void main() {
           findsOneWidget,
         );
         expect(find.text(messages.changeSetPendingCount(2)), findsOneWidget);
+        // Both proposal rows are composed from the tool's arguments at render
+        // time now, so the persisted English summaries on the fixture are no
+        // longer what a reader sees.
+        //
+        // Match the item's title alone. The row drops the leading kind label
+        // its chip already shows and re-adds it as `Add · `, so the localized
+        // template never appears whole; and the quotation marks around the
+        // title are locale-specific („…“ in German and Czech), which is what
+        // made the previous ASCII-quoted literal an English-only assertion.
         expect(
-          find.textContaining(
-            _t(
-              '"Run zero-gravity sardine feeder test"',
-              '"Schwerelos-Futterautomaten testen"',
-            ),
-          ),
+          find.textContaining(_manualTaskAgentAddItemTitle),
           findsOneWidget,
         );
         expect(
-          find.textContaining(_t('45m → 1h 15m', '45 Min. → 1 Std. 15 Min.')),
+          find.textContaining(messages.agentSummarySetEstimate(75)),
           findsOneWidget,
         );
         expect(find.text(messages.changeSetConfirmAll), findsOneWidget);


### PR DESCRIPTION
The nightly manual capture ([run 30682344259](https://github.com/matthiasn/lotti/actions/runs/30682344259)) failed in **all eleven locales**. This fixes it, and adds the pre-merge check whose absence let this be the third such regression in two days.

---

# 1. The fix

#3689 composes proposal summaries from the tool's arguments at render time rather than rendering the persisted `humanSummary`. That broke two assertions — and only one was visible in English.

**The estimate row** is composed from `minutes` now, so the fixture's persisted `"Estimate: 45m → 1h 15m"` is no longer what a reader sees. Asserts the localized template, which is the whole rendered text there.

**The add-item row** was English-only from the moment #3689 started composing it, because the quotation marks come from the locale:

| locale | `agentSummaryAddItem` |
|---|---|
| en | `Add: "{title}"` |
| de | `Hinzufügen: „{title}“` |
| cs | `Přidat: „{title}“` |

The assertion spelled out ASCII quotes. Before #3689 it passed everywhere because the fixture's own `humanSummary` used ASCII quotes in every language.

The fix matches the **item title alone**. Asserting the full localized template does not work either — the row drops the leading kind label its chip already shows and re-adds it as `Add · `, so the template never appears whole. That was an intermediate fix of mine that failed in all eleven locales, English included; worth stating because it looks like the obvious answer.

The title is now a single shared constant behind the fixture that supplies it and the assertion that looks for it.

---

# 2. The check (`manual-capture-check.yml`)

Nothing runs these suites before merge. They are opt-in on `LOTTI_SCREENSHOT_DIR`, so ordinary CI skips them, and since #3701 the publishing lane does not execute them on push or pull request either.

**The gap is wider than the cadence.** `manual.yml` does not watch `lib/` at all, yet the harnesses render real production widgets, so app code is what usually breaks them:

| PR | `lib/` files | matched `manual.yml` paths? |
|---|---|---|
| #3689 localized summaries | 29 | **none** — no manual workflow ran at all |
| #3699 collapsing header | many | only incidentally, via a `pubspec.yaml` version bump |

So the new workflow watches `lib/`, the harnesses, the registered screenshot tests, the demo-copy fixtures and the case registry. It runs the same capture for **one** locale, on pull requests only, and **publishes nothing**.

### Why German, not English

English is the weakest single choice available: every other locale falls back to it, so a rendering that only breaks once a translation is involved stays green. That is precisely how the add-item row above broke in German and Czech while English passed. Both recent regressions fail a German capture; only one fails an English one.

Override with the `MANUAL_CHECK_LOCALE` repository variable.

### Cost

One runner, roughly 18–20 minutes, only on pull requests that could plausibly break the harness. `cancel-in-progress` means iterating on a PR supersedes rather than stacks. No node, no WebP conversion, no manifest — none of it proves anything about the harness.

---

## Verification

- **All eleven locales pass** the four agent-suggestions cases. A green English run is exactly what let the locale-specific quoting through, so English alone is not evidence.
- Full **English** and **German** shards: 540 PNGs → 536 WebP (134 cases × 4 variants), zero failures across all twenty suites. The German one carried real weight — the capture stops at the first failing suite and this is the 9th of 20, so the nightly never ran the following eleven suites in *any* language.
- The check's own command is what those shards run, so it is verified passing on the fixed state; it was verified failing on the broken state while diagnosing (German failed at the add-item assertion, English at the estimate one).
- `actionlint` clean on both workflows, `make okf_check` clean, `fvm flutter analyze` clean.

Landing both together is deliberate: a check merged ahead of the fix would fail every subsequent `lib/` pull request against main's broken harness.

No CHANGELOG entry — test and CI only.

## Known limitation

The capture target stops at the first failing suite, so one run reports one broken suite rather than all of them. That is what hid the German breakage from me initially. Worth fixing separately; it needs the twenty invocation lines restructured into a loop that collects failures, which does not belong in this change.

## Separate observation, not changed here

#3689 traded `"Estimate: 45m → 1h 15m"` for `"Set estimate to 75 minutes"`, dropping the before→after transition and the humanized duration. Recorded on `lotti3-kcx`.
