### PR TITLE
chore: remove unused Daily OS APIs

### DIFF
--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -11,8 +11,7 @@ import 'package:lotti/features/agents/model/agent_enums.dart'
         AgentMessageKind,
         AgentMilestone,
         AgentTemplateKind,
-        ScheduledWakeStatus,
-        WakeReason;
+        ScheduledWakeStatus;
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
@@ -686,31 +685,6 @@ class DayAgentService {
     await syncService.upsertEntity(capture);
     onPersistedStateChanged?.call(captureId);
     return captureId;
-  }
-
-  /// Trigger a manual wake for [agentId].
-  void triggerReanalysis(String agentId) {
-    domainLogger.log(
-      LogDomain.agentRuntime,
-      'manual day-agent reanalysis triggered for '
-      '${DomainLogger.sanitizeId(agentId)}',
-      subDomain: 'lifecycle',
-    );
-    orchestrator.enqueueManualWake(
-      agentId: agentId,
-      reason: WakeReason.reanalysis.name,
-    );
-  }
-
-  /// Cancel a pending or scheduled wake for [agentId].
-  void cancelScheduledWake(String agentId) {
-    domainLogger.log(
-      LogDomain.agentRuntime,
-      'day-agent scheduled wake cancelled for '
-      '${DomainLogger.sanitizeId(agentId)}',
-      subDomain: 'lifecycle',
-    );
-    agentService.cancelPendingWake(agentId);
   }
 
   /// How many calendar days a per-day agent stays active past its own day.

--- a/lib/features/daily_os_next/logic/mock_day_agent.dart
+++ b/lib/features/daily_os_next/logic/mock_day_agent.dart
@@ -2,7 +2,6 @@ import 'package:lotti/features/daily_os_next/logic/day_agent_interface.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent_capture.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent_planning.dart';
-import 'package:meta/meta.dart';
 
 /// Scripted [DayAgentInterface] for the Capture + Reconcile preview.
 ///
@@ -210,12 +209,4 @@ class MockDayAgent implements DayAgentInterface {
     query: query,
   );
 
-  /// Test seam for the pure corpus-filter predicate.
-  @visibleForTesting
-  bool debugMatchesFilter(
-    TaskCorpusItem item,
-    TaskCorpusState state,
-    String? categoryId,
-    String? query,
-  ) => _planning.matchesFilter(item, state, categoryId, query);
 }

--- a/lib/features/daily_os_next/logic/mock_day_agent_planning.dart
+++ b/lib/features/daily_os_next/logic/mock_day_agent_planning.dart
@@ -470,8 +470,7 @@ class MockDayAgentPlanning {
     ];
   }
 
-  /// Pure corpus-filter predicate. Exposed for the facade's
-  /// `debugMatchesFilter` test seam.
+  /// Pure corpus-filter predicate used by [surfaceTaskCorpus].
   bool matchesFilter(
     TaskCorpusItem item,
     TaskCorpusState state,

--- a/lib/features/daily_os_next/logic/real_day_agent.dart
+++ b/lib/features/daily_os_next/logic/real_day_agent.dart
@@ -29,10 +29,9 @@ part 'real_day_agent_projection.dart';
 /// exception) so the UI can render a real error state instead of a
 /// scripted fallback that pretends the call succeeded:
 /// `submitCapture`, `parseCaptureToItems`, `surfacePendingDecisions`,
-/// `applyTriage`, `linkCapturePhraseToTask`, `breakCaptureLink`,
-/// `summarizeRecentPatterns`, `draftDayPlan`, `proposePlanDiff`,
-/// `acceptDiff`, `revertDiff`, `commitDay`, `currentPlanForDate`,
-/// `deletePlanForDate`.
+/// `applyTriage`, `breakCaptureLink`, `summarizeRecentPatterns`,
+/// `draftDayPlan`, `proposePlanDiff`, `acceptDiff`, `revertDiff`, `commitDay`,
+/// `currentPlanForDate`, `deletePlanForDate`.
 ///
 /// **Still mocked** — these methods still delegate to [mockFallback]
 /// because their agent-side tools have not shipped yet. Once each

--- a/lib/features/daily_os_next/logic/real_day_agent.dart
+++ b/lib/features/daily_os_next/logic/real_day_agent.dart
@@ -18,7 +18,6 @@ import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_job.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/daily_os_next/util/day_arithmetic.dart';
-import 'package:meta/meta.dart';
 
 part 'real_day_agent_projection.dart';
 
@@ -182,20 +181,6 @@ class RealDayAgent implements DayAgentInterface {
       deferTo: deferTo,
     );
     return TriageResult(action: action);
-  }
-
-  /// Not part of [DayAgentInterface] but exposed for the Reconcile
-  /// UI to call when the user re-points a parsed item to a different
-  /// task from the "did you mean…" overflow menu.
-  Future<ParsedItem> linkCapturePhraseToTask({
-    required String parsedItemId,
-    required String taskId,
-  }) async {
-    final updated = await captureService.linkCapturePhraseToTask(
-      captureItemId: parsedItemId,
-      taskId: taskId,
-    );
-    return _projectParsedItem(updated);
   }
 
   @override

