### PR TITLE
ci(manual): verify the screenshot harness before a change lands

### DIFF
--- a/.github/workflows/manual-capture-check.yml
+++ b/.github/workflows/manual-capture-check.yml
@@ -15,6 +15,11 @@ on:
       # way this breaks — and the reason it must be watched here. Both recent
       # regressions were lib/ changes that triggered no manual workflow at all.
       - 'lib/**'
+      # The suites read bundled inputs directly, so an asset-only change can
+      # break a capture: the shared harness loads Inter and Inconsolata from
+      # assets/fonts/, and the What's New capture decodes cover art from
+      # assets/design_system/.
+      - 'assets/**'
       - 'test/features/**/*_screenshots_test.dart'
       - 'test/features/daily_os_next/screenshot_harness.dart'
       - 'test/test_utils/screenshot_harness.dart'

--- a/.github/workflows/manual-capture-check.yml
+++ b/.github/workflows/manual-capture-check.yml
@@ -1,0 +1,92 @@
+# Verify that the manual screenshot harness still runs, before a change lands.
+#
+# The publishing lane (manual.yml) captures all eleven locales nightly. That
+# is the right cadence for refreshing media, but it means a UI change that
+# breaks the harness is only discovered the following night — three such
+# regressions landed in two days. This job runs the same capture on a pull
+# request, for one locale, and publishes nothing.
+name: Manual capture check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # The harnesses render real production widgets, so app code is the main
+      # way this breaks — and the reason it must be watched here. Both recent
+      # regressions were lib/ changes that triggered no manual workflow at all.
+      - 'lib/**'
+      - 'test/features/**/*_screenshots_test.dart'
+      - 'test/features/daily_os_next/screenshot_harness.dart'
+      - 'test/test_utils/screenshot_harness.dart'
+      - 'test/helpers/manual_demo_world.dart'
+      - 'test/helpers/manual_screenshot_locale.dart'
+      - 'test/helpers/manual_screenshot_*_text.dart'
+      - 'test/pages/create/create_measurement_dialog_screenshots_test.dart'
+      - 'docs-site/metadata/screenshot-cases.json'
+      - 'Makefile'
+      - 'pubspec.yaml'
+      - '.github/workflows/manual-capture-check.yml'
+
+# Superseded commits stop capturing immediately: this is a slow check and a
+# pull request under active work would otherwise stack up runners.
+concurrency:
+  group: manual-capture-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    name: Capture screenshots (${{ vars.MANUAL_CHECK_LOCALE || 'de' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout Lotti
+        uses: actions/checkout@v5
+
+      - name: Read the pinned Flutter version
+        uses: kuhnroyal/flutter-fvm-config-action@v2
+        id: flutter-version
+        with:
+          path: .fvmrc
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.flutter-version.outputs.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Install FVM
+        run: dart pub global activate fvm
+
+      - name: Install Flutter dependencies
+        run: fvm flutter pub get --enforce-lockfile
+
+      # One locale, and by default not the authoring one. English is the
+      # weakest choice available: every other locale falls back to it, so a
+      # rendering that only breaks once a translation is involved passes there.
+      # That is not hypothetical — the add-item proposal row broke in German
+      # and Czech (which quote with „…“) while English stayed green.
+      #
+      # Only the capture runs. WebP conversion and the manifest need node and
+      # prove nothing about the harness, and nothing here is published.
+      - name: Capture the registered screenshots
+        env:
+          MANUAL_CHECK_LOCALE: ${{ vars.MANUAL_CHECK_LOCALE || 'de' }}
+        run: >-
+          make manual_screenshots_locale
+          MANUAL_LOCALE="${MANUAL_CHECK_LOCALE}"
+          MANUAL_CAPTURE_DIR="${{ runner.temp }}/manual-capture-check"
+
+      # The captured frames are the evidence for why a case failed, and they
+      # are gone with the runner otherwise.
+      - name: Upload what was captured before the failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: manual-capture-check-${{ github.run_id }}
+          path: ${{ runner.temp }}/manual-capture-check
+          if-no-files-found: ignore
+          retention-days: 3

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -94,6 +94,15 @@ Genuinely path-filtered, both on pushes *and* pull requests to `main`:
 `python-tools-ci.yml` (the Python tools) and `manual.yml` (docs-site) — the latter
 also runs on a nightly cron (`23 2 * * *`) and on manual dispatch.
 
+`manual-capture-check.yml` is pull-request-only and exists because the two
+cadences above leave a gap: the harnesses render real production widgets, so
+app code is what usually breaks them, but `manual.yml` does not watch `lib/`
+and no longer captures on push at all. It runs the same capture for **one**
+locale and publishes nothing. The locale defaults to German rather than the
+authoring locale, because every other locale falls back to English — a
+rendering that only breaks once a translation is involved stays green there.
+Override with the `MANUAL_CHECK_LOCALE` repository variable.
+
 `manual.yml` is also the manual's **publishing** lane, built around a
 Cloudflare R2 bucket rather than git or Pages alone. Screenshots publish to
 `manual/screenshots/<version>/` and each version's built site to

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -5,8 +5,8 @@ description: Five platform targets from one codebase, the checks every branch ru
 resource: ../..
 tags: [architecture, ci, release, platforms, build]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-30T21:16:11Z }
-stale_after: 2027-01-30
+generated: { by: claude-code/opus-5, at: 2026-08-01T12:10:00Z }
+stale_after: 2027-02-01
 sources:
   - id: workflows
     resource: ../../.github/workflows

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -5,8 +5,8 @@ description: Where captured images live — never in this repository — and why
 resource: ../../test/test_utils/screenshot_harness.dart
 tags: [convention, screenshots, review, pull-request, lotti-docs]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T18:00:00Z }
-stale_after: 2027-01-18
+generated: { by: claude-code/opus-5, at: 2026-08-01T12:10:00Z }
+stale_after: 2027-02-01
 sources:
   - id: harness
     resource: ../../test/test_utils/screenshot_harness.dart
@@ -76,11 +76,18 @@ sooner.
 
 Whether the harness still *runs* is checked earlier and separately:
 `manual-capture-check.yml` captures one locale on any pull request touching
-`lib/`, a harness, or a registered screenshot test. It publishes nothing — it
-exists because these suites are opt-in and no other lane executes them, so
-without it a UI change can only be found to have broken the catalog the
-following night. Run a single locale the same way CI does when iterating on
-one language:
+`lib/`, `assets/`, a harness, or a registered screenshot test. It publishes
+nothing — it exists because these suites are opt-in, so no other *pull
+request* lane executes them and a UI change would otherwise only be found to
+have broken the catalog by the nightly capture.
+
+It defaults to **German**, not the authoring locale: every other locale falls
+back to English, so a rendering that only breaks once a translation is
+involved stays green there. That is not hypothetical — a proposal row whose
+quotation marks come from the locale (`„…“` in German and Czech, `"…"` in
+English) passed English and failed the other ten. Override with the
+`MANUAL_CHECK_LOCALE` repository variable. Run a single locale the same way CI
+does when iterating on one language:
 
 ```bash
 make manual_screenshots_shard MANUAL_LOCALE=de

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -72,8 +72,15 @@ full catalog does not fit in a single job's timeout — nightly and on dispatch
 only, four at a time, because eleven runners per merge is more than a catalog
 that rarely changes is worth. **A UI change therefore ships before its manual
 media does**; dispatch the workflow when a screenshot needs to be current
-sooner. Run a single locale the same way CI does when iterating on one
-language:
+sooner.
+
+Whether the harness still *runs* is checked earlier and separately:
+`manual-capture-check.yml` captures one locale on any pull request touching
+`lib/`, a harness, or a registered screenshot test. It publishes nothing — it
+exists because these suites are opt-in and no other lane executes them, so
+without it a UI change can only be found to have broken the catalog the
+following night. Run a single locale the same way CI does when iterating on
+one language:
 
 ```bash
 make manual_screenshots_shard MANUAL_LOCALE=de

--- a/test/README.md
+++ b/test/README.md
@@ -599,6 +599,14 @@ locales at roughly twelve minutes each, which is why CI fans the locales out
 across parallel jobs rather than looping — and why it does so nightly rather
 than per push.
 
+**Do not assume a green English run means the capture is healthy.** English is
+the fallback every other locale degrades to, so a rendering that only breaks
+once a translation is involved passes there — locale-specific quotation marks
+have already slipped through exactly this way. `manual-capture-check.yml`
+therefore captures German on pull requests that touch `lib/`, a harness, or a
+registered screenshot test; check a second locale locally before concluding a
+harness change is safe.
+
 The case contract lives in `docs-site/metadata/screenshot-cases.json`. Each
 case must name a deterministic source test and provide all four inputs:
 mobile-light, mobile-dark, desktop-light, and desktop-dark. The build converts

--- a/test/README.md
+++ b/test/README.md
@@ -603,9 +603,10 @@ than per push.
 the fallback every other locale degrades to, so a rendering that only breaks
 once a translation is involved passes there — locale-specific quotation marks
 have already slipped through exactly this way. `manual-capture-check.yml`
-therefore captures German on pull requests that touch `lib/`, a harness, or a
-registered screenshot test; check a second locale locally before concluding a
-harness change is safe.
+therefore defaults to capturing **German** on pull requests that touch `lib/`,
+`assets/`, a harness, or a registered screenshot test — override the locale
+with the `MANUAL_CHECK_LOCALE` repository variable. Check a second locale
+locally before concluding a harness change is safe.
 
 The case contract lives in `docs-site/metadata/screenshot-cases.json`. Each
 case must name a deterministic source test and provide all four inputs:


### PR DESCRIPTION
Re-submits the capture check that was meant to ship with #3708 but missed it: the PR was merged about two minutes before I pushed the commit, so GitHub never attached it and only the test fix landed. The workflow is unchanged from what that PR described, rebased onto current main.

Landing it separately is fine now — the harness fix it depended on is already on main.

## Why

Nothing runs the manual screenshot suites before merge. They are opt-in on `LOTTI_SCREENSHOT_DIR`, so ordinary CI skips them, and since #3701 the publishing lane does not execute them on push or pull request either. Three capture regressions landed in two days, each found a full day later by the nightly.

**The gap is wider than the cadence.** `manual.yml` does not watch `lib/` at all, yet the harnesses render real production widgets, so app code is what usually breaks them:

| PR | `lib/` files touched | matched `manual.yml` paths? |
|---|---|---|
| #3689 localized proposal summaries | 29 | **none** — no manual workflow ran at all |
| #3699 collapsing task header | many | only incidentally, via a `pubspec.yaml` version bump |

A cadence change alone would have caught neither.

## What

A pull-request-only workflow that runs the same capture for **one** locale and **publishes nothing**. It watches `lib/`, the harnesses, the registered screenshot tests, the demo-copy fixtures and the case registry.

### Why German, not the authoring locale

English is the weakest single choice available: every other locale falls back to it, so a rendering that only breaks once a translation is involved stays green there. That is exactly how #3689's add-item proposal row broke — German and Czech quote with `„…“` while English uses `"…"`, so English passed and ten locales failed.

Both recent regressions fail a German capture; only one fails an English one. Override with the `MANUAL_CHECK_LOCALE` repository variable.

### Cost

One runner, roughly 18–20 minutes, only on pull requests that could plausibly break the harness. `cancel-in-progress` means iterating on a PR supersedes rather than stacks. No node, no WebP conversion, no manifest — none of that proves anything about the harness, and nothing is published.

On failure it uploads whatever frames were captured, since those are the evidence for *why* a case broke and are otherwise gone with the runner.

## Verification

This PR touches the workflow file, which is in the workflow's own trigger paths, so **it validates itself** — the check running green here is the evidence that it triggers and passes against current main.

`actionlint` clean; `make okf_check` clean.

## Known limitation

The capture target stops at the first failing suite, so one run reports one broken suite rather than all twenty. That is what hid a German-only breakage during the #3708 diagnosis. Fixing it means restructuring the twenty invocation lines into a loop that collects failures — worth doing, but not inside a change that has to keep the nightly working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated pull-request screenshot check for relevant application and test changes.
  * Captures a configurable locale, defaulting to German, and preserves failed captures for review.

* **Documentation**
  * Documented the screenshot validation workflow and manual locale overrides.
  * Clarified that English-only checks are insufficient for validating localized rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->