### PR TITLE
fix: preserve demo media and links

### DIFF
--- a/knowledge/features/demo.md
+++ b/knowledge/features/demo.md
@@ -81,8 +81,8 @@ UI builds it on demand from the ambient `ProfileSwitcherScope` via
 One seed run writes the Intergalactic Penguin Logistics fixture plus the
 tutorial "first mission", then records what it wrote in
 `demo_seed_manifest.json` at the demo world's root: `seedVersion`, seed
-timestamp, locale tag, and the full id sets of seeded journal entities,
-entity definitions, and AI configs
+timestamp, locale tag, and the full id sets of seeded journal entities, entry
+links, entity definitions, and AI configs
 ([`demo_seed_manifest.dart`](../../lib/features/demo/seed/demo_seed_manifest.dart)).
 Every later decision reads that file:
 
@@ -92,7 +92,9 @@ Every later decision reads that file:
   when the stale world holds no demo-created work: `enterDemo` scans the
   non-active world's RAW rows against the manifest first (via a
   `WorldHandle`) — any non-deleted journal row not listed in the manifest,
-  or any non-manifest inference provider (the user's API key), counts.
+  any non-manifest active entry link, or any non-manifest inference provider
+  (the user's API key), counts. v4 manifests predate the link inventory, so
+  their deterministic seeded link IDs remain a compatibility allow-list.
   Deliberately not the exit sheet's candidate scan, which drops non-seeded
   entries with inbound links (a recording attached to a seeded task) and
   would green-light wiping them. A stale world with user work resumes
@@ -153,13 +155,17 @@ files live only in Cloudflare R2; the app bundle contains no demo artwork.
 
 After each profile bootstrap, `registerDemoMediaHydration` first proves the
 active guest is this product demo by reading its seed manifest. It filters the
-current catalog to image ids that manifest actually owns — essential when an
-older demo is resumed to protect user work — and launches a bounded-concurrency
+current catalog to image ids that manifest actually owns, then intersects that
+set with non-deleted database rows — essential when an older demo is resumed
+to protect user work, and so a permanently purged seeded image stays purged —
+and launches a bounded-concurrency
 `DemoMediaHydrator` without awaiting or registering it as switch-blocking
 startup work. Its getIt disposal callback cancels in-flight requests when the
 user leaves the demo. Existing files are accepted only when their digest
-matches. Missing or corrupt objects download to `.part`, pass the catalog
-checksum, and rename atomically inside that guest root. Individual failures are
+matches. Catalog directories are created synchronously before the background
+work begins, so mounted cover widgets can install their file watchers. Missing
+or corrupt objects download to `.part`, pass the catalog checksum, and rename
+atomically inside that guest root. Individual failures are
 logged and contained; placeholders remain usable and the next startup retries
 the incomplete catalog.
 

--- a/lib/features/demo/media/demo_media_hydrator.dart
+++ b/lib/features/demo/media/demo_media_hydrator.dart
@@ -97,6 +97,12 @@ class DemoMediaHydrator {
   bool _disposed = false;
 
   Future<DemoMediaHydrationResult> hydrate() async {
+    // File watchers are installed by mounted cover widgets before the first
+    // R2 response may arrive. Their parent directories must therefore exist
+    // synchronously, rather than only after [_hydrateAsset] writes a file.
+    for (final asset in assets) {
+      _target(asset).parent.createSync(recursive: true);
+    }
     var alreadyComplete = 0;
     var downloaded = 0;
     var failed = 0;

--- a/lib/features/demo/media/demo_media_startup.dart
+++ b/lib/features/demo/media/demo_media_startup.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
+import 'package:lotti/database/database.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/demo/media/demo_media_hydrator.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
@@ -24,6 +25,7 @@ Future<void> registerDemoMediaHydration({
   required List<DemoMediaAsset> catalog,
   @visibleForTesting DemoMediaDownload? download,
   @visibleForTesting http.Client? client,
+  @visibleForTesting Future<Set<String>> Function()? activeJournalIds,
   @visibleForTesting void Function()? closeDownloader,
   @visibleForTesting DemoMediaHydrationLaunch? launch,
 }) async {
@@ -45,10 +47,31 @@ Future<void> registerDemoMediaHydration({
   }
   if (manifest == null) return;
 
+  Set<String> presentIds;
+  try {
+    final readActiveJournalIds =
+        activeJournalIds ??
+        () async {
+          return (await serviceLocator<JournalDb>()
+                  .allNonDeletedJournalEntityIds())
+              .toSet();
+        };
+    presentIds = await readActiveJournalIds();
+  } catch (error, stackTrace) {
+    logger.error(
+      LogDomain.general,
+      error,
+      stackTrace: stackTrace,
+      subDomain: 'demoMediaJournal',
+      message: 'Unable to inspect demo media entities',
+    );
+    return;
+  }
+
   final seededIds = manifest.seededJournalIds.toSet();
   final requiredAssets = [
     for (final asset in catalog)
-      if (seededIds.contains(asset.id)) asset,
+      if (seededIds.contains(asset.id) && presentIds.contains(asset.id)) asset,
   ];
   if (requiredAssets.isEmpty) return;
 

--- a/lib/features/demo/seed/demo_seed_manifest.dart
+++ b/lib/features/demo/seed/demo_seed_manifest.dart
@@ -25,6 +25,7 @@ class DemoSeedManifest {
     required this.seededJournalIds,
     required this.seededDefinitionIds,
     required this.seededAiConfigIds,
+    this.seededLinkIds,
   });
 
   factory DemoSeedManifest.fromJson(Map<String, dynamic> json) {
@@ -35,6 +36,7 @@ class DemoSeedManifest {
       seededJournalIds: _idList(json['seededJournalIds']),
       seededDefinitionIds: _idList(json['seededDefinitionIds']),
       seededAiConfigIds: _idList(json['seededAiConfigIds']),
+      seededLinkIds: _optionalIdList(json['seededLinkIds']),
     );
   }
 
@@ -57,6 +59,10 @@ class DemoSeedManifest {
   /// Ids of every seeded AI config (providers, models, profiles, skills).
   final List<String> seededAiConfigIds;
 
+  /// Ids of every seeded entry-link row. `null` denotes a legacy manifest
+  /// written before link ownership was recorded.
+  final List<String>? seededLinkIds;
+
   /// Whether this world was seeded by the current app's seed content. A
   /// mismatch means the profile should be wiped and reseeded before reuse.
   bool get isCurrentVersion => seedVersion == demoSeedVersion;
@@ -68,6 +74,7 @@ class DemoSeedManifest {
     'seededJournalIds': seededJournalIds,
     'seededDefinitionIds': seededDefinitionIds,
     'seededAiConfigIds': seededAiConfigIds,
+    if (seededLinkIds != null) 'seededLinkIds': seededLinkIds,
   };
 
   /// The manifest file for a demo world rooted at [root].
@@ -95,4 +102,7 @@ class DemoSeedManifest {
 
   static List<String> _idList(dynamic value) =>
       List<String>.unmodifiable((value as List<dynamic>).cast<String>());
+
+  static List<String>? _optionalIdList(dynamic value) =>
+      value == null ? null : _idList(value);
 }

--- a/lib/features/demo/seed/demo_seeder.dart
+++ b/lib/features/demo/seed/demo_seeder.dart
@@ -115,6 +115,9 @@ class DemoSeeder {
       seededAiConfigIds: List.unmodifiable([
         for (final config in aiConfigs) config.id,
       ]),
+      seededLinkIds: List.unmodifiable([
+        for (final link in [...penguinWorld.links, ...tutorial.links]) link.id,
+      ]),
     );
     await manifest.write(world.root);
     return manifest;

--- a/lib/features/demo/state/demo_mode_gateway.dart
+++ b/lib/features/demo/state/demo_mode_gateway.dart
@@ -4,11 +4,13 @@ import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/app_root.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/demo/copy/demo_data_copier.dart';
+import 'package:lotti/features/demo/seed/demo_ids.dart';
 import 'package:lotti/features/demo/seed/demo_seed_manifest.dart';
 import 'package:lotti/features/demo/seed/demo_seeder.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
@@ -305,6 +307,7 @@ class DemoModeGateway {
       return await _hasUserWorkIn(
         profile: profile,
         journalIds: opened.journalDb.allNonDeletedJournalEntityIds,
+        entryLinks: opened.journalDb.linksForEntryIdsBidirectional,
         inferenceProviders: () => AiConfigRepository(
           opened.aiConfigDb,
         ).getConfigsByType(AiConfigType.inferenceProvider),
@@ -327,6 +330,7 @@ class DemoModeGateway {
       return await _hasUserWorkIn(
         profile: profile,
         journalIds: getIt<JournalDb>().allNonDeletedJournalEntityIds,
+        entryLinks: getIt<JournalDb>().linksForEntryIdsBidirectional,
         inferenceProviders: () => getIt<AiConfigRepository>().getConfigsByType(
           AiConfigType.inferenceProvider,
         ),
@@ -344,6 +348,7 @@ class DemoModeGateway {
   Future<bool> _hasUserWorkIn({
     required Profile profile,
     required Future<List<String>> Function() journalIds,
+    required Future<List<EntryLink>> Function(Set<String> ids) entryLinks,
     required Future<List<AiConfig>> Function() inferenceProviders,
   }) async {
     DemoSeedManifest? manifest;
@@ -359,8 +364,24 @@ class DemoModeGateway {
     if (ids.any((id) => !seededJournalIds.contains(id))) {
       return true;
     }
+    final links = await entryLinks(seededJournalIds);
+    if (links.any(
+      (link) => link.hidden != true && !_isSeededLink(manifest, link),
+    )) {
+      return true;
+    }
     final providers = await inferenceProviders();
     return providers.any((config) => !seededAiIds.contains(config.id));
+  }
+
+  /// Legacy v4 manifests did not record seeded link IDs. Their links were
+  /// all deterministic, so their established id scheme remains a safe
+  /// compatibility inventory while v5+ manifests use their exact IDs.
+  static bool _isSeededLink(DemoSeedManifest? manifest, EntryLink link) {
+    final seededLinkIds = manifest?.seededLinkIds;
+    if (seededLinkIds != null) return seededLinkIds.contains(link.id);
+    return link.id == demoUuid('manual-habitat-time-link') ||
+        link.id == demoUuid('link-${link.fromId}-${link.toId}');
   }
 
   Future<void> _createAndEnter(Locale locale) async {

--- a/test/features/demo/media/demo_media_hydrator_test.dart
+++ b/test/features/demo/media/demo_media_hydrator_test.dart
@@ -144,6 +144,7 @@ void main() {
       );
 
       final hydration = hydrator.hydrate();
+      expect(target(image).parent.existsSync(), isTrue);
       await requested.future;
       hydrator.dispose();
       response.complete(bytes);

--- a/test/features/demo/media/demo_media_startup_test.dart
+++ b/test/features/demo/media/demo_media_startup_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/demo/media/demo_media_hydrator.dart';
 import 'package:lotti/features/demo/media/demo_media_startup.dart';
@@ -23,10 +24,17 @@ void main() {
   late GetIt services;
   late Directory root;
   late MockDomainLogger logger;
+  late MockJournalDb journalDb;
 
   setUp(() {
     logger = MockDomainLogger();
-    services = GetIt.asNewInstance()..registerSingleton<DomainLogger>(logger);
+    journalDb = MockJournalDb();
+    when(
+      () => journalDb.allNonDeletedJournalEntityIds(),
+    ).thenAnswer((_) async => <String>[]);
+    services = GetIt.asNewInstance()
+      ..registerSingleton<DomainLogger>(logger)
+      ..registerSingleton<JournalDb>(journalDb);
     root = Directory.systemTemp.createTempSync('demo_media_startup_');
   });
 
@@ -96,6 +104,9 @@ void main() {
       seededDefinitionIds: const [],
       seededAiConfigIds: const [],
     ).write(root);
+    when(
+      () => journalDb.allNonDeletedJournalEntityIds(),
+    ).thenAnswer((_) async => [seeded.id]);
     final requested = <Uri>[];
     late Future<void> hydration;
 
@@ -132,6 +143,9 @@ void main() {
       seededDefinitionIds: const [],
       seededAiConfigIds: const [],
     ).write(root);
+    when(
+      () => journalDb.allNonDeletedJournalEntityIds(),
+    ).thenAnswer((_) async => [seeded.id]);
     final response = Completer<Uint8List>();
     late Future<void> hydration;
 
@@ -217,6 +231,9 @@ void main() {
       seededDefinitionIds: const [],
       seededAiConfigIds: const [],
     ).write(root);
+    when(
+      () => journalDb.allNonDeletedJournalEntityIds(),
+    ).thenAnswer((_) async => [seeded.id]);
     late Future<void> hydration;
 
     await registerDemoMediaHydration(
@@ -246,4 +263,34 @@ void main() {
       ),
     ).called(1);
   });
+
+  test(
+    'does not rehydrate a seeded image that was permanently purged',
+    () async {
+      final bytes = Uint8List.fromList([14]);
+      final purged = asset('purged-image', bytes);
+      await DemoSeedManifest(
+        seedVersion: demoSeedVersion,
+        seededAt: DateTime(2026, 8, 5),
+        localeTag: 'en',
+        seededJournalIds: [purged.id],
+        seededDefinitionIds: const [],
+        seededAiConfigIds: const [],
+      ).write(root);
+      var requests = 0;
+
+      await registerDemoMediaHydration(
+        serviceLocator: services,
+        profile: context(ProfileType.guest),
+        catalog: [purged],
+        download: (uri) async {
+          requests++;
+          return bytes;
+        },
+      );
+
+      expect(requests, 0);
+      expect(services.isRegistered<DemoMediaHydrator>(), isFalse);
+    },
+  );
 }

--- a/test/features/demo/media/demo_media_startup_test.dart
+++ b/test/features/demo/media/demo_media_startup_test.dart
@@ -220,6 +220,40 @@ void main() {
     expect(services.isRegistered<DemoMediaHydrator>(), isFalse);
   });
 
+  test(
+    'logs and skips hydration when journal rows cannot be inspected',
+    () async {
+      final seeded = asset('journal-read-failure', [12]);
+      await DemoSeedManifest(
+        seedVersion: demoSeedVersion,
+        seededAt: DateTime(2026, 8, 5),
+        localeTag: 'en',
+        seededJournalIds: [seeded.id],
+        seededDefinitionIds: const [],
+        seededAiConfigIds: const [],
+      ).write(root);
+
+      await registerDemoMediaHydration(
+        serviceLocator: services,
+        profile: context(ProfileType.guest),
+        catalog: [seeded],
+        activeJournalIds: () async => throw StateError('journal unavailable'),
+        download: (uri) async => Uint8List.fromList([12]),
+      );
+
+      expect(services.isRegistered<DemoMediaHydrator>(), isFalse);
+      verify(
+        () => logger.error(
+          LogDomain.general,
+          any(),
+          stackTrace: any(named: 'stackTrace'),
+          subDomain: 'demoMediaJournal',
+          message: 'Unable to inspect demo media entities',
+        ),
+      ).called(1);
+    },
+  );
+
   test('network failures are contained and logged per asset', () async {
     final bytes = Uint8List.fromList([13]);
     final seeded = asset('network-failure', bytes);

--- a/test/features/demo/seed/demo_seed_manifest_test.dart
+++ b/test/features/demo/seed/demo_seed_manifest_test.dart
@@ -13,6 +13,7 @@ void main() {
     seededJournalIds: const ['task-1', 'image-1'],
     seededDefinitionIds: const ['category-1'],
     seededAiConfigIds: const ['provider-1', 'model-1'],
+    seededLinkIds: const ['link-1'],
   );
 
   group('DemoSeedManifest', () {
@@ -27,6 +28,7 @@ void main() {
       expect(decoded.seededJournalIds, manifest.seededJournalIds);
       expect(decoded.seededDefinitionIds, manifest.seededDefinitionIds);
       expect(decoded.seededAiConfigIds, manifest.seededAiConfigIds);
+      expect(decoded.seededLinkIds, manifest.seededLinkIds);
       expect(decoded.isCurrentVersion, isTrue);
     });
 
@@ -43,6 +45,7 @@ void main() {
       final read = await DemoSeedManifest.read(root);
       expect(read, isNotNull);
       expect(read!.seededJournalIds, manifest.seededJournalIds);
+      expect(read.seededLinkIds, manifest.seededLinkIds);
       expect(read.seededAt, manifest.seededAt);
     });
 
@@ -60,6 +63,16 @@ void main() {
       });
       expect(stale.isCurrentVersion, isFalse);
       expect(manifest.isCurrentVersion, isTrue);
+    });
+
+    test('reads a v4 manifest without a seeded-link inventory', () {
+      final legacy = DemoSeedManifest.fromJson(
+        {
+          ...manifest.toJson(),
+        }..remove('seededLinkIds'),
+      );
+
+      expect(legacy.seededLinkIds, isNull);
     });
   });
 }

--- a/test/features/demo/seed/demo_seeder_test.dart
+++ b/test/features/demo/seed/demo_seeder_test.dart
@@ -260,6 +260,13 @@ void main() {
         tutorialLinks.map((link) => link.toId).toSet(),
         demoMediaForTask(demoTutorialTaskId).map((asset) => asset.id).toSet(),
       );
+      expect(
+        manifest.seededLinkIds,
+        containsAll([
+          ...fixture.links.map((link) => link.id),
+          ...tutorialLinks.map((link) => link.id),
+        ]),
+      );
 
       // Config flags: demo experience on top of the seeded defaults.
       expect(
@@ -354,6 +361,7 @@ void main() {
         hasLength(expectedAiConfigIds.length),
       );
       expect(manifest.seededJournalIds, persisted.seededJournalIds);
+      expect(persisted.seededLinkIds, manifest.seededLinkIds);
 
       // Isolation: the canary (active) world is byte-identical.
       expect(snapshotTree(canaryRealRoot), before);

--- a/test/features/demo/state/demo_mode_gateway_test.dart
+++ b/test/features/demo/state/demo_mode_gateway_test.dart
@@ -231,6 +231,48 @@ void main() {
       expect(root.existsSync(), isTrue);
     });
 
+    test('a stale v4 manifest with only a user-created link between seeded '
+        'tasks resumes instead of losing that relationship', () async {
+      final gateway = buildGateway();
+      await gateway.enterDemo(locale: const Locale('en'));
+      final first = (await gateway.findDemoProfile())!;
+      final root = registry.rootFor(first);
+      await DemoSeedManifest(
+        seedVersion: demoSeedVersion - 1,
+        seededAt: DateTime.utc(2026),
+        localeTag: 'en',
+        seededJournalIds: const ['seeded-task-a', 'seeded-task-b'],
+        seededDefinitionIds: const [],
+        seededAiConfigIds: const [],
+      ).write(root);
+      final work = WorldHandle.open(root);
+      await work.writeJournalEntity(
+        TestTaskFactory.create(id: 'seeded-task-a', title: 'Seeded A'),
+      );
+      await work.writeJournalEntity(
+        TestTaskFactory.create(id: 'seeded-task-b', title: 'Seeded B'),
+      );
+      await work.writeEntryLink(
+        EntryLink.basic(
+          id: 'user-created-link',
+          fromId: 'seeded-task-a',
+          toId: 'seeded-task-b',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+          vectorClock: null,
+        ),
+      );
+      await work.close();
+      activated.clear();
+      seededLocales.clear();
+
+      await gateway.enterDemo(locale: const Locale('en'));
+
+      expect(seededLocales, isEmpty);
+      expect(activated, [first.id]);
+      expect(root.existsSync(), isTrue);
+    });
+
     test('a stale manifest with only a user-connected AI provider (their '
         'API key) also resumes instead of wiping', () async {
       final gateway = buildGateway();

--- a/test/features/demo/state/demo_mode_gateway_test.dart
+++ b/test/features/demo/state/demo_mode_gateway_test.dart
@@ -273,6 +273,51 @@ void main() {
       expect(root.existsSync(), isTrue);
     });
 
+    test(
+      'a stale manifest inventories its seeded links before reseeding',
+      () async {
+        final gateway = buildGateway();
+        await gateway.enterDemo(locale: const Locale('en'));
+        final first = (await gateway.findDemoProfile())!;
+        final root = registry.rootFor(first);
+        await DemoSeedManifest(
+          seedVersion: demoSeedVersion - 1,
+          seededAt: DateTime.utc(2026),
+          localeTag: 'en',
+          seededJournalIds: const ['seeded-task-a', 'seeded-task-b'],
+          seededDefinitionIds: const [],
+          seededAiConfigIds: const [],
+          seededLinkIds: const ['seeded-link'],
+        ).write(root);
+        final work = WorldHandle.open(root);
+        await work.writeJournalEntity(
+          TestTaskFactory.create(id: 'seeded-task-a', title: 'Seeded A'),
+        );
+        await work.writeJournalEntity(
+          TestTaskFactory.create(id: 'seeded-task-b', title: 'Seeded B'),
+        );
+        await work.writeEntryLink(
+          EntryLink.basic(
+            id: 'seeded-link',
+            fromId: 'seeded-task-a',
+            toId: 'seeded-task-b',
+            createdAt: DateTime.utc(2026),
+            updatedAt: DateTime.utc(2026),
+            vectorClock: null,
+          ),
+        );
+        await work.close();
+        activated.clear();
+        seededLocales.clear();
+
+        await gateway.enterDemo(locale: const Locale('en'));
+
+        expect(seededLocales, ['en']);
+        expect(activated, isNotEmpty);
+        expect((await gateway.findDemoProfile())!.id, isNot(first.id));
+      },
+    );
+
     test('a stale manifest with only a user-connected AI provider (their '
         'API key) also resumes instead of wiping', () async {
       final gateway = buildGateway();


### PR DESCRIPTION
## Summary

Addresses the three post-merge review findings from #3827.

- create every R2 media parent directory before background hydration begins, so already-mounted cover widgets can watch for downloaded files
- record seeded entry-link IDs in new manifests and preserve v4 link-only user work through the prior deterministic seeded-link IDs
- hydrate only seeded image assets whose journal rows are still non-deleted, so a permanently purged image stays purged

## Validation

- scoped Dart analyzer: no issues
- focused demo hydrator, startup, manifest, seeder, and gateway tests: 62 passed
- knowledge-map validation and Mermaid parsing: passed
- full suite and patch coverage are delegated to CI's sharded matrix