### PR TITLE
feat: open task cover art full screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surfaces cover art and related photos, keeps long titles intact, and leaves
   the detailed AI brief collapsed until requested. Keyboard, reduced-motion,
   high-contrast, and screen-reader navigation are supported.
+- **Task cover art now opens full screen.** Tap the artwork at the top of a task
+  to use the same zoom, rotation and download viewer as linked photos.
 
 ## [1.0.3]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,7 @@
     <release version="1.0.4" date="2026-08-05">
       <description>
         <p>Changed: the task knowledge graph is now a readable local workspace. Instead of presenting the whole topology as a field of mostly anonymous dots, it shows a bounded one- or two-hop neighbourhood with prioritized full labels, stronger edges, exact-count aggregates for dense groups and photos, and a small topology map for long-distance jumps. A Connections list offers the same navigation grouped by relationship and direction, while density and filters control what remains visible. Task cover art now also appears directly in its circular graph node for faster visual recognition. The compact task inspector surfaces cover art and related photos, keeps long titles intact, and leaves the detailed AI brief collapsed until requested. Keyboard, reduced-motion, high-contrast, and screen-reader navigation are supported.</p>
+        <p>Changed: task cover art now opens full screen. Tap the artwork at the top of a task to use the same zoom, rotation and download viewer as linked photos.</p>
       </description>
     </release>
     <release version="1.0.3" date="2026-08-05">

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -15,7 +15,7 @@ sources:
   - id: pages
     resource: ../../../lib/features/tasks/ui/pages
     title: TaskDetailsPage and TaskForm
-    last_modified: 2026-08-03
+    last_modified: 2026-08-05
   - id: first-run
     resource: ../../../lib/features/tasks/ui/widgets/task_first_run_actions.dart
     title: First-run actions block
@@ -275,6 +275,12 @@ crumb segments. The page owns the gutter (see above).
 `TaskCompactAppBar` and `TaskExpandableAppBar` surface the task title in
 `subtitle2` once the scroll offset passes a threshold, so the title stays visible
 as the header scrolls away.
