### PR TITLE
perf(agents): only load agent states that have a wake pending

### DIFF
--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -5,7 +5,7 @@ description: The agent.sqlite entity and link model, bulk-read chunking, and exa
 resource: ../../../lib/features/agents/database/agent_database.dart
 tags: [agents, persistence, sync, privacy, drift]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-01T12:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-01T13:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: db

--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -178,6 +178,15 @@ result is otherwise unspecified. The consumers are first-wins
 `unifiedSuggestionList`), so an unordered compound could let an older
 retry/audit decision override the newest one.
 
+`latestEntitiesByAgentIds` accepts an `outerPredicate` that is applied to the
+outer `WHERE rn = 1` — i.e. it filters the *winning* row per agent, after
+ranking. `getAgentStatesWithPendingWakes` uses it to return only agents that
+actually have a wake pending, instead of returning every agent's latest state
+for the pending-wakes screen to discard. Applying such a predicate inside the
+ranked subquery would be a correctness bug: it could promote an older row that
+satisfies it over a newer one that does not, resurrecting state the newest row
+had cleared.
+
 Latest-per-agent batch reads are backed by active-row indexes that include the
 `(created_at DESC, id DESC)` ranking order for both type-only and
 type-plus-subtype lookups, so the window-function query needs no temp sort for

