### PR TITLE
test: address sync sequence review feedback

### DIFF
--- a/docs/implementation_plans/2026-02-18_test_suite_review_and_optimization.md
+++ b/docs/implementation_plans/2026-02-18_test_suite_review_and_optimization.md
@@ -592,7 +592,9 @@ documentation, not code.
     - No new CI check, lint rule, or pre-commit hook will be added for this
       review.
     - Remaining debt is handled in focused implementation PRs, using the
-      existing testing conventions and normal review/CI verification.
+      existing testing conventions—including the
+      [documented `SyncSequenceLogService` suite exception](../../test/README.md#documented-exception-syncsequencelogservice-facade-suites)—and
+      normal review/CI verification.
 
 ---
 

--- a/test/README.md
+++ b/test/README.md
@@ -157,8 +157,8 @@ responsibility-owned satellites:
 
 Shared generators, deterministic entities, and mock wiring live in
 `sync_sequence_log_service_test_helpers.dart`, which has no `main()`. A behavior
-belongs in exactly one satellite; collaborator-level unit coverage continues to
-live in the collaborator's own mirrored test file.
+belongs in exactly one of the five listed facade suites; collaborator-level
+unit coverage continues to live in the collaborator's own mirrored test file.
 
 ## Mocktail global-state hygiene
 

--- a/test/features/sync/sequence/sync_sequence_log_service_backfill_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_backfill_test.dart
@@ -804,13 +804,11 @@ void main() {
         // Sanity check: a second identical-counter record hits the cached
         // bound and does NOT rescan the range.
         clearInteractions(mockDb);
+        restoreSyncSequenceLogDefaults(mockDb);
         clearInteractions(mockLogging);
         when(
           () => mockDb.getLastCounterForHost(aliceHostId),
         ).thenAnswer((_) async => lastSeen);
-        when(
-          () => mockDb.updateHostActivity(any(), any()),
-        ).thenAnswer((_) async => 1);
         when(
           () => mockDb.getHostLastSeen(aliceHostId),
         ).thenAnswer((_) async => DateTime(2025, 1, 1));
@@ -820,12 +818,6 @@ void main() {
         when(
           () => mockDb.recordSequenceEntry(any()),
         ).thenAnswer((_) async => 1);
-        when(
-          () => mockDb.getPendingEntriesByPayloadId(
-            payloadType: any(named: 'payloadType'),
-            payloadId: any(named: 'payloadId'),
-          ),
-        ).thenAnswer((_) async => []);
         when(
           () => mockLogging.log(
             any<LogDomain>(),
@@ -844,6 +836,7 @@ void main() {
 
         // Retire: this must clear the materialized-bound cache.
         clearInteractions(mockDb);
+        restoreSyncSequenceLogDefaults(mockDb);
         clearInteractions(mockLogging);
         when(
           () => mockDb.retireExhaustedRequestedEntries(
@@ -876,12 +869,10 @@ void main() {
         // `_materializedUpperBound`, since `_lastCounterCache` is already
         // invalidated by any concurrent `recordSequenceEntry` path.
         clearInteractions(mockDb);
+        restoreSyncSequenceLogDefaults(mockDb);
         when(
           () => mockDb.getLastCounterForHost(aliceHostId),
         ).thenAnswer((_) async => lastSeen);
-        when(
-          () => mockDb.updateHostActivity(any(), any()),
-        ).thenAnswer((_) async => 1);
         when(
           () => mockDb.getHostLastSeen(aliceHostId),
         ).thenAnswer((_) async => DateTime(2025, 1, 1));
@@ -892,17 +883,8 @@ void main() {
           () => mockDb.recordSequenceEntry(any()),
         ).thenAnswer((_) async => 1);
         when(
-          () => mockDb.getPendingEntriesByPayloadId(
-            payloadType: any(named: 'payloadType'),
-            payloadId: any(named: 'payloadId'),
-          ),
-        ).thenAnswer((_) async => []);
-        when(
           () => mockDb.getCountersForHostInRange(any(), any(), any()),
         ).thenAnswer((_) async => <int>{});
-        when(
-          () => mockDb.batchInsertSequenceEntries(any()),
-        ).thenAnswer((_) async {});
 
         await service.recordReceivedEntry(
           entryId: 'post-retire',

--- a/test/features/sync/sequence/sync_sequence_log_service_receive_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_receive_test.dart
@@ -1395,14 +1395,12 @@ void main() {
       );
 
       clearInteractions(mockDb);
+      restoreSyncSequenceLogDefaults(mockDb);
       clearInteractions(mockLogging);
       // Re-stub after clearInteractions.
       when(
         () => mockDb.getLastCounterForHost(aliceHostId),
       ).thenAnswer((_) async => lastSeen);
-      when(
-        () => mockDb.updateHostActivity(any(), any()),
-      ).thenAnswer((_) async => 1);
       when(
         () => mockDb.getHostLastSeen(aliceHostId),
       ).thenAnswer((_) async => DateTime(2025, 1, 1));
@@ -1410,12 +1408,6 @@ void main() {
         () => mockDb.getEntryByHostAndCounter(aliceHostId, any()),
       ).thenAnswer((_) async => null);
       when(() => mockDb.recordSequenceEntry(any())).thenAnswer((_) async => 1);
-      when(
-        () => mockDb.getPendingEntriesByPayloadId(
-          payloadType: any(named: 'payloadType'),
-          payloadId: any(named: 'payloadId'),
-        ),
-      ).thenAnswer((_) async => []);
       when(
         () => mockLogging.log(
           any<LogDomain>(),
@@ -1483,13 +1475,11 @@ void main() {
         );
 
         clearInteractions(mockDb);
+        restoreSyncSequenceLogDefaults(mockDb);
         clearInteractions(mockLogging);
         when(
           () => mockDb.getLastCounterForHost(aliceHostId),
         ).thenAnswer((_) async => lastSeen);
-        when(
-          () => mockDb.updateHostActivity(any(), any()),
-        ).thenAnswer((_) async => 1);
         when(
           () => mockDb.getHostLastSeen(aliceHostId),
         ).thenAnswer((_) async => DateTime(2025, 1, 1));
@@ -1499,12 +1489,6 @@ void main() {
         when(
           () => mockDb.recordSequenceEntry(any()),
         ).thenAnswer((_) async => 1);
-        when(
-          () => mockDb.getPendingEntriesByPayloadId(
-            payloadType: any(named: 'payloadType'),
-            payloadId: any(named: 'payloadId'),
-          ),
-        ).thenAnswer((_) async => []);
         when(
           () => mockLogging.log(
             any<LogDomain>(),
@@ -1588,13 +1572,11 @@ void main() {
       );
 
       clearInteractions(mockDb);
+      restoreSyncSequenceLogDefaults(mockDb);
       clearInteractions(mockLogging);
       when(
         () => mockDb.getLastCounterForHost(aliceHostId),
       ).thenAnswer((_) async => lastSeen);
-      when(
-        () => mockDb.updateHostActivity(any(), any()),
-      ).thenAnswer((_) async => 1);
       when(
         () => mockDb.getHostLastSeen(aliceHostId),
       ).thenAnswer((_) async => DateTime(2025, 1, 1));
@@ -1602,12 +1584,6 @@ void main() {
         () => mockDb.getEntryByHostAndCounter(aliceHostId, any()),
       ).thenAnswer((_) async => null);
       when(() => mockDb.recordSequenceEntry(any())).thenAnswer((_) async => 1);
-      when(
-        () => mockDb.getPendingEntriesByPayloadId(
-          payloadType: any(named: 'payloadType'),
-          payloadId: any(named: 'payloadId'),
-        ),
-      ).thenAnswer((_) async => []);
       when(
         () => mockLogging.log(
           any<LogDomain>(),

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -543,9 +543,7 @@ void main() {
       // Reset mock to return 3 on next DB query (simulating that
       // counter 3 was marked as received by covered VC processing).
       reset(mockDb);
-      when(
-        () => mockDb.updateHostActivity(any(), any()),
-      ).thenAnswer((_) async => 1);
+      restoreSyncSequenceLogDefaults(mockDb);
       when(
         () => mockDb.getLastCounterForHost(aliceHostId),
       ).thenAnswer((_) async => 3);
@@ -557,17 +555,8 @@ void main() {
       ).thenAnswer((_) async => null);
       when(() => mockDb.recordSequenceEntry(any())).thenAnswer((_) async => 1);
       when(
-        () => mockDb.getCountersForHostInRange(any(), any(), any()),
-      ).thenAnswer((_) async => <int>{});
-      when(
         () => mockDb.batchInsertSequenceEntries(any()),
       ).thenAnswer((_) async {});
-      when(
-        () => mockDb.getPendingEntriesByPayloadId(
-          payloadType: any(named: 'payloadType'),
-          payloadId: any(named: 'payloadId'),
-        ),
-      ).thenAnswer((_) async => []);
 
       final gaps = await service.recordReceivedEntry(
         entryId: 'entry-5',
@@ -616,9 +605,7 @@ void main() {
         // On next call, cache miss → re-queries DB
         // But this time mock returns 2 (no covered VC to advance it)
         reset(mockDb);
-        when(
-          () => mockDb.updateHostActivity(any(), any()),
-        ).thenAnswer((_) async => 1);
+        restoreSyncSequenceLogDefaults(mockDb);
         when(
           () => mockDb.getLastCounterForHost(aliceHostId),
         ).thenAnswer((_) async => 2);
@@ -629,17 +616,8 @@ void main() {
           () => mockDb.recordSequenceEntry(any()),
         ).thenAnswer((_) async => 1);
         when(
-          () => mockDb.getCountersForHostInRange(any(), any(), any()),
-        ).thenAnswer((_) async => <int>{});
-        when(
           () => mockDb.batchInsertSequenceEntries(any()),
         ).thenAnswer((_) async {});
-        when(
-          () => mockDb.getPendingEntriesByPayloadId(
-            payloadType: any(named: 'payloadType'),
-            payloadId: any(named: 'payloadId'),
-          ),
-        ).thenAnswer((_) async => []);
 
         final gaps = await service.recordReceivedEntry(
           entryId: 'entry-5',

--- a/test/features/sync/sequence/sync_sequence_log_service_test_helpers.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test_helpers.dart
@@ -814,6 +814,7 @@ class RealSequenceLogTestBench {
         loggingService: logging,
       ),
     );
+    addTearDown(bench.close);
     bench.service.onMissingEntriesDetected = () {
       bench.missingCallbackCount++;
     };
@@ -841,8 +842,13 @@ class RealSequenceLogTestBench {
   final SyncDatabase database;
   final SyncSequenceLogService service;
   int missingCallbackCount = 0;
+  bool _closed = false;
 
-  Future<void> close() => database.close();
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await database.close();
+  }
 }
 
 Future<void> expectObservedCounter({
@@ -868,13 +874,32 @@ SyncSequenceLogItem createLogItem(
     hostId: hostId,
     counter: counter,
     entryId: entryId,
-    payloadType: 0, // SyncSequencePayloadType.journalEntity.index
+    payloadType: SyncSequencePayloadType.journalEntity.index,
     originatingHostId: originatingHostId,
     status: status.index,
     createdAt: DateTime(2024),
     updatedAt: DateTime(2024),
     requestCount: 0,
   );
+}
+
+/// Restores the default database stubs after a test resets or clears its mock.
+void restoreSyncSequenceLogDefaults(MockSyncDatabase mockDb) {
+  when(
+    () => mockDb.updateHostActivity(any(), any()),
+  ).thenAnswer((_) async => 1);
+  when(
+    () => mockDb.getCountersForHostInRange(any(), any(), any()),
+  ).thenAnswer((_) async => <int>{});
+  when(
+    () => mockDb.batchInsertSequenceEntries(any()),
+  ).thenAnswer((_) async {});
+  when(
+    () => mockDb.getPendingEntriesByPayloadId(
+      payloadType: any(named: 'payloadType'),
+      payloadId: any(named: 'payloadId'),
+    ),
+  ).thenAnswer((_) async => []);
 }
 
 /// Registers the fallback values shared by the split facade suites.
@@ -919,28 +944,13 @@ class SyncSequenceLogServiceTestBench {
         subDomain: any(named: 'subDomain'),
       ),
     ).thenReturn(null);
-    when(
-      () => mockDb.updateHostActivity(any(), any()),
-    ).thenAnswer((_) async => 1);
-    when(
-      () => mockDb.getCountersForHostInRange(any(), any(), any()),
-    ).thenAnswer((_) async => <int>{});
-    when(
-      () => mockDb.batchInsertSequenceEntries(any()),
-    ).thenAnswer((_) async {});
+    restoreSyncSequenceLogDefaults(mockDb);
     when(
       () => mockDb.getHostLastSeen(aliceHostId),
     ).thenAnswer((_) async => DateTime(2025, 1, 1));
     when(
       () => mockDb.getHostLastSeen(bobHostId),
     ).thenAnswer((_) async => DateTime(2025, 1, 1));
-    when(
-      () => mockDb.getPendingEntriesByPayloadId(
-        payloadType: any(named: 'payloadType'),
-        payloadId: any(named: 'payloadId'),
-      ),
-    ).thenAnswer((_) async => []);
-
     return SyncSequenceLogServiceTestBench._(
       mockDb: mockDb,
       mockVcService: mockVcService,


### PR DESCRIPTION
## Summary

Follow-up to #3804, which merged while its review feedback was being addressed.

- documents the facade-suite exception consistently
- replaces the raw payload-type index with the enum value
- makes the real-database test bench teardown automatic and idempotent
- centralizes restoration of default sync-database stubs after mock resets

This adds no CI checks or guardrails and changes no production behavior.

## Verification

- `fvm flutter test --reporter compact` for the five executable `SyncSequenceLogService` facade suites: 157 tests passed
- `fvm dart format .`: 0 files changed
- `fvm flutter analyze`: no issues found
- `git diff --check`