### PR TITLE
test: make test time deterministic

### DIFF
--- a/docs/implementation_plans/2026-03-27_test_quality_improvements.md
+++ b/docs/implementation_plans/2026-03-27_test_quality_improvements.md
@@ -79,13 +79,13 @@ across all test files. Work was parallelized across 14 batch agents.
 
 ### Result
 
-- **845 → 41 remaining** (95.1% reduction)
-- The 41 remaining are all intentional keeps:
-  - Production code calling `DateTime.now()` internally (widgets checking `isRecent`,
-    controllers computing "today", countdown timers)
-  - Comments referencing `DateTime.now()` (not actual calls)
-  - Tests verifying production code's real-time behavior (e.g., soft-delete timestamps)
-- Each remaining instance has an `// ignore: avoid_DateTime_now` comment explaining why
+- The March pass reduced 845 direct calls to 41 intentional keeps.
+- The August due-diligence follow-up removed the remaining direct wall-clock
+  reads from every normal unit and integration test. Production owners that
+  calculate "now" expose `clock`-backed behavior or an explicit `now` input,
+  while fixed fixtures cover data-only cases.
+- Direct wall-clock reads remain only in the tagged `tutorial-video` drivers
+  and `eval-live` model runs documented in `test/README.md`.
 
 ### Bonus: Fixed 3 pre-existing broken tests
 
