### PR TITLE
perf: reduce sync log volume while preserving diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0]
+### Fixed
+- **Deleting an entry no longer traps an otherwise healthy sync batch in
+  retries.** Bundled sends mistook a soft-deleted entry for a missing database
+  row, retried every valid sibling with it, and eventually left the whole batch
+  as failed. Deletion tombstones now travel in the bundle like every other
+  journal update.
+- **Detailed sync diagnostics stay useful without growing by tens of megabytes
+  a day.** Repetitive per-record bookkeeping is now represented by counted
+  samples, including separate totals for inserted versus merged outbox work and
+  sequence writes versus duplicate skips. Gap detections, actual backfill
+  requests, retries and errors remain complete so initial-sync and repair work
+  can still be investigated.
+
 ## [0.9.1074]
 ### Changed
 - **The task-list header gets out of the way while you read.** On a small

--- a/docs/architecture/sync_current_architecture.md
+++ b/docs/architecture/sync_current_architecture.md
@@ -57,6 +57,44 @@ It is a feedback system:
 
 That makes it powerful, but also very easy to amplify mistakes.
 
+## 2026-08-01 Sync Log Volume Update
+
+A 17-day capture from `logs/` contained 377,795 timestamped entries and
+82.55 MB of sync logs (about 22,400 entries/day). This was primarily telemetry
+amplification, not a send loop:
+
+| Category | Entries | Size | Share of bytes |
+| --- | ---: | ---: | ---: |
+| Outbound per-record bookkeeping | 267,789 | 65.22 MB | 79.2% |
+| Gap detection and backfill | 41,497 | 7.63 MB | 9.3% |
+| Inbound processing | 36,652 | 5.39 MB | 6.5% |
+| Network send, retry and errors | 26,454 | 3.26 MB | 4.0% |
+
+The five largest families were `sequence.recordSent`,
+`prepare.ensureCovered`, `enqueueMessage`, `enqueue.merge` and
+`outbox.enqueue`. Together they were repetitive per-record bookkeeping. They
+now use counted sampling: a representative first line followed by summaries
+with observed/suppressed/cumulative totals. This preserves comparisons between
+enqueue inserts and merges, and between sequence writes and duplicate skips.
+
+Two real work defects were separate from verbosity:
+
+- Persistence and outbox bookkeeping attempted the same sequence binding
+  49,406 extra times in the capture. A five-minute exact-binding LRU now skips
+  the immediate duplicate database upsert while reporting it as a counted
+  diagnostic.
+- 213 of 223 bundle failures immediately followed `missingEntity`. The
+  outbound bulk query had excluded soft-deleted journal rows, so legitimate
+  tombstones looked absent and retried the whole bundle. Outbound lookup now
+  includes deleted rows; a truly hard-purged child still aborts and remains
+  visible through the retry/error path.
+
+Backfill signal is intentionally retained. Actionable gaps, ranges, filtered
+queued counts and request sends remain one-line-per-event. Only the repeated
+no-work outcomes are counted samples (50 observations or 15 minutes), which
+keeps initial-sync/backfill amplification diagnosable while removing routine
+poll noise.
+
 ## Recent Fix Timeline
 
 These PRs matter directly for the current behavior:

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,12 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.0" date="2026-08-01">
+      <description>
+        <p>Fixed: deleting an entry no longer traps an otherwise healthy sync batch in retries. Bundled sends mistook a soft-deleted entry for a missing database row, retried every valid sibling with it, and eventually left the whole batch as failed. Deletion tombstones now travel in the bundle like every other journal update.</p>
+        <p>Fixed: detailed sync diagnostics stay useful without growing by tens of megabytes a day. Repetitive per-record bookkeeping is represented by counted samples, with separate totals for inserted versus merged outbox work and sequence writes versus duplicate skips. Gap detections, actual backfill requests, retries and errors remain complete so initial-sync and repair work can still be investigated.</p>
+      </description>
+    </release>
     <release version="0.9.1074" date="2026-07-31">
       <description>
         <p>Changed: the task-list header gets out of the way while you read. On a small phone the Tasks header — title, search field, saved-filter rail and active filter chips — took up to half the screen before the first task appeared. Scrolling down now folds it into a slim bar with the title and two buttons, so the reclaimed space shows two to three more tasks; a deliberate upward scroll (or a tap on the bar's title) brings the full header back. The same fold applies wherever the list is narrow, including the desktop split view's list pane. The slim bar still says what is narrowing the list: an ad-hoc filter is named as a count of its clauses, an active saved view shows its name next to the title, and an active search shows the query in quotes. Typed search text survives the fold, a list too short to scroll never collapses, and with reduced motion enabled the switch is instant instead of animated.</p>

--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -11,7 +11,7 @@ sources:
   - id: sync-src
     resource: ../../../lib/features/sync
     title: Sync feature source
-    last_modified: 2026-07-29
+    last_modified: 2026-08-01
   - id: get-it
     resource: ../../../lib/get_it.dart
     title: Default bootstrap wiring
@@ -24,6 +24,10 @@ sources:
     resource: ../../../docs/architecture/sync_current_architecture.md
     title: Failure history, log-backed investigations, tuning context
     last_modified: 2026-07-26
+  - id: domain-logging
+    resource: ../../../lib/services/domain_logging.dart
+    title: DomainLogger counted sampling
+    last_modified: 2026-08-01
 ---
 
 Sync replicates **one user's data across that user's own devices** over Matrix.
@@ -72,6 +76,26 @@ The default bootstrap in `lib/get_it.dart` wires `MatrixService`,
 `BackfillRequestService` and `BackfillResponseHandler`. That is the path these
 concepts describe. Construction order matters and is documented in
 [bootstrap and dependency injection](../../architecture/bootstrap-and-di.md).
+
+# Diagnostic logging policy
+
+The `sync` log domain remains disabled by default and is intended for bounded
+diagnostic captures. When enabled, failures, retries, gap detections, actionable
+backfill sends and repair lifecycle transitions are emitted individually. These
+are the events needed to explain non-convergence or an initial-sync backfill.
+
+High-frequency bookkeeping uses `DomainLogger.logSampled`: the first event is
+emitted immediately, followed by a counted summary every 100 observations or
+five minutes. Every summary carries `sampleKey`, `observed`, `suppressed` and
+cumulative `total`, so amplification remains measurable without one line per
+record. The sampled families are enqueue insert/merge outcomes, sequence
+binding writes and duplicate skips, vector-clock assignments, and embedded-link
+preparation. Backfill's two no-work outcomes use the same scheme with a
+50-observation / 15-minute window; actual requests remain unsampled.
+
+Sample keys are bounded categories, never entry IDs. Representative lines may
+carry IDs and vector clocks for diagnosis, but sync logging does not serialize
+full journal, agent or attachment payloads.
 
 # Code map
 

--- a/knowledge/features/sync/send-path.md
+++ b/knowledge/features/sync/send-path.md
@@ -11,11 +11,11 @@ sources:
   - id: outbox
     resource: ../../../lib/features/sync/outbox
     title: Outbox service, processor, repository
-    last_modified: 2026-07-14
+    last_modified: 2026-08-01
   - id: payload-sender
     resource: ../../../lib/features/sync/matrix/matrix_payload_sender.dart
     title: MatrixPayloadSender — wire encoding
-    last_modified: 2026-06-16
+    last_modified: 2026-08-01
   - id: media-repair
     resource: ../../../lib/features/sync/media
     title: Media self-healing — request and response
@@ -207,7 +207,7 @@ sequenceDiagram
   Proc->>Repo: claimNextBatch(maxSize: 50)
   Repo-->>Proc: List<OutboxItem>
   Proc->>Sender: send(SyncOutboxBundle)
-  Sender->>DB: journalEntityMapForIds(ids)
+  Sender->>DB: journalEntityMapForIdsIncludingDeleted(ids)
   DB-->>Sender: {id: JournalEntity, …}
   Sender->>Sender: build manifest + gzip
   Sender->>Room: m.file (manifest, encoding=gzip)
@@ -220,9 +220,11 @@ sequenceDiagram
 `MatrixPayloadSender.sendOutboxBundlePayload` builds the wire form:
 
 1. **Bulk-load** every `SyncJournalEntity` child's `JournalEntity` via
-   `JournalDb.journalEntityMapForIds` in one `WHERE id IN (…)` query. The
-   database is the system of record — the sender never reads per-child JSON
-   files from disk.
+   `JournalDb.journalEntityMapForIdsIncludingDeleted` in one `WHERE id IN (…)`
+   query. This outbound-only read includes soft-deleted rows because their
+   tombstones must reach peers; ordinary application bulk reads still hide
+   them. The database is the system of record — the sender never reads
+   per-child JSON files from disk.
 2. **Reconcile** each child envelope's `vectorClock` against the DB version.
 3. **Emit one manifest**:
    `{version: 1, entries: [{envelope: <SyncMessage>, payload: <JournalEntity?>}]}`.
@@ -247,6 +249,12 @@ send-side guard only. When the gzipped manifest exceeds it,
 Rows stay pending until acknowledged, so a failed manifest send simply
 re-bundles from outbox state next drain — no on-disk artifact survives across
 attempts.
+
+A journal child absent even from the including-deleted lookup was hard-purged,
+not merely soft-deleted. The sender aborts that bundle rather than silently
+acknowledging a manifest that omitted the child. Soft deletion therefore no
+longer sends every valid sibling through the retry loop; genuinely missing
+payloads still surface through the existing retry/error diagnostics.
 
 ## Receiver side
 

--- a/knowledge/features/sync/sequence-and-backfill.md
+++ b/knowledge/features/sync/sequence-and-backfill.md
@@ -11,7 +11,7 @@ sources:
   - id: sequence
     resource: ../../../lib/features/sync/sequence
     title: SyncSequenceLogService
-    last_modified: 2026-07-13
+    last_modified: 2026-08-01
   - id: status
     resource: ../../../lib/database/sync_sequence_status.dart
     title: SyncSequenceStatus
@@ -19,7 +19,7 @@ sources:
   - id: backfill
     resource: ../../../lib/features/sync/backfill
     title: Backfill request and response services
-    last_modified: 2026-07-05
+    last_modified: 2026-08-01
 ---
 
 # The accounting layer
@@ -75,6 +75,15 @@ deliberately does **not** terminalize plain `reserved` rows: a crash may have
 left a real local payload behind before outbox logging ran, and burning it would
 destroy recoverable data.
 
+Local persistence records the exact `(host, counter, entry, payload type)`
+binding immediately after its data commit. The outbox records it again as a
+fallback for direct enqueue and re-sync paths. `SyncSequenceCache` remembers a
+successful binding for five minutes and makes the normal second call
+idempotent; a later call reaches the database again in case lifecycle state
+changed. Counted `sequence.recordSent.write` and
+`sequence.recordSent.duplicate` diagnostics preserve the ratio between useful
+writes and redundant attempts without logging every binding.
+
 # `burned` versus `unresolvable`
 
 Both mean "no payload will arrive here", and the split is deliberate.
@@ -115,6 +124,13 @@ index), so neither blocks progress.
 2-minute interval (`backfillRequestInterval`, up to `backfillMaxRequestCount`
 = 10 per batch), supports a manual full historical backfill, and can re-request
 entries previously requested but never resolved.
