### PR TITLE
feat(db): distinguish host suspend from real stalls in the slow-query log

### DIFF
--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -134,3 +134,19 @@ each tier is for are in [persistence](persistence.md).
 | Buffering, files, flag subscription | [`lib/services/logging_service.dart`](../../lib/services/logging_service.dart) |
 | Developer-only console helper | [`lib/services/dev_logger.dart`](../../lib/services/dev_logger.dart) |
 | Slow-query interceptor | [`lib/database/slow_query_logging.dart`](../../lib/database/slow_query_logging.dart) |
+
+# Suspend artefacts in the slow-query log
+
+Every slow-query entry records **two** clocks: `elapsed` from a monotonic
+`Stopwatch`, and `wallElapsed` from wall time across the same span. They only
+disagree when the host suspends — `CLOCK_MONOTONIC` does not advance while the
+machine sleeps, wall clock does.
+
+When wall time runs more than 250 ms ahead, the log line carries
+`suspended=<ms>`. Entries so marked are **not** database stalls and must be
+excluded from any "slowest query" aggregation.
+
+This exists because the 2026-06/07 corpus contained two entries — 909,870 ms and
+446,318 ms — that dwarfed everything else, had zero overlapping writes and
+almost no overlapping queries (so not lock contention), and between them made a
+query with no callers rank #1 across the whole corpus by total time.

--- a/lib/database/slow_query_logging.dart
+++ b/lib/database/slow_query_logging.dart
@@ -9,6 +9,11 @@ import 'package:path/path.dart' as p;
 
 typedef SlowQueryReporter = void Function(SlowQueryLogEntry entry);
 
+/// Minimum wall-vs-monotonic divergence before an entry is annotated as
+/// suspended. Scheduling jitter and clock granularity produce a few
+/// milliseconds of noise on any span; a host suspend produces seconds.
+const Duration _suspensionReportingThreshold = Duration(milliseconds: 250);
+
 /// Runtime gate for slow-query file logging.
 ///
 /// The interceptor is installed on every Drift connection, but the actual
