### PR TITLE
fix(agents): retire finished day agents on every wake tick, not just at start-up

### DIFF
--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -5,7 +5,7 @@ description: Two durable synced entities instead of RPC — binding day directiv
 resource: ../../../lib/features/daily_os_next/agents/service/day_agent_directive_service.dart
 tags: [daily-os, coordination, directives, digest, rollups]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-02T12:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-02T20:00:00Z }
 stale_after: 2026-11-01
 sources:
   - id: agents
@@ -53,6 +53,11 @@ hourly tick after it. Ordering is the whole point: a finished agent is still
 very tick that was about to retire it. Covering the ticks and not just start-up
 is what catches a desktop session left open across the handover boundary, where
 the boundary arrives on a tick and no relaunch ever comes.
+
+The repair repeats if it crosses local midnight. Retirement's cutoff is a
+calendar date while the due query reads the clock *after* the repair, so a pass
+that straddles the boundary would decide the two on different days — leaving an
+agent active for exactly the pass that should have retired it.
 
 `restoreSubscriptions` retires as well, before it takes its snapshot of active
 agents — otherwise start-up would re-hydrate runtime state for agents it is

--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -45,11 +45,20 @@ because `getDueScheduledAgentStates` filters on `scheduledWakeAt` **only, not
 lifecycle**: a finished day still holding a deadline is otherwise due on every
 tick, forever.
 
-Retirement runs **before `ScheduledWakeManager.start()`**, not only from
-`restoreSubscriptions`. `start()` checks immediately, and the restore pass is
-several awaits further down the provider's init — so a finished agent would
-otherwise still be `active` for that first check and fire once per cold start,
-which is the spend this exists to stop.
+Retirement runs **ahead of every due-record pass**, not only at start-up. It is
+wired into `ScheduledWakeManager.beforeCheck`, which the manager awaits at the
+top of each `_checkAndEnqueue` — the immediate one in `start()` and every
+hourly tick after it. Ordering is the whole point: a finished agent is still
+`active` until the pass runs, so retiring afterwards would let it fire on the
+very tick that was about to retire it. Covering the ticks and not just start-up
+is what catches a desktop session left open across the handover boundary, where
+the boundary arrives on a tick and no relaunch ever comes.
+
+`restoreSubscriptions` retires as well, before it takes its snapshot of active
+agents — otherwise start-up would re-hydrate runtime state for agents it is
+about to retire. A pre-check failure is logged and the pass continues: stale
+retirement costs one wake, while skipping the pass would strand every genuinely
+due record behind it.
 
 Without this the active set grew by one per day of use and
 `restoreSubscriptions` re-hydrated every one of them on each launch — model

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -347,6 +347,13 @@ ScheduledWakeManager scheduledWakeManager(Ref ref) {
       await vectorClock.initialized;
       return vectorClock.getHost();
     },
+    // Retire finished day agents before every pass, including the immediate
+    // one in `start()`. A day agent whose day is over is still `active` until
+    // this runs, so its overdue wake would fire — once per cold start, and
+    // once per hourly tick for a session left open across the handover
+    // boundary. Read lazily: the day-agent service is not needed to build the
+    // manager, only to run a pass.
+    beforeCheck: () => ref.read(dayAgentServiceProvider).retirePastDayAgents(),
   );
   ref.onDispose(manager.stop);
   return manager;
