### PR TITLE
fix(agents): retire finished day agents before the wake manager starts

### DIFF
--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -45,6 +45,12 @@ because `getDueScheduledAgentStates` filters on `scheduledWakeAt` **only, not
 lifecycle**: a finished day still holding a deadline is otherwise due on every
 tick, forever.
 
+Retirement runs **before `ScheduledWakeManager.start()`**, not only from
+`restoreSubscriptions`. `start()` checks immediately, and the restore pass is
+several awaits further down the provider's init — so a finished agent would
+otherwise still be `active` for that first check and fire once per cold start,
+which is the spend this exists to stop.
+
 Without this the active set grew by one per day of use and
 `restoreSubscriptions` re-hydrated every one of them on each launch — model
 spend on days that are over, and the pressure behind much of the bounding work

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -503,10 +503,28 @@ Future<void> agentInitialization(Ref ref) async {
   // 3. Start the orchestrator on the local update stream.
   await orchestrator.start(updateNotifications.localUpdateStream);
 
-  // 3.5. Start the scheduled wake manager.
+  // 3.5. Retire finished day agents BEFORE the wake manager starts.
+  //
+  // `start()` runs a check immediately, and `restoreSubscriptions` — which
+  // otherwise owns retirement — is several awaits further down. A day agent
+  // whose day is over is still `active` at that moment, so its overdue wake
+  // fires once per cold start: precisely the spend retirement exists to stop.
+  // Best-effort, like every other step here; a failure must not stop start-up.
+  try {
+    await ref.read(dayAgentServiceProvider).retirePastDayAgents();
+  } catch (e, s) {
+    getIt<DomainLogger>().error(
+      LogDomain.agentRuntime,
+      e,
+      message: 'failed to retire past day agents before wake manager start',
+      stackTrace: s,
+    );
+  }
+
+  // 3.6. Start the scheduled wake manager.
   ref.watch(scheduledWakeManagerProvider).start();
 
-  // 3.6. Track project-linked activity without triggering immediate wakes.
+  // 3.7. Track project-linked activity without triggering immediate wakes.
   projectActivityMonitor.start();
 
   // 4. Wire the sync event processor for cross-device agent data.


### PR DESCRIPTION
Follow-up to #3759, from a review comment that landed as it merged.

## The gap

`ScheduledWakeManager.start()` runs at `agent_providers.dart:507` and
`start()` calls `_checkAndEnqueue()` immediately. `restoreSubscriptions` —
which owns retirement — is not reached until line 553, several awaited
initialisation steps later.

So on a cold start a day agent whose day is over is still `active` for that
first check, and its overdue wake fires. One wake per finished agent per cold
start: exactly the spend #3759 exists to stop.

The lifecycle guards added in #3759 do not help here, because at that moment
the agent genuinely *is* active — retirement simply has not run yet.

## The change

Retire before starting the manager. Best-effort, like the surrounding steps in
that initialiser: a failure logs and start-up continues.

`restoreSubscriptions` still retires as well, which is not redundant — it
covers the path where the day agent service is restored without going through
this initialiser.

## Verification

`agent_providers_test` and `day_agent_service_test` pass (132), analyzer clean,
`knowledge_check` green. The concept records why the ordering matters, so the
call does not look like a duplicate of the one in `restoreSubscriptions`.