### PR TITLE
fix: prevent Gemini API key log leaks

### DIFF
--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -142,10 +142,12 @@ because the native listing carries `displayName`, `description`,
 `inputTokenLimit`/`outputTokenLimit`, `supportedGenerationMethods` and a
 `thinking` flag that the compatible surface flattens away.
 
-The repository rewrites the saved base URL to the native host/path, authenticates
-with the `x-goog-api-key` **header** so the key never appears in the request URL,
-rejects a host-less base URL up front, follows `nextPageToken` pagination (capped
-at `maxCatalogPages`), skips and logs malformed rows instead of failing the whole
+The catalog and native generation paths rewrite the saved base URL to the native
+host/path and authenticate with the `x-goog-api-key` **header** so the key never
+appears in a request URL. Streaming, non-streaming fallback, multi-turn, and image
+generation diagnostics log only the endpoint host and path. The catalog rejects
+a host-less base URL up front, follows `nextPageToken` pagination (capped at
+`maxCatalogPages`), skips and logs malformed rows instead of failing the whole
 fetch, and drops rows not advertising `generateContent`.
 
 Ids in the curated `geminiModels` list are returned verbatim; unknown ids are

--- a/lib/features/ai/repository/gemini_image_generation.dart
+++ b/lib/features/ai/repository/gemini_image_generation.dart
@@ -35,7 +35,6 @@ Future<GeneratedImage> generateGeminiImage({
   final uri = GeminiUtils.buildGenerateContentUri(
     baseUrl: provider.baseUrl,
     model: model,
-    apiKey: provider.apiKey,
   );
 
   final body = GeminiUtils.buildImageGenerationRequestBody(
@@ -45,17 +44,17 @@ Future<GeneratedImage> generateGeminiImage({
   );
 
   developer.log(
-    'Gemini generateImage request to: $uri',
+    'Gemini generateImage request to: ${GeminiUtils.redactedEndpoint(uri)}',
     name: 'GeminiInferenceRepository',
   );
 
   final response = await httpClient
       .post(
         uri,
-        headers: const {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-        },
+        headers: GeminiUtils.buildRequestHeaders(
+          apiKey: provider.apiKey,
+          accept: 'application/json',
+        ),
         body: jsonEncode(body),
       )
       .timeout(const Duration(seconds: 120));

--- a/lib/features/ai/repository/gemini_inference_repository.dart
+++ b/lib/features/ai/repository/gemini_inference_repository.dart
@@ -117,8 +117,8 @@ class GeminiInferenceRepository {
     final uri = GeminiUtils.buildStreamGenerateContentUri(
       baseUrl: provider.baseUrl,
       model: model,
-      apiKey: provider.apiKey,
     );
+    final endpoint = GeminiUtils.redactedEndpoint(uri);
 
     final body = GeminiUtils.buildRequestBody(
       prompt: prompt,
@@ -132,28 +132,32 @@ class GeminiInferenceRepository {
     );
 
     developer.log(
-      'Gemini streamGenerateContent request to: $uri',
+      'Gemini streamGenerateContent request to: $endpoint',
       name: 'GeminiInferenceRepository',
     );
 
     http.Request buildStreamRequest() {
       return http.Request('POST', uri)
-        ..headers['Content-Type'] = 'application/json'
-        ..headers['Accept'] =
-            'application/x-ndjson, application/json, text/event-stream'
+        ..headers.addAll(
+          GeminiUtils.buildRequestHeaders(
+            apiKey: provider.apiKey,
+            accept: 'application/x-ndjson, application/json, text/event-stream',
+          ),
+        )
         ..body = jsonEncode(body);
     }
 
     final streamed = await _streamSender.send(
       buildRequest: buildStreamRequest,
       context:
-          'Gemini streamGenerateContent (model=$model, baseUrl=${provider.baseUrl})',
+          'Gemini streamGenerateContent (model=$model, endpoint=$endpoint)',
     );
     if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
       final bytes = await streamed.stream.toBytes();
       final reason = utf8.decode(bytes);
       throw Exception(
-        'Gemini streaming error ${streamed.statusCode} for model "$model" at ${provider.baseUrl}: $reason. '
+        'Gemini streaming error ${streamed.statusCode} for model "$model" at '
+        '$endpoint: $reason. '
         'If rate-limited (429), wait and retry.',
       );
     }
@@ -341,15 +345,17 @@ class GeminiInferenceRepository {
       final nonStreamingUri = GeminiUtils.buildGenerateContentUri(
         baseUrl: provider.baseUrl,
         model: model,
-        apiKey: provider.apiKey,
+      );
+      final nonStreamingEndpoint = GeminiUtils.redactedEndpoint(
+        nonStreamingUri,
       );
       final fallbackResp = await _httpClient
           .post(
             nonStreamingUri,
-            headers: const {
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-            },
+            headers: GeminiUtils.buildRequestHeaders(
+              apiKey: provider.apiKey,
+              accept: 'application/json',
+            ),
             body: jsonEncode(body),
           )
           .timeout(kNonStreamingTimeout);
@@ -410,7 +416,8 @@ class GeminiInferenceRepository {
         }
       } else {
         developer.log(
-          'Gemini non-stream fallback failed: HTTP ${fallbackResp.statusCode} for model "$model" at ${provider.baseUrl}. '
+          'Gemini non-stream fallback failed: HTTP ${fallbackResp.statusCode} '
+          'for model "$model" at $nonStreamingEndpoint. '
           'Body preview: ${fallbackResp.body.substring(0, fallbackResp.body.length > kPreviewLength ? kPreviewLength : fallbackResp.body.length)}. '
           'If this is a transient error or rate limit, please try again.',
           name: 'GeminiInferenceRepository',

--- a/lib/features/ai/repository/gemini_multiturn_inference.dart
+++ b/lib/features/ai/repository/gemini_multiturn_inference.dart
@@ -53,8 +53,8 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
   final uri = GeminiUtils.buildStreamGenerateContentUri(
     baseUrl: provider.baseUrl,
     model: model,
-    apiKey: provider.apiKey,
   );
+  final endpoint = GeminiUtils.redactedEndpoint(uri);
 
   final body = GeminiUtils.buildMultiTurnRequestBody(
     messages: messages,
@@ -69,16 +69,19 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
   );
 
   developer.log(
-    'Gemini multi-turn streamGenerateContent request to: $uri with '
+    'Gemini multi-turn streamGenerateContent request to: $endpoint with '
     '${messages.length} messages',
     name: 'GeminiInferenceRepository',
   );
 
   http.Request buildStreamRequest() {
     return http.Request('POST', uri)
-      ..headers['Content-Type'] = 'application/json'
-      ..headers['Accept'] =
-          'application/x-ndjson, application/json, text/event-stream'
+      ..headers.addAll(
+        GeminiUtils.buildRequestHeaders(
+          apiKey: provider.apiKey,
+          accept: 'application/x-ndjson, application/json, text/event-stream',
+        ),
+      )
       ..body = jsonEncode(body);
   }
 
@@ -86,7 +89,7 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
     buildRequest: buildStreamRequest,
     context:
         'Gemini multi-turn streamGenerateContent (model=$model, '
-        'baseUrl=${provider.baseUrl})',
+        'endpoint=$endpoint)',
   );
 
   if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
@@ -94,7 +97,7 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
     final reason = utf8.decode(bytes);
     throw Exception(
       'Gemini streaming error ${streamed.statusCode} for model "$model" at '
-      '${provider.baseUrl}: $reason. '
+      '$endpoint: $reason. '
       'If rate-limited (429), wait and retry.',
     );
   }

--- a/lib/features/ai/repository/gemini_utils.dart
+++ b/lib/features/ai/repository/gemini_utils.dart
@@ -9,6 +9,8 @@ import 'package:openai_dart/openai_dart.dart';
 ///
 /// Central responsibilities:
 /// - Construct streaming and non-streaming URIs while preserving scheme/host/port.
+/// - Build authenticated request headers without putting credentials in URIs.
+/// - Produce endpoint descriptions that are safe for diagnostics.
 /// - Build request bodies including system instructions, thinking config and tools.
 /// - Strip SSE `data:` prefixes and JSON array framing from mixed-format streams.
 class GeminiUtils {
@@ -18,15 +20,13 @@ class GeminiUtils {
   ///
   /// - Normalizes model IDs to `models/<id>`.
   /// - Ignores any existing path in `baseUrl` but preserves scheme/host/port.
-  /// - Appends `?key=<apiKey>` as required by Gemini.
+  /// - Omits authentication from the URI; callers use [buildRequestHeaders].
   static Uri buildStreamGenerateContentUri({
     required String baseUrl,
     required String model,
-    required String apiKey,
   }) => _buildGeminiUri(
     baseUrl: baseUrl,
     model: model,
-    apiKey: apiKey,
     endpoint: 'streamGenerateContent',
   );
 
@@ -34,13 +34,34 @@ class GeminiUtils {
   static Uri buildGenerateContentUri({
     required String baseUrl,
     required String model,
-    required String apiKey,
   }) => _buildGeminiUri(
     baseUrl: baseUrl,
     model: model,
-    apiKey: apiKey,
     endpoint: 'generateContent',
   );
+
+  /// Builds headers shared by native Gemini generation requests.
+  ///
+  /// Authentication deliberately uses `x-goog-api-key` instead of a query
+  /// parameter so URLs echoed by HTTP clients, proxies, or error logs cannot
+  /// expose the credential.
+  static Map<String, String> buildRequestHeaders({
+    required String apiKey,
+    required String accept,
+  }) => {
+    'Content-Type': 'application/json',
+    'Accept': accept,
+    'x-goog-api-key': apiKey,
+  };
+
+  /// Returns a safe diagnostic representation containing host and path only.
+  ///
+  /// User information and query parameters are excluded because either can
+  /// contain credentials even when current request builders do not add them.
+  static String redactedEndpoint(Uri uri) {
+    final host = uri.host.isEmpty ? '<local>' : uri.host;
+    return '$host${uri.path}';
+  }
 
   /// Builds the native `/v1beta/models` catalog URI from a provider base URL.
   ///
@@ -79,7 +100,6 @@ class GeminiUtils {
   static Uri _buildGeminiUri({
     required String baseUrl,
     required String model,
-    required String apiKey,
     required String endpoint,
   }) {
     final parsed = Uri.parse(baseUrl);
@@ -96,10 +116,7 @@ class GeminiUtils {
         ? trimmed
         : 'models/$trimmed';
     final path = '/v1beta/$modelPath:$endpoint';
-    return root.replace(
-      path: path,
-      queryParameters: <String, String>{'key': apiKey},
-    );
+    return root.replace(path: path);
   }
 
   /// Builds a Gemini request body including thinking config and function tools.

--- a/test/features/ai/repository/gemini_image_generation_test.dart
+++ b/test/features/ai/repository/gemini_image_generation_test.dart
@@ -420,6 +420,15 @@ void main() {
           endsWith(':generateContent'),
         );
         expect(client.lastRequest!.method, 'POST');
+        expect(client.lastRequest!.url.queryParameters, isEmpty);
+        expect(
+          client.lastRequest!.url.toString(),
+          isNot(contains(_provider().apiKey)),
+        );
+        expect(
+          client.lastRequest!.headers['x-goog-api-key'],
+          _provider().apiKey,
+        );
       },
     );
 

--- a/test/features/ai/repository/gemini_inference_repository_test.dart
+++ b/test/features/ai/repository/gemini_inference_repository_test.dart
@@ -157,7 +157,7 @@ void main() {
       final provider = AiConfigInferenceProvider(
         id: 'prov',
         baseUrl: 'https://generativelanguage.googleapis.com',
-        apiKey: 'key',
+        apiKey: 'sentinel-secret-key',
         name: 'Gemini',
         createdAt: DateTime(2024),
         inferenceProviderType: InferenceProviderType.gemini,
@@ -191,6 +191,12 @@ void main() {
       expect(toolsDelta.toolCalls!.length, 2);
       expect(toolsDelta.toolCalls![0].id, 'tool_turn0_0');
       expect(toolsDelta.toolCalls![1].id, 'tool_turn0_1');
+      expect(client.requests, hasLength(2));
+      for (final request in client.requests) {
+        expect(request.url.queryParameters, isEmpty);
+        expect(request.url.toString(), isNot(contains(provider.apiKey)));
+        expect(request.headers['x-goog-api-key'], provider.apiKey);
+      }
     });
 
     test('maps functionCall to tool call chunk', () async {
@@ -1299,50 +1305,93 @@ void main() {
       expect(sysFirstPart['text'], 'You are helpful.');
     });
 
-    test('includes API key in URL query parameter', () async {
-      http.BaseRequest? capturedRequest;
-      final client = _RequestCapturingClient(
-        onRequest: (req) => capturedRequest = req,
-        response: jsonEncode({
-          'candidates': [
-            {
-              'content': {
-                'role': 'model',
-                'parts': [
-                  {'text': 'Hi'},
-                ],
+    test(
+      'authenticates streaming via header without exposing the key',
+      () async {
+        const sentinelApiKey = 'sentinel-secret-key';
+        http.BaseRequest? capturedRequest;
+        final client = _RequestCapturingClient(
+          onRequest: (req) => capturedRequest = req,
+          response: jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': 'Hi'},
+                  ],
+                },
               },
-            },
-          ],
-        }),
-      );
+            ],
+          }),
+        );
 
-      final repo = GeminiInferenceRepository(httpClient: client);
-      final provider = AiConfigInferenceProvider(
-        id: 'prov',
-        baseUrl: 'https://generativelanguage.googleapis.com',
-        apiKey: 'my-secret-api-key',
-        name: 'Gemini',
-        createdAt: DateTime(2024),
-        inferenceProviderType: InferenceProviderType.gemini,
-      );
+        final repo = GeminiInferenceRepository(httpClient: client);
+        final provider = AiConfigInferenceProvider(
+          id: 'prov',
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          apiKey: sentinelApiKey,
+          name: 'Gemini',
+          createdAt: DateTime(2024),
+          inferenceProviderType: InferenceProviderType.gemini,
+        );
 
-      await repo
-          .generateText(
-            prompt: 'Hi',
-            model: 'gemini-2.5-flash',
-            temperature: 0.5,
-            thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 0),
-            provider: provider,
-          )
-          .toList();
+        await repo
+            .generateText(
+              prompt: 'Hi',
+              model: 'gemini-2.5-flash',
+              temperature: 0.5,
+              thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 0),
+              provider: provider,
+            )
+            .toList();
 
-      expect(capturedRequest, isNotNull);
-      expect(
-        capturedRequest!.url.queryParameters['key'],
-        'my-secret-api-key',
-      );
-    });
+        expect(capturedRequest, isNotNull);
+        expect(capturedRequest!.url.queryParameters, isEmpty);
+        expect(
+          capturedRequest!.url.toString(),
+          isNot(contains(sentinelApiKey)),
+        );
+        expect(capturedRequest!.headers['x-goog-api-key'], sentinelApiKey);
+      },
+    );
+
+    test(
+      'network exceptions cannot echo the API key through the URI',
+      () async {
+        const sentinelApiKey = 'sentinel-secret-key';
+        final repo = GeminiInferenceRepository(
+          httpClient: _UriEchoingFailureClient(),
+        );
+        final provider = AiConfigInferenceProvider(
+          id: 'prov',
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          apiKey: sentinelApiKey,
+          name: 'Gemini',
+          createdAt: DateTime(2024),
+          inferenceProviderType: InferenceProviderType.gemini,
+        );
+
+        await expectLater(
+          repo
+              .generateText(
+                prompt: 'Hi',
+                model: 'gemini-2.5-flash',
+                temperature: 0.5,
+                thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 0),
+                provider: provider,
+              )
+              .toList(),
+          throwsA(
+            isA<http.ClientException>().having(
+              (error) => error.toString(),
+              'message',
+              isNot(contains(sentinelApiKey)),
+            ),
+          ),
+        );
+      },
+    );
 
     test('constructs correct streaming endpoint URL', () async {
       http.BaseRequest? capturedRequest;
@@ -3084,5 +3133,13 @@ class _AlwaysTimeoutClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     onRequest?.call();
     throw TimeoutException('Simulated timeout', const Duration(seconds: 30));
+  }
+}
+
+/// Simulates a transport failure whose diagnostic includes the request URI.
+class _UriEchoingFailureClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    throw http.ClientException('network unavailable', request.url);
   }
 }

