### PR TITLE
fix: preserve duplicate blocked plan violations

### DIFF
--- a/docs/implementation_plans/2026-08-05_oversized_test_suite_decomposition.md
+++ b/docs/implementation_plans/2026-08-05_oversized_test_suite_decomposition.md
@@ -23,7 +23,7 @@ decomposition itself.
 | 1 | `sync_sequence_log_service_test.dart` | 6,871 | receive, backfill, population, covered clocks, facade/cache | Merged (#3804) |
 | 2 | `task_agent_workflow_test.dart` | 9,132 | wake execution, persistence, prompt/context delegation, workflow shell | Merged (#3806) |
 | 3 | `unified_ai_inference_repository_test.dart` | 8,593 | inference execution, tool-call processing, post-processing, repository shell | Merged (#3807) |
-| 4 | `eval_constraints_test.dart` | 8,228 | split the test-only constraint framework and mirror its focused source files | In progress |
+| 4 | `eval_constraints_test.dart` | 8,228 | split the test-only constraint framework and mirror its focused source files | Merged (#3808) |
 | 5 | `outbox_service_test.dart` | 7,820 | send pipeline, queue/database behavior, retry/maintenance, service shell | Planned |
 | 6 | `day_agent_workflow_test.dart` | 7,379 | day wake execution, context/prompt construction, persistence, workflow shell | Planned |
 | 7 | `wake_orchestrator_test.dart` | 6,905 | scheduling, drain/claim lifecycle, recovery, orchestrator shell | Planned |

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -467,13 +467,15 @@ builders live in `eval_constraints_test_helpers.dart`, which has no `main()`.
   escalation whose status note is merely non-empty. Both are wholly heuristic.
   `blockerBeforeBlocked` is mixed: a pass from actual blocker ordering and an
   unexcused ordering failure remain objective, while a pass that relies on a
-  reason naming a blocker is heuristic. The semantic paths catch the important
-  failure mode of saying nothing, but their string and structural presence tests
-  can pass without demonstrating comprehension. They remain visible per
-  constraint as weak priors, carry a caveat into the JSON and judge bundle, and
-  only those heuristic outcomes are excluded from the objective model
-  leaderboard. A reviewer must inspect the plan, changes, reasons, and status
-  notes before calling a heuristic green result good reasoning.
+  reason naming a blocker is heuristic. Every scheduled occurrence is evaluated
+  independently, including value-equal duplicate blocks; duplicate-id scoring
+  remains the separate `uniqueBlockIds` responsibility. The semantic paths catch
+  the important failure mode of saying nothing, but their string and structural
+  presence tests can pass without demonstrating comprehension. They remain
+  visible per constraint as weak priors, carry a caveat into the JSON and judge
+  bundle, and only those heuristic outcomes are excluded from the objective
+  model leaderboard. A reviewer must inspect the plan, changes, reasons, and
+  status notes before calling a heuristic green result good reasoning.
   `withinCapacityByEstimate` is mixed for the same reason: full-estimate
   accounting and failures remain objective. A pass is marked heuristic and
   excluded from the objective headline rate only when parsing free-form partial

--- a/test/features/daily_os_next/eval/framework/eval_constraints.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints.dart
@@ -8,6 +8,37 @@ part 'eval_constraints_estimates.dart';
 part 'eval_constraints_schedule.dart';
 part 'eval_constraints_trade.dart';
 
+/// Whether [prose] mentions the title of [taskId].
+bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
+  final title = outcome.inputs.taskById(taskId)?.title.trim();
+  if (title == null || title.isEmpty) return false;
+  if (RegExp(
+    r'\btask\s+' + RegExp.escape(title) + r'\b',
+    caseSensitive: false,
+  ).hasMatch(prose)) {
+    return true;
+  }
+  return _allowsBareTaskTitle(title) &&
+      RegExp(
+        r'(?:^|[^\w-])' + RegExp.escape(title) + r'(?=$|[^\w-])',
+        caseSensitive: false,
+      ).hasMatch(prose);
+}
+
+bool _taskIdNamed(String taskId, String prose) => RegExp(
+  r'(?:^|[^\w-])' + RegExp.escape(taskId) + r'(?=$|[^\w-])',
+  caseSensitive: false,
+).hasMatch(prose);
+
+bool _allowsBareTaskTitle(String title) {
+  final normalized = title.trim().toLowerCase();
+  return normalized != 'a' && normalized != 'i';
+}
+
+String _hhmm(DateTime time) =>
+    '${time.hour.toString().padLeft(2, '0')}:'
+    '${time.minute.toString().padLeft(2, '0')}';
+
 /// Objective constraints the day planner's output is scored against.
 ///
 /// Every scorer here is a pure function over an [EvalRunOutcome] — no I/O, no

--- a/test/features/daily_os_next/eval/framework/eval_constraints_content.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_content.dart
@@ -108,7 +108,7 @@ EvalConstraintResult scoreTaskWorkIsTyped(EvalRunOutcome outcome) {
 
 /// Whether [call] escalates under the reason the prompt names for an
 /// unsatisfiable directive, which needs no further explanation to count.
-bool _namesDirectiveReason(EvalToolCall call, Set<String> answering) =>
+bool _namesDirectiveReason(EvalToolCall call) =>
     switch (call.arguments['reasons']) {
       final List<Object?> list =>
         list.map((r) => '$r').contains('directiveUnsatisfiable'),
@@ -177,17 +177,11 @@ EvalConstraintResult scoreDirectiveHonoured(EvalRunOutcome outcome) {
           // exists or it does not — rather than semantic, because refereeing
           // what a note *means* by substring match is what got this scorer
           // wrong twice already.
-          (_namesDirectiveReason(call, answeringReasons) ||
+          (_namesDirectiveReason(call) ||
               '${call.arguments['note'] ?? ''}'.trim().isNotEmpty))
         call,
   ];
-  final escalatedAsDirective = escalations.any(
-    (call) => switch (call.arguments['reasons']) {
-      final List<Object?> list =>
-        list.map((r) => '$r').contains('directiveUnsatisfiable'),
-      _ => false,
-    },
-  );
+  final escalatedAsDirective = escalations.any(_namesDirectiveReason);
 
   // Prose the model attached to the plan, where a representation names its
   // commitment.
@@ -417,35 +411,9 @@ Set<String> _placedTaskIds(EvalRunOutcome outcome) => {
       ?block.taskId,
 };
 
-/// Whether [prose] mentions the title of [taskId].
-bool _titleNamed(EvalRunOutcome outcome, String taskId, String prose) {
-  final title = outcome.inputs.taskById(taskId)?.title.trim();
-  if (title == null || title.isEmpty) return false;
-  if (RegExp(
-    r'\btask\s+' + RegExp.escape(title) + r'\b',
-    caseSensitive: false,
-  ).hasMatch(prose)) {
-    return true;
-  }
-  return _allowsBareTaskTitle(title) &&
-      RegExp(
-        r'(?:^|[^\w-])' + RegExp.escape(title) + r'(?=$|[^\w-])',
-        caseSensitive: false,
-      ).hasMatch(prose);
-}
-
-bool _taskIdNamed(String taskId, String prose) => RegExp(
-  r'(?:^|[^\w-])' + RegExp.escape(taskId) + r'(?=$|[^\w-])',
-  caseSensitive: false,
-).hasMatch(prose);
-
 /// Blocks that consume capacity — `dropped` ones are recorded but not
 /// scheduled, matching `scheduledMinutesFor` in the parser.
 List<PlannedBlock> _scheduled(EvalRunOutcome outcome) => [
   for (final block in outcome.blocks)
     if (block.state != PlannedBlockState.dropped) block,
 ];
-
-String _hhmm(DateTime time) =>
-    '${time.hour.toString().padLeft(2, '0')}:'
-    '${time.minute.toString().padLeft(2, '0')}';

--- a/test/features/daily_os_next/eval/framework/eval_constraints_content_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_content_test.dart
@@ -184,46 +184,6 @@ void main() {
 
       expect(result.passed, isFalse);
     });
-
-    test('a dropped decided task does not count as placed', () {
-      final result = scoreDecidedTasksPlaced(
-        outcome(
-          blocks: [
-            block(
-              id: 'a',
-              startHour: 9,
-              endHour: 10,
-              taskId: 'task-1',
-              state: PlannedBlockState.dropped,
-            ),
-          ],
-          decidedTaskIds: const ['task-1'],
-        ),
-      );
-
-      expect(result.passed, isFalse);
-    });
-
-    test('dropping work the scenario wanted omitted honours the omission', () {
-      // The other direction of the same inconsistency: a dropped stale task
-      // used to fail the omission constraint even though it was not scheduled.
-      final result = scoreExpectedOmissionsHonoured(
-        outcome(
-          blocks: [
-            block(
-              id: 'a',
-              startHour: 9,
-              endHour: 10,
-              taskId: 'task-stale',
-              state: PlannedBlockState.dropped,
-            ),
-          ],
-          expectedOmissions: const {'task-stale'},
-        ),
-      );
-
-      expect(result.passed, isTrue);
-    });
   });
 
   group('taskWorkIsTyped', () {

--- a/test/features/daily_os_next/eval/framework/eval_constraints_estimates.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_estimates.dart
@@ -635,88 +635,51 @@ bool _hasAuditablePartialDisclosure({
       }
       if (disclosure.canQualify) hasMatchingSplit = true;
     }
-    for (final match in _partialRemainingPattern.allMatches(reason)) {
-      if (_evidenceFallsInsideTaskReference(
-            reason,
-            match,
-            taskId: taskId,
-            taskTitle: taskTitle,
-          ) ||
-          _tradeEvidenceHasExplicitNonTaskSubject(
-            reason,
-            match,
-            taskId: taskId,
-            taskTitle: taskTitle,
-          ) ||
-          _remainderDescribesContinuity(reason, match) ||
-          _evidenceIsSpeculative(reason, match)) {
-        continue;
-      }
-      if (_evidenceNamesAnotherTask(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-        corpus: corpus,
-      )) {
-        continue;
-      }
-      if (!_remainderIsRelatedToTask(reason, match)) continue;
-      if (_matchClauseIsNegated(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-        corpus: corpus,
-      )) {
-        return false;
-      }
-      final declaredRemaining = int.tryParse(match.group(1) ?? '');
-      if (declaredRemaining != remainingMinutes) return false;
-      if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
-        reasonHasBoundRemainder = true;
-      }
-    }
-    for (final match in _partialLeadingRemainingPattern.allMatches(reason)) {
-      if (_evidenceFallsInsideTaskReference(
-            reason,
-            match,
-            taskId: taskId,
-            taskTitle: taskTitle,
-          ) ||
-          _tradeEvidenceHasExplicitNonTaskSubject(
-            reason,
-            match,
-            taskId: taskId,
-            taskTitle: taskTitle,
-          ) ||
-          _remainderDescribesContinuity(reason, match) ||
-          _evidenceIsSpeculative(reason, match)) {
-        continue;
-      }
-      if (_evidenceNamesAnotherTask(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-        corpus: corpus,
-      )) {
-        continue;
-      }
-      if (!_remainderIsRelatedToTask(reason, match)) continue;
-      if (_matchClauseIsNegated(
-        reason,
-        match,
-        taskId: taskId,
-        taskTitle: taskTitle,
-        corpus: corpus,
-      )) {
-        return false;
-      }
-      final declaredRemaining = int.tryParse(match.group(1) ?? '');
-      if (declaredRemaining != remainingMinutes) return false;
-      if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
-        reasonHasBoundRemainder = true;
+    for (final pattern in [
+      _partialRemainingPattern,
+      _partialLeadingRemainingPattern,
+    ]) {
+      for (final match in pattern.allMatches(reason)) {
+        if (_evidenceFallsInsideTaskReference(
+              reason,
+              match,
+              taskId: taskId,
+              taskTitle: taskTitle,
+            ) ||
+            _tradeEvidenceHasExplicitNonTaskSubject(
+              reason,
+              match,
+              taskId: taskId,
+              taskTitle: taskTitle,
+            ) ||
+            _remainderDescribesContinuity(reason, match) ||
+            _evidenceIsSpeculative(reason, match)) {
+          continue;
+        }
+        if (_evidenceNamesAnotherTask(
+          reason,
+          match,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        )) {
+          continue;
+        }
+        if (!_remainderIsRelatedToTask(reason, match)) continue;
+        if (_matchClauseIsNegated(
+          reason,
+          match,
+          taskId: taskId,
+          taskTitle: taskTitle,
+          corpus: corpus,
+        )) {
+          return false;
+        }
+        final declaredRemaining = int.tryParse(match.group(1) ?? '');
+        if (declaredRemaining != remainingMinutes) return false;
+        if (disclosure.canQualify && _remainderIsTaskBound(reason, match)) {
+          reasonHasBoundRemainder = true;
+        }
       }
     }
     if (reasonMentionsPartial && reasonHasBoundRemainder) {
@@ -1688,11 +1651,6 @@ List<RegExp> _taskReferencePatterns(String taskId, String taskTitle) {
         caseSensitive: false,
       ),
   ];
-}
-
-bool _allowsBareTaskTitle(String title) {
-  final normalized = title.trim().toLowerCase();
-  return normalized != 'a' && normalized != 'i';
 }
 
 bool _evidenceFallsInsideTaskReference(

--- a/test/features/daily_os_next/eval/framework/eval_constraints_schedule.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_schedule.dart
@@ -113,7 +113,7 @@ EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
   const id = EvalConstraintIds.blockerBeforeBlocked;
   final noPlan = _requirePlan(outcome, id);
   if (noPlan != null) return noPlan;
-  final blocked = <PlannedBlock, EvalCorpusTask>{};
+  final blocked = <(PlannedBlock, EvalCorpusTask)>[];
   for (final block in _scheduled(outcome)) {
     final taskId = block.taskId;
     if (taskId == null) continue;
@@ -124,7 +124,7 @@ EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
     // available, and the prompt says so explicitly. Exempting these would
     // credit exactly the defect the constraint exists to catch — a plan that
     // schedules work the model was told cannot start.
-    if (task != null && task.isBlocked) blocked[block] = task;
+    if (task != null && task.isBlocked) blocked.add((block, task));
   }
   if (blocked.isEmpty) {
     return const EvalConstraintResult.notApplicable(
@@ -134,9 +134,7 @@ EvalConstraintResult scoreBlockerBeforeBlocked(EvalRunOutcome outcome) {
   }
   final violations = <String>[];
   var usedProseBypass = false;
-  for (final entry in blocked.entries) {
-    final block = entry.key;
-    final task = entry.value;
+  for (final (block, task) in blocked) {
     final blockerScheduledEarlier = _scheduled(outcome).any(
       (other) =>
           other.taskId != null &&

--- a/test/features/daily_os_next/eval/framework/eval_constraints_schedule_test.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_schedule_test.dart
@@ -182,6 +182,25 @@ void main() {
         expect(result.detail, isNot(contains('task-stale')));
       },
     );
+
+    test('a dropped decided task does not count as placed', () {
+      final result = scoreDecidedTasksPlaced(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-1',
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+          decidedTaskIds: const ['task-1'],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+    });
   });
 
   group('blockerBeforeBlocked', () {
@@ -385,6 +404,30 @@ void main() {
 
       expect(result.passed, isFalse);
       expect(result.detail, contains('task-blocker'));
+    });
+
+    test('evaluates value-equal blocked blocks independently', () {
+      final duplicate = block(
+        id: 'duplicate',
+        startHour: 9,
+        endHour: 10,
+        taskId: 'task-blocked',
+        reason: 'High priority work for the morning.',
+      );
+
+      final result = scoreBlockerBeforeBlocked(
+        outcome(
+          blocks: [duplicate, duplicate.copyWith()],
+          corpus: const [blocker, blocked],
+        ),
+      );
+
+      expect(result.passed, isFalse);
+      expect(
+        result.detail.split('; '),
+        hasLength(2),
+        reason: 'each scheduled occurrence must be scored independently',
+      );
     });
 
     test('treats a status-only BLOCKED task as blocked', () {
@@ -591,6 +634,25 @@ void main() {
 
     test('is not applicable when nothing is expected to be omitted', () {
       expect(scoreExpectedOmissionsHonoured(outcome()).isApplicable, isFalse);
+    });
+
+    test('dropping work the scenario wanted omitted honours the omission', () {
+      final result = scoreExpectedOmissionsHonoured(
+        outcome(
+          blocks: [
+            block(
+              id: 'a',
+              startHour: 9,
+              endHour: 10,
+              taskId: 'task-stale',
+              state: PlannedBlockState.dropped,
+            ),
+          ],
+          expectedOmissions: const {'task-stale'},
+        ),
+      );
+
+      expect(result.passed, isTrue);
     });
   });
 

--- a/test/features/daily_os_next/eval/framework/eval_constraints_test_helpers.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_test_helpers.dart
@@ -4,6 +4,10 @@ import 'eval_models.dart';
 
 /// Deterministic plan builders shared by the focused constraint suites.
 final planDate = DateTime(2026, 7, 18);
+final _dayId =
+    'dayplan-${planDate.year}-'
+    '${planDate.month.toString().padLeft(2, '0')}-'
+    '${planDate.day.toString().padLeft(2, '0')}';
 
 PlannedBlock block({
   required String id,
@@ -18,8 +22,8 @@ PlannedBlock block({
 }) => PlannedBlock(
   id: id,
   categoryId: 'cat-1',
-  startTime: DateTime(2026, 7, 18, startHour),
-  endTime: DateTime(2026, 7, 18, endHour),
+  startTime: DateTime(planDate.year, planDate.month, planDate.day, startHour),
+  endTime: DateTime(planDate.year, planDate.month, planDate.day, endHour),
   taskId: taskId,
   note: note,
   reason: reason,
@@ -49,7 +53,7 @@ EvalRunOutcome outcome({
   Set<String> createdTaskIds = const {},
 }) => EvalRunOutcome(
   inputs: EvalFixtureInputs(
-    dayId: 'dayplan-2026-07-18',
+    dayId: _dayId,
     planDate: planDate,
     corpus: corpus,
     decidedTaskIds: decidedTaskIds,

--- a/test/features/daily_os_next/eval/framework/eval_constraints_trade.dart
+++ b/test/features/daily_os_next/eval/framework/eval_constraints_trade.dart
@@ -42,8 +42,9 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   // identify at least one piece of work that was actually left out or only
   // partially represented.
   final placed = _placedTaskIds(outcome);
+  final placements = _estimatedTaskPlacements(outcome);
   final shortenedTasks = {
-    for (final entry in _estimatedTaskPlacements(outcome).entries)
+    for (final entry in placements.entries)
       if (entry.value.allocatedMinutes < entry.value.estimateMinutes) entry.key,
   };
   final deferred = [
@@ -58,7 +59,7 @@ EvalConstraintResult scoreSurfacedConflict(EvalRunOutcome outcome) {
   }
   final namedCasualties = [
     for (final taskId in deferred)
-      if (_taskTradeIsNamed(outcome, taskId)) taskId,
+      if (_taskTradeIsNamed(outcome, taskId, placements: placements)) taskId,
   ];
   return EvalConstraintResult(
     id: id,
@@ -77,11 +78,17 @@ typedef _TradeDisclosureEvidence = ({
   bool retractsAll,
 });
 
+final _subjectConjunctPattern = RegExp(
+  r'\s*(?:,\s*(?:and\s+)?|\s+(?:and|&)\s+)',
+  caseSensitive: false,
+);
+
 _TradeDisclosureEvidence _tradeDisclosureEvidence(
   EvalRunOutcome outcome,
   String taskId,
-  String prose,
-) {
+  String prose, {
+  required Map<String, _EstimatedTaskPlacement> placements,
+}) {
   final task = outcome.inputs.taskById(taskId);
   if (task == null) {
     return (
@@ -90,7 +97,7 @@ _TradeDisclosureEvidence _tradeDisclosureEvidence(
       retractsAll: false,
     );
   }
-  final placement = _estimatedTaskPlacements(outcome)[taskId];
+  final placement = placements[taskId];
   final structuralRemainder = placement == null
       ? task.estimateMinutes
       : placement.estimateMinutes - placement.allocatedMinutes;
@@ -442,12 +449,7 @@ bool _subjectIsOnlyCorpusTaskReferences(
   String subject,
   List<EvalCorpusTask> corpus,
 ) {
-  final conjuncts = subject.split(
-    RegExp(
-      r'\s*(?:,\s*(?:and\s+)?|\s+(?:and|&)\s+)',
-      caseSensitive: false,
-    ),
-  );
+  final conjuncts = subject.split(_subjectConjunctPattern);
   if (conjuncts.length < 2) return false;
   return conjuncts.every((conjunct) {
     return corpus.any(
@@ -465,20 +467,13 @@ bool _subjectContainsTaskReference(
   required String taskId,
   required String taskTitle,
 }) {
-  return subject
-      .split(
-        RegExp(
-          r'\s*(?:,\s*(?:and\s+)?|\s+(?:and|&)\s+)',
-          caseSensitive: false,
-        ),
-      )
-      .any((conjunct) {
-        return _subjectMatchesTaskReference(
-          conjunct,
-          taskId: taskId,
-          taskTitle: taskTitle,
-        );
-      });
+  return subject.split(_subjectConjunctPattern).any((conjunct) {
+    return _subjectMatchesTaskReference(
+      conjunct,
+      taskId: taskId,
+      taskTitle: taskTitle,
+    );
+  });
 }
 
 bool _subjectMatchesTaskReference(
@@ -556,8 +551,9 @@ bool _subjectStartsWithTaskReference(
 
 bool _taskTradeIsNamed(
   EvalRunOutcome outcome,
-  String taskId,
-) {
+  String taskId, {
+  required Map<String, _EstimatedTaskPlacement> placements,
+}) {
   final affirmativeNamedDispositions = <String>{};
   final deniedNamedDispositions = <String>{};
   var retractsAllDispositions = false;
@@ -568,7 +564,12 @@ bool _taskTradeIsNamed(
       final namesTask =
           _taskIdNamed(taskId, prose) || _titleNamed(outcome, taskId, prose);
       if (!namesTask) continue;
-      final evidence = _tradeDisclosureEvidence(outcome, taskId, prose);
+      final evidence = _tradeDisclosureEvidence(
+        outcome,
+        taskId,
+        prose,
+        placements: placements,
+      );
       affirmativeNamedDispositions.addAll(evidence.affirmative);
       deniedNamedDispositions.addAll(evidence.denied);
       retractsAllDispositions |= evidence.retractsAll;


### PR DESCRIPTION
## Summary
- follow up on the post-merge review of #3808
- preserve every scheduled blocked-block occurrence instead of collapsing value-equal `PlannedBlock` values in a map
- add a regression that fails on the merged implementation and verifies two equal occurrences are scored independently
- apply the seven valid review cleanups: shared helper ownership, duplicated-loop/regex removal, placement-map reuse, deterministic fixture derivation, and test-suite ownership
- record #3808 as merged and document the per-occurrence blocker-scoring invariant

## Validation
- regression test run before the fix — failed with one violation instead of two
- five focused evaluation executables — 410 cases passed
- `fvm flutter analyze` — no issues
- `fvm dart format .` — 4,107 files, no changes
- `make knowledge_check` — 90 OKF concepts valid, 25 validator tests pass, 464 Mermaid blocks parse
- `git diff --check` — clean

No CI checks, size limits, or guardrails are added.