### PR TITLE
chore: remove unused settings and cache code

### DIFF
--- a/lib/database/database_config_flags.dart
+++ b/lib/database/database_config_flags.dart
@@ -58,30 +58,6 @@ mixin _JournalDbConfigFlags on _$JournalDb {
     }, isBroadcast: true);
   }
 
-  Stream<Set<String>> watchActiveConfigFlagNames() {
-    return watchConfigFlags().map((configFlags) {
-      final activeFlags = <String>{};
-      for (final flag in configFlags) {
-        if (flag.status) {
-          activeFlags.add(flag.name);
-        }
-      }
-      return activeFlags;
-    });
-  }
-
-  bool findConfigFlag(String flagName, List<ConfigFlag> flags) {
-    var flag = false;
-
-    for (final configFlag in flags) {
-      if (configFlag.name == flagName) {
-        flag = configFlag.status;
-      }
-    }
-
-    return flag;
-  }
-
   Future<bool> getConfigFlag(String flagName) async {
     await _ensureConfigFlagsLoaded();
     return _configFlagsByName[flagName]?.status ?? false;
@@ -136,14 +112,6 @@ mixin _JournalDbConfigFlags on _$JournalDb {
     final result = await into(configFlags).insertOnConflictUpdate(configFlag);
     _setConfigFlag(configFlag);
     return result;
-  }
-
-  Future<void> toggleConfigFlag(String flagName) async {
-    final configFlag = await getConfigFlagByName(flagName);
-
-    if (configFlag != null) {
-      await upsertConfigFlag(configFlag.copyWith(status: !configFlag.status));
-    }
   }
 
   Future<List<bool>> _visiblePrivateStatuses() async {

--- a/lib/database/notifications_db.dart
+++ b/lib/database/notifications_db.dart
@@ -61,22 +61,6 @@ class NotificationsDb extends _$NotificationsDb {
     return rows.map(notificationFromDbEntity).toList();
   }
 
-  Future<int> unseenCount(DateTime now) async {
-    final row = await customSelect(
-      '''
-          SELECT COUNT(*) AS amount
-          FROM notifications
-          WHERE scheduled_for <= ?
-            AND seen_at IS NULL
-            AND acted_on_at IS NULL
-            AND deleted_at IS NULL
-          ''',
-      variables: [Variable<DateTime>(now)],
-      readsFrom: {notifications},
-    ).getSingle();
-    return row.read<int>('amount');
-  }
-
   // Read-modify-write under a Drift transaction so concurrent callers cannot
   // interleave and overwrite each other's vector-clock or lifecycle updates.
   Future<NotificationEntity?> upsertNotification(

--- a/lib/features/design_system/components/celebration/celebration_selection.dart
+++ b/lib/features/design_system/components/celebration/celebration_selection.dart
@@ -132,10 +132,7 @@ class CombineSelection extends CelebrationSelection {
 /// A process-wide monotonic counter that feeds [CelebrationSelection.resolve],
 /// so Random / Combine roll a new look on *every* completion across the app
 /// (rather than per build). Not for security — just to advance the deterministic
-/// resolve seed. Reset between tests via [debugResetCelebrationSeed].
+/// resolve seed.
 int _celebrationSeed = 0;
 
 int nextCelebrationSeed() => _celebrationSeed++;
-
-@visibleForTesting
-void debugResetCelebrationSeed() => _celebrationSeed = 0;

--- a/lib/features/settings_v2/domain/settings_node.dart
+++ b/lib/features/settings_v2/domain/settings_node.dart
@@ -1,32 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-/// Visual tone of a [NodeBadge]. Each tone resolves to a background /
-/// text pair in the design-system palette when the badge renders.
-enum NodeTone { info, teal, error }
-
 /// An immediate action a Settings tree row can perform without opening a
 /// settings detail panel.
 enum SettingsNodeAction { openManual }
-
-/// Small pill rendered to the right of a tree-row title — used for the
-/// "v2.4" (info), "Live" (teal) and "Retry" (error) cases seen in the
-/// Figma reference.
-@immutable
-class NodeBadge {
-  const NodeBadge({required this.label, required this.tone});
-
-  final String label;
-  final NodeTone tone;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is NodeBadge && other.label == label && other.tone == tone;
-
-  @override
-  int get hashCode => Object.hash(label, tone);
-}
 
 /// One node in the Settings tree. Branch nodes carry [children]; internal
 /// leaves carry [panel] (the id of the widget to render in the detail pane),
@@ -45,7 +22,6 @@ class SettingsNode {
     required this.desc,
     this.children,
     this.panel,
-    this.badge,
     this.action,
     this.sectionBreakBefore = false,
   });
@@ -73,9 +49,6 @@ class SettingsNode {
   /// should set this; action leaves and most branches leave it `null`.
   final String? panel;
 
-  /// Optional trailing pill.
-  final NodeBadge? badge;
-
   /// Immediate behavior for a non-navigational leaf, such as opening an
   /// external support resource. Action leaves intentionally have no panel.
   final SettingsNodeAction? action;
@@ -99,7 +72,6 @@ class SettingsNode {
           other.title == title &&
           other.desc == desc &&
           other.panel == panel &&
-          other.badge == badge &&
           other.action == action &&
           other.sectionBreakBefore == sectionBreakBefore &&
           listEquals(other.children, children);
@@ -111,7 +83,6 @@ class SettingsNode {
     title,
     desc,
     panel,
-    badge,
     action,
     sectionBreakBefore,
     children == null ? null : Object.hashAll(children!),

--- a/lib/features/settings_v2/domain/settings_tree_data.dart
+++ b/lib/features/settings_v2/domain/settings_tree_data.dart
@@ -34,7 +34,6 @@ List<SettingsNode> buildSettingsTree({
     String id,
     IconData icon, {
     String? panel,
-    NodeBadge? badge,
     SettingsNodeAction? action,
     bool sectionBreakBefore = false,
   }) {
@@ -45,7 +44,6 @@ List<SettingsNode> buildSettingsTree({
       title: l.title,
       desc: l.desc,
       panel: panel,
-      badge: badge,
       action: action,
       sectionBreakBefore: sectionBreakBefore,
     );
@@ -55,7 +53,6 @@ List<SettingsNode> buildSettingsTree({
     String id,
     IconData icon, {
     required List<SettingsNode> children,
-    NodeBadge? badge,
     String? panel,
   }) {
     final l = labels(id);
@@ -65,15 +62,9 @@ List<SettingsNode> buildSettingsTree({
       title: l.title,
       desc: l.desc,
       children: children,
-      badge: badge,
       panel: panel,
     );
   }
-
-  // Badges carry localized marketing copy (e.g. "v2.4", "Live") and
-  // stay off the tree until the i18n sweep lands. The [NodeBadge]
-  // type and rendering path remain in place so re-introducing them
-  // later is a one-liner per node.
 
   return [
     if (enableWhatsNew)

--- a/lib/features/settings_v2/ui/settings_v2_constants.dart
+++ b/lib/features/settings_v2/ui/settings_v2_constants.dart
@@ -28,9 +28,6 @@ class SettingsV2Constants {
   /// Chevron glyph size.
   static const double chevronSize = 18;
 
-  /// Badge chip.
-  static const double badgeHeight = 20;
-
   /// Nested-children indent rail.
   static const double childrenRailWidth = 1.5;
   static const double childrenRailAlpha = 0.28;
@@ -46,10 +43,6 @@ class SettingsV2Constants {
   /// mobile Sync list used before it was folded into the shared tree, so
   /// the Sync rows keep their teal-on-tinted-tile look.
   static const double accentTileFillAlpha = 0.12;
-
-  /// Badge background alpha (all tones share the same fill-to-text
-  /// contrast ratio).
-  static const double badgeBackgroundAlpha = 0.16;
 
   /// Animation durations (spec §3 "Motion").
   static const Duration rowFillTransition = Duration(milliseconds: 180);

--- a/lib/features/settings_v2/ui/tree/settings_node_indicators.dart
+++ b/lib/features/settings_v2/ui/tree/settings_node_indicators.dart
@@ -1,15 +1,13 @@
 import 'package:flutter/widgets.dart';
-import 'package:lotti/features/settings_v2/domain/settings_node.dart'
-    show NodeBadge;
 import 'package:lotti/features/settings_v2/ui/tree/outbox_count_indicator.dart';
 import 'package:lotti/features/settings_v2/ui/tree/settings_tree_row.dart'
     show SettingsTreeRow;
 
 /// Builds a live trailing indicator for a settings-tree row, by node id.
 ///
-/// Most rows have no live indicator; the static [NodeBadge] on the node
-/// covers fixed pills. This registry is for the handful of rows that need
-/// a *reactive* trailing widget (a stream-backed count, status dot, …) —
+/// Most rows have no live indicator. This registry is for the handful of rows
+/// that need a *reactive* trailing widget (a stream-backed count, status dot,
+/// …) —
 /// e.g. the `sync/outbox` pending count. Keyed by node id so the desktop
 /// tree view and the mobile drill-down render the same indicator from one
 /// definition, and [SettingsTreeRow] itself stays presentational (it just

--- a/lib/features/settings_v2/ui/tree/settings_tree_row.dart
+++ b/lib/features/settings_v2/ui/tree/settings_tree_row.dart
@@ -4,7 +4,7 @@ import 'package:lotti/features/settings_v2/domain/settings_node.dart';
 import 'package:lotti/features/settings_v2/ui/settings_v2_constants.dart';
 
 /// Renders one tree row per spec §3 "Row anatomy": left active rail,
-/// icon tile, title + description column, optional badge, chevron.
+/// icon tile, title + description column, optional live indicator, chevron.
 ///
 /// Stateless on purpose — visibility of the rail + chevron rotation
 /// + selected styling are all derived from the props so parents can
@@ -35,7 +35,7 @@ class SettingsTreeRow extends StatelessWidget {
   final bool accentIcon;
 
   /// Optional live trailing widget (e.g. the `sync/outbox` pending count),
-  /// rendered between the static [NodeBadge] and the chevron. Supplied by
+  /// rendered before the chevron. Supplied by
   /// the build sites via `settingsNodeIndicatorFor(node.id)` so the row
   /// stays presentational and the indicator owns its own (reactive) state.
   final Widget? trailing;
@@ -185,11 +185,6 @@ class SettingsTreeRow extends StatelessWidget {
                     ],
                   ),
                 ),
-                // Optional badge
-                if (node.badge case final badge?) ...[
-                  SizedBox(width: tokens.spacing.step3),
-                  _NodeBadgeChip(badge: badge, tokens: tokens),
-                ],
                 // Optional live indicator (e.g. outbox pending count).
                 if (trailing case final trailing?) ...[
                   SizedBox(width: tokens.spacing.step3),
@@ -214,48 +209,6 @@ class SettingsTreeRow extends StatelessWidget {
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _NodeBadgeChip extends StatelessWidget {
-  const _NodeBadgeChip({required this.badge, required this.tokens});
-
-  final NodeBadge badge;
-  final DsTokens tokens;
-
-  @override
-  Widget build(BuildContext context) {
-    const bgAlpha = SettingsV2Constants.badgeBackgroundAlpha;
-    final (bg, fg) = switch (badge.tone) {
-      NodeTone.info => (
-        tokens.colors.alert.info.defaultColor.withValues(alpha: bgAlpha),
-        tokens.colors.alert.info.ink,
-      ),
-      NodeTone.teal => (
-        tokens.colors.interactive.enabled.withValues(alpha: bgAlpha),
-        tokens.colors.interactive.enabled,
-      ),
-      NodeTone.error => (
-        tokens.colors.alert.error.defaultColor.withValues(alpha: bgAlpha),
-        tokens.colors.alert.error.ink,
-      ),
-    };
-    return Container(
-      height: SettingsV2Constants.badgeHeight,
-      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step3),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(tokens.radii.xl),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        badge.label,
-        style: tokens.typography.styles.others.caption.copyWith(
-          color: fg,
-          fontWeight: FontWeight.w600,
         ),
       ),
     );

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -99,14 +99,20 @@ final GetIt getIt = GetIt.instance;
 Future<void> registerSingletons() async {
   getIt
     ..registerSingleton<Fts5Db>(Fts5Db())
-    ..registerSingleton<UserActivityService>(UserActivityService())
+    ..registerSingleton<UserActivityService>(
+      UserActivityService(),
+      dispose: (service) => service.dispose(),
+    )
     ..registerSingleton<UserActivityGate>(
       UserActivityGate(
         activityService: getIt<UserActivityService>(),
         idleThreshold: SyncTuning.outboxIdleThreshold,
       ),
     )
-    ..registerSingleton<UpdateNotifications>(UpdateNotifications())
+    ..registerSingleton<UpdateNotifications>(
+      UpdateNotifications(),
+      dispose: (notifications) => notifications.dispose(),
+    )
     ..registerSingleton<SyncActivitySignaler>(
       SyncActivitySignaler(),
       dispose: (signaler) => signaler.dispose(),
@@ -153,7 +159,10 @@ Future<void> registerSingletons() async {
     updateNotifications: getIt<UpdateNotifications>(),
   );
   await entitiesCacheService.init();
-  getIt.registerSingleton<EntitiesCacheService>(entitiesCacheService);
+  getIt.registerSingleton<EntitiesCacheService>(
+    entitiesCacheService,
+    dispose: (service) => service.dispose(),
+  );
 
   final aiConfigRepository = AiConfigRepository(AiConfigDb());
   getIt.registerSingleton<AiConfigRepository>(aiConfigRepository);
@@ -739,7 +748,10 @@ Future<void> registerSingletons() async {
     )
     ..registerSingleton<LinkService>(LinkService())
     ..registerSingleton<Maintenance>(Maintenance())
-    ..registerSingleton<NavService>(NavService());
+    ..registerSingleton<NavService>(
+      NavService(),
+      dispose: (service) => service.dispose(),
+    );
 
   await _registerLateAndOptionalServices();
 }

--- a/lib/services/entities_cache_service.dart
+++ b/lib/services/entities_cache_service.dart
@@ -21,8 +21,6 @@ class EntitiesCacheService {
   Map<String, HabitDefinition> habitsById = {};
   Map<String, DashboardDefinition> dashboardsById = {};
   Map<String, LabelDefinition> labelsById = {};
-  Map<String, List<LabelDefinition>> labelsByCategoryId = {};
-  final List<LabelDefinition> _globalLabels = [];
   bool _showPrivateEntries = false;
 
   // Per-type fetch serialization flags
@@ -118,10 +116,6 @@ class EntitiesCacheService {
       for (final item in items) {
         categoriesById[item.id] = item;
       }
-      // Prune stale category keys from label lookup when categories change
-      labelsByCategoryId.removeWhere(
-        (catId, _) => !categoriesById.containsKey(catId),
-      );
     } finally {
       _categoriesLoading = false;
       if (_categoriesPending) {
@@ -191,31 +185,6 @@ class EntitiesCacheService {
         labelsById[label.id] = label;
       }
 
-      // Rebuild label lookup buckets
-      labelsByCategoryId.clear();
-      _globalLabels.clear();
-      for (final label in labels) {
-        if (label.deletedAt != null) continue;
-        final cats = label.applicableCategoryIds;
-        if (cats == null || cats.isEmpty) {
-          _globalLabels.add(label);
-        } else {
-          for (final catId in cats) {
-            labelsByCategoryId
-                .putIfAbsent(catId, () => <LabelDefinition>[])
-                .add(label);
-          }
-        }
-      }
-      // Sort buckets by label name (case-insensitive)
-      _globalLabels.sort(
-        (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      );
-      for (final entry in labelsByCategoryId.entries) {
-        entry.value.sort(
-          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-        );
-      }
     } finally {
       _labelsLoading = false;
       if (_labelsPending) {
@@ -270,34 +239,6 @@ class EntitiesCacheService {
             .where((label) => _showPrivateEntries || !(label.private ?? false))
             .toList()
           ..sortBy((label) => label.name.toLowerCase());
-    return res;
-  }
-
-  List<LabelDefinition> get globalLabels => List.unmodifiable(_globalLabels);
-
-  /// Returns union of global labels and labels scoped to [categoryId],
-  /// optionally filtering private entries based on [includePrivate].
-  List<LabelDefinition> availableLabelsForCategory(
-    String? categoryId, {
-    bool? includePrivate,
-  }) {
-    final allowPrivate = includePrivate ?? _showPrivateEntries;
-    final dedup = <String, LabelDefinition>{};
-    bool isVisible(LabelDefinition l) =>
-        l.deletedAt == null && (allowPrivate || !(l.private ?? false));
-
-    for (final l in _globalLabels.where(isVisible)) {
-      dedup[l.id] = l;
-    }
-    if (categoryId != null) {
-      final bucket =
-          labelsByCategoryId[categoryId] ?? const <LabelDefinition>[];
-      for (final l in bucket.where(isVisible)) {
-        dedup[l.id] = l;
-      }
-    }
-    final res = dedup.values.toList()
-      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
     return res;
   }
 

--- a/lib/services/portals/portal_service.dart
+++ b/lib/services/portals/portal_service.dart
@@ -26,7 +26,6 @@ class PortalConstants {
   static const String screenshotServiceName = 'ScreenshotPortalService';
 
   // Domain names for logging
-  static const String portalServiceDomain = 'PortalService';
   static const String initializationSubdomain = 'initialization';
   static const String availabilitySubdomain = 'isAvailable';
 
@@ -77,8 +76,6 @@ abstract class PortalService {
       _initialized = false;
     }
   }
-
-  bool get isInitialized => _initialized;
 
   DBusClient get client {
     if (!_initialized) {
@@ -182,17 +179,16 @@ abstract class PortalService {
     PortalService service,
     String serviceName,
   ) async {
-    if (!shouldUsePortal) {
-      // Handle non-Flatpak environments
-      switch (serviceName) {
-        case PortalConstants.screenshotServiceName:
-          return false; // Screenshots require portal
-        default:
-          return false;
-      }
-    }
-
     try {
+      if (!shouldUsePortal) {
+        // Handle non-Flatpak environments
+        switch (serviceName) {
+          case PortalConstants.screenshotServiceName:
+            return false; // Screenshots require portal
+          default:
+            return false;
+        }
+      }
       await service.initialize();
       final object = service.createPortalObject();
       final introspection = await object.introspect().timeout(
@@ -215,6 +211,8 @@ abstract class PortalService {
         );
       }
       return false;
+    } finally {
+      await service.dispose();
     }
   }
 }

--- a/lib/services/portals/screenshot_portal_service.dart
+++ b/lib/services/portals/screenshot_portal_service.dart
@@ -37,9 +37,8 @@ class ScreenshotPortalService extends PortalService {
       );
     }
 
-    await initialize();
-
     try {
+      await initialize();
       final object = createPortalObject();
 
       // Options for the screenshot
@@ -155,6 +154,8 @@ class ScreenshotPortalService extends PortalService {
         subDomain: 'takeScreenshot',
       );
       rethrow;
+    } finally {
+      await dispose();
     }
   }
 

--- a/test/database/database_config_flags_test.dart
+++ b/test/database/database_config_flags_test.dart
@@ -12,19 +12,6 @@ import 'package:mocktail/mocktail.dart';
 import '../mocks/mocks.dart';
 import 'test_utils.dart';
 
-/// The names of every flag [initConfigFlags] seeds **on**, derived from
-/// [expectedFlags] rather than restated.
-///
-/// Both sets describe the same seeded rows, so restating the active names by
-/// hand made a seed-default flip a two-place edit -- and missing the second
-/// place failed here rather than at the flag's own test. Deriving keeps the
-/// active-names expectation correct by construction: updating a `status:` in
-/// [expectedFlags] is now the whole edit.
-final Set<String> expectedActiveFlagNames = {
-  for (final flag in expectedFlags)
-    if (flag.status) flag.name,
-};
-
 final expectedFlags = <ConfigFlag>{
   const ConfigFlag(
     name: privateFlag,
@@ -217,7 +204,8 @@ void main() {
           ),
         );
 
-        await db?.toggleConfigFlag(recordLocationFlag);
+        final flag = await db?.getConfigFlagByName(recordLocationFlag);
+        await db?.upsertConfigFlag(flag!.copyWith(status: !flag.status));
 
         expect(
           await db?.getConfigFlagByName(recordLocationFlag),
@@ -242,7 +230,7 @@ void main() {
             .watchConfigFlag(recordLocationFlag)
             .take(2)
             .toList();
-        await db!.toggleConfigFlag(recordLocationFlag);
+        await db!.upsertConfigFlag(existingFlag.copyWith(status: true));
 
         expect(await emittedValuesFuture, [false, true]);
       },
@@ -255,55 +243,23 @@ void main() {
         await db!.upsertConfigFlag(existingFlag!.copyWith(status: false));
 
         final emittedFlagsFuture = db!.watchConfigFlags().take(2).toList();
-        await db!.toggleConfigFlag(recordLocationFlag);
+        await db!.upsertConfigFlag(existingFlag.copyWith(status: true));
         final emittedFlags = await emittedFlagsFuture;
         final initialFlags = emittedFlags.first;
         expect(
-          db!.findConfigFlag(recordLocationFlag, initialFlags.toList()),
+          initialFlags
+              .singleWhere((flag) => flag.name == recordLocationFlag)
+              .status,
           false,
         );
         final updatedFlags = emittedFlags.last;
 
         expect(
-          db!.findConfigFlag(recordLocationFlag, updatedFlags.toList()),
+          updatedFlags
+              .singleWhere((flag) => flag.name == recordLocationFlag)
+              .status,
           true,
         );
-      },
-    );
-
-    test(
-      'watchActiveConfigFlagNames returns active flag names correctly',
-      () async {
-        final existingFlag = await db!.getConfigFlagByName(recordLocationFlag);
-        await db!.upsertConfigFlag(existingFlag!.copyWith(status: false));
-
-        final emittedFlagsFuture = db!
-            .watchActiveConfigFlagNames()
-            .take(2)
-            .toList();
-        await db!.toggleConfigFlag(recordLocationFlag);
-        final emittedFlags = await emittedFlagsFuture;
-        final activeFlags = emittedFlags.first;
-        expect(activeFlags, expectedActiveFlagNames);
-        final updatedFlags = emittedFlags.last;
-        expect(updatedFlags, {...expectedActiveFlagNames, recordLocationFlag});
-      },
-    );
-
-    test(
-      'findConfigFlag finds config flag status correctly',
-      () async {
-        final flags = await db?.listConfigFlags().get();
-        expect(flags, isNotNull);
-
-        final result = db?.findConfigFlag(privateFlag, flags!);
-        expect(result, true);
-
-        final result2 = db?.findConfigFlag(recordLocationFlag, flags!);
-        expect(result2, false);
-
-        final result3 = db?.findConfigFlag('non-existent-flag', flags!);
-        expect(result3, false);
       },
     );
 

--- a/test/database/database_definitions_test.dart
+++ b/test/database/database_definitions_test.dart
@@ -460,7 +460,8 @@ void main() {
           expect((await db!.getLabelUsageCounts())['lbl-usage-priv'], 2);
 
           // With the flag off, the private entry's label no longer counts.
-          await db!.toggleConfigFlag(privateFlag);
+          final flag = await db!.getConfigFlagByName(privateFlag);
+          await db!.upsertConfigFlag(flag!.copyWith(status: false));
           expect((await db!.getLabelUsageCounts())['lbl-usage-priv'], 1);
         },
       );

--- a/test/database/database_task_queries_test.dart
+++ b/test/database/database_task_queries_test.dart
@@ -438,7 +438,8 @@ void main() {
           // Toggle explicitly to guarantee [false].
           final showPrivate = await db!.getConfigFlag('private');
           if (showPrivate) {
-            await db!.toggleConfigFlag('private');
+            final flag = await db!.getConfigFlagByName('private');
+            await db!.upsertConfigFlag(flag!.copyWith(status: false));
           }
 
           final results = await db!.getTasksSortedByDueDate(

--- a/test/database/journal_db/config_flags_test.dart
+++ b/test/database/journal_db/config_flags_test.dart
@@ -136,7 +136,8 @@ void main() {
       await initConfigFlags(db, inMemoryDatabase: true);
       // An existing install enabled Daily OS before the rollout flag was
       // temporarily removed from the app's seed list.
-      await db.toggleConfigFlag(enableDailyOsPageFlag);
+      final flag = await db.getConfigFlagByName(enableDailyOsPageFlag);
+      await db.upsertConfigFlag(flag!.copyWith(status: !flag.status));
       expect(await getStatus(enableDailyOsPageFlag), isTrue);
 
       // Re-running init should not reset their toggle.

--- a/test/database/notifications_db_test.dart
+++ b/test/database/notifications_db_test.dart
@@ -68,7 +68,6 @@ void main() {
         (await db.upcoming(now)).map((entity) => entity.id),
         ['upcoming'],
       );
-      expect(await db.unseenCount(now), 1);
       expect(
         (await db.forLinkedEntity('task-1')).map((entity) => entity.id),
         ['upcoming', 'due'],

--- a/test/features/design_system/components/celebration/celebration_selection_test.dart
+++ b/test/features/design_system/components/celebration/celebration_selection_test.dart
@@ -125,7 +125,6 @@ void main() {
 
   group('nextCelebrationSeed', () {
     test('advances on every call so surprise modes re-roll', () {
-      debugResetCelebrationSeed();
       final a = nextCelebrationSeed();
       final b = nextCelebrationSeed();
       final c = nextCelebrationSeed();

--- a/test/features/design_system/components/celebration/completion_celebration_test.dart
+++ b/test/features/design_system/components/celebration/completion_celebration_test.dart
@@ -265,7 +265,6 @@ void main() {
       tester,
     ) async {
       // Deterministic seed so the resolved pair is reproducible.
-      debugResetCelebrationSeed();
       Widget tree({required bool completed}) => makeTestableWidget(
         CompletionCelebration(
           completed: completed,

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -451,7 +451,6 @@ void main() {
     testWidgets('a combine selection layers a distinct second variant', (
       tester,
     ) async {
-      debugResetCelebrationSeed();
       await pumpRow(
         tester,
         extraOverrides: [

--- a/test/features/settings/ui/widgets/celebration_preview_stage_test.dart
+++ b/test/features/settings/ui/widgets/celebration_preview_stage_test.dart
@@ -110,7 +110,6 @@ void main() {
   testWidgets('a combine selection fires a layered (two-variant) burst', (
     tester,
   ) async {
-    debugResetCelebrationSeed();
     await tester.pumpWidget(
       makeTestableWidgetWithScaffold(
         const CelebrationPreviewStage(),

--- a/test/features/settings_v2/domain/settings_node_test.dart
+++ b/test/features/settings_v2/domain/settings_node_test.dart
@@ -3,44 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/settings_v2/domain/settings_node.dart';
 
 void main() {
-  group('NodeBadge', () {
-    test('two badges with identical label and tone are equal', () {
-      const a = NodeBadge(label: 'Live', tone: NodeTone.teal);
-      const b = NodeBadge(label: 'Live', tone: NodeTone.teal);
-      expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
-    });
-
-    test('badges differing only in label are not equal', () {
-      const a = NodeBadge(label: 'Live', tone: NodeTone.teal);
-      const b = NodeBadge(label: 'Beta', tone: NodeTone.teal);
-      expect(a, isNot(equals(b)));
-    });
-
-    test('badges differing only in tone are not equal', () {
-      const a = NodeBadge(label: 'v2.4', tone: NodeTone.info);
-      const b = NodeBadge(label: 'v2.4', tone: NodeTone.error);
-      expect(a, isNot(equals(b)));
-    });
-
-    test('a badge is not equal to an unrelated value', () {
-      const badge = NodeBadge(label: 'Live', tone: NodeTone.teal);
-      // ignore: unrelated_type_equality_checks
-      expect(badge == 'Live', isFalse);
-    });
-
-    test('identity short-circuit: a badge equals itself', () {
-      const badge = NodeBadge(label: 'Live', tone: NodeTone.teal);
-      expect(badge == badge, isTrue);
-    });
-  });
-
-  group('NodeTone', () {
-    test('exposes exactly info, teal and error values', () {
-      expect(NodeTone.values, [NodeTone.info, NodeTone.teal, NodeTone.error]);
-    });
-  });
-
   group('SettingsNode.hasChildren', () {
     test('is true when children is a non-empty list', () {
       const node = SettingsNode(
@@ -93,7 +55,6 @@ void main() {
       title: 'Backfill',
       desc: 'Fill gaps',
       panel: 'sync-backfill',
-      badge: NodeBadge(label: 'Live', tone: NodeTone.teal),
     );
 
     test('structurally identical leaves compare equal', () {
@@ -108,7 +69,6 @@ void main() {
         title: base().title,
         desc: base().desc,
         panel: base().panel,
-        badge: base().badge,
       );
       expect(base(), isNot(equals(other)));
     });
@@ -120,7 +80,6 @@ void main() {
         title: base().title,
         desc: base().desc,
         panel: base().panel,
-        badge: base().badge,
       );
       expect(base(), isNot(equals(other)));
     });
@@ -132,7 +91,6 @@ void main() {
         title: 'Other',
         desc: base().desc,
         panel: base().panel,
-        badge: base().badge,
       );
       expect(base(), isNot(equals(other)));
     });
@@ -144,7 +102,6 @@ void main() {
         title: base().title,
         desc: 'Other desc',
         panel: base().panel,
-        badge: base().badge,
       );
       expect(base(), isNot(equals(other)));
     });
@@ -156,19 +113,6 @@ void main() {
         title: base().title,
         desc: base().desc,
         panel: 'other-panel',
-        badge: base().badge,
-      );
-      expect(base(), isNot(equals(other)));
-    });
-
-    test('differing only in badge is not equal', () {
-      final other = SettingsNode(
-        id: base().id,
-        icon: base().icon,
-        title: base().title,
-        desc: base().desc,
-        panel: base().panel,
-        badge: const NodeBadge(label: 'Beta', tone: NodeTone.info),
       );
       expect(base(), isNot(equals(other)));
     });

--- a/test/features/settings_v2/domain/settings_tree_data_test.dart
+++ b/test/features/settings_v2/domain/settings_tree_data_test.dart
@@ -237,9 +237,9 @@ void main() {
       expect(_ids(_tree(enableWhatsNew: false)), isNot(contains('whats-new')));
     });
 
-    test('includes whats-new with no badge when on', () {
+    test('includes whats-new when on', () {
       final whatsNew = _tree().firstWhere((n) => n.id == 'whats-new');
-      expect(whatsNew.badge, isNull);
+      expect(whatsNew.panel, 'whats-new');
     });
   });
 
@@ -256,7 +256,6 @@ void main() {
         'agents/souls',
         'agents/pending-wakes',
       ]);
-      expect(agents.badge, isNull);
     });
   });
 

--- a/test/features/settings_v2/ui/tree/settings_tree_row_test.dart
+++ b/test/features/settings_v2/ui/tree/settings_tree_row_test.dart
@@ -9,13 +9,12 @@ import 'package:lotti/features/settings_v2/ui/tree/settings_tree_row.dart';
 
 import '../../../../widget_test_utils.dart';
 
-SettingsNode _branch({NodeBadge? badge}) => SettingsNode(
+SettingsNode _branch() => const SettingsNode(
   id: 'sync',
   icon: Icons.sync_rounded,
   title: 'Sync',
   desc: 'Configure sync and view stats',
-  badge: badge,
-  children: const [
+  children: [
     SettingsNode(
       id: 'sync/backfill',
       icon: Icons.cloud_download_outlined,
@@ -26,14 +25,13 @@ SettingsNode _branch({NodeBadge? badge}) => SettingsNode(
   ],
 );
 
-SettingsNode _leaf({NodeBadge? badge, String desc = 'Feature flags'}) =>
+SettingsNode _leaf({String desc = 'Feature flags'}) =>
     SettingsNode(
       id: 'flags',
       icon: Icons.flag_outlined,
       title: 'Flags',
       desc: desc,
       panel: 'flags',
-      badge: badge,
     );
 
 Future<void> _pumpRow(
@@ -217,36 +215,6 @@ void main() {
       // Minimum (not fixed) height: a single-line row sits at the floor;
       // a wrapped 2-line row would be taller, never clipped.
       expect(size.height, greaterThanOrEqualTo(SettingsV2Constants.rowHeight));
-    });
-  });
-
-  group('SettingsTreeRow — badge', () {
-    testWidgets('renders a badge label when present', (tester) async {
-      await _pumpRow(
-        tester,
-        node: _leaf(
-          badge: const NodeBadge(label: 'v2.4', tone: NodeTone.info),
-        ),
-      );
-      expect(find.text('v2.4'), findsOneWidget);
-    });
-
-    testWidgets('omits the badge chip when no badge is set', (tester) async {
-      await _pumpRow(tester, node: _leaf());
-      expect(find.text('v2.4'), findsNothing);
-      expect(find.text('Live'), findsNothing);
-    });
-
-    testWidgets('renders each NodeTone without throwing', (tester) async {
-      for (final tone in NodeTone.values) {
-        await _pumpRow(
-          tester,
-          node: _leaf(
-            badge: NodeBadge(label: tone.name, tone: tone),
-          ),
-        );
-        expect(find.text(tone.name), findsOneWidget);
-      }
     });
   });
 

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -214,7 +214,6 @@ class MockJournalDb extends Mock implements JournalDb {
     bool requireNew = false,
   }) => action();
 
-  @override
   Stream<Set<String>> watchActiveConfigFlagNames() {
     try {
       final result = super.noSuchMethod(

--- a/test/services/entities_cache_service_test.dart
+++ b/test/services/entities_cache_service_test.dart
@@ -25,12 +25,6 @@ enum _GeneratedLabelScope {
   cat2AndOrphan,
 }
 
-enum _GeneratedIncludePrivateOverride {
-  useConfig,
-  include,
-  exclude,
-}
-
 class _GeneratedLabelSpec {
   const _GeneratedLabelSpec({
     required this.seed,
@@ -88,13 +82,11 @@ class _GeneratedEntitiesCacheScenario {
   const _GeneratedEntitiesCacheScenario({
     required this.labelSpecs,
     required this.privateFlag,
-    required this.includePrivateOverride,
     required this.categorySlot,
   });
 
   final List<_GeneratedLabelSpec> labelSpecs;
   final bool privateFlag;
-  final _GeneratedIncludePrivateOverride includePrivateOverride;
   final int categorySlot;
 
   List<CategoryDefinition> get categories {
@@ -128,29 +120,6 @@ class _GeneratedEntitiesCacheScenario {
       4 => 'cat-2',
       _ => 'cat-3',
     };
-  }
-
-  bool? get includePrivate {
-    return switch (includePrivateOverride) {
-      _GeneratedIncludePrivateOverride.useConfig => null,
-      _GeneratedIncludePrivateOverride.include => true,
-      _GeneratedIncludePrivateOverride.exclude => false,
-    };
-  }
-
-  bool get effectiveIncludePrivate => includePrivate ?? privateFlag;
-
-  List<String> expectedAvailableIds() {
-    final scoped =
-        labels
-            .where((label) => _isVisible(label, includePrivate: true))
-            .where(_appliesToCategory)
-            .where(
-              (label) => effectiveIncludePrivate || !(label.private ?? false),
-            )
-            .toList()
-          ..sort(_compareLabelsByName);
-    return scoped.map((label) => label.id).toList();
   }
 
   List<String> expectedFilteredIds() {
@@ -195,7 +164,6 @@ class _GeneratedEntitiesCacheScenario {
   String toString() {
     return '_GeneratedEntitiesCacheScenario('
         'labelSpecs: $labelSpecs, privateFlag: $privateFlag, '
-        'includePrivateOverride: $includePrivateOverride, '
         'categorySlot: $categorySlot)';
   }
 }
@@ -203,10 +171,6 @@ class _GeneratedEntitiesCacheScenario {
 extension _AnyGeneratedEntitiesCacheScenario on glados.Any {
   glados.Generator<_GeneratedLabelScope> get entitiesCacheLabelScope =>
       glados.AnyUtils(this).choose(_GeneratedLabelScope.values);
-
-  glados.Generator<_GeneratedIncludePrivateOverride>
-  get entitiesCacheIncludePrivateOverride =>
-      glados.AnyUtils(this).choose(_GeneratedIncludePrivateOverride.values);
 
   glados.Generator<_GeneratedLabelSpec> get entitiesCacheLabelSpec =>
       glados.CombinableAny(this).combine4(
@@ -228,22 +192,19 @@ extension _AnyGeneratedEntitiesCacheScenario on glados.Any {
       );
 
   glados.Generator<_GeneratedEntitiesCacheScenario> get entitiesCacheScenario =>
-      glados.CombinableAny(this).combine4(
+      glados.CombinableAny(this).combine3(
         glados.ListAnys(
           this,
         ).listWithLengthInRange(0, 30, entitiesCacheLabelSpec),
         glados.AnyUtils(this).choose([false, true]),
-        entitiesCacheIncludePrivateOverride,
         glados.IntAnys(this).intInRange(0, 1000),
         (
           List<_GeneratedLabelSpec> labelSpecs,
           bool privateFlag,
-          _GeneratedIncludePrivateOverride includePrivateOverride,
           int categorySlot,
         ) => _GeneratedEntitiesCacheScenario(
           labelSpecs: labelSpecs,
           privateFlag: privateFlag,
-          includePrivateOverride: includePrivateOverride,
           categorySlot: categorySlot,
         ),
       );
@@ -351,20 +312,11 @@ void main() {
         privateFlag: scenario.privateFlag,
       );
 
-      final available = cache.availableLabelsForCategory(
-        scenario.categoryId,
-        includePrivate: scenario.includePrivate,
-      );
       final filtered = cache.filterLabelsForCategory(
         scenario.labels,
         scenario.categoryId,
       );
 
-      expect(
-        available.map((label) => label.id).toList(),
-        scenario.expectedAvailableIds(),
-        reason: scenario.toString(),
-      );
       expect(
         filtered.map((label) => label.id).toList(),
         scenario.expectedFilteredIds(),
@@ -375,66 +327,8 @@ void main() {
         scenario.expectedSortedLabelIds(),
         reason: scenario.toString(),
       );
-      expect(
-        available.map((label) => label.id).toSet(),
-        hasLength(available.length),
-        reason: 'availableLabelsForCategory must not duplicate label IDs',
-      );
     });
   }, tags: 'glados');
-
-  test('availableLabelsForCategory returns union of global + bucket', () async {
-    final work = CategoryDefinition(
-      id: 'work',
-      name: 'Work',
-      color: '#0000FF',
-      createdAt: testEpochDateTime,
-      updatedAt: testEpochDateTime,
-      vectorClock: null,
-      active: true,
-      private: false,
-    );
-    final home = CategoryDefinition(
-      id: 'home',
-      name: 'Home',
-      color: '#00FF00',
-      createdAt: testEpochDateTime,
-      updatedAt: testEpochDateTime,
-      vectorClock: null,
-      active: true,
-      private: false,
-    );
-
-    final global = testLabelDefinition1.copyWith(id: 'g', name: 'Global');
-    final scopedWork = testLabelDefinition1.copyWith(
-      id: 'w',
-      name: 'WorkOnly',
-      applicableCategoryIds: const ['work'],
-    );
-    final scopedHome = testLabelDefinition1.copyWith(
-      id: 'h',
-      name: 'HomeOnly',
-      applicableCategoryIds: const ['home'],
-    );
-    final privateLabel = testLabelDefinition1.copyWith(
-      id: 'p',
-      name: 'Private',
-      private: true,
-    );
-
-    final cache = await createCache(
-      categories: [work, home],
-      labels: [global, scopedWork, scopedHome, privateLabel],
-    );
-
-    final forWork = cache.availableLabelsForCategory('work');
-    final forHome = cache.availableLabelsForCategory('home');
-    final forNull = cache.availableLabelsForCategory(null);
-
-    expect(forWork.map((e) => e.id).toSet(), {'g', 'w'});
-    expect(forHome.map((e) => e.id).toSet(), {'g', 'h'});
-    expect(forNull.map((e) => e.id).toSet(), {'g'});
-  });
 
   test('filterLabelsForCategory filters by category scope', () async {
     final cache = await createCache();
@@ -457,312 +351,11 @@ void main() {
     expect(result.map((e) => e.id).toSet(), {'g', 'w', 'p'});
   });
 
-  test('prunes orphan category keys on categories update', () {
-    fakeAsync((async) {
-      final work = CategoryDefinition(
-        id: 'work',
-        name: 'Work',
-        color: '#0000FF',
-        createdAt: testEpochDateTime,
-        updatedAt: testEpochDateTime,
-        vectorClock: null,
-        active: true,
-        private: false,
-      );
-
-      final global = testLabelDefinition1.copyWith(id: 'g', name: 'Global');
-      final ghost = testLabelDefinition1.copyWith(
-        id: 'x',
-        name: 'Ghosted',
-        applicableCategoryIds: const ['ghost'],
-      );
-
-      final cache = createCacheSync(
-        async,
-        categories: [work],
-        labels: [global, ghost],
-        privateFlag: true,
-      );
-
-      // Before prune, ghost bucket exists
-      expect(
-        cache.availableLabelsForCategory('ghost').map((e) => e.id).toSet(),
-        {'g', 'x'},
-      );
-
-      // Trigger categories update (still only 'work') → prune removes 'ghost' key
-      when(() => journalDb.getAllCategories()).thenAnswer((_) async => [work]);
-      notifications.emit({categoriesNotification});
-      async.flushMicrotasks();
-
-      expect(
-        cache.availableLabelsForCategory('ghost').map((e) => e.id).toSet(),
-        {'g'},
-      );
-    });
-  });
-
-  test('availableLabelsForCategory respects private config flag', () {
-    fakeAsync((async) {
-      final cat = CategoryDefinition(
-        id: 'work',
-        name: 'Work',
-        color: '#0000FF',
-        createdAt: testEpochDateTime,
-        updatedAt: testEpochDateTime,
-        vectorClock: null,
-        active: true,
-        private: false,
-      );
-      final global = testLabelDefinition1.copyWith(id: 'g', name: 'Global');
-      final privGlobal = testLabelDefinition1.copyWith(
-        id: 'p',
-        name: 'Priv',
-        private: true,
-      );
-      final workPub = testLabelDefinition1.copyWith(
-        id: 'w',
-        name: 'WorkPub',
-        applicableCategoryIds: const ['work'],
-      );
-      final workPriv = testLabelDefinition1.copyWith(
-        id: 'wp',
-        name: 'WorkPriv',
-        private: true,
-        applicableCategoryIds: const ['work'],
-      );
-
-      // Start with private=false
-      final cache = createCacheSync(
-        async,
-        categories: [cat],
-        labels: [global, privGlobal, workPub, workPriv],
-      );
-
-      expect(
-        cache.availableLabelsForCategory('work').map((e) => e.id).toList(),
-        containsAllInOrder(['g', 'w']),
-      );
-      expect(
-        cache.availableLabelsForCategory('work').map((e) => e.id).toSet(),
-        isNot(containsAll(['p', 'wp'])),
-      );
-
-      // Flip to private=true via notification
-      when(
-        () => journalDb.getConfigFlag('private'),
-      ).thenAnswer((_) async => true);
-      notifications.emit({privateToggleNotification});
-      async.flushMicrotasks();
-
-      expect(
-        cache.availableLabelsForCategory('work').map((e) => e.id).toSet(),
-        containsAll(['g', 'p', 'w', 'wp']),
-      );
-    });
-  });
-
-  test(
-    'availableLabelsForCategory returns labels sorted case-insensitively',
-    () async {
-      final work = CategoryDefinition(
-        id: 'work',
-        name: 'Work',
-        color: '#0000FF',
-        createdAt: testEpochDateTime,
-        updatedAt: testEpochDateTime,
-        vectorClock: null,
-        active: true,
-        private: false,
-      );
-      final cache = await createCache(
-        categories: [work],
-        labels: [
-          testLabelDefinition1.copyWith(id: 'a', name: 'apple'),
-          testLabelDefinition1.copyWith(
-            id: 'b',
-            name: 'Banana',
-            applicableCategoryIds: const ['work'],
-          ),
-          testLabelDefinition1.copyWith(id: 'c', name: 'cherry'),
-        ],
-        privateFlag: true,
-      );
-
-      final res = cache.availableLabelsForCategory('work');
-      expect(res.map((l) => l.name).toList(), ['apple', 'Banana', 'cherry']);
-    },
-  );
-
-  test('availableLabelsForCategory handles deleted categories gracefully', () {
-    fakeAsync((async) {
-      final work = CategoryDefinition(
-        id: 'work',
-        name: 'Work',
-        color: '#0000FF',
-        createdAt: testEpochDateTime,
-        updatedAt: testEpochDateTime,
-        vectorClock: null,
-        active: true,
-        private: false,
-      );
-      final personal = CategoryDefinition(
-        id: 'personal',
-        name: 'Personal',
-        color: '#00FF00',
-        createdAt: testEpochDateTime,
-        updatedAt: testEpochDateTime,
-        vectorClock: null,
-        active: true,
-        private: false,
-      );
-      final global = testLabelDefinition1.copyWith(id: 'g', name: 'Global');
-      final scopedWork = testLabelDefinition1.copyWith(
-        id: 'w',
-        name: 'WorkOnly',
-        applicableCategoryIds: const ['work'],
-      );
-
-      final cache = createCacheSync(
-        async,
-        categories: [work, personal],
-        labels: [global, scopedWork],
-        privateFlag: true,
-      );
-
-      expect(
-        cache.availableLabelsForCategory('work').map((e) => e.id).toSet(),
-        {'g', 'w'},
-      );
-
-      // Simulate deleting the 'work' category
-      when(
-        () => journalDb.getAllCategories(),
-      ).thenAnswer((_) async => [personal]);
-      notifications.emit({categoriesNotification});
-      async.flushMicrotasks();
-
-      expect(
-        cache.availableLabelsForCategory('work').map((e) => e.id).toSet(),
-        {'g'},
-      );
-    });
-  });
-
   test('filterLabelsForCategory handles empty input list', () async {
     final cache = await createCache();
     final res = cache.filterLabelsForCategory(const [], 'any');
     expect(res, isEmpty);
   });
-
-  test('pruning cleans up multiple orphaned categories at once', () {
-    fakeAsync((async) {
-      CategoryDefinition makeCat(String id) => CategoryDefinition(
-        id: id,
-        name: id.toUpperCase(),
-        color: '#000000',
-        createdAt: testEpochDateTime,
-        updatedAt: testEpochDateTime,
-        vectorClock: null,
-        active: true,
-        private: false,
-      );
-
-      final a = makeCat('a');
-      final b = makeCat('b');
-      final c = makeCat('c');
-      final global = testLabelDefinition1.copyWith(id: 'g', name: 'Global');
-      final la = testLabelDefinition1.copyWith(
-        id: 'la',
-        name: 'A',
-        applicableCategoryIds: const ['a'],
-      );
-      final lb = testLabelDefinition1.copyWith(
-        id: 'lb',
-        name: 'B',
-        applicableCategoryIds: const ['b'],
-      );
-
-      final cache = createCacheSync(
-        async,
-        categories: [a, b, c],
-        labels: [global, la, lb],
-        privateFlag: true,
-      );
-
-      expect(
-        cache.availableLabelsForCategory('a').map((e) => e.id).toSet(),
-        {'g', 'la'},
-      );
-      expect(
-        cache.availableLabelsForCategory('b').map((e) => e.id).toSet(),
-        {'g', 'lb'},
-      );
-
-      // Drop both a and b at once
-      when(() => journalDb.getAllCategories()).thenAnswer((_) async => [c]);
-      notifications.emit({categoriesNotification});
-      async.flushMicrotasks();
-
-      expect(
-        cache.availableLabelsForCategory('a').map((e) => e.id).toSet(),
-        {'g'},
-      );
-      expect(
-        cache.availableLabelsForCategory('b').map((e) => e.id).toSet(),
-        {'g'},
-      );
-    });
-  });
-
-  test(
-    'availableLabelsForCategory de-duplicates labels present in multiple categories',
-    () async {
-      final cache = await createCache(
-        categories: [
-          CategoryDefinition(
-            id: 'a',
-            name: 'A',
-            color: '#000000',
-            createdAt: testEpochDateTime,
-            updatedAt: testEpochDateTime,
-            vectorClock: null,
-            active: true,
-            private: false,
-          ),
-          CategoryDefinition(
-            id: 'b',
-            name: 'B',
-            color: '#000000',
-            createdAt: testEpochDateTime,
-            updatedAt: testEpochDateTime,
-            vectorClock: null,
-            active: true,
-            private: false,
-          ),
-        ],
-        labels: [
-          testLabelDefinition1.copyWith(
-            id: 'multi',
-            name: 'Multi',
-            applicableCategoryIds: const ['a', 'b'],
-          ),
-          testLabelDefinition1.copyWith(id: 'g', name: 'Global'),
-        ],
-        privateFlag: true,
-      );
-
-      final ids = cache
-          .availableLabelsForCategory('a')
-          .map((e) => e.id)
-          .toList();
-      expect(
-        ids.where((id) => id == 'multi').length,
-        1,
-        reason: 'Label should not be duplicated in union',
-      );
-    },
-  );
 
   test('getDataTypeById returns data type when found', () async {
     final cache = await createCache(
@@ -898,30 +491,6 @@ void main() {
     },
   );
 
-  test('globalLabels returns only global labels sorted by name', () async {
-    final global1 = testLabelDefinition1.copyWith(id: 'g1', name: 'Zebra');
-    final global2 = testLabelDefinition1.copyWith(id: 'g2', name: 'Apple');
-    final scoped = testLabelDefinition1.copyWith(
-      id: 's',
-      name: 'Scoped',
-      applicableCategoryIds: const ['work'],
-    );
-    final deleted = testLabelDefinition1.copyWith(
-      id: 'd',
-      name: 'Deleted',
-      deletedAt: testEpochDateTime,
-    );
-
-    final cache = await createCache(
-      labels: [global1, global2, scoped, deleted],
-      privateFlag: true,
-    );
-
-    final globals = cache.globalLabels;
-    expect(globals.length, 2);
-    expect(globals.map((l) => l.name).toList(), ['Apple', 'Zebra']);
-  });
-
   test('showPrivateEntries reflects config flag', () {
     fakeAsync((async) {
       final cache = createCacheSync(async);
@@ -944,34 +513,6 @@ void main() {
       expect(cache.showPrivateEntries, false);
     });
   });
-
-  test(
-    'availableLabelsForCategory with includePrivate override ignores config flag',
-    () async {
-      final global = testLabelDefinition1.copyWith(id: 'g', name: 'Global');
-      final privateLabel = testLabelDefinition1.copyWith(
-        id: 'p',
-        name: 'Private',
-        private: true,
-      );
-
-      final cache = await createCache(labels: [global, privateLabel]);
-
-      // Config is false, but override to include private
-      final withPrivate = cache.availableLabelsForCategory(
-        null,
-        includePrivate: true,
-      );
-      expect(withPrivate.map((l) => l.id).toSet(), {'g', 'p'});
-
-      // Config is false, explicit override to exclude private
-      final withoutPrivate = cache.availableLabelsForCategory(
-        null,
-        includePrivate: false,
-      );
-      expect(withoutPrivate.map((l) => l.id).toSet(), {'g'});
-    },
-  );
 
   test('filterLabelsForCategory excludes deleted labels', () async {
     final cache = await createCache();

--- a/test/services/portals/portal_service_test.dart
+++ b/test/services/portals/portal_service_test.dart
@@ -40,19 +40,20 @@ class TestPortalService extends PortalService {
       return;
     }
     await super.initialize();
+    _isInitialized = true;
   }
 
-  @override
-  bool get isInitialized =>
-      mockClient != null ? _isInitialized : super.isInitialized;
+  bool get initializedForTesting => _isInitialized;
 
   @override
   Future<void> dispose() async {
-    if (mockClient != null) {
+    try {
+      if (mockClient == null) {
+        await super.dispose();
+      }
+    } finally {
       _isInitialized = false;
-      return;
     }
-    await super.dispose();
   }
 
   // ignore_for_file: use_setters_to_change_properties
@@ -99,9 +100,7 @@ void main() {
     });
 
     tearDown(() async {
-      if (service.isInitialized) {
-        await service.dispose();
-      }
+      await service.dispose();
       await getIt.reset();
     });
 
@@ -132,25 +131,25 @@ void main() {
         'should handle initialization when shouldUsePortal is false',
         () async {
           // Test in non-Flatpak environment
-          expect(service.isInitialized, isFalse);
+          expect(service.initializedForTesting, isFalse);
 
           await service.initialize();
 
-          expect(service.isInitialized, isTrue);
+          expect(service.initializedForTesting, isTrue);
           // Should throw StateError when accessing client in non-Flatpak mode
           expect(() => service.client, throwsStateError);
         },
       );
 
       test('should handle multiple initializations safely', () async {
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
 
         await service.initialize();
-        expect(service.isInitialized, isTrue);
+        expect(service.initializedForTesting, isTrue);
 
         // Second initialization should not cause issues
         await service.initialize();
-        expect(service.isInitialized, isTrue);
+        expect(service.initializedForTesting, isTrue);
       });
 
       test(
@@ -167,7 +166,7 @@ void main() {
 
           // Service should still initialize even if logging fails
           await failingService.initialize();
-          expect(failingService.isInitialized, isTrue);
+          expect(failingService.initializedForTesting, isTrue);
         },
       );
 
@@ -201,30 +200,30 @@ void main() {
 
     group('Disposal', () {
       test('should dispose successfully when initialized', () async {
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
 
         await service.initialize();
-        expect(service.isInitialized, isTrue);
+        expect(service.initializedForTesting, isTrue);
 
         await service.dispose();
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
       });
 
       test('should handle disposal when not initialized', () async {
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
 
         await expectLater(service.dispose(), completes);
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
       });
 
       test('should handle multiple disposals safely', () async {
         await service.initialize();
         await service.dispose();
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
 
         // Second disposal should not cause issues
         await service.dispose();
-        expect(service.isInitialized, isFalse);
+        expect(service.initializedForTesting, isFalse);
       });
     });
 
@@ -309,6 +308,9 @@ void main() {
       test(
         'should return false for ScreenshotPortalService when not in Flatpak',
         () async {
+          await service.initialize();
+          expect(service.initializedForTesting, isTrue);
+
           final available = await PortalService.isInterfaceAvailable(
             'org.freedesktop.portal.Screenshot',
             service,
@@ -316,6 +318,7 @@ void main() {
           );
 
           expect(available, isFalse);
+          expect(service.initializedForTesting, isFalse);
         },
       );
 

--- a/test/services/portals/screenshot_portal_service_test.dart
+++ b/test/services/portals/screenshot_portal_service_test.dart
@@ -51,9 +51,7 @@ void main() {
     });
 
     tearDown(() async {
-      if (service.isInitialized) {
-        await service.dispose();
-      }
+      await service.dispose();
       await getIt.reset();
     });
 
@@ -75,16 +73,6 @@ void main() {
       final hasFlatpakId = Platform.environment['FLATPAK_ID'] != null;
 
       expect(shouldUse, equals(isLinux && hasFlatpakId));
-    });
-
-    test('should initialize and dispose properly', () async {
-      expect(service.isInitialized, isFalse);
-
-      await service.initialize();
-      expect(service.isInitialized, isTrue);
-
-      await service.dispose();
-      expect(service.isInitialized, isFalse);
     });
 
     test('should throw when using uninitialized client', () {

--- a/test/utils/screenshots_test.dart
+++ b/test/utils/screenshots_test.dart
@@ -1034,10 +1034,7 @@ void main() {
         final portalService = ScreenshotPortalService();
 
         await portalService.initialize();
-        expect(portalService.isInitialized, isTrue);
-
         await portalService.dispose();
-        expect(portalService.isInitialized, isFalse);
 
         // Should not leak resources after disposal
         expect(() => portalService.client, throwsStateError);
@@ -1216,14 +1213,11 @@ void main() {
 
         final portalService = ScreenshotPortalService();
 
-        // Test initialization - should succeed even outside Flatpak
-        expect(portalService.isInitialized, isFalse);
-        await portalService.initialize();
-        expect(portalService.isInitialized, isTrue);
+        // Initialization should succeed even outside Flatpak.
+        await expectLater(portalService.initialize(), completes);
 
-        // Test disposal
-        await portalService.dispose();
-        expect(portalService.isInitialized, isFalse);
+        await expectLater(portalService.dispose(), completes);
+        expect(() => portalService.client, throwsStateError);
       });
 
       test('portal service client access should fail outside Flatpak', () {
@@ -1268,20 +1262,16 @@ void main() {
     group('Portal Service Lifecycle', () {
       test('should initialize portal service correctly', () async {
         final portalService = ScreenshotPortalService();
-        expect(portalService.isInitialized, isFalse);
-
-        await portalService.initialize();
-        expect(portalService.isInitialized, isTrue);
-
-        await portalService.dispose();
-        expect(portalService.isInitialized, isFalse);
+        await expectLater(portalService.initialize(), completes);
+        await expectLater(portalService.dispose(), completes);
+        expect(() => portalService.client, throwsStateError);
       });
 
       test('should handle portal service disposal', () async {
         final portalService = ScreenshotPortalService();
         await portalService.initialize();
-        await portalService.dispose();
-        expect(portalService.isInitialized, isFalse);
+        await expectLater(portalService.dispose(), completes);
+        expect(() => portalService.client, throwsStateError);
       });
     });
   });


### PR DESCRIPTION
## Summary

- remove three unused config-flag helpers and the unused notification count query
- delete the never-used Settings V2 static badge model/rendering path
- remove the redundant category-label cache API and its dead test scaffolding
- wire service disposal into GetIt and close portal resources deterministically
- remove the test-only celebration seed reset hook

This removes 807 net lines (93 additions, 900 deletions) and is expected to eliminate about 15 licensed DCM findings. Based on the provisional post-#3773 baseline, the unused-code count should move from about 186 to about 171; the authoritative count still needs the licensed macOS DCM run.

## Validation

- `fvm dart analyze` — no issues
- targeted affected tests — 408 passed, 1 Flatpak-only test skipped
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.