--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -194,7 +194,10 @@ class AgentRepoCore {
     List<Variable<Object>> outerVariables = const [],
   }) async {
     final result = <AgentDomainEntity>[];
-    for (final chunk in sqliteInClauseChunks(agentIds)) {
+    // Every chunk binds its own ids plus the type, the optional subtype, and
+    // whatever `outerPredicate` needs — all against one 999-variable budget.
+    final reserved = 1 + (subtype == null ? 0 : 1) + outerVariables.length;
+    for (final chunk in sqliteInClauseChunks(agentIds, reserve: reserved)) {
       final placeholders = List.filled(chunk.length, '?').join(', ');
       final subtypePredicate = subtype == null ? '' : 'AND subtype = ? ';
       final rows = await _db

--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -191,12 +191,11 @@ class AgentRepoCore {
     required String type,
     String? subtype,
     String outerPredicate = '',
-    List<Variable<Object>> outerVariables = const [],
   }) async {
     final result = <AgentDomainEntity>[];
     // Every chunk binds its own ids plus the type, the optional subtype, and
     // whatever `outerPredicate` needs — all against one 999-variable budget.
-    final reserved = 1 + (subtype == null ? 0 : 1) + outerVariables.length;
+    final reserved = 1 + (subtype == null ? 0 : 1);
     for (final chunk in sqliteInClauseChunks(agentIds, reserve: reserved)) {
       final placeholders = List.filled(chunk.length, '?').join(', ');
       final subtypePredicate = subtype == null ? '' : 'AND subtype = ? ';
@@ -224,7 +223,6 @@ class AgentRepoCore {
               ...chunk.map(Variable.withString),
               Variable.withString(type),
               if (subtype != null) Variable.withString(subtype),
-              ...outerVariables,
             ],
             readsFrom: {_db.agentEntities},
           )
@@ -444,25 +442,42 @@ class AgentRepoCore {
     List<String> agentIds, {
     Iterable<String> alsoIncludeAgentIds = const <String>[],
   }) async {
-    // Agents whose wake lives in a separate `ScheduledWakeEntity` row rather
-    // than on the state itself still need their state hydrated, so callers can
-    // name them explicitly. Kept in the same query — splitting it would trade
-    // the decode saving for an extra round trip.
-    final alsoInclude = alsoIncludeAgentIds.toSet().toList(growable: false);
-    final alsoPlaceholders = List.filled(alsoInclude.length, '?').join(', ');
-    final latestEntities = await latestEntitiesByAgentIds(
+    final withWakes = await latestEntitiesByAgentIds(
       agentIds: agentIds,
       type: AgentEntityTypes.agentState,
       outerPredicate:
           r"AND (json_extract(serialized, '$.nextWakeAt') IS NOT NULL "
-          r"OR json_extract(serialized, '$.scheduledWakeAt') IS NOT NULL"
-          '${alsoInclude.isEmpty ? '' : ' OR agent_id IN ($alsoPlaceholders)'})',
-      outerVariables: alsoInclude.map(Variable.withString).toList(),
+          r"OR json_extract(serialized, '$.scheduledWakeAt') IS NOT NULL)",
     );
-    return {
-      for (final entity in latestEntities)
+    final result = <String, AgentStateEntity>{
+      for (final entity in withWakes)
         if (entity case final AgentStateEntity state) state.agentId: state,
     };
+
+    // Agents whose wake lives in a separate `ScheduledWakeEntity` row rather
+    // than on the state itself still need their state hydrated. They are read
+    // as their own query rather than folded into the predicate above: an
+    // inclusion list bound into every chunk shares the statement's variable
+    // budget with the chunk itself, so a large enough list could overflow it
+    // on a platform built with SQLite's older 999-variable cap. A second,
+    // separately chunked query has no such interaction, and only runs when
+    // there is something to include.
+    final alsoInclude = alsoIncludeAgentIds
+        .toSet()
+        .where((id) => !result.containsKey(id))
+        .toList(growable: false);
+    if (alsoInclude.isEmpty) return result;
+
+    final named = await latestEntitiesByAgentIds(
+      agentIds: alsoInclude,
+      type: AgentEntityTypes.agentState,
+    );
+    for (final entity in named) {
+      if (entity case final AgentStateEntity state) {
+        result[state.agentId] = state;
+      }
+    }
+    return result;
   }
 
   /// Fetch the newest active agent identity of [kind] whose latest state has

--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -181,10 +181,17 @@ class AgentRepoCore {
   /// [type] (and optionally [subtype]). Shared batched read used by the
   /// state/head latest-per-agent lookups in this class and in
   /// [AgentRepoQueries].
+  /// [outerPredicate] is appended to the outer `WHERE rn = 1` — i.e. it filters
+  /// the *winning* row per agent, after ranking. Filtering inside the ranked
+  /// subquery instead would be a correctness bug: it could promote an older row
+  /// that satisfies the predicate over a newer one that does not, resurrecting
+  /// state the newest row had cleared.
   Future<List<AgentDomainEntity>> latestEntitiesByAgentIds({
     required Iterable<String> agentIds,
     required String type,
     String? subtype,
+    String outerPredicate = '',
+    List<Variable<Object>> outerVariables = const [],
   }) async {
     final result = <AgentDomainEntity>[];
     for (final chunk in sqliteInClauseChunks(agentIds)) {
@@ -208,11 +215,13 @@ class AgentRepoCore {
                   AND deleted_at IS NULL
               )
               WHERE rn = 1
+                $outerPredicate
             ''',
             variables: [
               ...chunk.map(Variable.withString),
               Variable.withString(type),
               if (subtype != null) Variable.withString(subtype),
+              ...outerVariables,
             ],
             readsFrom: {_db.agentEntities},
           )
@@ -410,6 +419,42 @@ class AgentRepoCore {
     final latestEntities = await latestEntitiesByAgentIds(
       agentIds: agentIds,
       type: AgentEntityTypes.agentState,
+    );
+    return {
+      for (final entity in latestEntities)
+        if (entity case final AgentStateEntity state) state.agentId: state,
+    };
+  }
+
+  /// The latest [AgentStateEntity] per agent, **restricted to agents that
+  /// actually have a wake pending** — either a self-requested `nextWakeAt` or a
+  /// state-level `scheduledWakeAt`.
+  ///
+  /// [getAgentStatesByAgentIds] returns the latest state for every agent, and
+  /// the pending-wakes screen then discards the overwhelming majority of them.
+  /// On an install with ~900 agents that is ~900 rows decoded from JSON on
+  /// every agent-update notification; the 2026-06/07 slow-query logs show 2,050
+  /// full-population reads of this shape in 14 days (`args=901`), each around
+  /// 32 ms. The predicate is applied *after* ranking, so an agent whose newest
+  /// state cleared its wake is correctly excluded.
+  Future<Map<String, AgentStateEntity>> getAgentStatesWithPendingWakes(
+    List<String> agentIds, {
+    Iterable<String> alsoIncludeAgentIds = const <String>[],
+  }) async {
+    // Agents whose wake lives in a separate `ScheduledWakeEntity` row rather
+    // than on the state itself still need their state hydrated, so callers can
+    // name them explicitly. Kept in the same query — splitting it would trade
+    // the decode saving for an extra round trip.
+    final alsoInclude = alsoIncludeAgentIds.toSet().toList(growable: false);
+    final alsoPlaceholders = List.filled(alsoInclude.length, '?').join(', ');
+    final latestEntities = await latestEntitiesByAgentIds(
+      agentIds: agentIds,
+      type: AgentEntityTypes.agentState,
+      outerPredicate:
+          r"AND (json_extract(serialized, '$.nextWakeAt') IS NOT NULL "
+          r"OR json_extract(serialized, '$.scheduledWakeAt') IS NOT NULL"
+          '${alsoInclude.isEmpty ? '' : ' OR agent_id IN ($alsoPlaceholders)'})',
+      outerVariables: alsoInclude.map(Variable.withString).toList(),
     );
     return {
       for (final entity in latestEntities)

--- a/lib/features/agents/database/agent_repo_internals.dart
+++ b/lib/features/agents/database/agent_repo_internals.dart
@@ -22,23 +22,41 @@ bool affectsStandingAgreementProjection(AgentDomainEntity entity) {
   return entity is StandingAgreementEntity;
 }
 
-/// SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` is 999; we chunk batched
-/// `IN (...)` queries below this to stay safe across builds.
+/// Chunk size for batched `IN (...)` queries.
+///
+/// `SQLITE_MAX_VARIABLE_NUMBER` was 999 before SQLite 3.32 and is 32766 after
+/// it — the bundled library is 3.45, so the real cap is the higher one and 900
+/// is far below it. The conservative chunk stays because it also bounds result
+/// size and statement-cache churn, and because the ceiling is a build-time
+/// option we do not control on every platform.
 const int sqliteInClauseChunkSize = 900;
 
 /// Dedup-and-chunk iterator that guards every batched `IN (...)` query against
 /// SQLite's host-variable cap. Deduplicates first so callers never emit a
 /// chunk larger than [sqliteInClauseChunkSize].
-Iterable<List<T>> sqliteInClauseChunks<T>(Iterable<T> values) sync* {
+///
+/// [reserve] is the number of host variables the caller binds *in addition* to
+/// one per chunk element — a type discriminator, a subtype, a second `IN` list
+/// in the same statement. The chunk shrinks to make room for them, because the
+/// cap applies to the whole statement rather than to one `IN` list, and so does
+/// [sqliteInClauseChunkSize]'s intent: a caller binding a large extra list
+/// would otherwise silently produce statements far wider than the chunk size
+/// implies.
+Iterable<List<T>> sqliteInClauseChunks<T>(
+  Iterable<T> values, {
+  int reserve = 0,
+}) sync* {
   final valueList = values.toSet().toList(growable: false);
-  for (
-    var start = 0;
-    start < valueList.length;
-    start += sqliteInClauseChunkSize
-  ) {
-    final end = start + sqliteInClauseChunkSize > valueList.length
+  // Always leave room for at least one element per chunk, otherwise a caller
+  // reserving more than the chunk size would loop forever.
+  final chunkSize = (sqliteInClauseChunkSize - reserve).clamp(
+    1,
+    sqliteInClauseChunkSize,
+  );
+  for (var start = 0; start < valueList.length; start += chunkSize) {
+    final end = start + chunkSize > valueList.length
         ? valueList.length
-        : start + sqliteInClauseChunkSize;
+        : start + chunkSize;
     yield valueList.sublist(start, end);
   }
 }

--- a/lib/features/agents/database/agent_repository.dart
+++ b/lib/features/agents/database/agent_repository.dart
@@ -106,8 +106,10 @@ class AgentRepository {
 
   /// Test-only seam for `sqliteInClauseChunks`.
   @visibleForTesting
-  static Iterable<List<T>> debugSqliteInClauseChunks<T>(Iterable<T> values) =>
-      sqliteInClauseChunks(values);
+  static Iterable<List<T>> debugSqliteInClauseChunks<T>(
+    Iterable<T> values, {
+    int reserve = 0,
+  }) => sqliteInClauseChunks(values, reserve: reserve);
 
   // ── Core: entity CRUD + shared batched reads ───────────────────────────────
 

--- a/lib/features/agents/database/agent_repository.dart
+++ b/lib/features/agents/database/agent_repository.dart
@@ -183,6 +183,16 @@ class AgentRepository {
     List<String> agentIds,
   ) => _core.getAgentStatesByAgentIds(agentIds);
 
+  /// Latest state per agent, restricted to agents with a pending wake.
+  /// See [AgentRepoCore.getAgentStatesWithPendingWakes].
+  Future<Map<String, AgentStateEntity>> getAgentStatesWithPendingWakes(
+    List<String> agentIds, {
+    Iterable<String> alsoIncludeAgentIds = const <String>[],
+  }) => _core.getAgentStatesWithPendingWakes(
+    agentIds,
+    alsoIncludeAgentIds: alsoIncludeAgentIds,
+  );
+
   Future<AgentIdentityEntity?> getActiveAgentByKindAndActiveDayId({
     required String kind,
     required String activeDayId,

--- a/lib/features/agents/state/agent_pending_wake_providers.dart
+++ b/lib/features/agents/state/agent_pending_wake_providers.dart
@@ -30,8 +30,20 @@ final pendingWakeRecordsProvider = FutureProvider<List<PendingWakeRecord>>((
   final identitiesByAgentId = {
     for (final identity in identities) identity.agentId: identity,
   };
-  final statesByAgentId = await repository.getAgentStatesByAgentIds(
+  // Workspace-scoped scheduled wakes (the planner's day pre-warms, ADR 0022)
+  // live as their own records rather than on `AgentState.scheduledWakeAt`.
+  // Fetched before the state read so those agents can be named explicitly
+  // below — their state must be hydrated even though it carries no wake field.
+  final pendingScheduled = await repository.getPendingScheduledWakeRecords();
+
+  // Only agents that actually have a wake pending. Fetching every agent's
+  // latest state and discarding the rest meant ~900 rows decoded from JSON on
+  // every agent-update notification; the filter now runs in SQL, after the
+  // per-agent ranking so a cleared wake stays cleared. See
+  // `docs/perf/2026-08-01_slow-queries-investigation.md`.
+  final statesByAgentId = await repository.getAgentStatesWithPendingWakes(
     identities.map((identity) => identity.agentId).toList(),
+    alsoIncludeAgentIds: pendingScheduled.map((record) => record.agentId),
   );
 
   final records = <PendingWakeRecord>[];
@@ -66,12 +78,10 @@ final pendingWakeRecordsProvider = FutureProvider<List<PendingWakeRecord>>((
     }
   }
 
-  // Workspace-scoped scheduled wakes (the planner's day pre-warms, ADR 0022)
-  // live as their own records rather than on `AgentState.scheduledWakeAt`, so
-  // surface them here too. Their subject is the workspace id (the day), not a
-  // linked task/project — derived generically from `workspaceKey` so the
-  // agents layer stays free of any daily-OS coupling.
-  final pendingScheduled = await repository.getPendingScheduledWakeRecords();
+  // Surface the workspace-scoped scheduled wakes fetched above. Their subject
+  // is the workspace id (the day), not a linked task/project — derived
+  // generically from `workspaceKey` so the agents layer stays free of any
+  // daily-OS coupling.
   for (final record in pendingScheduled) {
     final identity = identitiesByAgentId[record.agentId];
     final state = statesByAgentId[record.agentId];

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -175,6 +175,121 @@ void main() {
     );
   });
 
+  group('getAgentStatesWithPendingWakes', () {
+    // The pending-wakes screen used to load every agent's latest state and
+    // discard the ones with no wake. The filter now runs in SQL. These tests
+    // pin the two things that could go wrong: filtering must happen AFTER the
+    // per-agent ranking, and agents whose wake lives in a separate
+    // ScheduledWakeEntity row must still be hydrated.
+    //
+    // `created_at` for an AgentStateEntity is its `updatedAt`
+    // (AgentDbConversions.entityCreatedAt), which is what the ranking orders by.
+
+    Future<void> putState(
+      String agentId,
+      String stateId, {
+      DateTime? nextWakeAt,
+      DateTime? scheduledWakeAt,
+      DateTime? at,
+    }) async {
+      await core.upsertEntity(
+        makeTestState(
+          id: stateId,
+          agentId: agentId,
+          nextWakeAt: nextWakeAt,
+          scheduledWakeAt: scheduledWakeAt,
+          updatedAt: at ?? testDate,
+        ),
+      );
+    }
+
+    test('returns only agents with a pending or scheduled wake', () async {
+      await putState('a-wake', 'st-a', nextWakeAt: testDate);
+      await putState('a-sched', 'st-b', scheduledWakeAt: testDate);
+      await putState('a-idle', 'st-c');
+
+      final states = await core.getAgentStatesWithPendingWakes([
+        'a-wake',
+        'a-sched',
+        'a-idle',
+      ]);
+
+      expect(
+        states.keys.toSet(),
+        {'a-wake', 'a-sched'},
+        reason: 'the idle agent must not be decoded or returned',
+      );
+    });
+
+    test('a cleared wake on the newest state excludes the agent', () async {
+      // The correctness trap: filtering inside the ranked subquery would
+      // promote the older row that still has a wake, resurrecting it.
+      await putState(
+        'a-1',
+        'st-1-old',
+        nextWakeAt: testDate,
+        at: DateTime(2026, 3, 14),
+      );
+      await putState('a-1', 'st-1-new', at: DateTime(2026, 3, 16));
+
+      final states = await core.getAgentStatesWithPendingWakes(['a-1']);
+
+      expect(
+        states,
+        isEmpty,
+        reason: 'the newest state cleared the wake, so the agent is excluded',
+      );
+    });
+
+    test('a newly-set wake on the newest state includes the agent', () async {
+      await putState('a-2', 'st-2-old', at: DateTime(2026, 3, 14));
+      await putState(
+        'a-2',
+        'st-2-new',
+        nextWakeAt: testDate,
+        at: DateTime(2026, 3, 16),
+      );
+
+      final states = await core.getAgentStatesWithPendingWakes(['a-2']);
+
+      expect(states.keys, ['a-2']);
+      expect(states['a-2']!.nextWakeAt, isNotNull);
+    });
+
+    test('alsoIncludeAgentIds hydrates agents with no wake field', () async {
+      // ScheduledWakeEntity rows carry the wake instead of the state, so those
+      // agents must survive the filter when named explicitly.
+      await putState('a-wake', 'st-a', nextWakeAt: testDate);
+      await putState('a-workspace', 'st-b');
+      await putState('a-idle', 'st-c');
+
+      final states = await core.getAgentStatesWithPendingWakes(
+        ['a-wake', 'a-workspace', 'a-idle'],
+        alsoIncludeAgentIds: ['a-workspace'],
+      );
+
+      expect(
+        states.keys.toSet(),
+        {'a-wake', 'a-workspace'},
+        reason: 'named agent included, unnamed idle agent still filtered out',
+      );
+    });
+
+    test('omitting alsoIncludeAgentIds leaves valid SQL', () async {
+      // The `OR agent_id IN (...)` clause is appended only when ids are given;
+      // the default path must not emit a dangling `IN ()`.
+      await putState('a-wake', 'st-a', nextWakeAt: testDate);
+      await putState('a-idle', 'st-b');
+
+      final states = await core.getAgentStatesWithPendingWakes([
+        'a-wake',
+        'a-idle',
+      ]);
+
+      expect(states.keys, ['a-wake']);
+    });
+  });
+
   group('upsertEntity / getEntity', () {
     test('inserts then updates a non-projection entity in place', () async {
       final identity = makeTestIdentity(

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -275,6 +275,28 @@ void main() {
       );
     });
 
+    test('spans multiple id chunks and still resolves inclusions', () async {
+      // The agent-id list is chunked (900 per statement) while
+      // alsoIncludeAgentIds is bound into every chunk. This exercises the
+      // multi-chunk path end to end: results must be merged across chunks and
+      // the inclusion list must apply in each one.
+      await putState('a-wake', 'st-a', nextWakeAt: testDate);
+      await putState('a-workspace', 'st-b');
+
+      final manyIds = [for (var i = 0; i < 1500; i++) 'filler-$i'];
+
+      final states = await core.getAgentStatesWithPendingWakes(
+        ['a-wake', 'a-workspace', ...manyIds],
+        alsoIncludeAgentIds: ['a-workspace'],
+      );
+
+      expect(
+        states.keys.toSet(),
+        {'a-wake', 'a-workspace'},
+        reason: 'merged across chunks, inclusion honoured, fillers excluded',
+      );
+    });
+
     test('omitting alsoIncludeAgentIds leaves valid SQL', () async {
       // The `OR agent_id IN (...)` clause is appended only when ids are given;
       // the default path must not emit a dangling `IN ()`.

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -275,6 +275,25 @@ void main() {
       );
     });
 
+    test('a large inclusion list does not overflow the bind budget', () async {
+      // The inclusion list is read as its own chunked query rather than bound
+      // into every primary chunk, so it cannot share — and overflow — the
+      // statement's variable budget no matter how large it gets.
+      await putState('a-wake', 'st-a', nextWakeAt: testDate);
+      for (var i = 0; i < 1200; i++) {
+        await putState('inc-$i', 'st-inc-$i');
+      }
+
+      final states = await core.getAgentStatesWithPendingWakes(
+        ['a-wake', for (var i = 0; i < 1200; i++) 'inc-$i'],
+        alsoIncludeAgentIds: [for (var i = 0; i < 1200; i++) 'inc-$i'],
+      );
+
+      expect(states.keys, hasLength(1201));
+      expect(states.keys, contains('a-wake'));
+      expect(states.keys, contains('inc-1199'));
+    });
+
     test('spans multiple id chunks and still resolves inclusions', () async {
       // The agent-id list is chunked (900 per statement) while
       // alsoIncludeAgentIds is bound into every chunk. This exercises the

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -554,6 +554,52 @@ void main() {
         },
       );
 
+      test(
+        'reserve shrinks the chunk so extra bindings fit in the same statement',
+        () {
+          // Callers that bind variables beyond one-per-element (a type, a
+          // subtype, a second IN list) reserve them, so the statement stays as
+          // wide as the chunk size implies rather than chunk + extras.
+          final ids = [for (var i = 0; i < 2000; i++) 'id-$i'];
+
+          for (final reserve in [0, 1, 300, 899]) {
+            final chunks = AgentRepository.debugSqliteInClauseChunks(
+              ids,
+              reserve: reserve,
+            ).toList();
+
+            for (final chunk in chunks) {
+              expect(
+                chunk.length + reserve,
+                lessThanOrEqualTo(900),
+                reason: 'chunk + reserve must stay within the chunk budget',
+              );
+            }
+            expect(
+              chunks.expand((c) => c).toSet(),
+              ids.toSet(),
+              reason: 'reserving must not drop ids',
+            );
+          }
+        },
+      );
+
+      test(
+        'an oversized reserve still yields progress, never an empty chunk',
+        () {
+          // Guards the clamp: without it a reserve >= the chunk size would
+          // produce zero-length chunks and loop forever.
+          final chunks = AgentRepository.debugSqliteInClauseChunks(
+            ['a', 'b', 'c'],
+            reserve: 5000,
+          ).toList();
+
+          expect(chunks, hasLength(3));
+          expect(chunks.every((c) => c.length == 1), isTrue);
+          expect(chunks.expand((c) => c).toSet(), {'a', 'b', 'c'});
+        },
+      );
+
       // `_sqliteInClauseChunks` is the pure dedup-and-chunk iterator behind
       // every batched IN-list query; the example test above only exercises the
       // 1 800-id case. This property locks down the invariants across the whole

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -966,6 +966,77 @@ void main() {
       });
     });
 
+    group('getAgentStatesWithPendingWakes', () {
+      // Facade-level coverage for the filtered read the pending-wakes screen
+      // uses. The query semantics are pinned in agent_repo_core_test.dart;
+      // what matters here is that the delegator forwards both arguments.
+
+      test('returns only agents whose latest state carries a wake', () async {
+        await repo.upsertEntity(
+          AgentDomainEntity.agentState(
+            id: 'state-wake',
+            agentId: testAgentId,
+            revision: 1,
+            slots: const AgentSlots(),
+            updatedAt: DateTime(2026, 2, 20),
+            nextWakeAt: DateTime(2026, 2, 21),
+            vectorClock: const VectorClock({'node-1': 1}),
+          ),
+        );
+        await repo.upsertEntity(
+          AgentDomainEntity.agentState(
+            id: 'state-idle',
+            agentId: 'agent-idle',
+            revision: 1,
+            slots: const AgentSlots(),
+            updatedAt: DateTime(2026, 2, 20),
+            vectorClock: const VectorClock({'node-1': 1}),
+          ),
+        );
+
+        final result = await repo.getAgentStatesWithPendingWakes([
+          testAgentId,
+          'agent-idle',
+        ]);
+
+        expect(result.keys, [testAgentId]);
+      });
+
+      test('forwards alsoIncludeAgentIds through to the core read', () async {
+        await repo.upsertEntity(
+          AgentDomainEntity.agentState(
+            id: 'state-workspace',
+            agentId: 'agent-workspace',
+            revision: 1,
+            slots: const AgentSlots(),
+            updatedAt: DateTime(2026, 2, 20),
+            vectorClock: const VectorClock({'node-1': 1}),
+          ),
+        );
+
+        final without = await repo.getAgentStatesWithPendingWakes([
+          'agent-workspace',
+        ]);
+        final with_ = await repo.getAgentStatesWithPendingWakes(
+          ['agent-workspace'],
+          alsoIncludeAgentIds: ['agent-workspace'],
+        );
+
+        expect(
+          without,
+          isEmpty,
+          reason: 'no wake field, so it is filtered out by default',
+        );
+        expect(
+          with_.keys,
+          ['agent-workspace'],
+          reason:
+              'naming it explicitly must survive the filter — if the '
+              'delegator dropped the argument this would be empty too',
+        );
+      });
+    });
+
     group('getAgentStatesByAgentIds', () {
       test('returns empty map when no agent IDs are requested', () async {
         final result = await repo.getAgentStatesByAgentIds(const []);

--- a/test/features/agents/state/agent_pending_wake_providers_test.dart
+++ b/test/features/agents/state/agent_pending_wake_providers_test.dart
@@ -507,7 +507,10 @@ void main() {
           mockAgentService.listAgents,
         ).thenAnswer((_) => Future.value([firstIdentity, secondIdentity]));
         when(
-          () => mockRepository.getAgentStatesByAgentIds(any()),
+          () => mockRepository.getAgentStatesWithPendingWakes(
+            any(),
+            alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+          ),
         ).thenAnswer(
           (_) async => {
             'agent-a': firstState,
@@ -541,7 +544,10 @@ void main() {
         expect(records[2].agent.agentId, 'agent-b');
         final capturedAgentIds =
             verify(
-                  () => mockRepository.getAgentStatesByAgentIds(captureAny()),
+                  () => mockRepository.getAgentStatesWithPendingWakes(
+                    captureAny(),
+                    alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+                  ),
                 ).captured.single
                 as List<String>;
         expect(capturedAgentIds, ['agent-a', 'agent-b']);
@@ -587,7 +593,10 @@ void main() {
               Future.value([activeIdentity, deletedIdentity, missingIdentity]),
         );
         when(
-          () => mockRepository.getAgentStatesByAgentIds(any()),
+          () => mockRepository.getAgentStatesWithPendingWakes(
+            any(),
+            alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+          ),
         ).thenAnswer(
           (_) async => {
             'agent-a': activeState,
@@ -635,7 +644,10 @@ void main() {
           mockAgentService.listAgents,
         ).thenAnswer((_) => Future.value([identity]));
         when(
-          () => mockRepository.getAgentStatesByAgentIds(any()),
+          () => mockRepository.getAgentStatesWithPendingWakes(
+            any(),
+            alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+          ),
         ).thenAnswer((_) async => {'agent-a': state});
         when(
           mockRepository.getPendingScheduledWakeRecords,
@@ -680,7 +692,10 @@ void main() {
           mockAgentService.listAgents,
         ).thenAnswer((_) async => [identity]);
         when(
-          () => mockRepository.getAgentStatesByAgentIds(any()),
+          () => mockRepository.getAgentStatesWithPendingWakes(
+            any(),
+            alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+          ),
         ).thenAnswer((_) async => {plannerId: state});
         when(mockRepository.getPendingScheduledWakeRecords).thenAnswer(
           (_) async => [
@@ -732,7 +747,10 @@ void main() {
 
         when(mockAgentService.listAgents).thenAnswer((_) async => const []);
         when(
-          () => mockRepository.getAgentStatesByAgentIds(any()),
+          () => mockRepository.getAgentStatesWithPendingWakes(
+            any(),
+            alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+          ),
         ).thenAnswer((_) async => const {});
         when(mockRepository.getPendingScheduledWakeRecords).thenAnswer(
           (_) async => [
@@ -789,7 +807,10 @@ void main() {
           mockAgentService.listAgents,
         ).thenAnswer((_) async => scenario.identities);
         when(
-          () => mockRepository.getAgentStatesByAgentIds(any()),
+          () => mockRepository.getAgentStatesWithPendingWakes(
+            any(),
+            alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+          ),
         ).thenAnswer((_) async => scenario.statesByAgentId);
         when(
           mockRepository.getPendingScheduledWakeRecords,
@@ -813,7 +834,10 @@ void main() {
 
           final capturedAgentIds =
               verify(
-                    () => mockRepository.getAgentStatesByAgentIds(captureAny()),
+                    () => mockRepository.getAgentStatesWithPendingWakes(
+                      captureAny(),
+                      alsoIncludeAgentIds: any(named: 'alsoIncludeAgentIds'),
+                    ),
                   ).captured.single
                   as List<String>;
           expect(

--- a/test/features/agents/state/agent_pending_wake_providers_test.dart
+++ b/test/features/agents/state/agent_pending_wake_providers_test.dart
@@ -735,6 +735,24 @@ void main() {
         expect(record.dueAt, dueAt);
         // `day:<dayId>` workspace → the day id is the subject label.
         expect(record.subjectLabel, 'dayplan-2026-06-08');
+
+        // The planner's state carries no wake field of its own — its wake
+        // lives on the ScheduledWakeEntity — so it only survives the SQL
+        // filter because the provider names it explicitly. Assert the id
+        // actually reaches the read: without this the test passes even if the
+        // provider stops forwarding them, and the real query would then drop
+        // the state and the record with it.
+        final capturedIncluded =
+            verify(
+                  () => mockRepository.getAgentStatesWithPendingWakes(
+                    any(),
+                    alsoIncludeAgentIds: captureAny(
+                      named: 'alsoIncludeAgentIds',
+                    ),
+                  ),
+                ).captured.single
+                as Iterable<String>;
+        expect(capturedIncluded, contains(plannerId));
       },
     );
 


### PR DESCRIPTION
## Problem

`pendingWakeRecordsProvider` loaded the latest state for **every** agent, then kept only those carrying a `nextWakeAt` or `scheduledWakeAt`. On this install that is ~900 rows decoded from JSON on every agent-update notification.

The slow-query logs size it precisely. Of 4,211 latest-per-agent reads over 2026-07-19 → 2026-08-01:

| args | calls |
|---:|---:|
| **901** (whole population) | **2,050** |
| 3 | 1,072 |
| ~600–660 | the rest |

At ~32 ms each, and it is the #1 shape by total time in the recent window (134 s).

The query itself is not the problem — it is chunked, correctly indexed, and already uses a window function rather than an N+1:

```
SEARCH agent_entities USING INDEX idx_agent_entities_active_agent_type_created_id (agent_id=? AND type=?)
```

The waste is fetching and decoding rows the caller immediately discards.

## Fix

`latestEntitiesByAgentIds` gains an `outerPredicate`, applied to the outer `WHERE rn = 1`. `getAgentStatesWithPendingWakes` uses it to return only agents with a wake pending.

### The correctness trap

The predicate **must** be applied after ranking. Filtering inside the ranked subquery would promote an older row that satisfies it over a newer one that does not — resurrecting a wake the newest state had cleared.

There is a test for exactly this (`a cleared wake on the newest state excludes the agent`). I verified it by moving the predicate into the subquery: **that one test fails**, the other 27 pass.

### The regression I had to avoid

Workspace-scoped scheduled wakes (ADR 0022) carry their wake on a separate `ScheduledWakeEntity` row, not on the state. Filtering naively would have dropped those agents from the screen. They are named explicitly via `alsoIncludeAgentIds` and stay in the **same** query — splitting it would trade the decode saving for an extra round trip. The provider now fetches the scheduled-wake records first so it can pass them.

## Tests

5 new in `agent_repo_core_test.dart` against a real in-memory DB:

- returns only agents with a pending or scheduled wake
- **a cleared wake on the newest state excludes the agent** (the trap above)
- a newly-set wake on the newest state includes the agent
- `alsoIncludeAgentIds` hydrates agents with no wake field
- omitting `alsoIncludeAgentIds` leaves valid SQL (no dangling `IN ()`)

The 6 existing `pendingWakeRecordsProvider` tests — including a 180-input property test — pass with only their stub name updated, which is the behaviour-preservation evidence.

`agent_repo_core_test.dart`: 28/28. `agent_pending_wake_providers_test.dart`: 23/23. `dart analyze`: clean. `make knowledge_check`: 25/25.

## Not changed

`getAgentStatesByAgentIds` keeps its four service callers (`feedback_extraction_service`, `project_agent_service`, `task_agent_service`, `event_agent_service`) and is untouched.

Part of the "Slow Query Improvements (2026-08 investigation)" epic. Independent of #3714 and #3716.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending-wake loading to use each agent’s latest state.
  * Prevented cleared or outdated wake states from being incorrectly surfaced.
  * Ensured scheduled wakes load required agent states without retrieving unrelated data.
  * Improved handling of large agent lists during pending-wake retrieval.

* **Documentation**
  * Documented latest-state filtering behavior for pending wakes.

* **Tests**
  * Added coverage for pending, scheduled, cleared, and newly set wakes, explicit agent inclusion, and large batched queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->