### PR TITLE
chore: mark externally used declarations

### DIFF
--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -86,6 +86,8 @@ bool _isRunningInFlatpak() {
 /// uses the real `Platform.environment` check; tests set true/false to pin
 /// the branch regardless of host.
 @visibleForTesting
+// Assigned by tests outside DCM's `lib`-only usage graph.
+// ignore: unused-code
 bool? debugIsRunningInFlatpakOverride;
 
 /// True when the tasks tab is active and the tasks beamer location points

--- a/lib/database/database_config_flags.dart
+++ b/lib/database/database_config_flags.dart
@@ -143,6 +143,8 @@ mixin _JournalDbConfigFlags on _$JournalDb {
   /// retain stale flag values — and `initConfigFlags`/`insertFlagIfNotExists`
   /// would skip re-seeding because the stale cache reports the flags exist).
   @visibleForTesting
+  // Called by the shared database test harness outside DCM's `lib` scan.
+  // ignore: unused-code
   void resetConfigFlagCacheForTesting() {
     _configFlagsLoaded = false;
     _configFlagsBootstrap = null;

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -82,6 +82,8 @@ class SyncDatabase extends _$SyncDatabase
          ),
        );
 
+  // Used by database tests to wrap instrumented Drift connections.
+  // ignore: unused-code
   SyncDatabase.connect(super.c) : super.connect();
 
   bool inMemoryDatabase = false;

--- a/lib/features/agents/model/attention_negotiation.dart
+++ b/lib/features/agents/model/attention_negotiation.dart
@@ -253,6 +253,9 @@ class AttentionEvidenceRef {
   final String? label;
 
   /// Converts this evidence reference to JSON.
+  // jsonEncode reaches this dynamically when generated entity serializers
+  // expose AttentionEvidenceRef values; DCM cannot follow that invocation.
+  // ignore: unused-code
   Map<String, Object?> toJson() => {
     'kind': kind.name,
     'id': id,

--- a/lib/features/agents/ui/sidebar_wake_queue.dart
+++ b/lib/features/agents/ui/sidebar_wake_queue.dart
@@ -34,6 +34,8 @@ const Duration kSidebarWakeQueueScheduledLookahead = Duration(hours: 1);
 /// stack. Setting to `null` restores the production navigation path.
 @visibleForTesting
 abstract final class SidebarWakeQueueTestHooks {
+  // Assigned by widget tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   static void Function(String path)? navigatorOverride;
 }
 

--- a/lib/features/ai/model/inference_usage.dart
+++ b/lib/features/ai/model/inference_usage.dart
@@ -29,6 +29,9 @@ class InferenceUsage {
   final int? cachedInputTokens;
 
   /// Total tokens used (input + output)
+  // Read by multiple production inference and attribution paths; retain the
+  // explicit suppression for DCM's incomplete cross-library usage graph.
+  // ignore: unused-code
   int get totalTokens => (inputTokens ?? 0) + (outputTokens ?? 0);
 
   /// Whether any usage data is available

--- a/lib/features/categories/domain/category_icon.dart
+++ b/lib/features/categories/domain/category_icon.dart
@@ -122,7 +122,7 @@ class CategoryIconStrings {
   static const String fallbackCharacter = '?';
 
   /// Warning message prefix for invalid icon names (log output)
-  // Used by CategoryIcon.safeDeserialize below; DCM fails to connect the
+  // Used by CategoryIcon.fromJson below; DCM fails to connect the
   // static constant read in this file.
   // ignore: unused-code
   static const String invalidIconWarning =

--- a/lib/features/categories/domain/category_icon.dart
+++ b/lib/features/categories/domain/category_icon.dart
@@ -122,6 +122,9 @@ class CategoryIconStrings {
   static const String fallbackCharacter = '?';
 
   /// Warning message prefix for invalid icon names (log output)
+  // Used by CategoryIcon.safeDeserialize below; DCM fails to connect the
+  // static constant read in this file.
+  // ignore: unused-code
   static const String invalidIconWarning =
       'Warning: Invalid CategoryIcon name: ';
 }

--- a/lib/features/sync/g_counter.dart
+++ b/lib/features/sync/g_counter.dart
@@ -52,6 +52,9 @@ class GCounter extends Equatable {
   /// A fresh map each call, so a caller can't mutate this value object's state
   /// through the returned JSON (mirrors the value-object contract `Equatable`
   /// relies on).
+  // jsonEncode reaches this dynamically from generated entity serializers;
+  // DCM cannot follow that invocation through the generated JSON graph.
+  // ignore: unused-code
   Map<String, dynamic> toJson() => Map<String, dynamic>.from(byHost);
 
   @override

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -432,6 +432,8 @@ class _FirstDeviceCard extends ConsumerWidget {
 /// Follows the same override pattern as `beamToNamedOverride`. Null in
 /// production, where the real scanner is always used.
 @visibleForTesting
+// Assigned by widget and screenshot tests outside DCM's `lib` scan.
+// ignore: unused-code
 Widget Function(BuildContext context, double side)? scannerPreviewOverride;
 
 class _ScannerView extends StatefulWidget {

--- a/lib/features/sync/ui/widgets/sync_activity_indicator.dart
+++ b/lib/features/sync/ui/widgets/sync_activity_indicator.dart
@@ -16,6 +16,8 @@ import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
 abstract final class SyncActivityIndicatorTestHooks {
   /// Override the navigation callback the indicator triggers on tap.
   /// Setting to `null` restores the default `beamToNamed` behaviour.
+  // Assigned by widget tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   static void Function(String path)? navigatorOverride;
 }
 

--- a/lib/services/dev_logger.dart
+++ b/lib/services/dev_logger.dart
@@ -33,9 +33,13 @@ class DevLogger {
 
   /// Captured log messages. Logs are always added here regardless of
   /// [suppressOutput], allowing tests to verify logging behavior.
+  // Read extensively by tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   static final List<String> capturedLogs = [];
 
   /// Clears all captured logs. Call this in test setUp/tearDown.
+  // Called extensively by tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   static void clear() {
     capturedLogs.clear();
   }

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -421,6 +421,8 @@ Future<String?> getIdFromSavedRoute() async {
 }
 
 // Global override for testing
+// Assigned throughout widget tests outside DCM's `lib`-only usage graph.
+// ignore: unused-code
 void Function(String)? beamToNamedOverride;
 
 void beamToNamed(String path, {Object? data}) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -96,6 +96,8 @@ class NotificationService {
   /// catches around its own `await` for that, which is the part a `try`/`catch`
   /// around the bare call used to miss.
   @visibleForTesting
+  // Awaited by notification tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   late final Future<void> initialized;
 
   /// Memoized permission request — see [_requestPermissions].

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -466,9 +466,13 @@ class VectorClockService {
   // ---------------------------------------------------------------------------
 
   @visibleForTesting
+  // Called by vector-clock tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   Future<int> getNextAvailableCounter() async => _nextAvailableCounter;
 
   @visibleForTesting
+  // Called by vector-clock tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   Future<void> setNextAvailableCounter(int counter) async {
     _nextAvailableCounter = counter;
     _persistedCounter = counter;
@@ -476,6 +480,8 @@ class VectorClockService {
   }
 
   @visibleForTesting
+  // Called by vector-clock tests outside DCM's `lib`-only usage graph.
+  // ignore: unused-code
   Future<void> increment() async {
     final reservation = await reserveNextVectorClock();
     await reservation.commit();


### PR DESCRIPTION
## Summary

- document 17 declarations that are live through test, framework, generated-serialization, or external-tooling entry points
- add only declaration-scoped DCM `unused-code` suppressions; no broad exclusions and no runtime behavior changes
- reduce the projected licensed `dcm check-unused-code lib` result from 83 to 66 after merge

## Why

DCM scans `lib` as its usage graph and cannot see several legitimate callers in `test`, `integration_test`, framework dispatch, or generated serialization. Deleting these contracts would remove meaningful testability or runtime serialization behavior. Each suppression sits directly beside the declaration and states the concrete caller class.

## Validation

- `fvm dart format` on all 14 touched files: no changes
- exact-file `fvm dart analyze`: no issues
- 15 affected test files: 365 tests passed
- `git diff --check`: clean
- the approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards

No user-visible behavior changes; no changelog entry is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments for testing hooks, dynamic serialization paths, and externally accessed diagnostics.
* **Chores**
  * Suppressed false-positive unused-code and analyzer warnings without changing runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->