### PR TITLE
fix(nav): land on Tasks in every new service generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type is distinguishable without relying on colour. The linked-entries list
   shows a "More below" control while the list continues past the panel edge,
   and its fade no longer makes a scrollable section look disabled.
+- **Lotti opens on Tasks, and the demo no longer leaves traces in your own
+  journal's navigation.** Starting the app — or switching between the demo
+  world and your own — now always lands on the Tasks tab. Each tab also
+  returns to its own starting point, so leaving the demo while a demo entry
+  was open no longer leaves that tab pointing at an entry that only existed
+  in the demo.
 - **The penguin demo is easier to read and explore.** Its persistent banner is
   shorter, more prominent, and themed blue, with the exit action aligned in
   the same row; the exit sheet buttons align inline when space permits and

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -39,6 +39,7 @@
   <releases>
     <release version="1.0.4" date="2026-08-05">
       <description>
+        <p>Fixed: Lotti opens on Tasks, and the demo no longer leaves traces in your own journal's navigation. Starting the app — or switching between the demo world and your own — now always lands on the Tasks tab. Each tab also returns to its own starting point, so leaving the demo while a demo entry was open no longer leaves that tab pointing at an entry that only existed in the demo.</p>
         <p>Added: knowledge-graph photos now open full screen. Tapping an image in the graph inspector's photo carousel opens the shared full-screen viewer with zoom, rotation and download, and — new for collections — chevron buttons and the left/right arrow keys move through all of the entry's photos, with a position counter showing where you are.</p>
         <p>Fixed: the penguin demo banner is shorter, more prominent, and blue-themed, with its exit action aligned inline. The exit sheet buttons align inline when space permits and wrap safely when needed, seeded tasks have task-specific four-step checklists, and edits to seeded rows are preserved across seed updates.</p>
         <p>Changed: demo image downloads now show live progress. The demo banner reports the completed image count while its R2 catalog hydrates in the background, without delaying entry into the workspace.</p>

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -26,6 +26,7 @@ class NavService {
   }) {
     _journalDb = journalDb ?? getIt<JournalDb>();
     _settingsDb = settingsDb ?? getIt<SettingsDb>();
+    resetTabsToRoots();
 
     _navigationFlagsSub =
         Rx.combineLatest5<
@@ -147,6 +148,29 @@ class NavService {
   final BeamerDelegate tasksDelegate = tasksBeamerDelegate;
   final BeamerDelegate calendarDelegate = calendarBeamerDelegate;
   final BeamerDelegate settingsDelegate = settingsBeamerDelegate;
+
+  /// Sends every tab back to its root path and selects Tasks.
+  ///
+  /// The per-tab [BeamerDelegate]s are top-level finals, so they OUTLIVE
+  /// `getIt.reset()` — a profile switch replaces this service, the databases
+  /// and the whole widget tree, but not them. Without this, a tab kept the
+  /// route it held in the previous world: exit the demo after opening a
+  /// logbook entry and the Logbook tab still pointed at that demo entry's id,
+  /// which does not exist in the real journal. It also left the app on
+  /// whichever tab the previous world ended on, rather than the Tasks landing
+  /// this app defaults to.
+  ///
+  /// Called from the constructor, so it runs once per service generation —
+  /// which is exactly once per world, on cold start and on every switch.
+  void resetTabsToRoots() {
+    for (final spec in _tabSpecs) {
+      // Unconditionally, including disabled tabs: a flag can be turned back
+      // on later, and a stale route must not be waiting behind it.
+      spec.delegate.beamToReplacementNamed(spec.rootPath);
+    }
+    currentPath = _enabledTabSpecs.first.rootPath;
+    index = 0;
+  }
 
   bool get isHabitsPageEnabled => _isHabitsPageEnabled;
   bool get isDashboardsPageEnabled => _isDashboardsPageEnabled;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.4+4293
+version: 1.0.4+4294
 
 msix_config:
   display_name: LottiApp

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -890,5 +890,71 @@ void main() {
         },
       );
     });