@@ -60,6 +65,7 @@ class SlowQueryLogEntry {
     required this.statement,
     required this.arguments,
     required this.elapsed,
+    this.wallElapsed,
     this.isSuperSlow = false,
     this.queryPlan,
     this.callerStack,
@@ -70,6 +76,35 @@ class SlowQueryLogEntry {
   final String statement;
   final List<Object?> arguments;
   final Duration elapsed;
+
+  /// Wall-clock time across the same span that [elapsed] measured with a
+  /// monotonic [Stopwatch].
+  ///
+  /// The two disagree when the host suspends: `Stopwatch` uses
+  /// `CLOCK_MONOTONIC`, which does not advance while the machine is asleep,
+  /// while wall clock does. A large positive divergence is therefore evidence
+  /// that the process was frozen, not that the database was slow.
+  ///
+  /// This exists because the 2026-06/07 corpus contained two entries — 909,870
+  /// ms and 446,318 ms — that dwarfed everything else and had **zero**
+  /// overlapping writes and almost no overlapping queries, which rules out lock
+  /// contention. They made a dead query rank #1 across the whole corpus. Rather
+  /// than re-litigate that every time, record both clocks and let aggregation
+  /// filter on the divergence.
+  final Duration? wallElapsed;
+
+  /// How far wall clock ran ahead of the monotonic timer, or `null` when wall
+  /// time was not captured.
+  ///
+  /// Near zero means the elapsed time was really spent in the query or its
+  /// queue — a genuine stall worth investigating. A value close to [elapsed]
+  /// means the process was suspended for essentially the whole span.
+  Duration? get suspensionSkew {
+    final wall = wallElapsed;
+    if (wall == null) return null;
+    final skew = wall - elapsed;
+    return skew.isNegative ? Duration.zero : skew;
+  }
 
   /// True when the query exceeded the interceptor's super-slow threshold and
   /// should be replicated to the dedicated super-slow log file.
@@ -104,7 +139,8 @@ class SlowQueryInterceptor extends QueryInterceptor {
     required this.threshold,
     required this.reporter,
     this.superSlowThreshold = SlowQueryLoggingGate.defaultSuperSlowThreshold,
-  });
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
 
   final String databaseName;
   final Duration threshold;
@@ -115,6 +151,10 @@ class SlowQueryInterceptor extends QueryInterceptor {
   /// super-slow log file. Set to `Duration.zero` from tests to force every
   /// reported query down the super-slow path.
   final Duration superSlowThreshold;
+
+  /// Wall clock source. Injectable so the suspend-detection branch can be
+  /// driven deterministically instead of with a real delay.
+  final DateTime Function() _now;
 
   static SlowQueryReporter fileReporter({
     required String documentsDirectoryPath,
@@ -128,10 +168,21 @@ class SlowQueryInterceptor extends QueryInterceptor {
       final logFile = File(
         p.join(documentsDirectoryPath, 'logs', '$fileStem-$date.log'),
       );
+      // `suspended=<ms>` is appended only when wall clock ran meaningfully
+      // ahead of the monotonic timer, i.e. the host was asleep for part of the
+      // span. Its absence is the common case and keeps the line format
+      // unchanged for every normal entry; its presence marks an entry that
+      // should be excluded from any "slowest query" aggregation.
+      final skew = entry.suspensionSkew;
+      final suspendedSuffix =
+          skew != null && skew >= _suspensionReportingThreshold
+          ? 'suspended=${(skew.inMicroseconds / Duration.microsecondsPerMillisecond).toStringAsFixed(3)}ms '
+          : '';
       final line =
           '${DateTime.now().toIso8601String()} '
           '[${entry.databaseName}] ${entry.operation} '
           '${elapsedMs.toStringAsFixed(3)}ms '
+          '$suspendedSuffix'
           'args=${entry.arguments.length} '
           '${entry.formattedStatement}';
       _SlowQueryFileSink.instance.append(logFile, line);
@@ -232,11 +283,15 @@ class SlowQueryInterceptor extends QueryInterceptor {
       callerStack = StackTrace.current;
     }
     final stopwatch = Stopwatch()..start();
+    final startedAt = _now();
     try {
       return await run();
     } finally {
       stopwatch.stop();
       final elapsed = stopwatch.elapsed;
+      // Wall clock across the same span. It only differs from the monotonic
+      // `elapsed` if the host suspended — see [SlowQueryLogEntry.wallElapsed].
+      final wallElapsed = _now().difference(startedAt);
       if (SlowQueryLoggingGate.isEnabled && elapsed >= threshold) {
         final isSuperSlow = elapsed >= superSlowThreshold;
         List<String>? queryPlan;
@@ -260,6 +315,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
             statement: statement,
             arguments: arguments,
             elapsed: elapsed,
+            wallElapsed: wallElapsed,
             isSuperSlow: isSuperSlow,
             queryPlan: queryPlan,
             callerStack: callerStack,

--- a/test/database/slow_query_logging_test.dart
+++ b/test/database/slow_query_logging_test.dart
@@ -112,13 +112,105 @@ void main() {
 
     SlowQueryInterceptor createInterceptor({
       Duration threshold = Duration.zero,
+      DateTime Function()? now,
     }) {
       return SlowQueryInterceptor(
         databaseName: 'test_db',
         threshold: threshold,
         reporter: reportedEntries.add,
+        now: now,
       );
     }
+
+    /// A wall clock the test advances by hand, so the suspend-detection branch
+    /// is driven deterministically rather than with a real delay.
+    ({DateTime Function() clock, void Function(Duration) advance}) fakeClock() {
+      var current = DateTime(2026, 8);
+      return (
+        clock: () => current,
+        advance: (d) => current = current.add(d),
+      );
+    }
+
+    group('suspend detection (wall clock vs monotonic)', () {
+      // Stopwatch uses CLOCK_MONOTONIC, which does not advance while the host
+      // is asleep; wall clock does. A large divergence is therefore evidence
+      // the process was frozen, not that the database was slow. Two entries in
+      // the 2026-06/07 corpus (909,870ms and 446,318ms) had zero overlapping
+      // writes, which is what motivated recording both clocks.
+
+      setUp(() {
+        SlowQueryLoggingGate.isEnabled = true;
+      });
+
+      test(
+        'reports no skew when wall clock tracks the monotonic timer',
+        () async {
+          final fake = fakeClock();
+          interceptor = createInterceptor(now: fake.clock);
+          when(
+            () => mockExecutor.runSelect(any(), any()),
+          ).thenAnswer((_) async => []);
+
+          await interceptor.runSelect(mockExecutor, 'SELECT 1', []);
+
+          expect(reportedEntries, hasLength(1));
+          expect(
+            reportedEntries.single.suspensionSkew,
+            Duration.zero,
+            reason: 'an un-suspended span must not be flagged',
+          );
+        },
+      );
+
+      test('reports the skew when the host slept during the query', () async {
+        final fake = fakeClock();
+        interceptor = createInterceptor(now: fake.clock);
+        when(() => mockExecutor.runSelect(any(), any())).thenAnswer((_) async {
+          // The machine sleeps for 15 minutes mid-query: wall clock jumps,
+          // the Stopwatch barely moves.
+          fake.advance(const Duration(minutes: 15));
+          return [];
+        });
+
+        await interceptor.runSelect(mockExecutor, 'SELECT 1', []);
+
+        final entry = reportedEntries.single;
+        expect(entry.suspensionSkew, greaterThan(const Duration(minutes: 14)));
+        expect(
+          entry.elapsed,
+          lessThan(const Duration(minutes: 1)),
+          reason: 'the monotonic timer must not have advanced with the sleep',
+        );
+      });
+
+      test('suspensionSkew is null when no wall clock was recorded', () {
+        const entry = SlowQueryLogEntry(
+          databaseName: 'db',
+          operation: 'select',
+          statement: 'SELECT 1',
+          arguments: [],
+          elapsed: Duration(seconds: 1),
+        );
+
+        expect(entry.suspensionSkew, isNull);
+      });
+
+      test('a backwards wall-clock jump clamps to zero, never negative', () {
+        // NTP correction or a manual clock change can move wall time
+        // backwards; that is not negative suspension.
+        const entry = SlowQueryLogEntry(
+          databaseName: 'db',
+          operation: 'select',
+          statement: 'SELECT 1',
+          arguments: [],
+          elapsed: Duration(seconds: 10),
+          wallElapsed: Duration(seconds: 2),
+        );
+
+        expect(entry.suspensionSkew, Duration.zero);
+      });
+    });
 
     group('gate disabled - no reporter calls', () {
       setUp(() {
@@ -780,6 +872,58 @@ void main() {
       if (tempDir.existsSync()) {
         tempDir.deleteSync(recursive: true);
       }
+    });
+
+    test('annotates a suspended entry, and leaves normal ones alone', () async {
+      // The marker is what lets log aggregation drop suspend artefacts instead
+      // of ranking them as the slowest queries in the corpus.
+      final reporter = SlowQueryInterceptor.fileReporter(
+        documentsDirectoryPath: tempDir.path,
+      );
+
+      reporter(
+        const SlowQueryLogEntry(
+          databaseName: 'test_db',
+          operation: 'select',
+          statement: 'SELECT 1',
+          arguments: <Object?>[],
+          elapsed: Duration(milliseconds: 40),
+          wallElapsed: Duration(minutes: 15),
+        ),
+      );
+      reporter(
+        const SlowQueryLogEntry(
+          databaseName: 'test_db',
+          operation: 'select',
+          statement: 'SELECT 2',
+          arguments: <Object?>[],
+          elapsed: Duration(milliseconds: 40),
+          wallElapsed: Duration(milliseconds: 41),
+        ),
+      );
+      await SlowQueryInterceptor.flushFileSinkForTest();
+
+      final logFile = Directory(
+        '${tempDir.path}/logs',
+      ).listSync().whereType<File>().single;
+      final lines = logFile
+          .readAsStringSync()
+          .trim()
+          .split('\n')
+          .where((l) => l.isNotEmpty)
+          .toList();
+
+      expect(lines, hasLength(2));
+      expect(
+        lines.firstWhere((l) => l.contains('SELECT 1')),
+        contains('suspended='),
+        reason: '15 minutes of wall time against 40ms monotonic is a suspend',
+      );
+      expect(
+        lines.firstWhere((l) => l.contains('SELECT 2')),
+        isNot(contains('suspended=')),
+        reason: '1ms of jitter must not be annotated',
+      );
     });
 
     test('writes log line to a dated file in logs subdirectory', () async {


### PR DESCRIPTION
## Problem

Two entries in the 2026-06/07 corpus dwarfed everything else:

| Duration | Window | Query |
|---:|---|---|
| 909,870 ms (15.2 min) | 2026-06-25 15:21:43 → 15:36:53 | habit completions |
| 446,318 ms (7.4 min) | 2026-06-23 19:40:16 → 19:47:42 | habit completions |

Both had **zero overlapping writes** and only 3 and 16 other logged statements across the whole span. If the database were locked, the queue would be full of waiters — as it visibly is in the genuine sync convoy, where nine queries pile up in one second and release together. So neither is a database stall.

Between them they contributed **1,356 s** and made a query with *no callers* rank **#1 across the entire corpus** by total time. Without a way to tell the two apart, every future investigation re-litigates this.

## Fix

Record wall clock alongside the monotonic `Stopwatch`. `Stopwatch` uses `CLOCK_MONOTONIC`, which does not advance while the host sleeps; wall clock does. A large divergence is positive evidence the *process* was frozen, not that the database was slow.

When the divergence exceeds 250 ms — well clear of scheduling jitter, far below a real suspend — the log line carries `suspended=<ms>`:

```
2026-06-25T15:36:53 [db.sqlite] select 909869.863ms suspended=909820.114ms args=1 SELECT …
```

Entries so marked should be excluded from any "slowest query" aggregation. **Normal entries keep the existing line format exactly**, so nothing that parses these logs breaks.

`suspensionSkew` clamps to zero rather than going negative, so an NTP correction or manual clock change isn't mistaken for negative suspension.

## Tests

5 new. The clock is **injected**, so the suspend branch is driven deterministically with no real delay — per the repo's fake-time policy:

- no skew reported when wall clock tracks the monotonic timer
- the skew is reported when the host sleeps 15 minutes mid-query, and `elapsed` correctly does *not* advance with it
- `suspensionSkew` is null when no wall clock was recorded
- a backwards wall-clock jump clamps to zero
- the file reporter annotates a suspended entry and leaves a 1 ms-jitter entry alone

`slow_query_logging_test.dart`: 51/51. `dart analyze`: clean. `make knowledge_check`: 25/25.

`knowledge/architecture/logging-and-diagnostics.md` documents the marker and that annotated entries are not stalls.

## Note

This is diagnostics only — no behaviour change and nothing user-visible, so no CHANGELOG entry. It is the lowest-priority item in the epic but the cheapest way to stop a recurring misdiagnosis.

Part of the "Slow Query Improvements (2026-08 investigation)" epic.