### PR TITLE
feat(agents): the task-agent constitution is code-owned (ADR 0052)

### DIFF
--- a/docs/adr/0052-agent-directive-constitution.md
+++ b/docs/adr/0052-agent-directive-constitution.md
@@ -1,0 +1,184 @@
+# 0052 — An agent's constitution is code, not an evolvable directive
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-08
+
+## Context
+
+Template evolution rewrites an agent's directives. `propose_directives` takes
+`general_directive` and `report_directive` as complete strings — the session
+prompt says so explicitly: *"When proposing directives, output the COMPLETE new
+directives text, not a diff."* Approval writes both fields verbatim into a new
+template version. The only structural validation is that at least one is
+non-empty.
+
+That shape is what this ADR is about. Two questions follow from it: which rules
+may a rewrite touch, and how does an agent accumulate durable guidance without
+rewriting anything?
+
+**What is already safe.** The role, the wake-finishing contract, the job steps,
+every tool definition and its authority boundaries, the evidence-synthesis
+protocol and the model-tuned report contract are code-owned constants in
+`TaskAgentPromptBuilder` and `AgentToolRegistry`. Evolution cannot reach them.
+So "this is what you are, these are your tools" is not at risk today.
+
+**What was mixed up.** The seeded `taskAgentGeneralDirective` restates rules the
+scaffold already asserts:
+
+| Seeded directive section | Already code-owned in the scaffold |
+| --- | --- |
+| never re-open a user-checked item | `**Checklist sovereignty**` — overriding needs a `reason` naming later evidence |
+| never override a manual field change | the no-op rule — *"the user wins — make no call at all"* |
+| never change a user-set estimate | `**Estimates**` — never adjust retroactively |
+| never change a user-set title | `**Title**` — only when the task has none |
+| review recent user decisions first | `**Past decisions**` — the proposal ledger |
+| don't call tools speculatively | `**Confidence**` |
+| never change a user-set priority or due date | **nothing** |
+| handle rough transcripts, ask rather than assume | **nothing** |
+
+So the risk was not that evolution could delete the sovereignty rules — the
+scaffold keeps asserting almost all of them regardless. The real defects were
+smaller and duller: **two wordings of one rule**, one of them editable, costing
+payload on every wake and free to drift apart; and **two rules that lived only in
+the editable copy**, which a rewrite genuinely could drop.
+
+The compact scaffold used by the evaluated Qwen and Mistral profiles had already
+resolved this for itself: it carries its own constitution (`## Authority and
+Evidence`, `## Tool Discipline`) and *suppresses* a general directive that is
+byte-for-byte the seeded constant, appending only a genuinely customised one.
+The common scaffold never adopted that, so the same template produced a
+duplicated prompt on one path and a single one on the other.
+
+**What is missing entirely** is the additive layer. An agent has no way to
+accumulate a standing rule — "this project's estimates are always in ideal
+days", "never propose a due date for this recurring task" — other than by
+rewriting its whole general directive. The planner already has exactly this
+mechanism (ADR 0022 Decisions 9–10): `PlannerKnowledgeEntity` keyed statements
+with a ≤120-character always-injected hook, a `proposed → confirmed → retracted`
+lifecycle, per-key supersession and global/category/project scope, confirmed by
+the user in a panel. Task agents do not read it.
+
+## Decision
+
+Three layers, ordered by mutability. Each layer may add to the ones above it and
+may never contradict or remove them.
+
+| Layer | Home | Who writes it | Lifetime |
+| --- | --- | --- | --- |
+| **Constitution** | code constants in `TaskAgentPromptBuilder` | Lotti releases | changes when the app ships |
+| **Template directive** | `AgentTemplateVersionEntity.generalDirective` / `reportDirective` | evolution, user-approved | one version, rollback-able |
+| **Standing rules** | keyed knowledge entries | evolution, user-confirmed per rule | per rule, retractable |
+
+Concretely, and in this change:
+
+1. **The constitution is complete and single-sourced.** The two rules that lived
+   only in the seeded directive — user-set priority and due date are sovereign,
+   and input handling — move into the code-owned scaffold. Every rule an agent
+   must never lose is now a constant.
+2. **The seeded general directive is no longer rendered.** `buildSystemPrompt`
+   resolves it through `effectiveGeneralDirective`, which returns empty for the
+   seeded value and the text verbatim for anything else — the same
+   compatibility-sentinel pattern as `usesBuiltInReportContract`. Both scaffolds
+   now behave the way the compact one already did. A stock wake gets one wording
+   of each rule; an evolved directive is appended *after* the constitution, so it
+   adds rather than replaces.
+3. **The evolution session sees what is in effect.** For a stock template the
+   general directive shows as *"None. This template adds nothing on top of the
+   built-in task-agent constitution, which is code-owned…"*, mirroring the
+   report-directive fix. Silence would invite a proposal that restates rules the
+   agent already has and cannot lose.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Constitution: code constants, every wake
+  Constitution --> Directive: template adds guidance?
+  Directive --> StandingRules: confirmed keyed rules
+  Constitution --> StandingRules: stock template, nothing to add
+  StandingRules --> Prompt
+  Directive --> Prompt
+  Prompt --> [*]
+  note right of Constitution
+    Evolution cannot reach this layer.
+  end note
+  note right of Directive
+    Rewritable, user-approved, rollback-able.
+    Appended after the constitution.
+  end note
+```
+
+**The constant itself does not change.** `taskAgentGeneralDirective` keeps its
+exact text: templates seeded on earlier versions store it byte-for-byte and are
+recognised by that match, so editing it would reclassify every one of them as
+customised and start rendering it again. Its value is now its stability, exactly
+as for `taskAgentReportDirective`.
+
+**The compact scaffold text is not touched.** It already carries the
+constitution, and the 27B and Mistral numbers were measured against that exact
+wording. Changing a measured prompt needs an eval run, not an ADR. A test now
+pins that a stock template produces the compact scaffold plus the evidence
+protocol and nothing else.
+
+## Consequences
+
+**What this buys.** One authoritative wording per rule, owned by code, updated
+by shipping the app — including for templates that have already been evolved,
+which previously forked from the shipped baseline permanently
+(`seedDirectiveFields` backfills only when a field is *empty*). Stock wakes get a
+smaller prompt on the common scaffold. The two previously-unprotected rules
+become unloseable. And the evolution session can no longer be shown a directive
+the agent never received.
+
+**What it costs.** An evolved directive that duplicates constitution rules keeps
+its copy — the app cannot safely edit user-approved text — so those templates
+still pay for a second wording until their next evolution session. The
+`## Input Handling` and priority/due-date additions grow the common scaffold
+slightly; net payload for a stock template still falls, because the seeded
+directive it replaces was longer than both.
+
+**What it does not fix.** Nothing stops an evolved directive from *contradicting*
+the constitution in prose. Ordering (constitution first, template guidance last)
+and the fact that only the constitution is code-owned are the mitigations; a
+contradiction is still a bad proposal that the user can reject and roll back.
+Making contradiction structurally impossible would mean constraining what a
+directive may say, which is a larger change than this.
+
+**Migration.** None. No stored data is rewritten and no version is created; the
+change is in what gets rendered. A template whose directive was hand-edited to
+something other than the seed is unaffected.
+
+## Follow-ups
+
+Not in this change, in the order they earn their keep:
+
+1. **Make the report directive additive.** A custom report directive currently
+   flips `usesBuiltInReportContract` to false, which permanently disables the
+   model-tuned contract substitution for that template — the contract behind
+   Qwen3.6 27B's 10/14 → 13/14. Normal evolution output triggers this, and the
+   proposal card does not say so. An *addendum* appended after the model-tuned
+   contract removes the cliff.
+2. **Give task agents standing rules.** Reuse `PlannerKnowledgeEntity`: a
+   `propose_knowledge` evolution tool writing one keyed rule with a hook, a
+   scope and a rationale; the wake injects the confirmed Head set. Directive
+   rewrites become the escape hatch rather than the default move, and the session
+   prompt's contradiction between *"make the smallest directive changes"* and
+   *"output the COMPLETE new directives text"* dissolves, because an additive
+   proposal is a diff.
+3. **Constrain the rewrite itself** — section-scoped proposals, or a check that a
+   proposal does not contradict the constitution — only if 1 and 2 leave a real
+   gap.
+
+## Related
+
+- ADR 0022 — daily-OS planner: Decisions 9–10 define the knowledge lifecycle
+  this ADR proposes reusing for task agents
+- ADR 0051 — agenda-gated tool exposure; the same principle applied to tools
+  rather than directives
+- `knowledge/features/agents/templates-souls-evolution.md` — the evolution
+  ritual, version lifecycle and rollback
+- `knowledge/features/agents/task-agents.md` — prompt composition and the
+  directive substitution rules

