### PR TITLE
perf(sync): batch the outbox retry updates

### DIFF
--- a/lib/features/sync/outbox/outbox_repository.dart
+++ b/lib/features/sync/outbox/outbox_repository.dart
@@ -196,19 +196,30 @@ class DatabaseOutboxRepository implements OutboxRepository {
   Future<void> markRetryBatch(List<OutboxItem> items) async {
     if (items.isEmpty) return;
     final now = DateTime.now();
-    await _database.transaction(() async {
+    // One batched statement set rather than one round trip per row.
+    //
+    // A failed bundle retries up to `SyncTuning.outboxBundleMaxSize` (50) rows
+    // at once, and the loop this replaces issued 50 separate updates while
+    // holding sync.sqlite's single write lock. Every reader queues behind that
+    // lock — the 2026-06/07 logs caught nine sync reads finishing together
+    // after 25 s, which is the shape of queue-behind-a-writer. `batch` keeps
+    // the same transaction semantics (drift runs it in one) but collapses the
+    // round trips, so the lock is held for a fraction of the time.
+    // See `docs/perf/2026-08-01_slow-queries-investigation.md`.
+    await _database.batch((batch) {
       for (final item in items) {
         final retries = item.retries + 1;
         final newStatus = retries < maxRetries
             ? OutboxStatus.pending.index
             : OutboxStatus.error.index;
-        await _database.updateOutboxItem(
+        batch.update(
+          _database.outbox,
           OutboxCompanion(
-            id: Value(item.id),
             status: Value(newStatus),
             retries: Value(retries),
             updatedAt: Value(now),
           ),
+          where: (t) => t.id.equals(item.id),
         );
       }
     });

--- a/test/features/sync/outbox/outbox_repository_test.dart
+++ b/test/features/sync/outbox/outbox_repository_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/database/sync_db.dart';
@@ -459,6 +460,64 @@ void main() {
       });
 
       test(
+        'markRetryBatch issues one batched statement set, not one per row',
+        () async {
+          // The point of the change: a failed bundle retries up to
+          // SyncTuning.outboxBundleMaxSize (50) rows, and the previous loop
+          // held sync.sqlite's single write lock across one update round trip
+          // per row. Counting statements is the only way to assert that — a
+          // behavioural test passes either way.
+          //
+          // Counted with a drift QueryInterceptor over its own connection, so
+          // no counter has to leak into production code.
+          final counter = _StatementCounter();
+          final countedDb = SyncDatabase.connect(
+            DatabaseConnection(NativeDatabase.memory().interceptWith(counter)),
+          );
+          addTearDown(countedDb.close);
+          final countedRepo = DatabaseOutboxRepository(
+            countedDb,
+            maxRetries: 2,
+          );
+
+          for (var i = 0; i < 12; i++) {
+            await countedDb.addOutboxItem(
+              OutboxCompanion(
+                status: Value(OutboxStatus.sending.index),
+                subject: const Value('s'),
+                message: const Value('{}'),
+                createdAt: Value(DateTime(2024)),
+                updatedAt: Value(DateTime(2024)),
+                retries: const Value(0),
+              ),
+            );
+          }
+          final items = await countedDb.getOutboxItems(
+            statuses: const [OutboxStatus.sending],
+          );
+          expect(items, hasLength(12));
+
+          counter.reset();
+          await countedRepo.markRetryBatch(items);
+
+          expect(
+            counter.updates,
+            lessThan(12),
+            reason:
+                'a batched update must not cost one statement per row; '
+                'got ${counter.updates} discrete updates for 12 rows',
+          );
+
+          // …and the rows must still be updated correctly.
+          final after = await countedDb.getOutboxItems(
+            statuses: const [OutboxStatus.pending],
+          );
+          expect(after, hasLength(12));
+          expect(after.every((r) => r.retries == 1), isTrue);
+        },
+      );
+
+      test(
         'pruneSentOutboxItems (non-chunked) deletes only sent rows older '
         'than the retention window',
         () async {
@@ -823,4 +882,38 @@ void main() {
       );
     });
   });
+}
+
+/// Counts discrete statements drift sends to the executor.
+///
+/// `runBatched` is one call carrying many argument sets, which is exactly the
+/// distinction `markRetryBatch` is asserted on: a per-row loop shows up as N
+/// `runUpdate` calls, a batch as a single `runBatched`.
+class _StatementCounter extends QueryInterceptor {
+  int updates = 0;
+  int batches = 0;
+
+  void reset() {
+    updates = 0;
+    batches = 0;
+  }
+
+  @override
+  Future<int> runUpdate(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    updates++;
+    return executor.runUpdate(statement, args);
+  }
+
+  @override
+  Future<void> runBatched(
+    QueryExecutor executor,
+    BatchedStatements statements,
+  ) {
+    batches++;
+    return executor.runBatched(statements);
+  }
 }


### PR DESCRIPTION
## What the audit actually found

The task hypothesised a transaction wrapping network or file I/O holding sync.sqlite's write lock for tens of seconds. **There isn't one.**

I scanned every `transaction(...)` body in `lib/features/sync/**` and `lib/database/sync_db*.dart` for awaited non-database work — attachment reads, gzip, JSON encode/decode, matrix calls, `compute`, `Future.delayed`. Zero hits. The sync transactions are DB-only.

What they *do* hold the lock across is **per-row loops**:

| Site | Rows | Batchable? |
|---|---|---|
| `outbox_repository.dart:199` `markRetryBatch` | up to 50 | **yes** — this PR |
| `inbound_event_queue.dart:188` | per ingest | no — needs `insertReturningOrNull` per row to detect duplicates |
| `sync_db_lifecycle.dart:161`, `sync_db_outbox.dart:80` | bounded page sets | not worth it |

## The fix

`markRetryBatch` opened a transaction and issued **one update round trip per row**. A failed bundle retries up to `SyncTuning.outboxBundleMaxSize` (50) rows at once, so the write lock was held across 50 sequential statements — and every reader queues behind it. That is the convoy in the logs: nine sync reads that all started within one second finishing together after 25 s.

Replaced with a drift `batch`, which keeps the same transaction semantics (drift runs a batch in one transaction) while collapsing the round trips.

## Test

Counting statements is the only way to assert this — a behavioural test passes either way. The test uses a drift `QueryInterceptor` on its own connection, so **no counter leaks into production code**:

```dart
final counter = _StatementCounter();
final countedDb = SyncDatabase.connect(
  DatabaseConnection(NativeDatabase.memory().interceptWith(counter)),
);
```

`runBatched` is one call carrying many argument sets, so a per-row loop shows up as N `runUpdate` calls and a batch as a single `runBatched` — exactly the distinction being asserted.

**Revert check:** with the loop restored the test fails with `a batched update must not cost one statement per row; got 12 discrete updates for 12 rows`.

`outbox_repository_test.dart`: 24/24. `outbox_processor_test.dart`: 55/55. `dart analyze`: clean.

## Related

Complements #3720 (sync.sqlite read pool). That one moves readers off the write executor; this one shortens how long the writer holds the lock. Independent and individually mergeable.

Part of the "Slow Query Improvements (2026-08 investigation)" epic.