### PR TITLE
feat(agents): a template's instruction wins, and declares what it overrides

### DIFF
--- a/docs/adr/0052-agent-directive-constitution.md
+++ b/docs/adr/0052-agent-directive-constitution.md
@@ -181,12 +181,59 @@ still pay for a second wording until their next evolution session. The
 slightly; net payload for a stock template still falls, because the seeded
 directive it replaces was longer than both.
 
-**What it does not fix.** Nothing stops an evolved directive from *contradicting*
-the constitution in prose. Ordering (constitution first, template guidance last)
-and the fact that only the constitution is code-owned are the mitigations; a
-contradiction is still a bad proposal that the user can reject and roll back.
-Making contradiction structurally impossible would mean constraining what a
-directive may say, which is a larger change than this.
+**Precedence is stated, and it favours the user — with one narrow exception.**
+Ordering alone was the wrong mitigation: the template directive is appended
+*last*, the position a model reads as the final word, so a contradiction
+resolved by accident. But the fix is not "the scaffold wins" either, which was
+this ADR's first instinct and is wrong. Nearly everything in the scaffold is
+**default behaviour** — when to set an estimate, how a report is shaped, which
+observation category to use, how terse to be — describing what the agent does
+when no instruction covers the case. Changing a default is not a conflict to
+resolve; it is the reason the evolvable layer exists, and a blanket precedence
+rule would have a model discard a legitimate customisation the moment it brushed
+against any scaffold line.
+
+So the statement now says the template's instruction takes precedence, and names
+the two things that are not preferences at all and therefore stand regardless:
+
+* **No fabrication.** No wording makes an invented id or an unearned claim valid.
+* **The agent does not undo the user's own actions on its own judgement.** A
+  directive may lift this only by saying when to act on the user's behalf —
+  that is the user deciding, not the agent.
+
+An instruction that cannot be carried out safely produces the closest thing that
+can, plus an observation naming the gap, so a quietly impossible directive
+surfaces instead of being dropped.
+
+**An override declares what it overrides.** A directive that departs from a
+default is expected to name it and give the reason — *"Default: X. Here: Y,
+because Z."* — and a declared override is followed exactly. The wake holds both
+texts, so a stated departure gives the model the baseline *and* the argument for
+leaving it, instead of two paragraphs that disagree. An undeclared contradiction
+is still followed — user rules win, and every directive written before this
+convention contains undeclared departures — but it is recorded as an observation,
+which is what carries it into the next evolution session to be stated properly.
+The evolution prompt asks for the same declaration when a proposal is written.
+
+A *customised* report directive gets a narrower statement: it governs the
+report's shape and voice, not whether to publish at all. That one exists because
+evolved report directives in the wild descend from the seeded text that demanded
+`update_report` on every wake, and would otherwise read as licence to republish
+an unchanged report. This is a scoping rule rather than an exception to
+user primacy: wanting a report on every wake is a legitimate preference, it is
+simply a *behaviour* change, so it belongs in the general directive as a declared
+override — which the evolution prompt says explicitly.
+
+All of these are emitted only where a template actually contributes text, so a
+stock prompt — and every measured eval prompt built from one — is byte-for-byte
+what it was.
+
+**What it still does not fix.** Nothing checks a proposal before it is stored, so
+a directive can still be vague, contradictory or undeclared; the prompt only
+decides what a wake does with it afterwards. Structural enforcement would mean
+constraining what a directive may say — plausibly a typed override (which default,
+what replaces it, why) rather than prose, which is a larger change and belongs
+with the standing-rules work.
 
 **What an existing install gets**, by what its active template version holds:
 

--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -331,6 +331,20 @@ Common changes across the path:
   rendered, and it is appended after the constitution — it adds, never replaces
   (ADR 0052). Both scaffolds behave identically here; the compact one already
   did.
