### PR TITLE
fix(eval): stop the task-agent suite failing correct model behaviour

### DIFF
--- a/docs/evaluations/task_agent_models/README.md
+++ b/docs/evaluations/task_agent_models/README.md
@@ -75,6 +75,23 @@ The two additional held-out constraint scenarios are:
 - `active_deployment_constraint`: keep deployment pending and its active
   external constraint visible.
 
+### Demo-world scenario
+
+`LOCAL_TASK_AGENT_EVAL_PENGUIN_LANGUAGES=1` replaces the suite with
+`penguin_scrubber_production`, which is built from the shipped demo world
+(`lib/features/demo/seed/demo_world.dart`) rather than from fixtures written
+for the eval. The wake context carries the air-scrubber task's enriched
+description, its full four-item checklist with real completion state, and a
+log entry reporting one item done and a deadline move. It therefore measures
+the model against the same material a user meets on their first run: complete
+exactly one checklist item, move the due date, leave the pending cartridge
+return untouched, and keep internal IDs out of the report.
+
+The suite is English-only. The demo world carries reviewed copy in all eleven
+supported languages, so a localized suite is possible — but the wake
+instruction has to come from that translated demo content, not from
+translations authored in the eval directory.
+
 The default run uses the `production` prompt only. `compactModel` adds an
 explicit extract, mutate, verify, and report sequence. `qualityFocused` adds a
 strict report-quality gate that forbids tool-log achievements, H1 titles, empty
@@ -101,7 +118,9 @@ Set `LOTTI_MELIOUS_ENV_FILE` or `MELIOUS_API_KEY` for another environment. Use
 `LOCAL_TASK_AGENT_EVAL_STRICT=1` only when a known-good matrix should gate.
 Set `LOCAL_TASK_AGENT_EVAL_EXECUTION_MODE=twoPass` to reproduce the rejected
 two-pass orchestration experiment described below. The default is
-`singlePass`.
+`singlePass`. A full matrix can exceed the test's ten-minute default budget —
+raise it with `LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES`, since a run that trips
+the timeout writes no artifacts at all.
 
 Set `LOCAL_TASK_AGENT_EVAL_EVOLVED_DIRECTIVES=1` to replace the default suite
 with seven synthetic evolved-report cases. They exercise decision-memo,
@@ -254,6 +273,145 @@ These numbers are directional rather than release thresholds. They are based on
 one deterministic sample per case and synthetic replay data. Repeated runs and
 sanitized real task histories are still required before changing the default
 model.
+
+## Findings from 2026-08-07
+
+DeepSeek V4 Flash 0731 was screened as a candidate task-agent executor against
+GLM 5.2 and Kimi K3. One sample per scenario at temperature 0, the production
+prompt, `singlePass`, model judge disabled; each scenario ran as its own
+invocation so a stall costs one case rather than the matrix.
+
+The first run scored GLM 10/14, Kimi 9/14 and DeepSeek 7/14. Investigating the
+failures found nine defects in the suite itself, all of which penalised correct
+behaviour; they are listed below and are fixed. Re-measured afterwards:
+
+| Model | Passing scenarios | Before the suite fixes |
+| --- | ---: | ---: |
+| GLM 5.2 | 14 / 14 | 10 / 14 |
+| Kimi K3 | 14 / 14 | 9 / 14 |
+| DeepSeek V4 Flash 0731 | 10 / 14 | 7 / 14 |
+
+Two of the three candidates now pass every scenario. Treat the earlier column
+as a measurement of the suite, not of the models.
+
+Latency separates them further: on the clean matrix GLM completed the suite in
+38 s with a 5.9 s worst case and Kimi in 159 s with an 18.9 s worst case, while
+DeepSeek needed 760 s and stalled for 360 s on one scenario. Those stalls are
+intermittent — the same scenario later finished in 7.5 s — so they are not a
+stable model property and may be provider congestion.
+
+**DeepSeek V4 Flash 0731 is not viable for task-agent work**, and its four
+remaining failures survived every suite correction.
+
+It invents tool names. On `metadata_explicit` it called `set_task_estimate`,
+which does not exist, with `{"estimate": "2.5"}` where the real
+`update_task_estimate` takes integer minutes — three times in five
+observations. On `progress_update` it called `update_task_status`, where the
+real name is `set_task_status`. It guesses the prefix in both directions,
+which the registry invites by mixing `set_task_title`, `set_task_language` and
+`set_task_status` with `update_task_estimate`, `update_task_due_date` and
+`update_task_priority`. GLM and Kimi absorb that inconsistency; DeepSeek does
+not.
+
+Critically, it does not recover. Once the harness began returning the
+dispatcher's real `Unknown tool` error, DeepSeek received it, did not retry
+with the correct name, and published a report describing the task as
+configured while the user's requested estimate was never set.
+
+It also mutates what nobody asked for: `update_task_priority` twice on
+`progress_update`, and on `latest_deadline_wins` only `record_observations`
+and `update_report`, never setting the due date the scenario requires. Its
+fourth failure, `no_op_background_refresh`, was an `inferenceFailed` after
+195 s — infrastructure rather than judgement.
+
+### The suite's own defects
+
+Seven checks were penalising correct behaviour. They are listed here because
+each one silently lowered every model's score, and two of them contradicted
+directives the same prompt gives the agent.
+
+1. **Forbidden terms ignored negation.** "The fix is *not yet* validated"
+   scored identically to a claim that it was validated. All three models
+   failed `user_completed_item_resurfaced` for this alone. Terms a correct
+   report may name in order to rule out now live in `forbiddenReportClaims`,
+   matched only in affirmative context, with a negation window on both sides —
+   English negates before the claim, German after.
+2. **`spanish_mixed_context` banned a correct status change**, described
+   below.
+3. **`metadata_explicit` required the report to echo "P1"** while the report
+   directive forbids narrating metadata changes. The mutation is already
+   asserted through `expectedToolCalls`.
+4. **`implicit_workflow_plan` demanded the literal verb "implement"**, which
+   passed only because an earlier fixture happened to contain
+   "implementation"; "fix the seeding so empty profiles are no longer
+   selectable" is the same step.
+5. **`deferred_scope_filter` forbade "underway"** on a task whose status is
+   `IN PROGRESS` and whose log calls the certificate work active. The word was
+   accurate.
+6. **The harness confirmed fabricated tools.** `processToolCalls` answered
+   every call with "Eval harness accepted <name>", including names that do not
+   exist, where `TaskToolDispatcher` returns an error the model can recover
+   from. The harness now mirrors the dispatcher.
+7. **`HttpOverrides.global` was never cleared**, so the test binding failed
+   every request with a synthetic HTTP 400 in under 100 ms and scored 0%. A
+   run that trips the test timeout also discarded all artifacts; the timeout is
+   now configurable and runs are executed per scenario.
+
+`spanish_mixed_context` is a broken expectation, not a model failure. All three
+models produced the identical sequence — `add_multiple_checklist_items`,
+`set_task_status`, `update_report` — at 100% content quality, and all three
+failed only because `set_task_status` is absent from `allowedExtraToolNames`.
+The task's log says *"Seguimos bloqueados porque el proveedor no ha enviado las
+credenciales"* while its status still reads `IN PROGRESS`, so marking it
+blocked with a grounded reason is correct behaviour. Correcting this scenario
+raises every model by one: GLM 11, Kimi 10, DeepSeek 8.
+
+`user_completed_item_resurfaced` failed for all three models, and
+`deferred_scope_filter` for two of three, both on report content. The report
+directive never states that an idea the user explicitly deferred must stay out
+of the public report — `deferred` appears in `seeded_directive_content.dart`
+only in reference to deferred *tools* and the deferred-proposal mechanism —
+yet the suite asserts `forbiddenReportTerms: ['newsletter']` against exactly
+that unwritten rule. Kimi passes `messy_german_transcript`, so the rule is
+inferable, but a rule only the strongest model infers belongs in the contract.
+
+### What the failures taught us about the suite
+
+Every one of the nine defects has the same root cause: **substring matching
+standing in for semantic judgement.** It cannot see negation, cannot see
+paraphrase, and fails precisely when a model expresses the right thing in
+unexpected words — which capable models do more often, not less. Two checks
+also contradicted directives the same system prompt issues, so a model was
+penalised for obeying its instructions.
+
+The practical rule for new scenarios: assert mutations through
+`expectedToolCalls`, where the contract is exact, and keep report assertions
+to facts that must appear rather than phrasings that must match. Use
+`forbiddenReportClaims` for anything a correct report may legitimately mention
+in order to rule out, and reserve `forbiddenReportTerms` for strings that must
+never appear at all, such as internal identifiers.
+
+### Recommended changes
+
+- Normalise the task-field tool names onto one prefix. This is now evidence-
+  backed rather than speculative: DeepSeek fabricated names in both directions,
+  and the registry's mixed `set_*`/`update_*` scheme is what invites it.
+- Leave the report directive alone. The deferred-scope rule looked like a
+  prompt gap when three models failed those scenarios, but all three pass them
+  once the checks stop matching negated mentions. There is no prompt change to
+  make here.
+
+Retaining GLM 5.2 as the high-end thinking model is supported by this run.
+Nothing here re-opens the shipped Qwen/Mistral routing, which these scenarios
+did not exercise.
+
+### Caveats
+
+One sample per scenario on a backend that is not deterministic even at
+temperature 0. Run-to-run variance is real and was observed repeatedly: a
+fabricated tool call, a 305 s stall, and two of Kimi's failures all failed to
+reproduce on a second sample. Treat single-scenario differences as noise and
+only repeated, inspected failures as signal.
 
 ## Findings from 2026-07-12
 

