### PR TITLE
perf(agents): coalesce concurrent agent_entities by-id reads

### DIFF
--- a/docs/perf/2026-08-01_slow-queries-investigation.md
+++ b/docs/perf/2026-08-01_slow-queries-investigation.md
@@ -1,0 +1,201 @@
+# Slow-Query Investigation — 2026-06-16 → 2026-08-01
+
+Successor to [slow-queries-investigation.md](slow-queries-investigation.md)
+(2026-04-17/18). That snapshot covered 37 hours; this one covers **47 days**.
+
+## Corpus
+
+| | |
+|---|---|
+| `logs/slow_queries-2026-{06-16..08-01}.log` | 47 files, 94 MB, **263,600 entries** (2 unparsable) |
+| `logs/super_slow_queries-2026-{06-16..08-01}.log` | 47 files, 1.4 MB, **2,175 entries** |
+
+Thresholds: **slow ≥ 10 ms** (`lib/database/common.dart:121`), **super-slow ≥ 200 ms**
+(`lib/database/slow_query_logging.dart:24`). Super-slow entries additionally carry
+`EXPLAIN QUERY PLAN` rows, which is what makes plan-level conclusions possible here.
+
+## The measurement caveat — read this before prioritising anything
+
+The interceptor is installed **client-side of the isolate boundary**: `common.dart:173`
+wraps the `DatabaseConnection` returned by `NativeDatabase.createInBackground`. The
+`Stopwatch` in `SlowQueryInterceptor._measure` (`slow_query_logging.dart:234`) therefore
+measures **round-trip time** — IPC + time queued behind other statements on that
+database's isolate + actual SQLite execution.
+
+It is *not* query execution time. The logged durations prove it:
+
+| Shape (`agent.sqlite`) | n | p50 | p75 | p95 |
+|---|---:|---:|---:|---:|
+| `SELECT * FROM agent_entities WHERE id = ?` (PK lookup) | 92,787 | 19.0 ms | 30.8 ms | 77.6 ms |
+| `ROW_NUMBER()` ranked over ~900 `agent_id`s | 23,662 | 18.2 ms | 32.7 ms | 76.1 ms |
+| `agent_links WHERE to_id = ? AND type = ?` | 9,152 | 18.4 ms | 27.6 ms | 59.0 ms |
+| `journal WHERE deleted = FALSE AND id IN (…)` (`db.sqlite`) | 9,707 | 15.7 ms | 26.8 ms | 65.6 ms |
+
+A single-row primary-key lookup and a 901-parameter window function have **the same
+latency distribution**. That is a fixed ~15–20 ms per-round-trip floor.
+
+The query plans agree. Across all 2,175 super-slow entries, nearly every plan row is a
+clean `SEARCH … USING INDEX`. The only genuine full scans are:
+
+| Occurrences | Plan row |
+|---:|---|
+| 55 | `SCAN outbox USING INDEX idx_outbox_actionable_priority_created_at` |
+| 50 | `SCAN inbound_event_queue USING COVERING INDEX idx_inbound_event_queue_status_producer_enqueued` |
+| 201 | `USE TEMP B-TREE FOR ORDER BY` (`db.sqlite`, mostly the habit heatmap query) |
+
+**Conclusion: this is a round-trip-count problem, not a missing-index problem.**
+Adding indexes will buy almost nothing. Reducing the number of statements will buy
+almost everything.
+
+## Ranking correction — the naive #1 is already fixed
+
+Aggregating over all 47 days puts `habitCompletionsInRange` (`database.drift:897`) at
+#1 with 1,458 s. That is an artefact:
+
+- Its **last execution was 2026-07-05**. It was superseded by the deduplicating
+  `ROW_NUMBER` variant `getHabitCompletionsInRange`
+  (`lib/database/database_data_queries.dart:40`, landed in d36221b06, 2026-06-06).
+- 1,356 s of its 1,458 s comes from **two** outlier events (see "Mode C" below).
+- The drift query now has **no callers** and only generates dead code at
+  `database.g.dart:6986`. It should be deleted, not optimised.
+
+Everything below is therefore ranked over **2026-07-19 → 2026-08-01**, which reflects
+the code as it actually stands.
+
+## Top shapes by total time — last 14 days
+
+| # | Total | n | avg | p95 | max | DB | Shape |
+|--:|------:|--:|----:|----:|----:|----|-------|
+| 1 | 134.1 s | 4,211 | 32 ms | 87 ms | 494 ms | agent | `ROW_NUMBER()` latest-per-agent over ~900 ids |
+| 2 | 127.1 s | 4,201 | 30 ms | 75 ms | 1,068 ms | agent | `agent_entities WHERE id = ?` |
+| 3 | 90.8 s | 357 | 254 ms | 3,252 ms | 5,070 ms | sync | `COUNT(*) FROM outbox INDEXED BY …` |
+| 4 | 90.2 s | 4,127 | 22 ms | 41 ms | 251 ms | agent | `json_extract(serialized,'$.taskId') = ?` |
+| 5 | 89.0 s | 163 | 546 ms | 3,515 ms | 5,054 ms | sync | `outbox WHERE status=0 ORDER BY … LIMIT 1` |
+| 6 | 87.4 s | 1,734 | 50 ms | 163 ms | 982 ms | agent | `WHERE type='agent'` (loads every agent) |
+| 7 | 86.0 s | 31 | **2,775 ms** | 4,024 ms | 5,070 ms | sync | `sync_sequence_log WHERE host_id=? AND status=?` |
+| 8 | 72.7 s | 26 | **2,797 ms** | 3,590 ms | 4,785 ms | sync | `queue_markers WHERE room_id=?` |
+| 9 | 49.6 s | 1,067 | 47 ms | 130 ms | 1,257 ms | db | `journal WHERE deleted=FALSE AND id IN (…)` |
+| 10 | 47.1 s | 74 | 636 ms | 1,667 ms | 1,753 ms | db | habit heatmap `ROW_NUMBER` query |
+| 11 | 38.4 s | 1,472 | 26 ms | 44 ms | 1,256 ms | agent | `agent_entities WHERE agent_id=? AND type=?` |
+| 12 | 37.3 s | 316 | 118 ms | 417 ms | 687 ms | db | task `COUNT(*)` with correlated `labeled` subqueries |
+| 13 | 33.8 s | 1,514 | 22 ms | 41 ms | 295 ms | agent | `agent_links WHERE to_id=? AND type=?` |
+| 14 | 31.7 s | 527 | 60 ms | 114 ms | 149 ms | db | `linked_entries WHERE to_id IN (…) AND type=?` |
+| 15 | 31.4 s | 483 | 65 ms | 148 ms | 157 ms | db | `journal WHERE type IN (…) AND date_from/date_to` |
+
+`agent.sqlite` alone is ~half of all recent logged time, spread over ~16,000 calls
+averaging 22–50 ms — none of which has a bad plan.
+
+## Three failure modes
+
+### Mode A — N+1 round-trip storms (dominant total time)
+
+The headline number: `agent_entities WHERE id = ?` fired **92,787 times** across the
+window for **2,660 s (44 min)** of logged time. Burst structure:
+
+- **80.7%** of calls arrive in seconds containing **≥ 20** calls.
+- Worst single second: **606 calls** at `2026-07-08 14:51:12`.
+- Next worst: 597 (`06-17 11:28:16`), 592 (`06-20 23:27:27`), 586 (`07-05 22:24:14`).
+
+Every one of those is an indexed PK lookup that SQLite answers in microseconds. The
+44 minutes is ~92k × ~19 ms of isolate round-trip.
+
+Call sites: `agent_repo_core.dart:88`, `agent_attention_projection.dart:430`,
+`agent_attention_projection.dart:524`.
+
+A second, subtler N+1 hides inside a batch-shaped API: `journal WHERE deleted = FALSE
+AND id IN (?)` — the **single-argument** form — ran **5,791 times** (985 in the last 14
+days). A batch query invoked with one id per call is an N+1 wearing a batch costume.
+
+### Mode B — `sync.sqlite` lock convoys (tail latency)
+
+`sync.sqlite` is the only hot database opened with **no read pool** (`readPool: 0`);
+`db.sqlite` uses 4, `agent.sqlite` 2 (`lib/database/database.dart`,
+`lib/features/agents/database/agent_database.dart`). Reads therefore serialize behind
+writes on a single isolate.
+
+The convoy signature at `2026-07-01 19:29:48` — nine queries that all *started* within
+one second and all *finished* within 150 ms of each other:
+
+| Duration | Query |
+|---:|---|
+| 25,666.9 ms | `outbox WHERE status=0 ORDER BY … LIMIT 1` |
+| 25,666.9 ms | `COUNT(id) FROM outbox WHERE status IN (?,?)` |
+| 25,666.8 ms | `inbound_event_queue … LIMIT 1` |
+| 24,765.6 ms | `outbox WHERE status=0 …` |
+| 15,069.6 ms | `outbox WHERE status=0 …` |
+| 5,348.5 ms | `outbox WHERE status=0 …` |
+
+They waited together and released together — the shape of queue-behind-a-writer, not of
+slow plans. `PRAGMA busy_timeout = 5000` (`common.dart:76`) explains the dense cluster of
+maxima at ~5,069 ms across shapes 3, 5, 7 and 8.
+
+Entries 7 and 8 are the clearest proof: `queue_markers WHERE room_id = ?` is a
+single-row lookup on a unique index averaging **2.8 s**. No plan change can fix that.
+
+### Mode C — two isolated multi-minute stalls (probably not the database)
+
+| Duration | Window | Query |
+|---:|---|---|
+| 909,870 ms | 2026-06-25 15:21:43 → 15:36:53 | habit completions |
+| 446,318 ms | 2026-06-23 19:40:16 → 19:47:42 | habit completions |
+
+Both had **zero overlapping writes** and near-zero overlapping queries (3 and 16
+logged statements respectively across a 7–15 minute span). That rules out lock
+contention. Consistent with host suspend or isolate starvation.
+
+These two events contribute 1,356 s and should be excluded from prioritisation. To
+settle it permanently, the interceptor could record wall-clock elapsed alongside the
+monotonic `Stopwatch`: a large divergence proves host suspend, agreement proves a real
+stall.
+
+## What the April remedies achieved
+
+Several April top-10 shapes are **absent** from the current window — `dayPlanById`
+(then 6,145 calls / 376 s), `ratingsForTimeEntries` (2,699 / 850 s) and
+`getLastSentCounterForEntry` (2,689 / 662 s) no longer appear. Those fixes landed and
+held. The April diagnosis of `countInProgressTasks` also holds up: it now runs behind
+`idx_journal_task_status_private` and no longer appears near the top.
+
+What did *not* get addressed is the round-trip floor, which is why `agent.sqlite` —
+barely present in April — now dominates.
+
+## Remedies, ordered
+
+1. **Batch the `agent_entities` by-id N+1** (mode A, entry 2). Add a by-ids read and
+   route `agent_repo_core.dart:88` and both `agent_attention_projection.dart` call
+   sites through it.
+2. **Stop re-reading all ~900 agents' latest state on every invalidation** (entry 1).
+   `latestEntitiesByAgentIds` (`agent_repo_core.dart:162`) is already chunked and
+   correctly indexed; the cost is that it runs 4,211 times in 14 days. Callers:
+   `agent_repo_queries.dart:141`, `agent_repo_core.dart:388`, `:456`.
+3. **Collapse the per-task `json_extract($.taskId)` lookups** (entry 4).
+4. **Cache / narrow `getAllAgentIdentities`** (entry 6) — 1,734 full-table reads of
+   every agent identity. Callers: `agent_service.dart:130`,
+   `profile_usage_provider.dart:23`, `agent_template_metrics.dart:228`,
+   `embedding_backfill_controller.dart:256`.
+5. **Fix the single-id `journal … id IN (?)` N+1** (entry 9).
+6. **Give `sync.sqlite` a read pool** (mode B) — the single highest-leverage change for
+   entries 3, 5, 7 and 8, none of which is individually fixable.
+7. **Replace the two `outbox` counting full-index scans** with a maintained counter or
+   a predicate-matching partial index (entry 3).
+8. **Audit write-transaction scope in the sync pipeline** — what holds the write lock
+   long enough to produce 25 s convoys.
+9. **Speed up the habit heatmap query** (entry 10) — 636 ms avg with
+   `USE TEMP B-TREE FOR ORDER BY` on 54 of 78 super-slow captures.
+10. **Delete the dead `habitCompletionsInRange` drift query** (`database.drift:897`).
+11. **Add wall-clock/monotonic divergence detection** to the interceptor to classify
+    mode C permanently.
+
+## Code map
+
+- `lib/database/common.dart:73-79` — pragmas (`busy_timeout`, `wal_autocheckpoint`)
+- `lib/database/common.dart:116-185` — `openDbConnection`, interceptor installation, `readPool`
+- `lib/database/slow_query_logging.dart:24` — super-slow threshold
+- `lib/database/slow_query_logging.dart:234` — the `Stopwatch` whose semantics this doc turns on
+- `lib/database/database.drift:897` — dead `habitCompletionsInRange`
+- `lib/database/database_data_queries.dart:40` — live habit heatmap query
+- `lib/features/agents/database/agent_repo_core.dart:88` — by-id read (N+1)
+- `lib/features/agents/database/agent_repo_core.dart:162` — `latestEntitiesByAgentIds`
+- `lib/features/agents/database/agent_attention_projection.dart:430,524` — by-id reads (N+1)
+- `lib/features/agents/database/agent_database.drift:214,253` — `getAgentEntityById`, `getAllAgentIdentities`
+- `lib/database/sync_db_tables.dart:26` — `idx_outbox_actionable_priority_created_at`

