### PR TITLE
docs: lead README and Flathub copy with the personal-assistant framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduce Lotti as a private logbook with a staff of personal AI assistants
   — agents that read what you record and propose the next step, while proposed
   changes wait for your approval — and describe sync by its durable guarantee:
-  no server ever sees your data in readable form.
+  no server ever holds your data in readable form.
 
 ## [1.0.4]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **The store listing and README now say what Lotti actually is.** Both now
   introduce Lotti as a private logbook with a staff of personal AI assistants
-  — agents that read what you record and propose the next step, while every
-  change waits for your approval — and describe sync by its durable guarantee:
-  your data is never stored on any server.
+  — agents that read what you record and propose the next step, while proposed
+  changes wait for your approval — and describe sync by its durable guarantee:
+  no server ever sees your data in readable form.
 
 ## [1.0.4]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5]
+### Changed
+- **The store listing and README now say what Lotti actually is.** Both now
+  introduce Lotti as a private logbook with a staff of personal AI assistants
+  — agents that read what you record and propose the next step, while every
+  change waits for your approval — and describe sync by its durable guarantee:
+  your data is never stored on any server.
+
 ## [1.0.4]
 ### Added
 - **Knowledge-graph photos now open full screen.** Tapping an image in the

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -80,7 +80,7 @@ Lotti requests only the permissions it actually uses. What each one captures sta
 - ❌ No sharing with third parties, except the AI providers you configure
 - ❌ No backend servers collecting your data
 
-To be precise about what this does *not* say: two destinations you choose do receive something. The homeserver you configure receives, stores and relays your sync payloads as ciphertext — a transit store rather than an archive: nothing depends on it keeping history, because a device that already holds the data re-sends whatever a peer is missing — and it can see the account and traffic metadata that comes with relaying. The AI providers you configure receive the content of the requests routed to them. Neither is Lotti, and neither gets plaintext it was not given deliberately.
+To be precise about what this does *not* say: two destinations you choose do receive something. The homeserver you configure receives, stores and relays your sync payloads as ciphertext — a transit store rather than an archive: nothing depends on it keeping history, because a device that already holds the data re-sends whatever a peer is missing — and it can see the account and traffic metadata that comes with relaying. Sync never hands anything readable to a server, period. The AI providers you configure do receive the content of the requests you route to them — that is a configuration choice you made, not leakage. Neither destination is Lotti.
 
 Diagnostic logs are local too. *Settings → Advanced → Logging* controls routine diagnostic logging per domain; errors are always recorded regardless of those toggles. Either way the files stay on your device until you choose to share them.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -80,7 +80,7 @@ Lotti requests only the permissions it actually uses. What each one captures sta
 - ❌ No sharing with third parties, except the AI providers you configure
 - ❌ No backend servers collecting your data
 
-To be precise about what this does *not* say: two destinations you choose do receive something. The homeserver you configure receives, stores and relays your sync payloads as ciphertext, and can see the account and traffic metadata that comes with them. The AI providers you configure receive the content of the requests routed to them. Neither is Lotti, and neither gets plaintext it was not given deliberately.
+To be precise about what this does *not* say: two destinations you choose do receive something. The homeserver you configure receives, stores and relays your sync payloads as ciphertext — a transit store rather than an archive: nothing depends on it keeping history, because a device that already holds the data re-sends whatever a peer is missing — and it can see the account and traffic metadata that comes with relaying. The AI providers you configure receive the content of the requests routed to them. Neither is Lotti, and neither gets plaintext it was not given deliberately.
 
 Diagnostic logs are local too. *Settings → Advanced → Logging* controls routine diagnostic logging per domain; errors are always recorded regardless of those toggles. Either way the files stay on your device until you choose to share them.
 

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ emoji-font packages, is in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Status
 
-Currently 1.0.x. The application is in active daily use and
+The application is in active daily use and
 the agentic layer is real, working, and shipping. Development happens in the
 open, and the [changelog](CHANGELOG.md) is the honest version of what changed.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ as separate facts. Tasks, planned blocks, tracked time, voice notes, journal
 entries, habits, and health data live in a local database on your own devices,
 looked after by a staff of personal AI assistants: persistent agents that read
 what you record, keep the mess summarised, and propose the next step — while