+- **Precedence is stated in the prompt, and the template's instruction wins.**
+  `TaskAgentPromptBuilder.templateDirectivePrecedence` precedes a template's own
+  directive: the scaffold is *default behaviour* for cases no instruction covers,
+  and a directive that changes a default is the feature, not a conflict. Only
+  two things stand regardless, because they are not preferences — no fabrication,
+  and the agent never undoes the user's own actions on its own judgement (a
+  directive may lift that only by saying when to act on the user's behalf). An
+  override is expected to **declare** what it replaces and why; an undeclared
+  contradiction is still followed but recorded as an observation, which is what
+  carries it into the next evolution session. A *customised* report directive
+  additionally gets `reportDirectivePrecedence`, scoping it to the report's shape
+  and voice rather than to whether a report is published at all. Neither
+  statement appears for a stock template, so the shipped prompt is unchanged
+  (ADR 0052).
 - The compact contract treats a concrete, committed multi-step plan as checklist
   intent even without the words "create a checklist"; it does **not** treat
   speculation or a description of current state as authority.

--- a/knowledge/features/agents/templates-souls-evolution.md
+++ b/knowledge/features/agents/templates-souls-evolution.md
@@ -140,10 +140,18 @@ effect.** `propose_directives` carries complete `general_directive` and
 `report_directive` strings and approval writes them verbatim, so whatever the
 context builder displays is the baseline that gets adopted. For task agents
 `EvolutionContextBuilder` therefore renders the *effective* directives rather
-than the stored ones: the substituted report contract, and — for a stock
-template — an explicit "adds nothing on top of the built-in constitution" note
-instead of the seeded text the agent never receives. Silence there would invite a
-proposal that restates code-owned rules.
+than the stored ones — the substituted report contract, and nothing at all where
+a stock template's seeded directive used to appear.
+
+Every task-agent session also gets a `## What The Wake Already Carries` block,
+whether or not the template adds anything: the built-in prompt is framed as
+**default behaviour the directive may change**, with only two limits that are not
+preferences (no fabrication; the agent never undoes the user's own actions on its
+own judgement). It asks the session to **declare** each override — *"Default: X.
+Here: Y, because Z."* — because the wake receives both texts, and a declared
+departure is followed exactly where an unexplained contradiction makes the agent
+record a conflict instead. Without that block a session looking at an evolved
+directive has no idea a code-owned layer exists, and restates or contradicts it.
 
 The UI splits into two surfaces: `EvolutionReviewPage` (a history-first ritual
 home with a pending-session card, compact metrics and persisted history) and