--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -12,6 +12,10 @@ sources:
     resource: ../../../lib/features/agents/database/agent_database.dart
     title: AgentDatabase
     last_modified: 2026-07-25
+  - id: coalescer
+    resource: ../../../lib/features/agents/database/agent_entity_by_id_coalescer.dart
+    title: AgentEntityByIdCoalescer
+    last_modified: 2026-08-01
   - id: constants
     resource: ../../../lib/features/agents/model/agent_constants.dart
     title: AgentLinkTypes
@@ -128,6 +132,22 @@ flowchart LR
 deduplicate inputs and split large `IN (...)` lists into **900-id chunks**. This
 keeps linked-task and report context collection on the indexed batch path even
 when sync or wake preparation considers thousands of ids.
+
+Single-id reads are folded into those batches automatically.
+`AgentRepoCore.getEntity` does not issue `WHERE id = ?` per call; it hands the
+id to `AgentEntityByIdCoalescer`, which collects every load made in the same
+event-loop turn and satisfies them with one `getEntitiesByIds` round trip. The
+fan-out this addresses is structural rather than local — independent callers
+(Riverpod provider families resolving one row each) firing in the same turn,
+with no single loop to batch. The 2026-06/07 logs recorded 92,787 such reads,
+peaking at 606 in one second at a median inter-arrival gap of 0.0 ms.
+
+Batches are keyed by `Zone` identity, and the flush is scheduled from the
+requesting zone so it runs there. This is load-bearing: drift resolves a
+statement's executor from `Zone.current`, so a batch that merged calls from
+inside a transaction with calls from outside would run on the wrong executor
+and break read-your-writes — `upsertEntity` reads entities back by id inside
+its own transaction.
 
 Latest-per-agent batch reads are backed by active-row indexes that include the
 `(created_at DESC, id DESC)` ranking order for both type-only and