-proposed changes wait for your approval. No server ever sees your data in
-readable form; sync is end-to-end encrypted, and the relay between your devices
-stores and forwards only ciphertext it cannot read. AI is optional, and when
-you do set it up, the route
+proposed changes wait for your approval. No server ever holds your data in
+readable form; sync is end-to-end encrypted, and the relay between your
+devices holds only ciphertext — not forever. AI is optional, and when you do
+set it up, the route
 Lotti recommends is European infrastructure running open-weight models.
 
 macOS · Linux · Windows · iOS · Android. Flutter and Dart, GPL-3.0, in
@@ -60,10 +60,11 @@ storage layout rather than by careful prompting — see
   </picture>
 </p>
 
-**No server ever sees your data in the clear.** Your logbook lives on your
-devices. Sync is end-to-end encrypted, so the relay you choose stores and
-forwards only ciphertext it cannot read. No telemetry, and nothing uploaded
-to Lotti.
+**No server ever holds your data in readable form.** Your logbook lives on
+your devices. Sync is end-to-end encrypted: the relay you choose holds only
+ciphertext, not forever, and nothing depends on it keeping anything — a new
+device catches up because your other devices re-send history, not because a
+server archived it. No telemetry, and nothing uploaded to Lotti.
 
 **You choose the brain, and you can see what it cost.** Route each category of
 your life to the compute you are willing to stand behind: a local model for the
@@ -236,8 +237,8 @@ you configured them: ciphertext to the homeserver you chose, and inference
 requests to the provider you chose.
 
 *The other side of that:* there is no server-side backup and no account
-recovery, because no server ever holds a readable copy of your data. Sync is
-the redundancy story — but it is
+recovery, because no server holds a readable or lasting copy of your data.
+Sync is the redundancy story — but it is
 not automatic history. Pairing a device gives it everything written *from then
 on*; your existing settings and back catalogue arrive only when you run *Send
 settings* and *Send message history* from the device that already has them.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 
 Lotti records what you meant to do and what actually happened, and keeps them
 as separate facts. Tasks, planned blocks, tracked time, voice notes, journal
-entries, habits, and health data live in a local database on your own devices.
-There is no Lotti account and no Lotti server. AI is optional, and when
-you do set it up, the route Lotti recommends is European infrastructure running
-open-weight models. Nothing reaches your history without your approval.
+entries, habits, and health data live in a local database on your own devices,
+looked after by a staff of personal AI assistants: persistent agents that read
+what you record, keep the mess summarised, and propose the next step — while
+every change waits for your approval. Your data is never stored on any server;
+sync is end-to-end encrypted and only ever relays ciphertext between your own
+devices, ephemerally. AI is optional, and when you do set it up, the route
+Lotti recommends is European infrastructure running open-weight models.
 
 macOS · Linux · Windows · iOS · Android. Flutter and Dart, GPL-3.0, in
 development since 2016.
@@ -56,9 +59,9 @@ storage layout rather than by careful prompting — see
   </picture>
 </p>
 
-**There is no Lotti server.** Your logbook lives on your devices. Sync is
-self-hosted and end-to-end encrypted, so the relay only ever handles
-ciphertext. No account, no telemetry, and nothing uploaded to Lotti.
+**Your data never touches server-side storage.** Your logbook lives on your
+devices. Sync is end-to-end encrypted and ephemeral, so the relay only ever
+handles ciphertext in passing. No telemetry, and nothing uploaded to Lotti.
 
 **You choose the brain, and you can see what it cost.** Route each category of
 your life to the compute you are willing to stand behind: a local model for the
@@ -221,8 +224,9 @@ three. They are worth separating, because they fail in different ways.
 
 ### Your logbook is not collected
 
-There is no Lotti server. No account, no telemetry, no analytics, and nothing
-uploaded to Lotti. Entries live in local SQLite on each of your devices, with
+Nothing you record is ever stored server-side. No telemetry, no analytics, and
+nothing uploaded to Lotti. Entries live in local SQLite on each of your
+devices, with
 attachments beside it on the filesystem. That is structural rather than a policy
 commitment: there is nowhere for the data to go, and you can confirm it by
 reading the source or watching the traffic. Two things do leave, both because
@@ -230,7 +234,8 @@ you configured them: ciphertext to the homeserver you chose, and inference
 requests to the provider you chose.
 
 *The other side of that:* there is no server-side backup and no account
-recovery, because there is no account. Sync is the redundancy story — but it is
+recovery, because nothing of yours is stored on a server. Sync is the
+redundancy story — but it is
 not automatic history. Pairing a device gives it everything written *from then
 on*; your existing settings and back catalogue arrive only when you run *Send
 settings* and *Send message history* from the device that already has them.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ as separate facts. Tasks, planned blocks, tracked time, voice notes, journal
 entries, habits, and health data live in a local database on your own devices,
 looked after by a staff of personal AI assistants: persistent agents that read
 what you record, keep the mess summarised, and propose the next step — while
