### PR TITLE
fix: repair legacy week rollups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Fixed
+- **Weekly planning history from earlier builds opens and syncs again.** Some
+  saved weekly rollups omitted their start-of-week date, making otherwise valid
+  planning history unreadable. Lotti now restores the date from the rollup's
+  canonical Monday key; malformed remote records are classified as terminal
+  skips instead of being counted as successfully applied sync work.
 - **Deleting an entry no longer traps an otherwise healthy sync batch in
   retries.** Bundled sends mistook a soft-deleted entry for a missing database
   row, retried every valid sibling with it, and eventually left the whole batch

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -39,6 +39,7 @@
   <releases>
     <release version="1.0.0" date="2026-08-01">
       <description>
+        <p>Fixed: weekly planning history from earlier builds opens and syncs again. Some saved weekly rollups omitted their start-of-week date, making otherwise valid planning history unreadable. Lotti now restores the date from the rollup's canonical Monday key; malformed remote records are classified as terminal skips instead of being counted as successfully applied sync work.</p>
         <p>Fixed: deleting an entry no longer traps an otherwise healthy sync batch in retries. Bundled sends mistook a soft-deleted entry for a missing database row, retried every valid sibling with it, and eventually left the whole batch as failed. Deletion tombstones now travel in the bundle like every other journal update.</p>
         <p>Fixed: detailed sync diagnostics stay useful without growing by tens of megabytes a day. Repetitive per-record bookkeeping is represented by counted samples, with separate totals for inserted versus merged outbox work and sequence writes versus duplicate skips. Gap detections, actual backfill requests, retries and errors remain complete so initial-sync and repair work can still be investigated.</p>
       </description>

--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -24,10 +24,26 @@ sources:
     resource: ../../../lib/features/agents/model/agent_constants.dart
     title: AgentLinkTypes
     last_modified: 2026-07-24
+  - id: entity-model
+    resource: ../../../lib/features/agents/model/agent_domain_entity.dart
+    title: AgentDomainEntity
+    last_modified: 2026-08-01
+  - id: db-conversions
+    resource: ../../../lib/features/agents/database/agent_db_conversions.dart
+    title: AgentDbConversions
+    last_modified: 2026-08-01
   - id: sync-service
     resource: ../../../lib/features/agents/sync/agent_sync_service.dart
     title: AgentSyncService
     last_modified: 2026-06-13
+  - id: sync-processor
+    resource: ../../../lib/features/sync/matrix/sync_event_processor.dart
+    title: SyncEventProcessor
+    last_modified: 2026-08-01
+  - id: queue-adapter
+    resource: ../../../lib/features/sync/queue/queue_apply_adapter.dart
+    title: QueueApplyAdapter
+    last_modified: 2026-08-01
   - id: adr-0007
     resource: ../../../docs/adr/0007-token-usage-wake-run-log-storage.md
     title: ADR 0007 — Token usage and wake run log storage
@@ -212,6 +228,15 @@ attaches the sync event processor when one is registered.
 Concurrent agent state converges without user involvement — see
 [vector clocks and conflicts](../sync/vector-clocks-and-conflicts.md) for the
 G-counter merge that keeps concurrent wake counters from being lost.
+
+Legacy `WeekRollupEntity` JSON can omit `weekStart`. The shared
+`AgentDomainEntity.fromJson` read boundary repairs it only when the entity id is
+an exact `week_rollup:YYYY-MM-DD` key whose date is a real Monday. This covers
+both persisted rows and inline or file-backed sync payloads without mutating the
+decoded input map. An absent field paired with any other id throws a bounded
+`FormatException`; `SyncEventProcessor.prepare` treats that payload as
+unrecoverable, and `QueueApplyAdapter` returns a `permanentSkip` instead of
+spending the retry budget on deterministic poison data.
 
 | Scope | Contents |
 |-------|----------|

--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -142,10 +142,12 @@ because the native listing carries `displayName`, `description`,
 `inputTokenLimit`/`outputTokenLimit`, `supportedGenerationMethods` and a
 `thinking` flag that the compatible surface flattens away.
 
-The repository rewrites the saved base URL to the native host/path, authenticates
-with the `x-goog-api-key` **header** so the key never appears in the request URL,
-rejects a host-less base URL up front, follows `nextPageToken` pagination (capped
-at `maxCatalogPages`), skips and logs malformed rows instead of failing the whole
+The catalog and native generation paths rewrite the saved base URL to the native
+host/path and authenticate with the `x-goog-api-key` **header** so the key never
+appears in a request URL. Streaming, non-streaming fallback, multi-turn, and image
+generation diagnostics log only the endpoint host and path. The catalog rejects
+a host-less base URL up front, follows `nextPageToken` pagination (capped at
+`maxCatalogPages`), skips and logs malformed rows instead of failing the whole
 fetch, and drops rows not advertising `generateContent`.
 
 Ids in the curated `geminiModels` list are returned verbatim; unknown ids are

