### PR TITLE
test: journal create-menu manual case expects the unlinked task row

### DIFF
--- a/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
+++ b/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
@@ -754,7 +754,9 @@ void main() {
         final messages = _messages(tester);
         expect(find.text(messages.createEntryTitle), findsOneWidget);
         expect(find.text(messages.addActionAddEvent), findsOneWidget);
-        expect(find.text(messages.addActionAddTask), findsOneWidget);
+        // Unlinked host: the journal FAB's sheet creates a standalone task,
+        // so the row wears the plain verb, not the linked variant.
+        expect(find.text(messages.addActionCreateTask), findsOneWidget);
         expect(
           find.text(messages.taskFirstRunRecordAudio),
           findsOneWidget,


### PR DESCRIPTION
Follow-up to #3793: the *journal* create-menu manual-capture case still asserted the old bare-noun "Task" row (`addActionAddTask`). The journal FAB opens the Add sheet with no host, where the task row now reads "Add a task" (`addActionCreateTask`) — the task-host twin of this case was already fixed in #3793, this one was missed and broke the German manual capture lane on `main` ([failing run](https://github.com/matthiasn/lotti/actions/runs/30921347218/job/92032467139)).

Verified locally with `LOTTI_MANUAL_LOCALE=de` — all 36 cases in the journal manual suite pass. Once merged, the manual workflow can be dispatched for a fresh catalog build.

Test-only; no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the journal create-menu screenshot test to reflect the standalone task action label, “Create task.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->