--- a/lib/features/daily_os_next/logic/real_day_agent_projection.dart
+++ b/lib/features/daily_os_next/logic/real_day_agent_projection.dart
@@ -106,11 +106,6 @@ extension RealDayAgentProjection on RealDayAgent {
     );
   }
 
-  /// Test seam for [_projectCategory] — pure hex normalisation.
-  @visibleForTesting
-  DayAgentCategory debugProjectCategory(CategoryDefinition def) =>
-      _projectCategory(def);
-
   Future<DraftPlan> _projectDayPlan(
     DayPlanEntity entity,
     DateTime dayDate,
@@ -143,10 +138,6 @@ extension RealDayAgentProjection on RealDayAgent {
   /// per `taskId`; standalone blocks become one agenda item each so
   /// the Agenda surface mirrors the Day timeline instead of going
   /// silent when the model has not linked tasks yet.
-  /// Test seam for [_agendaFor] — pure block→agenda grouping/state fold.
-  @visibleForTesting
-  List<AgendaItem> debugAgendaFor(List<TimeBlock> blocks) => _agendaFor(blocks);
-
   List<AgendaItem> _agendaFor(List<TimeBlock> blocks) {
     final taskGroups = <String, List<TimeBlock>>{};
     final standalone = <TimeBlock>[];

--- a/lib/features/daily_os_next/state/day_agent_provider.dart
+++ b/lib/features/daily_os_next/state/day_agent_provider.dart
@@ -18,13 +18,12 @@ import 'package:lotti/services/db_notification.dart';
 
 /// Resolves the [DayAgentInterface] the UI talks to.
 ///
-/// Returns a [RealDayAgent] that delegates seven methods to the real
-/// agent layer: the capture/reconcile tools
+/// Returns a [RealDayAgent] that delegates supported methods to the real
+/// agent layer, including the capture/reconcile tools
 /// (`submitCapture`, `parseCaptureToItems`, `surfacePendingDecisions`,
-/// `applyTriage`, `linkCapturePhraseToTask`, `breakCaptureLink`), day-plan
-/// drafting/refinement/commit calls, and plan summary reads. Shutdown and task
-/// corpus methods still delegate to a held [MockDayAgent] fallback until their
-/// backend tools ship.
+/// `applyTriage`, `breakCaptureLink`), day-plan drafting/refinement/commit
+/// calls, and plan summary reads. Shutdown and task corpus methods still
+/// delegate to a held [MockDayAgent] fallback until their backend tools ship.
 ///
 /// Tests override this provider with their own implementation via
 /// `ProviderScope(overrides: [...])` (typically with a fresh

--- a/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
@@ -578,7 +578,7 @@ class _DraftingStepContentState extends ConsumerState<_DraftingStepContent> {
   /// result once Drafting is ready. Attribution of the newly-created task ids
   /// is best-effort: a reparse failure ships an empty list rather than
   /// blocking the close.
-  Future<void> _closeWithCreatedResult(DraftPlan draft) async {
+  Future<void> _closeWithCreatedResult() async {
     if (!mounted) return;
     ref.invalidate(currentDraftPlanProvider(widget.day));
     final createdTaskIds = await _attributeCreatedTaskIds();
@@ -619,11 +619,10 @@ class _DraftingStepContentState extends ConsumerState<_DraftingStepContent> {
       (previous, next) {
         final value = next.value;
         if (value == null || _advanced) return;
-        final draft = value.draft;
-        if (value.phase == DraftingPhase.ready && draft != null) {
+        if (value.phase == DraftingPhase.ready && value.draft != null) {
           _advanced = true;
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            unawaited(_closeWithCreatedResult(draft));
+            unawaited(_closeWithCreatedResult());
           });
         }
       },

--- a/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
@@ -67,8 +67,8 @@ class DayPlanningAdapt extends DayPlanningIntent {
 /// ready and invalidates [currentDraftPlanProvider] so the day surface
 /// shows the new plan.
 ///
-/// Resolves to a [DayPlanningResult]: a [DayPlanningCreated] (with the drafted
-/// plan and any newly-created task ids) when the create flow lands a plan, a
+/// Resolves to a [DayPlanningResult]: a [DayPlanningCreated] (with any
+/// newly-created task ids) when the create flow lands a plan, a
 /// [DayPlanningAdapted] when the Refine flow accepts one, or `null` when the
 /// user dismisses the modal (barrier tap, close button, or "looks good" with
 /// nothing to adapt). Existing callers that ignore the value are unaffected.
@@ -589,7 +589,7 @@ class _DraftingStepContentState extends ConsumerState<_DraftingStepContent> {
     final route = ModalRoute.of(context);
     if (route?.isCurrent ?? false) {
       Navigator.of(context).pop(
-        DayPlanningCreated(draft: draft, createdTaskIds: createdTaskIds),
+        DayPlanningCreated(createdTaskIds: createdTaskIds),
       );
     }
   }

--- a/lib/features/daily_os_next/ui/pages/day_planning_result.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_result.dart
@@ -1,5 +1,4 @@
 import 'package:lotti/features/daily_os_next/logic/day_agent_capture_models.dart';
-import 'package:lotti/features/daily_os_next/logic/day_agent_plan_models.dart';
 
 /// The outcome of a `showDayPlanningModal` interaction.
 ///
@@ -16,12 +15,8 @@ sealed class DayPlanningResult {
 /// reached `DraftingPhase.ready` with a non-null draft).
 final class DayPlanningCreated extends DayPlanningResult {
   const DayPlanningCreated({
-    required this.draft,
     this.createdTaskIds = const [],
   });
-
-  /// The persisted drafted plan.
-  final DraftPlan draft;
 
   /// Task ids newly materialized by this drafting run from approved,
   /// previously-unlinked capture items. Empty when nothing new was created or
@@ -32,10 +27,7 @@ final class DayPlanningCreated extends DayPlanningResult {
 /// An existing plan was adapted and persisted via the `DayPlanningAdapt`
 /// (Refine) flow.
 final class DayPlanningAdapted extends DayPlanningResult {
-  const DayPlanningAdapted({required this.draft});
-
-  /// The persisted adapted plan.
-  final DraftPlan draft;
+  const DayPlanningAdapted();
 }
 
 /// Attributes the task ids newly created by a drafting run.

--- a/lib/features/daily_os_next/ui/pages/refine_page.dart
+++ b/lib/features/daily_os_next/ui/pages/refine_page.dart
@@ -88,7 +88,7 @@ class _RefineModalContentState extends ConsumerState<RefineModalContent> {
             next.phase == RefinePhase.accepted) {
           Navigator.of(
             context,
-          ).pop(DayPlanningAdapted(draft: next.currentPlan));
+          ).pop(const DayPlanningAdapted());
         }
       },
     );
@@ -413,7 +413,7 @@ class RefinePage extends ConsumerWidget {
     ref.listen<RefineState>(refineControllerProvider(draft), (previous, next) {
       if (previous?.phase != RefinePhase.accepted &&
           next.phase == RefinePhase.accepted) {
-        Navigator.of(context).pop(DayPlanningAdapted(draft: next.currentPlan));
+        Navigator.of(context).pop(const DayPlanningAdapted());
       }
     });
 

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -334,46 +334,6 @@ void main() {
       );
     });
 
-    test('triggerReanalysis enqueues a manual reanalysis wake', () {
-      service.triggerReanalysis(agentId);
-
-      verify(
-        () => orchestrator.enqueueManualWake(
-          agentId: agentId,
-          reason: WakeReason.reanalysis.name,
-          workspaceKey: any(named: 'workspaceKey'),
-        ),
-      ).called(1);
-      final logMessage =
-          verify(
-                () => domainLogger.log(
-                  any(),
-                  captureAny(),
-                  subDomain: 'lifecycle',
-                  level: any(named: 'level'),
-                ),
-              ).captured.single
-              as String;
-      expect(logMessage, contains('manual day-agent reanalysis'));
-    });
-
-    test('cancelScheduledWake delegates pending wake cancellation', () {
-      service.cancelScheduledWake(agentId);
-
-      verify(() => agentService.cancelPendingWake(agentId)).called(1);
-      final logMessage =
-          verify(
-                () => domainLogger.log(
-                  any(),
-                  captureAny(),
-                  subDomain: 'lifecycle',
-                  level: any(named: 'level'),
-                ),
-              ).captured.single
-              as String;
-      expect(logMessage, contains('scheduled wake cancelled'));
-    });
-
     test(
       'restoreSubscriptions aborts before per-agent work when preload fails',
       () async {

--- a/test/features/daily_os_next/logic/mock_day_agent_test.dart
+++ b/test/features/daily_os_next/logic/mock_day_agent_test.dart
@@ -1039,69 +1039,40 @@ void main() {
       expect(await agent.currentPlanForDate(DateTime(2026, 5, 25)), isNull);
     });
   });
-  group('debugMatchesFilter — properties', () {
-    const categories = ['cat-a', 'cat-b'];
+  group('surfaceTaskCorpus — properties', () {
+    const categories = [null, 'cat_work', 'cat_health', 'cat_nope'];
     const queries = [null, '', '  ', 'deck', 'DECK', 'zzz'];
 
-    TaskCorpusItem item(int seed) => TaskCorpusItem(
-      title: seed.isEven ? 'Paint the deck $seed' : 'Inbox triage $seed',
-      category: DayAgentCategory(
-        id: categories[seed % categories.length],
-        name: 'Cat',
-        colorHex: '8E8E8E',
-      ),
-      state: TaskCorpusState
-          .values[1 + seed % (TaskCorpusState.values.length - 1)],
-    );
-
     glados.Glados3(
-      glados.any.intInRange(0, 50),
       glados.any.intInRange(0, TaskCorpusState.values.length),
-      glados.any.intInRange(0, 12),
+      glados.any.intInRange(0, categories.length),
+      glados.any.intInRange(0, queries.length),
       glados.ExploreConfig(numRuns: 120),
     ).test(
       'every item matching a narrowed filter also matches state=all with '
       'the same category/query (all is a superset)',
-      (seed, stateIndex, filterSeed) {
-        final agent = MockDayAgent();
-        final candidate = item(seed);
+      (stateIndex, categoryIndex, queryIndex) async {
+        final agent = MockDayAgent(pendingLatency: Duration.zero);
         final state =
             TaskCorpusState.values[stateIndex % TaskCorpusState.values.length];
-        final categoryId = filterSeed.isEven
-            ? null
-            : categories[filterSeed % categories.length];
-        final query = queries[filterSeed % queries.length];
+        final categoryId = categories[categoryIndex % categories.length];
+        final query = queries[queryIndex % queries.length];
 
-        final narrowed = agent.debugMatchesFilter(
-          candidate,
-          state,
-          categoryId,
-          query,
+        final narrowed = await agent.surfaceTaskCorpus(
+          stateFilter: state,
+          categoryId: categoryId,
+          query: query,
         );
-        final broad = agent.debugMatchesFilter(
-          candidate,
-          TaskCorpusState.all,
-          categoryId,
-          query,
+        final broad = await agent.surfaceTaskCorpus(
+          categoryId: categoryId,
+          query: query,
         );
 
-        if (narrowed) {
-          expect(
-            broad,
-            isTrue,
-            reason: 'state=$state cat=$categoryId q="$query" item=$seed',
-          );
-        }
-
-        // Oracle for the broad filter itself: category and query are the
-        // only remaining predicates under state=all.
-        final q = query?.trim().toLowerCase();
-        final expectedBroad =
-            (categoryId == null || candidate.category.id == categoryId) &&
-            (q == null ||
-                q.isEmpty ||
-                candidate.title.toLowerCase().contains(q));
-        expect(broad, expectedBroad);
+        expect(
+          narrowed.toSet().difference(broad.toSet()),
+          isEmpty,
+          reason: 'state=$state cat=$categoryId q="$query"',
+        );
       },
       tags: 'glados',
     );

--- a/test/features/daily_os_next/logic/mock_day_agent_test.dart
+++ b/test/features/daily_os_next/logic/mock_day_agent_test.dart
@@ -1049,8 +1049,7 @@ void main() {
       glados.any.intInRange(0, queries.length),
       glados.ExploreConfig(numRuns: 120),
     ).test(
-      'every item matching a narrowed filter also matches state=all with '
-      'the same category/query (all is a superset)',
+      'returns exactly the corpus rows selected by every filter combination',
       (stateIndex, categoryIndex, queryIndex) async {
         final agent = MockDayAgent(pendingLatency: Duration.zero);
         final state =
@@ -1058,19 +1057,24 @@ void main() {
         final categoryId = categories[categoryIndex % categories.length];
         final query = queries[queryIndex % queries.length];
 
-        final narrowed = await agent.surfaceTaskCorpus(
+        final corpus = await agent.surfaceTaskCorpus();
+        final actual = await agent.surfaceTaskCorpus(
           stateFilter: state,
           categoryId: categoryId,
           query: query,
         );
-        final broad = await agent.surfaceTaskCorpus(
-          categoryId: categoryId,
-          query: query,
-        );
+        final normalizedQuery = query?.trim().toLowerCase();
+        final expected = corpus.where((item) {
+          if (state != TaskCorpusState.all && item.state != state) return false;
+          if (categoryId != null && item.category.id != categoryId) return false;
+          return normalizedQuery == null ||
+              normalizedQuery.isEmpty ||
+              item.title.toLowerCase().contains(normalizedQuery);
+        }).map((item) => item.title);
 
         expect(
-          narrowed.toSet().difference(broad.toSet()),
-          isEmpty,
+          actual.map((item) => item.title),
+          expected,
           reason: 'state=$state cat=$categoryId q="$query"',
         );
       },

--- a/test/features/daily_os_next/logic/real_day_agent_test.dart
+++ b/test/features/daily_os_next/logic/real_day_agent_test.dart
@@ -5,9 +5,7 @@ import 'dart:async';
 import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/day_plan.dart';
-import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -1833,7 +1831,7 @@ void main() {
   });
 
   group(
-    'RealDayAgent.applyTriage / linkCapturePhraseToTask / breakCaptureLink',
+    'RealDayAgent.applyTriage / breakCaptureLink',
     () {
       late _TestBench bench;
 
@@ -1889,47 +1887,6 @@ void main() {
               deferTo: _asOf,
             ),
           ).called(1);
-        },
-      );
-
-      test(
-        'linkCapturePhraseToTask projects the updated parsed item',
-        () async {
-          final updated =
-              AgentDomainEntity.parsedItem(
-                    id: 'parsed-z',
-                    agentId: 'agent',
-                    captureId: 'cap',
-                    kind: ParsedItemKind.matched,
-                    title: 'Title',
-                    categoryId: 'cat-z',
-                    confidence: ParsedItemConfidence.high,
-                    confidenceScore: 0.9,
-                    matchedTaskId: testTask.meta.id,
-                    createdAt: _asOf,
-                    vectorClock: null,
-                  )
-                  as ParsedItemEntity;
-          when(
-            () => bench.captureService.linkCapturePhraseToTask(
-              captureItemId: any(named: 'captureItemId'),
-              taskId: any(named: 'taskId'),
-            ),
-          ).thenAnswer((_) async => updated);
-          when(
-            () => bench.journalDb.getCategoryById('cat-z'),
-          ).thenAnswer((_) async => null);
-          when(
-            () => bench.journalDb.journalEntityById(testTask.meta.id),
-          ).thenAnswer((_) async => testTask);
-
-          final item = await bench.adapter.linkCapturePhraseToTask(
-            parsedItemId: 'parsed-z',
-            taskId: testTask.meta.id,
-          );
-          expect(item.id, 'parsed-z');
-          expect(item.kind, ParsedItemKind.matched);
-          expect(item.matchedTaskTitle, testTask.data.title);
         },
       );
 
@@ -2840,112 +2797,4 @@ void main() {
     );
   });
 
-  group('debugAgendaFor — agenda state fold', () {
-    const cat = DayAgentCategory(id: 'c1', name: 'Deep', colorHex: '3B82F6');
-
-    TimeBlock block(
-      String id,
-      TimeBlockState state, {
-      String? taskId,
-      int hour = 9,
-    }) => TimeBlock(
-      id: id,
-      title: id,
-      start: _asOf.add(Duration(hours: hour)),
-      end: _asOf.add(Duration(hours: hour + 1)),
-      type: TimeBlockType.ai,
-      state: state,
-      category: cat,
-      taskId: taskId,
-    );
-
-    test(
-      'a partially worked group (inProgress + completed + drafted) folds to '
-      'inProgress, and a fully completed group folds to done',
-      () {
-        final bench = _TestBench.create();
-        final agenda = bench.adapter.debugAgendaFor([
-          // task-1: one of each — inProgress must win even though a block
-          // is already completed and another is still drafted.
-          block('p-done', TimeBlockState.completed, taskId: 'task-1'),
-          block(
-            'p-active',
-            TimeBlockState.inProgress,
-            taskId: 'task-1',
-            hour: 10,
-          ),
-          block(
-            'p-drafted',
-            TimeBlockState.drafted,
-            taskId: 'task-1',
-            hour: 11,
-          ),
-          // task-2: every block completed → done.
-          block('d-1', TimeBlockState.completed, taskId: 'task-2', hour: 12),
-          block('d-2', TimeBlockState.completed, taskId: 'task-2', hour: 13),
-        ]);
-
-        final partial = agenda.firstWhere((a) => a.taskId == 'task-1');
-        expect(partial.state, AgendaItemState.inProgress);
-        expect(partial.linkedBlockIds, ['p-done', 'p-active', 'p-drafted']);
-        expect(partial.totalEstimateMinutes, 180);
-
-        final completed = agenda.firstWhere((a) => a.taskId == 'task-2');
-        expect(completed.state, AgendaItemState.done);
-      },
-    );
-  });
-
-  group('projection pure helpers — properties', () {
-    late _TestBench bench;
-
-    setUp(() {
-      bench = _TestBench.create();
-    });
-
-    glados.Glados<String>(
-      glados.AnyUtils(glados.any).choose(const [
-        '#3B82F6',
-        '3B82F6',
-        '#3B82F6FF',
-        '#FFF',
-        'FFF',
-        '',
-        '#',
-        '#0F172A',
-      ]),
-      glados.ExploreConfig(numRuns: 120),
-    ).test(
-      'debugProjectCategory normalises hex per the documented contract',
-      (color) {
-        final def = CategoryDefinition(
-          id: 'cat-1',
-          name: 'Cat',
-          color: color,
-          createdAt: DateTime(2024),
-          updatedAt: DateTime(2024),
-          vectorClock: null,
-          private: false,
-          active: true,
-        );
-
-        final projected = bench.adapter.debugProjectCategory(def);
-
-        // Oracle mirroring the impl contract: strip '#', take the first six
-        // chars when long enough, fall back for empty, pass short raw
-        // through unchanged (documented quirk — NOT padded to 6).
-        final raw = color.replaceFirst('#', '');
-        final expected = raw.length >= 6
-            ? raw.substring(0, 6)
-            : (raw.isEmpty ? projected.colorHex : raw);
-        expect(projected.colorHex, expected, reason: 'color="$color"');
-        expect(projected.id, 'cat-1');
-        expect(projected.name, 'Cat');
-        if (raw.length >= 6) {
-          expect(projected.colorHex.length, 6);
-        }
-      },
-      tags: 'glados',
-    );
-  });
 }

--- a/test/features/daily_os_next/ui/pages/day_planning_result_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_planning_result_test.dart
@@ -88,25 +88,16 @@ void main() {
   });
 
   group('DayPlanningResult variants', () {
-    final draft = DraftPlan.emptyForDay(DateTime(2026, 7, 10));
-
     test('DayPlanningCreated defaults to no created task ids', () {
-      final result = DayPlanningCreated(draft: draft);
+      const result = DayPlanningCreated();
       expect(result.createdTaskIds, isEmpty);
-      expect(result.draft, same(draft));
     });
 
     test('DayPlanningCreated carries the attributed task ids', () {
-      final result = DayPlanningCreated(
-        draft: draft,
-        createdTaskIds: const ['t1', 't2'],
+      const result = DayPlanningCreated(
+        createdTaskIds: ['t1', 't2'],
       );
       expect(result.createdTaskIds, ['t1', 't2']);
-    });
-
-    test('DayPlanningAdapted carries the adapted plan', () {
-      final result = DayPlanningAdapted(draft: draft);
-      expect(result.draft, same(draft));
     });
   });
 }

--- a/test/features/daily_os_next/ui/pages/refine_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/refine_page_test.dart
@@ -575,7 +575,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 350));
 
       expect(popped, isA<DayPlanningAdapted>());
-      expect((popped! as DayPlanningAdapted).draft.scheduledMinutes, 99);
+      expect(agent.capturedDiff, same(singleChangeDiff));
+      expect(agent.acceptIndices, [0]);
       expect(find.byType(RefinePage), findsNothing);
     });
 
@@ -880,7 +881,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 600));
 
       expect(result, isA<DayPlanningAdapted>());
-      expect((result! as DayPlanningAdapted).draft.scheduledMinutes, 42);
+      expect(agent.capturedDiff, same(diff));
+      expect(agent.acceptIndices, [0]);
       expect(find.byType(RefineModalContent), findsNothing);
     });
   });


### PR DESCRIPTION
## Summary

- remove eight DCM-reported Daily OS declarations that have no production callers
- remove the tests that existed only for those dead seams
- keep corpus-filter coverage on the public `surfaceTaskCorpus` path
- stop carrying persisted draft objects in modal result markers when callers only need completion/task attribution

This is a code-hygiene-only change with no intended user-visible behavior change.

## DCM impact

The merged cleanup baseline is projected at approximately 97 reports. This removes eight additional known reports, so the expected licensed `dcm check-unused-code lib` result is approximately 89. The authoritative count still needs the licensed macOS run after merge.

## Validation

- `make analyze` — no issues
- 220 scoped tests across the six affected test files — passed
- final `real_day_agent_test.dart` rerun after patch cleanup — 57 passed
- `git diff --check` — clean

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Simplified daily planning results: created results now return newly created task IDs without draft plan data.
  * Refine acceptance results no longer include the updated draft plan.
  * Removed obsolete manual reanalysis, scheduled-wake cancellation, task-linking, and debug-only interfaces.
  * Updated filtering documentation and strengthened coverage for task-corpus filtering and refinement behavior.
* **Bug Fixes**
  * Preserved task attribution and modal cleanup throughout planning and refinement flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->