### PR TITLE
feat: seed demo media from verified R2 sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.4]
 ### Changed
+- **Demo setup now makes remote media preparation visible and verifiable.**
+  Cover art is downloaded from immutable, checksum-pinned sources before the
+  demo world becomes active, with an exact progress count on the preparation
+  screen. Offline setup still works through verified bundled copies, while a
+  corrupt download fails safely without leaving a half-created demo behind.
 - **The task knowledge graph is now a readable local workspace.** Instead of
   presenting the whole topology as a field of mostly anonymous dots, it shows a
   bounded one- or two-hop neighbourhood with prioritized full labels, stronger

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ manual_screenshots_locale:
 	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/pages/create/create_measurement_dialog_screenshots_test.dart
 	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/features/settings/ui/settings_preferences_screenshots_test.dart
 	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/features/knowledge_graph/ui/knowledge_graph_manual_screenshots_test.dart
 	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/features/projects/ui/pages/projects_manual_screenshots_test.dart
 	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/features/events/ui/pages/events_manual_screenshots_test.dart
 	LOTTI_MANUAL_LOCALE="$(MANUAL_LOCALE)" LOTTI_SCREENSHOT_DIR="$(MANUAL_CAPTURE_DIR)" fvm flutter test test/features/journal/ui/pages/journal_manual_screenshots_test.dart

--- a/docs-site/docs/organize-and-reflect/tasks.mdx
+++ b/docs-site/docs/organize-and-reflect/tasks.mdx
@@ -116,11 +116,21 @@ task instead of squeezing the entire journal into one diagram. Select a node to
 walk to it. Use Back and Forward to retrace the path, or select a point in the
 small topology map to jump to another part of the graph.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Knowledge graph centred on the orbital penguin habitat task, with readable relationship labels, large cover-art nodes, filters, topology map, and task inspector"
+/>
+
 Choose **Connections** when you prefer a list. It groups full, untruncated entry
 titles by relationship and direction, and selecting a row moves to the same new
 focus as the graph. Both views share the density, one-hop/two-hop, relationship,
 entry type, category, recency, and task-status filters. Dense groups and task
 photos collapse into exact-count nodes in the graph; select one to expand it.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Connections view grouping the orbital habitat task's linked entries by relationship and direction"
+/>
 
 The task inspector keeps the full title visible. When available, it places cover
 art first in a scrollable row with the task's related photos, and keeps the

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -99,11 +99,21 @@ toho, aby vměstnalo celý deník do jednoho diagramu. Výběrem uzlu k němu p�
 Pomocí Zpět a Vpřed se vracíš po cestě, nebo výběrem bodu v malé mapě topologie
 přeskočíš do jiné části grafu.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Znalostní graf vystředěný na úkol kontroly orbitálního obydlí tučňáků, s čitelnými popisky vztahů, velkými uzly s obálkami, filtry, mapou topologie a inspektorem úkolu"
+/>
+
 Pokud dáváš přednost seznamu, zvol **Spojení**. Úplné, nezkrácené názvy položek
 seskupuje podle vztahu a směru a výběr řádku přesune stejné nové zaměření jako
 graf. Obě zobrazení sdílejí hustotu, jeden či dva kroky a filtry podle vztahu,
 typu položky, kategorie, aktuálnosti a stavu úkolu. Husté skupiny a fotografie
 úkolu se v grafu sbalí do uzlů s přesným počtem; výběrem je rozbalíš.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Zobrazení Spojení seskupující propojené položky úkolu orbitálního obydlí podle vztahu a směru"
+/>
 
 Inspektor úkolu ponechává viditelný celý název. Pokud jsou k dispozici média,
 zobrazí nejprve obálku a za ní související fotografie v posuvné řadě; delší AI

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -123,11 +123,21 @@ opgave i stedet for at presse hele journalen ind i ét diagram. Vælg en node fo
 at gå til den. Brug Tilbage og Frem til at følge din rute igen, eller vælg et
 punkt i det lille topologikort for at hoppe til en anden del af grafen.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Vidensgraf centreret om opgaven med inspektion af pingvinernes kredsløbshabitat, med læsbare relationsetiketter, store omslagsnoder, filtre, topologikort og opgaveinspektør"
+/>
+
 Vælg **Forbindelser**, hvis du foretrækker en liste. Den grupperer fulde,
 uforkortede titler efter relation og retning, og et valg flytter til samme nye
 fokus som grafen. Begge visninger deler tæthed, et eller to led og filtre for
 relation, posttype, kategori, aktualitet og opgavestatus. Tætte grupper og
 opgavefotos samles i noder med et præcist antal; vælg en for at folde den ud.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Forbindelsesvisning, der grupperer kredsløbshabitat-opgavens linkede poster efter relation og retning"
+/>
 
 Opgaveinspektøren viser hele titlen. Når der er medier, kommer omslaget først i
 en vandret række med relaterede fotos, mens det længere AI-resumé forbliver

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -101,12 +101,22 @@ einen Knoten, um dorthin zu gehen. Mit Zurück und Vorwärts verfolgst du deinen
 Weg erneut; über einen Punkt in der kleinen Topologiekarte springst du in einen
 anderen Bereich des Graphen.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Wissensgraph rund um die Aufgabe zur Inspektion des Pinguin-Orbitalhabitats mit lesbaren Beziehungsbeschriftungen, großen Cover-Knoten, Filtern, Topologiekarte und Aufgabeninspektor"
+/>
+
 Wähle **Verbindungen**, wenn du eine Liste bevorzugst. Sie gruppiert vollständige,
 nicht gekürzte Titel nach Beziehung und Richtung. Eine Zeile führt zum selben
 neuen Fokus wie der Graph. Beide Ansichten teilen Dichte, ein oder zwei Schritte
 sowie Filter für Beziehung, Eintragstyp, Kategorie, Aktualität und Aufgabenstatus.
 Dichte Gruppen und Aufgabenfotos werden zu Knoten mit exakter Anzahl gebündelt;
 wähle einen solchen Knoten, um ihn aufzuklappen.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Verbindungsansicht, die die verknüpften Einträge der Orbitalhabitat-Aufgabe nach Beziehung und Richtung gruppiert"
+/>
 
 Der Aufgabeninspektor zeigt den vollständigen Titel. Wenn Medien vorhanden sind,
 steht das Cover am Anfang einer horizontalen Reihe mit zugehörigen Fotos; die

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -77,12 +77,22 @@ diagrama. Selecciona un nodo para desplazarte hasta él. Usa Atrás y Adelante
 para recorrer de nuevo el camino, o selecciona un punto del pequeño mapa de
 topología para saltar a otra zona del grafo.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Grafo de conocimiento centrado en la tarea de inspección del hábitat orbital de pingüinos, con etiquetas de relación legibles, nodos grandes con portada, filtros, mapa topológico e inspector de tareas"
+/>
+
 Elige **Conexiones** si prefieres una lista. Agrupa títulos completos y sin
 recortar por relación y dirección; al seleccionar una fila llegas al mismo
 nuevo foco que en el grafo. Ambas vistas comparten densidad, uno o dos saltos y
 filtros por relación, tipo de entrada, categoría, antigüedad y estado de la
 tarea. Los grupos densos y las fotos de la tarea se compactan en nodos con un
 recuento exacto; selecciona uno para expandirlo.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Vista Conexiones que agrupa las entradas vinculadas de la tarea del hábitat orbital por relación y dirección"
+/>
 
 El inspector mantiene visible el título completo. Cuando hay contenido visual,
 coloca primero la portada en una fila desplazable con las fotos relacionadas y

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -77,12 +77,22 @@ schéma. Sélectionne un nœud pour t’y déplacer. Utilise Revenir et Suivant 
 retracer ton chemin, ou sélectionne un point de la petite carte topologique pour
 sauter vers une autre partie du graphe.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Graphe de connaissances centré sur la tâche d’inspection de l’habitat orbital des manchots, avec libellés de relation lisibles, grands nœuds illustrés, filtres, carte topologique et inspecteur de tâche"
+/>
+
 Choisis **Connexions** si tu préfères une liste. Elle regroupe les titres
 complets, non tronqués, par relation et direction. Sélectionner une ligne conduit
 au même nouveau point focal que le graphe. Les deux vues partagent la densité,
 un ou deux niveaux et les filtres par relation, type d’entrée, catégorie,
 récence et état de tâche. Les groupes denses et les photos de la tâche se
 réduisent en nœuds avec un nombre exact ; sélectionne-en un pour le développer.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Vue Connexions regroupant les entrées liées à la tâche de l’habitat orbital par relation et direction"
+/>
 
 L’inspecteur garde le titre complet visible. Si des médias sont disponibles, la
 couverture apparaît en premier dans une rangée défilante avec les photos liées,

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -127,12 +127,22 @@ diario in un unico diagramma. Seleziona un nodo per raggiungerlo. Usa Indietro e
 Avanti per ripercorrere il percorso oppure seleziona un punto nella piccola
 mappa topologica per passare a un'altra parte del grafo.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Grafo della conoscenza centrato sull'attività di ispezione dell'habitat orbitale dei pinguini, con etichette delle relazioni leggibili, grandi nodi con copertina, filtri, mappa topologica e ispettore dell'attività"
+/>
+
 Scegli **Connessioni** se preferisci un elenco. Raggruppa titoli completi e non
 troncati per relazione e direzione; selezionare una riga porta allo stesso nuovo
 focus del grafo. Entrambe le viste condividono densità, uno o due passaggi e
 filtri per relazione, tipo di voce, categoria, periodo e stato dell'attività. I
 gruppi densi e le foto dell'attività si comprimono in nodi con un conteggio
 esatto; selezionane uno per espanderlo.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Vista Connessioni che raggruppa le voci collegate all'attività dell'habitat orbitale per relazione e direzione"
+/>
 
 L'ispettore mantiene visibile il titolo completo. Quando sono disponibili dei
 media, mette la copertina per prima in una riga scorrevole con le foto correlate

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -121,12 +121,22 @@ knooppunt om erheen te gaan. Gebruik Terug en Vooruit om je route opnieuw te
 volgen, of selecteer een punt in de kleine topologiekaart om naar een ander deel
 van de grafiek te springen.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Kennisgrafiek rond de taak voor inspectie van het pinguïnverblijf in een baan om de aarde, met leesbare relatielabels, grote omslagknooppunten, filters, topologiekaart en taakinspecteur"
+/>
+
 Kies **Verbindingen** als je liever een lijst gebruikt. Die groepeert volledige,
 niet-afgekorte titels op relatie en richting; een rij selecteren verplaatst naar
 dezelfde nieuwe focus als de grafiek. Beide weergaven delen dichtheid, één of
 twee stappen en filters voor relatie, invoertype, categorie, recentheid en
 taakstatus. Dichte groepen en taakfoto's worden samengevouwen tot knooppunten
 met een exact aantal; selecteer er een om die uit te vouwen.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Verbindingsweergave die gekoppelde items van de taak voor het orbitale verblijf groepeert op relatie en richting"
+/>
 
 De taakinspecteur houdt de volledige titel zichtbaar. Als er media zijn, staat
 de omslag vooraan in een horizontale rij met gerelateerde foto's en blijft de

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -107,12 +107,22 @@ Selecione um nó para ir até ele. Use Voltar e Avançar para refazer o caminho 
 selecione um ponto no pequeno mapa de topologia para saltar para outra parte do
 grafo.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Grafo de conhecimento centrado na tarefa de inspeção do habitat orbital dos pinguins, com rótulos de relações legíveis, nós grandes com capa, filtros, mapa de topologia e inspetor da tarefa"
+/>
+
 Escolha **Ligações** se preferir uma lista. Ela agrupa títulos completos, sem
 cortes, por relação e direção; selecionar uma linha leva ao mesmo novo foco do
 grafo. As duas vistas partilham densidade, um ou dois saltos e filtros por
 relação, tipo de entrada, categoria, recência e estado da tarefa. Grupos densos
 e fotografias da tarefa são agrupados em nós com uma contagem exata; selecione
 um para o expandir.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Vista Ligações que agrupa as entradas associadas à tarefa do habitat orbital por relação e direção"
+/>
 
 O inspetor mantém o título completo visível. Quando existem conteúdos visuais,
 coloca a capa em primeiro lugar numa fila horizontal com as fotografias

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -77,12 +77,22 @@ jurnal într-o singură diagramă. Selectați un nod pentru a merge la el. Folos
 Înapoi și Înainte pentru a reface traseul sau selectați un punct din mica hartă
 topologică pentru a sări în altă parte a grafului.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Graf de cunoștințe centrat pe sarcina de inspectare a habitatului orbital al pinguinilor, cu etichete lizibile pentru relații, noduri mari cu copertă, filtre, hartă topologică și inspectorul sarcinii"
+/>
+
 Alegeți **Conexiuni** dacă preferați o listă. Aceasta grupează titlurile complete,
 netrunchiate, după relație și direcție; selectarea unui rând mută la același nou
 punct focal ca graful. Ambele vizualizări folosesc aceeași densitate, unul sau
 doi pași și aceleași filtre pentru relație, tip de intrare, categorie, vechime
 și starea sarcinii. Grupurile dense și fotografiile sarcinii se restrâng în
 noduri cu un număr exact; selectați unul pentru a-l extinde.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Vizualizarea Conexiuni care grupează intrările legate de sarcina habitatului orbital după relație și direcție"
+/>
 
 Inspectorul păstrează vizibil titlul complet. Când există conținut vizual,
 așază coperta prima într-un rând orizontal cu fotografiile asociate și păstrează

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -122,12 +122,22 @@ till den. Använd Tillbaka och Framåt för att följa vägen igen,
 eller välj en punkt i den lilla topologikartan för att hoppa till en annan del
 av grafen.
 
+<ManualScreenshot
+  caseId="tasks/knowledge-graph"
+  alt="Kunskapsgraf centrerad på uppgiften att inspektera pingvinernas omloppshabitat, med läsbara relationsetiketter, stora omslagsnoder, filter, topologikarta och uppgiftsinspektör"
+/>
+
 Välj **Anslutningar** om du föredrar en lista. Den grupperar fullständiga,
 oförkortade titlar efter relation och riktning; en vald rad flyttar till samma
 nya fokus som grafen. Båda vyerna delar täthet, ett eller två steg och filter
 för relation, posttyp, kategori, aktualitet och uppgiftsstatus. Täta grupper och
 uppgiftsfoton fälls ihop till noder med ett exakt antal; välj en för att fälla
 ut den.
+
+<ManualScreenshot
+  caseId="tasks/knowledge-graph-connections"
+  alt="Anslutningsvy som grupperar omloppshabitat-uppgiftens länkade poster efter relation och riktning"
+/>
 
 Uppgiftsinspektören visar hela titeln. När medier finns kommer omslaget först i
 en horisontell rad med relaterade foton, medan den längre AI-sammanfattningen