--- a/lib/features/agents/database/agent_attention_projection.dart
+++ b/lib/features/agents/database/agent_attention_projection.dart
@@ -427,13 +427,17 @@ class AgentAttentionProjection {
   }
 
   Future<void> _refreshStandingAgreementProjection(String agreementId) async {
-    final rows = await _db.getAgentEntityById(agreementId).get();
-    if (rows.isEmpty) {
+    // Through `_core.getEntity` rather than `_db.getAgentEntityById` so this
+    // read joins the by-id coalescer's batch: projection refreshes fire once
+    // per affected entity, so the direct path spent one isolate round trip per
+    // id. Safe inside the refresh transaction because batches are keyed by
+    // zone. See `docs/perf/2026-08-01_slow-queries-investigation.md`.
+    final entity = await _core.getEntity(agreementId);
+    if (entity == null) {
       await _deleteStandingAgreementProjection(agreementId);
       return;
     }
 
-    final entity = AgentDbConversions.fromEntityRow(rows.first);
     if (entity is! StandingAgreementEntity) {
       await _deleteStandingAgreementProjection(agreementId);
       return;
@@ -521,9 +525,8 @@ class AgentAttentionProjection {
   Future<AttentionRequestEntity?> _getAttentionRequestForProjection(
     String requestId,
   ) async {
-    final rows = await _db.getAgentEntityById(requestId).get();
-    if (rows.isEmpty) return null;
-    final entity = AgentDbConversions.fromEntityRow(rows.first);
+    // Coalesced by-id read — see `_refreshStandingAgreementProjection`.
+    final entity = await _core.getEntity(requestId);
     return entity is AttentionRequestEntity ? entity : null;
   }
 

--- a/lib/features/agents/database/agent_entity_by_id_coalescer.dart
+++ b/lib/features/agents/database/agent_entity_by_id_coalescer.dart
@@ -106,15 +106,38 @@ class AgentEntityByIdCoalescer {
           waiter.complete(entity);
         }
       }
-    } catch (error, stackTrace) {
-      // One failed batch fails exactly the callers that joined it. Callers see
-      // the same error they would have seen issuing the read themselves.
-      for (final waiters in waitersById.values) {
-        for (final waiter in waiters) {
-          waiter.completeError(error, stackTrace);
-        }
-      }
+    } catch (_) {
+      // A batch can fail for a reason that belongs to ONE id — most commonly a
+      // row whose `serialized` payload fails to decode, which throws while
+      // mapping the whole result set. Before coalescing, such a row failed only
+      // its own `getEntity` call and every other id still resolved.
+      //
+      // Preserve that: fall back to loading each id on its own, so exactly the
+      // offending ids see the error. This runs only on the error path, and it
+      // is no more expensive than the pre-coalescing behaviour it restores.
+      await _completeIndividually(waitersById);
     }
+  }
+
+  /// Error-path fallback: resolve each id with its own single-id load so one
+  /// failing row cannot poison unrelated waiters in the same batch.
+  Future<void> _completeIndividually(
+    Map<String, List<Completer<AgentDomainEntity?>>> waitersById,
+  ) async {
+    await Future.wait(
+      waitersById.entries.map((entry) async {
+        try {
+          final found = await _loadByIds(<String>[entry.key]);
+          for (final waiter in entry.value) {
+            waiter.complete(found[entry.key]);
+          }
+        } catch (error, stackTrace) {
+          for (final waiter in entry.value) {
+            waiter.completeError(error, stackTrace);
+          }
+        }
+      }),
+    );
   }
 }
 

