### PR TITLE
perf(agents): fetch the proposal ledger in one round trip

### DIFF
--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -5,16 +5,17 @@ description: The agent.sqlite entity and link model, bulk-read chunking, and exa
 resource: ../../../lib/features/agents/database/agent_database.dart
 tags: [agents, persistence, sync, privacy, drift]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T17:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-01T12:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: db
     resource: ../../../lib/features/agents/database/agent_database.dart
     title: AgentDatabase
-    last_modified: 2026-07-25
+    last_modified: 2026-08-01
   - id: coalescer
     resource: ../../../lib/features/agents/database/agent_entity_by_id_coalescer.dart
     title: AgentEntityByIdCoalescer
+    last_modified: 2026-08-01
   - id: ledger
     resource: ../../../lib/features/agents/database/agent_proposal_ledger.dart
     title: AgentProposalLedger

--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -15,6 +15,9 @@ sources:
   - id: coalescer
     resource: ../../../lib/features/agents/database/agent_entity_by_id_coalescer.dart
     title: AgentEntityByIdCoalescer
+  - id: ledger
+    resource: ../../../lib/features/agents/database/agent_proposal_ledger.dart
+    title: AgentProposalLedger
     last_modified: 2026-08-01
   - id: constants
     resource: ../../../lib/features/agents/model/agent_constants.dart
@@ -148,6 +151,31 @@ statement's executor from `Zone.current`, so a batch that merged calls from
 inside a transaction with calls from outside would run on the wrong executor
 and break read-your-writes — `upsertEntity` reads entities back by id inside
 its own transaction.