--- a/lib/features/agents/database/agent_db_conversions.dart
+++ b/lib/features/agents/database/agent_db_conversions.dart
@@ -108,6 +108,8 @@ class AgentDbConversions {
   /// - `AgentStateEntity` counters: legacy scalar `wakeCounter` /
   ///   `totalSessionsCompleted` / `weeklyReviewCount` seeded into their per-host
   ///   `*ByHost` G-counter maps (see [_migrateGCounters]).
+  /// - `WeekRollupEntity.weekStart`: derived by [AgentDomainEntity.fromJson]
+  ///   from a canonical legacy row id when the field is absent.
   static AgentDomainEntity fromEntityRow(AgentEntity row) =>
       fromSerialized(row.serialized);
 

--- a/lib/features/agents/model/agent_domain_entity.dart
+++ b/lib/features/agents/model/agent_domain_entity.dart
@@ -842,8 +842,53 @@ abstract class AgentDomainEntity with _$AgentDomainEntity {
     DateTime? deletedAt,
   }) = AgentUnknownEntity;
 
+  /// Decodes an agent entity and applies bounded read-side compatibility
+  /// repairs before the generated decoder enforces the current schema.
+  ///
+  /// Early `weekRollup` rows omitted `weekStart` even though their canonical
+  /// id already contained the same Monday. Derive that one field without
+  /// mutating the caller's map. A malformed id is not guessed or echoed in the
+  /// diagnostic: sync can classify the fixed [FormatException] as permanent
+  /// and avoid retrying a poison payload.
   factory AgentDomainEntity.fromJson(Map<String, dynamic> json) =>
