### PR TITLE
fix: serialize waveform cache pruning

### DIFF
--- a/knowledge/features/speech/overview.md
+++ b/knowledge/features/speech/overview.md
@@ -5,13 +5,13 @@ description: Audio capture, app-wide playback, waveform extraction, and the tran
 resource: ../../../lib/features/speech
 tags: [speech, audio, recording, playback, transcripts]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T02:45:00Z }
+generated: { by: codex/gpt-5, at: 2026-08-01T17:53:53Z }
 stale_after: 2027-02-15
 sources:
   - id: src
     resource: ../../../lib/features/speech
     title: Speech feature source
-    last_modified: 2026-07-26
+    last_modified: 2026-08-01
   - id: vu
     resource: ../../../lib/features/speech/state/vu_meter.dart
     title: VuMeter — sliding-window RMS→VU
@@ -143,7 +143,12 @@ letting the two compete for the output device.
 
 Waveforms are extracted by `AudioWaveformService` and exposed through
 `audioWaveformProvider`, which caches them so scrubbing does not re-analyse the
-file.
+file. Disk-cache writes queue their prune passes per service instance, so two
+concurrent extractions cannot recursively list and delete the cache tree at the
+same time. Pruning retains the 1,000 newest files by modification time. A file
+that disappears after listing but before its metadata is read is treated as
+already cleaned up; the pass continues and preserves the cache bound without a
+spurious error log.
 
 # Related
 

--- a/lib/features/speech/services/audio_waveform_service.dart
+++ b/lib/features/speech/services/audio_waveform_service.dart
@@ -104,10 +104,7 @@ class _AudioWaveformCachePayload {
 }
 
 class _DatedCacheFile {
-  const _DatedCacheFile({
-    required this.file,
-    required this.modified,
-  });
+  const _DatedCacheFile({required this.file, required this.modified});
 
   final File file;
   final DateTime modified;
@@ -119,6 +116,20 @@ typedef AudioWaveformExtractor =
       required File waveOutFile,
       required WaveformZoom zoom,
     });