@@ -503,28 +510,14 @@ Future<void> agentInitialization(Ref ref) async {
   // 3. Start the orchestrator on the local update stream.
   await orchestrator.start(updateNotifications.localUpdateStream);
 
-  // 3.5. Retire finished day agents BEFORE the wake manager starts.
+  // 3.5. Start the scheduled wake manager.
   //
-  // `start()` runs a check immediately, and `restoreSubscriptions` — which
-  // otherwise owns retirement — is several awaits further down. A day agent
-  // whose day is over is still `active` at that moment, so its overdue wake
-  // fires once per cold start: precisely the spend retirement exists to stop.
-  // Best-effort, like every other step here; a failure must not stop start-up.
-  try {
-    await ref.read(dayAgentServiceProvider).retirePastDayAgents();
-  } catch (e, s) {
-    getIt<DomainLogger>().error(
-      LogDomain.agentRuntime,
-      e,
-      message: 'failed to retire past day agents before wake manager start',
-      stackTrace: s,
-    );
-  }
-
-  // 3.6. Start the scheduled wake manager.
+  // Retirement of finished day agents is wired into the manager's own
+  // pre-check (`beforeCheck`), so it runs ahead of the immediate check here
+  // and ahead of every hourly tick thereafter.
   ref.watch(scheduledWakeManagerProvider).start();
 
-  // 3.7. Track project-linked activity without triggering immediate wakes.
+  // 3.6. Track project-linked activity without triggering immediate wakes.
   projectActivityMonitor.start();
 
   // 4. Wire the sync event processor for cross-device agent data.

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -138,14 +138,16 @@ class ScheduledWakeManager {
     try {
       final before = beforeCheck;
       if (before != null) {
-        try {
-          await before();
-        } catch (e, s) {
-          _logError(
-            'pre-check repair failed; continuing with the due-record pass',
-            error: e,
-            stackTrace: s,
-          );
+        final startedOn = clock.now();
+        await _runPreCheck(before);
+        // The repair keys on the calendar day — retirement's handover cutoff
+        // does — while the due query below uses a `now` read after it. A pass
+        // that starts just before local midnight and finishes the repair just
+        // after would decide those two on different days, leaving an agent
+        // active for exactly the pass that should have retired it. Repeating
+        // the repair under the new day is cheaper than reasoning about it.
+        if (!_sameLocalDay(startedOn, clock.now())) {
+          await _runPreCheck(before);
         }
       }
       // Read after the pre-check: it can await sync writes, and a `now`
@@ -208,6 +210,23 @@ class ScheduledWakeManager {
       _isChecking = false;
     }
   }
+
+  /// Runs [before], logging a failure rather than aborting the pass: stale
+  /// repair costs a wake, while skipping the pass strands every due record.
+  Future<void> _runPreCheck(Future<void> Function() before) async {
+    try {
+      await before();
+    } catch (e, s) {
+      _logError(
+        'pre-check repair failed; continuing with the due-record pass',
+        error: e,
+        stackTrace: s,
+      );
+    }
+  }
+
+  static bool _sameLocalDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
 
   /// Fire pending [ScheduledWakeEntity] records that are due (ADR 0022).
   ///

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -150,16 +150,24 @@ class ScheduledWakeManager {
           await _runPreCheck(before);
         }
       }
+      // A `stop()` that landed while the pre-check was awaiting ends this
+      // pass here. Its replacement manager owns the schedule now, and a
+      // disposed pass that kept going would enqueue against it.
+      if (generation != _generation) return;
       // Read after the pre-check: it can await sync writes, and a `now`
       // captured before them would age across the pass it is meant to time.
       final now = clock.now();
       final dueStates = await _repository.getDueScheduledAgentStates(now);
+      if (generation != _generation) return;
 
       var enqueued = 0;
       var fastForwarded = 0;
       var skippedArchived = 0;
 
       for (final state in dueStates) {
+        // Re-checked per item: each iteration awaits the identity lookup and
+        // its own writes, so a `stop()` can land mid-loop.
+        if (generation != _generation) return;
         try {
           // Defense-in-depth (ADR 0022): the due query filters on
           // `scheduledWakeAt` only — not lifecycle — so an archived or missing
@@ -239,6 +247,9 @@ class ScheduledWakeManager {
     final dueRecords = await _repository.getDueScheduledWakeRecords(now);
     var enqueued = 0;
     for (final record in dueRecords) {
+      // As in the due-states loop: a `stop()` can land while this loop awaits
+      // the identity lookup, the host lookup or the claim write.
+      if (generation != _generation) return enqueued;
       try {
         // Same guard as the due-*states* loop above, and for the same reason:
         // `getDueScheduledWakeRecords` filters on the deadline, not lifecycle.

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -27,6 +27,7 @@ class ScheduledWakeManager {
     this.onPersistedStateChanged,
     this.requiresLease,
     this.localHostId,
+    this.beforeCheck,
     this.leaseSettle = const Duration(minutes: 3),
     this.leaseDuration = const Duration(minutes: 30),
   });
@@ -54,6 +55,19 @@ class ScheduledWakeManager {
   /// device with no sync host has no peers to race, so firing is correct and
   /// blocking would mean never running the digest at all.
   final Future<String?> Function()? localHostId;
+
+  /// Repair work that must precede every due-record pass, not just the first.
+  ///
+  /// Retiring finished day agents is the caller this exists for: retirement
+  /// decides which identities may still wake, so running it after a pass would
+  /// let a day agent fire on the very tick that was about to retire it. Wiring
+  /// it here rather than only at start-up is what covers a session left open
+  /// across the handover boundary — the boundary arrives on a tick, and the
+  /// tick now retires before it fires.
+  ///
+  /// A failure is logged and the pass continues: stale retirement costs a
+  /// wake, but skipping the pass would strand every genuinely due record.
+  final Future<void> Function()? beforeCheck;
 
   /// How long a claimant waits before confirming its claim.
   ///
@@ -122,6 +136,20 @@ class ScheduledWakeManager {
     // continuation must not then arm a timer the stop could never cancel.
     final generation = _generation;
     try {
+      final before = beforeCheck;
+      if (before != null) {
+        try {
+          await before();
+        } catch (e, s) {
+          _logError(
+            'pre-check repair failed; continuing with the due-record pass',
+            error: e,
+            stackTrace: s,
+          );
+        }
+      }
+      // Read after the pre-check: it can await sync writes, and a `now`
+      // captured before them would age across the pass it is meant to time.
       final now = clock.now();
       final dueStates = await _repository.getDueScheduledAgentStates(now);
 

--- a/test/features/agents/state/agent_providers_test.dart
+++ b/test/features/agents/state/agent_providers_test.dart
@@ -38,6 +38,7 @@ import 'package:lotti/features/ai/repository/ai_input_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/ollama_embedding_repository.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_trigger_tokens.dart';
+import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/notifications/repository/notification_repository.dart';
@@ -2309,6 +2310,37 @@ void main() {
       );
       expect(manager.requiresLease!(recordOn(null)), isFalse);
       expect(await manager.localHostId!(), 'host-a');
+    });
+
+    test('its pre-check retires finished day agents', () async {
+      final notifications = UpdateNotifications();
+      final dayAgentService = MockDayAgentService();
+      when(dayAgentService.retirePastDayAgents).thenAnswer((_) async => 2);
+
+      final container = ProviderContainer(
+        overrides: [
+          agentRepositoryProvider.overrideWithValue(MockAgentRepository()),
+          wakeOrchestratorProvider.overrideWithValue(MockWakeOrchestrator()),
+          agentSyncServiceProvider.overrideWithValue(MockAgentSyncService()),
+          updateNotificationsProvider.overrideWithValue(notifications),
+          domainLoggerProvider.overrideWithValue(MockDomainLogger()),
+          dayAgentServiceProvider.overrideWithValue(dayAgentService),
+        ],
+      );
+      addTearDown(() {
+        notifications.dispose();
+        container.dispose();
+      });
+
+      final manager = container.read(scheduledWakeManagerProvider);
+
+      // Building the manager must not run a retirement pass: the day-agent
+      // service is only needed when a pass actually runs.
+      verifyNever(dayAgentService.retirePastDayAgents);
+
+      await manager.beforeCheck!();
+
+      verify(dayAgentService.retirePastDayAgents).called(1);
     });
   });
 

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -2017,6 +2017,69 @@ void main() {
         });
       });
 
+      test('repeats the pre-check when it crosses local midnight', () {
+        // The repair keys on the calendar day; the due query below reads the
+        // clock after it. Straddling midnight, those disagree.
+        var currentTime = DateTime(2024, 3, 15, 23, 59, 59);
+        var calls = 0;
+
+        fakeAsync((async) {
+          withClock(Clock(() => currentTime), () {
+            when(
+              () => repository.getDueScheduledAgentStates(any()),
+            ).thenAnswer((_) async => <AgentStateEntity>[]);
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              beforeCheck: () async {
+                calls++;
+                // The first repair runs long enough to cross the boundary.
+                if (calls == 1) currentTime = DateTime(2024, 3, 16, 0, 0, 1);
+              },
+            )..start();
+            async.flushMicrotasks();
+
+            // Repeated under the new day, so an agent whose handover expired
+            // at midnight is retired before this pass reads what is due.
+            expect(calls, 2);
+
+            manager.stop();
+          });
+        });
+      });
+
+      test('does not repeat the pre-check within one local day', () {
+        var currentTime = DateTime(2024, 3, 15, 10, 30);
+        var calls = 0;
+
+        fakeAsync((async) {
+          withClock(Clock(() => currentTime), () {
+            when(
+              () => repository.getDueScheduledAgentStates(any()),
+            ).thenAnswer((_) async => <AgentStateEntity>[]);
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              beforeCheck: () async {
+                calls++;
+                currentTime = DateTime(2024, 3, 15, 10, 31);
+              },
+            )..start();
+            async.flushMicrotasks();
+
+            expect(calls, 1);
+
+            manager.stop();
+          });
+        });
+      });
+
       test('a failing pre-check does not strand the due records', () {
         final now = DateTime(2024, 3, 15, 10, 30);
         final pastSchedule = DateTime(2024, 3, 15, 9);

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -858,10 +858,12 @@ void main() {
               ..elapse(const Duration(minutes: 10))
               ..flushMicrotasks();
 
-            // The in-flight pass writes its claim; nothing after it should.
-            // Otherwise a disposed manager keeps re-claiming on a timer stop()
-            // never saw, racing a restarted one for the same digest.
-            verify(() => syncService.upsertEntity(any())).called(1);
+            // Not one claim written, not merely no wake fired: the pass
+            // re-checks its generation before touching each record, so a
+            // manager stopped mid-flight claims nothing at all. A disposed
+            // manager that kept claiming would race its replacement for the
+            // same digest, on a timer the stop never saw.
+            verifyNever(() => syncService.upsertEntity(any()));
             expectNoWake();
           });
         });