--- a/docs-site/metadata/screenshot-cases.json
+++ b/docs-site/metadata/screenshot-cases.json
@@ -170,6 +170,28 @@
       }
     },
     {
+      "id": "tasks/knowledge-graph",
+      "title": "Task knowledge graph",
+      "sourceTest": "test/features/knowledge_graph/ui/knowledge_graph_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "knowledge_graph_mobile_light.png",
+        "mobile-dark": "knowledge_graph_mobile_dark.png",
+        "desktop-light": "knowledge_graph_desktop_light.png",
+        "desktop-dark": "knowledge_graph_desktop_dark.png"
+      }
+    },
+    {
+      "id": "tasks/knowledge-graph-connections",
+      "title": "Task connections list",
+      "sourceTest": "test/features/knowledge_graph/ui/knowledge_graph_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "knowledge_graph_connections_mobile_light.png",
+        "mobile-dark": "knowledge_graph_connections_mobile_dark.png",
+        "desktop-light": "knowledge_graph_connections_desktop_light.png",
+        "desktop-dark": "knowledge_graph_connections_desktop_dark.png"
+      }
+    },
+    {
       "id": "tasks/agent-card",
       "title": "Assigned task agent summary",
       "sourceTest": "test/features/tasks/ui/widgets/task_manual_screenshots_test.dart",

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -39,6 +39,7 @@
   <releases>
     <release version="1.0.4" date="2026-08-05">
       <description>
+        <p>Changed: demo setup now makes remote media preparation visible and verifiable. Cover art is downloaded from immutable, checksum-pinned sources before the demo world becomes active, with an exact progress count on the preparation screen. Offline setup still works through verified bundled copies, while a corrupt download fails safely without leaving a half-created demo behind.</p>
         <p>Changed: the task knowledge graph is now a readable local workspace. Instead of presenting the whole topology as a field of mostly anonymous dots, it shows a bounded one- or two-hop neighbourhood with prioritized full labels, stronger edges, exact-count aggregates for dense groups and photos, and a small topology map for long-distance jumps. A Connections list offers the same navigation grouped by relationship and direction, while density and filters control what remains visible. Task cover art and photo nodes now appear at twice the standard node diameter, turning them into useful visual landmarks instead of icon-sized textures. The compact task inspector surfaces cover art and related photos, keeps long titles intact, and leaves the detailed AI brief collapsed until requested. Keyboard, reduced-motion, high-contrast, and screen-reader navigation are supported.</p>
         <p>Changed: task cover art now opens full screen. Tap the artwork at the top of a task to use the same zoom, rotation and download viewer as linked photos.</p>
       </description>

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -15,7 +15,11 @@ sources:
   - id: makefile
     resource: ../../Makefile
     title: manual_screenshots targets and their staging directories
-    last_modified: 2026-07-31
+    last_modified: 2026-08-06
+  - id: manual-demo-media
+    resource: ../../test/helpers/manual_demo_world.dart
+    title: Remote-only manual fixture media transport
+    last_modified: 2026-08-06
   - id: gitignore
     resource: ../../.gitignore
     title: The `screenshots` ignore rule
@@ -60,6 +64,16 @@ Which home an image belongs in follows from who regenerates it:
 `make manual_screenshots` stages captures and the materialized catalog under
 the gitignored `build/manual_capture/` and `build/manual_media/` directories;
 only the CI publish step talks to R2, using the `R2_*` repository secrets.
+
+The manual's Intergalactic Penguin Logistics fixture also reads its source
+cover art from R2, under immutable
+`demo-seed-media/<sha256>/<filename>` keys. This is input to capture, separate
+from the generated `manual/screenshots/` output. Manual suites deliberately
+disable the production bundled fallback so a missing object or checksum drift
+fails the capture. Flutter's widget-test binding returns HTTP 400 for every
+in-process `HttpClient`, so the opt-in harness transports those public bytes
+through `curl`; `DemoSeedMediaInstaller` still performs the authoritative
+SHA-256 verification before the files enter the fixture.
 
 It is a loop over two smaller targets, and CI uses those directly rather than
 the loop: `manual_screenshots_shard` captures **one** locale and converts only

--- a/knowledge/features/demo.md
+++ b/knowledge/features/demo.md
@@ -11,15 +11,27 @@ sources:
   - id: gateway
     resource: ../../lib/features/demo/state/demo_mode_gateway.dart
     title: DemoModeGateway
-    last_modified: 2026-08-05
+    last_modified: 2026-08-06
   - id: seeder
     resource: ../../lib/features/demo/seed/demo_seeder.dart
     title: DemoSeeder
-    last_modified: 2026-08-05
+    last_modified: 2026-08-06
   - id: world
     resource: ../../lib/features/demo/seed/demo_world.dart
     title: ManualDemoWorld penguin-logistics fixture
-    last_modified: 2026-08-05
+    last_modified: 2026-08-06
+  - id: seed-media
+    resource: ../../lib/features/demo/seed/demo_seed_media.dart
+    title: Checksum-pinned demo media installer
+    last_modified: 2026-08-06
+  - id: seed-progress
+    resource: ../../lib/features/demo/seed/demo_seed_progress.dart
+    title: Demo seed progress phases
+    last_modified: 2026-08-06
+  - id: entry-progress
+    resource: ../../lib/features/demo/ui/demo_entry_launcher.dart
+    title: Blocking demo-entry progress page
+    last_modified: 2026-08-06
   - id: dates
     resource: ../../lib/features/demo/seed/demo_dates.dart
     title: DemoDates semantic clock
@@ -119,13 +131,35 @@ stateDiagram-v2
 
 The seeder writes exclusively through the `WorldHandle` — never through
 getIt or `PersistenceLogic` — in dependency order: categories + labels +
-habits, AI configs (providers → models → profiles → skills), media bytes from
-the asset bundle, journal entities in reference order (habit completions among
-them, which is why the habit definitions precede them), then every
+habits, AI configs (providers → models → profiles → skills), verified media
+bytes, journal entities in reference order (habit completions among them, which
+is why the habit definitions precede them), then every
 `linked_entries` row (links last, because both endpoints must already exist),
 config flags (Daily OS, tooltips and the habits page on; sync, notifications,
 geolocation and dashboards off), and FTUE suppression in the demo's own
 `settings.sqlite`.
+
+The nine cover files have immutable, content-addressed R2 URLs plus SHA-256
+digests in `manualDemoCoverMedia`. Production tries R2 first and falls back to
+the identically verified bundled asset when the network is unavailable. A
+checksum mismatch never falls back: it is an integrity failure, not an offline
+case. Bytes are cached by digest and copied into the world before any
+`JournalImage` row that refers to them is written. If any required byte cannot
+be installed, seeding throws; `DemoWorldCreator` deletes the half-built guest
+directory and never activates it. There is therefore no database state that
+claims an image exists while its download is still pending.
+
+```mermaid
+flowchart LR
+    Prepare[Prepare guest world] --> Download[Download and verify media]
+    Download -->|network unavailable| Bundle[Verify bundled fallback]
+    Download -->|verified| Files[Write media files]
+    Bundle --> Files
+    Files --> Rows[Write image and content rows]
+    Rows --> Activate[Activate demo world]
+    Download -->|checksum or required-source failure| Delete[Delete guest world]
+    Bundle -->|missing or checksum failure| Delete
+```
 
 The habits page is on because the world carries three habits — two live daily
 ones under Penguin Operations and one retired — with three weeks of completion
@@ -231,7 +265,9 @@ Three ways in, one strip while inside:
 `DemoModeScaffold` wraps the app shell in `beamer_app.dart` and mounts the
 persistent banner while a demo world is active — structural height (a
 Column, never an overlay), absorbing the top safe-area itself. Entry and
-reset push a blocking full-screen progress route; the generation switch
+reset push a blocking full-screen progress route. It moves through preparing,
+media download with an exact completed/total count, content writes, and final
+activation; the demo remains inactive for the entire route. The generation switch
 replaces the entire tree, which is also why no post-exit toast can report
 the copied-item count (the gateway returns it for logs and tests only).
 Copy-apply *failures* do surface, though: they happen after the switch, so
@@ -262,7 +298,7 @@ through `t()` is missing from any of the nine catalogs.
 The world is 28 tasks in four clusters (launch readiness, habitat
 engineering, logistics & supply, colony life) across three categories, wired
 by ~110 `linked_entries` rows to each other and to 20 notes, 11 logged-time
-records and the nine bundled cover photos. That web is what the
+records and the nine checksum-pinned cover photos. That web is what the
 [knowledge graph](../../lib/features/knowledge_graph/README.md) walks:
 it BFSes two hops from the focus task, so a fixture of isolated tasks would
 render a single node. Four hub tasks carry six or more neighbours; every

--- a/lib/features/demo/seed/demo_seed_media.dart
+++ b/lib/features/demo/seed/demo_seed_media.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/utils/image_utils.dart';
+import 'package:path/path.dart' as p;
+
+/// Fetches one remote seed-media object as bytes.
+typedef DemoSeedUrlFetcher = Future<Uint8List> Function(Uri uri);
+
+/// Reports how many seed-media objects have been installed.
+typedef DemoSeedMediaProgressCallback =
+    void Function({required int completed, required int total});
+
+/// Immutable provenance for one image installed into a seeded demo world.
+///
+/// [sourceUrl] is optional so small or offline-only fixtures can remain
+/// bundled. [assetPath] is an optional fallback for the production demo when
+/// the remote object cannot be reached. Every source is checksum pinned.
+class DemoSeedMediaSource {
+  const DemoSeedMediaSource({
+    required this.fileName,
+    required this.sha256,
+    this.sourceUrl,
+    this.assetPath,
+  }) : assert(
+         sourceUrl != null || assetPath != null,
+         'Seed media needs a remote URL or bundled asset path.',
+       );
+
+  final String fileName;
+  final String sha256;
+  final String? sourceUrl;
+  final String? assetPath;
+}
+
+/// Installs checksum-pinned media before its [JournalImage] rows are written.
+class DemoSeedMediaInstaller {
+  DemoSeedMediaInstaller({
+    this.bundle,
+    DemoSeedUrlFetcher? fetchUrl,
+    http.Client Function()? httpClientFactory,
+    Directory? cacheRoot,
+  }) : _fetchUrl =
+           fetchUrl ??
+           ((uri) => _defaultFetchUrl(
+             uri,
+             (httpClientFactory ?? http.Client.new)(),
+           )),
+       _cacheRoot =
+           cacheRoot ??
+           Directory(
+             '${Directory.systemTemp.path}/lotti-demo-seed-media-cache',
+           );
+
+  final AssetBundle? bundle;
+  final DemoSeedUrlFetcher _fetchUrl;
+  final Directory _cacheRoot;
+
+  Future<List<File>> install({
+    required Directory documentsDirectory,
+    required List<JournalImage> images,
+    required Map<String, DemoSeedMediaSource> sources,
+    bool allowAssetFallback = true,
+    DemoSeedMediaProgressCallback? onProgress,
+  }) async {
+    final total = images.length;
+    onProgress?.call(completed: 0, total: total);
+    final installed = <File>[];
+    for (final image in images) {
+      final source = sources[image.meta.id];
+      if (source == null) {
+        throw StateError('Missing seed media source for ${image.meta.id}');
+      }
+      if (source.fileName != image.data.imageFile) {
+        throw StateError(
+          'Seed media filename ${source.fileName} does not match '
+          '${image.data.imageFile} for ${image.meta.id}',
+        );
+      }
+      final bytes = await _loadBytes(
+        source,
+        allowAssetFallback: allowAssetFallback,
+      );
+      final target = File(
+        getFullImagePath(
+          image,
+          documentsDirectory: documentsDirectory.path,
+        ),
+      );
+      await target.parent.create(recursive: true);
+      await target.writeAsBytes(bytes, flush: true);
+      installed.add(target);
+      onProgress?.call(completed: installed.length, total: total);
+    }
+    return installed;
+  }
+
+  Future<Uint8List> _loadBytes(
+    DemoSeedMediaSource source, {
+    required bool allowAssetFallback,
+  }) async {
+    final sourceUrl = source.sourceUrl;
+    if (sourceUrl != null) {
+      try {
+        return await _remoteBytes(source, Uri.parse(sourceUrl));
+      } on _DemoSeedMediaIntegrityException {
+        rethrow;
+      } catch (error) {
+        if (!allowAssetFallback || source.assetPath == null) {
+          throw StateError(
+            'Could not download required demo seed media $sourceUrl: $error',
+          );
+        }
+      }
+    }
+
+    final assetPath = source.assetPath;
+    final assetBundle = bundle;
+    if (assetPath == null || assetBundle == null) {
+      throw StateError(
+        'No available seed media source for ${source.fileName}',
+      );
+    }
+    final data = await assetBundle.load(assetPath);
+    final bytes = data.buffer.asUint8List(
+      data.offsetInBytes,
+      data.lengthInBytes,
+    );
+    _verify(bytes, source);
+    return bytes;
+  }
+
+  Future<Uint8List> _remoteBytes(
+    DemoSeedMediaSource source,
+    Uri uri,
+  ) async {
+    final cached = File(p.join(_cacheRoot.path, source.sha256));
+    if (cached.existsSync()) {
+      final bytes = await cached.readAsBytes();
+      try {
+        _verify(bytes, source);
+        return bytes;
+      } on _DemoSeedMediaIntegrityException {
+        await cached.delete();
+      }
+    }
+
+    final bytes = await _fetchUrl(uri);
+    _verify(bytes, source);
+    await _cacheRoot.create(recursive: true);
+    await cached.writeAsBytes(bytes, flush: true);
+    return bytes;
+  }
+
+  static void _verify(Uint8List bytes, DemoSeedMediaSource source) {
+    final actual = sha256.convert(bytes).toString();
+    if (actual != source.sha256) {
+      throw _DemoSeedMediaIntegrityException(
+        'Checksum mismatch for ${source.fileName}: '
+        'expected ${source.sha256}, got $actual',
+      );
+    }
+  }
+
+  static Future<Uint8List> _defaultFetchUrl(
+    Uri uri,
+    http.Client client,
+  ) async {
+    try {
+      final response = await client.get(uri);
+      if (response.statusCode != HttpStatus.ok) {
+        throw HttpException(
+          'Seed media returned HTTP ${response.statusCode}',
+          uri: uri,
+        );
+      }
+      return response.bodyBytes;
+    } finally {
+      client.close();
+    }
+  }
+}
+
+class _DemoSeedMediaIntegrityException implements Exception {
+  const _DemoSeedMediaIntegrityException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/demo/seed/demo_seed_progress.dart
+++ b/lib/features/demo/seed/demo_seed_progress.dart
@@ -1,0 +1,44 @@
+/// Stages exposed while an inactive demo world is being prepared.
+enum DemoSeedPhase {
+  preparing,
+  downloadingMedia,
+  writingContent,
+  activating,
+}
+
+/// Immutable progress snapshot for the blocking demo-entry surface.
+class DemoSeedProgress {
+  const DemoSeedProgress._({
+    required this.phase,
+    this.completed = 0,
+    this.total = 0,
+  });
+
+  const DemoSeedProgress.preparing() : this._(phase: DemoSeedPhase.preparing);
+
+  const DemoSeedProgress.downloadingMedia({
+    required int completed,
+    required int total,
+  }) : this._(
+         phase: DemoSeedPhase.downloadingMedia,
+         completed: completed,
+         total: total,
+       );
+
+  const DemoSeedProgress.writingContent()
+    : this._(phase: DemoSeedPhase.writingContent);
+
+  const DemoSeedProgress.activating() : this._(phase: DemoSeedPhase.activating);
+
+  final DemoSeedPhase phase;
+  final int completed;
+  final int total;
+
+  /// Completed fraction for the determinate media phase; otherwise `null`.
+  double? get fraction {
+    if (phase != DemoSeedPhase.downloadingMedia || total <= 0) return null;
+    return (completed / total).clamp(0, 1);
+  }
+}
+
+typedef DemoSeedProgressCallback = void Function(DemoSeedProgress progress);

--- a/lib/features/demo/seed/demo_seeder.dart
+++ b/lib/features/demo/seed/demo_seeder.dart
@@ -3,6 +3,8 @@ import 'dart:ui' show Locale;
 import 'package:flutter/services.dart' show AssetBundle;
 import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
 import 'package:lotti/features/demo/seed/demo_seed_text.dart';
 import 'package:lotti/features/demo/seed/demo_tutorial_content.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
@@ -29,21 +31,25 @@ import 'package:lotti/utils/consts.dart';
 class DemoSeeder {
   DemoSeeder({
     required this.world,
-    required this.bundle,
+    required AssetBundle bundle,
     DateTime Function()? clock,
-  }) : clock = clock ?? DateTime.now;
+    this.onProgress,
+    DemoSeedMediaInstaller? mediaInstaller,
+  }) : clock = clock ?? DateTime.now,
+       _mediaInstaller =
+           mediaInstaller ?? DemoSeedMediaInstaller(bundle: bundle);
 
   /// Storage handles of the (not yet active) demo world.
   final WorldHandle world;
-
-  /// Asset bundle carrying the nine cover-art webp files (production passes
-  /// `rootBundle`).
-  final AssetBundle bundle;
 
   /// Source of "now" for the world's semantic dates (due today, overdue by
   /// two days, logged last Tuesday) and for the manifest timestamp. Injected
   /// so tests stay deterministic.
   final DateTime Function() clock;
+
+  final DemoSeedProgressCallback? onProgress;
+
+  final DemoSeedMediaInstaller _mediaInstaller;
 
   /// Seeds the world in dependency order and returns the manifest that was
   /// written to `<root>/demo_seed_manifest.json`.
@@ -82,7 +88,20 @@ class DemoSeeder {
     }
 
     // Media bytes before the image entities that reference them.
-    await penguinWorld.installMediaFromBundle(bundle, world.root);
+    await _mediaInstaller.install(
+      documentsDirectory: world.root,
+      images: penguinWorld.coverImages,
+      sources: manualDemoCoverMedia,
+      onProgress: ({required completed, required total}) {
+        onProgress?.call(
+          DemoSeedProgress.downloadingMedia(
+            completed: completed,
+            total: total,
+          ),
+        );
+      },
+    );
+    onProgress?.call(const DemoSeedProgress.writingContent());
 
     // Journal entities in reference order: images, checklist items, the
     // checklists that list them, the tasks that own those checklists, then

--- a/lib/features/demo/seed/demo_world.dart
+++ b/lib/features/demo/seed/demo_world.dart
@@ -11,6 +11,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/demo/seed/demo_dates.dart';
 import 'package:lotti/features/demo/seed/demo_entity_factories.dart';
 import 'package:lotti/features/demo/seed/demo_ids.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
 import 'package:lotti/features/demo/seed/demo_seed_text.dart';
 import 'package:lotti/utils/image_utils.dart';
 
@@ -92,24 +93,56 @@ final String manualHeadsetWalkCoverImageId = demoUuid(
   'manual-penguin-headset-walk-cover',
 );
 
-final Map<String, String> manualDemoCoverAssets = <String, String>{
-  manualHabitatCoverImageId:
-      'assets/design_system/manual_task_cover_habitat.webp',
-  manualRollCallCoverImageId:
-      'assets/design_system/manual_task_cover_roll_call.webp',
-  manualLaunchReviewCoverImageId:
-      'assets/design_system/manual_task_cover_launch_review.webp',
-  manualLunchCoverImageId: 'assets/design_system/manual_task_cover_lunch.webp',
-  manualSardineFuturesCoverImageId:
-      'assets/design_system/manual_task_cover_sardine_futures.webp',
-  manualFishFeederCoverImageId:
-      'assets/design_system/manual_task_cover_feeder.webp',
-  manualSardineCargoCoverImageId:
-      'assets/design_system/manual_task_cover_cargo.webp',
-  manualPenguinPassengerCoverImageId:
-      'assets/design_system/manual_task_cover_legal.webp',
-  manualHeadsetWalkCoverImageId:
-      'assets/design_system/manual_task_cover_headset_walk.webp',
+const _demoSeedMediaBaseUrl =
+    'https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/demo-seed-media';
+
+DemoSeedMediaSource _demoCoverMedia({
+  required String fileName,
+  required String sha256,
+}) => DemoSeedMediaSource(
+  fileName: fileName,
+  sha256: sha256,
+  sourceUrl: '$_demoSeedMediaBaseUrl/$sha256/$fileName',
+  assetPath: 'assets/design_system/$fileName',
+);
+
+final Map<String, DemoSeedMediaSource> manualDemoCoverMedia = {
+  manualHabitatCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_habitat.webp',
+    sha256: '93fd246b1cd6d8bfaf2481c86c04183cf0b407629cfbea11c0ecc668f84cd7e7',
+  ),
+  manualRollCallCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_roll_call.webp',
+    sha256: '990fc5cb2c1c1241762cef41328d85fc7aa20f68c087d175aa8980504e6363c7',
+  ),
+  manualLaunchReviewCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_launch_review.webp',
+    sha256: '049f8c2b61a00bff209e3724b45b1dd436b06b38f1268ad4b92b6d6d97de1d7d',
+  ),
+  manualLunchCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_lunch.webp',
+    sha256: '59bc7eac24720315f9847c8c927b611c0efdfc2f9c540d35507f4a7da0c6610f',
+  ),
+  manualSardineFuturesCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_sardine_futures.webp',
+    sha256: '729dc0a2ab2126e7988af7ead9988c1b7333e349a782ac2e365ed9916d55fbe5',
+  ),
+  manualFishFeederCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_feeder.webp',
+    sha256: '9c77bd8bd2c3daaec79929eedb2cbe58c7ca76e1c9d18bac5887fdea7aa0ebb0',
+  ),
+  manualSardineCargoCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_cargo.webp',
+    sha256: 'fdd13bba93d14f85ee7bdf779403710c90b5689089ed1aefd4cbefb8aa8f2427',
+  ),
+  manualPenguinPassengerCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_legal.webp',
+    sha256: '6afa475279cfe9cf9eb54b6d8407f03a469b391d9d848146d2f03c45d61da5df',
+  ),
+  manualHeadsetWalkCoverImageId: _demoCoverMedia(
+    fileName: 'manual_task_cover_headset_walk.webp',
+    sha256: 'e98b257648a07310ee56db528b18a6f00e8a88cf45dde09e0395739a2df31957',
+  ),
 };
 
 // ---------------------------------------------------------------------------