-      _$AgentDomainEntityFromJson(json);
+      _$AgentDomainEntityFromJson(_repairLegacyWeekRollup(json));
+}
+
+final _canonicalWeekRollupId = RegExp(
+  r'^week_rollup:(\d{4})-(\d{2})-(\d{2})$',
+);
+
+const _invalidLegacyWeekRollupMessage =
+    'Legacy weekRollup is missing weekStart and its id is not a canonical '
+    'Monday';
+
+Map<String, dynamic> _repairLegacyWeekRollup(Map<String, dynamic> json) {
+  if (json['runtimeType'] != 'weekRollup' || json['weekStart'] != null) {
+    return json;
+  }
+
+  final id = json['id'];
+  final match = id is String ? _canonicalWeekRollupId.firstMatch(id) : null;
+  if (match == null) {
+    throw const FormatException(_invalidLegacyWeekRollupMessage);
+  }
+
+  final year = int.parse(match.group(1)!);
+  final month = int.parse(match.group(2)!);
+  final day = int.parse(match.group(3)!);
+  final weekStart = DateTime(year, month, day);
+  final isExactDate =
+      weekStart.year == year &&
+      weekStart.month == month &&
+      weekStart.day == day;
+  if (!isExactDate || weekStart.weekday != DateTime.monday) {
+    throw const FormatException(_invalidLegacyWeekRollupMessage);
+  }
+
+  return <String, dynamic>{
+    ...json,
+    'weekStart': weekStart.toIso8601String(),
+  };
 }
 
 extension AgentStateReportFreshness on AgentStateEntity {

--- a/lib/features/ai/repository/gemini_image_generation.dart
+++ b/lib/features/ai/repository/gemini_image_generation.dart
@@ -35,7 +35,6 @@ Future<GeneratedImage> generateGeminiImage({
   final uri = GeminiUtils.buildGenerateContentUri(
     baseUrl: provider.baseUrl,
     model: model,
-    apiKey: provider.apiKey,
   );
 
   final body = GeminiUtils.buildImageGenerationRequestBody(
@@ -45,17 +44,17 @@ Future<GeneratedImage> generateGeminiImage({
   );
 
   developer.log(
-    'Gemini generateImage request to: $uri',
+    'Gemini generateImage request to: ${GeminiUtils.redactedEndpoint(uri)}',
     name: 'GeminiInferenceRepository',
   );
 
   final response = await httpClient
       .post(
         uri,
-        headers: const {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-        },
+        headers: GeminiUtils.buildRequestHeaders(
+          apiKey: provider.apiKey,
+          accept: 'application/json',
+        ),
         body: jsonEncode(body),
       )
       .timeout(const Duration(seconds: 120));

--- a/lib/features/ai/repository/gemini_inference_repository.dart
+++ b/lib/features/ai/repository/gemini_inference_repository.dart
@@ -117,8 +117,8 @@ class GeminiInferenceRepository {
     final uri = GeminiUtils.buildStreamGenerateContentUri(
       baseUrl: provider.baseUrl,
       model: model,
-      apiKey: provider.apiKey,
     );
+    final endpoint = GeminiUtils.redactedEndpoint(uri);
 
     final body = GeminiUtils.buildRequestBody(
       prompt: prompt,
@@ -132,28 +132,32 @@ class GeminiInferenceRepository {
     );
 
     developer.log(
-      'Gemini streamGenerateContent request to: $uri',
+      'Gemini streamGenerateContent request to: $endpoint',
       name: 'GeminiInferenceRepository',
     );
 
     http.Request buildStreamRequest() {
       return http.Request('POST', uri)
-        ..headers['Content-Type'] = 'application/json'
-        ..headers['Accept'] =
-            'application/x-ndjson, application/json, text/event-stream'
+        ..headers.addAll(
+          GeminiUtils.buildRequestHeaders(
+            apiKey: provider.apiKey,
+            accept: 'application/x-ndjson, application/json, text/event-stream',
+          ),
+        )
         ..body = jsonEncode(body);
     }
 
     final streamed = await _streamSender.send(
       buildRequest: buildStreamRequest,
       context:
-          'Gemini streamGenerateContent (model=$model, baseUrl=${provider.baseUrl})',
+          'Gemini streamGenerateContent (model=$model, endpoint=$endpoint)',
     );
     if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
       final bytes = await streamed.stream.toBytes();
       final reason = utf8.decode(bytes);
       throw Exception(
-        'Gemini streaming error ${streamed.statusCode} for model "$model" at ${provider.baseUrl}: $reason. '
+        'Gemini streaming error ${streamed.statusCode} for model "$model" at '
+        '$endpoint: $reason. '
         'If rate-limited (429), wait and retry.',
       );
     }
@@ -341,15 +345,17 @@ class GeminiInferenceRepository {
       final nonStreamingUri = GeminiUtils.buildGenerateContentUri(
         baseUrl: provider.baseUrl,
         model: model,
-        apiKey: provider.apiKey,
+      );
+      final nonStreamingEndpoint = GeminiUtils.redactedEndpoint(
+        nonStreamingUri,
       );
       final fallbackResp = await _httpClient
           .post(
             nonStreamingUri,
-            headers: const {
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-            },
+            headers: GeminiUtils.buildRequestHeaders(
+              apiKey: provider.apiKey,
+              accept: 'application/json',
+            ),
             body: jsonEncode(body),
           )
           .timeout(kNonStreamingTimeout);
@@ -410,7 +416,8 @@ class GeminiInferenceRepository {
         }
       } else {
         developer.log(
-          'Gemini non-stream fallback failed: HTTP ${fallbackResp.statusCode} for model "$model" at ${provider.baseUrl}. '
+          'Gemini non-stream fallback failed: HTTP ${fallbackResp.statusCode} '
+          'for model "$model" at $nonStreamingEndpoint. '
           'Body preview: ${fallbackResp.body.substring(0, fallbackResp.body.length > kPreviewLength ? kPreviewLength : fallbackResp.body.length)}. '
           'If this is a transient error or rate limit, please try again.',
           name: 'GeminiInferenceRepository',

--- a/lib/features/ai/repository/gemini_multiturn_inference.dart
+++ b/lib/features/ai/repository/gemini_multiturn_inference.dart
@@ -53,8 +53,8 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
   final uri = GeminiUtils.buildStreamGenerateContentUri(
     baseUrl: provider.baseUrl,
     model: model,
-    apiKey: provider.apiKey,
   );
+  final endpoint = GeminiUtils.redactedEndpoint(uri);
 
   final body = GeminiUtils.buildMultiTurnRequestBody(
     messages: messages,
@@ -69,16 +69,19 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
   );
 
   developer.log(
-    'Gemini multi-turn streamGenerateContent request to: $uri with '
+    'Gemini multi-turn streamGenerateContent request to: $endpoint with '
     '${messages.length} messages',
     name: 'GeminiInferenceRepository',
   );
 
   http.Request buildStreamRequest() {
     return http.Request('POST', uri)
-      ..headers['Content-Type'] = 'application/json'
-      ..headers['Accept'] =
-          'application/x-ndjson, application/json, text/event-stream'
+      ..headers.addAll(
+        GeminiUtils.buildRequestHeaders(
+          apiKey: provider.apiKey,
+          accept: 'application/x-ndjson, application/json, text/event-stream',
+        ),
+      )
       ..body = jsonEncode(body);
   }
 
@@ -86,7 +89,7 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
     buildRequest: buildStreamRequest,
     context:
         'Gemini multi-turn streamGenerateContent (model=$model, '
-        'baseUrl=${provider.baseUrl})',
+        'endpoint=$endpoint)',
   );
 
   if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
@@ -94,7 +97,7 @@ Stream<CreateChatCompletionStreamResponse> generateGeminiTextWithMessages({
     final reason = utf8.decode(bytes);
     throw Exception(
       'Gemini streaming error ${streamed.statusCode} for model "$model" at '
-      '${provider.baseUrl}: $reason. '
+      '$endpoint: $reason. '
       'If rate-limited (429), wait and retry.',
     );
   }

--- a/lib/features/ai/repository/gemini_utils.dart
+++ b/lib/features/ai/repository/gemini_utils.dart
@@ -9,6 +9,8 @@ import 'package:openai_dart/openai_dart.dart';
 ///
 /// Central responsibilities:
 /// - Construct streaming and non-streaming URIs while preserving scheme/host/port.
+/// - Build authenticated request headers without putting credentials in URIs.
+/// - Produce endpoint descriptions that are safe for diagnostics.
 /// - Build request bodies including system instructions, thinking config and tools.
 /// - Strip SSE `data:` prefixes and JSON array framing from mixed-format streams.
 class GeminiUtils {
@@ -18,15 +20,13 @@ class GeminiUtils {
   ///
   /// - Normalizes model IDs to `models/<id>`.
   /// - Ignores any existing path in `baseUrl` but preserves scheme/host/port.
-  /// - Appends `?key=<apiKey>` as required by Gemini.
+  /// - Omits authentication from the URI; callers use [buildRequestHeaders].
   static Uri buildStreamGenerateContentUri({
     required String baseUrl,
     required String model,
-    required String apiKey,
   }) => _buildGeminiUri(
     baseUrl: baseUrl,
     model: model,
-    apiKey: apiKey,
     endpoint: 'streamGenerateContent',
   );
 
@@ -34,13 +34,34 @@ class GeminiUtils {
   static Uri buildGenerateContentUri({
     required String baseUrl,
     required String model,
-    required String apiKey,
   }) => _buildGeminiUri(
     baseUrl: baseUrl,
     model: model,
-    apiKey: apiKey,
     endpoint: 'generateContent',
   );
+
+  /// Builds headers shared by native Gemini generation requests.
+  ///
+  /// Authentication deliberately uses `x-goog-api-key` instead of a query
+  /// parameter so URLs echoed by HTTP clients, proxies, or error logs cannot
+  /// expose the credential.
+  static Map<String, String> buildRequestHeaders({
+    required String apiKey,
+    required String accept,
+  }) => {
+    'Content-Type': 'application/json',
+    'Accept': accept,
+    'x-goog-api-key': apiKey,
+  };
+
+  /// Returns a safe diagnostic representation containing host and path only.
+  ///
+  /// User information and query parameters are excluded because either can
+  /// contain credentials even when current request builders do not add them.
+  static String redactedEndpoint(Uri uri) {
+    final host = uri.host.isEmpty ? '<local>' : uri.host;
+    return '$host${uri.path}';
+  }
 
   /// Builds the native `/v1beta/models` catalog URI from a provider base URL.
   ///
@@ -79,7 +100,6 @@ class GeminiUtils {
   static Uri _buildGeminiUri({
     required String baseUrl,
     required String model,
-    required String apiKey,
     required String endpoint,
   }) {
     final parsed = Uri.parse(baseUrl);
@@ -96,10 +116,7 @@ class GeminiUtils {
         ? trimmed
         : 'models/$trimmed';
     final path = '/v1beta/$modelPath:$endpoint';
-    return root.replace(
-      path: path,
-      queryParameters: <String, String>{'key': apiKey},
-    );
+    return root.replace(path: path);
   }
 
   /// Builds a Gemini request body including thinking config and function tools.

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -92,6 +92,22 @@ Map<String, dynamic> _decodeSyncEventPayload(String raw) {
 Map<String, dynamic> decodeSyncEventPayloadForTesting(String raw) =>
     _decodeSyncEventPayload(raw);
 
+/// Internal classification signal for a sync payload that was found but can
+/// never succeed on retry (malformed JSON, invalid path, or a missing required
+/// body). The message is deliberately bounded and contains no payload data.
+///
+/// [SyncEventProcessor.prepare] converts this to `null`, which
+/// `QueueApplyAdapter` maps to a permanent skip. Retriable [IOException]s
+/// remain separate and continue to propagate to the queue retry path.
+class UnrecoverableSyncPayloadException implements Exception {
+  const UnrecoverableSyncPayloadException(this.payloadType);
+
+  final String payloadType;
+
+  @override
+  String toString() => 'Unrecoverable sync payload type=$payloadType';
+}
+
 /// Decodes timeline events from Matrix and persists them locally.
 class SyncEventProcessor {
   SyncEventProcessor({
@@ -266,9 +282,10 @@ class SyncEventProcessor {
   /// SQLite writer lock short-lived during [apply].
   ///
   /// Returns `null` when the envelope cannot be decoded into a [SyncMessage]
-  /// (malformed payload, unknown enum). Throws [FileSystemException] for
-  /// retriable attachment failures (not-yet-available, stale-but-not-
-  /// superseded) so the pipeline can schedule a retry.
+  /// (malformed payload, unknown enum) or a file-backed agent payload is
+  /// permanently unresolvable. Throws [FileSystemException] for retriable
+  /// attachment failures (not-yet-available, stale-but-not-superseded) so the
+  /// pipeline can schedule a retry.
   Future<PreparedSyncEvent?> prepare({required Event event}) async {
     try {
       final raw = event.text;
@@ -324,6 +341,13 @@ class SyncEventProcessor {
       // `await` so exceptions from prepare flow through the `catch` below
       // (Dart does not hook `catch` onto a returned future without it).
       return await _prepareForMessage(event: event, syncMessage: syncMessage);
+    } on UnrecoverableSyncPayloadException catch (error) {
+      _trace(
+        'skipping unrecoverable sync payload: $error '
+        'eventId=${event.eventId}',
+        subDomain: 'processor.skipUnrecoverable',
+      );
+      return null;
     } catch (error, stackTrace) {
       if (error is! FileSystemException) {
         _loggingService.error(

--- a/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
+++ b/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
@@ -47,10 +47,11 @@ extension _AgentHandlers on SyncEventProcessor {
   /// ensures we always get the version that matches this text event.
   ///
   /// Path-validation errors from [resolveJsonCandidateFile] (e.g. path
-  /// traversal) are permanent — logged and skipped. File-read
-  /// [FileSystemException]s are rethrown so the pipeline retries (attachment
-  /// may not have arrived yet). Other exceptions (corrupt JSON, parse errors)
-  /// are logged and return null to skip permanently.
+  /// traversal) are permanent — logged and surfaced as
+  /// [UnrecoverableSyncPayloadException]. File-read [FileSystemException]s are
+  /// rethrown so the pipeline retries (attachment may not have arrived yet).
+  /// Other exceptions (corrupt JSON, parse errors) are logged and receive the
+  /// same permanent classification.
   Future<T?> _resolveAgentPayload<T>({
     required T? inline,
     required String? jsonPath,
@@ -64,7 +65,7 @@ extension _AgentHandlers on SyncEventProcessor {
         '$typeName.skipped no payload and no jsonPath',
         subDomain: 'processor.resolve',
       );
-      return null;
+      throw UnrecoverableSyncPayloadException(typeName);
     }
     // Validate path first — throws FileSystemException for path traversal.
     // This is a permanent error (malformed jsonPath), so catch and skip.
@@ -78,7 +79,7 @@ extension _AgentHandlers on SyncEventProcessor {
         stackTrace: st,
         subDomain: 'resolve.$typeName.invalidPath',
       );
-      return null;
+      throw UnrecoverableSyncPayloadException(typeName);
     }
 
     // Fetch from the AttachmentIndex descriptor first to avoid reading
@@ -100,7 +101,7 @@ extension _AgentHandlers on SyncEventProcessor {
           stackTrace: st,
           subDomain: 'resolve.$typeName.parseFetched',
         );
-        return null;
+        throw UnrecoverableSyncPayloadException(typeName);
       }
     }
 
@@ -119,7 +120,7 @@ extension _AgentHandlers on SyncEventProcessor {
         stackTrace: st,
         subDomain: 'resolve.$typeName',
       );
-      return null;
+      throw UnrecoverableSyncPayloadException(typeName);
     }
   }
 

--- a/test/features/agents/database/agent_db_conversions_test.dart
+++ b/test/features/agents/database/agent_db_conversions_test.dart
@@ -655,6 +655,31 @@ void main() {
       expect(companion.updatedAt, Value(updatedAt));
     });
 
+    test('weekRollup row repairs a legacy missing weekStart', () {
+      final entity = makeTestWeekRollup(
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+      final legacyJson =
+          jsonDecode(jsonEncode(entity.toJson())) as Map<String, dynamic>
+            ..remove('weekStart');
+      final row = AgentEntity(
+        id: entity.id,
+        agentId: entity.agentId,
+        type: AgentEntityTypes.weekRollup,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        serialized: jsonEncode(legacyJson),
+        schemaVersion: 1,
+      );
+
+      final decoded = AgentDbConversions.fromEntityRow(row);
+
+      expect(decoded, isA<WeekRollupEntity>());
+      expect((decoded as WeekRollupEntity).weekStart, DateTime(2026, 5, 18));
+      expect(decoded.id, 'week_rollup:2026-05-18');
+    });
+
     test('daySummary writes type/subtype and roundtrips through a row', () {
       final entity = AgentDomainEntity.daySummary(
         id: 'day_agent_summary:dayplan-2026-06-08',

--- a/test/features/agents/model/agent_domain_entity_test.dart
+++ b/test/features/agents/model/agent_domain_entity_test.dart
@@ -925,6 +925,66 @@ void main() {
         expect(roundtripped.daysWithPlans, 0);
       });
 
+      test('WeekRollupEntity repairs a missing weekStart from its id', () {
+        final original = AgentDomainEntity.weekRollup(
+          id: 'week_rollup:2026-05-18',
+          agentId: 'daily_os_planner',
+          weekStart: DateTime(2026, 5, 18),
+          plannedMinutesByCategory: const {'cat-work': 480},
+          recordedMinutesByCategory: const {'cat-work': 310},
+          daysWithPlans: 5,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          vectorClock: vectorClock,
+        );
+        final legacyJson =
+            jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>
+              ..remove('weekStart');
+
+        final decoded = AgentDomainEntity.fromJson(legacyJson);
+
+        expect(decoded, equals(original));
+        expect(legacyJson, isNot(contains('weekStart')));
+      });
+
+      test(
+        'WeekRollupEntity rejects a missing weekStart with an invalid id',
+        () {
+          final original = AgentDomainEntity.weekRollup(
+            id: 'week_rollup:2026-05-18',
+            agentId: 'daily_os_planner',
+            weekStart: DateTime(2026, 5, 18),
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            vectorClock: vectorClock,
+          );
+          final legacyJson =
+              jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>
+                ..remove('weekStart')
+                ..['id'] =
+                    'week_rollup:not-a-date:'
+                    '${List.filled(100, 'private-data').join()}';
+
+          expect(
+            () => AgentDomainEntity.fromJson(legacyJson),
+            throwsA(
+              isA<FormatException>()
+                  .having(
+                    (error) => error.message,
+                    'message',
+                    'Legacy weekRollup is missing weekStart and its id is not '
+                        'a canonical Monday',
+                  )
+                  .having(
+                    (error) => error.toString().length,
+                    'bounded diagnostic length',
+                    lessThan(150),
+                  ),
+            ),
+          );
+        },
+      );
+
       test('AttentionRequestEntity roundtrips bounded bid fields', () {
         final original = AgentDomainEntity.attentionRequest(
           id: 'attention-request-001',

--- a/test/features/ai/repository/gemini_image_generation_test.dart
+++ b/test/features/ai/repository/gemini_image_generation_test.dart
@@ -420,6 +420,15 @@ void main() {
           endsWith(':generateContent'),
         );
         expect(client.lastRequest!.method, 'POST');
+        expect(client.lastRequest!.url.queryParameters, isEmpty);
+        expect(
+          client.lastRequest!.url.toString(),
+          isNot(contains(_provider().apiKey)),
+        );
+        expect(
+          client.lastRequest!.headers['x-goog-api-key'],
+          _provider().apiKey,
+        );
       },
     );
 

--- a/test/features/ai/repository/gemini_inference_repository_test.dart
+++ b/test/features/ai/repository/gemini_inference_repository_test.dart
@@ -157,7 +157,7 @@ void main() {
       final provider = AiConfigInferenceProvider(
         id: 'prov',
         baseUrl: 'https://generativelanguage.googleapis.com',
-        apiKey: 'key',
+        apiKey: 'sentinel-secret-key',
         name: 'Gemini',
         createdAt: DateTime(2024),
         inferenceProviderType: InferenceProviderType.gemini,
@@ -191,6 +191,12 @@ void main() {
       expect(toolsDelta.toolCalls!.length, 2);
       expect(toolsDelta.toolCalls![0].id, 'tool_turn0_0');
       expect(toolsDelta.toolCalls![1].id, 'tool_turn0_1');
+      expect(client.requests, hasLength(2));
+      for (final request in client.requests) {
+        expect(request.url.queryParameters, isEmpty);
+        expect(request.url.toString(), isNot(contains(provider.apiKey)));
+        expect(request.headers['x-goog-api-key'], provider.apiKey);
+      }
     });
 
     test('maps functionCall to tool call chunk', () async {
@@ -1299,50 +1305,93 @@ void main() {
       expect(sysFirstPart['text'], 'You are helpful.');
     });
 
-    test('includes API key in URL query parameter', () async {
-      http.BaseRequest? capturedRequest;
-      final client = _RequestCapturingClient(
-        onRequest: (req) => capturedRequest = req,
-        response: jsonEncode({
-          'candidates': [
-            {
-              'content': {
-                'role': 'model',
-                'parts': [
-                  {'text': 'Hi'},
-                ],
+    test(
+      'authenticates streaming via header without exposing the key',
+      () async {
+        const sentinelApiKey = 'sentinel-secret-key';
+        http.BaseRequest? capturedRequest;
+        final client = _RequestCapturingClient(
+          onRequest: (req) => capturedRequest = req,
+          response: jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': 'Hi'},
+                  ],
+                },
               },
-            },
-          ],
-        }),
-      );
+            ],
+          }),
+        );
 
-      final repo = GeminiInferenceRepository(httpClient: client);
-      final provider = AiConfigInferenceProvider(
-        id: 'prov',
-        baseUrl: 'https://generativelanguage.googleapis.com',
-        apiKey: 'my-secret-api-key',
-        name: 'Gemini',
-        createdAt: DateTime(2024),
-        inferenceProviderType: InferenceProviderType.gemini,
-      );
+        final repo = GeminiInferenceRepository(httpClient: client);
+        final provider = AiConfigInferenceProvider(
+          id: 'prov',
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          apiKey: sentinelApiKey,
+          name: 'Gemini',
+          createdAt: DateTime(2024),
+          inferenceProviderType: InferenceProviderType.gemini,
+        );
 
-      await repo
-          .generateText(
-            prompt: 'Hi',
-            model: 'gemini-2.5-flash',
-            temperature: 0.5,
-            thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 0),
-            provider: provider,
-          )
-          .toList();
+        await repo
+            .generateText(
+              prompt: 'Hi',
+              model: 'gemini-2.5-flash',
+              temperature: 0.5,
+              thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 0),
+              provider: provider,
+            )
+            .toList();
 
-      expect(capturedRequest, isNotNull);
-      expect(
-        capturedRequest!.url.queryParameters['key'],
-        'my-secret-api-key',
-      );
-    });
+        expect(capturedRequest, isNotNull);
+        expect(capturedRequest!.url.queryParameters, isEmpty);
+        expect(
+          capturedRequest!.url.toString(),
+          isNot(contains(sentinelApiKey)),
+        );
+        expect(capturedRequest!.headers['x-goog-api-key'], sentinelApiKey);
+      },
+    );
+
+    test(
+      'network exceptions cannot echo the API key through the URI',
+      () async {
+        const sentinelApiKey = 'sentinel-secret-key';
+        final repo = GeminiInferenceRepository(
+          httpClient: _UriEchoingFailureClient(),
+        );
+        final provider = AiConfigInferenceProvider(
+          id: 'prov',
+          baseUrl: 'https://generativelanguage.googleapis.com',
+          apiKey: sentinelApiKey,
+          name: 'Gemini',
+          createdAt: DateTime(2024),
+          inferenceProviderType: InferenceProviderType.gemini,
+        );
+
+        await expectLater(
+          repo
+              .generateText(
+                prompt: 'Hi',
+                model: 'gemini-2.5-flash',
+                temperature: 0.5,
+                thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 0),
+                provider: provider,
+              )
+              .toList(),
+          throwsA(
+            isA<http.ClientException>().having(
+              (error) => error.toString(),
+              'message',
+              isNot(contains(sentinelApiKey)),
+            ),
+          ),
+        );
+      },
+    );
 
     test('constructs correct streaming endpoint URL', () async {
       http.BaseRequest? capturedRequest;
@@ -3084,5 +3133,13 @@ class _AlwaysTimeoutClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     onRequest?.call();
     throw TimeoutException('Simulated timeout', const Duration(seconds: 30));
+  }
+}
+
+/// Simulates a transport failure whose diagnostic includes the request URI.
+class _UriEchoingFailureClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    throw http.ClientException('network unavailable', request.url);
   }
 }

--- a/test/features/ai/repository/gemini_multiturn_inference_test.dart
+++ b/test/features/ai/repository/gemini_multiturn_inference_test.dart
@@ -26,10 +26,14 @@ class _RecordingStreamClient extends http.BaseClient {
   final int statusCode;
   String? path;
   String? body;
+  Uri? url;
+  Map<String, String>? headers;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     path = request.url.path;
+    url = request.url;
+    headers = request.headers;
     if (request is http.Request) body = request.body;
     final data = _lines.map((l) => utf8.encode('$l\n') as List<int>);
     return http.StreamedResponse(
@@ -76,6 +80,9 @@ void main() {
         ).toList();
 
         expect(client.path, endsWith(':streamGenerateContent'));
+        expect(client.url!.queryParameters, isEmpty);
+        expect(client.url.toString(), isNot(contains(_provider().apiKey)));
+        expect(client.headers!['x-goog-api-key'], _provider().apiKey);
         expect(
           events.map((e) => e.choices?.first.delta?.content).join(),
           'Hello back',

--- a/test/features/ai/repository/gemini_test_clients.dart
+++ b/test/features/ai/repository/gemini_test_clients.dart
@@ -33,9 +33,11 @@ class RoutingFakeClient extends http.BaseClient {
 
   final List<String> streamLines;
   final String fallbackBody;
+  final List<http.BaseRequest> requests = [];
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    requests.add(request);
     final path = request.url.path;
     if (path.endsWith(':streamGenerateContent')) {
       final data = streamLines.map((l) => utf8.encode('$l\n') as List<int>);

--- a/test/features/ai/repository/gemini_utils_test.dart
+++ b/test/features/ai/repository/gemini_utils_test.dart
@@ -116,7 +116,6 @@ void main() {
       final uri = GeminiUtils.buildStreamGenerateContentUri(
         baseUrl: 'http://localhost:8080/openai/v1beta',
         model: 'gemini-2.0-pro-exp-02-05',
-        apiKey: 'abc',
       );
       expect(uri.scheme, 'http');
       expect(uri.host, 'localhost');
@@ -125,20 +124,37 @@ void main() {
         uri.path,
         '/v1beta/models/gemini-2.0-pro-exp-02-05:streamGenerateContent',
       );
-      expect(uri.queryParameters['key'], 'abc');
+      expect(uri.queryParameters, isEmpty);
     });
 
     test('non-stream URI handles models/ prefix and trailing slash', () {
       final uri = GeminiUtils.buildGenerateContentUri(
         baseUrl: 'https://generativelanguage.googleapis.com',
         model: 'models/gemini-2.0-flash/ ',
-        apiKey: 'xyz',
       );
       expect(
         uri.path,
         '/v1beta/models/gemini-2.0-flash:generateContent',
       );
-      expect(uri.queryParameters['key'], 'xyz');
+      expect(uri.queryParameters, isEmpty);
+    });
+
+    test('redacted endpoint strips userinfo and query secrets', () {
+      const sentinelApiKey = 'sentinel-secret-key';
+      final uri = Uri.parse(
+        'https://user:password@example.com/v1beta/models/gemini-pro:'
+        'generateContent?key=$sentinelApiKey&trace=verbose',
+      );
+
+      final endpoint = GeminiUtils.redactedEndpoint(uri);
+
+      expect(
+        endpoint,
+        'example.com/v1beta/models/gemini-pro:generateContent',
+      );
+      expect(endpoint, isNot(contains(sentinelApiKey)));
+      expect(endpoint, isNot(contains('password')));
+      expect(endpoint, isNot(contains('trace')));
     });
   });
 
@@ -1421,12 +1437,10 @@ void main() {
               final streamUri = GeminiUtils.buildStreamGenerateContentUri(
                 baseUrl: base,
                 model: model,
-                apiKey: 'k',
               );
               final plainUri = GeminiUtils.buildGenerateContentUri(
                 baseUrl: base,
                 model: model,
-                apiKey: 'k',
               );
 
               for (final (uri, endpoint) in [
@@ -1442,7 +1456,7 @@ void main() {
                 );
                 expect(uri.path, isNot(contains('models/models/')));
                 expect(uri.path, isNot(endsWith('/')));
-                expect(uri.queryParameters['key'], 'k');
+                expect(uri.queryParameters, isEmpty);
               }
             },
           );
@@ -1454,7 +1468,6 @@ void main() {
       final uri = GeminiUtils.buildGenerateContentUri(
         baseUrl: '//example.com',
         model: 'gemini-pro',
-        apiKey: 'k',
       );
       expect(uri.scheme, 'https');
       expect(uri.host, 'example.com');

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -219,6 +219,87 @@ void main() {
       verify(() => mockAgentRepo.upsertEntity(entity)).called(1);
     });
 
+    test('repairs a legacy week rollup before applying inbound sync', () async {
+      final entity = AgentDomainEntity.weekRollup(
+        id: 'week_rollup:2026-05-18',
+        agentId: 'daily_os_planner',
+        weekStart: DateTime(2026, 5, 18),
+        plannedMinutesByCategory: const {'cat-work': 480},
+        recordedMinutesByCategory: const {'cat-work': 310},
+        daysWithPlans: 5,
+        createdAt: DateTime(2026, 5, 24),
+        updatedAt: DateTime(2026, 5, 24, 12),
+        vectorClock: const VectorClock({'remote-host': 3}),
+      );
+      final envelope =
+          jsonDecode(
+                jsonEncode(
+                  SyncMessage.agentEntity(
+                    agentEntity: entity,
+                    status: SyncEntryStatus.update,
+                  ).toJson(),
+                ),
+              )
+              as Map<String, dynamic>;
+      (envelope['agentEntity'] as Map<String, dynamic>).remove('weekStart');
+      when(() => event.text).thenReturn(
+        base64.encode(utf8.encode(jsonEncode(envelope))),
+      );
+
+      await processor.process(event: event, journalDb: journalDb);
+
+      final applied =
+          verify(() => mockAgentRepo.upsertEntity(captureAny())).captured.single
+              as WeekRollupEntity;
+      expect(applied, entity);
+      expect(applied.weekStart, DateTime(2026, 5, 18));
+    });
+
+    test('skips an irreparable legacy week rollup during prepare', () async {
+      final entity = AgentDomainEntity.weekRollup(
+        id: 'week_rollup:2026-05-18',
+        agentId: 'daily_os_planner',
+        weekStart: DateTime(2026, 5, 18),
+        createdAt: DateTime(2026, 5, 24),
+        updatedAt: DateTime(2026, 5, 24, 12),
+        vectorClock: const VectorClock({'remote-host': 3}),
+      );
+      final envelope =
+          jsonDecode(
+                jsonEncode(
+                  SyncMessage.agentEntity(
+                    agentEntity: entity,
+                    status: SyncEntryStatus.update,
+                  ).toJson(),
+                ),
+              )
+              as Map<String, dynamic>;
+      final nested = (envelope['agentEntity'] as Map<String, dynamic>)
+        ..remove('weekStart')
+        ..['id'] = 'week_rollup:2026-05-17';
+      expect(nested['weekStart'], isNull);
+      when(() => event.text).thenReturn(
+        base64.encode(utf8.encode(jsonEncode(envelope))),
+      );
+
+      final prepared = await processor.prepare(event: event);
+
+      expect(prepared, isNull);
+      verifyNever(() => mockAgentRepo.upsertEntity(any()));
+      verify(
+        () => loggingService.log(
+          LogDomain.sync,
+          any<String>(
+            that: allOf(
+              contains('Legacy weekRollup is missing weekStart'),
+              isNot(contains('2026-05-17')),
+            ),
+          ),
+          subDomain: 'processor.skipUnrecoverable',
+        ),
+      ).called(1);
+    });
+
     test('applying a remote agent state keeps local scheduling fields '
         '(device-local, not synced)', () async {
       // Incoming causally dominates local, so it is applied — but the local

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -2672,6 +2672,37 @@ void main() {
         verify(() => mockAgentRepo.upsertEntity(entity)).called(1);
       });
 
+      test('file-backed irreparable week rollup is a permanent skip', () async {
+        final entity = AgentDomainEntity.weekRollup(
+          id: 'week_rollup:2026-05-18',
+          agentId: 'daily_os_planner',
+          weekStart: DateTime(2026, 5, 18),
+          createdAt: DateTime(2026, 5, 24),
+          updatedAt: DateTime(2026, 5, 24, 12),
+          vectorClock: const VectorClock({'remote-host': 3}),
+        );
+        final legacyJson =
+            jsonDecode(jsonEncode(entity.toJson())) as Map<String, dynamic>
+              ..remove('weekStart')
+              ..['id'] = 'week_rollup:2026-05-17';
+        const relativePath = '/agent_entities/invalid-rollup.json';
+        final file = File(
+          path.join(tempDir.path, stripLeadingSlashes(relativePath)),
+        );
+        file.parent.createSync(recursive: true);
+        file.writeAsStringSync(jsonEncode(legacyJson));
+        const message = SyncMessage.agentEntity(
+          status: SyncEntryStatus.update,
+          jsonPath: relativePath,
+        );
+        when(() => event.text).thenReturn(encodeMessage(message));
+
+        final prepared = await processor.prepare(event: event);
+
+        expect(prepared, isNull);
+        verifyNever(() => mockAgentRepo.upsertEntity(any()));
+      });
+
       test(
         'derives the agent payload sandbox from the injected loader',
         () async {


### PR DESCRIPTION
## Summary

- repair legacy `weekRollup` JSON that omitted `weekStart` by deriving it from an exact canonical Monday id
- reject irreparable rows with a bounded diagnostic so inbound sync permanently skips deterministic poison payloads
- cover direct model decode, persisted database rows, and the actual inbound sync processor path
- document the compatibility boundary and retry classification

## Why

Persisted or synced weekly rollups from an earlier schema can omit the required `weekStart` field. Generated decoding currently throws before either local reads or inbound sync can recover, producing repeated error handling for otherwise valid records.

The repair is intentionally narrow: it only applies to `weekRollup` payloads with no `weekStart`, and only accepts ids exactly matching `week_rollup:YYYY-MM-DD` where the date exists and is a Monday. Invalid ids are never echoed into diagnostics.

## Verification

- regression test reproduced the pre-fix `Null`-to-`String` cast failure
- `fvm dart format .`
- 216 tests across the three touched test files
- `fvm flutter analyze` — zero issues
- `make knowledge_check` — 88 concepts and 449 Mermaid blocks valid

## Dependency

Stacked on #3730 to preserve the ordered error-hardening dependency. Once #3730 merges, this PR can be retargeted to `main`.