@@ -94,18 +94,19 @@ failing before our changes. Root cause: `fakeAsync` breaks `SharedPreferences.ge
 (platform channel), so the handler's `await isBackfillEnabled()` would hang, preventing
 cooldown/rate-limit logic from executing.
 
-**Fix**: Replaced `fakeAsync` with regular `async` tests using real-time relative timestamps.
-The cooldown and rate-limit checks work correctly with real `DateTime.now()` since the cache
-entries just need correct relative timing.
+**Historical fix**: Replaced `fakeAsync` with regular `async` tests so
+`SharedPreferences` could complete. Those tests have since moved to
+`withClock` and fixed timestamps; no normal test depends on the wall clock.
 
-### Key patterns for intentional DateTime.now() keeps
+### August follow-up patterns
 
-| Pattern | Example | Why it must use real time |
-|---------|---------|-------------------------|
-| Widget `isRecent` check | `duration_widget_test.dart` | Widget calls `DateTime.now()` internally to determine if entry is < 12h old |
-| Controller "today" logic | `habits_controller_test.dart` | Controller maps completions by `DateTime.now().ymd` |
-| Countdown timers | `correction_capture_service_test.dart` | `remainingTime` getter calls `DateTime.now()` |
-| Soft-delete verification | `categories_repository_test.dart` | Asserts `deletedAt` is close to real current time |
+| Pattern | Example | Deterministic seam |
+|---------|---------|--------------------|
+| Widget `isRecent` check | `duration_widget_test.dart` | production reads `clock.now()`; the widget test uses `withClock` |
+| Controller "today" logic | `habits_controller_test.dart` | `habitsNowProvider` supplies one instant for buckets, due/later state, days, and streaks |
+| Soft-delete timestamps | `categories_repository_test.dart` | repository reads `clock.now()` once and the test asserts the exact timestamp |
+| Retention cutoff | `outbox_repository_test.dart` | repository forwards an explicit `now` to the database prune operation |
+| End-to-end UI pacing | `home_integration_test.dart` | bounded widget pumps replace real delays; the fixture label is fixed |
 
 ---
 
@@ -167,7 +168,7 @@ The following were evaluated but deferred due to extensive existing indirect cov
 
 | Metric | Before | After |
 |--------|--------|-------|
-| DateTime.now() in tests | 845 | 41 (intentional) |
+| DateTime.now() in normal tests | 845 | 0 (tagged tutorial/eval exceptions only) |
 | Duplicated mock classes | 8+ inline definitions | 0 (all centralized) |
 | Duplicated FakeController variants | 11 inline definitions | 0 (shared version) |
 | Untested AI repo/interface files | 4 | 0 |

--- a/integration_test/helpers/sync_test_helpers.dart
+++ b/integration_test/helpers/sync_test_helpers.dart
@@ -110,25 +110,24 @@ class TestConfig {
 JournalEntry createTestEntry({
   required String deviceName,
   required int index,
+  required DateTime timestamp,
   String? id,
-  DateTime? timestamp,
   String? text,
 }) {
   final entryId = id ?? uuid.v1();
-  final now = timestamp ?? DateTime.now();
 
   return JournalEntry(
     meta: Metadata(
       id: entryId,
-      createdAt: now,
-      dateFrom: now,
-      dateTo: now,
-      updatedAt: now,
+      createdAt: timestamp,
+      dateFrom: timestamp,
+      dateTo: timestamp,
+      updatedAt: timestamp,
       starred: false,
       vectorClock: VectorClock({deviceName: index}),
     ),
     entryText: EntryText(
-      plainText: text ?? 'Test from $deviceName #$index - $now',
+      plainText: text ?? 'Test from $deviceName #$index - $timestamp',
     ),
   );
 }
@@ -144,6 +143,7 @@ Future<void> sendTestMessage({
   final entry = createTestEntry(
     deviceName: deviceName,
     index: index,
+    timestamp: DateTime.utc(2024, 3, 15).add(Duration(seconds: index)),
     text: text,
   );
 

--- a/integration_test/home_integration_test.dart
+++ b/integration_test/home_integration_test.dart
@@ -56,16 +56,25 @@ void main() {
           expect(find.text('Flags'), findsOneWidget);
           expect(find.text('Maintenance'), findsOneWidget);
 
+          const testTag = 'integration-test-tag';
           await tester.tap(find.byIcon(MdiIcons.tag));
           await tester.pumpAndSettle();
+
+          // Make local retries idempotent if an earlier run stopped before
+          // reaching the cleanup at the end of this test.
+          if (find.text(testTag).evaluate().isNotEmpty) {
+            await tester.tap(find.text(testTag));
+            await tester.pumpAndSettle();
+            await tester.tap(find.byIcon(MdiIcons.trashCanOutline));
+            await tester.pumpAndSettle();
+            expect(find.text(testTag), findsNothing);
+          }
 
           await tester.tap(find.byKey(const Key('add_tag_action')));
           await tester.pumpAndSettle();
 
           await tester.tap(find.byIcon(MdiIcons.tagPlusOutline));
           await tester.pumpAndSettle();
-
-          const testTag = 'integration-test-tag';
 
           await tester.enterText(
             find.byKey(const Key('tag_name_field')),

--- a/integration_test/home_integration_test.dart
+++ b/integration_test/home_integration_test.dart
@@ -5,14 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:lotti/main.dart' as app;
 
-const debug = false;
-
-Future<void> waitSeconds(int s) async {
-  if (debug) {
-    await Future.delayed(Duration(seconds: s), () {});
-  }
-}
-
 void main() {
   app.main();
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -24,8 +16,6 @@ void main() {
         'tap add, create entry',
         (WidgetTester tester) async {
           await tester.pumpAndSettle();
-
-          await waitSeconds(1);
 
           expect(find.text('Search...'), findsWidgets);
 
@@ -46,15 +36,11 @@ void main() {
           // the unit tests for the editor widget itself.
           expect(editor, findsOneWidget);
 
-          await waitSeconds(1);
-
           final saveIcon = find.byIcon(Icons.save);
           await tester.tap(saveIcon);
           await tester.pumpAndSettle();
 
           //expect(find.text(testText), findsOneWidget);
-
-          await waitSeconds(1);
 
           final settings = find.byIcon(Icons.settings_outlined);
           await tester.tap(settings);
@@ -73,31 +59,24 @@ void main() {
           await tester.tap(find.byIcon(MdiIcons.tag));
           await tester.pumpAndSettle();
 
-          await waitSeconds(1);
-
           await tester.tap(find.byKey(const Key('add_tag_action')));
           await tester.pumpAndSettle();
-
-          await waitSeconds(1);
 
           await tester.tap(find.byIcon(MdiIcons.tagPlusOutline));
           await tester.pumpAndSettle();
 
-          await waitSeconds(1);
-
-          final testTag = DateTime.now().toString();
+          const testTag = 'integration-test-tag';
 
           await tester.enterText(
             find.byKey(const Key('tag_name_field')),
             testTag,
           );
-          await Future.delayed(const Duration(seconds: 1), () {});
+          await tester.pump();
 
           await tester.tap(find.byKey(const Key('tag_save')));
           await tester.pumpAndSettle();
 
           expect(find.text(testTag), findsOneWidget);
-          await waitSeconds(1);
 
           await tester.tap(find.text(testTag));
           await tester.pumpAndSettle();
@@ -106,8 +85,6 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(find.text(testTag), findsNothing);
-
-          await waitSeconds(2);
         },
       );
     },

--- a/knowledge/conventions/testing.md
+++ b/knowledge/conventions/testing.md
@@ -67,7 +67,9 @@ outlives its test.
   inside a fake zone will not advance the way it appears to.
 
 **Dates are deterministic.** Never `DateTime.now()` — use a fixed date such as
-`DateTime(2024, 3, 15)`, or inject `clock`.
+`DateTime(2024, 3, 15)`, or inject `clock`. The only wall-clock exceptions are
+the explicitly tagged `tutorial-video` drivers and `eval-live` model runs
+documented in `test/README.md`.
 
 # Shared infrastructure, not per-file improvisation
 

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/habits
     title: Habits feature source
-    last_modified: 2026-08-01
+    last_modified: 2026-08-05
   - id: definitions
     resource: ../../lib/classes/entity_definitions.dart
     title: HabitDefinition

--- a/knowledge/features/journal/overview.md
+++ b/knowledge/features/journal/overview.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../../lib/features/journal
     title: Journal feature source
-    last_modified: 2026-07-26
+    last_modified: 2026-08-05
   - id: repo
     resource: ../../../lib/features/journal/repository/journal_repository.dart
     title: JournalRepository facade

--- a/knowledge/features/onboarding.md
+++ b/knowledge/features/onboarding.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/onboarding
     title: Onboarding feature source
-    last_modified: 2026-07-26
+    last_modified: 2026-08-05
   - id: metrics-db
     resource: ../../lib/database/onboarding_metrics_db.dart
     title: OnboardingMetricsDb

--- a/knowledge/features/speech/overview.md
+++ b/knowledge/features/speech/overview.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../../lib/features/speech
     title: Speech feature source
-    last_modified: 2026-08-01
+    last_modified: 2026-08-05
   - id: vu
     resource: ../../../lib/features/speech/state/vu_meter.dart
     title: VuMeter — sliding-window RMS→VU

--- a/knowledge/features/sync/send-path.md
+++ b/knowledge/features/sync/send-path.md
@@ -11,7 +11,7 @@ sources:
   - id: outbox
     resource: ../../../lib/features/sync/outbox
     title: Outbox service, processor, repository
-    last_modified: 2026-08-01
+    last_modified: 2026-08-05
   - id: payload-sender
     resource: ../../../lib/features/sync/matrix/matrix_payload_sender.dart
     title: MatrixPayloadSender — wire encoding

--- a/lib/features/categories/repository/categories_repository.dart
+++ b/lib/features/categories/repository/categories_repository.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/conversions.dart';
@@ -117,7 +118,7 @@ class CategoryRepository {
     String? defaultTemplateId,
     bool? automaticInferenceEnabled,
   }) async {
-    final now = DateTime.now();
+    final now = clock.now();
 
     final category = CategoryDefinition(
       id: _uuid.v4(),
@@ -146,7 +147,7 @@ class CategoryRepository {
     CategoryDefinition category,
   ) async {
     final updated = category.copyWith(
-      updatedAt: DateTime.now(),
+      updatedAt: clock.now(),
     );
 
     await _persistenceLogic.upsertEntityDefinition(updated);
@@ -166,9 +167,10 @@ class CategoryRepository {
   Future<void> deleteCategory(String id) async {
     final category = await getCategoryById(id);
     if (category != null) {
+      final now = clock.now();
       final deleted = category.copyWith(
-        deletedAt: DateTime.now(),
-        updatedAt: DateTime.now(),
+        deletedAt: now,
+        updatedAt: now,
       );
       await _persistenceLogic.upsertEntityDefinition(deleted);
     }

--- a/lib/features/habits/state/habits_controller.dart
+++ b/lib/features/habits/state/habits_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -32,6 +33,11 @@ final habitsControllerProvider =
       name: 'habitsControllerProvider',
     );
 
+/// Provides the current instant used for habit bucketing and range queries.
+/// Tests override this with a fixed clock so midnight and due-time behavior is
+/// deterministic without sleeping or consulting the process wall clock.
+final habitsNowProvider = Provider<DateTime Function()>((ref) => clock.now);
+
 class HabitsController extends Notifier<HabitsState> {
   StreamSubscription<List<HabitDefinition>>? _definitionsSubscription;
   StreamSubscription<Set<String>>? _updateSubscription;
@@ -43,17 +49,19 @@ class HabitsController extends Notifier<HabitsState> {
 
   /// Tracks whether the habits tab was the active top-level tab on the
   /// previous nav-index emission. Used to detect the off→on edge that
-  /// triggers a recompute — `showHabit()` depends on `DateTime.now()`,
+  /// triggers a recompute — `showHabit()` depends on the current time,
   /// so re-entering the tab is the cue to refresh the due/later split
   /// without keeping a background ticker alive.
   bool _wasHabitsActive = false;
 
   late HabitsRepository _repository;
   late final NavService _navService = getIt<NavService>();
+  late DateTime Function() _now;
 
   @override
   HabitsState build() {
     _repository = ref.read(habitsRepositoryProvider);
+    _now = ref.read(habitsNowProvider);
 
     ref.onDispose(_cleanup);
 
@@ -85,7 +93,7 @@ class HabitsController extends Notifier<HabitsState> {
     // avoids touching disposed state if the provider is torn down
     // before the microtask drains.
     Future.microtask(_startWatching);
-    return HabitsState.initial();
+    return HabitsState.initial(now: _now());
   }
 
   void _cleanup() {
@@ -112,7 +120,7 @@ class HabitsController extends Notifier<HabitsState> {
   }
 
   Future<void> _fetchHabitCompletions() async {
-    final rangeStart = DateTime.now().dayAtMidnight.subtract(
+    final rangeStart = _now().dayAtMidnight.subtract(
       Duration(days: state.timeSpanDays),
     );
     _habitCompletions = await _repository.getHabitCompletionsInRange(
@@ -128,7 +136,8 @@ class HabitsController extends Notifier<HabitsState> {
     final failedByDay = <String, Set<String>>{};
     final allByDay = <String, Set<String>>{};
 
-    final today = DateTime.now().ymd;
+    final now = _now();
+    final today = now.ymd;
 
     void addId(Map<String, Set<String>> byDay, String day, String habitId) {
       byDay.putIfAbsent(day, () => <String>{}).add(habitId);
@@ -183,23 +192,23 @@ class HabitsController extends Notifier<HabitsState> {
         .where((item) => !completedToday.contains(item.id))
         .sorted(habitSorter);
 
-    final openNow = openHabits.where(showHabit).toList();
-    final pendingLater = openHabits.where((item) => !showHabit(item)).toList();
+    final openNow = openHabits.where((item) => showHabit(item, now: now)).toList();
+    final pendingLater = openHabits
+        .where((item) => !showHabit(item, now: now))
+        .toList();
 
     final completed = _habitDefinitions
         .where((item) => completedToday.contains(item.id))
         .sorted(habitSorter);
 
-    final now = DateTime.now();
-
     final shortStreakDays = daysInRange(
       rangeStart: now.subtract(const Duration(days: 3)),
-      rangeEnd: getEndOfToday(),
+      rangeEnd: getEndOfToday(now: now),
     );
 
     final longStreakDays = daysInRange(
       rangeStart: now.subtract(const Duration(days: 7)),
-      rangeEnd: getEndOfToday(),
+      rangeEnd: getEndOfToday(now: now),
     );
 
     final habitSuccessDays = <String, Set<String>>{};
@@ -249,7 +258,7 @@ class HabitsController extends Notifier<HabitsState> {
               )
               .toList();
 
-    final days = getHabitDays(state.timeSpanDays);
+    final days = getHabitDays(state.timeSpanDays, now: now);
 
     // Build intermediate state with all freshly computed fields
     // so habitMinY can use accurate data from totalForDay
@@ -299,7 +308,7 @@ class HabitsController extends Notifier<HabitsState> {
   Future<void> setTimeSpan(int timeSpanDays) async {
     state = state.copyWith(
       timeSpanDays: timeSpanDays,
-      days: getHabitDays(timeSpanDays),
+      days: getHabitDays(timeSpanDays, now: _now()),
     );
     await _fetchHabitCompletions();
     _determineHabitSuccessByDays();

--- a/lib/features/habits/state/habits_state.dart
+++ b/lib/features/habits/state/habits_state.dart
@@ -61,7 +61,7 @@ abstract class HabitsState with _$HabitsState {
   }) = _HabitsState;
 
   /// Creates the initial state with default values.
-  factory HabitsState.initial() => HabitsState(
+  factory HabitsState.initial({DateTime? now}) => HabitsState(
     habitDefinitions: [],
     habitCompletions: [],
     completedToday: <String>{},
@@ -69,7 +69,7 @@ abstract class HabitsState with _$HabitsState {
     openNow: [],
     pendingLater: [],
     completed: [],
-    days: getHabitDays(14),
+    days: getHabitDays(14, now: now),
     successfulToday: <String>{},
     successfulByDay: <String, Set<String>>{},
     skippedByDay: <String, Set<String>>{},
@@ -210,11 +210,13 @@ double habitMinY({
 ///
 /// Reads the current instant via [clock] (defaults to the wall clock) so
 /// callers can pin "today" deterministically in tests with `withClock`.
-List<String> getHabitDays(int timeSpanDays) {
-  final now = clock.now();
+List<String> getHabitDays(int timeSpanDays, {DateTime? now}) {
+  final currentTime = now ?? clock.now();
   final days = daysInRange(
-    rangeStart: now.dayAtMidnight.subtract(Duration(days: timeSpanDays)),
-    rangeEnd: now,
+    rangeStart: currentTime.dayAtMidnight.subtract(
+      Duration(days: timeSpanDays),
+    ),
+    rangeEnd: currentTime,
   )..sort();
   return days;
 }

--- a/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -65,7 +66,7 @@ class _DurationWidgetState extends ConsumerState<DurationWidget> {
     // widget is unmounted before the post-frame callback runs (the controller
     // is keepAlive and outlives the widget).
     if (_wasRecording && !isRecording) {
-      final duration = DateTime.now().difference(widget.item.meta.dateFrom);
+      final duration = clock.now().difference(widget.item.meta.dateFrom);
       if (duration >= const Duration(minutes: 1)) {
         final notifier = ref.read(sessionEndedControllerProvider.notifier);
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -116,7 +117,7 @@ class _DurationWidgetState extends ConsumerState<DurationWidget> {
       ),
     );
 
-    final isRecent = DateTime.now().difference(item.meta.dateFrom).inHours < 12;
+    final isRecent = clock.now().difference(item.meta.dateFrom).inHours < 12;
 
     final recording = _currentRecording;
 

--- a/lib/features/onboarding/state/onboarding_trigger_service.dart
+++ b/lib/features/onboarding/state/onboarding_trigger_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_planner_readiness.dart';
@@ -160,7 +161,7 @@ Future<bool> shouldAutoShowOnboarding(Ref ref) async {
     firstShownAt: firstShownAtRaw == null
         ? null
         : DateTime.tryParse(firstShownAtRaw),
-    now: DateTime.now(),
+    now: clock.now(),
   );
 }
 
@@ -223,7 +224,7 @@ class OnboardingWelcomeCadence extends AsyncNotifier<void> {
       if (stored[onboardingWelcomeFirstShownAtKey] == null) {
         await settingsDb.saveSettingsItem(
           onboardingWelcomeFirstShownAtKey,
-          DateTime.now().toUtc().toIso8601String(),
+          clock.now().toUtc().toIso8601String(),
         );
       }
     } catch (error, stackTrace) {

--- a/lib/features/speech/repository/audio_recorder_repository.dart
+++ b/lib/features/speech/repository/audio_recorder_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/audio_note.dart';
@@ -147,7 +148,7 @@ class AudioRecorderRepository {
   /// `null` and logs if starting fails (e.g. missing permission).
   Future<AudioNote?> startRecording() async {
     try {
-      final created = DateTime.now();
+      final created = clock.now();
       final fileName =
           '${DateFormat('yyyy-MM-dd_HH-mm-ss-S').format(created)}.m4a';
       final day = DateFormat('yyyy-MM-dd').format(created);

--- a/lib/features/sync/outbox/outbox_repository.dart
+++ b/lib/features/sync/outbox/outbox_repository.dart
@@ -77,9 +77,13 @@ abstract class OutboxRepository {
   /// Delete rows with `status = sent` older than [retention]. Never
   /// touches `pending`, `sending`, or `error` — error rows are kept
   /// forever so persistent failures remain inspectable.
+  ///
+  /// [now] pins the retention cutoff for deterministic callers; the database
+  /// wall clock remains the default when omitted.
   /// Returns the number of rows deleted.
   Future<int> pruneSentOutboxItems({
     required Duration retention,
+    DateTime? now,
   });
 
   /// Same retention semantics as [pruneSentOutboxItems], but the DELETE
@@ -228,8 +232,9 @@ class DatabaseOutboxRepository implements OutboxRepository {
   @override
   Future<int> pruneSentOutboxItems({
     required Duration retention,
+    DateTime? now,
   }) {
-    return _database.pruneSentOutboxItems(retention: retention);
+    return _database.pruneSentOutboxItems(retention: retention, now: now);
   }
 
   @override

--- a/lib/widgets/charts/utils.dart
+++ b/lib/widgets/charts/utils.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:core';
 import 'dart:math';
 
+import 'package:clock/clock.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -264,9 +265,16 @@ DateTime getRangeEnd({int shiftDays = 0}) {
   ).subtract(Duration(days: shiftDays));
 }
 
-DateTime getEndOfToday() {
-  final now = DateTime.now();
-  return DateTime(now.year, now.month, now.day, 23, 59, 59);
+DateTime getEndOfToday({DateTime? now}) {
+  final currentTime = now ?? clock.now();
+  return DateTime(
+    currentTime.year,
+    currentTime.month,
+    currentTime.day,
+    23,
+    59,
+    59,
+  );
 }
 
 String padLeft(num value) {
@@ -278,10 +286,10 @@ int minutesSinceMidnight(DateTime? dt) {
   return hoursPastMidnight * 60 + (dt?.minute ?? 0);
 }
 
-bool showHabit(HabitDefinition item) {
+bool showHabit(HabitDefinition item, {DateTime? now}) {
   final showFrom = item.habitSchedule.mapOrNull(daily: (d) => d.showFrom);
   final showFromMinuteOfDay = minutesSinceMidnight(showFrom);
-  final actualMinuteOfDay = minutesSinceMidnight(DateTime.now());
+  final actualMinuteOfDay = minutesSinceMidnight(now ?? clock.now());
   return actualMinuteOfDay >= showFromMinuteOfDay;
 }
 

--- a/lib/widgets/date_time/datetime_field.dart
+++ b/lib/widgets/date_time/datetime_field.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
@@ -77,7 +78,7 @@ Future<void> showDateTimePickerModal(
   required void Function(DateTime) setDateTime,
   CupertinoDatePickerMode mode = CupertinoDatePickerMode.dateAndTime,
 }) async {
-  var selectedDateTime = dateTime ?? DateTime.now();
+  var selectedDateTime = dateTime ?? clock.now();
 
   await ModalUtils.showSinglePageModal<void>(
     context: context,
@@ -96,7 +97,7 @@ Future<void> showDateTimePickerModal(
     stickyActionBar: DateTimeStickyActionBar(
       onCancel: () => Navigator.of(context).pop(),
       onNow: () {
-        setDateTime(DateTime.now());
+        setDateTime(clock.now());
         Navigator.of(context).pop();
       },
       onDone: () {

--- a/test/features/categories/repository/categories_repository_test.dart
+++ b/test/features/categories/repository/categories_repository_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -515,7 +516,11 @@ void main() {
             () => mockPersistenceLogic.upsertEntityDefinition(any()),
           ).thenAnswer((_) async => 1);
 
-          await repository.deleteCategory(categoryId);
+          final fixedNow = DateTime(2024, 3, 15, 10, 30);
+          await withClock(
+            Clock.fixed(fixedNow),
+            () => repository.deleteCategory(categoryId),
+          );
 
           // Verify upsertEntityDefinition was called with the deleted category
           final captured =
@@ -529,16 +534,8 @@ void main() {
           // Verify the category has deletedAt set
           expect(captured.id, equals(categoryId));
           expect(captured.name, equals('Category to Delete'));
-          expect(captured.deletedAt, isNotNull);
-          expect(
-            captured.deletedAt?.difference(DateTime.now()).inSeconds.abs(),
-            lessThan(5),
-          ); // Within 5 seconds
-          expect(captured.updatedAt, isNotNull);
-          expect(
-            captured.updatedAt.difference(DateTime.now()).inSeconds.abs(),
-            lessThan(5),
-          ); // Within 5 seconds
+          expect(captured.deletedAt, fixedNow);
+          expect(captured.updatedAt, fixedNow);
         },
       );
 

--- a/test/features/habits/state/habits_controller_filtering_test.dart
+++ b/test/features/habits/state/habits_controller_filtering_test.dart
@@ -29,6 +29,7 @@ void main() {
 
   const habitsTabIndex = 3;
   const otherTabIndex = 0;
+  final controllerNow = DateTime(2025, 12, 30, 10);
 
   // Use fixed dates for deterministic tests
   final lastWeek = DateTime(2025, 12, 23);
@@ -141,6 +142,7 @@ void main() {
     container = ProviderContainer(
       overrides: [
         habitsRepositoryProvider.overrideWithValue(mockRepository),
+        habitsNowProvider.overrideWithValue(() => controllerNow),
       ],
     );
   });
@@ -254,13 +256,7 @@ void main() {
   });
 
   group('Category filtering', () {
-    // The controller uses DateTime.now() internally to determine "today",
-    // so completion dates must match the real wall-clock date.
-    late DateTime controllerToday;
-
-    setUp(() {
-      controllerToday = DateTime.now(); // ignore: avoid_DateTime_now
-    });
+    final controllerToday = controllerNow;
 
     test('filters openNow by selected category', () async {
       when(

--- a/test/features/habits/state/habits_controller_test.dart
+++ b/test/features/habits/state/habits_controller_test.dart
@@ -30,6 +30,7 @@ void main() {
   late ProviderContainer container;
 
   const habitsTabIndex = 3;
+  final controllerNow = DateTime(2025, 12, 30, 10);
 
   // Use fixed dates for deterministic tests
   final lastWeek = DateTime(2025, 12, 23);
@@ -124,6 +125,7 @@ void main() {
     container = ProviderContainer(
       overrides: [
         habitsRepositoryProvider.overrideWithValue(mockRepository),
+        habitsNowProvider.overrideWithValue(() => controllerNow),
       ],
     );
   });
@@ -243,16 +245,8 @@ void main() {
   });
 
   group('_determineHabitSuccessByDays', () {
-    // The controller internally uses DateTime.now() to determine "today",
-    // so completion dates must match the real wall-clock date. We compute
-    // it once here to keep individual tests free of DateTime.now() calls.
-    late DateTime controllerToday;
-    late String controllerTodayYmd;
-
-    setUp(() {
-      controllerToday = DateTime.now(); // ignore: avoid_DateTime_now
-      controllerTodayYmd = controllerToday.ymd;
-    });
+    final controllerToday = controllerNow;
+    final controllerTodayYmd = controllerNow.ymd;
 
     test('processes completions and updates state fields', () async {
       // Setup completions

--- a/test/features/journal/ui/widgets/entry_details/duration_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/duration_widget_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -58,9 +59,8 @@ class _PreloadedSessionEndedController extends SessionEndedController {
 void main() {
   late _FakeTimeService fakeTimeService;
 
-  // A recent entry — dateFrom must be close to "now" so isRecent is true.
-  // We use a fixed date but the widget checks DateTime.now() internally,
-  // so we make the entry very recent relative to test execution.
+  // Shared deterministic fixture; clock-sensitive tests below pin their own
+  // current instant with withClock.
   final entryDateFrom = DateTime(2024, 3, 15, 10);
   const entryId = 'test-entry-1';
   final testEntry = JournalEntity.journalEntry(
@@ -159,54 +159,57 @@ void main() {
     testWidgets(
       'does not mark session ended for short sessions (< 1 minute)',
       (tester) async {
-        // Entry with dateFrom < 1 minute ago so the duration check fails.
-        // Must be relative to real DateTime.now() because the widget checks
-        // DateTime.now().difference(dateFrom).inHours < 12 internally.
-        final recentDate = DateTime.now().subtract(const Duration(seconds: 30));
-        const shortEntryId = 'short-entry';
-        final shortEntry = JournalEntity.journalEntry(
-          meta: Metadata(
-            id: shortEntryId,
-            createdAt: recentDate,
-            updatedAt: recentDate,
-            dateFrom: recentDate,
-            dateTo: recentDate,
-          ),
-        );
-
-        final container = buildSubjectWithContainer(
-          tester,
-          item: shortEntry,
-        );
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: makeTestableWidgetWithScaffold(
-              DurationWidget(item: shortEntry, linkedFrom: null),
+        final fixedNow = DateTime(2024, 3, 15, 10, 30);
+        await withClock(Clock.fixed(fixedNow), () async {
+          // Entry with dateFrom < 1 minute ago so the duration check fails.
+          final recentDate = fixedNow.subtract(const Duration(seconds: 30));
+          const shortEntryId = 'short-entry';
+          final shortEntry = JournalEntity.journalEntry(
+            meta: Metadata(
+              id: shortEntryId,
+              createdAt: recentDate,
+              updatedAt: recentDate,
+              dateFrom: recentDate,
+              dateTo: recentDate,
             ),
-          ),
-        );
-        await tester.pump();
+          );
 
-        // Simulate recording then stop
-        fakeTimeService.emit(
-          shortEntry.copyWith(
-            meta: shortEntry.meta.copyWith(
-              dateTo: recentDate.add(const Duration(seconds: 30)),
+          final container = buildSubjectWithContainer(
+            tester,
+            item: shortEntry,
+          );
+          await tester.pumpWidget(
+            UncontrolledProviderScope(
+              container: container,
+              child: makeTestableWidgetWithScaffold(
+                DurationWidget(item: shortEntry, linkedFrom: null),
+              ),
             ),
-          ),
-        );
-        await tester.pump();
+          );
+          await tester.pump();
 
-        fakeTimeService.emit(null);
-        await tester.pump();
-        await tester.pump();
+          // Simulate recording then stop
+          fakeTimeService.emit(
+            shortEntry.copyWith(
+              meta: shortEntry.meta.copyWith(
+                dateTo: recentDate.add(const Duration(seconds: 30)),
+              ),
+            ),
+          );
+          await tester.pump();
 
-        // Assert session was NOT marked ended for short session
-        expect(
-          container.read(sessionEndedControllerProvider).contains(shortEntryId),
-          isFalse,
-        );
+          fakeTimeService.emit(null);
+          await tester.pump();
+          await tester.pump();
+
+          // Assert session was NOT marked ended for short session
+          expect(
+            container
+                .read(sessionEndedControllerProvider)
+                .contains(shortEntryId),
+            isFalse,
+          );
+        });
       },
     );
 
@@ -263,48 +266,49 @@ void main() {
     testWidgets(
       'record button clears session state and starts recording',
       (tester) async {
-        // Use a recent entry so the record button is visible (isRecent check).
-        // Must be relative to real DateTime.now() because the widget checks
-        // DateTime.now().difference(dateFrom).inHours < 12 internally.
-        final recentDate = DateTime.now().subtract(const Duration(hours: 1));
-        final recentEntry = JournalEntity.journalEntry(
-          meta: Metadata(
-            id: entryId,
-            createdAt: recentDate,
-            updatedAt: recentDate,
-            dateFrom: recentDate,
-            dateTo: recentDate.add(const Duration(hours: 1)),
-          ),
-        );
-
-        await tester.pumpWidget(
-          makeTestableWidgetWithScaffold(
-            DurationWidget(
-              item: recentEntry,
-              linkedFrom: null,
+        final fixedNow = DateTime(2024, 3, 15, 10, 30);
+        await withClock(Clock.fixed(fixedNow), () async {
+          // Use a recent entry so the record button is visible.
+          final recentDate = fixedNow.subtract(const Duration(hours: 1));
+          final recentEntry = JournalEntity.journalEntry(
+            meta: Metadata(
+              id: entryId,
+              createdAt: recentDate,
+              updatedAt: recentDate,
+              dateFrom: recentDate,
+              dateTo: recentDate.add(const Duration(hours: 1)),
             ),
-            overrides: [
-              createEntryControllerOverride(recentEntry),
-              newestLinkedIdControllerProvider(null).overrideWith(
-                () => _StubNewestLinkedIdController(recentEntry.meta.id),
+          );
+
+          await tester.pumpWidget(
+            makeTestableWidgetWithScaffold(
+              DurationWidget(
+                item: recentEntry,
+                linkedFrom: null,
               ),
-              sessionEndedControllerProvider.overrideWith(
-                () => _PreloadedSessionEndedController({entryId}),
-              ),
-            ],
-          ),
-        );
-        await tester.pump();
+              overrides: [
+                createEntryControllerOverride(recentEntry),
+                newestLinkedIdControllerProvider(null).overrideWith(
+                  () => _StubNewestLinkedIdController(recentEntry.meta.id),
+                ),
+                sessionEndedControllerProvider.overrideWith(
+                  () => _PreloadedSessionEndedController({entryId}),
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
 
-        // The record button should be visible
-        final recordButton = find.byIcon(Icons.fiber_manual_record_sharp);
-        expect(recordButton, findsOneWidget);
+          // The record button should be visible
+          final recordButton = find.byIcon(Icons.fiber_manual_record_sharp);
+          expect(recordButton, findsOneWidget);
 
-        await tester.tap(recordButton);
-        await tester.pump();
+          await tester.tap(recordButton);
+          await tester.pump();
 
-        // Verify start was called on the time service
-        expect(fakeTimeService.startCalled, isTrue);
+          // Verify start was called on the time service
+          expect(fakeTimeService.startCalled, isTrue);
+        });
       },
     );
 

--- a/test/features/journal/ui/widgets/entry_details/entry_detail_footer_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_detail_footer_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -160,51 +161,52 @@ void main() {
     });
 
     testWidgets('time record button is tappable', (WidgetTester tester) async {
-      when(
-        mockTimeService.getStream,
-      ).thenAnswer((_) => Stream<JournalEntity>.fromIterable([]));
+      final fixedNow = DateTime(2024, 3, 15, 10, 30);
+      await withClock(Clock.fixed(fixedNow), () async {
+        when(
+          mockTimeService.getStream,
+        ).thenAnswer((_) => Stream<JournalEntity>.fromIterable([]));
 
-      // Must be relative to real time — the widget checks isRecent via
-      // DateTime.now().difference(dateFrom).inHours < 12 internally.
-      final recentDate = DateTime.now(); // ignore: avoid_DateTime_now
+        final recentDate = fixedNow;
 
-      final testEntry = testTextEntry.copyWith(
-        meta: testTextEntry.meta.copyWith(
-          dateFrom: recentDate,
-          dateTo: recentDate,
-        ),
-      );
-
-      when(
-        () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
-      ).thenAnswer((_) async => testEntry);
-
-      Future<void> mockStartTimer() => mockTimeService.start(testEntry, null);
-      when(mockStartTimer).thenAnswer((_) async {});
-
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          EntryDetailFooter(
-            entryId: testTextEntry.meta.id,
-            linkedFrom: null,
+        final testEntry = testTextEntry.copyWith(
+          meta: testTextEntry.meta.copyWith(
+            dateFrom: recentDate,
+            dateTo: recentDate,
           ),
-        ),
-      );
-      await tester.pumpAndSettle();
+        );
 
-      final recordIconFinder = find.byIcon(Icons.fiber_manual_record_sharp);
-      final stopIconFinder = find.byIcon(Icons.stop);
-      expect(recordIconFinder, findsOneWidget);
-      expect(stopIconFinder, findsNothing);
+        when(
+          () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+        ).thenAnswer((_) async => testEntry);
 
-      // At rest the duration renders humanized: "Duration: 0m".
-      final durationZeroFinder = find.textContaining('0m');
-      expect(durationZeroFinder, findsOneWidget);
+        Future<void> mockStartTimer() => mockTimeService.start(testEntry, null);
+        when(mockStartTimer).thenAnswer((_) async {});
 
-      await tester.tap(recordIconFinder);
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            EntryDetailFooter(
+              entryId: testTextEntry.meta.id,
+              linkedFrom: null,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      verify(mockStartTimer).called(1);
+        final recordIconFinder = find.byIcon(Icons.fiber_manual_record_sharp);
+        final stopIconFinder = find.byIcon(Icons.stop);
+        expect(recordIconFinder, findsOneWidget);
+        expect(stopIconFinder, findsNothing);
+
+        // At rest the duration renders humanized: "Duration: 0m".
+        final durationZeroFinder = find.textContaining('0m');
+        expect(durationZeroFinder, findsOneWidget);
+
+        await tester.tap(recordIconFinder);
+        await tester.pumpAndSettle();
+
+        verify(mockStartTimer).called(1);
+      });
     });
 
     testWidgets('time record stop button is tappable', (

--- a/test/features/journal/ui/widgets/list_cards/card_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/list_cards/card_image_widget_test.dart
@@ -171,7 +171,7 @@ void main() {
       File(filePath1).createSync();
 
       // Create second image data
-      final now = DateTime.now();
+      final now = DateTime(2024, 3, 15, 10, 30);
       final testImage2 = JournalImage(
         meta: Metadata(
           id: 'test-image-id-2',

--- a/test/features/onboarding/state/onboarding_trigger_service_test.dart
+++ b/test/features/onboarding/state/onboarding_trigger_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/settings_db.dart';
@@ -328,18 +329,20 @@ void main() {
       'returns true when the persisted shown count is under the max and '
       'the first-shown timestamp is recent',
       () async {
+        final fixedNow = DateTime.utc(2024, 3, 15, 10, 30);
         await settingsDb.saveSettingsItem(
           onboardingWelcomeShownCountKey,
           '${onboardingWelcomeMaxShows - 1}',
         );
         await settingsDb.saveSettingsItem(
           onboardingWelcomeFirstShownAtKey,
-          DateTime.now().toUtc().toIso8601String(),
+          fixedNow.toIso8601String(),
         );
         final container = createContainer();
 
-        final result = await container.read(
-          shouldAutoShowOnboardingProvider.future,
+        final result = await withClock(
+          Clock.fixed(fixedNow),
+          () => container.read(shouldAutoShowOnboardingProvider.future),
         );
 
         expect(result, isTrue);
@@ -473,10 +476,13 @@ void main() {
       'the very first call',
       () async {
         final container = createContainer();
+        final fixedNow = DateTime.utc(2024, 3, 15, 10, 30);
 
-        await container
-            .read(onboardingWelcomeCadenceProvider.notifier)
-            .recordShown();
+        await withClock(Clock.fixed(fixedNow), () {
+          return container
+              .read(onboardingWelcomeCadenceProvider.notifier)
+              .recordShown();
+        });
 
         expect(
           await settingsDb.itemByKey(onboardingWelcomeShownCountKey),
@@ -484,7 +490,7 @@ void main() {
         );
         expect(
           await settingsDb.itemByKey(onboardingWelcomeFirstShownAtKey),
-          isNotNull,
+          fixedNow.toIso8601String(),
         );
       },
     );

--- a/test/features/projects/state/project_detail_record_provider_test.dart
+++ b/test/features/projects/state/project_detail_record_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
@@ -1092,19 +1093,17 @@ void main() {
   });
 
   group('projectDetailNowProvider', () {
-    test('returns a wall-clock function (bounded by the test run)', () {
+    test('returns the clock-backed current instant', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
+      final fixedNow = DateTime(2024, 3, 15, 10, 30);
 
-      final nowFn = container.read(projectDetailNowProvider);
-      final before = DateTime.now();
-      final result = nowFn();
-      final after = DateTime.now();
+      final result = withClock(Clock.fixed(fixedNow), () {
+        final nowFn = container.read(projectDetailNowProvider);
+        return nowFn();
+      });
 
-      // The default wiring is DateTime.now — the result must fall inside
-      // the sampling window, not just be any DateTime.
-      expect(result.isBefore(before), isFalse);
-      expect(result.isAfter(after), isFalse);
+      expect(result, fixedNow);
     });
   });
 }

--- a/test/features/speech/repository/audio_recorder_repository_test.dart
+++ b/test/features/speech/repository/audio_recorder_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -462,18 +463,17 @@ void main() {
           ),
         ).thenAnswer((_) async {});
 
-        final result = await repository.startRecording();
+        final fixedNow = DateTime(2024, 3, 15, 10, 30);
+        final result = await withClock(
+          Clock.fixed(fixedNow),
+          repository.startRecording,
+        );
 
         expect(result, isNotNull);
         expect(result!.audioFile, endsWith('.m4a'));
         expect(result.audioDirectory, startsWith('/audio/'));
         expect(result.duration, Duration.zero);
-        expect(
-          result.createdAt.isBefore(
-            DateTime.now().add(const Duration(seconds: 1)),
-          ),
-          isTrue,
-        );
+        expect(result.createdAt, fixedNow);
         verify(
           () => mockAudioRecorder.start(
             any<RecordConfig>(),

--- a/test/features/sync/outbox/outbox_repository_test.dart
+++ b/test/features/sync/outbox/outbox_repository_test.dart
@@ -522,7 +522,7 @@ void main() {
         'pruneSentOutboxItems (non-chunked) deletes only sent rows older '
         'than the retention window',
         () async {
-          final now = DateTime.now();
+          final now = DateTime.utc(2024, 3, 15, 10, 30);
           // Old sent row → pruned.
           final oldSent = await insertRow(
             status: OutboxStatus.sent,
@@ -539,9 +539,10 @@ void main() {
             createdAt: now.subtract(const Duration(days: 30)),
           );
 
-          final deleted = await realRepo.pruneSentOutboxItems(
-            retention: const Duration(days: 7),
-          );
+        final deleted = await realRepo.pruneSentOutboxItems(
+          retention: const Duration(days: 7),
+          now: now,
+        );
 
           expect(deleted, 1);
           expect(await realDb.getOutboxItemById(oldSent), isNull);
@@ -788,20 +789,24 @@ void main() {
         'reads the count only for logging cardinality, so it has to be '
         'the same value the DB reported',
         () async {
+          final now = DateTime.utc(2024, 3, 15, 10, 30);
           when(
             () => database.pruneSentOutboxItems(
               retention: any(named: 'retention'),
+              now: any(named: 'now'),
             ),
           ).thenAnswer((_) async => 42);
 
           final deleted = await repository.pruneSentOutboxItems(
             retention: const Duration(days: 7),
+            now: now,
           );
 
           expect(deleted, 42);
           verify(
             () => database.pruneSentOutboxItems(
               retention: const Duration(days: 7),
+              now: now,
             ),
           ).called(1);
         },

--- a/test/features/user_activity/state/user_activity_service_test.dart
+++ b/test/features/user_activity/state/user_activity_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 
@@ -18,19 +19,14 @@ void main() {
       final sub = service.activityStream.listen(emitted.add);
       addTearDown(sub.cancel);
 
-      final before = DateTime.now();
-      service.updateActivity();
-      final after = DateTime.now();
+      final fixedNow = DateTime(2024, 3, 15, 10, 30);
+      await withClock(Clock.fixed(fixedNow), () async {
+        service.updateActivity();
+        expect(service.lastActivity, fixedNow);
 
-      expect(
-        service.lastActivity.isBefore(before) ||
-            service.lastActivity.isAfter(after),
-        isFalse,
-        reason: 'lastActivity must land between the surrounding now() reads',
-      );
-
-      await pumpEventQueue();
-      expect(emitted, [service.lastActivity]);
+        await pumpEventQueue();
+        expect(emitted, [fixedNow]);
+      });
     });
 
     test('activityStream broadcasts to multiple subscribers', () async {
@@ -54,13 +50,14 @@ void main() {
     test('updateActivity after dispose is silently ignored', () async {
       final service = UserActivityService();
       await service.dispose();
+      final fixedNow = DateTime(2024, 3, 15, 10, 30);
 
-      expect(service.updateActivity, returnsNormally);
-      // The timestamp still advances even though nothing is emitted.
       expect(
-        service.lastActivity,
-        isNot(DateTime.fromMillisecondsSinceEpoch(0)),
+        () => withClock(Clock.fixed(fixedNow), service.updateActivity),
+        returnsNormally,
       );
+      // The timestamp still advances even though nothing is emitted.
+      expect(service.lastActivity, fixedNow);
     });
   });
 }

--- a/test/widgets/date_time/datetime_field_test.dart
+++ b/test/widgets/date_time/datetime_field_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -303,34 +304,24 @@ void main() {
     testWidgets('complete flow: open modal, tap now button', (
       WidgetTester tester,
     ) async {
-      final setDates = <DateTime>[];
+      final fixedNow = DateTime(2024, 3, 15, 10, 30);
+      await withClock(Clock.fixed(fixedNow), () async {
+        final setDates = <DateTime>[];
 
-      await _pumpField(tester, dateTime: null, setDateTime: setDates.add);
+        await _pumpField(tester, dateTime: null, setDateTime: setDates.add);
 
-      // Tap field to open modal
-      await tester.tap(find.byType(TextField));
-      await tester.pumpAndSettle();
+        // Tap field to open modal
+        await tester.tap(find.byType(TextField));
+        await tester.pumpAndSettle();
 
-      // Tap Now button, bracketing the tap with wall-clock readings so the
-      // captured value can be pinned to the live-clock window.
-      final before = DateTime.now();
-      await tester.tap(find.text('Now'));
-      await tester.pumpAndSettle();
-      final after = DateTime.now();
+        await tester.tap(find.text('Now'));
+        await tester.pumpAndSettle();
 
-      // Verify callback was called exactly once with the current time
-      expect(setDates, hasLength(1));
-      final captured = setDates.single;
-      expect(
-        !captured.isBefore(before) && !captured.isAfter(after),
-        isTrue,
-        reason:
-            'onNow must pass the wall-clock time of the tap, '
-            'got $captured outside [$before, $after]',
-      );
+        expect(setDates, [fixedNow]);
 
-      // Verify modal is closed
-      expect(find.byType(DateTimeBottomSheet), findsNothing);
+        // Verify modal is closed
+        expect(find.byType(DateTimeBottomSheet), findsNothing);
+      });
     });
 
     testWidgets('complete flow: open modal, tap cancel', (


### PR DESCRIPTION
## Summary
- replace normal-test wall-clock coupling with fixed clocks, explicit now inputs, and deterministic fixtures
- make habit bucketing use one injected instant and forward an explicit outbox prune cutoff
- remove no-op real delays and generated labels from the home integration flow
- document that wall-clock reads remain only in tagged tutorial-video and eval-live runs

This PR adds no CI check, lint, size threshold, or guardrail.

## Verification
- targeted Flutter tests for all 12 touched test files: passed
- fvm flutter analyze: no issues
- make knowledge_check: 91 concepts and 465 Mermaid blocks passed
- negative regression check: the category timestamp assertion failed with the clock fix disabled, then passed after restoration

The full suite remains delegated to the existing ten-way sharded CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of timestamps across categories, habits, onboarding, journal recordings, speech recordings, and synchronization.
  * Preserved synchronized deletion and update times for categories.
  * Improved reliability of date- and time-sensitive behavior.

* **Documentation**
  * Updated testing guidance to clarify deterministic timing practices and supported exceptions.
  * Refreshed feature documentation metadata.

* **Tests**
  * Updated automated coverage to use fixed timestamps, reducing timing-related flakiness and improving assertion accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->