### PR TITLE
feat: add verified profile snapshot staging

### DIFF
--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,7 +5,7 @@ description: The eleven Drift/SQLite databases, how connections are opened and m
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-01T20:22:00Z }
+generated: { by: codex/gpt-5, at: 2026-08-05T22:23:21Z }
 stale_after: 2027-01-11
 sources:
   - id: sync-db
@@ -48,6 +48,10 @@ sources:
     resource: ../../lib/database/database_migration.dart
     title: JournalDb migration strategy
     last_modified: 2026-07-09
+  - id: backup-catalog
+    resource: ../../lib/features/backup_restore/domain/profile_backup_catalog.dart
+    title: Profile backup storage catalog
+    last_modified: 2026-08-06
   - id: update-notifications
     resource: ../../lib/services/db_notification.dart
     title: UpdateNotifications
@@ -70,15 +74,15 @@ migration work has to cover both, and embeddings are a third store again (below)
 | Database | File | Schema | Owns |
 |----------|------|--------|------|
 | `JournalDb` | `db.sqlite` | 45 | Journal entities, tasks, links, tags, config flags — the primary store |
-| `SyncDatabase` | `sync.sqlite` | 28 | Outbox, sequence log, host activity, inbound event queue, queue markers |
-| `AgentDatabase` | `agent.sqlite` | 18 | Agent state, reports, observations, change proposals, wake history |
+| `SyncDatabase` | `sync.sqlite` | 29 | Outbox, sequence log, host activity, inbound event queue, queue markers |
+| `AgentDatabase` | `agent.sqlite` | 19 | Agent state, reports, observations, change proposals, wake history |
 | `EditorDb` | `editor_drafts_db.sqlite` | 2 | Unsaved rich-text editor drafts |
 | `ConsumptionDatabase` | `ai_consumption.sqlite` | 2 | AI token usage and the interaction ledger |
 | `SettingsDb` | `settings.sqlite` | 1 | Key/value app settings, sync watermarks, saved filters |
 | `Fts5Db` | `fts5_db.sqlite` | 1 | Full-text search index |
 | `NotificationsDb` | `notifications.sqlite` | 1 | Scheduled and delivered notifications |
 | `OnboardingMetricsDb` | `onboarding_metrics.sqlite` | 1 | First-run and activation measurement |
-| `AiConfigDb` | (feature-local) | 1 | Providers, models, prompts, inference profiles |
+| `AiConfigDb` | `ai_config.sqlite` | 1 | Providers, models, prompts, inference profiles |
 | `DayProcessingDb` | `day_processing.sqlite` | 1 | Daily OS day-processing outbox |
 
 Splitting by concern is what makes a heavy background writer — sync ingestion,
@@ -331,6 +335,23 @@ Two consequences worth holding on to:
 Timestamps come from `package:clock`'s `clock.now()`, so tests can drive them
 with `withClock`.
 
+That helper is a **legacy per-database fallback**, not a supported profile
+backup. It copies only the main SQLite file, has no store identity, manifest,
+checksum, media coverage, encryption, coordinated quiescence, or restore path.
+A raw copy is not safe while WAL-backed writers are active.
+
+The implementation-consumable profile inventory now lives in
+`ProfileBackupCatalog`. It includes authoritative databases, media and sync
+sidecars; marks FTS, ObjectBox embeddings and waveform previews rebuildable;
+excludes logs, sibling guest worlds, the device-global profile registry and the
+legacy `backup/` directory; and rejects SQLite journal companions as evidence
+that strict quiescence has not been proven. `QuiescedProfileSnapshotService`
+can then copy a closed profile into a partial stage, rehash the source, validate
+SQLite integrity and schema versions, verify the manifest against the payload,
+and publish with one rename. It does not stop writers; lifecycle orchestration
+must satisfy that precondition. The full contract and remaining runtime layers
+are in [backup and restore](../features/backup-and-restore.md).
+
 `lib/database/maintenance.dart` owns physical database upkeep: whole-database
 deletion (`deleteAgentDb`, `deleteEditorDb`, `deleteSyncDb`), FTS rebuilding,
 and the `sent`-outbox purge. Historical re-send orchestration belongs to Sync
@@ -353,6 +374,7 @@ entity operations, which is where to look for it.
 | Slow-query interceptor | [`lib/database/slow_query_logging.dart`](../../lib/database/slow_query_logging.dart) |
 | Maintenance operations | [`lib/database/maintenance.dart`](../../lib/database/maintenance.dart) |
 | Historical Sync staging and retry | [`lib/features/sync/services/historical_sync_service.dart`](../../lib/features/sync/services/historical_sync_service.dart) |
+| Profile backup inventory, manifest and staging | [Backup and restore](../features/backup-and-restore.md) |
 
 Related: [bootstrap and dependency injection](bootstrap-and-di.md) for when each
 database is registered, [the sync feature](../features/sync/) for what fills

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -344,8 +344,11 @@ The implementation-consumable profile inventory now lives in
 `ProfileBackupCatalog`. It includes authoritative databases, media and sync
 sidecars; marks FTS, ObjectBox embeddings and waveform previews rebuildable;
 excludes logs, sibling guest worlds, the device-global profile registry and the
-legacy `backup/` directory; and rejects SQLite journal companions as evidence
-that strict quiescence has not been proven. `QuiescedProfileSnapshotService`
+legacy `backup/` directory. It also excludes the legacy Daily OS file outbox
+after its mandatory startup import into `day_processing.sqlite`, including
+recovered atomic scratch files retained for rollback. SQLite journal companions
+remain a hard rejection because they show that strict quiescence has not been
+proven. `QuiescedProfileSnapshotService`
 can then copy a closed profile into a partial stage, rehash the source, validate
 SQLite integrity and schema versions, verify the manifest against the payload,
 and publish with one rename. It does not stop writers; lifecycle orchestration

--- a/knowledge/features/backup-and-restore.md
+++ b/knowledge/features/backup-and-restore.md
@@ -156,17 +156,19 @@ backup.
 stateDiagram-v2
   [*] --> BoundaryCheck
   BoundaryCheck --> Inventory: source and staging are disjoint
-  Inventory --> Copying: required stores present
+  Inventory --> Copying: required stores present<br/>and known store shapes match
   Copying --> SourceRecheck: every file copied and locally verified
   SourceRecheck --> ManifestWrite: inventory and source hashes unchanged
   ManifestWrite --> StageVerification
-  StageVerification --> Published: manifest, payload, checksums and SQLite schemas agree
+  StageVerification --> TerminalSourceScan: manifest, real payload directory,<br/>checksums and SQLite schemas agree
+  TerminalSourceScan --> Published: source inventory still unchanged
   Published --> [*]
   BoundaryCheck --> Failed: invalid or overlapping roots
   Inventory --> Failed: unsafe path, link, companion or missing required store
   Copying --> Failed: source drift, copy mismatch or invalid SQLite
   SourceRecheck --> Failed: inventory or source digest drift
   StageVerification --> Failed: staged content or manifest drift
+  TerminalSourceScan --> Failed: source inventory drift after digest verification
   Failed --> PartialRemoved
   PartialRemoved --> [*]
 ```
@@ -174,11 +176,14 @@ stateDiagram-v2
 The service creates a uniquely named partial directory with the platform's
 temporary-directory primitive, then publishes with one directory rename. It
 never replaces an existing destination. Every copied file is SHA-256 checked
-against both the source and destination, and the whole source is checked again
-after a second inventory scan. SQLite copies are opened read-only with the
-`immutable=1` URI option, checked with `PRAGMA integrity_check`, and recorded
-with their `user_version`. A final verification repeats payload membership,
-checksums, integrity, and schema-version checks before publication.
+against both the source and destination. Known included stores must have their
+catalog-declared filesystem shape, and the whole source is checked after two
+post-copy inventory scans; the terminal scan runs after digest and staged-byte
+verification, immediately before publication. SQLite copies are opened
+read-only with the `immutable=1` URI option, checked with
+`PRAGMA integrity_check`, and recorded with their `user_version`. A final
+verification requires the payload root itself to be a real directory, then
+repeats payload membership, checksums, integrity, and schema-version checks.
 
 The immutable open is safe here only because strict quiescence is a caller
 precondition and the catalog rejects transaction companions. It must not be

--- a/knowledge/features/backup-and-restore.md
+++ b/knowledge/features/backup-and-restore.md
@@ -20,6 +20,10 @@ sources:
     resource: ../../lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
     title: QuiescedProfileSnapshotService
     last_modified: 2026-08-06
+  - id: legacy-day-processing-outbox
+    resource: ../../lib/features/daily_os_next/services/day_processing_startup.dart
+    title: Legacy Daily OS file outbox boundary
+    last_modified: 2026-07-25
   - id: profile-paths
     resource: ../../lib/features/profiles/profile_paths.dart
     title: Profile root boundaries
@@ -80,6 +84,7 @@ rename is a compile-time change instead of documentation drift.
 | Onboarding | `onboarding_metrics.sqlite` | include when present | Profile-local progress and measurements |
 | AI configuration | `ai_config.sqlite` | include, credential-sensitive | Providers and profiles; API keys currently live here |
 | Daily OS | `day_processing.sqlite` | include when present | Durable day-processing outbox |
+| Legacy Daily OS outbox | `.day_processing_outbox/` | exclude | Mandatory startup migration imports every recoverable job into the SQLite outbox; retained files are a temporary rollback copy |
 | Matrix SDK | `matrix/lotti_sync.db` | include, credential-sensitive | Login session and encryption state; absent in guest worlds |
 | Full-text search | `fts5_db.sqlite` | rebuild | Derived from JournalDb |
 | ObjectBox embeddings | `objectbox_embeddings*` | rebuild | Derived vector indexes |

--- a/knowledge/features/backup-and-restore.md
+++ b/knowledge/features/backup-and-restore.md
@@ -1,0 +1,222 @@
+---
+type: Feature Module
+title: Backup and restore
+description: The profile storage catalog, integrity manifest, and verified quiesced staging service that define a safe Lotti recovery artifact.
+resource: ../../lib/features/backup_restore
+tags: [backup, restore, recovery, integrity, local-first]
+status: draft
+generated: { by: codex/gpt-5, at: 2026-08-05T22:23:21Z }
+stale_after: 2027-02-22
+sources:
+  - id: catalog
+    resource: ../../lib/features/backup_restore/domain/profile_backup_catalog.dart
+    title: ProfileBackupCatalog
+    last_modified: 2026-08-06
+  - id: manifest
+    resource: ../../lib/features/backup_restore/domain/profile_backup_manifest.dart
+    title: ProfileBackupManifest
+    last_modified: 2026-08-06
+  - id: snapshot-service
+    resource: ../../lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
+    title: QuiescedProfileSnapshotService
+    last_modified: 2026-08-06
+  - id: profile-paths
+    resource: ../../lib/features/profiles/profile_paths.dart
+    title: Profile root boundaries
+    last_modified: 2026-08-05
+  - id: matrix-client
+    resource: ../../lib/features/sync/matrix/client.dart
+    title: Matrix SDK database path
+    last_modified: 2026-08-06
+  - id: legacy-backup
+    resource: ../../lib/database/common.dart
+    title: Legacy per-database backup helper
+    last_modified: 2026-06-05
+---
+
+# Current boundary
+
+The module currently defines the **capture boundary**, not a finished user
+flow:
+
+- `ProfileBackupCatalog` classifies every path below one active profile root.
+- `ProfileBackupManifest` records the catalog and format versions, producing app
+  version, profile type, store identities, discovered SQLite schema versions,
+  file sizes, and SHA-256 digests.
+- `QuiescedProfileSnapshotService` stages, verifies, and atomically publishes a
+  snapshot from a profile root whose writers have already been stopped.
+
+No runtime coordinator proves quiescence, encrypts, packages, or restores a
+bundle yet. A caller must not present the staged directory as a supported or
+portable backup until strict quiescence, authenticated encryption, restore
+rollback, and automated restore drills are all connected.
+
+# One profile, not one documents tree
+
+The active `getIt<Directory>` is the profile boundary. For the real profile that
+directory is also the device's real root, which contains two things that do not
+belong to the profile being captured:
+
+- `profiles.json`, the device-global registry of all worlds;
+- `guest_profiles/`, the sibling guest-world container.
+
+Both are excluded. A backup always represents exactly one world. Restoring it
+must not select a device's active profile or overwrite unrelated guest worlds.
+
+# Store inventory
+
+The catalog imports database filenames from their owning implementations, so a
+rename is a compile-time change instead of documentation drift.
+
+| Store | Path | Treatment | Reason |
+|-------|------|-----------|--------|
+| Journal | `db.sqlite` | include, required | Primary journal/task/definition authority |
+| Settings | `settings.sqlite` | include, required | Profile settings and authoritative host identity |
+| Sync | `sync.sqlite` | include when present | Pending outbox work and local replication progress |
+| Agents | `agent.sqlite` | include when present | Agent state, history, proposals, observations |
+| Editor drafts | `editor_drafts_db.sqlite` | include when present | Unsaved work has no other authority |
+| AI consumption | `ai_consumption.sqlite` | include when present | Local interaction and usage ledger |
+| Notifications | `notifications.sqlite` | include when present | Durable notification state |
+| Onboarding | `onboarding_metrics.sqlite` | include when present | Profile-local progress and measurements |
+| AI configuration | `ai_config.sqlite` | include, credential-sensitive | Providers and profiles; API keys currently live here |
+| Daily OS | `day_processing.sqlite` | include when present | Durable day-processing outbox |
+| Matrix SDK | `matrix/lotti_sync.db` | include, credential-sensitive | Login session and encryption state; absent in guest worlds |
+| Full-text search | `fts5_db.sqlite` | rebuild | Derived from JournalDb |
+| ObjectBox embeddings | `objectbox_embeddings*` | rebuild | Derived vector indexes |
+| Waveform cache | `audio_waveforms/` | rebuild | Derived from authoritative audio |
+| Media | `audio/`, `images/` | include | Bytes referenced by journal rows |
+| Sync sidecars | `agent_entities/`, `agent_links/`, `notifications/`, `outbox_bundles/` | include | May be referenced by pending sync work |
+| Demo seed metadata | `demo_seed_manifest.json` | include when present | Separates seed fixtures from guest-created work |
+| Logs | `logs/` | exclude | Diagnostic rather than authoritative; may contain sensitive text |
+| Legacy DB copies | `backup/` | exclude | Prevent recursion and importing stale migration copies |
+
+An unrecognized canonical path receives the `profile-content` store identity and
+is **included as personal data**. Completeness wins over size: newly introduced
+content must not disappear merely because an older catalog does not recognize
+its directory yet.
+
+# Path classification is a safety gate
+
+```mermaid
+flowchart TD
+  P["Profile-relative path"] --> V{"Canonical POSIX path?<br/>no root, drive, backslash, empty or traversal segment"}
+  V -->|no| Invalid["Reject malformed input"]
+  V -->|yes| O{"Inside a known excluded<br/>or rebuildable directory?"}
+  O -->|yes| Omit["Omit by catalog policy"]
+  O -->|no| J{"SQLite -wal, -shm, -journal,<br/>or interrupted atomic write?"}
+  J -->|yes| Unsafe["Abort snapshot: quiescence not proven"]
+  J -->|no| T{"Exact or directory<br/>include policy?"}
+  T -->|yes| Include["Include with stable store identity"]
+  T -->|no| Opaque["Include as profile-content"]
+```
+
+Bundle paths always use `/` regardless of host platform. Absolute paths,
+Windows drive prefixes, backslashes, repeated separators, `.` and `..` are
+invalid before any filesystem resolution occurs. Restore must repeat containment
+checks against its staging root; manifest validation is defense in depth, not a
+license to join untrusted strings directly.
+
+SQLite companions are not silently excluded. Their presence is a hard failure
+because raw-copy snapshotting is permitted only after every connection and
+read-pool isolate has closed cleanly. A future live exporter may use
+`VACUUM INTO` or SQLite's backup API per database, but that alone does not make
+eleven databases, Matrix, ObjectBox, and media one cross-store point-in-time
+snapshot. Whole-profile capture still requires a lifecycle barrier.
+
+# Manifest invariants
+
+`ProfileBackupManifest` accepts untrusted JSON only after these checks:
+
+- the format and catalog versions are positive and no newer than this build;
+- `createdAt` is canonical UTC with `Z` notation;
+- profile type is `real` or `guest`;
+- store ids and store paths are unique and canonical;
+- a schema version is non-negative and appears only on a SQLite store;
+- every file path is unique, belongs to its declared store, and has a
+  non-negative byte length plus a lowercase 64-character SHA-256 digest;
+- every file references a declared store.
+
+Stores and files are sorted before serialization. Deterministic manifests make
+encryption input, tests, diagnostics, and future signatures reproducible.
+
+# Verified quiesced staging
+
+`QuiescedProfileSnapshotService` accepts only an already-closed profile root.
+It deliberately does not reach into GetIt or own database shutdown: making a
+filesystem service pretend it can quiesce Drift read pools, Matrix, ObjectBox,
+and background workers would turn a lifecycle failure into a plausible-looking
+backup.
+
+```mermaid
+stateDiagram-v2
+  [*] --> BoundaryCheck
+  BoundaryCheck --> Inventory: source and staging are disjoint
+  Inventory --> Copying: required stores present
+  Copying --> SourceRecheck: every file copied and locally verified
+  SourceRecheck --> ManifestWrite: inventory and source hashes unchanged
+  ManifestWrite --> StageVerification
+  StageVerification --> Published: manifest, payload, checksums and SQLite schemas agree
+  Published --> [*]
+  BoundaryCheck --> Failed: invalid or overlapping roots
+  Inventory --> Failed: unsafe path, link, companion or missing required store
+  Copying --> Failed: source drift, copy mismatch or invalid SQLite
+  SourceRecheck --> Failed: inventory or source digest drift
+  StageVerification --> Failed: staged content or manifest drift
+  Failed --> PartialRemoved
+  PartialRemoved --> [*]
+```
+
+The service creates a uniquely named partial directory with the platform's
+temporary-directory primitive, then publishes with one directory rename. It
+never replaces an existing destination. Every copied file is SHA-256 checked
+against both the source and destination, and the whole source is checked again
+after a second inventory scan. SQLite copies are opened read-only with the
+`immutable=1` URI option, checked with `PRAGMA integrity_check`, and recorded
+with their `user_version`. A final verification repeats payload membership,
+checksums, integrity, and schema-version checks before publication.
+
+The immutable open is safe here only because strict quiescence is a caller
+precondition and the catalog rejects transaction companions. It must not be
+reused as a shortcut for inspecting a live WAL database.
+
+# Privacy and packaging boundary
+
+All included content is personal. `ai_config.sqlite` and the Matrix subtree have
+the stricter `credentials` classification because they currently contain API
+keys, access/session tokens, and encryption material. The manifest lives inside
+the protected payload; an implementation must not publish the staged directory
+or those fields as a plaintext portable backup.
+
+Rebuildable indexes are omitted both to reduce size and to avoid treating a
+derived projection as authority. Logs are excluded rather than merely marked
+sensitive because they are diagnostic history, not required for recovery.
+
+# Three operations that must stay distinct
+
+1. **Migration-time database fallback** — the existing `createDbBackup()` is a
+   best-effort copy of one database around a schema migration. It is not a
+   profile backup and carries no manifest or restore contract.
+2. **Whole-profile capture** — stop new work, strictly close all profile-bound
+   writers, classify and stage every file, validate databases and hashes, then
+   encrypt and atomically publish the artifact.
+3. **Restore** — authenticate and validate into an isolated staging profile,
+   quiesce the active world, preserve it for rollback, activate the candidate,
+   and delete the original only after the restored world boots successfully.
+
+Conflating these operations is the shortest route to a backup that looks real
+but loses WAL commits, sibling stores, media, or credentials.
+
+# Next implementation seams
+
+The catalog, manifest, and staging service are intentionally free of
+service-locator and UI dependencies. The next layers attach in order:
+
+1. a strict lifecycle coordinator that fails closed if any writer cannot stop;
+2. authenticated encrypted packaging and retention;
+3. staged restore with compatibility checks, activation, and rollback;
+4. localized UI and end-to-end restore drills.
+
+Related: [persistence](../architecture/persistence.md) for database connection
+and WAL behavior, [profiles and demo mode](../architecture/profiles-and-demo-mode.md)
+for world lifecycle, and [security and privacy](../architecture/security-and-privacy.md)
+for the current at-rest threat model.

--- a/knowledge/features/index.md
+++ b/knowledge/features/index.md
@@ -35,6 +35,7 @@ what it does for a user; these describe how it runs.
 
 * [Sync](sync/) - single-user multi-device replication over end-to-end encrypted Matrix.
 * [Notifications](notifications.md) - durable alerts that converge across devices.
+* [Backup and restore](backup-and-restore.md) - the independent recovery artifact: profile inventory, integrity manifest, and safe capture/restore boundary.
 
 # Shell, settings and look
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,16 @@
 # Knowledge Bundle Update Log
 
+## 2026-08-06
+* **Addition**: New feature concept
+  [Backup and restore](features/backup-and-restore.md) — the authoritative
+  profile-root inventory, include/rebuild/exclude/reject path policy, strict
+  manifest invariants, privacy boundary, and the lifecycle separation between
+  migration copies, complete profile capture, and rollback-safe restore.
+* **Implementation**: Extended [Backup and restore](features/backup-and-restore.md)
+  with the verified quiesced staging lifecycle: double source validation,
+  SQLite integrity and schema checks, staged manifest verification, fail-closed
+  cleanup, and atomic publication.
+
 ## 2026-08-05
 * **Correction**: [Demo mode](features/demo.md) — the fixture-ownership rule
   is now "additive only" rather than "never grow the fixture". The penguin

--- a/lib/features/backup_restore/README.md
+++ b/lib/features/backup_restore/README.md
@@ -35,10 +35,11 @@ lib/features/backup_restore/
 └── README.md
 ```
 
