### PR TITLE
fix(tasks): give the Linked Tasks header room above, not below

### DIFF
--- a/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
@@ -262,14 +262,23 @@ class _LinkedTasksHeader extends ConsumerWidget {
     return InkWell(
       onTap: onToggleExpanded,
       child: Padding(
-        // step2 vertically, not step3: the row's height is set by the overflow
-        // button's own 48pt target, so this padding is added on top of a
-        // control that is already at its minimum — it buys the header nothing
-        // but height. What is left still keeps the title clear of the card's
-        // top edge and of the first section label below it.
-        padding: EdgeInsets.symmetric(
-          horizontal: tokens.spacing.step5,
-          vertical: tokens.spacing.step2,
+        // Asymmetric, because what sits above and below the header is not
+        // symmetric. Only this padding separates the title from the card's top
+        // edge, while everything below it — an empty-state action, a section
+        // label, a linked row — brings its own top padding (step3 at
+        // DesignSystemListItem's small size). Matching 4pt on both sides
+        // therefore measured 4pt above the title and 14pt below it: the header
+        // sat three and a half times closer to the card's edge than to the
+        // content it labels, which reads as a title belonging to the border
+        // rather than to the list.
+        //
+        // step4 above and nothing below inverts that to 12pt / 10pt — the
+        // title now sits nearest the thing it names, and its distance from the
+        // card's top edge matches the Todos card above it on the same screen.
+        padding: EdgeInsets.only(
+          left: tokens.spacing.step5,
+          right: tokens.spacing.step5,
+          top: tokens.spacing.step4,
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {

--- a/test/features/tasks/ui/linked_tasks/linked_tasks_widget_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_tasks_widget_test.dart
@@ -273,6 +273,38 @@ void main() {
 
   group('LinkedTasksWidget rendering', () {
     testWidgets(
+      'the header sits nearer the content it labels than the card edge',
+      (tester) async {
+        await pumpWidget(tester, incoming: [], outgoing: []);
+
+        final card = tester.getRect(find.byType(DecoratedBox).first);
+        final title = tester.getRect(
+          find.byKey(const ValueKey('linked-tasks-card-title')),
+        );
+        final firstRow = tester.getRect(find.text('Link a task…'));
+
+        final above = title.top - card.top;
+        final below = firstRow.top - title.bottom;
+
+        // Proximity: a section title belongs to what follows it. Only the
+        // header's own padding holds it off the card's top edge, while the row
+        // beneath contributes step3 of its own, so symmetric header padding
+        // produces an asymmetric result — it measured 4pt above and 14pt below
+        // before this was made asymmetric.
+        expect(
+          above,
+          greaterThanOrEqualTo(below),
+          reason:
+              'the title must not sit closer to the border than to the '
+              'list it heads',
+        );
+        // Not merely ordered but comfortably clear of the edge: an earlier
+        // 4pt crowded the title against the border.
+        expect(above, greaterThanOrEqualTo(12));
+      },
+    );
+
+    testWidgets(
       'with no links it still renders a header carrying the link action — '
       'otherwise the feature has no reachable entry point at all',
       (tester) async {


### PR DESCRIPTION
## The problem

`_LinkedTasksHeader` padded itself symmetrically — `EdgeInsets.symmetric(vertical: step2)` — but what sits above and below it is not symmetric.

Above the title, that 4pt is the **only** thing holding it off the card's top edge. Below it, whatever follows brings its own top padding: `step3` (8pt) from `DesignSystemListItem` at `size: small`.

So equal padding produced an unequal result. Measured from the rendered tree, not estimated:

| | Before | After |
|---|---|---|
| Card top edge → title | 4pt | **12pt** |
| Title → first row | 14pt | **10pt** |

The header sat 3.5× closer to the card's border than to the list it names. A section title should be nearest the thing it labels.

## The change

One line of padding: `step4` on top, nothing on the bottom. That inverts the ratio and brings the title's distance from the card edge in line with the **Todos** card directly above it on the task page, which measures ~14.5pt there.

`DesignSystemListItem` is left alone — its `step3` is shared app-wide, and one card's imbalance is not a reason to move it.

## Before / after

Empty state, mobile dark:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/matthiasn/lotti-docs/main/pr-screenshots/linked-tasks-header-spacing/before/linked_tasks_empty_mobile_dark.png) | ![after](https://raw.githubusercontent.com/matthiasn/lotti-docs/main/pr-screenshots/linked-tasks-header-spacing/after/linked_tasks_empty_mobile_dark.png) |

Populated state, mobile dark — the header here also carries the chevron, count badge, Link button and overflow, so it is the case where extra top padding could have gone wrong:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/matthiasn/lotti-docs/main/pr-screenshots/linked-tasks-header-spacing/before/linked_tasks_populated_mobile_dark.png) | ![after](https://raw.githubusercontent.com/matthiasn/lotti-docs/main/pr-screenshots/linked-tasks-header-spacing/after/linked_tasks_populated_mobile_dark.png) |

Full pair — both states × mobile/desktop × light/dark, 8 images per side:
[`before/`](https://github.com/matthiasn/lotti-docs/tree/main/pr-screenshots/linked-tasks-header-spacing/before) · [`after/`](https://github.com/matthiasn/lotti-docs/tree/main/pr-screenshots/linked-tasks-header-spacing/after)

## Test

`the header sits nearer the content it labels than the card edge` asserts `above >= below`, plus `above >= 12` so the invariant cannot be satisfied by crowding both sides equally.

**Revert-checked**: with the old symmetric padding it fails with `Expected: a value greater than or equal to <14.0> / Actual: <4.0>` — the same pair of numbers the bug report showed.

## Checks

- `test/features/tasks/ui/linked_tasks/` + `task_form_test.dart` — 168 passed
- `flutter analyze lib/features/tasks test/features/tasks` — no issues
- `dart format` — clean

No CHANGELOG entry: a spacing correction inside one card, below the threshold of something a user would read about in release notes.