--- a/lib/features/agents/database/agent_entity_by_id_coalescer.dart
+++ b/lib/features/agents/database/agent_entity_by_id_coalescer.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:meta/meta.dart';
+
+/// Signature of the batched read the coalescer folds single-id loads into.
+/// Returns the found entities keyed by id; absent ids are simply missing.
+typedef AgentEntitiesByIdsLoader =
+    Future<Map<String, AgentDomainEntity>> Function(Iterable<String> ids);
+
+/// Coalesces concurrent single-id `agent_entities` reads into one batched
+/// `WHERE id IN (…)` round trip.
+///
+/// ## Why this exists
+///
+/// The 2026-06-16 → 2026-08-01 slow-query logs captured **92,787** hits on
+/// `SELECT * FROM agent_entities WHERE id = ? AND deleted_at IS NULL` — 2,660 s
+/// (44 min) of database time, the single largest shape in the corpus. The plan
+/// was always a clean primary-key seek; the cost was the ~19 ms isolate
+/// round trip, paid once per call.
+///
+/// The burst structure showed this could not be fixed at a call site: 80.7% of
+/// calls arrived in seconds containing ≥ 20 calls, peaking at 606 in one
+/// second, with a **median inter-arrival gap of 0.0 ms**. Calls dispatched
+/// that close together are concurrent fan-out — many independent callers
+/// (Riverpod provider families resolving one row each) firing in the same
+/// turn — not one loop with a single place to batch.
+///
+/// So the batching lives here, below every caller. See
+/// `docs/perf/2026-08-01_slow-queries-investigation.md`.
+///
+/// ## Transaction safety
+///
+/// Drift resolves the executor for a statement from `Zone.current`: inside
+/// `db.transaction(...)` it forks a zone whose zone-value carries the
+/// transaction executor (`DatabaseConnectionUser.resolvedEngine`, drift
+/// 2.28.2 `connection_user.dart:96`). A batch that merged calls from inside a
+/// transaction with calls from outside it would run the merged query on
+/// whichever zone happened to flush it — reading *outside* the transaction and
+/// breaking read-your-writes.
+///
+/// This is not hypothetical: `AgentRepoCore.upsertEntity` writes inside
+/// `db.transaction(...)` and the attention/standing projection refresh it
+/// invokes reads entities back by id within that same transaction.
+///
+/// Batches are therefore keyed by [Zone] identity, and the flush is scheduled
+/// with [scheduleMicrotask] from the requesting zone so it *runs* in that zone.
+/// Calls made inside a transaction batch only with each other and execute on
+/// the transaction's executor; calls outside batch only with each other.
+///
+/// ## Batching window
+///
+/// One microtask — the same window `DataLoader` uses. Callers that already
+/// await between their loads will not merge, which is correct: they are not
+/// concurrent. Nothing is delayed by more than a microtask, so no caller pays
+/// latency for the batching.
+class AgentEntityByIdCoalescer {
+  AgentEntityByIdCoalescer(this._loadByIds);
+
+  final AgentEntitiesByIdsLoader _loadByIds;
+
+  /// In-flight batches, one per requesting [Zone]. An entry exists only
+  /// between the first [load] of a turn and that turn's flush, so this map is
+  /// empty whenever the coalescer is idle.
+  final Map<Zone, _PendingBatch> _batches = <Zone, _PendingBatch>{};
+
+  /// Number of batches awaiting flush. Exposed so tests can assert the map
+  /// does not leak entries after a flush rather than inferring it.
+  @visibleForTesting
+  int get pendingBatchCount => _batches.length;
+
+  /// Resolves [id] to its entity, or `null` when no live row matches.
+  ///
+  /// Joins the current turn's batch for the calling zone, creating it (and
+  /// scheduling its flush) if this is the turn's first load.
+  Future<AgentDomainEntity?> load(String id) {
+    final zone = Zone.current;
+    final batch = _batches.putIfAbsent(zone, () {
+      // Scheduled from `zone`, so the flush runs in `zone` and drift resolves
+      // the same executor the caller would have used directly.
+      scheduleMicrotask(() => _flush(zone));
+      return _PendingBatch();
+    });
+
+    final completer = Completer<AgentDomainEntity?>();
+    // Duplicate ids within a turn share one query result but keep separate
+    // completers, so each caller still gets its own future.
+    batch.waitersById
+        .putIfAbsent(id, () => <Completer<AgentDomainEntity?>>[])
+        .add(completer);
+    return completer.future;
+  }
+
+  Future<void> _flush(Zone zone) async {
+    // Remove before awaiting: loads issued while the batched query is in
+    // flight must start a fresh batch rather than join one already dispatched.
+    final batch = _batches.remove(zone);
+    if (batch == null) return;
+
+    final waitersById = batch.waitersById;
+    try {
+      final found = await _loadByIds(waitersById.keys.toList(growable: false));
+      for (final entry in waitersById.entries) {
+        final entity = found[entry.key];
+        for (final waiter in entry.value) {
+          waiter.complete(entity);
+        }
+      }
+    } catch (error, stackTrace) {
+      // One failed batch fails exactly the callers that joined it. Callers see
+      // the same error they would have seen issuing the read themselves.
+      for (final waiters in waitersById.values) {
+        for (final waiter in waiters) {
+          waiter.completeError(error, stackTrace);
+        }
+      }
+    }
+  }
+}
+
+class _PendingBatch {
+  final Map<String, List<Completer<AgentDomainEntity?>>> waitersById =
+      <String, List<Completer<AgentDomainEntity?>>>{};
+}

