### PR TITLE
chore: remove unused model and UI plumbing

### DIFF
--- a/lib/features/agents/model/classified_feedback.dart
+++ b/lib/features/agents/model/classified_feedback.dart
@@ -5,7 +5,7 @@ part 'classified_feedback.freezed.dart';
 part 'classified_feedback.g.dart';
 
 /// A single classified feedback item extracted from agent data.
-@freezed
+@Freezed(fromJson: false, toJson: true)
 abstract class ClassifiedFeedbackItem with _$ClassifiedFeedbackItem {
   const factory ClassifiedFeedbackItem({
     required FeedbackSentiment sentiment,
@@ -32,9 +32,6 @@ abstract class ClassifiedFeedbackItem with _$ClassifiedFeedbackItem {
     @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
     ObservationPriority? observationPriority,
   }) = _ClassifiedFeedbackItem;
-
-  factory ClassifiedFeedbackItem.fromJson(Map<String, dynamic> json) =>
-      _$ClassifiedFeedbackItemFromJson(json);
 }
 
 /// Aggregated feedback for a time window.

--- a/lib/features/agents/model/classified_feedback.freezed.dart
+++ b/lib/features/agents/model/classified_feedback.freezed.dart
@@ -11,7 +11,6 @@ part of 'classified_feedback.dart';
 
 // dart format off
 T _$identity<T>(T value) => value;
-
 /// @nodoc
 mixin _$ClassifiedFeedbackItem {
 
@@ -221,11 +220,11 @@ return $default(_that.sentiment,_that.category,_that.source,_that.detail,_that.a
 }
 
 /// @nodoc
-@JsonSerializable()
+@JsonSerializable(createFactory: false)
 
 class _ClassifiedFeedbackItem implements ClassifiedFeedbackItem {
   const _ClassifiedFeedbackItem({required this.sentiment, required this.category, required this.source, required this.detail, required this.agentId, this.sourceEntityId, this.confidence, @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue) this.observationPriority});
-  factory _ClassifiedFeedbackItem.fromJson(Map<String, dynamic> json) => _$ClassifiedFeedbackItemFromJson(json);
+
 
 @override final  FeedbackSentiment sentiment;
 @override final  FeedbackCategory category;

--- a/lib/features/agents/model/classified_feedback.g.dart
+++ b/lib/features/agents/model/classified_feedback.g.dart
@@ -6,23 +6,6 @@ part of 'classified_feedback.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_ClassifiedFeedbackItem _$ClassifiedFeedbackItemFromJson(
-  Map<String, dynamic> json,
-) => _ClassifiedFeedbackItem(
-  sentiment: $enumDecode(_$FeedbackSentimentEnumMap, json['sentiment']),
-  category: $enumDecode(_$FeedbackCategoryEnumMap, json['category']),
-  source: json['source'] as String,
-  detail: json['detail'] as String,
-  agentId: json['agentId'] as String,
-  sourceEntityId: json['sourceEntityId'] as String?,
-  confidence: (json['confidence'] as num?)?.toDouble(),
-  observationPriority: $enumDecodeNullable(
-    _$ObservationPriorityEnumMap,
-    json['observationPriority'],
-    unknownValue: JsonKey.nullForUndefinedEnumValue,
-  ),
-);
-
 Map<String, dynamic> _$ClassifiedFeedbackItemToJson(
   _ClassifiedFeedbackItem instance,
 ) => <String, dynamic>{

--- a/lib/features/agents/model/improver_slot_keys.dart
+++ b/lib/features/agents/model/improver_slot_keys.dart
@@ -6,12 +6,6 @@ abstract final class ImproverSlotDefaults {
   /// Default number of days between one-on-one rituals.
   static const defaultFeedbackWindowDays = 7;
 
-  /// Default number of days between meta-improver rituals (monthly).
-  static const defaultMetaFeedbackWindowDays = 30;
-
-  /// Maximum allowed recursion depth for meta-improvers.
-  static const maxRecursionDepth = 2;
-
   /// Maximum number of template versions in a feedback window before
   /// flagging excessive directive churn.
   static const maxDirectiveChurnVersions = 3;

--- a/lib/features/ai/model/ai_input.dart
+++ b/lib/features/ai/model/ai_input.dart
@@ -52,7 +52,7 @@ abstract class AiActionItem with _$AiActionItem {
 /// audio transcript so the prompt can reference past activity. Image entries
 /// additionally nest their AI analysis results (summary, OCR, …) in
 /// [aiResponses] so the model can reason over extracted image content.
-@freezed
+@Freezed(fromJson: false, toJson: true)
 abstract class AiInputLogEntryObject with _$AiInputLogEntryObject {
   const factory AiInputLogEntryObject({
     required DateTime creationTimestamp,
@@ -65,9 +65,6 @@ abstract class AiInputLogEntryObject with _$AiInputLogEntryObject {
     // key on every prompt; only image entries with analyses carry it.
     @JsonKey(includeIfNull: false) List<AiInputAiResponseObject>? aiResponses,
   }) = _AiInputLogEntryObject;
-
-  factory AiInputLogEntryObject.fromJson(Map<String, dynamic> json) =>
-      _$AiInputLogEntryObjectFromJson(json);
 }
 
 /// One AI analysis response nested under an [AiInputLogEntryObject] — e.g. an

--- a/lib/features/ai/model/ai_input.freezed.dart
+++ b/lib/features/ai/model/ai_input.freezed.dart
@@ -596,7 +596,6 @@ as DateTime?,
 
 }
 
-
 /// @nodoc
 mixin _$AiInputLogEntryObject {
 
@@ -799,11 +798,11 @@ return $default(_that.creationTimestamp,_that.loggedDuration,_that.text,_that.au
 }
 
 /// @nodoc
-@JsonSerializable()
+@JsonSerializable(createFactory: false)
 
 class _AiInputLogEntryObject implements AiInputLogEntryObject {
   const _AiInputLogEntryObject({required this.creationTimestamp, required this.loggedDuration, required this.text, this.audioTranscript, this.transcriptLanguage, this.entryType, @JsonKey(includeIfNull: false) final  List<AiInputAiResponseObject>? aiResponses}): _aiResponses = aiResponses;
-  factory _AiInputLogEntryObject.fromJson(Map<String, dynamic> json) => _$AiInputLogEntryObjectFromJson(json);
+
 
 @override final  DateTime creationTimestamp;
 @override final  String loggedDuration;

--- a/lib/features/ai/model/ai_input.g.dart
+++ b/lib/features/ai/model/ai_input.g.dart
@@ -50,20 +50,6 @@ Map<String, dynamic> _$AiActionItemToJson(_AiActionItem instance) =>
       'checkedAt': instance.checkedAt?.toIso8601String(),
     };
 
-_AiInputLogEntryObject _$AiInputLogEntryObjectFromJson(
-  Map<String, dynamic> json,
-) => _AiInputLogEntryObject(
-  creationTimestamp: DateTime.parse(json['creationTimestamp'] as String),
-  loggedDuration: json['loggedDuration'] as String,
-  text: json['text'] as String,
-  audioTranscript: json['audioTranscript'] as String?,
-  transcriptLanguage: json['transcriptLanguage'] as String?,
-  entryType: json['entryType'] as String?,
-  aiResponses: (json['aiResponses'] as List<dynamic>?)
-      ?.map((e) => AiInputAiResponseObject.fromJson(e as Map<String, dynamic>))
-      .toList(),
-);
-
 Map<String, dynamic> _$AiInputLogEntryObjectToJson(
   _AiInputLogEntryObject instance,
 ) => <String, dynamic>{

--- a/lib/features/ai/ui/ai_response_summary.dart
+++ b/lib/features/ai/ui/ai_response_summary.dart
@@ -50,7 +50,6 @@ const _fadeOutPreviewMaxHeight = 200.0;
 class AiResponseSummary extends StatefulWidget {
   const AiResponseSummary(
     this.aiResponse, {
-    required this.linkedFromId,
     required this.fadeOut,
     this.collapsible = false,
     super.key,
@@ -60,7 +59,6 @@ class AiResponseSummary extends StatefulWidget {
   static const collapseToggleKey = Key('ai_response_summary_collapse_toggle');
 
   final AiResponseEntry aiResponse;
-  final String? linkedFromId;
   final bool fadeOut;
   final bool collapsible;
 

--- a/lib/features/ai_chat/ui/controllers/chat_recorder_controller.dart
+++ b/lib/features/ai_chat/ui/controllers/chat_recorder_controller.dart
@@ -110,8 +110,8 @@ class ChatRecorderController extends Notifier<ChatRecorderState> {
   /// Begins a batch recording: checks mic permission, records to a temp `.m4a`
   /// file, streams throttled amplitude into [ChatRecorderState.amplitudeHistory],
   /// and arms a [ChatRecorderConfig.maxSeconds] safety timer that auto-calls
-  /// [stopAndTranscribe]. No-op unless idle; sets a `concurrentOperation` error
-  /// if a start is already in flight. On any failure the partial recording is
+  /// [stopAndTranscribe]. No-op unless idle; records an error message if a
+  /// start is already in flight. On any failure the partial recording is
   /// cleaned up.
   Future<void> start() async {
     if (!ref.mounted) return;

--- a/lib/features/ai_chat/ui/controllers/chat_recorder_controller.dart
+++ b/lib/features/ai_chat/ui/controllers/chat_recorder_controller.dart
@@ -118,7 +118,6 @@ class ChatRecorderController extends Notifier<ChatRecorderState> {
     if (_isStarting) {
       state = state.copyWith(
         error: 'Another operation is in progress',
-        errorType: ChatRecorderErrorType.concurrentOperation,
       );
       return;
     }
@@ -135,7 +134,6 @@ class ChatRecorderController extends Notifier<ChatRecorderState> {
       if (!hasPerm) {
         state = state.copyWith(
           error: 'Microphone permission denied. Please enable it in Settings.',
-          errorType: ChatRecorderErrorType.permissionDenied,
         );
         await recorder.dispose();
         return;
@@ -222,7 +220,6 @@ class ChatRecorderController extends Notifier<ChatRecorderState> {
       if (ref.mounted) {
         state = state.copyWith(
           error: 'Failed to start recording: $e',
-          errorType: ChatRecorderErrorType.startFailed,
         );
       }
       await _cleanupInternal();
@@ -266,7 +263,6 @@ class ChatRecorderController extends Notifier<ChatRecorderState> {
         state = state.copyWith(
           status: ChatRecorderStatus.idle,
           error: 'No audio file available',
-          errorType: ChatRecorderErrorType.noAudioFile,
         );
       }
       return;
@@ -299,7 +295,6 @@ class ChatRecorderController extends Notifier<ChatRecorderState> {
             TranscriptionException(:final message) => message,
             _ => e.toString(),
           },
-          errorType: ChatRecorderErrorType.transcriptionFailed,
         );
       }
     } finally {

--- a/lib/features/ai_chat/ui/controllers/chat_recorder_state.dart
+++ b/lib/features/ai_chat/ui/controllers/chat_recorder_state.dart
@@ -4,17 +4,6 @@
 /// transcription.
 enum ChatRecorderStatus { idle, recording, processing }
 
-/// Classifies a recorder failure so the UI can map it to a localized message
-/// or recovery action. `concurrentOperation` flags a start attempt while
-/// another start/stop is mid-flight (see [ChatRecorderState.error]).
-enum ChatRecorderErrorType {
-  permissionDenied,
-  startFailed,
-  noAudioFile,
-  transcriptionFailed,
-  concurrentOperation,
-}
-
 /// Immutable snapshot of the shared voice recorder for the UI.
 ///
 /// Carries the [status], the rolling dBFS [amplitudeHistory] for the waveform,
@@ -29,7 +18,6 @@ class ChatRecorderState {
     this.transcript,
     this.partialTranscript,
     this.error,
-    this.errorType,
   });
 
   const ChatRecorderState.initial()
@@ -37,8 +25,7 @@ class ChatRecorderState {
       amplitudeHistory = const <double>[],
       transcript = null,
       partialTranscript = null,
-      error = null,
-      errorType = null;
+      error = null;
 
   // Fields
   final ChatRecorderStatus status;
@@ -46,10 +33,9 @@ class ChatRecorderState {
   final String? transcript; // last finished transcript waiting to be consumed
   final String? partialTranscript; // in-progress transcript during streaming
   final String? error;
-  final ChatRecorderErrorType? errorType;
 
   // Methods
-  /// Footgun: [transcript], [partialTranscript], [error], and [errorType] are
+  /// Footgun: [transcript], [partialTranscript], and [error] are
   /// NOT preserved when omitted — passing nothing resets them to null. This is
   /// deliberate (each new status implies a fresh result), so callers that want
   /// to keep a value must pass it explicitly (e.g. re-passing
@@ -61,7 +47,6 @@ class ChatRecorderState {
     String? transcript,
     String? partialTranscript,
     String? error,
-    ChatRecorderErrorType? errorType,
   }) {
     return ChatRecorderState(
       status: status ?? this.status,
@@ -69,7 +54,6 @@ class ChatRecorderState {
       transcript: transcript,
       partialTranscript: partialTranscript,
       error: error,
-      errorType: errorType,
     );
   }
 }

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -340,7 +340,6 @@ class _EntryDetailsContentState extends ConsumerState<EntryDetailsContent> {
       HabitCompletionEntry() => HabitSummary(item, showText: false),
       AiResponseEntry() => AiResponseSummary(
         item,
-        linkedFromId: linkedFrom?.id,
         fadeOut: true,
       ),
       Checklist() => ChecklistCardWrapper(

--- a/lib/features/journal/ui/widgets/nested_ai_responses_widget.dart
+++ b/lib/features/journal/ui/widgets/nested_ai_responses_widget.dart
@@ -339,7 +339,6 @@ class _NestedAiResponsesWidgetState
         key: ValueKey('nested-ai-response-size-${response.meta.id}'),
         child: AiResponseSummary(
           response,
-          linkedFromId: widget.linkedFromEntity.meta.id,
           fadeOut: false,
           // Long analyses (e.g. a full OCR extraction) start collapsed to a
           // faded preview so one card cannot dominate the nested thread.

--- a/lib/features/knowledge_graph_poc/ui/node_inspector_panel.dart
+++ b/lib/features/knowledge_graph_poc/ui/node_inspector_panel.dart
@@ -103,7 +103,6 @@ class NodeInspectorPanel extends StatelessWidget {
                       createdLabel: createdLabel,
                       categoryLabel:
                           categoryNames[node.categoryId] ?? node.categoryId,
-                      categoryNames: categoryNames,
                       style: style,
                       tokens: tokens,
                       cat: cat,
@@ -235,7 +234,6 @@ class _InspectorContent extends StatelessWidget {
     required this.now,
     required this.createdLabel,
     required this.categoryLabel,
-    required this.categoryNames,
     required this.style,
     required this.tokens,
     required this.cat,
@@ -248,7 +246,6 @@ class _InspectorContent extends StatelessWidget {
   final DateTime now;
   final String createdLabel;
   final String categoryLabel;
-  final Map<String, String> categoryNames;
   final GraphStyle style;
   final DsTokens tokens;
   final Color cat;

--- a/test/features/agents/model/classified_feedback_test.dart
+++ b/test/features/agents/model/classified_feedback_test.dart
@@ -1,46 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/classified_feedback.dart';
-
-// ── Generators for Glados round-trip ─────────────────────────────────────────
-
-extension _AnyClassifiedFeedback on glados.Any {
-  glados.Generator<FeedbackSentiment> get feedbackSentiment =>
-      glados.AnyUtils(this).choose(FeedbackSentiment.values);
-
-  glados.Generator<FeedbackCategory> get feedbackCategory =>
-      glados.AnyUtils(this).choose(FeedbackCategory.values);
-
-  glados.Generator<ObservationPriority?> get optionalObservationPriority =>
-      glados.AnyUtils(this).choose(<ObservationPriority?>[
-        null,
-        ...ObservationPriority.values,
-      ]);
-
-  glados.Generator<ClassifiedFeedbackItem> get classifiedFeedbackItem =>
-      glados.CombinableAny(this).combine4(
-        feedbackSentiment,
-        feedbackCategory,
-        glados.any.letterOrDigits,
-        optionalObservationPriority,
-        (
-          FeedbackSentiment sentiment,
-          FeedbackCategory category,
-          String source,
-          ObservationPriority? priority,
-        ) => ClassifiedFeedbackItem(
-          sentiment: sentiment,
-          category: category,
-          source: source.isEmpty ? 'src' : source,
-          detail: 'detail',
-          agentId: 'agent-1',
-          observationPriority: priority,
-        ),
-      );
-}
 
 void main() {
   ClassifiedFeedbackItem makeItem({
@@ -169,67 +129,8 @@ void main() {
     });
   });
 
-  group('ClassifiedFeedbackItem JSON with optional fields', () {
-    test('fromJson tolerates missing sourceEntityId (null)', () {
-      final json = <String, dynamic>{
-        'sentiment': 'positive',
-        'category': 'accuracy',
-        'source': 'decision',
-        'detail': 'confirmed proposal',
-        'agentId': 'agent-1',
-      };
-      final item = ClassifiedFeedbackItem.fromJson(json);
-      expect(item.sourceEntityId, isNull);
-      expect(item.confidence, isNull);
-      expect(item.observationPriority, isNull);
-    });
-
-    test('fromJson parses observationPriority correctly', () {
-      final json = <String, dynamic>{
-        'sentiment': 'negative',
-        'category': 'general',
-        'source': 'observation',
-        'detail': 'something went wrong',
-        'agentId': 'agent-2',
-        'observationPriority': 'critical',
-      };
-      final item = ClassifiedFeedbackItem.fromJson(json);
-      expect(item.observationPriority, equals(ObservationPriority.critical));
-    });
-
-    test('fromJson with unknown observationPriority value returns null', () {
-      final json = <String, dynamic>{
-        'sentiment': 'neutral',
-        'category': 'general',
-        'source': 'obs',
-        'detail': 'detail',
-        'agentId': 'agent-1',
-        'observationPriority': 'unknownValue',
-      };
-      final item = ClassifiedFeedbackItem.fromJson(json);
-      expect(item.observationPriority, isNull);
-    });
-  });
-
-  group('Glados JSON round-trips', () {
-    glados.Glados(
-      glados.any.classifiedFeedbackItem,
-      glados.ExploreConfig(numRuns: 120),
-    ).test(
-      'ClassifiedFeedbackItem toJson → fromJson round-trip preserves equality',
-      (item) {
-        final json = jsonDecode(jsonEncode(item.toJson()));
-        final restored = ClassifiedFeedbackItem.fromJson(
-          json as Map<String, dynamic>,
-        );
-        expect(restored, equals(item), reason: 'item=$item');
-      },
-      tags: 'glados',
-    );
-  });
-
   group('JSON serialization', () {
-    test('ClassifiedFeedbackItem roundtrips through JSON', () {
+    test('ClassifiedFeedbackItem emits the feedback transport shape', () {
       const item = ClassifiedFeedbackItem(
         sentiment: FeedbackSentiment.positive,
         category: FeedbackCategory.accuracy,
@@ -241,9 +142,16 @@ void main() {
       );
 
       final json = item.toJson();
-      final restored = ClassifiedFeedbackItem.fromJson(json);
-
-      expect(restored, item);
+      expect(json, {
+        'sentiment': 'positive',
+        'category': 'accuracy',
+        'source': 'decision',
+        'detail': 'confirmed proposal',
+        'agentId': 'agent-1',
+        'sourceEntityId': 'cd-123',
+        'confidence': 0.95,
+        'observationPriority': null,
+      });
     });
   });
 }

--- a/test/features/agents/ui/evolution/widgets/evolution_recorder_test_utils.dart
+++ b/test/features/agents/ui/evolution/widgets/evolution_recorder_test_utils.dart
@@ -88,7 +88,6 @@ class TranscriptEmittingController extends ChatRecorderController {
     state = state.copyWith(
       status: ChatRecorderStatus.idle,
       error: error,
-      errorType: ChatRecorderErrorType.transcriptionFailed,
     );
   }
 

--- a/test/features/ai/model/ai_input_test.dart
+++ b/test/features/ai/model/ai_input_test.dart
@@ -25,7 +25,7 @@ void main() {
       expect(AiActionItem.fromJson(_roundTrip(actionItem)), actionItem);
     });
 
-    test('AiInputLogEntryObject survives a round-trip', () {
+    test('AiInputLogEntryObject emits the prompt transport shape', () {
       final entry = AiInputLogEntryObject(
         creationTimestamp: DateTime(2024, 3, 15, 8, 30),
         loggedDuration: '00:45',
@@ -34,10 +34,17 @@ void main() {
         transcriptLanguage: 'en',
         entryType: 'text',
       );
-      expect(AiInputLogEntryObject.fromJson(_roundTrip(entry)), entry);
+      expect(_roundTrip(entry), {
+        'creationTimestamp': '2024-03-15T08:30:00.000',
+        'loggedDuration': '00:45',
+        'text': 'Did some work',
+        'audioTranscript': 'transcript',
+        'transcriptLanguage': 'en',
+        'entryType': 'text',
+      });
     });
 
-    test('AiInputLogEntryObject round-trips nested image AI analyses and '
+    test('AiInputLogEntryObject serializes nested image AI analyses and '
         'omits the key entirely when there are none', () {
       final imageEntry = AiInputLogEntryObject(
         creationTimestamp: DateTime(2026, 7, 23, 17, 5),
@@ -52,10 +59,14 @@ void main() {
           ),
         ],
       );
-      expect(
-        AiInputLogEntryObject.fromJson(_roundTrip(imageEntry)),
-        imageEntry,
-      );
+      final imageJson = _roundTrip(imageEntry);
+      expect(imageJson['aiResponses'], [
+        {
+          'model': 'mistral-ocr-latest',
+          'generatedAt': '2026-07-23T17:09:00.000',
+          'text': 'Datum: 05.10.26',
+        },
+      ]);
 
       // Prompt-size guard: entries without analyses must not render an
       // `aiResponses: null` key on every log line.

--- a/test/features/ai/ui/ai_response_summary_test.dart
+++ b/test/features/ai/ui/ai_response_summary_test.dart
@@ -52,7 +52,6 @@ void main() {
         WidgetTestBench(
           child: AiResponseSummary(
             aiResponse,
-            linkedFromId: 'test-id',
             fadeOut: false,
           ),
         ),
@@ -85,7 +84,6 @@ The image shows a beautiful landscape with mountains.''';
         WidgetTestBench(
           child: AiResponseSummary(
             aiResponse,
-            linkedFromId: 'test-id',
             fadeOut: false,
           ),
         ),
@@ -114,7 +112,6 @@ The image shows a beautiful landscape with mountains.''';
           WidgetTestBench(
             child: AiResponseSummary(
               aiResponse,
-              linkedFromId: 'test-id',
               fadeOut: true,
             ),
           ),
@@ -146,7 +143,6 @@ The image shows a beautiful landscape with mountains.''';
         WidgetTestBench(
           child: AiResponseSummary(
             aiResponse,
-            linkedFromId: 'test-id',
             fadeOut: false,
           ),
         ),
@@ -186,7 +182,6 @@ Help me implement OAuth 2.0 authentication in my Flutter app.
         WidgetTestBench(
           child: AiResponseSummary(
             aiResponse,
-            linkedFromId: 'test-id',
             fadeOut: false,
           ),
         ),
@@ -229,7 +224,6 @@ Style: isometric digital art. --ar 16:9
           WidgetTestBench(
             child: AiResponseSummary(
               aiResponse,
-              linkedFromId: 'test-id',
               fadeOut: false,
             ),
           ),
@@ -282,7 +276,6 @@ Style: isometric digital art. --ar 16:9
         WidgetTestBench(
           child: AiResponseSummary(
             aiResponse,
-            linkedFromId: 'test-id',
             fadeOut: false,
           ),
         ),
@@ -358,7 +351,6 @@ Style: isometric digital art. --ar 16:9
             child: SingleChildScrollView(
               child: AiResponseSummary(
                 buildResponse(text),
-                linkedFromId: 'test-id',
                 fadeOut: fadeOut,
                 collapsible: collapsible,
               ),
@@ -541,7 +533,6 @@ Style: isometric digital art. --ar 16:9
                 child: SingleChildScrollView(
                   child: AiResponseSummary(
                     entry,
-                    linkedFromId: 'test-id',
                     fadeOut: false,
                     collapsible: true,
                   ),

--- a/test/features/ai_chat/ui/controllers/chat_recorder_controller_test.dart
+++ b/test/features/ai_chat/ui/controllers/chat_recorder_controller_test.dart
@@ -2208,16 +2208,22 @@ void main() {
       glados.any.chatRecorderState,
       glados.ExploreConfig(numRuns: 120),
     ).test(
-      'copyWith with no nullable overrides resets transcript and error to null',
+      'copyWith with no nullable overrides resets result fields to null',
       (state) {
         // copyWith without optional field arguments always resets them to null
         // (they have no ?? fallback in the constructor call).
-        final updated = state.copyWith();
+        final seeded = state.copyWith(
+          transcript: 'transcript',
+          partialTranscript: 'partial',
+          error: 'error',
+        );
+        final updated = seeded.copyWith();
         expect(updated.transcript, isNull);
+        expect(updated.partialTranscript, isNull);
         expect(updated.error, isNull);
         // Non-nullable fields are preserved
-        expect(updated.status, state.status);
-        expect(updated.amplitudeHistory, state.amplitudeHistory);
+        expect(updated.status, seeded.status);
+        expect(updated.amplitudeHistory, seeded.amplitudeHistory);
       },
       tags: 'glados',
     );
@@ -2239,12 +2245,16 @@ void main() {
       const original = ChatRecorderState(
         status: ChatRecorderStatus.processing,
         amplitudeHistory: <double>[-20, -15],
+        transcript: 'transcript',
+        partialTranscript: 'partial',
+        error: 'error',
       );
       final copy = original.copyWith();
       expect(copy.status, original.status);
       expect(copy.amplitudeHistory, original.amplitudeHistory);
       // Optional nullable fields default to null when not supplied.
       expect(copy.transcript, isNull);
+      expect(copy.partialTranscript, isNull);
       expect(copy.error, isNull);
     });
 

--- a/test/features/ai_chat/ui/controllers/chat_recorder_controller_test.dart
+++ b/test/features/ai_chat/ui/controllers/chat_recorder_controller_test.dart
@@ -155,7 +155,7 @@ void main() {
 
   tearDown(tearDownTestGetIt);
 
-  test('start() without permission sets errorType and message', () async {
+  test('start() without permission sets an actionable message', () async {
     final mockRecorder = MockAudioRecorder();
     when(() => mockRecorder.hasPermission()).thenAnswer((_) async => false);
     when(() => mockRecorder.dispose()).thenAnswer((_) async {});
@@ -177,7 +177,6 @@ void main() {
     final controller = container.read(chatRecorderControllerProvider.notifier);
     await controller.start();
     final state = container.read(chatRecorderControllerProvider);
-    expect(state.errorType, ChatRecorderErrorType.permissionDenied);
     expect(state.error, contains('Microphone permission denied'));
   });
 
@@ -223,7 +222,7 @@ void main() {
       controller.start();
       async.flushMicrotasks();
       final state = container.read(chatRecorderControllerProvider);
-      expect(state.errorType, ChatRecorderErrorType.concurrentOperation);
+      expect(state.error, 'Another operation is in progress');
       gate.complete();
       // Allow the first start() to complete deterministically
       async.elapse(const Duration(milliseconds: 10));
@@ -412,7 +411,6 @@ void main() {
     await controller.start();
     await controller.stopAndTranscribe();
     final state = container.read(chatRecorderControllerProvider);
-    expect(state.errorType, ChatRecorderErrorType.transcriptionFailed);
     expect(state.error, contains('network down'));
     sub.close();
     container.dispose();
@@ -649,8 +647,8 @@ void main() {
 
     final mockSvc = MockAudioTranscriptionService();
     when(
-      () => mockSvc.transcribe(any()),
-    ).thenThrow(TimeoutException('timeout'));
+      () => mockSvc.transcribeStream(any()),
+    ).thenAnswer((_) => Stream.error(TimeoutException('timeout')));
 
     final container = ProviderContainer(
       overrides: [
@@ -671,7 +669,7 @@ void main() {
     await controller.stopAndTranscribe();
 
     final state = container.read(chatRecorderControllerProvider);
-    expect(state.errorType, ChatRecorderErrorType.transcriptionFailed);
+    expect(state.error, contains('timeout'));
     expect(
       await Directory('${baseTemp.path}/lotti_chat_rec').exists(),
       isFalse,
@@ -702,7 +700,6 @@ void main() {
     final controller = container.read(chatRecorderControllerProvider.notifier);
     await controller.start();
     final state = container.read(chatRecorderControllerProvider);
-    expect(state.errorType, ChatRecorderErrorType.startFailed);
     expect(state.error, contains('Failed to start recording'));
 
     sub.close();
@@ -1756,10 +1753,10 @@ void main() {
         // Call start() so the default tempDirectoryProvider lambda is actually
         // invoked. Permission is denied so it never reaches tempDir lookup,
         // but the lambda was created (covering the constructor branch on line
-        // 91). The permission denial sets errorType without crashing.
+        // 91). The permission denial surfaces without crashing.
         await container.read(chatRecorderControllerProvider.notifier).start();
         final afterState = container.read(chatRecorderControllerProvider);
-        expect(afterState.errorType, ChatRecorderErrorType.permissionDenied);
+        expect(afterState.error, contains('Microphone permission denied'));
       },
     );
   });
@@ -2180,7 +2177,6 @@ void main() {
           transcript: 'hello',
           partialTranscript: 'part',
           error: 'err',
-          errorType: ChatRecorderErrorType.permissionDenied,
         );
         final updated = original.copyWith(status: newStatus);
         expect(updated.status, newStatus);
@@ -2212,14 +2208,13 @@ void main() {
       glados.any.chatRecorderState,
       glados.ExploreConfig(numRuns: 120),
     ).test(
-      'copyWith with no nullable overrides always resets transcript/error/errorType to null',
+      'copyWith with no nullable overrides resets transcript and error to null',
       (state) {
         // copyWith without optional field arguments always resets them to null
         // (they have no ?? fallback in the constructor call).
         final updated = state.copyWith();
         expect(updated.transcript, isNull);
         expect(updated.error, isNull);
-        expect(updated.errorType, isNull);
         // Non-nullable fields are preserved
         expect(updated.status, state.status);
         expect(updated.amplitudeHistory, state.amplitudeHistory);
@@ -2235,11 +2230,10 @@ void main() {
       expect(s.amplitudeHistory, isEmpty);
       expect(s.transcript, isNull);
       expect(s.error, isNull);
-      expect(s.errorType, isNull);
     });
 
     test('copyWith without arguments preserves status and history', () {
-      // Note: transcript/error/errorType/partialTranscript are ALWAYS reset to
+      // Note: transcript/error/partialTranscript are ALWAYS reset to
       // null by copyWith unless explicitly provided — this is by design in the
       // state class (nullable fields are positional-null by default).
       const original = ChatRecorderState(
@@ -2252,33 +2246,6 @@ void main() {
       // Optional nullable fields default to null when not supplied.
       expect(copy.transcript, isNull);
       expect(copy.error, isNull);
-      expect(copy.errorType, isNull);
-    });
-
-    test('copyWith(status:) does not bleed into errorType', () {
-      const original = ChatRecorderState(
-        status: ChatRecorderStatus.idle,
-        amplitudeHistory: <double>[],
-        errorType: ChatRecorderErrorType.startFailed,
-      );
-      final updated = original.copyWith(status: ChatRecorderStatus.recording);
-      expect(updated.status, ChatRecorderStatus.recording);
-      expect(
-        updated.errorType,
-        isNull,
-        reason: 'copyWith always sets errorType to null unless overridden',
-      );
-    });
-
-    test('errorType variants are all settable', () {
-      for (final kind in ChatRecorderErrorType.values) {
-        const base = ChatRecorderState(
-          status: ChatRecorderStatus.idle,
-          amplitudeHistory: <double>[],
-        );
-        final updated = base.copyWith(errorType: kind);
-        expect(updated.errorType, kind);
-      }
     });
 
     test('transcript and error can be set independently', () {


### PR DESCRIPTION
## Summary

- remove seven genuine entries from the authoritative 97-item unused-code inventory
- make two AI models explicitly outbound-only and remove their unused JSON readers
- remove unused recorder error classification, widget parameters, inspector plumbing, and improver defaults
- keep serialization coverage focused on the transport shapes the app actually emits

## Impact

This is behavior-preserving code hygiene. It removes unused API surface and 197 net lines without changing rendered UI or user-visible recorder errors.

Screenshots are not applicable because the affected widget parameters were never read and the rendered surfaces are unchanged.

## Validation

- `fvm dart analyze` — no issues
- targeted Flutter tests — 112 passed:
  - `test/features/agents/model/classified_feedback_test.dart`
  - `test/features/ai/model/ai_input_test.dart`
  - `test/features/ai/ui/ai_response_summary_test.dart`
  - `test/features/ai_chat/ui/controllers/chat_recorder_controller_test.dart`
  - `test/features/knowledge_graph_poc/ui/node_inspector_panel_test.dart`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat recording error handling with clearer user-facing messages.
  * Simplified AI response display and nested response handling.

* **Improvements**
  * Updated AI and feedback data handling for more reliable outgoing JSON serialization.
  * Simplified node inspection category display.
  * Removed obsolete feedback-window and recursion settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->