@@ -420,7 +453,7 @@ class ManualDemoWorld {
         private: false,
       ),
     ];
-    final coverImages = manualDemoCoverAssets.entries.map((entry) {
+    final coverImages = manualDemoCoverMedia.entries.map((entry) {
       return JournalImage(
         meta: Metadata(
           id: entry.key,
@@ -433,7 +466,7 @@ class ManualDemoWorld {
         data: ImageData(
           capturedAt: anchor,
           imageId: '${entry.key}-file',
-          imageFile: entry.value.split('/').last,
+          imageFile: entry.value.fileName,
           imageDirectory: '/manual_demo/',
         ),
       );
@@ -2013,41 +2046,50 @@ class ManualDemoWorld {
       await target.parent.create(recursive: true);
       installedFiles.add(
         await File(
-          manualDemoCoverAssets[coverImage.meta.id]!,
+          manualDemoCoverMedia[coverImage.meta.id]!.assetPath!,
         ).copy(target.path),
       );
     }
     return installedFiles;
   }
 
-  /// Copies the bundled artwork out of [bundle] (e.g. `rootBundle`) into the
-  /// document-relative paths used by production cover-art widgets.
+  /// Installs checksum-pinned remote artwork into the document-relative paths
+  /// used by production cover-art widgets.
   ///
-  /// The production twin of [installMedia]: the nine cover webp files ship
-  /// inside the app bundle (`assets/design_system/`), so seeding a demo world
-  /// on a device must read them through the asset bundle rather than dart:io.
+  /// When the network is unavailable, the production path falls back to the
+  /// verified copies in [bundle]. Manual captures use
+  /// [installMediaFromRemote] so missing R2 objects cannot be hidden by that
+  /// fallback.
   Future<List<File>> installMediaFromBundle(
     AssetBundle bundle,
-    Directory documentsDirectory,
-  ) async {
-    final installedFiles = <File>[];
-    for (final coverImage in coverImages) {
-      final target = File(
-        getFullImagePath(
-          coverImage,
-          documentsDirectory: documentsDirectory.path,
-        ),
+    Directory documentsDirectory, {
+    DemoSeedMediaProgressCallback? onProgress,
+  }) => DemoSeedMediaInstaller(bundle: bundle).install(
+    documentsDirectory: documentsDirectory,
+    images: coverImages,
+    sources: manualDemoCoverMedia,
+    onProgress: onProgress,
+  );
+
+  /// Installs the manual fixture from its checksum-pinned remote sources.
+  ///
+  /// Unlike production demo entry, this has no bundled fallback: a manual
+  /// capture must prove the R2 seed catalog is complete instead of silently
+  /// rendering whatever happened to remain in the application bundle.
+  Future<List<File>> installMediaFromRemote(
+    Directory documentsDirectory, {
+    DemoSeedUrlFetcher? fetchUrl,
+    Directory? cacheRoot,
+    DemoSeedMediaProgressCallback? onProgress,
+  }) =>
+      DemoSeedMediaInstaller(
+        fetchUrl: fetchUrl,
+        cacheRoot: cacheRoot,
+      ).install(
+        documentsDirectory: documentsDirectory,
+        images: coverImages,
+        sources: manualDemoCoverMedia,
+        allowAssetFallback: false,
+        onProgress: onProgress,
       );
-      await target.parent.create(recursive: true);
-      final data = await bundle.load(
-        manualDemoCoverAssets[coverImage.meta.id]!,
-      );
-      await target.writeAsBytes(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-        flush: true,
-      );
-      installedFiles.add(target);
-    }
-    return installedFiles;
-  }
 }

--- a/lib/features/demo/state/demo_mode_gateway.dart
+++ b/lib/features/demo/state/demo_mode_gateway.dart
@@ -11,6 +11,8 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/demo/copy/demo_data_copier.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
 import 'package:lotti/features/demo/seed/demo_seeder.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
@@ -24,7 +26,11 @@ import 'package:lotti/services/domain_logging.dart';
 /// Seeds a freshly created demo world. Injectable so gateway tests can
 /// exercise the enter/reset decision logic without running the full seeder.
 typedef DemoSeedRunner =
-    Future<void> Function(WorldHandle world, Locale locale);
+    Future<void> Function(
+      WorldHandle world,
+      Locale locale,
+      DemoSeedProgressCallback? onProgress,
+    );
 
 /// The UI-facing entry/exit surface for demo mode.
 ///
@@ -41,11 +47,13 @@ class DemoModeGateway {
     DateTime Function()? clock,
     @visibleForTesting ProfileContext? Function()? profileContext,
     @visibleForTesting DemoSeedRunner? seedRunner,
+    @visibleForTesting DemoSeedMediaInstaller? seedMediaInstaller,
     @visibleForTesting this.prepareCopyOverride,
     @visibleForTesting this.applyCopyOverride,
   }) : _bundle = bundle ?? rootBundle,
        _clock = clock ?? DateTime.now,
        _profileContext = profileContext ?? _activeProfileContext {
+    _seedMediaInstaller = seedMediaInstaller;
     _seedRunner = seedRunner ?? _defaultSeedRunner;
   }
 
@@ -64,6 +72,7 @@ class DemoModeGateway {
   final DateTime Function() _clock;
   final ProfileContext? Function() _profileContext;
   late final DemoSeedRunner _seedRunner;
+  late final DemoSeedMediaInstaller? _seedMediaInstaller;
 
   /// Test seam replacing the read of the demo side in [exitWithCopy].
   @visibleForTesting
@@ -80,12 +89,17 @@ class DemoModeGateway {
   static ProfileContext? _activeProfileContext() =>
       getIt.isRegistered<ProfileContext>() ? getIt<ProfileContext>() : null;
 
-  Future<void> _defaultSeedRunner(WorldHandle world, Locale locale) =>
-      DemoSeeder(
-        world: world,
-        bundle: _bundle,
-        clock: _clock,
-      ).seed(locale: locale);
+  Future<void> _defaultSeedRunner(
+    WorldHandle world,
+    Locale locale,
+    DemoSeedProgressCallback? onProgress,
+  ) => DemoSeeder(
+    world: world,
+    bundle: _bundle,
+    clock: _clock,
+    onProgress: onProgress,
+    mediaInstaller: _seedMediaInstaller,
+  ).seed(locale: locale);
 
   /// Whether the running generation is the demo (guest) world.
   bool get isDemoActive => _profileContext()?.isGuest ?? false;
@@ -111,11 +125,14 @@ class DemoModeGateway {
   /// something the user made. [resetDemo] remains the explicit, confirmed
   /// wipe. While the demo is ALREADY active there is nothing to enter, so it
   /// degrades to the same staleness repair — see [refreshStaleDemoWorld].
-  Future<void> enterDemo({required Locale locale}) async {
+  Future<void> enterDemo({
+    required Locale locale,
+    DemoSeedProgressCallback? onProgress,
+  }) async {
     if (isDemoActive) {
       // Already inside: "Try the demo" has nothing to enter, but the world
       // underfoot may be stale — see [refreshStaleDemoWorld].
-      await refreshStaleDemoWorld(locale: locale);
+      await refreshStaleDemoWorld(locale: locale, onProgress: onProgress);
       return;
     }
     final existing = await findDemoProfile();
@@ -126,7 +143,7 @@ class DemoModeGateway {
       }
       await registry.deleteGuestProfile(existing.id);
     }
-    await _createAndEnter(locale);
+    await _createAndEnter(locale, onProgress: onProgress);
   }
 
   /// Reseeds a stale demo world the app is ALREADY sitting in.
@@ -153,6 +170,7 @@ class DemoModeGateway {
   Future<bool> refreshStaleDemoWorld({
     required Locale locale,
     FutureOr<void> Function()? onReseedStarted,
+    DemoSeedProgressCallback? onProgress,
   }) async {
     if (!isDemoActive) return false;
     final existing = await findDemoProfile();
@@ -160,7 +178,7 @@ class DemoModeGateway {
     if (await _hasCurrentSeed(existing)) return false;
     if (await _activeWorldHasUserWork(existing)) return false;
     await onReseedStarted?.call();
-    await resetDemo(locale: locale);
+    await resetDemo(locale: locale, onProgress: onProgress);
     return true;
   }
 
@@ -171,7 +189,10 @@ class DemoModeGateway {
   /// Wipes and reseeds the demo world, then enters it. When called while the
   /// demo is active it exits to the real world first so the demo databases
   /// are closed before their directory is deleted.
-  Future<void> resetDemo({required Locale locale}) async {
+  Future<void> resetDemo({
+    required Locale locale,
+    DemoSeedProgressCallback? onProgress,
+  }) async {
     if (isDemoActive) {
       await exitDemo();
     }
@@ -179,7 +200,7 @@ class DemoModeGateway {
     if (existing != null) {
       await registry.deleteGuestProfile(existing.id);
     }
-    await _createAndEnter(locale);
+    await _createAndEnter(locale, onProgress: onProgress);
   }
 
   /// Deletes the demo profile and its directory tree. Only legal while the
@@ -368,13 +389,20 @@ class DemoModeGateway {
     return providers.any((config) => !seededAiIds.contains(config.id));
   }
 
-  Future<void> _createAndEnter(Locale locale) async {
+  Future<void> _createAndEnter(
+    Locale locale, {
+    DemoSeedProgressCallback? onProgress,
+  }) async {
+    onProgress?.call(const DemoSeedProgress.preparing());
     await DemoWorldCreator(
       registry: registry,
-      activate: activate,
+      activate: (profileId) {
+        onProgress?.call(const DemoSeedProgress.activating());
+        return activate(profileId);
+      },
     ).createAndActivate(
       name: demoProfileName,
-      seed: (world) => _seedRunner(world, locale),
+      seed: (world) => _seedRunner(world, locale, onProgress),
     );
   }
 }

--- a/lib/features/demo/ui/demo_entry_launcher.dart
+++ b/lib/features/demo/ui/demo_entry_launcher.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
 import 'package:lotti/features/demo/state/demo_mode_gateway.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/progress_bars/design_system_circular_progress.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -23,9 +26,9 @@ import 'package:lotti/services/domain_logging.dart';
 Future<void> launchDemoEnter(
   BuildContext context, {
   DemoModeGateway? gateway,
-}) => _launch(context, gateway, (g, locale, showProgress) {
+}) => _launch(context, gateway, (g, locale, showProgress, onProgress) {
   showProgress();
-  return g.enterDemo(locale: locale);
+  return g.enterDemo(locale: locale, onProgress: onProgress);
 });
 
 /// Reseeds the demo world the app is ALREADY in when its seed content has
@@ -47,9 +50,10 @@ Future<void> launchStaleDemoRefresh(
 }) => _launch(
   context,
   gateway,
-  (g, locale, showProgress) => g.refreshStaleDemoWorld(
+  (g, locale, showProgress, onProgress) => g.refreshStaleDemoWorld(
     locale: locale,
     onReseedStarted: showProgress,
+    onProgress: onProgress,
   ),
   toastFailure: false,
 );
@@ -61,9 +65,9 @@ Future<void> launchStaleDemoRefresh(
 Future<void> launchDemoReset(
   BuildContext context, {
   DemoModeGateway? gateway,
-}) => _launch(context, gateway, (g, locale, showProgress) {
+}) => _launch(context, gateway, (g, locale, showProgress, onProgress) {
   showProgress();
-  return g.resetDemo(locale: locale);
+  return g.resetDemo(locale: locale, onProgress: onProgress);
 });
 
 Future<void> _launch(
@@ -73,6 +77,7 @@ Future<void> _launch(
     DemoModeGateway gateway,
     Locale locale,
     VoidCallback showProgress,
+    DemoSeedProgressCallback onProgress,
   )
   action, {
 
@@ -89,9 +94,12 @@ Future<void> _launch(
   }
   final locale = Localizations.localeOf(context);
   final navigator = Navigator.of(context, rootNavigator: true);
+  final progress = ValueNotifier<DemoSeedProgress>(
+    const DemoSeedProgress.preparing(),
+  );
   final progressRoute = MaterialPageRoute<void>(
     fullscreenDialog: true,
-    builder: (_) => const DemoEnteringProgressPage(),
+    builder: (_) => DemoEnteringProgressPage(progress: progress),
   );
   // Pushed by the action, not here: an action that may decide to do nothing
   // must not flash a blocking page on the way to that decision.
@@ -102,8 +110,10 @@ Future<void> _launch(
     unawaited(navigator.push(progressRoute));
   }
 
+  void updateProgress(DemoSeedProgress next) => progress.value = next;
+
   try {
-    await action(resolved, locale, showProgress);
+    await action(resolved, locale, showProgress, updateProgress);
     // A switch has replaced the whole tree, progress route included. An
     // action that decided to do NOTHING leaves this generation alive, so a
     // route raised on the way there has to come back off — otherwise the
@@ -131,6 +141,8 @@ Future<void> _launch(
         title: context.messages.demoEnterFailedToast,
       );
     }
+  } finally {
+    progress.dispose();
   }
 }
 
@@ -138,7 +150,9 @@ Future<void> _launch(
 /// seeded. Back navigation is disabled — the switch must not be interrupted
 /// mid-seed.
 class DemoEnteringProgressPage extends StatelessWidget {
-  const DemoEnteringProgressPage({super.key});
+  const DemoEnteringProgressPage({required this.progress, super.key});
+
+  final ValueListenable<DemoSeedProgress> progress;
 
   @override
   Widget build(BuildContext context) {
@@ -146,26 +160,70 @@ class DemoEnteringProgressPage extends StatelessWidget {
     return PopScope(
       canPop: false,
       child: Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const CircularProgressIndicator(),
-              SizedBox(height: tokens.spacing.step5),
-              Text(
-                context.messages.demoEnteringProgress,
-                textAlign: TextAlign.center,
-                style: tokens.typography.styles.body.bodyMedium.copyWith(
-                  color: tokens.colors.text.mediumEmphasis,
+        body: ValueListenableBuilder<DemoSeedProgress>(
+          valueListenable: progress,
+          builder: (context, value, _) => Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _DemoProgressIndicator(progress: value),
+                SizedBox(height: tokens.spacing.step5),
+                Text(
+                  context.messages.demoEnteringProgress,
+                  textAlign: TextAlign.center,
+                  style: tokens.typography.styles.body.bodyMedium.copyWith(
+                    color: tokens.colors.text.mediumEmphasis,
+                  ),
                 ),
-              ),
-            ],
+                if (value.phase != DemoSeedPhase.preparing) ...[
+                  SizedBox(height: tokens.spacing.step3),
+                  Text(
+                    _phaseLabel(context, value),
+                    textAlign: TextAlign.center,
+                    style: tokens.typography.styles.body.bodySmall.copyWith(
+                      color: tokens.colors.text.mediumEmphasis,
+                    ),
+                  ),
+                ],
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 }
+
+class _DemoProgressIndicator extends StatelessWidget {
+  const _DemoProgressIndicator({required this.progress});
+
+  final DemoSeedProgress progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final fraction = progress.fraction;
+    if (fraction == null) return const CircularProgressIndicator();
+    return DesignSystemCircularProgress(
+      value: fraction,
+      size: DesignSystemCircularProgressSize.large,
+      center: Text('${progress.completed}/${progress.total}'),
+      semanticsLabel: _phaseLabel(context, progress),
+    );
+  }
+}
+
+String _phaseLabel(BuildContext context, DemoSeedProgress progress) =>
+    switch (progress.phase) {
+      DemoSeedPhase.preparing => context.messages.demoEnteringProgress,
+      DemoSeedPhase.downloadingMedia =>
+        context.messages.demoDownloadingMediaProgress(
+          progress.completed,
+          progress.total,
+        ),
+      DemoSeedPhase.writingContent =>
+        context.messages.demoPreparingContentProgress,
+      DemoSeedPhase.activating => context.messages.demoActivatingProgress,
+    };
 
 /// "Try the demo" call to action for empty states.
 ///

--- a/lib/features/knowledge_graph/ui/task_knowledge_graph_page.dart
+++ b/lib/features/knowledge_graph/ui/task_knowledge_graph_page.dart
@@ -78,6 +78,7 @@ class TaskKnowledgeGraphPage extends ConsumerStatefulWidget {
   const TaskKnowledgeGraphPage({
     required this.taskId,
     this.mergeGraphData,
+    this.imageLoader,
     super.key,
   });
 
@@ -90,6 +91,10 @@ class TaskKnowledgeGraphPage extends ConsumerStatefulWidget {
     TaskGraphData expansion,
   )?
   mergeGraphData;
+
+  /// Optional deterministic image decoder for screenshot and widget hosts.
+  /// Production uses [decodeGraphImageFile].
+  final GraphImageLoader? imageLoader;
 
   @override
   ConsumerState<TaskKnowledgeGraphPage> createState() =>
@@ -281,6 +286,7 @@ class _TaskKnowledgeGraphPageState
       // Relaxed off the main thread in the provider so the first frame
       // renders without a layout pass on the UI thread.
       layout: visibleData.layout,
+      imageLoader: widget.imageLoader,
     );
   }
 

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2175,6 +2175,7 @@
   "defaultLanguage": "Výchozí jazyk",
   "deleteButton": "Smazat",
   "deleteDeviceLabel": "Odebrat ze synchronizace",
+  "demoActivatingProgress": "Otevírám demo svět…",
   "demoAiNudgeBody": "Demo svět obsahuje fiktivní poskytovatele AI, takže AI akce tady doopravdy neproběhnou. Připoj svůj vlastní AI účet a používej v demu skutečnou AI. Tvůj klíč zůstane v tomto demo světě, pokud si ho při odchodu nezkopíruješ.",
   "demoAiNudgeCancel": "Teď ne",
   "demoAiNudgeConfirm": "Nastavit skutečnou AI",
@@ -2202,6 +2203,17 @@
     }
   },
   "demoDeleteFailedToast": "Demo data se nepodařilo smazat — zkus to znovu.",
+  "demoDownloadingMediaProgress": "Stahuji obrázky dema · {completed} z {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Demo svět se nepodařilo otevřít — zkus to znovu.",
   "demoEnteringProgress": "Připravuji demo svět…",
   "demoExitCandidatesError": "Nepodařilo se zkontrolovat práci ke zkopírování. Demo můžeš přesto opustit.",
@@ -2211,6 +2223,7 @@
   "demoExitSheetTitle": "Opustit demo?",
   "demoExitTakeWork": "Vzít si práci s sebou…",
   "demoOnboardingExplore": "Prozkoumat s ukázkovými daty",
+  "demoPreparingContentProgress": "Připravuji úkoly a propojení…",
   "demoSettingsDeleteConfirm": "Smazat demo svět a všechna jeho data?",
   "demoSettingsDeleteTitle": "Smazat demo data",
   "demoSettingsDeleteToast": "Demo data smazána",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2408,6 +2408,7 @@
   "defaultLanguage": "Standardsprog",
   "deleteButton": "Slet",
   "deleteDeviceLabel": "Fjern fra synkronisering",
+  "demoActivatingProgress": "Åbner demoverdenen…",
   "demoAiNudgeBody": "Demoverdenen indeholder fiktive AI-udbydere, så AI-handlinger kan ikke rigtig køre her. Forbind din egen AI-konto for at bruge rigtig AI i demoen. Din nøgle bliver i denne demoverden, medmindre du kopierer den med, når du forlader den.",
   "demoAiNudgeCancel": "Ikke nu",
   "demoAiNudgeConfirm": "Opsæt rigtig AI",
@@ -2435,6 +2436,17 @@
     }
   },
   "demoDeleteFailedToast": "Demodataene kunne ikke slettes — prøv igen.",
+  "demoDownloadingMediaProgress": "Downloader demobilleder · {completed} af {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Demoverdenen kunne ikke åbnes — prøv igen.",
   "demoEnteringProgress": "Gør demoverdenen klar…",
   "demoExitCandidatesError": "Kunne ikke tjekke dit arbejde til kopiering. Du kan stadig forlade demoen.",
@@ -2444,6 +2456,7 @@
   "demoExitSheetTitle": "Forlad demoen?",
   "demoExitTakeWork": "Tag mit arbejde med…",
   "demoOnboardingExplore": "Udforsk med eksempeldata",
+  "demoPreparingContentProgress": "Gør opgaver og forbindelser klar…",
   "demoSettingsDeleteConfirm": "Slet demoverdenen og alle dens data?",
   "demoSettingsDeleteTitle": "Slet demodata",
   "demoSettingsDeleteToast": "Demodata slettet",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2168,6 +2168,7 @@
   "defaultLanguage": "Standardsprache",
   "deleteButton": "Löschen",
   "deleteDeviceLabel": "Aus Sync entfernen",
+  "demoActivatingProgress": "Demo-Welt wird geöffnet…",
   "demoAiNudgeBody": "Die Demo-Welt enthält fiktive KI-Anbieter, daher können KI-Aktionen hier nicht wirklich laufen. Verbinde dein eigenes KI-Konto, um echte KI in der Demo zu nutzen. Dein Schlüssel bleibt in dieser Demo-Welt, außer du kopierst ihn beim Verlassen mit.",
   "demoAiNudgeCancel": "Jetzt nicht",
   "demoAiNudgeConfirm": "Echte KI einrichten",
@@ -2195,6 +2196,17 @@
     }
   },
   "demoDeleteFailedToast": "Die Demo-Daten konnten nicht gelöscht werden — versuch es noch mal.",
+  "demoDownloadingMediaProgress": "Demo-Bilder werden geladen · {completed} von {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Die Demo-Welt konnte nicht geöffnet werden — versuch es noch mal.",
   "demoEnteringProgress": "Demo-Welt wird eingerichtet…",
   "demoExitCandidatesError": "Deine Arbeit zum Kopieren konnte nicht geprüft werden. Du kannst die Demo trotzdem verlassen.",
@@ -2204,6 +2216,7 @@
   "demoExitSheetTitle": "Demo verlassen?",
   "demoExitTakeWork": "Meine Arbeit mitnehmen…",
   "demoOnboardingExplore": "Mit Beispieldaten erkunden",
+  "demoPreparingContentProgress": "Aufgaben und Verbindungen werden vorbereitet…",
   "demoSettingsDeleteConfirm": "Demo-Welt und alle zugehörigen Daten löschen?",
   "demoSettingsDeleteTitle": "Demo-Daten löschen",
   "demoSettingsDeleteToast": "Demo-Daten gelöscht",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2743,6 +2743,7 @@
   "defaultLanguage": "Default Language",
   "deleteButton": "Delete",
   "deleteDeviceLabel": "Remove from sync",
+  "demoActivatingProgress": "Opening the demo world…",
   "demoAiNudgeBody": "The demo world ships with fictional AI providers, so AI actions can't really run here. Connect your own AI account to use real AI inside the demo. Your key stays in this demo world unless you copy it over when you leave.",
   "demoAiNudgeCancel": "Not now",
   "demoAiNudgeConfirm": "Set up real AI",
@@ -2770,6 +2771,17 @@
     }
   },
   "demoDeleteFailedToast": "Couldn't delete the demo data — try again.",
+  "demoDownloadingMediaProgress": "Downloading demo images · {completed} of {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Couldn't open the demo world — try again.",
   "demoEnteringProgress": "Setting up the demo world…",
   "demoExitCandidatesError": "Couldn't check for work to copy. You can still exit the demo.",
@@ -2779,6 +2791,7 @@
   "demoExitSheetTitle": "Leave the demo?",
   "demoExitTakeWork": "Take my work with me…",
   "demoOnboardingExplore": "Explore with sample data",
+  "demoPreparingContentProgress": "Preparing tasks and connections…",
   "demoSettingsDeleteConfirm": "Delete the demo world and everything in it?",
   "demoSettingsDeleteTitle": "Delete demo data",
   "demoSettingsDeleteToast": "Demo data deleted",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2168,6 +2168,7 @@
   "defaultLanguage": "Idioma predeterminado",
   "deleteButton": "Eliminar",
   "deleteDeviceLabel": "Quitar de la sincronización",
+  "demoActivatingProgress": "Abriendo el mundo de demostración…",
   "demoAiNudgeBody": "El mundo de demostración incluye proveedores de IA ficticios, así que las acciones de IA no pueden ejecutarse de verdad aquí. Conecta tu propia cuenta de IA para usar IA real dentro de la demostración. Tu clave se queda en este mundo de demostración salvo que la copies al salir.",
   "demoAiNudgeCancel": "Ahora no",
   "demoAiNudgeConfirm": "Configurar IA real",
@@ -2195,6 +2196,17 @@
     }
   },
   "demoDeleteFailedToast": "No se pudieron borrar los datos de la demo — inténtalo de nuevo.",
+  "demoDownloadingMediaProgress": "Descargando imágenes de la demo · {completed} de {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "No se pudo abrir el mundo de demostración — inténtalo de nuevo.",
   "demoEnteringProgress": "Preparando el mundo de demostración…",
   "demoExitCandidatesError": "No se pudo comprobar tu trabajo para copiar. Aun así puedes salir de la demo.",
@@ -2204,6 +2216,7 @@
   "demoExitSheetTitle": "¿Salir de la demo?",
   "demoExitTakeWork": "Llevarme mi trabajo…",
   "demoOnboardingExplore": "Explorar con datos de ejemplo",
+  "demoPreparingContentProgress": "Preparando tareas y conexiones…",
   "demoSettingsDeleteConfirm": "¿Eliminar el mundo de demostración y todos sus datos?",
   "demoSettingsDeleteTitle": "Eliminar datos de la demo",
   "demoSettingsDeleteToast": "Datos de la demo eliminados",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2168,6 +2168,7 @@
   "defaultLanguage": "Langue par défaut",
   "deleteButton": "Supprimer",
   "deleteDeviceLabel": "Retirer de la synchronisation",
+  "demoActivatingProgress": "Ouverture du monde démo…",
   "demoAiNudgeBody": "Le monde démo contient des fournisseurs d'IA fictifs, les actions d'IA ne peuvent donc pas vraiment s'exécuter ici. Connecte ton propre compte d'IA pour utiliser une IA réelle dans la démo. Ta clé reste dans ce monde démo, sauf si tu la copies en partant.",
   "demoAiNudgeCancel": "Pas maintenant",
   "demoAiNudgeConfirm": "Configurer l'IA réelle",
@@ -2195,6 +2196,17 @@
     }
   },
   "demoDeleteFailedToast": "Impossible de supprimer les données démo — réessaie.",
+  "demoDownloadingMediaProgress": "Téléchargement des images de démo · {completed} sur {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Impossible d'ouvrir le monde démo — réessaie.",
   "demoEnteringProgress": "Préparation du monde démo…",
   "demoExitCandidatesError": "Impossible de vérifier ton travail à copier. Tu peux quand même quitter la démo.",
@@ -2204,6 +2216,7 @@
   "demoExitSheetTitle": "Quitter la démo ?",
   "demoExitTakeWork": "Emporter mon travail…",
   "demoOnboardingExplore": "Explorer avec des données d'exemple",
+  "demoPreparingContentProgress": "Préparation des tâches et des connexions…",
   "demoSettingsDeleteConfirm": "Supprimer le monde démo et toutes ses données ?",
   "demoSettingsDeleteTitle": "Supprimer les données de démo",
   "demoSettingsDeleteToast": "Données de démo supprimées",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2408,6 +2408,7 @@
   "defaultLanguage": "Lingua di default",
   "deleteButton": "Cancella",
   "deleteDeviceLabel": "Rimuovi dalla sincronizzazione",
+  "demoActivatingProgress": "Apertura del mondo demo…",
   "demoAiNudgeBody": "Il mondo demo include provider di IA fittizi, quindi le azioni di IA non possono davvero funzionare qui. Collega il tuo account IA per usare l'IA reale nella demo. La tua chiave resta in questo mondo demo, a meno che tu non la copi quando esci.",
   "demoAiNudgeCancel": "Non ora",
   "demoAiNudgeConfirm": "Configura l'IA reale",
@@ -2435,6 +2436,17 @@
     }
   },
   "demoDeleteFailedToast": "Impossibile eliminare i dati demo — riprova.",
+  "demoDownloadingMediaProgress": "Download delle immagini demo · {completed} di {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Impossibile aprire il mondo demo — riprova.",
   "demoEnteringProgress": "Preparazione del mondo demo…",
   "demoExitCandidatesError": "Impossibile controllare il lavoro da copiare. Puoi comunque uscire dalla demo.",
@@ -2444,6 +2456,7 @@
   "demoExitSheetTitle": "Uscire dalla demo?",
   "demoExitTakeWork": "Porta il mio lavoro con me…",
   "demoOnboardingExplore": "Esplora con dati di esempio",
+  "demoPreparingContentProgress": "Preparazione di attività e collegamenti…",
   "demoSettingsDeleteConfirm": "Eliminare il mondo demo e tutti i suoi dati?",
   "demoSettingsDeleteTitle": "Elimina i dati demo",
   "demoSettingsDeleteToast": "Dati demo eliminati",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8315,6 +8315,12 @@ abstract class AppLocalizations {
   /// **'Remove from sync'**
   String get deleteDeviceLabel;
 
+  /// No description provided for @demoActivatingProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Opening the demo world…'**
+  String get demoActivatingProgress;
+
   /// No description provided for @demoAiNudgeBody.
   ///
   /// In en, this message translates to:
@@ -8435,6 +8441,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t delete the demo data — try again.'**
   String get demoDeleteFailedToast;
 
+  /// No description provided for @demoDownloadingMediaProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading demo images · {completed} of {total}'**
+  String demoDownloadingMediaProgress(int completed, int total);
+
   /// No description provided for @demoEnterFailedToast.
   ///
   /// In en, this message translates to:
@@ -8488,6 +8500,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Explore with sample data'**
   String get demoOnboardingExplore;
+
+  /// No description provided for @demoPreparingContentProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Preparing tasks and connections…'**
+  String get demoPreparingContentProgress;
 
   /// No description provided for @demoSettingsDeleteConfirm.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4959,6 +4959,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteDeviceLabel => 'Odebrat ze synchronizace';
 
   @override
+  String get demoActivatingProgress => 'Otevírám demo svět…';
+
+  @override
   String get demoAiNudgeBody =>
       'Demo svět obsahuje fiktivní poskytovatele AI, takže AI akce tady doopravdy neproběhnou. Připoj svůj vlastní AI účet a používej v demu skutečnou AI. Tvůj klíč zůstane v tomto demo světě, pokud si ho při odchodu nezkopíruješ.';
 
@@ -5033,6 +5036,11 @@ class AppLocalizationsCs extends AppLocalizations {
       'Demo data se nepodařilo smazat — zkus to znovu.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Stahuji obrázky dema · $completed z $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Demo svět se nepodařilo otevřít — zkus to znovu.';
 
@@ -5062,6 +5070,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Prozkoumat s ukázkovými daty';
+
+  @override
+  String get demoPreparingContentProgress => 'Připravuji úkoly a propojení…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4904,6 +4904,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteDeviceLabel => 'Fjern fra synkronisering';
 
   @override
+  String get demoActivatingProgress => 'Åbner demoverdenen…';
+
+  @override
   String get demoAiNudgeBody =>
       'Demoverdenen indeholder fiktive AI-udbydere, så AI-handlinger kan ikke rigtig køre her. Forbind din egen AI-konto for at bruge rigtig AI i demoen. Din nøgle bliver i denne demoverden, medmindre du kopierer den med, når du forlader den.';
 
@@ -4977,6 +4980,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Demodataene kunne ikke slettes — prøv igen.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Downloader demobilleder · $completed af $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Demoverdenen kunne ikke åbnes — prøv igen.';
 
@@ -5005,6 +5013,10 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Udforsk med eksempeldata';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Gør opgaver og forbindelser klar…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4939,6 +4939,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteDeviceLabel => 'Aus Sync entfernen';
 
   @override
+  String get demoActivatingProgress => 'Demo-Welt wird geöffnet…';
+
+  @override
   String get demoAiNudgeBody =>
       'Die Demo-Welt enthält fiktive KI-Anbieter, daher können KI-Aktionen hier nicht wirklich laufen. Verbinde dein eigenes KI-Konto, um echte KI in der Demo zu nutzen. Dein Schlüssel bleibt in dieser Demo-Welt, außer du kopierst ihn beim Verlassen mit.';
 
@@ -5012,6 +5015,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Demo-Daten konnten nicht gelöscht werden — versuch es noch mal.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Demo-Bilder werden geladen · $completed von $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Die Demo-Welt konnte nicht geöffnet werden — versuch es noch mal.';
 
@@ -5041,6 +5049,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Mit Beispieldaten erkunden';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Aufgaben und Verbindungen werden vorbereitet…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4877,6 +4877,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteDeviceLabel => 'Remove from sync';
 
   @override
+  String get demoActivatingProgress => 'Opening the demo world…';
+
+  @override
   String get demoAiNudgeBody =>
       'The demo world ships with fictional AI providers, so AI actions can\'t really run here. Connect your own AI account to use real AI inside the demo. Your key stays in this demo world unless you copy it over when you leave.';
 
@@ -4950,6 +4953,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'Couldn\'t delete the demo data — try again.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Downloading demo images · $completed of $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Couldn\'t open the demo world — try again.';
 
@@ -4979,6 +4987,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Explore with sample data';
+
+  @override
+  String get demoPreparingContentProgress => 'Preparing tasks and connections…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4970,6 +4970,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteDeviceLabel => 'Quitar de la sincronización';
 
   @override
+  String get demoActivatingProgress => 'Abriendo el mundo de demostración…';
+
+  @override
   String get demoAiNudgeBody =>
       'El mundo de demostración incluye proveedores de IA ficticios, así que las acciones de IA no pueden ejecutarse de verdad aquí. Conecta tu propia cuenta de IA para usar IA real dentro de la demostración. Tu clave se queda en este mundo de demostración salvo que la copies al salir.';
 
@@ -5043,6 +5046,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudieron borrar los datos de la demo — inténtalo de nuevo.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Descargando imágenes de la demo · $completed de $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'No se pudo abrir el mundo de demostración — inténtalo de nuevo.';
 
@@ -5072,6 +5080,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Explorar con datos de ejemplo';
+
+  @override
+  String get demoPreparingContentProgress => 'Preparando tareas y conexiones…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4986,6 +4986,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteDeviceLabel => 'Retirer de la synchronisation';
 
   @override
+  String get demoActivatingProgress => 'Ouverture du monde démo…';
+
+  @override
   String get demoAiNudgeBody =>
       'Le monde démo contient des fournisseurs d\'IA fictifs, les actions d\'IA ne peuvent donc pas vraiment s\'exécuter ici. Connecte ton propre compte d\'IA pour utiliser une IA réelle dans la démo. Ta clé reste dans ce monde démo, sauf si tu la copies en partant.';
 
@@ -5059,6 +5062,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Impossible de supprimer les données démo — réessaie.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Téléchargement des images de démo · $completed sur $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Impossible d\'ouvrir le monde démo — réessaie.';
 
@@ -5087,6 +5095,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Explorer avec des données d\'exemple';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Préparation des tâches et des connexions…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4964,6 +4964,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteDeviceLabel => 'Rimuovi dalla sincronizzazione';
 
   @override
+  String get demoActivatingProgress => 'Apertura del mondo demo…';
+
+  @override
   String get demoAiNudgeBody =>
       'Il mondo demo include provider di IA fittizi, quindi le azioni di IA non possono davvero funzionare qui. Collega il tuo account IA per usare l\'IA reale nella demo. La tua chiave resta in questo mondo demo, a meno che tu non la copi quando esci.';
 
@@ -5037,6 +5040,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile eliminare i dati demo — riprova.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Download delle immagini demo · $completed di $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Impossibile aprire il mondo demo — riprova.';
 
@@ -5065,6 +5073,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Esplora con dati di esempio';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Preparazione di attività e collegamenti…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4916,6 +4916,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteDeviceLabel => 'Uit synchronisatie verwijderen';
 
   @override
+  String get demoActivatingProgress => 'Demowereld openen…';
+
+  @override
   String get demoAiNudgeBody =>
       'De demowereld bevat fictieve AI-providers, dus AI-acties kunnen hier niet echt draaien. Koppel je eigen AI-account om echte AI in de demo te gebruiken. Je sleutel blijft in deze demowereld, tenzij je hem meekopieert bij het verlaten.';
 
@@ -4989,6 +4992,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Kon de demogegevens niet verwijderen — probeer het opnieuw.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Demoafbeeldingen downloaden · $completed van $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Kon de demowereld niet openen — probeer het opnieuw.';
 
@@ -5018,6 +5026,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Verkennen met voorbeeldgegevens';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Taken en verbindingen voorbereiden…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4948,6 +4948,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteDeviceLabel => 'Remover da sincronização';
 
   @override
+  String get demoActivatingProgress => 'A abrir o mundo de demonstração…';
+
+  @override
   String get demoAiNudgeBody =>
       'O mundo de demonstração inclui fornecedores de IA fictícios, por isso as ações de IA não podem realmente funcionar aqui. Liga a tua própria conta de IA para usar IA real dentro da demonstração. A tua chave fica neste mundo de demonstração, a menos que a copies ao sair.';
 
@@ -5021,6 +5024,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Não foi possível eliminar os dados da demonstração — tenta novamente.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'A transferir imagens da demonstração · $completed de $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Não foi possível abrir o mundo de demonstração — tenta novamente.';
 
@@ -5050,6 +5058,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Explorar com dados de exemplo';
+
+  @override
+  String get demoPreparingContentProgress => 'A preparar tarefas e ligações…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4988,6 +4988,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteDeviceLabel => 'Eliminați din sincronizare';
 
   @override
+  String get demoActivatingProgress => 'Se deschide lumea demo…';
+
+  @override
   String get demoAiNudgeBody =>
       'Lumea demo include furnizori de IA fictivi, așa că acțiunile de IA nu pot rula cu adevărat aici. Conectați contul dvs. de IA pentru a folosi IA reală în demo. Cheia dvs. rămâne în această lume demo, cu excepția cazului în care o copiați la ieșire.';
 
@@ -5062,6 +5065,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Datele demo nu au putut fi șterse — încercați din nou.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Se descarcă imaginile demo · $completed din $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Lumea demo nu a putut fi deschisă — încercați din nou.';
 
@@ -5091,6 +5099,10 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Explorați cu date de exemplu';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Se pregătesc sarcinile și conexiunile…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4906,6 +4906,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteDeviceLabel => 'Ta bort från synkronisering';
 
   @override
+  String get demoActivatingProgress => 'Öppnar demovärlden…';
+
+  @override
   String get demoAiNudgeBody =>
       'Demovärlden innehåller fiktiva AI-leverantörer, så AI-åtgärder kan inte köras på riktigt här. Anslut ditt eget AI-konto för att använda riktig AI i demon. Din nyckel stannar i den här demovärlden om du inte kopierar över den när du lämnar den.';
 
@@ -4979,6 +4982,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Demodatan kunde inte raderas — försök igen.';
 
   @override
+  String demoDownloadingMediaProgress(int completed, int total) {
+    return 'Hämtar demobilder · $completed av $total';
+  }
+
+  @override
   String get demoEnterFailedToast =>
       'Demovärlden kunde inte öppnas — försök igen.';
 
@@ -5008,6 +5016,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get demoOnboardingExplore => 'Utforska med exempeldata';
+
+  @override
+  String get demoPreparingContentProgress =>
+      'Förbereder uppgifter och kopplingar…';
 
   @override
   String get demoSettingsDeleteConfirm =>

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2407,6 +2407,7 @@
   "defaultLanguage": "Standaardtaal",
   "deleteButton": "Verwijderen",
   "deleteDeviceLabel": "Uit synchronisatie verwijderen",
+  "demoActivatingProgress": "Demowereld openen…",
   "demoAiNudgeBody": "De demowereld bevat fictieve AI-providers, dus AI-acties kunnen hier niet echt draaien. Koppel je eigen AI-account om echte AI in de demo te gebruiken. Je sleutel blijft in deze demowereld, tenzij je hem meekopieert bij het verlaten.",
   "demoAiNudgeCancel": "Niet nu",
   "demoAiNudgeConfirm": "Echte AI instellen",
@@ -2434,6 +2435,17 @@
     }
   },
   "demoDeleteFailedToast": "Kon de demogegevens niet verwijderen — probeer het opnieuw.",
+  "demoDownloadingMediaProgress": "Demoafbeeldingen downloaden · {completed} van {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Kon de demowereld niet openen — probeer het opnieuw.",
   "demoEnteringProgress": "Demowereld wordt klaargezet…",
   "demoExitCandidatesError": "Kon je werk om te kopiëren niet controleren. Je kunt de demo toch verlaten.",
@@ -2443,6 +2455,7 @@
   "demoExitSheetTitle": "Demo verlaten?",
   "demoExitTakeWork": "Mijn werk meenemen…",
   "demoOnboardingExplore": "Verkennen met voorbeeldgegevens",
+  "demoPreparingContentProgress": "Taken en verbindingen voorbereiden…",
   "demoSettingsDeleteConfirm": "Demowereld en alle bijbehorende gegevens verwijderen?",
   "demoSettingsDeleteTitle": "Demogegevens verwijderen",
   "demoSettingsDeleteToast": "Demogegevens verwijderd",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2407,6 +2407,7 @@
   "defaultLanguage": "Idioma padrão",
   "deleteButton": "Excluir",
   "deleteDeviceLabel": "Remover da sincronização",
+  "demoActivatingProgress": "A abrir o mundo de demonstração…",
   "demoAiNudgeBody": "O mundo de demonstração inclui fornecedores de IA fictícios, por isso as ações de IA não podem realmente funcionar aqui. Liga a tua própria conta de IA para usar IA real dentro da demonstração. A tua chave fica neste mundo de demonstração, a menos que a copies ao sair.",
   "demoAiNudgeCancel": "Agora não",
   "demoAiNudgeConfirm": "Configurar IA real",
@@ -2434,6 +2435,17 @@
     }
   },
   "demoDeleteFailedToast": "Não foi possível eliminar os dados da demonstração — tenta novamente.",