--- a/lib/features/agents/workflow/evolution_context_builder.dart
+++ b/lib/features/agents/workflow/evolution_context_builder.dart
@@ -260,29 +260,20 @@ again. The conversation should always be driving toward an approved proposal.
         : storedReportDirective;
 
     if (hasNewDirectives) {
+      // Every task-agent session is told the constitution exists, whether or
+      // not this template adds to it. Stating it only when the template adds
+      // nothing was the wrong half: a session looking at an evolved directive
+      // is the one most likely to restate a code-owned rule, or to write
+      // something that contradicts one.
+      if (isTaskAgent) {
+        _writeConstitutionNotice(buf, addsNothing: generalDirective.isEmpty);
+      }
       if (generalDirective.isNotEmpty) {
         buf
           ..writeln(
             '## Current General Directive (v${currentVersion.version})',
           )
           ..writeln(generalDirective)
-          ..writeln();
-      } else if (isTaskAgent) {
-        // Say so explicitly. Silence here reads as "no operational rules",
-        // which invites a proposal that restates the constitution — text the
-        // agent already receives from the scaffold and cannot be edited away.
-        buf
-          ..writeln(
-            '## Current General Directive (v${currentVersion.version})',
-          )
-          ..writeln(
-            'None. This template adds nothing on top of the built-in task-agent '
-            'constitution, which is code-owned: user sovereignty, tool '
-            'discipline, no-op rules, checklist sovereignty and input handling '
-            'are always in force and cannot be changed from here. Propose a '
-            'general directive only for guidance that ADDS to those rules, and '
-            'never restate them.',
-          )
           ..writeln();
       }
       if (reportDirective.isNotEmpty) {
@@ -367,6 +358,68 @@ again. The conversation should always be driving toward an approved proposal.
     );
 
     return buf.toString();
+  }
+
+  /// Tells the session which rules it is not writing.
+  ///
+  /// [addsNothing] distinguishes the two shapes a task-agent template can have:
+  /// a stock one whose whole contract is the built-in prompt, and an evolved one
+  /// whose directive sits on top of it. Both sessions need the same briefing,
+  /// and the evolved one needs it more — it is the session most likely to
+  /// restate a built-in rule or to depart from one without saying so.
+  ///
+  /// The framing is deliberately permissive (ADR 0052): the built-in prompt is
+  /// *default behaviour* a directive may change, not a wall. Only fabrication
+  /// and the agent's unilateral override of the user are held back, because
+  /// neither is a preference. What the session is asked for is a **declared**
+  /// override — the wake follows a stated departure exactly, where an
+  /// unexplained contradiction only earns an observation.
+  static void _writeConstitutionNotice(
+    StringBuffer buf, {
+    required bool addsNothing,
+  }) {
+    buf
+      ..writeln('## What The Wake Already Carries')
+      ..writeln(
+        'Every wake receives a code-owned prompt you are not writing here: how '
+        'the agent reads a task, the tools it may call, when to publish a '
+        'report, which observation category to use, how terse to be. Treat all '
+        'of it as DEFAULT behaviour — what the agent does when no instruction '
+        'from this template covers the case. A directive that changes a '
+        'default is not a conflict; it is what this field is for, and the '
+        "template's instruction wins.",
+      )
+      ..writeln()
+      ..writeln(
+        'Two limits are not preferences and a directive cannot lift them: the '
+        'agent may not fabricate — no wording makes an invented id or an '
+        "unearned claim valid — and it may not undo the user's own actions on "
+        'its own judgement, though a directive may tell it when to act on the '
+        "user's behalf, since that is the user deciding rather than the agent. "
+        'Everything else is open if it is stated clearly and can actually be '
+        'carried out.',
+      )
+      ..writeln()
+      ..writeln(
+        'DECLARE every override. Name the default you are replacing and the '
+        'reason — "Default: X. Here: Y, because Z." The wake receives the '
+        'defaults as well as your directive, so a declared override is '
+        'followed exactly, while an unexplained contradiction makes the agent '
+        'record a conflict instead of acting cleanly. Restating a default '
+        'without changing it is dead weight; drop it. Put behaviour changes in '
+        'the general directive — including a change to WHEN a report is '
+        'published, which the report directive does not govern; that one only '
+        "shapes the report's structure and voice.",
+      )
+      ..writeln()
+      ..writeln(
+        addsNothing
+            ? 'This template currently adds nothing on top of that.'
+            : 'The directive below is what this template adds on top of that. '
+                  'Anything in it that merely restates a built-in rule is dead '
+                  'weight and can be dropped.',
+      )
+      ..writeln();
   }
 
   static void _writeSeedChangelog(

--- a/lib/features/agents/workflow/task_agent_prompt_builder.dart
+++ b/lib/features/agents/workflow/task_agent_prompt_builder.dart
@@ -38,6 +38,7 @@ abstract final class TaskAgentPromptBuilder {
 
     if (TaskAgentEvidenceSynthesis.usesCompactScaffold(modelId)) {
       return _buildCompactEvidencePrompt(
+        version: version,
         generalDirective: trimmedGeneralDirective,
         legacyDirective: trimmedLegacyDirective,
         reportDirective: trimmedReportDirective,
@@ -53,8 +54,9 @@ abstract final class TaskAgentPromptBuilder {
         ..writeln()
         ..writeln()
         ..writeln('## Report Directive')
-        ..writeln()
-        ..write(trimmedReportDirective);
+        ..writeln();
+      _appendReportDirectivePrecedence(buf, version);
+      buf.write(trimmedReportDirective);
     } else {
       buf.write(taskAgentScaffoldReport);
     }
@@ -72,6 +74,8 @@ abstract final class TaskAgentPromptBuilder {
           ..writeln()
           ..writeln('## Your Operational Directives')
           ..writeln()
+          ..writeln(templateDirectivePrecedence)
+          ..writeln()
           ..write(trimmedGeneralDirective);
       }
     } else {
@@ -84,6 +88,8 @@ abstract final class TaskAgentPromptBuilder {
           ..writeln()
           ..writeln()
           ..writeln('## Your Personality & Directives')
+          ..writeln()
+          ..writeln(templateDirectivePrecedence)
           ..writeln()
           ..write(withLegacyFallback);
       }
@@ -166,6 +172,7 @@ abstract final class TaskAgentPromptBuilder {
   }
 
   static String _buildCompactEvidencePrompt({
+    required AgentTemplateVersionEntity version,
     required String generalDirective,
     required String legacyDirective,
     required String reportDirective,
@@ -182,6 +189,8 @@ abstract final class TaskAgentPromptBuilder {
           ..writeln()
           ..writeln('## Your Operational Directives')
           ..writeln()
+          ..writeln(templateDirectivePrecedence)
+          ..writeln()
           ..write(generalDirective);
       }
     } else {
@@ -194,6 +203,8 @@ abstract final class TaskAgentPromptBuilder {
           ..writeln()
           ..writeln('## Your Personality & Directives')
           ..writeln()
+          ..writeln(templateDirectivePrecedence)
+          ..writeln()
           ..write(withLegacyFallback);
       }
     }
@@ -203,12 +214,92 @@ abstract final class TaskAgentPromptBuilder {
         ..writeln()
         ..writeln()
         ..writeln('## Report Directive')
-        ..writeln()
-        ..write(reportDirective);
+        ..writeln();
+      _appendReportDirectivePrecedence(buf, version);
+      buf.write(reportDirective);
     }
 
     buf.write(TaskAgentEvidenceSynthesis.systemDirectiveForModel(modelId));
     return buf.toString();
+  }
+
+  /// Names the rules a template's own directive cannot relax, and concedes
+  /// everything else.
+  ///
+  /// Emitted only when a template actually contributes a directive, so a stock
+  /// prompt is byte-identical to what it was without this. It exists because
+  /// concatenation alone says nothing about precedence, and the template text
+  /// lands *last* — the position a model tends to treat as the final word.
+  ///
+  /// Deliberately **not** "the scaffold always wins" (ADR 0052). Nearly
+  /// everything in the scaffold is *default behaviour* — when to set an
+  /// estimate, how to shape a report, which observation category to use, how
+  /// terse to be — describing what the agent does when no instruction covers
+  /// the case. A directive that changes one is not a conflict to resolve; it is
+  /// the reason the evolvable layer exists. A blanket precedence rule would
+  /// have a model drop a legitimate customisation the moment it brushed against
+  /// any scaffold line.
+  ///
+  /// What genuinely cannot be instructed away is not the scaffold but the two
+  /// things that are not preferences: fabrication, which no instruction can
+  /// make valid, and the agent overriding the user on its *own* judgement —
+  /// which a directive may lift only by telling it when to act on the user's
+  /// behalf, since that is the user deciding rather than the agent.
+  ///
+  /// An override is expected to **declare** what it replaces, so the wake reads
+  /// a stated departure rather than two texts that disagree. An undeclared
+  /// contradiction is still followed — user rules win, and every directive
+  /// written before this convention existed contains undeclared departures — but
+  /// it is recorded, so the next evolution session can state it properly
+  /// instead of the ambiguity persisting forever.
+  ///
+  /// The escape hatch matters as much as the rule: an instruction that cannot
+  /// be carried out safely produces the closest thing that can, plus an
+  /// observation naming the gap — so a directive that is quietly impossible
+  /// surfaces to the user instead of being silently dropped.
+  static const templateDirectivePrecedence =
+      "What follows is this template's own instruction. It takes precedence "
+      'over the default behaviour above, which describes what to do when no '
+      'instruction covers the case. An override should name the default it '
+      'replaces and why — "Default: X. Here: Y, because Z." — and a declared '
+      'override is followed exactly. If it contradicts a default without '
+      'saying so, follow the instruction anyway and record the undeclared '
+      'conflict with `record_observations` so it can be stated properly. Two '
+      'limits are not preferences and stand regardless: never fabricate — no '
+      'instruction makes an invented id or an unearned claim valid — and never '
+      "undo the user's own actions on your own judgement, though an "
+      'instruction may tell you when to act on their behalf. If an instruction '
+      'cannot be carried out safely, do the closest thing that can and record '
+      'the gap.';
+
+  /// The same statement for a customised report directive, scoped to what a
+  /// report directive legitimately governs.
+  ///
+  /// Presentation is the template's to decide; *whether to publish at all* is
+  /// not. Without this, an evolved directive carried over from the seeded text
+  /// — which demanded `update_report` on every wake — reads as licence to
+  /// republish an unchanged report, which is the exact behaviour the `noOp`
+  /// scenario measures.
+  static const reportDirectivePrecedence =
+      'This directive governs the shape and voice of the report only. It does '
+      'not change when to publish one: a wake with nothing material to add '
+      'still ends with a brief plain-text note rather than republishing '
+      'unchanged content.';
+
+  /// Writes [reportDirectivePrecedence] only ahead of a *customised* report
+  /// directive.
+  ///
+  /// A stock template renders the substituted model-tuned contract here, which
+  /// is code-owned — telling it that it does not override itself would be
+  /// noise, and would change a measured prompt.
+  static void _appendReportDirectivePrecedence(
+    StringBuffer buf,
+    AgentTemplateVersionEntity version,
+  ) {
+    if (usesBuiltInReportContract(version)) return;
+    buf
+      ..writeln(reportDirectivePrecedence)
+      ..writeln();
   }
 
   /// Appends soul personality fields to the prompt buffer.

--- a/test/features/agents/workflow/evolution_context_builder_test.dart
+++ b/test/features/agents/workflow/evolution_context_builder_test.dart
@@ -497,9 +497,33 @@ void main() {
       // constitution the scaffold already carries.
       expect(
         ctx.initialUserMessage,
-        contains('adds nothing on top of the built-in task-agent'),
+        contains('## What The Wake Already Carries'),
       );
-      expect(ctx.initialUserMessage, contains('never restate them'));
+      expect(
+        ctx.initialUserMessage,
+        contains('This template currently adds nothing on top of that.'),
+      );
+      // The built-in text is framed as DEFAULT behaviour a directive may
+      // change, not as a wall: user rules win where they are sensible.
+      expect(
+        ctx.initialUserMessage,
+        contains('Treat all of it as DEFAULT behaviour'),
+      );
+      expect(
+        ctx.initialUserMessage,
+        contains("template's instruction wins"),
+      );
+      // Only the two non-preferences are held back.
+      expect(
+        ctx.initialUserMessage,
+        contains('Two limits are not preferences'),
+      );
+      // And an override has to say what it overrides.
+      expect(ctx.initialUserMessage, contains('DECLARE every override'));
+      expect(
+        ctx.initialUserMessage,
+        contains('Default: X. Here: Y, because Z.'),
+      );
     });
 
     test('an evolved directive is shown verbatim', () {
@@ -522,9 +546,19 @@ void main() {
         ctx.initialUserMessage,
         contains('Escalate contractual blockers within one wake.'),
       );
+      // The constitution notice reaches an evolved template too — that session
+      // is the one most likely to restate or contradict a code-owned rule.
       expect(
         ctx.initialUserMessage,
-        isNot(contains('adds nothing on top of the built-in task-agent')),
+        contains('## What The Wake Already Carries'),
+      );
+      expect(
+        ctx.initialUserMessage,
+        contains('is what this template adds on top'),
+      );
+      expect(
+        ctx.initialUserMessage,
+        isNot(contains('currently adds nothing on top')),
       );
     });
 
@@ -554,7 +588,7 @@ void main() {
       );
       expect(
         ctx.initialUserMessage,
-        isNot(contains('adds nothing on top of the built-in task-agent')),
+        isNot(contains('## What The Wake Already Carries')),
       );
     });
   });