-The catalog is deliberately conservative: known caches and diagnostics are
-omitted, unsafe transaction artifacts abort capture, and unknown profile files
-are included by default. That last rule makes storage additions fail toward a
-larger encrypted backup instead of silent data loss.
+The catalog is deliberately conservative: known caches, diagnostics, and
+superseded migration stores are omitted, unsafe transaction artifacts abort
+capture, and unknown profile files are included by default. That last rule
+makes storage additions fail toward a larger encrypted backup instead of
+silent data loss.
 
 The staging service scans one closed profile root, rejects journal companions
 and symbolic links, copies included bytes into a private partial directory,

--- a/lib/features/backup_restore/README.md
+++ b/lib/features/backup_restore/README.md
@@ -1,0 +1,65 @@
+# Backup and restore
+
+Backup and restore owns Lotti's independent recovery artifact. Sync keeps
+devices converged, but it can also propagate deletion or damaged state; it is
+therefore not a backup.
+
+The feature is being built in layers. The current module establishes the
+storage contract and can publish a verified snapshot from an already-quiesced
+profile. Encryption, restore, and settings flows build on that boundary. It
+does not yet expose a user-facing backup action.
+
+## What it will do for the user
+
+- Capture one complete active profile, including its authoritative databases,
+  media, and file-backed payloads.
+- Protect credentials and private content inside an authenticated encrypted
+  bundle.
+- Verify content before publishing a backup and again before changing a
+  profile during restore.
+- Restore through an isolated staging world, preserving the current world for
+  rollback until the restored one boots successfully.
+- Explain incompatible, corrupt, or incomplete backups without leaving the
+  user's profile half-replaced.
+
+## What this module owns now
+
+```text
+lib/features/backup_restore/
+├── domain/
+│   ├── profile_backup_catalog.dart   profile-root inventory and path policy
+│   └── profile_backup_manifest.dart  versioned stores, files, sizes, hashes
+├── service/
+│   └── quiesced_profile_snapshot_service.dart
+│                                       verified staging and atomic publish
+└── README.md
+```
+
+The catalog is deliberately conservative: known caches and diagnostics are
+omitted, unsafe transaction artifacts abort capture, and unknown profile files
+are included by default. That last rule makes storage additions fail toward a
+larger encrypted backup instead of silent data loss.
+
+The staging service scans one closed profile root, rejects journal companions
+and symbolic links, copies included bytes into a private partial directory,
+rehashes the source, runs SQLite integrity checks, verifies the staged payload
+against its manifest, and only then renames the directory into place. Any
+failure removes the partial stage and leaves an existing published snapshot
+untouched.
+
+## What it delegates
+
+Profile lifecycle code remains responsible for identifying and restarting the
+active world. Each database remains responsible for its own schema and
+migrations. The Matrix SDK and ObjectBox remain responsible for closing their
+stores. This feature coordinates those owners and refuses to snapshot when
+strict quiescence cannot be proven.
+
+Lifecycle quiescence, portable packaging, key handling, restore activation,
+retention, progress UI, and automated restore drills are follow-on layers built
+against the catalog, manifest, and staging contract.
+
+The store classifications, manifest invariants, privacy boundary, and planned
+capture lifecycle are documented in the knowledge bundle:
+
+**→ [knowledge/features/backup-and-restore.md](../../../knowledge/features/backup-and-restore.md)**

--- a/lib/features/backup_restore/domain/profile_backup_catalog.dart
+++ b/lib/features/backup_restore/domain/profile_backup_catalog.dart
@@ -440,7 +440,9 @@ abstract final class ProfileBackupCatalog {
           relativePath.startsWith('${store.relativePath}/')) {
         if (directoryMatch == null ||
             store.relativePath.length > directoryMatch.relativePath.length) {
-          directoryMatch = store;
+          // No current directory policies overlap; this preserves the intended
+          // longest-prefix behavior for future nested policies.
+          directoryMatch = store; // coverage:ignore-line
         }
       }
     }