+  "demoDownloadingMediaProgress": "A transferir imagens da demonstração · {completed} de {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Não foi possível abrir o mundo de demonstração — tenta novamente.",
   "demoEnteringProgress": "A preparar o mundo de demonstração…",
   "demoExitCandidatesError": "Não foi possível verificar o teu trabalho para copiar. Podes sair da demonstração na mesma.",
@@ -2443,6 +2455,7 @@
   "demoExitSheetTitle": "Sair da demo?",
   "demoExitTakeWork": "Levar o meu trabalho…",
   "demoOnboardingExplore": "Explorar com dados de exemplo",
+  "demoPreparingContentProgress": "A preparar tarefas e ligações…",
   "demoSettingsDeleteConfirm": "Apagar o mundo de demonstração e todos os seus dados?",
   "demoSettingsDeleteTitle": "Apagar dados da demo",
   "demoSettingsDeleteToast": "Dados da demo apagados",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2168,6 +2168,7 @@
   "defaultLanguage": "Limbă implicită",
   "deleteButton": "Ștergeți",
   "deleteDeviceLabel": "Eliminați din sincronizare",
+  "demoActivatingProgress": "Se deschide lumea demo…",
   "demoAiNudgeBody": "Lumea demo include furnizori de IA fictivi, așa că acțiunile de IA nu pot rula cu adevărat aici. Conectați contul dvs. de IA pentru a folosi IA reală în demo. Cheia dvs. rămâne în această lume demo, cu excepția cazului în care o copiați la ieșire.",
   "demoAiNudgeCancel": "Nu acum",
   "demoAiNudgeConfirm": "Configurați IA reală",
