### PR TITLE
fix: preserve framework summaries through shutdown

### DIFF
--- a/knowledge/architecture/bootstrap-and-di.md
+++ b/knowledge/architecture/bootstrap-and-di.md
@@ -160,7 +160,8 @@ Desktop close paths converge on one ordered teardown. `AppLifecycleListener`'s
 `WindowService.closeWindow()`, which releases SQLite handles before the process
 is allowed to exit. On macOS the immediate-exit path is only reached after
 that release — exiting earlier risks a half-flushed WAL. The pre-flush callback
-also drains pending framework-error counts as described in
+then drains pending framework-error counts after service/player teardown and
+immediately before `LoggingService.flush()`, as described in
 [Logging and diagnostics](logging-and-diagnostics.md#the-gate-and-what-bypasses-it).
 
 # Where to look

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -111,12 +111,14 @@ diagnostics. The first observation keeps Flutter's full console presentation,
 durable stack, and collected widget/render-object diagnostics; identical
 repeats emit only a counted, stack-free summary every 100 observations. A timer
 flushes any smaller pending burst after at most one minute even when the error
-stops recurring. Orderly shutdown drains pending counts before the final log
-flush, so a short burst is not lost when the app closes inside that minute.
-Distinct fingerprints remain independent, and an LRU cap of 256 signatures
-bounds the in-memory sampler itself. This preserves both the diagnostic context
-and evidence of a rebuild loop without allowing one framework exception to
-generate an unbounded error file.
+stops recurring. Orderly shutdown drains pending counts after service and
+player teardown, immediately before the final log flush, so a short burst from
+either normal operation or teardown is not lost when the app closes inside
+that minute. Distinct fingerprints remain independent, and an LRU cap of 256
+signatures bounds the in-memory sampler itself. Evicting a fingerprint emits
+its pending count before removing the state. This preserves both the diagnostic
+context and evidence of a rebuild loop without allowing one framework
+exception to generate an unbounded error file.
 
 **`sync` is the one domain that routes to its own file.** It is off by default
 and far noisier than everything else — a catch-up can produce thousands of lines

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -332,7 +332,15 @@ class _FrameworkErrorLimiter {
         );
     _states[fingerprint] = state;
     while (_states.length > _frameworkErrorFingerprintCapacity) {
-      _states.remove(_states.keys.first)?.summaryTimer?.cancel();
+      final evicted = _states.remove(_states.keys.first)!;
+      if (evicted.pending > 0) {
+        _emitFrameworkErrorSummary(
+          _takePendingSummary(evicted, now),
+          evicted.library,
+        );
+      } else {
+        evicted.summaryTimer?.cancel();
+      }
     }
 
     state.total++;

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -148,22 +148,23 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
   /// Both Flutter's app-exit callback and the window-manager callback await
   /// this same future. This prevents concurrent or duplicate Drift closes and
   /// ensures a second shutdown signal cannot let engine teardown race ahead of
-  /// the first teardown sequence.
+  /// the first teardown sequence. Pending framework summaries drain after
+  /// service/player teardown and immediately before the final log flush.
   Future<void> shutdown() => _shutdownFuture ??= _shutdown();
 
   Future<void> _shutdown() async {
-    try {
-      await _beforeLogFlush();
-    } catch (e, s) {
-      _logDisposalError(e, s, 'frameworkErrorSummaries');
-    }
-
     await _disposer.disposeAll();
 
     try {
       await _playerDisposer();
     } catch (e, s) {
       _logDisposalError(e, s, 'audioPlayer');
+    }
+
+    try {
+      await _beforeLogFlush();
+    } catch (e, s) {
+      _logDisposalError(e, s, 'frameworkErrorSummaries');
     }
 
     // Bounded so a hung file flush cannot indefinitely delay shutdown.

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -462,6 +462,7 @@ void main() {
       library: 'widgets library',
     );
     app.handleFlutterFrameworkError(oldestDetails);
+    app.handleFlutterFrameworkError(oldestDetails);
     for (var i = 1; i <= 256; i++) {
       app.handleFlutterFrameworkError(
         FlutterErrorDetails(
@@ -489,6 +490,17 @@ void main() {
         subDomain: 'widgets library',
       ),
     ).called(2);
+    verify(
+      () => domainLogger.error(
+        LogDomain.general,
+        any<Object>(),
+        subDomain: 'widgets library',
+        message: any<String>(
+          named: 'message',
+          that: allOf(contains('observed=1'), contains('total=2')),
+        ),
+      ),
+    ).called(1);
   });
 
   test('uncaught zone errors always echo to the console', () {

--- a/test/services/window_service_test.dart
+++ b/test/services/window_service_test.dart
@@ -124,6 +124,9 @@ void main() {
     test('shutdown drains framework summaries before log flush', () async {
       final callOrder = <String>[];
       final loggingService = MockLoggingService();
+      when(() => getIt<SettingsDb>().close()).thenAnswer((_) async {
+        callOrder.add('databaseClose');
+      });
       when(loggingService.flush).thenAnswer((_) async {
         callOrder.add('logFlush');
       });
@@ -133,13 +136,20 @@ void main() {
         skipWindowManagerSetup: true,
         isMacOSOverride: () => true,
         exitOverride: (_) {},
-        playerDisposerOverride: () async {},
+        playerDisposerOverride: () async {
+          callOrder.add('playerDispose');
+        },
         beforeLogFlush: () async {
           callOrder.add('frameworkSummaryDrain');
         },
       ).shutdown();
 
-      expect(callOrder, ['frameworkSummaryDrain', 'logFlush']);
+      expect(callOrder, [
+        'databaseClose',
+        'playerDispose',
+        'frameworkSummaryDrain',
+        'logFlush',
+      ]);
     });
 
     test('detached lifecycle event triggers macOS shutdown sequence', () async {


### PR DESCRIPTION
## Summary

- emit a pending counted framework-error summary before LRU eviction removes its limiter state
- run the shutdown summary drain after service/player teardown and immediately before the final log flush
- add deterministic regression coverage and update the logging/bootstrap knowledge concepts

## Review follow-up

Addresses the two late review threads on #3733:
- https://github.com/matthiasn/lotti/pull/3733#discussion_r3696080068
- https://github.com/matthiasn/lotti/pull/3733#discussion_r3696080069

Tracked by Beads lotti3-78z.3 and lotti3-78z.4.

## Verification

- fvm flutter test test/main_test.dart test/services/window_service_test.dart (23 passed)
- fvm flutter analyze (zero issues)
- make knowledge_check (88 concepts, 449 Mermaid blocks)
- fvm dart format . (0 changed)

## Release notes

No new entry: this completes review feedback for behavior merged today and not yet released.