### PR TITLE
refactor(agents): extract the duplicated agent error logging and attribution

### DIFF
--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -5,9 +5,17 @@ description: The agent.sqlite entity and link model, bulk-read chunking, and exa
 resource: ../../../lib/features/agents/database/agent_database.dart
 tags: [agents, persistence, sync, privacy, drift]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-04T00:59:29Z }
+generated: { by: claude-code/opus-5, at: 2026-08-06T17:10:00Z }
 stale_after: 2026-10-12
 sources:
+  - id: error-logging
+    resource: ../../../lib/features/agents/util/agent_error_logging.dart
+    title: AgentErrorLogging — the shared content-free diagnostic path
+    last_modified: 2026-08-06
+  - id: carrierless-attribution
+    resource: ../../../lib/features/agents/workflow/carrierless_attribution.dart
+    title: prepareAgentReportAttribution and finalizeCarrierlessAgentAttribution
+    last_modified: 2026-08-07
   - id: db
     resource: ../../../lib/features/agents/database/agent_database.dart
     title: AgentDatabase
@@ -519,6 +527,14 @@ output, raw tool arguments, or arbitrary exception strings.
 The durable agent message log remains the memory and audit surface; it is never
 copied into runtime log files.
 
+For the seven runtime and workflow classes that share `AgentErrorLogging`
+(`agents/util/agent_error_logging.dart`), the rule is enforced in one place: its
+no-logger fallback passes `error.runtimeType` to `developer.log`, never the error
+object. That mixin replaced a byte-identical copy of the method in each class, so
+the rule can no longer be upheld in six places and broken in the seventh.
+`DayAgentWorkflow` deliberately does not adopt it — its logger is non-nullable
+and it has no fallback branch at all — so it carries the rule on its own.
+
 # AI consumption provenance
 
 Every agent report carrier receives AI-consumption provenance. Task agents
@@ -557,3 +573,27 @@ report carrier is authoritative and the local attribution projection is updated
 after the report write. Log-compaction inference is a separate carrier-less AI
 operation, captured before each backend call and terminalized as **partial**
 because its checkpoint format has no attribution record.
+
+A wake that fails before it reaches inference, or takes a branch that makes no
+call, would otherwise leave its envelope open and look perpetually in flight.
+`finalizeCarrierlessAgentAttribution`
+(`agents/workflow/carrierless_attribution.dart`) closes it explicitly, and is a
+no-op unless **both** `AiInteractionCapture` and `AiAttributionService` are
+registered — attribution without capture would be an envelope over nothing. The
+close is contained on failure: bookkeeping never converts a successful wake into
+a failed one.
+
+**The pair is required to open an envelope as well as to close one.** The
+project and event workflows both open theirs through
+`prepareAgentReportAttribution` in the same file, which returns `null` — writing
+the report with no `aiAttributionV1` provenance — when there is no report or when
+`canRecordAgentConsumption` is false. Gating on `AiAttributionService` alone
+would attribute a wake whose interaction rows nobody recorded, so the wake would
+appear in the consumption surfaces at zero cost rather than not at all.
+
+The task path has not been migrated: `WakeOutputWriter` still opens its envelope
+on `AiAttributionService` alone, and `task_agent_execute.dart` still gates its
+consumption fields on `AiInteractionCapture` alone. Both halves of that path
+would have to move together, so it is left as it is rather than made
+half-consistent. `lib/get_it.dart` registers the two services adjacently, so no
+shipping configuration reaches the divergent state.

--- a/lib/features/agents/service/project_activity_monitor.dart
+++ b/lib/features/agents/service/project_activity_monitor.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -17,7 +17,7 @@ import 'package:lotti/services/domain_logging.dart';
 /// whether an affected project has a provisioned project agent, and persists a
 /// pending activity marker on the agent state. The scheduled 06:00 wake later
 /// decides whether to spend tokens on a fresh report.