@@ -2076,6 +2078,49 @@ void main() {
             expect(calls, 1);
 
             manager.stop();
+          });
+        });
+      });
+
+      test('a stop during the pre-check abandons the pass', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            // Created inside the zone: a Completer from the root zone
+            // resolves outside it, and `flushMicrotasks` would never run the
+            // continuation — the pass would stall before the due query and the
+            // test would pass without proving anything.
+            final gate = Completer<void>();
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async => [
+                makeTestState(scheduledWakeAt: DateTime(2024, 3, 15, 9)),
+              ],
+            );
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              beforeCheck: () => gate.future,
+            )..start();
+            async.flushMicrotasks();
+
+            // The stop lands while the repair is still awaiting.
+            manager.stop();
+            gate.complete();
+            async.flushMicrotasks();
+
+            // A disposed pass that carried on would enqueue against the
+            // manager that replaced it.
+            verifyNever(() => repository.getDueScheduledAgentStates(any()));
+            verifyNever(
+              () => orchestrator.enqueueManualWake(
+                agentId: any(named: 'agentId'),
+                reason: any(named: 'reason'),
+              ),
+            );
           });
         });
       });

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -1935,5 +1935,120 @@ void main() {
         });
       });
     });
+
+    group('beforeCheck', () {
+      test('runs before every due-record pass, not just the first', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final calls = <String>[];
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async {
+                calls.add('due');
+                return <AgentStateEntity>[];
+              },
+            );
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              beforeCheck: () async => calls.add('before'),
+            )..start();
+            async.flushMicrotasks();
+
+            // The immediate check must be preceded by the repair, or a day
+            // agent about to be retired fires on the very pass that retires it.
+            expect(calls, ['before', 'due']);
+
+            async
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+
+            // And the hourly tick — the boundary a long-running session
+            // crosses — repairs before it fires, too.
+            expect(calls, ['before', 'due', 'before', 'due']);
+
+            manager.stop();
+          });
+        });
+      });
+
+      test('an agent it retires does not fire on that same pass', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final pastSchedule = DateTime(2024, 3, 14, 9);
+        var retired = false;
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async => [makeTestState(scheduledWakeAt: pastSchedule)],
+            );
+            // The repair flips the identity dormant; the lifecycle guard in the
+            // pass then reads the post-repair value.
+            when(() => repository.getEntity(any())).thenAnswer(
+              (_) async => makeTestIdentity(
+                lifecycle: retired
+                    ? AgentLifecycle.dormant
+                    : AgentLifecycle.active,
+              ),
+            );
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              beforeCheck: () async => retired = true,
+            )..start();
+            async.flushMicrotasks();
+
+            verifyNever(
+              () => orchestrator.enqueueManualWake(
+                agentId: kTestAgentId,
+                reason: any(named: 'reason'),
+              ),
+            );
+
+            manager.stop();
+          });
+        });
+      });
+
+      test('a failing pre-check does not strand the due records', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final pastSchedule = DateTime(2024, 3, 15, 9);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async => [makeTestState(scheduledWakeAt: pastSchedule)],
+            );
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              beforeCheck: () async => throw Exception('retirement failed'),
+            )..start();
+            async.flushMicrotasks();
+
+            // Stale retirement costs one wake; skipping the pass would strand
+            // every genuinely due record behind it.
+            verify(
+              () => orchestrator.enqueueManualWake(
+                agentId: kTestAgentId,
+                reason: WakeReason.scheduled.name,
+              ),
+            ).called(1);
+
+            manager.stop();
+          });
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Follow-up to #3759 / #3761, closing the last of the three retirement gaps.

