### PR TITLE
feat: profile infrastructure for demo mode — isolated guest worlds, capability-gated sync, in-app switching

### DIFF
--- a/docs/adr/0049-profile-scoped-storage-and-demo-mode.md
+++ b/docs/adr/0049-profile-scoped-storage-and-demo-mode.md
@@ -1,0 +1,80 @@
+# ADR 0049: Profile-scoped storage and the demo-mode sync boundary
+
+Date: 2026-08-05
+Status: accepted
+
+## Context
+
+Demo mode needs a play world with complete isolation from real data: its own
+root path, databases, settings, and sync identity, with zero possibility of
+cross-contamination. Before this change the app had two independent root
+resolution mechanisms (the getIt `Directory` singleton for file I/O, and a
+fresh `findDocumentsDirectory()` call inside every database open), several
+device-global stores (SharedPreferences, keychain, TTS model cache), and a
+sync stack whose `enable_matrix` flag gated only outbox *sends* — enqueues,
+the inbound pipeline, backfill timers, and a startup node-profile broadcast
+all ran unconditionally.
+
+## Decision
+
+**One path authority.** The getIt `Directory` singleton is registered to the
+active profile root; `openDbConnection` falls back to it and never re-derives
+the OS path once a root is registered. Guest worlds nest under
+`<realRoot>/guest_profiles/<uuid>/`; the real world stays at the existing
+root, unmoved (backward compatible).
+
+**Per-profile (inside the profile root):** all Drift databases including
+`settings.sqlite` (hence the sync host ID `VC_HOST`, minted fresh per world),
+entity JSON sidecars, media, waveform caches, agent files, logs, backups,
+embeddings, and — real world only — the `matrix/` session store.
+
+**Global (device):**
+
+| Store | Scope rationale |
+|-------|-----------------|
+| SharedPreferences (whats-new seen, `seen_` hints, recording style, backfill toggle) | Device-level UX memory; not path-scopable; leaking "seen hint X" into a demo is desirable, carries no user data. |
+| Keychain `MATRIX_CONFIG` (Matrix credentials) | OS keychains are app-scoped. Stays global and real-only: guest worlds never construct a reader (see below), and keeping it global preserves a future "promote demo to synced" without re-login. |
+| Window geometry | Device/hardware state — moved from SettingsDb to SharedPreferences (with one-time migration) so a switch doesn't snap the window. |
+| TTS model cache (`tts_models/`) | Content-addressable blobs, no user data; hundreds of MB not worth duplicating. |
+| OS temp dir / `sqlite3.tempDirectory` | Anonymous transient spill files, process-global property. |
+| `profiles.json` | The registry lists worlds; by definition it cannot live inside one. |
+
+**Sync is structurally absent in guest worlds, not disabled.** Registration
+branches on `ProfileCapabilities.syncEnabled`: guests get an
+`InertOutboxService` (all enqueues are counted no-ops) and none of the Matrix
+stack — no client, no inbound queue, no backfill timers, no broadcasts, no
+VC-burn handlers. This is stronger than any flag: a guest world produces zero
+outbox rows and has no code path that reads the keychain credentials.
+
+## Sync-config sharing analysis (requirement 9)
+
+Sharing the Matrix *credentials* store between worlds is safe **only**
+because guest worlds have no reader. Sharing sync *state* (room id, host id,
+sequence log) would be catastrophic — a demo world writing into the real
+outbox or claiming counters in the real sequence space corrupts the real
+device's sync history. Hence: credentials global-but-unread, all sync state
+per-profile. Should a guest world ever be promoted to a synced world, it
+must (a) keep its own host ID, (b) create or join a **new** room — never the
+real room — and (c) opt into the full stack via capabilities. That promotion
+is explicitly out of scope here and recorded as an open question.
+
+## Consequences
+
+- Existing installs see no change: no registry file means "real world,
+  active"; the first mutation writes `profiles.json`.
+- Every database or store added in the future MUST resolve its path through
+  the registered root (or an explicit provider) and be added to
+  `ServiceDisposer` + `WorldHandle`; the audit tests fail on OS-path
+  re-derivation.
+- The demo world's logs, backups, and slow-query captures land inside the
+  guest directory and are deleted with it.
+- In-app switching tears down the whole service generation; anything holding
+  a getIt singleton across generations is a bug (the generation-keyed
+  ProviderScope is the enforcement mechanism for widgets).
+
+## Open questions
+
+- Promoting a guest world to a synced world (new room, existing credentials)
+  — deliberately unimplemented.
+- Multiple concurrent guest worlds are supported by the registry; the UI
+  exposes a single demo world for now.

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -144,7 +144,7 @@ class _DeviceOutbox {
     required this.deviceName,
   });
 
-  final OutboxService service;
+  final MatrixOutboxService service;
   final _ObservedOutboxMessageSender sender;
   final JournalDb journalDb;
   final SyncDatabase syncDb;
@@ -168,7 +168,7 @@ class _DeviceOutbox {
       loggingService: loggingService,
     );
     final sender = _ObservedOutboxMessageSender(matrixService);