+
+When the expandable app bar has cover art, the whole artwork is an interactive
+image surface. A tap opens the same full-screen, zoomable viewer used by linked
+image entries, including rotation, download and zoom controls. The cover uses a
+task-specific Hero tag so an expanded linked image lower on the same detail page
+cannot become the transition source by mistake.
 
 The header is exercised in isolation under **Widgetbook → Tasks → Desktop task
 header**, whose Playground drives priority, status, category, due date, labels and

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -50,18 +50,7 @@ class EntryImageWidget extends ConsumerWidget {
     return GestureDetector(
       onTap: () {
         focusNode.unfocus();
-        Navigator.of(context, rootNavigator: true).push(
-          PageRouteBuilder<void>(
-            opaque: false,
-            barrierColor: Theme.of(
-              context,
-            ).colorScheme.scrim.withValues(alpha: 0.82),
-            pageBuilder: (context, animation, secondaryAnimation) =>
-                HeroPhotoViewRouteWrapper(
-                  file: file,
-                ),
-          ),
-        );
+        showFullscreenImageViewer(context, file: file);
       },
       child: ColoredBox(
         color: Colors.black,
@@ -85,17 +74,44 @@ class EntryImageWidget extends ConsumerWidget {
   }
 }
 
+/// Opens [file] in the shared full-screen, zoomable image viewer.
+///
+/// [heroTag] identifies the source image for the transition. Callers outside
+/// [EntryImageWidget] should provide a distinct tag so another image on the
+/// current route cannot be selected as the Hero source.
+void showFullscreenImageViewer(
+  BuildContext context, {
+  required File file,
+  Object heroTag = 'entry_img',
+}) {
+  Navigator.of(context, rootNavigator: true).push(
+    PageRouteBuilder<void>(
+      opaque: false,
+      barrierColor: Theme.of(
+        context,
+      ).colorScheme.scrim.withValues(alpha: 0.82),
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          HeroPhotoViewRouteWrapper(
+            file: file,
+            heroTag: heroTag,
+          ),
+    ),
+  );
+}
+
 // from https://github.com/bluefireteam/photo_view/blob/master/example/lib/screens/examples/hero_example.dart
 class HeroPhotoViewRouteWrapper extends StatefulWidget {
   const HeroPhotoViewRouteWrapper({
     required this.file,
     super.key,
     this.backgroundDecoration,
+    this.heroTag = 'entry_img',
     this.imageExporter,
   });
 
   final File file;
   final BoxDecoration? backgroundDecoration;
+  final Object heroTag;
 
   /// Saves the image to a platform-appropriate destination. Defaults to
   /// [defaultImageExporter]; injected in tests to avoid real platform channels.
@@ -264,8 +280,8 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
                         ),
                     controller: _photoController,
                     scaleStateController: _scaleStateController,
-                    heroAttributes: const PhotoViewHeroAttributes(
-                      tag: 'entry_img',
+                    heroAttributes: PhotoViewHeroAttributes(
+                      tag: widget.heroTag,
                     ),
                     minScale: PhotoViewComputedScale.contained,
                     maxScale: PhotoViewComputedScale.covered * 4,

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -273,6 +273,7 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
                 Positioned.fill(
                   child: PhotoView(
                     imageProvider: imageProvider,
+                    enableRotation: true,
                     backgroundDecoration:
                         widget.backgroundDecoration ??
                         BoxDecoration(

--- a/lib/features/tasks/ui/cover_art_background.dart
+++ b/lib/features/tasks/ui/cover_art_background.dart
@@ -6,7 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
 import 'package:lotti/features/tasks/ui/file_watcher_mixin.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/utils/image_utils.dart';
 
 /// Bucket size (physical pixels) for quantizing the decode target.
@@ -47,7 +49,7 @@ int? coverArtCacheExtent(double maxExtent, double devicePixelRatio) {
   return math.min(buckets * coverArtDecodeBucket, coverArtMaxDecodeExtent);
 }
 
-/// Background widget for displaying task cover art in SliverAppBar.
+/// Displays task cover art in a SliverAppBar and opens it full screen on tap.
 class CoverArtBackground extends ConsumerStatefulWidget {
   const CoverArtBackground({
     required this.imageId,
@@ -120,7 +122,15 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
       return const SizedBox.shrink();
     }
 
-    return Stack(
+    final file = File(path);
+    final heroTag = 'task_cover_art_${widget.imageId}';
+    void openViewer() => showFullscreenImageViewer(
+      context,
+      file: file,
+      heroTag: heroTag,
+    );
+
+    final coverArt = Stack(
       fit: StackFit.expand,
       children: [
         LayoutBuilder(
@@ -137,7 +147,7 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
             final cacheExtent =
                 coverArtCacheExtent(constraints.maxWidth, devicePixelRatio) ??
                 coverArtCacheExtent(constraints.maxHeight, devicePixelRatio);
-            final fileImage = FileImage(File(path));
+            final fileImage = FileImage(file);
             ImageProvider imageProvider = fileImage;
             if (cacheExtent != null) {
               imageProvider = ResizeImage(
@@ -192,6 +202,22 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
           child: SizedBox.expand(),
         ),
       ],
+    );
+
+    return Semantics(
+      button: true,
+      label: context.messages.entryTypeLabelJournalImage,
+      onTap: openViewer,
+      child: ExcludeSemantics(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: openViewer,
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: Hero(tag: heroTag, child: coverArt),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/test/features/ratings/repository/rating_repository_test.dart
+++ b/test/features/ratings/repository/rating_repository_test.dart
@@ -19,6 +19,7 @@ import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 
 void main() {
@@ -69,6 +70,7 @@ void main() {
   );
 
   setUpAll(() {
+    registerAllFallbackValues();
     registerFallbackValue(testRatingEntry);
     registerFallbackValue(fallbackLink);
     registerFallbackValue(
@@ -542,8 +544,6 @@ void main() {
     group('sequence-log integration', () {
       late MockSyncSequenceLogService mockSequenceLog;
       late MockDomainLogger mockDomainLogger;
-
-      setUpAll(() => registerFallbackValue(testVectorClock));
 
       setUp(() {
         mockSequenceLog = MockSyncSequenceLogService();

--- a/test/features/tasks/ui/cover_art_background_test.dart
+++ b/test/features/tasks/ui/cover_art_background_test.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
+import 'dart:ui' show SemanticsAction;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
 import 'package:lotti/features/tasks/ui/cover_art_background.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/editor_state_service.dart';
@@ -367,6 +369,40 @@ void main() {
           expect(shrink.height, 0.0);
         },
       );
+
+      testWidgets('tapping cover art opens the full-screen image viewer', (
+        tester,
+      ) async {
+        final image = buildJournalImage();
+        createInvalidImageFile(image);
+
+        await tester.pumpWidget(
+          buildSubject(image, height: 225, width: 400),
+        );
+        await tester.pump();
+
+        expect(find.byType(HeroPhotoViewRouteWrapper), findsNothing);
+        final semantics = tester.getSemantics(
+          find.byType(CoverArtBackground),
+        );
+        expect(semantics.label, 'Photo');
+        expect(
+          semantics.getSemanticsData().hasAction(SemanticsAction.tap),
+          isTrue,
+        );
+
+        await tester.tap(find.byType(CoverArtBackground));
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(HeroPhotoViewRouteWrapper), findsOneWidget);
+        final viewer = tester.widget<HeroPhotoViewRouteWrapper>(
+          find.byType(HeroPhotoViewRouteWrapper),
+        );
+        expect(viewer.file.path, getFullImagePath(image));
+        expect(viewer.heroTag, 'task_cover_art_image-1');
+        expect(find.byIcon(Icons.close_rounded), findsOneWidget);
+      });
     });
 
     testWidgets('renders SizedBox.shrink when entry is not JournalImage', (

--- a/test/features/tasks/ui/cover_art_background_test.dart
+++ b/test/features/tasks/ui/cover_art_background_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/tasks/ui/cover_art_background.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/utils/image_utils.dart';
+import 'package:photo_view/photo_view.dart';
 
 import '../../../helpers/fake_entry_controller.dart';
 import '../../../mocks/mocks.dart';
@@ -401,6 +402,8 @@ void main() {
         );
         expect(viewer.file.path, getFullImagePath(image));
         expect(viewer.heroTag, 'task_cover_art_image-1');
+        final photoView = tester.widget<PhotoView>(find.byType(PhotoView));
+        expect(photoView.enableRotation, isTrue);
         expect(find.byIcon(Icons.close_rounded), findsOneWidget);
       });
     });


### PR DESCRIPTION
## What changed

- Make task-detail cover art open the shared full-screen image viewer used by linked image entries.
- Preserve zoom, rotation, download, close, and keyboard behavior by routing both entry images and cover art through one viewer helper.
- Give task covers an isolated Hero tag, click cursor, and accessible Photo button semantics.
- Add a regression test plus task architecture and 1.0.4 release-note updates.

## Why

Task cover art was rendered as a passive app-bar background, while linked image cards already opened the full-screen viewer. The viewer route was embedded inside `EntryImageWidget`, so the cover had no reusable entry point.

## User impact

Tapping the artwork at the top of task details now opens the same zoomable, rotatable, downloadable full-screen view as a linked photo.

## Visual review

### Mobile (dark)

| Before | After |
|---|---|
| ![Mobile task cover before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/task-cover-fullscreen/9e6eb163b887b9ba5669623f6335c1221dd74da9/before/task_detail_mobile_dark.png) | ![Mobile task cover full-screen viewer](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/task-cover-fullscreen/9e6eb163b887b9ba5669623f6335c1221dd74da9/after/task_detail_mobile_dark.png) |

### Desktop (dark)

| Before | After |
|---|---|
| ![Desktop task cover before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/task-cover-fullscreen/9e6eb163b887b9ba5669623f6335c1221dd74da9/before/task_detail_desktop_dark.png) | ![Desktop task cover full-screen viewer](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/task-cover-fullscreen/9e6eb163b887b9ba5669623f6335c1221dd74da9/after/task_detail_desktop_dark.png) |

## Validation

- `fvm flutter analyze lib/features/journal/ui/widgets/entry_image_widget.dart lib/features/tasks/ui/cover_art_background.dart test/features/tasks/ui/cover_art_background_test.dart`
- `fvm flutter test test/features/tasks/ui/cover_art_background_test.dart test/features/journal/ui/widgets/entry_image_widget_test.dart`
- `make knowledge_check`
- `xmllint --noout flatpak/com.matthiasn.lotti.metainfo.xml`
- Task manual screenshot harness: mobile + desktop dark

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task cover art can now be opened in a full-screen image viewer.
  - Use zoom, rotation, download, and close controls while viewing cover art.
  - Added smooth transitions between task cover art and the full-screen viewer.

- **Documentation**
  - Updated release notes and task detail documentation to describe the new cover art viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->