-every change waits for your approval. Your data is never stored on any server;
-sync is end-to-end encrypted and only ever relays ciphertext between your own
-devices, ephemerally. AI is optional, and when you do set it up, the route
+proposed changes wait for your approval. No server ever sees your data in
+readable form; sync is end-to-end encrypted, and the relay between your devices
+stores and forwards only ciphertext it cannot read. AI is optional, and when
+you do set it up, the route
 Lotti recommends is European infrastructure running open-weight models.
 
 macOS · Linux · Windows · iOS · Android. Flutter and Dart, GPL-3.0, in
@@ -59,9 +60,10 @@ storage layout rather than by careful prompting — see
   </picture>
 </p>
 
-**Your data never touches server-side storage.** Your logbook lives on your
-devices. Sync is end-to-end encrypted and ephemeral, so the relay only ever
-handles ciphertext in passing. No telemetry, and nothing uploaded to Lotti.
+**No server ever sees your data in the clear.** Your logbook lives on your
+devices. Sync is end-to-end encrypted, so the relay you choose stores and
+forwards only ciphertext it cannot read. No telemetry, and nothing uploaded
+to Lotti.
 
 **You choose the brain, and you can see what it cost.** Route each category of
 your life to the compute you are willing to stand behind: a local model for the
@@ -224,8 +226,8 @@ three. They are worth separating, because they fail in different ways.
 
 ### Your logbook is not collected
 
-Nothing you record is ever stored server-side. No telemetry, no analytics, and
-nothing uploaded to Lotti. Entries live in local SQLite on each of your
+Lotti collects nothing. No telemetry, no analytics, and nothing uploaded to
+Lotti. Entries live in local SQLite on each of your
 devices, with
 attachments beside it on the filesystem. That is structural rather than a policy
 commitment: there is nowhere for the data to go, and you can confirm it by
@@ -234,8 +236,8 @@ you configured them: ciphertext to the homeserver you chose, and inference
 requests to the provider you chose.
 
 *The other side of that:* there is no server-side backup and no account
-recovery, because nothing of yours is stored on a server. Sync is the
-redundancy story — but it is
+recovery, because no server ever holds a readable copy of your data. Sync is
+the redundancy story — but it is
 not automatic history. Pairing a device gives it everything written *from then
 on*; your existing settings and back catalogue arrive only when you run *Send
 settings* and *Send message history* from the device that already has them.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ emoji-font packages, is in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Status
 
-Currently 0.9.x, working toward 1.0. The application is in active daily use and
+Currently 1.0.x. The application is in active daily use and
 the agentic layer is real, working, and shipping. Development happens in the
 open, and the [changelog](CHANGELOG.md) is the honest version of what changed.
 

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -7,13 +7,13 @@
   <summary>Private logbook with AI assistants</summary>
   <description>
     <p>
-      Lotti gives you a private logbook and a staff of personal AI assistants to go with it. Record your day the way it actually happens — tasks, tracked time, voice notes, transcriptions, journal entries, habits, and health data — and long-living agents read what you record, keep it summarised, remember the context you would otherwise lose, and propose the next step. Nothing changes without your approval: agents suggest, you decide.
+      Lotti gives you a private logbook and a staff of personal AI assistants to go with it. Record your day the way it actually happens — tasks, tracked time, voice notes, transcriptions, journal entries, habits, and health data — and long-living agents read what you record, keep it summarised, remember the context you would otherwise lose, and propose the next step. Agents suggest, you decide: every proposed change waits for your approval, with one small exception — an initial title or language for an otherwise empty task.
     </p>
     <p>
-      All of it happens on your own devices. Your data is never stored on any server: multi-device sync is end-to-end encrypted and relays only ciphertext, ephemerally, between devices you have verified. There is no telemetry. On capable hardware the AI models run locally too, so your data never has to leave the machine; on lighter hardware, or to save battery, you route inference — per life category — to a cloud provider you choose. Your logbook is an ordinary SQLite file on your own disk, readable without Lotti, so there is nothing to export and nothing to unlock.
+      All of it happens on your own devices. No server ever sees your data in readable form: multi-device sync is end-to-end encrypted, and the homeserver you choose stores and relays only ciphertext, with keys that reach only devices you have verified. There is no telemetry. On capable hardware the AI models run locally too, so your data never has to leave the machine; on lighter hardware, or to save battery, you route inference — per life category — to a cloud provider you choose. Your logbook is ordinary SQLite on your own disk with attachments in ordinary files beside it, readable without Lotti, so there is nothing to export and nothing to unlock.
     </p>
     <p>