@@ -2195,6 +2196,17 @@
     }
   },
   "demoDeleteFailedToast": "Datele demo nu au putut fi șterse — încercați din nou.",
+  "demoDownloadingMediaProgress": "Se descarcă imaginile demo · {completed} din {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Lumea demo nu a putut fi deschisă — încercați din nou.",
   "demoEnteringProgress": "Se pregătește lumea demo…",
   "demoExitCandidatesError": "Nu s-a putut verifica lucrul de copiat. Puteți totuși ieși din demo.",
@@ -2204,6 +2216,7 @@
   "demoExitSheetTitle": "Părăsiți demo-ul?",
   "demoExitTakeWork": "Luați-vă munca cu dvs.…",
   "demoOnboardingExplore": "Explorați cu date de exemplu",
+  "demoPreparingContentProgress": "Se pregătesc sarcinile și conexiunile…",
   "demoSettingsDeleteConfirm": "Ștergeți lumea demo și toate datele ei?",
   "demoSettingsDeleteTitle": "Ștergeți datele demo",
   "demoSettingsDeleteToast": "Datele demo au fost șterse",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2408,6 +2408,7 @@
   "defaultLanguage": "Standardspråk",
   "deleteButton": "Radera",
   "deleteDeviceLabel": "Ta bort från synkronisering",