--- a/test/features/agents/workflow/task_agent_prompt_builder_test.dart
+++ b/test/features/agents/workflow/task_agent_prompt_builder_test.dart
@@ -494,6 +494,84 @@ Lead with the decision. Keep it to three sentences.''';
       );
     });
 
+    test('a template directive is labelled as additive, not final', () {
+      // Concatenation alone says nothing about precedence, and the template
+      // text lands last — the position a model reads as the final word. Both
+      // scaffolds must say which side wins.
+      for (final modelId in <String?>[null, 'qwen3.5-122b-a10b']) {
+        final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+          version: makeTestTemplateVersion(
+            generalDirective: 'Escalate contractual blockers within one wake.',
+          ),
+          soulVersion: null,
+          modelId: modelId,
+        );
+
+        expect(
+          prompt,
+          contains(TaskAgentPromptBuilder.templateDirectivePrecedence),
+          reason: 'modelId: $modelId',
+        );
+        expect(
+          prompt.indexOf(
+            TaskAgentPromptBuilder.templateDirectivePrecedence,
+          ),
+          lessThan(prompt.indexOf('Escalate contractual blockers')),
+          reason: 'the statement must precede the directive it governs',
+        );
+      }
+    });
+
+    test('a custom report directive is scoped to shape, not to timing', () {
+      // The evolved directives in the wild descend from the seeded text that
+      // demanded `update_report` every wake. Without this, such a directive
+      // reads as licence to republish an unchanged report.
+      final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+        version: makeTestTemplateVersion(
+          reportDirective: 'Lead the report with a risk callout.',
+        ),
+        soulVersion: null,
+      );
+
+      expect(
+        prompt,
+        contains(TaskAgentPromptBuilder.reportDirectivePrecedence),
+      );
+      expect(
+        prompt.indexOf(TaskAgentPromptBuilder.reportDirectivePrecedence),
+        lessThan(prompt.indexOf('Lead the report with a risk callout.')),
+      );
+    });
+
+    test('a stock prompt gains neither statement', () {
+      // Both are emitted only where a template actually contributes text, so
+      // the shipped prompt — and every measured eval prompt built from it — is
+      // byte-identical to what it was.
+      for (final modelId in <String?>[null, 'qwen3.5-122b-a10b']) {
+        final prompt = TaskAgentPromptBuilder.buildSystemPrompt(
+          version: makeTestTemplateVersion(
+            generalDirective: taskAgentGeneralDirective,
+            reportDirective: taskAgentReportDirective,
+          ),
+          soulVersion: null,
+          modelId: modelId,
+        );
+
+        expect(
+          prompt,
+          isNot(
+            contains(TaskAgentPromptBuilder.templateDirectivePrecedence),
+          ),
+          reason: 'modelId: $modelId',
+        );
+        expect(
+          prompt,
+          isNot(contains(TaskAgentPromptBuilder.reportDirectivePrecedence)),
+          reason: 'the substituted contract does not override itself',
+        );
+      }
+    });
+
     test('a stock template never surfaces its legacy persona blob', () {
       // Seeded templates carry both a `directives` blurb and the seeded
       // general directive. Suppressing the latter must not promote the former:


### PR DESCRIPTION
Follow-up to #3853, which made the task-agent constitution code-owned. That PR
left the precedence between the built-in prompt and a template's own directive
implicit, and told the evolution session about the built-in layer only when the
template added nothing.

## Why

Two gaps, both about the same thing — a template's directive and the built-in
prompt sit in one document with nothing saying how they relate.

**In every wake.** The scaffold and the directive are concatenated, and the
directive lands *last* — the position a model reads as the final word. A
contradiction resolved by accident of ordering, in either direction.

**In the evolution session.** #3853 emitted "this template adds nothing on top of
the constitution" only when the effective general directive was empty. That is
the wrong half: a session looking at an *evolved* directive is the one most
likely to restate a built-in rule, or to write something that contradicts one,
and it was told nothing.

## The rule, and why it is not "the scaffold wins"

That was this change's first instinct and it is wrong. Nearly everything in the
built-in prompt is **default behaviour** — when to set an estimate, how a report
is shaped, which observation category to use, how terse to be — describing what
the agent does when no instruction covers the case. Changing a default is not a
conflict to resolve; it is the reason the evolvable layer exists. A blanket
precedence rule would have a model discard a legitimate customisation the moment
it brushed against any scaffold line, which would quietly neuter the layer #3853
spent three commits protecting.

So: **the template's instruction takes precedence.** Two limits stand regardless,
because they are not preferences at all:

* **No fabrication.** No wording makes an invented id or an unearned claim valid.
* **The agent does not undo the user's own actions on its own judgement.** A
  directive may lift this only by saying when to act on the user's behalf —
  that is the user deciding, not the agent.

And an instruction that cannot be carried out safely produces the closest thing
that can, plus an observation naming the gap, so a quietly impossible directive
surfaces instead of being dropped.

## An override declares what it overrides

A directive that departs from a default names it and gives the reason —
*"Default: X. Here: Y, because Z."* — and a declared override is followed
exactly. The wake holds both texts, so a stated departure gives the model the
baseline *and* the argument for leaving it, rather than two paragraphs that
disagree.

An **undeclared** contradiction is still followed. Every directive written before
this convention contains undeclared departures, and rejecting them would silently
revert those agents to defaults — the exact "user rules lose" failure this is
meant to prevent. Instead it is recorded as an observation, which carries it into
the next evolution session to be stated properly. Declaration is about clarity
and confidence, not validity.

The evolution prompt asks for the same declaration when a proposal is written, so
the convention arrives from both ends.

## Scoping, not an exception

A customised report directive keeps a narrower statement: it governs the report's
shape and voice, not whether to publish. Evolved report directives in the wild
descend from the seeded text that demanded `update_report` on every wake, and
would otherwise read as licence to republish an unchanged report. Wanting a
report every wake is still a legitimate preference — it is a *behaviour* change,
so it belongs in the general directive as a declared override, which the
evolution prompt now says explicitly.

## Payload

Both statements are emitted only where a template actually contributes text, so a
stock prompt — and every measured eval prompt built from one — is byte-for-byte
what it was. A test pins that.

## Testing

5,439 tests pass across `test/features/agents/` and `test/features/ai/eval`.
Analyzer clean, `make knowledge_check` clean (92 concepts, 472 mermaid blocks).
New tests cover: the statement preceding the directive it governs on both
scaffolds, the report-directive statement preceding a customised contract only,
a stock prompt gaining neither, and the evolution briefing reaching an evolved
template as well as a stock one.

No CHANGELOG entry: no user-visible runtime change.

## Not in this change

Enforcement is still prose. A **typed** override — which default, what replaces
it, why — would make declaration structural rather than requested, and belongs
with the standing-rules work in ADR 0052's follow-up list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task-agent prompts now clearly explain which template instructions override default guidance.
  * Prompts identify non-negotiable safeguards, including no-fabrication and user-action boundaries.
  * Custom instructions must declare what they replace and why; undeclared conflicts are recorded.
  * Evolution context now includes a “What The Wake Already Carries” section describing defaults and limits.
  * Report-specific guidance is explicitly scoped to report format and voice.

* **Documentation**
  * Updated directive precedence and validation guidance across agent documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->