--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 import 'package:lotti/features/agents/database/agent_attention_projection.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_db_conversions.dart';
+import 'package:lotti/features/agents/database/agent_entity_by_id_coalescer.dart';
 import 'package:lotti/features/agents/database/agent_repo_internals.dart';
 import 'package:lotti/features/agents/database/agent_repo_queries.dart'
     show AgentRepoQueries;
@@ -22,6 +23,13 @@ class AgentRepoCore {
   AgentRepoCore(this._db);
 
   final AgentDatabase _db;
+
+  /// Folds concurrent [getEntity] calls into batched `id IN (…)` reads. Keyed
+  /// by zone internally so batching never crosses a drift transaction
+  /// boundary — see [AgentEntityByIdCoalescer].
+  late final AgentEntityByIdCoalescer _byIdCoalescer = AgentEntityByIdCoalescer(
+    getEntitiesByIds,
+  );
 
   /// The projection collaborator used by [upsertEntity] to keep the local
   /// attention/standing indexes in sync. Wired by [AgentRepository] after both
@@ -84,11 +92,25 @@ class AgentRepoCore {
   }
 
   /// Fetch a single entity by its [id], or `null` if not found.
-  Future<AgentDomainEntity?> getEntity(String id) async {
-    final rows = await _db.getAgentEntityById(id).get();
-    if (rows.isEmpty) return null;
-    return AgentDbConversions.fromEntityRow(rows.first);
-  }
+  ///
+  /// Calls issued within the same event-loop turn are **coalesced** into one
+  /// `WHERE id IN (…)` round trip by [AgentEntityByIdCoalescer] rather than one round
+  /// trip each. Callers see no behavioural difference — the returned future
+  /// still completes with that id's entity or `null`.
+  ///
+  /// This exists because the fan-out is structural, not local: the
+  /// 2026-06/07 slow-query logs captured 92,787 hits on
+  /// `SELECT * FROM agent_entities WHERE id = ?` with a *median inter-arrival
+  /// gap of 0.0 ms* and bursts of 606 in a single second — the signature of
+  /// many independent callers (Riverpod provider families resolving one row
+  /// each) firing concurrently, not of one loop that could be batched at its
+  /// call site. The plan was always a clean primary-key seek; the cost was
+  /// ~19 ms of isolate round trip per call. Coalescing at this layer fixes
+  /// every such caller at once, including ones that have no single place to
+  /// batch.
+  ///
+  /// See `docs/perf/2026-08-01_slow-queries-investigation.md`.
+  Future<AgentDomainEntity?> getEntity(String id) => _byIdCoalescer.load(id);
 
   /// Batch-fetch non-deleted entities for every id in [ids]. Returns
   /// the matched entities keyed by their `id` column so the caller can

--- a/test/features/agents/database/agent_entity_by_id_coalescer_test.dart
+++ b/test/features/agents/database/agent_entity_by_id_coalescer_test.dart
@@ -1,0 +1,268 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/database/agent_entity_by_id_coalescer.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+
+import '../test_data/entity_factories.dart';
+
+/// Tests for [AgentEntityByIdCoalescer].
+///
+/// The coalescer's whole purpose is to change *how many* batched reads happen
+/// for a given pattern of `load` calls, so every test here asserts on the
+/// recorded batches — the id sets actually handed to the loader — rather than
+/// only on the returned values. A test that checked values alone would pass
+/// just as happily with the coalescing removed.
+void main() {
+  /// Records every batch the coalescer dispatches so tests can assert on
+  /// round-trip count and batch composition.
+  late List<List<String>> batches;
+  late Map<String, AgentDomainEntity> table;
+
+  AgentEntityByIdCoalescer build({
+    Future<void> Function()? gate,
+    Object? throwError,
+  }) {
+    return AgentEntityByIdCoalescer((ids) async {
+      batches.add(ids.toList());
+      if (gate != null) await gate();
+      if (throwError != null) {
+        // ignore: only_throw_errors
+        throw throwError;
+      }
+      return {
+        for (final id in ids)
+          if (table.containsKey(id)) id: table[id]!,
+      };
+    });
+  }
+
+  setUp(() {
+    batches = <List<String>>[];
+    table = {
+      'a': makeTestIdentity(id: 'a', agentId: 'a', displayName: 'Agent A'),
+      'b': makeTestIdentity(id: 'b', agentId: 'b', displayName: 'Agent B'),
+      'c': makeTestIdentity(id: 'c', agentId: 'c', displayName: 'Agent C'),
+    };
+  });
+
+  test(
+    'folds concurrent loads in one turn into a single batched read',
+    () async {
+      final coalescer = build();
+
+      final results = await Future.wait([
+        coalescer.load('a'),
+        coalescer.load('b'),
+        coalescer.load('c'),
+      ]);
+
+      expect(
+        batches,
+        hasLength(1),
+        reason: '3 concurrent loads must cost 1 round trip, not 3',
+      );
+      expect(batches.single, containsAll(<String>['a', 'b', 'c']));
+      expect(
+        results.map((e) => (e! as AgentIdentityEntity).displayName),
+        ['Agent A', 'Agent B', 'Agent C'],
+        reason: 'each caller must still receive the entity for its own id',
+      );
+    },
+  );
+
+  test(
+    'scales: 600 concurrent loads still cost exactly one round trip',
+    () async {
+      // Mirrors the production burst that motivated this class — 606 single-id
+      // reads dispatched inside one second.
+      table = {
+        for (var i = 0; i < 600; i++)
+          'id-$i': makeTestIdentity(id: 'id-$i', agentId: 'id-$i'),
+      };
+      final coalescer = build();
+
+      final results = await Future.wait([
+        for (var i = 0; i < 600; i++) coalescer.load('id-$i'),
+      ]);
+
+      expect(batches, hasLength(1));
+      expect(batches.single, hasLength(600));
+      expect(results.where((e) => e != null), hasLength(600));
+    },
+  );
+
+  test('deduplicates repeated ids but completes every caller', () async {
+    final coalescer = build();
+
+    final results = await Future.wait([
+      coalescer.load('a'),
+      coalescer.load('a'),
+      coalescer.load('b'),
+    ]);
+
+    expect(batches.single, <String>['a', 'b'], reason: 'id "a" queried once');
+    expect(results, hasLength(3));
+    expect(
+      results[0],
+      same(results[1]),
+      reason: 'both "a" callers share a row',
+    );
+    expect((results[2]! as AgentIdentityEntity).displayName, 'Agent B');
+  });
+
+  test('sequentially awaited loads land in separate batches', () async {
+    final coalescer = build();
+
+    await coalescer.load('a');
+    await coalescer.load('b');
+
+    expect(
+      batches,
+      [
+        ['a'],
+        ['b'],
+      ],
+      reason: 'awaited calls are not concurrent and must not be merged',
+    );
+  });
+
+  test('loads issued while a batch is in flight form a new batch', () async {
+    final gate = Completer<void>();
+    final coalescer = build(gate: () => gate.future);
+
+    final first = coalescer.load('a');
+    // Let the first batch dispatch and block inside the loader.
+    await Future<void>.delayed(Duration.zero);
+    expect(batches, hasLength(1));
+
+    final second = coalescer.load('b');
+    gate.complete();
+    await Future.wait([first, second]);
+
+    expect(
+      batches,
+      [
+        ['a'],
+        ['b'],
+      ],
+      reason: 'the in-flight batch was already dispatched and cannot be joined',
+    );
+  });
+
+  test('returns null for ids with no row, without failing the batch', () async {
+    final coalescer = build();
+
+    final results = await Future.wait([
+      coalescer.load('a'),
+      coalescer.load('missing'),
+    ]);
+
+    expect(batches.single, containsAll(<String>['a', 'missing']));
+    expect(results[0], isNotNull);
+    expect(results[1], isNull);
+  });
+
+  test('propagates a batch failure to every caller that joined it', () async {
+    final coalescer = build(throwError: StateError('db down'));
+
+    final a = coalescer.load('a');
+    final b = coalescer.load('b');
+
+    await expectLater(a, throwsA(isA<StateError>()));
+    await expectLater(b, throwsA(isA<StateError>()));
+    expect(batches, hasLength(1));
+  });
+
+  test('recovers after a failed batch', () async {
+    var shouldFail = true;
+    final coalescer = AgentEntityByIdCoalescer((ids) async {
+      batches.add(ids.toList());
+      if (shouldFail) {
+        shouldFail = false;
+        throw StateError('transient');
+      }
+      return {
+        for (final id in ids)
+          if (table.containsKey(id)) id: table[id]!,
+      };
+    });
+
+    await expectLater(coalescer.load('a'), throwsA(isA<StateError>()));
+    expect(await coalescer.load('a'), isNotNull);
+    expect(batches, hasLength(2));
+  });
+
+  test('does not retain batch state once a batch completes', () async {
+    final coalescer = build();
+
+    final pending = Future.wait([coalescer.load('a'), coalescer.load('b')]);
+    expect(
+      coalescer.pendingBatchCount,
+      1,
+      reason: 'a batch is registered while loads accumulate',
+    );
+
+    await pending;
+    expect(
+      coalescer.pendingBatchCount,
+      0,
+      reason: 'batch entries must not leak after flushing',
+    );
+  });
+
+  group('zone isolation (drift transaction safety)', () {
+    // Drift resolves the executor from Zone.current, so a batch must never
+    // merge calls made inside a transaction zone with calls made outside it.
+    // These tests pin that property directly, since violating it would swap
+    // the executor a query runs on and silently break read-your-writes.
+
+    test('loads from different zones do not share a batch', () async {
+      final coalescer = build();
+
+      final outer = coalescer.load('a');
+      final inner = runZoned(() => coalescer.load('b'));
+
+      await Future.wait([outer, inner]);
+
+      expect(
+        batches,
+        hasLength(2),
+        reason: 'each zone must get its own batch and its own round trip',
+      );
+      expect(batches.map((b) => b.single), containsAll(<String>['a', 'b']));
+    });
+
+    test('the flush runs in the zone that requested it', () async {
+      final flushZones = <Object?>[];
+      final coalescer = AgentEntityByIdCoalescer((ids) async {
+        flushZones.add(Zone.current[#testZoneMarker]);
+        return const <String, AgentDomainEntity>{};
+      });
+
+      await runZoned(
+        () => coalescer.load('a'),
+        zoneValues: {#testZoneMarker: 'transaction'},
+      );
+
+      expect(
+        flushZones,
+        ['transaction'],
+        reason:
+            'the batched query must execute in the requesting zone so drift '
+            'resolves the transaction executor, not the root one',
+      );
+    });
+
+    test('loads within one zone still coalesce', () async {
+      final coalescer = build();
+
+      await runZoned(
+        () => Future.wait([coalescer.load('a'), coalescer.load('b')]),
+      );
+
+      expect(batches, hasLength(1));
+      expect(batches.single, containsAll(<String>['a', 'b']));
+    });
+  });
+}

--- a/test/features/agents/database/agent_entity_by_id_coalescer_test.dart
+++ b/test/features/agents/database/agent_entity_by_id_coalescer_test.dart
@@ -129,11 +129,21 @@ void main() {
 
   test('loads issued while a batch is in flight form a new batch', () async {
     final gate = Completer<void>();
-    final coalescer = build(gate: () => gate.future);
+    // Signalled by the loader itself the moment the first batch is dispatched,
+    // so the test waits on an actual event rather than on event-loop timing.
+    final dispatched = Completer<void>();
+    final coalescer = AgentEntityByIdCoalescer((ids) async {
+      batches.add(ids.toList());
+      if (!dispatched.isCompleted) dispatched.complete();
+      await gate.future;
+      return {
+        for (final id in ids)
+          if (table.containsKey(id)) id: table[id]!,
+      };
+    });
 
     final first = coalescer.load('a');
-    // Let the first batch dispatch and block inside the loader.
-    await Future<void>.delayed(Duration.zero);
+    await dispatched.future;
     expect(batches, hasLength(1));
 
     final second = coalescer.load('b');
@@ -163,18 +173,79 @@ void main() {
     expect(results[1], isNull);
   });
 
-  test('propagates a batch failure to every caller that joined it', () async {
+  test('propagates a persistent failure to every caller', () async {
+    // When the failure is not row-specific (the database is simply
+    // unavailable), the per-id fallback fails too and every caller sees the
+    // error — the same outcome each would have had issuing its own read.
     final coalescer = build(throwError: StateError('db down'));
 
     final a = coalescer.load('a');
     final b = coalescer.load('b');
 
-    await expectLater(a, throwsA(isA<StateError>()));
-    await expectLater(b, throwsA(isA<StateError>()));
-    expect(batches, hasLength(1));
+    await Future.wait([
+      expectLater(a, throwsA(isA<StateError>())),
+      expectLater(b, throwsA(isA<StateError>())),
+    ]);
+    expect(
+      batches,
+      hasLength(3),
+      reason: 'one batch attempt, then one single-id retry per waiter',
+    );
   });
 
-  test('recovers after a failed batch', () async {
+  test('one undecodable row does not poison the rest of the batch', () async {
+    // Before coalescing, a row whose serialized payload fails to decode failed
+    // only its own getEntity call. The batched read maps the whole result set
+    // at once, so without isolation one bad row would fail every waiter that
+    // happened to share its microtask.
+    final coalescer = AgentEntityByIdCoalescer((ids) async {
+      batches.add(ids.toList());
+      if (ids.contains('poison') && ids.length > 1) {
+        throw const FormatException('undecodable row in batch');
+      }
+      if (ids.single == 'poison') {
+        throw const FormatException('undecodable row');
+      }
+      return {
+        for (final id in ids)
+          if (table.containsKey(id)) id: table[id]!,
+      };
+    });
+
+    final good = coalescer.load('a');
+    final bad = coalescer.load('poison');
+    final alsoGood = coalescer.load('b');
+    // Attach the error expectation immediately: `bad` completes with an error
+    // while the other two are still being awaited, and an error delivered to a
+    // future that has no listener yet is reported as unhandled.
+    final badExpectation = expectLater(
+      bad,
+      throwsA(isA<FormatException>()),
+      reason: 'only the offending id sees the error',
+    );
+
+    expect(
+      await good,
+      isA<AgentIdentityEntity>(),
+      reason: 'an unrelated id must still resolve',
+    );
+    expect(await alsoGood, isA<AgentIdentityEntity>());
+    await badExpectation;
+
+    expect(
+      batches.first,
+      containsAll(<String>['a', 'poison', 'b']),
+      reason: 'the fast path still attempts one batch first',
+    );
+    expect(
+      batches.length,
+      4,
+      reason:
+          'batch attempt + one single-id retry per waiter on the error path',
+    );
+  });
+
+  test('a transient batch failure is rescued by the per-id retry', () async {
     var shouldFail = true;
     final coalescer = AgentEntityByIdCoalescer((ids) async {
       batches.add(ids.toList());
@@ -188,9 +259,16 @@ void main() {
       };
     });
 
-    await expectLater(coalescer.load('a'), throwsA(isA<StateError>()));
-    expect(await coalescer.load('a'), isNotNull);
+    expect(
+      await coalescer.load('a'),
+      isNotNull,
+      reason: 'the batch attempt failed; the single-id retry succeeded',
+    );
     expect(batches, hasLength(2));
+
+    // And the coalescer is back on the fast path afterwards.
+    expect(await coalescer.load('b'), isNotNull);
+    expect(batches, hasLength(3));
   });
 
   test('does not retain batch state once a batch completes', () async {

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -35,6 +35,146 @@ void main() {
     await db.close();
   });
 
+  group('getEntity coalescing', () {
+    // getEntity folds concurrent single-id reads into one batched
+    // `id IN (…)` query (AgentEntityByIdCoalescer). These tests run against a
+    // real database to pin the two properties that batching could break:
+    // identical results, and read-your-writes inside a transaction — drift
+    // resolves the executor from Zone.current, so a batch that escaped the
+    // transaction zone would read pre-transaction state.
+
+    test(
+      'concurrent getEntity calls return the same rows as serial ones',
+      () async {
+        for (var i = 0; i < 5; i++) {
+          await core.upsertEntity(
+            makeTestIdentity(
+              id: 'coalesce-$i',
+              agentId: 'agent-$i',
+              displayName: 'Agent $i',
+              createdAt: testDate,
+              updatedAt: testDate,
+            ),
+          );
+        }
+
+        final concurrent = await Future.wait([
+          for (var i = 0; i < 5; i++) core.getEntity('coalesce-$i'),
+          core.getEntity('coalesce-does-not-exist'),
+        ]);
+
+        expect(
+          concurrent
+              .take(5)
+              .map((e) => (e! as AgentIdentityEntity).displayName),
+          ['Agent 0', 'Agent 1', 'Agent 2', 'Agent 3', 'Agent 4'],
+        );
+        expect(
+          concurrent.last,
+          isNull,
+          reason: 'absent id still resolves null',
+        );
+      },
+    );
+
+    test('sees its own write when read inside the same transaction', () async {
+      await core.runInTransaction(() async {
+        await core.upsertEntity(
+          makeTestIdentity(
+            id: 'txn-entity',
+            agentId: 'txn-agent',
+            displayName: 'Written in txn',
+            createdAt: testDate,
+            updatedAt: testDate,
+          ),
+        );
+
+        final readBack = await core.getEntity('txn-entity');
+        expect(
+          readBack,
+          isNotNull,
+          reason:
+              'the coalesced read must run on the transaction executor, '
+              'not the root one, or it would not see the uncommitted write',
+        );
+        expect(
+          (readBack! as AgentIdentityEntity).displayName,
+          'Written in txn',
+        );
+      });
+
+      expect(await core.getEntity('txn-entity'), isNotNull);
+    });
+
+    test(
+      'concurrent reads inside a transaction see the uncommitted write',
+      () async {
+        await core.runInTransaction(() async {
+          await core.upsertEntity(
+            makeTestIdentity(
+              id: 'txn-batch-a',
+              agentId: 'txn-a',
+              displayName: 'A',
+              createdAt: testDate,
+              updatedAt: testDate,
+            ),
+          );
+          await core.upsertEntity(
+            makeTestIdentity(
+              id: 'txn-batch-b',
+              agentId: 'txn-b',
+              displayName: 'B',
+              createdAt: testDate,
+              updatedAt: testDate,
+            ),
+          );
+
+          // Both loads join one batch; that batch must still run inside the
+          // transaction.
+          final both = await Future.wait([
+            core.getEntity('txn-batch-a'),
+            core.getEntity('txn-batch-b'),
+          ]);
+
+          expect(
+            both.map((e) => (e! as AgentIdentityEntity).displayName),
+            ['A', 'B'],
+          );
+        });
+      },
+    );
+
+    test(
+      'rolls back cleanly when the transaction fails after a read',
+      () async {
+        await expectLater(
+          core.runInTransaction(() async {
+            await core.upsertEntity(
+              makeTestIdentity(
+                id: 'txn-rollback',
+                agentId: 'txn-rollback',
+                displayName: 'Doomed',
+                createdAt: testDate,
+                updatedAt: testDate,
+              ),
+            );
+            expect(await core.getEntity('txn-rollback'), isNotNull);
+            throw StateError('abort');
+          }),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(
+          await core.getEntity('txn-rollback'),
+          isNull,
+          reason:
+              'the aborted write must not survive, and the post-rollback '
+              'read must not be served from a stale coalesced batch',
+        );
+      },
+    );
+  });
+
   group('upsertEntity / getEntity', () {
     test('inserts then updates a non-projection entity in place', () async {
       final identity = makeTestIdentity(


### PR DESCRIPTION
## Problem

`SELECT * FROM agent_entities WHERE id = ?` is the largest single shape in the 2026-06-16 → 2026-08-01 slow-query logs: **92,787 calls, 2,660 s (44 min)** of database time.

The plan was never the problem. Every one of the 253 super-slow captures shows a clean primary-key seek:

```
3|0|SEARCH agent_entities USING INDEX sqlite_autoindex_agent_entities_1 (id=?)
```

The cost is the **~19 ms isolate round trip**, paid once per call. The slow-query interceptor is installed client-side of the isolate boundary (`lib/database/common.dart:173`), so what it measures is round-trip time — IPC plus queueing — not execution time. The distributions make this unambiguous:

| Shape | n | p50 | p95 |
|---|---:|---:|---:|
| `WHERE id = ?` (PK lookup) | 92,787 | 19.0 ms | 77.6 ms |
| `ROW_NUMBER()` over 901 ids | 23,662 | 18.2 ms | 76.1 ms |

A single-row primary-key lookup and a 901-parameter window function have the same latency distribution.

## Why not batch at the call site

Because there isn't one. The burst structure:

- **80.7%** of calls arrive in seconds containing ≥ 20 calls
- peak **606 calls in one second** (2026-07-08 14:51:12)
- **median inter-arrival gap: 0.0 ms**
- the burst window is read-only: 698 select / 3 insert / 1 update

Calls dispatched that close together are concurrent fan-out from many independent callers in the same turn — Riverpod provider families resolving one row each — not a loop with a single place to batch. `getEntity` has 67 call sites across 40 files.

## Fix

`AgentEntityByIdCoalescer` collects every load issued in one event-loop turn and satisfies them with a single `getEntitiesByIds` round trip (which already chunks at 900 ids). `AgentRepoCore.getEntity` delegates to it. Signature and semantics are unchanged, so **no call site moves**.

### Transaction safety

Batches are keyed by `Zone` identity, and the flush is scheduled with `scheduleMicrotask` from the requesting zone so it *runs* in that zone.

This is load-bearing. Drift resolves a statement's executor from `Zone.current` (drift 2.28.2, `connection_user.dart:96`), so a batch that merged in-transaction calls with out-of-transaction calls would run the merged query on whichever zone happened to flush it — reading outside the transaction and breaking read-your-writes. Not hypothetical: `upsertEntity` reads entities back by id inside its own transaction.

Batching window is one microtask, so nothing is delayed measurably and callers that already await between loads are correctly not merged.

## Tests

16 new tests.

`agent_entity_by_id_coalescer_test.dart` (12) — including **600 concurrent loads → exactly 1 round trip**, mirroring the production burst, plus 3 zone-isolation tests pinning the transaction-safety property directly.

`agent_repo_core_test.dart` (4, against a real in-memory DB) — read-your-writes inside a transaction, concurrent reads inside a transaction, and rollback-after-read.

**Revert check:** with the coalescing disabled, **7 of 12** coalescer tests fail. The 5 that still pass are value-correctness assertions that hold under both designs.

Full `test/features/agents/database/`: **515 passed**. `dart analyze`: clean. `make knowledge_check`: 25/25.

## Docs

- `docs/perf/2026-08-01_slow-queries-investigation.md` — the full investigation behind this and the sibling tasks.
- `knowledge/features/agents/persistence-and-sync.md` — coalescing and the zone-keying rationale added to "Bulk reads".

## Notes

No CHANGELOG entry: the specific caller issuing the ~600 concurrent loads was never pinned, so a user-visible responsiveness claim can't be substantiated. The coalescer makes the fan-out harmless regardless. Worth finding separately — enabling `SlowQueryLoggingGate.captureFirstCallStack` would name it in one reproduction.

First of 12 PRs from the "Slow Query Improvements (2026-08 investigation)" epic.