--- a/lib/features/backup_restore/domain/profile_backup_catalog.dart
+++ b/lib/features/backup_restore/domain/profile_backup_catalog.dart
@@ -1,0 +1,516 @@
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/editor_db.dart';
+import 'package:lotti/database/fts5_db.dart';
+import 'package:lotti/database/notifications_db.dart';
+import 'package:lotti/database/onboarding_metrics_db.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/ai/database/ai_config_db.dart';
+import 'package:lotti/features/ai/database/objectbox_embedding_store.dart';
+import 'package:lotti/features/ai/database/sharded_embedding_store.dart';
+import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
+import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
+import 'package:lotti/features/profiles/profile_paths.dart';
+import 'package:lotti/features/sync/matrix/client.dart';
+import 'package:path/path.dart' as p;
+
+/// The physical shape of one cataloged profile store.
+enum BackupStoreKind {
+  /// A SQLite database copied only after every connection is closed.
+  sqliteDatabase,
+
+  /// A directory whose files are classified recursively.
+  directory,
+
+  /// A single non-database file.
+  file,
+
+  /// Forward-compatible profile content not yet assigned a dedicated store.
+  opaqueProfileContent,
+}
+
+/// What snapshot code must do when it encounters a profile-relative path.
+enum BackupPathTreatment {
+  /// Preserve the path in the protected backup payload.
+  include,
+
+  /// Omit the path because the app can deterministically regenerate it.
+  rebuild,
+
+  /// Omit the path because it is outside the active profile backup boundary.
+  exclude,
+
+  /// Abort capture because the path proves the source is not safely quiesced.
+  reject,
+}
+
+/// The minimum protection required for a path included in a backup.
+enum BackupSensitivity {
+  /// User content that belongs only inside the encrypted bundle payload.
+  personal,
+
+  /// Credentials or session material requiring explicit encrypted handling.
+  credentials,
+
+  /// Content that is intentionally omitted and carries no bundle requirement.
+  none,
+}
+
+/// One stable store or path policy in the profile backup contract.
+class ProfileBackupStore {
+  const ProfileBackupStore({
+    required this.id,
+    required this.relativePath,
+    required this.kind,
+    required this.treatment,
+    required this.sensitivity,
+    required this.required,
+    required this.rationale,
+  });
+
+  /// Stable identity written into backup manifests.
+  final String id;
+
+  /// Canonical path below the active profile root.
+  ///
+  /// An empty value is reserved for the include-by-default root policy.
+  final String relativePath;
+
+  /// Physical shape of this store.
+  final BackupStoreKind kind;
+
+  /// Snapshot treatment for this store.
+  final BackupPathTreatment treatment;
+
+  /// Protection required if the store is included.
+  final BackupSensitivity sensitivity;
+
+  /// Whether a usable initialized profile must contain this store.
+  final bool required;
+
+  /// Architectural reason for the treatment.
+  final String rationale;
+}
+
+/// Fully resolved policy for one concrete file or directory.
+class BackupPathDecision {
+  const BackupPathDecision({
+    required this.storeId,
+    required this.kind,
+    required this.treatment,
+    required this.sensitivity,
+    required this.required,
+    required this.rationale,
+  });
+
+  factory BackupPathDecision.fromStore(ProfileBackupStore store) =>
+      BackupPathDecision(
+        storeId: store.id,
+        kind: store.kind,
+        treatment: store.treatment,
+        sensitivity: store.sensitivity,
+        required: store.required,
+        rationale: store.rationale,
+      );
+
+  /// Stable store identity used by the manifest.
+  final String storeId;
+
+  /// Physical shape of the matched store.
+  final BackupStoreKind kind;
+
+  /// Required handling for this path.
+  final BackupPathTreatment treatment;
+
+  /// Required protection for included content.
+  final BackupSensitivity sensitivity;
+
+  /// Whether the matched store is mandatory in an initialized profile.
+  final bool required;
+
+  /// Architectural reason for the decision.
+  final String rationale;
+}
+
+/// Versioned source-of-truth for the active profile backup boundary.
+abstract final class ProfileBackupCatalog {
+  /// Increment when path classification or store identity changes.
+  static const int version = 1;
+
+  static const String _audioWaveformDirectory = 'audio_waveforms';
+  static const String _legacyBackupDirectory = 'backup';
+  static const String _logsDirectory = 'logs';
+
+  static const ProfileBackupStore _opaqueProfileContent = ProfileBackupStore(
+    id: 'profile-content',
+    relativePath: '',
+    kind: BackupStoreKind.opaqueProfileContent,
+    treatment: BackupPathTreatment.include,
+    sensitivity: BackupSensitivity.personal,
+    required: false,
+    rationale:
+        'Unknown profile-root content is included by default so a newly added '
+        'authoritative file cannot be silently omitted by an older catalog.',
+  );
+
+  /// Every fixed store and directory policy known to this catalog version.
+  static const List<ProfileBackupStore> stores = [
+    ProfileBackupStore(
+      id: 'journal',
+      relativePath: journalDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: true,
+      rationale: 'Primary journal, task, definition, and link authority.',
+    ),
+    ProfileBackupStore(
+      id: 'sync',
+      relativePath: syncDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Owns pending outbox work and local sync progress.',
+    ),
+    ProfileBackupStore(
+      id: 'agents',
+      relativePath: agentDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Owns agent state, history, proposals, and observations.',
+    ),
+    ProfileBackupStore(
+      id: 'editor-drafts',
+      relativePath: editorDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Unsaved editor drafts cannot be reconstructed elsewhere.',
+    ),
+    ProfileBackupStore(
+      id: 'ai-consumption',
+      relativePath: consumptionDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Owns the local AI usage and interaction ledger.',
+    ),
+    ProfileBackupStore(
+      id: 'settings',
+      relativePath: settingsDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: true,
+      rationale: 'Owns profile-local settings and authoritative host identity.',
+    ),
+    ProfileBackupStore(
+      id: 'full-text-index',
+      relativePath: fts5DbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.rebuild,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale: 'A derived search index rebuilt from the journal database.',
+    ),
+    ProfileBackupStore(
+      id: 'notifications',
+      relativePath: notificationsDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Owns scheduled, delivered, and synced notifications.',
+    ),
+    ProfileBackupStore(
+      id: 'onboarding-metrics',
+      relativePath: onboardingMetricsDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Owns profile-local onboarding progress and measurements.',
+    ),
+    ProfileBackupStore(
+      id: 'ai-config',
+      relativePath: aiConfigDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.credentials,
+      required: false,
+      rationale:
+          'Owns AI providers, models, prompts, profiles, and currently API keys.',
+    ),
+    ProfileBackupStore(
+      id: 'day-processing',
+      relativePath: dayProcessingDbFileName,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Owns the durable Daily OS processing outbox.',
+    ),
+    ProfileBackupStore(
+      id: 'matrix-sdk',
+      relativePath: matrixDatabaseRelativePath,
+      kind: BackupStoreKind.sqliteDatabase,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.credentials,
+      required: false,
+      rationale:
+          'Contains Matrix login sessions and encryption state for real profiles.',
+    ),
+    ProfileBackupStore(
+      id: 'audio-media',
+      relativePath: 'audio',
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale:
+          'Audio bytes are authoritative files referenced by journal rows.',
+    ),
+    ProfileBackupStore(
+      id: 'image-media',
+      relativePath: 'images',
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale:
+          'Image bytes are authoritative files referenced by journal rows.',
+    ),
+    ProfileBackupStore(
+      id: 'agent-entity-sidecars',
+      relativePath: 'agent_entities',
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'File-backed sync payloads may be referenced by pending work.',
+    ),
+    ProfileBackupStore(
+      id: 'agent-link-sidecars',
+      relativePath: 'agent_links',
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'File-backed sync payloads may be referenced by pending work.',
+    ),
+    ProfileBackupStore(
+      id: 'notification-sidecars',
+      relativePath: 'notifications',
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Synced notification payloads back pending outbox rows.',
+    ),
+    ProfileBackupStore(
+      id: 'outbox-bundles',
+      relativePath: 'outbox_bundles',
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale: 'Pending bundle files may be referenced by the sync outbox.',
+    ),
+    ProfileBackupStore(
+      id: 'matrix-auxiliary',
+      relativePath: matrixDatabaseDirectoryName,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.credentials,
+      required: false,
+      rationale:
+          'Future Matrix SDK files inherit the session-store protection.',
+    ),
+    ProfileBackupStore(
+      id: 'demo-seed-metadata',
+      relativePath: demoSeedManifestFileName,
+      kind: BackupStoreKind.file,
+      treatment: BackupPathTreatment.include,
+      sensitivity: BackupSensitivity.personal,
+      required: false,
+      rationale:
+          'Guest restore needs the seed boundary to preserve user additions.',
+    ),
+    ProfileBackupStore(
+      id: 'embedding-index',
+      relativePath: kObjectBoxEmbeddingsDirectoryName,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.rebuild,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale: 'Legacy embeddings are derived from authoritative entities.',
+    ),
+    ProfileBackupStore(
+      id: 'sharded-embedding-index',
+      relativePath: kObjectBoxShardedEmbeddingsDirectoryName,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.rebuild,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale: 'Vector indexes are derived from authoritative entities.',
+    ),
+    ProfileBackupStore(
+      id: 'audio-waveform-cache',
+      relativePath: _audioWaveformDirectory,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.rebuild,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale:
+          'Waveform previews are a bounded cache derived from audio files.',
+    ),
+    ProfileBackupStore(
+      id: 'diagnostic-logs',
+      relativePath: _logsDirectory,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.exclude,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale:
+          'Diagnostics are not profile authority and may contain secrets.',
+    ),
+    ProfileBackupStore(
+      id: 'legacy-database-backups',
+      relativePath: _legacyBackupDirectory,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.exclude,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale:
+          'Excluding nested backups prevents recursion and stale restores.',
+    ),
+    ProfileBackupStore(
+      id: 'guest-profile-container',
+      relativePath: guestProfilesDirName,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.exclude,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale:
+          'One backup represents one active profile, never sibling worlds.',
+    ),
+    ProfileBackupStore(
+      id: 'profile-registry',
+      relativePath: profilesRegistryFileName,
+      kind: BackupStoreKind.file,
+      treatment: BackupPathTreatment.exclude,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale:
+          'The registry is device-global metadata outside any one profile.',
+    ),
+    _opaqueProfileContent,
+  ];
+
+  static final RegExp _atomicTemporaryFile = RegExp(
+    r'(?:\.tmp\.\d+\.\d+\.media|\.bak\.\d+)$',
+  );
+
+  /// Resolves the catalog policy for one canonical profile-relative path.
+  static BackupPathDecision classify(String relativePath) {
+    validateRelativePath(relativePath);
+
+    for (final store in stores) {
+      if (store.relativePath.isNotEmpty &&
+          store.kind != BackupStoreKind.directory &&
+          relativePath == store.relativePath) {
+        return BackupPathDecision.fromStore(store);
+      }
+    }
+
+    ProfileBackupStore? directoryMatch;
+    for (final store in stores) {
+      if (store.kind != BackupStoreKind.directory ||
+          store.relativePath.isEmpty) {
+        continue;
+      }
+      if (relativePath == store.relativePath ||
+          relativePath.startsWith('${store.relativePath}/')) {
+        if (directoryMatch == null ||
+            store.relativePath.length > directoryMatch.relativePath.length) {
+          directoryMatch = store;
+        }
+      }
+    }
+    if (relativePath.startsWith('$profilesRegistryFileName.tmp.') ||
+        relativePath.startsWith('$profilesRegistryFileName.bak.')) {
+      return BackupPathDecision.fromStore(
+        stores.firstWhere((store) => store.id == 'profile-registry'),
+      );
+    }
+    if (directoryMatch != null &&
+        (directoryMatch.treatment == BackupPathTreatment.exclude ||
+            directoryMatch.treatment == BackupPathTreatment.rebuild)) {
+      return BackupPathDecision.fromStore(directoryMatch);
+    }
+    if (_isSqliteCompanion(relativePath)) {
+      return const BackupPathDecision(
+        storeId: 'sqlite-companion',
+        kind: BackupStoreKind.file,
+        treatment: BackupPathTreatment.reject,
+        sensitivity: BackupSensitivity.personal,
+        required: false,
+        rationale:
+            'A WAL, SHM, or rollback journal means quiescence was not proven.',
+      );
+    }
+    if (_atomicTemporaryFile.hasMatch(relativePath)) {
+      return const BackupPathDecision(
+        storeId: 'interrupted-atomic-write',
+        kind: BackupStoreKind.file,
+        treatment: BackupPathTreatment.reject,
+        sensitivity: BackupSensitivity.personal,
+        required: false,
+        rationale:
+            'Temporary or moved-aside files require recovery before capture.',
+      );
+    }
+    if (directoryMatch != null) {
+      return BackupPathDecision.fromStore(directoryMatch);
+    }
+
+    return BackupPathDecision.fromStore(_opaqueProfileContent);
+  }
+
+  /// Rejects absolute, escaping, platform-specific, or non-normal paths.
+  static void validateRelativePath(String relativePath) {
+    if (relativePath.isEmpty ||
+        relativePath.startsWith('/') ||
+        relativePath.contains(r'\') ||
+        relativePath.contains(':') ||
+        p.posix.normalize(relativePath) != relativePath) {
+      throw FormatException(
+        'Backup paths must be canonical profile-relative POSIX paths.',
+        relativePath,
+      );
+    }
+    final segments = relativePath.split('/');
+    if (segments.any(
+      (segment) => segment.isEmpty || segment == '.' || segment == '..',
+    )) {
+      throw FormatException(
+        'Backup paths may not contain empty or traversal segments.',
+        relativePath,
+      );
+    }
+  }
+
+  static bool _isSqliteCompanion(String relativePath) {
+    for (final suffix in const ['-wal', '-shm', '-journal']) {
+      if (relativePath.endsWith(suffix)) return true;
+    }
+    return false;
+  }
+}

--- a/lib/features/backup_restore/domain/profile_backup_catalog.dart
+++ b/lib/features/backup_restore/domain/profile_backup_catalog.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/ai/database/objectbox_embedding_store.dart';
 import 'package:lotti/features/ai/database/sharded_embedding_store.dart';
 import 'package:lotti/features/ai_consumption/database/consumption_database.dart';
 import 'package:lotti/features/daily_os_next/database/day_processing_db.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_startup.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
 import 'package:lotti/features/profiles/profile_paths.dart';
 import 'package:lotti/features/sync/matrix/client.dart';
@@ -370,6 +371,17 @@ abstract final class ProfileBackupCatalog {
       required: false,
       rationale:
           'Waveform previews are a bounded cache derived from audio files.',
+    ),
+    ProfileBackupStore(
+      id: 'legacy-day-processing-outbox',
+      relativePath: legacyDayProcessingOutboxDirectory,
+      kind: BackupStoreKind.directory,
+      treatment: BackupPathTreatment.exclude,
+      sensitivity: BackupSensitivity.none,
+      required: false,
+      rationale:
+          'The mandatory startup migration imports every recoverable legacy '
+          'job into day_processing.sqlite before backup can be requested.',
     ),
     ProfileBackupStore(
       id: 'diagnostic-logs',

--- a/lib/features/backup_restore/domain/profile_backup_manifest.dart
+++ b/lib/features/backup_restore/domain/profile_backup_manifest.dart
@@ -173,20 +173,8 @@ class ProfileBackupManifest {
     required List<BackupManifestStore> stores,
     required List<BackupManifestFile> files,
   }) {
-    if (formatVersion > currentFormatVersion) {
-      throw UnsupportedError(
-        'Backup format $formatVersion is newer than supported '
-        '$currentFormatVersion.',
-      );
-    }
     if (formatVersion < 1) {
       throw const FormatException('Backup formatVersion must be positive.');
-    }
-    if (catalogVersion > ProfileBackupCatalog.version) {
-      throw UnsupportedError(
-        'Backup catalog $catalogVersion is newer than supported '
-        '${ProfileBackupCatalog.version}.',
-      );
     }
     if (catalogVersion < 1) {
       throw const FormatException('Backup catalogVersion must be positive.');
@@ -255,7 +243,10 @@ class ProfileBackupManifest {
         );
       }
       if (file.sizeBytes < 0) {
-        throw FormatException('Backup file size may not be negative.', file);
+        throw FormatException(
+          'Backup file size may not be negative: ${file.relativePath}',
+          file.sizeBytes,
+        );
       }
       if (!_sha256Pattern.hasMatch(file.sha256)) {
         throw FormatException('Invalid SHA-256 digest.', file.sha256);
@@ -464,11 +455,11 @@ List<Map<String, Object?>> _requiredMapList(
         if (entry is! Map<Object?, Object?>) {
           throw FormatException('Manifest field $key must contain objects.');
         }
-        return entry.map((key, value) {
-          if (key is! String) {
+        return entry.map((entryKey, entryValue) {
+          if (entryKey is! String) {
             throw FormatException('Manifest field $key has a non-string key.');
           }
-          return MapEntry(key, value);
+          return MapEntry(entryKey, entryValue);
         });
       })
       .toList(growable: false);

--- a/lib/features/backup_restore/domain/profile_backup_manifest.dart
+++ b/lib/features/backup_restore/domain/profile_backup_manifest.dart
@@ -1,0 +1,475 @@
+import 'package:collection/collection.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_catalog.dart';
+import 'package:meta/meta.dart';
+
+final RegExp _storeIdPattern = RegExp(r'^[a-z0-9]+(?:-[a-z0-9]+)*$');
+final RegExp _sha256Pattern = RegExp(r'^[a-f0-9]{64}$');
+
+/// One store declaration captured in a backup manifest.
+@immutable
+class BackupManifestStore {
+  const BackupManifestStore({
+    required this.id,
+    required this.relativePath,
+    required this.kind,
+    required this.sensitivity,
+    required this.required,
+    this.schemaVersion,
+  });
+
+  factory BackupManifestStore.fromJson(Map<String, Object?> json) {
+    final kind = _requiredEnum(json, 'kind', BackupStoreKind.values);
+    return BackupManifestStore(
+      id: _requiredString(json, 'id'),
+      relativePath: _storeRelativePath(json, kind),
+      kind: kind,
+      sensitivity: _requiredEnum(
+        json,
+        'sensitivity',
+        BackupSensitivity.values,
+      ),
+      required: _requiredBool(json, 'required'),
+      schemaVersion: _optionalInt(json, 'schemaVersion'),
+    );
+  }
+
+  /// Stable catalog identity.
+  final String id;
+
+  /// Canonical root path of the store within the profile.
+  final String relativePath;
+
+  /// Physical shape of the store.
+  final BackupStoreKind kind;
+
+  /// Protection required for the store's contents.
+  final BackupSensitivity sensitivity;
+
+  /// Whether restore requires the store to be present.
+  final bool required;
+
+  /// SQLite `user_version` captured from a validated database copy.
+  final int? schemaVersion;
+
+  /// JSON representation embedded in the manifest.
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'relativePath': relativePath,
+    'kind': kind.name,
+    'sensitivity': sensitivity.name,
+    'required': required,
+    if (schemaVersion != null) 'schemaVersion': schemaVersion,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BackupManifestStore &&
+          id == other.id &&
+          relativePath == other.relativePath &&
+          kind == other.kind &&
+          sensitivity == other.sensitivity &&
+          required == other.required &&
+          schemaVersion == other.schemaVersion;
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    relativePath,
+    kind,
+    sensitivity,
+    required,
+    schemaVersion,
+  );
+}
+
+/// One copied file and its content-integrity metadata.
+@immutable
+class BackupManifestFile {
+  const BackupManifestFile({
+    required this.storeId,
+    required this.relativePath,
+    required this.sizeBytes,
+    required this.sha256,
+  });
+
+  factory BackupManifestFile.fromJson(Map<String, Object?> json) =>
+      BackupManifestFile(
+        storeId: _requiredString(json, 'storeId'),
+        relativePath: _requiredString(json, 'relativePath'),
+        sizeBytes: _requiredInt(json, 'sizeBytes'),
+        sha256: _requiredString(json, 'sha256'),
+      );
+
+  /// Stable ID of the owning [BackupManifestStore].
+  final String storeId;
+
+  /// Canonical path below the snapshot root.
+  final String relativePath;
+
+  /// Exact byte length used during verification.
+  final int sizeBytes;
+
+  /// Lowercase hexadecimal SHA-256 digest of the copied bytes.
+  final String sha256;
+
+  /// JSON representation embedded in the manifest.
+  Map<String, Object?> toJson() => {
+    'storeId': storeId,
+    'relativePath': relativePath,
+    'sizeBytes': sizeBytes,
+    'sha256': sha256,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BackupManifestFile &&
+          storeId == other.storeId &&
+          relativePath == other.relativePath &&
+          sizeBytes == other.sizeBytes &&
+          sha256 == other.sha256;
+
+  @override
+  int get hashCode => Object.hash(storeId, relativePath, sizeBytes, sha256);
+}
+
+/// Versioned description of one complete, verified profile snapshot.
+@immutable
+class ProfileBackupManifest {
+  /// Creates a manifest using the current format and catalog versions.
+  factory ProfileBackupManifest({
+    required DateTime createdAt,
+    required String appVersion,
+    required String profileType,
+    required List<BackupManifestStore> stores,
+    required List<BackupManifestFile> files,
+  }) => ProfileBackupManifest._validated(
+    formatVersion: currentFormatVersion,
+    catalogVersion: ProfileBackupCatalog.version,
+    createdAt: createdAt,
+    appVersion: appVersion,
+    profileType: profileType,
+    stores: stores,
+    files: files,
+  );
+
+  const ProfileBackupManifest._({
+    required this.formatVersion,
+    required this.catalogVersion,
+    required this.createdAt,
+    required this.appVersion,
+    required this.profileType,
+    required this.stores,
+    required this.files,
+  });
+
+  factory ProfileBackupManifest._validated({
+    required int formatVersion,
+    required int catalogVersion,
+    required DateTime createdAt,
+    required String appVersion,
+    required String profileType,
+    required List<BackupManifestStore> stores,
+    required List<BackupManifestFile> files,
+  }) {
+    if (formatVersion > currentFormatVersion) {
+      throw UnsupportedError(
+        'Backup format $formatVersion is newer than supported '
+        '$currentFormatVersion.',
+      );
+    }
+    if (formatVersion < 1) {
+      throw const FormatException('Backup formatVersion must be positive.');
+    }
+    if (catalogVersion > ProfileBackupCatalog.version) {
+      throw UnsupportedError(
+        'Backup catalog $catalogVersion is newer than supported '
+        '${ProfileBackupCatalog.version}.',
+      );
+    }
+    if (catalogVersion < 1) {
+      throw const FormatException('Backup catalogVersion must be positive.');
+    }
+    if (!createdAt.isUtc) {
+      throw const FormatException('Backup createdAt must be UTC.');
+    }
+    if (appVersion.trim().isEmpty) {
+      throw const FormatException('Backup appVersion may not be empty.');
+    }
+    if (profileType != 'real' && profileType != 'guest') {
+      throw FormatException('Unsupported backup profileType.', profileType);
+    }
+
+    final sortedStores = [...stores]..sort((a, b) => a.id.compareTo(b.id));
+    final storeIds = <String>{};
+    final storePaths = <String>{};
+    for (final store in sortedStores) {
+      if (!_storeIdPattern.hasMatch(store.id)) {
+        throw FormatException('Invalid backup store id.', store.id);
+      }
+      if (store.kind != BackupStoreKind.opaqueProfileContent ||
+          store.relativePath.isNotEmpty) {
+        ProfileBackupCatalog.validateRelativePath(store.relativePath);
+      }
+      if (!storeIds.add(store.id)) {
+        throw FormatException('Duplicate backup store id.', store.id);
+      }
+      if (!storePaths.add(store.relativePath)) {
+        throw FormatException(
+          'Duplicate backup store path.',
+          store.relativePath,
+        );
+      }
+      if (store.schemaVersion case final schemaVersion?) {
+        if (store.kind != BackupStoreKind.sqliteDatabase || schemaVersion < 0) {
+          throw FormatException(
+            'schemaVersion is valid only for SQLite stores and may not be '
+            'negative.',
+            schemaVersion,
+          );
+        }
+      }
+    }
+
+    final storesById = {for (final store in sortedStores) store.id: store};
+    final sortedFiles = [...files]
+      ..sort((a, b) => a.relativePath.compareTo(b.relativePath));
+    final filePaths = <String>{};
+    for (final file in sortedFiles) {
+      ProfileBackupCatalog.validateRelativePath(file.relativePath);
+      if (!filePaths.add(file.relativePath)) {
+        throw FormatException('Duplicate backup file path.', file.relativePath);
+      }
+      final store = storesById[file.storeId];
+      if (store == null) {
+        throw FormatException(
+          'Backup file references an unknown store.',
+          file.storeId,
+        );
+      }
+      if (!_belongsToStore(file.relativePath, store)) {
+        throw FormatException(
+          'Backup file does not belong to its declared store.',
+          file.relativePath,
+        );
+      }
+      if (file.sizeBytes < 0) {
+        throw FormatException('Backup file size may not be negative.', file);
+      }
+      if (!_sha256Pattern.hasMatch(file.sha256)) {
+        throw FormatException('Invalid SHA-256 digest.', file.sha256);
+      }
+    }
+
+    return ProfileBackupManifest._(
+      formatVersion: formatVersion,
+      catalogVersion: catalogVersion,
+      createdAt: createdAt,
+      appVersion: appVersion,
+      profileType: profileType,
+      stores: List.unmodifiable(sortedStores),
+      files: List.unmodifiable(sortedFiles),
+    );
+  }
+
+  /// Parses and validates an untrusted manifest document.
+  factory ProfileBackupManifest.fromJson(Map<String, Object?> json) {
+    final formatVersion = _requiredInt(json, 'formatVersion');
+    if (formatVersion > currentFormatVersion) {
+      throw UnsupportedError(
+        'Backup format $formatVersion is newer than supported '
+        '$currentFormatVersion.',
+      );
+    }
+    final catalogVersion = _requiredInt(json, 'catalogVersion');
+    if (catalogVersion > ProfileBackupCatalog.version) {
+      throw UnsupportedError(
+        'Backup catalog $catalogVersion is newer than supported '
+        '${ProfileBackupCatalog.version}.',
+      );
+    }
+    final createdAtRaw = _requiredString(json, 'createdAt');
+    if (!createdAtRaw.endsWith('Z')) {
+      throw const FormatException('Backup createdAt must use UTC Z notation.');
+    }
+    final createdAt = DateTime.tryParse(createdAtRaw);
+    if (createdAt == null || !createdAt.isUtc) {
+      throw FormatException('Invalid backup createdAt.', createdAtRaw);
+    }
+
+    return ProfileBackupManifest._validated(
+      formatVersion: formatVersion,
+      catalogVersion: catalogVersion,
+      createdAt: createdAt,
+      appVersion: _requiredString(json, 'appVersion'),
+      profileType: _requiredString(json, 'profileType'),
+      stores: _requiredMapList(
+        json,
+        'stores',
+      ).map(BackupManifestStore.fromJson).toList(growable: false),
+      files: _requiredMapList(
+        json,
+        'files',
+      ).map(BackupManifestFile.fromJson).toList(growable: false),
+    );
+  }
+
+  /// Current on-disk manifest format.
+  static const int currentFormatVersion = 1;
+
+  /// Manifest structure version.
+  final int formatVersion;
+
+  /// Catalog version used to classify the profile.
+  final int catalogVersion;
+
+  /// UTC instant at which capture began.
+  final DateTime createdAt;
+
+  /// Lotti package version that produced the snapshot.
+  final String appVersion;
+
+  /// Profile kind (`real` or `guest`) without device-global registry state.
+  final String profileType;
+
+  /// Stable store declarations present in this snapshot.
+  final List<BackupManifestStore> stores;
+
+  /// Every copied file, sorted by canonical relative path.
+  final List<BackupManifestFile> files;
+
+  /// JSON representation written inside the protected bundle payload.
+  Map<String, Object?> toJson() => {
+    'formatVersion': formatVersion,
+    'catalogVersion': catalogVersion,
+    'createdAt': createdAt.toIso8601String(),
+    'appVersion': appVersion,
+    'profileType': profileType,
+    'stores': [for (final store in stores) store.toJson()],
+    'files': [for (final file in files) file.toJson()],
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ProfileBackupManifest &&
+          formatVersion == other.formatVersion &&
+          catalogVersion == other.catalogVersion &&
+          createdAt == other.createdAt &&
+          appVersion == other.appVersion &&
+          profileType == other.profileType &&
+          const ListEquality<BackupManifestStore>().equals(
+            stores,
+            other.stores,
+          ) &&
+          const ListEquality<BackupManifestFile>().equals(files, other.files);
+
+  @override
+  int get hashCode => Object.hash(
+    formatVersion,
+    catalogVersion,
+    createdAt,
+    appVersion,
+    profileType,
+    Object.hashAll(stores),
+    Object.hashAll(files),
+  );
+
+  static bool _belongsToStore(
+    String relativePath,
+    BackupManifestStore store,
+  ) {
+    return switch (store.kind) {
+      BackupStoreKind.sqliteDatabase ||
+      BackupStoreKind.file => relativePath == store.relativePath,
+      BackupStoreKind.directory => relativePath.startsWith(
+        '${store.relativePath}/',
+      ),
+      BackupStoreKind.opaqueProfileContent => true,
+    };
+  }
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.isEmpty) {
+    throw FormatException('Manifest field $key must be a non-empty string.');
+  }
+  return value;
+}
+
+int _requiredInt(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! int) {
+    throw FormatException('Manifest field $key must be an integer.');
+  }
+  return value;
+}
+
+int? _optionalInt(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value == null) return null;
+  if (value is! int) {
+    throw FormatException('Manifest field $key must be an integer.');
+  }
+  return value;
+}
+
+bool _requiredBool(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! bool) {
+    throw FormatException('Manifest field $key must be a boolean.');
+  }
+  return value;
+}
+
+String _storeRelativePath(
+  Map<String, Object?> json,
+  BackupStoreKind kind,
+) {
+  final value = json['relativePath'];
+  if (value is! String ||
+      (value.isEmpty && kind != BackupStoreKind.opaqueProfileContent)) {
+    throw const FormatException(
+      'Manifest store relativePath must be a string; only an opaque root '
+      'store may use an empty path.',
+    );
+  }
+  return value;
+}
+
+T _requiredEnum<T extends Enum>(
+  Map<String, Object?> json,
+  String key,
+  List<T> values,
+) {
+  final name = _requiredString(json, key);
+  for (final value in values) {
+    if (value.name == name) return value;
+  }
+  throw FormatException('Manifest field $key has an unknown value.', name);
+}
+
+List<Map<String, Object?>> _requiredMapList(
+  Map<String, Object?> json,
+  String key,
+) {
+  final value = json[key];
+  if (value is! List<Object?>) {
+    throw FormatException('Manifest field $key must be a list.');
+  }
+  return value
+      .map((entry) {
+        if (entry is! Map<Object?, Object?>) {
+          throw FormatException('Manifest field $key must contain objects.');
+        }
+        return entry.map((key, value) {
+          if (key is! String) {
+            throw FormatException('Manifest field $key has a non-string key.');
+          }
+          return MapEntry(key, value);
+        });
+      })
+      .toList(growable: false);
+}

--- a/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
+++ b/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
@@ -1,0 +1,718 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_catalog.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_manifest.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+import 'package:uuid/uuid.dart';
+
+/// File name of the manifest beside a staged snapshot payload.
+const profileBackupManifestFileName = 'manifest.json';
+
+/// Directory containing profile-root files inside a staged snapshot.
+const profileBackupPayloadDirectoryName = 'payload';
+
+/// Base failure reported while staging a quiesced profile.
+class ProfileSnapshotException implements Exception {
+  const ProfileSnapshotException(this.message, {this.cause});
+
+  /// Actionable failure description.
+  final String message;
+
+  /// Lower-level error, when one exists.
+  final Object? cause;
+
+  @override
+  String toString() => cause == null
+      ? 'ProfileSnapshotException: $message'
+      : 'ProfileSnapshotException: $message ($cause)';
+}
+
+/// The source changed after capture began and cannot be trusted as quiesced.
+class ProfileSnapshotSourceChangedException extends ProfileSnapshotException {
+  const ProfileSnapshotSourceChangedException(super.message, {super.cause});
+}
+
+/// Staged bytes or a SQLite database failed integrity validation.
+class ProfileSnapshotValidationException extends ProfileSnapshotException {
+  const ProfileSnapshotValidationException(super.message, {super.cause});
+}
+
+/// Deterministic lifecycle seams for real-I/O snapshot tests.
+@visibleForTesting
+@immutable
+class ProfileSnapshotTestHooks {
+  const ProfileSnapshotTestHooks({
+    this.afterFileCopied,
+    this.beforeFinalSourceVerification,
+    this.beforePublish,
+  });
+
+  /// Runs after the target file is written, before source stability is checked.
+  final Future<void> Function({
+    required File sourceFile,
+    required File targetFile,
+    required String relativePath,
+  })?
+  afterFileCopied;
+
+  /// Runs after the final inventory scan, before source hashes are rechecked.
+  final Future<void> Function()? beforeFinalSourceVerification;
+
+  /// Runs immediately before the completed partial directory is verified.
+  final Future<void> Function(Directory partialDirectory)? beforePublish;
+}
+
+/// A verified snapshot that has been atomically published in the staging root.
+@immutable
+class StagedProfileSnapshot {
+  const StagedProfileSnapshot({
+    required this.directory,
+    required this.payloadDirectory,
+    required this.manifest,
+  });
+
+  /// Published snapshot directory containing the payload and manifest.
+  final Directory directory;
+
+  /// Profile-root-shaped payload directory.
+  final Directory payloadDirectory;
+
+  /// Parsed manifest verified against [payloadDirectory].
+  final ProfileBackupManifest manifest;
+}
+
+/// Builds an integrity-checked snapshot from an already-quiesced profile root.
+///
+/// This service does not stop application writers. Its caller must first prove
+/// strict quiescence. Journal companions and source mutation make the operation
+/// fail closed, so lifecycle code cannot accidentally turn a live filesystem
+/// copy into an apparently valid backup.
+class QuiescedProfileSnapshotService {
+  QuiescedProfileSnapshotService({
+    String Function()? snapshotIdGenerator,
+    DateTime Function()? now,
+    @visibleForTesting this.testHooks,
+  }) : _snapshotIdGenerator = snapshotIdGenerator ?? const Uuid().v4,
+       _now = now ?? DateTime.now;
+
+  final String Function() _snapshotIdGenerator;
+  final DateTime Function() _now;
+
+  /// Optional deterministic hooks used only by real-I/O tests.
+  @visibleForTesting
+  final ProfileSnapshotTestHooks? testHooks;
+
+  static final RegExp _safeSnapshotId = RegExp(r'^[a-zA-Z0-9_-]+$');
+
+  /// Stages and atomically publishes one closed profile snapshot.
+  Future<StagedProfileSnapshot> stage({
+    required Directory sourceRoot,
+    required Directory stagingParent,
+    required String appVersion,
+    required String profileType,
+  }) async {
+    _validateTreeBoundary(sourceRoot, stagingParent);
+    final createdAt = _now().toUtc();
+
+    final inventory = await _scanIncludedEntries(sourceRoot);
+    _validateRequiredStores(inventory);
+
+    final snapshotId = _snapshotIdGenerator();
+    if (!_safeSnapshotId.hasMatch(snapshotId)) {
+      throw ProfileSnapshotException(
+        'Snapshot id contains unsafe path characters: $snapshotId',
+      );
+    }
+
+    stagingParent.createSync(recursive: true);
+    _validateResolvedTreeBoundary(sourceRoot, stagingParent);
+
+    final finalDirectory = Directory(
+      p.join(stagingParent.path, 'profile-snapshot-$snapshotId'),
+    );
+    if (FileSystemEntity.typeSync(finalDirectory.path, followLinks: false) !=
+        FileSystemEntityType.notFound) {
+      throw ProfileSnapshotException(
+        'Snapshot destination already exists: ${finalDirectory.path}',
+      );
+    }
+
+    final partialDirectory = await stagingParent.createTemp(
+      '.profile-snapshot-$snapshotId.partial-',
+    );
+    try {
+      final payloadDirectory = Directory(
+        p.join(partialDirectory.path, profileBackupPayloadDirectoryName),
+      )..createSync();
+
+      final records = <BackupManifestFile>[];
+      final manifestStores = <String, BackupManifestStore>{};
+
+      for (final entry in inventory.where(
+        (entry) => entry.kind == _SnapshotEntryKind.directory,
+      )) {
+        Directory(
+          p.joinAll([
+            payloadDirectory.path,
+            ...entry.relativePath.split('/'),
+          ]),
+        ).createSync(recursive: true);
+        _addManifestStore(manifestStores, entry.decision);
+      }
+
+      for (final entry in inventory.where(
+        (entry) => entry.kind == _SnapshotEntryKind.file,
+      )) {
+        final sourceFile = File(
+          p.joinAll([sourceRoot.path, ...entry.relativePath.split('/')]),
+        );
+        final targetFile = File(
+          p.joinAll([
+            payloadDirectory.path,
+            ...entry.relativePath.split('/'),
+          ]),
+        );
+        targetFile.parent.createSync(recursive: true);
+
+        final digest = await _copyAndVerifyStableSource(
+          sourceFile: sourceFile,
+          targetFile: targetFile,
+          relativePath: entry.relativePath,
+          initialStat: entry.stat,
+        );
+        final schemaVersion =
+            entry.decision.kind == BackupStoreKind.sqliteDatabase
+            ? _validateSqlite(targetFile)
+            : null;
+        _addManifestStore(
+          manifestStores,
+          entry.decision,
+          schemaVersion: schemaVersion,
+        );
+        records.add(
+          BackupManifestFile(
+            storeId: entry.decision.storeId,
+            relativePath: entry.relativePath,
+            sizeBytes: digest.sizeBytes,
+            sha256: digest.sha256,
+          ),
+        );
+      }
+
+      final finalInventory = await _scanIncludedEntries(sourceRoot);
+      _validateSameInventory(inventory, finalInventory);
+      await testHooks?.beforeFinalSourceVerification?.call();
+      await _validateSourceDigests(sourceRoot, records);
+
+      final manifest = ProfileBackupManifest(
+        createdAt: createdAt,
+        appVersion: appVersion,
+        profileType: profileType,
+        stores: manifestStores.values.toList(growable: false),
+        files: records,
+      );
+      final manifestFile = File(
+        p.join(partialDirectory.path, profileBackupManifestFileName),
+      );
+      await manifestFile.writeAsString(
+        const JsonEncoder.withIndent('  ').convert(manifest.toJson()),
+        flush: true,
+      );
+
+      await testHooks?.beforePublish?.call(partialDirectory);
+      final verifiedManifest = await _verifyPartialSnapshot(partialDirectory);
+      if (verifiedManifest != manifest) {
+        throw const ProfileSnapshotValidationException(
+          'Staged manifest changed before publication.',
+        );
+      }
+
+      final publishedDirectory = await partialDirectory.rename(
+        finalDirectory.path,
+      );
+      return StagedProfileSnapshot(
+        directory: publishedDirectory,
+        payloadDirectory: Directory(
+          p.join(
+            publishedDirectory.path,
+            profileBackupPayloadDirectoryName,
+          ),
+        ),
+        manifest: verifiedManifest,
+      );
+    } catch (error, stackTrace) {
+      try {
+        if (partialDirectory.existsSync()) {
+          await partialDirectory.delete(recursive: true);
+        }
+      } catch (cleanupError) {
+        Error.throwWithStackTrace(
+          ProfileSnapshotException(
+            'Snapshot failed and its partial stage could not be removed.',
+            cause: '$error; cleanup: $cleanupError',
+          ),
+          stackTrace,
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  static void _validateTreeBoundary(
+    Directory sourceRoot,
+    Directory stagingParent,
+  ) {
+    if (!sourceRoot.existsSync()) {
+      throw ProfileSnapshotException(
+        'Profile source does not exist: ${sourceRoot.path}',
+      );
+    }
+    final source = p.normalize(sourceRoot.absolute.path);
+    final staging = p.normalize(stagingParent.absolute.path);
+    if (p.equals(source, staging) ||
+        p.isWithin(source, staging) ||
+        p.isWithin(staging, source)) {
+      throw const ProfileSnapshotException(
+        'Snapshot source and staging directory may not overlap.',
+      );
+    }
+  }
+
+  static void _validateResolvedTreeBoundary(
+    Directory sourceRoot,
+    Directory stagingParent,
+  ) {
+    final source = p.normalize(sourceRoot.resolveSymbolicLinksSync());
+    final staging = p.normalize(stagingParent.resolveSymbolicLinksSync());
+    if (p.equals(source, staging) ||
+        p.isWithin(source, staging) ||
+        p.isWithin(staging, source)) {
+      throw const ProfileSnapshotException(
+        'Resolved snapshot source and staging directory may not overlap.',
+      );
+    }
+  }
+
+  static Future<List<_SnapshotSourceEntry>> _scanIncludedEntries(
+    Directory sourceRoot,
+  ) async {
+    final entries = <_SnapshotSourceEntry>[];
+
+    Future<void> scan(Directory directory, String relativeDirectory) async {
+      final children = await directory.list(followLinks: false).toList()
+        ..sort((a, b) => p.basename(a.path).compareTo(p.basename(b.path)));
+      for (final child in children) {
+        final name = p.basename(child.path);
+        final relativePath = relativeDirectory.isEmpty
+            ? name
+            : '$relativeDirectory/$name';
+        final decision = ProfileBackupCatalog.classify(relativePath);
+        if (decision.treatment == BackupPathTreatment.reject) {
+          throw ProfileSnapshotException(
+            'Unsafe snapshot source at $relativePath: ${decision.rationale}',
+          );
+        }
+        if (decision.treatment == BackupPathTreatment.exclude ||
+            decision.treatment == BackupPathTreatment.rebuild) {
+          continue;
+        }
+
+        final type = FileSystemEntity.typeSync(child.path, followLinks: false);
+        if (type == FileSystemEntityType.link) {
+          throw ProfileSnapshotException(
+            'Snapshot source may not contain symbolic links: $relativePath',
+          );
+        }
+        if (type == FileSystemEntityType.directory) {
+          final stat = child.statSync();
+          entries.add(
+            _SnapshotSourceEntry(
+              relativePath: relativePath,
+              kind: _SnapshotEntryKind.directory,
+              decision: decision,
+              stat: stat,
+            ),
+          );
+          await scan(Directory(child.path), relativePath);
+          continue;
+        }
+        if (type == FileSystemEntityType.file) {
+          entries.add(
+            _SnapshotSourceEntry(
+              relativePath: relativePath,
+              kind: _SnapshotEntryKind.file,
+              decision: decision,
+              stat: child.statSync(),
+            ),
+          );
+          continue;
+        }
+        throw ProfileSnapshotSourceChangedException(
+          'Snapshot source disappeared while scanning: $relativePath',
+        );
+      }
+    }
+
+    await scan(sourceRoot, '');
+    entries.sort((a, b) => a.relativePath.compareTo(b.relativePath));
+    return entries;
+  }
+
+  static void _validateRequiredStores(List<_SnapshotSourceEntry> inventory) {
+    final present = inventory.map((entry) => entry.relativePath).toSet();
+    for (final store in ProfileBackupCatalog.stores) {
+      if (store.required &&
+          store.treatment == BackupPathTreatment.include &&
+          !present.contains(store.relativePath)) {
+        throw ProfileSnapshotValidationException(
+          'Required profile store is missing: ${store.relativePath}',
+        );
+      }
+    }
+  }
+
+  static void _validateSameInventory(
+    List<_SnapshotSourceEntry> initial,
+    List<_SnapshotSourceEntry> finalInventory,
+  ) {
+    if (initial.length != finalInventory.length) {
+      throw const ProfileSnapshotSourceChangedException(
+        'Profile file inventory changed during snapshot capture.',
+      );
+    }
+    for (var index = 0; index < initial.length; index++) {
+      final before = initial[index];
+      final after = finalInventory[index];
+      if (before.relativePath != after.relativePath ||
+          before.kind != after.kind ||
+          before.stat.size != after.stat.size ||
+          before.stat.modified.toUtc() != after.stat.modified.toUtc()) {
+        throw ProfileSnapshotSourceChangedException(
+          'Profile path changed during snapshot capture: '
+          '${before.relativePath}',
+        );
+      }
+    }
+  }
+
+  Future<_FileDigest> _copyAndVerifyStableSource({
+    required File sourceFile,
+    required File targetFile,
+    required String relativePath,
+    required FileStat initialStat,
+  }) async {
+    if (FileSystemEntity.typeSync(sourceFile.path, followLinks: false) !=
+        FileSystemEntityType.file) {
+      throw ProfileSnapshotSourceChangedException(
+        'Source path is no longer a regular file: $relativePath',
+      );
+    }
+    final digestSink = _DigestSink();
+    final converter = sha256.startChunkedConversion(digestSink);
+    final output = targetFile.openWrite();
+    var sizeBytes = 0;
+    try {
+      await for (final chunk in sourceFile.openRead()) {
+        converter.add(chunk);
+        output.add(chunk);
+        sizeBytes += chunk.length;
+      }
+      await output.flush();
+    } finally {
+      converter.close();
+      await output.close();
+    }
+    final copiedSha256 = digestSink.digest.toString();
+
+    await testHooks?.afterFileCopied?.call(
+      sourceFile: sourceFile,
+      targetFile: targetFile,
+      relativePath: relativePath,
+    );
+
+    final finalType = FileSystemEntity.typeSync(
+      sourceFile.path,
+      followLinks: false,
+    );
+    if (finalType == FileSystemEntityType.notFound) {
+      throw ProfileSnapshotSourceChangedException(
+        'Source file disappeared during snapshot capture: $relativePath',
+      );
+    }
+    if (finalType != FileSystemEntityType.file) {
+      throw ProfileSnapshotSourceChangedException(
+        'Source path stopped being a regular file: $relativePath',
+      );
+    }
+    final finalStat = sourceFile.statSync();
+    if (initialStat.size != finalStat.size ||
+        initialStat.modified.toUtc() != finalStat.modified.toUtc() ||
+        sizeBytes != initialStat.size) {
+      throw ProfileSnapshotSourceChangedException(
+        'Source file changed during snapshot capture: $relativePath',
+      );
+    }
+
+    final stableSource = await _hashFile(sourceFile);
+    if (stableSource.sizeBytes != sizeBytes ||
+        stableSource.sha256 != copiedSha256) {
+      throw ProfileSnapshotSourceChangedException(
+        'Source bytes changed during snapshot capture: $relativePath',
+      );
+    }
+    final copiedTarget = await _hashFile(targetFile);
+    if (copiedTarget.sizeBytes != sizeBytes ||
+        copiedTarget.sha256 != copiedSha256) {
+      throw ProfileSnapshotValidationException(
+        'Copied bytes failed verification: $relativePath',
+      );
+    }
+    return _FileDigest(sizeBytes: sizeBytes, sha256: copiedSha256);
+  }
+
+  static Future<void> _validateSourceDigests(
+    Directory sourceRoot,
+    List<BackupManifestFile> records,
+  ) async {
+    for (final record in records) {
+      final sourceFile = File(
+        p.joinAll([sourceRoot.path, ...record.relativePath.split('/')]),
+      );
+      if (!sourceFile.existsSync()) {
+        throw ProfileSnapshotSourceChangedException(
+          'Source file disappeared before publication: ${record.relativePath}',
+        );
+      }
+      final digest = await _hashFile(sourceFile);
+      if (digest.sizeBytes != record.sizeBytes ||
+          digest.sha256 != record.sha256) {
+        throw ProfileSnapshotSourceChangedException(
+          'Source bytes changed before publication: ${record.relativePath}',
+        );
+      }
+    }
+  }
+
+  static int _validateSqlite(File databaseFile) {
+    Database? database;
+    try {
+      database = sqlite3.open(
+        Uri.file(
+          databaseFile.path,
+        ).replace(queryParameters: const {'immutable': '1'}).toString(),
+        mode: OpenMode.readOnly,
+        uri: true,
+      );
+      final check = database.select('PRAGMA integrity_check');
+      if (check.length != 1 || check.single.values.single != 'ok') {
+        throw ProfileSnapshotValidationException(
+          'SQLite integrity_check failed for ${databaseFile.path}: $check',
+        );
+      }
+      return database.userVersion;
+    } on ProfileSnapshotValidationException {
+      rethrow;
+    } catch (error) {
+      throw ProfileSnapshotValidationException(
+        'Unable to validate SQLite database: ${databaseFile.path}',
+        cause: error,
+      );
+    } finally {
+      database?.dispose();
+    }
+  }
+
+  static void _addManifestStore(
+    Map<String, BackupManifestStore> target,
+    BackupPathDecision decision, {
+    int? schemaVersion,
+  }) {
+    final catalogStore = ProfileBackupCatalog.stores.firstWhere(
+      (store) => store.id == decision.storeId,
+    );
+    final candidate = BackupManifestStore(
+      id: catalogStore.id,
+      relativePath: catalogStore.relativePath,
+      kind: catalogStore.kind,
+      sensitivity: catalogStore.sensitivity,
+      required: catalogStore.required,
+      schemaVersion: schemaVersion,
+    );
+    final existing = target[decision.storeId];
+    if (existing?.schemaVersion == null) {
+      target[decision.storeId] = candidate;
+    }
+  }
+
+  static Future<ProfileBackupManifest> _verifyPartialSnapshot(
+    Directory partialDirectory,
+  ) async {
+    final manifestFile = File(
+      p.join(partialDirectory.path, profileBackupManifestFileName),
+    );
+    if (!manifestFile.existsSync()) {
+      throw const ProfileSnapshotValidationException(
+        'Staged snapshot manifest is missing.',
+      );
+    }
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(await manifestFile.readAsString());
+    } catch (error) {
+      throw ProfileSnapshotValidationException(
+        'Staged snapshot manifest is not valid JSON.',
+        cause: error,
+      );
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const ProfileSnapshotValidationException(
+        'Staged snapshot manifest root must be an object.',
+      );
+    }
+    final ProfileBackupManifest manifest;
+    try {
+      manifest = ProfileBackupManifest.fromJson(decoded);
+    } catch (error) {
+      throw ProfileSnapshotValidationException(
+        'Staged snapshot manifest failed validation.',
+        cause: error,
+      );
+    }
+    final payloadDirectory = Directory(
+      p.join(partialDirectory.path, profileBackupPayloadDirectoryName),
+    );
+    if (!payloadDirectory.existsSync()) {
+      throw const ProfileSnapshotValidationException(
+        'Staged snapshot payload is missing.',
+      );
+    }
+
+    final actualPaths = <String>[];
+    await for (final entity in payloadDirectory.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      final type = FileSystemEntity.typeSync(entity.path, followLinks: false);
+      if (type == FileSystemEntityType.link) {
+        throw const ProfileSnapshotValidationException(
+          'Staged snapshot payload may not contain symbolic links.',
+        );
+      }
+      if (type == FileSystemEntityType.file) {
+        actualPaths.add(_manifestRelativePath(entity.path, payloadDirectory));
+        continue;
+      }
+      if (type != FileSystemEntityType.directory) {
+        throw const ProfileSnapshotValidationException(
+          'Staged snapshot payload contains an unsupported filesystem entry.',
+        );
+      }
+    }
+    actualPaths.sort();
+    final expectedPaths = manifest.files
+        .map((file) => file.relativePath)
+        .toList(growable: false);
+    if (!_sameStrings(actualPaths, expectedPaths)) {
+      throw ProfileSnapshotValidationException(
+        'Staged payload files do not match the manifest. '
+        'actual=$actualPaths expected=$expectedPaths',
+      );
+    }
+
+    final storesById = {for (final store in manifest.stores) store.id: store};
+    for (final record in manifest.files) {
+      final file = File(
+        p.joinAll([
+          payloadDirectory.path,
+          ...record.relativePath.split('/'),
+        ]),
+      );
+      final digest = await _hashFile(file);
+      if (digest.sizeBytes != record.sizeBytes ||
+          digest.sha256 != record.sha256) {
+        throw ProfileSnapshotValidationException(
+          'Staged file failed checksum verification: ${record.relativePath}',
+        );
+      }
+      if (storesById[record.storeId]?.kind == BackupStoreKind.sqliteDatabase) {
+        final schemaVersion = _validateSqlite(file);
+        if (schemaVersion != storesById[record.storeId]?.schemaVersion) {
+          throw ProfileSnapshotValidationException(
+            'SQLite schema version changed for ${record.relativePath}.',
+          );
+        }
+      }
+    }
+    return manifest;
+  }
+
+  static Future<_FileDigest> _hashFile(File file) async {
+    final digestSink = _DigestSink();
+    final converter = sha256.startChunkedConversion(digestSink);
+    var sizeBytes = 0;
+    try {
+      await for (final chunk in file.openRead()) {
+        converter.add(chunk);
+        sizeBytes += chunk.length;
+      }
+    } finally {
+      converter.close();
+    }
+    return _FileDigest(
+      sizeBytes: sizeBytes,
+      sha256: digestSink.digest.toString(),
+    );
+  }
+
+  static String _manifestRelativePath(
+    String entityPath,
+    Directory payloadDirectory,
+  ) => p.split(p.relative(entityPath, from: payloadDirectory.path)).join('/');
+
+  static bool _sameStrings(List<String> left, List<String> right) {
+    if (left.length != right.length) return false;
+    for (var index = 0; index < left.length; index++) {
+      if (left[index] != right[index]) return false;
+    }
+    return true;
+  }
+}
+
+enum _SnapshotEntryKind { file, directory }
+
+@immutable
+class _SnapshotSourceEntry {
+  const _SnapshotSourceEntry({
+    required this.relativePath,
+    required this.kind,
+    required this.decision,
+    required this.stat,
+  });
+
+  final String relativePath;
+  final _SnapshotEntryKind kind;
+  final BackupPathDecision decision;
+  final FileStat stat;
+}
+
+@immutable
+class _FileDigest {
+  const _FileDigest({required this.sizeBytes, required this.sha256});
+
+  final int sizeBytes;
+  final String sha256;
+}
+
+class _DigestSink implements Sink<Digest> {
+  late Digest digest;
+
+  @override
+  void add(Digest data) => digest = data;
+
+  @override
+  void close() {}
+}

--- a/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
+++ b/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
@@ -124,6 +124,7 @@ class QuiescedProfileSnapshotService {
     required String profileType,
   }) async {
     _validateTreeBoundary(sourceRoot, stagingParent);
+    _validateResolvedTreeBoundary(sourceRoot, stagingParent);
     final createdAt = _now().toUtc();
 
     final inventory = await _scanIncludedEntries(sourceRoot);
@@ -137,7 +138,6 @@ class QuiescedProfileSnapshotService {
     }
 
     stagingParent.createSync(recursive: true);
-    _validateResolvedTreeBoundary(sourceRoot, stagingParent);
 
     final finalDirectory = Directory(
       p.join(stagingParent.path, 'profile-snapshot-$snapshotId'),
@@ -299,7 +299,7 @@ class QuiescedProfileSnapshotService {
     Directory stagingParent,
   ) {
     final source = p.normalize(sourceRoot.resolveSymbolicLinksSync());
-    final staging = p.normalize(stagingParent.resolveSymbolicLinksSync());
+    final staging = _resolveThroughExistingAncestor(stagingParent);
     if (p.equals(source, staging) ||
         p.isWithin(source, staging) ||
         p.isWithin(staging, source)) {
@@ -307,6 +307,32 @@ class QuiescedProfileSnapshotService {
         'Resolved snapshot source and staging directory may not overlap.',
       );
     }
+  }
+
+  static String _resolveThroughExistingAncestor(Directory directory) {
+    var ancestor = Directory(p.normalize(directory.absolute.path));
+    final missingSegments = <String>[];
+    while (FileSystemEntity.typeSync(ancestor.path, followLinks: false) ==
+        FileSystemEntityType.notFound) {
+      final parent = ancestor.parent;
+      // A filesystem root always exists; this guards only a broken platform
+      // implementation of the ancestor walk.
+      // coverage:ignore-start
+      if (p.equals(parent.path, ancestor.path)) {
+        throw ProfileSnapshotException(
+          'Unable to resolve snapshot staging path: ${directory.path}',
+        );
+      }
+      // coverage:ignore-end
+      missingSegments.add(p.basename(ancestor.path));
+      ancestor = parent;
+    }
+    return p.normalize(
+      p.joinAll([
+        ancestor.resolveSymbolicLinksSync(),
+        ...missingSegments.reversed,
+      ]),
+    );
   }
 
   static Future<List<_SnapshotSourceEntry>> _scanIncludedEntries(
@@ -375,13 +401,29 @@ class QuiescedProfileSnapshotService {
   }
 
   static void _validateRequiredStores(List<_SnapshotSourceEntry> inventory) {
-    final present = inventory.map((entry) => entry.relativePath).toSet();
+    final entriesByPath = {
+      for (final entry in inventory) entry.relativePath: entry,
+    };
     for (final store in ProfileBackupCatalog.stores) {
-      if (store.required &&
-          store.treatment == BackupPathTreatment.include &&
-          !present.contains(store.relativePath)) {
+      if (!store.required || store.treatment != BackupPathTreatment.include) {
+        continue;
+      }
+      final entry = entriesByPath[store.relativePath];
+      if (entry == null) {
         throw ProfileSnapshotValidationException(
           'Required profile store is missing: ${store.relativePath}',
+        );
+      }
+      final expectedKind = store.kind == BackupStoreKind.directory
+          ? _SnapshotEntryKind.directory
+          : _SnapshotEntryKind.file;
+      if (entry.kind != expectedKind) {
+        final expectedDescription = expectedKind == _SnapshotEntryKind.file
+            ? 'a regular file'
+            : 'a directory';
+        throw ProfileSnapshotValidationException(
+          'Required profile store ${store.relativePath} must be '
+          '$expectedDescription.',
         );
       }
     }

--- a/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
+++ b/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
@@ -128,7 +128,7 @@ class QuiescedProfileSnapshotService {
     final createdAt = _now().toUtc();
 
     final inventory = await _scanIncludedEntries(sourceRoot);
-    _validateRequiredStores(inventory);
+    _validateIncludedStores(inventory);
 
     final snapshotId = _snapshotIdGenerator();
     if (!_safeSnapshotId.hasMatch(snapshotId)) {
@@ -238,6 +238,8 @@ class QuiescedProfileSnapshotService {
           'Staged manifest changed before publication.',
         );
       }
+      final terminalInventory = await _scanIncludedEntries(sourceRoot);
+      _validateSameInventory(inventory, terminalInventory);
 
       final publishedDirectory = await partialDirectory.rename(
         finalDirectory.path,
@@ -400,19 +402,22 @@ class QuiescedProfileSnapshotService {
     return entries;
   }
 
-  static void _validateRequiredStores(List<_SnapshotSourceEntry> inventory) {
+  static void _validateIncludedStores(List<_SnapshotSourceEntry> inventory) {
     final entriesByPath = {
       for (final entry in inventory) entry.relativePath: entry,
     };
     for (final store in ProfileBackupCatalog.stores) {
-      if (!store.required || store.treatment != BackupPathTreatment.include) {
+      if (store.treatment != BackupPathTreatment.include) {
         continue;
       }
       final entry = entriesByPath[store.relativePath];
       if (entry == null) {
-        throw ProfileSnapshotValidationException(
-          'Required profile store is missing: ${store.relativePath}',
-        );
+        if (store.required) {
+          throw ProfileSnapshotValidationException(
+            'Required profile store is missing: ${store.relativePath}',
+          );
+        }
+        continue;
       }
       final expectedKind = store.kind == BackupStoreKind.directory
           ? _SnapshotEntryKind.directory
@@ -422,7 +427,7 @@ class QuiescedProfileSnapshotService {
             ? 'a regular file'
             : 'a directory';
         throw ProfileSnapshotValidationException(
-          'Required profile store ${store.relativePath} must be '
+          'Profile store ${store.relativePath} must be '
           '$expectedDescription.',
         );
       }
@@ -643,9 +648,18 @@ class QuiescedProfileSnapshotService {
     final payloadDirectory = Directory(
       p.join(partialDirectory.path, profileBackupPayloadDirectoryName),
     );
-    if (!payloadDirectory.existsSync()) {
+    final payloadType = FileSystemEntity.typeSync(
+      payloadDirectory.path,
+      followLinks: false,
+    );
+    if (payloadType == FileSystemEntityType.notFound) {
       throw const ProfileSnapshotValidationException(
         'Staged snapshot payload is missing.',
+      );
+    }
+    if (payloadType != FileSystemEntityType.directory) {
+      throw const ProfileSnapshotValidationException(
+        'Staged snapshot payload must be a real directory.',
       );
     }
 

--- a/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
+++ b/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
@@ -47,6 +47,7 @@ class ProfileSnapshotValidationException extends ProfileSnapshotException {
 class ProfileSnapshotTestHooks {
   const ProfileSnapshotTestHooks({
     this.afterFileCopied,
+    this.beforeSourceRehash,
     this.beforeFinalSourceVerification,
     this.beforePublish,
   });
@@ -58,6 +59,13 @@ class ProfileSnapshotTestHooks {
     required String relativePath,
   })?
   afterFileCopied;
+
+  /// Runs after source metadata is stable, before source bytes are rehashed.
+  final Future<void> Function({
+    required File sourceFile,
+    required String relativePath,
+  })?
+  beforeSourceRehash;
 
   /// Runs after the final inventory scan, before source hashes are rechecked.
   final Future<void> Function()? beforeFinalSourceVerification;
@@ -250,6 +258,9 @@ class QuiescedProfileSnapshotService {
           await partialDirectory.delete(recursive: true);
         }
       } catch (cleanupError) {
+        // An OS-level cleanup failure cannot be induced portably without
+        // weakening the production filesystem boundary.
+        // coverage:ignore-start
         Error.throwWithStackTrace(
           ProfileSnapshotException(
             'Snapshot failed and its partial stage could not be removed.',
@@ -257,6 +268,7 @@ class QuiescedProfileSnapshotService {
           ),
           stackTrace,
         );
+        // coverage:ignore-end
       }
       Error.throwWithStackTrace(error, stackTrace);
     }
@@ -457,6 +469,10 @@ class QuiescedProfileSnapshotService {
       );
     }
 
+    await testHooks?.beforeSourceRehash?.call(
+      sourceFile: sourceFile,
+      relativePath: relativePath,
+    );
     final stableSource = await _hashFile(sourceFile);
     if (stableSource.sizeBytes != sizeBytes ||
         stableSource.sha256 != copiedSha256) {

--- a/lib/features/sync/matrix/client.dart
+++ b/lib/features/sync/matrix/client.dart
@@ -6,14 +6,25 @@ import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+/// Directory below the active profile root that owns Matrix SDK state.
+const matrixDatabaseDirectoryName = 'matrix';
+
+/// Default logical database name passed to the Matrix SDK.
+const matrixDatabaseName = 'lotti_sync';
+
+/// Default Matrix SDK database path relative to the active profile root.
+const matrixDatabaseRelativePath =
+    '$matrixDatabaseDirectoryName/$matrixDatabaseName.db';
+
 Future<Client> createMatrixClient({
   required Directory documentsDirectory,
   String? deviceDisplayName,
   String? dbName,
   bool? singleInstance,
 }) async {
-  final name = dbName ?? 'lotti_sync';
-  final path = '${documentsDirectory.path}/matrix/$name.db';
+  final name = dbName ?? matrixDatabaseName;
+  final path =
+      '${documentsDirectory.path}/$matrixDatabaseDirectoryName/$name.db';
 
   sqfliteFfiInit();
   final dbFactory = createDatabaseFactoryFfi(ffiInit: sqfliteFfiInit);

--- a/test/features/backup_restore/domain/profile_backup_catalog_test.dart
+++ b/test/features/backup_restore/domain/profile_backup_catalog_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_catalog.dart';
+
+void main() {
+  group('ProfileBackupCatalog', () {
+    test('enumerates every SQLite store with a stable identity', () {
+      final sqliteStores = ProfileBackupCatalog.stores
+          .where((store) => store.kind == BackupStoreKind.sqliteDatabase)
+          .toList(growable: false);
+
+      expect(
+        {for (final store in sqliteStores) store.relativePath: store.id},
+        {
+          'db.sqlite': 'journal',
+          'sync.sqlite': 'sync',
+          'agent.sqlite': 'agents',
+          'editor_drafts_db.sqlite': 'editor-drafts',
+          'ai_consumption.sqlite': 'ai-consumption',
+          'settings.sqlite': 'settings',
+          'fts5_db.sqlite': 'full-text-index',
+          'notifications.sqlite': 'notifications',
+          'onboarding_metrics.sqlite': 'onboarding-metrics',
+          'ai_config.sqlite': 'ai-config',
+          'day_processing.sqlite': 'day-processing',
+          'matrix/lotti_sync.db': 'matrix-sdk',
+        },
+      );
+      expect(
+        sqliteStores.map((store) => store.id).toSet(),
+        hasLength(sqliteStores.length),
+      );
+    });
+
+    test('distinguishes protected authoritative and rebuildable stores', () {
+      expect(
+        ProfileBackupCatalog.classify('ai_config.sqlite'),
+        isA<BackupPathDecision>()
+            .having(
+              (decision) => decision.treatment,
+              'treatment',
+              BackupPathTreatment.include,
+            )
+            .having(
+              (decision) => decision.sensitivity,
+              'sensitivity',
+              BackupSensitivity.credentials,
+            ),
+      );
+      expect(
+        ProfileBackupCatalog.classify('matrix/lotti_sync.db'),
+        isA<BackupPathDecision>()
+            .having(
+              (decision) => decision.storeId,
+              'storeId',
+              'matrix-sdk',
+            )
+            .having(
+              (decision) => decision.sensitivity,
+              'sensitivity',
+              BackupSensitivity.credentials,
+            ),
+      );
+      expect(
+        ProfileBackupCatalog.classify('fts5_db.sqlite').treatment,
+        BackupPathTreatment.rebuild,
+      );
+      expect(
+        ProfileBackupCatalog.classify(
+          'objectbox_embeddings_sharded/category/data.mdb',
+        ).treatment,
+        BackupPathTreatment.rebuild,
+      );
+      expect(
+        ProfileBackupCatalog.classify(
+          'audio_waveforms/ab/entry.json',
+        ).treatment,
+        BackupPathTreatment.rebuild,
+      );
+    });
+
+    test('includes opaque media and sidecars by default', () {
+      for (final path in [
+        'audio/2026-08-06/recording.m4a',
+        'images/2026-08-06/photo.jpg',
+        'agent_entities/agent.json',
+        'agent_links/link.json',
+        'notifications/notification.json',
+        'outbox_bundles/bundle.json',
+        'future_feature/new_store.bin',
+      ]) {
+        expect(
+          ProfileBackupCatalog.classify(path),
+          isA<BackupPathDecision>()
+              .having(
+                (decision) => decision.treatment,
+                '$path treatment',
+                BackupPathTreatment.include,
+              )
+              .having(
+                (decision) => decision.sensitivity,
+                '$path sensitivity',
+                BackupSensitivity.personal,
+              ),
+        );
+      }
+    });
+
+    test('excludes device-global, diagnostic, and recursive content', () {
+      for (final path in [
+        'profiles.json',
+        'profiles.json.tmp.123.456.media',
+        'profiles.json.bak.123',
+        'guest_profiles/demo/db.sqlite',
+        'backup/db.2026-08-06.sqlite',
+        'logs/general-2026-08-06.log',
+        'logs/general.log.tmp.123.456.media',
+      ]) {
+        expect(
+          ProfileBackupCatalog.classify(path).treatment,
+          BackupPathTreatment.exclude,
+          reason: path,
+        );
+      }
+    });
+
+    test('rejects SQLite companions and interrupted atomic writes', () {
+      for (final path in [
+        'db.sqlite-wal',
+        'sync.sqlite-shm',
+        'agent.sqlite-journal',
+        'future_store.sqlite-wal',
+        'agent_entities/id.json.tmp.123.456.media',
+        'agent_entities/id.json.bak.123',
+      ]) {
+        expect(
+          ProfileBackupCatalog.classify(path).treatment,
+          BackupPathTreatment.reject,
+          reason: path,
+        );
+      }
+    });
+
+    test('refuses non-canonical or escaping paths', () {
+      for (final path in [
+        '',
+        '/db.sqlite',
+        '../db.sqlite',
+        'images/../db.sqlite',
+        r'images\entry.jpg',
+        'images//entry.jpg',
+        'C:/db.sqlite',
+      ]) {
+        expect(
+          () => ProfileBackupCatalog.classify(path),
+          throwsFormatException,
+          reason: path,
+        );
+      }
+    });
+  });
+}

--- a/test/features/backup_restore/domain/profile_backup_catalog_test.dart
+++ b/test/features/backup_restore/domain/profile_backup_catalog_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/backup_restore/domain/profile_backup_catalog.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_startup.dart';
 
 void main() {
   group('ProfileBackupCatalog', () {
@@ -114,6 +115,7 @@ void main() {
         'backup/db.2026-08-06.sqlite',
         'logs/general-2026-08-06.log',
         'logs/general.log.tmp.123.456.media',
+        '$legacyDayProcessingOutboxDirectory/job.json.tmp.1737000000000000.4242.media',
       ]) {
         expect(
           ProfileBackupCatalog.classify(path).treatment,

--- a/test/features/backup_restore/domain/profile_backup_manifest_test.dart
+++ b/test/features/backup_restore/domain/profile_backup_manifest_test.dart
@@ -17,6 +17,21 @@ void main() {
     schemaVersion: 45,
   );
 
+  ProfileBackupManifest validManifest() => ProfileBackupManifest(
+    createdAt: DateTime.utc(2026, 8, 6),
+    appVersion: '1.0.4+4285',
+    profileType: 'real',
+    stores: [journalStore()],
+    files: const [
+      BackupManifestFile(
+        storeId: 'journal',
+        relativePath: 'db.sqlite',
+        sizeBytes: 1,
+        sha256: hashA,
+      ),
+    ],
+  );
+
   group('ProfileBackupManifest', () {
     test('round-trips a deterministic, path-sorted manifest', () {
       final manifest = ProfileBackupManifest(
@@ -53,10 +68,14 @@ void main() {
         manifest.files.map((file) => file.relativePath),
         ['db.sqlite', 'images/entry.jpg'],
       );
+      final roundTripped = ProfileBackupManifest.fromJson(manifest.toJson());
+      expect(roundTripped, manifest);
+      expect(roundTripped.hashCode, manifest.hashCode);
       expect(
-        ProfileBackupManifest.fromJson(manifest.toJson()),
-        manifest,
+        roundTripped.stores.first.hashCode,
+        manifest.stores.first.hashCode,
       );
+      expect(roundTripped.files.first.hashCode, manifest.files.first.hashCode);
       expect(manifest.toJson()['formatVersion'], 1);
       expect(manifest.toJson()['catalogVersion'], 1);
     });
@@ -186,11 +205,292 @@ void main() {
         throwsUnsupportedError,
       );
       expect(
+        () => ProfileBackupManifest.fromJson({...json, 'catalogVersion': 2}),
+        throwsUnsupportedError,
+      );
+      expect(
         () => ProfileBackupManifest.fromJson({
           ...json,
           'createdAt': '2026-08-06T00:00:00+02:00',
         }),
         throwsFormatException,
+      );
+      expect(
+        () => ProfileBackupManifest.fromJson({
+          ...json,
+          'createdAt': 'not-a-dateZ',
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects invalid typed manifest semantics', () {
+      const file = BackupManifestFile(
+        storeId: 'journal',
+        relativePath: 'db.sqlite',
+        sizeBytes: 1,
+        sha256: hashA,
+      );
+      final cases = <({String name, void Function() create})>[
+        (
+          name: 'local creation time',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: [journalStore()],
+            files: const [file],
+          ),
+        ),
+        (
+          name: 'blank app version',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '   ',
+            profileType: 'real',
+            stores: [journalStore()],
+            files: const [file],
+          ),
+        ),
+        (
+          name: 'unknown profile type',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'temporary',
+            stores: [journalStore()],
+            files: const [file],
+          ),
+        ),
+        (
+          name: 'invalid store id',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: const [
+              BackupManifestStore(
+                id: 'Invalid_ID',
+                relativePath: 'db.sqlite',
+                kind: BackupStoreKind.sqliteDatabase,
+                sensitivity: BackupSensitivity.personal,
+                required: true,
+                schemaVersion: 45,
+              ),
+            ],
+            files: const [],
+          ),
+        ),
+        (
+          name: 'duplicate store id',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: [
+              journalStore(),
+              const BackupManifestStore(
+                id: 'journal',
+                relativePath: 'other.sqlite',
+                kind: BackupStoreKind.sqliteDatabase,
+                sensitivity: BackupSensitivity.personal,
+                required: false,
+              ),
+            ],
+            files: const [],
+          ),
+        ),
+        (
+          name: 'duplicate store path',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: [
+              journalStore(),
+              const BackupManifestStore(
+                id: 'journal-copy',
+                relativePath: 'db.sqlite',
+                kind: BackupStoreKind.sqliteDatabase,
+                sensitivity: BackupSensitivity.personal,
+                required: false,
+              ),
+            ],
+            files: const [],
+          ),
+        ),
+        (
+          name: 'schema on a directory store',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: const [
+              BackupManifestStore(
+                id: 'media',
+                relativePath: 'images',
+                kind: BackupStoreKind.directory,
+                sensitivity: BackupSensitivity.personal,
+                required: false,
+                schemaVersion: 1,
+              ),
+            ],
+            files: const [],
+          ),
+        ),
+        (
+          name: 'negative schema version',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: const [
+              BackupManifestStore(
+                id: 'journal',
+                relativePath: 'db.sqlite',
+                kind: BackupStoreKind.sqliteDatabase,
+                sensitivity: BackupSensitivity.personal,
+                required: true,
+                schemaVersion: -1,
+              ),
+            ],
+            files: const [],
+          ),
+        ),
+        (
+          name: 'file outside its declared store',
+          create: () => ProfileBackupManifest(
+            createdAt: DateTime.utc(2026, 8, 6),
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+            stores: [journalStore()],
+            files: const [
+              BackupManifestFile(
+                storeId: 'journal',
+                relativePath: 'other.sqlite',
+                sizeBytes: 1,
+                sha256: hashA,
+              ),
+            ],
+          ),
+        ),
+      ];
+
+      for (final testCase in cases) {
+        expect(
+          testCase.create,
+          throwsFormatException,
+          reason: testCase.name,
+        );
+      }
+    });
+
+    test('rejects malformed untrusted manifest fields', () {
+      final validJson = validManifest().toJson();
+      final malformed = <({String name, Map<String, Object?> json})>[
+        (
+          name: 'zero format version',
+          json: {...validJson, 'formatVersion': 0},
+        ),
+        (
+          name: 'zero catalog version',
+          json: {...validJson, 'catalogVersion': 0},
+        ),
+        (
+          name: 'empty required string',
+          json: {...validJson, 'appVersion': ''},
+        ),
+        (
+          name: 'non-integer schema',
+          json: {
+            ...validJson,
+            'stores': [
+              {...journalStore().toJson(), 'schemaVersion': '45'},
+            ],
+          },
+        ),
+        (
+          name: 'non-boolean required flag',
+          json: {
+            ...validJson,
+            'stores': [
+              {...journalStore().toJson(), 'required': 'yes'},
+            ],
+          },
+        ),
+        (
+          name: 'unknown store kind',
+          json: {
+            ...validJson,
+            'stores': [
+              {...journalStore().toJson(), 'kind': 'archive'},
+            ],
+          },
+        ),
+        (
+          name: 'non-list stores',
+          json: {...validJson, 'stores': 'journal'},
+        ),
+        (
+          name: 'non-object store',
+          json: {
+            ...validJson,
+            'stores': [1],
+          },
+        ),
+      ];
+
+      for (final testCase in malformed) {
+        expect(
+          () => ProfileBackupManifest.fromJson(testCase.json),
+          throwsFormatException,
+          reason: testCase.name,
+        );
+      }
+    });
+
+    test('reports the specific invalid value and manifest field', () {
+      expect(
+        () => ProfileBackupManifest(
+          createdAt: DateTime.utc(2026, 8, 6),
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+          stores: [journalStore()],
+          files: const [
+            BackupManifestFile(
+              storeId: 'journal',
+              relativePath: 'db.sqlite',
+              sizeBytes: -1,
+              sha256: hashA,
+            ),
+          ],
+        ),
+        throwsA(
+          isA<FormatException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('db.sqlite'),
+              )
+              .having((error) => error.source, 'source', -1),
+        ),
+      );
+
+      final validJson = validManifest().toJson();
+      expect(
+        () => ProfileBackupManifest.fromJson({
+          ...validJson,
+          'stores': const [
+            <Object?, Object?>{1: 'journal'},
+          ],
+        }),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('field stores'),
+          ),
+        ),
       );
     });
   });

--- a/test/features/backup_restore/domain/profile_backup_manifest_test.dart
+++ b/test/features/backup_restore/domain/profile_backup_manifest_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_catalog.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_manifest.dart';
+
+void main() {
+  const hashA =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const hashB =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  BackupManifestStore journalStore() => const BackupManifestStore(
+    id: 'journal',
+    relativePath: 'db.sqlite',
+    kind: BackupStoreKind.sqliteDatabase,
+    sensitivity: BackupSensitivity.personal,
+    required: true,
+    schemaVersion: 45,
+  );
+
+  group('ProfileBackupManifest', () {
+    test('round-trips a deterministic, path-sorted manifest', () {
+      final manifest = ProfileBackupManifest(
+        createdAt: DateTime.utc(2026, 8, 6, 12, 30),
+        appVersion: '1.0.4+4285',
+        profileType: 'real',
+        stores: [
+          journalStore(),
+          const BackupManifestStore(
+            id: 'media',
+            relativePath: 'images',
+            kind: BackupStoreKind.directory,
+            sensitivity: BackupSensitivity.personal,
+            required: false,
+          ),
+        ],
+        files: const [
+          BackupManifestFile(
+            storeId: 'media',
+            relativePath: 'images/entry.jpg',
+            sizeBytes: 4,
+            sha256: hashB,
+          ),
+          BackupManifestFile(
+            storeId: 'journal',
+            relativePath: 'db.sqlite',
+            sizeBytes: 1024,
+            sha256: hashA,
+          ),
+        ],
+      );
+
+      expect(
+        manifest.files.map((file) => file.relativePath),
+        ['db.sqlite', 'images/entry.jpg'],
+      );
+      expect(
+        ProfileBackupManifest.fromJson(manifest.toJson()),
+        manifest,
+      );
+      expect(manifest.toJson()['formatVersion'], 1);
+      expect(manifest.toJson()['catalogVersion'], 1);
+    });
+
+    test('rejects files that do not resolve to a declared store', () {
+      expect(
+        () => ProfileBackupManifest(
+          createdAt: DateTime.utc(2026, 8, 6),
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+          stores: [journalStore()],
+          files: const [
+            BackupManifestFile(
+              storeId: 'missing',
+              relativePath: 'db.sqlite',
+              sizeBytes: 1,
+              sha256: hashA,
+            ),
+          ],
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('represents forward-compatible files with an opaque root store', () {
+      final manifest = ProfileBackupManifest(
+        createdAt: DateTime.utc(2026, 8, 6),
+        appVersion: '1.0.4+4285',
+        profileType: 'real',
+        stores: const [
+          BackupManifestStore(
+            id: 'profile-content',
+            relativePath: '',
+            kind: BackupStoreKind.opaqueProfileContent,
+            sensitivity: BackupSensitivity.personal,
+            required: false,
+          ),
+        ],
+        files: const [
+          BackupManifestFile(
+            storeId: 'profile-content',
+            relativePath: 'future_feature/data.bin',
+            sizeBytes: 1,
+            sha256: hashA,
+          ),
+        ],
+      );
+
+      expect(ProfileBackupManifest.fromJson(manifest.toJson()), manifest);
+    });
+
+    test('rejects duplicate, unsafe, and malformed file records', () {
+      final base = <String, Object?>{
+        'formatVersion': 1,
+        'catalogVersion': 1,
+        'createdAt': '2026-08-06T00:00:00.000Z',
+        'appVersion': '1.0.4+4285',
+        'profileType': 'real',
+        'stores': [journalStore().toJson()],
+      };
+
+      for (final files in [
+        [
+          {
+            'storeId': 'journal',
+            'relativePath': 'db.sqlite',
+            'sizeBytes': 1,
+            'sha256': hashA,
+          },
+          {
+            'storeId': 'journal',
+            'relativePath': 'db.sqlite',
+            'sizeBytes': 1,
+            'sha256': hashA,
+          },
+        ],
+        [
+          {
+            'storeId': 'journal',
+            'relativePath': '../db.sqlite',
+            'sizeBytes': 1,
+            'sha256': hashA,
+          },
+        ],
+        [
+          {
+            'storeId': 'journal',
+            'relativePath': 'db.sqlite',
+            'sizeBytes': -1,
+            'sha256': hashA,
+          },
+        ],
+        [
+          {
+            'storeId': 'journal',
+            'relativePath': 'db.sqlite',
+            'sizeBytes': 1,
+            'sha256': 'not-a-sha256',
+          },
+        ],
+      ]) {
+        expect(
+          () => ProfileBackupManifest.fromJson({...base, 'files': files}),
+          throwsFormatException,
+        );
+      }
+    });
+
+    test('rejects future formats and non-UTC creation timestamps', () {
+      final json = ProfileBackupManifest(
+        createdAt: DateTime.utc(2026, 8, 6),
+        appVersion: '1.0.4+4285',
+        profileType: 'guest',
+        stores: [journalStore()],
+        files: const [
+          BackupManifestFile(
+            storeId: 'journal',
+            relativePath: 'db.sqlite',
+            sizeBytes: 1,
+            sha256: hashA,
+          ),
+        ],
+      ).toJson();
+
+      expect(
+        () => ProfileBackupManifest.fromJson({...json, 'formatVersion': 2}),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => ProfileBackupManifest.fromJson({
+          ...json,
+          'createdAt': '2026-08-06T00:00:00+02:00',
+        }),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
+++ b/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
@@ -132,6 +132,30 @@ void main() {
       expect(stagingParent.listSync(), isEmpty);
     });
 
+    test('uses a safe generated id when no generator is injected', () async {
+      createRequiredDatabases();
+      final snapshot =
+          await QuiescedProfileSnapshotService(
+            now: () => DateTime.utc(2026, 8, 6, 12, 30),
+          ).stage(
+            sourceRoot: sourceRoot,
+            stagingParent: stagingParent,
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+          );
+
+      expect(
+        p.basename(snapshot.directory.path),
+        matches(
+          RegExp(
+            '^profile-snapshot-[0-9a-f]{8}-[0-9a-f]{4}-'
+            r'[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+          ),
+        ),
+      );
+      expect(snapshot.manifest.createdAt, DateTime.utc(2026, 8, 6, 12, 30));
+    });
+
     test('preserves an existing snapshot destination', () async {
       createRequiredDatabases();
       final existing = Directory(
@@ -577,6 +601,49 @@ void main() {
       expect(stagingParent.listSync(), isEmpty);
     });
 
+    test('detects a file replaced before its copy starts', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+      final external = File(p.join(testRoot.path, 'outside.jpg'))
+        ..writeAsStringSync('outside');
+      var replaced = false;
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (!replaced && relativePath == 'db.sqlite') {
+                    replaced = true;
+                    image.deleteSync();
+                    Link(image.path).createSync(external.path);
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('no longer a regular file'),
+          ),
+        ),
+      );
+      expect(replaced, isTrue);
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
     test('detects source size drift immediately after copying', () async {
       createRequiredDatabases();
       final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
@@ -611,6 +678,42 @@ void main() {
           ),
         ),
       );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects byte drift between metadata and source rehash', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('AAAA');
+      var mutated = false;
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            beforeSourceRehash:
+                ({required sourceFile, required relativePath}) async {
+                  if (!mutated && relativePath == 'images/photo.jpg') {
+                    mutated = true;
+                    sourceFile.writeAsStringSync('BBBB');
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('Source bytes changed'),
+          ),
+        ),
+      );
+      expect(mutated, isTrue);
       expect(stagingParent.listSync(), isEmpty);
     });
 

--- a/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
+++ b/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
@@ -238,6 +238,50 @@ void main() {
       expect(stagingParent.listSync(), isEmpty);
     });
 
+    test('rejects an optional directory store represented by a file', () async {
+      createRequiredDatabases();
+      File(p.join(sourceRoot.path, 'audio')).writeAsStringSync('not a folder');
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('Profile store audio must be a directory'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('rejects an optional database represented by a directory', () async {
+      createRequiredDatabases();
+      Directory(p.join(sourceRoot.path, 'sync.sqlite')).createSync();
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('Profile store sync.sqlite must be a regular file'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
     test('rejects symbolic links in included source content', () async {
       createRequiredDatabases();
       final external = File(p.join(testRoot.path, 'outside.jpg'))
@@ -880,6 +924,40 @@ void main() {
       expect(stagingParent.listSync(), isEmpty);
     });
 
+    test('detects a source file added after digest verification', () async {
+      createRequiredDatabases();
+      var added = false;
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            beforePublish: (partialDirectory) async {
+              added = true;
+              final lateFile = File(
+                p.join(sourceRoot.path, 'images/after-digest.jpg'),
+              );
+              lateFile.parent.createSync(recursive: true);
+              lateFile.writeAsStringSync('late');
+            },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('inventory changed'),
+          ),
+        ),
+      );
+      expect(added, isTrue);
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
     test('cleans a failed publish and succeeds when retried', () async {
       createRequiredDatabases();
       var publishAttempts = 0;
@@ -983,6 +1061,23 @@ void main() {
                   'linked.jpg',
                 ),
               ).createSync(p.join(testRoot.path, 'outside.jpg'));
+            },
+          ),
+          (
+            name: 'a symbolic link replacing the staged payload root',
+            expectedMessage: 'payload must be a real directory',
+            tamper: (partialDirectory) {
+              final payload = Directory(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupPayloadDirectoryName,
+                ),
+              );
+              final externalPayload = Directory(
+                p.join(testRoot.path, 'external-payload'),
+              );
+              payload.renameSync(externalPayload.path);
+              Link(payload.path).createSync(externalPayload.path);
             },
           ),
           (

--- a/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
+++ b/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
@@ -1,0 +1,1079 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/backup_restore/domain/profile_backup_manifest.dart';
+import 'package:lotti/features/backup_restore/service/quiesced_profile_snapshot_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  late Directory testRoot;
+  late Directory sourceRoot;
+  late Directory stagingParent;
+
+  setUp(() {
+    testRoot = Directory.systemTemp.createTempSync('lotti_snapshot_test_');
+    sourceRoot = Directory(p.join(testRoot.path, 'source'))
+      ..createSync(recursive: true);
+    stagingParent = Directory(p.join(testRoot.path, 'staging'))
+      ..createSync(recursive: true);
+  });
+
+  tearDown(() {
+    if (testRoot.existsSync()) {
+      testRoot.deleteSync(recursive: true);
+    }
+  });
+
+  void createWalDatabase(
+    String relativePath, {
+    required int schemaVersion,
+    required String value,
+  }) {
+    final file = File(p.join(sourceRoot.path, relativePath));
+    file.parent.createSync(recursive: true);
+    final database = sqlite3.open(file.path);
+    try {
+      database
+        ..execute('PRAGMA journal_mode = WAL')
+        ..execute('CREATE TABLE snapshot_probe (value TEXT NOT NULL)')
+        ..execute('INSERT INTO snapshot_probe VALUES (?)', [value])
+        ..execute('PRAGMA user_version = $schemaVersion');
+      expect(
+        File('${file.path}-wal').existsSync(),
+        isTrue,
+        reason: 'the fixture must exercise a database that was WAL-backed',
+      );
+    } finally {
+      database.dispose();
+    }
+  }
+
+  void createRequiredDatabases() {
+    createWalDatabase(
+      'db.sqlite',
+      schemaVersion: 45,
+      value: 'committed journal value',
+    );
+    createWalDatabase(
+      'settings.sqlite',
+      schemaVersion: 1,
+      value: 'profile setting',
+    );
+  }
+
+  QuiescedProfileSnapshotService service({
+    ProfileSnapshotTestHooks? hooks,
+  }) => QuiescedProfileSnapshotService(
+    snapshotIdGenerator: () => 'snapshot-id',
+    now: () => DateTime.utc(2026, 8, 6, 12, 30),
+    testHooks: hooks,
+  );
+
+  group('QuiescedProfileSnapshotService', () {
+    test('reports actionable exception diagnostics', () {
+      expect(
+        const ProfileSnapshotException('capture failed').toString(),
+        'ProfileSnapshotException: capture failed',
+      );
+      expect(
+        const ProfileSnapshotException(
+          'capture failed',
+          cause: FileSystemException('disk unavailable'),
+        ).toString(),
+        contains('disk unavailable'),
+      );
+    });
+
+    test('rejects a missing source before creating staging output', () async {
+      sourceRoot.deleteSync(recursive: true);
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotException>().having(
+            (error) => error.message,
+            'message',
+            contains('does not exist'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('rejects an unsafe generated snapshot id', () async {
+      createRequiredDatabases();
+      final unsafeService = QuiescedProfileSnapshotService(
+        snapshotIdGenerator: () => '../escape',
+      );
+
+      await expectLater(
+        unsafeService.stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotException>().having(
+            (error) => error.message,
+            'message',
+            contains('unsafe path characters'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('preserves an existing snapshot destination', () async {
+      createRequiredDatabases();
+      final existing = Directory(
+        p.join(stagingParent.path, 'profile-snapshot-snapshot-id'),
+      )..createSync();
+      final sentinel = File(p.join(existing.path, 'sentinel'))
+        ..writeAsStringSync('keep me');
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotException>().having(
+            (error) => error.message,
+            'message',
+            contains('already exists'),
+          ),
+        ),
+      );
+      expect(sentinel.readAsStringSync(), 'keep me');
+      expect(
+        stagingParent.listSync().map((entry) => entry.path),
+        [existing.path],
+      );
+    });
+
+    test('requires every mandatory authoritative store', () async {
+      createWalDatabase(
+        'settings.sqlite',
+        schemaVersion: 1,
+        value: 'profile setting',
+      );
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('db.sqlite'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('rejects symbolic links in included source content', () async {
+      createRequiredDatabases();
+      final external = File(p.join(testRoot.path, 'outside.jpg'))
+        ..writeAsStringSync('outside');
+      final images = Directory(p.join(sourceRoot.path, 'images'))..createSync();
+      Link(p.join(images.path, 'linked.jpg')).createSync(external.path);
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotException>().having(
+            (error) => error.message,
+            'message',
+            contains('symbolic links'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('rejects a staging symlink that resolves inside the source', () async {
+      createRequiredDatabases();
+      final stagingLink = Link(p.join(testRoot.path, 'staging-link'))
+        ..createSync(sourceRoot.path);
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: Directory(stagingLink.path),
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotException>().having(
+            (error) => error.message,
+            'message',
+            contains('Resolved snapshot source'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test(
+      'stages a verified closed WAL world and omits non-authority',
+      () async {
+        createRequiredDatabases();
+        final includedFiles = <String, List<int>>{
+          'images/2026-08-06/photo.jpg': [1, 2, 3, 4],
+          'audio/2026-08-06/recording.m4a': [5, 6, 7],
+          'agent_entities/agent.json': utf8.encode('{"agent":true}'),
+          'future_feature/data.bin': [8, 9],
+        };
+        for (final entry in includedFiles.entries) {
+          final file = File(p.join(sourceRoot.path, entry.key));
+          file.parent.createSync(recursive: true);
+          file.writeAsBytesSync(entry.value);
+        }
+
+        for (final path in [
+          'logs/general.log',
+          'backup/legacy.sqlite',
+          'guest_profiles/guest/db.sqlite',
+          'objectbox_embeddings_sharded/default/data.mdb',
+          'audio_waveforms/ab/cache.json',
+          'fts5_db.sqlite',
+        ]) {
+          final file = File(p.join(sourceRoot.path, path));
+          file.parent.createSync(recursive: true);
+          file.writeAsStringSync('not part of the snapshot');
+        }
+        File(p.join(sourceRoot.path, 'profiles.json')).writeAsStringSync('{}');
+
+        final snapshot = await service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        );
+
+        expect(
+          p.basename(snapshot.directory.path),
+          'profile-snapshot-snapshot-id',
+        );
+        expect(snapshot.directory.existsSync(), isTrue);
+        expect(
+          stagingParent.listSync().where(
+            (entry) => p.basename(entry.path).contains('.partial'),
+          ),
+          isEmpty,
+        );
+
+        final manifestPaths = snapshot.manifest.files
+            .map((file) => file.relativePath)
+            .toList(growable: false);
+        expect(manifestPaths, orderedEquals([...manifestPaths]..sort()));
+        expect(
+          manifestPaths,
+          containsAll(<String>[
+            'db.sqlite',
+            'settings.sqlite',
+            ...includedFiles.keys,
+          ]),
+        );
+        for (final excludedPath in [
+          'logs/general.log',
+          'backup/legacy.sqlite',
+          'guest_profiles/guest/db.sqlite',
+          'objectbox_embeddings_sharded/default/data.mdb',
+          'audio_waveforms/ab/cache.json',
+          'fts5_db.sqlite',
+          'profiles.json',
+        ]) {
+          expect(manifestPaths, isNot(contains(excludedPath)));
+        }
+
+        final stores = {
+          for (final store in snapshot.manifest.stores) store.id: store,
+        };
+        expect(stores['journal']?.schemaVersion, 45);
+        expect(stores['settings']?.schemaVersion, 1);
+        expect(stores['profile-content']?.relativePath, isEmpty);
+
+        for (final record in snapshot.manifest.files) {
+          final copied = File(
+            p.join(snapshot.payloadDirectory.path, record.relativePath),
+          );
+          expect(copied.existsSync(), isTrue, reason: record.relativePath);
+          expect(copied.lengthSync(), record.sizeBytes);
+          expect(
+            sha256.convert(copied.readAsBytesSync()).toString(),
+            record.sha256,
+          );
+        }
+
+        final restoredJournal = sqlite3.open(
+          p.join(snapshot.payloadDirectory.path, 'db.sqlite'),
+          mode: OpenMode.readOnly,
+        );
+        try {
+          expect(
+            restoredJournal
+                .select(
+                  'SELECT value FROM snapshot_probe',
+                )
+                .single['value'],
+            'committed journal value',
+          );
+        } finally {
+          restoredJournal.dispose();
+        }
+
+        final manifestJson =
+            jsonDecode(
+                  File(
+                    p.join(
+                      snapshot.directory.path,
+                      profileBackupManifestFileName,
+                    ),
+                  ).readAsStringSync(),
+                )
+                as Map<String, dynamic>;
+        expect(
+          ProfileBackupManifest.fromJson(manifestJson),
+          snapshot.manifest,
+        );
+      },
+    );
+
+    test('rejects an SQLite companion and removes the partial stage', () async {
+      createRequiredDatabases();
+      File(
+        p.join(sourceRoot.path, 'future_store.sqlite-wal'),
+      ).writeAsBytesSync([1, 2, 3]);
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(isA<ProfileSnapshotException>()),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test(
+      'detects same-size source mutation even with restored mtime',
+      () async {
+        createRequiredDatabases();
+        final source = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+        source.parent.createSync(recursive: true);
+        source.writeAsStringSync('AAAA');
+        final originalModified = source.lastModifiedSync();
+        var mutated = false;
+
+        await expectLater(
+          service(
+            hooks: ProfileSnapshotTestHooks(
+              afterFileCopied:
+                  ({
+                    required sourceFile,
+                    required targetFile,
+                    required relativePath,
+                  }) async {
+                    if (!mutated && relativePath == 'images/photo.jpg') {
+                      mutated = true;
+                      sourceFile
+                        ..writeAsStringSync('BBBB')
+                        ..setLastModifiedSync(originalModified);
+                    }
+                  },
+            ),
+          ).stage(
+            sourceRoot: sourceRoot,
+            stagingParent: stagingParent,
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+          ),
+          throwsA(isA<ProfileSnapshotSourceChangedException>()),
+        );
+        expect(mutated, isTrue);
+        expect(stagingParent.listSync(), isEmpty);
+      },
+    );
+
+    test('detects a file added after the initial inventory scan', () async {
+      createRequiredDatabases();
+      var added = false;
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (!added && relativePath == 'settings.sqlite') {
+                    added = true;
+                    final file = File(
+                      p.join(sourceRoot.path, 'images/late.jpg'),
+                    );
+                    file.parent.createSync(recursive: true);
+                    file.writeAsStringSync('late');
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('inventory changed'),
+          ),
+        ),
+      );
+      expect(added, isTrue);
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects metadata drift in the final inventory scan', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+      var mutated = false;
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (!mutated && relativePath == 'settings.sqlite') {
+                    mutated = true;
+                    image.writeAsStringSync('changed size');
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('images/photo.jpg'),
+          ),
+        ),
+      );
+      expect(mutated, isTrue);
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects a source file removed immediately after copying', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (relativePath == 'images/photo.jpg') {
+                    sourceFile.deleteSync();
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('disappeared during'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects a source file replaced by a symbolic link', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+      final external = File(p.join(testRoot.path, 'outside.jpg'))
+        ..writeAsStringSync('outside');
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (relativePath == 'images/photo.jpg') {
+                    sourceFile.deleteSync();
+                    Link(sourceFile.path).createSync(external.path);
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('stopped being a regular file'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects source size drift immediately after copying', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (relativePath == 'images/photo.jpg') {
+                    sourceFile.writeAsStringSync('longer source');
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('changed during'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects copied target corruption before manifesting it', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            afterFileCopied:
+                ({
+                  required sourceFile,
+                  required targetFile,
+                  required relativePath,
+                }) async {
+                  if (relativePath == 'images/photo.jpg') {
+                    targetFile.writeAsStringSync('corrupt');
+                  }
+                },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('Copied bytes failed'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('rehashes source bytes after the final inventory scan', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('AAAA');
+      final originalModified = image.lastModifiedSync();
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            beforeFinalSourceVerification: () async {
+              image
+                ..writeAsStringSync('BBBB')
+                ..setLastModifiedSync(originalModified);
+            },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('before publication'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('detects source removal after the final inventory scan', () async {
+      createRequiredDatabases();
+      final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+      image.parent.createSync(recursive: true);
+      image.writeAsStringSync('original');
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            beforeFinalSourceVerification: () async {
+              image.deleteSync();
+            },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotSourceChangedException>().having(
+            (error) => error.message,
+            'message',
+            contains('disappeared before publication'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test('cleans a failed publish and succeeds when retried', () async {
+      createRequiredDatabases();
+      var publishAttempts = 0;
+      final snapshotService = service(
+        hooks: ProfileSnapshotTestHooks(
+          beforePublish: (partialDirectory) async {
+            publishAttempts++;
+            if (publishAttempts == 1) {
+              throw const FileSystemException('injected publish failure');
+            }
+          },
+        ),
+      );
+
+      await expectLater(
+        snapshotService.stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+
+      final retry = await snapshotService.stage(
+        sourceRoot: sourceRoot,
+        stagingParent: stagingParent,
+        appVersion: '1.0.4+4285',
+        profileType: 'real',
+      );
+      expect(retry.directory.existsSync(), isTrue);
+      expect(publishAttempts, 2);
+    });
+
+    final stagedTamperCases =
+        <
+          ({
+            String name,
+            String expectedMessage,
+            void Function(Directory partialDirectory) tamper,
+          })
+        >[
+          (
+            name: 'a missing staged manifest',
+            expectedMessage: 'manifest is missing',
+            tamper: (partialDirectory) {
+              File(
+                p.join(partialDirectory.path, profileBackupManifestFileName),
+              ).deleteSync();
+            },
+          ),
+          (
+            name: 'invalid staged manifest JSON',
+            expectedMessage: 'not valid JSON',
+            tamper: (partialDirectory) {
+              File(
+                p.join(partialDirectory.path, profileBackupManifestFileName),
+              ).writeAsStringSync('{');
+            },
+          ),
+          (
+            name: 'a non-object staged manifest',
+            expectedMessage: 'root must be an object',
+            tamper: (partialDirectory) {
+              File(
+                p.join(partialDirectory.path, profileBackupManifestFileName),
+              ).writeAsStringSync('[]');
+            },
+          ),
+          (
+            name: 'a staged manifest missing required fields',
+            expectedMessage: 'failed validation',
+            tamper: (partialDirectory) {
+              File(
+                p.join(partialDirectory.path, profileBackupManifestFileName),
+              ).writeAsStringSync('{}');
+            },
+          ),
+          (
+            name: 'a missing staged payload',
+            expectedMessage: 'payload is missing',
+            tamper: (partialDirectory) {
+              Directory(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupPayloadDirectoryName,
+                ),
+              ).deleteSync(recursive: true);
+            },
+          ),
+          (
+            name: 'a symbolic link in the staged payload',
+            expectedMessage: 'may not contain symbolic links',
+            tamper: (partialDirectory) {
+              Link(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupPayloadDirectoryName,
+                  'images',
+                  'linked.jpg',
+                ),
+              ).createSync(p.join(testRoot.path, 'outside.jpg'));
+            },
+          ),
+          (
+            name: 'an extra staged payload file',
+            expectedMessage: 'do not match the manifest',
+            tamper: (partialDirectory) {
+              File(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupPayloadDirectoryName,
+                  'images',
+                  'extra.jpg',
+                ),
+              ).writeAsStringSync('extra');
+            },
+          ),
+          (
+            name: 'a renamed staged payload file',
+            expectedMessage: 'do not match the manifest',
+            tamper: (partialDirectory) {
+              final images = Directory(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupPayloadDirectoryName,
+                  'images',
+                ),
+              );
+              File(p.join(images.path, 'photo.jpg')).renameSync(
+                p.join(images.path, 'renamed.jpg'),
+              );
+            },
+          ),
+          (
+            name: 'staged payload checksum drift',
+            expectedMessage: 'checksum verification',
+            tamper: (partialDirectory) {
+              File(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupPayloadDirectoryName,
+                  'images',
+                  'photo.jpg',
+                ),
+              ).writeAsStringSync('tampered');
+            },
+          ),
+        ];
+
+    for (final testCase in stagedTamperCases) {
+      test('rejects ${testCase.name} and removes the partial stage', () async {
+        createRequiredDatabases();
+        final image = File(p.join(sourceRoot.path, 'images/photo.jpg'));
+        image.parent.createSync(recursive: true);
+        image.writeAsStringSync('original');
+        File(p.join(testRoot.path, 'outside.jpg')).writeAsStringSync('outside');
+
+        await expectLater(
+          service(
+            hooks: ProfileSnapshotTestHooks(
+              beforePublish: (partialDirectory) async {
+                testCase.tamper(partialDirectory);
+              },
+            ),
+          ).stage(
+            sourceRoot: sourceRoot,
+            stagingParent: stagingParent,
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+          ),
+          throwsA(
+            isA<ProfileSnapshotValidationException>().having(
+              (error) => error.message,
+              'message',
+              contains(testCase.expectedMessage),
+            ),
+          ),
+        );
+        expect(stagingParent.listSync(), isEmpty);
+      });
+    }
+
+    test('rejects a valid manifest changed before publication', () async {
+      createRequiredDatabases();
+
+      await expectLater(
+        service(
+          hooks: ProfileSnapshotTestHooks(
+            beforePublish: (partialDirectory) async {
+              final manifestFile = File(
+                p.join(
+                  partialDirectory.path,
+                  profileBackupManifestFileName,
+                ),
+              );
+              final manifestJson =
+                  jsonDecode(manifestFile.readAsStringSync())
+                      as Map<String, dynamic>;
+              manifestJson['appVersion'] = 'changed-version';
+              manifestFile.writeAsStringSync(jsonEncode(manifestJson));
+            },
+          ),
+        ).stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('manifest changed'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test(
+      'rejects staged SQLite schema drift with a matching checksum',
+      () async {
+        createRequiredDatabases();
+
+        await expectLater(
+          service(
+            hooks: ProfileSnapshotTestHooks(
+              beforePublish: (partialDirectory) async {
+                final copiedDatabase = File(
+                  p.join(
+                    partialDirectory.path,
+                    profileBackupPayloadDirectoryName,
+                    'db.sqlite',
+                  ),
+                );
+                final database = sqlite3.open(copiedDatabase.path);
+                try {
+                  database.userVersion = 46;
+                } finally {
+                  database.dispose();
+                }
+
+                final manifestFile = File(
+                  p.join(
+                    partialDirectory.path,
+                    profileBackupManifestFileName,
+                  ),
+                );
+                final manifestJson =
+                    jsonDecode(manifestFile.readAsStringSync())
+                        as Map<String, dynamic>;
+                final files = (manifestJson['files']! as List<dynamic>)
+                    .cast<Map<String, dynamic>>();
+                files.singleWhere(
+                    (record) => record['relativePath'] == 'db.sqlite',
+                  )
+                  ..['sizeBytes'] = copiedDatabase.lengthSync()
+                  ..['sha256'] = sha256
+                      .convert(copiedDatabase.readAsBytesSync())
+                      .toString();
+                manifestFile.writeAsStringSync(jsonEncode(manifestJson));
+              },
+            ),
+          ).stage(
+            sourceRoot: sourceRoot,
+            stagingParent: stagingParent,
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+          ),
+          throwsA(
+            isA<ProfileSnapshotValidationException>().having(
+              (error) => error.message,
+              'message',
+              contains('schema version changed'),
+            ),
+          ),
+        );
+        expect(stagingParent.listSync(), isEmpty);
+      },
+    );
+
+    test('rejects b-tree damage while running integrity_check', () async {
+      final journal = File(p.join(sourceRoot.path, 'db.sqlite'));
+      final database = sqlite3.open(journal.path);
+      late int pageSize;
+      try {
+        database
+          ..execute('CREATE TABLE probe (value INTEGER NOT NULL)')
+          ..execute('INSERT INTO probe VALUES (1)')
+          ..userVersion = 45;
+        pageSize =
+            database.select('PRAGMA page_size').single.values.single! as int;
+      } finally {
+        database.dispose();
+      }
+      final damagedBytes = journal.readAsBytesSync()..[pageSize] = 0;
+      journal.writeAsBytesSync(damagedBytes, flush: true);
+      createWalDatabase(
+        'settings.sqlite',
+        schemaVersion: 1,
+        value: 'profile setting',
+      );
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('Unable to validate SQLite database'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
+    test(
+      'fails integrity validation for a corrupt required database',
+      () async {
+        File(p.join(sourceRoot.path, 'db.sqlite')).writeAsStringSync('corrupt');
+        createWalDatabase(
+          'settings.sqlite',
+          schemaVersion: 1,
+          value: 'profile setting',
+        );
+
+        await expectLater(
+          service().stage(
+            sourceRoot: sourceRoot,
+            stagingParent: stagingParent,
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+          ),
+          throwsA(isA<ProfileSnapshotValidationException>()),
+        );
+        expect(stagingParent.listSync(), isEmpty);
+      },
+    );
+
+    test('refuses a staging parent nested inside the source root', () async {
+      createRequiredDatabases();
+      final nested = Directory(p.join(sourceRoot.path, 'staging'));
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: nested,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(isA<ProfileSnapshotException>()),
+      );
+      expect(nested.existsSync(), isFalse);
+    });
+  });
+}

--- a/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
+++ b/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/backup_restore/domain/profile_backup_manifest.dart';
 import 'package:lotti/features/backup_restore/service/quiesced_profile_snapshot_service.dart';
+import 'package:lotti/features/daily_os_next/services/day_processing_startup.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
 
@@ -211,6 +212,32 @@ void main() {
       expect(stagingParent.listSync(), isEmpty);
     });
 
+    test('rejects a required database represented by a directory', () async {
+      Directory(p.join(sourceRoot.path, 'db.sqlite')).createSync();
+      createWalDatabase(
+        'settings.sqlite',
+        schemaVersion: 1,
+        value: 'profile setting',
+      );
+
+      await expectLater(
+        service().stage(
+          sourceRoot: sourceRoot,
+          stagingParent: stagingParent,
+          appVersion: '1.0.4+4285',
+          profileType: 'real',
+        ),
+        throwsA(
+          isA<ProfileSnapshotValidationException>().having(
+            (error) => error.message,
+            'message',
+            contains('must be a regular file'),
+          ),
+        ),
+      );
+      expect(stagingParent.listSync(), isEmpty);
+    });
+
     test('rejects symbolic links in included source content', () async {
       createRequiredDatabases();
       final external = File(p.join(testRoot.path, 'outside.jpg'))
@@ -260,6 +287,40 @@ void main() {
     });
 
     test(
+      'rejects a missing staging path beneath a symlinked source ancestor',
+      () async {
+        createRequiredDatabases();
+        final stagingLink = Link(p.join(testRoot.path, 'source-link'))
+          ..createSync(sourceRoot.path);
+        final nested = Directory(
+          p.join(stagingLink.path, 'created-by-snapshot', 'staging'),
+        );
+
+        await expectLater(
+          service().stage(
+            sourceRoot: sourceRoot,
+            stagingParent: nested,
+            appVersion: '1.0.4+4285',
+            profileType: 'real',
+          ),
+          throwsA(
+            isA<ProfileSnapshotException>().having(
+              (error) => error.message,
+              'message',
+              contains('Resolved snapshot source'),
+            ),
+          ),
+        );
+        expect(
+          Directory(
+            p.join(sourceRoot.path, 'created-by-snapshot'),
+          ).existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test(
       'stages a verified closed WAL world and omits non-authority',
       () async {
         createRequiredDatabases();
@@ -282,6 +343,7 @@ void main() {
           'objectbox_embeddings_sharded/default/data.mdb',
           'audio_waveforms/ab/cache.json',
           'fts5_db.sqlite',
+          '$legacyDayProcessingOutboxDirectory/job.json.tmp.1737000000000000.4242.media',
         ]) {
           final file = File(p.join(sourceRoot.path, path));
           file.parent.createSync(recursive: true);
@@ -327,6 +389,7 @@ void main() {
           'objectbox_embeddings_sharded/default/data.mdb',
           'audio_waveforms/ab/cache.json',
           'fts5_db.sqlite',
+          '$legacyDayProcessingOutboxDirectory/job.json.tmp.1737000000000000.4242.media',
           'profiles.json',
         ]) {
           expect(manifestPaths, isNot(contains(excludedPath)));

--- a/test/features/profiles/service/profile_switcher_test.dart
+++ b/test/features/profiles/service/profile_switcher_test.dart
@@ -177,6 +177,10 @@ void main() {
           lifecycleHolder: holder,
           restoreWindow: false,
         );
+        // Registration starts editor-state and onboarding database work in
+        // background isolates. Finish that generation's startup requests
+        // before the switch deliberately closes its database channels.
+        await settlePendingDbWork();
         final journalDbGen1 = getIt<JournalDb>();
         expect(getIt<ProfileContext>().profile.id, guest1.id);
 

--- a/test/features/sync/matrix/client_test.dart
+++ b/test/features/sync/matrix/client_test.dart
@@ -41,7 +41,9 @@ void main() {
         // unverified device is excluded instead of halting all sends.
         expect(client.shareKeysWith, ShareKeysWith.directlyVerifiedOnly);
 
-        final dbFile = File('${tempDir.path}/matrix/custom_db.db');
+        final dbFile = File(
+          '${tempDir.path}/$matrixDatabaseDirectoryName/custom_db.db',
+        );
         expect(dbFile.existsSync(), isTrue);
       },
     );
@@ -62,7 +64,8 @@ void main() {
       addTearDown(() async => client.dispose());
 
       expect(client.clientName, 'lotti');
-      final dbFile = File('${tempDir.path}/matrix/lotti_sync.db');
+      expect(matrixDatabaseRelativePath, 'matrix/lotti_sync.db');
+      final dbFile = File('${tempDir.path}/$matrixDatabaseRelativePath');
       expect(dbFile.existsSync(), isTrue);
     });
   });


### PR DESCRIPTION
## What

- add a versioned profile backup catalog covering authoritative databases, Matrix state, media, sidecars, rebuildable indexes, diagnostics, and device-global exclusions
- add a strict deterministic manifest with store identities, schema versions, file sizes, and SHA-256 digests
- add verified snapshot staging for an already-quiesced profile root, including source mutation detection, SQLite integrity checks, staged payload verification, cleanup, retry, and atomic publication
- expose the Matrix database path as shared constants so the inventory follows the SDK location
- document the capture boundary and remaining lifecycle, encryption, restore, UI, and restore-drill seams

## Why

Matrix sync is not an independent recovery artifact, and the legacy database helper copies only one SQLite main file. This establishes a fail-closed, implementation-consumable foundation for complete local-first backups without pretending that filesystem copying can quiesce active Drift read pools, Matrix, ObjectBox, or background writers.

This PR does **not** add a user-visible backup action, encryption, lifecycle quiescence, or restore activation yet.

## Safety properties

- rejects traversal, symlinks, journal companions, interrupted atomic writes, overlapping roots, missing required stores, and source drift
- includes unknown canonical profile content by default to avoid silent loss when new stores appear
- copies into a unique partial stage and never replaces an existing published destination
- re-verifies source hashes, manifest membership, staged checksums, SQLite integrity, and schema versions before one directory rename

## Verification

- `fvm flutter analyze lib/features/backup_restore test/features/backup_restore lib/features/sync/matrix/client.dart test/features/sync/matrix/client_test.dart` — no issues
- 67 focused tests across the catalog, manifest, staging service, and Matrix path constants — all pass
- `make knowledge_check` — 92 concepts, 0 errors/warnings; 469 Mermaid blocks parsed
- no screenshots or changelog entry: this is internal backup infrastructure with no runtime UI or released behavior change
- the repository's full roughly 27,000-test suite is delegated to the standard ten-shard CI run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profile backup snapshot support with cataloged data stores and deterministic manifests.
  - Backups verify paths, required content, database integrity, file checksums, and source stability before publication.
  - Unsafe files, symbolic links, incomplete stores, and corrupted or modified data are rejected, with failed snapshots cleaned up safely.
  - Snapshots are staged and published atomically after verification succeeds.

- **Documentation**
  - Added backup-and-restore specifications, architecture details, feature guidance, and planned follow-up documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->