### PR TITLE
fix: defer knowledge graph detail navigation

### DIFF
--- a/knowledge/features/knowledge_graph.md
+++ b/knowledge/features/knowledge_graph.md
@@ -96,6 +96,14 @@ preferences change motion and relationship stroke strength respectively. The
 topology minimap exposes one labelled orientation region rather than claiming a
 screen-reader button action that has no meaningful single destination.
 
+The full-detail sidebar embeds the app's real entry page in a nested
+`Navigator`. `KnowledgeGraphView` may reserve the responsive sidebar slot from
+its root `LayoutBuilder`, but it must activate `EntryDetailSidebar` only in a
+later frame. Mounting the nested Navigator while that ancestor is performing
+layout mutates the overlay render subtree during layout and triggers Flutter's
+render-object mutation assertion. Once activated, the sidebar stays mounted
+through later viewport resizes; only its reserved width is recomputed.
+
 # Inspector data
 
 `task_graph_provider.dart` projects journal entities and typed `EntryLink`

--- a/lib/features/knowledge_graph/ui/knowledge_graph_view.dart
+++ b/lib/features/knowledge_graph/ui/knowledge_graph_view.dart
@@ -1106,7 +1106,7 @@ class _KnowledgeGraphViewState extends State<KnowledgeGraphView>
                     right: tokens.spacing.step5,
                     child: SizedBox(
                       width: (size.width * 0.34).clamp(360.0, 460.0),
-                      child: EntryDetailSidebar(
+                      child: _DeferredEntryDetailSidebar(
                         key: ValueKey(_focusId),
                         entryId: _focusId,
                         onClose: () => setState(() => _detailsOpen = false),
@@ -1157,6 +1157,55 @@ class _KnowledgeGraphViewState extends State<KnowledgeGraphView>
           );
         },
       ),
+    );
+  }
+}
+
+/// Defers the nested detail navigator until after the graph's layout callback.
+///
+/// [KnowledgeGraphView] builds its responsive workspace from a [LayoutBuilder].
+/// [EntryDetailSidebar] activates a nested [Navigator] route through Flutter's
+/// overlay portal. Activating that subtree while the layout builder is inside
+/// `performLayout` can reattach one of the task page's own layout builders and
+/// trip Flutter's render-object mutation guard. The first frame reserves the
+/// panel slot; the post-frame rebuild activates the navigator in the normal
+/// build phase.
+class _DeferredEntryDetailSidebar extends StatefulWidget {
+  const _DeferredEntryDetailSidebar({
+    required this.entryId,
+    required this.onClose,
+    required this.tokens,
+    super.key,
+  });
+
+  final String entryId;
+  final VoidCallback onClose;
+  final DsTokens tokens;
+
+  @override
+  State<_DeferredEntryDetailSidebar> createState() =>
+      _DeferredEntryDetailSidebarState();
+}
+
+class _DeferredEntryDetailSidebarState
+    extends State<_DeferredEntryDetailSidebar> {
+  bool _active = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _active = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_active) return const SizedBox.expand();
+    return EntryDetailSidebar(
+      entryId: widget.entryId,
+      onClose: widget.onClose,
+      tokens: widget.tokens,
     );
   }
 }