+
+Backfill observability deliberately distinguishes work from polling. Gap
+detections, ranges, filtered queued rows and sent-request counts are logged for
+every actionable event, including manual full-history backfill. The frequent
+`no actionable entries` and `no missing entries` outcomes are counted samples,
+so a no-op storm is still visible by its cumulative total without producing a
+line for every timer or drain nudge.
 
 # Responding
 

--- a/lib/database/database_journal_queries.dart
+++ b/lib/database/database_journal_queries.dart
@@ -140,6 +140,34 @@ mixin _JournalDbJournalQueries on _$JournalDb, _JournalDbConfigFlags {
     return result;
   }
 
+  /// Bulk-fetches journal entities for outbound sync, including soft-deleted
+  /// rows so deletion tombstones can be serialized and delivered to peers.
+  ///
+  /// Most application reads intentionally hide deleted rows and should use
+  /// [journalEntityMapForIds]. The outbox is different: a locally deleted
+  /// entity is still a real sync payload. Treating it as absent makes a whole
+  /// bundle retry until its cap and increments retries for valid siblings.
+  Future<Map<String, JournalEntity>> journalEntityMapForIdsIncludingDeleted(
+    Iterable<String> ids,
+  ) async {
+    final idList = ids.toSet().toList(growable: false);
+    if (idList.isEmpty) {
+      return const <String, JournalEntity>{};
+    }
+    final result = <String, JournalEntity>{};
+    for (var i = 0; i < idList.length; i += _sqliteInListChunk) {
+      final end = (i + _sqliteInListChunk).clamp(0, idList.length);
+      final chunk = idList.sublist(i, end);
+      final dbEntities = await (select(
+        journal,
+      )..where((row) => row.id.isIn(chunk))).get();
+      for (final dbEntity in dbEntities) {
+        result[dbEntity.id] = fromDbEntity(dbEntity);
+      }
+    }
+    return result;
+  }
+
   Future<List<JournalEntity>> getJournalEntities({
     required List<String> types,
     required List<bool> starredStatuses,

--- a/lib/features/sync/backfill/backfill_request_service.dart
+++ b/lib/features/sync/backfill/backfill_request_service.dart
@@ -103,6 +103,21 @@ class BackfillRequestService {
     );
   }
 
+  void _traceSampled(
+    String message, {
+    required String sampleKey,
+    String? subDomain,
+  }) {
+    _domainLogger?.logSampled(
+      LogDomain.sync,
+      message,
+      sampleKey: sampleKey,
+      subDomain: subDomain ?? 'backfill',
+      every: 50,
+      maxInterval: const Duration(minutes: 15),
+    );
+  }
+
   /// Start the periodic backfill request processing.
   /// Uses bounded limits (age and per-host) for automatic backfill.
   void start() {
@@ -337,9 +352,12 @@ class BackfillRequestService {
       // that index regardless of the historical log size.
       final hasActionable = await _sequenceLogService.hasActionableEntries();
       if (!hasActionable) {
-        _trace(
+        _traceSampled(
           'processBackfillRequests: no actionable entries '
           '(useLimits=$useLimits bypassDebounce=$bypassDebounce)',
+          sampleKey:
+              'backfill.process.noActionable.$useLimits.'
+              '$bypassDebounce',
           subDomain: 'backfill.process',
         );
         return 0;
@@ -372,9 +390,12 @@ class BackfillRequestService {
       );
 
       if (missing.isEmpty) {
-        _trace(
+        _traceSampled(
           'processBackfillRequests: no missing entries '
           '(useLimits=$useLimits bypassDebounce=$bypassDebounce)',
+          sampleKey:
+              'backfill.process.noMissing.$useLimits.'
+              '$bypassDebounce',
           subDomain: 'backfill.process',
         );
         return 0;

--- a/lib/features/sync/matrix/matrix_payload_sender.dart
+++ b/lib/features/sync/matrix/matrix_payload_sender.dart
@@ -384,13 +384,16 @@ class MatrixPayloadSender {
     };
     final journalEntityById = journalEntityIds.isEmpty
         ? const <String, JournalEntity>{}
-        : await journalDb.journalEntityMapForIds(journalEntityIds);
+        : await journalDb.journalEntityMapForIdsIncludingDeleted(
+            journalEntityIds,
+          );
 
     final host = await vectorClockService?.getHost();
 
-    // Track journal-entity children whose DB row vanished between enqueue
-    // and dequeue (rare, but possible if the entity was deleted locally
-    // mid-flight). Silently dropping such children would let the bundle
+    // Track journal-entity children whose DB row was hard-purged between
+    // enqueue and dequeue. Soft-deleted rows are deliberately included above
+    // because their tombstones must sync. Silently dropping a hard-missing
+    // child would let the bundle
     // ack while one entity never reaches peers — permanent data loss.
     // Failing the whole bundle drops to the existing retry path; once the
     // row caps out it ends up in `error` status so an operator can

--- a/lib/features/sync/outbox/outbox_enqueue_writer.dart
+++ b/lib/features/sync/outbox/outbox_enqueue_writer.dart
@@ -61,6 +61,19 @@ class OutboxEnqueueWriter {
   final Future<void> Function({Duration delay}) _enqueueNextSendRequest;
   final SyncSequenceLogService? _sequenceLogService;
 
+  void _logEnqueueSample(
+    String message, {
+    required String sampleKey,
+    String subDomain = 'enqueueMessage',
+  }) {
+    _loggingService.logSampled(
+      LogDomain.sync,
+      message,
+      sampleKey: 'outbox.$sampleKey',
+      subDomain: subDomain,
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Message preparation
   // ---------------------------------------------------------------------------
@@ -95,18 +108,18 @@ class OutboxEnqueueWriter {
         final capped = links.length > SyncTuning.maxEmbeddedEntryLinks
             ? links.sublist(links.length - SyncTuning.maxEmbeddedEntryLinks)
             : links;
-        _loggingService.log(
-          LogDomain.sync,
+        _logEnqueueSample(
           'enqueueMessage.attachedLinks id=${journalMsg.id} '
           'count=${links.length} embedded=${capped.length} '
           'from=$fromCount to=$toCount',
+          sampleKey: 'attachLinks.present',
           subDomain: 'enqueueMessage.attachLinks',
         );
         journalMsg = journalMsg.copyWith(entryLinks: capped);
       } else {
-        _loggingService.log(
-          LogDomain.sync,
+        _logEnqueueSample(
           'enqueueMessage.noLinks id=${journalMsg.id}',
+          sampleKey: 'attachLinks.none',
           subDomain: 'enqueueMessage.attachLinks',
         );
       }
@@ -423,16 +436,11 @@ class OutboxEnqueueWriter {
             );
           }
 
-          // Log covered clocks for debugging
-          final coveredVcStrings = coveredClocks
-              ?.map((vc) => vc.vclock)
-              .toList();
-          _loggingService.log(
-            LogDomain.sync,
+          _logEnqueueSample(
             'enqueue MERGED type=SyncJournalEntity id=${msg.id} '
-            'coveredClocks=${coveredClocks?.length ?? 0} covered=$coveredVcStrings '
+            'coveredClocks=${coveredClocks?.length ?? 0} '
             'latest=${latestVc?.vclock}',
-            subDomain: 'enqueueMessage',
+            sampleKey: 'merge.SyncJournalEntity',
           );
 
           // Still record in sequence log for the new counter
@@ -493,11 +501,10 @@ class OutboxEnqueueWriter {
         payloadSize: Value(outboxSize),
       ),
     );
-    _loggingService.log(
-      LogDomain.sync,
+    _logEnqueueSample(
       'enqueue type=SyncJournalEntity subject=${'$hostHash:$localCounter'} '
       'id=${msg.id} attachBytes=$fileLength embeddedLinks=$embeddedLinksCount',
-      subDomain: 'enqueueMessage',
+      sampleKey: 'insert.SyncJournalEntity',
     );
 
     // Record in sequence log for backfill support (self-healing sync)
@@ -660,17 +667,12 @@ class OutboxEnqueueWriter {
             );
           }
 
-          // Log covered clocks for debugging
-          final coveredVcStrings = coveredClocks
-              ?.map((vc) => vc.vclock)
-              .toList();
           final latestVcStr = msg.entryLink.vectorClock?.vclock;
-          _loggingService.log(
-            LogDomain.sync,
+          _logEnqueueSample(
             'enqueue MERGED type=SyncEntryLink id=$linkId '
-            'coveredClocks=${coveredClocks?.length ?? 0} covered=$coveredVcStrings '
+            'coveredClocks=${coveredClocks?.length ?? 0} '
             'latest=$latestVcStr',
-            subDomain: 'enqueueMessage',
+            sampleKey: 'merge.SyncEntryLink',
           );
 
           // Still record in sequence log for the new counter
@@ -727,11 +729,10 @@ class OutboxEnqueueWriter {
         payloadSize: Value(outboxLinkSize),
       ),
     );
-    _loggingService.log(
-      LogDomain.sync,
+    _logEnqueueSample(
       'enqueue type=SyncEntryLink subject=$subject '
       'from=${msg.entryLink.fromId} to=${msg.entryLink.toId}',
-      subDomain: 'enqueueMessage',
+      sampleKey: 'insert.SyncEntryLink',
     );
 
     // Record in sequence log for backfill support (self-healing sync)

--- a/lib/features/sync/outbox/outbox_enqueue_writer_agent.dart
+++ b/lib/features/sync/outbox/outbox_enqueue_writer_agent.dart
@@ -194,28 +194,23 @@ extension OutboxEnqueueAgent on OutboxEnqueueWriter {
           );
         }
 
-        final coveredVcStrings = coveredClocks?.map((vc) => vc.vclock).toList();
-        _loggingService.log(
-          LogDomain.sync,
+        _logEnqueueSample(
           'enqueue MERGED type=$typeName id=$id '
-          'coveredClocks=${coveredClocks?.length ?? 0} '
-          'covered=$coveredVcStrings',
-          subDomain: 'enqueueMessage',
+          'coveredClocks=${coveredClocks?.length ?? 0}',
+          sampleKey: 'merge.$typeName',
         );
       } catch (e, st) {
-        _loggingService
-          ..error(
-            LogDomain.sync,
-            e,
-            stackTrace: st,
-            subDomain: 'enqueueMessage.agentMerge',
-          )
-          // Fallback: proceed without merging covered clocks
-          ..log(
-            LogDomain.sync,
-            'enqueue MERGED type=$typeName id=$id (no VC merge)',
-            subDomain: 'enqueueMessage',
-          );
+        _loggingService.error(
+          LogDomain.sync,
+          e,
+          stackTrace: st,
+          subDomain: 'enqueueMessage.agentMerge',
+        );
+        // Fallback: proceed without merging covered clocks.
+        _logEnqueueSample(
+          'enqueue MERGED type=$typeName id=$id (no VC merge)',
+          sampleKey: 'merge.$typeName.noVectorClock',
+        );
       }
 
       final mergedJson = json.encode(mergedMessage.toJson());
@@ -296,10 +291,9 @@ extension OutboxEnqueueAgent on OutboxEnqueueWriter {
         payloadSize: Value(outboxAgentSize),
       ),
     );
-    _loggingService.log(
-      LogDomain.sync,
+    _logEnqueueSample(
       'enqueue type=$typeName subject=$subject',
-      subDomain: 'enqueueMessage',
+      sampleKey: 'insert.$typeName',
     );
 
     // Record in sequence log for backfill support (self-healing sync)

--- a/lib/features/sync/outbox/outbox_enqueue_writer_simple.dart
+++ b/lib/features/sync/outbox/outbox_enqueue_writer_simple.dart
@@ -15,10 +15,9 @@ extension OutboxEnqueueSimple on OutboxEnqueueWriter {
     await _syncDatabase.addOutboxItem(
       commonFields.copyWith(subject: Value(subject)),
     );
-    _loggingService.log(
-      LogDomain.sync,
+    _logEnqueueSample(
       logMessage,
-      subDomain: 'enqueueMessage',
+      sampleKey: 'insert.simple',
     );
     return false;
   }
@@ -108,11 +107,10 @@ extension OutboxEnqueueSimple on OutboxEnqueueWriter {
         ),
       );
       if (affectedRows > 0) {
-        _loggingService.log(
-          LogDomain.sync,
+        _logEnqueueSample(
           'enqueue MERGED type=SyncConfigFlag subject=$key '
           'status=${msg.status}',
-          subDomain: 'enqueueMessage',
+          sampleKey: 'merge.SyncConfigFlag',
         );
         unawaited(_enqueueNextSendRequest(delay: const Duration(seconds: 1)));
         return true;
@@ -125,11 +123,10 @@ extension OutboxEnqueueSimple on OutboxEnqueueWriter {
         outboxEntryId: Value(key),
       ),
     );
-    _loggingService.log(
-      LogDomain.sync,
+    _logEnqueueSample(
       'enqueue type=SyncConfigFlag subject=$key '
       'status=${msg.status}',
-      subDomain: 'enqueueMessage',
+      sampleKey: 'insert.SyncConfigFlag',
     );
     return false;
   }
@@ -201,10 +198,9 @@ extension OutboxEnqueueSimple on OutboxEnqueueWriter {
         payloadSize: Value(outboxSize),
       ),
     );
-    _loggingService.log(
-      LogDomain.sync,
+    _logEnqueueSample(
       'enqueue type=SyncNotification id=${msg.id} attachBytes=$fileLength',
-      subDomain: 'enqueueMessage',
+      sampleKey: 'insert.SyncNotification',
     );
 
     await recordNotificationSent(

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -277,10 +277,6 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   int? _lastLoggedDbNudgeCount;
   DateTime? _lastLoggedDbNudgeAt;
 
-  void _syncLog(String message, {String? subDomain}) {
-    _domainLogger?.log(LogDomain.sync, message, subDomain: subDomain);
-  }
-
   /// Persists [entity]'s JSON payload under the documents directory and
   /// enqueues a `SyncMessage.notification` referencing it. Skips enqueue (and
   /// logs) if the derived payload path escapes the documents root.
@@ -505,8 +501,13 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
         ),
       };
 
-      _syncLog(
-        'enqueue type=${messageToEnqueue.runtimeType} priority=$priority',
+      _loggingService.logSampled(
+        LogDomain.sync,
+        'enqueue type=${messageToEnqueue.runtimeType} priority=$priority '
+        'outcome=${merged ? 'merged' : 'inserted'}',
+        sampleKey:
+            'outbox.enqueue.${messageToEnqueue.runtimeType}.'
+            '${merged ? 'merged' : 'inserted'}',
         subDomain: 'outbox.enqueue',
       );
 

--- a/lib/features/sync/sequence/sync_sequence_cache.dart
+++ b/lib/features/sync/sequence/sync_sequence_cache.dart
@@ -39,6 +39,13 @@ import 'package:lotti/database/sync_db.dart';
 /// entry_ids, routinely took 40–600 ms and dominated the image-paste freeze.
 /// LRU-bounded; entries are added on lookup and refreshed on `recordSentEntry`
 /// so the cached value cannot lag a concurrent write.
+///
+/// ## Recent sent-binding LRU
+/// Exact `(host, counter, entry, payload type)` bindings are remembered after
+/// a successful sequence-log write. Persistence records bindings immediately
+/// after its DB commit for crash safety, while the outbox records them again
+/// as a fallback for direct/resync enqueue paths. The exact-binding LRU makes
+/// that normal double-call idempotent without weakening either call site.
 class SyncSequenceCache {
   SyncSequenceCache(this._syncDatabase);
 
@@ -46,6 +53,13 @@ class SyncSequenceCache {
 
   /// LRU capacity for [_lastSentCounterByEntry].
   static const int lastSentCounterCacheCapacity = 2048;
+
+  /// LRU capacity for exact sent sequence bindings.
+  static const int sentBindingCacheCapacity = 4096;
+
+  /// Exact bindings only suppress the immediate persistence → outbox repeat.
+  /// Let later calls reach the DB again in case row status changed meanwhile.
+  static const sentBindingCacheTtl = Duration(minutes: 5);
 
   /// TTL applied to every per-host and the last-sent cache window.
   static const cacheTtl = Duration(minutes: 5);
@@ -60,6 +74,11 @@ class SyncSequenceCache {
 
   final LinkedHashMap<String, int?> _lastSentCounterByEntry =
       LinkedHashMap<String, int?>();
+  final LinkedHashMap<
+    ({String hostId, int counter, String entryId, int payloadType}),
+    DateTime
+  >
+  _sentBindings = LinkedHashMap();
 
   // Separate global TTL for the entry-keyed [_lastSentCounterByEntry] LRU. It
   // is keyed by `host::entryId` and is also size-bounded by
@@ -257,6 +276,64 @@ class SyncSequenceCache {
     }
   }
 
+  // ── Exact sent-binding LRU ────────────────────────────────────────────────
+
+  ({String hostId, int counter, String entryId, int payloadType}) _sentBinding({
+    required String hostId,
+    required int counter,
+    required String entryId,
+    required int payloadType,
+  }) => (
+    hostId: hostId,
+    counter: counter,
+    entryId: entryId,
+    payloadType: payloadType,
+  );
+
+  /// Returns whether this exact sequence binding was recently written, and
+  /// refreshes its LRU position when present.
+  bool containsSentBinding({
+    required String hostId,
+    required int counter,
+    required String entryId,
+    required int payloadType,
+  }) {
+    final binding = _sentBinding(
+      hostId: hostId,
+      counter: counter,
+      entryId: entryId,
+      payloadType: payloadType,
+    );
+    final recordedAt = _sentBindings.remove(binding);
+    if (recordedAt == null) return false;
+    if (clock.now().difference(recordedAt) > sentBindingCacheTtl) {
+      return false;
+    }
+    _sentBindings[binding] = recordedAt;
+    return true;
+  }
+
+  /// Remembers a successfully persisted exact sequence binding.
+  void rememberSentBinding({
+    required String hostId,
+    required int counter,
+    required String entryId,
+    required int payloadType,
+  }) {
+    final binding = _sentBinding(
+      hostId: hostId,
+      counter: counter,
+      entryId: entryId,
+      payloadType: payloadType,
+    );
+    _sentBindings
+      ..remove(binding)
+      ..[binding] = clock.now();
+    while (_sentBindings.length > sentBindingCacheCapacity) {
+      _sentBindings.remove(_sentBindings.keys.first);
+    }
+  }
+
   // ── Testing ───────────────────────────────────────────────────────────────
 
   /// Force-expire every cache. Surfaced through
@@ -274,6 +351,7 @@ class SyncSequenceCache {
     _materializedUpperBound.clear();
     _hostCacheExpiry.clear();
     _lastSentCounterByEntry.clear();
+    _sentBindings.clear();
     _lastSentCacheExpiry = null;
   }
 }

--- a/lib/features/sync/sequence/sync_sequence_sender.dart
+++ b/lib/features/sync/sequence/sync_sequence_sender.dart
@@ -42,6 +42,21 @@ class SyncSequenceSender {
       // Only record entries for our own host when sending
       if (hostId != myHost) continue;
 
+      if (_cache.containsSentBinding(
+        hostId: hostId,
+        counter: counter,
+        entryId: entryId,
+        payloadType: payloadType.index,
+      )) {
+        _tracer.traceSampled(
+          'duplicateSkipped type=$payloadType hostId=$hostId '
+          'counter=$counter entryId=$entryId',
+          sampleKey: 'sequence.recordSent.duplicate.${payloadType.name}',
+          subDomain: 'sequence.recordSent.duplicate',
+        );
+        continue;
+      }
+
       final now = DateTime.now();
       await _syncDatabase.recordSequenceEntry(
         SyncSequenceLogCompanion(
@@ -55,6 +70,12 @@ class SyncSequenceSender {
           updatedAt: Value(now),
         ),
       );
+      _cache.rememberSentBinding(
+        hostId: hostId,
+        counter: counter,
+        entryId: entryId,
+        payloadType: payloadType.index,
+      );
 
       // Keep the cache consistent with the write we just issued so a
       // subsequent `getLastSentVectorClockForEntry` does not race back to
@@ -65,8 +86,9 @@ class SyncSequenceSender {
         _cache.touchLastSentCache(cacheKey, counter);
       }
 
-      _tracer.trace(
+      _tracer.traceSampled(
         'recordSentEntry type=$payloadType hostId=$hostId counter=$counter entryId=$entryId',
+        sampleKey: 'sequence.recordSent.write.${payloadType.name}',
         subDomain: 'sequence.recordSent',
       );
     }

--- a/lib/features/sync/sequence/sync_sequence_tracer.dart
+++ b/lib/features/sync/sequence/sync_sequence_tracer.dart
@@ -33,6 +33,22 @@ class SyncSequenceTracer {
     );
   }
 
+  void traceSampled(
+    String message, {
+    required String sampleKey,
+    String? subDomain,
+    int every = 100,
+  }) {
+    final sub = subDomain ?? 'sequence';
+    (_domainLogger ?? _loggingService).logSampled(
+      LogDomain.sync,
+      message,
+      sampleKey: sampleKey,
+      subDomain: sub,
+      every: every,
+    );
+  }
+
   void error(
     Object error,
     StackTrace stackTrace, {

--- a/lib/features/sync/vector_clock_logging.dart
+++ b/lib/features/sync/vector_clock_logging.dart
@@ -42,9 +42,12 @@ void logVectorClockAssignment(
       if (entry.value != null) '${entry.key}=${entry.value}',
   ];
 
-  loggingService.log(
+  loggingService.logSampled(
     LogDomain.sync,
     parts.join(' '),
+    sampleKey:
+        'vectorClock.$subDomain.$action.${type ?? 'unknown'}.'
+        '${reason ?? 'unspecified'}',
     subDomain: subDomain,
   );
 }

--- a/lib/services/domain_logging.dart
+++ b/lib/services/domain_logging.dart
@@ -1,5 +1,7 @@
+import 'dart:collection';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/services/logging_domains.dart';
@@ -35,6 +37,10 @@ class DomainLogger {
   final LoggingService _loggingService;
   static final _dateFmt = DateFormat('yyyy-MM-dd');
 
+  static const int _sampleStateCapacity = 256;
+  final LinkedHashMap<String, _LogSampleState> _sampleStates =
+      LinkedHashMap<String, _LogSampleState>();
+
   /// File stem for the daily PII-safe error log.
   static const String errorSafeLogStem = 'error-safe';
 
@@ -68,6 +74,56 @@ class DomainLogger {
       level: level.name.toUpperCase(),
       subDomain: subDomain,
       message: message,
+    );
+  }
+
+  /// Logs a representative event immediately, then emits counted summaries
+  /// every [every] observations or when [maxInterval] has elapsed.
+  ///
+  /// This is intended for high-volume diagnostic paths where retaining every
+  /// record would obscure the signal. Emitted messages include `observed`,
+  /// `suppressed`, and cumulative `total` counters, so callers can still spot
+  /// amplification and compare operation categories. [sampleKey] must be a
+  /// bounded, non-user-derived category key; the logger retains at most 256
+  /// keys and evicts the least recently sampled key beyond that limit.
+  void logSampled(
+    LogDomain domain,
+    String message, {
+    required String sampleKey,
+    String? subDomain,
+    InsightLevel level = InsightLevel.info,
+    int every = 100,
+    Duration maxInterval = const Duration(minutes: 5),
+  }) {
+    if (!enabledDomains.contains(domain)) return;
+    assert(every > 0, 'every must be positive');
+    assert(maxInterval > Duration.zero, 'maxInterval must be positive');
+
+    final now = clock.now();
+    final stateKey = '${domain.wireName}:$sampleKey';
+    final state = _sampleStates.remove(stateKey) ?? _LogSampleState(now);
+    _sampleStates[stateKey] = state;
+    while (_sampleStates.length > _sampleStateCapacity) {
+      _sampleStates.remove(_sampleStates.keys.first);
+    }
+
+    state.total++;
+    state.pending++;
+    final elapsed = now.difference(state.lastEmittedAt);
+    final shouldEmit =
+        state.total == 1 || state.pending >= every || elapsed >= maxInterval;
+    if (!shouldEmit) return;
+
+    final observed = state.pending;
+    state
+      ..pending = 0
+      ..lastEmittedAt = now;
+    log(
+      domain,
+      '$message sampleKey=$sampleKey observed=$observed '
+      'suppressed=${observed - 1} total=${state.total}',
+      subDomain: subDomain,
+      level: level,
     );
   }
 
@@ -171,7 +227,7 @@ class DomainLogger {
     );
   }
 
-  String _now() => DateTime.now().toIso8601String();
+  String _now() => clock.now().toIso8601String();
 
   /// Best-effort synchronous append. File-sink errors are swallowed so logging
   /// never interferes with app flows. Skipped entirely in test environments.
@@ -212,4 +268,12 @@ class DomainLogger {
     if (id.length < 6) return '[id:$id]';
     return '[id:${id.substring(0, 6)}]';
   }
+}
+
+class _LogSampleState {
+  _LogSampleState(this.lastEmittedAt);
+
+  DateTime lastEmittedAt;
+  int pending = 0;
+  int total = 0;
 }

--- a/test/database/database_journal_queries_test.dart
+++ b/test/database/database_journal_queries_test.dart
@@ -1500,6 +1500,42 @@ void main() {
           expect(map['chunk-500']!.entryText?.plainText, 'entry 500');
         },
       );
+
+      test(
+        'outbound bulk lookup includes soft-deleted tombstones only on the '
+        'explicit sync path',
+        () async {
+          final deletedAt = DateTime.utc(2026, 8);
+          final active = buildTextEntry(
+            id: 'outbound-active',
+            timestamp: deletedAt.subtract(const Duration(minutes: 1)),
+            text: 'active',
+          );
+          final tombstone = buildTextEntry(
+            id: 'outbound-deleted',
+            timestamp: deletedAt.subtract(const Duration(minutes: 2)),
+            text: 'deleted',
+            deletedAt: deletedAt,
+          );
+          await db!.upsertJournalDbEntity(toDbEntity(active));
+          await db!.upsertJournalDbEntity(toDbEntity(tombstone));
+
+          final ordinary = await db!.journalEntityMapForIds({
+            active.meta.id,
+            tombstone.meta.id,
+          });
+          final outbound = await db!.journalEntityMapForIdsIncludingDeleted({
+            active.meta.id,
+            tombstone.meta.id,
+            'missing',
+          });
+
+          expect(ordinary.keys, contains(active.meta.id));
+          expect(ordinary.keys, isNot(contains(tombstone.meta.id)));
+          expect(outbound.keys.toSet(), {active.meta.id, tombstone.meta.id});
+          expect(outbound[tombstone.meta.id]!.meta.deletedAt, deletedAt);
+        },
+      );
     });
   });
 

--- a/test/features/sync/matrix/matrix_message_sender_test.dart
+++ b/test/features/sync/matrix/matrix_message_sender_test.dart
@@ -29,6 +29,7 @@ import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 
+import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 
 enum _GeneratedSendMessageKind {
@@ -444,6 +445,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
+    registerAllFallbackValues();
     registerFallbackValue(
       MatrixFile(bytes: Uint8List(0), name: 'fallback'),
     );
@@ -478,6 +480,25 @@ void main() {
         subDomain: any<String>(named: 'subDomain'),
       ),
     ).thenAnswer((_) {});
+    // Keep the existing payload-content assertions independent of the
+    // high-volume sampling policy, which is covered by domain_logging_test.
+    when(
+      () => loggingService.logSampled(
+        any<LogDomain>(),
+        any<String>(),
+        sampleKey: any<String>(named: 'sampleKey'),
+        subDomain: any<String?>(named: 'subDomain'),
+        level: any(named: 'level'),
+        every: any<int>(named: 'every'),
+        maxInterval: any<Duration>(named: 'maxInterval'),
+      ),
+    ).thenAnswer((invocation) {
+      loggingService.log(
+        invocation.positionalArguments[0] as LogDomain,
+        invocation.positionalArguments[1] as String,
+        subDomain: invocation.namedArguments[#subDomain] as String?,
+      );
+    });
     when(
       () => loggingService.error(
         any<LogDomain>(),
@@ -3001,7 +3022,9 @@ void main() {
       // invocation fails loudly via the assertion below rather than a
       // mocktail "missing stub" surprise.
       when(
-        () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+        () => journalDb.journalEntityMapForIdsIncludingDeleted(
+          any<Iterable<String>>(),
+        ),
       ).thenAnswer((_) async => const <String, JournalEntity>{});
     });
 
@@ -3032,7 +3055,9 @@ void main() {
 
         var journalLookupCalls = 0;
         when(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).thenAnswer((inv) async {
           journalLookupCalls++;
           final ids = (inv.positionalArguments.single as Iterable<String>)
@@ -3269,7 +3294,9 @@ void main() {
           entryText: const EntryText(plainText: 'from db'),
         );
         when(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).thenAnswer((inv) async {
           final ids = (inv.positionalArguments.first as Iterable<String>)
               .toSet();
@@ -3306,7 +3333,9 @@ void main() {
 
         expect(stripped, isNotNull);
         verify(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).called(1);
 
         final manifest = decodeManifestFromUpload(capturedFile!);
@@ -3513,7 +3542,9 @@ void main() {
       'data loss); the failed bundle drops to the standard retry/cap path',
       () async {
         when(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).thenAnswer((_) async => const <String, JournalEntity>{});
 
         final bundle = SyncOutboxBundle(
@@ -3718,7 +3749,9 @@ void main() {
           entryText: EntryText(plainText: blob),
         );
         when(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).thenAnswer((_) async => {'huge-entry': entity});
 
         final result = await sender.sendOutboxBundlePayloadForTesting(
@@ -3765,7 +3798,9 @@ void main() {
       'metadata location',
       () async {
         when(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).thenAnswer((_) async => const <String, JournalEntity>{});
 
         final stripped = await sender.sendOutboxBundlePayloadForTesting(
@@ -4329,7 +4364,9 @@ void main() {
           entryText: const EntryText(plainText: 'no msg vc'),
         );
         when(
-          () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+          () => journalDb.journalEntityMapForIdsIncludingDeleted(
+            any<Iterable<String>>(),
+          ),
         ).thenAnswer(
           (_) async => {'bundle-null-msgvc': entity},
         );
@@ -4383,7 +4420,7 @@ void main() {
 
         // logVectorClockAssignment must have been called for reason=message_missing
         verify(
-          () => loggingService.log(
+          () => loggingService.logSampled(
             LogDomain.sync,
             any<String>(
               that: allOf(
@@ -4391,6 +4428,9 @@ void main() {
                 contains('assigned={host-A: 99}'),
               ),
             ),
+            sampleKey:
+                'vectorClock.send.outboxBundle.adoptDb.assign.'
+                'SyncJournalEntity.message_missing',
             subDomain: 'send.outboxBundle.adoptDb',
           ),
         ).called(1);

--- a/test/features/sync/matrix/matrix_payload_sender_test.dart
+++ b/test/features/sync/matrix/matrix_payload_sender_test.dart
@@ -296,6 +296,71 @@ void main() {
   });
 
   group('sendOutboxBundlePayload attachments', () {
+    test('embeds a soft-deleted journal tombstone in the manifest', () async {
+      final deletedAt = DateTime.utc(2026, 8);
+      final tombstone = JournalEntity.journalEntry(
+        meta: Metadata(
+          id: 'deleted-child',
+          createdAt: deletedAt.subtract(const Duration(minutes: 2)),
+          updatedAt: deletedAt,
+          dateFrom: deletedAt.subtract(const Duration(minutes: 2)),
+          dateTo: deletedAt.subtract(const Duration(minutes: 1)),
+          deletedAt: deletedAt,
+        ),
+        entryText: const EntryText(plainText: 'deleted payload'),
+      );
+      when(
+        () => journalDb.journalEntityMapForIdsIncludingDeleted(
+          any<Iterable<String>>(),
+        ),
+      ).thenAnswer((_) async => {'deleted-child': tombstone});
+
+      MatrixFile? uploadedManifest;
+      when(
+        () => room.sendFileEvent(
+          any<MatrixFile>(),
+          extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+        ),
+      ).thenAnswer((invocation) async {
+        uploadedManifest = invocation.positionalArguments.first as MatrixFile;
+        return 'manifest-event';
+      });
+
+      final result = await payloadSender.sendOutboxBundlePayload(
+        room: room,
+        message: const SyncOutboxBundle(
+          children: [
+            SyncMessage.journalEntity(
+              id: 'deleted-child',
+              jsonPath: '/journal/deleted-child.json',
+              vectorClock: null,
+              status: SyncEntryStatus.update,
+            ),
+          ],
+          jsonPath: '/outbox_bundles/deleted-child.json',
+        ),
+      );
+
+      expect(result, isNotNull);
+      final manifest =
+          json.decode(
+                utf8.decode(gzip.decode(uploadedManifest!.bytes)),
+              )
+              as Map<String, dynamic>;
+      final record =
+          (manifest['entries'] as List).single as Map<String, dynamic>;
+      final payload = JournalEntity.fromJson(
+        record['payload'] as Map<String, dynamic>,
+      );
+      expect(payload.meta.id, 'deleted-child');
+      expect(payload.meta.deletedAt, deletedAt);
+      verify(
+        () => journalDb.journalEntityMapForIdsIncludingDeleted(
+          any<Iterable<String>>(),
+        ),
+      ).called(1);
+    });
+
     // Media rows are supposed to be excluded from bundles at claim time
     // (`filePath != null` makes a row travel alone), so this path is defence
     // in depth for rows enqueued by a build that had not yet moved the
@@ -362,7 +427,9 @@ void main() {
         ..writeAsBytesSync(List<int>.filled(9, 2));
 
       when(
-        () => journalDb.journalEntityMapForIds(any<Iterable<String>>()),
+        () => journalDb.journalEntityMapForIdsIncludingDeleted(
+          any<Iterable<String>>(),
+        ),
       ).thenAnswer(
         (_) async => {
           'img-child': image,

--- a/test/features/sync/outbox/outbox_service_test.dart
+++ b/test/features/sync/outbox/outbox_service_test.dart
@@ -226,6 +226,26 @@ void main() {
   setUp(() async {
     syncDatabase = MockSyncDatabase();
     loggingService = MockDomainLogger();
+    // Preserve the existing content-focused assertions while production now
+    // routes hot-path enqueue diagnostics through counted sampling. The
+    // sampling policy itself is covered by domain_logging_test.dart.
+    when(
+      () => loggingService.logSampled(
+        any<LogDomain>(),
+        any<String>(),
+        sampleKey: any<String>(named: 'sampleKey'),
+        subDomain: any<String?>(named: 'subDomain'),
+        level: any(named: 'level'),
+        every: any<int>(named: 'every'),
+        maxInterval: any<Duration>(named: 'maxInterval'),
+      ),
+    ).thenAnswer((invocation) {
+      loggingService.log(
+        invocation.positionalArguments[0] as LogDomain,
+        invocation.positionalArguments[1] as String,
+        subDomain: invocation.namedArguments[#subDomain] as String?,
+      );
+    });
     repository = MockOutboxRepository();
     messageSender = MockOutboxMessageSender();
     processor = MockOutboxProcessor();

--- a/test/features/sync/sequence/sync_sequence_sender_test.dart
+++ b/test/features/sync/sequence/sync_sequence_sender_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/sync_db.dart';
@@ -103,6 +104,68 @@ void main() {
 
       final key = cache.lastSentCacheKey(myHost, 'e1');
       expect(cache.getLastSent(key), 7);
+    },
+  );
+
+  test(
+    'skips an exact duplicate binding but reports the duplicate count',
+    () async {
+      const vectorClock = VectorClock({myHost: 7});
+
+      await sender.recordSentEntry(entryId: 'e1', vectorClock: vectorClock);
+      await sender.recordSentEntry(entryId: 'e1', vectorClock: vectorClock);
+
+      verify(() => db.recordSequenceEntry(any())).called(1);
+      verify(
+        () => logging.logSampled(
+          LogDomain.sync,
+          any<String>(that: contains('duplicateSkipped')),
+          sampleKey: 'sequence.recordSent.duplicate.journalEntity',
+          subDomain: 'sequence.recordSent.duplicate',
+          // ignore: avoid_redundant_argument_values
+          every: 100,
+        ),
+      ).called(1);
+    },
+  );
+
+  test('does not collapse distinct counters or payload types', () async {
+    await sender.recordSentEntry(
+      entryId: 'shared-id',
+      vectorClock: const VectorClock({myHost: 1}),
+    );
+    await sender.recordSentEntry(
+      entryId: 'shared-id',
+      vectorClock: const VectorClock({myHost: 2}),
+    );
+    await sender.recordSentEntry(
+      entryId: 'shared-id',
+      vectorClock: const VectorClock({myHost: 2}),
+      payloadType: SyncSequencePayloadType.entryLink,
+    );
+
+    verify(() => db.recordSequenceEntry(any())).called(3);
+  });
+
+  test(
+    'rechecks an exact binding after the duplicate window expires',
+    () async {
+      var now = DateTime.utc(2026, 8);
+
+      await withClock(Clock(() => now), () async {
+        await sender.recordSentEntry(
+          entryId: 'e1',
+          vectorClock: const VectorClock({myHost: 7}),
+        );
+        now = now.add(SyncSequenceCache.sentBindingCacheTtl);
+        now = now.add(const Duration(microseconds: 1));
+        await sender.recordSentEntry(
+          entryId: 'e1',
+          vectorClock: const VectorClock({myHost: 7}),
+        );
+      });
+
+      verify(() => db.recordSequenceEntry(any())).called(2);
     },
   );
 

--- a/test/features/sync/vector_clock_logging_test.dart
+++ b/test/features/sync/vector_clock_logging_test.dart
@@ -25,9 +25,10 @@ void main() {
       // carrying the action plus the always-present clock fields.
       final message =
           verify(
-                () => loggingService.log(
+                () => loggingService.logSampled(
                   LogDomain.sync,
                   captureAny(),
+                  sampleKey: 'vectorClock.test.ASSIGN.unknown.unspecified',
                   subDomain: 'test',
                 ),
               ).captured.single
@@ -54,9 +55,10 @@ void main() {
 
       final message =
           verify(
-                () => loggingService.log(
+                () => loggingService.logSampled(
                   LogDomain.sync,
                   captureAny(),
+                  sampleKey: 'vectorClock.apply.ASSIGN.JournalEntry.sync',
                   subDomain: 'apply',
                 ),
               ).captured.single
@@ -80,9 +82,10 @@ void main() {
 
       final message =
           verify(
-                () => loggingService.log(
+                () => loggingService.logSampled(
                   LogDomain.sync,
                   captureAny(),
+                  sampleKey: 'vectorClock.test.ASSIGN.unknown.unspecified',
                   subDomain: 'test',
                 ),
               ).captured.single
@@ -101,9 +104,10 @@ void main() {
 
       final message =
           verify(
-                () => loggingService.log(
+                () => loggingService.logSampled(
                   LogDomain.sync,
                   captureAny(),
+                  sampleKey: 'vectorClock.test.CHECK.unknown.unspecified',
                   subDomain: 'test',
                 ),
               ).captured.single

--- a/test/services/domain_logging_test.dart
+++ b/test/services/domain_logging_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/database/logging_types.dart';
@@ -231,6 +232,70 @@ void main() {
           level: any(named: 'level'),
         ),
       );
+    });
+  });
+
+  group('DomainLogger.logSampled', () {
+    late MockLoggingService mockLoggingService;
+    late DomainLogger logger;
+    late DateTime now;
+
+    setUp(() {
+      mockLoggingService = MockLoggingService();
+      stubLoggingService(mockLoggingService);
+      logger = DomainLogger(loggingService: mockLoggingService)
+        ..enabledDomains.add(LogDomain.sync);
+      now = DateTime.utc(2026, 8);
+    });
+
+    test('emits the first event and a counted threshold summary', () {
+      withClock(Clock(() => now), () {
+        for (var i = 0; i < 4; i++) {
+          logger.logSampled(
+            LogDomain.sync,
+            'hot operation index=$i',
+            sampleKey: 'sync.hot.operation',
+            subDomain: 'hot',
+            every: 3,
+          );
+        }
+      });
+
+      final messages = verify(
+        () => mockLoggingService.captureEvent(
+          captureAny<Object>(),
+          domain: 'sync',
+          subDomain: 'hot',
+        ),
+      ).captured.cast<String>();
+      expect(messages, hasLength(2));
+      expect(messages.first, contains('observed=1 suppressed=0 total=1'));
+      expect(messages.last, contains('observed=3 suppressed=2 total=4'));
+    });
+
+    test('emits pending observations after the maximum interval', () {
+      withClock(Clock(() => now), () {
+        logger.logSampled(
+          LogDomain.sync,
+          'first',
+          sampleKey: 'sync.interval',
+        );
+        now = now.add(const Duration(minutes: 6));
+        logger.logSampled(
+          LogDomain.sync,
+          'next',
+          sampleKey: 'sync.interval',
+        );
+      });
+
+      final messages = verify(
+        () => mockLoggingService.captureEvent(
+          captureAny<Object>(),
+          domain: 'sync',
+        ),
+      ).captured.cast<String>();
+      expect(messages, hasLength(2));
+      expect(messages.last, contains('observed=1 suppressed=0 total=2'));
     });
   });
 


### PR DESCRIPTION
## Summary

- add counted sampling for repetitive sync bookkeeping while retaining every gap, backfill request, retry, warning, and error
- avoid immediate duplicate sequence-log persistence for identical outbound bindings
- include soft-deleted journal tombstones in outbound bundle lookup so valid siblings do not enter repeated retry cycles
- document the measured log composition and the resulting production logging policy

## Root cause and impact

A 17-day sync-log capture contained 82.55 MB across 377,795 entries. Outbound bookkeeping accounted for 79.2% of bytes, dominated by repeated sequence recording, vector-clock preparation, and enqueue metadata. Backfill checks were mostly intentional but 95.6% produced no work, making per-check logging disproportionately noisy.

The same capture also exposed real unnecessary work:

- 97,832 sequence-recording calls represented 48,426 unique bindings, leaving roughly 49,406 duplicate database upserts
- 213 of 223 outbound bundle failures followed a soft-deleted journal entity being treated as missing

This change samples routine high-frequency events with cumulative observed/suppressed counts, so operators can still quantify duplicate work and initial-sync/backfill behavior. Detected gaps, requested ranges, actual backfill sends, retries, and failures remain unsampled.

Soft-deleted tombstones now use an outbound-only lookup that includes deleted rows. Truly hard-purged bundle children still fail through the existing retry/cap path to prevent silent data loss.

Based on the captured composition, expected sync-log byte reduction is approximately 75–80%.

## Validation

- `fvm dart analyze` — no issues
- 416 focused tests covering the touched sync, database, and logging files — passed
- new regression tests were also run with each fix reverted and failed as expected
- `make knowledge_check` — 88 concepts and 449 Mermaid blocks validated
- `git diff --check` — clean

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync bundles now include deleted entries correctly, preventing valid batches from unnecessary retries or failures.
  * Duplicate sequence updates are suppressed while preserving distinct updates.
* **Improvements**
  * Sync diagnostics are now sampled and aggregated, reducing log volume while retaining actionable gap, backfill, retry, and error information.
  * Added clearer documentation for sync behavior, diagnostics, and the version 1.0.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->