## The gap

`retirePastDayAgents` ran from `restoreSubscriptions` and from a step placed just before `ScheduledWakeManager.start()` — both start-up only. An app left running across the handover boundary therefore never retired anything: the boundary arrives on an hourly tick, and a finished day agent kept firing on every tick until the next relaunch. On a desktop session left open for days that is the whole of the spend retirement exists to stop.

## The fix

Move retirement onto the manager's own pass, via a `beforeCheck` hook awaited at the top of `_checkAndEnqueue`. That covers:

- the immediate check in `start()` — preserving the ordering the removed start-up step existed for, so #3761 does not regress;
- every hourly tick after it — the case this PR is about.

Ordering is the point rather than an implementation detail: a finished agent is still `active` until the pass runs, so retiring *after* a pass would let it fire on the very tick that was about to retire it.

A failing pre-check is logged and the pass continues. Stale retirement costs one wake; aborting the pass would strand every genuinely due record behind it.

`restoreSubscriptions` keeps its own call — it must not hydrate runtime state for agents it is about to retire.

## Tests

Three new tests in `scheduled_wake_manager_test.dart`:

- the repair runs before the due query on the immediate check **and** on the next tick (asserts the call order, not just that it ran);
- an agent the repair retires does not fire on that same pass;
- a throwing pre-check still lets the due records fire.

The first two fail with the hook invocation reverted; the third guards against an implementation without the inner catch, where the throw precedes the due query.

No CHANGELOG entry: the user-visible behaviour is already described under 1.0.1 ("Assistants for past days stop waking up"), and this bug never shipped.

## Not in scope

`lotti3-1ox` — the cutoff is computed from one device's local calendar while the dormant flip syncs to every peer. Same class as `lotti3-v9k` (the shared digest record has no canonical time zone) and wants the same answer, so it is tracked separately rather than guessed at here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled-wake reliability by retiring completed day agents before startup, hourly, and other due-wake checks.
  * Added local date-boundary handling to prevent outdated agents from running after a new day begins.
  * Wake processing now continues when retirement checks encounter errors.
  * Prevented stopped wake managers from making claims during in-progress processing.

* **Documentation**
  * Updated coordination protocol guidance to reflect the revised agent retirement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->