-    final service = OutboxService(
+    final service = MatrixOutboxService(
       syncDatabase: syncDb,
       loggingService: loggingService,
       vectorClockService: vectorClockService,
@@ -206,7 +206,7 @@ class _DeviceMediaRepair {
 
   factory _DeviceMediaRepair.wire({
     required MatrixService matrixService,
-    required OutboxService outboxService,
+    required MatrixOutboxService outboxService,
     required JournalDb journalDb,
     required VectorClockService vectorClockService,
     required Directory documentsDirectory,

--- a/knowledge/architecture/bootstrap-and-di.md
+++ b/knowledge/architecture/bootstrap-and-di.md
@@ -41,47 +41,50 @@ services; GetIt services must not resolve Riverpod providers.** A GetIt
 singleton that needed a provider would have to reach for a container that does
 not exist yet at registration time.
 
-`main()` bridges the two exactly once, overriding a handful of providers with
-the already-constructed singletons so the widget tree and the service layer
-share one instance rather than building a second:
+`LottiAppRoot` bridges the two once **per service generation**:
+`buildProviderOverrides()` (in `lib/app_bootstrap.dart`) overrides a handful
+of providers with the already-constructed singletons, and the `ProviderScope`
+carries a generation-keyed `ValueKey` so that an in-app profile switch (see
+[profiles and demo mode](profiles-and-demo-mode.md)) discards the whole scope
+and rebinds every provider against the freshly registered generation. In
+guest worlds `matrixServiceProvider` is deliberately left unoverridden — the
+Matrix stack does not exist there, and accidental resolution fails loudly.
 
 ```dart
-runApp(
-  ProviderScope(
-    overrides: [
-      matrixServiceProvider.overrideWithValue(getIt<MatrixService>()),
-      maintenanceProvider.overrideWithValue(getIt<Maintenance>()),
-      journalDbProvider.overrideWithValue(getIt<JournalDb>()),
-      syncDatabaseProvider.overrideWithValue(getIt<SyncDatabase>()),
-      loggingServiceProvider.overrideWithValue(getIt<LoggingService>()),
-      outboxServiceProvider.overrideWithValue(getIt<OutboxService>()),
-      aiConfigRepositoryProvider.overrideWithValue(getIt<AiConfigRepository>()),
-    ],
-    child: const MyBeamerApp(),
-  ),
+ProviderScope(
+  key: ValueKey('profile-gen-$_generation'),
+  overrides: buildProviderOverrides(getIt<ProfileContext>()),
+  child: const MyBeamerApp(),
 );
 ```
 
 # Startup sequence
 
+The bootstrap is split along the profile-switch boundary
+(`lib/app_bootstrap.dart`): `registerProcessLogging()` and
+`initPlatformOnce()` run exactly once per process, while
+`resolveActiveProfile()` + `bootstrapProfileServices()` run once per service
+generation — on cold boot and again after every in-app profile switch.
+
 ```mermaid
 flowchart TD
   FD["ensureFileDescriptorSoftLimit()"] --> Zone["runZonedGuarded"]
-  Zone --> Log["Register LoggingService + DomainLogger first"]
-  Log --> Binding["WidgetsFlutterBinding.ensureInitialized()"]
-  Binding --> Media["MediaKit.ensureInitialized() (failure is non-fatal)"]
-  Media --> Window{"isDesktop?"}
-  Window -->|yes| WM["windowManager: 1280x720, min 360x640, then show + focus"]
-  Window -->|no| Docs
-  WM --> Docs["findDocumentsDirectory()"]
-  Docs --> Early["Register SecureStorage, Directory, SettingsDb, WindowService"]
-  Early --> Restore["WindowService.restore()"]
-  Restore --> TZ["tz.initializeTimeZones()"]
-  TZ --> Singletons["registerSingletons()"]
+  Zone --> Log["registerProcessLogging(): LoggingService + DomainLogger first"]
+  Log --> Platform["initPlatformOnce(): binding, orientation lock,<br/>MediaKit (non-fatal), windowManager show+focus,<br/>timezones, vodozemac init"]
+  Platform --> Resolve["resolveActiveProfile(): findDocumentsDirectory()<br/>+ profiles.json → active Profile + root"]
+  Resolve --> Early["bootstrapProfileServices(): register SecureStorage,<br/>ProfileContext, Directory(profile root), SettingsDb, WindowService"]
+  Early --> Restore["WindowService.restore() (cold boot only)"]
+  Restore --> Singletons["registerSingletons(profile: ctx)"]
   Singletons --> Lifecycle["AppLifecycleListener(onExitRequested)"]
   Lifecycle --> ErrorHook["FlutterError.onError = handleFlutterFrameworkError"]
-  ErrorHook --> Run["runApp(ProviderScope(...MyBeamerApp))"]
+  ErrorHook --> Run["runApp(LottiAppRoot) → generation-keyed ProviderScope"]
 ```
+
+The registered `Directory` is the **active profile root**, not the raw OS
+documents directory — every database open and file write resolves through it
+(`openDbConnection` falls back to it; see
+[profiles and demo mode](profiles-and-demo-mode.md) for the isolation
+contract).
 
 Four details in that sequence are deliberate and easy to break:
 
@@ -103,8 +106,14 @@ Four details in that sequence are deliberate and easy to break:
 
 # Registration order inside `registerSingletons()`
 
-`registerSingletons()` is a single long function, and its order encodes a real
-dependency graph rather than a filing preference.
+`registerSingletons({required ProfileContext profile})` is a single long
+function, and its order encodes a real dependency graph rather than a filing
+preference. The Matrix phase is conditional on the profile's capabilities:
+real profiles build the full sync stack (`_registerMatrixSyncStack` in
+`lib/get_it_sync.dart`), guest/demo worlds register only an
+`InertOutboxService` — no Matrix client, no inbound queue, no backfill
+timers, no startup broadcast (see
+[profiles and demo mode](profiles-and-demo-mode.md)).
 
 ```mermaid
 flowchart TD
@@ -115,19 +124,19 @@ flowchart TD
     P2["initConfigFlags(JournalDb)<br/>LoggingService.listenToConfigFlag()"]
   end
   subgraph Phase3["3. Caches and config"]
-    P3["EntitiesCacheService.init()<br/>AiConfigRepository(AiConfigDb())<br/>vodozemac init, DayProcessingDb + outbox cutover"]
+    P3["EntitiesCacheService.init()<br/>AiConfigRepository(AiConfigDb())<br/>DayProcessingDb + outbox cutover,<br/>SyncSequenceLogService, NotificationScheduler,<br/>ConsumptionRepository"]
   end
-  subgraph Phase4["4. Matrix sync chain"]
-    P4["createMatrixClient → MatrixSdkGateway → MatrixMessageSender<br/>→ SyncEventProcessor → QueuePipelineCoordinator<br/>→ MatrixService → OutboxService"]
+  subgraph Phase4["4. Sync boundary (capability-gated)"]
+    P4["syncEnabled: createMatrixClient → MatrixSdkGateway<br/>→ MatrixMessageSender → SyncEventProcessor<br/>→ QueuePipelineCoordinator → MatrixService<br/>→ MatrixOutboxService + backfill/media/broadcast<br/>guest: InertOutboxService only"]
   end
-  subgraph Phase5["5. Outbox-dependent services"]
-    P5["ConsumptionSyncService, AiAttributionService,<br/>NotificationRepository, SyncNodeProfileBroadcaster,<br/>BackfillResponseHandler, BackfillRequestService"]
+  subgraph Phase5["5. Outbox-dependent services (both modes)"]
+    P5["ConsumptionSyncService, AiAttributionService,<br/>NotificationRepository"]
   end
   subgraph Phase6["6. Logic layer"]
     P6["MetadataService, GeolocationService, PersistenceLogic,<br/>EditorStateService, HealthImport, LinkService,<br/>Maintenance, NavService"]
   end
   Phase1 --> Phase2 --> Phase3 --> Phase4 --> Phase5 --> Phase6
-  Phase6 --> Late["_registerLateAndOptionalServices()"]
+  Phase6 --> Late["_registerLateAndOptionalServices(profile)"]
 ```
 
 **Config flags gate construction.** `initConfigFlags(getIt<JournalDb>())` runs
@@ -181,7 +190,10 @@ immediately before `LoggingService.flush()`, as described in
 | Concern | File |
 |---------|------|
 | Entry point, zone guard, error handlers | [`lib/main.dart`](../../lib/main.dart) |
+| Process-once vs per-generation bootstrap | [`lib/app_bootstrap.dart`](../../lib/app_bootstrap.dart) |
+| Generation-keyed ProviderScope + switch splash | [`lib/app_root.dart`](../../lib/app_root.dart) |
 | Singleton graph | [`lib/get_it.dart`](../../lib/get_it.dart) |
+| Capability-gated sync registration | [`lib/get_it_sync.dart`](../../lib/get_it_sync.dart) |
 | Late/optional and platform-conditional services | [`lib/get_it_helpers.dart`](../../lib/get_it_helpers.dart) |
 | Maintenance-only registrations | [`lib/get_it_maintenance.dart`](../../lib/get_it_maintenance.dart) |
 | Provider overrides bridging GetIt into Riverpod | [`lib/providers/service_providers.dart`](../../lib/providers/service_providers.dart) |

--- a/knowledge/architecture/profiles-and-demo-mode.md
+++ b/knowledge/architecture/profiles-and-demo-mode.md
@@ -38,7 +38,7 @@ the pre-existing documents root — existing installs never move a byte. Each
 **guest** profile (the demo workspace) lives under
 `<realRoot>/guest_profiles/<uuid>/`.
 
-```
+```text
 <realRoot>/                      ← real world (unchanged layout)
   profiles.json                  ← registry: profiles + active marker (global)
   db.sqlite, settings.sqlite, …

--- a/knowledge/architecture/profiles-and-demo-mode.md
+++ b/knowledge/architecture/profiles-and-demo-mode.md
@@ -1,0 +1,159 @@
+---
+type: Architecture
+title: Profiles and demo mode
+description: How guest worlds are isolated from the real world — registry, path scoping, capability-gated sync, and the in-app switch.
+resource: ../../lib/features/profiles/
+tags: [architecture, profiles, demo-mode, isolation, sync, storage]
+status: draft
+generated: { by: claude/fable-5, at: 2026-08-05T12:00:00Z }
+stale_after: 2027-02-05
+sources:
+  - id: registry
+    resource: ../../lib/features/profiles/repository/profile_registry.dart
+    title: ProfileRegistry (profiles.json)
+    last_modified: 2026-08-05
+  - id: switcher
+    resource: ../../lib/features/profiles/service/profile_switcher.dart
+    title: ProfileSwitcher
+    last_modified: 2026-08-05
+  - id: world-handle
+    resource: ../../lib/features/profiles/service/world_handle.dart
+    title: WorldHandle
+    last_modified: 2026-08-05
+  - id: sync-registration
+    resource: ../../lib/get_it_sync.dart
+    title: Capability-gated sync registration
+    last_modified: 2026-08-05
+  - id: db-common
+    resource: ../../lib/database/common.dart
+    title: openDbConnection profile-root fallback
+    last_modified: 2026-08-05
+---
+
+# One process, many worlds
+
+A **profile** is a complete world: its own root directory holding every
+database, JSON sidecar, media file, log, and setting. The **real** profile is
+the pre-existing documents root — existing installs never move a byte. Each
+**guest** profile (the demo workspace) lives under
+`<realRoot>/guest_profiles/<uuid>/`.
+
+```
+<realRoot>/                      ← real world (unchanged layout)
+  profiles.json                  ← registry: profiles + active marker (global)
+  db.sqlite, settings.sqlite, …
+  images/, tasks/, logs/, matrix/, …
+  guest_profiles/
+    <uuid>/                      ← one guest world, same layout
+      db.sqlite, settings.sqlite, …
+      images/, tasks/, logs/, …  (never matrix/ — no sync stack)
+```
+
+`ProfileRegistry` owns `profiles.json` (atomic writes, lenient parsing — a
+corrupt file degrades to "real world, active"). It is deliberately **not** in
+getIt: getIt is reset on every switch, the registry must survive them.
+
+# The isolation contract
+
+1. **One path authority.** The getIt `Directory` singleton is registered to
+   the active profile root, and `openDbConnection` falls back to it instead
+   of re-deriving the OS documents directory
+   ([`lib/database/common.dart`](../../lib/database/common.dart)). Every
+   Drift file, sidecar, media file, and log follows the active root. The
+   regression tests in
+   [`test/database/common_test.dart`](../../test/database/common_test.dart)
+   make path_provider throw to prove no code path re-derives the OS root.
+2. **Sync is structurally absent in guest worlds.** `registerSingletons`
+   consults `ProfileCapabilities`: guests get an `InertOutboxService`
+   (counted no-op enqueues, never-emitting login-gate stream) and none of the
+   Matrix stack — the client (and its `matrix/` store), inbound queue,
+   backfill timers, node-profile startup broadcast, and VC-burn handlers are
+   never constructed. The device-global keychain credentials
+   (`MATRIX_CONFIG`) therefore have no reader in a guest world.
+3. **Own sync identity for free.** The host ID (`VC_HOST`) lives in
+   `settings.sqlite`; a guest world has its own settings database, so
+   `VectorClockService.setNewHost()` mints a fresh host ID on the world's
+   first boot. Guest worlds can never collide with the real sync identity.
+4. **Device state stays global.** Window geometry (SharedPreferences), UI
+   hint/whats-new flags (SharedPreferences), keychain sync credentials
+   (unread in guests), the TTS model cache, and the OS temp directory are
+   deliberately not world-scoped — the rationale per item is in
+   [ADR 0049](../../docs/adr/0049-profile-scoped-storage-and-demo-mode.md).
+
+The audit test
+[`test/features/profiles/service/world_handle_test.dart`](../../test/features/profiles/service/world_handle_test.dart)
+plants a canary real root and asserts it stays byte-identical while a guest
+world is written.
+
+# Switching worlds
+
+```mermaid
+stateDiagram-v2
+  [*] --> RealActive: cold boot (marker = real)
+  RealActive --> Seeding: DemoWorldCreator.createAndActivate
+  Seeding --> Switching: world populated via WorldHandle,\nmarker → guest
+  Seeding --> RealActive: seed failed → guest dir removed
+  Switching --> GuestActive: teardown + bootstrap + new scope generation
+  GuestActive --> Switching2: switchTo(real)
+  Switching2 --> RealActive
+  GuestActive --> GuestActive: app restart (marker read at boot)
+```
+
+`ProfileSwitcher.switchTo` (owned by `LottiAppRoot`, outside getIt) runs:
+
+1. **Persist the marker first** — a crash mid-switch reopens the intended
+   world on next launch.
+2. Splash replaces the tree (unmounting every widget listener), one frame
+   settles.
+3. **Quiesce**: `TimeService.stop()` persists a running timer,
+   `AudioPlayerController.disposeActivePlayer()`, app-exit listener
+   disposed, `WindowService.detachForRestart()`.
+4. **Teardown**: `ServiceDisposer.disposeAll()` (services then databases,
+   settings last), bounded log flush, `getIt.reset()` (fires remaining
+   dispose callbacks).
+5. **Bootstrap**: fresh process logging, `resolveActiveProfile()`,
+   `bootstrapProfileServices(restoreWindow: false)`, new app-exit listener.
+6. The root bumps its generation key; the new `ProviderScope` recomputes the
+   getIt bridge overrides (`buildProviderOverrides`).
+
+A teardown/bootstrap failure leaves the app on the splash; recovery is an
+app restart, which boots the marked world from a clean process.
+
+# Populate first, then migrate
+
+Demo creation deliberately populates the world **before** the live app is
+re-pointed at it: `WorldHandle.open(root)` builds a second, non-active set of
+database handles with explicit documents-directory providers (nothing can
+fall back to the active root), the seeder writes through them, then
+`DemoWorldCreator` hot-switches. The "documents migration" is the re-pointing
+of the whole documents layer at the seeded root — not a data move.
+
+`WorldHandle` writes must arrive with fully formed metadata: getIt-coupled
+logic (PersistenceLogic, repositories) must never run against a non-active
+world.
+
+# Riverpod surface
+
+`profileContextProvider` (overridden per generation) exposes the active
+world; `syncFeatureAvailableProvider` gates every sync UI surface, and
+`demoModeActiveProvider` drives demo-only chrome. In guest worlds
+`matrixServiceProvider` is left unoverridden so accidental resolution fails
+loudly instead of silently no-opping.
+
+# Where to look
+
+| Concern | File |
+|---------|------|
+| Registry + profiles.json | [`lib/features/profiles/repository/profile_registry.dart`](../../lib/features/profiles/repository/profile_registry.dart) |
+| Capabilities + context | [`lib/features/profiles/model/profile_context.dart`](../../lib/features/profiles/model/profile_context.dart) |
+| Switch orchestration | [`lib/features/profiles/service/profile_switcher.dart`](../../lib/features/profiles/service/profile_switcher.dart) |
+| Non-active world access | [`lib/features/profiles/service/world_handle.dart`](../../lib/features/profiles/service/world_handle.dart) |
+| Demo creation ordering | [`lib/features/profiles/service/demo_world_creator.dart`](../../lib/features/profiles/service/demo_world_creator.dart) |
+| Sync boundary registration | [`lib/get_it_sync.dart`](../../lib/get_it_sync.dart) |
+| Inert outbox | [`lib/features/sync/outbox/inert_outbox_service.dart`](../../lib/features/sync/outbox/inert_outbox_service.dart) |
+| Capability providers | [`lib/features/profiles/state/profile_providers.dart`](../../lib/features/profiles/state/profile_providers.dart) |
+
+Related: [bootstrap and DI](bootstrap-and-di.md) for the generation loop,
+[sync overview](../features/sync/overview.md) for what the real stack does,
+and [ADR 0049](../../docs/adr/0049-profile-scoped-storage-and-demo-mode.md)
+for the storage-scoping decision.

--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -533,6 +533,12 @@ clean it up:
 
 The correctness of the whole feature rests on a few sharp assumptions:
 
+- The stack described here exists only in **real profiles**. Guest/demo
+  worlds never construct it — they register an inert outbox instead, have
+  their own per-world host ID, and never read the keychain Matrix
+  credentials. See
+  [profiles and demo mode](../../architecture/profiles-and-demo-mode.md).
+
 - Sender-side `coveredVectorClocks` enrichment must stay correct, or offline
   convergence stops being sound.
 - File-backed payload replay depends on attachment dedupe and ordering in

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -65,9 +65,7 @@ void registerProcessLogging() {
 Future<void> initPlatformOnce() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Platform startup call; controller behavior is covered by focused tests.
-  // coverage:ignore-start
   await appOrientationController.lockToPortrait();
-  // coverage:ignore-end
   try {
     MediaKit.ensureInitialized();
   } catch (e) {
@@ -101,11 +99,9 @@ Future<void> initPlatformOnce() async {
   tz.initializeTimeZones();
   // Loading the database does not pick a zone — without this the package's
   // `local` stays UTC and scheduled reminders land hours off.
-  // coverage:ignore-start
   await configureLocalTimezone(
     onError: handleTimezoneConfigurationError,
   );
-  // coverage:ignore-end
 
   // Process-global crypto init for the vodozemac bindings; required before
   // any Matrix stack is constructed, harmless when none ever is.

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/ai/repository/ai_config_repository.dart'
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/profiles/state/profile_providers.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
@@ -199,9 +200,16 @@ Future<ProfileContext> bootstrapProfileServices(
 
 /// The getIt→Riverpod bridge overrides, recomputed for every service
 /// generation so a rebuilt ProviderScope binds to the fresh singletons.
+///
+/// In guest worlds [matrixServiceProvider] is deliberately NOT overridden:
+/// the Matrix stack is never constructed there, and an accidental resolution
+/// should fail loudly (UnimplementedError) instead of silently no-opping —
+/// every sync surface is expected to gate on [syncFeatureAvailableProvider].
 List<Override> buildProviderOverrides(ProfileContext context) {
   return [
-    matrixServiceProvider.overrideWithValue(getIt<MatrixService>()),
+    profileContextProvider.overrideWithValue(context),
+    if (context.capabilities.syncEnabled)
+      matrixServiceProvider.overrideWithValue(getIt<MatrixService>()),
     maintenanceProvider.overrideWithValue(getIt<Maintenance>()),
     journalDbProvider.overrideWithValue(getIt<JournalDb>()),
     syncDatabaseProvider.overrideWithValue(getIt<SyncDatabase>()),

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -58,7 +58,10 @@ void registerProcessLogging() {
 }
 
 /// One-time, process-global platform initialization. Never re-run on a
-/// profile switch.
+/// profile switch. Excluded from coverage: every line is a native platform
+/// call (window manager, MediaKit, orientation, vodozemac) that cannot run
+/// under flutter test.
+// coverage:ignore-start
 Future<void> initPlatformOnce() async {
   WidgetsFlutterBinding.ensureInitialized();
   // Platform startup call; controller behavior is covered by focused tests.
@@ -108,6 +111,7 @@ Future<void> initPlatformOnce() async {
   // any Matrix stack is constructed, harmless when none ever is.
   await vod.init();
 }
+// coverage:ignore-end
 
 /// What [resolveActiveProfile] found: the OS-derived real root and the
 /// registry's view of which world should be running.
@@ -164,6 +168,7 @@ Future<ProfileContext> bootstrapProfileServices(
   ProfileBootInfo info, {
   required AppLifecycleHolder lifecycleHolder,
   bool restoreWindow = true,
+  bool registerLateAndOptional = true,
 }) async {
   // A dangling marker can point at a world whose directory was removed
   // externally; recreate the skeleton rather than failing boot.
@@ -194,7 +199,10 @@ Future<ProfileContext> bootstrapProfileServices(
     await getIt<WindowService>().restore();
   }
 
-  await registerSingletons(profile: context);
+  await registerSingletons(
+    profile: context,
+    registerLateAndOptional: registerLateAndOptional,
+  );
   return context;
 }
 

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -1,0 +1,212 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/maintenance.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart'
+    hide aiConfigRepositoryProvider;
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/sync/matrix/matrix_service.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/features/sync/secure_storage.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/main.dart';
+import 'package:lotti/providers/service_providers.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/services/window_service.dart';
+import 'package:lotti/utils/file_utils.dart';
+import 'package:lotti/utils/platform.dart';
+import 'package:lotti/utils/timezone.dart';
+import 'package:lotti/widgets/media/image_viewer_orientation_scope.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:window_manager/window_manager.dart';
+
+/// The bootstrap is split along the profile-switch boundary:
+///
+/// - [registerProcessLogging] and [initPlatformOnce] run exactly once per
+///   process. They own state that must survive a profile switch (log sinks
+///   flush per-write against the active root; native inits are not
+///   re-runnable).
+/// - [resolveActiveProfile] and [bootstrapProfileServices] run once per
+///   service generation: on cold boot and again after every profile switch,
+///   re-pointing the entire documents/database layer at the active world.
+
+/// Registers the process-lifetime logging pair. LoggingService resolves its
+/// log directory per write via the registered `Directory`, so a single
+/// instance follows the active profile across switches.
+void registerProcessLogging() {
+  final loggingService = LoggingService();
+  getIt
+    ..registerSingleton<LoggingService>(
+      loggingService,
+      dispose: (service) => service.dispose(),
+    )
+    ..registerSingleton<DomainLogger>(
+      DomainLogger(loggingService: loggingService),
+    );
+}
+
+/// One-time, process-global platform initialization. Never re-run on a
+/// profile switch.
+Future<void> initPlatformOnce() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  // Platform startup call; controller behavior is covered by focused tests.
+  // coverage:ignore-start
+  await appOrientationController.lockToPortrait();
+  // coverage:ignore-end
+  try {
+    MediaKit.ensureInitialized();
+  } catch (e) {
+    getIt<DomainLogger>().error(
+      LogDomain.general,
+      e,
+      subDomain:
+          'MediaKit initialization failed - continuing without media support',
+    );
+  }
+  Animate.restartOnHotReload = true;
+
+  if (isDesktop) {
+    await windowManager.ensureInitialized();
+
+    // Configure window options for flatpak compatibility
+    const windowOptions = WindowOptions(
+      size: AppConstants.defaultWindowSize,
+      minimumSize: AppConstants.minimumWindowSize,
+      center: true,
+      backgroundColor: Colors.transparent,
+      skipTaskbar: false,
+      titleBarStyle: TitleBarStyle.normal,
+    );
+    await windowManager.waitUntilReadyToShow(windowOptions, () async {
+      await windowManager.show();
+      await windowManager.focus();
+    });
+  }
+
+  tz.initializeTimeZones();
+  // Loading the database does not pick a zone — without this the package's
+  // `local` stays UTC and scheduled reminders land hours off.
+  // coverage:ignore-start
+  await configureLocalTimezone(
+    onError: handleTimezoneConfigurationError,
+  );
+  // coverage:ignore-end
+
+  // Process-global crypto init for the vodozemac bindings; required before
+  // any Matrix stack is constructed, harmless when none ever is.
+  await vod.init();
+}
+
+/// What [resolveActiveProfile] found: the OS-derived real root and the
+/// registry's view of which world should be running.
+class ProfileBootInfo {
+  const ProfileBootInfo({
+    required this.realRoot,
+    required this.registry,
+    required this.active,
+    required this.activeRoot,
+  });
+
+  final Directory realRoot;
+  final ProfileRegistry registry;
+  final Profile active;
+  final Directory activeRoot;
+}
+
+/// Reads the registry at the OS documents root and resolves the active
+/// profile. Pure read — a missing or corrupt registry resolves to the real
+/// world.
+Future<ProfileBootInfo> resolveActiveProfile() async {
+  final realRoot = await findDocumentsDirectory();
+  final registry = ProfileRegistry(
+    realRoot: realRoot,
+    logging: getIt.isRegistered<DomainLogger>() ? getIt<DomainLogger>() : null,
+  );
+  final state = await registry.load();
+  final active = state.activeProfile;
+  return ProfileBootInfo(
+    realRoot: realRoot,
+    registry: registry,
+    active: active,
+    activeRoot: registry.rootFor(active),
+  );
+}
+
+/// Owns the app-exit listener across generations. The listener is created
+/// after each bootstrap and disposed during window teardown (via the
+/// WindowService beforeLogFlush hook) or a profile switch.
+class AppLifecycleHolder {
+  AppLifecycleListener? listener;
+
+  void dispose() {
+    listener?.dispose();
+    listener = null;
+  }
+}
+
+/// Per-generation service bootstrap: registers the world-scoped singletons
+/// for the active profile and runs the full [registerSingletons] sequence
+/// against its root. Runs on cold boot and after every profile switch;
+/// expects getIt to contain only the process-lifetime registrations.
+Future<ProfileContext> bootstrapProfileServices(
+  ProfileBootInfo info, {
+  required AppLifecycleHolder lifecycleHolder,
+  bool restoreWindow = true,
+}) async {
+  // A dangling marker can point at a world whose directory was removed
+  // externally; recreate the skeleton rather than failing boot.
+  if (!info.activeRoot.existsSync()) {
+    await info.activeRoot.create(recursive: true);
+  }
+
+  final context = ProfileContext.forProfile(
+    profile: info.active,
+    root: info.activeRoot,
+  );
+
+  getIt
+    ..registerSingleton<SecureStorage>(SecureStorage())
+    ..registerSingleton<ProfileContext>(context)
+    ..registerSingleton<Directory>(info.activeRoot)
+    ..registerSingleton<SettingsDb>(SettingsDb())
+    ..registerSingleton<WindowService>(
+      WindowService(
+        beforeLogFlush: () async {
+          lifecycleHolder.dispose();
+          flushPendingFrameworkErrorSummaries();
+        },
+      ),
+    );
+
+  if (restoreWindow) {
+    await getIt<WindowService>().restore();
+  }
+
+  await registerSingletons(profile: context);
+  return context;
+}
+
+/// The getIt→Riverpod bridge overrides, recomputed for every service
+/// generation so a rebuilt ProviderScope binds to the fresh singletons.
+List<Override> buildProviderOverrides(ProfileContext context) {
+  return [
+    matrixServiceProvider.overrideWithValue(getIt<MatrixService>()),
+    maintenanceProvider.overrideWithValue(getIt<Maintenance>()),
+    journalDbProvider.overrideWithValue(getIt<JournalDb>()),
+    syncDatabaseProvider.overrideWithValue(getIt<SyncDatabase>()),
+    loggingServiceProvider.overrideWithValue(getIt<LoggingService>()),
+    outboxServiceProvider.overrideWithValue(getIt<OutboxService>()),
+    aiConfigRepositoryProvider.overrideWithValue(getIt<AiConfigRepository>()),
+  ];
+}

--- a/lib/app_root.dart
+++ b/lib/app_root.dart
@@ -16,10 +16,21 @@ class LottiAppRoot extends StatefulWidget {
     required this.registry,
     required this.lifecycleHolder,
     super.key,
+    @visibleForTesting this.appBuilder,
+    @visibleForTesting this.teardownOverride,
+    @visibleForTesting this.bootstrapOverride,
   });
 
   final ProfileRegistry registry;
   final AppLifecycleHolder lifecycleHolder;
+
+  /// Test seam: replaces MyBeamerApp so widget tests can exercise the
+  /// generation/splash machinery without booting the whole app shell.
+  final WidgetBuilder? appBuilder;
+
+  /// Test seams forwarded to the internally owned [ProfileSwitcher].
+  final Future<void> Function()? teardownOverride;
+  final Future<void> Function()? bootstrapOverride;
 
   @override
   State<LottiAppRoot> createState() => LottiAppRootState();
@@ -45,6 +56,8 @@ class LottiAppRootState extends State<LottiAppRoot> {
           _switching = false;
         });
       },
+      teardownOverride: widget.teardownOverride,
+      bootstrapOverride: widget.bootstrapOverride,
     );
   }
 
@@ -58,7 +71,9 @@ class LottiAppRootState extends State<LottiAppRoot> {
       child: ProviderScope(
         key: ValueKey('profile-gen-$_generation'),
         overrides: buildProviderOverrides(getIt<ProfileContext>()),
-        child: const MyBeamerApp(),
+        child: widget.appBuilder != null
+            ? Builder(builder: widget.appBuilder!)
+            : const MyBeamerApp(),
       ),
     );
   }

--- a/lib/app_root.dart
+++ b/lib/app_root.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/beamer/beamer_app.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
+import 'package:lotti/get_it.dart';
+
+/// Root widget above the ProviderScope. Deliberately Riverpod-free: on a
+/// profile switch the entire scope below is discarded via a new generation
+/// key, so every provider — including the getIt bridge overrides — rebinds
+/// against the freshly registered service generation.
+class LottiAppRoot extends StatefulWidget {
+  const LottiAppRoot({super.key});
+
+  @override
+  State<LottiAppRoot> createState() => LottiAppRootState();
+}
+
+class LottiAppRootState extends State<LottiAppRoot> {
+  int _generation = 0;
+
+  /// Discards the current ProviderScope and rebuilds it against the current
+  /// getIt registrations. Called by the profile switcher after it has torn
+  /// down the old generation and bootstrapped the new one.
+  void bumpGeneration() {
+    setState(() => _generation++);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      key: ValueKey('profile-gen-$_generation'),
+      overrides: buildProviderOverrides(getIt<ProfileContext>()),
+      child: const MyBeamerApp(),
+    );
+  }
+}

--- a/lib/app_root.dart
+++ b/lib/app_root.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/app_bootstrap.dart';
 import 'package:lotti/beamer/beamer_app.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/profiles/service/profile_switcher.dart';
 import 'package:lotti/get_it.dart';
 
 /// Root widget above the ProviderScope. Deliberately Riverpod-free: on a
@@ -10,7 +12,14 @@ import 'package:lotti/get_it.dart';
 /// key, so every provider — including the getIt bridge overrides — rebinds
 /// against the freshly registered service generation.
 class LottiAppRoot extends StatefulWidget {
-  const LottiAppRoot({super.key});
+  const LottiAppRoot({
+    required this.registry,
+    required this.lifecycleHolder,
+    super.key,
+  });
+
+  final ProfileRegistry registry;
+  final AppLifecycleHolder lifecycleHolder;
 
   @override
   State<LottiAppRoot> createState() => LottiAppRootState();
@@ -18,20 +27,83 @@ class LottiAppRoot extends StatefulWidget {
 
 class LottiAppRootState extends State<LottiAppRoot> {
   int _generation = 0;
+  bool _switching = false;
+  late final ProfileSwitcher _switcher;
 
-  /// Discards the current ProviderScope and rebuilds it against the current
-  /// getIt registrations. Called by the profile switcher after it has torn
-  /// down the old generation and bootstrapped the new one.
-  void bumpGeneration() {
-    setState(() => _generation++);
+  @override
+  void initState() {
+    super.initState();
+    _switcher = ProfileSwitcher(
+      registry: widget.registry,
+      lifecycleHolder: widget.lifecycleHolder,
+      onSwitchStarted: () async {
+        setState(() => _switching = true);
+      },
+      onSwitchCompleted: () {
+        setState(() {
+          _generation++;
+          _switching = false;
+        });
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    return ProviderScope(
-      key: ValueKey('profile-gen-$_generation'),
-      overrides: buildProviderOverrides(getIt<ProfileContext>()),
-      child: const MyBeamerApp(),
+    if (_switching) {
+      return const ProfileSwitchSplash();
+    }
+    return ProfileSwitcherScope(
+      switcher: _switcher,
+      child: ProviderScope(
+        key: ValueKey('profile-gen-$_generation'),
+        overrides: buildProviderOverrides(getIt<ProfileContext>()),
+        child: const MyBeamerApp(),
+      ),
     );
   }
+}
+
+/// Minimal full-screen splash shown while a profile switch tears down one
+/// service generation and bootstraps the next. Deliberately free of
+/// localization and providers — nothing from the old generation may be
+/// alive while it is on screen.
+class ProfileSwitchSplash extends StatelessWidget {
+  const ProfileSwitchSplash({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      ),
+    );
+  }
+}
+
+/// Exposes the [ProfileSwitcher] to the widget tree. Mounted ABOVE the
+/// ProviderScope, so it survives generation rebuilds and can be reached
+/// from any generation's widgets.
+class ProfileSwitcherScope extends InheritedWidget {
+  const ProfileSwitcherScope({
+    required this.switcher,
+    required super.child,
+    super.key,
+  });
+
+  final ProfileSwitcher switcher;
+
+  static ProfileSwitcher of(BuildContext context) {
+    final scope = context
+        .dependOnInheritedWidgetOfExactType<ProfileSwitcherScope>();
+    assert(scope != null, 'No ProfileSwitcherScope found in context');
+    return scope!.switcher;
+  }
+
+  @override
+  bool updateShouldNotify(ProfileSwitcherScope oldWidget) =>
+      switcher != oldWidget.switcher;
 }

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -6,6 +6,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/database/slow_query_logging.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:path/path.dart' as p;
@@ -78,6 +79,21 @@ void _setupDatabase(Database database) {
     ..execute('PRAGMA wal_autocheckpoint = 200;');
 }
 
+/// Resolves the directory database files live in when no explicit
+/// [openDbConnection] provider is passed.
+///
+/// The registered [Directory] singleton is the active profile root (real or
+/// guest world) and is the single source of truth for all persisted paths —
+/// database opens must never re-derive the OS documents directory, or a DB
+/// could land outside the active profile. The OS fallback exists only for
+/// bare unit tests that construct a database before any root is registered.
+Future<Directory> _defaultDocumentsDirectory() async {
+  if (getIt.isRegistered<Directory>()) {
+    return getIt<Directory>();
+  }
+  return findDocumentsDirectory();
+}
+
 /// Opens a database connection with lazy initialization.
 ///
 /// Creates a [LazyDatabase] that initializes the actual database connection
@@ -100,7 +116,10 @@ void _setupDatabase(Database database) {
 ///   are caught by the coalescers in `JournalDb` and by counting round-trips
 ///   in tests. Pass [Duration.zero] in tests and deep-dive captures to
 ///   surface every query.
-/// - [documentsDirectoryProvider]: Optional provider for documents directory (for testing)
+/// - [documentsDirectoryProvider]: Optional provider for the documents
+///   directory. Defaults to the registered active-profile root; pass an
+///   explicit provider to open a database in a different world (tests,
+///   profile seeding).
 /// - [tempDirectoryProvider]: Optional provider for temp directory (for testing)
 ///
 /// Returns a [LazyDatabase] instance that will initialize on first use.
@@ -136,7 +155,8 @@ LazyDatabase openDbConnection(
     }
 
     final dbFolder =
-        await (documentsDirectoryProvider?.call() ?? findDocumentsDirectory());
+        await (documentsDirectoryProvider?.call() ??
+            _defaultDocumentsDirectory());
     final file = File(p.join(dbFolder.path, fileName));
     // Ensure parent directory exists before opening to avoid SQLITE_CANTOPEN (14)
     try {

--- a/lib/database/fts5_db.dart
+++ b/lib/database/fts5_db.dart
@@ -45,8 +45,6 @@ class Fts5Db extends _$Fts5Db {
       await deleteEntry('"$uuid"');
     }
 
-    final entitiesCacheService = getIt<EntitiesCacheService>();
-
     final plainText = entry.entryText?.plainText ?? '';
     final title = entry.maybeMap(
       task: (task) => task.data.title,
@@ -56,7 +54,10 @@ class Fts5Db extends _$Fts5Db {
 
     final summary = entry.maybeMap(
       measurement: (m) {
-        final dataType = entitiesCacheService.getDataTypeById(
+        // Resolved lazily so non-measurement indexing (incl. seeding a
+        // non-active world through WorldHandle) never touches the active
+        // generation's cache.
+        final dataType = getIt<EntitiesCacheService>().getDataTypeById(
           m.data.dataTypeId,
         );
         final value = m.data.value;

--- a/lib/database/fts5_db.dart
+++ b/lib/database/fts5_db.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:drift/drift.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/common.dart';
@@ -11,13 +13,18 @@ const fts5DbFileName = 'fts5_db.sqlite';
 
 @DriftDatabase(include: {'fts5_db.drift'})
 class Fts5Db extends _$Fts5Db {
-  Fts5Db({this.inMemoryDatabase = false})
-    : super(
-        openDbConnection(
-          fts5DbFileName,
-          inMemoryDatabase: inMemoryDatabase,
-        ),
-      );
+  Fts5Db({
+    this.inMemoryDatabase = false,
+    Future<Directory> Function()? documentsDirectoryProvider,
+    Future<Directory> Function()? tempDirectoryProvider,
+  }) : super(
+         openDbConnection(
+           fts5DbFileName,
+           inMemoryDatabase: inMemoryDatabase,
+           documentsDirectoryProvider: documentsDirectoryProvider,
+           tempDirectoryProvider: tempDirectoryProvider,
+         ),
+       );
 
   final bool inMemoryDatabase;
 

--- a/lib/features/ai/database/ai_config_db.dart
+++ b/lib/features/ai/database/ai_config_db.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:lotti/database/common.dart';
@@ -11,13 +12,18 @@ const aiConfigDbFileName = 'ai_config.sqlite';
 
 @DriftDatabase(include: {'ai_config_db.drift'})
 class AiConfigDb extends _$AiConfigDb {
-  AiConfigDb({this.inMemoryDatabase = false})
-    : super(
-        openDbConnection(
-          aiConfigDbFileName,
-          inMemoryDatabase: inMemoryDatabase,
-        ),
-      );
+  AiConfigDb({
+    this.inMemoryDatabase = false,
+    Future<Directory> Function()? documentsDirectoryProvider,
+    Future<Directory> Function()? tempDirectoryProvider,
+  }) : super(
+         openDbConnection(
+           aiConfigDbFileName,
+           inMemoryDatabase: inMemoryDatabase,
+           documentsDirectoryProvider: documentsDirectoryProvider,
+           tempDirectoryProvider: tempDirectoryProvider,
+         ),
+       );
 
   bool inMemoryDatabase = false;
 

--- a/lib/features/profiles/model/profile.dart
+++ b/lib/features/profiles/model/profile.dart
@@ -76,6 +76,23 @@ class Profile {
     if (hostId != null) 'hostId': hostId,
   };
 
+  /// A registry dirName may only be empty (the real root) or a relative
+  /// path of plain segments — no traversal, no absolute paths, no drive
+  /// letters. A malformed profiles.json must never be able to point a
+  /// world outside the real root.
+  static bool _isSafeDirName(String dirName) {
+    if (dirName.isEmpty) return true;
+    if (dirName.startsWith('/') || dirName.contains(':')) return false;
+    final segments = dirName.split('/');
+    return segments.every(
+      (segment) =>
+          segment.isNotEmpty &&
+          segment != '.' &&
+          segment != '..' &&
+          !segment.contains(r'\'),
+    );
+  }
+
   /// Lenient parse: returns null on any malformed field.
   static Profile? tryFromJson(Object? json) {
     if (json is! Map<String, dynamic>) return null;
@@ -87,7 +104,7 @@ class Profile {
     final hostId = json['hostId'];
     if (id is! String || id.isEmpty) return null;
     if (name is! String) return null;
-    if (dirName is! String) return null;
+    if (dirName is! String || !_isSafeDirName(dirName)) return null;
     final type = ProfileType.values.asNameMap()[typeName];
     if (type == null) return null;
     final createdAt = createdAtRaw is String

--- a/lib/features/profiles/model/profile.dart
+++ b/lib/features/profiles/model/profile.dart
@@ -1,0 +1,183 @@
+import 'package:clock/clock.dart';
+
+/// The kind of world a profile describes.
+enum ProfileType {
+  /// The user's real data at the pre-existing documents root.
+  real,
+
+  /// An isolated guest/demo world under `guest_profiles/<id>/`.
+  guest,
+}
+
+/// One entry in the profile registry (`profiles.json`).
+///
+/// Deliberately hand-rolled (no freezed): registry parsing must degrade
+/// gracefully on malformed input — [tryFromJson] returns null instead of
+/// throwing, so a corrupt file collapses to the synthesized default registry
+/// rather than blocking boot.
+class Profile {
+  const Profile({
+    required this.id,
+    required this.type,
+    required this.name,
+    required this.dirName,
+    required this.createdAt,
+    this.hostId,
+  });
+
+  /// Synthesized registry entry for the pre-existing real world. Used when
+  /// no `profiles.json` exists yet (every install predating profiles).
+  factory Profile.realDefault() => Profile(
+    id: realProfileId,
+    type: ProfileType.real,
+    name: 'Default',
+    dirName: '',
+    createdAt: clock.now(),
+  );
+
+  /// The fixed id of the real profile; its data lives at the real root
+  /// itself ([dirName] is empty) and is never moved.
+  static const String realProfileId = 'real';
+
+  final String id;
+  final ProfileType type;
+
+  /// Display name, e.g. 'Demo'.
+  final String name;
+
+  /// Root directory relative to the real root, using `/` separators
+  /// (platform-independent registry format). Empty for the real profile.
+  final String dirName;
+
+  final DateTime createdAt;
+
+  /// Informational copy of the world's sync host ID, written after the
+  /// world's first boot. The authoritative value lives in the world's own
+  /// settings database.
+  final String? hostId;
+
+  bool get isGuest => type == ProfileType.guest;
+
+  Profile copyWith({String? name, String? hostId}) => Profile(
+    id: id,
+    type: type,
+    name: name ?? this.name,
+    dirName: dirName,
+    createdAt: createdAt,
+    hostId: hostId ?? this.hostId,
+  );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'id': id,
+    'type': type.name,
+    'name': name,
+    'dirName': dirName,
+    'createdAt': createdAt.toIso8601String(),
+    if (hostId != null) 'hostId': hostId,
+  };
+
+  /// Lenient parse: returns null on any malformed field.
+  static Profile? tryFromJson(Object? json) {
+    if (json is! Map<String, dynamic>) return null;
+    final id = json['id'];
+    final typeName = json['type'];
+    final name = json['name'];
+    final dirName = json['dirName'];
+    final createdAtRaw = json['createdAt'];
+    final hostId = json['hostId'];
+    if (id is! String || id.isEmpty) return null;
+    if (name is! String) return null;
+    if (dirName is! String) return null;
+    final type = ProfileType.values.asNameMap()[typeName];
+    if (type == null) return null;
+    final createdAt = createdAtRaw is String
+        ? DateTime.tryParse(createdAtRaw)
+        : null;
+    if (createdAt == null) return null;
+    if (hostId is! String?) return null;
+    return Profile(
+      id: id,
+      type: type,
+      name: name,
+      dirName: dirName,
+      createdAt: createdAt,
+      hostId: hostId,
+    );
+  }
+}
+
+/// The persisted content of `profiles.json`.
+class ProfileRegistryState {
+  const ProfileRegistryState({
+    required this.version,
+    required this.activeProfileId,
+    required this.profiles,
+  });
+
+  /// Default state for installs without a registry file: the real world,
+  /// active, untouched.
+  factory ProfileRegistryState.initial() => ProfileRegistryState(
+    version: schemaVersion,
+    activeProfileId: Profile.realProfileId,
+    profiles: [Profile.realDefault()],
+  );
+
+  static const int schemaVersion = 1;
+
+  final int version;
+  final String activeProfileId;
+  final List<Profile> profiles;
+
+  Profile? profileById(String id) {
+    for (final profile in profiles) {
+      if (profile.id == id) return profile;
+    }
+    return null;
+  }
+
+  /// The active profile, falling back to the real profile if the marker is
+  /// dangling (e.g. the guest dir was deleted externally).
+  Profile get activeProfile =>
+      profileById(activeProfileId) ??
+      profileById(Profile.realProfileId) ??
+      Profile.realDefault();
+
+  ProfileRegistryState copyWith({
+    String? activeProfileId,
+    List<Profile>? profiles,
+  }) => ProfileRegistryState(
+    version: version,
+    activeProfileId: activeProfileId ?? this.activeProfileId,
+    profiles: profiles ?? this.profiles,
+  );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'version': version,
+    'activeProfileId': activeProfileId,
+    'profiles': [for (final profile in profiles) profile.toJson()],
+  };
+
+  /// Lenient parse: returns null when the document as a whole is unusable.
+  /// Individual malformed profile entries are dropped; a state without a
+  /// real profile is considered unusable.
+  static ProfileRegistryState? tryFromJson(Object? json) {
+    if (json is! Map<String, dynamic>) return null;
+    final version = json['version'];
+    final activeProfileId = json['activeProfileId'];
+    final profilesRaw = json['profiles'];
+    if (version is! int || version < 1) return null;
+    if (activeProfileId is! String || activeProfileId.isEmpty) return null;
+    if (profilesRaw is! List) return null;
+    final profiles = [
+      for (final entry in profilesRaw)
+        if (Profile.tryFromJson(entry) case final Profile profile) profile,
+    ];
+    final state = ProfileRegistryState(
+      version: version,
+      activeProfileId: activeProfileId,
+      profiles: profiles,
+    );
+    if (state.profileById(Profile.realProfileId) == null) return null;
+    return state;
+  }
+}

--- a/lib/features/profiles/model/profile.dart
+++ b/lib/features/profiles/model/profile.dart
@@ -107,6 +107,14 @@ class Profile {
     if (dirName is! String || !_isSafeDirName(dirName)) return null;
     final type = ProfileType.values.asNameMap()[typeName];
     if (type == null) return null;
+    // Cross-validate type and dirName: the real profile lives at the root
+    // itself; every guest lives under the guest container. A parseable
+    // entry must not be able to alias a guest onto the real root (or vice
+    // versa).
+    if (type == ProfileType.real && dirName.isNotEmpty) return null;
+    if (type == ProfileType.guest && !dirName.startsWith('guest_profiles/')) {
+      return null;
+    }
     final createdAt = createdAtRaw is String
         ? DateTime.tryParse(createdAtRaw)
         : null;

--- a/lib/features/profiles/model/profile_context.dart
+++ b/lib/features/profiles/model/profile_context.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:lotti/features/profiles/model/profile.dart';
+
+/// What a world is allowed to do. Guest worlds structurally exclude
+/// capabilities rather than disabling them: excluded stacks are never
+/// constructed, so they cannot touch device-global state (keychain sync
+/// credentials, health stores).
+class ProfileCapabilities {
+  const ProfileCapabilities({
+    required this.syncEnabled,
+    required this.healthImportEnabled,
+  });
+
+  /// The real world: everything on.
+  static const ProfileCapabilities real = ProfileCapabilities(
+    syncEnabled: true,
+    healthImportEnabled: true,
+  );
+
+  /// Guest worlds: no sync stack (own host ID, zero outbox traffic, never
+  /// reads Matrix credentials), no health import (device health data must
+  /// not bleed into a play world).
+  static const ProfileCapabilities guest = ProfileCapabilities(
+    syncEnabled: false,
+    healthImportEnabled: false,
+  );
+
+  final bool syncEnabled;
+  final bool healthImportEnabled;
+}
+
+/// Immutable description of the world the current service generation runs
+/// in. Registered in getIt by the bootstrap before any other service, so
+/// registration and runtime code can consult it.
+class ProfileContext {
+  const ProfileContext({
+    required this.profile,
+    required this.root,
+    required this.capabilities,
+  });
+
+  /// Builds the context for [profile] rooted at [root], with capabilities
+  /// derived from the profile type.
+  factory ProfileContext.forProfile({
+    required Profile profile,
+    required Directory root,
+  }) => ProfileContext(
+    profile: profile,
+    root: root,
+    capabilities: profile.isGuest
+        ? ProfileCapabilities.guest
+        : ProfileCapabilities.real,
+  );
+
+  final Profile profile;
+
+  /// The profile's root directory — the same instance the bootstrap
+  /// registers as the getIt `Directory` singleton.
+  final Directory root;
+
+  final ProfileCapabilities capabilities;
+
+  bool get isGuest => profile.isGuest;
+}

--- a/lib/features/profiles/profile_paths.dart
+++ b/lib/features/profiles/profile_paths.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Directory under the real root that holds every guest world.
+const String guestProfilesDirName = 'guest_profiles';
+
+/// Registry file at the real root; global by definition (it lists worlds,
+/// so it cannot live inside one).
+const String profilesRegistryFileName = 'profiles.json';
+
+/// Resolves the root directory of a guest profile.
+Directory guestProfileRoot(Directory realRoot, String profileId) =>
+    Directory(p.join(realRoot.path, guestProfilesDirName, profileId));
+
+/// Guards recursive deletes: only paths inside a `guest_profiles/` segment
+/// may ever be removed wholesale. Throws [ArgumentError] otherwise.
+void assertIsGuestRoot(Directory dir) {
+  final segments = p.split(p.normalize(dir.absolute.path));
+  final index = segments.indexOf(guestProfilesDirName);
+  if (index == -1 || index == segments.length - 1) {
+    throw ArgumentError.value(
+      dir.path,
+      'dir',
+      'not a guest profile root (must be a child of $guestProfilesDirName)',
+    );
+  }
+}

--- a/lib/features/profiles/repository/profile_registry.dart
+++ b/lib/features/profiles/repository/profile_registry.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/profile_paths.dart';
+import 'package:lotti/features/sync/matrix/utils/atomic_write.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
+/// Owns `profiles.json` at the real root.
+///
+/// Deliberately NOT registered in getIt: getIt is reset on every profile
+/// switch, while the registry describes all worlds and must survive
+/// generations. It is constructed with the real root explicitly and never
+/// resolves paths through the active profile.
+class ProfileRegistry {
+  ProfileRegistry({required this.realRoot, this.logging});
+
+  final Directory realRoot;
+  final DomainLogger? logging;
+
+  static const Uuid _uuid = Uuid();
+
+  File get registryFile =>
+      File(p.join(realRoot.path, profilesRegistryFileName));
+
+  /// Pure read. A missing or corrupt file yields the synthesized default
+  /// (real profile, active) without persisting anything — the file is only
+  /// ever written by mutations.
+  Future<ProfileRegistryState> load() async {
+    try {
+      if (!registryFile.existsSync()) {
+        return ProfileRegistryState.initial();
+      }
+      final raw = await registryFile.readAsString();
+      final state = ProfileRegistryState.tryFromJson(jsonDecode(raw));
+      if (state == null) {
+        logging?.log(
+          LogDomain.general,
+          'profiles.json unusable, falling back to default registry',
+          subDomain: 'profileRegistry',
+        );
+        return ProfileRegistryState.initial();
+      }
+      return state;
+    } catch (e, st) {
+      logging?.error(
+        LogDomain.general,
+        e,
+        stackTrace: st,
+        subDomain: 'profileRegistry.load',
+      );
+      return ProfileRegistryState.initial();
+    }
+  }
+
+  /// Creates the registry entry and directory skeleton for a new guest
+  /// world. The world's databases are created lazily by whoever opens it.
+  Future<Profile> createGuestProfile({required String name}) async {
+    final state = await load();
+    final id = _uuid.v4();
+    final profile = Profile(
+      id: id,
+      type: ProfileType.guest,
+      name: name,
+      dirName: '$guestProfilesDirName/$id',
+      createdAt: clock.now(),
+    );
+    await guestProfileRoot(realRoot, id).create(recursive: true);
+    await _save(
+      state.copyWith(profiles: [...state.profiles, profile]),
+    );
+    return profile;
+  }
+
+  /// Persists the active-world marker. Written BEFORE a switch begins so a
+  /// crash mid-switch reopens the intended world on next launch.
+  Future<void> setActiveProfile(String id) async {
+    final state = await load();
+    if (state.profileById(id) == null) {
+      throw ArgumentError.value(id, 'id', 'unknown profile');
+    }
+    await _save(state.copyWith(activeProfileId: id));
+  }
+
+  /// Updates mutable fields (name, informational hostId) of a profile.
+  Future<void> updateProfile(Profile profile) async {
+    final state = await load();
+    if (state.profileById(profile.id) == null) {
+      throw ArgumentError.value(profile.id, 'profile', 'unknown profile');
+    }
+    await _save(
+      state.copyWith(
+        profiles: [
+          for (final existing in state.profiles)
+            if (existing.id == profile.id) profile else existing,
+        ],
+      ),
+    );
+  }
+
+  /// Removes a guest world: registry entry and its whole directory tree.
+  /// Refuses to delete the real profile or the currently active profile.
+  Future<void> deleteGuestProfile(String id) async {
+    final state = await load();
+    final profile = state.profileById(id);
+    if (profile == null) {
+      throw ArgumentError.value(id, 'id', 'unknown profile');
+    }
+    if (!profile.isGuest) {
+      throw ArgumentError.value(id, 'id', 'only guest profiles can be deleted');
+    }
+    if (state.activeProfileId == id) {
+      throw StateError('cannot delete the active profile');
+    }
+    final root = rootFor(profile);
+    assertIsGuestRoot(root);
+    if (root.existsSync()) {
+      await root.delete(recursive: true);
+    }
+    await _save(
+      state.copyWith(
+        profiles: [
+          for (final existing in state.profiles)
+            if (existing.id != id) existing,
+        ],
+      ),
+    );
+  }
+
+  /// Resolves a profile's root directory. The stored [Profile.dirName] uses
+  /// `/` separators; joining per segment keeps this platform-independent.
+  Directory rootFor(Profile profile) {
+    if (profile.dirName.isEmpty) return realRoot;
+    return Directory(
+      p.joinAll([realRoot.path, ...profile.dirName.split('/')]),
+    );
+  }
+
+  Future<void> _save(ProfileRegistryState state) async {
+    await atomicWriteString(
+      text: const JsonEncoder.withIndent('  ').convert(state.toJson()),
+      filePath: registryFile.path,
+      logging: logging,
+      subDomain: 'profileRegistry',
+    );
+  }
+}

--- a/lib/features/profiles/repository/profile_registry.dart
+++ b/lib/features/profiles/repository/profile_registry.dart
@@ -132,11 +132,23 @@ class ProfileRegistry {
 
   /// Resolves a profile's root directory. The stored [Profile.dirName] uses
   /// `/` separators; joining per segment keeps this platform-independent.
+  /// Defense in depth on top of the parse-time dirName validation: the
+  /// resolved path must stay inside the real root.
   Directory rootFor(Profile profile) {
     if (profile.dirName.isEmpty) return realRoot;
-    return Directory(
+    final resolved = Directory(
       p.joinAll([realRoot.path, ...profile.dirName.split('/')]),
     );
+    final normalizedRoot = p.normalize(realRoot.absolute.path);
+    final normalized = p.normalize(resolved.absolute.path);
+    if (!p.isWithin(normalizedRoot, normalized)) {
+      throw ArgumentError.value(
+        profile.dirName,
+        'profile.dirName',
+        'resolves outside the real root',
+      );
+    }
+    return resolved;
   }
 
   Future<void> _save(ProfileRegistryState state) async {

--- a/lib/features/profiles/service/demo_world_creator.dart
+++ b/lib/features/profiles/service/demo_world_creator.dart
@@ -30,8 +30,11 @@ class DemoWorldCreator {
     try {
       await seed(world);
     } catch (_) {
-      await world.close();
-      await registry.deleteGuestProfile(profile.id);
+      try {
+        await world.close();
+      } finally {
+        await registry.deleteGuestProfile(profile.id);
+      }
       rethrow;
     }
     await world.close();

--- a/lib/features/profiles/service/demo_world_creator.dart
+++ b/lib/features/profiles/service/demo_world_creator.dart
@@ -1,0 +1,41 @@
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/profiles/service/world_handle.dart';
+
+/// Creates and activates a guest world, honoring the required ordering:
+/// the demo tree is FULLY populated (via a second, non-active set of
+/// database handles) before the live documents layer is re-pointed at it —
+/// the "migration" is the hot switch itself, not a data move.
+class DemoWorldCreator {
+  const DemoWorldCreator({
+    required this.registry,
+    required this.activate,
+  });
+
+  final ProfileRegistry registry;
+
+  /// Switches the running app to the given profile id — in production this
+  /// is `ProfileSwitcher.switchTo`.
+  final Future<void> Function(String profileId) activate;
+
+  /// Creates the profile, seeds its world through [seed], then switches the
+  /// running app into it. If seeding throws, the half-built world is removed
+  /// and the real world stays active.
+  Future<Profile> createAndActivate({
+    required Future<void> Function(WorldHandle world) seed,
+    String name = 'Demo',
+  }) async {
+    final profile = await registry.createGuestProfile(name: name);
+    final world = WorldHandle.open(registry.rootFor(profile));
+    try {
+      await seed(world);
+    } catch (_) {
+      await world.close();
+      await registry.deleteGuestProfile(profile.id);
+      rethrow;
+    }
+    await world.close();
+    await activate(profile.id);
+    return profile;
+  }
+}

--- a/lib/features/profiles/service/profile_switcher.dart
+++ b/lib/features/profiles/service/profile_switcher.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/speech/state/audio_player_controller.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/main.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/services/service_disposer.dart';
+import 'package:lotti/services/time_service.dart';
+import 'package:lotti/services/window_service.dart';
+
+/// Orchestrates in-app profile switches: persist the active-world marker,
+/// quiesce the running generation, tear it down, and bootstrap the next one
+/// against the new root.
+///
+/// Lives OUTSIDE getIt — it must survive `getIt.reset()`. Owned by the app
+/// root widget, which supplies the UI hooks: [onSwitchStarted] swaps the
+/// tree to a splash (unmounting every widget that watches the old
+/// generation's services) and [onSwitchCompleted] rebuilds the ProviderScope
+/// against the fresh registrations.
+class ProfileSwitcher {
+  ProfileSwitcher({
+    required this.registry,
+    required this.lifecycleHolder,
+    required this.onSwitchStarted,
+    required this.onSwitchCompleted,
+    @visibleForTesting Future<void> Function()? settleFrame,
+    @visibleForTesting Future<void> Function()? teardownOverride,
+    @visibleForTesting Future<void> Function()? bootstrapOverride,
+  }) : _settleFrame = settleFrame ?? _endOfFrame {
+    _teardown = teardownOverride ?? _defaultTeardown;
+    _bootstrap = bootstrapOverride ?? _bootstrapGeneration;
+  }
+
+  final ProfileRegistry registry;
+  final AppLifecycleHolder lifecycleHolder;
+
+  /// Must synchronously replace the widget tree with the switch splash.
+  final Future<void> Function() onSwitchStarted;
+
+  /// Called after the new generation is bootstrapped; rebuilds the scope.
+  final void Function() onSwitchCompleted;
+
+  final Future<void> Function() _settleFrame;
+  late final Future<void> Function() _teardown;
+  late final Future<void> Function() _bootstrap;
+
+  bool _switching = false;
+  bool get isSwitching => _switching;
+
+  static Future<void> _endOfFrame() => WidgetsBinding.instance.endOfFrame;
+
+  /// Switches the app to [profileId]. The marker is persisted FIRST so a
+  /// crash mid-switch reopens the intended world on next launch.
+  ///
+  /// If teardown or bootstrap throws, the app stays on the switch splash and
+  /// the error propagates; recovery is an app restart, which boots the
+  /// marked world from a clean process.
+  Future<void> switchTo(String profileId) async {
+    if (_switching) return;
+    _switching = true;
+    try {
+      final state = await registry.load();
+      if (state.profileById(profileId) == null) {
+        throw ArgumentError.value(profileId, 'profileId', 'unknown profile');
+      }
+      if (state.activeProfileId == profileId) return;
+
+      await registry.setActiveProfile(profileId);
+
+      // Splash replaces the app tree; wait a frame so every widget-level
+      // listener detaches before the services below are disposed.
+      await onSwitchStarted();
+      await _settleFrame();
+
+      await _teardown();
+      await _bootstrap();
+
+      onSwitchCompleted();
+    } finally {
+      _switching = false;
+    }
+  }
+
+  /// Default teardown: quiesce, dispose the service generation, reset getIt.
+  Future<void> _defaultTeardown() async {
+    await _quiesce();
+    await _teardownGeneration();
+  }
+
+  /// Stops runtime activity that persists state, while the old generation's
+  /// services are still alive to receive the writes.
+  Future<void> _quiesce() async {
+    if (getIt.isRegistered<TimeService>()) {
+      try {
+        await getIt<TimeService>().stop();
+      } catch (e, st) {
+        _logError(e, st, 'TimeService.stop');
+      }
+    }
+    try {
+      await AudioPlayerController.disposeActivePlayer();
+    } catch (e, st) {
+      _logError(e, st, 'AudioPlayerController.disposeActivePlayer');
+    }
+    lifecycleHolder.dispose();
+    if (getIt.isRegistered<WindowService>()) {
+      getIt<WindowService>().detachForRestart();
+    }
+  }
+
+  Future<void> _teardownGeneration() async {
+    await ServiceDisposer(getIt, _logError).disposeAll();
+
+    // Best-effort final flush of the outgoing generation's log sink before
+    // getIt.reset() disposes the LoggingService.
+    try {
+      if (getIt.isRegistered<LoggingService>()) {
+        await getIt<LoggingService>().flush().timeout(
+          const Duration(seconds: 1),
+        );
+      }
+    } catch (_) {
+      // Logging is best-effort during teardown.
+    }
+
+    // Fires the remaining registered dispose callbacks (UpdateNotifications,
+    // EntitiesCacheService, NavService, EmbeddingStore, ...). Databases were
+    // already closed above; they are registered without dispose callbacks,
+    // so there is no double-close.
+    await getIt.reset();
+  }
+
+  Future<void> _bootstrapGeneration() async {
+    registerProcessLogging();
+    final info = await resolveActiveProfile();
+    await bootstrapProfileServices(
+      info,
+      lifecycleHolder: lifecycleHolder,
+      // The window keeps its current geometry across an in-app switch.
+      restoreWindow: false,
+    );
+    lifecycleHolder.listener = AppLifecycleListener(
+      onExitRequested: handleAppExitRequested,
+    );
+  }
+
+  void _logError(dynamic error, StackTrace stackTrace, String service) {
+    try {
+      if (getIt.isRegistered<DomainLogger>()) {
+        getIt<DomainLogger>().error(
+          LogDomain.general,
+          error as Object,
+          stackTrace: stackTrace,
+          subDomain: 'profileSwitch_$service',
+        );
+      }
+    } catch (_) {
+      // The logger itself may already be torn down.
+    }
+  }
+}

--- a/lib/features/profiles/service/profile_switcher.dart
+++ b/lib/features/profiles/service/profile_switcher.dart
@@ -28,8 +28,10 @@ class ProfileSwitcher {
     required this.onSwitchStarted,
     required this.onSwitchCompleted,
     @visibleForTesting Future<void> Function()? settleFrame,
-    @visibleForTesting Future<void> Function()? teardownOverride,
-    @visibleForTesting Future<void> Function()? bootstrapOverride,
+    // Test seams (also forwarded by LottiAppRoot's own seams); production
+    // callers must leave these null.
+    Future<void> Function()? teardownOverride,
+    Future<void> Function()? bootstrapOverride,
   }) : _settleFrame = settleFrame ?? _endOfFrame {
     _teardown = teardownOverride ?? _defaultTeardown;
     _bootstrap = bootstrapOverride ?? _bootstrapGeneration;

--- a/lib/features/profiles/service/profile_switcher.dart
+++ b/lib/features/profiles/service/profile_switcher.dart
@@ -120,7 +120,11 @@ class ProfileSwitcher {
     }
     lifecycleHolder.dispose();
     if (getIt.isRegistered<WindowService>()) {
-      getIt<WindowService>().detachForRestart();
+      try {
+        await getIt<WindowService>().detachForRestart();
+      } catch (e, st) {
+        _logError(e, st, 'WindowService.detachForRestart');
+      }
     }
   }
 

--- a/lib/features/profiles/service/profile_switcher.dart
+++ b/lib/features/profiles/service/profile_switcher.dart
@@ -9,6 +9,7 @@ import 'package:lotti/main.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/service_disposer.dart';
+import 'package:lotti/services/startup_tasks.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/window_service.dart';
 
@@ -96,6 +97,15 @@ class ProfileSwitcher {
   /// Stops runtime activity that persists state, while the old generation's
   /// services are still alive to receive the writes.
   Future<void> _quiesce() async {
+    // Fire-and-forget startup work (MatrixService.init, sequence-log
+    // migration) must not still be running when its services are disposed.
+    if (getIt.isRegistered<StartupTasks>()) {
+      try {
+        await getIt<StartupTasks>().settle();
+      } catch (e, st) {
+        _logError(e, st, 'StartupTasks.settle');
+      }
+    }
     if (getIt.isRegistered<TimeService>()) {
       try {
         await getIt<TimeService>().stop();

--- a/lib/features/profiles/service/world_handle.dart
+++ b/lib/features/profiles/service/world_handle.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/editor_db.dart';
+import 'package:lotti/database/fts5_db.dart';
+import 'package:lotti/database/notifications_db.dart';
+import 'package:lotti/database/onboarding_metrics_db.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/ai/database/ai_config_db.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+
+/// A complete set of storage handles rooted at [root], independent of the
+/// active getIt generation. Used to populate a world BEFORE switching the
+/// live app to it (demo seeding) and to read/write the inactive side during
+/// exit copy-over.
+///
+/// Every database is constructed with an explicit documents-directory
+/// provider so nothing can fall back to the process-active profile root.
+/// Construction is cheap — every Drift database is a LazyDatabase whose file
+/// opens on first query.
+///
+/// Contract: getIt-coupled logic (PersistenceLogic, repositories,
+/// EntitiesCacheService) must NOT be run against a non-active WorldHandle.
+/// Writes go through the DB-level APIs plus the explicit JSON sidecar seam;
+/// entities are expected to arrive with fully formed metadata.
+class WorldHandle {
+  WorldHandle._({
+    required this.root,
+    required this.journalDb,
+    required this.settingsDb,
+    required this.syncDb,
+    required this.agentDb,
+    required this.editorDb,
+    required this.notificationsDb,
+    required this.consumptionDb,
+    required this.onboardingMetricsDb,
+    required this.dayProcessingDb,
+    required this.fts5Db,
+    required this.aiConfigDb,
+  });
+
+  factory WorldHandle.open(Directory root) {
+    Future<Directory> provider() async => root;
+    return WorldHandle._(
+      root: root,
+      journalDb: JournalDb(
+        readPool: 0,
+        documentsDirectoryProvider: provider,
+        documentsDirectory: root,
+      ),
+      settingsDb: SettingsDb(documentsDirectoryProvider: provider),
+      syncDb: SyncDatabase(documentsDirectoryProvider: provider),
+      agentDb: AgentDatabase(
+        readPool: 0,
+        documentsDirectoryProvider: provider,
+      ),
+      editorDb: EditorDb(documentsDirectoryProvider: provider),
+      notificationsDb: NotificationsDb(
+        readPool: 0,
+        documentsDirectoryProvider: provider,
+      ),
+      consumptionDb: ConsumptionDatabase(
+        readPool: 0,
+        documentsDirectoryProvider: provider,
+      ),
+      onboardingMetricsDb: OnboardingMetricsDb(
+        documentsDirectoryProvider: provider,
+      ),
+      dayProcessingDb: DayProcessingDb(
+        readPool: 0,
+        documentsDirectoryProvider: provider,
+      ),
+      fts5Db: Fts5Db(documentsDirectoryProvider: provider),
+      aiConfigDb: AiConfigDb(documentsDirectoryProvider: provider),
+    );
+  }
+
+  final Directory root;
+  final JournalDb journalDb;
+  final SettingsDb settingsDb;
+  final SyncDatabase syncDb;
+  final AgentDatabase agentDb;
+  final EditorDb editorDb;
+  final NotificationsDb notificationsDb;
+  final ConsumptionDatabase consumptionDb;
+  final OnboardingMetricsDb onboardingMetricsDb;
+  final DayProcessingDb dayProcessingDb;
+  final Fts5Db fts5Db;
+  final AiConfigDb aiConfigDb;
+
+  /// Writes [entity] into this world: journal row, JSON sidecar (written by
+  /// JournalDb itself against this world's root — the `_documentsDirectory`
+  /// constructor binding is what keeps it out of the active world), and —
+  /// for searchable kinds — the FTS index.
+  ///
+  /// Note: `Fts5Db.insertText` resolves the ACTIVE generation's
+  /// EntitiesCacheService, but only consults it for measurement entries;
+  /// seeding writes tasks, entries, images and checklists, which never touch
+  /// that path.
+  Future<void> writeJournalEntity(JournalEntity entity) async {
+    await journalDb.updateJournalEntity(entity);
+    await fts5Db.insertText(entity);
+  }
+
+  Future<void> writeEntityDefinition(EntityDefinition definition) =>
+      journalDb.upsertEntityDefinition(definition);
+
+  Future<void> writeEntryLink(EntryLink link) =>
+      journalDb.upsertEntryLink(link);
+
+  Future<void> writeAiConfig(AiConfig config) => aiConfigDb.saveConfig(config);
+
+  Future<void> writeSetting(String key, String value) =>
+      settingsDb.saveSettingsItem(key, value);
+
+  /// Closes every database, mirroring the ServiceDisposer order (settings
+  /// last).
+  Future<void> close() async {
+    await aiConfigDb.close();
+    await journalDb.close();
+    await syncDb.close();
+    await agentDb.close();
+    await editorDb.close();
+    await fts5Db.close();
+    await consumptionDb.close();
+    await notificationsDb.close();
+    await onboardingMetricsDb.close();
+    await dayProcessingDb.close();
+    await settingsDb.close();
+  }
+}

--- a/lib/features/profiles/state/profile_providers.dart
+++ b/lib/features/profiles/state/profile_providers.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
+
+/// The active world's context. Overridden per service generation in the
+/// root ProviderScope (see `buildProviderOverrides`); resolving it without
+/// an override is a wiring bug and fails loudly.
+final profileContextProvider = Provider<ProfileContext>(
+  (ref) => throw UnimplementedError(
+    'profileContextProvider must be overridden in the root ProviderScope',
+  ),
+);
+
+/// Whether the active world runs the sync stack. Guest/demo worlds do not:
+/// sync UI surfaces (settings section, outbox pages, verification listener,
+/// activity indicator) must gate on this instead of resolving MatrixService,
+/// which is not registered in guest mode.
+///
+/// Falls back to `true` when no profile context is overridden so the
+/// long tail of existing widget tests — which pump sync surfaces with a
+/// mocked MatrixService and no profile plumbing — keeps the real-profile
+/// behavior. Production always has the override.
+final syncFeatureAvailableProvider = Provider<bool>((ref) {
+  try {
+    return ref.watch(profileContextProvider).capabilities.syncEnabled;
+  } catch (_) {
+    return true;
+  }
+});
+
+/// Whether the active world is a guest/demo world. Drives the persistent
+/// demo banner and demo-only affordances. Falls back to `false` (real
+/// world) when no profile context is overridden, mirroring
+/// [syncFeatureAvailableProvider].
+final demoModeActiveProvider = Provider<bool>((ref) {
+  try {
+    return ref.watch(profileContextProvider).isGuest;
+  } catch (_) {
+    return false;
+  }
+});

--- a/lib/features/sync/outbox/inert_outbox_service.dart
+++ b/lib/features/sync/outbox/inert_outbox_service.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:lotti/classes/notification_entity.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
+import 'package:meta/meta.dart';
+
+/// [OutboxService] for worlds that must never sync (guest/demo profiles).
+///
+/// Every enqueue is a no-op: no outbox row, no sequence-log claim, no payload
+/// file. This is the isolation guarantee — a guest world produces zero sync
+/// traffic by construction, not because a flag happens to be off. The gate
+/// stream never emits, so no "not logged in" toasts appear in demo mode.
+class InertOutboxService implements OutboxService {
+  final StreamController<void> _gateController =
+      StreamController<void>.broadcast();
+
+  /// Counts swallowed enqueue calls so isolation tests can assert that write
+  /// paths routed here rather than silently reaching a real outbox.
+  @visibleForTesting
+  int enqueueAttempts = 0;
+
+  @override
+  Future<void> enqueueNotification(
+    NotificationEntity entity, {
+    String? originatingHostId,
+  }) async {
+    enqueueAttempts++;
+  }
+
+  @override
+  Future<void> enqueueNotificationStateUpdate({
+    required String id,
+    required VectorClock vectorClock,
+    required String originatingHostId,
+    DateTime? seenAt,
+    DateTime? actedOnAt,
+    DateTime? deletedAt,
+  }) async {
+    enqueueAttempts++;
+  }
+
+  @override
+  Future<void> enqueueMessage(SyncMessage syncMessage) async {
+    enqueueAttempts++;
+  }
+
+  @override
+  Future<void> enqueueMessageOrThrow(SyncMessage syncMessage) async {
+    enqueueAttempts++;
+  }
+
+  @override
+  Stream<void> get notLoggedInGateStream => _gateController.stream;
+
+  @override
+  Future<void> dispose() async {
+    await _gateController.close();
+  }
+}

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -57,14 +57,56 @@ abstract class _OutboxServiceBase {
 
 /// App-facing write boundary for outbound sync.
 ///
+/// Every feature write path resolves this abstract type. Real profiles get
+/// the Matrix-backed [MatrixOutboxService]; guest/demo profiles get the
+/// `InertOutboxService`, so a world without a sync stack produces zero
+/// outbox rows by construction rather than by configuration.
+abstract class OutboxService {
+  /// Persists [entity]'s JSON payload under the documents directory and
+  /// enqueues a `SyncMessage.notification` referencing it.
+  Future<void> enqueueNotification(
+    NotificationEntity entity, {
+    String? originatingHostId,
+  });
+
+  /// Enqueues a `SyncMessage.notificationStateUpdate` carrying the changed
+  /// seen/acted/deleted timestamps for notification [id].
+  Future<void> enqueueNotificationStateUpdate({
+    required String id,
+    required VectorClock vectorClock,
+    required String originatingHostId,
+    DateTime? seenAt,
+    DateTime? actedOnAt,
+    DateTime? deletedAt,
+  });
+
+  /// Enqueues [syncMessage], logging and swallowing routine preparation or
+  /// persistence failures so background sync callers remain best-effort.
+  Future<void> enqueueMessage(SyncMessage syncMessage);
+
+  /// Enqueues [syncMessage] and propagates preparation or persistence
+  /// failures after logging them.
+  Future<void> enqueueMessageOrThrow(SyncMessage syncMessage);
+
+  /// Emits whenever a send is attempted while sync is enabled but the client
+  /// is not logged in; the UI shows a one-time toast.
+  Stream<void> get notLoggedInGateStream;
+
+  Future<void> dispose();
+}
+
+/// Matrix-backed [OutboxService] for real profiles.
+///
 /// Features enqueue `SyncMessage`s here; the service persists them to the outbox
 /// table in `sync_db` (merging/superseding redundant work and enriching them
 /// with sequence metadata), then nudges the send runner. It waits for the
 /// user-activity idle gate before draining so outbound sending yields to live
 /// input. The actual claim → send → mark-sent/retry loop lives in
 /// `OutboxProcessor`; this class owns enqueue + scheduling.
-class OutboxService extends _OutboxServiceBase with _OutboxSend {
-  OutboxService({
+class MatrixOutboxService extends _OutboxServiceBase
+    with _OutboxSend
+    implements OutboxService {
+  MatrixOutboxService({
     required SyncDatabase syncDatabase,
     required this._loggingService,
     required this._vectorClockService,
@@ -249,6 +291,7 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   /// Emits an event whenever `sendNext` is invoked while sync is enabled but
   /// the Matrix service is not logged in. Consumers (UI) can use this to show
   /// a one-time toast informing the user.
+  @override
   Stream<void> get notLoggedInGateStream => _loginGateEventsController.stream;
 
   @override
@@ -280,6 +323,7 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   /// Persists [entity]'s JSON payload under the documents directory and
   /// enqueues a `SyncMessage.notification` referencing it. Skips enqueue (and
   /// logs) if the derived payload path escapes the documents root.
+  @override
   Future<void> enqueueNotification(
     NotificationEntity entity, {
     String? originatingHostId,
@@ -309,6 +353,7 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   /// Enqueues a `SyncMessage.notificationStateUpdate` carrying the changed
   /// seen/acted/deleted timestamps for notification [id]. No payload file is
   /// written — the state fields ride inline in the envelope.
+  @override
   Future<void> enqueueNotificationStateUpdate({
     required String id,
     required VectorClock vectorClock,
@@ -344,6 +389,7 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   /// Enqueues [syncMessage], logging and swallowing routine preparation or
   /// persistence failures so ordinary background sync callers remain
   /// best-effort.
+  @override
   Future<void> enqueueMessage(SyncMessage syncMessage) =>
       _enqueueMessage(syncMessage);
 
@@ -352,6 +398,7 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   ///
   /// Use this for user-initiated operations whose UI must distinguish a fully
   /// queued batch from a partial or failed batch.
+  @override
   Future<void> enqueueMessageOrThrow(SyncMessage syncMessage) =>
       _enqueueMessage(syncMessage, rethrowFailure: true);
 
@@ -565,6 +612,7 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
   /// Tears the service down: marks it disposed (so in-flight callbacks
   /// short-circuit), closes the runner, cancels every subscription/timer, and
   /// disposes the activity gate if this service owns it. Idempotent in effect.
+  @override
   Future<void> dispose() async {
     _isDisposed = true;
     _clientRunner.close();

--- a/lib/features/sync/ui/widgets/matrix/incoming_verification_modal.dart
+++ b/lib/features/sync/ui/widgets/matrix/incoming_verification_modal.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/profiles/state/profile_providers.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/features/sync/state/matrix_unverified_provider.dart';
 import 'package:lotti/features/sync/state/matrix_verification_modal_lock_provider.dart';
@@ -200,6 +201,13 @@ class _IncomingVerificationWrapperState
   @override
   void initState() {
     super.initState();
+
+    // Guest/demo worlds have no Matrix stack; resolving matrixServiceProvider
+    // there would throw. No sync means no incoming verifications to listen
+    // for.
+    if (!ref.read(syncFeatureAvailableProvider)) {
+      return;
+    }
 
     _subscription = ref
         .read(matrixServiceProvider)

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -101,7 +101,13 @@ final GetIt getIt = GetIt.instance;
 /// Registers the full per-generation service graph for [profile]'s world.
 /// Called by the bootstrap after the profile-scoped primitives (Directory,
 /// SettingsDb, SecureStorage, ProfileContext) are in place.
-Future<void> registerSingletons({required ProfileContext profile}) async {
+Future<void> registerSingletons({
+  required ProfileContext profile,
+  // Test seam: registration tests exercise the full graph without starting
+  // late/optional runtime work (MatrixService.init, embedding pipeline).
+  // Production callers must leave this true.
+  bool registerLateAndOptional = true,
+}) async {
   getIt
     ..registerSingleton<Fts5Db>(Fts5Db())
     ..registerSingleton<UserActivityService>(
@@ -386,7 +392,9 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
       dispose: (service) => service.dispose(),
     );
 
-  await _registerLateAndOptionalServices(profile: profile);
+  if (registerLateAndOptional) {
+    await _registerLateAndOptionalServices(profile: profile);
+  }
 }
 
 String? _noMatrixUserId() => null;

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -57,6 +57,7 @@ import 'package:lotti/features/sync/media/media_repair_service.dart';
 import 'package:lotti/features/sync/media/media_request_handler.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/onboarding/onboarding_sync_service.dart';
+import 'package:lotti/features/sync/outbox/inert_outbox_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/repository/sync_node_profile_repository.dart';
@@ -93,6 +94,7 @@ import 'package:meta/meta.dart';
 
 part 'get_it_helpers.dart';
 part 'get_it_maintenance.dart';
+part 'get_it_sync.dart';
 
 final GetIt getIt = GetIt.instance;
 
@@ -181,9 +183,6 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
         documentsDirectory: documentsDirectory,
       ),
     );
-  final client = await createMatrixClient(
-    documentsDirectory: documentsDirectory,
-  );
   final loggingService = getIt<LoggingService>();
   final userActivityService = getIt<UserActivityService>();
   final userActivityGate = getIt<UserActivityGate>();
@@ -259,34 +258,16 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
     logger: domainLogger,
   );
 
-  final sentEventRegistry = SentEventRegistry();
-  final matrixGateway = MatrixSdkGateway(
-    client: client,
-    sentEventRegistry: sentEventRegistry,
-  );
-  final matrixMessageSender = MatrixMessageSender(
-    loggingService: domainLogger,
-    journalDb: journalDb,
-    documentsDirectory: documentsDirectory,
-    sentEventRegistry: sentEventRegistry,
-    vectorClockService: vectorClockService,
-    domainLogger: domainLogger,
-  );
-  // Shared in-memory index of latest attachment events keyed by relativePath.
-  // Verbose per-event logging is off in production; SDK pagination bursts
-  // would otherwise produce thousands of `attachmentIndex.*` lines in a
-  // single second. The wrapping `batch.summary` carries the aggregate.
-  final attachmentIndex = AttachmentIndex(
-    logging: domainLogger,
-    verboseLogging: false,
-  );
-  // Self-healing sync: sequence log service for gap detection
+  // Self-healing sync: sequence log service for gap detection. Shared
+  // across modes — consumption sync and maintenance consult it, and in a
+  // guest world it only ever touches that world's own sync.sqlite.
   final syncSequenceLogService = SyncSequenceLogService(
     syncDatabase: syncDatabase,
     vectorClockService: vectorClockService,
     loggingService: domainLogger,
     domainLogger: domainLogger,
   );
+  getIt.registerSingleton<SyncSequenceLogService>(syncSequenceLogService);
 
   // NotificationService is lazily registered above so it doesn't have to
   // initialise the platform plugin at startup. Pass a thunk instead of
@@ -298,144 +279,46 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
   );
   getIt.registerSingleton<NotificationScheduler>(notificationScheduler);
 
-  // SyncEventProcessor is constructed first; its `backfillResponseHandler`
-  // (a `late final`) is assigned below once BackfillResponseHandler exists.
-  // The chain BackfillResponseHandler → OutboxService → MatrixService →
-  // SyncEventProcessor prevents constructor-time injection.
-  final syncEventProcessor = SyncEventProcessor(
-    loggingService: domainLogger,
-    domainLogger: domainLogger,
-    updateNotifications: getIt<UpdateNotifications>(),
-    aiConfigRepository: aiConfigRepository,
-    savedTaskFiltersRepository: savedTaskFiltersRepository,
-    settingsDb: settingsDb,
-    journalEntityLoader: SmartJournalEntityLoader(
-      attachmentIndex: attachmentIndex,
-      loggingService: domainLogger,
-    ),
-    attachmentIndex: attachmentIndex,
-    sequenceLogService: syncSequenceLogService,
-    journalDb: journalDb,
-    vectorClockService: vectorClockService,
-    notificationsDb: notificationsDb,
-    notificationScheduler: notificationScheduler,
-    syncNodeProfileRepository: syncNodeProfileRepository,
-  );
-
   // Consumption repository has no circular dependency (only ConsumptionDatabase),
   // so — unlike the agent repository, which is wired via Riverpod — it can be
   // constructed here and injected directly onto the inbound sync collaborators.
   final consumptionRepository = ConsumptionRepository(
     getIt<ConsumptionDatabase>(),
   );
-  syncEventProcessor.consumptionRepository = consumptionRepository;
 
-  final collectSyncMetrics = await journalDb.getConfigFlag(enableLoggingFlag);
-
-  final roomManager = SyncRoomManager(
-    gateway: matrixGateway,
-    settingsDb: settingsDb,
-    loggingService: domainLogger,
-  );
-
-  // Session manager is ordinarily created inside MatrixService, but
-  // Phase 2 needs it at hand to build the QueuePipelineCoordinator
-  // before MatrixService so both end up sharing the same instance.
-  final sessionManager = MatrixSessionManager(
-    gateway: matrixGateway,
-    roomManager: roomManager,
-    loggingService: domainLogger,
-  );
-
-  // Phase-2 queue pipeline owns inbound ingestion unconditionally. The
-  // dedicated ingestor below drives attachment recording + downloads on
-  // the queue's live + bootstrap paths so descriptor JSONs land on disk
-  // before the worker tries to apply their companion sync events.
-  // `verboseLogging: false` matches the `attachmentIndex` setting above
-  // — steady-state per-event logging would flood the general log on
-  // large catch-ups.
-  final localVcDominanceCheck = AgentVcDominanceCheck(
-    agentDb: getIt<AgentDatabase>(),
-  );
-  final queueAttachmentIngestor = AttachmentIngestor(
-    documentsDirectory: documentsDirectory,
-    verboseLogging: false,
-    localVcDominates: localVcDominanceCheck.check,
-  );
-  final queuePipelineCoordinator = QueuePipelineCoordinator(
-    syncDb: syncDatabase,
-    settingsDb: settingsDb,
-    journalDb: journalDb,
-    sessionManager: sessionManager,
-    roomManager: roomManager,
-    eventProcessor: syncEventProcessor,
-    sequenceLogService: syncSequenceLogService,
-    activityGate: userActivityGate,
-    logging: domainLogger,
-    attachmentIndex: attachmentIndex,
-    updateNotifications: getIt<UpdateNotifications>(),
-    attachmentIngestor: queueAttachmentIngestor,
-    sentEventRegistry: sentEventRegistry,
-    activitySignaler: getIt<SyncActivitySignaler>(),
-  );
-
-  final matrixService = MatrixService(
-    gateway: matrixGateway,
-    loggingService: domainLogger,
-    activityGate: userActivityGate,
-    messageSender: matrixMessageSender,
-    settingsDb: settingsDb,
-    eventProcessor: syncEventProcessor,
-    secureStorage: secureStorage,
-    collectSyncMetrics: collectSyncMetrics,
-    roomManager: roomManager,
-    sessionManager: sessionManager,
-    queueCoordinator: queuePipelineCoordinator,
-  );
-
-  getIt
-    ..registerSingleton<MatrixSyncGateway>(matrixGateway)
-    ..registerSingleton<MatrixMessageSender>(matrixMessageSender)
-    ..registerSingleton<SentEventRegistry>(sentEventRegistry)
-    ..registerSingleton<AttachmentIndex>(
-      attachmentIndex,
-      dispose: (index) => index.dispose(),
-    )
-    ..registerSingleton<SyncEventProcessor>(syncEventProcessor)
-    ..registerSingleton<MatrixService>(matrixService)
-    ..registerSingleton<SyncSequenceLogService>(syncSequenceLogService)
-    ..registerSingleton<OutboxService>(
-      OutboxService(
-        syncDatabase: syncDatabase,
-        loggingService: domainLogger,
-        vectorClockService: vectorClockService,
-        journalDb: journalDb,
-        documentsDirectory: documentsDirectory,
-        userActivityService: userActivityService,
-        activityGate: userActivityGate,
-        matrixService: matrixService,
-        sequenceLogService: syncSequenceLogService,
-        domainLogger: domainLogger,
-        activitySignaler: getIt<SyncActivitySignaler>(),
-      ),
+  // The sync boundary. Real profiles construct the full Matrix stack; guest
+  // worlds register an inert outbox and nothing else, so the stack — and its
+  // keychain credential reads, timers and startup broadcasts — is
+  // structurally absent rather than merely disabled.
+  var matrixUserId = _noMatrixUserId;
+  if (profile.capabilities.syncEnabled) {
+    matrixUserId = await _registerMatrixSyncStack(
+      documentsDirectory: documentsDirectory,
+      domainLogger: domainLogger,
+      userActivityService: userActivityService,
+      userActivityGate: userActivityGate,
+      journalDb: journalDb,
+      notificationsDb: notificationsDb,
+      settingsDb: settingsDb,
+      syncDatabase: syncDatabase,
+      vectorClockService: vectorClockService,
+      secureStorage: secureStorage,
+      aiConfigRepository: aiConfigRepository,
+      savedTaskFiltersRepository: savedTaskFiltersRepository,
+      syncNodeProfileRepository: syncNodeProfileRepository,
+      syncSequenceLogService: syncSequenceLogService,
+      notificationScheduler: notificationScheduler,
+      consumptionRepository: consumptionRepository,
     );
+  } else {
+    _registerInertSyncStack();
+  }
 
-  // Self-healing sync: create backfill services after OutboxService is available
   final outboxService = getIt<OutboxService>();
-  final onboardingSyncService = OnboardingSyncService(
-    syncDatabase: syncDatabase,
-    enqueueMessage: outboxService.enqueueMessageOrThrow,
-    getHostId: vectorClockService.getHost,
-    getSnapshotCoverage: syncDatabase.resolvedSequenceUpperBounds,
-    getLocalUserId: () => client.userID,
-    getLocalDeviceId: () => client.deviceID,
-    logging: domainLogger,
-  );
-  syncEventProcessor.onboardingSyncService = onboardingSyncService;
-  matrixService.onSyncMessageSent = onboardingSyncService.handleMessageSent;
 
   // Sync-aware consumption and attribution services, now that OutboxService
-  // is available.
+  // is available. In guest worlds these bind to the inert outbox and a null
+  // Matrix identity.
   final consumptionSyncService = ConsumptionSyncService(
     repository: consumptionRepository,
     outboxService: outboxService,
@@ -448,7 +331,7 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
     ..registerSingleton<AiAttributionIdentityResolver>(
       AiAttributionIdentityResolver(
         settingsDb,
-        matrixUserId: () => client.userID,
+        matrixUserId: matrixUserId,
       ),
     )
     ..registerSingleton<AiAttributionService>(
@@ -473,260 +356,8 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
     updateNotifications: getIt<UpdateNotifications>(),
     scheduler: notificationScheduler,
   );
-  getIt.registerSingleton<NotificationRepository>(notificationRepository);
-
-  // Sync-node profile broadcaster: probes the local node's capabilities and
-  // broadcasts (over the outbox) whenever the snapshot changes. Registered
-  // here because it depends on both the repository (created earlier) and the
-  // outbox service. The initial broadcast is fire-and-forget — boot must
-  // never await it — and we wrap the future in a try/catch right here so an
-  // unexpected probe / enqueue failure is captured under SYNC_NODE_PROFILE
-  // instead of escaping to the zone error handler.
-  final syncNodeProfileBroadcaster = SyncNodeProfileBroadcaster(
-    repository: syncNodeProfileRepository,
-    probe: defaultSyncNodeCapabilityProbe,
-    vectorClockService: vectorClockService,
-    outboxService: outboxService,
-    domainLogger: domainLogger,
-  );
-  getIt.registerSingleton<SyncNodeProfileBroadcaster>(
-    syncNodeProfileBroadcaster,
-  );
-  // Unconditional broadcast on every startup so late-joining peers and peers
-  // that wiped settings always converge on the current snapshot within a
-  // session — the receiver's directory upsert is last-write-wins by
-  // updatedAt, so redundant re-broadcasts of unchanged content are cheap.
-  unawaited(() async {
-    try {
-      await syncNodeProfileBroadcaster.broadcast();
-    } catch (error, stackTrace) {
-      domainLogger.error(
-        LogDomain.sync,
-        error,
-        stackTrace: stackTrace,
-        subDomain: 'startupBroadcast',
-      );
-    }
-  }());
-
-  Future<void> enqueueOwnUnresolvableMarker({
-    required String hostId,
-    required int counter,
-  }) async {
-    final existing = await syncSequenceLogService.getEntryByHostAndCounter(
-      hostId,
-      counter,
-    );
-    final existingStatus = existing?.status;
-    if (existingStatus == SyncSequenceStatus.received.index ||
-        existingStatus == SyncSequenceStatus.backfilled.index ||
-        existingStatus == SyncSequenceStatus.deleted.index) {
-      domainLogger.log(
-        LogDomain.sync,
-        'vc.burn.broadcast.skipBound host=$hostId counter=$counter '
-        'status=$existingStatus',
-        subDomain: 'vc.burn.broadcast',
-      );
-      return;
-    }
-
-    await outboxService.enqueueMessage(
-      SyncMessage.backfillResponse(
-        hostId: hostId,
-        counter: counter,
-        deleted: false,
-        unresolvable: true,
-      ),
-    );
-    await syncSequenceLogService.markOwnCounterUnresolvable(
-      hostId: hostId,
-      counter: counter,
-    );
-  }
-
-  // Proactive VC burn broadcast: when a reservation releases (write rejected,
-  // scope threw, commitWhen=false), enqueue a SyncBackfillResponse with
-  // unresolvable=true so peers close the gap on arrival instead of having to
-  // issue a backfill request first. Registered here because the handler has
-  // to fire into OutboxService, which is only now available. The handler is
-  // awaited by VectorClockService so the durable enqueue attempt finishes
-  // before `release()` returns; failures are still swallowed here because the
-  // VC counter is already persisted and cannot be rewound.
-  vectorClockService.setBurnHandler((hostId, counter) async {
-    // [hostId] is the host captured at reservation time, not whatever
-    // [VectorClockService.getHost] returns now — if setNewHost ran between
-    // reserve and release the broadcast would otherwise be attributed to
-    // the new host, producing a phantom unresolvable on the new host's
-    // counter space and leaving the actual burnt counter on the old host
-    // unannounced.
-    try {
-      // Enqueue first. If the outbox write fails, the row remains
-      // `burnPending` and startup/backfill can retry; terminalizing first
-      // would make a transient outbox failure silently drop the proactive
-      // repair signal.
-      await enqueueOwnUnresolvableMarker(
-        hostId: hostId,
-        counter: counter,
-      );
-      domainLogger.log(
-        LogDomain.sync,
-        'vc.burn.broadcast host=$hostId counter=$counter',
-        subDomain: 'vc.burn.broadcast',
-      );
-    } catch (error, stackTrace) {
-      domainLogger.error(
-        LogDomain.sync,
-        error,
-        message:
-            'vc burn broadcast failed; counter $counter will fall back to '
-            'reactive backfill resolution',
-        stackTrace: stackTrace,
-        subDomain: 'vc.burn.broadcast',
-      );
-    }
-  });
-
-  // Crash recovery for counters explicitly released in a previous process but
-  // not yet broadcast as unresolvable. Plain `reserved` rows are not retried
-  // here: a crash after the payload DB write but before outbox/sequence
-  // logging can leave a real payload behind, so only `burnPending` rows are
-  // authoritative burns.
-  unawaited(
-    Future<void>(() async {
-      try {
-        final hostId = await vectorClockService.getHost();
-        if (hostId == null) return;
-        final counters = await syncSequenceLogService
-            .burnPendingCountersForHost(
-              hostId: hostId,
-            );
-        var reconciled = 0;
-        for (final counter in counters) {
-          try {
-            await enqueueOwnUnresolvableMarker(
-              hostId: hostId,
-              counter: counter,
-            );
-            reconciled++;
-          } catch (error, stackTrace) {
-            domainLogger.error(
-              LogDomain.sync,
-              error,
-              message:
-                  'vc burn reconciliation failed for host=$hostId '
-                  'counter=$counter; continuing',
-              stackTrace: stackTrace,
-              subDomain: 'vc.burn.reconcile',
-            );
-          }
-        }
-        if (counters.isNotEmpty) {
-          domainLogger.log(
-            LogDomain.sync,
-            'vc.burn.reconcile host=$hostId count=$reconciled '
-            'attempted=${counters.length} '
-            'counters=$counters',
-            subDomain: 'vc.burn.reconcile',
-          );
-        }
-        final reservedCounters = await syncSequenceLogService
-            .reservedCountersForHost(hostId: hostId);
-        if (reservedCounters.isNotEmpty) {
-          domainLogger.error(
-            LogDomain.sync,
-            'vc.reserved.audit host=$hostId '
-            'count=${reservedCounters.length} '
-            'counters=$reservedCounters',
-            subDomain: 'vc.reserved.audit',
-          );
-        }
-      } catch (error, stackTrace) {
-        domainLogger.error(
-          LogDomain.sync,
-          error,
-          message:
-              'vc burn reconciliation failed; burn-pending counters will retry '
-              'on the next startup or reactive backfill',
-          stackTrace: stackTrace,
-          subDomain: 'vc.burn.reconcile',
-        );
-      }
-    }),
-  );
-  final backfillResponseHandler = BackfillResponseHandler(
-    journalDb: journalDb,
-    sequenceLogService: syncSequenceLogService,
-    outboxService: outboxService,
-    loggingService: domainLogger,
-    vectorClockService: vectorClockService,
-    domainLogger: domainLogger,
-    notificationsDb: notificationsDb,
-    onboardingSyncService: onboardingSyncService,
-  )..consumptionRepository = consumptionRepository;
-  final backfillRequestService = BackfillRequestService(
-    sequenceLogService: syncSequenceLogService,
-    syncDatabase: syncDatabase,
-    outboxService: outboxService,
-    vectorClockService: vectorClockService,
-    loggingService: domainLogger,
-    documentsDirectory: documentsDirectory,
-    queueCoordinator: queuePipelineCoordinator,
-    domainLogger: domainLogger,
-    onboardingSyncService: onboardingSyncService,
-  );
-  syncSequenceLogService.onMissingEntriesDetected = () {
-    backfillRequestService.nudge();
-    // Barren-bridge recovery: when the most recent reconnect bridge
-    // finished without accepting anything and a live event now reveals
-    // a missing counter, run an unbounded history walk to close the
-    // hole immediately instead of waiting for the normal backfill
-    // cadence. No-op when no barren bridge was recorded.
-    queuePipelineCoordinator.maybeStartGapRecovery();
-  };
-
-  // After a bridge walk settles, re-analyse the sequence log and
-  // dispatch a backfill request for anything still missing — nudges
-  // during the walk are dropped by the `isBridgeInFlight` gate, so
-  // this hook is how the service learns the walk finished.
-  queuePipelineCoordinator.onBridgeCompleted = backfillRequestService.nudge;
-  onboardingSyncService.onInboundSuppressionEnded =
-      backfillRequestService.nudgeAfterDrain;
-
-  // Set-once assignment of the late-final `backfillResponseHandler`. Must
-  // run before MatrixService consumes any inbound timeline events.
-  syncEventProcessor.backfillResponseHandler = backfillResponseHandler;
-
-  // Media self-healing, both halves. The requester turns the loader's
-  // "blob missing locally" signal into a broadcast request; the responder
-  // answers peers' requests with the blob. Wiring the listener is what makes
-  // the signal actionable — unsubscribed, a missing image or recording is
-  // observed on every load and silently dropped.
-  final mediaRepairService = MediaRepairService(
-    outboxService: outboxService,
-    vectorClockService: vectorClockService,
-    loggingService: domainLogger,
-  );
-  syncEventProcessor
-    ..missingMediaListener = mediaRepairService.reportMissing
-    ..mediaRequestHandler = MediaRequestHandler(
-      journalDb: journalDb,
-      outboxService: outboxService,
-      vectorClockService: vectorClockService,
-      documentsDirectory: documentsDirectory,
-      loggingService: domainLogger,
-    );
-
-  // Start the backfill request service
-  backfillRequestService.start();
-
   getIt
-    ..registerSingleton<BackfillResponseHandler>(backfillResponseHandler)
-    ..registerSingleton<BackfillRequestService>(backfillRequestService)
-    ..registerSingleton<OnboardingSyncService>(onboardingSyncService)
-    ..registerSingleton<MediaRepairService>(
-      mediaRepairService,
-      dispose: (service) => service.dispose(),
-    )
+    ..registerSingleton<NotificationRepository>(notificationRepository)
     ..registerSingleton<MetadataService>(
       MetadataService(vectorClockService: vectorClockService),
     )
@@ -755,5 +386,7 @@ Future<void> registerSingletons({required ProfileContext profile}) async {
       dispose: (service) => service.dispose(),
     );
 
-  await _registerLateAndOptionalServices();
+  await _registerLateAndOptionalServices(profile: profile);
 }
+
+String? _noMatrixUserId() => null;

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
-import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:get_it/get_it.dart';
 import 'package:health/health.dart';
 import 'package:lotti/database/database.dart';
@@ -38,6 +37,7 @@ import 'package:lotti/features/notifications/repository/notification_repository.
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/features/onboarding/repository/onboarding_metrics_repository.dart';
 import 'package:lotti/features/onboarding/state/onboarding_rollout.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/speech/services/audio_waveform_service.dart';
 import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/backfill/backfill_response_handler.dart';
@@ -96,7 +96,10 @@ part 'get_it_maintenance.dart';
 
 final GetIt getIt = GetIt.instance;
 
-Future<void> registerSingletons() async {
+/// Registers the full per-generation service graph for [profile]'s world.
+/// Called by the bootstrap after the profile-scoped primitives (Directory,
+/// SettingsDb, SecureStorage, ProfileContext) are in place.
+Future<void> registerSingletons({required ProfileContext profile}) async {
   getIt
     ..registerSingleton<Fts5Db>(Fts5Db())
     ..registerSingleton<UserActivityService>(
@@ -167,7 +170,6 @@ Future<void> registerSingletons() async {
   final aiConfigRepository = AiConfigRepository(AiConfigDb());
   getIt.registerSingleton<AiConfigRepository>(aiConfigRepository);
 
-  await vod.init();
   final documentsDirectory = getIt<Directory>();
   final dayProcessingDb = DayProcessingDb();
   getIt

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -86,6 +86,7 @@ import 'package:lotti/services/link_service.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
+import 'package:lotti/services/startup_tasks.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/utils/consts.dart';
@@ -135,6 +136,7 @@ Future<void> registerSingletons({
     ..registerSingleton<EditorDb>(EditorDb())
     ..registerSingleton<OnboardingMetricsDb>(OnboardingMetricsDb())
     ..registerSingleton<SyncDatabase>(SyncDatabase())
+    ..registerSingleton<StartupTasks>(StartupTasks())
     ..registerSingleton<VectorClockService>(VectorClockService())
     ..registerSingleton<TimeService>(
       // When a new timer replaces a still-running one, persist the outgoing
@@ -376,15 +378,21 @@ Future<void> registerSingletons({
       ),
     )
     ..registerSingleton<PersistenceLogic>(PersistenceLogic())
-    ..registerSingleton<EditorStateService>(EditorStateService())
-    ..registerSingleton<HealthImport>(
+    ..registerSingleton<EditorStateService>(EditorStateService());
+  // Device health data must not bleed into a play world: like the sync
+  // stack, health import is structurally absent in guest profiles, and its
+  // UI surfaces gate on the capability.
+  if (profile.capabilities.healthImportEnabled) {
+    getIt.registerSingleton<HealthImport>(
       HealthImport(
         persistenceLogic: getIt<PersistenceLogic>(),
         db: getIt<JournalDb>(),
         health: HealthService(Health()),
         deviceInfo: DeviceInfoPlugin(),
       ),
-    )
+    );
+  }
+  getIt
     ..registerSingleton<LinkService>(LinkService())
     ..registerSingleton<Maintenance>(Maintenance())
     ..registerSingleton<NavService>(

--- a/lib/get_it_helpers.dart
+++ b/lib/get_it_helpers.dart
@@ -99,7 +99,7 @@ Future<void> _registerLateAndOptionalServices({
   // Guest worlds have no MatrixService registered — the sync stack is
   // structurally absent, so there is nothing to init.
   if (profile.capabilities.syncEnabled) {
-    unawaited(getIt<MatrixService>().init());
+    getIt<StartupTasks>().track(getIt<MatrixService>().init());
   }
 
   // Label validator used by the assignment processor
@@ -172,6 +172,6 @@ Future<void> _registerLateAndOptionalServices({
   // Skipped in guest worlds: their sequence log stays empty because nothing
   // ever enqueues.
   if (profile.capabilities.syncEnabled) {
-    unawaited(_checkAndPopulateSequenceLog());
+    getIt<StartupTasks>().track(_checkAndPopulateSequenceLog());
   }
 }

--- a/lib/get_it_helpers.dart
+++ b/lib/get_it_helpers.dart
@@ -87,14 +87,20 @@ void _safeLog(String message, {required bool isError}) {
 /// one-time sequence-log backfill. Split from [registerSingletons] for file
 /// size; every dependency is resolved through [getIt], so no state is
 /// threaded in from the caller.
-Future<void> _registerLateAndOptionalServices() async {
+Future<void> _registerLateAndOptionalServices({
+  required ProfileContext profile,
+}) async {
   // Register services that might fail in sandboxed environments using lazy loading
   _registerLazyServiceSafely<AudioWaveformService>(
     AudioWaveformService.new,
     'AudioWaveformService',
   );
 
-  unawaited(getIt<MatrixService>().init());
+  // Guest worlds have no MatrixService registered — the sync stack is
+  // structurally absent, so there is nothing to init.
+  if (profile.capabilities.syncEnabled) {
+    unawaited(getIt<MatrixService>().init());
+  }
 
   // Label validator used by the assignment processor
   _registerLazyServiceSafely<LabelValidator>(
@@ -162,6 +168,10 @@ Future<void> _registerLateAndOptionalServices() async {
   }
   // coverage:ignore-end
 
-  // Automatically populate sequence log if empty (one-time migration)
-  unawaited(_checkAndPopulateSequenceLog());
+  // Automatically populate sequence log if empty (one-time migration).
+  // Skipped in guest worlds: their sequence log stays empty because nothing
+  // ever enqueues.
+  if (profile.capabilities.syncEnabled) {
+    unawaited(_checkAndPopulateSequenceLog());
+  }
 }

--- a/lib/get_it_sync.dart
+++ b/lib/get_it_sync.dart
@@ -173,8 +173,8 @@ Future<String? Function()> _registerMatrixSyncStack({
     getHostId: vectorClockService.getHost,
     getSnapshotCoverage: syncDatabase.resolvedSequenceUpperBounds,
     // trivial accessor thunks, consumed only during
-    // coverage:ignore-start
     // live onboarding-sync rounds against a logged-in client.
+    // coverage:ignore-start
     getLocalUserId: () => client.userID,
     getLocalDeviceId: () => client.deviceID,
     // coverage:ignore-end
@@ -209,8 +209,8 @@ Future<String? Function()> _registerMatrixSyncStack({
       await syncNodeProfileBroadcaster.broadcast();
     } catch (error, stackTrace) {
       // defensive: only reachable when the probe or
-      // coverage:ignore-start
       // the outbox write infrastructure itself fails.
+      // coverage:ignore-start
       domainLogger.error(
         LogDomain.sync,
         error,
@@ -234,10 +234,10 @@ Future<String? Function()> _registerMatrixSyncStack({
         existingStatus == SyncSequenceStatus.backfilled.index ||
         existingStatus == SyncSequenceStatus.deleted.index) {
       // guards a live-sync race: a peer's response
-      // coverage:ignore-start
       // about this very counter landing between reserve and release. The
       // receive path ignores own-host entries, so the state cannot be
       // constructed in-process.
+      // coverage:ignore-start
       domainLogger.log(
         LogDomain.sync,
         'vc.burn.broadcast.skipBound host=$hostId counter=$counter '
@@ -292,9 +292,6 @@ Future<String? Function()> _registerMatrixSyncStack({
         subDomain: 'vc.burn.broadcast',
       );
     } catch (error, stackTrace) {
-      // defensive: reachable only when the outbox or
-      // coverage:ignore-start
-      // sequence-log write infrastructure itself fails mid-broadcast.
       domainLogger.error(
         LogDomain.sync,
         error,
@@ -304,7 +301,6 @@ Future<String? Function()> _registerMatrixSyncStack({
         stackTrace: stackTrace,
         subDomain: 'vc.burn.broadcast',
       );
-      // coverage:ignore-end
     }
   });
 
@@ -332,8 +328,8 @@ Future<String? Function()> _registerMatrixSyncStack({
             reconciled++;
           } catch (error, stackTrace) {
             // defensive per-counter containment for
-            // coverage:ignore-start
             // infrastructure write failures.
+            // coverage:ignore-start
             domainLogger.error(
               LogDomain.sync,
               error,
@@ -368,8 +364,8 @@ Future<String? Function()> _registerMatrixSyncStack({
         }
       } catch (error, stackTrace) {
         // defensive: whole-pass containment when the
-        // coverage:ignore-start
         // sequence log itself cannot be read.
+        // coverage:ignore-start
         domainLogger.error(
           LogDomain.sync,
           error,

--- a/lib/get_it_sync.dart
+++ b/lib/get_it_sync.dart
@@ -172,8 +172,11 @@ Future<String? Function()> _registerMatrixSyncStack({
     enqueueMessage: outboxService.enqueueMessageOrThrow,
     getHostId: vectorClockService.getHost,
     getSnapshotCoverage: syncDatabase.resolvedSequenceUpperBounds,
+    // coverage:ignore-start — trivial accessor thunks, consumed only during
+    // live onboarding-sync rounds against a logged-in client.
     getLocalUserId: () => client.userID,
     getLocalDeviceId: () => client.deviceID,
+    // coverage:ignore-end
     logging: domainLogger,
   );
   syncEventProcessor.onboardingSyncService = onboardingSyncService;
@@ -200,16 +203,19 @@ Future<String? Function()> _registerMatrixSyncStack({
   // that wiped settings always converge on the current snapshot within a
   // session — the receiver's directory upsert is last-write-wins by
   // updatedAt, so redundant re-broadcasts of unchanged content are cheap.
-  unawaited(() async {
+  getIt<StartupTasks>().track(() async {
     try {
       await syncNodeProfileBroadcaster.broadcast();
     } catch (error, stackTrace) {
+      // coverage:ignore-start — defensive: only reachable when the probe or
+      // the outbox write infrastructure itself fails.
       domainLogger.error(
         LogDomain.sync,
         error,
         stackTrace: stackTrace,
         subDomain: 'startupBroadcast',
       );
+      // coverage:ignore-end
     }
   }());
 
@@ -225,6 +231,10 @@ Future<String? Function()> _registerMatrixSyncStack({
     if (existingStatus == SyncSequenceStatus.received.index ||
         existingStatus == SyncSequenceStatus.backfilled.index ||
         existingStatus == SyncSequenceStatus.deleted.index) {
+      // coverage:ignore-start — guards a live-sync race: a peer's response
+      // about this very counter landing between reserve and release. The
+      // receive path ignores own-host entries, so the state cannot be
+      // constructed in-process.
       domainLogger.log(
         LogDomain.sync,
         'vc.burn.broadcast.skipBound host=$hostId counter=$counter '
@@ -232,6 +242,7 @@ Future<String? Function()> _registerMatrixSyncStack({
         subDomain: 'vc.burn.broadcast',
       );
       return;
+      // coverage:ignore-end
     }
 
     await outboxService.enqueueMessage(
@@ -278,6 +289,8 @@ Future<String? Function()> _registerMatrixSyncStack({
         subDomain: 'vc.burn.broadcast',
       );
     } catch (error, stackTrace) {
+      // coverage:ignore-start — defensive: reachable only when the outbox or
+      // sequence-log write infrastructure itself fails mid-broadcast.
       domainLogger.error(
         LogDomain.sync,
         error,
@@ -287,6 +300,7 @@ Future<String? Function()> _registerMatrixSyncStack({
         stackTrace: stackTrace,
         subDomain: 'vc.burn.broadcast',
       );
+      // coverage:ignore-end
     }
   });
 
@@ -295,7 +309,7 @@ Future<String? Function()> _registerMatrixSyncStack({
   // here: a crash after the payload DB write but before outbox/sequence
   // logging can leave a real payload behind, so only `burnPending` rows are
   // authoritative burns.
-  unawaited(
+  getIt<StartupTasks>().track(
     Future<void>(() async {
       try {
         final hostId = await vectorClockService.getHost();
@@ -313,6 +327,8 @@ Future<String? Function()> _registerMatrixSyncStack({
             );
             reconciled++;
           } catch (error, stackTrace) {
+            // coverage:ignore-start — defensive per-counter containment for
+            // infrastructure write failures.
             domainLogger.error(
               LogDomain.sync,
               error,
@@ -322,6 +338,7 @@ Future<String? Function()> _registerMatrixSyncStack({
               stackTrace: stackTrace,
               subDomain: 'vc.burn.reconcile',
             );
+            // coverage:ignore-end
           }
         }
         if (counters.isNotEmpty) {
@@ -345,6 +362,8 @@ Future<String? Function()> _registerMatrixSyncStack({
           );
         }
       } catch (error, stackTrace) {
+        // coverage:ignore-start — defensive: whole-pass containment when the
+        // sequence log itself cannot be read.
         domainLogger.error(
           LogDomain.sync,
           error,
@@ -354,6 +373,7 @@ Future<String? Function()> _registerMatrixSyncStack({
           stackTrace: stackTrace,
           subDomain: 'vc.burn.reconcile',
         );
+        // coverage:ignore-end
       }
     }),
   );

--- a/lib/get_it_sync.dart
+++ b/lib/get_it_sync.dart
@@ -1,0 +1,445 @@
+part of 'get_it.dart';
+
+/// Registers the complete Matrix sync stack for a real profile: client,
+/// gateway, inbound queue pipeline, MatrixService, the Matrix-backed outbox,
+/// onboarding sync, node-profile broadcasting, VC-burn handling, backfill and
+/// media self-healing.
+///
+/// Guest profiles never call this — see [_registerInertSyncStack]. Returns
+/// the Matrix user-id thunk consumed by the AI attribution identity
+/// resolver.
+Future<String? Function()> _registerMatrixSyncStack({
+  required Directory documentsDirectory,
+  required DomainLogger domainLogger,
+  required UserActivityService userActivityService,
+  required UserActivityGate userActivityGate,
+  required JournalDb journalDb,
+  required NotificationsDb notificationsDb,
+  required SettingsDb settingsDb,
+  required SyncDatabase syncDatabase,
+  required VectorClockService vectorClockService,
+  required SecureStorage secureStorage,
+  required AiConfigRepository aiConfigRepository,
+  required SavedTaskFiltersRepository savedTaskFiltersRepository,
+  required SyncNodeProfileRepository syncNodeProfileRepository,
+  required SyncSequenceLogService syncSequenceLogService,
+  required NotificationScheduler notificationScheduler,
+  required ConsumptionRepository consumptionRepository,
+}) async {
+  final client = await createMatrixClient(
+    documentsDirectory: documentsDirectory,
+  );
+
+  final sentEventRegistry = SentEventRegistry();
+  final matrixGateway = MatrixSdkGateway(
+    client: client,
+    sentEventRegistry: sentEventRegistry,
+  );
+  final matrixMessageSender = MatrixMessageSender(
+    loggingService: domainLogger,
+    journalDb: journalDb,
+    documentsDirectory: documentsDirectory,
+    sentEventRegistry: sentEventRegistry,
+    vectorClockService: vectorClockService,
+    domainLogger: domainLogger,
+  );
+  // Shared in-memory index of latest attachment events keyed by relativePath.
+  // Verbose per-event logging is off in production; SDK pagination bursts
+  // would otherwise produce thousands of `attachmentIndex.*` lines in a
+  // single second. The wrapping `batch.summary` carries the aggregate.
+  final attachmentIndex = AttachmentIndex(
+    logging: domainLogger,
+    verboseLogging: false,
+  );
+
+  // SyncEventProcessor is constructed first; its `backfillResponseHandler`
+  // (a `late final`) is assigned below once BackfillResponseHandler exists.
+  // The chain BackfillResponseHandler → OutboxService → MatrixService →
+  // SyncEventProcessor prevents constructor-time injection.
+  final syncEventProcessor = SyncEventProcessor(
+    loggingService: domainLogger,
+    domainLogger: domainLogger,
+    updateNotifications: getIt<UpdateNotifications>(),
+    aiConfigRepository: aiConfigRepository,
+    savedTaskFiltersRepository: savedTaskFiltersRepository,
+    settingsDb: settingsDb,
+    journalEntityLoader: SmartJournalEntityLoader(
+      attachmentIndex: attachmentIndex,
+      loggingService: domainLogger,
+    ),
+    attachmentIndex: attachmentIndex,
+    sequenceLogService: syncSequenceLogService,
+    journalDb: journalDb,
+    vectorClockService: vectorClockService,
+    notificationsDb: notificationsDb,
+    notificationScheduler: notificationScheduler,
+    syncNodeProfileRepository: syncNodeProfileRepository,
+  )..consumptionRepository = consumptionRepository;
+
+  final collectSyncMetrics = await journalDb.getConfigFlag(enableLoggingFlag);
+
+  final roomManager = SyncRoomManager(
+    gateway: matrixGateway,
+    settingsDb: settingsDb,
+    loggingService: domainLogger,
+  );
+
+  // Session manager is ordinarily created inside MatrixService, but
+  // Phase 2 needs it at hand to build the QueuePipelineCoordinator
+  // before MatrixService so both end up sharing the same instance.
+  final sessionManager = MatrixSessionManager(
+    gateway: matrixGateway,
+    roomManager: roomManager,
+    loggingService: domainLogger,
+  );
+
+  // Phase-2 queue pipeline owns inbound ingestion unconditionally. The
+  // dedicated ingestor below drives attachment recording + downloads on
+  // the queue's live + bootstrap paths so descriptor JSONs land on disk
+  // before the worker tries to apply their companion sync events.
+  // `verboseLogging: false` matches the `attachmentIndex` setting above
+  // — steady-state per-event logging would flood the general log on
+  // large catch-ups.
+  final localVcDominanceCheck = AgentVcDominanceCheck(
+    agentDb: getIt<AgentDatabase>(),
+  );
+  final queueAttachmentIngestor = AttachmentIngestor(
+    documentsDirectory: documentsDirectory,
+    verboseLogging: false,
+    localVcDominates: localVcDominanceCheck.check,
+  );
+  final queuePipelineCoordinator = QueuePipelineCoordinator(
+    syncDb: syncDatabase,
+    settingsDb: settingsDb,
+    journalDb: journalDb,
+    sessionManager: sessionManager,
+    roomManager: roomManager,
+    eventProcessor: syncEventProcessor,
+    sequenceLogService: syncSequenceLogService,
+    activityGate: userActivityGate,
+    logging: domainLogger,
+    attachmentIndex: attachmentIndex,
+    updateNotifications: getIt<UpdateNotifications>(),
+    attachmentIngestor: queueAttachmentIngestor,
+    sentEventRegistry: sentEventRegistry,
+    activitySignaler: getIt<SyncActivitySignaler>(),
+  );
+
+  final matrixService = MatrixService(
+    gateway: matrixGateway,
+    loggingService: domainLogger,
+    activityGate: userActivityGate,
+    messageSender: matrixMessageSender,
+    settingsDb: settingsDb,
+    eventProcessor: syncEventProcessor,
+    secureStorage: secureStorage,
+    collectSyncMetrics: collectSyncMetrics,
+    roomManager: roomManager,
+    sessionManager: sessionManager,
+    queueCoordinator: queuePipelineCoordinator,
+  );
+
+  getIt
+    ..registerSingleton<MatrixSyncGateway>(matrixGateway)
+    ..registerSingleton<MatrixMessageSender>(matrixMessageSender)
+    ..registerSingleton<SentEventRegistry>(sentEventRegistry)
+    ..registerSingleton<AttachmentIndex>(
+      attachmentIndex,
+      dispose: (index) => index.dispose(),
+    )
+    ..registerSingleton<SyncEventProcessor>(syncEventProcessor)
+    ..registerSingleton<MatrixService>(matrixService)
+    ..registerSingleton<OutboxService>(
+      MatrixOutboxService(
+        syncDatabase: syncDatabase,
+        loggingService: domainLogger,
+        vectorClockService: vectorClockService,
+        journalDb: journalDb,
+        documentsDirectory: documentsDirectory,
+        userActivityService: userActivityService,
+        activityGate: userActivityGate,
+        matrixService: matrixService,
+        sequenceLogService: syncSequenceLogService,
+        domainLogger: domainLogger,
+        activitySignaler: getIt<SyncActivitySignaler>(),
+      ),
+    );
+
+  // Self-healing sync: create backfill services after OutboxService is available
+  final outboxService = getIt<OutboxService>();
+  final onboardingSyncService = OnboardingSyncService(
+    syncDatabase: syncDatabase,
+    enqueueMessage: outboxService.enqueueMessageOrThrow,
+    getHostId: vectorClockService.getHost,
+    getSnapshotCoverage: syncDatabase.resolvedSequenceUpperBounds,
+    getLocalUserId: () => client.userID,
+    getLocalDeviceId: () => client.deviceID,
+    logging: domainLogger,
+  );
+  syncEventProcessor.onboardingSyncService = onboardingSyncService;
+  matrixService.onSyncMessageSent = onboardingSyncService.handleMessageSent;
+
+  // Sync-node profile broadcaster: probes the local node's capabilities and
+  // broadcasts (over the outbox) whenever the snapshot changes. Registered
+  // here because it depends on both the repository (created earlier) and the
+  // outbox service. The initial broadcast is fire-and-forget — boot must
+  // never await it — and we wrap the future in a try/catch right here so an
+  // unexpected probe / enqueue failure is captured under SYNC_NODE_PROFILE
+  // instead of escaping to the zone error handler.
+  final syncNodeProfileBroadcaster = SyncNodeProfileBroadcaster(
+    repository: syncNodeProfileRepository,
+    probe: defaultSyncNodeCapabilityProbe,
+    vectorClockService: vectorClockService,
+    outboxService: outboxService,
+    domainLogger: domainLogger,
+  );
+  getIt.registerSingleton<SyncNodeProfileBroadcaster>(
+    syncNodeProfileBroadcaster,
+  );
+  // Unconditional broadcast on every startup so late-joining peers and peers
+  // that wiped settings always converge on the current snapshot within a
+  // session — the receiver's directory upsert is last-write-wins by
+  // updatedAt, so redundant re-broadcasts of unchanged content are cheap.
+  unawaited(() async {
+    try {
+      await syncNodeProfileBroadcaster.broadcast();
+    } catch (error, stackTrace) {
+      domainLogger.error(
+        LogDomain.sync,
+        error,
+        stackTrace: stackTrace,
+        subDomain: 'startupBroadcast',
+      );
+    }
+  }());
+
+  Future<void> enqueueOwnUnresolvableMarker({
+    required String hostId,
+    required int counter,
+  }) async {
+    final existing = await syncSequenceLogService.getEntryByHostAndCounter(
+      hostId,
+      counter,
+    );
+    final existingStatus = existing?.status;
+    if (existingStatus == SyncSequenceStatus.received.index ||
+        existingStatus == SyncSequenceStatus.backfilled.index ||
+        existingStatus == SyncSequenceStatus.deleted.index) {
+      domainLogger.log(
+        LogDomain.sync,
+        'vc.burn.broadcast.skipBound host=$hostId counter=$counter '
+        'status=$existingStatus',
+        subDomain: 'vc.burn.broadcast',
+      );
+      return;
+    }
+
+    await outboxService.enqueueMessage(
+      SyncMessage.backfillResponse(
+        hostId: hostId,
+        counter: counter,
+        deleted: false,
+        unresolvable: true,
+      ),
+    );
+    await syncSequenceLogService.markOwnCounterUnresolvable(
+      hostId: hostId,
+      counter: counter,
+    );
+  }
+
+  // Proactive VC burn broadcast: when a reservation releases (write rejected,
+  // scope threw, commitWhen=false), enqueue a SyncBackfillResponse with
+  // unresolvable=true so peers close the gap on arrival instead of having to
+  // issue a backfill request first. Registered here because the handler has
+  // to fire into OutboxService, which is only now available. The handler is
+  // awaited by VectorClockService so the durable enqueue attempt finishes
+  // before `release()` returns; failures are still swallowed here because the
+  // VC counter is already persisted and cannot be rewound.
+  vectorClockService.setBurnHandler((hostId, counter) async {
+    // [hostId] is the host captured at reservation time, not whatever
+    // [VectorClockService.getHost] returns now — if setNewHost ran between
+    // reserve and release the broadcast would otherwise be attributed to
+    // the new host, producing a phantom unresolvable on the new host's
+    // counter space and leaving the actual burnt counter on the old host
+    // unannounced.
+    try {
+      // Enqueue first. If the outbox write fails, the row remains
+      // `burnPending` and startup/backfill can retry; terminalizing first
+      // would make a transient outbox failure silently drop the proactive
+      // repair signal.
+      await enqueueOwnUnresolvableMarker(
+        hostId: hostId,
+        counter: counter,
+      );
+      domainLogger.log(
+        LogDomain.sync,
+        'vc.burn.broadcast host=$hostId counter=$counter',
+        subDomain: 'vc.burn.broadcast',
+      );
+    } catch (error, stackTrace) {
+      domainLogger.error(
+        LogDomain.sync,
+        error,
+        message:
+            'vc burn broadcast failed; counter $counter will fall back to '
+            'reactive backfill resolution',
+        stackTrace: stackTrace,
+        subDomain: 'vc.burn.broadcast',
+      );
+    }
+  });
+
+  // Crash recovery for counters explicitly released in a previous process but
+  // not yet broadcast as unresolvable. Plain `reserved` rows are not retried
+  // here: a crash after the payload DB write but before outbox/sequence
+  // logging can leave a real payload behind, so only `burnPending` rows are
+  // authoritative burns.
+  unawaited(
+    Future<void>(() async {
+      try {
+        final hostId = await vectorClockService.getHost();
+        if (hostId == null) return;
+        final counters = await syncSequenceLogService
+            .burnPendingCountersForHost(
+              hostId: hostId,
+            );
+        var reconciled = 0;
+        for (final counter in counters) {
+          try {
+            await enqueueOwnUnresolvableMarker(
+              hostId: hostId,
+              counter: counter,
+            );
+            reconciled++;
+          } catch (error, stackTrace) {
+            domainLogger.error(
+              LogDomain.sync,
+              error,
+              message:
+                  'vc burn reconciliation failed for host=$hostId '
+                  'counter=$counter; continuing',
+              stackTrace: stackTrace,
+              subDomain: 'vc.burn.reconcile',
+            );
+          }
+        }
+        if (counters.isNotEmpty) {
+          domainLogger.log(
+            LogDomain.sync,
+            'vc.burn.reconcile host=$hostId count=$reconciled '
+            'attempted=${counters.length} '
+            'counters=$counters',
+            subDomain: 'vc.burn.reconcile',
+          );
+        }
+        final reservedCounters = await syncSequenceLogService
+            .reservedCountersForHost(hostId: hostId);
+        if (reservedCounters.isNotEmpty) {
+          domainLogger.error(
+            LogDomain.sync,
+            'vc.reserved.audit host=$hostId '
+            'count=${reservedCounters.length} '
+            'counters=$reservedCounters',
+            subDomain: 'vc.reserved.audit',
+          );
+        }
+      } catch (error, stackTrace) {
+        domainLogger.error(
+          LogDomain.sync,
+          error,
+          message:
+              'vc burn reconciliation failed; burn-pending counters will retry '
+              'on the next startup or reactive backfill',
+          stackTrace: stackTrace,
+          subDomain: 'vc.burn.reconcile',
+        );
+      }
+    }),
+  );
+  final backfillResponseHandler = BackfillResponseHandler(
+    journalDb: journalDb,
+    sequenceLogService: syncSequenceLogService,
+    outboxService: outboxService,
+    loggingService: domainLogger,
+    vectorClockService: vectorClockService,
+    domainLogger: domainLogger,
+    notificationsDb: notificationsDb,
+    onboardingSyncService: onboardingSyncService,
+  )..consumptionRepository = consumptionRepository;
+  final backfillRequestService = BackfillRequestService(
+    sequenceLogService: syncSequenceLogService,
+    syncDatabase: syncDatabase,
+    outboxService: outboxService,
+    vectorClockService: vectorClockService,
+    loggingService: domainLogger,
+    documentsDirectory: documentsDirectory,
+    queueCoordinator: queuePipelineCoordinator,
+    domainLogger: domainLogger,
+    onboardingSyncService: onboardingSyncService,
+  );
+  syncSequenceLogService.onMissingEntriesDetected = () {
+    backfillRequestService.nudge();
+    // Barren-bridge recovery: when the most recent reconnect bridge
+    // finished without accepting anything and a live event now reveals
+    // a missing counter, run an unbounded history walk to close the
+    // hole immediately instead of waiting for the normal backfill
+    // cadence. No-op when no barren bridge was recorded.
+    queuePipelineCoordinator.maybeStartGapRecovery();
+  };
+
+  // After a bridge walk settles, re-analyse the sequence log and
+  // dispatch a backfill request for anything still missing — nudges
+  // during the walk are dropped by the `isBridgeInFlight` gate, so
+  // this hook is how the service learns the walk finished.
+  queuePipelineCoordinator.onBridgeCompleted = backfillRequestService.nudge;
+  onboardingSyncService.onInboundSuppressionEnded =
+      backfillRequestService.nudgeAfterDrain;
+
+  // Set-once assignment of the late-final `backfillResponseHandler`. Must
+  // run before MatrixService consumes any inbound timeline events.
+  syncEventProcessor.backfillResponseHandler = backfillResponseHandler;
+
+  // Media self-healing, both halves. The requester turns the loader's
+  // "blob missing locally" signal into a broadcast request; the responder
+  // answers peers' requests with the blob. Wiring the listener is what makes
+  // the signal actionable — unsubscribed, a missing image or recording is
+  // observed on every load and silently dropped.
+  final mediaRepairService = MediaRepairService(
+    outboxService: outboxService,
+    vectorClockService: vectorClockService,
+    loggingService: domainLogger,
+  );
+  syncEventProcessor
+    ..missingMediaListener = mediaRepairService.reportMissing
+    ..mediaRequestHandler = MediaRequestHandler(
+      journalDb: journalDb,
+      outboxService: outboxService,
+      vectorClockService: vectorClockService,
+      documentsDirectory: documentsDirectory,
+      loggingService: domainLogger,
+    );
+
+  // Start the backfill request service
+  backfillRequestService.start();
+
+  getIt
+    ..registerSingleton<BackfillResponseHandler>(backfillResponseHandler)
+    ..registerSingleton<BackfillRequestService>(backfillRequestService)
+    ..registerSingleton<OnboardingSyncService>(onboardingSyncService)
+    ..registerSingleton<MediaRepairService>(
+      mediaRepairService,
+      dispose: (service) => service.dispose(),
+    );
+
+  return () => client.userID;
+}
+
+/// Registers the sync boundary for guest/demo worlds: an inert outbox and
+/// nothing else. No Matrix client (so the device-global keychain credentials
+/// are never read), no inbound queue, no backfill timers, no node-profile
+/// broadcast, no VC-burn handler — the sync stack is structurally absent,
+/// which is the demo-mode isolation guarantee.
+void _registerInertSyncStack() {
+  getIt.registerSingleton<OutboxService>(InertOutboxService());
+}

--- a/lib/get_it_sync.dart
+++ b/lib/get_it_sync.dart
@@ -172,7 +172,8 @@ Future<String? Function()> _registerMatrixSyncStack({
     enqueueMessage: outboxService.enqueueMessageOrThrow,
     getHostId: vectorClockService.getHost,
     getSnapshotCoverage: syncDatabase.resolvedSequenceUpperBounds,
-    // coverage:ignore-start — trivial accessor thunks, consumed only during
+    // trivial accessor thunks, consumed only during
+    // coverage:ignore-start
     // live onboarding-sync rounds against a logged-in client.
     getLocalUserId: () => client.userID,
     getLocalDeviceId: () => client.deviceID,
@@ -207,7 +208,8 @@ Future<String? Function()> _registerMatrixSyncStack({
     try {
       await syncNodeProfileBroadcaster.broadcast();
     } catch (error, stackTrace) {
-      // coverage:ignore-start — defensive: only reachable when the probe or
+      // defensive: only reachable when the probe or
+      // coverage:ignore-start
       // the outbox write infrastructure itself fails.
       domainLogger.error(
         LogDomain.sync,
@@ -231,7 +233,8 @@ Future<String? Function()> _registerMatrixSyncStack({
     if (existingStatus == SyncSequenceStatus.received.index ||
         existingStatus == SyncSequenceStatus.backfilled.index ||
         existingStatus == SyncSequenceStatus.deleted.index) {
-      // coverage:ignore-start — guards a live-sync race: a peer's response
+      // guards a live-sync race: a peer's response
+      // coverage:ignore-start
       // about this very counter landing between reserve and release. The
       // receive path ignores own-host entries, so the state cannot be
       // constructed in-process.
@@ -289,7 +292,8 @@ Future<String? Function()> _registerMatrixSyncStack({
         subDomain: 'vc.burn.broadcast',
       );
     } catch (error, stackTrace) {
-      // coverage:ignore-start — defensive: reachable only when the outbox or
+      // defensive: reachable only when the outbox or
+      // coverage:ignore-start
       // sequence-log write infrastructure itself fails mid-broadcast.
       domainLogger.error(
         LogDomain.sync,
@@ -327,7 +331,8 @@ Future<String? Function()> _registerMatrixSyncStack({
             );
             reconciled++;
           } catch (error, stackTrace) {
-            // coverage:ignore-start — defensive per-counter containment for
+            // defensive per-counter containment for
+            // coverage:ignore-start
             // infrastructure write failures.
             domainLogger.error(
               LogDomain.sync,
@@ -362,7 +367,8 @@ Future<String? Function()> _registerMatrixSyncStack({
           );
         }
       } catch (error, stackTrace) {
-        // coverage:ignore-start — defensive: whole-pass containment when the
+        // defensive: whole-pass containment when the
+        // coverage:ignore-start
         // sequence log itself cannot be read.
         domainLogger.error(
           LogDomain.sync,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,7 +80,12 @@ Future<void> main() async {
       configureFrameworkErrorSuppression(scheduleIntervalSummaries: true);
       FlutterError.onError = handleFlutterFrameworkError;
 
-      runApp(const LottiAppRoot());
+      runApp(
+        LottiAppRoot(
+          registry: bootInfo.registry,
+          lifecycleHolder: lifecycleHolder,
+        ),
+      );
     },
     handleUncaughtZoneError,
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,10 @@ void handleTimezoneConfigurationError(Object error, StackTrace stackTrace) {
   );
 }
 
+// The process entry point cannot execute under flutter test; its pieces are
+// covered individually (app_bootstrap_test, get_it tests, main_test for the
+// error machinery below).
+// coverage:ignore-start
 Future<void> main() async {
   // Raise the file descriptor soft limit before anything opens an FD. On
   // macOS, GUI apps inherit launchd's legacy soft limit of 256, which is
@@ -90,6 +94,7 @@ Future<void> main() async {
     handleUncaughtZoneError,
   );
 }
+// coverage:ignore-end
 
 /// Global framework error handler: presents the error on the console exactly
 /// like Flutter's default handler and persists its full stack once per stable

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,37 +1,17 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:ui' show AppExitResponse;
 
 import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_animate/flutter_animate.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/beamer/beamer_app.dart';
-import 'package:lotti/database/database.dart';
-import 'package:lotti/database/maintenance.dart';
-import 'package:lotti/database/settings_db.dart';
-import 'package:lotti/database/sync_db.dart';
-import 'package:lotti/features/ai/repository/ai_config_repository.dart'
-    hide aiConfigRepositoryProvider;
-import 'package:lotti/features/sync/matrix/matrix_service.dart';
-import 'package:lotti/features/sync/outbox/outbox_service.dart';
-import 'package:lotti/features/sync/secure_storage.dart';
+import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/app_root.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/domain_logging.dart';
-import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/fd_limits.dart';
-import 'package:lotti/utils/file_utils.dart';
-import 'package:lotti/utils/platform.dart';
-import 'package:lotti/utils/timezone.dart';
-import 'package:lotti/widgets/media/image_viewer_orientation_scope.dart';
-import 'package:media_kit/media_kit.dart';
-import 'package:timezone/data/latest.dart' as tz;
-import 'package:window_manager/window_manager.dart';
 
 class AppConstants {
   const AppConstants._();
@@ -55,7 +35,6 @@ void flushPendingFrameworkErrorSummaries() {
 }
 
 /// Records a startup timezone-resolution failure without aborting startup.
-@visibleForTesting
 void handleTimezoneConfigurationError(Object error, StackTrace stackTrace) {
   getIt<DomainLogger>().error(
     LogDomain.general,
@@ -74,19 +53,10 @@ Future<void> main() async {
 
   await runZonedGuarded(
     () async {
-      // Register DomainLogger immediately after its LoggingService sink so the
-      // startup diagnostics below — and the runZonedGuarded error handler — can
-      // resolve it before registerSingletons() runs. registerSingletons() then
-      // reuses this instance instead of re-registering.
-      final loggingService = LoggingService();
-      getIt
-        ..registerSingleton<LoggingService>(
-          loggingService,
-          dispose: (service) => service.dispose(),
-        )
-        ..registerSingleton<DomainLogger>(
-          DomainLogger(loggingService: loggingService),
-        );
+      // Register DomainLogger immediately so the startup diagnostics below —
+      // and the runZonedGuarded error handler — can resolve it before
+      // registerSingletons() runs.
+      registerProcessLogging();
 
       getIt<DomainLogger>().log(
         LogDomain.general,
@@ -94,93 +64,23 @@ Future<void> main() async {
         subDomain: 'fdLimits',
       );
 
-      WidgetsFlutterBinding.ensureInitialized();
-      // Platform startup call; controller behavior is covered by focused tests.
-      // coverage:ignore-start
-      await appOrientationController.lockToPortrait();
-      // coverage:ignore-end
-      try {
-        MediaKit.ensureInitialized();
-      } catch (e) {
-        getIt<DomainLogger>().error(
-          LogDomain.general,
-          e,
-          subDomain:
-              'MediaKit initialization failed - continuing without media support',
-        );
-      }
-      Animate.restartOnHotReload = true;
+      await initPlatformOnce();
 
-      if (isDesktop) {
-        await windowManager.ensureInitialized();
-
-        // Configure window options for flatpak compatibility
-        const windowOptions = WindowOptions(
-          size: AppConstants.defaultWindowSize,
-          minimumSize: AppConstants.minimumWindowSize,
-          center: true,
-          backgroundColor: Colors.transparent,
-          skipTaskbar: false,
-          titleBarStyle: TitleBarStyle.normal,
-        );
-        await windowManager.waitUntilReadyToShow(windowOptions, () async {
-          await windowManager.show();
-          await windowManager.focus();
-        });
-      }
-
-      final docDir = await findDocumentsDirectory();
-      AppLifecycleListener? appLifecycleListener;
-
-      getIt
-        ..registerSingleton<SecureStorage>(SecureStorage())
-        ..registerSingleton<Directory>(docDir)
-        ..registerSingleton<SettingsDb>(SettingsDb())
-        ..registerSingleton<WindowService>(
-          WindowService(
-            beforeLogFlush: () async {
-              appLifecycleListener?.dispose();
-              appLifecycleListener = null;
-              flushPendingFrameworkErrorSummaries();
-            },
-          ),
-        );
-
-      await getIt<WindowService>().restore();
-      tz.initializeTimeZones();
-      // Loading the database does not pick a zone — without this the
-      // package's `local` stays UTC and scheduled reminders land hours off.
-      // coverage:ignore-start
-      await configureLocalTimezone(
-        onError: handleTimezoneConfigurationError,
+      final bootInfo = await resolveActiveProfile();
+      final lifecycleHolder = AppLifecycleHolder();
+      await bootstrapProfileServices(
+        bootInfo,
+        lifecycleHolder: lifecycleHolder,
       );
-      // coverage:ignore-end
 
-      await registerSingletons();
-
-      appLifecycleListener = AppLifecycleListener(
+      lifecycleHolder.listener = AppLifecycleListener(
         onExitRequested: handleAppExitRequested,
       );
 
       configureFrameworkErrorSuppression(scheduleIntervalSummaries: true);
       FlutterError.onError = handleFlutterFrameworkError;
 
-      runApp(
-        ProviderScope(
-          overrides: [
-            matrixServiceProvider.overrideWithValue(getIt<MatrixService>()),
-            maintenanceProvider.overrideWithValue(getIt<Maintenance>()),
-            journalDbProvider.overrideWithValue(getIt<JournalDb>()),
-            syncDatabaseProvider.overrideWithValue(getIt<SyncDatabase>()),
-            loggingServiceProvider.overrideWithValue(getIt<LoggingService>()),
-            outboxServiceProvider.overrideWithValue(getIt<OutboxService>()),
-            aiConfigRepositoryProvider.overrideWithValue(
-              getIt<AiConfigRepository>(),
-            ),
-          ],
-          child: const MyBeamerApp(),
-        ),
-      );
+      runApp(const LottiAppRoot());
     },
     handleUncaughtZoneError,
   );

--- a/lib/services/service_disposer.dart
+++ b/lib/services/service_disposer.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/ai/database/embedding_store.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/service/embedding_service.dart';
 import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -108,6 +109,10 @@ class ServiceDisposer {
     await _disposeAsyncSafely<OnboardingMetricsDb>(
       (db) => db.close(),
       'OnboardingMetricsDb',
+    );
+    await _disposeAsyncSafely<DayProcessingDb>(
+      (db) => db.close(),
+      'DayProcessingDb',
     );
     await _disposeAsyncSafely<SettingsDb>((db) => db.close(), 'SettingsDb');
   }

--- a/lib/services/startup_tasks.dart
+++ b/lib/services/startup_tasks.dart
@@ -1,15 +1,30 @@
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+
 /// Tracks fire-and-forget startup work (MatrixService.init, the one-time
-/// sequence-log migration) so an in-app profile switch can wait for it —
-/// bounded — before tearing the service generation down. Without this, a
-/// switch right after boot could dispose services out from under their own
-/// startup futures.
+/// sequence-log migration, the node-profile broadcast) so an in-app profile
+/// switch can wait for it — bounded — before tearing the service generation
+/// down. Without this, a switch right after boot could dispose services out
+/// from under their own startup futures.
 class StartupTasks {
   final List<Future<void>> _tracked = [];
 
-  /// Registers [future] as startup work. Errors are already handled (or
-  /// deliberately logged) by the work itself; tracking must never rethrow.
+  /// Registers [future] as startup work. A failure is recorded under the
+  /// general domain (so the "why did sync never start" diagnostic survives)
+  /// and then contained — tracking must never rethrow into settle.
   void track(Future<void> future) {
-    _tracked.add(future.catchError((Object _) {}));
+    _tracked.add(
+      future.catchError((Object error, StackTrace stackTrace) {
+        if (getIt.isRegistered<DomainLogger>()) {
+          getIt<DomainLogger>().error(
+            LogDomain.general,
+            error,
+            stackTrace: stackTrace,
+            subDomain: 'startupTasks',
+          );
+        }
+      }),
+    );
   }
 
   /// Waits for all tracked work, bounded by [timeout]. Late work past the

--- a/lib/services/startup_tasks.dart
+++ b/lib/services/startup_tasks.dart
@@ -1,0 +1,23 @@
+/// Tracks fire-and-forget startup work (MatrixService.init, the one-time
+/// sequence-log migration) so an in-app profile switch can wait for it —
+/// bounded — before tearing the service generation down. Without this, a
+/// switch right after boot could dispose services out from under their own
+/// startup futures.
+class StartupTasks {
+  final List<Future<void>> _tracked = [];
+
+  /// Registers [future] as startup work. Errors are already handled (or
+  /// deliberately logged) by the work itself; tracking must never rethrow.
+  void track(Future<void> future) {
+    _tracked.add(future.catchError((Object _) {}));
+  }
+
+  /// Waits for all tracked work, bounded by [timeout]. Late work past the
+  /// bound is abandoned to its own error handling.
+  Future<void> settle({Duration timeout = const Duration(seconds: 5)}) async {
+    if (_tracked.isEmpty) return;
+    await Future.wait(
+      _tracked,
+    ).timeout(timeout, onTimeout: () => const []).then((_) {});
+  }
+}

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -180,6 +180,11 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
   void detachForRestart() {
     windowManager.removeListener(this);
     WidgetsBinding.instance.removeObserver(this);
+    if (isDesktop) {
+      // Without this, a switch that fails after teardown would leave
+      // preventClose set with no listener to honor the close request.
+      unawaited(windowManager.setPreventClose(false));
+    }
   }
 
   /// Stops native/background work and closes every database exactly once.

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -172,6 +172,16 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
     }
   }
 
+  /// Detaches this instance from the window manager and the widgets binding
+  /// without tearing the window down. Called during an in-app profile
+  /// switch: the outgoing generation's WindowService must stop observing
+  /// window events, or it would keep writing geometry after its service
+  /// generation is disposed.
+  void detachForRestart() {
+    windowManager.removeListener(this);
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
   /// Stops native/background work and closes every database exactly once.
   ///
   /// Both Flutter's app-exit callback and the window-manager callback await

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -177,13 +177,15 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
   /// switch: the outgoing generation's WindowService must stop observing
   /// window events, or it would keep writing geometry after its service
   /// generation is disposed.
-  void detachForRestart() {
+  Future<void> detachForRestart() async {
     windowManager.removeListener(this);
     WidgetsBinding.instance.removeObserver(this);
     if (isDesktop) {
-      // Without this, a switch that fails after teardown would leave
-      // preventClose set with no listener to honor the close request.
-      unawaited(windowManager.setPreventClose(false));
+      // Awaited so the release cannot race the next generation's
+      // WindowService re-arming preventClose; without it, a switch that
+      // fails after teardown would leave preventClose set with no listener
+      // to honor the close request.
+      await windowManager.setPreventClose(false);
     }
   }
 

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/speech/state/audio_player_controller.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/app_prefs_service.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/service_disposer.dart';
@@ -27,11 +28,13 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
     @visibleForTesting PlatformCheck? isMacOSOverride,
     AsyncDisposer? beforeLogFlush,
     @visibleForTesting bool skipWindowManagerSetup = false,
+    @visibleForTesting AppPrefs? prefsOverride,
   }) : _exitFn = exitOverride ?? immediateExit,
        _playerDisposer =
            playerDisposerOverride ?? AudioPlayerController.disposeActivePlayer,
        _beforeLogFlush = beforeLogFlush ?? (() async {}),
-       _isMacOS = isMacOSOverride ?? (() => isMacOS) {
+       _isMacOS = isMacOSOverride ?? (() => isMacOS),
+       _prefs = prefsOverride ?? makeSharedPrefsService() {
     if (!skipWindowManagerSetup) {
       windowManager.addListener(this);
       if (isDesktop) {
@@ -51,19 +54,45 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
   final AsyncDisposer _playerDisposer;
   final AsyncDisposer _beforeLogFlush;
   final PlatformCheck _isMacOS;
+  final AppPrefs _prefs;
 
   final sizeKey = 'WINDOW_SIZE';
   final offsetKey = 'WINDOW_OFFSET';
 
+  /// Window geometry is device state, not world state: it lives in
+  /// SharedPreferences so it survives profile switches, with a one-time
+  /// read-through migration from the legacy per-profile SettingsDb rows.
   Future<void> restore() async {
     if (isDesktop) {
-      final restoredValues = await getIt<SettingsDb>().itemsByKeys({
+      final (size, offset) = await resolveGeometry();
+      await _applyRestoredSize(size);
+      await _applyRestoredOffset(offset);
+    }
+  }
+
+  /// Reads persisted window geometry, migrating legacy SettingsDb rows into
+  /// SharedPreferences when the prefs entries are absent.
+  @visibleForTesting
+  Future<(String?, String?)> resolveGeometry() async {
+    var size = await _prefs.getString(sizeKey);
+    var offset = await _prefs.getString(offsetKey);
+    if (size == null || offset == null) {
+      final legacy = await getIt<SettingsDb>().itemsByKeys({
         sizeKey,
         offsetKey,
       });
-      await _applyRestoredSize(restoredValues[sizeKey]);
-      await _applyRestoredOffset(restoredValues[offsetKey]);
+      final legacySize = legacy[sizeKey];
+      final legacyOffset = legacy[offsetKey];
+      if (size == null && legacySize != null) {
+        size = legacySize;
+        await _prefs.setString(key: sizeKey, value: legacySize);
+      }
+      if (offset == null && legacyOffset != null) {
+        offset = legacyOffset;
+        await _prefs.setString(key: offsetKey, value: legacyOffset);
+      }
     }
+    return (size, offset);
   }
 
   Future<void> _applyRestoredSize(String? sizeString) async {
@@ -105,17 +134,17 @@ class WindowService with WidgetsBindingObserver implements WindowListener {
 
   Future<void> _onMoved() async {
     final offset = await windowManager.getPosition();
-    await getIt<SettingsDb>().saveSettingsItem(
-      offsetKey,
-      '${offset.dx},${offset.dy}',
+    await _prefs.setString(
+      key: offsetKey,
+      value: '${offset.dx},${offset.dy}',
     );
   }
 
   Future<void> _onResized() async {
     final size = await windowManager.getSize();
-    await getIt<SettingsDb>().saveSettingsItem(
-      sizeKey,
-      '${size.width},${size.height}',
+    await _prefs.setString(
+      key: sizeKey,
+      value: '${size.width},${size.height}',
     );
   }
 

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -1,0 +1,223 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/sync/matrix/matrix_service.dart';
+import 'package:lotti/features/sync/outbox/inert_outbox_service.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/service_disposer.dart';
+import 'package:lotti/services/vector_clock_service.dart';
+import 'package:path/path.dart' as p;
+
+import 'helpers/entity_factories.dart';
+
+/// Recursive snapshot of a directory subtree: relative path -> file length.
+/// [exclude] prunes subtrees (e.g. the guest worlds container).
+Map<String, int> snapshotTree(Directory dir, {Set<String> exclude = const {}}) {
+  final result = <String, int>{};
+  if (!dir.existsSync()) return result;
+  for (final entity in dir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    final rel = p.relative(entity.path, from: dir.path);
+    final top = p.split(rel).first;
+    if (exclude.contains(top)) continue;
+    result[rel] = entity.lengthSync();
+  }
+  return result;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory osRoot;
+  var keychainReads = 0;
+
+  void mockChannels() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (MethodCall call) async => osRoot.path,
+      )
+      ..setMockMethodCallHandler(
+        const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+        (MethodCall call) async {
+          if (call.method == 'read' || call.method == 'readAll') {
+            keychainReads++;
+          }
+          return null;
+        },
+      )
+      ..setMockMethodCallHandler(
+        const MethodChannel('window_manager'),
+        (MethodCall call) async => null,
+      );
+  }
+
+  void unmockChannels() {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    for (final channel in const [
+      'plugins.flutter.io/path_provider',
+      'plugins.it_nomads.com/flutter_secure_storage',
+      'window_manager',
+    ]) {
+      messenger.setMockMethodCallHandler(MethodChannel(channel), null);
+    }
+  }
+
+  setUp(() async {
+    await getIt.reset();
+    osRoot = Directory.systemTemp.createTempSync('lotti_boot_');
+    keychainReads = 0;
+    mockChannels();
+  });
+
+  tearDown(() async {
+    await pumpEventQueue(times: 200);
+    await ServiceDisposer(getIt, (e, s, n) {}).disposeAll();
+    await getIt.reset();
+    unmockChannels();
+    if (osRoot.existsSync()) {
+      await osRoot.delete(recursive: true);
+    }
+  });
+
+  group('resolveActiveProfile', () {
+    test(
+      'no registry file resolves to the real world at the OS root',
+      () async {
+        final info = await resolveActiveProfile();
+
+        expect(info.active.id, Profile.realProfileId);
+        expect(info.activeRoot.path, osRoot.path);
+        expect(info.realRoot.path, osRoot.path);
+      },
+    );
+
+    test('active guest marker resolves to the guest root', () async {
+      final registry = ProfileRegistry(realRoot: osRoot);
+      final guest = await registry.createGuestProfile(name: 'Demo');
+      await registry.setActiveProfile(guest.id);
+
+      final info = await resolveActiveProfile();
+
+      expect(info.active.id, guest.id);
+      expect(info.activeRoot.path, registry.rootFor(guest).path);
+      expect(info.realRoot.path, osRoot.path);
+    });
+  });
+
+  group('guest boot isolation audit', () {
+    test(
+      'a full guest bootstrap never touches the real world, constructs no '
+      'Matrix stack, reads no keychain, and mints its own host id',
+      () async {
+        // Canary content standing in for a real user's world.
+        File(
+          p.join(osRoot.path, 'db.sqlite'),
+        ).writeAsStringSync('real journal');
+        Directory(
+          p.join(osRoot.path, 'images', '2026-08-01'),
+        ).createSync(recursive: true);
+        File(
+          p.join(osRoot.path, 'images', '2026-08-01', 'photo.jpg'),
+        ).writeAsStringSync('real photo');
+
+        final registry = ProfileRegistry(realRoot: osRoot);
+        final guest = await registry.createGuestProfile(name: 'Demo');
+        await registry.setActiveProfile(guest.id);
+        final before = snapshotTree(
+          osRoot,
+          exclude: {'guest_profiles'},
+        );
+
+        registerProcessLogging();
+        final info = await resolveActiveProfile();
+        final context = await bootstrapProfileServices(
+          info,
+          lifecycleHolder: AppLifecycleHolder(),
+          restoreWindow: false,
+        );
+
+        // Capability wiring.
+        expect(context.isGuest, isTrue);
+        expect(context.capabilities.syncEnabled, isFalse);
+        expect(getIt<ProfileContext>().profile.id, guest.id);
+        expect(getIt<Directory>().path, registry.rootFor(guest).path);
+
+        // The Matrix stack is structurally absent; the outbox is inert.
+        expect(getIt.isRegistered<MatrixService>(), isFalse);
+        expect(getIt<OutboxService>(), isA<InertOutboxService>());
+
+        // The provider bridge omits matrixServiceProvider in guest mode:
+        // 7 overrides instead of the real profile's 8.
+        expect(buildProviderOverrides(context), hasLength(7));
+
+        // A representative write lands in the guest world only.
+        final task = TestTaskFactory.create(id: 'guest-task-1');
+        await getIt<JournalDb>().updateJournalEntity(task);
+        final persisted = await getIt<JournalDb>().journalEntityById(
+          'guest-task-1',
+        );
+        expect(persisted, isNotNull);
+        final guestSidecars = Directory(
+          p.join(registry.rootFor(guest).path, 'tasks'),
+        );
+        expect(guestSidecars.existsSync(), isTrue);
+
+        // Own sync identity: the host id exists in the guest settings db;
+        // the real world has no settings.sqlite at all.
+        final hostId = await getIt<VectorClockService>().getHost();
+        expect(hostId, isNotNull);
+        expect(
+          File(p.join(osRoot.path, 'settings.sqlite')).existsSync(),
+          isFalse,
+        );
+
+        // Zero keychain reads during the whole guest boot + write.
+        expect(keychainReads, 0);
+
+        // Let unawaited startup writes settle, then: the real world is
+        // byte-identical.
+        await pumpEventQueue(times: 200);
+        expect(
+          snapshotTree(osRoot, exclude: {'guest_profiles'}),
+          before,
+        );
+      },
+    );
+  });
+
+  group('real-profile bootstrap', () {
+    test('registers the world-scoped primitives against the OS root', () async {
+      registerProcessLogging();
+      final info = await resolveActiveProfile();
+      final context = await bootstrapProfileServices(
+        info,
+        lifecycleHolder: AppLifecycleHolder(),
+        restoreWindow: false,
+        registerLateAndOptional: false,
+      );
+
+      expect(context.isGuest, isFalse);
+      expect(getIt<Directory>().path, osRoot.path);
+
+      // The full Matrix stack exists in a real profile...
+      expect(getIt.isRegistered<MatrixService>(), isTrue);
+      expect(getIt<OutboxService>(), isA<MatrixOutboxService>());
+      // ...its session store lives under the real root...
+      expect(
+        File(p.join(osRoot.path, 'matrix', 'lotti_sync.db')).existsSync(),
+        isTrue,
+      );
+      // ...and the bridge carries all 8 overrides including Matrix.
+      expect(buildProviderOverrides(context), hasLength(8));
+    });
+  });
+}

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -269,6 +269,31 @@ void main() {
       expect(actor, isNotNull);
     });
 
+    test(
+      'a burn broadcast against a dead sync database is contained and does '
+      'not fail the release',
+      () async {
+        registerProcessLogging();
+        final lifecycleHolder = AppLifecycleHolder();
+        addTearDown(lifecycleHolder.dispose);
+        await bootstrapProfileServices(
+          await resolveActiveProfile(),
+          lifecycleHolder: lifecycleHolder,
+          restoreWindow: false,
+          registerLateAndOptional: false,
+        );
+        await settlePendingDbWork();
+        final reservation = await getIt<VectorClockService>()
+            .reserveNextVectorClock();
+
+        // Shutdown race: the sync database dies before the release's burn
+        // broadcast runs. The handler must contain the failure — the
+        // counter stays burn-pending for the next boot's reconciliation.
+        await getIt<SyncDatabase>().close();
+        await expectLater(reservation.release(), completes);
+      },
+    );
+
     test('window close after a guest bootstrap runs the pre-flush hook and '
         'releases the app-exit listener', () async {
       final registry = ProfileRegistry(realRoot: osRoot);

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -12,6 +13,7 @@ import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/inert_outbox_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
@@ -338,8 +340,21 @@ void main() {
           await syncDb.reservedSequenceCountersForHost(hostId: crashHost),
           [4],
         );
-        // Startup broadcast + the reconciled marker.
-        expect(await syncDb.watchOutboxCount().first, greaterThanOrEqualTo(2));
+        // The queued messages contain exactly one unresolvable marker for
+        // the burned counter — and none for the merely-reserved one.
+        final queued = await syncDb.oldestOutboxItems(50);
+        final markers = queued
+            .map(
+              (item) => SyncMessage.fromJson(
+                jsonDecode(item.message) as Map<String, dynamic>,
+              ),
+            )
+            .whereType<SyncBackfillResponse>()
+            .where((message) => message.hostId == crashHost)
+            .toList();
+        expect(markers, hasLength(1));
+        expect(markers.single.counter, 3);
+        expect(markers.single.unresolvable, isTrue);
         // The reconciled world kept the crashed process's host identity.
         expect(await getIt<VectorClockService>().getHost(), crashHost);
       },

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -1,11 +1,13 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/app_bootstrap.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/ai_consumption/service/ai_attribution_identity_resolver.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
@@ -17,6 +19,7 @@ import 'package:lotti/features/sync/utils.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/service_disposer.dart';
 import 'package:lotti/services/vector_clock_service.dart';
+import 'package:lotti/services/window_service.dart';
 import 'package:path/path.dart' as p;
 
 import 'helpers/db_settle.dart';
@@ -137,6 +140,9 @@ void main() {
         final registry = ProfileRegistry(realRoot: osRoot);
         final guest = await registry.createGuestProfile(name: 'Demo');
         await registry.setActiveProfile(guest.id);
+        // The guest dir vanished externally (dangling marker): boot must
+        // recreate the skeleton rather than fail.
+        await registry.rootFor(guest).delete(recursive: true);
         final before = snapshotTree(
           osRoot,
           exclude: {'guest_profiles'},
@@ -149,7 +155,8 @@ void main() {
         final context = await bootstrapProfileServices(
           info,
           lifecycleHolder: lifecycleHolder,
-          restoreWindow: false,
+          // Default restoreWindow: exercises the cold-boot geometry restore
+          // against the mocked window_manager channel.
         );
 
         // Capability wiring.
@@ -250,6 +257,35 @@ void main() {
       final sequenceLog = getIt<SyncSequenceLogService>();
       expect(sequenceLog.onMissingEntriesDetected, isNotNull);
       sequenceLog.onMissingEntriesDetected!.call();
+
+      // The AI attribution identity resolver consumes the Matrix user-id
+      // thunk wired by the sync registration (no session → null id, local
+      // principal only).
+      final actor = await getIt<AiAttributionIdentityResolver>()
+          .humanInitiator();
+      expect(actor, isNotNull);
+    });
+
+    test('window close after a guest bootstrap runs the pre-flush hook and '
+        'releases the app-exit listener', () async {
+      final registry = ProfileRegistry(realRoot: osRoot);
+      final guest = await registry.createGuestProfile(name: 'Demo');
+      await registry.setActiveProfile(guest.id);
+      registerProcessLogging();
+      final lifecycleHolder = AppLifecycleHolder();
+      await bootstrapProfileServices(
+        await resolveActiveProfile(),
+        lifecycleHolder: lifecycleHolder,
+        restoreWindow: false,
+        registerLateAndOptional: false,
+      );
+      lifecycleHolder.listener = AppLifecycleListener();
+      await settlePendingDbWork();
+
+      await getIt<WindowService>().shutdown();
+
+      // The shutdown pre-flush hook disposed the app-exit listener.
+      expect(lifecycleHolder.listener, isNull);
     });
 
     test(

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -139,9 +139,11 @@ void main() {
 
         registerProcessLogging();
         final info = await resolveActiveProfile();
+        final lifecycleHolder = AppLifecycleHolder();
+        addTearDown(lifecycleHolder.dispose);
         final context = await bootstrapProfileServices(
           info,
-          lifecycleHolder: AppLifecycleHolder(),
+          lifecycleHolder: lifecycleHolder,
           restoreWindow: false,
         );
 
@@ -198,9 +200,11 @@ void main() {
     test('registers the world-scoped primitives against the OS root', () async {
       registerProcessLogging();
       final info = await resolveActiveProfile();
+      final lifecycleHolder = AppLifecycleHolder();
+      addTearDown(lifecycleHolder.dispose);
       final context = await bootstrapProfileServices(
         info,
-        lifecycleHolder: AppLifecycleHolder(),
+        lifecycleHolder: lifecycleHolder,
         restoreWindow: false,
         registerLateAndOptional: false,
       );

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/app_bootstrap.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
@@ -12,6 +13,7 @@ import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/inert_outbox_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
+import 'package:lotti/features/sync/utils.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/service_disposer.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -249,5 +251,62 @@ void main() {
       expect(sequenceLog.onMissingEntriesDetected, isNotNull);
       sequenceLog.onMissingEntriesDetected!.call();
     });
+
+    test(
+      'burn-pending counters from a crashed process are reconciled into '
+      'unresolvable markers at boot',
+      () async {
+        // Simulate the previous process: a persisted host id and a vector
+        // clock counter that was released (burned) but whose outbound
+        // marker never reached the outbox before the crash.
+        const crashHost = 'crash-host-1';
+        Future<Directory> provider() async => osRoot;
+        final priorSettings = SettingsDb(documentsDirectoryProvider: provider);
+        await priorSettings.saveSettingsItem(hostKey, crashHost);
+        await priorSettings.saveSettingsItem(nextAvailableCounterKey, '5');
+        await priorSettings.close();
+        final priorSync = SyncDatabase(documentsDirectoryProvider: provider);
+        await priorSync.markReservedSequenceCounterBurnPending(
+          hostId: crashHost,
+          counter: 3,
+        );
+        // A plain reserved counter (crash between reserve and write): must
+        // NOT be broadcast as unresolvable — only audited.
+        await priorSync.recordReservedSequenceCounter(
+          hostId: crashHost,
+          counter: 4,
+        );
+        await priorSync.close();
+
+        registerProcessLogging();
+        final info = await resolveActiveProfile();
+        final lifecycleHolder = AppLifecycleHolder();
+        addTearDown(lifecycleHolder.dispose);
+        await bootstrapProfileServices(
+          info,
+          lifecycleHolder: lifecycleHolder,
+          restoreWindow: false,
+          registerLateAndOptional: false,
+        );
+
+        // Reconciliation is fire-and-forget; settle it, then: the burn is
+        // terminal and its unresolvable marker is queued for peers.
+        await settlePendingDbWork();
+        final syncDb = getIt<SyncDatabase>();
+        expect(
+          await syncDb.burnPendingSequenceCountersForHost(hostId: crashHost),
+          isEmpty,
+        );
+        // The plain reservation was audited, not burned.
+        expect(
+          await syncDb.reservedSequenceCountersForHost(hostId: crashHost),
+          [4],
+        );
+        // Startup broadcast + the reconciled marker.
+        expect(await syncDb.watchOutboxCount().first, greaterThanOrEqualTo(2));
+        // The reconciled world kept the crashed process's host identity.
+        expect(await getIt<VectorClockService>().getHost(), crashHost);
+      },
+    );
   });
 }

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -20,6 +20,7 @@ import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/utils.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/service_disposer.dart';
+import 'package:lotti/services/startup_tasks.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:path/path.dart' as p;
@@ -324,8 +325,11 @@ void main() {
           info,
           lifecycleHolder: lifecycleHolder,
           restoreWindow: false,
-          registerLateAndOptional: false,
         );
+        // Late services ran too: settle the tracked startup work
+        // (MatrixService.init against the mocked keychain — no config, no
+        // session — and the sequence-log migration).
+        await getIt<StartupTasks>().settle();
 
         // Reconciliation is fire-and-forget; settle it, then: the burn is
         // terminal and its unresolvable marker is queued for peers.

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/services/service_disposer.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:path/path.dart' as p;
 
+import 'helpers/db_settle.dart';
 import 'helpers/entity_factories.dart';
 
 /// Recursive snapshot of a directory subtree: relative path -> file length.
@@ -79,7 +80,7 @@ void main() {
   });
 
   tearDown(() async {
-    await pumpEventQueue(times: 200);
+    await settlePendingDbWork();
     await ServiceDisposer(getIt, (e, s, n) {}).disposeAll();
     await getIt.reset();
     unmockChannels();

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -4,12 +4,14 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/app_bootstrap.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/inert_outbox_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/service_disposer.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -223,6 +225,29 @@ void main() {
       );
       // ...and the bridge carries all 8 overrides including Matrix.
       expect(buildProviderOverrides(context), hasLength(8));
+
+      // The startup node-profile broadcast reaches the outbox: real sync
+      // wiring, end to end, without any network.
+      await settlePendingDbWork();
+      final syncDb = getIt<SyncDatabase>();
+      final countAfterBoot = await syncDb.watchOutboxCount().first;
+      expect(countAfterBoot, greaterThanOrEqualTo(1));
+
+      // Releasing a reserved vector clock burns the counter: the burn
+      // handler broadcasts an unresolvable backfill marker through the
+      // outbox so peers can close the gap.
+      final reservation = await getIt<VectorClockService>()
+          .reserveNextVectorClock();
+      await reservation.release();
+      await settlePendingDbWork();
+      final countAfterBurn = await syncDb.watchOutboxCount().first;
+      expect(countAfterBurn, greaterThan(countAfterBoot));
+
+      // The gap-detection hook is wired to the backfill nudge; invoking it
+      // must not throw (nudge is a no-op without missing entries).
+      final sequenceLog = getIt<SyncSequenceLogService>();
+      expect(sequenceLog.onMissingEntriesDetected, isNotNull);
+      sequenceLog.onMissingEntriesDetected!.call();
     });
   });
 }

--- a/test/app_root_test.dart
+++ b/test/app_root_test.dart
@@ -71,6 +71,7 @@ void main() {
         var generationBuilds = 0;
         late BuildContext appContext;
         final bootstrapGate = Completer<void>();
+        final bootstrapEntered = Completer<void>();
         await tester.pumpWidget(
           LottiAppRoot(
             registry: registry,
@@ -86,7 +87,10 @@ void main() {
             teardownOverride: () async {},
             // Parks the switch after the splash is up, so the splash state
             // is deterministically observable.
-            bootstrapOverride: () => bootstrapGate.future,
+            bootstrapOverride: () {
+              bootstrapEntered.complete();
+              return bootstrapGate.future;
+            },
           ),
         );
 
@@ -97,9 +101,14 @@ void main() {
         late Future<void> pending;
         await tester.runAsync(() async {
           pending = switcher.switchTo(guest2.id);
-          // Let the registry IO and the splash setState land; the switch
-          // then blocks on the frame settle + the bootstrap gate.
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          // Registry IO and the splash setState land, the frame settle
+          // passes, and the switch parks on the bootstrap gate — a
+          // deterministic signal, no wall-clock sleep. Frames keep being
+          // produced so the frame settle can pass.
+          while (!bootstrapEntered.isCompleted) {
+            await tester.pump(const Duration(milliseconds: 16));
+            await Future<void>.delayed(Duration.zero);
+          }
         });
         await tester.pump();
 
@@ -108,10 +117,6 @@ void main() {
         expect(find.text('generation-alive'), findsNothing);
 
         bootstrapGate.complete();
-        await tester.runAsync(
-          () => Future<void>.delayed(const Duration(milliseconds: 50)),
-        );
-        await tester.pump();
         await tester.runAsync(() => pending);
         await tester.pump();
 

--- a/test/app_root_test.dart
+++ b/test/app_root_test.dart
@@ -1,13 +1,130 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/app_bootstrap.dart';
 import 'package:lotti/app_root.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/maintenance.dart';
+import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart'
+    hide aiConfigRepositoryProvider;
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
 import 'package:lotti/features/profiles/service/profile_switcher.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
+
+import 'mocks/mocks.dart';
 
 void main() {
+  group('LottiAppRoot', () {
+    late Directory realRoot;
+    late ProfileRegistry registry;
+
+    setUp(() async {
+      await getIt.reset();
+      realRoot = Directory.systemTemp.createTempSync('lotti_app_root_');
+      registry = ProfileRegistry(realRoot: realRoot);
+    });
+
+    tearDown(() async {
+      await getIt.reset();
+      if (realRoot.existsSync()) {
+        await realRoot.delete(recursive: true);
+      }
+    });
+
+    void registerBridgeSingletons(Profile profile) {
+      getIt
+        ..registerSingleton<ProfileContext>(
+          ProfileContext.forProfile(
+            profile: profile,
+            root: registry.rootFor(profile),
+          ),
+        )
+        ..registerSingleton<Maintenance>(MockMaintenance())
+        ..registerSingleton<JournalDb>(MockJournalDb())
+        ..registerSingleton<SyncDatabase>(MockSyncDatabase())
+        ..registerSingleton<LoggingService>(MockLoggingService())
+        ..registerSingleton<OutboxService>(MockOutboxService())
+        ..registerSingleton<AiConfigRepository>(MockAiConfigRepository());
+    }
+
+    testWidgets(
+      'a switch shows the splash, then rebuilds a fresh generation',
+      (tester) async {
+        late Profile guest1;
+        late Profile guest2;
+        // Registry work is real file IO — it must run outside the
+        // FakeAsync test zone.
+        await tester.runAsync(() async {
+          guest1 = await registry.createGuestProfile(name: 'Demo 1');
+          guest2 = await registry.createGuestProfile(name: 'Demo 2');
+          await registry.setActiveProfile(guest1.id);
+        });
+        registerBridgeSingletons(guest1);
+
+        var generationBuilds = 0;
+        late BuildContext appContext;
+        final bootstrapGate = Completer<void>();
+        await tester.pumpWidget(
+          LottiAppRoot(
+            registry: registry,
+            lifecycleHolder: AppLifecycleHolder(),
+            appBuilder: (context) {
+              appContext = context;
+              generationBuilds++;
+              return const Text(
+                'generation-alive',
+                textDirection: TextDirection.ltr,
+              );
+            },
+            teardownOverride: () async {},
+            // Parks the switch after the splash is up, so the splash state
+            // is deterministically observable.
+            bootstrapOverride: () => bootstrapGate.future,
+          ),
+        );
+
+        expect(find.text('generation-alive'), findsOneWidget);
+        final buildsBeforeSwitch = generationBuilds;
+
+        final switcher = ProfileSwitcherScope.of(appContext);
+        late Future<void> pending;
+        await tester.runAsync(() async {
+          pending = switcher.switchTo(guest2.id);
+          // Let the registry IO and the splash setState land; the switch
+          // then blocks on the frame settle + the bootstrap gate.
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+        });
+        await tester.pump();
+
+        // While switching, the whole tree is the splash.
+        expect(find.byType(ProfileSwitchSplash), findsOneWidget);
+        expect(find.text('generation-alive'), findsNothing);
+
+        bootstrapGate.complete();
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 50)),
+        );
+        await tester.pump();
+        await tester.runAsync(() => pending);
+        await tester.pump();
+
+        // A NEW generation was built (fresh ProviderScope key), not a
+        // resumed old one.
+        expect(find.text('generation-alive'), findsOneWidget);
+        expect(generationBuilds, greaterThan(buildsBeforeSwitch));
+        final reloaded = await tester.runAsync(() => registry.load());
+        expect(reloaded!.activeProfileId, guest2.id);
+      },
+    );
+  });
+
   group('ProfileSwitchSplash', () {
     testWidgets('shows a bare progress indicator with no app chrome', (
       tester,

--- a/test/app_root_test.dart
+++ b/test/app_root_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/app_root.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/profiles/service/profile_switcher.dart';
+
+void main() {
+  group('ProfileSwitchSplash', () {
+    testWidgets('shows a bare progress indicator with no app chrome', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const ProfileSwitchSplash());
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // Deliberately provider- and localization-free: nothing from the old
+      // generation may be needed to render it.
+      expect(find.byType(Scaffold), findsOneWidget);
+    });
+  });
+
+  group('ProfileSwitcherScope', () {
+    ProfileSwitcher buildSwitcher(Directory root) => ProfileSwitcher(
+      registry: ProfileRegistry(realRoot: root),
+      lifecycleHolder: AppLifecycleHolder(),
+      onSwitchStarted: () async {},
+      onSwitchCompleted: () {},
+      settleFrame: () async {},
+      teardownOverride: () async {},
+      bootstrapOverride: () async {},
+    );
+
+    testWidgets('of() resolves the switcher from above the scope', (
+      tester,
+    ) async {
+      final root = Directory.systemTemp.createTempSync('lotti_scope_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final switcher = buildSwitcher(root);
+      late ProfileSwitcher resolved;
+
+      await tester.pumpWidget(
+        ProfileSwitcherScope(
+          switcher: switcher,
+          child: Builder(
+            builder: (context) {
+              resolved = ProfileSwitcherScope.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(identical(resolved, switcher), isTrue);
+    });
+
+    testWidgets('updateShouldNotify fires only on a new switcher instance', (
+      tester,
+    ) async {
+      final root = Directory.systemTemp.createTempSync('lotti_scope_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final switcherA = buildSwitcher(root);
+      final switcherB = buildSwitcher(root);
+
+      final scopeA = ProfileSwitcherScope(
+        switcher: switcherA,
+        child: const SizedBox.shrink(),
+      );
+      final scopeSameSwitcher = ProfileSwitcherScope(
+        switcher: switcherA,
+        child: const SizedBox.shrink(),
+      );
+      final scopeB = ProfileSwitcherScope(
+        switcher: switcherB,
+        child: const SizedBox.shrink(),
+      );
+
+      expect(scopeSameSwitcher.updateShouldNotify(scopeA), isFalse);
+      expect(scopeB.updateShouldNotify(scopeA), isTrue);
+    });
+  });
+}

--- a/test/database/common_test.dart
+++ b/test/database/common_test.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
 
 import 'package:clock/clock.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/editor_db.dart';
+import 'package:lotti/database/fts5_db.dart';
+import 'package:lotti/features/ai/database/ai_config_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:path/path.dart' as p;
@@ -337,6 +340,96 @@ void main() {
       // Verify file exists
       expect(File(p.join(testDir.path, editorDbFileName)).existsSync(), isTrue);
     });
+  });
+
+  group('openDbConnection profile-root fallback', () {
+    late Directory testDir;
+
+    setUp(() {
+      testDir = setupTestDirectory();
+      setupTestDirectoryWithGetIt(testDir);
+      // Any path_provider hit means a database bypassed the registered
+      // profile root — make that a hard failure, not a silent fallback.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (MethodCall methodCall) async {
+              throw PlatformException(
+                code: 'forbidden',
+                message:
+                    'path_provider must not be consulted '
+                    'when a profile root is registered',
+              );
+            },
+          );
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      await cleanupTestDirectoryWithGetIt(testDir);
+    });
+
+    test('EditorDb without provider opens under the registered root', () async {
+      final db = EditorDb();
+      await db.allDrafts().get();
+      await db.close();
+
+      expect(File(p.join(testDir.path, editorDbFileName)).existsSync(), isTrue);
+    });
+
+    test('Fts5Db without provider opens under the registered root', () async {
+      final db = Fts5Db();
+      await db.customSelect('SELECT 1').get();
+      await db.close();
+
+      expect(File(p.join(testDir.path, fts5DbFileName)).existsSync(), isTrue);
+    });
+
+    test(
+      'AiConfigDb without provider opens under the registered root',
+      () async {
+        final db = AiConfigDb();
+        await db.customSelect('SELECT 1').get();
+        await db.close();
+
+        expect(
+          File(p.join(testDir.path, aiConfigDbFileName)).existsSync(),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'explicit documentsDirectoryProvider overrides the registered root',
+      () async {
+        final otherDir = setupTestDirectory();
+        try {
+          final db = Fts5Db(
+            documentsDirectoryProvider: () async => otherDir,
+            tempDirectoryProvider: () async => otherDir,
+          );
+          await db.customSelect('SELECT 1').get();
+          await db.close();
+
+          expect(
+            File(p.join(otherDir.path, fts5DbFileName)).existsSync(),
+            isTrue,
+          );
+          expect(
+            File(p.join(testDir.path, fts5DbFileName)).existsSync(),
+            isFalse,
+          );
+        } finally {
+          if (otherDir.existsSync()) {
+            await otherDir.delete(recursive: true);
+          }
+        }
+      },
+    );
   });
 
   group('File Path Construction Tests', () {

--- a/test/features/profiles/model/profile_context_test.dart
+++ b/test/features/profiles/model/profile_context_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
+
+void main() {
+  Profile profileOfType(ProfileType type) => Profile(
+    id: type == ProfileType.real ? Profile.realProfileId : 'g1',
+    type: type,
+    name: 'x',
+    dirName: type == ProfileType.real ? '' : 'guest_profiles/g1',
+    createdAt: DateTime(2026),
+  );
+
+  group('ProfileContext.forProfile', () {
+    test('real profiles get full capabilities', () {
+      final context = ProfileContext.forProfile(
+        profile: profileOfType(ProfileType.real),
+        root: Directory('/data/lotti'),
+      );
+
+      expect(context.isGuest, isFalse);
+      expect(context.capabilities.syncEnabled, isTrue);
+      expect(context.capabilities.healthImportEnabled, isTrue);
+    });
+
+    test('guest profiles structurally exclude sync and health import', () {
+      final context = ProfileContext.forProfile(
+        profile: profileOfType(ProfileType.guest),
+        root: Directory('/data/lotti/guest_profiles/g1'),
+      );
+
+      expect(context.isGuest, isTrue);
+      expect(context.capabilities.syncEnabled, isFalse);
+      expect(context.capabilities.healthImportEnabled, isFalse);
+    });
+  });
+}

--- a/test/features/profiles/model/profile_test.dart
+++ b/test/features/profiles/model/profile_test.dart
@@ -71,6 +71,13 @@ void main() {
       expect(profile.createdAt, now);
     });
 
+    test('copyWith without arguments retains hostId and name', () {
+      final same = guest().copyWith();
+
+      expect(same.hostId, 'host-abc');
+      expect(same.name, 'Demo');
+    });
+
     test('copyWith updates hostId without touching identity', () {
       final updated = guest().copyWith(hostId: 'host-new', name: 'Demo 2');
 
@@ -128,6 +135,18 @@ void main() {
       ).toJson();
 
       expect(ProfileRegistryState.tryFromJson(json), isNull);
+    });
+
+    test('a state with no real profile still yields a synthesized active '
+        'profile', () {
+      final state = ProfileRegistryState(
+        version: 1,
+        activeProfileId: 'gone',
+        profiles: [guest()],
+      );
+
+      expect(state.activeProfile.id, Profile.realProfileId);
+      expect(state.activeProfile.type, ProfileType.real);
     });
 
     test('dangling active marker falls back to the real profile', () {

--- a/test/features/profiles/model/profile_test.dart
+++ b/test/features/profiles/model/profile_test.dart
@@ -55,6 +55,20 @@ void main() {
         Profile.tryFromJson(guest().toJson()..['hostId'] = 42),
         isNull,
       );
+      for (final dirName in [
+        '../evil',
+        '/absolute',
+        'guest_profiles/../escape',
+        'guest_profiles/.',
+        r'guest_profiles\evil',
+        'C:/evil',
+      ]) {
+        expect(
+          Profile.tryFromJson(guest().toJson()..['dirName'] = dirName),
+          isNull,
+          reason: 'dirName "$dirName" must be rejected',
+        );
+      }
     });
 
     test('realDefault is the fixed real profile at the root itself', () {

--- a/test/features/profiles/model/profile_test.dart
+++ b/test/features/profiles/model/profile_test.dart
@@ -1,0 +1,156 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+
+void main() {
+  final createdAt = DateTime(2026, 8, 5, 12);
+
+  Profile guest({String id = 'g1'}) => Profile(
+    id: id,
+    type: ProfileType.guest,
+    name: 'Demo',
+    dirName: 'guest_profiles/$id',
+    createdAt: createdAt,
+    hostId: 'host-abc',
+  );
+
+  group('Profile', () {
+    test('JSON round-trip preserves every field', () {
+      final parsed = Profile.tryFromJson(guest().toJson());
+
+      expect(parsed, isNotNull);
+      expect(parsed!.id, 'g1');
+      expect(parsed.type, ProfileType.guest);
+      expect(parsed.name, 'Demo');
+      expect(parsed.dirName, 'guest_profiles/g1');
+      expect(parsed.createdAt, createdAt);
+      expect(parsed.hostId, 'host-abc');
+    });
+
+    test('hostId is optional and omitted from JSON when null', () {
+      final profile = Profile.realDefault();
+      final json = profile.toJson();
+
+      expect(json.containsKey('hostId'), isFalse);
+      expect(Profile.tryFromJson(json)!.hostId, isNull);
+    });
+
+    test('tryFromJson rejects malformed entries instead of throwing', () {
+      expect(Profile.tryFromJson(null), isNull);
+      expect(Profile.tryFromJson('not a map'), isNull);
+      expect(Profile.tryFromJson(<String, dynamic>{}), isNull);
+      expect(
+        Profile.tryFromJson(guest().toJson()..['type'] = 'alien'),
+        isNull,
+      );
+      expect(
+        Profile.tryFromJson(guest().toJson()..['createdAt'] = 'yesterday-ish'),
+        isNull,
+      );
+      expect(
+        Profile.tryFromJson(guest().toJson()..['id'] = ''),
+        isNull,
+      );
+      expect(
+        Profile.tryFromJson(guest().toJson()..['hostId'] = 42),
+        isNull,
+      );
+    });
+
+    test('realDefault is the fixed real profile at the root itself', () {
+      final now = DateTime(2026, 8, 5, 9, 30);
+      final profile = withClock(
+        Clock.fixed(now),
+        Profile.realDefault,
+      );
+
+      expect(profile.id, Profile.realProfileId);
+      expect(profile.type, ProfileType.real);
+      expect(profile.dirName, isEmpty);
+      expect(profile.isGuest, isFalse);
+      expect(profile.createdAt, now);
+    });
+
+    test('copyWith updates hostId without touching identity', () {
+      final updated = guest().copyWith(hostId: 'host-new', name: 'Demo 2');
+
+      expect(updated.id, 'g1');
+      expect(updated.dirName, 'guest_profiles/g1');
+      expect(updated.hostId, 'host-new');
+      expect(updated.name, 'Demo 2');
+    });
+  });
+
+  group('ProfileRegistryState', () {
+    test('initial state is the active real profile only', () {
+      final state = ProfileRegistryState.initial();
+
+      expect(state.version, ProfileRegistryState.schemaVersion);
+      expect(state.activeProfileId, Profile.realProfileId);
+      expect(state.profiles, hasLength(1));
+      expect(state.activeProfile.type, ProfileType.real);
+    });
+
+    test('JSON round-trip preserves profiles and active marker', () {
+      final state = ProfileRegistryState(
+        version: 1,
+        activeProfileId: 'g1',
+        profiles: [Profile.realDefault(), guest()],
+      );
+
+      final parsed = ProfileRegistryState.tryFromJson(state.toJson());
+
+      expect(parsed, isNotNull);
+      expect(parsed!.activeProfileId, 'g1');
+      expect(parsed.profiles.map((profile) => profile.id), ['real', 'g1']);
+      expect(parsed.activeProfile.id, 'g1');
+    });
+
+    test('malformed profile entries are dropped, not fatal', () {
+      final json = ProfileRegistryState(
+        version: 1,
+        activeProfileId: Profile.realProfileId,
+        profiles: [Profile.realDefault(), guest()],
+      ).toJson();
+      (json['profiles'] as List).insert(1, {'garbage': true});
+
+      final parsed = ProfileRegistryState.tryFromJson(json);
+
+      expect(parsed, isNotNull);
+      expect(parsed!.profiles.map((profile) => profile.id), ['real', 'g1']);
+    });
+
+    test('a registry without a real profile is unusable', () {
+      final json = ProfileRegistryState(
+        version: 1,
+        activeProfileId: 'g1',
+        profiles: [guest()],
+      ).toJson();
+
+      expect(ProfileRegistryState.tryFromJson(json), isNull);
+    });
+
+    test('dangling active marker falls back to the real profile', () {
+      final state = ProfileRegistryState(
+        version: 1,
+        activeProfileId: 'deleted-guest',
+        profiles: [Profile.realDefault()],
+      );
+
+      expect(state.activeProfile.id, Profile.realProfileId);
+    });
+
+    test('tryFromJson rejects structurally unusable documents', () {
+      expect(ProfileRegistryState.tryFromJson(null), isNull);
+      expect(ProfileRegistryState.tryFromJson([]), isNull);
+      expect(
+        ProfileRegistryState.tryFromJson({
+          'version': 'one',
+          'activeProfileId': 'real',
+          'profiles': <Object>[],
+        }),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/profiles/profile_paths_test.dart
+++ b/test/features/profiles/profile_paths_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/profiles/profile_paths.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('guestProfileRoot', () {
+    test('nests the guest world under guest_profiles/<id>', () {
+      final root = guestProfileRoot(Directory('/data/lotti'), 'abc');
+
+      expect(
+        p.split(root.path).sublist(p.split(root.path).length - 3),
+        ['lotti', guestProfilesDirName, 'abc'],
+      );
+    });
+  });
+
+  group('assertIsGuestRoot', () {
+    test('accepts a child of guest_profiles', () {
+      expect(
+        () => assertIsGuestRoot(
+          guestProfileRoot(Directory('/data/lotti'), 'abc'),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('rejects the real root — the delete guard must hold', () {
+      expect(
+        () => assertIsGuestRoot(Directory('/data/lotti')),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects the guest_profiles container itself', () {
+      expect(
+        () => assertIsGuestRoot(
+          Directory(p.join('/data/lotti', guestProfilesDirName)),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects traversal that escapes guest_profiles', () {
+      expect(
+        () => assertIsGuestRoot(
+          Directory('/data/lotti/guest_profiles/abc/../..'),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/features/profiles/repository/profile_registry_test.dart
+++ b/test/features/profiles/repository/profile_registry_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/profile_paths.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory realRoot;
+  late ProfileRegistry registry;
+
+  setUp(() {
+    realRoot = Directory.systemTemp.createTempSync('lotti_profile_registry_');
+    registry = ProfileRegistry(realRoot: realRoot);
+  });
+
+  tearDown(() async {
+    if (realRoot.existsSync()) {
+      await realRoot.delete(recursive: true);
+    }
+  });
+
+  group('load', () {
+    test('missing file yields default registry without writing it', () async {
+      final state = await registry.load();
+
+      expect(state.activeProfileId, Profile.realProfileId);
+      expect(state.profiles.single.type, ProfileType.real);
+      expect(registry.registryFile.existsSync(), isFalse);
+    });
+
+    test('corrupt file falls back to default registry', () async {
+      registry.registryFile.writeAsStringSync('{"version": "not json-y}');
+
+      final state = await registry.load();
+
+      expect(state.activeProfileId, Profile.realProfileId);
+      expect(state.profiles.single.type, ProfileType.real);
+    });
+
+    test('registry without a real profile falls back to default', () async {
+      registry.registryFile.writeAsStringSync(
+        jsonEncode({
+          'version': 1,
+          'activeProfileId': 'g1',
+          'profiles': <Object>[],
+        }),
+      );
+
+      final state = await registry.load();
+
+      expect(state.activeProfileId, Profile.realProfileId);
+    });
+  });
+
+  group('createGuestProfile', () {
+    test('persists the entry and creates the directory skeleton', () async {
+      final profile = await registry.createGuestProfile(name: 'Demo');
+
+      expect(profile.isGuest, isTrue);
+      expect(profile.dirName, 'guest_profiles/${profile.id}');
+      expect(
+        guestProfileRoot(realRoot, profile.id).existsSync(),
+        isTrue,
+      );
+
+      final reloaded = await registry.load();
+      expect(reloaded.profileById(profile.id)!.name, 'Demo');
+      // Creation must not silently activate the new world.
+      expect(reloaded.activeProfileId, Profile.realProfileId);
+    });
+
+    test('rootFor resolves the guest world under guest_profiles', () async {
+      final profile = await registry.createGuestProfile(name: 'Demo');
+
+      expect(
+        registry.rootFor(profile).path,
+        p.join(realRoot.path, guestProfilesDirName, profile.id),
+      );
+      expect(
+        registry.rootFor(Profile.realDefault()).path,
+        realRoot.path,
+      );
+    });
+  });
+
+  group('setActiveProfile', () {
+    test('round-trips through the persisted marker', () async {
+      final profile = await registry.createGuestProfile(name: 'Demo');
+
+      await registry.setActiveProfile(profile.id);
+      expect((await registry.load()).activeProfileId, profile.id);
+
+      await registry.setActiveProfile(Profile.realProfileId);
+      expect((await registry.load()).activeProfileId, Profile.realProfileId);
+    });
+
+    test('rejects unknown profiles', () async {
+      expect(
+        () => registry.setActiveProfile('nope'),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('updateProfile', () {
+    test('persists hostId written after first world boot', () async {
+      final profile = await registry.createGuestProfile(name: 'Demo');
+
+      await registry.updateProfile(profile.copyWith(hostId: 'host-1'));
+
+      expect(
+        (await registry.load()).profileById(profile.id)!.hostId,
+        'host-1',
+      );
+    });
+  });
+
+  group('deleteGuestProfile', () {
+    test('removes the entry and the directory tree', () async {
+      final profile = await registry.createGuestProfile(name: 'Demo');
+      final guestRoot = registry.rootFor(profile);
+      File(p.join(guestRoot.path, 'db.sqlite')).writeAsStringSync('x');
+
+      await registry.deleteGuestProfile(profile.id);
+
+      expect(guestRoot.existsSync(), isFalse);
+      expect((await registry.load()).profileById(profile.id), isNull);
+      // The real root and registry survive.
+      expect(realRoot.existsSync(), isTrue);
+    });
+
+    test('refuses to delete the real profile', () async {
+      expect(
+        () => registry.deleteGuestProfile(Profile.realProfileId),
+        throwsArgumentError,
+      );
+    });
+
+    test('refuses to delete the active profile', () async {
+      final profile = await registry.createGuestProfile(name: 'Demo');
+      await registry.setActiveProfile(profile.id);
+
+      expect(
+        () => registry.deleteGuestProfile(profile.id),
+        throwsStateError,
+      );
+      expect(registry.rootFor(profile).existsSync(), isTrue);
+    });
+  });
+}

--- a/test/features/profiles/repository/profile_registry_test.dart
+++ b/test/features/profiles/repository/profile_registry_test.dart
@@ -106,6 +106,21 @@ void main() {
   });
 
   group('updateProfile', () {
+    test('rejects unknown profiles', () async {
+      expect(
+        () => registry.updateProfile(
+          Profile(
+            id: 'nope',
+            type: ProfileType.guest,
+            name: 'ghost',
+            dirName: 'guest_profiles/nope',
+            createdAt: DateTime(2026),
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
     test('persists hostId written after first world boot', () async {
       final profile = await registry.createGuestProfile(name: 'Demo');
 
@@ -119,6 +134,13 @@ void main() {
   });
 
   group('deleteGuestProfile', () {
+    test('rejects unknown ids', () async {
+      expect(
+        () => registry.deleteGuestProfile('nope'),
+        throwsArgumentError,
+      );
+    });
+
     test('removes the entry and the directory tree', () async {
       final profile = await registry.createGuestProfile(name: 'Demo');
       final guestRoot = registry.rootFor(profile);

--- a/test/features/profiles/repository/profile_registry_test.dart
+++ b/test/features/profiles/repository/profile_registry_test.dart
@@ -55,6 +55,34 @@ void main() {
     });
   });
 
+  group('path traversal defense', () {
+    test('rootFor refuses a dirName that escapes the real root', () {
+      final doctored = Profile(
+        id: 'evil',
+        type: ProfileType.guest,
+        name: 'evil',
+        dirName: 'guest_profiles/../../elsewhere',
+        createdAt: DateTime(2026),
+      );
+
+      expect(() => registry.rootFor(doctored), throwsArgumentError);
+    });
+
+    test('a doctored profiles.json entry is dropped at parse time', () async {
+      final guest = await registry.createGuestProfile(name: 'Demo');
+      final raw =
+          jsonDecode(await registry.registryFile.readAsString())
+              as Map<String, dynamic>;
+      ((raw['profiles'] as List).last as Map<String, dynamic>)['dirName'] =
+          '../../outside/${guest.id}';
+      registry.registryFile.writeAsStringSync(jsonEncode(raw));
+
+      final state = await registry.load();
+
+      expect(state.profileById(guest.id), isNull);
+    });
+  });
+
   group('createGuestProfile', () {
     test('persists the entry and creates the directory skeleton', () async {
       final profile = await registry.createGuestProfile(name: 'Demo');
@@ -98,8 +126,8 @@ void main() {
     });
 
     test('rejects unknown profiles', () async {
-      expect(
-        () => registry.setActiveProfile('nope'),
+      await expectLater(
+        registry.setActiveProfile('nope'),
         throwsArgumentError,
       );
     });
@@ -107,8 +135,8 @@ void main() {
 
   group('updateProfile', () {
     test('rejects unknown profiles', () async {
-      expect(
-        () => registry.updateProfile(
+      await expectLater(
+        registry.updateProfile(
           Profile(
             id: 'nope',
             type: ProfileType.guest,
@@ -135,8 +163,8 @@ void main() {
 
   group('deleteGuestProfile', () {
     test('rejects unknown ids', () async {
-      expect(
-        () => registry.deleteGuestProfile('nope'),
+      await expectLater(
+        registry.deleteGuestProfile('nope'),
         throwsArgumentError,
       );
     });
@@ -155,8 +183,8 @@ void main() {
     });
 
     test('refuses to delete the real profile', () async {
-      expect(
-        () => registry.deleteGuestProfile(Profile.realProfileId),
+      await expectLater(
+        registry.deleteGuestProfile(Profile.realProfileId),
         throwsArgumentError,
       );
     });
@@ -165,8 +193,8 @@ void main() {
       final profile = await registry.createGuestProfile(name: 'Demo');
       await registry.setActiveProfile(profile.id);
 
-      expect(
-        () => registry.deleteGuestProfile(profile.id),
+      await expectLater(
+        registry.deleteGuestProfile(profile.id),
         throwsStateError,
       );
       expect(registry.rootFor(profile).existsSync(), isTrue);

--- a/test/features/profiles/service/demo_world_creator_test.dart
+++ b/test/features/profiles/service/demo_world_creator_test.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/profiles/service/demo_world_creator.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory realRoot;
+  late ProfileRegistry registry;
+  late List<String> activated;
+
+  setUp(() {
+    realRoot = Directory.systemTemp.createTempSync('lotti_creator_');
+    registry = ProfileRegistry(realRoot: realRoot);
+    activated = [];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            throw PlatformException(code: 'forbidden');
+          },
+        );
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    if (realRoot.existsSync()) {
+      await realRoot.delete(recursive: true);
+    }
+  });
+
+  DemoWorldCreator buildCreator() => DemoWorldCreator(
+    registry: registry,
+    activate: (id) async => activated.add(id),
+  );
+
+  group('DemoWorldCreator.createAndActivate', () {
+    test('seeds the world BEFORE activating it', () async {
+      var worldPopulatedAtActivation = false;
+      final creator = DemoWorldCreator(
+        registry: registry,
+        activate: (id) async {
+          activated.add(id);
+          final profile = (await registry.load()).profileById(id)!;
+          worldPopulatedAtActivation = File(
+            p.join(registry.rootFor(profile).path, 'settings.sqlite'),
+          ).existsSync();
+        },
+      );
+
+      final created = await creator.createAndActivate(
+        seed: (world) => world.writeSetting('demo_seed_version', '1'),
+      );
+
+      expect(activated, [created.id]);
+      // The requirement's ordering: populate first, then re-point the
+      // documents layer. Activation must observe a populated world.
+      expect(worldPopulatedAtActivation, isTrue);
+      expect((await registry.load()).profileById(created.id), isNotNull);
+    });
+
+    test('a failed seed removes the half-built world and never '
+        'activates', () async {
+      final creator = buildCreator();
+
+      await expectLater(
+        creator.createAndActivate(
+          seed: (world) async {
+            await world.writeSetting('partial', 'x');
+            throw StateError('seed boom');
+          },
+        ),
+        throwsStateError,
+      );
+
+      expect(activated, isEmpty);
+      final state = await registry.load();
+      expect(state.profiles.where((profile) => profile.isGuest), isEmpty);
+      final guestContainer = Directory(
+        p.join(realRoot.path, 'guest_profiles'),
+      );
+      if (guestContainer.existsSync()) {
+        expect(guestContainer.listSync(), isEmpty);
+      }
+    });
+  });
+}

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -269,6 +269,14 @@ void main() {
       // failure is recovered by an app restart, which boots straight into
       // the intended world from a clean process.
       expect((await registry.load()).activeProfileId, guest.id);
+
+      // The guard is released: a follow-up call is accepted and — because
+      // the marker already points at the target — resolves as the
+      // documented same-profile no-op instead of re-tearing a dead
+      // generation.
+      await expectLater(switcher.switchTo(guest.id), completes);
+      expect(attempts, 1);
+      expect(switcher.isSwitching, isFalse);
     });
   });
 }

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -153,6 +153,10 @@ void main() {
         await registry.setActiveProfile(guest1.id);
 
         final holder = AppLifecycleHolder();
+        // The real bootstrap attaches an AppLifecycleListener to the
+        // binding; leaked, it would assert on lifecycle transitions
+        // dispatched by unrelated tests later in the same runner.
+        addTearDown(holder.dispose);
         registerProcessLogging();
         await bootstrapProfileServices(
           await resolveActiveProfile(),

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -9,9 +9,14 @@ import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
 import 'package:lotti/features/profiles/service/profile_switcher.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/service_disposer.dart';
+import 'package:lotti/services/time_service.dart';
+import 'package:lotti/services/window_service.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/db_settle.dart';
+import '../../../mocks/mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -187,6 +192,57 @@ void main() {
         // The generation really was rebuilt: fresh database instances.
         expect(identical(getIt<JournalDb>(), journalDbGen1), isFalse);
         expect((await registry.load()).activeProfileId, guest2.id);
+      },
+    );
+
+    test(
+      'quiesce failures are contained, logged, and do not abort the switch',
+      () async {
+        await getIt.reset();
+        addTearDown(getIt.reset);
+        final domainLogger = MockDomainLogger();
+        when(
+          () => domainLogger.error(
+            any<LogDomain>(),
+            any<Object>(),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+            subDomain: any<String?>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+        final timeService = MockTimeService();
+        when(timeService.stop).thenThrow(StateError('timer boom'));
+        final windowService = MockWindowService();
+        when(windowService.detachForRestart).thenAnswer((_) {});
+        getIt
+          ..registerSingleton<DomainLogger>(domainLogger)
+          ..registerSingleton<TimeService>(timeService)
+          ..registerSingleton<WindowService>(windowService);
+
+        final guest = await registry.createGuestProfile(name: 'Demo');
+        var bootstrapped = false;
+        final switcher = ProfileSwitcher(
+          registry: registry,
+          lifecycleHolder: AppLifecycleHolder(),
+          onSwitchStarted: () async {},
+          onSwitchCompleted: () {},
+          settleFrame: () async {},
+          // Default teardown path: quiesce + dispose + getIt.reset.
+          bootstrapOverride: () async => bootstrapped = true,
+        );
+
+        await switcher.switchTo(guest.id);
+
+        expect(bootstrapped, isTrue);
+        verify(timeService.stop).called(1);
+        verify(windowService.detachForRestart).called(1);
+        verify(
+          () => domainLogger.error(
+            LogDomain.general,
+            any<Object>(),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+            subDomain: 'profileSwitch_TimeService.stop',
+          ),
+        ).called(1);
       },
     );
 

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -1,12 +1,18 @@
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
 import 'package:lotti/features/profiles/service/profile_switcher.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/service_disposer.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   late Directory realRoot;
   late ProfileRegistry registry;
   late List<String> calls;
@@ -103,6 +109,78 @@ void main() {
 
         expect(calls, ['splash', 'teardown', 'bootstrap', 'completed']);
         expect((await registry.load()).activeProfileId, guest.id);
+      },
+    );
+
+    test(
+      'default teardown + bootstrap re-point the whole service generation '
+      'at the target world',
+      () async {
+        // Real seams: only the frame settle is stubbed (no frames are
+        // pumped in a plain test).
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          ..setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (MethodCall call) async => realRoot.path,
+          )
+          ..setMockMethodCallHandler(
+            const MethodChannel(
+              'plugins.it_nomads.com/flutter_secure_storage',
+            ),
+            (MethodCall call) async => null,
+          )
+          ..setMockMethodCallHandler(
+            const MethodChannel('window_manager'),
+            (MethodCall call) async => null,
+          );
+        addTearDown(() async {
+          await pumpEventQueue(times: 200);
+          await ServiceDisposer(getIt, (e, s, n) {}).disposeAll();
+          await getIt.reset();
+          for (final channel in const [
+            'plugins.flutter.io/path_provider',
+            'plugins.it_nomads.com/flutter_secure_storage',
+            'window_manager',
+          ]) {
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+                .setMockMethodCallHandler(MethodChannel(channel), null);
+          }
+        });
+
+        await getIt.reset();
+        final guest1 = await registry.createGuestProfile(name: 'Demo 1');
+        final guest2 = await registry.createGuestProfile(name: 'Demo 2');
+        await registry.setActiveProfile(guest1.id);
+
+        final holder = AppLifecycleHolder();
+        registerProcessLogging();
+        await bootstrapProfileServices(
+          await resolveActiveProfile(),
+          lifecycleHolder: holder,
+          restoreWindow: false,
+        );
+        final journalDbGen1 = getIt<JournalDb>();
+        expect(getIt<ProfileContext>().profile.id, guest1.id);
+
+        final switcher = ProfileSwitcher(
+          registry: registry,
+          lifecycleHolder: holder,
+          onSwitchStarted: () async => calls.add('splash'),
+          onSwitchCompleted: () => calls.add('completed'),
+          settleFrame: () async {},
+        );
+
+        await switcher.switchTo(guest2.id);
+
+        expect(calls, ['splash', 'completed']);
+        expect(getIt<ProfileContext>().profile.id, guest2.id);
+        expect(
+          getIt<Directory>().path,
+          registry.rootFor(guest2).path,
+        );
+        // The generation really was rebuilt: fresh database instances.
+        expect(identical(getIt<JournalDb>(), journalDbGen1), isFalse);
+        expect((await registry.load()).activeProfileId, guest2.id);
       },
     );
 

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -11,12 +11,19 @@ import 'package:lotti/features/profiles/service/profile_switcher.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/service_disposer.dart';
+import 'package:lotti/services/startup_tasks.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/db_settle.dart';
 import '../../../mocks/mocks.dart';
+
+class _ThrowingStartupTasks extends StartupTasks {
+  @override
+  Future<void> settle({Duration timeout = const Duration(seconds: 5)}) =>
+      throw StateError('settle boom');
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -212,9 +219,12 @@ void main() {
         final timeService = MockTimeService();
         when(timeService.stop).thenThrow(StateError('timer boom'));
         final windowService = MockWindowService();
-        when(windowService.detachForRestart).thenAnswer((_) {});
+        when(
+          windowService.detachForRestart,
+        ).thenAnswer((_) async => throw StateError('detach boom'));
         getIt
           ..registerSingleton<DomainLogger>(domainLogger)
+          ..registerSingleton<StartupTasks>(_ThrowingStartupTasks())
           ..registerSingleton<TimeService>(timeService)
           ..registerSingleton<WindowService>(windowService);
 
@@ -235,14 +245,20 @@ void main() {
         expect(bootstrapped, isTrue);
         verify(timeService.stop).called(1);
         verify(windowService.detachForRestart).called(1);
-        verify(
-          () => domainLogger.error(
-            LogDomain.general,
-            any<Object>(),
-            stackTrace: any<StackTrace?>(named: 'stackTrace'),
-            subDomain: 'profileSwitch_TimeService.stop',
-          ),
-        ).called(1);
+        for (final failedStep in [
+          'profileSwitch_StartupTasks.settle',
+          'profileSwitch_TimeService.stop',
+          'profileSwitch_WindowService.detachForRestart',
+        ]) {
+          verify(
+            () => domainLogger.error(
+              LogDomain.general,
+              any<Object>(),
+              stackTrace: any<StackTrace?>(named: 'stackTrace'),
+              subDomain: failedStep,
+            ),
+          ).called(1);
+        }
       },
     );
 

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/app_bootstrap.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/repository/profile_registry.dart';
+import 'package:lotti/features/profiles/service/profile_switcher.dart';
+
+void main() {
+  late Directory realRoot;
+  late ProfileRegistry registry;
+  late List<String> calls;
+
+  setUp(() {
+    realRoot = Directory.systemTemp.createTempSync('lotti_switcher_');
+    registry = ProfileRegistry(realRoot: realRoot);
+    calls = [];
+  });
+
+  tearDown(() async {
+    if (realRoot.existsSync()) {
+      await realRoot.delete(recursive: true);
+    }
+  });
+
+  ProfileSwitcher buildSwitcher() => ProfileSwitcher(
+    registry: registry,
+    lifecycleHolder: AppLifecycleHolder(),
+    onSwitchStarted: () async => calls.add('splash'),
+    onSwitchCompleted: () => calls.add('completed'),
+    settleFrame: () async => calls.add('settle'),
+    teardownOverride: () async => calls.add('teardown'),
+    bootstrapOverride: () async => calls.add('bootstrap'),
+  );
+
+  group('ProfileSwitcher.switchTo', () {
+    test('persists the marker BEFORE teardown, then runs the sequence in '
+        'order', () async {
+      final guest = await registry.createGuestProfile(name: 'Demo');
+      String? markerAtTeardown;
+      final switcher = ProfileSwitcher(
+        registry: registry,
+        lifecycleHolder: AppLifecycleHolder(),
+        onSwitchStarted: () async => calls.add('splash'),
+        onSwitchCompleted: () => calls.add('completed'),
+        settleFrame: () async => calls.add('settle'),
+        teardownOverride: () async {
+          calls.add('teardown');
+          markerAtTeardown = (await registry.load()).activeProfileId;
+        },
+        bootstrapOverride: () async => calls.add('bootstrap'),
+      );
+
+      await switcher.switchTo(guest.id);
+
+      // A crash after teardown must reopen the DEMO world on next launch:
+      // the marker has to be durable before anything is torn down.
+      expect(markerAtTeardown, guest.id);
+      expect(calls, ['splash', 'settle', 'teardown', 'bootstrap', 'completed']);
+      expect(switcher.isSwitching, isFalse);
+    });
+
+    test('switching to the already-active profile is a no-op', () async {
+      final switcher = buildSwitcher();
+
+      await switcher.switchTo(Profile.realProfileId);
+
+      expect(calls, isEmpty);
+    });
+
+    test('unknown profile throws without touching the marker', () async {
+      final switcher = buildSwitcher();
+
+      await expectLater(
+        switcher.switchTo('nope'),
+        throwsArgumentError,
+      );
+      expect((await registry.load()).activeProfileId, Profile.realProfileId);
+      expect(calls, isEmpty);
+      expect(switcher.isSwitching, isFalse);
+    });
+
+    test(
+      'reentrant switch requests are ignored while one is running',
+      () async {
+        final guest = await registry.createGuestProfile(name: 'Demo');
+        late ProfileSwitcher switcher;
+        switcher = ProfileSwitcher(
+          registry: registry,
+          lifecycleHolder: AppLifecycleHolder(),
+          onSwitchStarted: () async => calls.add('splash'),
+          onSwitchCompleted: () => calls.add('completed'),
+          settleFrame: () async {},
+          teardownOverride: () async {
+            calls.add('teardown');
+            // A second switch fired mid-flight must be dropped by the guard.
+            await switcher.switchTo(Profile.realProfileId);
+          },
+          bootstrapOverride: () async => calls.add('bootstrap'),
+        );
+
+        await switcher.switchTo(guest.id);
+
+        expect(calls, ['splash', 'teardown', 'bootstrap', 'completed']);
+        expect((await registry.load()).activeProfileId, guest.id);
+      },
+    );
+
+    test('guard resets after a failed switch so a retry is possible', () async {
+      final guest = await registry.createGuestProfile(name: 'Demo');
+      var attempts = 0;
+      final switcher = ProfileSwitcher(
+        registry: registry,
+        lifecycleHolder: AppLifecycleHolder(),
+        onSwitchStarted: () async {},
+        onSwitchCompleted: () => calls.add('completed'),
+        settleFrame: () async {},
+        teardownOverride: () async {
+          attempts++;
+          if (attempts == 1) throw StateError('teardown boom');
+        },
+        bootstrapOverride: () async {},
+      );
+
+      await expectLater(switcher.switchTo(guest.id), throwsStateError);
+      expect(switcher.isSwitching, isFalse);
+
+      // The durable marker already points at the guest world: a mid-switch
+      // failure is recovered by an app restart, which boots straight into
+      // the intended world from a clean process.
+      expect((await registry.load()).activeProfileId, guest.id);
+    });
+  });
+}

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -11,6 +11,8 @@ import 'package:lotti/features/profiles/service/profile_switcher.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/service_disposer.dart';
 
+import '../../../helpers/db_settle.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late Directory realRoot;
@@ -134,7 +136,7 @@ void main() {
             (MethodCall call) async => null,
           );
         addTearDown(() async {
-          await pumpEventQueue(times: 200);
+          await settlePendingDbWork();
           await ServiceDisposer(getIt, (e, s, n) {}).disposeAll();
           await getIt.reset();
           for (final channel in const [

--- a/test/features/profiles/service/world_handle_test.dart
+++ b/test/features/profiles/service/world_handle_test.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/profiles/service/world_handle.dart';
+import 'package:lotti/features/sync/utils.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:path/path.dart' as p;
+
+import '../../../helpers/entity_factories.dart';
+import '../../../mocks/mocks.dart';
+
+/// Recursive snapshot of a directory: relative path -> file length.
+Map<String, int> snapshotTree(Directory dir) {
+  final result = <String, int>{};
+  if (!dir.existsSync()) return result;
+  for (final entity in dir.listSync(recursive: true)) {
+    if (entity is File) {
+      result[p.relative(entity.path, from: dir.path)] = entity.lengthSync();
+    }
+  }
+  return result;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory worldRoot;
+  late Directory canaryRealRoot;
+
+  setUp(() {
+    worldRoot = Directory.systemTemp.createTempSync('lotti_world_');
+    canaryRealRoot = Directory.systemTemp.createTempSync('lotti_canary_');
+    // Plant canary content so "untouched" is a meaningful assertion.
+    File(p.join(canaryRealRoot.path, 'db.sqlite')).writeAsStringSync('real');
+    Directory(
+      p.join(canaryRealRoot.path, 'text_entries'),
+    ).createSync(recursive: true);
+
+    // The ACTIVE generation points at the canary; any WorldHandle write that
+    // falls back to the active root or the OS path is an isolation breach.
+    getIt
+      ..registerSingleton<Directory>(canaryRealRoot)
+      ..registerSingleton<EntitiesCacheService>(MockEntitiesCacheService());
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            throw PlatformException(code: 'forbidden');
+          },
+        );
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await getIt.reset();
+    for (final dir in [worldRoot, canaryRealRoot]) {
+      if (dir.existsSync()) {
+        await dir.delete(recursive: true);
+      }
+    }
+  });
+
+  group('WorldHandle', () {
+    test('writes land exclusively under the world root; the active world '
+        'stays byte-identical', () async {
+      final before = snapshotTree(canaryRealRoot);
+
+      final world = WorldHandle.open(worldRoot);
+      final task = TestTaskFactory.create(
+        id: 'seed-task-1',
+        title: 'Inspect orbital penguin habitat',
+        plainText: 'demo seed',
+      );
+      await world.writeJournalEntity(task);
+      await world.writeEntityDefinition(
+        CategoryDefinition(
+          id: 'seed-category',
+          createdAt: DateTime(2026, 7, 17),
+          updatedAt: DateTime(2026, 7, 17),
+          name: 'Penguin Operations',
+          vectorClock: null,
+          private: false,
+          active: true,
+        ),
+      );
+      await world.writeEntryLink(
+        EntryLink.basic(
+          id: 'seed-link-1',
+          fromId: 'seed-task-1',
+          toId: 'seed-task-1',
+          createdAt: DateTime(2026, 7, 17),
+          updatedAt: DateTime(2026, 7, 17),
+          vectorClock: null,
+        ),
+      );
+      await world.writeSetting('demo_seed_version', '1');
+      await world.close();
+
+      // World content is real and readable back.
+      final reopened = WorldHandle.open(worldRoot);
+      final persisted = await reopened.journalDb.journalEntityById(
+        'seed-task-1',
+      );
+      expect(persisted, isNotNull);
+      expect(
+        persisted!.maybeMap(
+          task: (Task task) => task.data.title,
+          orElse: () => '',
+        ),
+        'Inspect orbital penguin habitat',
+      );
+      expect(
+        await reopened.settingsDb.itemByKey('demo_seed_version'),
+        '1',
+      );
+      // The world's own settings file exists → its future host ID lives
+      // here, not in the real world's settings.sqlite.
+      expect(
+        File(p.join(worldRoot.path, 'settings.sqlite')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(worldRoot.path, 'db.sqlite')).existsSync(),
+        isTrue,
+      );
+      // JSON sidecar landed under the world root.
+      final sidecars = Directory(
+        p.join(worldRoot.path, 'tasks'),
+      ).listSync(recursive: true).whereType<File>();
+      expect(sidecars, isNotEmpty);
+      await reopened.close();
+
+      // Isolation: the canary tree is byte-identical.
+      expect(snapshotTree(canaryRealRoot), before);
+      // And the world root holds no marker of the real world's host key.
+      expect(
+        await WorldHandle.open(worldRoot).settingsDb.itemByKey(hostKey),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/profiles/service/world_handle_test.dart
+++ b/test/features/profiles/service/world_handle_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/profiles/service/world_handle.dart';
 import 'package:lotti/features/sync/utils.dart';
 import 'package:lotti/get_it.dart';
@@ -103,6 +104,16 @@ void main() {
         ),
       );
       await world.writeSetting('demo_seed_version', '1');
+      await world.writeAiConfig(
+        AiConfig.inferenceProvider(
+          id: 'seed-provider',
+          baseUrl: 'https://example.invalid',
+          apiKey: 'fake',
+          name: 'Mission Control Router',
+          createdAt: DateTime(2026, 7, 17),
+          inferenceProviderType: InferenceProviderType.genericOpenAi,
+        ),
+      );
       await world.close();
 
       // World content is real and readable back.
@@ -121,6 +132,10 @@ void main() {
       expect(
         await reopened.settingsDb.itemByKey('demo_seed_version'),
         '1',
+      );
+      expect(
+        await reopened.aiConfigDb.configById('seed-provider').getSingleOrNull(),
+        isNotNull,
       );
       // The world's own settings file exists → its future host ID lives
       // here, not in the real world's settings.sqlite.

--- a/test/features/profiles/service/world_handle_test.dart
+++ b/test/features/profiles/service/world_handle_test.dart
@@ -157,10 +157,9 @@ void main() {
       // Isolation: the canary tree is byte-identical.
       expect(snapshotTree(canaryRealRoot), before);
       // And the world root holds no marker of the real world's host key.
-      expect(
-        await WorldHandle.open(worldRoot).settingsDb.itemByKey(hostKey),
-        isNull,
-      );
+      final third = WorldHandle.open(worldRoot);
+      expect(await third.settingsDb.itemByKey(hostKey), isNull);
+      await third.close();
     });
   });
 }

--- a/test/features/profiles/state/profile_providers_test.dart
+++ b/test/features/profiles/state/profile_providers_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/profiles/model/profile.dart';
+import 'package:lotti/features/profiles/model/profile_context.dart';
+import 'package:lotti/features/profiles/state/profile_providers.dart';
+
+void main() {
+  ProfileContext contextOfType(ProfileType type) => ProfileContext.forProfile(
+    profile: Profile(
+      id: type == ProfileType.real ? Profile.realProfileId : 'g1',
+      type: type,
+      name: 'x',
+      dirName: type == ProfileType.real ? '' : 'guest_profiles/g1',
+      createdAt: DateTime(2026),
+    ),
+    root: Directory('/data/lotti'),
+  );
+
+  ProviderContainer containerWith(ProfileContext context) {
+    final container = ProviderContainer(
+      overrides: [profileContextProvider.overrideWithValue(context)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('profile providers', () {
+    test('real profile: sync available, demo inactive', () {
+      final container = containerWith(contextOfType(ProfileType.real));
+
+      expect(container.read(syncFeatureAvailableProvider), isTrue);
+      expect(container.read(demoModeActiveProvider), isFalse);
+    });
+
+    test('guest profile: sync unavailable, demo active', () {
+      final container = containerWith(contextOfType(ProfileType.guest));
+
+      expect(container.read(syncFeatureAvailableProvider), isFalse);
+      expect(container.read(demoModeActiveProvider), isTrue);
+    });
+
+    test('unoverridden context resolves loudly', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        () => container.read(profileContextProvider),
+        throwsA(
+          isA<ProviderException>().having(
+            (exception) => exception.exception,
+            'exception',
+            isUnimplementedError,
+          ),
+        ),
+      );
+    });
+
+    test('fallbacks without override match the real-profile defaults', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(syncFeatureAvailableProvider), isTrue);
+      expect(container.read(demoModeActiveProvider), isFalse);
+    });
+  });
+}

--- a/test/features/sync/outbox/inert_outbox_service_test.dart
+++ b/test/features/sync/outbox/inert_outbox_service_test.dart
@@ -1,0 +1,112 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/notification_entity.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/features/sync/outbox/inert_outbox_service.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
+
+void main() {
+  late InertOutboxService service;
+
+  final notification = NotificationEntity.taskOverdue(
+    meta: NotificationMeta(
+      id: 'n1',
+      createdAt: DateTime(2026, 8, 5),
+      updatedAt: DateTime(2026, 8, 5),
+      scheduledFor: DateTime(2026, 8, 6),
+      vectorClock: const VectorClock({'host': 1}),
+      originatingHostId: 'host',
+    ),
+    linkedTaskId: 'task-1',
+    title: 'Overdue',
+    body: 'Task is overdue',
+  );
+
+  setUp(() {
+    service = InertOutboxService();
+  });
+
+  tearDown(() async {
+    await service.dispose();
+  });
+
+  group('InertOutboxService', () {
+    test('enqueueMessage swallows the message and only counts it', () async {
+      await service.enqueueMessage(
+        const SyncMessage.journalEntity(
+          id: 'demo-entry',
+          jsonPath: '/text_entries/demo-entry.json',
+          vectorClock: VectorClock({'host': 1}),
+          status: SyncEntryStatus.initial,
+        ),
+      );
+
+      expect(service.enqueueAttempts, 1);
+    });
+
+    test('enqueueMessageOrThrow never throws in a guest world', () async {
+      await expectLater(
+        service.enqueueMessageOrThrow(
+          const SyncMessage.journalEntity(
+            id: 'demo-entry',
+            jsonPath: '/text_entries/demo-entry.json',
+            vectorClock: VectorClock({'host': 1}),
+            status: SyncEntryStatus.update,
+          ),
+        ),
+        completes,
+      );
+      expect(service.enqueueAttempts, 1);
+    });
+
+    test('enqueueNotification writes no payload file and counts', () async {
+      await service.enqueueNotification(notification);
+
+      expect(service.enqueueAttempts, 1);
+    });
+
+    test('enqueueNotificationStateUpdate is a counted no-op', () async {
+      await service.enqueueNotificationStateUpdate(
+        id: 'n1',
+        vectorClock: const VectorClock({'host': 1}),
+        originatingHostId: 'host',
+        seenAt: DateTime(2026),
+      );
+
+      expect(service.enqueueAttempts, 1);
+    });
+
+    test('notLoggedInGateStream never emits, so no demo-mode toasts', () {
+      fakeAsync((async) {
+        var events = 0;
+        service.notLoggedInGateStream.listen((_) => events++);
+
+        for (var i = 0; i < 5; i++) {
+          service.enqueueMessage(
+            SyncMessage.journalEntity(
+              id: 'demo-$i',
+              jsonPath: '/text_entries/demo-$i.json',
+              vectorClock: const VectorClock({'host': 1}),
+              status: SyncEntryStatus.update,
+            ),
+          );
+        }
+        async
+          ..elapse(const Duration(minutes: 5))
+          ..flushMicrotasks();
+
+        expect(events, 0);
+        expect(service.enqueueAttempts, 5);
+      });
+    });
+
+    test('dispose closes the gate stream', () async {
+      await service.dispose();
+
+      await expectLater(
+        service.notLoggedInGateStream.isEmpty,
+        completion(isTrue),
+      );
+    });
+  });
+}

--- a/test/features/sync/outbox/outbox_service_test.dart
+++ b/test/features/sync/outbox/outbox_service_test.dart
@@ -45,7 +45,7 @@ import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 import '../../ai_consumption/test_utils.dart';
 
-class TestableOutboxService extends OutboxService {
+class TestableOutboxService extends MatrixOutboxService {
   TestableOutboxService({
     required super.syncDatabase,
     required super.loggingService,
@@ -115,7 +115,7 @@ OutboxService buildSequenceLogService({
   required UserActivityGate gate,
   SyncSequenceLogService? sequenceLogService,
 }) {
-  return OutboxService(
+  return MatrixOutboxService(
     syncDatabase: syncDatabase,
     loggingService: loggingService,
     vectorClockService: vectorClockService,
@@ -879,7 +879,7 @@ void main() {
     when(ownedGate.waitUntilIdle).thenAnswer((_) async {});
     when(ownedGate.dispose).thenAnswer((_) async {});
 
-    final serviceOwned = OutboxService(
+    final serviceOwned = MatrixOutboxService(
       syncDatabase: syncDatabase,
       loggingService: loggingService,
       vectorClockService: vectorClockService,
@@ -903,7 +903,7 @@ void main() {
     when(externalGate.waitUntilIdle).thenAnswer((_) async {});
     when(externalGate.dispose).thenAnswer((_) async {});
 
-    final serviceExternal = OutboxService(
+    final serviceExternal = MatrixOutboxService(
       syncDatabase: syncDatabase,
       loggingService: loggingService,
       vectorClockService: vectorClockService,
@@ -2597,7 +2597,7 @@ void main() {
 
       final matrixService = stubMatrixService();
 
-      final svc = OutboxService(
+      final svc = MatrixOutboxService(
         syncDatabase: syncDatabase,
         loggingService: loggingService,
         vectorClockService: vectorClockService,
@@ -2761,7 +2761,7 @@ void main() {
 
   test('throws when neither matrix service nor message sender provided', () {
     expect(
-      () => OutboxService(
+      () => MatrixOutboxService(
         syncDatabase: syncDatabase,
         loggingService: loggingService,
         vectorClockService: vectorClockService,
@@ -2776,7 +2776,7 @@ void main() {
   test('constructs with matrixService fallback sender', () async {
     final matrixService = stubMatrixService();
 
-    final serviceWithMatrix = OutboxService(
+    final serviceWithMatrix = MatrixOutboxService(
       syncDatabase: syncDatabase,
       loggingService: loggingService,
       vectorClockService: vectorClockService,
@@ -2825,7 +2825,7 @@ void main() {
 
       // Inject matrixService by replacing the sender with MatrixOutboxMessageSender
       // and re-creating the service with matrixService for login gate.
-      final gatedSvc = OutboxService(
+      final gatedSvc = MatrixOutboxService(
         syncDatabase: syncDatabase,
         loggingService: loggingService,
         vectorClockService: vectorClockService,
@@ -2861,7 +2861,7 @@ void main() {
       final matrixService = stubMatrixService();
       when(matrixService.isLoggedIn).thenReturn(true);
 
-      final svc = OutboxService(
+      final svc = MatrixOutboxService(
         syncDatabase: syncDatabase,
         loggingService: loggingService,
         vectorClockService: vectorClockService,
@@ -2909,7 +2909,7 @@ void main() {
         when(matrixService.isLoggedIn).thenAnswer((_) => loggedIn);
 
         fakeAsync((async) {
-          final svc = OutboxService(
+          final svc = MatrixOutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
             vectorClockService: vectorClockService,
@@ -2984,7 +2984,7 @@ void main() {
         addTearDown(connectivityController.close);
 
         fakeAsync((async) {
-          final svc = OutboxService(
+          final svc = MatrixOutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
             vectorClockService: vectorClockService,
@@ -3248,7 +3248,7 @@ void main() {
       });
 
       await withClock(Clock(() => now), () async {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3388,7 +3388,7 @@ void main() {
       ).thenAnswer((_) => countController.stream);
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3467,7 +3467,7 @@ void main() {
 
       fakeAsync((async) {
         gateReleased = Completer<void>();
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3542,7 +3542,7 @@ void main() {
       ).thenAnswer((_) async => OutboxProcessingResult.none);
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3595,7 +3595,7 @@ void main() {
       ).thenAnswer((_) => const Stream<int>.empty());
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3663,7 +3663,7 @@ void main() {
       ).thenAnswer((_) async => OutboxProcessingResult.none);
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3709,7 +3709,7 @@ void main() {
       ).thenAnswer((_) => countController.stream);
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3759,7 +3759,7 @@ void main() {
         ).thenAnswer((_) => countController.stream);
 
         fakeAsync((async) {
-          final svc = OutboxService(
+          final svc = MatrixOutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
             vectorClockService: vectorClockService,
@@ -3833,7 +3833,7 @@ void main() {
       ).thenAnswer((_) => countController.stream);
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3879,7 +3879,7 @@ void main() {
       ).thenAnswer((_) => countController.stream);
 
       fakeAsync((async) {
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -3928,7 +3928,7 @@ void main() {
         OutboxService? svc;
         runZonedGuarded(
           () {
-            svc = OutboxService(
+            svc = MatrixOutboxService(
               syncDatabase: syncDatabase,
               loggingService: loggingService,
               vectorClockService: vectorClockService,
@@ -4008,7 +4008,7 @@ void main() {
 
       fakeAsync((async) {
         gateReleased = Completer<void>();
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -4112,7 +4112,7 @@ void main() {
 
         fakeAsync((async) {
           gateReleased = Completer<void>();
-          final svc = OutboxService(
+          final svc = MatrixOutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
             vectorClockService: vectorClockService,
@@ -4209,7 +4209,7 @@ void main() {
 
         fakeAsync((async) {
           fetchPending = Completer<List<OutboxItem>>();
-          final svc = OutboxService(
+          final svc = MatrixOutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
             vectorClockService: vectorClockService,
@@ -5448,7 +5448,7 @@ void main() {
           () => nullHostVcs.getHostHash(),
         ).thenAnswer((_) async => 'hash123');
 
-        final serviceWithNullHost = OutboxService(
+        final serviceWithNullHost = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: nullHostVcs,
@@ -6816,7 +6816,7 @@ void main() {
         final matrixService = stubMatrixService();
         when(matrixService.isLoggedIn).thenReturn(false);
 
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,
@@ -6873,7 +6873,7 @@ void main() {
         // service at t0, then call sendNext after the 5 s grace elapsed.
         var now = DateTime(2026, 3, 15, 10);
         await withClock(Clock(() => now), () async {
-          final svc = OutboxService(
+          final svc = MatrixOutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
             vectorClockService: vectorClockService,
@@ -7027,7 +7027,7 @@ void main() {
         ).thenAnswer((_) async => <OutboxItem>[]);
 
         final gate = createGate();
-        final svc = OutboxService(
+        final svc = MatrixOutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
           vectorClockService: vectorClockService,

--- a/test/helpers/db_settle.dart
+++ b/test/helpers/db_settle.dart
@@ -14,14 +14,27 @@ import 'package:lotti/get_it.dart';
 /// query on the same connection is FIFO-ordered behind the pending work,
 /// so awaiting it guarantees quiescence.
 Future<void> settlePendingDbWork() async {
+  Future<void> probe(Future<void> Function() query) async {
+    try {
+      await query();
+      // Database already closed (e.g. after an explicit shutdown in the
+      // test body): nothing can be pending on a closed connection.
+      // ignore: avoid_catching_errors
+    } on StateError {
+      // Intentionally swallowed — see above.
+    }
+  }
+
   if (getIt.isRegistered<EditorDb>()) {
-    await getIt<EditorDb>().customSelect('SELECT 1').get();
+    await probe(() => getIt<EditorDb>().customSelect('SELECT 1').get());
   }
   if (getIt.isRegistered<JournalDb>()) {
-    await getIt<JournalDb>().customSelect('SELECT 1').get();
+    await probe(() => getIt<JournalDb>().customSelect('SELECT 1').get());
   }
   if (getIt.isRegistered<OnboardingMetricsDb>()) {
-    await getIt<OnboardingMetricsDb>().customSelect('SELECT 1').get();
+    await probe(
+      () => getIt<OnboardingMetricsDb>().customSelect('SELECT 1').get(),
+    );
   }
   await pumpEventQueue(times: 100);
 }

--- a/test/helpers/db_settle.dart
+++ b/test/helpers/db_settle.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/editor_db.dart';
+import 'package:lotti/database/onboarding_metrics_db.dart';
+import 'package:lotti/get_it.dart';
+
+/// Waits for fire-and-forget database work started during registration
+/// (EditorStateService.init, the onboarding first-seen write) to finish
+/// before databases are closed.
+///
+/// `pumpEventQueue` cannot see requests in flight on drift's BACKGROUND
+/// isolates; closing a database with a pending cross-isolate request
+/// completes it with a channel-closed error that fails the test. A probe
+/// query on the same connection is FIFO-ordered behind the pending work,
+/// so awaiting it guarantees quiescence.
+Future<void> settlePendingDbWork() async {
+  if (getIt.isRegistered<EditorDb>()) {
+    await getIt<EditorDb>().customSelect('SELECT 1').get();
+  }
+  if (getIt.isRegistered<JournalDb>()) {
+    await getIt<JournalDb>().customSelect('SELECT 1').get();
+  }
+  if (getIt.isRegistered<OnboardingMetricsDb>()) {
+    await getIt<OnboardingMetricsDb>().customSelect('SELECT 1').get();
+  }
+  await pumpEventQueue(times: 100);
+}

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -100,9 +100,9 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_servi
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_week_context_service.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
-import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/services/day_audio_transcript_writer.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -102,6 +102,7 @@ import 'package:lotti/features/daily_os_next/agents/service/day_agent_week_conte
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/daily_os_next/services/day_audio_transcript_writer.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_outbox_repository.dart';
 import 'package:lotti/features/daily_os_next/services/day_processing_runtime.dart';
@@ -785,6 +786,8 @@ class MockNotificationService extends Mock implements NotificationService {}
 class MockNotificationsDb extends Mock implements NotificationsDb {}
 
 class MockOnboardingMetricsDb extends Mock implements OnboardingMetricsDb {}
+
+class MockDayProcessingDb extends Mock implements DayProcessingDb {}
 
 class MockConsumptionDatabase extends Mock implements ConsumptionDatabase {}
 

--- a/test/services/service_disposer_test.dart
+++ b/test/services/service_disposer_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/ai/database/embedding_store.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/service/embedding_service.dart';
 import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
 import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -107,6 +108,10 @@ void main() {
       when(onboardingMetricsDb.close).thenAnswer((_) async {
         order.add('OnboardingMetricsDb');
       });
+      final dayProcessingDb = MockDayProcessingDb();
+      when(dayProcessingDb.close).thenAnswer((_) async {
+        order.add('DayProcessingDb');
+      });
       final settingsDb = MockSettingsDb();
       when(settingsDb.close).thenAnswer((_) async {
         order.add('SettingsDb');
@@ -127,6 +132,7 @@ void main() {
         ..registerSingleton<ConsumptionDatabase>(consumptionDb)
         ..registerSingleton<NotificationsDb>(notificationsDb)
         ..registerSingleton<OnboardingMetricsDb>(onboardingMetricsDb)
+        ..registerSingleton<DayProcessingDb>(dayProcessingDb)
         ..registerSingleton<SettingsDb>(settingsDb);
 
       await disposer.disposeAll();
@@ -146,6 +152,7 @@ void main() {
         'ConsumptionDatabase',
         'NotificationsDb',
         'OnboardingMetricsDb',
+        'DayProcessingDb',
         'SettingsDb',
       ]);
       expect(loggedErrors, isEmpty);

--- a/test/services/startup_tasks_test.dart
+++ b/test/services/startup_tasks_test.dart
@@ -2,7 +2,12 @@ import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/startup_tasks.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
 
 void main() {
   group('StartupTasks', () {
@@ -23,11 +28,32 @@ void main() {
       expect(done, isTrue);
     });
 
-    test('a failing tracked task never breaks settle', () async {
+    test('a failing tracked task is logged, and settle completes', () async {
+      await getIt.reset();
+      addTearDown(getIt.reset);
+      final domainLogger = MockDomainLogger();
+      when(
+        () => domainLogger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          subDomain: any<String?>(named: 'subDomain'),
+        ),
+      ).thenAnswer((_) {});
+      getIt.registerSingleton<DomainLogger>(domainLogger);
+
       final tasks = StartupTasks()
         ..track(Future<void>.error(StateError('startup boom')));
 
       await expectLater(tasks.settle(), completes);
+      verify(
+        () => domainLogger.error(
+          LogDomain.general,
+          any<Object>(that: isStateError),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          subDomain: 'startupTasks',
+        ),
+      ).called(1);
     });
 
     test('settle abandons work past the bound instead of hanging', () {

--- a/test/services/startup_tasks_test.dart
+++ b/test/services/startup_tasks_test.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/services/startup_tasks.dart';
+
+void main() {
+  group('StartupTasks', () {
+    test('settle with nothing tracked completes immediately', () async {
+      await expectLater(StartupTasks().settle(), completes);
+    });
+
+    test('settle waits for tracked work', () async {
+      final tasks = StartupTasks();
+      var done = false;
+      final gate = Completer<void>();
+      tasks.track(gate.future.then((_) => done = true));
+
+      final settling = tasks.settle();
+      gate.complete();
+      await settling;
+
+      expect(done, isTrue);
+    });
+
+    test('a failing tracked task never breaks settle', () async {
+      final tasks = StartupTasks()
+        ..track(Future<void>.error(StateError('startup boom')));
+
+      await expectLater(tasks.settle(), completes);
+    });
+
+    test('settle abandons work past the bound instead of hanging', () {
+      fakeAsync((async) {
+        final tasks = StartupTasks()..track(Completer<void>().future);
+        var settled = false;
+        tasks.settle().then((_) => settled = true);
+
+        async
+          ..elapse(const Duration(seconds: 6))
+          ..flushMicrotasks();
+
+        expect(settled, isTrue);
+      });
+    });
+  });
+}

--- a/test/services/window_service_test.dart
+++ b/test/services/window_service_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/app_prefs_service.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/window_service.dart';
@@ -16,6 +17,10 @@ import 'package:mocktail/mocktail.dart';
 import '../mocks/mocks.dart';
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(<String>{});
+  });
+
   group('WindowService shutdown sequence', () {
     setUp(() async {
       await getIt.reset();
@@ -248,6 +253,87 @@ void main() {
 
       verify(() => getIt<SettingsDb>().close()).called(1);
       verify(() => getIt<OutboxService>().dispose()).called(1);
+    });
+
+    group('window geometry persistence', () {
+      AppPrefs recordingPrefs(
+        Map<String, String> store,
+        List<({String key, String value})> writes,
+      ) => AppPrefs(
+        getBool: (_) async => null,
+        setBool: ({required key, required value}) async => true,
+        getString: (key) async => store[key],
+        setString: ({required key, required value}) async {
+          writes.add((key: key, value: value));
+          store[key] = value;
+          return true;
+        },
+      );
+
+      WindowService buildService(AppPrefs prefs) => WindowService(
+        skipWindowManagerSetup: true,
+        isMacOSOverride: () => false,
+        exitOverride: (_) {},
+        playerDisposerOverride: () async {},
+        prefsOverride: prefs,
+      );
+
+      test(
+        'resolveGeometry prefers prefs and never touches SettingsDb',
+        () async {
+          final writes = <({String key, String value})>[];
+          final prefs = recordingPrefs({
+            'WINDOW_SIZE': '800.0,600.0',
+            'WINDOW_OFFSET': '10.0,20.0',
+          }, writes);
+
+          final (size, offset) = await buildService(prefs).resolveGeometry();
+
+          expect(size, '800.0,600.0');
+          expect(offset, '10.0,20.0');
+          expect(writes, isEmpty);
+          verifyNever(
+            () => getIt<SettingsDb>().itemsByKeys(any()),
+          );
+        },
+      );
+
+      test(
+        'resolveGeometry migrates legacy SettingsDb rows into prefs',
+        () async {
+          when(
+            () => getIt<SettingsDb>().itemsByKeys(any()),
+          ).thenAnswer(
+            (_) async => {
+              'WINDOW_SIZE': '1024.0,768.0',
+              'WINDOW_OFFSET': '5.0,6.0',
+            },
+          );
+          final writes = <({String key, String value})>[];
+          final prefs = recordingPrefs({}, writes);
+
+          final (size, offset) = await buildService(prefs).resolveGeometry();
+
+          expect(size, '1024.0,768.0');
+          expect(offset, '5.0,6.0');
+          expect(writes, [
+            (key: 'WINDOW_SIZE', value: '1024.0,768.0'),
+            (key: 'WINDOW_OFFSET', value: '5.0,6.0'),
+          ]);
+        },
+      );
+
+      test('resolveGeometry returns nulls when nothing is persisted', () async {
+        when(
+          () => getIt<SettingsDb>().itemsByKeys(any()),
+        ).thenAnswer((_) async => {});
+        final prefs = recordingPrefs({}, []);
+
+        final (size, offset) = await buildService(prefs).resolveGeometry();
+
+        expect(size, isNull);
+        expect(offset, isNull);
+      });
     });
 
     test('non-macOS shutdown calls disposeAll', () async {


### PR DESCRIPTION
## What this is

Infrastructure for the upcoming **demo mode with guest accounts**: fully isolated "guest worlds" with their own root directory, databases, settings, and sync identity — plus the machinery to seed one and switch into it in-app. **No user-visible changes yet**: no entry points, no demo content, no banner (those follow in a second PR). For a real profile, boot behavior is preserved.

## Changes

### Unified path resolution (the isolation keystone)
- `openDbConnection` now falls back to the registered getIt `Directory` (the active profile root) instead of re-deriving the OS documents directory on every database open (`lib/database/common.dart`). Regression tests make `path_provider` throw to prove no code path re-derives the OS root.
- `Fts5Db` and `AiConfigDb` gain the `documentsDirectoryProvider`/`tempDirectoryProvider` seams (the only two Drift DBs missing them).

### Profile model
- `profiles.json` registry at the real root (atomic writes, lenient parsing that degrades to "real world, active"); guest worlds nest under `guest_profiles/<uuid>/`. Existing installs are untouched — no registry file simply means the real world.
- `ProfileContext`/`ProfileCapabilities`: guests structurally exclude sync and health import.

### Bootstrap split (`lib/app_bootstrap.dart`, `lib/app_root.dart`)
- `main()` = process logging → `initPlatformOnce()` → `resolveActiveProfile()` → `bootstrapProfileServices()` → `LottiAppRoot`.
- `LottiAppRoot` owns a generation-keyed `ProviderScope` whose getIt bridge overrides are recomputed per service generation.
- `registerSingletons({required ProfileContext profile})`.

### Sync structurally absent in guest worlds
- `OutboxService` becomes the abstract write boundary; the Matrix-backed concrete class is renamed `MatrixOutboxService` (body unchanged). Guests get `InertOutboxService` — every enqueue is a counted no-op, the login-gate stream never emits.
- Registration branches on capabilities (`lib/get_it_sync.dart`): guests construct **no** Matrix client (keychain credentials are never read), no inbound queue, no backfill timers, no node-profile broadcast, no VC-burn handlers.
- Host IDs are per-world for free: `VC_HOST` lives in each world's own `settings.sqlite`.
- `matrixServiceProvider` is left unoverridden in guest mode so accidental resolution fails loudly; sync UI gates on `syncFeatureAvailableProvider`.

### In-app switching
- `ProfileSwitcher`: marker-first (a crash mid-switch reopens the intended world), splash → quiesce (timer stop, audio player, window detach) → `ServiceDisposer.disposeAll()` → `getIt.reset()` → re-bootstrap → new scope generation.
- `WorldHandle`: a second, non-active set of DB handles at an arbitrary world root — used to **populate a demo world before switching into it** (`DemoWorldCreator`), and later for exit copy-over.

### Standalone fixes
- `ServiceDisposer` now closes `DayProcessingDb` (previously leaked on shutdown).
- Window geometry moved from SettingsDb to SharedPreferences (device state, not world state) with one-time migration.

### Docs
- New concept `knowledge/architecture/profiles-and-demo-mode.md` (isolation contract + switch state diagram), updated `bootstrap-and-di.md` and sync overview, new ADR 0049 (storage-scoping decision + sync-config sharing analysis).

## Testing

- New: profile registry/model/paths, provider gates, inert outbox, switcher orchestration, `DemoWorldCreator` ordering + failed-seed rollback, and a **byte-identical canary audit** proving `WorldHandle` writes never touch the active world (this test caught a real bug during development: `JournalDb` writes its own JSON sidecar, which needed binding to the world root).
- `make analyze`: zero issues. `make knowledge_check`: 25/25, all mermaid parses.
- No CHANGELOG entry: nothing user-visible changes in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile management with isolated storage for real and guest/demo profiles.
  * Added pre-populated demo worlds and safe profile switching.
  * Guest worlds now operate without synchronization or access to Matrix credentials.
  * Improved startup, lifecycle handling, and window-state persistence across profile changes.

* **Documentation**
  * Added architecture guidance covering profile storage, demo mode, startup behavior, and synchronization boundaries.

* **Bug Fixes**
  * Improved database path isolation and ensured services shut down cleanly during profile changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->