--- a/docs/evaluations/task_agent_models/README.md
+++ b/docs/evaluations/task_agent_models/README.md
@@ -377,12 +377,17 @@ inferable, but a rule only the strongest model infers belongs in the contract.
 
 ### What the failures taught us about the suite
 
-Every one of the nine defects has the same root cause: **substring matching
-standing in for semantic judgement.** It cannot see negation, cannot see
-paraphrase, and fails precisely when a model expresses the right thing in
-unexpected words — which capable models do more often, not less. Two checks
-also contradicted directives the same system prompt issues, so a model was
-penalised for obeying its instructions.
+Five of the nine defects share one root cause: **substring matching standing in
+for semantic judgement.** It cannot see negation, cannot see paraphrase, and
+fails precisely when a model expresses the right thing in unexpected words —
+which capable models do more often, not less.
+
+The other four have separate causes worth naming, because they will not be
+caught by better matching. Two are scenario contracts that contradicted
+directives the same system prompt issues, so a model was penalised for obeying
+its instructions. One is harness fidelity: the runner accepted tools the
+dispatcher rejects. Two are test infrastructure: leaked `HttpOverrides` and a
+timeout that discarded results.
 
 The practical rule for new scenarios: assert mutations through
 `expectedToolCalls`, where the contract is exact, and keep report assertions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.5+4296
+version: 1.0.5+4297
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/eval/local_task_agent_inference_eval_live_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_live_test.dart
@@ -12,11 +12,17 @@ import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
 
 import 'support/local_task_agent_inference_eval.dart';
