### PR TITLE
test: isolate shared test state

### DIFF
--- a/test/features/agents/sync/fork_healer_test.dart
+++ b/test/features/agents/sync/fork_healer_test.dart
@@ -20,15 +20,22 @@ import 'in_memory_agent_repository.dart';
 const _agentId = 'agent-1';
 
 void main() {
-  setUpAll(registerAllFallbackValues);
+  setUpAll(() {
+    registerAllFallbackValues();
+    getIt
+      ..pushNewScope()
+      ..registerSingleton<DomainLogger>(MockDomainLogger());
+  });
+
+  tearDownAll(() async {
+    await getIt.resetScope();
+    await getIt.popScope();
+  });
 
   late InMemoryAgentRepository repo;
   late ForkHealer healer;
 
   setUp(() {
-    if (!getIt.isRegistered<DomainLogger>()) {
-      getIt.registerSingleton<DomainLogger>(MockDomainLogger());
-    }
     final bench = makeForkBench();
     repo = bench.repo;
     healer = bench.healer;

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -24,9 +24,6 @@ import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
 
 // We need to register fallback values for complex types that will be used with 'any()' matcher
-class FakeCreateChatCompletionRequest extends Fake
-    implements CreateChatCompletionRequest {}
-
 class FakeGeminiThinkingConfig extends Fake implements GeminiThinkingConfig {}
 
 /// Shared scaffolding for CloudInferenceRepository tests: a container with

--- a/test/features/journal/state/image_paste_controller_test.dart
+++ b/test/features/journal/state/image_paste_controller_test.dart
@@ -36,8 +36,6 @@ class MockClipboardDataReader extends Mock implements ClipboardDataReader {}
 
 class MockDataReaderFile extends Mock implements DataReaderFile {}
 
-class FakeJournalImage extends Fake implements JournalImage {}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/test/features/journal/state/linked_from_entries_controller_test.dart
+++ b/test/features/journal/state/linked_from_entries_controller_test.dart
@@ -11,17 +11,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockLinkedFromEntriesController extends LinkedFromEntriesController {
-  MockLinkedFromEntriesController(this._entities);
-
-  final List<JournalEntity> _entities;
-
-  @override
-  Future<List<JournalEntity>> build() async {
-    return _entities;
-  }
-}
-
 void main() {
   late MockJournalRepository mockJournalRepository;
   late MockUpdateNotifications mockUpdateNotifications;

--- a/test/features/sync/matrix/matrix_service_pipeline_test.dart
+++ b/test/features/sync/matrix/matrix_service_pipeline_test.dart
@@ -8,14 +8,10 @@ import 'package:lotti/features/sync/matrix/pipeline/sync_metrics.dart';
 import 'package:lotti/features/sync/matrix/sent_event_registry.dart';
 import 'package:lotti/features/sync/matrix/sync_event_processor.dart';
 import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
-import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockQueuePipelineCoordinator extends Mock
-    implements QueuePipelineCoordinator {}
 
 class _MockInboundQueue extends Mock implements InboundQueue {}
 

--- a/test/features/sync/ui/sync_modal_test.dart
+++ b/test/features/sync/ui/sync_modal_test.dart
@@ -19,9 +19,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
-class MockSyncMaintenanceRepository extends Mock
-    implements SyncMaintenanceRepository {}
-
 class SpySyncController extends SyncMaintenanceController {
   SpySyncController();
 


### PR DESCRIPTION
## Summary

- isolate the fork-healer suite DomainLogger registration in a GetIt scope and restore the prior process-wide state after the suite
- reuse five exact test doubles that already exist in the central mock catalog
- add no CI check, lint, file-size threshold, or other guardrail

## Verification

- fvm flutter test for all six touched test files (158 tests)
- fvm flutter analyze (zero issues)

Test-only cleanup; no changelog or metainfo entry is needed.