-      Under the hood, sync runs over Matrix using Vodozemac (Rust) for Megolm crypto; the homeserver relays only ciphertext between your own devices, and encryption keys reach only devices you have verified.
+      Under the hood, sync runs over Matrix using Vodozemac (Rust) for Megolm crypto; how long encrypted history stays available for catching up new devices depends on the homeserver you run.
     </p>
     <p>Get support and join the Lotti community on Discord via the Contact link.</p>
     <p>What it does:</p>
@@ -42,7 +42,7 @@
   <releases>
     <release version="1.0.5" date="2026-08-07">
       <description>
-        <p>Changed: the store listing and README now say what Lotti actually is. Both introduce Lotti as a private logbook with a staff of personal AI assistants — agents that read what you record and propose the next step, while every change waits for your approval — and describe sync by its durable guarantee: your data is never stored on any server.</p>
+        <p>Changed: the store listing and README now say what Lotti actually is. Both introduce Lotti as a private logbook with a staff of personal AI assistants — agents that read what you record and propose the next step, while proposed changes wait for your approval — and describe sync by its durable guarantee: no server ever sees your data in readable form.</p>
       </description>
     </release>
     <release version="1.0.4" date="2026-08-05">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -10,10 +10,10 @@
       Lotti gives you a private logbook and a staff of personal AI assistants to go with it. Record your day the way it actually happens — tasks, tracked time, voice notes, transcriptions, journal entries, habits, and health data — and long-living agents read what you record, keep it summarised, remember the context you would otherwise lose, and propose the next step. Agents suggest, you decide: every proposed change waits for your approval, with one small exception — an initial title or language for an otherwise empty task.
     </p>
     <p>
-      All of it happens on your own devices. No server ever sees your data in readable form: multi-device sync is end-to-end encrypted, and the homeserver you choose stores and relays only ciphertext, with keys that reach only devices you have verified. There is no telemetry. On capable hardware the AI models run locally too, so your data never has to leave the machine; on lighter hardware, or to save battery, you route inference — per life category — to a cloud provider you choose. Your logbook is ordinary SQLite on your own disk with attachments in ordinary files beside it, readable without Lotti, so there is nothing to export and nothing to unlock.
+      All of it happens on your own devices. No server ever holds your data in readable form: multi-device sync is end-to-end encrypted, and the relay between your verified devices holds only ciphertext — not forever, and nothing depends on it keeping anything. There is no telemetry. On capable hardware the AI models run locally too, so your data never has to leave the machine; on lighter hardware, or to save battery, you route inference — per life category — to a cloud provider you choose. Your logbook is ordinary SQLite on your own disk with attachments in ordinary files beside it, readable without Lotti, so there is nothing to export and nothing to unlock.
     </p>
     <p>
-      Under the hood, sync runs over Matrix using Vodozemac (Rust) for Megolm crypto; how long encrypted history stays available for catching up new devices depends on the homeserver you run.
+      Under the hood, sync runs over Matrix using Vodozemac (Rust) for Megolm crypto; the homeserver relays only ciphertext between your own devices, and encryption keys reach only devices you have verified. A new device catches up because your other devices re-send history, not because a server stored it.
     </p>
     <p>Get support and join the Lotti community on Discord via the Contact link.</p>
     <p>What it does:</p>
@@ -42,7 +42,7 @@
   <releases>
     <release version="1.0.5" date="2026-08-07">
       <description>
-        <p>Changed: the store listing and README now say what Lotti actually is. Both introduce Lotti as a private logbook with a staff of personal AI assistants — agents that read what you record and propose the next step, while proposed changes wait for your approval — and describe sync by its durable guarantee: no server ever sees your data in readable form.</p>
+        <p>Changed: the store listing and README now say what Lotti actually is. Both introduce Lotti as a private logbook with a staff of personal AI assistants — agents that read what you record and propose the next step, while proposed changes wait for your approval — and describe sync by its durable guarantee: no server ever holds your data in readable form.</p>
       </description>
     </release>
     <release version="1.0.4" date="2026-08-05">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -4,13 +4,16 @@
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
   <name>Lotti</name>