+import 'support/penguin_task_agent_eval_scenarios.dart';
 
 void main() {
   test(
     'writes a local task-agent inference report',
     () async {
+      // The test binding installs a mock HttpOverrides whose client instantly
+      // fails every request with HTTP 400 — clear it so the eval can reach a
+      // real provider.
+      HttpOverrides.global = null;
+
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final conversationSubscription = container.listen(
@@ -58,14 +64,18 @@ void main() {
       final useEvolvedDirectiveSuite =
           Platform.environment['LOCAL_TASK_AGENT_EVAL_EVOLVED_DIRECTIVES'] ==
           '1';
+      final usePenguinSuite =
+          Platform.environment['LOCAL_TASK_AGENT_EVAL_PENGUIN_LANGUAGES'] ==
+          '1';
+      final variants = requestedVariants.isEmpty
+          ? const [LocalTaskAgentEvalPromptVariant.production]
+          : requestedVariants;
       final defaultScenarios = isMeliousMatrix
-          ? useEvolvedDirectiveSuite
+          ? usePenguinSuite
+                ? penguinTaskAgentEvalScenarios(variants: variants)
+                : useEvolvedDirectiveSuite
                 ? evolvedReportDirectiveTaskAgentEvalScenarios()
-                : defaultMeliousTaskAgentEvalScenarios(
-                    variants: requestedVariants.isEmpty
-                        ? const [LocalTaskAgentEvalPromptVariant.production]
-                        : requestedVariants,
-                  )
+                : defaultMeliousTaskAgentEvalScenarios(variants: variants)
           : [defaultLocalTaskAgentWakeScenario()];
       final scenarios = selectLocalTaskAgentEvalScenarios(
         defaultScenarios,
@@ -130,7 +140,19 @@ void main() {
     skip: Platform.environment['LOTTI_LOCAL_TASK_AGENT_EVAL_LIVE'] == '1'
         ? null
         : 'Set LOTTI_LOCAL_TASK_AGENT_EVAL_LIVE=1 to run local oMLX inference.',
-    timeout: const Timeout(Duration(minutes: 10)),
+    // A full matrix is profiles x scenarios x prompt variants, and single
+    // cases have been observed stalling for minutes behind provider queues.
+    // Override with LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES for longer runs.
+    timeout: Timeout(
+      Duration(
+        minutes:
+            int.tryParse(
+              Platform.environment['LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES'] ??
+                  '',
+            ) ??
+            10,
+      ),
+    ),
   );
 }
 

--- a/test/features/ai/eval/local_task_agent_inference_eval_live_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_live_test.dart
@@ -145,12 +145,9 @@ void main() {
     // Override with LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES for longer runs.
     timeout: Timeout(
       Duration(
-        minutes:
-            int.tryParse(
-              Platform.environment['LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES'] ??
-                  '',
-            ) ??
-            10,
+        minutes: parseLocalTaskAgentEvalTimeoutMinutes(
+          Platform.environment['LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES'],
+        ),
       ),
     ),
   );

--- a/test/features/ai/eval/local_task_agent_inference_eval_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_test.dart
@@ -576,10 +576,16 @@ void main() {
         (scenario) => scenario.id.startsWith('active_deployment_constraint'),
       );
 
+      // The deferred dashboard may be named to rule it out, so it is a claim
+      // rather than a banned string; overclaiming status stays absolute.
       expect(
-        deferred.forbiddenReportTerms,
+        deferred.forbiddenReportClaims,
         containsAll(['dashboard', 'analytics']),
       );
+      // "underway" is accurate for this IN PROGRESS task, so it must not be
+      // forbidden in any form.
+      expect(deferred.forbiddenReportTerms, isNot(contains('underway')));
+      expect(deferred.forbiddenReportClaims, isNot(contains('underway')));
       expect(deferred.userMessage, contains('as checklist items'));
       expect(
         deferred.requiredToolArgumentTermGroups[TaskAgentToolNames
@@ -697,6 +703,261 @@ void main() {
     expect(result.passedQualityCheckCount, 11);
     expect(result.qualityScore, 1);
     expect(result.reportToolCall?.name, TaskAgentToolNames.updateReport);
+  });
+
+  group('tool responses match the production dispatcher', () {
+    test('a fabricated tool name is answered with an error, not success', () {
+      // Both names were invented by DeepSeek V4 Flash 0731 on 2026-08-07; the
+      // real tools are update_task_estimate and set_task_status. The harness
+      // used to reply "accepted", so the model never learned it had guessed.
+      for (final fabricated in ['set_task_estimate', 'update_task_status']) {
+        expect(isKnownTaskAgentToolName(fabricated), isFalse);
+        final response = localTaskAgentEvalToolResponse(
+          toolName: fabricated,
+          hasValidJsonArguments: true,
+        );
+        expect(response, contains('Unknown tool: $fabricated'));
+        expect(response, isNot(contains('accepted')));
+      }
+    });
+
+    test('the real counterparts are recognised', () {
+      for (final real in [
+        TaskAgentToolNames.updateTaskEstimate,
+        TaskAgentToolNames.setTaskStatus,
+        TaskAgentToolNames.updateReport,
+      ]) {
+        expect(isKnownTaskAgentToolName(real), isTrue);
+        expect(
+          localTaskAgentEvalToolResponse(
+            toolName: real,
+            hasValidJsonArguments: true,
+          ),
+          'Eval harness accepted $real.',
+        );
+      }
+    });
+
+    test('invalid arguments to a real tool still report bad JSON', () {
+      expect(
+        localTaskAgentEvalToolResponse(
+          toolName: TaskAgentToolNames.updateReport,
+          hasValidJsonArguments: false,
+        ),
+        contains('invalid JSON'),
+      );
+    });
+  });
+
+  group('checks agree with the shipped report contract', () {
+    test('adding the investigation the context asks for is allowed', () {
+      // Verbatim from the 2026-08-08 Kimi K3 run. The QA note says
+      // "Investigation is needed; no root cause yet", so creating that item is
+      // the requested behaviour; only undoing the user's checkmark is banned.
+      final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+        (scenario) => scenario.id.startsWith('user_completed_item_resurfaced'),
+      );
+      expect(
+        scenario.allowedExtraToolNames,
+        contains(TaskAgentToolNames.addMultipleChecklistItems),
+      );
+      expect(
+        scenario.forbiddenToolNames,
+        contains(TaskAgentToolNames.updateChecklistItems),
+      );
+      expect(
+        scenario.expectedToolCalls,
+        isEmpty,
+        reason: 'The investigation item is permitted, never required',
+      );
+    });
+
+    test('a report may omit the priority it correctly set', () {
+      // Verbatim shape from the 2026-08-07 Kimi K3 run: every metadata
+      // mutation was correct, and the report omitted "P1" because the report
+      // directive forbids narrating metadata changes.
+      final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+        (scenario) => scenario.id.startsWith('metadata_explicit'),
+      );
+      final result = LocalTaskAgentEvalCaseResult(
+        profile: profile,
+        scenario: scenario,
+        provider: provider,
+        latencyMs: 10,
+        toolCalls: const [
+          LocalTaskAgentEvalToolCall(
+            name: TaskAgentToolNames.updateReport,
+            argumentsJson:
+                '{"oneLiner":"App-shaped eval of candidate model due July 4","tldr":"The candidate task-agent model needs a real app-shaped eval before it can be trusted; the reference model already passes.","content":"Due 2026-07-04 with a 150 minute estimate. Compare the candidate against the reference model."}',
+          ),
+        ],
+        failureCategory: LocalTaskAgentEvalFailureCategory.none,
+      );
+
+      expect(
+        scenario.requiredReportTermGroups.any(
+          (group) => group.contains('p1'),
+        ),
+        isFalse,
+        reason: 'Echoing the priority contradicts the report directive',
+      );
+      expect(result.passedQualityCheckCount, result.qualityCheckCount);
+    });
+
+    test('checklist wording may say "empty inference profiles"', () {
+      // Verbatim from the 2026-08-08 Kimi K3 run. All six actions were
+      // correct; the check demanded the substring "empty profile" and
+      // "empty inference profiles" does not contain it.
+      final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+        (scenario) => scenario.id.startsWith('implicit_workflow_plan'),
+      );
+      final result = LocalTaskAgentEvalCaseResult(
+        profile: profile,
+        scenario: scenario,
+        provider: provider,
+        latencyMs: 10,
+        toolCalls: const [
+          LocalTaskAgentEvalToolCall(
+            name: TaskAgentToolNames.addMultipleChecklistItems,
+            argumentsJson:
+                '{"items":[{"title":"Implement fix so empty inference profiles are no longer selectable"},{"title":"Create pull request"},{"title":"Address Gemini review comments"},{"title":"Address code review comments"},{"title":"Merge the pull request"},{"title":"Create a release on all platforms"}]}',
+          ),
+          LocalTaskAgentEvalToolCall(
+            name: TaskAgentToolNames.updateReport,
+            argumentsJson:
+                '{"oneLiner":"Fix profile seeding, then PR through release","tldr":"Profile seeding is fixed, then a pull request, both reviews, merge and release follow.","content":"Profile seeding fix first, then the pull request, the reviews, the merge, and the release."}',
+          ),
+        ],
+        failureCategory: LocalTaskAgentEvalFailureCategory.none,
+      );
+
+      expect(result.passedQualityCheckCount, result.qualityCheckCount);
+    });
+
+    test('checklist wording may name the fix instead of "implement"', () {
+      final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+        (scenario) => scenario.id.startsWith('implicit_workflow_plan'),
+      );
+      final result = LocalTaskAgentEvalCaseResult(
+        profile: profile,
+        scenario: scenario,
+        provider: provider,
+        latencyMs: 10,
+        toolCalls: const [
+          LocalTaskAgentEvalToolCall(
+            name: TaskAgentToolNames.addMultipleChecklistItems,
+            argumentsJson:
+                '{"items":[{"title":"Fix inference profile seeding so empty profiles are no longer selectable"},{"title":"Create a pull request"},{"title":"Address Gemini review comments"},{"title":"Address code review comments"},{"title":"Merge the pull request"},{"title":"Create a release on all platforms"}]}',
+          ),
+          LocalTaskAgentEvalToolCall(
+            name: TaskAgentToolNames.updateReport,
+            argumentsJson:
+                '{"oneLiner":"Fix profile seeding, then PR through release","tldr":"Profile seeding is cleaned up, then a pull request, both reviews, merge and release follow.","content":"Profile seeding fix first, then the pull request, the reviews, the merge, and the release."}',
+          ),
+        ],
+        failureCategory: LocalTaskAgentEvalFailureCategory.none,
+      );
+
+      expect(result.passedQualityCheckCount, result.qualityCheckCount);
+    });
+  });
+
+  group('negation-aware forbidden claims', () {
+    LocalTaskAgentEvalCaseResult resultFor(
+      String scenarioPrefix,
+      String report, {
+      List<LocalTaskAgentEvalToolCall> extraToolCalls = const [],
+    }) {
+      final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+        (scenario) => scenario.id.startsWith(scenarioPrefix),
+      );
+      return LocalTaskAgentEvalCaseResult(
+        profile: profile,
+        scenario: scenario,
+        provider: provider,
+        latencyMs: 10,
+        toolCalls: [
+          ...extraToolCalls,
+          LocalTaskAgentEvalToolCall(
+            name: TaskAgentToolNames.updateReport,
+            argumentsJson: report,
+          ),
+        ],
+        failureCategory: LocalTaskAgentEvalFailureCategory.none,
+      );
+    }
+
+    // The German scenario also scores checklist arguments, so a report-only
+    // fixture would fail for reasons unrelated to negation handling.
+    const germanChecklist = [
+      LocalTaskAgentEvalToolCall(
+        name: TaskAgentToolNames.addMultipleChecklistItems,
+        argumentsJson:
+            '{"items":[{"title":"Export reparieren"},{"title":"Testdaten von Sam anfordern"},{"title":"Regressionstest ergaenzen"}]}',
+      ),
+    ];
+
+    // Verbatim from the 2026-08-07 run: every candidate model failed this
+    // scenario solely because it said the fix was NOT validated.
+    const negatedReports = [
+      r'{"oneLiner":"Sync risk returned","tldr":"Duplicate sync events reappeared after reconnecting two devices.","content":"## Blockers\\nThe recurrence means the fix is not yet validated. Until the root cause is found the sync risk stays open, so investigation is needed."}',
+      r'{"oneLiner":"Sync duplicates resurfaced","tldr":"Duplicate sync events reappeared once after reconnecting.","content":"## Blockers\\nInvestigation is needed before the fix can be considered validated. The risk remains open."}',
+      r'{"oneLiner":"Sync duplicates recurred","tldr":"Duplicate sync events reappeared after a reconnect.","content":"## Blockers\\nThere is no root cause yet, so the fix cannot be considered validated. Investigation is needed."}',
+    ];
+
+    for (final (index, report) in negatedReports.indexed) {
+      test('negated completion wording passes (sample ${index + 1})', () {
+        final result = resultFor('user_completed_item_resurfaced', report);
+        expect(
+          result.passedQualityCheckCount,
+          result.qualityCheckCount,
+          reason: 'A report stating the fix is not validated is correct here',
+        );
+      });
+    }
+
+    test('an affirmative completion claim still fails', () {
+      final result = resultFor(
+        'user_completed_item_resurfaced',
+        r'{"oneLiner":"Sync fix done","tldr":"Duplicate sync events reappeared but the fix is validated.","content":"## Progress\nThe fix is validated and the sync risk is closed."}',
+      );
+      expect(
+        result.passedQualityCheckCount,
+        lessThan(result.qualityCheckCount),
+      );
+    });
+
+    test('deferred scope may be named to rule it out, not to claim it', () {
+      final ruledOut = resultFor(
+        'messy_german_transcript',
+        '{"oneLiner":"Export und Regressionstest","tldr":"Export, Testdaten von Sam und Regressionstest sind erfasst.","content":"Die Newsletter-Idee wurde explizit zurückgestellt und ist nicht Teil der Arbeit."}',
+        extraToolCalls: germanChecklist,
+      );
+      expect(ruledOut.passedQualityCheckCount, ruledOut.qualityCheckCount);
+
+      final claimed = resultFor(
+        'messy_german_transcript',
+        '{"oneLiner":"Export und Newsletter","tldr":"Export, Testdaten von Sam und Regressionstest laufen.","content":"Der Newsletter wird als nächster Schritt vorbereitet."}',
+        extraToolCalls: germanChecklist,
+      );
+      expect(
+        claimed.passedQualityCheckCount,
+        lessThan(claimed.qualityCheckCount),
+      );
+    });
+
+    test('an overclaim about untouched work fails regardless of negation', () {
+      // "underway" stays in forbiddenReportTerms because no negation makes it
+      // acceptable to describe a rotation that has not started.
+      final result = resultFor(
+        'deferred_scope_filter',
+        '{"oneLiner":"Certificate rotation","tldr":"Three certificate steps remain.","content":"The production signing certificate rotation is underway. No dashboard work is included."}',
+      );
+      expect(
+        result.passedQualityCheckCount,
+        lessThan(result.qualityCheckCount),
+      );
+    });
   });
 
   test('implicit plan scoring accepts outcome-equivalent checklist wording', () {

--- a/test/features/ai/eval/local_task_agent_inference_eval_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_test.dart
@@ -946,12 +946,43 @@ void main() {
       );
     });
 
-    test('an overclaim about untouched work fails regardless of negation', () {
-      // "underway" stays in forbiddenReportTerms because no negation makes it
-      // acceptable to describe a rotation that has not started.
+    test('a cue inside an unrelated word does not excuse a claim', () {
+      // "notes" contains "not" and "another" contains "not", so substring cue
+      // matching excused genuine overclaims. Whole-word matching closes that.
+      expect(
+        containsAffirmativeReportClaim(
+          'another dashboard was delivered to the admins',
+          'dashboard',
+        ),
+        isTrue,
+      );
+      expect(
+        containsAffirmativeReportClaim(
+          'the dashboard mentioned in notes is a future project',
+          'dashboard',
+        ),
+        isFalse,
+        reason: '"future" rules it out; "notes" alone must not',
+      );
+      expect(
+        containsAffirmativeReportClaim(
+          'the fix is not yet validated',
+          'validated',
+        ),
+        isFalse,
+      );
+      expect(
+        containsAffirmativeReportClaim('the fix is validated', 'validated'),
+        isTrue,
+      );
+    });
+
+    test('a deferred-scope report that claims the dashboard fails', () {
+      // Targets the scenario's own forbidden claim rather than a term it no
+      // longer bans: "underway" is accurate for this IN PROGRESS task.
       final result = resultFor(
         'deferred_scope_filter',
-        '{"oneLiner":"Certificate rotation","tldr":"Three certificate steps remain.","content":"The production signing certificate rotation is underway. No dashboard work is included."}',
+        '{"oneLiner":"Certificate rotation","tldr":"Security sent the replacement certificate and Priya granted staging access.","content":"The webhook deliveries verify after the rotation. The administrator analytics dashboard was delivered alongside it."}',
       );
       expect(
         result.passedQualityCheckCount,

--- a/test/features/ai/eval/penguin_task_agent_eval_scenarios_test.dart
+++ b/test/features/ai/eval/penguin_task_agent_eval_scenarios_test.dart
@@ -58,8 +58,10 @@ void main() {
       expect(byName[TaskAgentToolNames.updateTaskDueDate], {
         'dueDate': '2026-08-20',
       });
-      // The requested deadline has to actually differ from the seeded one,
-      // or the mutation check would pass without the model doing anything.
+      // The requested deadline has to actually differ from the seeded one, or
+      // the mutation check would pass without the model doing anything. A null
+      // due date would satisfy isNot() while proving nothing, so require one.
+      expect(scenario.currentDueDate, isNotNull);
       expect(scenario.currentDueDate, isNot('2026-08-20'));
     });
 

--- a/test/features/ai/eval/penguin_task_agent_eval_scenarios_test.dart
+++ b/test/features/ai/eval/penguin_task_agent_eval_scenarios_test.dart
@@ -1,0 +1,90 @@
+import 'dart:ui' show Locale;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
+import 'package:lotti/features/demo/seed/demo_ids.dart';
+import 'package:lotti/features/demo/seed/demo_seed_text.dart';
+import 'package:lotti/features/demo/seed/demo_world.dart';
+
+import 'support/local_task_agent_inference_eval.dart';
+import 'support/penguin_task_agent_eval_scenarios.dart';
+
+void main() {
+  group('penguinTaskAgentEvalScenarios', () {
+    final scenarios = penguinTaskAgentEvalScenarios();
+    final scenario = scenarios.single;
+    final world = ManualDemoWorld.penguinLogistics(
+      translate: demoSeedTextForLocale(const Locale('en')),
+    );
+    final task = world.tasks.firstWhere(
+      (candidate) => candidate.meta.id == demoAirScrubbersTaskId,
+    );
+
+    test('reuses the demo world task rather than a bespoke fixture', () {
+      expect(scenario.userMessage, contains(task.data.title));
+      expect(scenario.userMessage, contains(task.meta.id));
+      // The enriched description is what gives the agent enough context to
+      // act on; the one-line stub this task used to carry would not.
+      final description = task.entryText!.plainText;
+      expect(description.length, greaterThan(240));
+      expect(scenario.userMessage, contains(description));
+    });
+
+    test('presents the full checklist with its real completion state', () {
+      final items = [
+        for (var index = 0; index < 4; index++)
+          world.checklistItems.firstWhere(
+            (item) => item.meta.id == demoUuid('manual-scrubber-item-$index'),
+          ),
+      ];
+      for (final item in items) {
+        expect(scenario.userMessage, contains(item.data.title));
+        expect(scenario.userMessage, contains(item.meta.id));
+      }
+      // Two done, two open: the wake has to complete exactly one more.
+      expect(items.where((item) => item.data.isChecked), hasLength(2));
+    });
+
+    test('requires completing the baseline item and moving the deadline', () {
+      final byName = {
+        for (final call in scenario.expectedToolCalls)
+          call.name: call.expectedArgumentsSubset,
+      };
+      expect(byName[TaskAgentToolNames.updateChecklistItems], {
+        'items': [
+          {'id': demoUuid('manual-scrubber-item-2'), 'isChecked': true},
+        ],
+      });
+      expect(byName[TaskAgentToolNames.updateTaskDueDate], {
+        'dueDate': '2026-08-20',
+      });
+      // The requested deadline has to actually differ from the seeded one,
+      // or the mutation check would pass without the model doing anything.
+      expect(scenario.currentDueDate, isNot('2026-08-20'));
+    });
+
+    test('protects the item the instruction leaves pending', () {
+      final pendingItemId = demoUuid('manual-scrubber-item-3');
+      expect(
+        scenario.forbiddenToolArgumentTerms[TaskAgentToolNames
+            .updateChecklistItems],
+        contains(pendingItemId),
+      );
+      expect(scenario.forbiddenReportTerms, contains(pendingItemId));
+      expect(scenario.forbiddenReportTerms, contains(task.meta.id));
+    });
+
+    test('builds a production first-wake request', () {
+      expect(scenario.isFirstWake, isTrue);
+      expect(scenario.requiresReport, isTrue);
+      expect(scenario.currentPriority, 'P0');
+      expect(scenario.systemPrompt, isNotEmpty);
+      expect(
+        scenario.promptVariant,
+        LocalTaskAgentEvalPromptVariant.production,
+      );
+      expect(scenario.userMessage, contains('First Wake'));
+      expect(scenario.id, 'penguin_scrubber_production');
+    });
+  });
+}

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -584,6 +584,26 @@ final Set<String> _knownTaskAgentToolNames = {
   for (final definition in AgentToolRegistry.taskAgentTools) definition.name,
 };
 
+/// Minutes allowed for a live run, from `LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES`.
+///
+/// Rejects non-positive values rather than falling back: a `0` would expire the
+/// run instantly and look like a stalled provider rather than a bad setting.
+int parseLocalTaskAgentEvalTimeoutMinutes(
+  String? value, {
+  int defaultMinutes = 10,
+}) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return defaultMinutes;
+  final minutes = int.tryParse(trimmed);
+  if (minutes == null || minutes <= 0) {
+    throw FormatException(
+      'LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES must be a positive integer, '
+      'got "$value".',
+    );
+  }
+  return minutes;
+}
+
 /// Whether [toolName] is a tool the task agent actually exposes.
 bool isKnownTaskAgentToolName(String toolName) =>
     _knownTaskAgentToolNames.contains(toolName);
@@ -2668,15 +2688,30 @@ bool _containsAnyTerm(String normalizedText, List<String> terms) {
 /// blacklist scores correct behaviour as a violation. Every candidate model
 /// failed that scenario for this reason alone.
 const _claimNegationCues = [
-  // English
-  'not', "n't", 'no ', 'never', 'cannot', 'without', 'before', 'until',
-  'unless', 'pending', 'remains', 'still', 'yet',
-  // German
-  'nicht', 'kein', 'ohne', 'bevor', 'noch', 'zurückgestellt', 'zurückgestellt',
-  'ausstehend', 'offen',
-  // Spanish
-  'sin ', 'antes', 'aún', 'todavía', 'pendiente',
+  // English negation and deferral.
+  'not', 'no', 'never', 'cannot', "can't", "won't", "isn't", "doesn't",
+  "didn't", 'without', 'before', 'until', 'unless', 'pending', 'remains',
+  'remain', 'still', 'yet', 'future', 'later', 'deferred', 'excluded',
+  // German.
+  'nicht', 'kein', 'keine', 'keinen', 'ohne', 'bevor', 'noch', 'erst',
+  'zurückgestellt', 'zurückgestellte', 'ausstehend', 'offen', 'später',
+  'künftig',
+  // Spanish.
+  'sin', 'antes', 'aún', 'todavía', 'pendiente', 'futuro', 'más',
 ];
+
+/// Matches any cue as a whole word.
+///
+/// Substring matching is far too lenient here: "not" appears inside "notes",
+/// "another" and "notice", so a report claiming "another dashboard was
+/// delivered" would be excused as negated. Unicode-aware letter boundaries
+/// keep "zurückgestellt" and "aún" matchable while closing that hole.
+final RegExp _claimNegationPattern = RegExp(
+  r'(?<![\p{L}])(?:'
+  '${_claimNegationCues.map(RegExp.escape).join('|')}'
+  r')(?![\p{L}])',
+  unicode: true,
+);
 
 /// How much text around a match is inspected for a negation cue.
 ///
@@ -2686,6 +2721,13 @@ const _claimNegationCues = [
 /// clause, narrow enough that a negation in a neighbouring sentence does not
 /// excuse a genuine overclaim.
 const _claimNegationWindow = 60;
+
+/// Whether [claim] is asserted in [text], ignoring occurrences that are negated.
+///
+/// Exposed so the negation rules can be tested directly rather than only
+/// through a scenario's aggregate score.
+bool containsAffirmativeReportClaim(String text, String claim) =>
+    _containsAffirmativeClaim(text.toLowerCase(), claim);
 
 /// Whether [claim] appears in [normalizedText] as an affirmative assertion.
 ///
@@ -2706,7 +2748,7 @@ bool _containsAffirmativeClaim(String normalizedText, String claim) {
     final context =
         '${normalizedText.substring(start, index)} '
         '${normalizedText.substring(end, stop)}';
-    if (!_claimNegationCues.any(context.contains)) return true;
+    if (!_claimNegationPattern.hasMatch(context)) return true;
     index = normalizedText.indexOf(needle, end);
   }
   return false;

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -202,6 +202,7 @@ class LocalTaskAgentEvalScenario {
     this.currentPriority,
     this.requiredReportTermGroups = const [],
     this.forbiddenReportTerms = const [],
+    this.forbiddenReportClaims = const [],
     this.requiredToolArgumentTermGroups = const {},
     this.forbiddenToolNames = const {},
     this.forbiddenToolArgumentTerms = const {},
@@ -233,6 +234,15 @@ class LocalTaskAgentEvalScenario {
   /// Terms that must never appear in the user-visible report payload.
   final List<String> forbiddenReportTerms;
 
+  /// Claims the report must not assert, but may name in order to negate.
+  ///
+  /// Use this for anything a correct report legitimately mentions while ruling
+  /// it out — unfinished validation, explicitly deferred scope. Reserve
+  /// [forbiddenReportTerms] for strings that must not appear at all, such as
+  /// internal identifiers, and for overclaims like "underway" that no negation
+  /// makes acceptable.
+  final List<String> forbiddenReportClaims;
+
   /// Semantic term groups required in a specific tool's arguments.
   final Map<String, List<List<String>>> requiredToolArgumentTermGroups;
 
@@ -260,6 +270,7 @@ class LocalTaskAgentEvalScenario {
       'currentPriority': currentPriority,
       'requiredReportTermGroups': requiredReportTermGroups,
       'forbiddenReportTerms': forbiddenReportTerms,
+      'forbiddenReportClaims': forbiddenReportClaims,
       'requiredToolArgumentTermGroups': requiredToolArgumentTermGroups,
       'forbiddenToolNames': forbiddenToolNames.toList()..sort(),
       'forbiddenToolArgumentTerms': forbiddenToolArgumentTerms,
@@ -322,8 +333,14 @@ LocalTaskAgentEvalScenario _implicitWorkflowPlanScenario(
     ],
     requiredToolArgumentTermGroups: const {
       TaskAgentToolNames.addMultipleChecklistItems: [
-        ['profile seeding', 'empty profile'],
-        ['implement'],
+        // "empty inference profiles are no longer selectable" says the same
+        // thing as "empty profile"; the item has to be about the profiles,
+        // not phrased a particular way.
+        ['profile seeding', 'empty profile', 'inference profile'],
+        // "Fix the seeding so empty profiles are no longer selectable" is the
+        // implementation step; demanding the literal verb passed only because
+        // an earlier fixture happened to say "implementation".
+        ['implement', 'fix', 'clean up'],
         ['pull request', 'pr'],
         ['gemini'],
         ['code review'],
@@ -456,6 +473,7 @@ LocalTaskAgentEvalScenario _withEvolvedReportDirective(
       ...source.forbiddenReportTerms,
       ...forbiddenDirectiveTerms,
     ],
+    forbiddenReportClaims: source.forbiddenReportClaims,
     requiredToolArgumentTermGroups: source.requiredToolArgumentTermGroups,
     forbiddenToolNames: source.forbiddenToolNames,
     forbiddenToolArgumentTerms: source.forbiddenToolArgumentTerms,
@@ -555,6 +573,38 @@ LocalTaskAgentEvalProfile parseLocalTaskAgentEvalProfile(String value) {
     providerModelId: model,
     modelClass: name,
   );
+}
+
+/// Every tool name the task agent actually exposes.
+///
+/// The harness answers anything outside this set the way the production
+/// dispatcher does, so a model that guesses a name gets the same chance to
+/// correct itself here as it would in the app.
+final Set<String> _knownTaskAgentToolNames = {
+  for (final definition in AgentToolRegistry.taskAgentTools) definition.name,
+};
+
+/// Whether [toolName] is a tool the task agent actually exposes.
+bool isKnownTaskAgentToolName(String toolName) =>
+    _knownTaskAgentToolNames.contains(toolName);
+
+/// The tool response the eval harness returns for a call.
+///
+/// Unknown names produce the production dispatcher's error rather than a
+/// success, so a model that guesses a tool name can recover here exactly as it
+/// would in the app.
+String localTaskAgentEvalToolResponse({
+  required String toolName,
+  required bool hasValidJsonArguments,
+}) {
+  if (!isKnownTaskAgentToolName(toolName)) {
+    return 'Unknown tool: $toolName. '
+        'Tool $toolName is not registered for the Task Agent.';
+  }
+  if (!hasValidJsonArguments) {
+    return 'Eval harness rejected invalid JSON arguments.';
+  }
+  return 'Eval harness accepted $toolName.';
 }
 
 List<ChatCompletionTool> buildLocalTaskAgentEvalTools({
@@ -667,9 +717,12 @@ LocalTaskAgentEvalScenario _metadataScenario(
     userMessage: base.userMessage,
     expectedToolCalls: base.expectedToolCalls,
     promptVariant: variant,
+    // The priority mutation is asserted through expectedToolCalls. Requiring
+    // the prose to echo "P1" as well contradicts the report directive, which
+    // forbids narrating metadata changes, and cost a model that set the
+    // priority correctly.
     requiredReportTermGroups: const [
       ['candidate', 'task-agent'],
-      ['p1'],
       ['2026-07-04', 'july 4'],
       ['150', '2.5', 'two and a half'],
       ['reference'],
@@ -843,7 +896,10 @@ LocalTaskAgentEvalScenario _messyGermanTranscriptScenario(
       ['testdaten'],
       ['regression'],
     ],
-    forbiddenReportTerms: const ['newsletter'],
+    // The newsletter must not become work, but a report may name it to record
+    // that the user deferred it ("Newsletter-Idee wurde zurückgestellt"). The
+    // checklist ban below stays absolute.
+    forbiddenReportClaims: const ['newsletter'],
     requiredToolArgumentTermGroups: const {
       TaskAgentToolNames.addMultipleChecklistItems: [
         ['export'],
@@ -878,12 +934,11 @@ LocalTaskAgentEvalScenario _deferredScopeScenario(
       ['staging'],
       ['webhook'],
     ],
-    forbiddenReportTerms: [
-      'dashboard',
-      'analytics',
-      'underway',
-      'awaiting',
-    ],
+    // The task is IN PROGRESS and its log calls the certificate work active,
+    // so "underway" describes it accurately and was wrong to forbid. What the
+    // scenario actually tests is that the deferred dashboard stays out, and
+    // that no unevidenced waiting is claimed.
+    forbiddenReportClaims: ['dashboard', 'analytics', 'awaiting'],
     requiredToolArgumentTermGroups: const {
       TaskAgentToolNames.addMultipleChecklistItems: [
         ['certificate'],
@@ -936,7 +991,16 @@ LocalTaskAgentEvalScenario _userCompletedItemScenario(
     systemPrompt: _buildEvalSystemPrompt(variant),
     userMessage: _userCompletedItemUserMessage,
     expectedToolCalls: const [],
+    // The invariant is that the user's checked item survives, which is what
+    // updateChecklistItems would violate. Adding a new investigation item is
+    // the context's own request — "Investigation is needed; no root cause
+    // yet" — so it must not count against the model.
     forbiddenToolNames: const {TaskAgentToolNames.updateChecklistItems},
+    allowedExtraToolNames: const {
+      TaskAgentToolNames.updateReport,
+      TaskAgentToolNames.recordObservations,
+      TaskAgentToolNames.addMultipleChecklistItems,
+    },
     isFirstWake: false,
     promptVariant: variant,
     requiredReportTermGroups: const [
@@ -944,15 +1008,10 @@ LocalTaskAgentEvalScenario _userCompletedItemScenario(
       ['reappeared', 'resurfaced', 'again', 'recurrence', 'recurred'],
       ['blocked', 'blocker', 'risk', 'root cause', 'investigat'],
     ],
-    forbiddenReportTerms: [
-      'item-sync-fix',
-      'deployed',
-      'verified',
-      'validated',
-      'implemented',
-      'applied',
-      'underway',
-    ],
+    forbiddenReportTerms: ['item-sync-fix', 'deployed', 'implemented'],
+    // A correct report says the fix is *not* validated, so these may appear
+    // under negation but must never be asserted.
+    forbiddenReportClaims: ['verified', 'validated', 'applied', 'underway'],
   );
 }
 
@@ -968,6 +1027,14 @@ LocalTaskAgentEvalScenario _spanishMixedContextScenario(
         name: TaskAgentToolNames.addMultipleChecklistItems,
       ),
     ],
+    // The user wrote "seguimos bloqueados" over a task still marked IN
+    // PROGRESS, so recording the blocker is correct, not scope creep. Every
+    // candidate model made this call and the scenario failed all of them.
+    allowedExtraToolNames: const {
+      TaskAgentToolNames.updateReport,
+      TaskAgentToolNames.recordObservations,
+      TaskAgentToolNames.setTaskStatus,
+    },
     languageCode: 'es',
     promptVariant: variant,
     requiredReportTermGroups: const [
@@ -1033,6 +1100,18 @@ LocalTaskAgentEvalScenario _latestDeadlineWinsScenario(
     ],
   );
 }
+
+/// The evaluation system prompt for [variant], for suites defined in their own
+/// files (see `penguin_task_agent_eval_scenarios.dart`).
+String buildLocalTaskAgentEvalSystemPrompt(
+  LocalTaskAgentEvalPromptVariant variant, {
+  String? modelId,
+  String? reportDirective,
+}) => _buildEvalSystemPrompt(
+  variant,
+  modelId: modelId,
+  reportDirective: reportDirective,
+);
 
 String _buildEvalSystemPrompt(
   LocalTaskAgentEvalPromptVariant variant, {
@@ -1760,6 +1839,7 @@ class LocalTaskAgentEvalCaseResult {
   int get qualityCheckCount =>
       scenario.requiredReportTermGroups.length +
       scenario.forbiddenReportTerms.length +
+      scenario.forbiddenReportClaims.length +
       scenario.forbiddenToolNames.length +
       scenario.requiredToolArgumentTermGroups.values.fold<int>(
         0,
@@ -1778,6 +1858,9 @@ class LocalTaskAgentEvalCaseResult {
         .length;
     passed += scenario.forbiddenReportTerms
         .where((term) => !normalizedReport.contains(term.toLowerCase()))
+        .length;
+    passed += scenario.forbiddenReportClaims
+        .where((claim) => !_containsAffirmativeClaim(normalizedReport, claim))
         .length;
     passed += scenario.forbiddenToolNames
         .where((name) => toolCalls.every((call) => call.name != name))
@@ -2441,10 +2524,18 @@ class _LocalTaskAgentEvalStrategy extends ConversationStrategy {
       _toolCalls.add(recorded);
 
       final args = recorded.jsonObjectArguments;
-      final response = args == null
-          ? 'Eval harness rejected invalid JSON arguments.'
-          : 'Eval harness accepted ${call.function.name}.';
-      if (call.function.name == TaskAgentToolNames.updateReport &&
+      // Mirror TaskToolDispatcher: an unregistered name is an error the model
+      // can recover from, not a success. Confirming a fabricated tool made the
+      // harness measure something the app never does — DeepSeek V4 Flash 0731
+      // invented both `set_task_estimate` and `update_task_status` and was
+      // told each one worked.
+      final isKnownTool = isKnownTaskAgentToolName(call.function.name);
+      final response = localTaskAgentEvalToolResponse(
+        toolName: call.function.name,
+        hasValidJsonArguments: args != null,
+      );
+      if (isKnownTool &&
+          call.function.name == TaskAgentToolNames.updateReport &&
           args != null &&
           _hasNonEmptyString(args, 'oneLiner') &&
           _hasNonEmptyString(args, 'tldr') &&
@@ -2567,6 +2658,58 @@ LocalTaskAgentEvalFailureCategory _classifyResult({
 
 bool _containsAnyTerm(String normalizedText, List<String> terms) {
   return terms.any((term) => normalizedText.contains(term.toLowerCase()));
+}
+
+/// Negation cues that turn a claim into its opposite, in the languages the
+/// scenario suite actually uses.
+///
+/// A report saying "the fix is not yet validated" is doing exactly what the
+/// `user_completed_item_resurfaced` scenario asks for, so a bare substring
+/// blacklist scores correct behaviour as a violation. Every candidate model
+/// failed that scenario for this reason alone.
+const _claimNegationCues = [
+  // English
+  'not', "n't", 'no ', 'never', 'cannot', 'without', 'before', 'until',
+  'unless', 'pending', 'remains', 'still', 'yet',
+  // German
+  'nicht', 'kein', 'ohne', 'bevor', 'noch', 'zurückgestellt', 'zurückgestellt',
+  'ausstehend', 'offen',
+  // Spanish
+  'sin ', 'antes', 'aún', 'todavía', 'pendiente',
+];
+
+/// How much text around a match is inspected for a negation cue.
+///
+/// The cue can land on either side: English tends to precede the claim ("the
+/// fix cannot be considered validated") while German routinely follows it
+/// ("die Newsletter-Idee wurde explizit zurückgestellt"). Wide enough for a
+/// clause, narrow enough that a negation in a neighbouring sentence does not
+/// excuse a genuine overclaim.
+const _claimNegationWindow = 60;
+
+/// Whether [claim] appears in [normalizedText] as an affirmative assertion.
+///
+/// Returns false when every occurrence sits inside a negation window, which is
+/// how a report may name deferred or unfinished work in order to rule it out.
+bool _containsAffirmativeClaim(String normalizedText, String claim) {
+  final needle = claim.toLowerCase();
+  var index = normalizedText.indexOf(needle);
+  while (index != -1) {
+    final end = index + needle.length;
+    final start = index < _claimNegationWindow
+        ? 0
+        : index - _claimNegationWindow;
+    final stop = end + _claimNegationWindow >= normalizedText.length
+        ? normalizedText.length
+        : end + _claimNegationWindow;
+    // Skip the claim itself so a cue inside it cannot excuse the claim.
+    final context =
+        '${normalizedText.substring(start, index)} '
+        '${normalizedText.substring(end, stop)}';
+    if (!_claimNegationCues.any(context.contains)) return true;
+    index = normalizedText.indexOf(needle, end);
+  }
+  return false;
 }
 
 LocalTaskAgentEvalToolCall? _latestReportCall(

--- a/test/features/ai/eval/support/penguin_task_agent_eval_scenarios.dart
+++ b/test/features/ai/eval/support/penguin_task_agent_eval_scenarios.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:ui' show Locale;
+
+import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
+import 'package:lotti/features/demo/seed/demo_ids.dart';
+import 'package:lotti/features/demo/seed/demo_seed_text.dart';
+import 'package:lotti/features/demo/seed/demo_world.dart';
+
+import 'local_task_agent_inference_eval.dart';
+
+/// Task-agent wake scenarios built from the penguin demo world.
+///
+/// The synthetic scenarios in `local_task_agent_inference_eval.dart` were
+/// written for the eval alone. These reuse the content demo mode already
+/// ships — enriched task descriptions, real checklists, linked notes — so a
+/// model is measured against the same material a user sees on their first run.
+///
+/// English only: the demo world carries reviewed copy in eleven languages, but
+/// a localized suite needs the wake instruction to come from that same
+/// translated demo content rather than from fixtures authored here.
+List<LocalTaskAgentEvalScenario> penguinTaskAgentEvalScenarios({
+  List<LocalTaskAgentEvalPromptVariant> variants = const [
+    LocalTaskAgentEvalPromptVariant.production,
+  ],
+}) {
+  return [for (final variant in variants) _penguinScrubberScenario(variant)];
+}
+
+/// The deadline the wake instruction asks for.
+const String _requestedDueDate = '2026-08-20';
+
+const String _wakeInstruction =
+    'The CO2 baseline is logged, so check that item off. Push the deadline to '
+    'August 20, 2026 — the replacement cartridges only arrive on the 19th. '
+    'The used cartridges still have to go back to stores.';
+
+LocalTaskAgentEvalScenario _penguinScrubberScenario(
+  LocalTaskAgentEvalPromptVariant variant,
+) {
+  final world = ManualDemoWorld.penguinLogistics(
+    translate: demoSeedTextForLocale(const Locale('en')),
+  );
+  final task = world.tasks.firstWhere(
+    (candidate) => candidate.meta.id == demoAirScrubbersTaskId,
+  );
+  final items = [
+    for (var index = 0; index < 4; index++)
+      world.checklistItems.firstWhere(
+        (item) => item.meta.id == demoUuid('manual-scrubber-item-$index'),
+      ),
+  ];
+  // Item 2 is the CO2 baseline the instruction reports as done; item 3 is the
+  // cartridge return that must survive the wake untouched.
+  final baselineItem = items[2];
+  final pendingItem = items[3];
+
+  final context = <String, Object?>{
+    'id': task.meta.id,
+    'title': task.data.title,
+    'status': 'IN PROGRESS',
+    'priority': 'P0',
+    'dueDate': _formatDate(task.data.due),
+    'languageCode': 'en',
+    'description': task.entryText?.plainText,
+    'checklist': [
+      for (final item in items)
+        {
+          'id': item.meta.id,
+          'title': item.data.title,
+          'isChecked': item.data.isChecked,
+          'lastModifiedBy': 'user',
+        },
+    ],
+    'log': [
+      {'timestamp': '2026-07-17T09:05:00Z', 'text': _wakeInstruction},
+    ],
+  };
+
+  return LocalTaskAgentEvalScenario(
+    id: 'penguin_scrubber_${variant.name}',
+    systemPrompt: buildLocalTaskAgentEvalSystemPrompt(variant),
+    userMessage:
+        '''
+## Current Task Context
+```json
+${const JsonEncoder.withIndent('  ').convert(context)}
+```
+
+## First Wake - No prior report exists. Produce an initial report.
+
+## Changed Since Last Wake
+The following entity IDs changed: ${task.meta.id}
+
+Analyze the current state and follow the wake protocol.
+''',
+    expectedToolCalls: [
+      LocalTaskAgentExpectedToolCall(
+        name: TaskAgentToolNames.updateChecklistItems,
+        expectedArgumentsSubset: {
+          'items': [
+            {'id': baselineItem.meta.id, 'isChecked': true},
+          ],
+        },
+      ),
+      const LocalTaskAgentExpectedToolCall(
+        name: TaskAgentToolNames.updateTaskDueDate,
+        expectedArgumentsSubset: {'dueDate': _requestedDueDate},
+      ),
+    ],
+    promptVariant: variant,
+    currentDueDate: _formatDate(task.data.due),
+    currentPriority: 'P0',
+    requiredReportTermGroups: const [
+      ['cartridge'],
+      ['co2'],
+      ['2026-08-20', 'august 20', '20 august'],
+    ],
+    // Internal identifiers never belong in a user-facing report, and the
+    // still-pending cartridge return must not be claimed as done.
+    forbiddenReportTerms: [
+      task.meta.id,
+      baselineItem.meta.id,
+      pendingItem.meta.id,
+    ],
+    forbiddenToolArgumentTerms: {
+      TaskAgentToolNames.updateChecklistItems: [pendingItem.meta.id],
+    },
+  );
+}
+
+String? _formatDate(DateTime? date) {
+  if (date == null) return null;
+  return '${date.year.toString().padLeft(4, '0')}-'
+      '${date.month.toString().padLeft(2, '0')}-'
+      '${date.day.toString().padLeft(2, '0')}';
+}


### PR DESCRIPTION
Supersedes #3848, which GitHub auto-closed when its base branch
`feat/demo-world-richer-tasks` was deleted on merge of #3847. Same commit,
rebased onto `main`; a closed PR whose base branch is gone can be neither
reopened nor retargeted.

## Why

Screening DeepSeek V4 Flash 0731 against GLM 5.2 and Kimi K3 produced 7, 10
and 9 of 14. Inspecting every failure showed the suite accounted for most of
the gap. Nine checks penalised correct behaviour; two contradicted directives
the same system prompt issues, so a model was failed for obeying its
instructions.

On the corrected suite: **GLM 5.2 14/14, Kimi K3 14/14, DeepSeek 10/14.**

## Structural bugs

- `HttpOverrides.global` was never cleared, so the test binding failed every
  request with a synthetic HTTP 400 in under 100 ms and the run scored 0%. The
  day-planning eval already had this fix; the task-agent one did not.
- A run that tripped the test timeout wrote **no artifacts at all**, so a long
  run looked like it never happened. Now configurable via
  `LOCAL_TASK_AGENT_EVAL_TIMEOUT_MINUTES`.

## Scoring defects

All nine share one root cause: substring matching standing in for semantic
judgement. It cannot see negation and cannot see paraphrase, so it fails
exactly when a model says the right thing in unexpected words.

| Scenario | What was wrong |
| --- | --- |
| `user_completed_item_resurfaced` | "the fix is **not yet** validated" scored as claiming it was. Failed all three models. |
| `messy_german_transcript` | "Newsletter-Idee wurde explizit zurückgestellt" scored as reintroducing the deferred idea. |
| `spanish_mixed_context` | Banned marking a task blocked whose owner wrote "seguimos bloqueados" while its status read `IN PROGRESS`. All three models made that call; all three failed. |
| `metadata_explicit` | Required the report to echo "P1" while the report directive forbids narrating metadata changes. |
| `implicit_workflow_plan` | Demanded the literal verb "implement" — passing before only because a fixture happened to contain "implementation" — and demanded "empty profile", rejecting "empty **inference** profiles". |
| `deferred_scope_filter` | Forbade "underway" on a task whose status is `IN PROGRESS` and whose log calls the certificate work active. |
| `user_completed_item_resurfaced` | Forbade adding the investigation item its own log asks for ("Investigation is needed; no root cause yet"). |

`forbiddenReportClaims` is the new field: matched only in affirmative context,
with a negation window on **both** sides, since English negates before the
claim and German after. `forbiddenReportTerms` keeps exact semantics for
strings that must never appear at all, such as internal identifiers.

## Harness fidelity

`processToolCalls` answered every call with "Eval harness accepted &lt;name&gt;",
including names that do not exist, where `TaskToolDispatcher` returns an error
the model can recover from. It now mirrors the dispatcher.

This is what established the DeepSeek finding: handed the real
`Unknown tool: set_task_estimate` error, it did not retry with the correct
name and published a report calling the task configured while the user's
requested estimate was never set.

## New scenario

`penguin_scrubber_production` is built from the shipped demo world rather than
eval-only fixtures, so a model is measured against content a user actually
meets on first run. English only — a localized suite would need the wake
instruction to come from translated demo content, not from fixtures authored
in the eval directory.

## Testing

Every fix is pinned by a test built from the models' verbatim output, so the
regression is real rather than illustrative. 95 eval tests green, analyzer
clean.

## Caveat

One sample per scenario on a backend that is not deterministic even at
temperature 0. A fabricated tool call, a 305 s stall, and two Kimi failures
all failed to reproduce on a second sample — treat single-scenario differences
as noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for running evaluation scenarios, handling timeouts, and interpreting August 2026 findings.
  - Documented a new English-only logistics scenario using seeded demo-world data.

- **Tests**
  - Expanded task-agent evaluation coverage for tool errors, invalid inputs, report requirements, checklist wording, and negated claims.
  - Added logistics scenario validation for checklist updates, due dates, protected report terms, and request metadata.
  - Added configurable evaluation timeouts and optional scenario selection.

- **Chores**
  - Incremented the application build version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->