-class ProjectActivityMonitor {
+class ProjectActivityMonitor with AgentErrorLogging {
   ProjectActivityMonitor({
     required this._notifications,
     required this._agentRepository,
@@ -31,7 +31,11 @@ class ProjectActivityMonitor {
   final AgentRepository _agentRepository;
   final ProjectRepository _projectRepository;
   final AgentSyncService _syncService;
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentRuntime;
   final Clock _clock;
 
   StreamSubscription<Set<String>>? _subscription;
@@ -42,24 +46,6 @@ class ProjectActivityMonitor {
       message,
       subDomain: subDomain,
     );
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentRuntime,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'ProjectActivityMonitor',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   /// Start tracking local project activity.
@@ -126,7 +112,7 @@ class ProjectActivityMonitor {
         subDomain: 'activity',
       );
     } catch (error, stackTrace) {
-      _logError(
+      logError(
         'failed to mark project activity for '
         '${DomainLogger.sanitizeId(projectId)}',
         error: error,

--- a/lib/features/agents/util/agent_error_logging.dart
+++ b/lib/features/agents/util/agent_error_logging.dart
@@ -1,0 +1,68 @@
+import 'dart:developer' as developer;
+
+import 'package:lotti/services/domain_logging.dart';
+
+/// Structured-with-fallback error logging for the agent runtime and workflow
+/// classes.
+///
+/// Seven classes across `wake/`, `workflow/` and `service/` carried a
+/// byte-identical copy of this method, differing only in the [LogDomain] and the
+/// `developer.log` source name. A copy per class means a fix to one leaves the
+/// other six behind, which is the only reason this mixin exists — the behaviour
+/// is exactly what those copies did.
+///
+/// Deliberately **not** adopted by `DayAgentWorkflow`: its logger is
+/// non-nullable and it has no fallback branch at all, so folding it in here
+/// would add an unreachable-but-real code path to it. That contract difference
+/// is intentional, not an eighth copy left behind.
+mixin AgentErrorLogging {
+  /// The structured logger, when one was injected.
+  ///
+  /// Every adopting class already exposes this as a field; the mixin only
+  /// requires that it be readable.
+  DomainLogger? get domainLogger;
+
+  /// Which logging domain this class's failures belong to.
+  ///
+  /// `agentRuntime` for the wake machinery, `agentWorkflow` for the workflows.
+  LogDomain get errorLogDomain;
+
+  /// The `developer.log` source name used by the fallback path.
+  ///
+  /// Derived from the concrete type rather than restated per class, so renaming
+  /// a class cannot leave its diagnostics naming a class that no longer exists.
+  /// This yields the same strings the hand-written copies hard-coded, because
+  /// nothing in this repository's build configuration passes `--obfuscate`.
+  /// Override it if a class ever needs a name that is not its own.
+  String get errorLogName => '$runtimeType';
+
+  /// Reports [message], optionally caused by [error], to the structured logger —
+  /// or to `developer.log` when no logger was injected.
+  ///
+  /// When [error] is present it becomes the logged object and [message] the
+  /// accompanying context; with no [error], [message] *is* the logged object.
+  /// That asymmetry is what the original copies did and what the log surfaces
+  /// expect.
+  ///
+  /// The fallback path passes only `error.runtimeType`, never the error itself:
+  /// these paths carry journal content, which must not reach a developer
+  /// console verbatim.
+  void logError(String message, {Object? error, StackTrace? stackTrace}) {
+    final logger = domainLogger;
+    if (logger != null) {
+      logger.error(
+        errorLogDomain,
+        error ?? message,
+        message: error != null ? message : null,
+        stackTrace: stackTrace,
+      );
+    } else {
+      developer.log(
+        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
+        name: errorLogName,
+        error: error?.runtimeType,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/services/domain_logging.dart';
 
@@ -28,7 +28,7 @@ class _HandledCheckSequence {
 /// last report) are fast-forwarded to the next future time slot without
 /// executing, avoiding unnecessary LLM calls after prolonged app absence.
 /// Non-project agents (e.g., improver agents) are always enqueued.
-class ScheduledWakeManager {
+class ScheduledWakeManager with AgentErrorLogging {
   ScheduledWakeManager({
     required this._repository,
     required this._orchestrator,
@@ -46,7 +46,11 @@ class ScheduledWakeManager {
   final AgentRepository _repository;
   final WakeOrchestrator _orchestrator;
   final AgentSyncService _syncService;
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentRuntime;
   final void Function(String agentId)? onPersistedStateChanged;
 
   final Duration checkInterval;
@@ -263,7 +267,7 @@ class ScheduledWakeManager {
           );
           enqueued++;
         } catch (e, s) {
-          _logError(
+          logError(
             'failed to process ${DomainLogger.sanitizeId(state.agentId)}',
             error: e,
             stackTrace: s,
@@ -286,7 +290,7 @@ class ScheduledWakeManager {
         );
       }
     } catch (e, s) {
-      _logError('error checking scheduled wakes', error: e, stackTrace: s);
+      logError('error checking scheduled wakes', error: e, stackTrace: s);
     }
   }
 
@@ -296,7 +300,7 @@ class ScheduledWakeManager {
     try {
       await before();
     } catch (e, s) {
-      _logError(
+      logError(
         'pre-check repair failed; continuing with the due-record pass',
         error: e,
         stackTrace: s,
@@ -401,7 +405,7 @@ class ScheduledWakeManager {
         onPersistedStateChanged?.call(record.agentId);
         enqueued++;
       } catch (e, s) {
-        _logError(
+        logError(
           'failed to fire scheduled-wake record '
           '${DomainLogger.sanitizeId(record.id)}',
           error: e,
@@ -609,23 +613,5 @@ class ScheduledWakeManager {
 
   void _log(String message) {
     domainLogger?.log(LogDomain.agentRuntime, message, subDomain: 'schedule');
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentRuntime,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'ScheduledWakeManager',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 }

--- a/lib/features/agents/wake/wake_batch_router.dart
+++ b/lib/features/agents/wake/wake_batch_router.dart
@@ -327,7 +327,7 @@ extension WakeBatchRouter on WakeOrchestrator {
       }
       onPersistedStateChanged?.call(agentId);
     } catch (error, stackTrace) {
-      _logError(
+      logError(
         'failed to persist stale report watermark for '
         '${DomainLogger.sanitizeId(agentId)}',
         error: error,
@@ -436,7 +436,7 @@ extension WakeBatchRouter on WakeOrchestrator {
       // Mirror is intentionally left untouched: we don't know whether the
       // persisted flag still applies, so we fail open without rewriting
       // local state.
-      _logError(
+      logError(
         'content-gate: error checking content for '
         '${DomainLogger.sanitizeId(job.agentId)}',
         error: e,

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -196,7 +196,7 @@ extension WakeDrainEngine on WakeOrchestrator {
               // escapes that boundary (for example, a logging implementation
               // throwing before `_executeJob` enters its outer try/finally).
               runner.release(job.agentId);
-              _logError(
+              logError(
                 'unexpected wake execution failure for '
                 '${DomainLogger.sanitizeId(job.runKey)}',
                 error: error,
@@ -268,7 +268,7 @@ extension WakeDrainEngine on WakeOrchestrator {
     try {
       entity = await repository.getEntity(job.agentId);
     } catch (error, stackTrace) {
-      _logError(
+      logError(
         'failed to load agent policy; allowing wake to proceed',
         error: error,
         stackTrace: stackTrace,
@@ -316,7 +316,7 @@ extension WakeDrainEngine on WakeOrchestrator {
       try {
         await repository.insertWakeRun(entry: entry);
       } catch (e, s) {
-        _logError(
+        logError(
           'insertWakeRun failed for ${DomainLogger.sanitizeId(job.runKey)}',
           error: e,
           stackTrace: s,
@@ -327,7 +327,7 @@ extension WakeDrainEngine on WakeOrchestrator {
 
       final executor = wakeExecutor;
       if (executor == null) {
-        _logError('no wakeExecutor set — marking run as failed');
+        logError('no wakeExecutor set — marking run as failed');
         await _safeUpdateStatus(
           job.runKey,
           WakeRunStatus.failed.name,
@@ -354,7 +354,7 @@ extension WakeDrainEngine on WakeOrchestrator {
             threadId,
           ).timeout(WakeOrchestrator.wakeStartHookTimeout);
         } catch (e, s) {
-          _logError(
+          logError(
             'pre-wake hook failed for ${DomainLogger.sanitizeId(job.agentId)}',
             error: e,
             stackTrace: s,
@@ -527,7 +527,7 @@ extension WakeDrainEngine on WakeOrchestrator {
       } catch (e) {
         _suppression.clearPreRegistered(job.agentId);
         final elapsed = clock.now().difference(startTime);
-        _logError(
+        logError(
           'wake failed in ${elapsed.inMilliseconds}ms '
           'for ${DomainLogger.sanitizeId(job.runKey)}',
           error: e,
@@ -562,7 +562,7 @@ extension WakeDrainEngine on WakeOrchestrator {
         errorMessage: errorMessage,
       );
     } catch (e, s) {
-      _logError(
+      logError(
         'failed to update wake run status '
         'for ${DomainLogger.sanitizeId(runKey)} to $status',
         error: e,
@@ -604,7 +604,7 @@ extension WakeDrainEngine on WakeOrchestrator {
       }
       onPersistedStateChanged?.call(agentId);
     } catch (error, stackTrace) {
-      _logError(
+      logError(
         'failed to persist fresh report watermark for '
         '${DomainLogger.sanitizeId(agentId)}',
         error: error,

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
@@ -9,6 +8,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_time_utils.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/agents/wake/run_key_factory.dart';
 import 'package:lotti/features/agents/wake/wake_queue.dart';
 import 'package:lotti/features/agents/wake/wake_runner.dart';
@@ -138,7 +138,7 @@ int _defaultMaxConcurrentWakes() => defaultAgentWakeConcurrency;
 /// - Enqueues [WakeJob]s into [WakeQueue] with deterministic run keys.
 /// - Dispatches queued jobs through [WakeRunner] (single-flight per agent).
 /// - Persists every wake attempt to the [AgentRepository] wake-run log.
-class WakeOrchestrator {
+class WakeOrchestrator with AgentErrorLogging {
   WakeOrchestrator({
     required this.repository,
     required this.queue,
@@ -171,7 +171,11 @@ class WakeOrchestrator {
   final MaxConcurrentWakes maxConcurrentWakes;
 
   /// Optional domain logger for structured, PII-safe logging.
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentRuntime;
 
   /// Optional callback that performs the actual agent execution during
   /// [processNext]. When set, the orchestrator delegates to this function
@@ -389,24 +393,6 @@ class WakeOrchestrator {
 
   void _log(String message, {String? subDomain}) {
     domainLogger?.log(LogDomain.agentRuntime, message, subDomain: subDomain);
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentRuntime,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'WakeOrchestrator',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   // ── Subscription management ────────────────────────────────────────────────

--- a/lib/features/agents/wake/wake_throttle_coordinator.dart
+++ b/lib/features/agents/wake/wake_throttle_coordinator.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/services/domain_logging.dart';
 
 /// Manages throttle timing with deferred drains and deadlines.
@@ -10,7 +10,7 @@ import 'package:lotti/services/domain_logging.dart';
 /// Ensures that subscription-triggered wakes for the same agent are spaced
 /// at least [throttleWindow] apart. Persists the `nextWakeAt` timestamp
 /// to the agent's state entity so the UI can show a countdown timer.
-class WakeThrottleCoordinator {
+class WakeThrottleCoordinator with AgentErrorLogging {
   WakeThrottleCoordinator({
     required this.repository,
     required this.onDrainRequested,
@@ -23,31 +23,17 @@ class WakeThrottleCoordinator {
   final Future<void> Function() onDrainRequested;
   final void Function(String agentId)? onPersistedStateChanged;
   final Duration throttleWindow;
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentRuntime;
 
   final _throttleDeadlines = <String, DateTime>{};
   final _deferredDrainTimers = <String, Timer>{};
 
   void _log(String message, {String? subDomain}) {
     domainLogger?.log(LogDomain.agentRuntime, message, subDomain: subDomain);
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentRuntime,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'WakeThrottleCoordinator',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   /// Whether [agentId] is still inside its cooldown window. Evicts the
@@ -104,7 +90,7 @@ class WakeThrottleCoordinator {
         onPersistedStateChanged?.call(agentId);
       }
     } catch (e, s) {
-      _logError(
+      logError(
         'failed to persist throttle deadline '
         'for ${DomainLogger.sanitizeId(agentId)}',
         error: e,
@@ -164,7 +150,7 @@ class WakeThrottleCoordinator {
         onPersistedStateChanged?.call(agentId);
       }
     } catch (e, s) {
-      _logError(
+      logError(
         'failed to clear persisted throttle '
         'for ${DomainLogger.sanitizeId(agentId)}',
         error: e,

--- a/lib/features/agents/workflow/agent_wake_memory.dart
+++ b/lib/features/agents/workflow/agent_wake_memory.dart
@@ -83,8 +83,10 @@ class AgentWakeMemory {
     if (domainLogger != null) {
       domainLogger!.error(logDomain, error, message: message);
     } else {
-      // Fallback so failures never vanish silently (same convention as the
-      // workflows' _logError helpers).
+      // Fallback so failures never vanish silently — the same convention the
+      // AgentErrorLogging mixin applies. Kept separate rather than folded into
+      // it: this helper drops a message with no error and carries no stack
+      // trace, so adopting the mixin would change what compaction reports.
       developer.log(
         '$message (errorType=${error.runtimeType})',
         name: 'AgentWakeMemory',

--- a/lib/features/agents/workflow/carrierless_attribution.dart
+++ b/lib/features/agents/workflow/carrierless_attribution.dart
@@ -1,0 +1,76 @@
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
+import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
+import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
+import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
+import 'package:lotti/get_it.dart';
+
+/// Whether this process can both record an AI interaction and attribute it.
+///
+/// Both services are optional registrations, and consumption accounting needs
+/// the pair: capture supplies the interaction rows, attribution the wake-level
+/// envelope that owns them. Attributing without capture would leave an envelope
+/// over nothing.
+bool get canRecordAgentConsumption =>
+    getIt.isRegistered<AiInteractionCapture>() &&
+    getIt.isRegistered<AiAttributionService>();
+
+/// Opens a wake's attribution envelope over the report it is about to write.
+///
+/// Returns `null` when there is no report to attribute ([reportId] is `null`),
+/// or when [canRecordAgentConsumption] is false. Both halves matter: the
+/// envelope exists to own the interaction rows capture records, so preparing one
+/// while capture is unregistered attributes a wake whose cost was never
+/// measured — an envelope over nothing, which is the same reason
+/// [canRecordAgentConsumption] requires the pair rather than either service
+/// alone.
+Future<AiWorkAttribution?> prepareAgentReportAttribution({
+  required String runKey,
+  required String? reportId,
+}) async {
+  if (reportId == null || !canRecordAgentConsumption) return null;
+  return getIt<AiAttributionService>().prepareCompletion(
+    attributionId: agentWakeAttributionId(runKey),
+    outputs: [
+      AiArtifactReference(type: AiArtifactType.agentReport, id: reportId),
+    ],
+  );
+}
+
+/// Terminalizes a wake's attribution envelope when no *carrier* interaction ever
+/// recorded against it.
+///
+/// A wake normally closes its envelope as a side effect of the inference call it
+/// made. When the wake fails before reaching inference — or takes a branch that
+/// makes no call at all — the envelope would otherwise stay open forever and the
+/// wake would look perpetually in-flight in the consumption surfaces. This
+/// closes it explicitly with [status] and [errorCode].
+///
+/// A no-op when [canRecordAgentConsumption] is false, and contained on failure:
+/// bookkeeping must never turn an otherwise-successful wake into a failed one,
+/// so [logger] reports the failure and the wake proceeds.
+Future<void> finalizeCarrierlessAgentAttribution({
+  required String runKey,
+  required AiWorkStatus status,
+  required String errorCode,
+  required AgentErrorLogging logger,
+  String? errorSummary,
+}) async {
+  if (!canRecordAgentConsumption) return;
+  try {
+    final service = getIt<AiAttributionService>();
+    final attribution = await service.prepareCompletion(
+      attributionId: agentWakeAttributionId(runKey),
+      outputs: const [],
+      status: status,
+      errorCode: errorCode,
+      errorSummary: errorSummary,
+    );
+    await service.finalize(attribution);
+  } catch (error, stackTrace) {
+    logger.logError(
+      'failed to terminalize carrier-less attribution',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+}

--- a/lib/features/agents/workflow/event_agent_workflow.dart
+++ b/lib/features/agents/workflow/event_agent_workflow.dart
@@ -1,5 +1,3 @@
-import 'dart:developer' as developer;
-
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
@@ -10,7 +8,9 @@ import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/service/soul_document_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/tools/event_tool_definitions.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/agents/util/text_utils.dart';
+import 'package:lotti/features/agents/workflow/carrierless_attribution.dart';
 import 'package:lotti/features/agents/workflow/deferred_change_items.dart';
 import 'package:lotti/features/agents/workflow/event_agent_context_builder.dart';
 import 'package:lotti/features/agents/workflow/event_agent_strategy.dart';
@@ -24,7 +24,6 @@ import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
 import 'package:lotti/features/ai/util/profile_resolver.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
-import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -40,7 +39,7 @@ import 'package:uuid/uuid.dart';
 /// no health band. It does persist deferred proposals (follow-up tasks) as a
 /// pending change set. After a successful run the content gate is cleared
 /// (`awaitingContent = false`).
-class EventAgentWorkflow {
+class EventAgentWorkflow with AgentErrorLogging {
   EventAgentWorkflow({
     required this.agentRepository,
     required this.conversationRepository,
@@ -62,7 +61,11 @@ class EventAgentWorkflow {
   final JournalRepository journalRepository;
   final AgentTemplateService templateService;
   final SoulDocumentService? soulDocumentService;
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentWorkflow;
   final void Function(String agentId)? onPersistedStateChanged;
 
   static const _uuid = Uuid();
@@ -71,29 +74,11 @@ class EventAgentWorkflow {
       EventAgentContextBuilder(
         agentRepository: agentRepository,
         journalRepository: journalRepository,
-        logError: _logError,
+        logError: logError,
       );
 
   void _log(String message, {String? subDomain}) {
     domainLogger?.log(LogDomain.agentWorkflow, message, subDomain: subDomain);
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentWorkflow,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'EventAgentWorkflow',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   /// Execute a full wake cycle for the given event agent.
@@ -193,35 +178,20 @@ class EventAgentWorkflow {
       systemMessage: systemPrompt,
       maxTurns: agentIdentity.config.maxTurnsPerWake,
     );
-    final recordConsumption =
-        getIt.isRegistered<AiInteractionCapture>() &&
-        getIt.isRegistered<AiAttributionService>();
+    final recordConsumption = canRecordAgentConsumption;
 
-    Future<void> finalizeCarrierlessAttribution({
-      required AiWorkStatus status,
-      required String errorCode,
-      String? errorSummary,
-    }) async {
-      if (!recordConsumption) return;
-      try {
-        final attribution = await getIt<AiAttributionService>()
-            .prepareCompletion(
-              attributionId: agentWakeAttributionId(runKey),
-              outputs: const [],
-              status: status,
-              errorCode: errorCode,
-              errorSummary: errorSummary,
-            );
-        await getIt<AiAttributionService>().finalize(attribution);
-      } catch (error, stackTrace) {
-        _logError(
-          'failed to terminalize carrier-less attribution',
-          error: error,
-          stackTrace: stackTrace,
-        );
-      }
-    }
-
+    // Persist the user message for inspectability as the full blob — *not* as a
+    // v2 prompt record (ADR 0020), unlike the otherwise near-identical project
+    // path in `project_agent_execute.dart`.
+    //
+    // That difference is deliberate, not drift. A v2 record stores a prompt
+    // minus its derivable log block and re-derives that block on read, which
+    // presupposes a compacted memory log to derive it from. A v1 event agent has
+    // none: it is a narrate-only recap assembled from the event, its
+    // observations and its linked entries, so every byte of this prompt is
+    // non-derivable and there is nothing to elide. Storing a record here would
+    // add a marker pointing at an empty derivation and cost a reconstruction
+    // pass to get the same string back.
     try {
       final userPayloadId = _uuid.v4();
       await syncService.upsertEntity(
@@ -246,7 +216,7 @@ class EventAgentWorkflow {
         ),
       );
     } catch (e) {
-      _logError('failed to persist user message', error: e);
+      logError('failed to persist user message', error: e);
     }
 
     try {
@@ -275,7 +245,7 @@ class EventAgentWorkflow {
             soulVersionId: templateCtx.soulVersion?.id,
           );
         } catch (e) {
-          _logError('failed to record template provenance', error: e);
+          logError('failed to record template provenance', error: e);
         }
       }
 
@@ -360,19 +330,10 @@ class EventAgentWorkflow {
       final extractedObservations = strategy.extractObservations();
       final deferredItems = strategy.extractDeferredItems();
       final reportId = hasReport ? _uuid.v4() : null;
-      AiWorkAttribution? attributionEnvelope;
-      if (reportId != null && getIt.isRegistered<AiAttributionService>()) {
-        attributionEnvelope = await getIt<AiAttributionService>()
-            .prepareCompletion(
-              attributionId: agentWakeAttributionId(runKey),
-              outputs: [
-                AiArtifactReference(
-                  type: AiArtifactType.agentReport,
-                  id: reportId,
-                ),
-              ],
-            );
-      }
+      final attributionEnvelope = await prepareAgentReportAttribution(
+        runKey: runKey,
+        reportId: reportId,
+      );
 
       await syncService.runInTransaction(() async {
         final latestState =
@@ -528,14 +489,16 @@ class EventAgentWorkflow {
         try {
           await getIt<AiAttributionService>().finalize(attributionEnvelope);
         } catch (error, stackTrace) {
-          _logError(
+          logError(
             'report attribution projection remains pending for recovery',
             error: error,
             stackTrace: stackTrace,
           );
         }
       } else if (recordConsumption) {
-        await finalizeCarrierlessAttribution(
+        await finalizeCarrierlessAgentAttribution(
+          runKey: runKey,
+          logger: this,
           status: AiWorkStatus.partial,
           errorCode: 'output_carrier_unavailable',
         );
@@ -554,9 +517,11 @@ class EventAgentWorkflow {
               error: 'event agent produced no recap',
             );
     } catch (e, s) {
-      _logError('wake failed', error: e, stackTrace: s);
+      logError('wake failed', error: e, stackTrace: s);
 
-      await finalizeCarrierlessAttribution(
+      await finalizeCarrierlessAgentAttribution(
+        runKey: runKey,
+        logger: this,
         status: AiWorkStatus.failed,
         errorCode: e.runtimeType.toString(),
         errorSummary: e.toString(),
@@ -577,7 +542,7 @@ class EventAgentWorkflow {
           );
         });
       } catch (stateError, s) {
-        _logError(
+        logError(
           'failed to update failure count',
           error: stateError,
           stackTrace: s,
@@ -622,7 +587,7 @@ class EventAgentWorkflow {
         ),
       );
     } catch (e, s) {
-      _logError('failed to persist token usage', error: e, stackTrace: s);
+      logError('failed to persist token usage', error: e, stackTrace: s);
     }
   }
 
@@ -684,7 +649,7 @@ class EventAgentWorkflow {
         rethrowInferenceErrors: true,
       );
     } catch (e, s) {
-      _logError(
+      logError(
         'forced update_report retry failed — persisting partial wake',
         error: e,
         stackTrace: s,

--- a/lib/features/agents/workflow/project_agent_execute.dart
+++ b/lib/features/agents/workflow/project_agent_execute.dart
@@ -102,7 +102,7 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
           runKey: runKey,
         );
       } catch (e) {
-        _logError('failed to capture wake inputs', error: e);
+        logError('failed to capture wake inputs', error: e);
       }
     }
 
@@ -197,34 +197,7 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
       systemMessage: systemPrompt,
       maxTurns: agentIdentity.config.maxTurnsPerWake,
     );
-    final recordConsumption =
-        getIt.isRegistered<AiInteractionCapture>() &&
-        getIt.isRegistered<AiAttributionService>();
-
-    Future<void> finalizeCarrierlessAttribution({
-      required AiWorkStatus status,
-      required String errorCode,
-      String? errorSummary,
-    }) async {
-      if (!recordConsumption) return;
-      try {
-        final attribution = await getIt<AiAttributionService>()
-            .prepareCompletion(
-              attributionId: agentWakeAttributionId(runKey),
-              outputs: const [],
-              status: status,
-              errorCode: errorCode,
-              errorSummary: errorSummary,
-            );
-        await getIt<AiAttributionService>().finalize(attribution);
-      } catch (error, stackTrace) {
-        _logError(
-          'failed to terminalize carrier-less attribution',
-          error: error,
-          stackTrace: stackTrace,
-        );
-      }
-    }
+    final recordConsumption = canRecordAgentConsumption;
 
     // 8a. Persist user message for inspectability — as a v2 prompt record
     // when the read flipped (the log block is derivable from the synced
@@ -263,7 +236,7 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
         ),
       );
     } catch (e) {
-      _logError('failed to persist user message', error: e);
+      logError('failed to persist user message', error: e);
     }
 
     try {
@@ -292,7 +265,7 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
             soulVersionId: templateCtx.soulVersion?.id,
           );
         } catch (e) {
-          _logError('failed to record template provenance', error: e);
+          logError('failed to record template provenance', error: e);
         }
       }
 
@@ -354,19 +327,10 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
       final reportId = reportContent.isEmpty
           ? null
           : ProjectAgentWorkflow._uuid.v4();
-      AiWorkAttribution? attributionEnvelope;
-      if (reportId != null && getIt.isRegistered<AiAttributionService>()) {
-        attributionEnvelope = await getIt<AiAttributionService>()
-            .prepareCompletion(
-              attributionId: agentWakeAttributionId(runKey),
-              outputs: [
-                AiArtifactReference(
-                  type: AiArtifactType.agentReport,
-                  id: reportId,
-                ),
-              ],
-            );
-      }
+      final attributionEnvelope = await prepareAgentReportAttribution(
+        runKey: runKey,
+        reportId: reportId,
+      );
       await syncService.runInTransaction(() async {
         final latestState =
             await agentRepository.getAgentState(agentId) ?? state;
@@ -555,14 +519,16 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
         try {
           await getIt<AiAttributionService>().finalize(attributionEnvelope);
         } catch (error, stackTrace) {
-          _logError(
+          logError(
             'report attribution projection remains pending for recovery',
             error: error,
             stackTrace: stackTrace,
           );
         }
       } else if (recordConsumption) {
-        await finalizeCarrierlessAttribution(
+        await finalizeCarrierlessAgentAttribution(
+          runKey: runKey,
+          logger: this,
           status: AiWorkStatus.partial,
           errorCode: 'output_carrier_unavailable',
         );
@@ -577,9 +543,11 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
 
       return const WakeResult(success: true);
     } catch (e, s) {
-      _logError('wake failed', error: e, stackTrace: s);
+      logError('wake failed', error: e, stackTrace: s);
 
-      await finalizeCarrierlessAttribution(
+      await finalizeCarrierlessAgentAttribution(
+        runKey: runKey,
+        logger: this,
         status: AiWorkStatus.failed,
         errorCode: e.runtimeType.toString(),
         errorSummary: e.toString(),
@@ -593,7 +561,7 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
           ),
         );
       } catch (stateError, s) {
-        _logError(
+        logError(
           'failed to update failure count',
           error: stateError,
           stackTrace: s,

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -1,5 +1,3 @@
-import 'dart:developer' as developer;
-
 import 'package:clock/clock.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
@@ -15,8 +13,10 @@ import 'package:lotti/features/agents/service/soul_document_service.dart';
 import 'package:lotti/features/agents/sync/agent_input_capture_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/agents/util/text_utils.dart';
 import 'package:lotti/features/agents/workflow/agent_wake_memory.dart';
+import 'package:lotti/features/agents/workflow/carrierless_attribution.dart';
 import 'package:lotti/features/agents/workflow/deferred_change_items.dart';
 import 'package:lotti/features/agents/workflow/project_agent_context_builder.dart';
 import 'package:lotti/features/agents/workflow/project_agent_strategy.dart';
@@ -32,7 +32,6 @@ import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
 import 'package:lotti/features/ai/util/profile_resolver.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
-import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -48,7 +47,7 @@ part 'project_agent_execute.dart';
 /// pattern). Fetches the project entity + linked tasks, builds a system prompt
 /// with project context, runs the conversation, and persists report,
 /// observations, and state updates.
-class ProjectAgentWorkflow {
+class ProjectAgentWorkflow with AgentErrorLogging {
   ProjectAgentWorkflow({
     required this.agentRepository,
     required this.conversationRepository,
@@ -74,7 +73,11 @@ class ProjectAgentWorkflow {
   final JournalRepository journalRepository;
   final AgentTemplateService templateService;
   final SoulDocumentService? soulDocumentService;
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentWorkflow;
   final void Function(String agentId)? onPersistedStateChanged;
 
   /// Captures the wake's project-linked journal entries into the agent's
@@ -97,7 +100,7 @@ class ProjectAgentWorkflow {
       ProjectAgentContextBuilder(
         agentRepository: agentRepository,
         journalRepository: journalRepository,
-        logError: _logError,
+        logError: logError,
       );
 
   void _log(String message, {String? subDomain}) {
@@ -106,24 +109,6 @@ class ProjectAgentWorkflow {
       message,
       subDomain: subDomain,
     );
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentWorkflow,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'ProjectAgentWorkflow',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   /// Execute a full wake cycle for the given project agent.
@@ -209,7 +194,7 @@ class ProjectAgentWorkflow {
         ),
       );
     } catch (e, s) {
-      _logError('failed to persist token usage', error: e, stackTrace: s);
+      logError('failed to persist token usage', error: e, stackTrace: s);
     }
   }
 

--- a/lib/features/agents/workflow/task_agent_execute.dart
+++ b/lib/features/agents/workflow/task_agent_execute.dart
@@ -67,7 +67,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
             linkedEntities: linked,
           );
         } catch (e) {
-          _logError('failed to fetch image AI responses for capture', error: e);
+          logError('failed to fetch image AI responses for capture', error: e);
         }
         captureSucceeded = await memory.capture(
           agentId: agentId,
@@ -85,7 +85,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
       } catch (e) {
         // Source rendering failed (the capture call itself absorbs its own
         // errors inside [AgentWakeMemory.capture]).
-        _logError('failed to capture wake inputs', error: e);
+        logError('failed to capture wake inputs', error: e);
       }
     }
 
@@ -307,7 +307,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
         ),
       );
     } catch (e) {
-      _logError('failed to persist system prompt', error: e);
+      logError('failed to persist system prompt', error: e);
       // Non-fatal: continue with execution even if audit fails.
     }
     try {
@@ -348,7 +348,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
         ),
       );
     } catch (e) {
-      _logError('failed to persist user message', error: e);
+      logError('failed to persist user message', error: e);
       // Non-fatal: continue with execution even if audit fails.
     }
 
@@ -549,7 +549,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
           soulVersionId: templateCtx.soulVersion?.id,
         );
       } catch (e) {
-        _logError('failed to record template provenance', error: e);
+        logError('failed to record template provenance', error: e);
         // Non-fatal: the wake can proceed without provenance tracking.
       }
 
@@ -723,7 +723,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
               toolName: '${TaskAgentReportEditor.auditToolPrefix}_failed',
               errorMessage: editResult.error.runtimeType.toString(),
             );
-            _logError(
+            logError(
               'report editor failed; preserving executor report',
               error: editResult.error,
               stackTrace: editResult.stackTrace,
@@ -760,7 +760,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
             toolName: '${TaskAgentReportEditor.auditToolPrefix}_failed',
             errorMessage: e.runtimeType.toString(),
           );
-          _logError(
+          logError(
             'report editor failed; preserving executor report',
             error: e,
             stackTrace: s,
@@ -866,7 +866,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
         mutatedEntries: executor.mutatedEntries,
       );
     } catch (e, s) {
-      _logError('wake failed', error: e, stackTrace: s);
+      logError('wake failed', error: e, stackTrace: s);
 
       // Suggestions flushed mid-wake are already committed and stay visible;
       // `WakeOutputWriter` never ran, so nothing else will raise their inbox
@@ -890,7 +890,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
           ),
         );
       } catch (stateError, s) {
-        _logError(
+        logError(
           'failed to update failure count',
           error: stateError,
           stackTrace: s,

--- a/lib/features/agents/workflow/task_agent_persistence_helpers.dart
+++ b/lib/features/agents/workflow/task_agent_persistence_helpers.dart
@@ -38,7 +38,7 @@ extension TaskAgentPersistenceHelpers on TaskAgentWorkflow {
         ),
       );
     } catch (e, s) {
-      _logError('failed to persist token usage', error: e, stackTrace: s);
+      logError('failed to persist token usage', error: e, stackTrace: s);
     }
   }
 
@@ -83,7 +83,7 @@ extension TaskAgentPersistenceHelpers on TaskAgentWorkflow {
         await store.deleteEntityEmbeddings(previousReportId);
       }
     } catch (e, s) {
-      _logError('failed to embed agent report', error: e, stackTrace: s);
+      logError('failed to embed agent report', error: e, stackTrace: s);
     }
   }
 }

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -23,6 +23,7 @@ import 'package:lotti/features/agents/service/task_agent_service.dart';
 import 'package:lotti/features/agents/sync/agent_input_capture_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/agents/workflow/agent_wake_memory.dart';
 import 'package:lotti/features/agents/workflow/change_proposal_filter.dart';
 import 'package:lotti/features/agents/workflow/change_set_builder.dart';
@@ -65,8 +66,8 @@ import 'package:uuid/uuid.dart';
 
 export 'package:lotti/features/agents/workflow/wake_result.dart';
 
-part 'task_agent_persistence_helpers.dart';
 part 'task_agent_execute.dart';
+part 'task_agent_persistence_helpers.dart';
 
 /// Assembles context, runs a conversation, and persists results for a single
 /// Task Agent wake cycle.
@@ -90,7 +91,7 @@ part 'task_agent_execute.dart';
 /// 12. Persist new observation notes (agentJournal entries).
 /// 13. Persist updated agent state (revision, wake counter, failure count).
 /// 14. Clean up the in-memory conversation in a `finally` block.
-class TaskAgentWorkflow {
+class TaskAgentWorkflow with AgentErrorLogging {
   TaskAgentWorkflow({
     required this.agentRepository,
     required this.conversationRepository,
@@ -133,7 +134,11 @@ class TaskAgentWorkflow {
   final SoulDocumentService? soulDocumentService;
 
   /// Optional domain logger for structured, PII-safe logging.
+  @override
   final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentWorkflow;
 
   /// Optional embedding dependencies. When both are provided, agent reports
   /// are embedded for vector search after persistence. The pipeline is
@@ -202,7 +207,7 @@ class TaskAgentWorkflow {
     syncService: syncService,
     aiInputRepository: aiInputRepository,
     journalDb: journalDb,
-    logError: _logError,
+    logError: logError,
   );
 
   void _log(String message, {String? subDomain}) {
@@ -211,24 +216,6 @@ class TaskAgentWorkflow {
       message,
       subDomain: subDomain,
     );
-  }
-
-  void _logError(String message, {Object? error, StackTrace? stackTrace}) {
-    if (domainLogger != null) {
-      domainLogger!.error(
-        LogDomain.agentWorkflow,
-        error ?? message,
-        message: error != null ? message : null,
-        stackTrace: stackTrace,
-      );
-    } else {
-      developer.log(
-        '$message${error != null ? ' (errorType=${error.runtimeType})' : ''}',
-        name: 'TaskAgentWorkflow',
-        error: error?.runtimeType,
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   /// Execute a full wake cycle for the given agent.
@@ -333,7 +320,7 @@ class TaskAgentWorkflow {
         rethrowInferenceErrors: true,
       );
     } catch (e, s) {
-      _logError(
+      logError(
         'forced update_report retry failed — persisting partial wake',
         error: e,
         stackTrace: s,

--- a/test/features/agents/util/agent_error_logging_test.dart
+++ b/test/features/agents/util/agent_error_logging_test.dart
@@ -1,0 +1,168 @@
+// The explicit `message: null` / `stackTrace: null` / `errorSummary: null`
+// arguments below sit inside `verify(...)` calls, where passing the default
+// explicitly *is* the assertion — the point is that the mixin forwarded null
+// rather than fabricating a value.
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+
+/// A workflow-shaped adopter: nullable logger, `agentWorkflow` domain.
+class _Workflow with AgentErrorLogging {
+  _Workflow(this.domainLogger);
+
+  @override
+  final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentWorkflow;
+}
+
+/// A runtime-shaped adopter, to prove the domain is per-class and not baked in.
+class _Runtime with AgentErrorLogging {
+  _Runtime(this.domainLogger);
+
+  @override
+  final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentRuntime;
+}
+
+/// An adopter that overrides the derived name.
+class _Renamed with AgentErrorLogging {
+  _Renamed(this.domainLogger);
+
+  @override
+  final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentRuntime;
+
+  @override
+  String get errorLogName => 'CustomName';
+}
+
+void main() {
+  late MockDomainLogger logger;
+
+  setUp(() {
+    logger = MockDomainLogger();
+    when(
+      () => logger.error(
+        any<LogDomain>(),
+        any<Object>(),
+        message: any<String?>(named: 'message'),
+        stackTrace: any<StackTrace?>(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) {});
+  });
+
+  group('with a structured logger', () {
+    test('logs the error as the subject and the message as context', () {
+      // The asymmetry matters to the log surfaces: when there is a cause, the
+      // cause is the logged object and the human sentence is metadata.
+      final error = StateError('boom');
+      final trace = StackTrace.current;
+
+      _Workflow(
+        logger,
+      ).logError('wake failed', error: error, stackTrace: trace);
+
+      verify(
+        () => logger.error(
+          LogDomain.agentWorkflow,
+          error,
+          message: 'wake failed',
+          stackTrace: trace,
+        ),
+      ).called(1);
+    });
+
+    test('logs the message as the subject when there is no cause', () {
+      // With no error, the sentence *is* the subject and `message` stays null —
+      // otherwise the log row would have an empty subject.
+      _Workflow(logger).logError('nothing to do');
+
+      verify(
+        () => logger.error(
+          LogDomain.agentWorkflow,
+          'nothing to do',
+          message: null,
+          stackTrace: null,
+        ),
+      ).called(1);
+    });
+
+    test('routes to the domain the adopting class declares', () {
+      _Runtime(logger).logError('scan failed');
+
+      verify(
+        () => logger.error(
+          LogDomain.agentRuntime,
+          'scan failed',
+          message: null,
+          stackTrace: null,
+        ),
+      ).called(1);
+    });
+
+    test('forwards a null stack trace rather than fabricating one', () {
+      final error = StateError('boom');
+
+      _Workflow(logger).logError('wake failed', error: error);
+
+      verify(
+        () => logger.error(
+          LogDomain.agentWorkflow,
+          error,
+          message: 'wake failed',
+          stackTrace: null,
+        ),
+      ).called(1);
+    });
+  });
+
+  group('without a structured logger', () {
+    // The fallback writes to `developer.log`, whose output is not observable
+    // from a test binding. These assert the reachable contract — that the
+    // fallback is taken silently and cannot throw — rather than pretending to
+    // verify the console text.
+    test('does not touch the logger and completes', () {
+      expect(
+        () => _Workflow(null).logError('wake failed', error: StateError('x')),
+        returnsNormally,
+      );
+      verifyNever(
+        () => logger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          message: any<String?>(named: 'message'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      );
+    });
+
+    test('completes with no cause and no stack trace', () {
+      expect(() => _Runtime(null).logError('idle'), returnsNormally);
+    });
+  });
+
+  group('errorLogName', () {
+    test('defaults to the concrete type, so a rename cannot leave it stale', () {
+      // This is why the name is derived rather than restated per class: the
+      // seven hand-written copies each hard-coded a string that a rename would
+      // silently orphan.
+      expect(_Workflow(logger).errorLogName, '_Workflow');
+      expect(_Runtime(logger).errorLogName, '_Runtime');
+    });
+
+    test('is overridable when a class needs a name that is not its own', () {
+      expect(_Renamed(logger).errorLogName, 'CustomName');
+    });
+  });
+}

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/wake/scheduled_wake_manager.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -276,16 +277,52 @@ void main() {
 
   ScheduledWakeManager createAndStart({
     Duration checkInterval = const Duration(minutes: 1),
+    DomainLogger? domainLogger,
   }) {
     return ScheduledWakeManager(
       repository: repository,
       orchestrator: orchestrator,
       syncService: syncService,
       checkInterval: checkInterval,
+      domainLogger: domainLogger,
     )..start();
   }
 
   group('ScheduledWakeManager', () {
+    test('a failed pass is contained and reported as runtime', () async {
+      // The manager polls on a timer. A failing pass must not escape into the
+      // timer callback — an uncaught error there would tear down the poll and
+      // silently stop every scheduled wake for the rest of the process.
+      //
+      // Also pins the domain: `agentRuntime`, so these are visible to a reader
+      // filtering runtime failures rather than workflow ones.
+      final logger = MockDomainLogger();
+      when(
+        () => logger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          message: any<String?>(named: 'message'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).thenAnswer((_) {});
+      when(
+        () => repository.getDueScheduledAgentStates(any()),
+      ).thenAnswer((_) async => throw StateError('due query failed'));
+
+      final manager = createAndStart(domainLogger: logger);
+      addTearDown(manager.stop);
+      await pumpEventQueue();
+
+      verify(
+        () => logger.error(
+          LogDomain.agentRuntime,
+          any<Object>(),
+          message: 'error checking scheduled wakes',
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).called(1);
+    });
+
     glados.Glados(
       glados.any.scheduledWakeBatchScenario,
       glados.ExploreConfig(numRuns: 180),

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -257,6 +257,75 @@ void main() {
       );
 
       test(
+        'a failed stale-watermark write is contained and reported',
+        () async {
+          // The watermark is a hint that the report has drifted, not the report
+          // itself. A failed write must not escape into the notification
+          // listener that triggered it — that stream drives every subscription,
+          // so an error there would stop content gating for all agents.
+          final signalAt = DateTime(2026, 7, 16, 9, 30);
+          final state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(activeTaskId: 'entity-1'),
+                    updatedAt: DateTime(2026, 7, 16, 9),
+                    vectorClock: null,
+                  )
+                  as AgentStateEntity;
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+
+          final logger = MockDomainLogger();
+          when(
+            () => logger.error(
+              any<LogDomain>(),
+              any<Object>(),
+              message: any<String?>(named: 'message'),
+              stackTrace: any<StackTrace?>(named: 'stackTrace'),
+            ),
+          ).thenAnswer((_) {});
+
+          orchestrator =
+              WakeOrchestrator(
+                  repository: mockRepository,
+                  queue: queue,
+                  runner: runner,
+                  syncEntityWriter: (_) async =>
+                      throw StateError('watermark write failed'),
+                  domainLogger: logger,
+                )
+                ..disableAutomaticUpdatesRuntime('agent-1')
+                ..addSubscription(makeSub());
+          final controller = StreamController<Set<String>>.broadcast();
+
+          await withClock(Clock.fixed(signalAt), () async {
+            await orchestrator.start(controller.stream);
+            controller.add({'entity-1'});
+            await pumpEventQueue();
+          });
+
+          // Reported under the runtime domain, naming the agent by sanitized id
+          // so the diagnostic is actionable without leaking content.
+          verify(
+            () => logger.error(
+              LogDomain.agentRuntime,
+              any<Object>(),
+              message: any<String?>(
+                named: 'message',
+                that: contains('failed to persist stale report watermark'),
+              ),
+              stackTrace: any<StackTrace?>(named: 'stackTrace'),
+            ),
+          ).called(1);
+          // The wake path stayed unaffected.
+          expect(queue.isEmpty, isTrue);
+          await controller.close();
+        },
+      );
+
+      test(
         'requestContentWake marks the report stale without queueing '
         'inference when automatic updates are off',
         () async {

--- a/test/features/agents/wake/wake_throttle_coordinator_test.dart
+++ b/test/features/agents/wake/wake_throttle_coordinator_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/wake/wake_throttle_coordinator.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:meta/meta.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -326,16 +327,66 @@ void main() {
   WakeThrottleCoordinator createCoordinator({
     required Future<void> Function() onDrainRequested,
     void Function(String agentId)? onPersistedStateChanged,
+    DomainLogger? domainLogger,
   }) {
     return WakeThrottleCoordinator(
       repository: repository,
       onDrainRequested: onDrainRequested,
       onPersistedStateChanged: onPersistedStateChanged,
       throttleWindow: _generatedThrottleWindow,
+      domainLogger: domainLogger,
     );
   }
 
   group('WakeThrottleCoordinator', () {
+    test('a failed deadline persist is contained and reported as runtime', () {
+      // Throttling is an in-memory decision; the persisted `nextWakeAt` only
+      // survives a restart. A write failure must therefore not propagate into
+      // the caller that was merely recording a deadline.
+      //
+      // Also pins the domain: these failures belong to `agentRuntime`, not
+      // `agentWorkflow`, because a reader filtering on the workflow domain
+      // would otherwise never see them.
+      final logger = MockDomainLogger();
+      when(
+        () => logger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          message: any<String?>(named: 'message'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).thenAnswer((_) {});
+      when(
+        () => repository.upsertEntity(any()),
+      ).thenAnswer((_) async => throw StateError('write failed'));
+
+      fakeAsync((async) {
+        final coordinator = createCoordinator(
+          onDrainRequested: () async {},
+          domainLogger: logger,
+        );
+        addTearDown(coordinator.dispose);
+
+        expect(
+          () => coordinator.setDeadline('agent-1'),
+          returnsNormally,
+        );
+        async.flushMicrotasks();
+      });
+
+      verify(
+        () => logger.error(
+          LogDomain.agentRuntime,
+          any<Object>(),
+          message: any<String?>(
+            named: 'message',
+            that: contains('failed to persist throttle deadline'),
+          ),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).called(1);
+    });
+
     test('setDeadline persists next wake timestamp and notifies', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final persistedAgentIds = <String>[];

--- a/test/features/agents/workflow/carrierless_attribution_test.dart
+++ b/test/features/agents/workflow/carrierless_attribution_test.dart
@@ -1,0 +1,344 @@
+// The explicit `message: null` / `stackTrace: null` / `errorSummary: null`
+// arguments below sit inside `verify(...)` calls, where passing the default
+// explicitly *is* the assertion — the point is that the mixin forwarded null
+// rather than fabricating a value.
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/util/agent_error_logging.dart';
+import 'package:lotti/features/agents/workflow/carrierless_attribution.dart';
+import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
+import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
+import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../ai_consumption/test_utils.dart';
+
+/// Stands in for the workflow that owns the call.
+class _Caller with AgentErrorLogging {
+  _Caller(this.domainLogger);
+
+  @override
+  final DomainLogger? domainLogger;
+
+  @override
+  LogDomain get errorLogDomain => LogDomain.agentWorkflow;
+}
+
+void main() {
+  late MockAiAttributionService attribution;
+  late MockDomainLogger logger;
+  late _Caller caller;
+
+  // The shared harness already registers AiWorkAttribution, AiWorkStatus and
+  // the artifact list this file's `any(named:)` matchers need.
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    attribution = MockAiAttributionService();
+    logger = MockDomainLogger();
+    caller = _Caller(logger);
+    when(
+      () => logger.error(
+        any<LogDomain>(),
+        any<Object>(),
+        message: any<String?>(named: 'message'),
+        stackTrace: any<StackTrace?>(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) {});
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  /// Registers whichever halves of the consumption pair the test needs.
+  void register({bool capture = true, bool attribute = true}) {
+    if (capture) {
+      getIt.registerSingleton<AiInteractionCapture>(MockAiInteractionCapture());
+    }
+    if (attribute) {
+      getIt.registerSingleton<AiAttributionService>(attribution);
+    }
+  }
+
+  group('canRecordAgentConsumption', () {
+    test('requires both halves of the pair', () {
+      expect(canRecordAgentConsumption, isFalse);
+
+      register(attribute: false);
+      expect(canRecordAgentConsumption, isFalse);
+    });
+
+    test('is true only when capture and attribution are both registered', () {
+      register();
+      expect(canRecordAgentConsumption, isTrue);
+    });
+
+    test('is false when attribution is registered without capture', () {
+      // Attribution alone would open an envelope over interactions nobody
+      // records, which is worse than not accounting at all.
+      register(capture: false);
+      expect(canRecordAgentConsumption, isFalse);
+    });
+  });
+
+  group('prepareAgentReportAttribution', () {
+    /// Stubs `prepareCompletion` for the two-argument report call, which relies
+    /// on the service's default `status`/`errorCode` rather than passing them.
+    void stubPrepare() {
+      when(
+        () => attribution.prepareCompletion(
+          attributionId: any(named: 'attributionId'),
+          outputs: any(named: 'outputs'),
+        ),
+      ).thenAnswer((_) async => makeAiWorkAttribution(attributionId: 'a1'));
+    }
+
+    test('opens an envelope naming the report as its output', () async {
+      register();
+      stubPrepare();
+
+      final envelope = await prepareAgentReportAttribution(
+        runKey: 'run-1',
+        reportId: 'report-1',
+      );
+
+      expect(envelope, isNotNull);
+      verify(
+        () => attribution.prepareCompletion(
+          // Derived from the run key, so the envelope the wake later finalizes
+          // is the one it opened here.
+          attributionId: agentWakeAttributionId('run-1'),
+          outputs: const [
+            AiArtifactReference(
+              type: AiArtifactType.agentReport,
+              id: 'report-1',
+            ),
+          ],
+        ),
+      ).called(1);
+    });
+
+    test('returns null when the wake produced no report', () async {
+      register();
+      stubPrepare();
+
+      expect(
+        await prepareAgentReportAttribution(runKey: 'run-1', reportId: null),
+        isNull,
+      );
+      verifyZeroInteractions(attribution);
+    });
+
+    // The regression: attribution alone used to be enough to open an envelope,
+    // so a process with attribution but no capture attributed a wake whose
+    // interaction rows nobody was recording — an envelope over nothing, with a
+    // cost of zero, indistinguishable in the consumption surfaces from a wake
+    // that genuinely spent nothing.
+    test(
+      'returns null when attribution is registered without capture',
+      () async {
+        register(capture: false);
+
+        expect(
+          await prepareAgentReportAttribution(
+            runKey: 'run-1',
+            reportId: 'report-1',
+          ),
+          isNull,
+        );
+        verifyZeroInteractions(attribution);
+      },
+    );
+
+    test('returns null when neither half is registered', () async {
+      register(capture: false, attribute: false);
+
+      expect(
+        await prepareAgentReportAttribution(
+          runKey: 'run-1',
+          reportId: 'report-1',
+        ),
+        isNull,
+      );
+      verifyZeroInteractions(attribution);
+    });
+  });
+
+  group('finalizeCarrierlessAgentAttribution', () {
+    test('closes the envelope with the given status and error code', () async {
+      register();
+      when(
+        () => attribution.prepareCompletion(
+          attributionId: any(named: 'attributionId'),
+          outputs: any(named: 'outputs'),
+          status: any(named: 'status'),
+          errorCode: any(named: 'errorCode'),
+          errorSummary: any(named: 'errorSummary'),
+        ),
+      ).thenAnswer(
+        (_) async => makeAiWorkAttribution(attributionId: 'a1'),
+      );
+      when(() => attribution.finalize(any())).thenAnswer((_) async {});
+
+      await finalizeCarrierlessAgentAttribution(
+        runKey: 'run-1',
+        status: AiWorkStatus.failed,
+        errorCode: 'inference_unavailable',
+        errorSummary: 'no route',
+        logger: caller,
+      );
+
+      verify(
+        () => attribution.prepareCompletion(
+          // Derived from the run key, so the envelope closed is the one the
+          // wake opened.
+          attributionId: agentWakeAttributionId('run-1'),
+          outputs: const [],
+          status: AiWorkStatus.failed,
+          errorCode: 'inference_unavailable',
+          errorSummary: 'no route',
+        ),
+      ).called(1);
+      verify(() => attribution.finalize(any())).called(1);
+    });
+
+    test('does nothing when the consumption pair is unavailable', () async {
+      register(capture: false, attribute: false);
+
+      await finalizeCarrierlessAgentAttribution(
+        runKey: 'run-1',
+        status: AiWorkStatus.failed,
+        errorCode: 'x',
+        logger: caller,
+      );
+
+      verifyZeroInteractions(attribution);
+    });
+
+    test('does nothing when only capture is registered', () async {
+      register(attribute: false);
+
+      await expectLater(
+        finalizeCarrierlessAgentAttribution(
+          runKey: 'run-1',
+          status: AiWorkStatus.failed,
+          errorCode: 'x',
+          logger: caller,
+        ),
+        completes,
+      );
+      verifyZeroInteractions(attribution);
+    });
+
+    test('contains a prepareCompletion failure and reports it', () async {
+      // Bookkeeping must never fail an otherwise-successful wake, so the error
+      // is logged and swallowed rather than propagated.
+      register();
+      when(
+        () => attribution.prepareCompletion(
+          attributionId: any(named: 'attributionId'),
+          outputs: any(named: 'outputs'),
+          status: any(named: 'status'),
+          errorCode: any(named: 'errorCode'),
+          errorSummary: any(named: 'errorSummary'),
+        ),
+      ).thenAnswer((_) async => throw StateError('session gone'));
+
+      await expectLater(
+        finalizeCarrierlessAgentAttribution(
+          runKey: 'run-1',
+          status: AiWorkStatus.failed,
+          errorCode: 'x',
+          logger: caller,
+        ),
+        completes,
+      );
+
+      verify(
+        () => logger.error(
+          LogDomain.agentWorkflow,
+          any<Object>(),
+          message: 'failed to terminalize carrier-less attribution',
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).called(1);
+      verifyNever(() => attribution.finalize(any()));
+    });
+
+    test('contains a finalize failure and reports it', () async {
+      register();
+      when(
+        () => attribution.prepareCompletion(
+          attributionId: any(named: 'attributionId'),
+          outputs: any(named: 'outputs'),
+          status: any(named: 'status'),
+          errorCode: any(named: 'errorCode'),
+          errorSummary: any(named: 'errorSummary'),
+        ),
+      ).thenAnswer(
+        (_) async => makeAiWorkAttribution(attributionId: 'a1'),
+      );
+      when(
+        () => attribution.finalize(any()),
+      ).thenAnswer((_) async => throw StateError('write failed'));
+
+      await expectLater(
+        finalizeCarrierlessAgentAttribution(
+          runKey: 'run-1',
+          status: AiWorkStatus.failed,
+          errorCode: 'x',
+          logger: caller,
+        ),
+        completes,
+      );
+
+      verify(
+        () => logger.error(
+          LogDomain.agentWorkflow,
+          any<Object>(),
+          message: 'failed to terminalize carrier-less attribution',
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).called(1);
+    });
+
+    test('passes a null errorSummary through unchanged', () async {
+      register();
+      when(
+        () => attribution.prepareCompletion(
+          attributionId: any(named: 'attributionId'),
+          outputs: any(named: 'outputs'),
+          status: any(named: 'status'),
+          errorCode: any(named: 'errorCode'),
+          errorSummary: any(named: 'errorSummary'),
+        ),
+      ).thenAnswer(
+        (_) async => makeAiWorkAttribution(attributionId: 'a1'),
+      );
+      when(() => attribution.finalize(any())).thenAnswer((_) async {});
+
+      await finalizeCarrierlessAgentAttribution(
+        runKey: 'run-2',
+        status: AiWorkStatus.partial,
+        errorCode: 'output_carrier_unavailable',
+        logger: caller,
+      );
+
+      verify(
+        () => attribution.prepareCompletion(
+          attributionId: agentWakeAttributionId('run-2'),
+          outputs: const [],
+          status: AiWorkStatus.partial,
+          errorCode: 'output_carrier_unavailable',
+          errorSummary: null,
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/features/agents/workflow/task_agent_workflow_memory_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_memory_test.dart
@@ -7,9 +7,11 @@ import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/projection/content_digest.dart';
 import 'package:lotti/features/agents/workflow/task_agent_workflow.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
+import '../../../test_data/test_data.dart';
 import 'task_agent_workflow_test_helpers.dart';
 
 void main() {
@@ -113,6 +115,95 @@ void main() {
           // The workflow rendered the linked journal entry into a source.
           expect(capture.sources.map((s) => s.contentEntryId), ['linked-1']);
           expect(capture.sources.single.content['text'], 'a captured note');
+        },
+      );
+
+      test(
+        'an image-analysis lookup failure degrades the capture, not the wake',
+        () async {
+          // Image AI analyses hang off the image, not the task, so they need a
+          // second bulk lookup. That lookup is an enrichment: losing it must
+          // capture *without* analyses rather than skip the capture or fail the
+          // wake, because the task sources themselves are already in hand.
+          final capture = RecordingCaptureService();
+          final linkedEntry = makeLinkedTimeEntry(
+            id: 'linked-1',
+            dateFrom: DateTime(2024, 6),
+            dateTo: DateTime(2024, 6),
+            text: 'a captured note',
+          );
+          // A linked *image* is required: the enrichment lookup short-circuits
+          // when the task has none, so without one the failing call is never
+          // reached and this test would pass vacuously.
+          when(
+            () => mockJournalDb.getLinkedEntities(taskId),
+          ).thenAnswer((_) async => [linkedEntry, testImageEntry]);
+          when(
+            () => mockJournalDb.getBulkLinkedEntities(any()),
+          ).thenAnswer((_) async => throw StateError('bulk lookup failed'));
+
+          final logger = MockDomainLogger();
+          when(
+            () => logger.error(
+              any<LogDomain>(),
+              any<Object>(),
+              message: any<String?>(named: 'message'),
+              stackTrace: any<StackTrace?>(named: 'stackTrace'),
+            ),
+          ).thenAnswer((_) {});
+
+          final workflow = createTestWorkflow(
+            agentRepository: mockAgentRepository,
+            conversationRepository: mockConversationRepository,
+            aiInputRepository: mockAiInputRepository,
+            aiConfigRepository: mockAiConfigRepository,
+            journalDb: mockJournalDb,
+            cloudInferenceRepository: mockCloudInferenceRepository,
+            journalRepository: mockJournalRepository,
+            checklistRepository: mockChecklistRepository,
+            labelsRepository: mockLabelsRepository,
+            syncService: mockSyncService,
+            templateService: mockTemplateService,
+            inputCaptureService: capture,
+            domainLogger: logger,
+          );
+          stubFullExecutePath(
+            mockAgentRepository: mockAgentRepository,
+            mockAiInputRepository: mockAiInputRepository,
+            mockAiConfigRepository: mockAiConfigRepository,
+            mockConversationManager: mockConversationManager,
+            testAgentState: testAgentState,
+            geminiModel: geminiModel,
+            geminiProvider: geminiProvider,
+            agentId: agentId,
+            taskId: taskId,
+          );
+
+          final result = await workflow.execute(
+            agentIdentity: testAgentIdentity,
+            runKey: runKey,
+            triggerTokens: {},
+            threadId: threadId,
+          );
+
+          // Wake succeeded, and the capture still carries both task sources —
+          // the note and the image itself. Only the image's *analyses* were
+          // lost, which is the degradation this path is designed for.
+          expect(result.success, isTrue);
+          expect(capture.callCount, 1);
+          expect(
+            capture.sources.map((s) => s.contentEntryId),
+            containsAll(['linked-1', testImageEntry.meta.id]),
+          );
+          // And the lost enrichment was reported rather than swallowed.
+          verify(
+            () => logger.error(
+              LogDomain.agentWorkflow,
+              any<Object>(),
+              message: 'failed to fetch image AI responses for capture',
+              stackTrace: any<StackTrace?>(named: 'stackTrace'),
+            ),
+          ).called(1);
         },
       );
 


### PR DESCRIPTION
> **Stacked on #3836.** Base is `refactor/dd-1-break-agents-daily-os-cycle`, so review that one first — this diff shows only DD-2's changes.

## Why

Two duplications where a fix to one copy leaves the others behind:

**1. `_logError` — seven byte-identical copies.** 17 lines each, differing only in the `LogDomain` and the `developer.log` source name:

```
agents/wake/wake_orchestrator.dart
agents/wake/scheduled_wake_manager.dart
agents/wake/wake_throttle_coordinator.dart
agents/workflow/task_agent_workflow.dart
agents/workflow/project_agent_workflow.dart
agents/workflow/event_agent_workflow.dart
agents/service/project_activity_monitor.dart
```

These methods enforce a hard privacy rule (`knowledge/features/agents/persistence-and-sync.md` — "Diagnostics are content-free": the fallback may log `error.runtimeType`, never the error). Seven copies means that rule was being upheld in seven independent places.

**2. The carrier-less attribution closure — two copies.** ~24 identical lines inlined in `event_agent_workflow.dart` and `project_agent_execute.dart`, plus the same two-registration guard.

**Behaviour is unchanged.** Net **−133 lines** of production code.

## What replaces them

`agents/util/agent_error_logging.dart` — the `AgentErrorLogging` mixin. Adopters now declare two things instead of seventeen lines: the logger field and their `errorLogDomain`.

The `developer.log` name is **derived** from the concrete type rather than restated per class, so a rename cannot leave a diagnostic naming a class that no longer exists. This is behaviour-identical: all seven hard-coded strings were already exactly their own class names, and nothing in the build configuration passes `--obfuscate`.

`agents/workflow/carrierless_attribution.dart` — `finalizeCarrierlessAgentAttribution` plus `canRecordAgentConsumption`. Both halves of the consumption pair are required, because attribution without capture opens an envelope over nothing; the close is contained, because bookkeeping must never turn a successful wake into a failed one.

### `DayAgentWorkflow` deliberately does not adopt the mixin

Same signature, genuinely different body: its logger is non-nullable and it has **no fallback branch at all**. Folding it in would add an unreachable-but-real code path and break the "behaviour unchanged" claim. Recorded in both the mixin docstring and the concept so it doesn't read as an eighth copy left behind.

## A comment that should always have been there

`event_agent_workflow.dart` persists its user message as a full blob where the near-identical project path writes a v2 prompt record (ADR 0020). That difference is **deliberate** — a v1 event agent is a narrate-only recap with no compacted memory log, so nothing in its prompt is derivable and there is nothing to elide.

Nothing said so. During the audit that produced this work, the silence read as silent drift, with one path "behind" the other. It isn't. The comment now states why, because that misreading cost real investigation time and would cost the next reader the same.

## Verification

- `flutter analyze` — **0 issues** across `lib` + `test`
- `test/features/agents` + `test/features/daily_os_next` — **7,927 passed, 9 skipped, 0 failed** (skips pre-existing)
- 17 new tests across the two new files
- **Regression-checked:** breaking the mixin's error/message asymmetry fails 2 tests, so they are not vacuous
- `make okf_check` / `make knowledge_check` — clean

## On measuring this

The obvious metric misleads here, so stating it plainly: shared 8-line windows between `event_agent_workflow.dart` and `project_agent_execute.dart` went **74 → 111** despite both files shrinking. That is an artefact — removing unique lines from between two shared regions merges them into one longer run, and overlapping windows then count more.

The defensible numbers are the duplicated *definitions*: **7 → 1** and **2 → 0**, for −133 production lines. The remaining parallelism between those two files is the shared wake-pipeline shape, deliberately left for a follow-up.

## Not in scope

The wake-pipeline template, the `evolution` / `soul_evolution` UI trees (52/47/41 duplicated blocks), and the inference provider adapters (gemini vs gemini-multiturn 56, melious vs mistral 39). Those are the bulk of the duplication in this area; this PR takes the two cases that carried actual correctness risk.

## No CHANGELOG entry

Nothing here is observable at runtime — an internal refactor, which `AGENTS.md` says to skip. **No screenshots** for the same reason: not a pixel changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recording agent attribution when a wake ends without producing model output, including failed or skipped runs.
  - Added centralized handling for agent errors with structured details and safe fallback logging.

- **Bug Fixes**
  - Improved resilience across scheduled wakes, workflows, persistence, and activity updates so operational failures are logged without unnecessarily interrupting processing.
  - Preserved successful wake outcomes when enrichment or attribution services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->