### PR TITLE
fix(agents): coalesce a wake trigger that arrives during an in-flight pass

### DIFF
--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -5,13 +5,13 @@ description: Two durable synced entities instead of RPC — binding day directiv
 resource: ../../../lib/features/daily_os_next/agents/service/day_agent_directive_service.dart
 tags: [daily-os, coordination, directives, digest, rollups]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-02T22:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-03T12:00:00Z }
 stale_after: 2026-11-01
 sources:
   - id: agents
     resource: ../../../lib/features/daily_os_next/agents
     title: Directive, status and digest services
-    last_modified: 2026-08-02
+    last_modified: 2026-08-03
   - id: adr-0032
     resource: ../../../docs/adr/0032-hierarchical-day-agent-coordination.md
     title: ADR 0032 — Hierarchical day-agent coordination
@@ -240,7 +240,11 @@ Generations bound the loop at both ends. A `stop()` mid-pass cancels the queued
 re-run, since the schedule it belonged to is gone. A trigger raised by a
 *restart* — `start()`'s immediate check landing while the old pass winds down —
 is handed to a fresh invocation instead of being dropped, or the restarted
-manager would wait a full interval for its first scan.
+manager would wait a full interval for its first scan. That handoff inherits
+the old pass's handled rows: work enqueued just before `stop()` can still look
+due until its asynchronous state update lands, and forgetting it at the
+generation boundary would bill the restarted scan twice. The set crosses only
+this in-flight handoff; an independent later scan starts clean.
 
 The lease recovers the **claim**, not the run. A crash after the `consumed` flip
 but before the job finishes still loses that day's briefing, because

--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -212,6 +212,15 @@ The lease expires. A device that claims and then crashes or goes offline
 `leaseUntil` any device takes over. A device with no sync host fires unleased —
 it has no peers to race.
 
+Takeover is timely because every "not yet" branch arms its own one-shot
+re-check: the periodic tick is hourly, so a lease expiring at 06:34 would
+otherwise wait until 07:00. Those re-checks are timers that fire once, so
+`_checkAndEnqueue` **coalesces** a trigger arriving during an in-flight pass and
+re-runs once when that pass finishes, rather than dropping it on the
+already-running guard — which would lose the trigger outright, not delay it. A
+`stop()` mid-pass cancels the queued re-run: the generation it was queued under
+is gone.
+
 The lease recovers the **claim**, not the run. A crash after the `consumed` flip
 but before the job finishes still loses that day's briefing, because
 `_ensurePendingDigestWake` sees a consumed record and arms tomorrow's slot. That

--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -5,7 +5,7 @@ description: Two durable synced entities instead of RPC — binding day directiv
 resource: ../../../lib/features/daily_os_next/agents/service/day_agent_directive_service.dart
 tags: [daily-os, coordination, directives, digest, rollups]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-02T20:00:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-02T20:30:00Z }
 stale_after: 2026-11-01
 sources:
   - id: agents
@@ -217,9 +217,23 @@ re-check: the periodic tick is hourly, so a lease expiring at 06:34 would
 otherwise wait until 07:00. Those re-checks are timers that fire once, so
 `_checkAndEnqueue` **coalesces** a trigger arriving during an in-flight pass and
 re-runs once when that pass finishes, rather than dropping it on the
-already-running guard — which would lose the trigger outright, not delay it. A
-`stop()` mid-pass cancels the queued re-run: the generation it was queued under
-is gone.
+already-running guard — which would lose the trigger outright, not delay it.
+
+The re-run re-reads everything and skips only the rows this invocation already
+acted on. Both halves are load-bearing. It must re-read, because a state that
+became due *during* a long pass is exactly what the re-run is for. And it must
+skip what it handled, because neither write is guaranteed to have landed — the
+wake clears `scheduledWakeAt` asynchronously, and a record's consume-write can
+fail outright and leave it pending. `enqueueManualWake` supersedes only work
+still *queued*, so firing a row twice bills twice. Rows are marked handled
+before the work, not after: a partial failure waits for the next invocation
+rather than being retried microseconds later.
+
+Generations bound the loop at both ends. A `stop()` mid-pass cancels the queued
+re-run, since the schedule it belonged to is gone. A trigger raised by a
+*restart* — `start()`'s immediate check landing while the old pass winds down —
+is handed to a fresh invocation instead of being dropped, or the restarted
+manager would wait a full interval for its first scan.
 
 The lease recovers the **claim**, not the run. A crash after the `consumed` flip
 but before the job finishes still loses that day's briefing, because

