### PR TITLE
refactor(db): drop the dead habitCompletionsInRange drift query

### DIFF
--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -894,14 +894,6 @@ SELECT * FROM journal
   AND deleted = false
   ORDER BY date_from DESC;
 
-habitCompletionsInRange:
-SELECT * FROM journal
-  WHERE type = 'HabitCompletionEntry'
-  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
-  AND date_from >= :rangeStart
-  AND deleted = false
-  ORDER BY date_from ASC;
-
 quantitativeByType:
 SELECT * FROM journal
   WHERE type = 'QuantitativeEntry'

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6981,14 +6981,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
-  Selectable<JournalDbEntity> habitCompletionsInRange(DateTime rangeStart) {
-    return customSelect(
-      'SELECT * FROM journal WHERE type = \'HabitCompletionEntry\' AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND date_from >= ?1 AND deleted = FALSE ORDER BY date_from ASC',
-      variables: [Variable<DateTime>(rangeStart)],
-      readsFrom: {journal, configFlags},
-    ).asyncMap(journal.mapFromRow);
-  }
-
   Selectable<JournalDbEntity> quantitativeByType(
     String? subtype,
     DateTime rangeStart,


### PR DESCRIPTION
## What

`habitCompletionsInRange` (`database.drift:897`) has **no callers**. Removed, and regenerated.

## Why it looked like the most important query in the corpus

Aggregated across all 47 days of slow-query logs it ranks **#1 by total time, 1,458 s**. That number is an artefact three times over:

1. **1,356 s of it is two events** — 909,870 ms (2026-06-25) and 446,318 ms (2026-06-23). Both had **zero overlapping writes** and almost no overlapping queries across a 7–15 minute span, so neither is database contention. Compare the genuine sync convoy, where nine queries piled up in one second and released together.
2. **Its last execution was 2026-07-05.** It was superseded by `getHabitCompletionsInRange` (`database_data_queries.dart:40`), which deduplicates to one row per habit/day rather than returning every historic write.
3. Ranked over the last 14 days — the window that reflects current code — it does not appear at all.

This is exactly the trap that would send someone optimising a query that never runs, so it is worth having the deletion be explicit rather than silent.

## Verification

- No references anywhere outside the `.drift` definition and its generated output.
- Regenerated with `make build_runner` (**not** a filtered build, which prunes tracked generated files outside the filter).
- Diff is the query plus its 8 generated lines. `dart analyze`: clean.

No CHANGELOG entry — invisible to users.

Part of the "Slow Query Improvements (2026-08 investigation)" epic.