+  "demoActivatingProgress": "Öppnar demovärlden…",
   "demoAiNudgeBody": "Demovärlden innehåller fiktiva AI-leverantörer, så AI-åtgärder kan inte köras på riktigt här. Anslut ditt eget AI-konto för att använda riktig AI i demon. Din nyckel stannar i den här demovärlden om du inte kopierar över den när du lämnar den.",
   "demoAiNudgeCancel": "Inte nu",
   "demoAiNudgeConfirm": "Ställ in riktig AI",
@@ -2435,6 +2436,17 @@
     }
   },
   "demoDeleteFailedToast": "Demodatan kunde inte raderas — försök igen.",
+  "demoDownloadingMediaProgress": "Hämtar demobilder · {completed} av {total}",
+  "@demoDownloadingMediaProgress": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "demoEnterFailedToast": "Demovärlden kunde inte öppnas — försök igen.",
   "demoEnteringProgress": "Gör i ordning demovärlden…",
   "demoExitCandidatesError": "Det gick inte att kontrollera ditt arbete att kopiera. Du kan ändå lämna demon.",
@@ -2444,6 +2456,7 @@
   "demoExitSheetTitle": "Lämna demon?",
   "demoExitTakeWork": "Ta med mitt arbete…",
   "demoOnboardingExplore": "Utforska med exempeldata",
+  "demoPreparingContentProgress": "Förbereder uppgifter och kopplingar…",
   "demoSettingsDeleteConfirm": "Radera demovärlden och alla dess data?",
   "demoSettingsDeleteTitle": "Radera demodata",
   "demoSettingsDeleteToast": "Demodata raderade",

--- a/test/features/daily_os_next/ui/pages/day_page_screenshots_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_screenshots_test.dart
@@ -1149,7 +1149,10 @@ void main() {
       'lotti-manual-daily-os-',
     );
     _manualDocumentsDirectory = documentsDirectory;
-    await _manualWorld.installMedia(documentsDirectory);
+    await _manualWorld.installMediaFromRemote(
+      documentsDirectory,
+      fetchUrl: fetchManualDemoSeedMedia,
+    );
     final mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt

--- a/test/features/demo/seed/demo_seed_media_test.dart
+++ b/test/features/demo/seed/demo_seed_media_test.dart
@@ -1,0 +1,331 @@
+import 'dart:io';
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
+import 'package:lotti/utils/image_utils.dart';
+
+import '../../../helpers/entity_factories.dart';
+
+class _MemoryAssetBundle extends CachingAssetBundle {
+  _MemoryAssetBundle(this.assets);
+
+  final Map<String, Uint8List> assets;
+
+  @override
+  Future<ByteData> load(String key) async => ByteData.sublistView(assets[key]!);
+}
+
+void main() {
+  late Directory documentsDirectory;
+  late Directory cacheRoot;
+
+  setUp(() {
+    documentsDirectory = Directory.systemTemp.createTempSync(
+      'lotti-demo-seed-media-documents-',
+    );
+    cacheRoot = Directory.systemTemp.createTempSync(
+      'lotti-demo-seed-media-cache-',
+    );
+  });
+
+  tearDown(() {
+    documentsDirectory.deleteSync(recursive: true);
+    cacheRoot.deleteSync(recursive: true);
+  });
+
+  test(
+    'downloads, verifies, caches, and installs remote image bytes',
+    () async {
+      final bytes = Uint8List.fromList([1, 2, 3, 4]);
+      final source = _source(bytes: bytes);
+      final image = _image(source.fileName);
+      var fetches = 0;
+      final progress = <(int, int)>[];
+      final installer = DemoSeedMediaInstaller(
+        cacheRoot: cacheRoot,
+        fetchUrl: (_) async {
+          fetches++;
+          return bytes;
+        },
+      );
+
+      for (var run = 0; run < 2; run++) {
+        final targetRoot = run == 0
+            ? documentsDirectory
+            : Directory.systemTemp.createTempSync(
+                'lotti-demo-seed-media-second-',
+              );
+        if (run == 1) addTearDown(() => targetRoot.deleteSync(recursive: true));
+
+        final installed = await installer.install(
+          documentsDirectory: targetRoot,
+          images: [image],
+          sources: {image.meta.id: source},
+          onProgress: ({required completed, required total}) {
+            progress.add((completed, total));
+          },
+        );
+
+        expect(installed, hasLength(1));
+        expect(await installed.single.readAsBytes(), bytes);
+        expect(
+          installed.single.path,
+          getFullImagePath(image, documentsDirectory: targetRoot.path),
+        );
+      }
+
+      expect(fetches, 1, reason: 'the checksum-addressed cache is reused');
+      expect(progress, [(0, 1), (1, 1), (0, 1), (1, 1)]);
+    },
+  );
+
+  test(
+    'falls back to a verified bundled asset when the network fails',
+    () async {
+      final bytes = Uint8List.fromList([5, 6, 7]);
+      final source = _source(bytes: bytes, assetPath: 'assets/cover.webp');
+      final image = _image(source.fileName);
+      final installer = DemoSeedMediaInstaller(
+        bundle: _MemoryAssetBundle({'assets/cover.webp': bytes}),
+        cacheRoot: cacheRoot,
+        fetchUrl: (_) async => throw const SocketException('offline'),
+      );
+
+      final installed = await installer.install(
+        documentsDirectory: documentsDirectory,
+        images: [image],
+        sources: {image.meta.id: source},
+      );
+
+      expect(await installed.single.readAsBytes(), bytes);
+    },
+  );
+
+  test('installs a verified asset-only source without fetching', () async {
+    final bytes = Uint8List.fromList([11, 12, 13]);
+    final image = _image('asset-only.webp');
+    var fetched = false;
+    final installer = DemoSeedMediaInstaller(
+      bundle: _MemoryAssetBundle({'assets/asset-only.webp': bytes}),
+      cacheRoot: cacheRoot,
+      fetchUrl: (_) async {
+        fetched = true;
+        return bytes;
+      },
+    );
+
+    final installed = await installer.install(
+      documentsDirectory: documentsDirectory,
+      images: [image],
+      sources: {
+        image.id: DemoSeedMediaSource(
+          fileName: image.data.imageFile,
+          sha256: sha256.convert(bytes).toString(),
+          assetPath: 'assets/asset-only.webp',
+        ),
+      },
+    );
+
+    expect(fetched, isFalse);
+    expect(await installed.single.readAsBytes(), bytes);
+  });
+
+  test('discards a corrupt cache entry and refetches verified bytes', () async {
+    final bytes = Uint8List.fromList([14, 15, 16]);
+    final source = _source(bytes: bytes);
+    final image = _image(source.fileName);
+    final cached = File('${cacheRoot.path}/${source.sha256}');
+    await cached.writeAsBytes([99], flush: true);
+    var fetches = 0;
+    final installer = DemoSeedMediaInstaller(
+      cacheRoot: cacheRoot,
+      fetchUrl: (_) async {
+        fetches++;
+        return bytes;
+      },
+    );
+
+    final installed = await installer.install(
+      documentsDirectory: documentsDirectory,
+      images: [image],
+      sources: {image.id: source},
+    );
+
+    expect(fetches, 1);
+    expect(await installed.single.readAsBytes(), bytes);
+    expect(await cached.readAsBytes(), bytes);
+  });
+
+  test('rejects provenance whose filename differs from the image row', () {
+    final bytes = Uint8List.fromList([17]);
+    final image = _image('row.webp');
+    final installer = DemoSeedMediaInstaller(cacheRoot: cacheRoot);
+
+    expect(
+      installer.install(
+        documentsDirectory: documentsDirectory,
+        images: [image],
+        sources: {image.id: _source(bytes: bytes)},
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('does not match row.webp'),
+        ),
+      ),
+    );
+  });
+
+  test(
+    'default HTTP transport accepts 200 and rejects other statuses',
+    () async {
+      final bytes = Uint8List.fromList([18, 19]);
+      final image = _image('cover.webp');
+      final installer = DemoSeedMediaInstaller(
+        cacheRoot: cacheRoot,
+        httpClientFactory: () => MockClient((request) async {
+          if (request.url.path == '/cover.webp') {
+            return http.Response.bytes(bytes, HttpStatus.ok);
+          }
+          return http.Response('', HttpStatus.serviceUnavailable);
+        }),
+      );
+
+      final installed = await installer.install(
+        documentsDirectory: documentsDirectory,
+        images: [image],
+        sources: {
+          image.id: DemoSeedMediaSource(
+            fileName: image.data.imageFile,
+            sha256: sha256.convert(bytes).toString(),
+            sourceUrl: 'https://media.example/cover.webp',
+          ),
+        },
+        allowAssetFallback: false,
+      );
+      expect(await installed.single.readAsBytes(), bytes);
+
+      final unavailable = _image('unavailable.webp');
+      final unavailableBytes = Uint8List.fromList([20]);
+      await expectLater(
+        installer.install(
+          documentsDirectory: documentsDirectory,
+          images: [unavailable],
+          sources: {
+            unavailable.id: DemoSeedMediaSource(
+              fileName: unavailable.data.imageFile,
+              sha256: sha256.convert(unavailableBytes).toString(),
+              sourceUrl: 'https://media.example/unavailable.webp',
+            ),
+          },
+          allowAssetFallback: false,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('HTTP 503'),
+          ),
+        ),
+      );
+    },
+  );
+
+  test(
+    'reports a missing usable source when its bundled fallback is absent',
+    () async {
+      final bytes = Uint8List.fromList([24]);
+      final image = _image('bundle-only.webp');
+      final installer = DemoSeedMediaInstaller(cacheRoot: cacheRoot);
+
+      await expectLater(
+        installer.install(
+          documentsDirectory: documentsDirectory,
+          images: [image],
+          sources: {
+            image.id: DemoSeedMediaSource(
+              fileName: image.data.imageFile,
+              sha256: sha256.convert(bytes).toString(),
+              assetPath: 'assets/bundle-only.webp',
+            ),
+          },
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('No available seed media source'),
+          ),
+        ),
+      );
+    },
+  );
+
+  test('required remote media fails closed and leaves no image file', () async {
+    final expected = Uint8List.fromList([8, 9, 10]);
+    final source = _source(bytes: expected);
+    final image = _image(source.fileName);
+    final installer = DemoSeedMediaInstaller(
+      cacheRoot: cacheRoot,
+      fetchUrl: (_) async => Uint8List.fromList([99]),
+    );
+
+    await expectLater(
+      installer.install(
+        documentsDirectory: documentsDirectory,
+        images: [image],
+        sources: {image.meta.id: source},
+        allowAssetFallback: false,
+      ),
+      throwsA(
+        predicate<Object>(
+          (error) => error.toString().contains('Checksum mismatch'),
+          'a checksum mismatch',
+        ),
+      ),
+    );
+    expect(
+      File(
+        getFullImagePath(image, documentsDirectory: documentsDirectory.path),
+      ).existsSync(),
+      isFalse,
+    );
+  });
+
+  test('rejects an image whose seed provenance is missing', () async {
+    final image = _image('missing.webp');
+    final installer = DemoSeedMediaInstaller(cacheRoot: cacheRoot);
+
+    await expectLater(
+      installer.install(
+        documentsDirectory: documentsDirectory,
+        images: [image],
+        sources: const {},
+      ),
+      throwsA(isA<StateError>()),
+    );
+  });
+}
+
+DemoSeedMediaSource _source({required Uint8List bytes, String? assetPath}) =>
+    DemoSeedMediaSource(
+      fileName: 'cover.webp',
+      sha256: sha256.convert(bytes).toString(),
+      sourceUrl: 'https://media.example/demo/cover.webp',
+      assetPath: assetPath,
+    );
+
+JournalImage _image(String fileName) {
+  final image = TestImageFactory.create(id: 'image-id');
+  return image.copyWith(
+    data: image.data.copyWith(
+      imageFile: fileName,
+      imageDirectory: '/manual_demo/',
+    ),
+  );
+}

--- a/test/features/demo/seed/demo_seed_progress_test.dart
+++ b/test/features/demo/seed/demo_seed_progress_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
+
+void main() {
+  test('media progress exposes a bounded determinate fraction', () {
+    expect(
+      const DemoSeedProgress.downloadingMedia(
+        completed: 3,
+        total: 9,
+      ).fraction,
+      closeTo(1 / 3, 0.0001),
+    );
+    expect(
+      const DemoSeedProgress.downloadingMedia(
+        completed: 12,
+        total: 9,
+      ).fraction,
+      1,
+    );
+    expect(
+      const DemoSeedProgress.downloadingMedia(
+        completed: -1,
+        total: 9,
+      ).fraction,
+      0,
+    );
+    expect(
+      const DemoSeedProgress.downloadingMedia(
+        completed: 0,
+        total: 0,
+      ).fraction,
+      isNull,
+    );
+  });
+
+  test('non-media phases remain indeterminate', () {
+    expect(const DemoSeedProgress.preparing().fraction, isNull);
+    expect(const DemoSeedProgress.writingContent().fraction, isNull);
+    expect(const DemoSeedProgress.activating().fraction, isNull);
+  });
+}

--- a/test/features/demo/seed/demo_seeder_test.dart
+++ b/test/features/demo/seed/demo_seeder_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
 import 'package:lotti/features/demo/seed/demo_seeder.dart';
 import 'package:lotti/features/demo/seed/demo_tutorial_content.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
@@ -90,11 +92,19 @@ void main() {
     }
   });
 
-  DemoSeeder seeder() => DemoSeeder(
-    world: world,
-    bundle: _FileSystemAssetBundle(),
-    clock: () => seedTime,
-  );
+  DemoSeeder seeder({DemoSeedProgressCallback? onProgress}) {
+    final bundle = _FileSystemAssetBundle();
+    return DemoSeeder(
+      world: world,
+      bundle: bundle,
+      clock: () => seedTime,
+      onProgress: onProgress,
+      mediaInstaller: DemoSeedMediaInstaller(
+        bundle: bundle,
+        fetchUrl: (_) async => throw const SocketException('offline in test'),
+      ),
+    );
+  }
 
   // The tutorial's own entities — the only demo-only content, deliberately
   // spelled out so a change there is visible in the diff. Everything else is