--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -5,7 +5,7 @@ description: Two durable synced entities instead of RPC — binding day directiv
 resource: ../../../lib/features/daily_os_next/agents/service/day_agent_directive_service.dart
 tags: [daily-os, coordination, directives, digest, rollups]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-02T20:30:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-02T22:00:00Z }
 stale_after: 2026-11-01
 sources:
   - id: agents
@@ -228,6 +228,13 @@ fail outright and leave it pending. `enqueueManualWake` supersedes only work
 still *queued*, so firing a row twice bills twice. Rows are marked handled
 before the work, not after: a partial failure waits for the next invocation
 rather than being retried microseconds later.
+
+A record the lease *deferred* is deliberately left unmarked. It armed the very
+one-shot re-check the coalesced re-run is answering, so treating it as handled
+would make the re-run skip the record it was woken for — and confirmation or
+takeover would wait for the next hourly tick, which is the delay this whole
+mechanism exists to remove. Only records actually fired, or consumed as stale,
+are marked.
 
 Generations bound the loop at both ends. A `stop()` mid-pass cancels the queued
 re-run, since the schedule it belonged to is gone. A trigger raised by a

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -139,6 +139,15 @@ class ScheduledWakeManager {
   /// expiring while another pass is in flight would wait for the next hourly
   /// tick before any device could take it over. Re-running once afterwards
   /// costs one extra query and answers every trigger, however many arrived.
+  ///
+  /// The re-run covers the **record** path only. Records are what carry
+  /// sub-hour deadlines, and they are consumed as they fire, so re-reading
+  /// them is safe. Due *states* are not: `scheduledWakeAt` is cleared by the
+  /// wake itself, so an immediate second pass would still see the agent as due
+  /// and enqueue it again — and `enqueueManualWake` supersedes only work still
+  /// queued, so a run that had already started would be billed twice. Nothing
+  /// is lost by skipping them: a due state stays due until its wake runs, and
+  /// the pass that just finished read them microseconds ago.
   Future<void> _checkAndEnqueue() async {
     if (_isChecking) {
       _rerunRequested = true;
@@ -148,10 +157,12 @@ class ScheduledWakeManager {
     // A stop during the pass must not be followed by a re-run: the generation
     // it was queued under is gone, and a restarted manager owns the schedule.
     final entryGeneration = _generation;
+    var includeDueStates = true;
     try {
       do {
         _rerunRequested = false;
-        await _runPass();
+        await _runPass(includeDueStates: includeDueStates);
+        includeDueStates = false;
       } while (_rerunRequested && _generation == entryGeneration);
     } finally {
       _rerunRequested = false;
@@ -159,7 +170,7 @@ class ScheduledWakeManager {
     }
   }
 
-  Future<void> _runPass() async {
+  Future<void> _runPass({required bool includeDueStates}) async {
     // Captured before the first await: `stop()` may land while this pass is
     // waiting on the repository, the host lookup or the claim write, and the
     // continuation must not then arm a timer the stop could never cancel.
@@ -186,7 +197,9 @@ class ScheduledWakeManager {
       // Read after the pre-check: it can await sync writes, and a `now`
       // captured before them would age across the pass it is meant to time.
       final now = clock.now();
-      final dueStates = await _repository.getDueScheduledAgentStates(now);
+      final dueStates = includeDueStates
+          ? await _repository.getDueScheduledAgentStates(now)
+          : const <AgentStateEntity>[];
       if (generation != _generation) return;
 
       var enqueued = 0;

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -9,12 +9,13 @@ import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/services/domain_logging.dart';
 
-/// What one [ScheduledWakeManager._checkAndEnqueue] invocation has already
-/// acted on, so its coalesced re-runs do not act on the same row twice.
+/// What one logical check sequence has already acted on, so its coalesced
+/// re-runs and an in-flight restart handoff do not act on the same row twice.
 ///
-/// Scoped to the invocation, not the manager: across invocations the rows are
-/// genuinely due again, and a long-lived set would suppress real work.
-class _HandledThisInvocation {
+/// Scoped to the sequence, not the manager: later independent checks must
+/// re-read genuinely due rows, while a restart arriving before the old pass
+/// releases the single-flight guard is still part of that pass's handoff.
+class _HandledCheckSequence {
   final agentIds = <String>{};
   final recordIds = <String>{};
 }
@@ -162,7 +163,9 @@ class ScheduledWakeManager {
   /// supersedes only work still queued, not a run already under way. Skipping
   /// the whole path instead of the handled rows would lose a state that became
   /// due *during* a long pass, which is the case the re-run exists for.
-  Future<void> _checkAndEnqueue() async {
+  Future<void> _checkAndEnqueue([
+    _HandledCheckSequence? inheritedHandled,
+  ]) async {
     if (_isChecking) {
       _rerunRequested = true;
       _rerunGeneration = _generation;
@@ -170,7 +173,7 @@ class ScheduledWakeManager {
     }
     _isChecking = true;
     final entryGeneration = _generation;
-    final handled = _HandledThisInvocation();
+    final handled = inheritedHandled ?? _HandledCheckSequence();
     try {
       do {
         _rerunRequested = false;
@@ -186,11 +189,11 @@ class ScheduledWakeManager {
       // scan, so hand it to a fresh invocation now that the guard is clear.
       final restarted = _rerunRequested && _rerunGeneration == _generation;
       _rerunRequested = false;
-      if (restarted) unawaited(_checkAndEnqueue());
+      if (restarted) unawaited(_checkAndEnqueue(handled));
     }
   }
 
-  Future<void> _runPass(_HandledThisInvocation handled) async {
+  Future<void> _runPass(_HandledCheckSequence handled) async {
     // Captured before the first await: `stop()` may land while this pass is
     // waiting on the repository, the host lookup or the claim write, and the
     // continuation must not then arm a timer the stop could never cancel.
@@ -314,7 +317,7 @@ class ScheduledWakeManager {
   Future<int> _processDueRecords(
     DateTime now,
     int generation,
-    _HandledThisInvocation handled,
+    _HandledCheckSequence handled,
   ) async {
     final dueRecords = await _repository.getDueScheduledWakeRecords(now);
     var enqueued = 0;

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -322,11 +322,12 @@ class ScheduledWakeManager {
       // As in the due-states loop: a `stop()` can land while this loop awaits
       // the identity lookup, the host lookup or the claim write.
       if (generation != _generation) return enqueued;
-      // Marked before the work, not after: if the consume-write fails the
-      // record is still pending, and a re-run microseconds later would fire it
-      // a second time — a transient write error must not become a second
-      // billed wake. It stays due for the next invocation.
-      if (!handled.recordIds.add(record.id)) continue;
+      // Skipped only once this invocation has *acted* on it. A record the
+      // lease deferred armed a one-shot re-check, and that timer is precisely
+      // what the coalesced re-run is answering — marking it here would make
+      // the re-run skip the record it was woken for, so confirmation or
+      // takeover would wait for the next hourly tick.
+      if (handled.recordIds.contains(record.id)) continue;
       try {
         // Same guard as the due-*states* loop above, and for the same reason:
         // `getDueScheduledWakeRecords` filters on the deadline, not lifecycle.
@@ -343,6 +344,7 @@ class ScheduledWakeManager {
         }
         final lifecycle = identity.mapOrNull(agent: (e) => e.lifecycle);
         if (lifecycle != AgentLifecycle.active) {
+          handled.recordIds.add(record.id);
           await _consumeStaleWakeRecord(record, now);
           continue;
         }
@@ -370,6 +372,11 @@ class ScheduledWakeManager {
                 !current.scheduledAt.isAtSameMomentAs(approved.scheduledAt))) {
           continue;
         }
+        // Marked before the enqueue, not after: if the consume-write below
+        // fails the record is still pending, and a re-run microseconds later
+        // would fire it a second time — a transient write error must not
+        // become a second billed wake. It stays due for the next invocation.
+        handled.recordIds.add(record.id);
         _orchestrator.enqueueManualWake(
           agentId: record.agentId,
           reason: record.reason,

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -91,6 +91,10 @@ class ScheduledWakeManager {
   int _generation = 0;
   bool _isChecking = false;
 
+  /// Set when a trigger arrives while a pass is already running, so that pass
+  /// runs once more instead of the trigger being lost. See [_checkAndEnqueue].
+  bool _rerunRequested = false;
+
   /// Start periodic checking. Also immediately checks for missed wakes.
   void start() {
     unawaited(_checkAndEnqueue());
@@ -128,9 +132,34 @@ class ScheduledWakeManager {
     });
   }
 
+  /// Runs a due-record pass, coalescing any trigger that arrives during it.
+  ///
+  /// Dropping the overlapping trigger would lose it outright: the re-checks
+  /// armed by [_scheduleRecheck] are one-shot timers, so a foreign lease
+  /// expiring while another pass is in flight would wait for the next hourly
+  /// tick before any device could take it over. Re-running once afterwards
+  /// costs one extra query and answers every trigger, however many arrived.
   Future<void> _checkAndEnqueue() async {
-    if (_isChecking) return;
+    if (_isChecking) {
+      _rerunRequested = true;
+      return;
+    }
     _isChecking = true;
+    // A stop during the pass must not be followed by a re-run: the generation
+    // it was queued under is gone, and a restarted manager owns the schedule.
+    final entryGeneration = _generation;
+    try {
+      do {
+        _rerunRequested = false;
+        await _runPass();
+      } while (_rerunRequested && _generation == entryGeneration);
+    } finally {
+      _rerunRequested = false;
+      _isChecking = false;
+    }
+  }
+
+  Future<void> _runPass() async {
     // Captured before the first await: `stop()` may land while this pass is
     // waiting on the repository, the host lookup or the claim write, and the
     // continuation must not then arm a timer the stop could never cancel.
@@ -214,8 +243,6 @@ class ScheduledWakeManager {
       }
     } catch (e, s) {
       _logError('error checking scheduled wakes', error: e, stackTrace: s);
-    } finally {
-      _isChecking = false;
     }
   }
 

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -9,6 +9,16 @@ import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/services/domain_logging.dart';
 
+/// What one [ScheduledWakeManager._checkAndEnqueue] invocation has already
+/// acted on, so its coalesced re-runs do not act on the same row twice.
+///
+/// Scoped to the invocation, not the manager: across invocations the rows are
+/// genuinely due again, and a long-lived set would suppress real work.
+class _HandledThisInvocation {
+  final agentIds = <String>{};
+  final recordIds = <String>{};
+}
+
 /// Manages scheduled wakes for agents that need to wake on a time-based
 /// schedule (e.g., daily project digests, weekly one-on-one rituals).
 ///
@@ -95,6 +105,10 @@ class ScheduledWakeManager {
   /// runs once more instead of the trigger being lost. See [_checkAndEnqueue].
   bool _rerunRequested = false;
 
+  /// The generation [_rerunRequested] was raised under. A request from a newer
+  /// generation belongs to a restarted manager, not to the pass in flight.
+  int _rerunGeneration = 0;
+
   /// Start periodic checking. Also immediately checks for missed wakes.
   void start() {
     unawaited(_checkAndEnqueue());
@@ -140,37 +154,43 @@ class ScheduledWakeManager {
   /// tick before any device could take it over. Re-running once afterwards
   /// costs one extra query and answers every trigger, however many arrived.
   ///
-  /// The re-run covers the **record** path only. Records are what carry
-  /// sub-hour deadlines, and they are consumed as they fire, so re-reading
-  /// them is safe. Due *states* are not: `scheduledWakeAt` is cleared by the
-  /// wake itself, so an immediate second pass would still see the agent as due
-  /// and enqueue it again — and `enqueueManualWake` supersedes only work still
-  /// queued, so a run that had already started would be billed twice. Nothing
-  /// is lost by skipping them: a due state stays due until its wake runs, and
-  /// the pass that just finished read them microseconds ago.
+  /// The re-run re-reads everything and skips only what this invocation has
+  /// already acted on. It has to re-read: the wake clears `scheduledWakeAt`
+  /// and the record flips to `consumed`, and neither has necessarily landed
+  /// when the re-run starts — a consume-write can even have failed outright.
+  /// Acting twice would be billed twice, because `enqueueManualWake`
+  /// supersedes only work still queued, not a run already under way. Skipping
+  /// the whole path instead of the handled rows would lose a state that became
+  /// due *during* a long pass, which is the case the re-run exists for.
   Future<void> _checkAndEnqueue() async {
     if (_isChecking) {
       _rerunRequested = true;
+      _rerunGeneration = _generation;
       return;
     }
     _isChecking = true;
-    // A stop during the pass must not be followed by a re-run: the generation
-    // it was queued under is gone, and a restarted manager owns the schedule.
     final entryGeneration = _generation;
-    var includeDueStates = true;
+    final handled = _HandledThisInvocation();
     try {
       do {
         _rerunRequested = false;
-        await _runPass(includeDueStates: includeDueStates);
-        includeDueStates = false;
+        await _runPass(handled);
+        // A `stop()` during the pass ends the schedule this loop belongs to;
+        // anything raised since then is the next generation's business.
       } while (_rerunRequested && _generation == entryGeneration);
     } finally {
-      _rerunRequested = false;
       _isChecking = false;
+      // A trigger from a *newer* generation is a restart's immediate check
+      // arriving while this pass was still winding down. Dropping it would
+      // leave the restarted manager waiting a full interval for its first
+      // scan, so hand it to a fresh invocation now that the guard is clear.
+      final restarted = _rerunRequested && _rerunGeneration == _generation;
+      _rerunRequested = false;
+      if (restarted) unawaited(_checkAndEnqueue());
     }
   }
 
-  Future<void> _runPass({required bool includeDueStates}) async {
+  Future<void> _runPass(_HandledThisInvocation handled) async {
     // Captured before the first await: `stop()` may land while this pass is
     // waiting on the repository, the host lookup or the claim write, and the
     // continuation must not then arm a timer the stop could never cancel.
@@ -197,9 +217,7 @@ class ScheduledWakeManager {
       // Read after the pre-check: it can await sync writes, and a `now`
       // captured before them would age across the pass it is meant to time.
       final now = clock.now();
-      final dueStates = includeDueStates
-          ? await _repository.getDueScheduledAgentStates(now)
-          : const <AgentStateEntity>[];
+      final dueStates = await _repository.getDueScheduledAgentStates(now);
       if (generation != _generation) return;
 
       var enqueued = 0;
@@ -210,6 +228,12 @@ class ScheduledWakeManager {
         // Re-checked per item: each iteration awaits the identity lookup and
         // its own writes, so a `stop()` can land mid-loop.
         if (generation != _generation) return;
+        // Already acted on by an earlier pass of this same invocation; the
+        // wake it enqueued has not necessarily cleared `scheduledWakeAt` yet.
+        // Marked before the work, not after: a partial failure must not let a
+        // re-run enqueue the same agent again. It stays due for the next
+        // invocation.
+        if (!handled.agentIds.add(state.agentId)) continue;
         try {
           // Defense-in-depth (ADR 0022): the due query filters on
           // `scheduledWakeAt` only — not lifecycle — so an archived or missing
@@ -244,7 +268,11 @@ class ScheduledWakeManager {
         }
       }
 
-      final recordsEnqueued = await _processDueRecords(now, generation);
+      final recordsEnqueued = await _processDueRecords(
+        now,
+        generation,
+        handled,
+      );
 
       if (dueStates.isNotEmpty || recordsEnqueued > 0) {
         _log(
@@ -283,13 +311,22 @@ class ScheduledWakeManager {
   /// `scheduledWakeAt` path. After enqueuing, the record is flipped to
   /// [ScheduledWakeStatus.consumed] in place (not hard-deleted) so a
   /// concurrent device's flip converges via LWW instead of resurrecting it.
-  Future<int> _processDueRecords(DateTime now, int generation) async {
+  Future<int> _processDueRecords(
+    DateTime now,
+    int generation,
+    _HandledThisInvocation handled,
+  ) async {
     final dueRecords = await _repository.getDueScheduledWakeRecords(now);
     var enqueued = 0;
     for (final record in dueRecords) {
       // As in the due-states loop: a `stop()` can land while this loop awaits
       // the identity lookup, the host lookup or the claim write.
       if (generation != _generation) return enqueued;
+      // Marked before the work, not after: if the consume-write fails the
+      // record is still pending, and a re-run microseconds later would fire it
+      // a second time — a transient write error must not become a second
+      // billed wake. It stays due for the next invocation.
+      if (!handled.recordIds.add(record.id)) continue;
       try {
         // Same guard as the due-*states* loop above, and for the same reason:
         // `getDueScheduledWakeRecords` filters on the deadline, not lifecycle.

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -2239,6 +2239,51 @@ void main() {
         });
       });
 
+      test('a restart handoff does not enqueue an already-handled row', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final pastSchedule = DateTime(2024, 3, 15, 9);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            final passes = gatedDueQuery(gate, [0]);
+            // The wake has been enqueued but has not yet cleared this row, so
+            // the restart's immediate scan still sees it as due.
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async => [makeTestState(scheduledWakeAt: pastSchedule)],
+            );
+
+            final manager = createAndStart();
+            async.flushMicrotasks();
+            verify(
+              () => orchestrator.enqueueManualWake(
+                agentId: kTestAgentId,
+                reason: WakeReason.scheduled.name,
+              ),
+            ).called(1);
+
+            // The old pass is now waiting on its due-record query. The
+            // restart must get an immediate scan without forgetting what that
+            // still-in-flight pass already enqueued.
+            manager
+              ..stop()
+              ..start();
+            gate.complete();
+            async.flushMicrotasks();
+
+            expect(passes(), 2, reason: 'the restart still scans immediately');
+            verifyNever(
+              () => orchestrator.enqueueManualWake(
+                agentId: kTestAgentId,
+                reason: WakeReason.scheduled.name,
+              ),
+            );
+
+            manager.stop();
+          });
+        });
+      });
+
       test('a stop during the pass cancels the queued re-run', () {
         final now = DateTime(2024, 3, 15, 10, 30);
 

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -738,6 +738,61 @@ void main() {
         });
       });
 
+      test('a lease-deferred record stays eligible for the re-run', () {
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final record = leased();
+            // Created inside the zone so `flushMicrotasks` runs its
+            // continuation; a root-zone Completer would stall the pass.
+            final hostGate = Completer<void>();
+            var hostLookups = 0;
+
+            when(
+              () => repository.getDueScheduledAgentStates(any()),
+            ).thenAnswer((_) async => []);
+            when(
+              () => repository.getDueScheduledWakeRecords(any()),
+            ).thenAnswer((_) async => [record]);
+            when(
+              () => syncService.upsertEntity(any()),
+            ).thenAnswer((_) async {});
+            when(
+              () => repository.getEntity(record.id),
+            ).thenAnswer((_) async => record);
+
+            final manager = ScheduledWakeManager(
+              repository: repository,
+              orchestrator: orchestrator,
+              syncService: syncService,
+              checkInterval: const Duration(minutes: 1),
+              requiresLease: (r) => r.workspaceKey == digestWorkspace,
+              localHostId: () async {
+                hostLookups++;
+                if (hostLookups == 1) await hostGate.future;
+                return 'host-a';
+              },
+            )..start();
+
+            // A tick lands while the first pass is stalled on the host lookup.
+            async
+              ..flushMicrotasks()
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+
+            hostGate.complete();
+            async.flushMicrotasks();
+
+            // The re-run is answering the very timer this record armed, so
+            // skipping it as "already handled" would leave confirmation or
+            // takeover waiting for the next hourly tick.
+            expect(hostLookups, 2);
+            expectNoWake();
+
+            manager.stop();
+          });
+        });
+      });
+
       test('the deadline survives a peer in another timezone', () {
         fakeAsync((async) {
           withClock(Clock.fixed(now), () {

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -1939,15 +1939,21 @@ void main() {
     });
 
     group('overlapping triggers', () {
-      /// Stubs the due query so the first pass blocks on [gate], and counts
-      /// how many passes reached it.
+      /// Stubs the due-*record* query — the path a coalesced re-run covers —
+      /// so the first pass blocks on [gate], and counts how many passes
+      /// reached it.
       int Function() gatedDueQuery(Completer<void> gate, List<int> counter) {
-        when(() => repository.getDueScheduledAgentStates(any())).thenAnswer((
+        // Nothing due on the state path unless a test says otherwise; the
+        // record path below is what these tests measure.
+        when(
+          () => repository.getDueScheduledAgentStates(any()),
+        ).thenAnswer((_) async => <AgentStateEntity>[]);
+        when(() => repository.getDueScheduledWakeRecords(any())).thenAnswer((
           _,
         ) async {
           counter[0]++;
           if (counter[0] == 1) await gate.future;
-          return <AgentStateEntity>[];
+          return <ScheduledWakeEntity>[];
         });
         return () => counter[0];
       }
@@ -2011,6 +2017,43 @@ void main() {
           });
         },
       );
+
+      test('the re-run does not enqueue a due agent a second time', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final pastSchedule = DateTime(2024, 3, 15, 9);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            gatedDueQuery(gate, [0]);
+            // Still due on the re-run: `scheduledWakeAt` is cleared by the
+            // wake itself, which has not run yet.
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async => [makeTestState(scheduledWakeAt: pastSchedule)],
+            );
+
+            final manager = createAndStart();
+            async
+              ..flushMicrotasks()
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+
+            gate.complete();
+            async.flushMicrotasks();
+
+            // A second enqueue would bill a second inference: supersede only
+            // removes work still queued, not a run that has already started.
+            verify(
+              () => orchestrator.enqueueManualWake(
+                agentId: kTestAgentId,
+                reason: WakeReason.scheduled.name,
+              ),
+            ).called(1);
+
+            manager.stop();
+          });
+        });
+      });
 
       test('a stop during the pass cancels the queued re-run', () {
         final now = DateTime(2024, 3, 15, 10, 30);

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -1938,6 +1938,108 @@ void main() {
       });
     });
 
+    group('overlapping triggers', () {
+      /// Stubs the due query so the first pass blocks on [gate], and counts
+      /// how many passes reached it.
+      int Function() gatedDueQuery(Completer<void> gate, List<int> counter) {
+        when(() => repository.getDueScheduledAgentStates(any())).thenAnswer((
+          _,
+        ) async {
+          counter[0]++;
+          if (counter[0] == 1) await gate.future;
+          return <AgentStateEntity>[];
+        });
+        return () => counter[0];
+      }
+
+      test('a tick during an in-flight pass re-runs it once, not never', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            final passes = gatedDueQuery(gate, [0]);
+
+            final manager = createAndStart();
+            async.flushMicrotasks();
+            expect(passes(), 1, reason: 'first pass is blocked on the gate');
+
+            // The periodic tick lands while that pass is still running. The
+            // re-checks armed for lease expiry are one-shot timers, so
+            // dropping this would lose the trigger, not merely delay it.
+            async
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+            expect(passes(), 1, reason: 'still one pass — the tick coalesced');
+
+            gate.complete();
+            async.flushMicrotasks();
+
+            // Re-run happens on completion, without waiting for another tick.
+            expect(passes(), 2);
+
+            manager.stop();
+          });
+        });
+      });
+
+      test(
+        'several triggers during one pass coalesce into a single re-run',
+        () {
+          final now = DateTime(2024, 3, 15, 10, 30);
+
+          fakeAsync((async) {
+            withClock(Clock.fixed(now), () {
+              final gate = Completer<void>();
+              final passes = gatedDueQuery(gate, [0]);
+
+              final manager = createAndStart();
+              async.flushMicrotasks();
+
+              async
+                ..elapse(const Duration(minutes: 3))
+                ..flushMicrotasks();
+
+              gate.complete();
+              async.flushMicrotasks();
+
+              // Three ticks were absorbed; the point is to answer them, not to
+              // replay one pass per dropped trigger.
+              expect(passes(), 2);
+
+              manager.stop();
+            });
+          });
+        },
+      );
+
+      test('a stop during the pass cancels the queued re-run', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            final passes = gatedDueQuery(gate, [0]);
+
+            final manager = createAndStart();
+            async.flushMicrotasks();
+
+            async
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+
+            // The generation the re-run was queued under is gone; a restarted
+            // manager owns the schedule from here.
+            manager.stop();
+            gate.complete();
+            async.flushMicrotasks();
+
+            expect(passes(), 1);
+          });
+        });
+      });
+    });
+
     group('beforeCheck', () {
       test('runs before every due-record pass, not just the first', () {
         final now = DateTime(2024, 3, 15, 10, 30);

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -1994,9 +1994,8 @@ void main() {
               final passes = gatedDueQuery(gate, [0]);
 
               final manager = createAndStart();
-              async.flushMicrotasks();
-
               async
+                ..flushMicrotasks()
                 ..elapse(const Duration(minutes: 3))
                 ..flushMicrotasks();
 
@@ -2022,9 +2021,8 @@ void main() {
             final passes = gatedDueQuery(gate, [0]);
 
             final manager = createAndStart();
-            async.flushMicrotasks();
-
             async
+              ..flushMicrotasks()
               ..elapse(const Duration(minutes: 1))
               ..flushMicrotasks();
 

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -2055,6 +2055,135 @@ void main() {
         });
       });
 
+      test('the re-run picks up a state that became due during the pass', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        var secondQuery = false;
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            gatedDueQuery(gate, [0]);
+            // Nothing due when the pass starts; an agent becomes due while it
+            // is stalled on the repository.
+            when(() => repository.getDueScheduledAgentStates(any())).thenAnswer(
+              (_) async => secondQuery
+                  ? [makeTestState(scheduledWakeAt: DateTime(2024, 3, 15, 10))]
+                  : <AgentStateEntity>[],
+            );
+
+            final manager = createAndStart();
+            async
+              ..flushMicrotasks()
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+
+            secondQuery = true;
+            gate.complete();
+            async.flushMicrotasks();
+
+            // Suppressing the whole state path on a re-run would leave this
+            // agent undiscovered until the next hourly tick.
+            verify(
+              () => orchestrator.enqueueManualWake(
+                agentId: kTestAgentId,
+                reason: WakeReason.scheduled.name,
+              ),
+            ).called(1);
+
+            manager.stop();
+          });
+        });
+      });
+
+      test('a record whose consume-write failed is not fired twice', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final record =
+            AgentDomainEntity.scheduledWake(
+                  id: 'wake-rec-1',
+                  agentId: kTestAgentId,
+                  scheduledAt: DateTime(2024, 3, 15, 10),
+                  status: ScheduledWakeStatus.pending,
+                  reason: WakeReason.scheduled.name,
+                  updatedAt: DateTime(2024, 3, 15, 10),
+                  vectorClock: null,
+                  triggerTokens: const ['token'],
+                )
+                as ScheduledWakeEntity;
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            var calls = 0;
+            when(
+              () => repository.getDueScheduledAgentStates(any()),
+            ).thenAnswer((_) async => <AgentStateEntity>[]);
+            // Still pending on the re-read: the consume-write below failed.
+            when(() => repository.getDueScheduledWakeRecords(any())).thenAnswer(
+              (_) async {
+                calls++;
+                if (calls == 1) await gate.future;
+                return [record];
+              },
+            );
+            when(() => syncService.upsertEntity(any())).thenThrow(
+              Exception('consume write failed'),
+            );
+
+            final manager = createAndStart();
+            async
+              ..flushMicrotasks()
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+
+            gate.complete();
+            async.flushMicrotasks();
+
+            // A transient write error must not become a second billed wake.
+            verify(
+              () => orchestrator.enqueueManualWake(
+                agentId: any(named: 'agentId'),
+                reason: any(named: 'reason'),
+                triggerTokens: any(named: 'triggerTokens'),
+                workspaceKey: any(named: 'workspaceKey'),
+                supersede: any(named: 'supersede'),
+                initiator: any(named: 'initiator'),
+              ),
+            ).called(1);
+
+            manager.stop();
+          });
+        });
+      });
+
+      test('a restart during the pass still gets its immediate check', () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+
+        fakeAsync((async) {
+          withClock(Clock.fixed(now), () {
+            final gate = Completer<void>();
+            final passes = gatedDueQuery(gate, [0]);
+
+            final manager = createAndStart();
+            async.flushMicrotasks();
+
+            // Stopped and restarted while the first pass is still stalled.
+            manager
+              ..stop()
+              ..start();
+            async.flushMicrotasks();
+
+            gate.complete();
+            async.flushMicrotasks();
+
+            // The restart's own immediate check must survive the old pass;
+            // otherwise it waits a full interval for its first scan.
+            expect(passes(), 2);
+
+            manager.stop();
+          });
+        });
+      });
+
       test('a stop during the pass cancels the queued re-run', () {
         final now = DateTime(2024, 3, 15, 10, 30);
 


### PR DESCRIPTION
Stacked on #3766 — review that one first; this PR's diff is the second commit.

## The gap

`ScheduledWakeManager._checkAndEnqueue` returned immediately when a pass was already running. That guard is right about not running two passes at once, but wrong about what to do with the trigger: it dropped it.

That matters because the re-checks armed by `_scheduleRecheck` — for the lease settle and for lease expiry — are **one-shot** timers. The periodic tick is hourly, so a foreign lease expiring at 06:34 while another pass happened to be in flight was not delayed to 06:35, it was lost until 07:00.

Not specific to leases: any trigger arriving mid-pass was dropped silently.

## The fix

Record that the pass was asked again, and re-run once when it finishes. Coalescing rather than queueing is deliberate — the point is to answer the triggers, not to replay one pass per dropped trigger, and each pass re-reads the records anyway.

A `stop()` during the pass cancels the queued re-run: the generation it was queued under is gone, and a restarted manager owns the schedule.

The pass body moved into `_runPass` so the loop can own `_isChecking`; the body itself is unchanged apart from losing its `finally`.

## Tests

- a tick landing during an in-flight pass re-runs it once the pass completes, without waiting for another tick;
- three ticks during one pass coalesce into a single re-run;
- a stop during the pass cancels the queued re-run.

The first two fail with the coalescing reverted. The third asserts an absence and passes either way — it guards the generation check against a future simplification.

No CHANGELOG entry: no user-visible behaviour outside the unreleased lease work, and the exposure was a delayed takeover, not a lost digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled wake reliability during overlapping checks and restarts.
  * Prevented duplicate wake-ups, including when processing is interrupted or partially fails.
  * Preserved deferred work and ensured newly due agents are detected promptly.
  * Stopped canceled or outdated checks from running after shutdown or restart.

* **Documentation**
  * Expanded the coordination protocol with guidance for lease handling, trigger coalescing, and restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->