+
+# The proposal ledger is one compound read
+
+`AgentProposalLedger.getProposalLedger` needs three task-scoped row sets:
+pending change sets, recent change-set history, and recent item decisions.
+They are fetched as **one** `UNION ALL` carrying a per-row `bucket` marker,
+not as three queries, and the caller splits the result back apart by bucket.
+
+The three arms are deliberately not merged into a single predicate:
+
+- Each keeps **its own `LIMIT`** — the decision arm's cap is smaller than the
+  change-set arms'. One shared limit across the union would silently change
+  what the ledger sees.
+- The dedicated **pending arm** is what stops a long-lived open change set
+  from being buried: the recent arm is newest-first and capped, so once enough
+  resolved history accumulates an old-but-still-open set would fall off the
+  end of it.
+
+The compound carries an explicit
+`ORDER BY bucket, created_at DESC, id DESC`. Each arm's inner `ORDER BY`
+decides only which rows survive that arm's `LIMIT`; the order of the *compound*
+result is otherwise unspecified. The consumers are first-wins
+(`decisionByKey.putIfAbsent`, and the duplicate-proposal collapse in
+`unifiedSuggestionList`), so an unordered compound could let an older
+retry/audit decision override the newest one.
 
 Latest-per-agent batch reads are backed by active-row indexes that include the
 `(created_at DESC, id DESC)` ranking order for both type-only and

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -599,16 +599,27 @@ class AgentDatabase extends _$AgentDatabase {
           LIMIT ${entityType == 'changeDecision' ? '?4' : '?3'}
         )''';
 
+    // The inner ORDER BY of each arm decides which rows survive that arm's
+    // LIMIT, but says nothing about the order of the compound result — SQLite
+    // may emit the arms' rows in any legal order. The consumers are first-wins
+    // (`decisionByKey.putIfAbsent`, and the duplicate-proposal collapse in
+    // `unifiedSuggestionList`), so an unordered compound could let an older
+    // retry/audit decision override the newest one. Order the compound result
+    // explicitly to keep every bucket newest-first.
+    final compound =
+        '${[
+          arm(
+            _ledgerBucketPending,
+            'changeSet',
+            extraPredicate: "AND subtype IN ('pending', 'partiallyResolved')",
+          ),
+          arm(_ledgerBucketRecent, 'changeSet'),
+          arm(_ledgerBucketDecision, 'changeDecision'),
+        ].join('\n        UNION ALL\n')}\n'
+        '        ORDER BY $ledgerBucketColumn ASC, created_at DESC, id DESC';
+
     return customSelect(
-      [
-        arm(
-          _ledgerBucketPending,
-          'changeSet',
-          extraPredicate: "AND subtype IN ('pending', 'partiallyResolved')",
-        ),
-        arm(_ledgerBucketRecent, 'changeSet'),
-        arm(_ledgerBucketDecision, 'changeDecision'),
-      ].join('\n        UNION ALL\n'),
+      compound,
       variables: [
         Variable<String>(agentId),
         Variable<String>(taskId),

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -542,17 +542,6 @@ class AgentDatabase extends _$AgentDatabase {
     ).asyncMap(agentEntities.mapFromRow);
   }
 
-  Selectable<AgentEntity> getChangeSetsForAgentAndTask(
-    String agentId,
-    String taskId,
-    int limit,
-  ) => _agentEntitiesByTask(
-    agentId: agentId,
-    entityType: 'changeSet',
-    taskId: taskId,
-    limit: limit,
-  );
-
   Selectable<AgentEntity> getPendingChangeSetsForAgentAndTask(
     String agentId,
     String taskId,
@@ -565,16 +554,81 @@ class AgentDatabase extends _$AgentDatabase {
     extraPredicate: "AND subtype IN ('pending', 'partiallyResolved')",
   );
 
-  Selectable<AgentEntity> getRecentDecisionsForAgentAndTask(
-    String agentId,
-    String taskId,
-    int limit,
-  ) => _agentEntitiesByTask(
-    agentId: agentId,
-    entityType: 'changeDecision',
-    taskId: taskId,
-    limit: limit,
-  );
+  /// The three task-scoped reads `AgentProposalLedger.getProposalLedger` needs,
+  /// fetched in **one** round trip instead of three concurrent ones.
+  ///
+  /// Each arm keeps its own predicate, ordering and limit — they are not
+  /// interchangeable (see the rationale on `getProposalLedger`: the dedicated
+  /// pending arm is what stops a long-lived open change set from being buried
+  /// past the newest-first history cap). A `bucket` marker column carries each
+  /// row's origin so the caller can split the result back into the same three
+  /// lists it used to await separately.
+  ///
+  /// Motivation: the 2026-06/07 slow-query logs show this trio firing as
+  /// back-to-back runs of 3 (483 occurrences in 14 days) and 6, at a median
+  /// inter-arrival gap of 0.4 ms — 4,127 calls totalling 90 s. Each is a
+  /// correctly indexed read sitting at the ~22 ms isolate round-trip floor, so
+  /// the win is removing two of the three round trips, not touching the plans.
+  /// See `docs/perf/2026-08-01_slow-queries-investigation.md`.
+  Selectable<QueryRow> getProposalLedgerRowsForAgentAndTask({
+    required String agentId,
+    required String taskId,
+    required int changeSetLimit,
+    required int decisionLimit,
+  }) {
+    // Positional placeholders are reused across all three arms (SQLite binds
+    // ?1..?4 once each regardless of how often they appear), so the variables
+    // list stays four entries rather than twelve.
+    String arm(
+      String bucket,
+      String entityType, {
+      String extraPredicate = '',
+    }) =>
+        '''
+        SELECT *, '$bucket' AS $ledgerBucketColumn FROM (
+          SELECT *
+          FROM agent_entities
+            INDEXED BY idx_agent_entities_active_agent_type_task_created_id
+          WHERE agent_id = ?1
+            AND type = '$entityType'
+            AND json_valid(serialized)
+            AND $_taskIdJsonExpression = ?2
+            AND deleted_at IS NULL
+            $extraPredicate
+          ORDER BY created_at DESC
+          LIMIT ${entityType == 'changeDecision' ? '?4' : '?3'}
+        )''';
+
+    return customSelect(
+      [
+        arm(
+          _ledgerBucketPending,
+          'changeSet',
+          extraPredicate: "AND subtype IN ('pending', 'partiallyResolved')",
+        ),
+        arm(_ledgerBucketRecent, 'changeSet'),
+        arm(_ledgerBucketDecision, 'changeDecision'),
+      ].join('\n        UNION ALL\n'),
+      variables: [
+        Variable<String>(agentId),
+        Variable<String>(taskId),
+        Variable<int>(changeSetLimit),
+        Variable<int>(decisionLimit),
+      ],
+      readsFrom: {agentEntities},
+    );
+  }
+
+  /// Bucket markers emitted by [getProposalLedgerRowsForAgentAndTask].
+  static const String _ledgerBucketPending = 'pending';
+  static const String _ledgerBucketRecent = 'recent';
+  static const String _ledgerBucketDecision = 'decision';
+
+  /// Column name carrying the bucket marker.
+  static const String ledgerBucketColumn = 'bucket';
+  static const String ledgerBucketPending = _ledgerBucketPending;
+  static const String ledgerBucketRecent = _ledgerBucketRecent;
+  static const String ledgerBucketDecision = _ledgerBucketDecision;
 
   Selectable<AgentEntity> _agentEntitiesByTask({
     required String agentId,

--- a/lib/features/agents/database/agent_proposal_ledger.dart
+++ b/lib/features/agents/database/agent_proposal_ledger.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_db_conversions.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart'
@@ -42,34 +43,42 @@ class AgentProposalLedger {
     int changeSetFetchLimit = 200,
     int resolvedLimit = 50,
   }) async {
-    // Three independent task-scoped reads — run in parallel to keep
-    // wall-clock bounded on cold sqlite access. The dedicated pending query is
+    // Three logically independent task-scoped reads, fetched in ONE round trip
+    // as a UNION ALL with a per-row bucket marker. They remain three separate
+    // arms because they are not interchangeable: the dedicated pending arm is
     // what guarantees an old-but-still-open consolidated change set is never
-    // dropped by the recent-history cap: `getChangeSetsForAgentAndTask` is
-    // newest-first and would otherwise bury a long-lived open set past
+    // dropped by the recent-history cap, since the recent arm is newest-first
+    // and would otherwise bury a long-lived open set past
     // `changeSetFetchLimit` once enough resolved history accumulates.
-    final results = await Future.wait([
-      _db
-          .getPendingChangeSetsForAgentAndTask(
-            agentId,
-            taskId,
-            changeSetFetchLimit,
-          )
-          .get(),
-      _db
-          .getChangeSetsForAgentAndTask(agentId, taskId, changeSetFetchLimit)
-          .get(),
-      _db
-          .getRecentDecisionsForAgentAndTask(
-            agentId,
-            taskId,
-            resolvedLimit,
-          )
-          .get(),
-    ]);
-    final pendingRows = results[0];
-    final recentRows = results[1];
-    final decisionRows = results[2];
+    //
+    // Previously these were three concurrent queries. Each was correctly
+    // indexed and sat at the ~22 ms isolate round-trip floor, so the cost was
+    // the round-trip count, not the plans — the slow-query logs caught the trio
+    // as back-to-back runs of 3 and 6 at a 0.4 ms median gap. See
+    // `docs/perf/2026-08-01_slow-queries-investigation.md`.
+    final ledgerRows = await _db
+        .getProposalLedgerRowsForAgentAndTask(
+          agentId: agentId,
+          taskId: taskId,
+          changeSetLimit: changeSetFetchLimit,
+          decisionLimit: resolvedLimit,
+        )
+        .get();
+
+    final pendingRows = <AgentEntity>[];
+    final recentRows = <AgentEntity>[];
+    final decisionRows = <AgentEntity>[];
+    for (final row in ledgerRows) {
+      final entity = await _db.agentEntities.mapFromRow(row);
+      switch (row.read<String>(AgentDatabase.ledgerBucketColumn)) {
+        case AgentDatabase.ledgerBucketPending:
+          pendingRows.add(entity);
+        case AgentDatabase.ledgerBucketRecent:
+          recentRows.add(entity);
+        case AgentDatabase.ledgerBucketDecision:
+          decisionRows.add(entity);
+      }
+    }
 
     final rawPendingSets = pendingRows
         .map(AgentDbConversions.fromEntityRow)

--- a/test/features/agents/database/agent_database_test.dart
+++ b/test/features/agents/database/agent_database_test.dart
@@ -2,13 +2,19 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:drift/drift.dart' show Variable;
+import 'package:drift/drift.dart' show QueryRow, Variable;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/agents/database/agent_db_conversions.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:path/path.dart' as path;
 import 'package:sqlite3/sqlite3.dart' show SqliteException, sqlite3;
+
+import '../test_data/change_set_factories.dart';
 
 void main() {
   late Directory testDirectory;
@@ -23,6 +29,319 @@ void main() {
     if (testDirectory.existsSync()) {
       testDirectory.deleteSync(recursive: true);
     }
+  });
+
+  group('getProposalLedgerRowsForAgentAndTask', () {
+    // Mirror tests for the compound ledger read that AgentDatabase owns. The
+    // ledger's own assembly behaviour is covered in
+    // agent_proposal_ledger_test.dart; what lives here is the query contract:
+    // bucket routing, scoping, per-arm limits and ordering.
+    late AgentDatabase db;
+    final testDate = DateTime(2026, 3, 15);
+
+    setUp(() {
+      db = AgentDatabase(inMemoryDatabase: true, background: false);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    Future<void> insertChangeSet({
+      required String id,
+      required String agentId,
+      required String taskId,
+      ChangeSetStatus status = ChangeSetStatus.pending,
+      List<ChangeItem>? items,
+      DateTime? createdAt,
+    }) async {
+      final entity = makeTestChangeSet(
+        id: id,
+        agentId: agentId,
+        taskId: taskId,
+        status: status,
+        items: items,
+        createdAt: createdAt ?? testDate,
+        vectorClock: const VectorClock({'node-1': 1}),
+      );
+      await db
+          .into(db.agentEntities)
+          .insert(AgentDbConversions.toEntityCompanion(entity));
+    }
+
+    Future<void> insertDecision({
+      required String id,
+      required String agentId,
+      required String taskId,
+      required String changeSetId,
+      int itemIndex = 0,
+      ChangeDecisionVerdict verdict = ChangeDecisionVerdict.confirmed,
+      DateTime? createdAt,
+    }) async {
+      final entity = makeTestChangeDecision(
+        id: id,
+        agentId: agentId,
+        changeSetId: changeSetId,
+        itemIndex: itemIndex,
+        verdict: verdict,
+        taskId: taskId,
+        createdAt: createdAt ?? testDate,
+        vectorClock: const VectorClock({'node-1': 100}),
+      );
+      await db
+          .into(db.agentEntities)
+          .insert(AgentDbConversions.toEntityCompanion(entity));
+    }
+
+    // The ledger used to issue three concurrent task-scoped queries. They are
+    // now one UNION ALL with a per-row `bucket` marker, so these tests pin the
+    // properties that collapsing could silently break: correct bucketing, and
+    // independent per-arm limits.
+
+    test('returns all three buckets from one query', () async {
+      await insertChangeSet(
+        id: 'cs-open',
+        agentId: 'agent-1',
+        taskId: 'task-1',
+      );
+      await insertChangeSet(
+        id: 'cs-done',
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        status: ChangeSetStatus.resolved,
+      );
+      await insertDecision(
+        id: 'cd-1',
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        changeSetId: 'cs-done',
+      );
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 200,
+            decisionLimit: 50,
+          )
+          .get();
+
+      final idsByBucket = <String, Set<String>>{};
+      for (final row in rows) {
+        idsByBucket
+            .putIfAbsent(
+              row.read<String>(AgentDatabase.ledgerBucketColumn),
+              () => <String>{},
+            )
+            .add(row.read<String>('id'));
+      }
+
+      expect(
+        idsByBucket[AgentDatabase.ledgerBucketPending],
+        {'cs-open'},
+        reason:
+            'the pending arm filters on subtype, so the resolved set is out',
+      );
+      expect(
+        idsByBucket[AgentDatabase.ledgerBucketRecent],
+        {'cs-open', 'cs-done'},
+        reason: 'the recent arm is unfiltered change-set history',
+      );
+      expect(idsByBucket[AgentDatabase.ledgerBucketDecision], {'cd-1'});
+    });
+
+    test('every bucket comes back newest-first', () async {
+      // Rows are inserted OLDEST-FIRST with genuinely distinct created_at
+      // values, so a compound result that preserved insertion order would fail
+      // this. (An earlier version of this test varied only the vector clock,
+      // leaving every created_at identical — it could not fail, and did not.)
+      //
+      // It matters because the consumers are first-wins
+      // (decisionByKey.putIfAbsent, and the duplicate-proposal collapse), so an
+      // unordered compound lets an older retry/audit decision win.
+      for (var i = 0; i < 3; i++) {
+        await insertChangeSet(
+          id: 'cs-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          createdAt: DateTime(2026, 3, 10 + i),
+        );
+        await insertDecision(
+          id: 'cd-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          changeSetId: 'cs-0',
+          createdAt: DateTime(2026, 3, 20 + i),
+        );
+      }
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 200,
+            decisionLimit: 50,
+          )
+          .get();
+
+      final byBucket = <String, List<DateTime>>{};
+      for (final row in rows) {
+        byBucket
+            .putIfAbsent(
+              row.read<String>(AgentDatabase.ledgerBucketColumn),
+              () => <DateTime>[],
+            )
+            .add(row.read<DateTime>('created_at'));
+      }
+
+      expect(byBucket.keys, hasLength(3), reason: 'all three buckets present');
+      for (final entry in byBucket.entries) {
+        expect(
+          entry.value.toSet(),
+          hasLength(greaterThan(1)),
+          reason:
+              'bucket "${entry.key}" must contain distinct timestamps, '
+              'or the ordering assertion below proves nothing',
+        );
+        final sortedDesc = [...entry.value]..sort((a, b) => b.compareTo(a));
+        expect(
+          entry.value,
+          sortedDesc,
+          reason: 'bucket "${entry.key}" must be newest-first',
+        );
+      }
+    });
+
+    test('scopes to the requested agent and task', () async {
+      await insertChangeSet(id: 'mine', agentId: 'agent-1', taskId: 'task-1');
+      await insertChangeSet(
+        id: 'other-task',
+        agentId: 'agent-1',
+        taskId: 't-2',
+      );
+      await insertChangeSet(
+        id: 'other-agent',
+        agentId: 'agent-2',
+        taskId: 'task-1',
+      );
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 200,
+            decisionLimit: 50,
+          )
+          .get();
+
+      expect(rows.map((r) => r.read<String>('id')).toSet(), {'mine'});
+    });
+
+    test('applies the change-set and decision limits independently', () async {
+      for (var i = 0; i < 4; i++) {
+        await insertChangeSet(
+          id: 'cs-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          status: ChangeSetStatus.resolved,
+        );
+        await insertDecision(
+          id: 'cd-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          changeSetId: 'cs-$i',
+        );
+      }
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 3,
+            decisionLimit: 1,
+          )
+          .get();
+
+      final counts = <String, int>{};
+      for (final row in rows) {
+        final bucket = row.read<String>(AgentDatabase.ledgerBucketColumn);
+        counts[bucket] = (counts[bucket] ?? 0) + 1;
+      }
+
+      expect(
+        counts[AgentDatabase.ledgerBucketRecent],
+        3,
+        reason: 'the change-set arm honours changeSetLimit',
+      );
+      expect(
+        counts[AgentDatabase.ledgerBucketDecision],
+        1,
+        reason:
+            'the decision arm honours its own, smaller decisionLimit — a '
+            'single shared LIMIT across the union would break this',
+      );
+    });
+
+    test(
+      'a long-lived open set survives a recent-history cap that would bury it',
+      () async {
+        // The reason the pending arm exists: the recent arm is newest-first and
+        // capped, so with changeSetLimit: 2 the two NEWER resolved sets fill it
+        // completely and the older open set never appears there. Only the
+        // dedicated pending arm surfaces it.
+        //
+        // The timestamps must genuinely differ for this to mean anything —
+        // an earlier version varied only the vector clock and so never
+        // established which rows the cap would drop.
+        await insertChangeSet(
+          id: 'cs-old-open',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          createdAt: DateTime(2026, 3, 2),
+        );
+        for (var i = 0; i < 3; i++) {
+          await insertChangeSet(
+            id: 'cs-newer-$i',
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            status: ChangeSetStatus.resolved,
+            createdAt: DateTime(2026, 3, 10 + i),
+          );
+        }
+
+        final rows = await db
+            .getProposalLedgerRowsForAgentAndTask(
+              agentId: 'agent-1',
+              taskId: 'task-1',
+              changeSetLimit: 2,
+              decisionLimit: 50,
+            )
+            .get();
+
+        String bucketOf(QueryRow r) =>
+            r.read<String>(AgentDatabase.ledgerBucketColumn);
+
+        final recentIds = rows
+            .where((r) => bucketOf(r) == AgentDatabase.ledgerBucketRecent)
+            .map((r) => r.read<String>('id'))
+            .toSet();
+        final pendingIds = rows
+            .where((r) => bucketOf(r) == AgentDatabase.ledgerBucketPending)
+            .map((r) => r.read<String>('id'))
+            .toSet();
+
+        expect(
+          recentIds,
+          isNot(contains('cs-old-open')),
+          reason: 'the cap must genuinely bury the open set in the recent arm',
+        );
+        expect(
+          pendingIds,
+          contains('cs-old-open'),
+          reason: 'the dedicated pending arm is what keeps it visible',
+        );
+      },
+    );
   });
 
   group('AgentDatabase migration', () {

--- a/test/features/agents/database/agent_proposal_ledger_test.dart
+++ b/test/features/agents/database/agent_proposal_ledger_test.dart
@@ -131,6 +131,56 @@ void main() {
       expect(idsByBucket[AgentDatabase.ledgerBucketDecision], {'cd-1'});
     });
 
+    test('every bucket comes back newest-first', () async {
+      // The consumers are first-wins (decisionByKey.putIfAbsent, and the
+      // duplicate-proposal collapse), so a compound result in some other legal
+      // order would let an older retry/audit decision override the newest one.
+      for (var i = 0; i < 3; i++) {
+        await insertChangeSet(
+          id: 'cs-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          clock: i + 1,
+        );
+        await insertDecision(
+          id: 'cd-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          changeSetId: 'cs-0',
+          clock: 100 + i,
+        );
+      }
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 200,
+            decisionLimit: 50,
+          )
+          .get();
+
+      final byBucket = <String, List<DateTime>>{};
+      for (final row in rows) {
+        byBucket
+            .putIfAbsent(
+              row.read<String>(AgentDatabase.ledgerBucketColumn),
+              () => <DateTime>[],
+            )
+            .add(row.read<DateTime>('created_at'));
+      }
+
+      expect(byBucket.keys, isNotEmpty);
+      for (final entry in byBucket.entries) {
+        final sortedDesc = [...entry.value]..sort((a, b) => b.compareTo(a));
+        expect(
+          entry.value,
+          sortedDesc,
+          reason: 'bucket "${entry.key}" must be newest-first',
+        );
+      }
+    });
+
     test('scopes to the requested agent and task', () async {
       await insertChangeSet(id: 'mine', agentId: 'agent-1', taskId: 'task-1');
       await insertChangeSet(

--- a/test/features/agents/database/agent_proposal_ledger_test.dart
+++ b/test/features/agents/database/agent_proposal_ledger_test.dart
@@ -73,6 +73,183 @@ void main() {
         .insert(AgentDbConversions.toEntityCompanion(entity));
   }
 
+  group('getProposalLedgerRowsForAgentAndTask (single round trip)', () {
+    // The ledger used to issue three concurrent task-scoped queries. They are
+    // now one UNION ALL with a per-row `bucket` marker, so these tests pin the
+    // properties that collapsing could silently break: correct bucketing, and
+    // independent per-arm limits.
+
+    test('returns all three buckets from one query', () async {
+      await insertChangeSet(
+        id: 'cs-open',
+        agentId: 'agent-1',
+        taskId: 'task-1',
+      );
+      await insertChangeSet(
+        id: 'cs-done',
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        status: ChangeSetStatus.resolved,
+      );
+      await insertDecision(
+        id: 'cd-1',
+        agentId: 'agent-1',
+        taskId: 'task-1',
+        changeSetId: 'cs-done',
+      );
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 200,
+            decisionLimit: 50,
+          )
+          .get();
+
+      final idsByBucket = <String, Set<String>>{};
+      for (final row in rows) {
+        idsByBucket
+            .putIfAbsent(
+              row.read<String>(AgentDatabase.ledgerBucketColumn),
+              () => <String>{},
+            )
+            .add(row.read<String>('id'));
+      }
+
+      expect(
+        idsByBucket[AgentDatabase.ledgerBucketPending],
+        {'cs-open'},
+        reason:
+            'the pending arm filters on subtype, so the resolved set is out',
+      );
+      expect(
+        idsByBucket[AgentDatabase.ledgerBucketRecent],
+        {'cs-open', 'cs-done'},
+        reason: 'the recent arm is unfiltered change-set history',
+      );
+      expect(idsByBucket[AgentDatabase.ledgerBucketDecision], {'cd-1'});
+    });
+
+    test('scopes to the requested agent and task', () async {
+      await insertChangeSet(id: 'mine', agentId: 'agent-1', taskId: 'task-1');
+      await insertChangeSet(
+        id: 'other-task',
+        agentId: 'agent-1',
+        taskId: 't-2',
+      );
+      await insertChangeSet(
+        id: 'other-agent',
+        agentId: 'agent-2',
+        taskId: 'task-1',
+      );
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 200,
+            decisionLimit: 50,
+          )
+          .get();
+
+      expect(rows.map((r) => r.read<String>('id')).toSet(), {'mine'});
+    });
+
+    test('applies the change-set and decision limits independently', () async {
+      for (var i = 0; i < 4; i++) {
+        await insertChangeSet(
+          id: 'cs-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          status: ChangeSetStatus.resolved,
+        );
+        await insertDecision(
+          id: 'cd-$i',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          changeSetId: 'cs-$i',
+        );
+      }
+
+      final rows = await db
+          .getProposalLedgerRowsForAgentAndTask(
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            changeSetLimit: 3,
+            decisionLimit: 1,
+          )
+          .get();
+
+      final counts = <String, int>{};
+      for (final row in rows) {
+        final bucket = row.read<String>(AgentDatabase.ledgerBucketColumn);
+        counts[bucket] = (counts[bucket] ?? 0) + 1;
+      }
+
+      expect(
+        counts[AgentDatabase.ledgerBucketRecent],
+        3,
+        reason: 'the change-set arm honours changeSetLimit',
+      );
+      expect(
+        counts[AgentDatabase.ledgerBucketDecision],
+        1,
+        reason:
+            'the decision arm honours its own, smaller decisionLimit — a '
+            'single shared LIMIT across the union would break this',
+      );
+    });
+
+    test(
+      'a long-lived open set survives a recent-history cap that would bury it',
+      () async {
+        // The reason the pending arm exists at all: the recent arm is
+        // newest-first and capped, so an old-but-still-open set must still
+        // reach the ledger through its own arm.
+        await insertChangeSet(
+          id: 'cs-old-open',
+          agentId: 'agent-1',
+          taskId: 'task-1',
+        );
+        for (var i = 0; i < 3; i++) {
+          await insertChangeSet(
+            id: 'cs-newer-$i',
+            agentId: 'agent-1',
+            taskId: 'task-1',
+            status: ChangeSetStatus.resolved,
+            clock: 10 + i,
+          );
+        }
+
+        final rows = await db
+            .getProposalLedgerRowsForAgentAndTask(
+              agentId: 'agent-1',
+              taskId: 'task-1',
+              changeSetLimit: 2,
+              decisionLimit: 50,
+            )
+            .get();
+
+        final pendingIds = rows
+            .where(
+              (r) =>
+                  r.read<String>(AgentDatabase.ledgerBucketColumn) ==
+                  AgentDatabase.ledgerBucketPending,
+            )
+            .map((r) => r.read<String>('id'))
+            .toSet();
+
+        expect(
+          pendingIds,
+          contains('cs-old-open'),
+          reason:
+              'the dedicated pending arm is what keeps the open set visible',
+        );
+      },
+    );
+  });
+
   test('empty ledger when the agent has no change sets', () async {
     final result = await ledger.getProposalLedger('agent-1', taskId: 'task-1');
     expect(result.open, isEmpty);

--- a/test/features/agents/database/agent_proposal_ledger_test.dart
+++ b/test/features/agents/database/agent_proposal_ledger_test.dart
@@ -34,6 +34,7 @@ void main() {
     ChangeSetStatus status = ChangeSetStatus.pending,
     List<ChangeItem>? items,
     int clock = 1,
+    DateTime? createdAt,
   }) async {
     final entity = makeTestChangeSet(
       id: id,
@@ -41,7 +42,7 @@ void main() {
       taskId: taskId,
       status: status,
       items: items,
-      createdAt: testDate,
+      createdAt: createdAt ?? testDate,
       vectorClock: VectorClock({'node-1': clock}),
     );
     await db
@@ -57,6 +58,7 @@ void main() {
     int itemIndex = 0,
     ChangeDecisionVerdict verdict = ChangeDecisionVerdict.confirmed,
     int clock = 100,
+    DateTime? createdAt,
   }) async {
     final entity = makeTestChangeDecision(
       id: id,
@@ -65,7 +67,7 @@ void main() {
       itemIndex: itemIndex,
       verdict: verdict,
       taskId: taskId,
-      createdAt: testDate,
+      createdAt: createdAt ?? testDate,
       vectorClock: VectorClock({'node-1': clock}),
     );
     await db
@@ -73,230 +75,51 @@ void main() {
         .insert(AgentDbConversions.toEntityCompanion(entity));
   }
 
-  group('getProposalLedgerRowsForAgentAndTask (single round trip)', () {
-    // The ledger used to issue three concurrent task-scoped queries. They are
-    // now one UNION ALL with a per-row `bucket` marker, so these tests pin the
-    // properties that collapsing could silently break: correct bucketing, and
-    // independent per-arm limits.
+  test('the newest decision for an item wins in the ledger', () async {
+    // This is the invariant the compound ORDER BY protects: getProposalLedger
+    // keeps the FIRST decision it sees per item (decisionByKey.putIfAbsent), so
+    // the decision rows must arrive newest-first. Asserting it here, at the
+    // consumer, rather than on raw row order — the row-order assertion cannot
+    // distinguish the two implementations, because SQLite 3.45 happens to emit
+    // each UNION ALL arm in its inner order even without the explicit ORDER BY.
+    await insertChangeSet(
+      id: 'cs-1',
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: ChangeSetStatus.resolved,
+      items: const [
+        ChangeItem(
+          toolName: 'update_task_estimate',
+          args: {'minutes': 30},
+          humanSummary: 'Estimate 30m',
+        ),
+      ],
+      createdAt: DateTime(2026, 3, 2),
+    );
+    // An older audit/retry row, then the decision that actually stands.
+    await insertDecision(
+      id: 'cd-old',
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      changeSetId: 'cs-1',
+      createdAt: DateTime(2026, 3, 5),
+    );
+    await insertDecision(
+      id: 'cd-new',
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      changeSetId: 'cs-1',
+      verdict: ChangeDecisionVerdict.rejected,
+      createdAt: DateTime(2026, 3, 9),
+    );
 
-    test('returns all three buckets from one query', () async {
-      await insertChangeSet(
-        id: 'cs-open',
-        agentId: 'agent-1',
-        taskId: 'task-1',
-      );
-      await insertChangeSet(
-        id: 'cs-done',
-        agentId: 'agent-1',
-        taskId: 'task-1',
-        status: ChangeSetStatus.resolved,
-      );
-      await insertDecision(
-        id: 'cd-1',
-        agentId: 'agent-1',
-        taskId: 'task-1',
-        changeSetId: 'cs-done',
-      );
+    final result = await ledger.getProposalLedger('agent-1', taskId: 'task-1');
 
-      final rows = await db
-          .getProposalLedgerRowsForAgentAndTask(
-            agentId: 'agent-1',
-            taskId: 'task-1',
-            changeSetLimit: 200,
-            decisionLimit: 50,
-          )
-          .get();
-
-      final idsByBucket = <String, Set<String>>{};
-      for (final row in rows) {
-        idsByBucket
-            .putIfAbsent(
-              row.read<String>(AgentDatabase.ledgerBucketColumn),
-              () => <String>{},
-            )
-            .add(row.read<String>('id'));
-      }
-
-      expect(
-        idsByBucket[AgentDatabase.ledgerBucketPending],
-        {'cs-open'},
-        reason:
-            'the pending arm filters on subtype, so the resolved set is out',
-      );
-      expect(
-        idsByBucket[AgentDatabase.ledgerBucketRecent],
-        {'cs-open', 'cs-done'},
-        reason: 'the recent arm is unfiltered change-set history',
-      );
-      expect(idsByBucket[AgentDatabase.ledgerBucketDecision], {'cd-1'});
-    });
-
-    test('every bucket comes back newest-first', () async {
-      // The consumers are first-wins (decisionByKey.putIfAbsent, and the
-      // duplicate-proposal collapse), so a compound result in some other legal
-      // order would let an older retry/audit decision override the newest one.
-      for (var i = 0; i < 3; i++) {
-        await insertChangeSet(
-          id: 'cs-$i',
-          agentId: 'agent-1',
-          taskId: 'task-1',
-          clock: i + 1,
-        );
-        await insertDecision(
-          id: 'cd-$i',
-          agentId: 'agent-1',
-          taskId: 'task-1',
-          changeSetId: 'cs-0',
-          clock: 100 + i,
-        );
-      }
-
-      final rows = await db
-          .getProposalLedgerRowsForAgentAndTask(
-            agentId: 'agent-1',
-            taskId: 'task-1',
-            changeSetLimit: 200,
-            decisionLimit: 50,
-          )
-          .get();
-
-      final byBucket = <String, List<DateTime>>{};
-      for (final row in rows) {
-        byBucket
-            .putIfAbsent(
-              row.read<String>(AgentDatabase.ledgerBucketColumn),
-              () => <DateTime>[],
-            )
-            .add(row.read<DateTime>('created_at'));
-      }
-
-      expect(byBucket.keys, isNotEmpty);
-      for (final entry in byBucket.entries) {
-        final sortedDesc = [...entry.value]..sort((a, b) => b.compareTo(a));
-        expect(
-          entry.value,
-          sortedDesc,
-          reason: 'bucket "${entry.key}" must be newest-first',
-        );
-      }
-    });
-
-    test('scopes to the requested agent and task', () async {
-      await insertChangeSet(id: 'mine', agentId: 'agent-1', taskId: 'task-1');
-      await insertChangeSet(
-        id: 'other-task',
-        agentId: 'agent-1',
-        taskId: 't-2',
-      );
-      await insertChangeSet(
-        id: 'other-agent',
-        agentId: 'agent-2',
-        taskId: 'task-1',
-      );
-
-      final rows = await db
-          .getProposalLedgerRowsForAgentAndTask(
-            agentId: 'agent-1',
-            taskId: 'task-1',
-            changeSetLimit: 200,
-            decisionLimit: 50,
-          )
-          .get();
-
-      expect(rows.map((r) => r.read<String>('id')).toSet(), {'mine'});
-    });
-
-    test('applies the change-set and decision limits independently', () async {
-      for (var i = 0; i < 4; i++) {
-        await insertChangeSet(
-          id: 'cs-$i',
-          agentId: 'agent-1',
-          taskId: 'task-1',
-          status: ChangeSetStatus.resolved,
-        );
-        await insertDecision(
-          id: 'cd-$i',
-          agentId: 'agent-1',
-          taskId: 'task-1',
-          changeSetId: 'cs-$i',
-        );
-      }
-
-      final rows = await db
-          .getProposalLedgerRowsForAgentAndTask(
-            agentId: 'agent-1',
-            taskId: 'task-1',
-            changeSetLimit: 3,
-            decisionLimit: 1,
-          )
-          .get();
-
-      final counts = <String, int>{};
-      for (final row in rows) {
-        final bucket = row.read<String>(AgentDatabase.ledgerBucketColumn);
-        counts[bucket] = (counts[bucket] ?? 0) + 1;
-      }
-
-      expect(
-        counts[AgentDatabase.ledgerBucketRecent],
-        3,
-        reason: 'the change-set arm honours changeSetLimit',
-      );
-      expect(
-        counts[AgentDatabase.ledgerBucketDecision],
-        1,
-        reason:
-            'the decision arm honours its own, smaller decisionLimit — a '
-            'single shared LIMIT across the union would break this',
-      );
-    });
-
-    test(
-      'a long-lived open set survives a recent-history cap that would bury it',
-      () async {
-        // The reason the pending arm exists at all: the recent arm is
-        // newest-first and capped, so an old-but-still-open set must still
-        // reach the ledger through its own arm.
-        await insertChangeSet(
-          id: 'cs-old-open',
-          agentId: 'agent-1',
-          taskId: 'task-1',
-        );
-        for (var i = 0; i < 3; i++) {
-          await insertChangeSet(
-            id: 'cs-newer-$i',
-            agentId: 'agent-1',
-            taskId: 'task-1',
-            status: ChangeSetStatus.resolved,
-            clock: 10 + i,
-          );
-        }
-
-        final rows = await db
-            .getProposalLedgerRowsForAgentAndTask(
-              agentId: 'agent-1',
-              taskId: 'task-1',
-              changeSetLimit: 2,
-              decisionLimit: 50,
-            )
-            .get();
-
-        final pendingIds = rows
-            .where(
-              (r) =>
-                  r.read<String>(AgentDatabase.ledgerBucketColumn) ==
-                  AgentDatabase.ledgerBucketPending,
-            )
-            .map((r) => r.read<String>('id'))
-            .toSet();
-
-        expect(
-          pendingIds,
-          contains('cs-old-open'),
-          reason:
-              'the dedicated pending arm is what keeps the open set visible',
-        );
-      },
+    expect(result.resolved, hasLength(1));
+    expect(
+      result.resolved.single.verdict,
+      ChangeDecisionVerdict.rejected,
+      reason: 'the later rejection must not be overridden by the older confirm',
     );
   });
 


### PR DESCRIPTION
## Problem

`AgentProposalLedger.getProposalLedger` issued **three concurrent** task-scoped reads — pending change sets, recent change sets, recent decisions.

The slow-query logs caught the trio directly. Over 2026-07-19 → 2026-08-01:

| | |
|---|---|
| calls | 4,127 |
| total | 90.2 s |
| avg | 22 ms |
| back-to-back runs of exactly **3** | 483 |
| runs of 6 | 154 |
| median inter-arrival gap | **0.4 ms** |

And it is accelerating: **4,127 of 7,865 lifetime calls landed in the last 14 of 47 days.**

Every one is correctly indexed — the plan pins `idx_agent_entities_active_agent_type_task_created_id` and seeks cleanly:

```
SEARCH agent_entities USING INDEX idx_agent_entities_active_agent_type_task_created_id (agent_id=? AND type=?)
```

Each call just sat at the ~22 ms isolate round-trip floor. (The interceptor is client-side of the isolate boundary, so logged durations are round-trip time, not execution time — see the investigation doc.) The cost is the round-trip *count*.

## Fix

One `UNION ALL` with a per-row `bucket` marker; the caller splits the result back into the same three lists. Three round trips become one.

The arms stay separate **deliberately** — they are not interchangeable and each needs its own `LIMIT`:

- the **pending** arm filters on `subtype IN ('pending','partiallyResolved')` with the change-set limit
- the **recent** arm is unfiltered newest-first history with the change-set limit
- the **decision** arm reads `changeDecision` with a *different*, smaller limit

The dedicated pending arm is what keeps a long-lived open change set from being buried past the newest-first history cap once enough resolved history accumulates. A single shared `LIMIT` across the union would silently break that — so there is a test for exactly it.

Positional placeholders are reused across arms (`?1..?4` bind once each regardless of repetition), so the variables list stays four entries rather than twelve.

## Removed

`getChangeSetsForAgentAndTask` and `getRecentDecisionsForAgentAndTask` have no remaining callers. `getPendingChangeSetsForAgentAndTask` is still used by `agent_repo_evolution.dart:371` and stays.

## Tests

4 new, on top of the 4 existing ledger tests (all still pass unchanged, which is the semantics-preservation evidence):

- all three buckets return from one query, correctly routed
- agent/task scoping
- **independent per-arm limits** — `changeSetLimit: 3, decisionLimit: 1` must yield 3 and 1; a shared limit fails this
- **a long-lived open set survives a recent-history cap that would bury it** — the reason the pending arm exists

`dart analyze`: clean. Focused tests: 8/8.

Part of the "Slow Query Improvements (2026-08 investigation)" epic; independent of #3714.