--- a/test/features/ai/repository/gemini_multiturn_inference_test.dart
+++ b/test/features/ai/repository/gemini_multiturn_inference_test.dart
@@ -26,10 +26,14 @@ class _RecordingStreamClient extends http.BaseClient {
   final int statusCode;
   String? path;
   String? body;
+  Uri? url;
+  Map<String, String>? headers;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     path = request.url.path;
+    url = request.url;
+    headers = request.headers;
     if (request is http.Request) body = request.body;
     final data = _lines.map((l) => utf8.encode('$l\n') as List<int>);
     return http.StreamedResponse(
@@ -76,6 +80,9 @@ void main() {
         ).toList();
 
         expect(client.path, endsWith(':streamGenerateContent'));
+        expect(client.url!.queryParameters, isEmpty);
+        expect(client.url.toString(), isNot(contains(_provider().apiKey)));
+        expect(client.headers!['x-goog-api-key'], _provider().apiKey);
         expect(
           events.map((e) => e.choices?.first.delta?.content).join(),
           'Hello back',

--- a/test/features/ai/repository/gemini_test_clients.dart
+++ b/test/features/ai/repository/gemini_test_clients.dart
@@ -33,9 +33,11 @@ class RoutingFakeClient extends http.BaseClient {
 
   final List<String> streamLines;
   final String fallbackBody;
+  final List<http.BaseRequest> requests = [];
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    requests.add(request);
     final path = request.url.path;
     if (path.endsWith(':streamGenerateContent')) {
       final data = streamLines.map((l) => utf8.encode('$l\n') as List<int>);

--- a/test/features/ai/repository/gemini_utils_test.dart
+++ b/test/features/ai/repository/gemini_utils_test.dart
@@ -116,7 +116,6 @@ void main() {
       final uri = GeminiUtils.buildStreamGenerateContentUri(
         baseUrl: 'http://localhost:8080/openai/v1beta',
         model: 'gemini-2.0-pro-exp-02-05',
-        apiKey: 'abc',
       );
       expect(uri.scheme, 'http');
       expect(uri.host, 'localhost');
@@ -125,20 +124,37 @@ void main() {
         uri.path,
         '/v1beta/models/gemini-2.0-pro-exp-02-05:streamGenerateContent',
       );
-      expect(uri.queryParameters['key'], 'abc');
+      expect(uri.queryParameters, isEmpty);
     });
 
     test('non-stream URI handles models/ prefix and trailing slash', () {
       final uri = GeminiUtils.buildGenerateContentUri(
         baseUrl: 'https://generativelanguage.googleapis.com',
         model: 'models/gemini-2.0-flash/ ',
-        apiKey: 'xyz',
       );
       expect(
         uri.path,
         '/v1beta/models/gemini-2.0-flash:generateContent',
       );
-      expect(uri.queryParameters['key'], 'xyz');
+      expect(uri.queryParameters, isEmpty);
+    });
+
+    test('redacted endpoint strips userinfo and query secrets', () {
+      const sentinelApiKey = 'sentinel-secret-key';
+      final uri = Uri.parse(
+        'https://user:password@example.com/v1beta/models/gemini-pro:'
+        'generateContent?key=$sentinelApiKey&trace=verbose',
+      );
+
+      final endpoint = GeminiUtils.redactedEndpoint(uri);
+
+      expect(
+        endpoint,
+        'example.com/v1beta/models/gemini-pro:generateContent',
+      );
+      expect(endpoint, isNot(contains(sentinelApiKey)));
+      expect(endpoint, isNot(contains('password')));
+      expect(endpoint, isNot(contains('trace')));
     });
   });
 
@@ -1421,12 +1437,10 @@ void main() {
               final streamUri = GeminiUtils.buildStreamGenerateContentUri(
                 baseUrl: base,
                 model: model,
-                apiKey: 'k',
               );
               final plainUri = GeminiUtils.buildGenerateContentUri(
                 baseUrl: base,
                 model: model,
-                apiKey: 'k',
               );
 
               for (final (uri, endpoint) in [
@@ -1442,7 +1456,7 @@ void main() {
                 );
                 expect(uri.path, isNot(contains('models/models/')));
                 expect(uri.path, isNot(endsWith('/')));
-                expect(uri.queryParameters['key'], 'k');
+                expect(uri.queryParameters, isEmpty);
               }
             },
           );
@@ -1454,7 +1468,6 @@ void main() {
       final uri = GeminiUtils.buildGenerateContentUri(
         baseUrl: '//example.com',
         model: 'gemini-pro',
-        apiKey: 'k',
       );
       expect(uri.scheme, 'https');
       expect(uri.host, 'example.com');


### PR DESCRIPTION
## Summary

- authenticate native Gemini streaming, fallback, multi-turn, and image-generation requests with the `x-goog-api-key` header
- remove credentials from generation request URLs
- redact endpoint diagnostics to host and path only
- cover URI-echoing transport failures and every native generation request shape

## Root cause

Native Gemini generation URLs carried the API key in a query parameter. Direct request diagnostics and HTTP exceptions that included the request URI could therefore persist the credential in logs.

## Impact

Gemini request behavior is unchanged, but credentials no longer appear in request URLs or endpoint diagnostics. Authentication now matches the existing native Gemini model-catalog path.

## Validation

- `fvm flutter test test/features/ai/repository/gemini_utils_test.dart test/features/ai/repository/gemini_inference_repository_test.dart test/features/ai/repository/gemini_multiturn_inference_test.dart test/features/ai/repository/gemini_image_generation_test.dart` — 168 tests passed
- `fvm dart analyze` — no issues
- `make knowledge_check` — 88 concepts and 449 Mermaid blocks validated

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Gemini API keys are now sent securely in request headers instead of URL query parameters.
  - Diagnostic logs and error messages redact credentials and sensitive URL details.

- **Bug Fixes**
  - Improved protection against API key exposure across streaming, fallback, multi-turn, and image-generation requests.
  - Preserved endpoint and request behavior while strengthening credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->