### PR TITLE
ci(flatpak): fail the build when the Flathub Flutter tag drifts from .fvmrc

### DIFF
--- a/.github/workflows/flatpak-foreign-deps.yml
+++ b/.github/workflows/flatpak-foreign-deps.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".fvmrc"
       - ".github/workflows/flatpak-foreign-deps.yml"
       - "flatpak/**"
       - "pubspec.lock"
@@ -23,6 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # Ahead of the Flutter toolchain setup: a drifted pin is a two-second
+      # answer, and there is no reason to install an SDK to find it out.
+      - name: Validate Flutter pin guard
+        run: python3 -m unittest check_flutter_pin_test
+        working-directory: flatpak
+      - name: Check Flathub manifest Flutter tag matches .fvmrc
+        run: python3 flatpak/check_flutter_pin.py
       - name: Cache Pub Packages
         uses: actions/cache@v4
         with:

--- a/flatpak/check_flutter_pin.py
+++ b/flatpak/check_flutter_pin.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Assert the Flathub manifest's Flutter SDK tag matches ``.fvmrc``.
+
+``.fvmrc`` is the single source of truth for the Flutter version: FVM reads it
+locally, ``kuhnroyal/flutter-fvm-config-action`` reads it in CI, and Codemagic
+reads it for release builds. The Flathub manifest is the one remaining pin that
+is not derived from it — ``flatpak/com.matthiasn.lotti.flatpak-flutter.yml``
+carries a literal ``tag:`` on the Flutter SDK source, because Flathub builds
+from the committed file and reviewers read it.
+
+A hand-maintained duplicate drifts. It already has: 3.41.1 reached the manifest
+in its own follow-up commit (c9b4d7ab8) after the version bump missed it, and
+3.44.0 sat in the manifest while ``.fvmrc`` said 3.44.7. That one stayed
+invisible because pubspec's floor was exactly ``flutter >=3.44.0``, so the
+manifest resolved to a version that happened to still satisfy it.
+
+Deriving the tag at build time would have hidden that rather than surfaced it,
+so the pin stays literal and this check guards it at PR time instead.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+FLUTTER_SDK_URL = "https://github.com/flutter/flutter.git"
+
+# A YAML sequence item, e.g. "      - type: git". Captures the indentation so a
+# block ends at the next item introduced at the same depth or shallower.
+LIST_ITEM_RE = re.compile(r"^(\s*)-\s")
+
+
+def read_fvmrc_version(fvmrc: Path) -> str:
+    """Return the Flutter version pinned in ``.fvmrc``.
+
+    Raises ValueError when the file has no usable ``flutter`` entry, so a
+    malformed pin fails the check instead of comparing against ``None``.
+    """
+    config = json.loads(fvmrc.read_text())
+    version = config.get("flutter")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError(f"{fvmrc} has no usable 'flutter' version: {config!r}")
+    return version.strip()
+
+
+def read_manifest_flutter_tag(manifest: Path) -> str:
+    """Return the ``tag:`` of the manifest's Flutter SDK git source.
+
+    Parsed by hand rather than with PyYAML so the check needs no dependency
+    beyond the standard library, matching ``check_foreign_deps.py``.
+
+    Raises ValueError unless exactly one Flutter SDK source carrying a tag is
+    found. Both extremes matter: zero matches would make the check pass
+    vacuously if the manifest were restructured, and more than one would mean
+    the answer is ambiguous.
+    """
+    tags: list[str] = []
+    lines = manifest.read_text().splitlines()
+
+    for index, line in enumerate(lines):
+        if line.split("#", 1)[0].strip() != f"url: {FLUTTER_SDK_URL}":
+            continue
+
+        # Walk the rest of this sequence item looking for its tag. The item
+        # started at the most recent "- " line, so anything up to the next one
+        # at that depth or shallower still belongs to this source.
+        block_indent = _enclosing_item_indent(lines, index)
+        for candidate in lines[index + 1 :]:
+            item = LIST_ITEM_RE.match(candidate)
+            if item is not None and len(item.group(1)) <= block_indent:
+                break
+            stripped = candidate.split("#", 1)[0].strip()
+            if stripped.startswith("tag:"):
+                tags.append(stripped[len("tag:") :].strip())
+                break
+
+    if len(tags) != 1:
+        raise ValueError(
+            f"expected exactly one tagged {FLUTTER_SDK_URL} source in "
+            f"{manifest}, found {len(tags)}"
+        )
+    return tags[0]
+
+
+def _enclosing_item_indent(lines: list[str], index: int) -> int:
+    """Indentation of the sequence item that contains ``lines[index]``."""
+    for candidate in reversed(lines[: index + 1]):
+        item = LIST_ITEM_RE.match(candidate)
+        if item is not None:
+            return len(item.group(1))
+    return 0
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    fvmrc = repo_root / ".fvmrc"
+    manifest = repo_root / "flatpak" / "com.matthiasn.lotti.flatpak-flutter.yml"
+
+    try:
+        pinned = read_fvmrc_version(fvmrc)
+        tagged = read_manifest_flutter_tag(manifest)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Flutter pin check could not run: {error}", file=sys.stderr)
+        return 1
+
+    if pinned != tagged:
+        print(
+            f"Flutter version pins disagree:\n"
+            f"  .fvmrc pins {pinned}\n"
+            f"  {manifest.relative_to(repo_root)} tags {tagged}\n\n"
+            f".fvmrc is the source of truth — set the manifest's Flutter SDK "
+            f"tag to {pinned}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Flutter pin consistent: {pinned}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/flatpak/check_flutter_pin_test.py
+++ b/flatpak/check_flutter_pin_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Tests for the Flathub Flutter pin guard.
+
+The guard's whole value is that it fires. Most of these tests therefore pin the
+ways it could quietly stop firing — an unparsed manifest, a restructured source
+list, a commented-out tag — rather than only the happy path.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_flutter_pin import read_fvmrc_version, read_manifest_flutter_tag
+
+
+MANIFEST = """\
+modules:
+  - name: lotti
+    sources:
+      - type: git
+        url: https://github.com/matthiasn/lotti
+        commit: COMMIT_PLACEHOLDER
+        disable-lfs: true
+      - type: git
+        url: https://github.com/flutter/flutter.git
+        tag: {tag}
+        dest: flutter
+        disable-lfs: true
+      - type: script
+        dest-filename: lotti-wrapper.sh
+"""
+
+
+class ReadFvmrcVersionTest(unittest.TestCase):
+    def _write(self, contents: str) -> Path:
+        directory = Path(tempfile.mkdtemp())
+        path = directory / ".fvmrc"
+        path.write_text(contents)
+        return path
+
+    def test_reads_the_pinned_version(self):
+        path = self._write(json.dumps({"flutter": "3.44.8"}))
+        self.assertEqual(read_fvmrc_version(path), "3.44.8")
+
+    def test_tolerates_surrounding_whitespace(self):
+        path = self._write(json.dumps({"flutter": " 3.44.8\n"}))
+        self.assertEqual(read_fvmrc_version(path), "3.44.8")
+
+    def test_rejects_a_missing_flutter_entry(self):
+        # Comparing against None would make every manifest tag "wrong" — but
+        # for the wrong reason, and with a baffling message.
+        path = self._write(json.dumps({"channel": "stable"}))
+        with self.assertRaises(ValueError):
+            read_fvmrc_version(path)
+
+    def test_rejects_a_non_string_version(self):
+        path = self._write(json.dumps({"flutter": 3.44}))
+        with self.assertRaises(ValueError):
+            read_fvmrc_version(path)
+
+
+class ReadManifestFlutterTagTest(unittest.TestCase):
+    def _write(self, contents: str) -> Path:
+        directory = Path(tempfile.mkdtemp())
+        path = directory / "manifest.yml"
+        path.write_text(contents)
+        return path
+
+    def test_reads_the_flutter_sdk_tag(self):
+        path = self._write(MANIFEST.format(tag="3.44.8"))
+        self.assertEqual(read_manifest_flutter_tag(path), "3.44.8")
+
+    def test_ignores_the_app_source_which_carries_a_commit(self):
+        # The app source sits directly above the SDK source and is also a git
+        # source. Confusing the two would read COMMIT_PLACEHOLDER as a version.
+        path = self._write(MANIFEST.format(tag="3.44.8"))
+        self.assertNotIn("PLACEHOLDER", read_manifest_flutter_tag(path))
+
+    def test_does_not_walk_past_the_end_of_its_own_source(self):
+        # A tag belonging to a *later* source must not be attributed to the
+        # Flutter SDK when the SDK's own tag is gone.
+        path = self._write(
+            """\
+    sources:
+      - type: git
+        url: https://github.com/flutter/flutter.git
+        dest: flutter
+      - type: git
+        url: https://github.com/example/other.git
+        tag: 9.9.9
+"""
+        )
+        with self.assertRaises(ValueError):
+            read_manifest_flutter_tag(path)
+
+    def test_rejects_a_manifest_with_no_flutter_source(self):
+        # The vacuous-pass case: if the manifest is restructured and the URL no
+        # longer appears, the guard must fail loudly rather than report success.
+        path = self._write("modules:\n  - name: lotti\n    sources: []\n")
+        with self.assertRaises(ValueError):
+            read_manifest_flutter_tag(path)
+
+    def test_rejects_two_flutter_sources(self):
+        path = self._write(
+            MANIFEST.format(tag="3.44.8") + MANIFEST.format(tag="3.44.0")
+        )
+        with self.assertRaises(ValueError):
+            read_manifest_flutter_tag(path)
+
+    def test_ignores_a_commented_out_tag(self):
+        path = self._write(
+            """\
+    sources:
+      - type: git
+        url: https://github.com/flutter/flutter.git
+        # tag: 3.44.0
+        tag: 3.44.8
+"""
+        )
+        self.assertEqual(read_manifest_flutter_tag(path), "3.44.8")
+
+
+class RepositoryPinsTest(unittest.TestCase):
+    def test_the_checked_in_pins_agree(self):
+        # Guards the guard: proves it runs against the real files and that the
+        # manifest parser still finds a tag in the manifest as committed.
+        repo_root = Path(__file__).resolve().parents[1]
+        manifest = repo_root / "flatpak" / "com.matthiasn.lotti.flatpak-flutter.yml"
+        self.assertEqual(
+            read_fvmrc_version(repo_root / ".fvmrc"),
+            read_manifest_flutter_tag(manifest),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -58,19 +58,27 @@ written down. Most consumers follow it automatically; one does not:
 | GitHub Actions lanes | Yes — `kuhnroyal/flutter-fvm-config-action` reads it |
 | Codemagic Windows release | Yes — `environment.flutter: fvm` reads it |
 | [`.vscode/settings.json`](../../.vscode/settings.json) | Yes — points at the `.fvm/flutter_sdk` symlink, which `fvm use` repoints |
-| [`flatpak/com.matthiasn.lotti.flatpak-flutter.yml`](../../flatpak/com.matthiasn.lotti.flatpak-flutter.yml) | **No — hand-edit the Flutter `tag:`** |
+| [`flatpak/com.matthiasn.lotti.flatpak-flutter.yml`](../../flatpak/com.matthiasn.lotti.flatpak-flutter.yml) | **No — hand-edit the Flutter `tag:`**, but CI fails if you forget |
 
 So a Flutter bump is `.fvmrc` **plus** the Flatpak manifest's Flutter `tag:`.
-Both currently read 3.44.8. Drift there is easy to miss because a stale tag
-still resolves as long as it clears the `>=3.44.0` constraint floor — the
-manifest sat at 3.44.0 through several pin bumps before anyone noticed, meaning
-Flathub users ran an engine nobody else was building against.
+Both currently read 3.44.8.
 
-A stale pin does not announce itself. It surfaces one layer down, as
-`pub get` failing version solving — "the current Dart SDK version is X, because
-lotti requires SDK version >=3.12.0 <4.0.0, version solving failed" — which
-reads like a dependency problem rather than a toolchain one. The Windows lane
-sat broken this way across a dozen consecutive release tags.
+The manifest keeps a literal tag on purpose. Flathub builds from the committed
+file and reviewers read it, so deriving the tag at build time would make the
+committed pin stale and *invisible* rather than stale and wrong.
+[`flatpak/check_flutter_pin.py`](../../flatpak/check_flutter_pin.py) closes the
+gap instead: `flatpak-foreign-deps.yml` runs it on every push, and on any PR
+touching `.fvmrc` or `flatpak/`.
+
+The guard exists because drift here is silent by construction. A stale tag
+still resolves as long as it clears the `>=3.44.0` constraint floor, so the
+manifest sat at 3.44.0 through several pin bumps before anyone noticed, meaning
+Flathub users ran an engine nobody else was building against. When it does
+break, it surfaces one layer down as `pub get` failing version solving — "the
+current Dart SDK version is X, because lotti requires SDK version >=3.12.0
+<4.0.0, version solving failed" — which reads like a dependency problem rather
+than a toolchain one. The Windows lane sat broken this way across a dozen
+consecutive release tags.
 
 # Continuous integration
 


### PR DESCRIPTION
## Why

`flatpak/com.matthiasn.lotti.flatpak-flutter.yml` is the last Flutter version
pin not derived from `.fvmrc`, and a hand-maintained duplicate drifts. It
already has, twice:

- **3.41.1** reached the manifest in its own follow-up commit (`c9b4d7ab8`)
  after the version bump missed it.
- **3.44.0** sat in the manifest while `.fvmrc` said 3.44.7.

That second one stayed invisible because a stale tag still resolves as long as
it clears the `>=3.44.0` constraint floor — nothing complains until the floor
moves. When it finally breaks it surfaces one layer down, as `pub get` failing
version solving, which reads like a dependency problem rather than a toolchain
one. The Windows lane sat broken that way across a dozen consecutive release
tags.

The pins happen to agree today (both 3.44.8). This is about the mechanism, not
an open defect.

## Why a guard rather than deriving the tag

`prepare_flathub_build.sh` already substitutes `COMMIT_PLACEHOLDER`, so reading
`.fvmrc` and substituting the tag would have been the natural-looking fix. It
was the wrong one: Flathub builds from the **committed** manifest and reviewers
read it, so deriving at build time makes the committed pin stale and
*invisible* rather than stale and wrong. It would have hidden exactly the class
of bug that cost the Windows lane a dozen tags.

So the pin stays literal, and CI checks it at PR time.

## What changed

- `flatpak/check_flutter_pin.py` — compares `.fvmrc`'s `flutter` value with the
  manifest's Flutter SDK `tag:`. Stdlib-only parsing (regex, no PyYAML),
  matching `check_foreign_deps.py`, so the step needs no dependency install.
- `flatpak-foreign-deps.yml` — runs it **before** the Flutter toolchain setup;
  a drifted pin is a two-second answer and needs no SDK. `.fvmrc` added to the
  PR path filter so a version-only bump trips it too (the push trigger has no
  path filter and already would).
- `knowledge/architecture/platform-and-release.md` — the consumer table claimed
  this pin had no automation, which is no longer true. Now records why it stays
  literal rather than derived.

## A guard that stops firing is worse than no guard

The script fails unless **exactly one** tagged Flutter SDK source exists. Zero
matches would pass vacuously if the manifest were restructured; two would mean
the answer is ambiguous. Both raise rather than return.

11 unittest cases cover that plus the near-miss traps: the app source directly
above it is also a `git` source but carries `COMMIT_PLACEHOLDER`; a `tag:`
belonging to a *later* source must not be attributed to the SDK; a commented-out
tag is ignored. One test runs the parser against the real committed files, so
the guard cannot drift from the manifest's actual shape.

**Verified it fires:** injecting `tag: 3.44.0` into the real manifest exits 1
with a message naming both values, and the repo-pins test fails. Restored and
re-confirmed clean.

## Checks

- `python3 -m unittest check_flutter_pin_test` — 11 passed
- `python3 flatpak/check_flutter_pin.py` — clean against the committed files
- `make knowledge_check` — exit 0, 88 concepts, 451 mermaid blocks, 0 errors

No CHANGELOG entry: CI-only, nothing a user sees.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect mismatches between the configured Flutter version and the Flatpak package version.
  * Improved error reporting for malformed or ambiguous version settings.

* **Tests**
  * Added automated coverage for version parsing, manifest validation, malformed inputs, and matching repository configurations.

* **Documentation**
  * Documented the required Flutter version updates and the new validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->