+
+/// Deterministic lifecycle hooks used by the waveform cache real-I/O tests.
+@visibleForTesting
+class AudioWaveformServiceTestHooks {
+  const AudioWaveformServiceTestHooks({
+    this.beforeCachePrune,
+    this.beforeCacheFileStat,
+    this.onCacheWritten,
+  });
+
+  final Future<void> Function()? beforeCachePrune;
+  final Future<void> Function(File file)? beforeCacheFileStat;
+  final void Function(File file)? onCacheWritten;
+}
 
 Future<Waveform> _defaultWaveformExtractor({
   required File audioFile,
@@ -169,6 +180,7 @@ class AudioWaveformService {
     AudioWaveformExtractor? extractor,
     this._zoom = _defaultZoom,
     @visibleForTesting int maxCacheEntries = _maxCacheEntries,
+    @visibleForTesting this.testHooks,
   }) : _extractor = extractor ?? _defaultWaveformExtractor,
        _maxEntries = maxCacheEntries;
 
@@ -177,6 +189,11 @@ class AudioWaveformService {
 
   /// Cache-prune threshold; injectable so tests don't need 1000+ files.
   final int _maxEntries;
+
+  @visibleForTesting
+  final AudioWaveformServiceTestHooks? testHooks;
+
+  Future<void> _pruneTail = Future<void>.value();
 
   DomainLogger get _loggingService => getIt<DomainLogger>();
 
@@ -214,14 +231,10 @@ class AudioWaveformService {
           cached.audioFileRelativePath ==
               AudioUtils.getRelativeAudioPath(audio) &&
           cached.audioFileSizeBytes == stat.size &&
-          cached.audioFileModifiedAt.isAtSameMomentAs(
-            stat.modified.toUtc(),
-          )) {
+          cached.audioFileModifiedAt.isAtSameMomentAs(stat.modified.toUtc())) {
         return AudioWaveformData(
           amplitudes: cached.amplitudes,
-          bucketDuration: Duration(
-            microseconds: cached.bucketDurationMicros,
-          ),
+          bucketDuration: Duration(microseconds: cached.bucketDurationMicros),
           audioDuration: Duration(milliseconds: cached.audioDurationMs),
         );
       }
@@ -364,7 +377,8 @@ class AudioWaveformService {
     try {
       cacheFile.parent.createSync(recursive: true);
       cacheFile.writeAsStringSync(jsonEncode(payload.toJson()));
-      await _pruneCacheIfNeeded();
+      testHooks?.onCacheWritten?.call(cacheFile);
+      await _enqueueCachePrune();
     } catch (error, stackTrace) {
       _loggingService.error(
         LogDomain.speech,
@@ -392,18 +406,11 @@ class AudioWaveformService {
     }
 
     final maxAmplitude = waveform.flags == 0 ? 32768.0 : 128.0;
-    final pixelAmplitudes = List<double>.generate(
-      pixelCount,
-      (int index) {
-        final min = waveform.getPixelMin(index).abs();
-        final max = waveform.getPixelMax(index).abs();
-        return math.min(
-          1,
-          math.max(min, max) / maxAmplitude,
-        );
-      },
-      growable: false,
-    );
+    final pixelAmplitudes = List<double>.generate(pixelCount, (int index) {
+      final min = waveform.getPixelMin(index).abs();
+      final max = waveform.getPixelMax(index).abs();
+      return math.min(1, math.max(min, max) / maxAmplitude);
+    }, growable: false);
 
     if (pixelCount <= targetBuckets) {
       return pixelAmplitudes;
@@ -443,13 +450,20 @@ class AudioWaveformService {
         waveform.samplesPerPixel / waveform.sampleRate.toDouble();
     final pixelsPerBucket = waveform.length / reducedBuckets;
     final bucketSeconds = secondsPerPixel * pixelsPerBucket;
-    return Duration(
-      microseconds: (bucketSeconds * 1000000).round(),
-    );
+    return Duration(microseconds: (bucketSeconds * 1000000).round());
+  }
+
+  /// Queues every prune after the previous pass so concurrent waveform writes
+  /// cannot list and mutate the cache tree at the same time.
+  Future<void> _enqueueCachePrune() {
+    final prune = _pruneTail.then((_) => _pruneCacheIfNeeded());
+    _pruneTail = prune;
+    return prune;
   }
 
   Future<void> _pruneCacheIfNeeded() async {
     try {
+      await testHooks?.beforeCachePrune?.call();
       if (!_cacheDirectory.existsSync()) {
         return;
       }
@@ -468,19 +482,19 @@ class AudioWaveformService {
 
       final datedFiles = <_DatedCacheFile>[];
       for (final file in files) {
-        // Keeping this async avoids blocking the UI isolate during large prunes.
-        // ignore: avoid_slow_async_io
-        final modified = await file.lastModified();
-        datedFiles.add(
-          _DatedCacheFile(
-            file: file,
-            modified: modified,
-          ),
-        );
+        try {
+          await testHooks?.beforeCacheFileStat?.call(file);
+          // Keeping this async avoids blocking the UI isolate during large
+          // prunes.
+          // ignore: avoid_slow_async_io
+          final modified = await file.lastModified();
+          datedFiles.add(_DatedCacheFile(file: file, modified: modified));
+        } on PathNotFoundException {
+          // Another service instance or external cleanup already removed it.
+          continue;
+        }
       }
-      datedFiles.sort(
-        (a, b) => a.modified.compareTo(b.modified),
-      );
+      datedFiles.sort((a, b) => a.modified.compareTo(b.modified));
 
       final toRemove = datedFiles.length - _maxEntries;
       for (var i = 0; i < toRemove; i++) {

--- a/test/features/speech/services/audio_waveform_service_test.dart
+++ b/test/features/speech/services/audio_waveform_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
@@ -64,9 +65,7 @@ void main() {
   setUpAll(() {
     TestWidgetsFlutterBinding.ensureInitialized();
     registerFallbackValue(StateError('waveform missing'));
-    registerFallbackValue(
-      const FileSystemException('permission denied'),
-    );
+    registerFallbackValue(const FileSystemException('permission denied'));
     registerFallbackValue(StackTrace.fromString('fallback'));
   });
 
@@ -89,9 +88,7 @@ void main() {
       ..registerSingleton<DomainLogger>(mockDomainLogger)
       ..registerSingleton<Directory>(tempDir);
 
-    service = AudioWaveformService(
-      extractor: extractor.extract,
-    );
+    service = AudioWaveformService(extractor: extractor.extract);
   });
 
   tearDown(() async {
@@ -209,9 +206,7 @@ void main() {
     )..addAll(overrides ?? <String, dynamic>{});
     file
       ..createSync(recursive: true)
-      ..writeAsStringSync(
-        const JsonEncoder.withIndent('  ').convert(payload),
-      );
+      ..writeAsStringSync(const JsonEncoder.withIndent('  ').convert(payload));
   }
 
   /// Creates [count] cache files whose content is intentionally INVALID
@@ -233,14 +228,9 @@ void main() {
   }
 
   test('extracts waveform for long audio (no gating)', () async {
-    final audio = createAudio(
-      duration: const Duration(minutes: 5),
-    );
+    final audio = createAudio(duration: const Duration(minutes: 5));
 
-    final result = await service.loadWaveform(
-      audio,
-      targetBuckets: 200,
-    );
+    final result = await service.loadWaveform(audio, targetBuckets: 200);
 
     expect(result, isNotNull);
     // The core path must yield real data, not just a non-null shell.
@@ -272,22 +262,10 @@ void main() {
       sampleRate: 48000,
       samplesPerPixel: 480,
       length: 4,
-      data: <int>[
-        -32768,
-        32767,
-        -16384,
-        16384,
-        -8192,
-        8192,
-        0,
-        0,
-      ],
+      data: <int>[-32768, 32767, -16384, 16384, -8192, 8192, 0, 0],
     );
 
-    final result = await service.loadWaveform(
-      audio,
-      targetBuckets: 2,
-    );
+    final result = await service.loadWaveform(audio, targetBuckets: 2);
 
     expect(result, isNotNull);
     expect(result!.amplitudes, hasLength(2));
@@ -309,10 +287,7 @@ void main() {
     );
     expect(cacheFile.existsSync(), isTrue);
 
-    final cached = await service.loadWaveform(
-      audio,
-      targetBuckets: 2,
-    );
+    final cached = await service.loadWaveform(audio, targetBuckets: 2);
     expect(cached, isNotNull);
     expect(cached!.amplitudes.first, closeTo(result.amplitudes.first, 1e-6));
     expect(cached.amplitudes.last, closeTo(result.amplitudes.last, 1e-6));
@@ -359,10 +334,7 @@ void main() {
       data: <int>[-1, 1, -1, 1],
     );
 
-    final result = await service.loadWaveform(
-      audio,
-      targetBuckets: 2,
-    );
+    final result = await service.loadWaveform(audio, targetBuckets: 2);
 
     expect(result, isNotNull);
     expect(result!.amplitudes, <double>[0.2, 0.4]);
@@ -379,16 +351,7 @@ void main() {
         sampleRate: 48000,
         samplesPerPixel: 480,
         length: 4,
-        data: <int>[
-          -32768,
-          32767,
-          -16384,
-          16384,
-          -8192,
-          8192,
-          0,
-          0,
-        ],
+        data: <int>[-32768, 32767, -16384, 16384, -8192, 8192, 0, 0],
       );
     }
 
@@ -451,9 +414,7 @@ void main() {
       writeCache(
         audio: audio,
         bucketCount: 2,
-        overrides: <String, dynamic>{
-          'version': audioWaveformCacheVersion - 1,
-        },
+        overrides: <String, dynamic>{'version': audioWaveformCacheVersion - 1},
       );
 
       extractor
@@ -474,9 +435,7 @@ void main() {
       writeCache(
         audio: audio,
         bucketCount: 2,
-        overrides: <String, dynamic>{
-          'sampleCount': 3,
-        },
+        overrides: <String, dynamic>{'sampleCount': 3},
       );
 
       extractor
@@ -536,16 +495,7 @@ void main() {
             sampleRate: 48000,
             samplesPerPixel: 480,
             length: 4,
-            data: <int>[
-              -4096,
-              4096,
-              -2048,
-              2048,
-              -1024,
-              1024,
-              0,
-              0,
-            ],
+            data: <int>[-4096, 4096, -2048, 2048, -1024, 1024, 0, 0],
           );
 
         final result = await service.loadWaveform(audio, targetBuckets: 2);
@@ -583,10 +533,7 @@ void main() {
         data: <int>[],
       );
 
-      final result = await service.loadWaveform(
-        audio,
-        targetBuckets: 4,
-      );
+      final result = await service.loadWaveform(audio, targetBuckets: 4);
 
       expect(result, isNotNull);
       expect(result!.amplitudes, isEmpty);
@@ -606,16 +553,10 @@ void main() {
         sampleRate: 48000,
         samplesPerPixel: 480,
         length: 1,
-        data: <int>[
-          -32768,
-          32767,
-        ],
+        data: <int>[-32768, 32767],
       );
 
-      final result = await service.loadWaveform(
-        audio,
-        targetBuckets: 4,
-      );
+      final result = await service.loadWaveform(audio, targetBuckets: 4);
 
       expect(result, isNotNull);
       expect(result!.amplitudes, <double>[1]);
@@ -635,28 +576,14 @@ void main() {
         sampleRate: 48000,
         samplesPerPixel: 480,
         length: 2,
-        data: <int>[
-          -128,
-          127,
-          -64,
-          64,
-        ],
+        data: <int>[-128, 127, -64, 64],
       );
 
-      final result = await service.loadWaveform(
-        audio,
-        targetBuckets: 2,
-      );
+      final result = await service.loadWaveform(audio, targetBuckets: 2);
 
       expect(result, isNotNull);
-      expect(
-        result!.amplitudes.first,
-        closeTo(1.0, 1e-6),
-      );
-      expect(
-        result.amplitudes.last,
-        closeTo(0.5, 1e-6),
-      );
+      expect(result!.amplitudes.first, closeTo(1.0, 1e-6));
+      expect(result.amplitudes.last, closeTo(0.5, 1e-6));
     });
 
     test(
@@ -673,20 +600,10 @@ void main() {
           sampleRate: 48000,
           samplesPerPixel: 480,
           length: 3,
-          data: <int>[
-            -32768,
-            32767,
-            -16384,
-            16384,
-            -8192,
-            8192,
-          ],
+          data: <int>[-32768, 32767, -16384, 16384, -8192, 8192],
         );
 
-        final result = await service.loadWaveform(
-          audio,
-          targetBuckets: 10,
-        );
+        final result = await service.loadWaveform(audio, targetBuckets: 10);
 
         expect(result, isNotNull);
         expect(result!.amplitudes, hasLength(3));
@@ -727,10 +644,7 @@ void main() {
       final expectedBlended =
           amplitudes.reduce(math.max) * 0.7 + expectedRms * 0.3;
 
-      final result = await service.loadWaveform(
-        audio,
-        targetBuckets: 1,
-      );
+      final result = await service.loadWaveform(audio, targetBuckets: 1);
 
       expect(result, isNotNull);
       expect(result!.amplitudes, hasLength(1));
@@ -752,16 +666,10 @@ void main() {
         data: List<int>.filled(8, 0),
       );
 
-      final result = await service.loadWaveform(
-        audio,
-        targetBuckets: 4,
-      );
+      final result = await service.loadWaveform(audio, targetBuckets: 4);
 
       expect(result, isNotNull);
-      expect(
-        result!.amplitudes.every((value) => value == 0),
-        isTrue,
-      );
+      expect(result!.amplitudes.every((value) => value == 0), isTrue);
     });
 
     test('amplitudes are clamped to the range [0, 1]', () async {
@@ -776,18 +684,10 @@ void main() {
         sampleRate: 48000,
         samplesPerPixel: 480,
         length: 2,
-        data: <int>[
-          -40000,
-          40000,
-          -32000,
-          32000,
-        ],
+        data: <int>[-40000, 40000, -32000, 32000],
       );
 
-      final result = await service.loadWaveform(
-        audio,
-        targetBuckets: 2,
-      );
+      final result = await service.loadWaveform(audio, targetBuckets: 2);
 
       expect(result, isNotNull);
       expect(
@@ -820,10 +720,7 @@ void main() {
           subDomain: 'audio_waveform_service',
         ),
       ).called(1);
-      expect(
-        extractor.lastWaveOutFile?.existsSync(),
-        isFalse,
-      );
+      expect(extractor.lastWaveOutFile?.existsSync(), isFalse);
     });
 
     test('logs state error when extractor cannot provide waveform', () async {
@@ -1098,10 +995,7 @@ void main() {
       );
 
       expect(sanitizedSegment.length, inInclusiveRange(1, 60));
-      expect(
-        RegExp(r'^[A-Za-z0-9._-]+$').hasMatch(sanitizedSegment),
-        isTrue,
-      );
+      expect(RegExp(r'^[A-Za-z0-9._-]+$').hasMatch(sanitizedSegment), isTrue);
     });
   });
 
@@ -1226,12 +1120,7 @@ void main() {
       final sanitized = audio.meta.id.replaceAll(RegExp('[^a-zA-Z0-9_-]'), '_');
       final prefix = sanitized.length >= 2 ? sanitized.substring(0, 2) : '00';
       final cacheFile = File(
-        p.join(
-          tempDir.path,
-          'audio_waveforms',
-          prefix,
-          '${sanitized}_4.json',
-        ),
+        p.join(tempDir.path, 'audio_waveforms', prefix, '${sanitized}_4.json'),
       );
       expect(cacheFile.existsSync(), isTrue);
     });
@@ -1249,12 +1138,7 @@ void main() {
       final sanitized = audio.meta.id.replaceAll(RegExp('[^a-zA-Z0-9_-]'), '_');
       final prefix = sanitized.length >= 2 ? sanitized.substring(0, 2) : '00';
       final cacheFile = File(
-        p.join(
-          tempDir.path,
-          'audio_waveforms',
-          prefix,
-          '${sanitized}_2.json',
-        ),
+        p.join(tempDir.path, 'audio_waveforms', prefix, '${sanitized}_2.json'),
       );
       expect(cacheFile.existsSync(), isTrue);
     });
@@ -1274,12 +1158,7 @@ void main() {
       final sanitized = longId.replaceAll(RegExp('[^a-zA-Z0-9_-]'), '_');
       final prefix = sanitized.substring(0, 2);
       final cacheFile = File(
-        p.join(
-          tempDir.path,
-          'audio_waveforms',
-          prefix,
-          '${sanitized}_3.json',
-        ),
+        p.join(tempDir.path, 'audio_waveforms', prefix, '${sanitized}_3.json'),
       );
       expect(
         Directory(p.join(tempDir.path, 'audio_waveforms', prefix)).existsSync(),
@@ -1313,12 +1192,7 @@ void main() {
       final sanitized = audio.meta.id.replaceAll(RegExp('[^a-zA-Z0-9_-]'), '_');
       final prefix = sanitized.substring(0, 2);
       final cacheFile = File(
-        p.join(
-          tempDir.path,
-          'audio_waveforms',
-          prefix,
-          '${sanitized}_3.json',
-        ),
+        p.join(tempDir.path, 'audio_waveforms', prefix, '${sanitized}_3.json'),
       );
       expect(cacheFile.existsSync(), isTrue);
     });
@@ -1341,6 +1215,112 @@ void main() {
   });
 
   group('cache pruning', () {
+    test(
+      'serializes prune passes started by concurrent cache writes',
+      () async {
+        final releaseFirstPrune = Completer<void>();
+        final bothCachesWritten = Completer<void>();
+        var cacheWrites = 0;
+        var activePrunes = 0;
+        var maxConcurrentPrunes = 0;
+        var pruneStarts = 0;
+        service = AudioWaveformService(
+          extractor: extractor.extract,
+          maxCacheEntries: 1,
+          testHooks: AudioWaveformServiceTestHooks(
+            onCacheWritten: (_) {
+              cacheWrites++;
+              if (cacheWrites == 2) {
+                bothCachesWritten.complete();
+              }
+            },
+            beforeCachePrune: () async {
+              pruneStarts++;
+              activePrunes++;
+              maxConcurrentPrunes = math.max(maxConcurrentPrunes, activePrunes);
+              if (pruneStarts == 1) {
+                await releaseFirstPrune.future;
+              }
+              activePrunes--;
+            },
+          ),
+        );
+        final firstAudio = createAudio(
+          duration: const Duration(seconds: 10),
+          audioId: 'concurrent-first',
+          fileName: 'concurrent-first.m4a',
+        );
+        final secondAudio = createAudio(
+          duration: const Duration(seconds: 11),
+          audioId: 'concurrent-second',
+          fileName: 'concurrent-second.m4a',
+        );
+
+        final first = service.loadWaveform(firstAudio, targetBuckets: 2);
+        final second = service.loadWaveform(secondAudio, targetBuckets: 2);
+        await bothCachesWritten.future;
+        final concurrentPrunesBeforeRelease = maxConcurrentPrunes;
+        releaseFirstPrune.complete();
+        final results = await Future.wait([first, second]);
+        expect(results, everyElement(isNotNull));
+        expect(pruneStarts, 2);
+        expect(concurrentPrunesBeforeRelease, 1);
+        expect(maxConcurrentPrunes, 1);
+        final remainingFiles = Directory(
+          p.join(tempDir.path, 'audio_waveforms'),
+        ).listSync(recursive: true).whereType<File>().toList();
+        expect(remainingFiles, hasLength(1));
+        verifyNever(
+          () => mockDomainLogger.error(
+            LogDomain.speech,
+            any<Object>(),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+            subDomain: 'cache_prune',
+          ),
+        );
+      },
+    );
+
+    test('continues pruning when a listed cache file disappears', () async {
+      var removedListedFile = false;
+      service = AudioWaveformService(
+        extractor: extractor.extract,
+        maxCacheEntries: 2,
+        testHooks: AudioWaveformServiceTestHooks(
+          beforeCacheFileStat: (file) async {
+            if (!removedListedFile && p.basename(file.path) == 'entry_0.json') {
+              removedListedFile = true;
+              file.deleteSync();
+            }
+          },
+        ),
+      );
+      populateCacheEntries(4);
+      clearInteractions(mockDomainLogger);
+      final audio = createAudio(
+        duration: const Duration(seconds: 12),
+        audioId: 'disappearing-cache-entry',
+        fileName: 'disappearing.m4a',
+      );
+
+      final result = await service.loadWaveform(audio, targetBuckets: 2);
+
+      expect(result, isNotNull);
+      expect(removedListedFile, isTrue);
+      final remainingFiles = Directory(
+        p.join(tempDir.path, 'audio_waveforms'),
+      ).listSync(recursive: true).whereType<File>().toList();
+      expect(remainingFiles, hasLength(2));
+      verifyNever(
+        () => mockDomainLogger.error(
+          LogDomain.speech,
+          any<Object>(),
+          stackTrace: any<StackTrace>(named: 'stackTrace'),
+          subDomain: 'cache_prune',
+        ),
+      );
+    });
+
     test('prunes oldest files when exceeding the cache limit', () async {
       // Small injected limit: 19 files exercise the same pruning path the
       // production 1000-entry limit does, without 1000+ file creations.
@@ -1364,16 +1344,7 @@ void main() {
           sampleRate: 48000,
           samplesPerPixel: 480,
           length: 4,
-          data: <int>[
-            -32768,
-            32767,
-            -16384,
-            16384,
-            -8192,
-            8192,
-            0,
-            0,
-          ],
+          data: <int>[-32768, 32767, -16384, 16384, -8192, 8192, 0, 0],
         );
 
       final result = await service.loadWaveform(audio, targetBuckets: 2);
@@ -1612,56 +1583,52 @@ void main() {
       glados.IntAnys(glados.any).intInRange(1, 200),
       glados.IntAnys(glados.any).intInRange(1, 300),
       glados.ExploreConfig(numRuns: 150),
-    ).test(
-      'amplitudes clamp to [0, 1]; length == min(pixels, buckets); '
-      'no downsampling when buckets >= pixels',
-      (pixelCount, targetBuckets) {
-        // Deterministic pseudo-random 16-bit min/max pairs per pixel.
-        final data = <int>[
-          for (var i = 0; i < pixelCount; i++) ...[
-            -((i * 2654435761) % 32768),
-            (i * 40503) % 32768,
-          ],
-        ];
-        final waveform = Waveform(
-          version: 1,
-          flags: 0,
-          sampleRate: 48000,
-          samplesPerPixel: 480,
-          length: pixelCount,
-          data: data,
-        );
+    ).test('amplitudes clamp to [0, 1]; length == min(pixels, buckets); '
+        'no downsampling when buckets >= pixels', (pixelCount, targetBuckets) {
+      // Deterministic pseudo-random 16-bit min/max pairs per pixel.
+      final data = <int>[
+        for (var i = 0; i < pixelCount; i++) ...[
+          -((i * 2654435761) % 32768),
+          (i * 40503) % 32768,
+        ],
+      ];
+      final waveform = Waveform(
+        version: 1,
+        flags: 0,
+        sampleRate: 48000,
+        samplesPerPixel: 480,
+        length: pixelCount,
+        data: data,
+      );
 
-        final normalized = AudioWaveformService().debugNormalizeWaveform(
-          waveform: waveform,
-          targetBuckets: targetBuckets,
-        );
+      final normalized = AudioWaveformService().debugNormalizeWaveform(
+        waveform: waveform,
+        targetBuckets: targetBuckets,
+      );
 
-        expect(
-          normalized.length,
-          math.min(pixelCount, targetBuckets),
-          reason: 'pixels=$pixelCount buckets=$targetBuckets',
-        );
-        for (final v in normalized) {
-          expect(v, greaterThanOrEqualTo(0.0));
-          expect(v, lessThanOrEqualTo(1.0));
+      expect(
+        normalized.length,
+        math.min(pixelCount, targetBuckets),
+        reason: 'pixels=$pixelCount buckets=$targetBuckets',
+      );
+      for (final v in normalized) {
+        expect(v, greaterThanOrEqualTo(0.0));
+        expect(v, lessThanOrEqualTo(1.0));
+      }
+      if (pixelCount <= targetBuckets) {
+        // Identity path: pure per-pixel normalization, no blending.
+        for (var i = 0; i < pixelCount; i++) {
+          final expected = math.min(
+            1,
+            math.max(
+                  waveform.getPixelMin(i).abs(),
+                  waveform.getPixelMax(i).abs(),
+                ) /
+                32768,
+          );
+          expect(normalized[i], closeTo(expected, 1e-9));
         }
-        if (pixelCount <= targetBuckets) {
-          // Identity path: pure per-pixel normalization, no blending.
-          for (var i = 0; i < pixelCount; i++) {
-            final expected = math.min(
-              1,
-              math.max(
-                    waveform.getPixelMin(i).abs(),
-                    waveform.getPixelMax(i).abs(),
-                  ) /
-                  32768,
-            );
-            expect(normalized[i], closeTo(expected, 1e-9));
-          }
-        }
-      },
-      tags: 'glados',
-    );
+      }
+    }, tags: 'glados');
   });
 }


### PR DESCRIPTION
## Summary

- serialize every waveform cache-prune pass behind a per-service future tail
- treat a cache file disappearing between recursive listing and lastModified as benign, then continue pruning
- add deterministic real-I/O regressions for concurrent writes, cache bounds, and vanished files
- document the waveform disk-cache lifecycle in the speech knowledge concept

Tracked by Beads lotti3-78z.5.

## Verification

- regressions confirmed failing before the production fix
- fvm flutter test test/features/speech/services/audio_waveform_service_test.dart (43 passed)
- targeted coverage: every newly added production line hit
- fvm flutter analyze (zero issues)
- make knowledge_check (88 concepts, 449 Mermaid blocks)
- fvm dart format . (0 changed on final run)

## Notes

The repository formatter normalized the two touched Dart files; the semantic production changes are limited to the prune queue, disappeared-file handling, and deterministic test hooks.

No CHANGELOG or metainfo entry: this removes an internal cache-maintenance error without changing user-visible behavior.