+
+    group('landing tab per service generation', () {
+      // Every tab's BeamerDelegate is a top-level final, so it survives
+      // `getIt.reset()` — a profile switch replaces this service, the
+      // databases and the widget tree, but not them.
+      NavService buildGeneration() => NavService(
+        journalDb: mockJournalDb,
+        settingsDb: settingsDb,
+      );
+
+      test(
+        "a new generation lands on Tasks and forgets the previous world's "
+        'routes',
+        () async {
+          // The user walks into the Logbook and opens an entry, then leaves
+          // the app sitting there — e.g. inside the demo world.
+          final previousWorld = buildGeneration()
+            ..beamToNamed('/journal/demo-entry-id');
+          expect(
+            previousWorld.currentPath,
+            '/journal/demo-entry-id',
+          );
+          expect(
+            previousWorld.index,
+            previousWorld.journalIndex,
+          );
+          await previousWorld.dispose();
+
+          // Switching profiles bootstraps a fresh service generation.
+          final nextWorld = buildGeneration();
+          addTearDown(nextWorld.dispose);
+
+          expect(
+            nextWorld.index,
+            0,
+            reason: 'a new world must land on the Tasks tab',
+          );
+          expect(nextWorld.currentPath, '/tasks');
+          expect(
+            nextWorld.journalDelegate.configuration.uri.path,
+            '/journal',
+            reason:
+                'the Logbook tab still pointed at an entry id from the world '
+                'the user just left',
+          );
+          expect(nextWorld.tasksDelegate.configuration.uri.path, '/tasks');
+        },
+      );
+
+      test('every tab root is restored, including disabled ones', () async {
+        final previousWorld = buildGeneration();
+        // Events is disabled in this harness; its delegate can still be
+        // carrying a route from a world where the flag was on.
+        previousWorld.eventsDelegate.beamToReplacementNamed('/events/stale-id');
+        await previousWorld.dispose();
+
+        final nextWorld = buildGeneration();
+        addTearDown(nextWorld.dispose);
+
+        expect(
+          nextWorld.eventsDelegate.configuration.uri.path,
+          '/events',
+          reason: 'a disabled tab kept a stale route behind its flag',
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes two related navigation complaints: the app lands on **Logbook** instead of Tasks when switching between the demo world and the real one, and the same on ordinary app start.

## Root cause

Every tab's `BeamerDelegate` is a **top-level final** in `lib/beamer/beamer_delegates.dart`, so it outlives `getIt.reset()`. A profile switch tears down the service generation, the databases and the whole widget tree — but not the delegates. They kept the route they held in the world the user just left.

This is easy to miss by reading `NavService` alone: its own fields already default to `currentPath = '/tasks'` and `index = 0`, so the service looks right in isolation. I confirmed the real state with a probe across two generations:

```
gen1  index=1  path=/journal/demo-entry-id  journalDelegate=/journal/demo-entry-id
gen2  index=0  path=/tasks                  journalDelegate=/journal/demo-entry-id   ← stale
                                            tasksDelegate=/                          ← NotFound for its own locationBuilder
```

So the new world started with the Logbook tab pointing at an entry id that **does not exist in the real journal**, and the Tasks delegate sitting at `/`, which its own `locationBuilder` maps to `NotFound`.

## Fix

`NavService.resetTabsToRoots()`, called from the constructor — once per service generation, i.e. exactly once per world, covering both cold start and every switch. It beams each tab back to its root path and selects Tasks.

Disabled tabs are reset too, deliberately: a config flag can be turned back on later, and a stale route from an abandoned world must not be waiting behind it.

## Tests

Two regression tests in `nav_service_test.dart` that assert on the **delegates' configuration**, which is where the stale state actually lived — asserting on `index`/`currentPath` alone would pass either way and prove nothing:

1. A new generation lands on Tasks and the Logbook delegate no longer points at the previous world's entry.
2. Every tab root is restored, including tabs disabled by a flag.

Both were re-run against the reverted fix and fail as required. No regressions: the full `test/services`, `test/beamer` and `test/features/tasks` suites pass (2,400+ tests), plus a sample of the 96 test files that touch `NavService`.

Analyzer clean; CHANGELOG + flatpak metainfo updated; version bumped to 1.0.4+4293.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The app now opens on the Tasks tab at startup.
  * Switching between the demo environment and personal journal starts each tab at its correct location.
  * Stale navigation paths are cleared, including paths from disabled tabs.
  * Returning to a workspace no longer restores unrelated navigation history.

* **Documentation**
  * Added release notes for version 1.0.4 covering the navigation fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->