### PR TITLE
test: reset shared test globals

### DIFF
--- a/docs/implementation_plans/2026-08-05_oversized_test_suite_decomposition.md
+++ b/docs/implementation_plans/2026-08-05_oversized_test_suite_decomposition.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-05
 
-**Status:** In progress
+**Status:** Complete
 
 **Scope:** The seven largest non-exempt test suites found in the August 2026
 engineering due-diligence review
@@ -26,7 +26,7 @@ decomposition itself.
 | 4 | `eval_constraints_test.dart` | 8,228 | split the test-only constraint framework and mirror its focused source files | Merged (#3808) |
 | 5 | `outbox_service_test.dart` | 7,820 | send pipeline, queue/database behavior, retry/maintenance, service shell | Merged (#3811) |
 | 6 | `day_agent_workflow_test.dart` | 7,379 | day wake execution, context/prompt construction, persistence, workflow shell | Merged (#3812) |
-| 7 | `wake_orchestrator_test.dart` | 6,905 | scheduling, drain/claim lifecycle, recovery, orchestrator shell | In progress |
+| 7 | `wake_orchestrator_test.dart` | 6,905 | scheduling, drain/claim lifecycle, recovery, orchestrator shell | Merged (#3813) |
 
 Line counts are the review baseline, not enforced thresholds. They exist so a
 PR cannot present a cosmetic rename as decomposition.

--- a/knowledge/conventions/testing.md
+++ b/knowledge/conventions/testing.md
@@ -11,7 +11,7 @@ sources:
   - id: test-readme
     resource: ../../test/README.md
     title: Test guidelines
-    last_modified: 2026-07-25
+    last_modified: 2026-08-05
   - id: agents-md
     resource: ../../AGENTS.md
     title: Repository guidelines
@@ -44,9 +44,12 @@ Two consequences:
 - **Passing locally proves less than it looks.** A file that passes alone can
   still be the file that breaks CI.
 
-`test/flutter_test_config.dart` registers a global `tearDown(resetMocktailState)`
-for exactly this reason. [`test/README.md`](../../test/README.md) carries the full
-account of the Mocktail case; do not re-derive it here.
+`test/flutter_test_config.dart` registers global teardown for exactly this
+reason. It resets Mocktail's matcher state and restores the process-wide test
+baseline for DevLogger, Google Fonts, Drift warnings, and GetIt's reassignment
+policy after every test. Suite-owned GetIt registrations and resources still
+belong to the suite that created them. [`test/README.md`](../../test/README.md)
+carries the full account of the Mocktail case; do not re-derive it here.
 
 # Fake time is mandatory
 

--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,16 @@
 - **Never pass `--coverage` to an ad-hoc `flutter test <file>` run.** It rewrites the shared `coverage/lcov.info` with only that file's data, clobbering a full-suite report someone else may be relying on. Generate coverage only through the `make` targets (`make test` / `make coverage` / `make coverage_standard`), which manage `coverage/` as a unit.
 - Prefer `tester.pump(duration)` over `tester.pumpAndSettle()` (10s default timeout → hangs if an animation never settles). Never pass `pumpAndSettle` a duration > 1s.
 
+## Shared process state
+
+The optimized CI runner executes many test files in one isolate.
+`test/flutter_test_config.dart` therefore restores the shared baseline after
+every test for Mocktail matchers, DevLogger output and captured logs, Google
+Fonts runtime fetching, Drift's multiple-database warning policy, and GetIt's
+reassignment policy. Tests still own every GetIt registration, stream,
+database, timer, and platform-channel handler they create; clean those up in
+the suite's teardown.
+
 ## Aged-history cost gates
 
 Daily OS cost regressions live under

--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -3,12 +3,23 @@ import 'dart:io';
 
 import 'package:drift/drift.dart' show driftRuntimeOptions;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'test_utils/clipboard_test_context.dart';
 import 'test_utils/native_drag_drop_test_context.dart';
+
+/// Restores process-wide test configuration without disposing suite-owned
+/// registrations or resources.
+void resetSharedTestGlobals({required bool allowFontDownloads}) {
+  GoogleFonts.config.allowRuntimeFetching = allowFontDownloads;
+  driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+  DevLogger.suppressOutput = true;
+  DevLogger.clear();
+  GetIt.I.allowReassignment = false;
+}
 
 /// Runs before every test file. Use this to set global test configuration
 /// that keeps tests fast and deterministic across runners (flutter test,
@@ -48,6 +59,15 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // stubs live on the mock instances, so setUpAll-created stubs keep
   // working.
   tearDown(resetMocktailState);
+
+  // Restore the process-wide configuration that individual tests are allowed
+  // to override. GetIt registrations remain the owning suite's responsibility;
+  // only its reassignment policy is reset here.
+  tearDown(
+    () => resetSharedTestGlobals(
+      allowFontDownloads: allowFontDownloads,
+    ),
+  );
 
   await testMain();
 }

--- a/test/flutter_test_config_test.dart
+++ b/test/flutter_test_config_test.dart
@@ -1,0 +1,30 @@
+import 'package:drift/drift.dart' show driftRuntimeOptions;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lotti/services/dev_logger.dart';
+
+import 'flutter_test_config.dart';
+
+void main() {
+  test('resetSharedTestGlobals restores the shared test baseline', () {
+    final allowFontDownloads = GoogleFonts.config.allowRuntimeFetching;
+
+    DevLogger.log(name: 'SharedStateTest', message: 'captured');
+    GoogleFonts.config.allowRuntimeFetching = !allowFontDownloads;
+    driftRuntimeOptions.dontWarnAboutMultipleDatabases = false;
+    DevLogger.suppressOutput = false;
+    GetIt.I.allowReassignment = true;
+
+    resetSharedTestGlobals(allowFontDownloads: allowFontDownloads);
+
+    expect(
+      GoogleFonts.config.allowRuntimeFetching,
+      allowFontDownloads,
+    );
+    expect(driftRuntimeOptions.dontWarnAboutMultipleDatabases, isTrue);
+    expect(DevLogger.suppressOutput, isTrue);
+    expect(DevLogger.capturedLogs, isEmpty);
+    expect(GetIt.I.allowReassignment, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

- restore process-wide test configuration after every test for DevLogger, Google Fonts, Drift warnings, and GetIt's reassignment policy
- keep suite-owned GetIt registrations and resources under their existing local teardown ownership
- add a focused regression test for the shared baseline and document the optimizer/isolate contract
- mark the seven oversized-suite decompositions complete after #3813 merged

## Why

The optimized test runner executes many test files in one isolate. The shared test configuration initialized these flags once, but individual tests could change them and leave the changed value for later files. In particular, several suites set `DevLogger.suppressOutput` or `GetIt.allowReassignment` without restoring the shared baseline.

This central reset confines those configuration changes to the test that made them without hiding leaked registrations, streams, databases, timers, or platform-channel handlers; those remain the owning suite's responsibility.

This PR adds no CI check, lint, size threshold, or other guardrail.

## Verification

- `fvm flutter test test/flutter_test_config_test.dart`
- regression test rerun with the reset intentionally disabled: failed on the leaked Google Fonts value, then passed after restoration
- `fvm flutter analyze` — no issues
- `fvm dart format .` — 4,126 files, 0 changed
- `make knowledge_check` — 90 concepts valid, 464 Mermaid blocks parsed

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards and exercises the shared-isolate behavior authoritatively.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by resetting shared Google Fonts, Drift, logging, and service configuration after each test.
  * Preserved font-download settings while ensuring shared test state is restored reliably.

* **Documentation**
  * Added guidance on shared process state, CI test isolates, teardown behavior, and cleanup responsibilities.
  * Marked the test-suite decomposition implementation plan as complete.

* **Tests**
  * Added coverage confirming shared test state is properly reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->