--- a/docs/adr/0052-agent-directive-constitution.md
+++ b/docs/adr/0052-agent-directive-constitution.md
@@ -54,6 +54,29 @@ byte-for-byte the seeded constant, appending only a genuinely customised one.
 The common scaffold never adopted that, so the same template produced a
 duplicated prompt on one path and a single one on the other.
 
+**The defect that decides who any of this reaches.** "Are these our directives?"
+was answered by comparing the stored text against today's seeded constant. That
+is an equality test against a moving target: `taskAgentReportDirective` was
+edited on 2026-04-19 (#2971) and 2026-06-07 (#3286), `taskAgentGeneralDirective`
+on 2026-03-02 (#2737) and 2026-06-07 (#3286). **Every install seeded before the
+last edit stores the older text, fails the comparison, and is classified as
+customised** — without anyone having customised anything.
+
+For the general directive that only means the constitution work below skips
+those installs. For the report directive the consequence is live today and worse:
+`usesBuiltInReportContract` returns false, the model-tuned evidence-synthesis
+contract is never substituted, and the agent instead receives the superseded
+seeded text headed `## MANDATORY FINAL TOOL CALL` — which mandates
+`update_report` on *every* wake. That is exactly the behaviour the `noOp`
+scenario penalises, and the eval harness cannot reproduce it, because the harness
+seeds the current constant and passes the comparison. An aged install can
+therefore churn reports for a reason the suite reports as fixed.
+
+The signal that answers the question directly is already stored:
+`AgentTemplateVersionEntity.authoredBy` is `system` for seeding,
+`evolution_agent` for an approved proposal, `user` for a hand-edit in the
+template detail page.
+
 **What is missing entirely** is the additive layer. An agent has no way to
 accumulate a standing rule — "this project's estimates are always in ideal
 days", "never propose a due date for this recurring task" — other than by
@@ -87,7 +110,25 @@ Concretely, and in this change:
    now behave the way the compact one already did. A stock wake gets one wording
    of each rule; an evolved directive is appended *after* the constitution, so it
    adds rather than replaces.
-3. **The evolution session sees what is in effect.** For a stock template the
+3. **Provenance decides whether directives are ours, not string equality.**
+   `AgentAuthors.isSystemAuthored` — exactly `system` — settles both
+   `usesBuiltInGeneralDirective` and `usesBuiltInReportContract` before any text
+   is compared, so a template seeded under any release is recognised. The
+   equality test stays as the fallback for versions whose author cannot settle
+   it. Two deliberate narrowings:
+
+   * **`system:config_change` is not system authorship.** It is stamped on
+     versions that *copy* directives forward after a model or profile change, so
+     on an install that evolved a template and then switched models it sits on
+     evolved text. Reading it as seeding would delete a user-approved directive
+     from the prompt — a worse failure than the one being fixed.
+   * **That copy-forward now preserves the directive's author** rather than
+     restamping it, because a model swap does not write a directive. The config
+     change stays visible in version history through the `modelId`/`profileId`
+     difference. Rows already stamped `system:config_change` keep falling back to
+     the text comparison, which is exactly today's behaviour for them.
+
+4. **The evolution session sees what is in effect.** For a stock template the
    general directive shows as *"None. This template adds nothing on top of the
    built-in task-agent constitution, which is code-owned…"*, mirroring the
    report-directive fix. Silence would invite a proposal that restates rules the
@@ -147,9 +188,26 @@ contradiction is still a bad proposal that the user can reject and roll back.
 Making contradiction structurally impossible would mean constraining what a
 directive may say, which is a larger change than this.
 
+**What an existing install gets**, by what its active template version holds:
+
+| State | Before | After |
+| --- | --- | --- |
+| Seeded on the current release | seeded constitution rendered on top of the scaffold's | constitution once, from the scaffold; ~1.5 kB smaller |
+| Seeded on an older release | read as customised: stale constitution rendered, model-tuned report contract **disabled** | recognised by author; same as a current seed |
+| Evolved or hand-edited | rendered verbatim | rendered verbatim, after a complete constitution |
+| Evolved, then model changed (`system:config_change`) | rendered verbatim | rendered verbatim — provenance deliberately declines to claim it |
+| Legacy, no split fields | `directives` blob rendered | unchanged |
+
+Personality is untouched in every row: soul versions have no sentinel and no
+substitution, so an evolved soul is rendered exactly as before.
+
 **Migration.** None. No stored data is rewritten and no version is created; the
-change is in what gets rendered. A template whose directive was hand-edited to
-something other than the seed is unaffected.
+change is in what gets rendered and how provenance is read. Re-seeding stale
+directive text onto old templates — as `seedDayAgentCaptureReconcileDirective`
+does for the day agent — would additionally repair installs whose stored text is
+genuinely outdated rather than merely misclassified. That is a separate decision,
+because it mints a version per template on upgrade and changes what an evolved
+template inherits.
 
 ## Follow-ups
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,3 +107,4 @@ Each ADR should contain:
 - [`0049-profile-scoped-storage-and-demo-mode.md`](./0049-profile-scoped-storage-and-demo-mode.md)
 - [`0050-multi-tenant-worlds.md`](./0050-multi-tenant-worlds.md)
 - [`0051-agenda-gated-tool-exposure.md`](./0051-agenda-gated-tool-exposure.md)
+- [`0052-agent-directive-constitution.md`](./0052-agent-directive-constitution.md)

--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -32,6 +32,10 @@ sources:
     resource: ../../../docs/adr/0006-change-set-deferred-tool-confirmation.md
     title: ADR 0006 — Change set deferred tool confirmation
     last_modified: 2026-02-28
+  - id: adr-0052
+    resource: ../../../docs/adr/0052-agent-directive-constitution.md
+    title: ADR 0052 — An agent's constitution is code, not an evolvable directive
+    last_modified: 2026-08-08
 ---
 
 # Creation
@@ -309,6 +313,14 @@ Common changes across the path:
   `propose_directives` takes a complete rewrite rather than a delta, so a
   session shown the seeded text would rewrite a contract that was never in
   effect and have it adopted wholesale.
+- The **general** directive follows the same rule via
+  `effectiveGeneralDirective`: the seeded `taskAgentGeneralDirective` resolves to
+  empty because the scaffold's constitution already asserts user sovereignty,
+  tool discipline, the no-op rules, checklist sovereignty, priority/due-date
+  sovereignty and input handling. Only an evolved or hand-written directive is
+  rendered, and it is appended after the constitution — it adds, never replaces
+  (ADR 0052). Both scaffolds behave identically here; the compact one already
+  did.
 - The compact contract treats a concrete, committed multi-step plan as checklist
   intent even without the words "create a checklist"; it does **not** treat
   speculation or a description of current state as authority.

--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -313,6 +313,16 @@ Common changes across the path:
   `propose_directives` takes a complete rewrite rather than a delta, so a
   session shown the seeded text would rewrite a contract that was never in
   effect and have it adopted wholesale.
+- **Whether a directive is Lotti's own is decided by provenance, not by text.**
+  `AgentAuthors.isSystemAuthored(version.authoredBy)` — exactly `system` —
+  settles both checks before any comparison; the exact-match against the seeded
+  constant is only the fallback for versions whose author cannot settle it.
+  Comparing text alone misclassified every install seeded before a constant was
+  last edited as *customised*, which disabled the model-tuned report contract for
+  it and left the superseded "call `update_report` every wake" text in force.
+  `system:config_change` deliberately does **not** count as system authorship —
+  it marks a version that copied directives forward, so on an evolved template it
+  sits on evolved text — and that copy-forward now preserves the original author.
 - The **general** directive follows the same rule via
   `effectiveGeneralDirective`: the seeded `taskAgentGeneralDirective` resolves to
   empty because the scaffold's constitution already asserts user sovereignty,

--- a/knowledge/features/agents/templates-souls-evolution.md
+++ b/knowledge/features/agents/templates-souls-evolution.md
@@ -28,6 +28,14 @@ sources:
     resource: ../../../docs/adr/0012-recursive-self-improvement-depth-policy.md
     title: ADR 0012 — Recursive self-improvement depth policy
     last_modified: 2026-03-01
+  - id: adr-0052
+    resource: ../../../docs/adr/0052-agent-directive-constitution.md
+    title: ADR 0052 — An agent's constitution is code, not an evolvable directive
+    last_modified: 2026-08-08
+  - id: prompt-builder
+    resource: ../../../lib/features/agents/workflow/task_agent_prompt_builder.dart
+    title: TaskAgentPromptBuilder — scaffold constants and effective directives
+    last_modified: 2026-08-08
 ---
 
 # Two axes: skills and personality
@@ -38,6 +46,22 @@ The feature separates **what an agent does** from **who it is**:
 |---|------|--------------|
 | **Template** | Operational directives — skills | Template row + version rows + head pointer |
 | **Soul** | `voiceDirective`, `toneBounds`, `coachingStyle`, `antiSycophancyPolicy` | Soul row + version rows + head pointer |
+
+Neither axis is the whole prompt. A third, **unversioned and unrewritable**
+layer sits above both: the constitution in `TaskAgentPromptBuilder`'s scaffold
+constants — role, wake-finishing contract, tool authority boundaries, user
+sovereignty, no-op rules, checklist sovereignty, input handling. Evolution
+cannot reach it, it changes only when the app ships, and a template directive is
+rendered *after* it, so a directive adds to the constitution and never replaces
+it (ADR 0052).
+
+That is why a stock task-agent template contributes **nothing** to its own
+prompt: `TaskAgentPromptBuilder.effectiveGeneralDirective` resolves the seeded
+`taskAgentGeneralDirective` to empty, because the scaffold already states those
+rules and two wordings of one rule — one of them editable — is a drift risk paid
+for on every wake. The seeded constant is kept byte-for-byte stable as the
+compatibility sentinel that recognises templates seeded on earlier versions, the
+same arrangement as `taskAgentReportDirective`.
 
 ```mermaid
 erDiagram
@@ -110,6 +134,16 @@ stateDiagram-v2
 ```
 
 **Only one active evolution session per template** at a time.
+
+**A proposal is a whole rewrite, so the session must be shown what is in
+effect.** `propose_directives` carries complete `general_directive` and
+`report_directive` strings and approval writes them verbatim, so whatever the
+context builder displays is the baseline that gets adopted. For task agents
+`EvolutionContextBuilder` therefore renders the *effective* directives rather
+than the stored ones: the substituted report contract, and — for a stock
+template — an explicit "adds nothing on top of the built-in constitution" note
+instead of the seeded text the agent never receives. Silence there would invite a
+proposal that restates code-owned rules.
 
 The UI splits into two surfaces: `EvolutionReviewPage` (a history-first ritual
 home with a pending-session card, compact metrics and persisted history) and

--- a/lib/features/agents/model/agent_constants.dart
+++ b/lib/features/agents/model/agent_constants.dart
@@ -84,6 +84,25 @@ abstract final class AgentReportScopes {
 abstract final class AgentAuthors {
   static const evolutionAgent = 'evolution_agent';
   static const system = 'system';
+
+  /// A version whose directives were written by seeding rather than by a person
+  /// or the evolution agent.
+  ///
+  /// This is the provenance signal the prompt builder uses to decide whether a
+  /// template carries Lotti's own directives (ADR 0052). It answers that
+  /// question directly, where comparing the text against today's seeded
+  /// constant only answers it for a template seeded since that constant last
+  /// changed — every earlier install reads as customised and silently loses the
+  /// substitutions the constants exist to drive.
+  ///
+  /// Deliberately exact rather than a `system:`-prefix match. Namespaced system
+  /// authors such as `system:config_change` are stamped on versions that *copy*
+  /// directives forward, so on an install that evolved a template and then
+  /// changed its model, that stamp sits on evolved text. Treating it as system
+  /// authorship would suppress a user-approved directive, which is a worse
+  /// failure than the one this fixes.
+  static bool isSystemAuthored(String authoredBy) =>
+      authoredBy.trim() == system;
 }
 
 /// Fixed schedule constants for recurring agent work.

--- a/lib/features/agents/service/agent_template_crud.dart
+++ b/lib/features/agents/service/agent_template_crud.dart
@@ -140,12 +140,19 @@ class AgentTemplateCrud {
           templateId,
         );
         if (activeVersion != null) {
+          // The directives are copied verbatim, so their author is unchanged —
+          // a model swap does not write a directive. Preserving it keeps the
+          // provenance the prompt builder reads (ADR 0052) intact across a
+          // config change; stamping a new author here made a seeded template
+          // look customised and an evolved one look system-authored. The
+          // config change itself stays visible in the version history through
+          // the modelId/profileId difference from the version it supersedes.
           await createVersion(
             templateId: templateId,
             directives: activeVersion.directives,
             generalDirective: activeVersion.generalDirective,
             reportDirective: activeVersion.reportDirective,
-            authoredBy: 'system:config_change',
+            authoredBy: activeVersion.authoredBy,
           );
         }
       }

--- a/lib/features/agents/workflow/evolution_context_builder.dart
+++ b/lib/features/agents/workflow/evolution_context_builder.dart
@@ -226,24 +226,34 @@ again. The conversation should always be driving toward an approved proposal.
     // Present directives — use split fields when available, fall back to
     // the legacy single field.
     //
-    // Task agents get the *effective* report directive rather than the stored
-    // one. For a stock template the stored value is `taskAgentReportDirective`,
-    // which `TaskAgentPromptBuilder` always substitutes and the agent therefore
-    // never receives — and the two contradict each other, the seeded text
-    // demanding `update_report` on every wake where the substituted one asks
-    // for a plain-text note when nothing changed. Showing the stored text here
-    // had this session rewriting a directive that was never in effect, and
-    // `propose_directives` takes a complete rewrite rather than a delta, so the
-    // wrong baseline would be adopted wholesale.
-    final generalDirective = currentVersion.generalDirective.trim();
+    // Task agents get the *effective* directives rather than the stored ones,
+    // because for a stock template neither stored value is what the agent
+    // receives (ADR 0052). The report field holds `taskAgentReportDirective`,
+    // which `TaskAgentPromptBuilder` always substitutes — and the two
+    // contradict each other, the seeded text demanding `update_report` on every
+    // wake where the substituted one asks for a plain-text note when nothing
+    // changed. The general field holds the seeded constitution, which the
+    // scaffold now states instead. Showing a stored text here had this session
+    // rewriting a directive that was never in effect, and `propose_directives`
+    // takes a complete rewrite rather than a delta, so the wrong baseline would
+    // be adopted wholesale.
+    final storedGeneralDirective = currentVersion.generalDirective.trim();
     final storedReportDirective = currentVersion.reportDirective.trim();
+    final isTaskAgent = template.kind == AgentTemplateKind.taskAgent;
+    // Same rule as the report directive: show what the agent receives. A stock
+    // task-agent template stores the seeded general directive, which the prompt
+    // builder no longer renders because the scaffold's constitution already
+    // states those rules — so an empty effective directive means "this template
+    // adds nothing on top of the constitution", not "the agent has no rules".
+    final generalDirective = isTaskAgent
+        ? TaskAgentPromptBuilder.effectiveGeneralDirective(currentVersion)
+        : storedGeneralDirective;
     // Whether this template uses the split fields at all is decided by what is
     // stored, so a legacy template with neither still falls back to its single
     // `directives` field below.
     final hasNewDirectives =
-        generalDirective.isNotEmpty || storedReportDirective.isNotEmpty;
-    final reportDirective =
-        template.kind == AgentTemplateKind.taskAgent && hasNewDirectives
+        storedGeneralDirective.isNotEmpty || storedReportDirective.isNotEmpty;
+    final reportDirective = isTaskAgent && hasNewDirectives
         ? TaskAgentPromptBuilder.effectiveReportDirective(
             version: currentVersion,
           ).trim()
@@ -256,6 +266,23 @@ again. The conversation should always be driving toward an approved proposal.
             '## Current General Directive (v${currentVersion.version})',
           )
           ..writeln(generalDirective)
+          ..writeln();
+      } else if (isTaskAgent) {
+        // Say so explicitly. Silence here reads as "no operational rules",
+        // which invites a proposal that restates the constitution — text the
+        // agent already receives from the scaffold and cannot be edited away.
+        buf
+          ..writeln(
+            '## Current General Directive (v${currentVersion.version})',
+          )
+          ..writeln(
+            'None. This template adds nothing on top of the built-in task-agent '
+            'constitution, which is code-owned: user sovereignty, tool '
+            'discipline, no-op rules, checklist sovereignty and input handling '
+            'are always in force and cannot be changed from here. Propose a '
+            'general directive only for guidance that ADDS to those rules, and '
+            'never restate them.',
+          )
           ..writeln();
       }
       if (reportDirective.isNotEmpty) {

--- a/lib/features/agents/workflow/task_agent_prompt_builder.dart
+++ b/lib/features/agents/workflow/task_agent_prompt_builder.dart
@@ -22,12 +22,18 @@ abstract final class TaskAgentPromptBuilder {
     required SoulDocumentVersionEntity? soulVersion,
     String? modelId,
   }) {
-    final trimmedGeneralDirective = version.generalDirective.trim();
+    final trimmedGeneralDirective = effectiveGeneralDirective(version);
     final trimmedReportDirective = effectiveReportDirective(
       version: version,
       modelId: modelId,
     );
-    final trimmedLegacyDirective = version.directives.trim();
+    // The legacy blob is a fallback for versions predating the split fields, so
+    // it is keyed on the *stored* general directive being absent. Keying it on
+    // the effective one would surface the blob for every stock template, whose
+    // stored directive is the seeded constitution rather than nothing.
+    final trimmedLegacyDirective = version.generalDirective.trim().isEmpty
+        ? version.directives.trim()
+        : '';
 
     if (TaskAgentEvidenceSynthesis.usesCompactScaffold(modelId)) {
       return _buildCompactEvidencePrompt(
@@ -69,16 +75,16 @@ abstract final class TaskAgentPromptBuilder {
       }
     } else {
       // No soul: legacy combined heading.
-      final effectiveGeneralDirective = trimmedGeneralDirective.isNotEmpty
+      final withLegacyFallback = trimmedGeneralDirective.isNotEmpty
           ? trimmedGeneralDirective
           : trimmedLegacyDirective;
-      if (effectiveGeneralDirective.isNotEmpty) {
+      if (withLegacyFallback.isNotEmpty) {
         buf
           ..writeln()
           ..writeln()
           ..writeln('## Your Personality & Directives')
           ..writeln()
-          ..write(effectiveGeneralDirective);
+          ..write(withLegacyFallback);
       }
     }
 
@@ -102,6 +108,33 @@ abstract final class TaskAgentPromptBuilder {
     return configuredReportDirective.isEmpty ||
         configuredReportDirective == taskAgentReportDirective.trim();
   }
+
+  /// Whether [version] carries Lotti's seeded general directive rather than
+  /// template-specific guidance.
+  ///
+  /// The seeded text restates rules the scaffold already asserts — user
+  /// sovereignty, tool discipline, input handling — so rendering both spends
+  /// payload on a second, *editable* wording of a code-owned rule. The same
+  /// exact-match **compatibility sentinel** as
+  /// [usesBuiltInReportContract] applies: templates seeded on earlier versions
+  /// store the constant byte-for-byte and are recognised by it, so the constant
+  /// must stay stable even though it is no longer rendered.
+  static bool usesBuiltInGeneralDirective(AgentTemplateVersionEntity version) {
+    final configured = version.generalDirective.trim();
+    return configured.isEmpty || configured == taskAgentGeneralDirective.trim();
+  }
+
+  /// The general directive this wake actually receives.
+  ///
+  /// Empty for a stock template: the constitution in the scaffold is the whole
+  /// operational contract, and there is nothing template-specific to add. An
+  /// evolved or hand-written directive is returned verbatim and rendered after
+  /// the scaffold, so it can add to the constitution but never replaces it.
+  static String effectiveGeneralDirective(
+    AgentTemplateVersionEntity version,
+  ) => usesBuiltInGeneralDirective(version)
+      ? ''
+      : version.generalDirective.trim();
 
   /// Resolves the report directive that is authoritative for this wake.
   ///
@@ -133,8 +166,7 @@ abstract final class TaskAgentPromptBuilder {
 
     if (soulVersion != null) {
       _appendSoulPersonality(buf, soulVersion);
-      if (generalDirective.isNotEmpty &&
-          generalDirective != taskAgentGeneralDirective.trim()) {
+      if (generalDirective.isNotEmpty) {
         buf
           ..writeln()
           ..writeln()
@@ -143,17 +175,16 @@ abstract final class TaskAgentPromptBuilder {
           ..write(generalDirective);
       }
     } else {
-      final effectiveGeneralDirective = generalDirective.isNotEmpty
+      final withLegacyFallback = generalDirective.isNotEmpty
           ? generalDirective
           : legacyDirective;
-      if (effectiveGeneralDirective.isNotEmpty &&
-          effectiveGeneralDirective != taskAgentGeneralDirective.trim()) {
+      if (withLegacyFallback.isNotEmpty) {
         buf
           ..writeln()
           ..writeln()
           ..writeln('## Your Personality & Directives')
           ..writeln()
-          ..write(effectiveGeneralDirective);
+          ..write(withLegacyFallback);
       }
     }
 
@@ -465,6 +496,11 @@ linked task's own agent does not push updates to you.
 - **Status**: never set a status the task already has. "IN PROGRESS" when time
   is being logged, "BLOCKED" or "ON HOLD" only with a stated reason. DONE and
   REJECTED are user-only. Never infer a status from assumption.
+- **Priority and due date**: a value the user set is sovereign. Change it only
+  when the user asks, or when dated evidence newer than their change makes it
+  clearly wrong — and say which evidence in your reasoning. When you disagree
+  and have no such evidence, surface the discrepancy in the report or an
+  observation and leave the field alone.
 - **Language**: write the report and TLDR in the task's `languageCode`. If it
   is null, detect it and call `set_task_language`; if it is already set, do not.
 - **Checklist sovereignty**: items record who last toggled them and when.
@@ -528,6 +564,13 @@ The `## Open Proposal Guard` lists your open suggestions and their fingerprints.
    near-identical.
 3. **Do not re-propose rejected or retracted items** unless the context has
    materially changed; when you do, justify it in the report.
+
+## Input Handling
+
+User input arrives imperfect: rough audio transcripts, typos, shorthand, half
+sentences. Infer the intent and act on it without complaint. When the intent is
+genuinely ambiguous, ask rather than assume — and never treat a garbled input as
+authority for a mutation you would not otherwise make.
 
 ## Important
 

--- a/lib/features/agents/workflow/task_agent_prompt_builder.dart
+++ b/lib/features/agents/workflow/task_agent_prompt_builder.dart
@@ -1,3 +1,4 @@
+import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/seeded_directive_content.dart';
 import 'package:lotti/features/agents/workflow/task_agent_evidence_synthesis.dart';
@@ -97,16 +98,21 @@ abstract final class TaskAgentPromptBuilder {
   /// Evidence synthesis substitutes its model-tuned report contract only for
   /// this seeded value. A custom directive remains authoritative.
   ///
-  /// The exact-match against [taskAgentReportDirective] is a **compatibility
-  /// sentinel**, not a content check: templates seeded on earlier versions
-  /// store that text byte-for-byte and are recognised by it. Editing the
-  /// constant would reclassify every one of them as customised and silently
-  /// stop substituting the model-tuned contract for them, so the constant has
-  /// to stay stable even though it is never rendered.
+  /// Provenance decides first: a system-authored version holds directives
+  /// seeding wrote, whichever release wrote them.
+  ///
+  /// The exact-match against [taskAgentReportDirective] remains as a
+  /// **compatibility sentinel** for versions whose author cannot settle it —
+  /// notably `system:config_change`, which copies directives forward. It is not
+  /// enough on its own: the constant has been edited (2026-04-19, 2026-06-07),
+  /// so every template seeded before the last edit fails the comparison and is
+  /// read as customised, which silently disables the model-tuned contract for
+  /// it. The constant still has to stay stable, and is still never rendered.
   static bool usesBuiltInReportContract(AgentTemplateVersionEntity version) {
     final configuredReportDirective = version.reportDirective.trim();
-    return configuredReportDirective.isEmpty ||
-        configuredReportDirective == taskAgentReportDirective.trim();
+    if (configuredReportDirective.isEmpty) return true;
+    if (AgentAuthors.isSystemAuthored(version.authoredBy)) return true;
+    return configuredReportDirective == taskAgentReportDirective.trim();
   }
 
   /// Whether [version] carries Lotti's seeded general directive rather than
@@ -114,14 +120,18 @@ abstract final class TaskAgentPromptBuilder {
   ///
   /// The seeded text restates rules the scaffold already asserts — user
   /// sovereignty, tool discipline, input handling — so rendering both spends
-  /// payload on a second, *editable* wording of a code-owned rule. The same
-  /// exact-match **compatibility sentinel** as
-  /// [usesBuiltInReportContract] applies: templates seeded on earlier versions
-  /// store the constant byte-for-byte and are recognised by it, so the constant
-  /// must stay stable even though it is no longer rendered.
+  /// payload on a second, *editable* wording of a code-owned rule.
+  ///
+  /// Resolved the same way as [usesBuiltInReportContract]: provenance first,
+  /// then the exact-match sentinel for versions whose author cannot settle it.
+  /// The general-directive constant has its own edit history (2026-03-02,
+  /// 2026-06-07), so text comparison alone would read an install seeded before
+  /// the last edit as customised.
   static bool usesBuiltInGeneralDirective(AgentTemplateVersionEntity version) {
     final configured = version.generalDirective.trim();
-    return configured.isEmpty || configured == taskAgentGeneralDirective.trim();
+    if (configured.isEmpty) return true;
+    if (AgentAuthors.isSystemAuthored(version.authoredBy)) return true;
+    return configured == taskAgentGeneralDirective.trim();
   }
 
   /// The general directive this wake actually receives.

--- a/test/features/agents/service/agent_template_service_test.dart
+++ b/test/features/agents/service/agent_template_service_test.dart
@@ -1559,9 +1559,13 @@ void main() {
         activeVersion.reportDirective,
         reason: '$scenario',
       );
+      // The directives are copied, not written, so their author carries over.
+      // A model swap that restamped the author made a seeded template read as
+      // customised — and an evolved one read as system-authored, which would
+      // suppress a user-approved directive (ADR 0052).
       expect(
         newVersion.authoredBy,
-        'system:config_change',
+        activeVersion.authoredBy,
         reason: '$scenario',
       );
       expect(

--- a/test/features/agents/workflow/evolution_context_builder_test.dart
+++ b/test/features/agents/workflow/evolution_context_builder_test.dart
@@ -469,4 +469,93 @@ void main() {
       );
     });
   });
+
+  group('general directive shown to the evolution session', () {
+    test('a stock task agent is told the constitution is code-owned', () {
+      final ctx = builder.build(
+        template: makeTestTemplate(displayName: 'Laura'),
+        currentVersion: makeTestTemplateVersion(
+          id: 'v1',
+          generalDirective: taskAgentGeneralDirective,
+          reportDirective: taskAgentReportDirective,
+        ),
+        recentVersions: const [],
+        instanceReports: const [],
+        instanceObservations: const [],
+        pastNotes: const [],
+        metrics: makeTestMetrics(),
+        changesSinceLastSession: 0,
+      );
+
+      // Not the seeded body: the prompt builder no longer renders it, so a
+      // session shown that text would rewrite rules the agent never received.
+      expect(
+        ctx.initialUserMessage,
+        isNot(contains('User input is direct evidence of user intent.')),
+      );
+      // And not silence either — silence invites a proposal that restates the
+      // constitution the scaffold already carries.
+      expect(
+        ctx.initialUserMessage,
+        contains('adds nothing on top of the built-in task-agent'),
+      );
+      expect(ctx.initialUserMessage, contains('never restate them'));
+    });
+
+    test('an evolved directive is shown verbatim', () {
+      final ctx = builder.build(
+        template: makeTestTemplate(displayName: 'Laura'),
+        currentVersion: makeTestTemplateVersion(
+          id: 'v2',
+          generalDirective: 'Escalate contractual blockers within one wake.',
+          reportDirective: taskAgentReportDirective,
+        ),
+        recentVersions: const [],
+        instanceReports: const [],
+        instanceObservations: const [],
+        pastNotes: const [],
+        metrics: makeTestMetrics(),
+        changesSinceLastSession: 0,
+      );
+
+      expect(
+        ctx.initialUserMessage,
+        contains('Escalate contractual blockers within one wake.'),
+      );
+      expect(
+        ctx.initialUserMessage,
+        isNot(contains('adds nothing on top of the built-in task-agent')),
+      );
+    });
+
+    test('a non-task template still shows its stored general directive', () {
+      // The substitution is a task-agent rule; a project-agent session must
+      // keep seeing exactly what its own prompt builder renders.
+      final ctx = builder.build(
+        template: makeTestTemplate(
+          displayName: 'Max',
+          kind: AgentTemplateKind.projectAgent,
+        ),
+        currentVersion: makeTestTemplateVersion(
+          id: 'v1',
+          generalDirective: projectAgentGeneralDirective,
+        ),
+        recentVersions: const [],
+        instanceReports: const [],
+        instanceObservations: const [],
+        pastNotes: const [],
+        metrics: makeTestMetrics(),
+        changesSinceLastSession: 0,
+      );
+
+      expect(
+        ctx.initialUserMessage,
+        contains(projectAgentGeneralDirective.trim().split('\n').first),
+      );
+      expect(
+        ctx.initialUserMessage,
+        isNot(contains('adds nothing on top of the built-in task-agent')),
+      );
+    });
+  });
 }

--- a/test/features/agents/workflow/task_agent_prompt_builder_test.dart
+++ b/test/features/agents/workflow/task_agent_prompt_builder_test.dart
@@ -416,6 +416,84 @@ Lead with the decision. Keep it to three sentences.''';
       expect(prompt, contains('User actions are sovereign.'));
     });
 
+    test('an install seeded on an older release is still recognised', () {
+      // The whole reason provenance decides before text: both seeded constants
+      // have been edited, so a template seeded before the last edit stores text
+      // that matches neither constant. Judged on text alone it reads as
+      // customised — which renders a stale constitution *and* disables the
+      // model-tuned report contract, the one that tells a wake not to
+      // republish an unchanged report.
+      const oldSeededGeneral =
+          '## User Sovereignty\n\nAn older release wrote '
+          'this text, which no constant matches today.';
+      const oldSeededReport =
+          '## MANDATORY FINAL TOOL CALL\n\nAn older '
+          'release wrote this too.';
+      final version = makeTestTemplateVersion(
+        generalDirective: oldSeededGeneral,
+        reportDirective: oldSeededReport,
+        authoredBy: 'system',
+      );
+
+      expect(TaskAgentPromptBuilder.usesBuiltInGeneralDirective(version), true);
+      expect(TaskAgentPromptBuilder.usesBuiltInReportContract(version), true);
+
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: version,
+        soulVersion: null,
+      );
+
+      expect(prompt, isNot(contains('An older release wrote this text')));
+      expect(prompt, isNot(contains('MANDATORY FINAL TOOL CALL')));
+      expect(prompt, contains('do not republish unchanged content'));
+      expect(prompt, contains('## Input Handling'));
+    });
+
+    test('a config-change stamp never counts as system authorship', () {
+      // `system:config_change` is stamped on versions that COPY directives
+      // forward, so on an install that evolved a template and then changed its
+      // model it sits on evolved text. Treating it as seeding would delete a
+      // user-approved directive from the prompt.
+      final version = makeTestTemplateVersion(
+        generalDirective: 'Escalate contractual blockers within one wake.',
+        reportDirective: 'Lead with the delivery decision.',
+        authoredBy: 'system:config_change',
+      );
+
+      expect(
+        TaskAgentPromptBuilder.usesBuiltInGeneralDirective(version),
+        false,
+      );
+      expect(TaskAgentPromptBuilder.usesBuiltInReportContract(version), false);
+
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: version,
+        soulVersion: null,
+      );
+
+      expect(
+        prompt,
+        contains('Escalate contractual blockers within one wake.'),
+      );
+      expect(prompt, contains('Lead with the delivery decision.'));
+    });
+
+    test('an evolved directive is never mistaken for a seeded one', () {
+      final version = makeTestTemplateVersion(
+        generalDirective: 'Escalate contractual blockers within one wake.',
+        authoredBy: 'evolution_agent',
+      );
+
+      expect(
+        TaskAgentPromptBuilder.usesBuiltInGeneralDirective(version),
+        false,
+      );
+      expect(
+        TaskAgentPromptBuilder.effectiveGeneralDirective(version),
+        'Escalate contractual blockers within one wake.',
+      );
+    });
+
     test('a stock template never surfaces its legacy persona blob', () {
       // Seeded templates carry both a `directives` blurb and the seeded
       // general directive. Suppressing the latter must not promote the former:

--- a/test/features/agents/workflow/task_agent_prompt_builder_test.dart
+++ b/test/features/agents/workflow/task_agent_prompt_builder_test.dart
@@ -304,6 +304,135 @@ Use the task language and omit empty sections.
     });
   });
 
+  group('the constitution is code-owned', () {
+    // The rules an agent must never lose — user sovereignty, tool discipline,
+    // input handling — belong to the scaffold, not to the evolvable
+    // `generalDirective`. See docs/adr/0052-agent-directive-constitution.md.
+    // Each assertion names a rule that used to live only in the seeded
+    // directive, which one evolution session could paraphrase away.
+    const codeOwnedRules = <String>[
+      'Checklist sovereignty', // user-checked items keep their state
+      'a value the user set is sovereign', // priority and due date
+      'the user wins — make no call at all', // no-op rule
+      'Never change an existing title', // title
+      'DONE and\n  REJECTED are user-only', // status
+      '## Input Handling', // rough transcripts, ask rather than assume
+      '**Past decisions**', // proposal-ledger discipline
+    ];
+
+    test('identifies only an empty and the seeded general directive as built '
+        'in', () {
+      for (final scenario in [
+        (directive: '', expected: true),
+        (directive: taskAgentGeneralDirective, expected: true),
+        (directive: '  $taskAgentGeneralDirective  ', expected: true),
+        (directive: 'Escalate contractual blockers.', expected: false),
+      ]) {
+        final version = makeTestTemplateVersion(
+          generalDirective: scenario.directive,
+        );
+        expect(
+          TaskAgentPromptBuilder.usesBuiltInGeneralDirective(version),
+          scenario.expected,
+          reason: scenario.directive,
+        );
+        expect(
+          TaskAgentPromptBuilder.effectiveGeneralDirective(version),
+          scenario.expected ? '' : scenario.directive.trim(),
+          reason: scenario.directive,
+        );
+      }
+    });
+
+    test('a stock template gets the rules from the scaffold, not a second '
+        'editable copy', () {
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: makeTestTemplateVersion(
+          generalDirective: taskAgentGeneralDirective,
+          reportDirective: taskAgentReportDirective,
+        ),
+        soulVersion: null,
+      );
+
+      for (final rule in codeOwnedRules) {
+        expect(prompt, contains(rule), reason: rule);
+      }
+      // The seeded wording is not rendered on top of it: two wordings of one
+      // rule cost payload and can disagree once one of them is evolved.
+      expect(
+        prompt,
+        isNot(contains('User input is direct evidence of user intent.')),
+        reason: 'the seeded restatement must not be rendered as well',
+      );
+      expect(prompt, isNot(contains('## Your Personality & Directives')));
+    });
+
+    test('an evolved directive that drops the rules cannot remove them', () {
+      // The failure this design prevents: `propose_directives` takes a whole
+      // rewrite, so a session that paraphrases and omits a bullet used to
+      // delete a sovereignty guarantee outright.
+      const evolved = '''
+## Voice
+
+Lead with the decision. Keep it to three sentences.''';
+
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: makeTestTemplateVersion(generalDirective: evolved),
+        soulVersion: null,
+      );
+
+      for (final rule in codeOwnedRules) {
+        expect(prompt, contains(rule), reason: rule);
+      }
+      // The evolved text is still honoured — it adds, it does not replace.
+      expect(prompt, contains('Lead with the decision.'));
+      expect(
+        prompt.indexOf('Lead with the decision.'),
+        greaterThan(prompt.indexOf('## Input Handling')),
+        reason: 'template guidance is appended after the constitution',
+      );
+    });
+
+    test('the measured compact prompt is unchanged for a stock template', () {
+      // The compact scaffold already suppressed the seeded directive and
+      // carries its own constitution; the numbers behind it were measured on
+      // that exact text. A stock template must therefore produce the scaffold
+      // plus the evidence protocol and nothing else.
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: makeTestTemplateVersion(
+          generalDirective: taskAgentGeneralDirective,
+          reportDirective: taskAgentReportDirective,
+        ),
+        soulVersion: null,
+        modelId: 'qwen3.5-122b-a10b',
+      );
+
+      expect(
+        prompt,
+        startsWith(TaskAgentPromptBuilder.taskAgentCompactScaffold),
+      );
+      expect(prompt, isNot(contains('## Your Personality & Directives')));
+      expect(prompt, isNot(contains('## Your Operational Directives')));
+      expect(prompt, contains('User actions are sovereign.'));
+    });
+
+    test('a stock template never surfaces its legacy persona blob', () {
+      // Seeded templates carry both a `directives` blurb and the seeded
+      // general directive. Suppressing the latter must not promote the former:
+      // the legacy fallback is for versions that predate the split fields.
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: makeTestTemplateVersion(
+          directives: 'You are Laura, a diligent task management agent.',
+          generalDirective: taskAgentGeneralDirective,
+        ),
+        soulVersion: null,
+      );
+
+      expect(prompt, isNot(contains('You are Laura')));
+      expect(prompt, contains('## Input Handling'));
+    });
+  });
+
   group('the seeded report directive is never rendered', () {
     // The constant reads like the live rule and contradicts it. On 2026-08-08
     // it was mistaken for production behaviour and a correct evaluation result

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/seeded_directive_content.dart';
@@ -1157,7 +1158,14 @@ String _buildEvalSystemPrompt(
                 '$taskAgentGeneralDirective${_evalVariantDirective(variant)}',
             reportDirective:
                 reportDirective ?? _reportDirectiveForVariant(variant),
-            authoredBy: 'system',
+            // A variant is a tuned directive, not seeded text, so it must not
+            // claim system authorship: since ADR 0052 that is the provenance
+            // signal saying "these are Lotti's own directives", and claiming it
+            // here would make the prompt builder drop the very variant this
+            // matrix exists to measure. The `production` variant appends
+            // nothing, so it still resolves to the shipped stock prompt through
+            // the text sentinel.
+            authoredBy: AgentAuthors.evolutionAgent,
             createdAt: DateTime.utc(2026, 7, 10),
             vectorClock: null,
           )

--- a/test/features/ai/eval/task_agent_workflow_eval_harness_test.dart
+++ b/test/features/ai/eval/task_agent_workflow_eval_harness_test.dart
@@ -250,6 +250,18 @@ void main() {
         contains('do not republish unchanged content'),
         reason: 'the no-op rule the scenario tests must be in the real prompt',
       );
+      // The eval fleet runs on the common scaffold, and since ADR 0052 the
+      // restraint rules come from that scaffold rather than from the seeded
+      // general directive. Pin them here: a suite that measures models against
+      // a prompt missing them is measuring the wrong thing.
+      for (final rule in const [
+        'Checklist sovereignty',
+        'a value the user set is sovereign',
+        'the user wins — make no call at all',
+        '## Input Handling',
+      ]) {
+        expect(prompt, contains(rule), reason: rule);
+      }
       expect(
         prompt,
         isNot(contains('MANDATORY FINAL TOOL CALL')),


### PR DESCRIPTION
Follow-up to #3852, from a review of what template evolution is allowed to change.

## Why

`propose_directives` takes `general_directive` and `report_directive` as complete
strings — the session prompt says so: *"output the COMPLETE new directives text,
not a diff."* Approval writes both verbatim. So the question is which rules a
rewrite may touch.

**What was already safe.** Role, wake-finishing contract, job steps, tool
definitions and their authority boundaries, the evidence protocol and the
model-tuned report contract are code constants. Evolution cannot reach them.

**What the review initially got wrong**, and the ADR records it: the sovereignty
rules were *not* one paraphrase away from deletion. The scaffold already asserts
almost all of them — checklist sovereignty, the no-op rule, title, estimates,
status, proposal-ledger discipline. The real defects are duller:

* **Two wordings of one rule**, one of them editable, paid for on every wake and
  free to drift apart once evolved.
* **Two rules that lived only in the editable copy**: user-set priority and due
  date are sovereign, and input handling. A rewrite genuinely could drop those.

The compact scaffold used by the evaluated Qwen and Mistral profiles had already
solved this for itself — it carries its own constitution and suppresses a
byte-for-byte seeded directive. The common scaffold never adopted that, so one
template produced a duplicated prompt on one path and a single one on the other.

## What this changes

ADR 0052 records the three-layer contract — code-owned constitution, rewritable
template directive, standing rules — and step 1 implements the first layer:

* the two unprotected rules move into the code-owned scaffold;
* `effectiveGeneralDirective` resolves the seeded value to empty, so a stock wake
  gets one wording of each rule and an evolved directive is appended *after* the
  constitution: it adds, it never replaces;
* the evolution session is shown the effective directive, with an explicit
  "adds nothing on top of the constitution" note for a stock template — the same
  fix as the report directive in #3852, which existed because a session was
  rewriting a contract the agent never received.

The seeded constant is unchanged. It is the compatibility sentinel recognising
templates seeded on earlier versions; editing it would reclassify all of them as
customised and start rendering it again.

**The compact scaffold text is untouched.** It already carries the constitution
and the 27B/Mistral numbers were measured on that exact wording. A test pins that
a stock template yields the compact scaffold plus the evidence protocol and
nothing else.

## Eval implication

The eval fleet (GLM 5.2, Kimi K3, Qwen3.5 397B, Qwen3.6 27B, DeepSeek) runs on
the **common** scaffold, which this PR edits: the seeded restatement is gone, two
bullets are added, net payload for a stock template falls. Same rules, one
wording. The harness test now pins that those rules are present in the built eval
prompt, so the suite cannot silently start measuring a prompt without them. A
re-run of `penguin_wake_workflow_eval_live_test.dart` is the honest confirmation
and has not been done here.

## Not in this PR

Recorded as follow-ups in the ADR, in order:

1. **Make the report directive additive.** A custom report directive flips
   `usesBuiltInReportContract` to false, which permanently disables the
   model-tuned contract for that template — the contract behind 27B's 10/14 →
   13/14. Normal evolution output triggers it and the proposal card does not say
   so.
2. **Give task agents standing rules.** `PlannerKnowledgeEntity` (ADR 0022) is
   already the right mechanism: keyed statements, always-injected hook,
   proposed → confirmed → retracted, scoped. Task agents do not read it. That is
   the additive layer, and it dissolves the session prompt's contradiction
   between "smallest directive changes" and "output the COMPLETE text".

## What an already-running install gets (added after review)

The question that shaped the third commit: what happens to a system that has
evolved its agents a few times? The answer turned out to be less about evolution
than about **age**.

"Are these our directives?" was decided by comparing stored text to today's
seeded constant — an equality test against a moving target.
`taskAgentReportDirective` was edited 2026-04-19 (#2971) and 2026-06-07 (#3286),
`taskAgentGeneralDirective` 2026-03-02 (#2737) and 2026-06-07 (#3286). **Every
install seeded before the last edit fails that comparison and is classified as
customised**, without anyone having customised anything. For the report directive
that is live today and worse than duplication: the model-tuned contract is never
substituted, so the agent runs on the superseded `## MANDATORY FINAL TOOL CALL`
text mandating `update_report` every wake — the behaviour `noOp` penalises, and
one the harness cannot reproduce because it seeds the current constant.

`AgentAuthors.isSystemAuthored` now settles both checks before any comparison,
with the equality test kept as fallback. `system:config_change` deliberately does
**not** count — it marks a version that copied directives forward, so on an
evolved template it sits on evolved text, and claiming it would delete a
user-approved directive. That copy-forward now preserves the original author.

| Install state | Before | After |
| --- | --- | --- |
| Seeded on current release | seeded constitution on top of the scaffold's | constitution once, from the scaffold |
| Seeded on an older release | read as customised; model-tuned report contract **disabled** | recognised by author |
| Evolved / hand-edited | verbatim | verbatim, after a complete constitution |
| Evolved, then model changed | verbatim | verbatim — provenance declines to claim it |
| Legacy, no split fields | `directives` blob | unchanged |

Personality is untouched in every row: soul versions have no sentinel and no
substitution.

This fixes *misclassification*, not stale text — an install seeded in March still
runs March's wording, now correctly recognised as ours. Re-seeding, as
`seedDayAgentCaptureReconcileDirective` does for the day agent, is left as a
separate decision in the ADR because it mints a version per template on upgrade.

The rule immediately earned itself: the local-inference eval fixtures claimed
`authoredBy: 'system'` for *tuned* variant directives, so the builder correctly
dropped them and two tests failed. A variant is not seeded text; they are stamped
as evolution-authored now.

## Testing

`make knowledge_check` clean (92 concepts, 472 mermaid blocks). Analyzer clean.
5,436 tests pass across `test/features/agents/` and `test/features/ai/eval`. New tests: the sentinel and its effective resolution,
a stock template getting the rules once, an evolved directive that omits them not
being able to remove them, the compact prompt staying byte-identical, the legacy
persona blob not being promoted, and the three evolution-context cases. Each new
assertion was re-run with the change reverted — three fail.

No CHANGELOG entry: nothing a user sees at runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in guidance for task-agent priority, due-date handling, checklist sovereignty, and ambiguous input.
  - Custom or evolved directives are preserved and applied alongside built-in guidance.
  - Evolution sessions now clearly show the effective directives in use.
  - Improved handling of legacy and customized task-agent configurations.

- **Documentation**
  - Added architecture documentation describing directive layers, compatibility behavior, migration, and evolution workflows.
  - Updated task-agent feature documentation with the new directive composition rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->