### PR TITLE
Fix: lib/database/database_links_ratings.dart

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -141,6 +141,16 @@ class JournalDb extends _$JournalDb
          ),
        );
 
+  /// Test-only seam: lets tests wrap a [DatabaseConnection] with a
+  /// [QueryInterceptor] (e.g. to count real SQL statements) before handing
+  /// it to [JournalDb] — mirrors [SyncDatabase.connect].
+  @visibleForTesting
+  JournalDb.connect(super.connection)
+    : inMemoryDatabase = true,
+      _loggingService = null,
+      _documentsDirectory = null,
+      super.connect();
+
   @override
   bool inMemoryDatabase = false;
   final DomainLogger? _loggingService;

--- a/lib/database/database_links_ratings.dart
+++ b/lib/database/database_links_ratings.dart
@@ -191,15 +191,28 @@ mixin _JournalDbLinksRatings
   /// Single-shot query executed by the basic-links coalescer. Extracted as a
   /// protected seam so tests can count DB round-trips without depending on
   /// a query interceptor.
+  ///
+  /// While modern SQLite defaults `SQLITE_MAX_VARIABLE_NUMBER` to 32,766,
+  /// requiring >32k distinct entry ids in a single microtask wave to exceed the
+  /// cap (which no current caller produces), the id set is chunked by
+  /// `_sqliteInListChunk` to maintain a consistent chunking discipline with
+  /// the other bulk-by-id helpers in this file.
   @protected
   @visibleForTesting
   Future<List<EntryLink>> runBasicLinksQueryForIds(Set<String> ids) async {
-    final rows =
-        await (select(linkedEntries)..where(
-              (t) => t.toId.isIn(ids.toList()) & t.type.equals('BasicLink'),
-            ))
-            .get();
-    return rows.map(entryLinkFromLinkedDbEntry).toList();
+    final idList = ids.toList(growable: false);
+    final combined = <EntryLink>[];
+    for (var i = 0; i < idList.length; i += _sqliteInListChunk) {
+      final end = (i + _sqliteInListChunk).clamp(0, idList.length);
+      final chunk = idList.sublist(i, end);
+      final rows =
+          await (select(linkedEntries)..where(
+                (t) => t.toId.isIn(chunk) & t.type.equals('BasicLink'),
+              ))
+              .get();
+      combined.addAll(rows.map(entryLinkFromLinkedDbEntry));
+    }
+    return combined;
   }
 
   Future<List<EntryLink>> _coalesceBasicLinks(Set<String> ids) {

--- a/test/database/basic_links_coalescing_test.dart
+++ b/test/database/basic_links_coalescing_test.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: avoid_redundant_argument_values
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/database/database.dart';
@@ -158,6 +160,68 @@ void main() {
       },
     );
   });
+
+  group('basicLinksForEntryIds batch chunking', () {
+    // _sqliteInListChunk is private to the library, so tests hardcode 500
+    // with this explanatory comment.
+    const chunkSize = 500;
+
+    test(
+      'issues 1 SELECT for 500 ids, 2 for 501 ids, and 3 for 1001 ids',
+      () async {
+        final counter = _LinkedEntriesSelectCounter();
+        final countedBench = await CoalescingDbBench.create(
+          () => JournalDb.connect(
+            DatabaseConnection(NativeDatabase.memory().interceptWith(counter)),
+          ),
+        );
+        addTearDown(countedBench.tearDown);
+        final countedDb = countedBench.db;
+
+        counter.reset();
+        await countedDb.basicLinksForEntryIds({
+          for (var i = 0; i < chunkSize; i++) 'id-500-$i',
+        });
+        expect(counter.count, 1);
+
+        counter.reset();
+        await countedDb.basicLinksForEntryIds({
+          for (var i = 0; i < chunkSize + 1; i++) 'id-501-$i',
+        });
+        expect(counter.count, 2);
+
+        counter.reset();
+        await countedDb.basicLinksForEntryIds({
+          for (var i = 0; i < chunkSize * 2 + 1; i++) 'id-1001-$i',
+        });
+        expect(counter.count, 3);
+      },
+    );
+
+    test(
+      'completeness check: 501 inserted links queried in one wave are all returned across the chunk seam',
+      () async {
+        const count = chunkSize + 1;
+        final targetIds = <String>{};
+
+        for (var i = 0; i < count; i++) {
+          final targetId = 'target-$i';
+          targetIds.add(targetId);
+          await insertBasicLink(fromId: 'parent-$i', toId: targetId);
+        }
+
+        db.basicLinkQueryCount = 0;
+        final results = await db.basicLinksForEntryIds(targetIds);
+
+        expect(results.length, count);
+        expect(
+          results.map((link) => link.toId).toSet(),
+          targetIds,
+        );
+        expect(db.basicLinkQueryCount, 1);
+      },
+    );
+  });
 }
 
 /// Subclass whose `runBasicLinksQueryForIds` throws, so the coalescer's
@@ -173,5 +237,25 @@ class _FailingLinksJournalDb extends JournalDb {
   Future<List<EntryLink>> runBasicLinksQueryForIds(Set<String> ids) {
     attempts += 1;
     return Future<List<EntryLink>>.error(failure);
+  }
+}
+
+class _LinkedEntriesSelectCounter extends QueryInterceptor {
+  int count = 0;
+
+  void reset() {
+    count = 0;
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> runSelect(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    if (statement.contains('linked_entries')) {
+      count += 1;
+    }
+    return executor.runSelect(statement, args);
   }
 }


### PR DESCRIPTION
`runBasicLinksQueryForIds` issues a single `to_id IN (…)` query over the full merged wave set without chunking, which can exceed SQLite's bind-variable limit when many callers coalesce. Applying the same chunking pattern used elsewhere in this file (e.g. `getBulkLinkedTimeSpans`) with `_sqliteInListChunk` fixes this.

_This change was drafted with AI assistance and reviewed by a human before this PR was opened._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading link ratings for large sets of records by avoiding database query size limitations.
  * Combined results from multiple queries seamlessly when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->