--- a/test/features/knowledge_graph/ui/knowledge_graph_view_test.dart
+++ b/test/features/knowledge_graph/ui/knowledge_graph_view_test.dart
@@ -1933,10 +1933,16 @@ void main() {
 
         // Tap the inspector's Open button → `_detailsOpen = true`.
         await tester.tap(find.byIcon(Icons.open_in_full_rounded));
-        // One frame mounts the overlay; a second lets the (async) controller
-        // build resolve to its null value so the sidebar swaps its initial
-        // spinner for the data shell.
+        // The graph itself is built from a LayoutBuilder callback. Mount only a
+        // stable slot in that layout frame; activating the nested Navigator
+        // there would mutate its overlay subtree during layout.
         await tester.pump();
+        expect(find.byType(EntryDetailSidebar), findsNothing);
+
+        // The next build activates the sidebar outside the layout callback; a
+        // final frame lets the async controller resolve to its null data shell.
+        await tester.pump();
+        expect(find.byType(EntryDetailSidebar), findsOneWidget);
         await tester.pump();
 
         // The full-details overlay is now rendered above the inspector. With the
@@ -1944,6 +1950,16 @@ void main() {
         // shell (proving the cheap path, not the heavy `_DetailBody`).
         expect(find.byType(EntryDetailSidebar), findsOneWidget);
         expect(find.text('Entry not found'), findsOneWidget);
+
+        final wideWidth = tester.getSize(find.byType(EntryDetailSidebar)).width;
+        tester.view.physicalSize = const Size(1000, 800);
+        await tester.pump();
+        await tester.pump();
+        expect(
+          tester.getSize(find.byType(EntryDetailSidebar)).width,
+          lessThan(wideWidth),
+        );
+        expect(tester.takeException(), isNull);
 
         // Tap the overlay's close button → `_detailsOpen = false`.
         await tester.tap(find.byIcon(Icons.close_rounded));

--- a/test/features/knowledge_graph/ui/knowledge_graph_view_test.dart
+++ b/test/features/knowledge_graph/ui/knowledge_graph_view_test.dart
@@ -7,8 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/journal/model/entry_state.dart';
-import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/ui/pages/entry_details_page.dart';
 import 'package:lotti/features/knowledge_graph/domain/graph_keyboard_navigation.dart';
 import 'package:lotti/features/knowledge_graph/domain/graph_layout_engine.dart';
 import 'package:lotti/features/knowledge_graph/domain/graph_models.dart';
@@ -22,10 +21,16 @@ import 'package:lotti/features/knowledge_graph/ui/knowledge_graph_painter.dart';
 import 'package:lotti/features/knowledge_graph/ui/knowledge_graph_view.dart';
 import 'package:lotti/features/knowledge_graph/ui/node_inspector_panel.dart';
 import 'package:lotti/features/knowledge_graph/ui/topology_minimap.dart';
+import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/time_service.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../helpers/fake_entry_controller.dart';
 import '../../../mocks/mocks.dart';
+import '../../../test_data/test_data.dart';
 import '../../../widget_test_utils.dart';
 
 void main() {
@@ -1892,21 +1897,22 @@ void main() {
   });
 
   group('full-details overlay (desktop)', () {
-    // The overlay's [EntryDetailSidebar] is a ConsumerWidget that watches
-    // `entryControllerProvider(focusId)`. Building it for real would pull in
-    // the app's full provider/getIt graph and the heavy TaskForm/details
-    // widgets. Instead, the focus entry's controller is overridden with one
-    // whose `build` resolves to `null` (no entry) — so the sidebar renders its
-    // cheap "Entry not found" shell and never builds `_DetailBody`. The base
-    // [EntryController]'s field initializers still touch getIt, so a minimal
-    // get_it (setUpTestGetIt + a mock EditorStateService) is registered just for
-    // these cases.
     setUp(() async {
       await setUpTestGetIt(
         additionalSetup: () {
-          getIt.registerSingleton<EditorStateService>(
-            MockEditorStateService(),
-          );
+          final entitiesCache = MockEntitiesCacheService();
+          final timeService = MockTimeService();
+          final userActivityService = MockUserActivityService();
+          when(
+            () => entitiesCache.getCategoryById(any()),
+          ).thenReturn(null);
+          when(timeService.getStream).thenAnswer((_) => const Stream.empty());
+          when(userActivityService.updateActivity).thenReturn(null);
+          getIt
+            ..registerSingleton<EditorStateService>(MockEditorStateService())
+            ..registerSingleton<EntitiesCacheService>(entitiesCache)
+            ..registerSingleton<TimeService>(timeService)
+            ..registerSingleton<UserActivityService>(userActivityService);
         },
       );
     });
@@ -1916,15 +1922,13 @@ void main() {
       'tapping Open shows the EntryDetailSidebar; closing it hides it again',
       (tester) async {
         final scenario = taskEgoNetworkScenario();
+        final entry = testTextEntry.copyWith(
+          meta: testTextEntry.meta.copyWith(id: scenario.seedId),
+        );
         await pumpView(
           tester,
           scenario: scenario,
-          extraOverrides: [
-            // The focus at open time is the scenario seed (`t0`).
-            entryControllerProvider(scenario.seedId).overrideWith(
-              _NullEntryController.new,
-            ),
-          ],
+          extraOverrides: [createEntryControllerOverride(entry)],
         );
 
         // The inspector is docked (desktop), the overlay is not open yet.
@@ -1939,17 +1943,23 @@ void main() {
         await tester.pump();
         expect(find.byType(EntryDetailSidebar), findsNothing);
 
-        // The next build activates the sidebar outside the layout callback; a
-        // final frame lets the async controller resolve to its null data shell.
+        // The next build activates the sidebar outside the layout callback;
+        // another frame lets the synchronous entry controller build the real
+        // nested Navigator and EntryDetailsPage route.
         await tester.pump();
         expect(find.byType(EntryDetailSidebar), findsOneWidget);
-        await tester.pump();
+        // Flutter Animate schedules a zero-duration restart timer when the real
+        // detail route mounts. Advance fake time so that timer cannot leak out
+        // of this regression test.
+        await tester.pump(const Duration(milliseconds: 1));
 
-        // The full-details overlay is now rendered above the inspector. With the
-        // controller resolved to a null entry it shows the "Entry not found"
-        // shell (proving the cheap path, not the heavy `_DetailBody`).
+        // The full-details overlay is now rendered above the inspector. This
+        // must exercise the route that caused the production layout mutation,
+        // not the sidebar's empty/loading shell.
         expect(find.byType(EntryDetailSidebar), findsOneWidget);
-        expect(find.text('Entry not found'), findsOneWidget);
+        expect(find.byType(EntryDetailsPage), findsOneWidget);
+        expect(find.byType(Navigator), findsNWidgets(2));
+        expect(tester.takeException(), isNull);
 
         final wideWidth = tester.getSize(find.byType(EntryDetailSidebar)).width;
         tester.view.physicalSize = const Size(1000, 800);
@@ -1971,12 +1981,4 @@ void main() {
       },
     );
   });
-}
-
-/// Minimal [EntryController] whose `build` resolves to `null` (no entry), so the
-/// [EntryDetailSidebar] renders its "Entry not found" shell without building the
-/// heavy real detail widgets — and without the app's provider/getIt graph.
-class _NullEntryController extends EntryController {
-  @override
-  Future<EntryState?> build() async => null;
 }


### PR DESCRIPTION
## What changed

- reserve the desktop detail-sidebar slot during the knowledge-graph layout frame
- activate the sidebar's nested navigator on the following normal build frame
- cover opening, responsive resizing, and closing the detail sidebar in one regression test

## Why

Opening full task details from the graph could activate `EntryDetailSidebar`'s nested `Navigator` while the graph's root `LayoutBuilder` was inside `performLayout`. Flutter's overlay portal then reattached layout-builder descendants and tripped the render-object mutation guard, cascading into deactivated-ancestor and hit-test failures.

The first frame now mounts a stable placeholder at the final panel size. A post-frame rebuild activates the nested navigator outside the layout callback, without changing the visible sidebar design.

## Validation

- `fvm flutter test test/features/knowledge_graph/ui/knowledge_graph_view_test.dart`
- `fvm dart analyze`
- the regression was confirmed red before the fix: the sidebar mounted in the first layout frame instead of being deferred

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

## Screenshots

No visual pixels change in this lifecycle-only fix; the sidebar occupies the same responsive slot after its one-frame deferred activation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the knowledge graph details panel’s loading behavior to prevent layout issues when opening it.
  * Enhanced responsive behavior so the details panel adapts correctly to narrower screen sizes without errors.

* **Tests**
  * Added coverage for staged panel loading and responsive layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->