### PR TITLE
docs(persistence): correct the database inventory and record the read-pool hazard

### DIFF
--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,7 +5,7 @@ description: The eleven Drift/SQLite databases, how connections are opened and m
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T20:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-01T17:00:00Z }
 stale_after: 2027-01-11
 sources:
   - id: notifications
@@ -50,8 +50,8 @@ migration work has to cover both, and embeddings are a third store again (below)
 | Database | File | Schema | Owns |
 |----------|------|--------|------|
 | `JournalDb` | `db.sqlite` | 45 | Journal entities, tasks, links, tags, config flags — the primary store |
-| `SyncDatabase` | `sync.sqlite` | 27 | Outbox, sequence log, host activity, inbound event queue, queue markers |
-| `AgentDatabase` | `agent.sqlite` | 17 | Agent state, reports, observations, change proposals, wake history |
+| `SyncDatabase` | `sync.sqlite` | 28 | Outbox, sequence log, host activity, inbound event queue, queue markers |
+| `AgentDatabase` | `agent.sqlite` | 18 | Agent state, reports, observations, change proposals, wake history |
 | `EditorDb` | `editor_drafts_db.sqlite` | 2 | Unsaved rich-text editor drafts |
 | `ConsumptionDatabase` | `ai_consumption.sqlite` | 2 | AI token usage and the interaction ledger |
 | `SettingsDb` | `settings.sqlite` | 1 | Key/value app settings, sync watermarks, saved filters |
@@ -94,7 +94,29 @@ flowchart TD
   the UI isolate. It is set to `false` only when opening from an actor isolate,
   where nesting isolates would be wrong.
 - **`readPool` offloads heavy reads** to read-only isolates. It only takes
-  effect when `background` is true.
+  effect when `background` is true, and `inMemoryDatabase: true` bypasses it —
+  a test that wants to exercise a pool must be file-backed.
+
+  | Database | `readPool` |
+  |----------|-----------:|
+  | `db.sqlite` (`JournalDb`) | 4 |
+  | `agent.sqlite` (`AgentDatabase`) | 2 |
+  | `notifications.sqlite` (`NotificationsDb`) | 2 |
+  | `ai_consumption.sqlite` (`ConsumptionDatabase`) | 1 |
+  | `day_processing.sqlite` (`DayProcessingDb`) | 1 |
+
+  Anything not listed — including `sync.sqlite` — takes `openDbConnection`'s
+  default of 0.
+
+  **A pool is not a free win.** Only reads outside a transaction reach it, so
+  adding one to a database whose callers do *check-then-act* changes an
+  invariant they were relying on: at 0, every read serialises behind the writer
+  on one executor, which implicitly protects a read that informs a later write.
+  Giving `sync.sqlite` a pool was attempted and abandoned for exactly this
+  (#3720) — it made four read-after-write races reachable in the outbox,
+  sequence-log and inbound-queue paths, none of which wrap their read and write
+  in a transaction. Audit those call sites before adding a pool to a database
+  that has them.
 - **Pragmas are applied per connection** through the `setup` callback, so read-
   pool isolates inherit them:
 

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -8,6 +8,10 @@ status: stable
 generated: { by: claude-code/opus-5, at: 2026-08-01T15:45:00Z }
 stale_after: 2027-01-11
 sources:
+  - id: sync-db
+    resource: ../../lib/database/sync_db.dart
+    title: SyncDatabase
+    last_modified: 2026-07-27
   - id: agent-db
     resource: ../../lib/features/agents/database/agent_database.dart
     title: AgentDatabase
@@ -15,15 +19,15 @@ sources:
   - id: notifications-db
     resource: ../../lib/database/notifications_db.dart
     title: NotificationsDb
-    last_modified: 2026-08-01
+    last_modified: 2026-05-17
   - id: consumption-db
     resource: ../../lib/features/ai_consumption/database/consumption_database.dart
     title: ConsumptionDatabase
-    last_modified: 2026-08-01
+    last_modified: 2026-07-21
   - id: day-processing-db
     resource: ../../lib/features/daily_os_next/database/day_processing_db.dart
     title: DayProcessingDb
-    last_modified: 2026-08-01
+    last_modified: 2026-07-25
   - id: notifications
     resource: ../../lib/services/db_notification.dart
     title: UpdateNotifications token vocabulary

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,9 +5,25 @@ description: The eleven Drift/SQLite databases, how connections are opened and m
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-01T17:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-01T15:45:00Z }
 stale_after: 2027-01-11
 sources:
+  - id: agent-db
+    resource: ../../lib/features/agents/database/agent_database.dart
+    title: AgentDatabase
+    last_modified: 2026-08-01
+  - id: notifications-db
+    resource: ../../lib/database/notifications_db.dart
+    title: NotificationsDb
+    last_modified: 2026-08-01
+  - id: consumption-db
+    resource: ../../lib/features/ai_consumption/database/consumption_database.dart
+    title: ConsumptionDatabase
+    last_modified: 2026-08-01
+  - id: day-processing-db
+    resource: ../../lib/features/daily_os_next/database/day_processing_db.dart
+    title: DayProcessingDb
+    last_modified: 2026-08-01
   - id: notifications
     resource: ../../lib/services/db_notification.dart
     title: UpdateNotifications token vocabulary
@@ -108,15 +124,23 @@ flowchart TD
   Anything not listed — including `sync.sqlite` — takes `openDbConnection`'s
   default of 0.
 
-  **A pool is not a free win.** Only reads outside a transaction reach it, so
-  adding one to a database whose callers do *check-then-act* changes an
-  invariant they were relying on: at 0, every read serialises behind the writer
-  on one executor, which implicitly protects a read that informs a later write.
-  Giving `sync.sqlite` a pool was attempted and abandoned for exactly this
-  (#3720) — it made four read-after-write races reachable in the outbox,
-  sequence-log and inbound-queue paths, none of which wrap their read and write
-  in a transaction. Audit those call sites before adding a pool to a database
-  that has them.
+  **A pool is not a free win, and `readPool: 0` is not a substitute for a
+  transaction.** A single executor serialises individual *statements*, not
+  *sequences*: a read, an `await`, and a later write can still interleave with
+  another caller's statements on the same executor. So a check-then-act pair
+  that is not wrapped in a transaction is **already racy at 0**.
+
+  What a pool changes is how easy the race is to hit. Pooled reads can also
+  serve a snapshot taken before a queued write commits, which widens the window
+  from "interleaved between statements" to "stale by a whole transaction".
+
+  Giving `sync.sqlite` a pool was attempted and abandoned on those grounds
+  (#3720): review surfaced four read-after-write pairs in the outbox,
+  sequence-log and inbound-queue paths — none inside a transaction — that the
+  pool would have made materially more likely to fire, without the PR
+  addressing any of them. The durable fix for those sites is a transaction
+  around the read and the write, which is worth doing whether or not a pool is
+  ever added.
 - **Pragmas are applied per connection** through the `setup` callback, so read-
   pool isolates inherit them:
 


### PR DESCRIPTION
Salvaged from #3720, which was **closed unmerged**. These corrections are independent of the change that was abandoned, so they shouldn't be lost with it.

## Wrong schema versions

`SyncDatabase` is **28** (listed as 27) and `AgentDatabase` **18** (listed as 17). Anyone using this map to reason about migrations or reproduce an installed schema started from the wrong numbers. Checked the rest of the table against source at the same time — `JournalDb` at 45 and the others are accurate.

## Incomplete read-pool inventory

The concept implied only `JournalDb` and `AgentDatabase` have pools. In fact five do: `NotificationsDb` is 2, `ConsumptionDatabase` and `DayProcessingDb` are 1. All are now listed by name and file, with an explicit note that anything unlisted takes the default of 0.

Also records that `inMemoryDatabase: true` bypasses the pool — a test meaning to exercise one has to be file-backed, or it passes without touching a pool at all.

## Why `sync.sqlite` is deliberately not among them

This is the part worth having written down. A pool serves only **non-transactional** reads, so adding one to a database whose callers do *check-then-act* removes a protection they were implicitly relying on: at `readPool: 0` every read serialises behind the writer on a single executor.

#3720 tried it and made four read-after-write races reachable:

- `findPendingByEntryId` → `addOutboxItem`: two concurrent enqueues for one entry both see "no pending row" and both insert
- `getEntryByHostAndCounter` → `recordSequenceEntry`: the terminal guard reads a pre-commit snapshot, then overwrites a recovered `received` row with `burned`
- `_resurrectWhere` selecting a pre-commit `abandoned` snapshot, burning the 50-attempt cap without 50 real failures
- the lazy watermark rebuild overwriting a newer watermark

None of those pairs is inside a transaction, and there are ~20 similar call sites in `lib/features/sync/`. The next person to reach for the one-line default change should know that before, not after.

Docs only. `make knowledge_check`: 25/25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated persistence architecture documentation with current schema version information.
  * Expanded connection pool guidance, including defaults, configured pools, and concurrency considerations.
  * Documented historical context for a previous database pooling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->