### PR TITLE
feat(demo): seed expedition habits into the penguin world

### DIFF
--- a/knowledge/features/demo.md
+++ b/knowledge/features/demo.md
@@ -118,12 +118,21 @@ stateDiagram-v2
 ```
 
 The seeder writes exclusively through the `WorldHandle` — never through
-getIt or `PersistenceLogic` — in dependency order: categories + labels, AI
-configs (providers → models → profiles → skills), media bytes from the asset
-bundle, journal entities in reference order, then every `linked_entries` row
-(links last, because both endpoints must already exist), config
-flags (Daily OS and tooltips on; sync, notifications, geolocation, habits,
-dashboards off), and FTUE suppression in the demo's own `settings.sqlite`.
+getIt or `PersistenceLogic` — in dependency order: categories + labels +
+habits, AI configs (providers → models → profiles → skills), media bytes from
+the asset bundle, journal entities in reference order (habit completions among
+them, which is why the habit definitions precede them), then every
+`linked_entries` row (links last, because both endpoints must already exist),
+config flags (Daily OS, tooltips and the habits page on; sync, notifications,
+geolocation and dashboards off), and FTUE suppression in the demo's own
+`settings.sqlite`.
+
+The habits page is on because the world carries three habits — two live daily
+ones under Penguin Operations and one retired — with three weeks of completion
+history ending *yesterday*, so the demo opens with a real streak and something
+still to tick off. The history is deliberately imperfect: it contains a skipped
+day and a failure, because a page of unbroken green teaches nothing about what
+the states look like.
 Everything arrives with `vectorClock: null` — a guest world has no sync
 stack to stamp one.
 

--- a/lib/features/demo/seed/demo_seed_manifest.dart
+++ b/lib/features/demo/seed/demo_seed_manifest.dart
@@ -5,7 +5,7 @@ import 'package:path/path.dart' as p;
 
 /// Version of the demo seed content. Bump when the seeded world changes in a
 /// way that should trigger a wipe-and-reseed of existing demo profiles.
-const demoSeedVersion = 3;
+const demoSeedVersion = 4;
 
 /// File name of the manifest written at the demo world's root.
 const demoSeedManifestFileName = 'demo_seed_manifest.json';

--- a/lib/features/demo/seed/demo_seeder.dart
+++ b/lib/features/demo/seed/demo_seeder.dart
@@ -63,6 +63,11 @@ class DemoSeeder {
     for (final label in penguinWorld.labels) {
       await world.writeEntityDefinition(label);
     }
+    // Habits before their completion entries, which are journal entities
+    // written in the block below and reference these ids.
+    for (final habit in penguinWorld.habits) {
+      await world.writeEntityDefinition(habit);
+    }
 
     // AI configs in dependency order: providers → models → profiles →
     // skills.
@@ -114,6 +119,7 @@ class DemoSeeder {
       seededDefinitionIds: List.unmodifiable([
         for (final category in penguinWorld.categories) category.id,
         for (final label in penguinWorld.labels) label.id,
+        for (final habit in penguinWorld.habits) habit.id,
       ]),
       seededAiConfigIds: List.unmodifiable([
         for (final config in aiConfigs) config.id,
@@ -123,9 +129,13 @@ class DemoSeeder {
     return manifest;
   }
 
-  /// Seeds the default flag rows, then adjusts the demo experience: Daily OS
-  /// and tooltips on; sync, notifications, geolocation, and the legacy
-  /// habits/dashboards pages off.
+  /// Seeds the default flag rows, then adjusts the demo experience: Daily OS,
+  /// tooltips and the habits page on; sync, notifications, geolocation and the
+  /// dashboards page off.
+  ///
+  /// Habits are on because the world seeds three of them with three weeks of
+  /// completion history — the page has something to show, and hiding it would
+  /// leave that data unreachable.
   Future<void> _configureFlags() async {
     await initConfigFlags(world.journalDb, inMemoryDatabase: false);
     const statuses = <String, bool>{
@@ -134,7 +144,7 @@ class DemoSeeder {
       enableMatrixFlag: false,
       enableNotificationsFlag: false,
       recordLocationFlag: false,
-      enableHabitsPageFlag: false,
+      enableHabitsPageFlag: true,
       enableDashboardsPageFlag: false,
     };
     for (final entry in statuses.entries) {

--- a/lib/features/demo/seed/demo_world.dart
+++ b/lib/features/demo/seed/demo_world.dart
@@ -123,6 +123,19 @@ final Map<String, String> manualDemoCoverAssets = <String, String>{
 /// Habitat engineering: the pressure/air/water/power side of the colony.
 const demoHabitatCategoryId = 'manual-habitat-engineering';
 
+/// Habit definition ids. Plain slugs rather than [demoUuid] values, like the
+/// category and label ids beside them: habits are reached through
+/// `/settings/habits/by_id/:habitId`, and settings routes carry no `isUuid`
+/// gate. Only journal entities — including the completions below — need a
+/// real UUID.
+/// Days of habit completion history seeded before today. Comfortably beyond
+/// the habits page's own 14-day window so the chart is full at either edge.
+const _habitHistoryDays = 21;
+
+const manualRollCallHabitId = 'habit-emperor-roll-call';
+const manualHabitatSealsHabitId = 'habit-habitat-seals';
+const manualSardineForecastHabitId = 'habit-sardine-forecast';
+
 /// Logistics & supply: everything that moves fish and parts between moons.
 const demoLogisticsCategoryId = 'manual-logistics-supply';
 
@@ -322,6 +335,8 @@ class ManualDemoWorld {
     required this.timeRecords,
     required this.entries,
     required this.links,
+    required this.habits,
+    required this.habitCompletions,
   });
 
   /// Builds the Intergalactic Penguin Logistics world.
@@ -1529,6 +1544,126 @@ class ManualDemoWorld {
       for (final (from, to) in _demoEntryPairs) link(from, to),
     ];
 
+    HabitDefinition habit({
+      required String id,
+      required String name,
+      required String description,
+      String? categoryId,
+      HabitSchedule? schedule,
+      DateTime? activeFrom,
+      bool priority = false,
+      bool private = false,
+      bool active = true,
+    }) => HabitDefinition(
+      id: id,
+      name: name,
+      description: description,
+      createdAt: anchor,
+      updatedAt: anchor,
+      vectorClock: null,
+      habitSchedule:
+          schedule ?? const HabitSchedule.daily(requiredCompletions: 1),
+      activeFrom: activeFrom,
+      active: active,
+      private: private,
+      priority: priority,
+      categoryId: categoryId,
+    );
+
+    final habits = <HabitDefinition>[
+      habit(
+        id: manualRollCallHabitId,
+        name: t('Emperor penguin roll call', 'Kaiserpinguine durchzählen'),
+        description: t(
+          'Account for all 37 expedition penguins before launch.',
+          'Vor dem Start alle 37 Expeditionspinguine erfassen.',
+        ),
+        categoryId: manualDemoCategoryId,
+        schedule: HabitSchedule.daily(
+          requiredCompletions: 1,
+          showFrom: dates.today(6),
+          alertAtTime: dates.today(6, 30),
+        ),
+        // Well before the completion history below, so the habit does not
+        // look like it started mid-streak.
+        activeFrom: dates.daysAgo(_habitHistoryDays + 7),
+        priority: true,
+      ),
+      habit(
+        id: manualHabitatSealsHabitId,
+        name: t('Walk the habitat seals', 'Habitatdichtungen ablaufen'),
+        description: t(
+          'Inspect every pressure seal after the artificial sunrise.',
+          'Nach dem künstlichen Sonnenaufgang jede Druckdichtung inspizieren.',
+        ),
+        categoryId: manualDemoCategoryId,
+        activeFrom: dates.daysAgo(_habitHistoryDays + 7),
+        private: true,
+      ),
+      // Retired on purpose: the habits page has a distinct treatment for an
+      // inactive habit, and a world where every habit is live never shows
+      // it. It carries no completions for the same reason.
+      habit(
+        id: manualSardineForecastHabitId,
+        name: t('Review sardine forecast', 'Sardinenprognose prüfen'),
+        description: t(
+          'Paused while the Europa exchange recalibrates its fish index.',
+          'Pausiert, während die Europa-Börse ihren Fischindex neu kalibriert.',
+        ),
+        categoryId: demoLogisticsCategoryId,
+        active: false,
+      ),
+    ];
+
+    HabitCompletionEntry completion({
+      required String habitId,
+      required int daysAgo,
+      required HabitCompletionType type,
+      required int hour,
+    }) {
+      final at = dates.daysAgo(daysAgo, hour);
+      return HabitCompletionEntry(
+        meta: TestMetadataFactory.create(
+          id: demoUuid('habit-completion-$habitId-$daysAgo'),
+          createdAt: at,
+          categoryId: manualDemoCategoryId,
+        ),
+        data: HabitCompletionData(
+          dateFrom: at,
+          dateTo: at,
+          habitId: habitId,
+          completionType: type,
+        ),
+      );
+    }
+
+    // A history that reads as lived-in rather than perfect: the roll call is
+    // near-unbroken with one skipped day, the seal walk is patchier and has
+    // a genuine failure. Both stop short of today, so the demo opens with
+    // something the user can actually tick off.
+    final habitCompletions = <HabitCompletionEntry>[
+      for (var day = _habitHistoryDays; day >= 1; day--)
+        if (day != 5)
+          completion(
+            habitId: manualRollCallHabitId,
+            daysAgo: day,
+            type: day == 9
+                ? HabitCompletionType.skip
+                : (HabitCompletionType.success),
+            hour: 6,
+          ),
+      for (var day = _habitHistoryDays; day >= 1; day--)
+        if (day % 3 != 0)
+          completion(
+            habitId: manualHabitatSealsHabitId,
+            daysAgo: day,
+            type: day == 4
+                ? HabitCompletionType.fail
+                : (HabitCompletionType.success),
+            hour: 7,
+          ),
+    ];
+
     return ManualDemoWorld._(
       category: category,
       categories: [
@@ -1557,6 +1692,8 @@ class ManualDemoWorld {
         ),
       ],
       labels: labels,
+      habits: habits,
+      habitCompletions: habitCompletions,
       coverImages: coverImages,
       checklists: [habitatChecklist, ...expansionChecklists],
       checklistItems: [
@@ -1779,6 +1916,16 @@ class ManualDemoWorld {
   /// knowledge graph around it, actually has to show.
   final List<JournalEntry> entries;
 
+  /// Expedition habits: two live daily habits under Penguin Operations and
+  /// one retired habit, so the habits page has an inactive row to render as
+  /// well as active ones.
+  final List<HabitDefinition> habits;
+
+  /// Completion history for the live habits, ending yesterday. The habits
+  /// page reads a 14-day window, so [_habitHistoryDays] covers it with room
+  /// left for the streak counts to be real.
+  final List<HabitCompletionEntry> habitCompletions;
+
   /// Every `linked_entries` row in the world: task↔task, task↔note,
   /// task↔logged time and task↔photo. Written by the seeder after the
   /// entities themselves, since both endpoints must already exist.
@@ -1792,6 +1939,7 @@ class ManualDemoWorld {
     ...tasks,
     ...timeRecords,
     ...entries,
+    ...habitCompletions,
   ];
 
   Task get orbitalHabitatTask => taskById(manualOrbitalHabitatTaskId);

--- a/test/features/demo/seed/demo_seeder_test.dart
+++ b/test/features/demo/seed/demo_seeder_test.dart
@@ -118,6 +118,9 @@ void main() {
     demoBlockedLabelId,
     demoWaitingLabelId,
     demoResearchLabelId,
+    manualRollCallHabitId,
+    manualHabitatSealsHabitId,
+    manualSardineForecastHabitId,
   };
 
   const expectedAiConfigIds = {
@@ -260,11 +263,16 @@ void main() {
         isTrue,
       );
       expect(await world.journalDb.getConfigFlag(enableTooltipFlag), isTrue);
+      // On, because the world seeds habits with completion history — the
+      // page would otherwise hide data the seed just wrote.
+      expect(
+        await world.journalDb.getConfigFlag(enableHabitsPageFlag),
+        isTrue,
+      );
       for (final flag in [
         enableMatrixFlag,
         enableNotificationsFlag,
         recordLocationFlag,
-        enableHabitsPageFlag,
         enableDashboardsPageFlag,
       ]) {
         expect(

--- a/test/features/demo/seed/demo_world_test.dart
+++ b/test/features/demo/seed/demo_world_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 import 'dart:ui' show Locale;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/demo/seed/demo_seed_text.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/utils/image_utils.dart';
@@ -529,6 +531,75 @@ void main() {
         world.penguinPassengerTask,
         same(world.taskById(manualPenguinPassengerTaskId)),
       );
+    });
+
+    test('habits carry a lived-in completion history that stops before '
+        'today, and the retired habit carries none', () {
+      final now = DateTime(2026, 9, 14, 8);
+      final world = ManualDemoWorld.penguinLogistics(now: now);
+
+      expect(
+        world.habits.map((habit) => habit.id),
+        [
+          manualRollCallHabitId,
+          manualHabitatSealsHabitId,
+          manualSardineForecastHabitId,
+        ],
+      );
+
+      final retired = world.habits.singleWhere(
+        (habit) => habit.id == manualSardineForecastHabitId,
+      );
+      expect(
+        retired.active,
+        isFalse,
+        reason: 'the habits page needs an inactive row to render',
+      );
+
+      final byHabit = <String, List<HabitCompletionEntry>>{};
+      for (final completion in world.habitCompletions) {
+        byHabit.putIfAbsent(completion.data.habitId, () => []).add(completion);
+      }
+      expect(
+        byHabit.keys.toSet(),
+        {manualRollCallHabitId, manualHabitatSealsHabitId},
+        reason: 'a retired habit must not accrue completions',
+      );
+
+      final midnight = DateTime(now.year, now.month, now.day);
+      for (final completion in world.habitCompletions) {
+        expect(
+          completion.data.dateFrom.isBefore(midnight),
+          isTrue,
+          reason:
+              '${completion.meta.id} lands on or after today — the demo '
+              'must open with something left to tick off',
+        );
+        expect(
+          midnight.difference(completion.data.dateFrom).inDays,
+          lessThanOrEqualTo(21),
+          reason: 'history beyond the seeded window is unreachable',
+        );
+        expect(isUuid(completion.meta.id), isTrue);
+      }
+
+      // Every habit is active well before its own history starts, so no
+      // streak begins on the day the habit appeared.
+      for (final habit in world.habits.where((h) => h.activeFrom != null)) {
+        final earliest = byHabit[habit.id]
+            ?.map((c) => c.data.dateFrom)
+            .reduce((a, b) => a.isBefore(b) ? a : b);
+        if (earliest == null) continue;
+        expect(habit.activeFrom!.isBefore(earliest), isTrue);
+      }
+
+      // Not a perfect record: the page has to show a skip and a failure.
+      final types = world.habitCompletions
+          .map((completion) => completion.data.completionType)
+          .toSet();
+      expect(types, contains(HabitCompletionType.success));
+      expect(types, contains(HabitCompletionType.skip));
+      expect(types, contains(HabitCompletionType.fail));
     });
 
     test('installMedia copies every bundled cover into the document-relative '

--- a/test/features/settings/ui/settings_definitions_screenshots_test.dart
+++ b/test/features/settings/ui/settings_definitions_screenshots_test.dart
@@ -236,8 +236,11 @@ HabitDefinition _habit({
   categoryId: categoryId,
 );
 
+// Ids (and copy) come from the shared penguin world, which owns these three
+// habits and seeds them into the demo. The composition here stays local: the
+// settings pages need categories the demo world deliberately does not have.
 final HabitDefinition _rollCall = _habit(
-  id: 'habit-emperor-roll-call',
+  id: manualRollCallHabitId,
   name: _t('Emperor penguin roll call', 'Kaiserpinguine durchzählen'),
   description: _t(
     'Account for all 37 expedition penguins before launch.',
@@ -253,7 +256,7 @@ final HabitDefinition _rollCall = _habit(
   priority: true,
 );
 final HabitDefinition _habitatSealWalk = _habit(
-  id: 'habit-habitat-seals',
+  id: manualHabitatSealsHabitId,
   name: _t('Walk the habitat seals', 'Habitatdichtungen ablaufen'),
   description: _t(
     'Inspect every pressure seal after the artificial sunrise.',
@@ -263,7 +266,7 @@ final HabitDefinition _habitatSealWalk = _habit(
   private: true,
 );
 final HabitDefinition _sardineForecast = _habit(
-  id: 'habit-sardine-forecast',
+  id: manualSardineForecastHabitId,
   name: _t('Review sardine forecast', 'Sardinenprognose prüfen'),
   description: _t(
     'Paused while the Europa exchange recalibrates its fish index.',


### PR DESCRIPTION
The demo world had no habits and hid the page behind `enable_habits_page: false`,
so a whole surface of the app was unreachable from the demo.

## What the world gains

Three habits, owned by the shared `ManualDemoWorld` alongside its categories and
labels:

| Habit | Category | State |
|---|---|---|
| Emperor penguin roll call | Penguin Operations | daily, priority, `showFrom` 06:00 with a 06:30 alert |
| Walk the habitat seals | Penguin Operations | daily, private |
| Review sardine forecast | Logistics & Supply | **retired**, so the page has an inactive row to render |

Their ids are plain slugs, like the category and label ids beside them — habits
are reached through `/settings/habits/by_id/:habitId`, and settings routes carry
no `isUuid` gate. The completions are journal entities, so those do get
`demoUuid` ids.

## The completion history

Three weeks of it, which comfortably covers the habits page's own 14-day window
so the chart is full at either edge and the streak counts are real rather than
truncated. Two deliberate choices:

- **It ends yesterday.** The demo should open with something still to tick off,
  not a finished day.
- **It is imperfect** — a skipped day on the roll call, a failure on the seal
  walk, gaps on both. A page of unbroken green teaches nothing about what the
  states actually look like, which is the whole point of a demo.

The retired habit accrues no completions, and both live habits are `activeFrom`
a week before their own history starts, so no streak begins on the day its habit
appeared.

`enable_habits_page` flips on for the same reason it was off before: it should
follow whether there is anything to show. `demoSeedVersion` goes to 4 so
existing demo worlds reseed into the new content on next boot.

## Fixture ownership

`settings_definitions_screenshots_test.dart` already defined these three habits
itself. It keeps its own composition — the settings pages need mission-control,
fish-diplomacy and human-maintenance categories the demo world deliberately does
not have — but now takes the three ids from the world instead of repeating the
literals, so there is one place that decides what a penguin habit is called.

## Verification

- `test/features/demo/seed/` — 56 pass, including a new world test asserting the
  history stops before today, stays inside the seeded window, uses real UUIDs,
  covers success/skip/fail, and that the retired habit has no completions
- `demo_seeder_test` — habit ids appear in the manifest's `seededDefinitionIds`
  and the flag is asserted on rather than off
- `settings_definitions_screenshots_test` — 60 pass
- `day_page_screenshots_test` + `task_manual_screenshots_test` (de) — 83 pass,
  confirming the extra journal entities do not disturb the manual suites that
  share the world
- `make knowledge_check` — 91 concepts, 0 errors; the demo concept's seeding
  order and flag list now match the code

No CHANGELOG entry: demo mode has not shipped, and this is content added to the
unreleased 1.0.3 feature rather than a change a user of a released version could
notice.