@@ -147,8 +157,24 @@ void main() {
     test('seeds the complete penguin world into the demo databases and '
         'leaves the active world untouched', () async {
       final before = snapshotTree(canaryRealRoot);
+      final progress = <DemoSeedProgress>[];
 
-      final manifest = await seeder().seed(locale: const Locale('en'));
+      final manifest = await seeder(
+        onProgress: progress.add,
+      ).seed(locale: const Locale('en'));
+
+      expect(progress.first.phase, DemoSeedPhase.downloadingMedia);
+      expect(progress.first.completed, 0);
+      expect(progress.first.total, 9);
+      expect(
+        progress.where(
+          (value) =>
+              value.phase == DemoSeedPhase.downloadingMedia &&
+              value.completed == 9,
+        ),
+        hasLength(1),
+      );
+      expect(progress.last.phase, DemoSeedPhase.writingContent);
 
       // Category and labels.
       final category = await world.journalDb.getCategoryById(

--- a/test/features/demo/seed/demo_world_test.dart
+++ b/test/features/demo/seed/demo_world_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:ui' show Locale;
 
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -23,6 +25,15 @@ final originalTaskIds = <String>[
   manualPenguinPassengerTaskId,
   manualHeadsetWalkTaskId,
 ];
+
+class _MemoryAssetBundle extends CachingAssetBundle {
+  _MemoryAssetBundle(this.assets);
+
+  final Map<String, Uint8List> assets;
+
+  @override
+  Future<ByteData> load(String key) async => ByteData.sublistView(assets[key]!);
+}
 
 void main() {
   group('ManualDemoWorld.penguinLogistics', () {
@@ -625,9 +636,75 @@ void main() {
         );
         // Byte identity with the repo asset, so the demo world shows the
         // exact artwork the manual documents.
-        final asset = File(manualDemoCoverAssets[coverImage.meta.id]!);
+        final source = manualDemoCoverMedia[coverImage.meta.id]!;
+        final asset = File(source.assetPath!);
         expect(target.lengthSync(), asset.lengthSync());
+        expect(
+          sha256.convert(asset.readAsBytesSync()).toString(),
+          source.sha256,
+          reason: '${coverImage.meta.id} must match its pinned digest',
+        );
+        final sourceUri = Uri.parse(source.sourceUrl!);
+        expect(sourceUri.pathSegments, contains(source.sha256));
+        expect(sourceUri.pathSegments.last, source.fileName);
       }
+    });
+
+    test('remote-first installation reports progress and has a verified '
+        'bundled fallback for production seeding', () async {
+      final bundleDocuments = Directory.systemTemp.createTempSync(
+        'lotti_world_bundle_',
+      );
+      final remoteDocuments = Directory.systemTemp.createTempSync(
+        'lotti_world_remote_',
+      );
+      final cacheRoot = Directory.systemTemp.createTempSync('lotti_world_r2_');
+      addTearDown(() => bundleDocuments.delete(recursive: true));
+      addTearDown(() => remoteDocuments.delete(recursive: true));
+      addTearDown(() => cacheRoot.delete(recursive: true));
+      final world = ManualDemoWorld.penguinLogistics();
+      final bytesByAsset = <String, Uint8List>{
+        for (final source in manualDemoCoverMedia.values)
+          source.assetPath!: File(source.assetPath!).readAsBytesSync(),
+      };
+      final bundleProgress = <(int, int)>[];
+
+      final bundled = await world.installMediaFromBundle(
+        _MemoryAssetBundle(bytesByAsset),
+        bundleDocuments,
+        onProgress: ({required completed, required total}) {
+          bundleProgress.add((completed, total));
+        },
+      );
+
+      expect(bundled, hasLength(world.coverImages.length));
+      expect(bundleProgress.first, (0, world.coverImages.length));
+      expect(bundleProgress.last, (
+        world.coverImages.length,
+        world.coverImages.length,
+      ));
+
+      final remoteProgress = <(int, int)>[];
+      final remote = await world.installMediaFromRemote(
+        remoteDocuments,
+        cacheRoot: cacheRoot,
+        fetchUrl: (uri) async {
+          final source = manualDemoCoverMedia.values.singleWhere(
+            (value) => value.sourceUrl == uri.toString(),
+          );
+          return bytesByAsset[source.assetPath!]!;
+        },
+        onProgress: ({required completed, required total}) {
+          remoteProgress.add((completed, total));
+        },
+      );
+
+      expect(remote, hasLength(world.coverImages.length));
+      expect(remoteProgress.first, (0, world.coverImages.length));
+      expect(remoteProgress.last, (
+        world.coverImages.length,
+        world.coverImages.length,
+      ));
     });
   });
 }

--- a/test/features/demo/state/demo_mode_gateway_test.dart
+++ b/test/features/demo/state/demo_mode_gateway_test.dart
@@ -14,6 +14,8 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/demo/copy/demo_data_copier.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
 import 'package:lotti/features/demo/seed/demo_seed_text.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/demo/state/demo_mode_gateway.dart';
@@ -59,7 +61,7 @@ void main() {
       registry: registry,
       activate: (id) async => activated.add(id),
       profileContext: () => activeContext,
-      seedRunner: (world, locale) async {
+      seedRunner: (world, locale, _) async {
         seededLocales.add(locale.toLanguageTag());
         // Minimal marker write proving the seed ran against THIS world; the
         // manifest is what enterDemo consults on the next entry.
@@ -100,9 +102,13 @@ void main() {
     test('first entry creates the Demo guest profile, seeds it in the given '
         'locale, and activates it', () async {
       final gateway = buildGateway();
+      final progress = <DemoSeedProgress>[];
       expect(await gateway.demoProfileExists(), isFalse);
 
-      await gateway.enterDemo(locale: const Locale('de'));
+      await gateway.enterDemo(
+        locale: const Locale('de'),
+        onProgress: progress.add,
+      );
 
       final profile = await gateway.findDemoProfile();
       expect(profile, isNotNull);
@@ -113,6 +119,10 @@ void main() {
       // The seed ran against the new profile's own root.
       final manifest = await DemoSeedManifest.read(registry.rootFor(profile));
       expect(manifest?.localeTag, 'de');
+      expect(
+        progress.map((value) => value.phase),
+        [DemoSeedPhase.preparing, DemoSeedPhase.activating],
+      );
     });
 
     test(
@@ -530,7 +540,7 @@ void main() {
           if (id == Profile.realProfileId) activeContext = null;
         },
         profileContext: () => activeContext,
-        seedRunner: (world, locale) async =>
+        seedRunner: (world, locale, _) async =>
             seededLocales.add(locale.toLanguageTag()),
       );
       await registry.setActiveProfile(first.id);
@@ -608,7 +618,7 @@ void main() {
           registry: registry,
           activate: (id) async => order.add('activate:$id'),
           profileContext: () => activeContext,
-          seedRunner: (_, _) async {},
+          seedRunner: (_, _, _) async {},
           prepareCopyOverride: (ids, aiIds) async {
             order.add('prepare:${ids.single}+${aiIds.single}');
             return plan;
@@ -786,6 +796,10 @@ void main() {
         activate: (id) async => activated.add(id),
         profileContext: () => activeContext,
         bundle: _FileSystemAssetBundle(),
+        seedMediaInstaller: DemoSeedMediaInstaller(
+          bundle: _FileSystemAssetBundle(),
+          fetchUrl: (_) async => throw const SocketException('offline in test'),
+        ),
         clock: () => DateTime(2026, 8, 5, 10),
       );
 
@@ -862,7 +876,7 @@ void main() {
             ..registerSingleton<Fts5Db>(fts);
         },
         profileContext: () => activeContext,
-        seedRunner: (_, _) async {},
+        seedRunner: (_, _, _) async {},
       );
 
       final copied = await gateway.exitWithCopy(selectedIds: {'user-task'});

--- a/test/features/demo/ui/demo_entry_launcher_test.dart
+++ b/test/features/demo/ui/demo_entry_launcher_test.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/demo/seed/demo_seed_progress.dart';
 import 'package:lotti/features/demo/state/demo_mode_gateway.dart';
 import 'package:lotti/features/demo/ui/demo_entry_launcher.dart';
+import 'package:lotti/features/design_system/components/progress_bars/design_system_circular_progress.dart';
 import 'package:lotti/features/profiles/state/profile_providers.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -17,7 +19,10 @@ import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
 void main() {
-  setUpAll(registerAllFallbackValues);
+  setUpAll(() {
+    registerAllFallbackValues();
+    registerFallbackValue((DemoSeedProgress _) {});
+  });
 
   late MockDemoModeGateway gateway;
 
@@ -42,13 +47,59 @@ void main() {
     );
   }
 
+  testWidgets('progress page distinguishes media download from preparation', (
+    tester,
+  ) async {
+    final progress = ValueNotifier<DemoSeedProgress>(
+      const DemoSeedProgress.preparing(),
+    );
+    addTearDown(progress.dispose);
+
+    await tester.pumpWidget(
+      host(
+        builder: (_) => DemoEnteringProgressPage(progress: progress),
+      ),
+    );
+    expect(find.text('Setting up the demo world…'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    progress.value = const DemoSeedProgress.downloadingMedia(
+      completed: 3,
+      total: 9,
+    );
+    await tester.pump();
+
+    expect(find.text('Downloading demo images · 3 of 9'), findsOneWidget);
+    final indicator = tester.widget<DesignSystemCircularProgress>(
+      find.byType(DesignSystemCircularProgress),
+    );
+    expect(indicator.value, closeTo(1 / 3, 0.0001));
+    expect(find.text('3/9'), findsOneWidget);
+
+    progress.value = const DemoSeedProgress.writingContent();
+    await tester.pump();
+    expect(find.text('Preparing tasks and connections…'), findsOneWidget);
+
+    progress.value = const DemoSeedProgress.activating();
+    await tester.pump();
+    expect(find.text('Opening the demo world…'), findsOneWidget);
+  });
+
   group('launchDemoEnter', () {
     testWidgets('shows the blocking progress route and enters with the '
         'ambient locale', (tester) async {
       final entered = Completer<void>();
+      DemoSeedProgressCallback? reportProgress;
       when(
-        () => gateway.enterDemo(locale: any(named: 'locale')),
-      ).thenAnswer((_) => entered.future);
+        () => gateway.enterDemo(
+          locale: any(named: 'locale'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((invocation) {
+        reportProgress =
+            invocation.namedArguments[#onProgress] as DemoSeedProgressCallback;
+        return entered.future;
+      });
 
       await tester.pumpWidget(
         host(
@@ -66,7 +117,20 @@ void main() {
 
       expect(find.byType(DemoEnteringProgressPage), findsOneWidget);
       expect(find.text('Demo-Welt wird eingerichtet…'), findsOneWidget);
-      verify(() => gateway.enterDemo(locale: const Locale('de'))).called(1);
+      reportProgress!(
+        const DemoSeedProgress.downloadingMedia(completed: 2, total: 9),
+      );
+      await tester.pump();
+      expect(
+        find.text('Demo-Bilder werden geladen · 2 von 9'),
+        findsOneWidget,
+      );
+      verify(
+        () => gateway.enterDemo(
+          locale: const Locale('de'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).called(1);
 
       entered.complete();
       await tester.pump();
@@ -77,7 +141,10 @@ void main() {
       tester,
     ) async {
       when(
-        () => gateway.enterDemo(locale: any(named: 'locale')),
+        () => gateway.enterDemo(
+          locale: any(named: 'locale'),
+          onProgress: any(named: 'onProgress'),
+        ),
       ).thenAnswer((_) async => throw StateError('seed boom'));
 
       await tester.pumpWidget(
@@ -110,7 +177,10 @@ void main() {
       addTearDown(getIt.reset);
       final entered = Completer<void>();
       when(
-        () => gateway.enterDemo(locale: any(named: 'locale')),
+        () => gateway.enterDemo(
+          locale: any(named: 'locale'),
+          onProgress: any(named: 'onProgress'),
+        ),
       ).thenAnswer((_) => entered.future);
 
       await tester.pumpWidget(
@@ -176,7 +246,10 @@ void main() {
     ) async {
       final reset = Completer<void>();
       when(
-        () => gateway.resetDemo(locale: any(named: 'locale')),
+        () => gateway.resetDemo(
+          locale: any(named: 'locale'),
+          onProgress: any(named: 'onProgress'),
+        ),
       ).thenAnswer((_) => reset.future);
 
       await tester.pumpWidget(
@@ -193,8 +266,67 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
 
       expect(find.byType(DemoEnteringProgressPage), findsOneWidget);
-      verify(() => gateway.resetDemo(locale: const Locale('en'))).called(1);
+      verify(
+        () => gateway.resetDemo(
+          locale: const Locale('en'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).called(1);
       reset.complete();
+      await tester.pump();
+    });
+  });
+
+  group('launchStaleDemoRefresh', () {
+    testWidgets('waits for the gateway before showing progress, then forwards '
+        'seed progress without a failure toast', (tester) async {
+      final refresh = Completer<bool>();
+      DemoSeedProgressCallback? reportProgress;
+      VoidCallback? onReseedStarted;
+      when(
+        () => gateway.refreshStaleDemoWorld(
+          locale: any(named: 'locale'),
+          onReseedStarted: any(named: 'onReseedStarted'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((invocation) {
+        onReseedStarted =
+            invocation.namedArguments[#onReseedStarted] as VoidCallback;
+        reportProgress =
+            invocation.namedArguments[#onProgress] as DemoSeedProgressCallback;
+        return refresh.future;
+      });
+
+      await tester.pumpWidget(
+        host(
+          builder: (context) => TextButton(
+            onPressed: () =>
+                unawaited(launchStaleDemoRefresh(context, gateway: gateway)),
+            child: const Text('refresh'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('refresh'));
+      await tester.pump();
+
+      expect(find.byType(DemoEnteringProgressPage), findsNothing);
+      onReseedStarted!();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      reportProgress!(
+        const DemoSeedProgress.downloadingMedia(completed: 5, total: 9),
+      );
+      await tester.pump();
+
+      expect(find.text('Downloading demo images · 5 of 9'), findsOneWidget);
+      verify(
+        () => gateway.refreshStaleDemoWorld(
+          locale: const Locale('en'),
+          onReseedStarted: any(named: 'onReseedStarted'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).called(1);
+      refresh.complete(true);
       await tester.pump();
     });
   });
@@ -227,7 +359,10 @@ void main() {
       tester,
     ) async {
       when(
-        () => gateway.enterDemo(locale: any(named: 'locale')),
+        () => gateway.enterDemo(
+          locale: any(named: 'locale'),
+          onProgress: any(named: 'onProgress'),
+        ),
       ).thenAnswer((_) async {});
 
       await tester.pumpWidget(button(demoActive: false, journalEmpty: true));
@@ -237,7 +372,12 @@ void main() {
       await tester.tap(find.text('Try the demo'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
-      verify(() => gateway.enterDemo(locale: any(named: 'locale'))).called(1);
+      verify(
+        () => gateway.enterDemo(
+          locale: any(named: 'locale'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).called(1);
     });
   });
 }

--- a/test/features/events/ui/pages/events_manual_screenshots_test.dart
+++ b/test/features/events/ui/pages/events_manual_screenshots_test.dart
@@ -144,7 +144,10 @@ void main() {
     documentsDirectory = await Directory.systemTemp.createTemp(
       'lotti-manual-events-',
     );
-    final installedMedia = await world.installMedia(documentsDirectory);
+    final installedMedia = await world.installMediaFromRemote(
+      documentsDirectory,
+      fetchUrl: fetchManualDemoSeedMedia,
+    );
     await transcodeManualDemoMediaToPng(installedMedia);
 
     final missionControl = CategoryTestUtils.createTestCategory(

--- a/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
+++ b/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
@@ -213,7 +213,10 @@ void main() {
     documentsDirectory = await Directory.systemTemp.createTemp(
       'lotti-manual-journal-',
     );
-    final installedMedia = await world.installMedia(documentsDirectory);
+    final installedMedia = await world.installMediaFromRemote(
+      documentsDirectory,
+      fetchUrl: fetchManualDemoSeedMedia,
+    );
     await transcodeManualDemoMediaToPng(installedMedia);
 
     final missionControl = CategoryTestUtils.createTestCategory(

--- a/test/features/knowledge_graph/ui/knowledge_graph_manual_screenshots_test.dart
+++ b/test/features/knowledge_graph/ui/knowledge_graph_manual_screenshots_test.dart
@@ -1,0 +1,343 @@
+/// Deterministic manual captures for the production knowledge-graph workspace.
+///
+/// The fixture uses the same checksum-pinned R2 cover art as demo seeding. It
+/// deliberately has no bundled fallback so a documentation run fails when the
+/// published seed-media catalog is incomplete.
+library;
+
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/daily_os_next/ui/category_color.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/knowledge_graph/domain/graph_layout_engine.dart';
+import 'package:lotti/features/knowledge_graph/domain/graph_models.dart';
+import 'package:lotti/features/knowledge_graph/state/task_graph_provider.dart';
+import 'package:lotti/features/knowledge_graph/ui/knowledge_graph_painter.dart';
+import 'package:lotti/features/knowledge_graph/ui/knowledge_graph_view.dart';
+import 'package:lotti/features/knowledge_graph/ui/task_knowledge_graph_page.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/utils/image_utils.dart';
+
+import '../../../helpers/manual_demo_world.dart';
+import '../../daily_os_next/screenshot_harness.dart';
+
+const _subdir = 'knowledge_graph';
+
+TaskGraphData _graphData(
+  ManualDemoWorld world,
+  Directory documentsDirectory,
+) {
+  final entities = <String, JournalEntity>{
+    for (final entity in <JournalEntity>[
+      ...world.coverImages,
+      ...world.checklistItems,
+      ...world.checklists,
+      ...world.tasks,
+      ...world.timeRecords,
+      ...world.entries,
+    ])
+      entity.id: entity,
+  };
+  final coverPathById = <String, String>{
+    for (final image in world.coverImages)
+      image.id: getFullImagePath(
+        image,
+        documentsDirectory: documentsDirectory.path,
+      ),
+  };
+
+  final edges = <GraphEdge>[
+    for (final link in world.links)
+      if (entities.containsKey(link.fromId) && entities.containsKey(link.toId))
+        GraphEdge(
+          fromId: link.fromId,
+          toId: link.toId,
+          kind: edgeKindFor(
+            link,
+            entities[link.fromId]!,
+            entities[link.toId]!,
+          ),
+        ),
+    for (final task in world.tasks)
+      for (final checklistId in task.data.checklistIds ?? const <String>[])
+        if (entities.containsKey(checklistId))
+          GraphEdge(
+            fromId: task.id,
+            toId: checklistId,
+            kind: GraphEdgeKind.association,
+          ),
+    for (final checklist in world.checklists)
+      for (final itemId in checklist.data.linkedChecklistItems)
+        if (entities.containsKey(itemId))
+          GraphEdge(
+            fromId: checklist.id,
+            toId: itemId,
+            kind: GraphEdgeKind.checklist,
+          ),
+  ];
+
+  final directImagePathsByTask = <String, List<String>>{};
+  for (final edge in edges) {
+    final from = entities[edge.fromId];
+    final to = entities[edge.toId];
+    if (from is Task && to is JournalImage) {
+      directImagePathsByTask
+          .putIfAbsent(from.id, () => <String>[])
+          .add(coverPathById[to.id]!);
+    } else if (to is Task && from is JournalImage) {
+      directImagePathsByTask
+          .putIfAbsent(to.id, () => <String>[])
+          .add(coverPathById[from.id]!);
+    }
+  }
+
+  final scenario = GraphScenario(
+    name: graphNodeLabelFor(world.orbitalHabitatTask),
+    seedId: world.orbitalHabitatTask.id,
+    nodes: [
+      for (final entity in entities.values)
+        GraphNode(
+          id: entity.id,
+          type: graphNodeTypeFor(entity),
+          label: graphNodeLabelFor(entity),
+          categoryId: entity.categoryId ?? kUncategorized,
+          createdAt: entity.meta.createdAt,
+          imagePath: entity is JournalImage ? coverPathById[entity.id] : null,
+          coverImagePath: entity is Task
+              ? coverPathById[entity.data.coverArtId]
+              : null,
+          coverImageCropX: entity is Task ? entity.data.coverArtCropX : 0.5,
+          taskStatus: entity is Task
+              ? graphTaskStatusFor(entity.data.status)
+              : null,
+          mediaPaths: entity is Task
+              ? <String>{
+                  ?coverPathById[entity.data.coverArtId],
+                  ...directImagePathsByTask[entity.id] ?? const <String>[],
+                }.toList(growable: false)
+              : const [],
+        ),
+    ],
+    edges: edges,
+    now: manualDemoNow,
+  );
+
+  return TaskGraphData(
+    scenario: scenario,
+    categoryColors: {
+      for (final category in world.categories)
+        if (category.color case final color? when color.isNotEmpty)
+          category.id: categoryColorFromHex(color),
+    },
+    categoryNames: {
+      for (final category in world.categories) category.id: category.name,
+    },
+    layout: computeLayoutForScenario(scenario),
+  );
+}
+
+Widget _app({
+  required TaskGraphData data,
+  required ScreenshotDevice device,
+  required Brightness brightness,
+  required GraphImageLoader imageLoader,
+}) => RepaintBoundary(
+  key: screenshotBoundaryKey,
+  child: ProviderScope(
+    overrides: [
+      taskGraphProvider(manualOrbitalHabitatTaskId).overrideWith(
+        (ref) async => data,
+      ),
+    ],
+    child: MediaQuery(
+      data: MediaQueryData(
+        size: device.size,
+        disableAnimations: true,
+      ),
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: brightness == Brightness.dark
+            ? DesignSystemTheme.dark()
+            : DesignSystemTheme.light(),
+        locale: manualScreenshotLocale,
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: TaskKnowledgeGraphPage(
+          taskId: manualOrbitalHabitatTaskId,
+          imageLoader: imageLoader,
+        ),
+      ),
+    ),
+  ),
+);
+
+Future<void> _pumpWorkspace(
+  WidgetTester tester, {
+  required TaskGraphData data,
+  required ManualDemoWorld world,
+  required Directory documentsDirectory,
+  required ScreenshotDevice device,
+  required Brightness brightness,
+}) async {
+  await primeManualDemoCoverArt(
+    tester,
+    documentsDirectory: documentsDirectory,
+    world: world,
+    // Inspector tiles are 224 logical px wide. Prime the explicit test
+    // MediaQuery key plus the 2x desktop and 3x mobile device-ratio keys.
+    extents: const [224, 448, 672],
+    includeRawFileImage: true,
+    includeExactResizeKeys: true,
+  );
+  final imagePaths = <String>{
+    for (final node in data.scenario.nodes) ...[
+      ?node.imagePath,
+      ?node.coverImagePath,
+      ...node.mediaPaths,
+    ],
+  };
+  final decoded = <String, ui.Image>{};
+  await tester.runAsync(() async {
+    for (final path in imagePaths) {
+      decoded[path] = await decodeGraphImageFile(path, 512);
+    }
+  });
+  addTearDown(() {
+    for (final image in decoded.values) {
+      image.dispose();
+    }
+  });
+
+  applyScreenshotDevice(tester, device);
+  await tester.pumpWidget(
+    _app(
+      data: data,
+      device: device,
+      brightness: brightness,
+      imageLoader: (path, _) async => decoded[path]!.clone(),
+    ),
+  );
+  await settleFrames(tester, 24);
+}
+
+KnowledgeGraphPainter _painter(WidgetTester tester) {
+  final paint = tester.widget<CustomPaint>(
+    find.descendant(
+      of: find.byType(KnowledgeGraphView),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is CustomPaint && widget.painter is KnowledgeGraphPainter,
+      ),
+    ),
+  );
+  return paint.painter! as KnowledgeGraphPainter;
+}
+
+void main() {
+  if (!screenshotCaptureEnabled) {
+    test(
+      'knowledge-graph manual screenshot harness (opt-in)',
+      () {},
+      skip: 'Set LOTTI_SCREENSHOT_DIR to capture manual screenshots.',
+    );
+    return;
+  }
+
+  setUpAll(loadScreenshotFonts);
+
+  late ManualDemoWorld world;
+  late Directory documentsDirectory;
+  late TaskGraphData data;
+
+  setUp(() async {
+    world = ManualDemoWorld.penguinLogistics();
+    documentsDirectory = Directory.systemTemp.createTempSync(
+      'lotti-manual-knowledge-graph-',
+    );
+    final installed = await world.installMediaFromRemote(
+      documentsDirectory,
+      fetchUrl: fetchManualDemoSeedMedia,
+    );
+    await transcodeManualDemoMediaToPng(installed);
+    data = _graphData(world, documentsDirectory);
+  });
+
+  tearDown(() async {
+    if (documentsDirectory.existsSync()) {
+      await documentsDirectory.delete(recursive: true);
+    }
+  });
+
+  for (final device in [miniDevice, desktopDevice]) {
+    final formFactor = device.isPhone ? 'mobile' : 'desktop';
+    for (final brightness in Brightness.values) {
+      final theme = brightness.name;
+
+      testWidgets('$formFactor graph — $theme', (tester) async {
+        await _pumpWorkspace(
+          tester,
+          data: data,
+          world: world,
+          documentsDirectory: documentsDirectory,
+          device: device,
+          brightness: brightness,
+        );
+
+        final painter = _painter(tester);
+        expect(painter.scenario.nodes, isNotEmpty);
+        expect(
+          painter.scenario.nodeById(manualOrbitalHabitatTaskId).coverImagePath,
+          isNotNull,
+        );
+        expect(painter.images, hasLength(manualDemoCoverMedia.length));
+
+        await captureScreenshot(
+          tester,
+          'knowledge_graph_${formFactor}_$theme',
+          subdir: _subdir,
+        );
+      });
+
+      testWidgets('$formFactor connections — $theme', (tester) async {
+        await _pumpWorkspace(
+          tester,
+          data: data,
+          world: world,
+          documentsDirectory: documentsDirectory,
+          device: device,
+          brightness: brightness,
+        );
+        await tester.tap(
+          find.byKey(const ValueKey('knowledge-graph-mode-connections')),
+        );
+        await settleFrames(tester);
+
+        expect(
+          find.byKey(const ValueKey('knowledge-graph-connections-list')),
+          findsOneWidget,
+        );
+        expect(
+          find.text(world.orbitalHabitatTask.data.title),
+          findsWidgets,
+        );
+
+        await captureScreenshot(
+          tester,
+          'knowledge_graph_connections_${formFactor}_$theme',
+          subdir: _subdir,
+        );
+      });
+    }
+  }
+}

--- a/test/features/knowledge_graph/ui/task_knowledge_graph_page_test.dart
+++ b/test/features/knowledge_graph/ui/task_knowledge_graph_page_test.dart
@@ -253,6 +253,7 @@ void main() {
     Size surface = const Size(390, 844),
     Future<TaskGraphData> Function(TaskGraphData, TaskGraphData)?
     mergeGraphData,
+    GraphImageLoader? imageLoader,
     List<Override> extraOverrides = const [],
   }) async {
     await tester.pumpWidget(
@@ -260,6 +261,7 @@ void main() {
         TaskKnowledgeGraphPage(
           taskId: taskId,
           mergeGraphData: mergeGraphData,
+          imageLoader: imageLoader,
         ),
         mediaQueryData: MediaQueryData(size: surface),
         overrides: [providerOverride, ...extraOverrides],
@@ -424,6 +426,28 @@ void main() {
     expect(find.byType(KnowledgeGraphView), findsNothing);
     expect(find.text(l10n.knowledgeGraphError), findsNothing);
     expect(find.text(l10n.knowledgeGraphTitle), findsOneWidget);
+  });
+
+  testWidgets('forwards an injected image loader to the graph view', (
+    tester,
+  ) async {
+    Future<Never> imageLoader(String _, int _) async =>
+        throw StateError('The no-image scenario must not invoke the loader');
+    await pumpPage(
+      tester,
+      taskGraphProvider(taskId).overrideWith(
+        (ref) async => multiNodeData(),
+      ),
+      imageLoader: imageLoader,
+    );
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<KnowledgeGraphView>(find.byType(KnowledgeGraphView))
+          .imageLoader,
+      same(imageLoader),
+    );
   });
 
   testWidgets(

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -333,7 +333,10 @@ void main() {
       'lotti-manual-tasks-',
     );
     documentsDirectory = testDocumentsDirectory;
-    final installedMedia = await world.installMedia(testDocumentsDirectory);
+    final installedMedia = await world.installMediaFromRemote(
+      testDocumentsDirectory,
+      fetchUrl: fetchManualDemoSeedMedia,
+    );
     await transcodeManualDemoMediaToPng(installedMedia);
 
     final entitiesCache = MockEntitiesCacheService();

--- a/test/helpers/manual_demo_world.dart
+++ b/test/helpers/manual_demo_world.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/demo/seed/demo_seed_media.dart';
 import 'package:lotti/features/demo/seed/demo_seed_text.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/demo/seed/demo_world_ai.dart';
@@ -44,6 +45,33 @@ final List<AiConfigSkill> manualDemoAiSkills = demoAiSkills(
   manualDemoNow,
 );
 
+/// Fetches immutable R2 seed media outside Flutter's widget-test HttpClient.
+///
+/// `TestWidgetsFlutterBinding` intentionally replaces all in-process HTTP
+/// responses with status 400. The opt-in manual capture suites still need to
+/// prove that their published R2 source objects exist, so they use curl as a
+/// byte transport and leave checksum verification to [DemoSeedMediaInstaller].
+Future<Uint8List> fetchManualDemoSeedMedia(Uri uri) async {
+  final result = await Process.run(
+    'curl',
+    [
+      '--fail',
+      '--silent',
+      '--show-error',
+      '--location',
+      uri.toString(),
+    ],
+    stdoutEncoding: null,
+  );
+  if (result.exitCode != 0) {
+    throw HttpException(
+      'Could not fetch manual demo seed media: ${result.stderr}',
+      uri: uri,
+    );
+  }
+  return Uint8List.fromList(result.stdout as List<int>);
+}
+
 /// Re-encodes installed manual artwork as PNG bytes in place.
 ///
 /// The headless Flutter test engine can leave resized WebP decoding pending,
@@ -76,6 +104,7 @@ Future<void> primeManualDemoCoverArt(
   List<int> extents = const [48, 96, 144, 216, 1280, 2048, 3072],
   Set<String>? imageIds,
   bool includeRawFileImage = false,
+  bool includeExactResizeKeys = false,
 }) async {
   await tester.runAsync(() async {
     final coverImages = imageIds == null
@@ -123,6 +152,11 @@ Future<void> primeManualDemoCoverArt(
             width: extent,
             policy: ResizeImagePolicy.fit,
           ),
+          if (includeExactResizeKeys)
+            ResizeImage(
+              fileImage,
+              width: extent,
+            ),
         ];
         final codec = await ui.instantiateImageCodec(
           bytes,


### PR DESCRIPTION
## Summary

- Seed the demo world’s cover art from immutable, SHA-256-pinned R2 objects before writing `JournalImage` rows.
- Keep offline demo entry reliable with a separately verified bundled fallback; a corrupt remote object fails closed.
- Show exact media-download progress during demo entry, reset, and stale-world reseeding.
- Add the topology workspace to the manual screenshot catalog and document the remote-only capture input.

## Visual change

| Before | After |
| --- | --- |
| ![Before: generic demo setup spinner](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/demo-r2-seed-progress/2f95f0312dfea7fb5ec7316aa22787aec6ed09ba/before/demo_entry_progress_mobile_dark.png) | ![After: determinate download progress](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/demo-r2-seed-progress/2f95f0312dfea7fb5ec7316aa22787aec6ed09ba/after/demo_entry_progress_mobile_dark.png) |

## Validation

- `fvm dart analyze .`
- Focused Flutter tests for demo seeding, progress UI/state, gateway, and knowledge-graph page (93 passing); focused changed production paths reach 100% line coverage except pre-existing unmodified branches in the two large host files.
- `make knowledge_check`
- `npm --prefix docs-site run typecheck`
- `npm --prefix docs-site test -- --runInBand` (77 passing)
- Manual knowledge-graph capture: all eight mobile/desktop × light/dark workspace and Connections frames passed.

The approximately 27,000-test full suite is intentionally delegated to CI’s ten shards; Codecov is authoritative for patch coverage.