-  <summary>Open-source private logbook with a local agentic layer</summary>
+  <summary>Private logbook with AI assistants</summary>
   <description>
     <p>
-      Lotti is an open-source personal logbook — tasks, time recordings, voice notes, transcriptions, journal entries, habits, and health data — paired with an agentic layer of long-living AI agents that observe, suggest, summarise, and nudge. The agents run on your machine. With a powerful enough device, the model they call can run locally too — meaning your data never has to leave the device at all. On lighter hardware, or when you need to save battery, you keep the same agentic experience and route inference to a cloud provider you choose, on a per-category basis.
+      Lotti gives you a private logbook and a staff of personal AI assistants to go with it. Record your day the way it actually happens — tasks, tracked time, voice notes, transcriptions, journal entries, habits, and health data — and long-living agents read what you record, keep it summarised, remember the context you would otherwise lose, and propose the next step. Nothing changes without your approval: agents suggest, you decide.
     </p>
     <p>
-      No accounts, no telemetry, no cloud storage. End-to-end encrypted multi-device sync runs over Matrix using Vodozemac (Rust) for Megolm crypto; the homeserver you bring relays only ciphertext between your own devices, and encryption keys reach only devices you have verified. Your logbook is an ordinary SQLite file on your own disk, readable without Lotti, so there is nothing to export and nothing to unlock.
+      All of it happens on your own devices. Your data is never stored on any server: multi-device sync is end-to-end encrypted and relays only ciphertext, ephemerally, between devices you have verified. There is no telemetry. On capable hardware the AI models run locally too, so your data never has to leave the machine; on lighter hardware, or to save battery, you route inference — per life category — to a cloud provider you choose. Your logbook is an ordinary SQLite file on your own disk, readable without Lotti, so there is nothing to export and nothing to unlock.
+    </p>
+    <p>
+      Under the hood, sync runs over Matrix using Vodozemac (Rust) for Megolm crypto; the homeserver relays only ciphertext between your own devices, and encryption keys reach only devices you have verified.
     </p>
     <p>Get support and join the Lotti community on Discord via the Contact link.</p>
     <p>What it does:</p>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.5" date="2026-08-07">
+      <description>
+        <p>Changed: the store listing and README now say what Lotti actually is. Both introduce Lotti as a private logbook with a staff of personal AI assistants — agents that read what you record and propose the next step, while every change waits for your approval — and describe sync by its durable guarantee: your data is never stored on any server.</p>
+      </description>
+    </release>
     <release version="1.0.4" date="2026-08-05">
       <description>
         <p>Fixed: Lotti opens on Tasks, and the demo no longer leaves traces in your own journal's navigation. Starting the app — or switching between the demo world and your own — now always lands on the Tasks tab. Each tab also returns to its own starting point, so leaving the demo while a demo entry was open no longer leaves that tab pointing at an entry that only existed in the demo.</p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.4+4294
+version: 1.0.5+4295
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
## What

Reframes the public-facing copy — README opening, Flathub summary and description — around the product's actual promise: a private logbook looked after by a staff of personal AI assistants, with every change waiting for approval.

## Why

- The old copy led with what Lotti *isn't* (no account, no server) and with insider vocabulary ("agentic layer", "Matrix + Vodozemac") before saying what it does for the user.
- "No account" is not a durable claim: a paid hosted-sync option is planned (deliberately unmentioned here until it ships). The durable claim is that **user data is never stored on any server** — sync relays only ciphertext, ephemerally. All server-related claims now lean on that instead.
- The Flathub summary ("Open-source private logbook with a local agentic layer", 54 chars) exceeded Flathub's ~35-char quality guideline; it is now "Private logbook with AI assistants" (34 chars).
- The Matrix/Vodozemac/Megolm detail moves from the Flathub opener into an "under the hood" third paragraph.

The GitHub repo tagline was updated to match (not part of this diff — repo metadata).

No CHANGELOG entry: no runtime behaviour changes.

## Validation

- `xmllint --noout` passes on the metainfo; `appstreamcli validate` reports only pre-existing notes in old release-notes sections (lines 823+), untouched by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated privacy and data-handling information to clarify local storage, encrypted synchronization, ephemeral relay handling, and AI infrastructure options.
  - Clarified European infrastructure and configured provider options for AI requests.
  - Expanded the app description to highlight local-first storage, encrypted synchronization, no telemetry, configurable AI inference, and approval-controlled agent actions.
  - Added version 1.0.5 release notes and updated the displayed app version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->