### PR TITLE
feat(goals): deterministic goal runtime — Phase A, headless (PR 2)

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -1,0 +1,124 @@
+---
+type: Feature Module
+title: Goal Agents — Deterministic Runtime
+description: The Phase A tier of goal-driven agents — evidence- and cadence-triggered evaluation of goal criteria into convergent daily progress registers, with escalation wakes armed only on status transitions.
+resource: ../../lib/features/goals
+tags: [goals, agents, runtime, wake, evaluation]
+status: draft
+generated: { by: claude-code/fable-5, at: 2026-08-09T02:30:00Z }
+stale_after: 2026-10-12
+sources:
+  - id: goals-src
+    resource: ../../lib/features/goals
+    title: Goals feature source
+    last_modified: 2026-08-09
+  - id: phase-a
+    resource: ../../lib/features/goals/runtime/goal_agent_phase_a.dart
+    title: GoalAgentPhaseA — the deterministic tick
+    last_modified: 2026-08-09
+  - id: signal-reader
+    resource: ../../lib/features/goals/evaluation/goal_signal_reader.dart
+    title: GoalSignalReader — journal-backed daily aggregates
+    last_modified: 2026-08-09
+  - id: evaluator
+    resource: ../../lib/features/goals/evaluation/goal_progress_evaluator.dart
+    title: GoalProgressEvaluator — pure criteria-tree fold
+    last_modified: 2026-08-09
+  - id: policy
+    resource: ../../lib/features/goals/evaluation/goal_track_policy.dart
+    title: GoalTrackPolicy — status derivation rules
+    last_modified: 2026-08-09
+  - id: vocabulary
+    resource: ../../lib/classes/goal_criterion.dart
+    title: GoalCriterion tree (shared vocabulary in lib/classes)
+    last_modified: 2026-08-09
+  - id: sync-dispatcher
+    resource: ../../lib/features/goals/sync/goal_signal_sync_dispatcher.dart
+    title: GoalSignalSyncDispatcher — the sync blind-spot bridge
+    last_modified: 2026-08-09
+  - id: adr-0054
+    resource: ../../docs/adr/0054-deterministic-first-two-tier-wakes.md
+    title: "ADR 0054: Deterministic-First Two-Tier Wakes"
+    last_modified: 2026-08-08
+---
+
+# Goal Agents — Deterministic Runtime
+
+One long-lived agent per user goal (ADR 0053), built deterministic-first
+(ADR 0054): the invariant is that **a tick that changes nothing costs €0
+and writes no messages**. What runs today is Phase A — the model-free
+tier; the LLM tier (Phase B) consumes the escalation wakes this tier arms
+and is a later increment, as are the banner surface (ADR 0058) and the
+goal chat.
+
+## Runtime flow
+
+```mermaid
+flowchart TD
+    subgraph triggers [Triggers — every device]
+        SIG[localUpdateStream signals\nleaf dataTypes, habitIds,\nmeasurable ids] --> ORCH[WakeOrchestrator\nsubscription match]
+        SYNC[syncUpdateStream] --> DISP[GoalSignalSyncDispatcher]
+        CAD[cadence ScheduledWakeEntity\nworkspace goal-cadence,\ndaily at 06:00 local] --> MGR[ScheduledWakeManager]
+    end
+    ORCH --> PA[GoalAgentPhaseA.execute]
+    DISP --> PA
+    MGR --> PA
+    PA --> HEAD[spec head → active version\nno head = clean no-op]
+    HEAD --> REARM[re-arm cadence\nrecurrence by re-arm]
+    REARM --> READ[GoalSignalReader\njournal → GoalSignalWindow]
+    READ --> EVAL[GoalProgressEvaluator\n+ GoalTrackPolicy]
+    EVAL --> REG[upsert goalProgress register\ngoal_progress:agent:evaluation-day\nrecompute, never accumulate]
+    REG --> TRANS{status transitioned vs\nlast persisted status?}
+    TRANS -- no --> DONE[return — the €0 no-op]
+    TRANS -- yes --> ESC[arm escalation wake\ngoal-escalation:periodKey,\nUTC deadline, lease-elected]
+    ESC --> NUDGE[nudge ScheduledWakeManager\nrequestCheck on arming device]
+```
+
+## Invariants
+
+- **Convergence over coordination.** The register row id is deterministic
+  per `(agentId, evaluation-day)`; every device recomputes the same
+  content from the same journal, so concurrent Phase A runs converge
+  instead of duplicating. A recompute over a synced row carries that
+  row's vector clock forward — dropping it would make the write causally
+  concurrent with its own input.
+- **Transitions compare against the last persisted status** — today's own
+  earlier row first, yesterday's otherwise — so an escalation wake that
+  re-runs Phase A is a no-op, not a self-re-arming loop.
+- **Grace history is a consecutive, same-spec-version streak**: prior-row
+  collection stops at the first missing day and at the first row computed
+  under a superseded spec version.
+- **Borrowed data semantics.** Quantitative day totals follow the health
+  charts' per-type aggregation (`cumulative_step_count` day total is the
+  daily max), point-sample types keep the day's latest sample, habit days
+  follow the habits UI's latest-completion-per-day collapse with
+  success-only counting, and day keys re-stamp the local calendar date as
+  midnight UTC. The goal agent must never disagree with the chart the
+  user is looking at.
+- **Phase B is reachable only through the lease.** Sync-received signals
+  run Phase A directly (the orchestrator deliberately listens local-only);
+  anything LLM-worthy becomes a `goal-escalation:<periodKey>` scheduled
+  wake whose lease election picks exactly one device.
+- **Calendar arithmetic is component-based** (`DateTime(y, m, d ± n)`),
+  never `Duration` math, so DST transitions cannot shift the cadence hour,
+  skip a prior-day register key, or truncate a 25-hour day's query range.
+
+## Gotchas
+
+- `agent_wiring.dart` silently routes unregistered kinds to the
+  task-agent workflow; the bootstrap merges the Daily OS and Goals runner
+  maps, and `test/app_bootstrap_test.dart` pins both registrations — do
+  not turn that merge back into a replacement.
+- Subscriptions are in-memory: `GoalRuntimeMaintenance.restoreSubscriptions`
+  rebuilds them at startup. A goal agent synced in mid-session is not
+  subscribed until restart (known limitation, tracked for the Phase B
+  increment).
+- Imported workout rules currently produce metric leaves whose dataTypes
+  only match `QuantitativeEntry` rows; workout-entry signals are a
+  documented follow-up.
+
+## Related
+
+- [Agents](agents/) — the shared runtime this plugs into.
+- [Daily OS](daily_os_next/) — the reference plug-in implementation.
+- ADRs 0053–0058 in `docs/adr/` — the decision record for this feature.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -77,6 +77,7 @@ README, this is the way in:
 | [`lib/database/`](../lib/database) | [Persistence layer](architecture/persistence.md) | the whole tree |
 | [`lib/beamer/`](../lib/beamer) | [Navigation and app shell](architecture/navigation.md) | the whole tree |
 | [`lib/classes/`](../lib/classes) | [Domain concepts](domain/) | the entity unions; not every class |
+| [`lib/features/goals/`](../lib/features/goals) | [Goal agents — deterministic runtime](features/goals.md) | Phase A: signal reading, evaluation, registers, escalation; entities/vocabulary live in `lib/classes` |
 | [`lib/l10n/`](../lib/l10n) | [Localization](conventions/localization.md) | the ARB workflow |
 | [`lib/logic/`](../lib/logic) | [Persistence layer](architecture/persistence.md) | **almost nothing** — `PersistenceLogic` appears only as a node in the write-path diagram. The import paths and the rest of the tree are undocumented; read the code |
 | [`lib/themes/`](../lib/themes) | [Tokens and theming](features/design_system/tokens-and-theming.md) | **`theme_overrides.dart` only**, as the token-injection seam |

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/daily_os_next/agents/state/day_agent_workflow_pro
 import 'package:lotti/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/demo/media/demo_media_startup.dart';
+import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
@@ -242,12 +243,20 @@ List<Override> buildProviderOverrides(ProfileContext context) {
     loggingServiceProvider.overrideWithValue(getIt<LoggingService>()),
     outboxServiceProvider.overrideWithValue(getIt<OutboxService>()),
     aiConfigRepositoryProvider.overrideWithValue(getIt<AiConfigRepository>()),
-    // Daily OS plugs its day agent into the shared runtime.
+    // Daily OS and Goals plug their agent kinds into the shared runtime.
+    // These are MERGES, not replacements: a kind missing from the map
+    // silently falls back to the task-agent workflow.
     agentWakeRunnersProvider.overrideWith(
-      (ref) => ref.watch(dayAgentWakeRunnersProvider),
+      (ref) => {
+        ...ref.watch(dayAgentWakeRunnersProvider),
+        ...ref.watch(goalAgentWakeRunnersProvider),
+      },
     ),
     agentRuntimeMaintenanceProvider.overrideWith(
-      (ref) => ref.watch(dailyOsRuntimeMaintenanceProvider),
+      (ref) => [
+        ...ref.watch(dailyOsRuntimeMaintenanceProvider),
+        ref.watch(goalRuntimeMaintenanceProvider),
+      ],
     ),
     promptLogWrapRenderersProvider.overrideWithValue(
       dayPromptLogWrapRenderers,

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -29,6 +29,7 @@ import 'package:lotti/features/design_system/components/toasts/toast_messenger.d
 import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
@@ -1286,6 +1287,10 @@ class _MyBeamerAppState extends ConsumerState<MyBeamerApp> {
     ref
       ..listen(agentInitializationProvider, (_, _) {})
       ..listen(syncedAudioInferenceListenerProvider, (_, _) {})
+      // goalSignalSyncListenerProvider: run the deterministic goal tier
+      // (Phase A) when synced signals arrive — the orchestrator only
+      // listens locally (ADR 0054).
+      ..listen(goalSignalSyncListenerProvider, (_, _) {})
       ..watch(dayProcessingRuntimeProvider);
 
     final themingState = ref.watch(themingControllerProvider);

--- a/lib/classes/goal_trigger_tokens.dart
+++ b/lib/classes/goal_trigger_tokens.dart
@@ -1,0 +1,29 @@
+/// Workspace keys of the goal-agent wake records (ADR 0054).
+///
+/// Lives in `lib/classes` (the `day_agent_trigger_tokens.dart` precedent)
+/// because the shared agent runtime's lease predicate must recognize these
+/// without `features/agents` importing the goals feature.
+library;
+
+/// The recurring deterministic tick — one per goal agent, re-armed on
+/// every run (recurrence by re-arm; no schema change).
+const goalCadenceWorkspaceKey = 'goal-cadence';
+
+/// Prefix of the per-period escalation workspaces. Escalation records are
+/// lease-elected: exactly one device runs the LLM tier for a given
+/// period's transition.
+const goalEscalationWorkspacePrefix = 'goal-escalation';
+
+/// Workspace key of the escalation wake for one evaluation period.
+///
+/// Scoped per period (ADR 0054's `goal-escalation:<periodKey>`) so an
+/// overdue prior period's escalation is never superseded away by the next
+/// period's — each period's transition keeps its own record identity.
+String goalEscalationWorkspaceKey(String periodKey) =>
+    '$goalEscalationWorkspacePrefix:$periodKey';
+
+/// Whether a scheduled-wake workspace is a goal escalation (the lease
+/// predicate's test).
+bool isGoalEscalationWorkspace(String? workspaceKey) =>
+    workspaceKey != null &&
+    workspaceKey.startsWith('$goalEscalationWorkspacePrefix:');

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/day_agent_trigger_tokens.dart';
+import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
@@ -336,8 +337,10 @@ ScheduledWakeManager scheduledWakeManager(Ref ref) {
     // is shared rather than device-local: every device firing it means one
     // inference billed per device for a single result. Everything else stays
     // on the unleased path.
+    // Lease-elected records: work that must run on exactly one device.
     requiresLease: (record) =>
-        record.workspaceKey == coordinatorDigestWorkspaceKey,
+        record.workspaceKey == coordinatorDigestWorkspaceKey ||
+        isGoalEscalationWorkspace(record.workspaceKey),
     // `getHost()` reads a `late` field the service only assigns in `init()`,
     // so a cold start that reaches here first throws
     // LateInitializationError. The manager would catch that as a per-record

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -114,7 +114,6 @@ class ScheduledWakeManager with AgentErrorLogging {
   /// generation belongs to a restarted manager, not to the pass in flight.
   int _rerunGeneration = 0;
 
-  /// Start periodic checking. Also immediately checks for missed wakes.
   /// Runs one scan pass now (single-flighted with the periodic timer).
   ///
   /// For callers that just persisted an immediately-due record — e.g. a
@@ -124,6 +123,7 @@ class ScheduledWakeManager with AgentErrorLogging {
     unawaited(_checkAndEnqueue());
   }
 
+  /// Start periodic checking. Also immediately checks for missed wakes.
   void start() {
     unawaited(_checkAndEnqueue());
 

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -115,6 +115,15 @@ class ScheduledWakeManager with AgentErrorLogging {
   int _rerunGeneration = 0;
 
   /// Start periodic checking. Also immediately checks for missed wakes.
+  /// Runs one scan pass now (single-flighted with the periodic timer).
+  ///
+  /// For callers that just persisted an immediately-due record — e.g. a
+  /// goal Phase A arming an escalation — and must not wait out the hourly
+  /// poll on the arming device.
+  void requestCheck() {
+    unawaited(_checkAndEnqueue());
+  }
+
   void start() {
     unawaited(_checkAndEnqueue());
 

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -24,18 +24,19 @@ today:
   truncate) plus structural checks (empty composites, unsatisfiable
   quotas, blank identifiers, duplicate criterion ids).
 
-Nothing here touches the database, the network, or the agent runtime: the
-evaluator is the Phase A of the two-tier wake design (ADR 0054) and is
-consumed today by its unit tests and by the goal-agent evaluation harness
-(`test/features/agents/eval/goal/`), which cross-checks its fixture
-arithmetic against this evaluator.
+The deterministic runtime RUNS (Phase A of ADR 0054): `runtime/` holds the
+per-tick executor (`GoalAgentPhaseA`) and startup maintenance, `sync/` the
+synced-signal dispatcher, `service/` transactional goal creation, and
+`state/` the providers that plug the `goal_agent` kind into the shared
+agent runtime (merged in `app_bootstrap.dart`). Persistence entities live
+on `AgentDomainEntity` (`goalSpecVersion`/`goalSpecHead`/`goalProgress`/
+`goalNudge`) with `GoalSpecValidator` gating every decode path.
 
-The persistence entities exist (`goalSpecVersion`/`goalSpecHead`/
-`goalProgress`/`goalNudge` variants on `AgentDomainEntity`, with
-`GoalSpecValidator` gating decode). The runtime (agent kind, wake wiring),
-the banner surface (procedural text banners, ADR 0058), and the
-conversation UI follow in later increments; the plan of record is
-`docs/implementation_plans/2026-08-08_goal_agents_design.md`.
+The LLM tier (Phase B), the banner surface (procedural text banners,
+ADR 0058), and the conversation UI follow in later increments; the plan of
+record is `docs/implementation_plans/2026-08-08_goal_agents_design.md`.
+
+Runtime map: [knowledge/features/goals.md](../../../knowledge/features/goals.md).
 
 Decisions: ADRs
 [0053](../../../docs/adr/0053-goal-driven-agents-per-goal-producers.md),
@@ -44,5 +45,5 @@ Decisions: ADRs
 [0056](../../../docs/adr/0056-need-to-know-visual-brief-boundary.md),
 [0057](../../../docs/adr/0057-decade-scale-agent-memory.md),
 [0058](../../../docs/adr/0058-procedural-text-banners-no-generative-imagery.md).
-A `knowledge/` concept will be added when the runtime ships and there is
-running behavior to document.
+The runtime's knowledge concept is
+[knowledge/features/goals.md](../../../knowledge/features/goals.md).

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -126,27 +126,18 @@ class GoalSignalReader {
     final byDay = <DateTime, num>{};
     switch (healthTypes[dataType]?.aggregationType) {
       case HealthAggregationType.none:
-        final latestByDay = <DateTime, JournalEntity>{};
+        final latestFromByDay = <DateTime, DateTime>{};
         for (final entity in entities) {
           entity.maybeMap(
             quantitative: (quant) {
               final day = GoalWindow.dayUtc(quant.data.dateFrom);
-              final current = latestByDay[day];
-              final currentFrom = current?.maybeMap(
-                quantitative: (q) => q.data.dateFrom,
-                orElse: () => null,
-              );
+              final currentFrom = latestFromByDay[day];
               if (currentFrom == null ||
                   quant.data.dateFrom.isAfter(currentFrom)) {
-                latestByDay[day] = entity;
+                latestFromByDay[day] = quant.data.dateFrom;
+                byDay[day] = quant.data.value;
               }
             },
-            orElse: () {},
-          );
-        }
-        for (final entry in latestByDay.entries) {
-          entry.value.maybeMap(
-            quantitative: (quant) => byDay[entry.key] = quant.data.value,
             orElse: () {},
           );
         }

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -126,6 +126,9 @@ class GoalSignalReader {
     final byDay = <DateTime, num>{};
     switch (healthTypes[dataType]?.aggregationType) {
       case HealthAggregationType.none:
+        // Same display normalization as `aggregateNone`: percentage types
+        // store fractions (body fat 0.18) but chart — and target — as 18.
+        final multiplier = dataType.contains('PERCENTAGE') ? 100 : 1;
         final latestFromByDay = <DateTime, DateTime>{};
         for (final entity in entities) {
           entity.maybeMap(
@@ -135,7 +138,7 @@ class GoalSignalReader {
               if (currentFrom == null ||
                   quant.data.dateFrom.isAfter(currentFrom)) {
                 latestFromByDay[day] = quant.data.dateFrom;
-                byDay[day] = quant.data.value;
+                byDay[day] = quant.data.value * multiplier;
               }
             },
             orElse: () {},

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -1,0 +1,187 @@
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/dashboards/config/dashboard_health_config.dart';
+import 'package:lotti/features/dashboards/state/health_data.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+
+/// Reads the journal into a [GoalSignalWindow] for one criteria tree —
+/// the seam between the pure evaluator and the database (Phase A of
+/// ADR 0054; the reader promised by the kickoff plan).
+///
+/// Semantics are deliberately borrowed, not reinvented:
+///
+/// - Quantitative day totals use the SAME per-type aggregation as the
+///   health charts (`aggregateByType`): `cumulative_step_count` is a
+///   running counter, so its day total is the day's max, not a sum.
+///   Diverging here would make the goal agent disagree with the chart the
+///   user is looking at.
+/// - Habit days use the SAME latest-completion-per-day collapse as the
+///   habits UI (`getHabitCompletionsByHabitId`), and only
+///   [HabitCompletionType.success] counts toward a quota.
+/// - Day keys re-stamp the LOCAL wall-clock date as midnight UTC
+///   ([GoalWindow.dayUtc] over `meta.dateFrom`), matching the `ymd`
+///   bucketing of `habits_controller` — a calendar-date key, not a
+///   timezone conversion.
+class GoalSignalReader {
+  const GoalSignalReader({required this._journalDb});
+
+  final JournalDb _journalDb;
+
+  /// Loads every signal series the [criteria] tree needs to be evaluated
+  /// at [reference], covering the widest leaf window plus the short-term
+  /// trend lookback.
+  Future<GoalSignalWindow> read({
+    required GoalCriterion criteria,
+    required DateTime reference,
+    int shortTermDays = 3,
+  }) async {
+    final needs = _SignalNeeds()..collect(criteria);
+    final rangeStart = _rangeStart(criteria, reference, shortTermDays);
+    // End of the reference day in local time: `date_to <= rangeEnd` must
+    // include entries recorded later today.
+    final rangeEnd = DateTime(
+      reference.year,
+      reference.month,
+      reference.day,
+    ).add(const Duration(days: 1));
+
+    final quantitative = <String, Map<DateTime, num>>{};
+    for (final dataType in needs.quantitativeTypes) {
+      final entities = await _journalDb.getQuantitativeByType(
+        type: dataType,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+      final byDay = <DateTime, num>{};
+      // aggregateByType returns [] for types absent from healthTypes —
+      // that would silently evaluate real data as a tracker gap, so
+      // unknown types fall back to a plain daily sum.
+      final observations = healthTypes.containsKey(dataType)
+          ? aggregateByType(entities, dataType)
+          : aggregateDailySum(entities);
+      for (final observation in observations) {
+        byDay[GoalWindow.dayUtc(observation.dateTime)] = observation.value;
+      }
+      quantitative[dataType] = byDay;
+    }
+
+    final habits = <String, Map<DateTime, int>>{};
+    for (final habitId in needs.habitIds) {
+      final entities = await _journalDb.getHabitCompletionsByHabitId(
+        habitId: habitId,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+      final byDay = <DateTime, int>{};
+      for (final entity in entities) {
+        entity.maybeMap(
+          habitCompletion: (completion) {
+            // The query already collapsed to the latest completion per
+            // day (the habits-UI rule); only success feeds a quota.
+            if (completion.data.completionType == HabitCompletionType.success) {
+              byDay[GoalWindow.dayUtc(completion.data.dateFrom)] = 1;
+            }
+          },
+          orElse: () {},
+        );
+      }
+      habits[habitId] = byDay;
+    }
+
+    final measurables = <String, Map<DateTime, num>>{};
+    for (final dataTypeId in needs.measurableTypeIds) {
+      final entities = await _journalDb.getMeasurementsByType(
+        type: dataTypeId,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+      final byDay = <DateTime, num>{};
+      for (final entity in entities) {
+        entity.maybeMap(
+          measurement: (measurement) {
+            final day = GoalWindow.dayUtc(measurement.data.dateFrom);
+            byDay[day] = (byDay[day] ?? 0) + measurement.data.value;
+          },
+          orElse: () {},
+        );
+      }
+      measurables[dataTypeId] = byDay;
+    }
+
+    return GoalSignalWindow(
+      quantitativeDailySums: quantitative,
+      habitSuccessesByDay: habits,
+      measurableDailySums: measurables,
+    );
+  }
+
+  /// Earliest day any leaf's period (or the short-term lookback, or the
+  /// grace-period prior window) reaches back to, as a local date.
+  DateTime _rangeStart(
+    GoalCriterion criteria,
+    DateTime reference,
+    int shortTermDays,
+  ) {
+    var earliest = GoalWindow.dayUtc(
+      reference,
+    ).subtract(Duration(days: shortTermDays - 1));
+    void visit(GoalCriterion criterion) {
+      switch (criterion) {
+        case GoalCriterionMetric(:final window) ||
+            GoalCriterionMeasurable(:final window) ||
+            GoalCriterionHabit(:final window):
+          // One extra period back so the policy's prior-attainment grace
+          // check can be computed from the same window.
+          final start = window.periodRange(reference).start;
+          final length = window.lengthInDays(reference);
+          final withPrior = start.subtract(Duration(days: length));
+          if (withPrior.isBefore(earliest)) earliest = withPrior;
+        case GoalCriterionAllOf(:final criteria) ||
+            GoalCriterionAnyOf(:final criteria) ||
+            GoalCriterionAtLeastCount(:final criteria):
+          criteria.forEach(visit);
+      }
+    }
+
+    visit(criteria);
+    // Back to local wall-clock for the DB range query.
+    return DateTime(earliest.year, earliest.month, earliest.day);
+  }
+}
+
+/// The notification tokens a goal's criteria tree subscribes to: leaf
+/// `dataType` strings (quantitative entries notify with their dataType),
+/// `habitId`s (habit completions notify with their habitId) and
+/// measurable `dataTypeId`s (measurements notify with theirs).
+Set<String> goalSignalTriggerTokens(GoalCriterion criteria) {
+  final needs = _SignalNeeds()..collect(criteria);
+  return {
+    ...needs.quantitativeTypes,
+    ...needs.habitIds,
+    ...needs.measurableTypeIds,
+  };
+}
+
+class _SignalNeeds {
+  final quantitativeTypes = <String>{};
+  final habitIds = <String>{};
+  final measurableTypeIds = <String>{};
+
+  void collect(GoalCriterion criterion) {
+    switch (criterion) {
+      case GoalCriterionMetric(:final dataType):
+        quantitativeTypes.add(dataType);
+      case GoalCriterionHabit(:final habitId):
+        habitIds.add(habitId);
+      case GoalCriterionMeasurable(:final dataTypeId):
+        measurableTypeIds.add(dataTypeId);
+      case GoalCriterionAllOf(:final criteria) ||
+          GoalCriterionAnyOf(:final criteria) ||
+          GoalCriterionAtLeastCount(:final criteria):
+        criteria.forEach(collect);
+    }
+  }
+}

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -40,13 +40,14 @@ class GoalSignalReader {
   }) async {
     final needs = _SignalNeeds()..collect(criteria);
     final rangeStart = _rangeStart(criteria, reference, shortTermDays);
-    // End of the reference day in local time: `date_to <= rangeEnd` must
-    // include entries recorded later today.
+    // Next local calendar midnight, by component construction: adding a
+    // 24h Duration lands at 23:00 on a DST fall-back day and would drop
+    // the final hour's entries from `date_to <= rangeEnd`.
     final rangeEnd = DateTime(
       reference.year,
       reference.month,
-      reference.day,
-    ).add(const Duration(days: 1));
+      reference.day + 1,
+    );
 
     final quantitative = <String, Map<DateTime, num>>{};
     for (final dataType in needs.quantitativeTypes) {
@@ -55,17 +56,7 @@ class GoalSignalReader {
         rangeStart: rangeStart,
         rangeEnd: rangeEnd,
       );
-      final byDay = <DateTime, num>{};
-      // aggregateByType returns [] for types absent from healthTypes —
-      // that would silently evaluate real data as a tracker gap, so
-      // unknown types fall back to a plain daily sum.
-      final observations = healthTypes.containsKey(dataType)
-          ? aggregateByType(entities, dataType)
-          : aggregateDailySum(entities);
-      for (final observation in observations) {
-        byDay[GoalWindow.dayUtc(observation.dateTime)] = observation.value;
-      }
-      quantitative[dataType] = byDay;
+      quantitative[dataType] = _bucketQuantitative(entities, dataType);
     }
 
     final habits = <String, Map<DateTime, int>>{};
@@ -116,6 +107,61 @@ class GoalSignalReader {
       habitSuccessesByDay: habits,
       measurableDailySums: measurables,
     );
+  }
+
+  /// One deterministic value per day, honoring the health config's
+  /// per-type aggregation:
+  ///
+  /// - `dailyMax` (cumulative counters like steps): the day's peak;
+  /// - `dailySum` / `dailyTimeSum`: the day's total (hours for time);
+  /// - `none` (point samples like weight or heart rate): the day's LATEST
+  ///   sample — `aggregateNone` returns every raw sample, and folding
+  ///   those into a day-keyed map would keep whichever the query order
+  ///   put last (the oldest, since results are newest-first);
+  /// - unknown types: a daily sum, never silence.
+  Map<DateTime, num> _bucketQuantitative(
+    List<JournalEntity> entities,
+    String dataType,
+  ) {
+    final byDay = <DateTime, num>{};
+    switch (healthTypes[dataType]?.aggregationType) {
+      case HealthAggregationType.none:
+        final latestByDay = <DateTime, JournalEntity>{};
+        for (final entity in entities) {
+          entity.maybeMap(
+            quantitative: (quant) {
+              final day = GoalWindow.dayUtc(quant.data.dateFrom);
+              final current = latestByDay[day];
+              final currentFrom = current?.maybeMap(
+                quantitative: (q) => q.data.dateFrom,
+                orElse: () => null,
+              );
+              if (currentFrom == null ||
+                  quant.data.dateFrom.isAfter(currentFrom)) {
+                latestByDay[day] = entity;
+              }
+            },
+            orElse: () {},
+          );
+        }
+        for (final entry in latestByDay.entries) {
+          entry.value.maybeMap(
+            quantitative: (quant) => byDay[entry.key] = quant.data.value,
+            orElse: () {},
+          );
+        }
+      case HealthAggregationType.dailyMax:
+      case HealthAggregationType.dailySum:
+      case HealthAggregationType.dailyTimeSum:
+        for (final observation in aggregateByType(entities, dataType)) {
+          byDay[GoalWindow.dayUtc(observation.dateTime)] = observation.value;
+        }
+      case null:
+        for (final observation in aggregateDailySum(entities)) {
+          byDay[GoalWindow.dayUtc(observation.dateTime)] = observation.value;
+        }
+    }
+    return byDay;
   }
 
   /// Earliest day any leaf's period (or the short-term lookback, or the

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -1,0 +1,231 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/goal_progress_models.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/workflow/wake_result.dart';
+import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
+import 'package:lotti/features/goals/evaluation/goal_progress_evaluator.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/evaluation/goal_track_policy.dart';
+import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
+
+/// Workspace key of the recurring deterministic tick (re-armed on every
+/// run — recurrence by re-arm, no schema change; ADR 0054 Decision 3).
+const goalCadenceWorkspaceKey = 'goal-cadence';
+
+/// Workspace key of the immediate escalation wake Phase A arms when a tick
+/// is LLM-worthy; the scheduled-wake manager's lease election picks exactly
+/// one device to run it (ADR 0054 Decision 5).
+const goalEscalationWorkspaceKey = 'goal-escalation';
+
+/// Local hour at which the daily cadence tick fires.
+const goalCadenceHour = 6;
+
+/// How many prior daily register rows feed the grace-period check.
+const goalPriorLookbackDays = 3;
+
+/// Phase A of the goal-agent wake (ADR 0054): deterministic, model-free,
+/// idempotent — the tier that runs on every tick, on every device, and
+/// costs €0.
+///
+/// One execution: load the spec head → re-arm the cadence wake → read
+/// signals → evaluate → derive the track status → upsert the day's
+/// `goalProgress` register row → arm an escalation wake if (and only if)
+/// something is LLM-worthy. Phase B (PR 3) consumes the escalation; until
+/// it lands, an escalation wake firing re-runs this tier, which is a
+/// harmless no-op thanks to the keyed register.
+class GoalAgentPhaseA {
+  const GoalAgentPhaseA({
+    required this._repository,
+    required this._syncService,
+    required this._signalReader,
+    this._evaluator = const GoalProgressEvaluator(),
+    this._policy = const GoalTrackPolicy(),
+  });
+
+  final AgentRepository _repository;
+  final AgentSyncService _syncService;
+  final GoalSignalReader _signalReader;
+  final GoalProgressEvaluator _evaluator;
+  final GoalTrackPolicy _policy;
+
+  /// The `AgentWakeRunner`-shaped entry point.
+  Future<WakeResult> execute({
+    required AgentIdentityEntity agentIdentity,
+    required String runKey,
+    required Set<String> triggerTokens,
+    required String threadId,
+  }) async {
+    final agentId = agentIdentity.agentId;
+    final now = clock.now();
+
+    final head = await _repository.getEntity(goalSpecHeadId(agentId));
+    if (head is! GoalSpecHeadEntity) {
+      // No spec yet: nothing to evaluate, nothing to schedule. Not an
+      // error — creation writes the spec before the first wake can fire.
+      return const WakeResult(success: true);
+    }
+    final version = await _repository.getEntity(head.versionId);
+    if (version is! GoalSpecVersionEntity) {
+      return WakeResult(
+        success: false,
+        error: 'goal spec head ${head.versionId} points at nothing',
+      );
+    }
+
+    await _rearmCadence(agentId, now);
+
+    final signals = await _signalReader.read(
+      criteria: version.criteria,
+      reference: now,
+      shortTermDays: _policy.shortTermDays,
+    );
+    final evaluation = _evaluator.evaluate(version.criteria, signals, now);
+    final shortTerm = _evaluator.shortTermAttainment(
+      version.criteria,
+      signals,
+      now,
+      days: _policy.shortTermDays,
+    );
+
+    final priors = await _priorRegisterRows(agentId, now);
+    final targetDate = version.targetDate;
+    final trackStatus = _policy.derive(
+      evaluation: evaluation,
+      shortTermAttainment: shortTerm,
+      priorAttainments: [for (final row in priors) row.attainment],
+      targetDatePassed:
+          targetDate != null &&
+          GoalWindow.dayUtc(now).isAfter(GoalWindow.dayUtc(targetDate)),
+    );
+
+    final facts = GoalWakeFacts(
+      trackStatus: trackStatus,
+      previousStatus: priors.isEmpty ? null : priors.first.trackStatus,
+      evaluation: evaluation,
+      shortTermAttainment: shortTerm,
+    );
+
+    await _upsertRegister(
+      agentId: agentId,
+      version: version,
+      evaluation: evaluation,
+      facts: facts,
+      now: now,
+    );
+
+    if (facts.needsEscalation) {
+      await _armEscalation(agentId, now);
+    }
+
+    return const WakeResult(success: true);
+  }
+
+  /// Recurrence by re-arm: every run schedules the next cadence tick, and
+  /// `GoalRuntimeMaintenance.beforeWakeScan` self-heals a missing record.
+  Future<void> _rearmCadence(String agentId, DateTime now) =>
+      _syncService.upsertEntity(goalCadenceWake(agentId, now));
+
+  /// Escalation is a scheduled wake due immediately: the manager's lease
+  /// election guarantees exactly one device runs it, and an armer that
+  /// dies is picked up remotely within the hourly poll (ADR 0054).
+  Future<void> _armEscalation(String agentId, DateTime now) =>
+      _syncService.upsertEntity(goalEscalationWake(agentId, now));
+
+  /// Most-recent-first register rows for the trailing
+  /// [goalPriorLookbackDays] days before the evaluation day.
+  Future<List<GoalProgressEntity>> _priorRegisterRows(
+    String agentId,
+    DateTime now,
+  ) async {
+    const day = GoalWindow.day();
+    final rows = <GoalProgressEntity>[];
+    for (var back = 1; back <= goalPriorLookbackDays; back++) {
+      final key = day.periodKey(now.subtract(Duration(days: back)));
+      final row = await _repository.getEntity(goalProgressId(agentId, key));
+      if (row is GoalProgressEntity) rows.add(row);
+    }
+    return rows;
+  }
+
+  /// Recompute-never-accumulate: the day's row is rewritten wholesale, so
+  /// N devices evaluating the same day converge on identical content.
+  Future<void> _upsertRegister({
+    required String agentId,
+    required GoalSpecVersionEntity version,
+    required GoalEvaluation evaluation,
+    required GoalWakeFacts facts,
+    required DateTime now,
+  }) async {
+    final periodKey = const GoalWindow.day().periodKey(now);
+    final id = goalProgressId(agentId, periodKey);
+    final existing = await _repository.getEntity(id);
+    await _syncService.upsertEntity(
+      AgentDomainEntity.goalProgress(
+        id: id,
+        agentId: agentId,
+        periodKey: periodKey,
+        trackStatus: facts.trackStatus,
+        attainment: evaluation.attainment,
+        dataCoverage: evaluation.dataCoverage,
+        satisfied: evaluation.satisfied,
+        specVersionId: version.id,
+        createdAt: existing is GoalProgressEntity ? existing.createdAt : now,
+        updatedAt: now,
+        vectorClock: null,
+        criterionResults: [
+          for (final result in evaluation.results.values)
+            GoalCriterionProgress(
+              criterionId: result.criterionId,
+              actual: result.actual,
+              target: result.target,
+              ratio: result.ratio,
+              satisfied: result.satisfied,
+              sampleCount: result.sampleCount,
+              paceFeasible: result.paceFeasible,
+            ),
+        ],
+        paceFeasible: evaluation.paceFeasible,
+        shortTermAttainment: facts.shortTermAttainment,
+      ),
+    );
+  }
+}
+
+/// The next cadence tick for [agentId] as of [now]: today at
+/// [goalCadenceHour] local if still ahead, else tomorrow. Deterministic id
+/// → re-arming overwrites (LWW) instead of accumulating.
+AgentDomainEntity goalCadenceWake(String agentId, DateTime now) {
+  final today = DateTime(now.year, now.month, now.day, goalCadenceHour);
+  final next = now.isBefore(today) ? today : today.add(const Duration(days: 1));
+  return AgentDomainEntity.scheduledWake(
+    id: scheduledWakeRecordId(agentId, workspaceKey: goalCadenceWorkspaceKey),
+    agentId: agentId,
+    scheduledAt: next,
+    status: ScheduledWakeStatus.pending,
+    reason: WakeReason.scheduled.name,
+    updatedAt: now,
+    vectorClock: null,
+    workspaceKey: goalCadenceWorkspaceKey,
+  );
+}
+
+/// An escalation wake due immediately (see `_armEscalation`).
+AgentDomainEntity goalEscalationWake(String agentId, DateTime now) =>
+    AgentDomainEntity.scheduledWake(
+      id: scheduledWakeRecordId(
+        agentId,
+        workspaceKey: goalEscalationWorkspaceKey,
+      ),
+      agentId: agentId,
+      scheduledAt: now,
+      status: ScheduledWakeStatus.pending,
+      reason: WakeReason.scheduled.name,
+      updatedAt: now,
+      vectorClock: null,
+      workspaceKey: goalEscalationWorkspaceKey,
+    );

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -1,5 +1,6 @@
 import 'package:clock/clock.dart';
 import 'package:lotti/classes/goal_progress_models.dart';
+import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
@@ -12,15 +13,6 @@ import 'package:lotti/features/goals/evaluation/goal_progress_evaluator.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/features/goals/evaluation/goal_track_policy.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
-
-/// Workspace key of the recurring deterministic tick (re-armed on every
-/// run — recurrence by re-arm, no schema change; ADR 0054 Decision 3).
-const goalCadenceWorkspaceKey = 'goal-cadence';
-
-/// Workspace key of the immediate escalation wake Phase A arms when a tick
-/// is LLM-worthy; the scheduled-wake manager's lease election picks exactly
-/// one device to run it (ADR 0054 Decision 5).
-const goalEscalationWorkspaceKey = 'goal-escalation';
 
 /// Local hour at which the daily cadence tick fires.
 const goalCadenceHour = 6;
@@ -45,7 +37,13 @@ class GoalAgentPhaseA {
     required this._signalReader,
     this._evaluator = const GoalProgressEvaluator(),
     this._policy = const GoalTrackPolicy(),
+    this._onEscalationArmed,
   });
+
+  /// Nudges the scheduled-wake manager after an escalation is armed, so a
+  /// local transition is processed promptly instead of waiting out the
+  /// hourly poll. Sync-received records still ride the poll (by design).
+  final void Function()? _onEscalationArmed;
 
   final AgentRepository _repository;
   final AgentSyncService _syncService;
@@ -79,6 +77,14 @@ class GoalAgentPhaseA {
 
     await _rearmCadence(agentId, now);
 
+    final startDate = version.startDate;
+    if (startDate != null &&
+        GoalWindow.dayUtc(now).isBefore(GoalWindow.dayUtc(startDate))) {
+      // The goal has not begun: no register row, no escalation — the
+      // cadence tick above keeps checking until the start day arrives.
+      return const WakeResult(success: true);
+    }
+
     final signals = await _signalReader.read(
       criteria: version.criteria,
       reference: now,
@@ -92,7 +98,11 @@ class GoalAgentPhaseA {
       days: _policy.shortTermDays,
     );
 
-    final priors = await _priorRegisterRows(agentId, now);
+    final periodKey = const GoalWindow.day().periodKey(now);
+    final existingToday = await _repository.getEntity(
+      goalProgressId(agentId, periodKey),
+    );
+    final priors = await _priorRegisterRows(agentId, now, version.id);
     final targetDate = version.targetDate;
     final trackStatus = _policy.derive(
       evaluation: evaluation,
@@ -103,9 +113,17 @@ class GoalAgentPhaseA {
           GoalWindow.dayUtc(now).isAfter(GoalWindow.dayUtc(targetDate)),
     );
 
+    // The transition compares against the LAST PERSISTED status — today's
+    // own earlier run first (so an escalation wake re-running Phase A the
+    // same day is the documented no-op), yesterday's row otherwise.
+    final previousStatus = existingToday is GoalProgressEntity
+        ? existingToday.trackStatus
+        : priors.isEmpty
+        ? null
+        : priors.first.trackStatus;
     final facts = GoalWakeFacts(
       trackStatus: trackStatus,
-      previousStatus: priors.isEmpty ? null : priors.first.trackStatus,
+      previousStatus: previousStatus,
       evaluation: evaluation,
       shortTermAttainment: shortTerm,
     );
@@ -116,10 +134,13 @@ class GoalAgentPhaseA {
       evaluation: evaluation,
       facts: facts,
       now: now,
+      periodKey: periodKey,
+      existing: existingToday is GoalProgressEntity ? existingToday : null,
     );
 
     if (facts.needsEscalation) {
-      await _armEscalation(agentId, now);
+      await _armEscalation(agentId, now, periodKey);
+      _onEscalationArmed?.call();
     }
 
     return const WakeResult(success: true);
@@ -133,21 +154,36 @@ class GoalAgentPhaseA {
   /// Escalation is a scheduled wake due immediately: the manager's lease
   /// election guarantees exactly one device runs it, and an armer that
   /// dies is picked up remotely within the hourly poll (ADR 0054).
-  Future<void> _armEscalation(String agentId, DateTime now) =>
-      _syncService.upsertEntity(goalEscalationWake(agentId, now));
+  Future<void> _armEscalation(
+    String agentId,
+    DateTime now,
+    String periodKey,
+  ) => _syncService.upsertEntity(goalEscalationWake(agentId, now, periodKey));
 
   /// Most-recent-first register rows for the trailing
   /// [goalPriorLookbackDays] days before the evaluation day.
+  ///
+  /// The policy reads these as a CONSECUTIVE streak, so collection stops
+  /// at the first gap (a day the app never evaluated must not compact an
+  /// older bad day into "yesterday") and at the first row computed
+  /// against a different spec version (a revised goal starts its grace
+  /// history fresh). Date math is calendar-component arithmetic — a
+  /// Duration would drift across DST transitions.
   Future<List<GoalProgressEntity>> _priorRegisterRows(
     String agentId,
     DateTime now,
+    String specVersionId,
   ) async {
     const day = GoalWindow.day();
     final rows = <GoalProgressEntity>[];
     for (var back = 1; back <= goalPriorLookbackDays; back++) {
-      final key = day.periodKey(now.subtract(Duration(days: back)));
+      final key = day.periodKey(
+        DateTime(now.year, now.month, now.day - back),
+      );
       final row = await _repository.getEntity(goalProgressId(agentId, key));
-      if (row is GoalProgressEntity) rows.add(row);
+      if (row is! GoalProgressEntity) break;
+      if (row.specVersionId != specVersionId) break;
+      rows.add(row);
     }
     return rows;
   }
@@ -160,10 +196,10 @@ class GoalAgentPhaseA {
     required GoalEvaluation evaluation,
     required GoalWakeFacts facts,
     required DateTime now,
+    required String periodKey,
+    required GoalProgressEntity? existing,
   }) async {
-    final periodKey = const GoalWindow.day().periodKey(now);
     final id = goalProgressId(agentId, periodKey);
-    final existing = await _repository.getEntity(id);
     await _syncService.upsertEntity(
       AgentDomainEntity.goalProgress(
         id: id,
@@ -174,9 +210,12 @@ class GoalAgentPhaseA {
         dataCoverage: evaluation.dataCoverage,
         satisfied: evaluation.satisfied,
         specVersionId: version.id,
-        createdAt: existing is GoalProgressEntity ? existing.createdAt : now,
+        createdAt: existing?.createdAt ?? now,
         updatedAt: now,
-        vectorClock: null,
+        // Carry the row we read: dropping it would make this recompute
+        // causally CONCURRENT with the peer value it is based on, letting
+        // wall-clock LWW revert fresh progress.
+        vectorClock: existing?.vectorClock,
         criterionResults: [
           for (final result in evaluation.results.values)
             GoalCriterionProgress(
@@ -214,18 +253,24 @@ AgentDomainEntity goalCadenceWake(String agentId, DateTime now) {
   );
 }
 
-/// An escalation wake due immediately (see `_armEscalation`).
-AgentDomainEntity goalEscalationWake(String agentId, DateTime now) =>
-    AgentDomainEntity.scheduledWake(
-      id: scheduledWakeRecordId(
-        agentId,
-        workspaceKey: goalEscalationWorkspaceKey,
-      ),
-      agentId: agentId,
-      scheduledAt: now,
-      status: ScheduledWakeStatus.pending,
-      reason: WakeReason.scheduled.name,
-      updatedAt: now,
-      vectorClock: null,
-      workspaceKey: goalEscalationWorkspaceKey,
-    );
+/// An escalation wake due immediately, scoped to its evaluation period
+/// (see `_armEscalation`). The deadline is stored in UTC: it is an
+/// absolute moment a failover peer in another timezone must read
+/// correctly, unlike the cadence's deliberately local fixed hour.
+AgentDomainEntity goalEscalationWake(
+  String agentId,
+  DateTime now,
+  String periodKey,
+) => AgentDomainEntity.scheduledWake(
+  id: scheduledWakeRecordId(
+    agentId,
+    workspaceKey: goalEscalationWorkspaceKey(periodKey),
+  ),
+  agentId: agentId,
+  scheduledAt: now.toUtc(),
+  status: ScheduledWakeStatus.pending,
+  reason: WakeReason.scheduled.name,
+  updatedAt: now,
+  vectorClock: null,
+  workspaceKey: goalEscalationWorkspaceKey(periodKey),
+);

--- a/lib/features/goals/runtime/goal_runtime_maintenance.dart
+++ b/lib/features/goals/runtime/goal_runtime_maintenance.dart
@@ -1,0 +1,108 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/agent_service.dart';
+import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+/// Startup and pre-scan maintenance for goal agents (the
+/// [AgentRuntimeMaintenance] contract): subscriptions are in-memory and
+/// must be rebuilt every launch; cadence wakes are re-armed by each run
+/// but self-healed here in case the last run died before re-arming.
+///
+/// Every per-agent repair is individually contained — one broken goal must
+/// never take the others (or another feature's maintenance) down with it.
+class GoalRuntimeMaintenance implements AgentRuntimeMaintenance {
+  GoalRuntimeMaintenance({
+    required this._agentService,
+    required this._repository,
+    required this._syncService,
+    required this._goalAgentService,
+    this._domainLogger,
+  });
+
+  final AgentService _agentService;
+  final AgentRepository _repository;
+  final AgentSyncService _syncService;
+  final GoalAgentService _goalAgentService;
+  final DomainLogger? _domainLogger;
+
+  @override
+  Future<void> restoreSubscriptions() async {
+    for (final identity in await _activeGoalAgents()) {
+      try {
+        final criteria = await _headCriteria(identity.agentId);
+        if (criteria == null) continue;
+        _goalAgentService.registerSignalSubscription(
+          identity.agentId,
+          criteria,
+        );
+      } catch (error, stackTrace) {
+        _log('restoreSubscriptions', identity.agentId, error, stackTrace);
+      }
+    }
+  }
+
+  @override
+  Future<void> beforeWakeScan() async {
+    final now = clock.now();
+    for (final identity in await _activeGoalAgents()) {
+      try {
+        final record = await _repository.getEntity(
+          scheduledWakeRecordId(
+            identity.agentId,
+            workspaceKey: goalCadenceWorkspaceKey,
+          ),
+        );
+        final needsHeal =
+            record is! ScheduledWakeEntity ||
+            (record.status == ScheduledWakeStatus.consumed &&
+                record.scheduledAt.isBefore(now));
+        if (needsHeal) {
+          await _syncService.upsertEntity(
+            goalCadenceWake(identity.agentId, now),
+          );
+        }
+      } catch (error, stackTrace) {
+        _log('beforeWakeScan', identity.agentId, error, stackTrace);
+      }
+    }
+  }
+
+  Future<List<AgentIdentityEntity>> _activeGoalAgents() async {
+    final agents = await _agentService.listAgents(
+      lifecycle: AgentLifecycle.active,
+    );
+    return agents
+        .where((agent) => agent.kind == AgentKinds.goalAgent)
+        .toList(growable: false);
+  }
+
+  Future<GoalCriterion?> _headCriteria(String agentId) async {
+    final head = await _repository.getEntity(goalSpecHeadId(agentId));
+    if (head is! GoalSpecHeadEntity) return null;
+    final version = await _repository.getEntity(head.versionId);
+    if (version is! GoalSpecVersionEntity) return null;
+    return version.criteria;
+  }
+
+  void _log(
+    String phase,
+    String agentId,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    _domainLogger?.error(
+      LogDomain.agentRuntime,
+      error,
+      message: 'goal runtime maintenance $phase failed for one agent',
+      stackTrace: stackTrace,
+    );
+  }
+}

--- a/lib/features/goals/runtime/goal_runtime_maintenance.dart
+++ b/lib/features/goals/runtime/goal_runtime_maintenance.dart
@@ -1,5 +1,6 @@
 import 'package:clock/clock.dart';
 import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -35,7 +36,14 @@ class GoalRuntimeMaintenance implements AgentRuntimeMaintenance {
 
   @override
   Future<void> restoreSubscriptions() async {
-    for (final identity in await _activeGoalAgents()) {
+    final List<AgentIdentityEntity> agents;
+    try {
+      agents = await _activeGoalAgents();
+    } catch (error, stackTrace) {
+      _log('restoreSubscriptions', 'listAgents', error, stackTrace);
+      return;
+    }
+    for (final identity in agents) {
       try {
         final criteria = await _headCriteria(identity.agentId);
         if (criteria == null) continue;
@@ -52,7 +60,14 @@ class GoalRuntimeMaintenance implements AgentRuntimeMaintenance {
   @override
   Future<void> beforeWakeScan() async {
     final now = clock.now();
-    for (final identity in await _activeGoalAgents()) {
+    final List<AgentIdentityEntity> agents;
+    try {
+      agents = await _activeGoalAgents();
+    } catch (error, stackTrace) {
+      _log('beforeWakeScan', 'listAgents', error, stackTrace);
+      return;
+    }
+    for (final identity in agents) {
       try {
         final record = await _repository.getEntity(
           scheduledWakeRecordId(

--- a/lib/features/goals/runtime/goal_wake_facts.dart
+++ b/lib/features/goals/runtime/goal_wake_facts.dart
@@ -1,0 +1,37 @@
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
+
+/// The deterministic facts one Phase A tick derives for a goal agent
+/// (ADR 0054): everything downstream — escalation, and in PR 3 the FACTS
+/// block and the tool gate — reads these, never raw signals.
+class GoalWakeFacts {
+  const GoalWakeFacts({
+    required this.trackStatus,
+    required this.evaluation,
+    this.previousStatus,
+    this.shortTermAttainment,
+  });
+
+  /// Policy-derived status for the evaluation day.
+  final GoalTrackStatus trackStatus;
+
+  /// The most recent previously persisted status, if any register row
+  /// exists for a prior day.
+  final GoalTrackStatus? previousStatus;
+
+  final GoalEvaluation evaluation;
+  final double? shortTermAttainment;
+
+  /// Whether the status changed against the last persisted register row.
+  /// A first-ever evaluation counts as a transition (there is a new fact
+  /// where there was none).
+  bool get statusTransitioned => trackStatus != previousStatus;
+
+  /// Whether this tick warrants waking the LLM tier (Phase B, PR 3).
+  ///
+  /// v1 policy: only a status transition is LLM-worthy — an unchanged
+  /// status is the common no-op tick that must cost €0 and write no
+  /// messages. Ad staleness and dialogue triggers join this predicate
+  /// with PR 5's nudge state.
+  bool get needsEscalation => statusTransitioned;
+}

--- a/lib/features/goals/service/goal_agent_service.dart
+++ b/lib/features/goals/service/goal_agent_service.dart
@@ -2,6 +2,7 @@ import 'package:clock/clock.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/classes/goal_spec_validator.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -21,18 +22,25 @@ import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 class GoalAgentService {
   GoalAgentService({
     required this._agentService,
+    required this._repository,
     required this._syncService,
     required this._orchestrator,
   });
 
   final AgentService _agentService;
+  final AgentRepository _repository;
   final AgentSyncService _syncService;
   final WakeOrchestrator _orchestrator;
 
-  /// Creates a goal agent with its v1 spec.
+  /// Creates a goal agent with its v1 spec — identity, state, spec
+  /// version, head and first cadence tick in ONE transaction (nested
+  /// `runInTransaction` calls join the outer one), so a failure anywhere
+  /// leaves no orphaned half-goal behind.
   ///
-  /// Throws [ArgumentError] when [criteria] fails structural validation —
-  /// an unsatisfiable or corrupt goal must not exist even for a moment.
+  /// Throws [ArgumentError] when [criteria] fails structural validation,
+  /// and [StateError] when a goal already exists for a caller-supplied
+  /// [agentId] — spec v1 is immutable and must never be rewritten by a
+  /// repeated create.
   Future<AgentIdentityEntity> createGoalAgent({
     required String title,
     required String statement,
@@ -46,17 +54,23 @@ class GoalAgentService {
     if (issues.isNotEmpty) {
       throw ArgumentError('Invalid goal criteria: ${issues.join('; ')}');
     }
+    if (agentId != null &&
+        await _repository.getEntity(goalSpecHeadId(agentId)) != null) {
+      throw StateError(
+        'goal $agentId already exists; spec v1 is immutable — revise via '
+        'a new version, never a repeated create',
+      );
+    }
 
-    final identity = await _agentService.createAgent(
-      kind: AgentKinds.goalAgent,
-      displayName: title,
-      config: const AgentConfig(),
-      agentId: agentId,
-    );
     final now = clock.now();
-    final versionId = '${identity.agentId}:spec-v1';
-
-    await _syncService.runInTransaction(() async {
+    final identity = await _syncService.runInTransaction(() async {
+      final identity = await _agentService.createAgent(
+        kind: AgentKinds.goalAgent,
+        displayName: title,
+        config: const AgentConfig(),
+        agentId: agentId,
+      );
+      final versionId = '${identity.agentId}:spec-v1';
       await _syncService.upsertEntity(
         AgentDomainEntity.goalSpecVersion(
           id: versionId,
@@ -87,6 +101,7 @@ class GoalAgentService {
       await _syncService.upsertEntity(
         goalCadenceWake(identity.agentId, now),
       );
+      return identity;
     });
 
     registerSignalSubscription(identity.agentId, criteria);

--- a/lib/features/goals/service/goal_agent_service.dart
+++ b/lib/features/goals/service/goal_agent_service.dart
@@ -1,0 +1,113 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_spec_validator.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/service/agent_service.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+
+/// Creates and wires goal agents (ADR 0053: one durable identity per goal).
+///
+/// Creation is the only write path for a v1 goal spec: the criteria tree is
+/// validated before anything is persisted, the initial `goalSpecVersion` +
+/// `goalSpecHead` land in one transaction with the identity, and the agent
+/// leaves this method live — subscribed to its signals and armed with its
+/// first cadence tick.
+class GoalAgentService {
+  GoalAgentService({
+    required this._agentService,
+    required this._syncService,
+    required this._orchestrator,
+  });
+
+  final AgentService _agentService;
+  final AgentSyncService _syncService;
+  final WakeOrchestrator _orchestrator;
+
+  /// Creates a goal agent with its v1 spec.
+  ///
+  /// Throws [ArgumentError] when [criteria] fails structural validation —
+  /// an unsatisfiable or corrupt goal must not exist even for a moment.
+  Future<AgentIdentityEntity> createGoalAgent({
+    required String title,
+    required String statement,
+    required GoalCriterion criteria,
+    DateTime? startDate,
+    DateTime? targetDate,
+    String? rationale,
+    String? agentId,
+  }) async {
+    final issues = GoalSpecValidator.criterionIssues(criteria);
+    if (issues.isNotEmpty) {
+      throw ArgumentError('Invalid goal criteria: ${issues.join('; ')}');
+    }
+
+    final identity = await _agentService.createAgent(
+      kind: AgentKinds.goalAgent,
+      displayName: title,
+      config: const AgentConfig(),
+      agentId: agentId,
+    );
+    final now = clock.now();
+    final versionId = '${identity.agentId}:spec-v1';
+
+    await _syncService.runInTransaction(() async {
+      await _syncService.upsertEntity(
+        AgentDomainEntity.goalSpecVersion(
+          id: versionId,
+          agentId: identity.agentId,
+          version: 1,
+          status: GoalSpecVersionStatus.active,
+          authoredBy: 'user',
+          title: title,
+          statement: statement,
+          criteria: criteria,
+          createdAt: now,
+          vectorClock: null,
+          startDate: startDate,
+          targetDate: targetDate,
+          rationale: rationale,
+        ),
+      );
+      await _syncService.upsertEntity(
+        AgentDomainEntity.goalSpecHead(
+          id: goalSpecHeadId(identity.agentId),
+          agentId: identity.agentId,
+          versionId: versionId,
+          updatedAt: now,
+          vectorClock: null,
+        ),
+      );
+      // First cadence tick — recurrence by re-arm starts here.
+      await _syncService.upsertEntity(
+        goalCadenceWake(identity.agentId, now),
+      );
+    });
+
+    registerSignalSubscription(identity.agentId, criteria);
+    return identity;
+  }
+
+  /// Evidence-triggered wakes: the goal agent listens to exactly the
+  /// signals its criteria reference — leaf dataTypes, habitIds and
+  /// measurable ids — never a global sentinel.
+  void registerSignalSubscription(String agentId, GoalCriterion criteria) {
+    _orchestrator.addSubscription(
+      AgentSubscription(
+        id: goalSignalSubscriptionId(agentId),
+        agentId: agentId,
+        matchEntityIds: goalSignalTriggerTokens(criteria),
+        deferPropagatedMatches: false,
+      ),
+    );
+  }
+}
+
+/// Stable subscription id, so repeated `restoreSubscriptions` replace
+/// instead of accumulate.
+String goalSignalSubscriptionId(String agentId) => '${agentId}_goal_signals';

--- a/lib/features/goals/service/goal_agent_service.dart
+++ b/lib/features/goals/service/goal_agent_service.dart
@@ -54,16 +54,18 @@ class GoalAgentService {
     if (issues.isNotEmpty) {
       throw ArgumentError('Invalid goal criteria: ${issues.join('; ')}');
     }
-    if (agentId != null &&
-        await _repository.getEntity(goalSpecHeadId(agentId)) != null) {
-      throw StateError(
-        'goal $agentId already exists; spec v1 is immutable — revise via '
-        'a new version, never a repeated create',
-      );
-    }
-
     final now = clock.now();
     final identity = await _syncService.runInTransaction(() async {
+      // Inside the transaction, not a preflight: two concurrent creates
+      // for the same caller-supplied id must serialize here, so the loser
+      // sees the winner's head and cannot rewrite the immutable spec v1.
+      if (agentId != null &&
+          await _repository.getEntity(goalSpecHeadId(agentId)) != null) {
+        throw StateError(
+          'goal $agentId already exists; spec v1 is immutable — revise via '
+          'a new version, never a repeated create',
+        );
+      }
       final identity = await _agentService.createAgent(
         kind: AgentKinds.goalAgent,
         displayName: title,

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -22,6 +22,9 @@ final goalAgentPhaseAProvider = Provider<GoalAgentPhaseA>(
     repository: ref.watch(agentRepositoryProvider),
     syncService: ref.watch(agentSyncServiceProvider),
     signalReader: ref.watch(goalSignalReaderProvider),
+    // A locally armed escalation must not wait out the hourly poll.
+    onEscalationArmed: () =>
+        ref.read(scheduledWakeManagerProvider).requestCheck(),
   ),
   name: 'goalAgentPhaseAProvider',
 );
@@ -29,6 +32,7 @@ final goalAgentPhaseAProvider = Provider<GoalAgentPhaseA>(
 final goalAgentServiceProvider = Provider<GoalAgentService>(
   (ref) => GoalAgentService(
     agentService: ref.watch(agentServiceProvider),
+    repository: ref.watch(agentRepositoryProvider),
     syncService: ref.watch(agentSyncServiceProvider),
     orchestrator: ref.watch(wakeOrchestratorProvider),
   ),
@@ -66,6 +70,7 @@ final goalRuntimeMaintenanceProvider = Provider<GoalRuntimeMaintenance>(
     repository: ref.watch(agentRepositoryProvider),
     syncService: ref.watch(agentSyncServiceProvider),
     goalAgentService: ref.watch(goalAgentServiceProvider),
+    domainLogger: ref.watch(domainLoggerProvider),
   ),
   name: 'goalRuntimeMaintenanceProvider',
 );
@@ -75,6 +80,7 @@ final goalSignalSyncDispatcherProvider = Provider<GoalSignalSyncDispatcher>(
     agentService: ref.watch(agentServiceProvider),
     repository: ref.watch(agentRepositoryProvider),
     phaseA: ref.watch(goalAgentPhaseAProvider),
+    domainLogger: ref.watch(domainLoggerProvider),
   ),
   name: 'goalSignalSyncDispatcherProvider',
 );
@@ -86,6 +92,7 @@ final goalSignalSyncListenerProvider = Provider<GoalSignalSyncListener>(
     final listener = GoalSignalSyncListener(
       updateNotifications: ref.watch(updateNotificationsProvider),
       dispatcher: ref.watch(goalSignalSyncDispatcherProvider),
+      domainLogger: ref.watch(domainLoggerProvider),
     )..start();
     ref.onDispose(listener.dispose);
     return listener;

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
+import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
+import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+
+/// Goal-agent runtime wiring (the Daily OS plug-in pattern: providers live
+/// in the owning feature; `features/agents` never imports goals).
+
+final goalSignalReaderProvider = Provider<GoalSignalReader>(
+  (ref) => GoalSignalReader(journalDb: ref.watch(journalDbProvider)),
+  name: 'goalSignalReaderProvider',
+);
+
+final goalAgentPhaseAProvider = Provider<GoalAgentPhaseA>(
+  (ref) => GoalAgentPhaseA(
+    repository: ref.watch(agentRepositoryProvider),
+    syncService: ref.watch(agentSyncServiceProvider),
+    signalReader: ref.watch(goalSignalReaderProvider),
+  ),
+  name: 'goalAgentPhaseAProvider',
+);
+
+final goalAgentServiceProvider = Provider<GoalAgentService>(
+  (ref) => GoalAgentService(
+    agentService: ref.watch(agentServiceProvider),
+    syncService: ref.watch(agentSyncServiceProvider),
+    orchestrator: ref.watch(wakeOrchestratorProvider),
+  ),
+  name: 'goalAgentServiceProvider',
+);
+
+/// The goals contribution to `agentWakeRunnersProvider` — merged with the
+/// other features' maps in `buildProviderOverrides`. An unmerged map means
+/// goal wakes silently fall back to the task-agent workflow, which the
+/// bootstrap regression test pins against.
+final goalAgentWakeRunnersProvider = Provider<Map<String, AgentWakeRunner>>(
+  (ref) => <String, AgentWakeRunner>{
+    AgentKinds.goalAgent:
+        ({
+          required agentIdentity,
+          required runKey,
+          required triggerTokens,
+          required threadId,
+        }) => ref
+            .read(goalAgentPhaseAProvider)
+            .execute(
+              agentIdentity: agentIdentity,
+              runKey: runKey,
+              triggerTokens: triggerTokens,
+              threadId: threadId,
+            ),
+  },
+  name: 'goalAgentWakeRunnersProvider',
+);
+
+/// The goals contribution to `agentRuntimeMaintenanceProvider`.
+final goalRuntimeMaintenanceProvider = Provider<GoalRuntimeMaintenance>(
+  (ref) => GoalRuntimeMaintenance(
+    agentService: ref.watch(agentServiceProvider),
+    repository: ref.watch(agentRepositoryProvider),
+    syncService: ref.watch(agentSyncServiceProvider),
+    goalAgentService: ref.watch(goalAgentServiceProvider),
+  ),
+  name: 'goalRuntimeMaintenanceProvider',
+);
+
+final goalSignalSyncDispatcherProvider = Provider<GoalSignalSyncDispatcher>(
+  (ref) => GoalSignalSyncDispatcher(
+    agentService: ref.watch(agentServiceProvider),
+    repository: ref.watch(agentRepositoryProvider),
+    phaseA: ref.watch(goalAgentPhaseAProvider),
+  ),
+  name: 'goalSignalSyncDispatcherProvider',
+);
+
+/// Constructed for app lifetime via `ref.listen` in the app shell (the
+/// synced-audio listener pattern).
+final goalSignalSyncListenerProvider = Provider<GoalSignalSyncListener>(
+  (ref) {
+    final listener = GoalSignalSyncListener(
+      updateNotifications: ref.watch(updateNotificationsProvider),
+      dispatcher: ref.watch(goalSignalSyncDispatcherProvider),
+    )..start();
+    ref.onDispose(listener.dispose);
+    return listener;
+  },
+  name: 'goalSignalSyncListenerProvider',
+);

--- a/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
+++ b/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
@@ -38,40 +38,53 @@ class GoalSignalSyncDispatcher {
   final _inFlight = <String>{};
 
   /// Runs Phase A for every goal agent whose signal tokens intersect the
-  /// synced batch. Never throws.
+  /// synced batch. Never throws; each agent is contained individually so
+  /// one corrupt goal cannot suppress updates for unrelated goals.
   Future<void> dispatchBatch(Set<String> tokens) async {
+    final List<AgentIdentityEntity> agents;
     try {
-      final agents = await _agentService.listAgents(
+      agents = await _agentService.listAgents(
         lifecycle: AgentLifecycle.active,
       );
-      for (final identity in agents) {
-        if (identity.kind != AgentKinds.goalAgent) continue;
-        if (_inFlight.contains(identity.agentId)) continue;
+    } catch (error, stackTrace) {
+      _log('listing agents for a synced batch failed', error, stackTrace);
+      return;
+    }
+    for (final identity in agents) {
+      if (identity.kind != AgentKinds.goalAgent) continue;
+      if (_inFlight.contains(identity.agentId)) continue;
+      _inFlight.add(identity.agentId);
+      try {
         final matched = await _matchedTokens(identity.agentId, tokens);
         if (matched.isEmpty) continue;
-        _inFlight.add(identity.agentId);
-        try {
-          final runKey =
-              'goal-sync:${identity.agentId}:'
-              '${clock.now().millisecondsSinceEpoch}';
-          await _phaseA.execute(
-            agentIdentity: identity,
-            runKey: runKey,
-            triggerTokens: matched,
-            threadId: runKey,
-          );
-        } finally {
-          _inFlight.remove(identity.agentId);
-        }
+        final runKey =
+            'goal-sync:${identity.agentId}:'
+            '${clock.now().millisecondsSinceEpoch}';
+        await _phaseA.execute(
+          agentIdentity: identity,
+          runKey: runKey,
+          triggerTokens: matched,
+          threadId: runKey,
+        );
+      } catch (error, stackTrace) {
+        _log(
+          'goal signal sync dispatch failed for one agent',
+          error,
+          stackTrace,
+        );
+      } finally {
+        _inFlight.remove(identity.agentId);
       }
-    } catch (error, stackTrace) {
-      _domainLogger?.error(
-        LogDomain.sync,
-        error,
-        message: 'goal signal sync dispatch failed for one batch',
-        stackTrace: stackTrace,
-      );
     }
+  }
+
+  void _log(String message, Object error, StackTrace stackTrace) {
+    _domainLogger?.error(
+      LogDomain.sync,
+      error,
+      message: message,
+      stackTrace: stackTrace,
+    );
   }
 
   Future<Set<String>> _matchedTokens(
@@ -93,16 +106,29 @@ class GoalSignalSyncListener {
   GoalSignalSyncListener({
     required this._updateNotifications,
     required this._dispatcher,
+    this._domainLogger,
   });
 
   final UpdateNotifications _updateNotifications;
   final GoalSignalSyncDispatcher _dispatcher;
+  final DomainLogger? _domainLogger;
   StreamSubscription<void>? _subscription;
 
   void start() {
     _subscription ??= _updateNotifications.syncUpdateStream
         .asyncMap(_dispatcher.dispatchBatch)
-        .listen((_) {});
+        .listen(
+          (_) {},
+          // A stream error must be visible, not a silent end of synced
+          // goal evaluation for the rest of the app lifetime.
+          onError: (Object error, StackTrace stackTrace) =>
+              _domainLogger?.error(
+                LogDomain.sync,
+                error,
+                message: 'goal signal sync stream errored',
+                stackTrace: stackTrace,
+              ),
+        );
   }
 
   Future<void> dispose() async {

--- a/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
+++ b/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/agent_service.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+/// Bridges the sync blind spot for goal signals (ADR 0054 Decision 4).
+///
+/// `WakeOrchestrator` deliberately listens to `localUpdateStream` only —
+/// synced writes must not wake LLM tiers. But goal *Phase A* is
+/// deterministic and idempotent (keyed registers), so a desktop receiving
+/// phone-imported steps runs the €0 tier directly and converges instead of
+/// showing stale registers. Phase B is never triggered from here: if
+/// Phase A finds an LLM-worthy transition it arms the escalation wake, and
+/// the scheduled-wake manager's lease election picks exactly one device.
+class GoalSignalSyncDispatcher {
+  GoalSignalSyncDispatcher({
+    required this._agentService,
+    required this._repository,
+    required this._phaseA,
+    this._domainLogger,
+  });
+
+  final AgentService _agentService;
+  final AgentRepository _repository;
+  final GoalAgentPhaseA _phaseA;
+  final DomainLogger? _domainLogger;
+
+  /// Per-agent single flight: a burst of synced batches must not stack
+  /// concurrent evaluations of the same goal.
+  final _inFlight = <String>{};
+
+  /// Runs Phase A for every goal agent whose signal tokens intersect the
+  /// synced batch. Never throws.
+  Future<void> dispatchBatch(Set<String> tokens) async {
+    try {
+      final agents = await _agentService.listAgents(
+        lifecycle: AgentLifecycle.active,
+      );
+      for (final identity in agents) {
+        if (identity.kind != AgentKinds.goalAgent) continue;
+        if (_inFlight.contains(identity.agentId)) continue;
+        final matched = await _matchedTokens(identity.agentId, tokens);
+        if (matched.isEmpty) continue;
+        _inFlight.add(identity.agentId);
+        try {
+          final runKey =
+              'goal-sync:${identity.agentId}:'
+              '${clock.now().millisecondsSinceEpoch}';
+          await _phaseA.execute(
+            agentIdentity: identity,
+            runKey: runKey,
+            triggerTokens: matched,
+            threadId: runKey,
+          );
+        } finally {
+          _inFlight.remove(identity.agentId);
+        }
+      }
+    } catch (error, stackTrace) {
+      _domainLogger?.error(
+        LogDomain.sync,
+        error,
+        message: 'goal signal sync dispatch failed for one batch',
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<Set<String>> _matchedTokens(
+    String agentId,
+    Set<String> tokens,
+  ) async {
+    final head = await _repository.getEntity(goalSpecHeadId(agentId));
+    if (head is! GoalSpecHeadEntity) return const {};
+    final version = await _repository.getEntity(head.versionId);
+    if (version is! GoalSpecVersionEntity) return const {};
+    return goalSignalTriggerTokens(version.criteria).intersection(tokens);
+  }
+}
+
+/// App-lifetime subscription pumping synced batches into the dispatcher
+/// (the `SyncedAudioInferenceListener` pattern: `asyncMap` serializes
+/// batches; the 1-second sync batching window is the debounce).
+class GoalSignalSyncListener {
+  GoalSignalSyncListener({
+    required this._updateNotifications,
+    required this._dispatcher,
+  });
+
+  final UpdateNotifications _updateNotifications;
+  final GoalSignalSyncDispatcher _dispatcher;
+  StreamSubscription<void>? _subscription;
+
+  void start() {
+    _subscription ??= _updateNotifications.syncUpdateStream
+        .asyncMap(_dispatcher.dispatchBatch)
+        .listen((_) {});
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
 import 'package:lotti/features/agents/workflow/prompt_log_wrap.dart';
 import 'package:lotti/features/agents/workflow/prompt_record.dart';
@@ -18,6 +19,7 @@ import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_identity_resolver.dart';
 import 'package:lotti/features/daily_os_next/agents/state/daily_os_runtime_maintenance.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
+import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
 import 'package:lotti/features/profiles/model/profile.dart';
 import 'package:lotti/features/profiles/model/profile_context.dart';
 import 'package:lotti/features/profiles/repository/profile_registry.dart';
@@ -453,6 +455,12 @@ void main() {
         overrides: [
           ...buildProviderOverrides(context),
           dayAgentServiceProvider.overrideWithValue(MockDayAgentService()),
+          // Same reasoning for the goal chain's leaves: these tests assert
+          // wiring, not behavior, and the real ones pull in the agent DB.
+          agentRepositoryProvider.overrideWithValue(MockAgentRepository()),
+          agentSyncServiceProvider.overrideWithValue(MockAgentSyncService()),
+          agentServiceProvider.overrideWithValue(MockAgentService()),
+          wakeOrchestratorProvider.overrideWithValue(MockWakeOrchestrator()),
         ],
       );
       addTearDown(container.dispose);
@@ -477,8 +485,36 @@ void main() {
         realContext(),
       ).read(agentRuntimeMaintenanceProvider);
 
-      expect(maintenance, hasLength(1));
-      expect(maintenance.single, isA<DailyOsRuntimeMaintenance>());
+      expect(maintenance, hasLength(2));
+      expect(maintenance.first, isA<DailyOsRuntimeMaintenance>());
+    });
+
+    test('registers the goal_agent wake runner', () {
+      // Without this a goal wake silently falls through to the task-agent
+      // workflow (agent_wiring's unregistered-kind fallback) — the exact
+      // failure ADR 0054's deterministic tier exists to prevent.
+      final runners = containerFor(
+        realContext(),
+      ).read(agentWakeRunnersProvider);
+
+      expect(runners.keys, contains(AgentKinds.goalAgent));
+      expect(runners[AgentKinds.goalAgent], isNotNull);
+      // And the merge kept Daily OS intact — a replacement instead of a
+      // merge would silently unregister the other feature's kind.
+      expect(runners.keys, contains(AgentKinds.dayAgent));
+    });
+
+    test('registers goal runtime maintenance alongside Daily OS', () {
+      // Without this no goal subscription survives a restart and a missed
+      // cadence re-arm is never healed.
+      final maintenance = containerFor(
+        realContext(),
+      ).read(agentRuntimeMaintenanceProvider);
+
+      expect(
+        maintenance.whereType<GoalRuntimeMaintenance>(),
+        hasLength(1),
+      );
     });
 
     test('registers both day prompt-log wrap renderers', () {
@@ -521,9 +557,9 @@ void main() {
 
       expect(
         container.read(agentWakeRunnersProvider).keys,
-        contains(AgentKinds.dayAgent),
+        containsAll([AgentKinds.dayAgent, AgentKinds.goalAgent]),
       );
-      expect(container.read(agentRuntimeMaintenanceProvider), hasLength(1));
+      expect(container.read(agentRuntimeMaintenanceProvider), hasLength(2));
       expect(container.read(promptLogWrapRenderersProvider), hasLength(2));
       expect(container.read(dailyOsSetupSheetLauncherProvider), isNotNull);
     });

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -289,6 +289,23 @@ void main() {
   }
 
   group('ScheduledWakeManager', () {
+    test('requestCheck runs a scan pass without start (the goal Phase A '
+        'escalation nudge)', () async {
+      when(
+        () => repository.getDueScheduledAgentStates(any()),
+      ).thenAnswer((_) async => []);
+      final manager = ScheduledWakeManager(
+        repository: repository,
+        orchestrator: orchestrator,
+        syncService: syncService,
+      );
+      addTearDown(manager.stop);
+
+      manager.requestCheck();
+      await untilCalled(() => repository.getDueScheduledWakeRecords(any()));
+      verify(() => repository.getDueScheduledWakeRecords(any())).called(1);
+    });
+
     test('a failed pass is contained and reported as runtime', () async {
       // The manager polls on a timer. A failing pass must not escape into the
       // timer callback — an uncaught error there would tear down the poll and

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -261,6 +261,51 @@ void main() {
     );
   });
 
+  test('percentage point samples are normalized to display units, '
+      'matching the chart', () async {
+    const bodyFat = GoalCriterion.metric(
+      criterionId: 'bf',
+      dataType: 'HealthDataType.BODY_FAT_PERCENTAGE',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.max,
+      target: 18,
+      direction: GoalDirection.atMost,
+    );
+    when(
+      () => journalDb.getQuantitativeByType(
+        type: 'HealthDataType.BODY_FAT_PERCENTAGE',
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        JournalEntity.quantitative(
+          meta: meta(DateTime(2026, 8, 8, 8)),
+          data: QuantitativeData.discreteQuantityData(
+            dateFrom: DateTime(2026, 8, 8, 8),
+            dateTo: DateTime(2026, 8, 8, 8),
+            // Stored as a fraction; the chart — and a user target of
+            // "18%" — read it ×100 (`aggregateNone` normalization).
+            value: 0.18,
+            dataType: 'HealthDataType.BODY_FAT_PERCENTAGE',
+            unit: '%',
+          ),
+        ),
+      ],
+    );
+
+    final window = await reader.read(criteria: bodyFat, reference: reference);
+    expect(
+      window
+          .quantitativeDailySums['HealthDataType.BODY_FAT_PERCENTAGE']![DateTime.utc(
+        2026,
+        8,
+        8,
+      )],
+      18,
+    );
+  });
+
   test('measurements sum per day', () async {
     const water = GoalCriterion.measurable(
       criterionId: 'water',

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -1,0 +1,287 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/classes/health.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  late MockJournalDb journalDb;
+  late GoalSignalReader reader;
+
+  final reference = DateTime(2026, 8, 8, 14, 30);
+
+  Metadata meta(DateTime dateFrom, {String? id}) => Metadata(
+    id: id ?? 'e-${dateFrom.millisecondsSinceEpoch}',
+    createdAt: dateFrom,
+    updatedAt: dateFrom,
+    dateFrom: dateFrom,
+    dateTo: dateFrom,
+  );
+
+  JournalEntity steps(DateTime at, num value) => JournalEntity.quantitative(
+    meta: meta(at),
+    data: QuantitativeData.cumulativeQuantityData(
+      dateFrom: at,
+      dateTo: at,
+      value: value,
+      dataType: 'cumulative_step_count',
+      unit: 'count',
+    ),
+  );
+
+  JournalEntity habit(DateTime at, HabitCompletionType type) =>
+      JournalEntity.habitCompletion(
+        meta: meta(at),
+        data: HabitCompletionData(
+          habitId: 'gym-habit',
+          dateFrom: at,
+          dateTo: at,
+          completionType: type,
+        ),
+      );
+
+  JournalEntity measurement(DateTime at, num value) =>
+      JournalEntity.measurement(
+        meta: meta(at),
+        data: MeasurementData(
+          dateFrom: at,
+          dateTo: at,
+          value: value,
+          dataTypeId: 'water-id',
+        ),
+      );
+
+  setUp(() {
+    journalDb = MockJournalDb();
+    reader = GoalSignalReader(journalDb: journalDb);
+    when(
+      () => journalDb.getQuantitativeByType(
+        type: any(named: 'type'),
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(
+      () => journalDb.getHabitCompletionsByHabitId(
+        habitId: any(named: 'habitId'),
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(
+      () => journalDb.getMeasurementsByType(
+        type: any(named: 'type'),
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => []);
+  });
+
+  const stepsCriterion = GoalCriterion.metric(
+    criterionId: 'steps',
+    dataType: 'cumulative_step_count',
+    window: GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: 10000,
+  );
+
+  test(
+    'cumulative step samples collapse to the day MAX, keyed dayUtc',
+    () async {
+      // A running counter sampled three times: the day total is the peak,
+      // not the sum — matching the health chart the user actually sees.
+      when(
+        () => journalDb.getQuantitativeByType(
+          type: 'cumulative_step_count',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          steps(DateTime(2026, 8, 7, 9), 2100),
+          steps(DateTime(2026, 8, 7, 15), 6400),
+          steps(DateTime(2026, 8, 7, 21), 9800),
+          steps(DateTime(2026, 8, 8, 8), 1200),
+        ],
+      );
+
+      final window = await reader.read(
+        criteria: stepsCriterion,
+        reference: reference,
+      );
+
+      expect(
+        window.quantitativeDailySums['cumulative_step_count'],
+        {
+          DateTime.utc(2026, 8, 7): 9800,
+          DateTime.utc(2026, 8, 8): 1200,
+        },
+      );
+    },
+  );
+
+  test(
+    'unknown quantitative types fall back to a daily sum, not silence',
+    () async {
+      const custom = GoalCriterion.metric(
+        criterionId: 'rows',
+        dataType: 'custom_rowing_meters',
+        window: GoalWindow.day(),
+        aggregation: GoalAggregation.sum,
+        target: 2000,
+      );
+      when(
+        () => journalDb.getQuantitativeByType(
+          type: 'custom_rowing_meters',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          JournalEntity.quantitative(
+            meta: meta(DateTime(2026, 8, 8, 7)),
+            data: QuantitativeData.discreteQuantityData(
+              dateFrom: DateTime(2026, 8, 8, 7),
+              dateTo: DateTime(2026, 8, 8, 7),
+              value: 800,
+              dataType: 'custom_rowing_meters',
+              unit: 'm',
+            ),
+          ),
+          JournalEntity.quantitative(
+            meta: meta(DateTime(2026, 8, 8, 18)),
+            data: QuantitativeData.discreteQuantityData(
+              dateFrom: DateTime(2026, 8, 8, 18),
+              dateTo: DateTime(2026, 8, 8, 18),
+              value: 1400,
+              dataType: 'custom_rowing_meters',
+              unit: 'm',
+            ),
+          ),
+        ],
+      );
+
+      final window = await reader.read(criteria: custom, reference: reference);
+      expect(
+        window.quantitativeDailySums['custom_rowing_meters']![DateTime.utc(
+          2026,
+          8,
+          8,
+        )],
+        2200,
+      );
+    },
+  );
+
+  test(
+    'only success completions count; skip and fail days are absent',
+    () async {
+      const gym = GoalCriterion.habit(
+        criterionId: 'gym',
+        habitId: 'gym-habit',
+        window: GoalWindow.calendarWeek(),
+        targetCount: 3,
+      );
+      when(
+        () => journalDb.getHabitCompletionsByHabitId(
+          habitId: 'gym-habit',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          habit(DateTime(2026, 8, 3, 18), HabitCompletionType.success),
+          habit(DateTime(2026, 8, 5, 18), HabitCompletionType.skip),
+          habit(DateTime(2026, 8, 6, 18), HabitCompletionType.fail),
+        ],
+      );
+
+      final window = await reader.read(criteria: gym, reference: reference);
+      expect(
+        window.habitSuccessesByDay['gym-habit'],
+        {DateTime.utc(2026, 8, 3): 1},
+      );
+    },
+  );
+
+  test('measurements sum per day', () async {
+    const water = GoalCriterion.measurable(
+      criterionId: 'water',
+      dataTypeId: 'water-id',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      target: 2000,
+    );
+    when(
+      () => journalDb.getMeasurementsByType(
+        type: 'water-id',
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        measurement(DateTime(2026, 8, 8, 9), 500),
+        measurement(DateTime(2026, 8, 8, 13), 700),
+      ],
+    );
+
+    final window = await reader.read(criteria: water, reference: reference);
+    expect(
+      window.measurableDailySums['water-id']![DateTime.utc(2026, 8, 8)],
+      1200,
+    );
+  });
+
+  test(
+    'the query range covers the widest window plus a prior period',
+    () async {
+      await reader.read(criteria: stepsCriterion, reference: reference);
+      final captured = verify(
+        () => journalDb.getQuantitativeByType(
+          type: 'cumulative_step_count',
+          rangeStart: captureAny(named: 'rangeStart'),
+          rangeEnd: captureAny(named: 'rangeEnd'),
+        ),
+      ).captured;
+      final rangeStart = captured[0] as DateTime;
+      final rangeEnd = captured[1] as DateTime;
+      // Rolling 7 ending Aug 8 starts Aug 2; one extra period back for the
+      // grace check reaches Jul 26.
+      expect(rangeStart, DateTime(2026, 7, 26));
+      // End of the reference day so late entries today are included.
+      expect(rangeEnd, DateTime(2026, 8, 9));
+    },
+  );
+
+  test('trigger tokens are exactly the leaf identifiers', () {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'root',
+      criteria: [
+        stepsCriterion,
+        GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: 'gym-habit',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+        GoalCriterion.measurable(
+          criterionId: 'water',
+          dataTypeId: 'water-id',
+          window: GoalWindow.day(),
+          aggregation: GoalAggregation.sum,
+          target: 2000,
+        ),
+      ],
+    );
+    expect(
+      goalSignalTriggerTokens(composite),
+      {'cumulative_step_count', 'gym-habit', 'water-id'},
+    );
+  });
+}

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -199,6 +199,9 @@ void main() {
           habit(DateTime(2026, 8, 3, 18), HabitCompletionType.success),
           habit(DateTime(2026, 8, 5, 18), HabitCompletionType.skip),
           habit(DateTime(2026, 8, 6, 18), HabitCompletionType.fail),
+          // Defensive: a stray non-habit entity in the result set is
+          // skipped, never counted.
+          measurement(DateTime(2026, 8, 4, 18), 1),
         ],
       );
 
@@ -259,23 +262,35 @@ void main() {
     },
   );
 
-  test('trigger tokens are exactly the leaf identifiers', () {
+  test('trigger tokens are exactly the leaf identifiers, through every '
+      'composite shape', () {
     const composite = GoalCriterion.allOf(
       criterionId: 'root',
       criteria: [
         stepsCriterion,
-        GoalCriterion.habit(
-          criterionId: 'gym',
-          habitId: 'gym-habit',
-          window: GoalWindow.calendarWeek(),
-          targetCount: 3,
+        GoalCriterion.anyOf(
+          criterionId: 'either',
+          criteria: [
+            GoalCriterion.habit(
+              criterionId: 'gym',
+              habitId: 'gym-habit',
+              window: GoalWindow.calendarWeek(),
+              targetCount: 3,
+            ),
+          ],
         ),
-        GoalCriterion.measurable(
-          criterionId: 'water',
-          dataTypeId: 'water-id',
-          window: GoalWindow.day(),
-          aggregation: GoalAggregation.sum,
-          target: 2000,
+        GoalCriterion.atLeastCount(
+          criterionId: 'some',
+          criteria: [
+            GoalCriterion.measurable(
+              criterionId: 'water',
+              dataTypeId: 'water-id',
+              window: GoalWindow.day(),
+              aggregation: GoalAggregation.sum,
+              target: 2000,
+            ),
+          ],
+          successes: 1,
         ),
       ],
     );
@@ -283,5 +298,70 @@ void main() {
       goalSignalTriggerTokens(composite),
       {'cumulative_step_count', 'gym-habit', 'water-id'},
     );
+  });
+
+  test('composite trees widen the query range across all leaf windows, and '
+      'stray entity types in a result set are ignored', () async {
+    const composite = GoalCriterion.anyOf(
+      criterionId: 'either',
+      criteria: [
+        stepsCriterion,
+        GoalCriterion.atLeastCount(
+          criterionId: 'some',
+          criteria: [
+            GoalCriterion.measurable(
+              criterionId: 'water',
+              dataTypeId: 'water-id',
+              window: GoalWindow.day(),
+              aggregation: GoalAggregation.sum,
+              target: 2000,
+            ),
+          ],
+          successes: 1,
+        ),
+      ],
+    );
+    // A habit completion arriving in a quantitative/measurable result set
+    // (defensive: the query filters by subtype, decode does not) must be
+    // skipped, not crash or count.
+    when(
+      () => journalDb.getMeasurementsByType(
+        type: 'water-id',
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        habit(DateTime(2026, 8, 8, 9), HabitCompletionType.success),
+        measurement(DateTime(2026, 8, 8, 9), 500),
+      ],
+    );
+    when(
+      () => journalDb.getQuantitativeByType(
+        type: 'cumulative_step_count',
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer(
+      (_) async => [measurement(DateTime(2026, 8, 8, 9), 500)],
+    );
+
+    final window = await reader.read(criteria: composite, reference: reference);
+    expect(
+      window.measurableDailySums['water-id']![DateTime.utc(2026, 8, 8)],
+      500,
+    );
+    expect(window.quantitativeDailySums['cumulative_step_count'], isEmpty);
+
+    // The rolling-7 leaf dominates the range: Jul 26 (window + one prior
+    // period), even though the other leaf is a single day.
+    final captured = verify(
+      () => journalDb.getMeasurementsByType(
+        type: 'water-id',
+        rangeStart: captureAny(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).captured;
+    expect(captured.single, DateTime(2026, 7, 26));
   });
 }

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -213,6 +213,54 @@ void main() {
     },
   );
 
+  test("point-sample types (aggregation none) keep the day's LATEST "
+      'sample', () async {
+    const weight = GoalCriterion.metric(
+      criterionId: 'weight',
+      dataType: 'HealthDataType.WEIGHT',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.max,
+      target: 80,
+      direction: GoalDirection.atMost,
+    );
+    JournalEntity sample(DateTime at, num value) => JournalEntity.quantitative(
+      meta: meta(at),
+      data: QuantitativeData.discreteQuantityData(
+        dateFrom: at,
+        dateTo: at,
+        value: value,
+        dataType: 'HealthDataType.WEIGHT',
+        unit: 'kg',
+      ),
+    );
+    when(
+      () => journalDb.getQuantitativeByType(
+        type: 'HealthDataType.WEIGHT',
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer(
+      // Newest-first, like the real query: without deterministic
+      // reduction the OLDEST sample would win the day-keyed map.
+      (_) async => [
+        sample(DateTime(2026, 8, 8, 21), 79.4),
+        sample(DateTime(2026, 8, 8, 7), 81.2),
+        // Defensive: a stray non-quantitative row is skipped, not bucketed.
+        measurement(DateTime(2026, 8, 8, 12), 1),
+      ],
+    );
+
+    final window = await reader.read(criteria: weight, reference: reference);
+    expect(
+      window.quantitativeDailySums['HealthDataType.WEIGHT']![DateTime.utc(
+        2026,
+        8,
+        8,
+      )],
+      79.4,
+    );
+  });
+
   test('measurements sum per day', () async {
     const water = GoalCriterion.measurable(
       criterionId: 'water',

--- a/test/features/goals/runtime/goal_agent_phase_a_test.dart
+++ b/test/features/goals/runtime/goal_agent_phase_a_test.dart
@@ -2,6 +2,7 @@ import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
@@ -11,6 +12,7 @@ import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -177,7 +179,7 @@ void main() {
       await run(onTrackSignals());
       expect(
         upserts.whereType<ScheduledWakeEntity>().where(
-          (w) => w.workspaceKey == goalEscalationWorkspaceKey,
+          (w) => isGoalEscalationWorkspace(w.workspaceKey),
         ),
         hasLength(1),
       );
@@ -206,7 +208,7 @@ void main() {
     await run(onTrackSignals());
     expect(
       upserts.whereType<ScheduledWakeEntity>().where(
-        (w) => w.workspaceKey == goalEscalationWorkspaceKey,
+        (w) => isGoalEscalationWorkspace(w.workspaceKey),
       ),
       isEmpty,
     );
@@ -270,6 +272,197 @@ void main() {
       expect(register.trackStatus, GoalTrackStatus.achieved);
     },
   );
+
+  test('re-running the SAME day with an unchanged status is a no-op — the '
+      'escalation wake cannot re-arm itself forever', () async {
+    stubSpec();
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-08'),
+        agentId: agentId,
+        periodKey: '2026-08-08',
+        trackStatus: GoalTrackStatus.onTrack,
+        attainment: 1,
+        dataCoverage: 1,
+        satisfied: true,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: DateTime(2026, 8, 8, 6),
+        updatedAt: DateTime(2026, 8, 8, 6),
+        vectorClock: null,
+      ),
+    );
+    // No yesterday row at all: without the today-row comparison this
+    // would look like a first evaluation and escalate again.
+    await run(onTrackSignals());
+    expect(
+      upserts.whereType<ScheduledWakeEntity>().where(
+        (w) => isGoalEscalationWorkspace(w.workspaceKey),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('escalation wakes are period-scoped, lease-recognizable, and carry '
+      'a UTC deadline', () async {
+    stubSpec();
+    await run(onTrackSignals());
+    final escalation = upserts.whereType<ScheduledWakeEntity>().singleWhere(
+      (w) => isGoalEscalationWorkspace(w.workspaceKey),
+    );
+    expect(escalation.workspaceKey, 'goal-escalation:2026-08-08');
+    expect(escalation.scheduledAt.isUtc, isTrue);
+  });
+
+  test('the escalation callback nudges the wake manager exactly when an '
+      'escalation is armed', () async {
+    stubSpec();
+    var nudges = 0;
+    final nudging = GoalAgentPhaseA(
+      repository: repository,
+      syncService: syncService,
+      signalReader: _FakeSignalReader(onTrackSignals()),
+      onEscalationArmed: () => nudges++,
+    );
+    await withClock(
+      fixedClock,
+      () => nudging.execute(
+        agentIdentity: identity,
+        runKey: 'run-1',
+        triggerTokens: const {},
+        threadId: 'thread-1',
+      ),
+    );
+    expect(nudges, 1);
+  });
+
+  test('a gap in the register history breaks the grace streak', () async {
+    stubSpec();
+    // Two days ago was bad, but YESTERDAY is missing: the old bad day
+    // must not compact forward into "the immediately preceding period".
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-06')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-06'),
+        agentId: agentId,
+        periodKey: '2026-08-06',
+        trackStatus: GoalTrackStatus.atRisk,
+        attainment: 0.5,
+        dataCoverage: 1,
+        satisfied: false,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: DateTime(2026, 8, 6),
+        updatedAt: DateTime(2026, 8, 6),
+        vectorClock: null,
+      ),
+    );
+    final badWeek = GoalSignalWindow(
+      quantitativeDailySums: {
+        'cumulative_step_count': {
+          for (var day = 2; day <= 8; day++) DateTime.utc(2026, 8, day): 6000,
+        },
+      },
+    );
+    await run(badWeek);
+    final register = upserts.whereType<GoalProgressEntity>().single;
+    // First bad period as far as the CONSECUTIVE streak knows → grace.
+    expect(register.trackStatus, GoalTrackStatus.atRisk);
+  });
+
+  test('rows from a superseded spec version do not exhaust grace', () async {
+    stubSpec();
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-07')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-07'),
+        agentId: agentId,
+        periodKey: '2026-08-07',
+        trackStatus: GoalTrackStatus.offTrack,
+        attainment: 0.3,
+        dataCoverage: 1,
+        satisfied: false,
+        specVersionId: '$agentId:spec-v0-old',
+        createdAt: DateTime(2026, 8, 7),
+        updatedAt: DateTime(2026, 8, 7),
+        vectorClock: null,
+      ),
+    );
+    final badWeek = GoalSignalWindow(
+      quantitativeDailySums: {
+        'cumulative_step_count': {
+          for (var day = 2; day <= 8; day++) DateTime.utc(2026, 8, day): 6000,
+        },
+      },
+    );
+    await run(badWeek);
+    final register = upserts.whereType<GoalProgressEntity>().single;
+    // A revised goal starts its grace history fresh.
+    expect(register.trackStatus, GoalTrackStatus.atRisk);
+  });
+
+  test(
+    'a goal that has not started yet writes nothing but keeps ticking',
+    () async {
+      when(
+        () => repository.getEntity(goalSpecHeadId(agentId)),
+      ).thenAnswer((_) async => specHead);
+      when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+        (_) async => AgentDomainEntity.goalSpecVersion(
+          id: '$agentId:spec-v1',
+          agentId: agentId,
+          version: 1,
+          status: GoalSpecVersionStatus.active,
+          authoredBy: 'user',
+          title: 'Daily steps',
+          statement: 'Average 10,000 steps a day.',
+          criteria: criteria,
+          createdAt: DateTime(2026),
+          vectorClock: null,
+          startDate: DateTime(2026, 9),
+        ),
+      );
+      final result = await run(onTrackSignals());
+      expect(result.success, isTrue);
+      expect(upserts.whereType<GoalProgressEntity>(), isEmpty);
+      // The cadence tick still re-arms, so the start day is not missed.
+      expect(
+        upserts.whereType<ScheduledWakeEntity>().where(
+          (w) => w.workspaceKey == goalCadenceWorkspaceKey,
+        ),
+        hasLength(1),
+      );
+    },
+  );
+
+  test('recomputing over a synced register carries its vector clock', () async {
+    stubSpec();
+    const peerClock = VectorClock({'peer-host': 7});
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-08'),
+        agentId: agentId,
+        periodKey: '2026-08-08',
+        trackStatus: GoalTrackStatus.onTrack,
+        attainment: 1,
+        dataCoverage: 1,
+        satisfied: true,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: DateTime(2026, 8, 8, 6),
+        updatedAt: DateTime(2026, 8, 8, 6),
+        vectorClock: peerClock,
+      ),
+    );
+    await run(onTrackSignals());
+    final register = upserts.whereType<GoalProgressEntity>().single;
+    // Dropping it would make this write causally concurrent with the row
+    // it is based on, letting wall-clock LWW revert fresh progress.
+    expect(register.vectorClock, peerClock);
+  });
 
   test('re-running the same day preserves the register createdAt', () async {
     stubSpec();

--- a/test/features/goals/runtime/goal_agent_phase_a_test.dart
+++ b/test/features/goals/runtime/goal_agent_phase_a_test.dart
@@ -244,6 +244,33 @@ void main() {
     expect(register.trackStatus, GoalTrackStatus.offTrack);
   });
 
+  test(
+    'a passed target date resolves to achieved for a satisfied goal',
+    () async {
+      when(
+        () => repository.getEntity(goalSpecHeadId(agentId)),
+      ).thenAnswer((_) async => specHead);
+      when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+        (_) async => AgentDomainEntity.goalSpecVersion(
+          id: '$agentId:spec-v1',
+          agentId: agentId,
+          version: 1,
+          status: GoalSpecVersionStatus.active,
+          authoredBy: 'user',
+          title: 'Daily steps',
+          statement: 'Average 10,000 steps a day.',
+          criteria: criteria,
+          createdAt: DateTime(2026),
+          vectorClock: null,
+          targetDate: DateTime(2026, 8),
+        ),
+      );
+      await run(onTrackSignals());
+      final register = upserts.whereType<GoalProgressEntity>().single;
+      expect(register.trackStatus, GoalTrackStatus.achieved);
+    },
+  );
+
   test('re-running the same day preserves the register createdAt', () async {
     stubSpec();
     final created = DateTime(2026, 8, 8, 6);

--- a/test/features/goals/runtime/goal_agent_phase_a_test.dart
+++ b/test/features/goals/runtime/goal_agent_phase_a_test.dart
@@ -1,0 +1,272 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/workflow/wake_result.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+class _FakeSignalReader extends GoalSignalReader {
+  _FakeSignalReader(this.window) : super(journalDb: MockJournalDb());
+
+  final GoalSignalWindow window;
+
+  @override
+  Future<GoalSignalWindow> read({
+    required GoalCriterion criteria,
+    required DateTime reference,
+    int shortTermDays = 3,
+  }) async => window;
+}
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  // Saturday 2026-08-08, 14:30 local.
+  final now = DateTime(2026, 8, 8, 14, 30);
+  final fixedClock = Clock.fixed(now);
+  const agentId = 'goal-agent-1';
+
+  const criteria = GoalCriterion.metric(
+    criterionId: 'steps',
+    dataType: 'cumulative_step_count',
+    window: GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: 10000,
+  );
+
+  final identity =
+      AgentDomainEntity.agent(
+            id: agentId,
+            agentId: agentId,
+            kind: AgentKinds.goalAgent,
+            displayName: 'Daily steps',
+            lifecycle: AgentLifecycle.active,
+            mode: AgentInteractionMode.autonomous,
+            allowedCategoryIds: const {},
+            currentStateId: '$agentId:state',
+            config: const AgentConfig(),
+            createdAt: DateTime(2026),
+            updatedAt: DateTime(2026),
+            vectorClock: null,
+          )
+          as AgentIdentityEntity;
+
+  final specVersion = AgentDomainEntity.goalSpecVersion(
+    id: '$agentId:spec-v1',
+    agentId: agentId,
+    version: 1,
+    status: GoalSpecVersionStatus.active,
+    authoredBy: 'user',
+    title: 'Daily steps',
+    statement: 'Average 10,000 steps a day.',
+    criteria: criteria,
+    createdAt: DateTime(2026),
+    vectorClock: null,
+  );
+
+  final specHead = AgentDomainEntity.goalSpecHead(
+    id: goalSpecHeadId(agentId),
+    agentId: agentId,
+    versionId: '$agentId:spec-v1',
+    updatedAt: DateTime(2026),
+    vectorClock: null,
+  );
+
+  GoalSignalWindow onTrackSignals() => GoalSignalWindow(
+    quantitativeDailySums: {
+      'cumulative_step_count': {
+        for (var day = 2; day <= 8; day++) DateTime.utc(2026, 8, day): 11000,
+      },
+    },
+  );
+
+  late MockAgentRepository repository;
+  late MockAgentSyncService syncService;
+  late List<AgentDomainEntity> upserts;
+
+  GoalAgentPhaseA phaseA(GoalSignalWindow signals) => GoalAgentPhaseA(
+    repository: repository,
+    syncService: syncService,
+    signalReader: _FakeSignalReader(signals),
+  );
+
+  setUp(() {
+    repository = MockAgentRepository();
+    syncService = MockAgentSyncService();
+    upserts = [];
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+  });
+
+  void stubSpec() {
+    when(
+      () => repository.getEntity(goalSpecHeadId(agentId)),
+    ).thenAnswer((_) async => specHead);
+    when(
+      () => repository.getEntity('$agentId:spec-v1'),
+    ).thenAnswer((_) async => specVersion);
+  }
+
+  Future<WakeResult> run(GoalSignalWindow signals) => withClock(
+    fixedClock,
+    () => phaseA(signals).execute(
+      agentIdentity: identity,
+      runKey: 'run-1',
+      triggerTokens: const {'cumulative_step_count'},
+      threadId: 'thread-1',
+    ),
+  );
+
+  test('a goal without a spec head is a clean no-op', () async {
+    final result = await run(onTrackSignals());
+    expect(result.success, isTrue);
+    expect(upserts, isEmpty);
+  });
+
+  test('a dangling head is a failed wake, not a silent one', () async {
+    when(
+      () => repository.getEntity(goalSpecHeadId(agentId)),
+    ).thenAnswer((_) async => specHead);
+    final result = await run(onTrackSignals());
+    expect(result.success, isFalse);
+    expect(result.error, contains('spec-v1'));
+  });
+
+  test(
+    'a tick evaluates, re-arms the cadence, and writes the register',
+    () async {
+      stubSpec();
+      final result = await run(onTrackSignals());
+      expect(result.success, isTrue);
+
+      final cadence = upserts.whereType<ScheduledWakeEntity>().singleWhere(
+        (w) => w.workspaceKey == goalCadenceWorkspaceKey,
+      );
+      // 14:30 is past today's 06:00 tick → tomorrow 06:00.
+      expect(cadence.scheduledAt, DateTime(2026, 8, 9, goalCadenceHour));
+      expect(cadence.status, ScheduledWakeStatus.pending);
+
+      final register = upserts.whereType<GoalProgressEntity>().single;
+      expect(register.id, goalProgressId(agentId, '2026-08-08'));
+      expect(register.periodKey, '2026-08-08');
+      expect(register.trackStatus, GoalTrackStatus.onTrack);
+      expect(register.attainment, 1.0);
+      expect(register.satisfied, isTrue);
+      expect(register.specVersionId, '$agentId:spec-v1');
+      expect(register.criterionResults.single.criterionId, 'steps');
+    },
+  );
+
+  test(
+    'the first-ever evaluation escalates (a new fact where none was)',
+    () async {
+      stubSpec();
+      await run(onTrackSignals());
+      expect(
+        upserts.whereType<ScheduledWakeEntity>().where(
+          (w) => w.workspaceKey == goalEscalationWorkspaceKey,
+        ),
+        hasLength(1),
+      );
+    },
+  );
+
+  test('an unchanged status is the €0 no-op: no escalation armed', () async {
+    stubSpec();
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-07')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-07'),
+        agentId: agentId,
+        periodKey: '2026-08-07',
+        trackStatus: GoalTrackStatus.onTrack,
+        attainment: 1,
+        dataCoverage: 1,
+        satisfied: true,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: DateTime(2026, 8, 7),
+        updatedAt: DateTime(2026, 8, 7),
+        vectorClock: null,
+      ),
+    );
+    await run(onTrackSignals());
+    expect(
+      upserts.whereType<ScheduledWakeEntity>().where(
+        (w) => w.workspaceKey == goalEscalationWorkspaceKey,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('prior bad register rows feed the grace check into offTrack', () async {
+    stubSpec();
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-07')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-07'),
+        agentId: agentId,
+        periodKey: '2026-08-07',
+        trackStatus: GoalTrackStatus.atRisk,
+        attainment: 0.62,
+        dataCoverage: 1,
+        satisfied: false,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: DateTime(2026, 8, 7),
+        updatedAt: DateTime(2026, 8, 7),
+        vectorClock: null,
+      ),
+    );
+    final badWeek = GoalSignalWindow(
+      quantitativeDailySums: {
+        'cumulative_step_count': {
+          for (var day = 2; day <= 8; day++) DateTime.utc(2026, 8, day): 6000,
+        },
+      },
+    );
+    await run(badWeek);
+    final register = upserts.whereType<GoalProgressEntity>().single;
+    // 0.6 attainment with a bad prior period → grace exhausted.
+    expect(register.trackStatus, GoalTrackStatus.offTrack);
+  });
+
+  test('re-running the same day preserves the register createdAt', () async {
+    stubSpec();
+    final created = DateTime(2026, 8, 8, 6);
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-08'),
+        agentId: agentId,
+        periodKey: '2026-08-08',
+        trackStatus: GoalTrackStatus.onTrack,
+        attainment: 1,
+        dataCoverage: 1,
+        satisfied: true,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: created,
+        updatedAt: created,
+        vectorClock: null,
+      ),
+    );
+    await run(onTrackSignals());
+    final register = upserts.whereType<GoalProgressEntity>().single;
+    expect(register.createdAt, created);
+    expect(register.updatedAt, now);
+  });
+}

--- a/test/features/goals/runtime/goal_runtime_maintenance_test.dart
+++ b/test/features/goals/runtime/goal_runtime_maintenance_test.dart
@@ -1,0 +1,210 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
+import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  setUpAll(() {
+    registerAllFallbackValues();
+    registerFallbackValue(
+      AgentSubscription(id: 'f', agentId: 'f', matchEntityIds: const {}),
+    );
+  });
+
+  final now = DateTime(2026, 8, 8, 14, 30);
+  final fixedClock = Clock.fixed(now);
+
+  const criteria = GoalCriterion.habit(
+    criterionId: 'gym',
+    habitId: 'gym-habit',
+    window: GoalWindow.calendarWeek(),
+    targetCount: 3,
+  );
+
+  AgentIdentityEntity goalIdentity(String id) =>
+      AgentDomainEntity.agent(
+            id: id,
+            agentId: id,
+            kind: AgentKinds.goalAgent,
+            displayName: id,
+            lifecycle: AgentLifecycle.active,
+            mode: AgentInteractionMode.autonomous,
+            allowedCategoryIds: const {},
+            currentStateId: '$id:state',
+            config: const AgentConfig(),
+            createdAt: DateTime(2026),
+            updatedAt: DateTime(2026),
+            vectorClock: null,
+          )
+          as AgentIdentityEntity;
+
+  late MockAgentService agentService;
+  late MockAgentRepository repository;
+  late MockAgentSyncService syncService;
+  late MockWakeOrchestrator orchestrator;
+  late GoalRuntimeMaintenance maintenance;
+  late List<AgentDomainEntity> upserts;
+
+  void stubSpec(String agentId) {
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: agentId,
+        statement: 'x',
+        criteria: criteria,
+        createdAt: DateTime(2026),
+        vectorClock: null,
+      ),
+    );
+  }
+
+  setUp(() {
+    agentService = MockAgentService();
+    repository = MockAgentRepository();
+    syncService = MockAgentSyncService();
+    orchestrator = MockWakeOrchestrator();
+    maintenance = GoalRuntimeMaintenance(
+      agentService: agentService,
+      repository: repository,
+      syncService: syncService,
+      goalAgentService: GoalAgentService(
+        agentService: agentService,
+        syncService: syncService,
+        orchestrator: orchestrator,
+      ),
+    );
+    upserts = [];
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    when(() => orchestrator.addSubscription(any())).thenReturn(null);
+  });
+
+  test('restoreSubscriptions re-registers every active goal agent, and one '
+      'broken goal does not take the others down', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer(
+      (_) async => [goalIdentity('goal-a'), goalIdentity('goal-b')],
+    );
+    stubSpec('goal-b');
+    // goal-a's head read explodes; goal-b must still be restored.
+    when(
+      () => repository.getEntity(goalSpecHeadId('goal-a')),
+    ).thenThrow(StateError('boom'));
+
+    await maintenance.restoreSubscriptions();
+
+    final captured = verify(
+      () => orchestrator.addSubscription(captureAny()),
+    ).captured;
+    expect(captured, hasLength(1));
+    expect(
+      (captured.single as AgentSubscription).id,
+      goalSignalSubscriptionId('goal-b'),
+    );
+  });
+
+  test('beforeWakeScan heals a missing cadence record', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [goalIdentity('goal-a')]);
+
+    await withClock(fixedClock, maintenance.beforeWakeScan);
+
+    final cadence = upserts.whereType<ScheduledWakeEntity>().single;
+    expect(cadence.agentId, 'goal-a');
+    expect(cadence.workspaceKey, goalCadenceWorkspaceKey);
+  });
+
+  test('beforeWakeScan leaves a pending future cadence alone', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [goalIdentity('goal-a')]);
+    when(
+      () => repository.getEntity(
+        scheduledWakeRecordId(
+          'goal-a',
+          workspaceKey: goalCadenceWorkspaceKey,
+        ),
+      ),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.scheduledWake(
+        id: scheduledWakeRecordId(
+          'goal-a',
+          workspaceKey: goalCadenceWorkspaceKey,
+        ),
+        agentId: 'goal-a',
+        scheduledAt: now.add(const Duration(hours: 12)),
+        status: ScheduledWakeStatus.pending,
+        reason: WakeReason.scheduled.name,
+        updatedAt: now,
+        vectorClock: null,
+        workspaceKey: goalCadenceWorkspaceKey,
+      ),
+    );
+
+    await withClock(fixedClock, maintenance.beforeWakeScan);
+    expect(upserts, isEmpty);
+  });
+
+  test('beforeWakeScan re-arms after a consumed tick whose run died before '
+      're-arming', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [goalIdentity('goal-a')]);
+    when(
+      () => repository.getEntity(
+        scheduledWakeRecordId(
+          'goal-a',
+          workspaceKey: goalCadenceWorkspaceKey,
+        ),
+      ),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.scheduledWake(
+        id: scheduledWakeRecordId(
+          'goal-a',
+          workspaceKey: goalCadenceWorkspaceKey,
+        ),
+        agentId: 'goal-a',
+        scheduledAt: now.subtract(const Duration(hours: 8)),
+        status: ScheduledWakeStatus.consumed,
+        reason: WakeReason.scheduled.name,
+        updatedAt: now.subtract(const Duration(hours: 8)),
+        vectorClock: null,
+        workspaceKey: goalCadenceWorkspaceKey,
+        consumedAt: now.subtract(const Duration(hours: 8)),
+      ),
+    );
+
+    await withClock(fixedClock, maintenance.beforeWakeScan);
+    expect(upserts.whereType<ScheduledWakeEntity>(), hasLength(1));
+  });
+}

--- a/test/features/goals/runtime/goal_runtime_maintenance_test.dart
+++ b/test/features/goals/runtime/goal_runtime_maintenance_test.dart
@@ -178,6 +178,22 @@ void main() {
     },
   );
 
+  test(
+    'a listAgents failure is contained in both maintenance passes',
+    () async {
+      when(
+        () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+      ).thenThrow(StateError('db gone'));
+      await expectLater(maintenance.restoreSubscriptions(), completes);
+      await expectLater(
+        withClock(fixedClock, maintenance.beforeWakeScan),
+        completes,
+      );
+      verifyNever(() => orchestrator.addSubscription(any()));
+      expect(upserts, isEmpty);
+    },
+  );
+
   test('beforeWakeScan heals a missing cadence record', () async {
     when(
       () => agentService.listAgents(lifecycle: AgentLifecycle.active),

--- a/test/features/goals/runtime/goal_runtime_maintenance_test.dart
+++ b/test/features/goals/runtime/goal_runtime_maintenance_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -131,6 +132,49 @@ void main() {
       goalSignalSubscriptionId('goal-b'),
     );
   });
+
+  test(
+    'a repository explosion in beforeWakeScan is contained and logged',
+    () async {
+      final logger = MockDomainLogger();
+      when(
+        () => logger.error(
+          any(),
+          any<Object>(),
+          stackTrace: any(named: 'stackTrace'),
+          subDomain: any(named: 'subDomain'),
+          message: any(named: 'message'),
+        ),
+      ).thenReturn(null);
+      final loggingMaintenance = GoalRuntimeMaintenance(
+        agentService: agentService,
+        repository: repository,
+        syncService: syncService,
+        goalAgentService: GoalAgentService(
+          agentService: agentService,
+          syncService: syncService,
+          orchestrator: orchestrator,
+        ),
+        domainLogger: logger,
+      );
+      when(
+        () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+      ).thenAnswer((_) async => [goalIdentity('goal-a')]);
+      when(() => repository.getEntity(any())).thenThrow(StateError('boom'));
+
+      await withClock(fixedClock, loggingMaintenance.beforeWakeScan);
+
+      verify(
+        () => logger.error(
+          LogDomain.agentRuntime,
+          any<Object>(),
+          stackTrace: any(named: 'stackTrace'),
+          subDomain: any(named: 'subDomain'),
+          message: any(named: 'message'),
+        ),
+      ).called(1);
+    },
+  );
 
   test('beforeWakeScan heals a missing cadence record', () async {
     when(

--- a/test/features/goals/runtime/goal_runtime_maintenance_test.dart
+++ b/test/features/goals/runtime/goal_runtime_maintenance_test.dart
@@ -2,13 +2,13 @@ import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
-import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -96,6 +96,7 @@ void main() {
       syncService: syncService,
       goalAgentService: GoalAgentService(
         agentService: agentService,
+        repository: repository,
         syncService: syncService,
         orchestrator: orchestrator,
       ),
@@ -152,6 +153,7 @@ void main() {
         syncService: syncService,
         goalAgentService: GoalAgentService(
           agentService: agentService,
+          repository: repository,
           syncService: syncService,
           orchestrator: orchestrator,
         ),

--- a/test/features/goals/service/goal_agent_service_test.dart
+++ b/test/features/goals/service/goal_agent_service_test.dart
@@ -134,19 +134,41 @@ void main() {
   });
 
   test(
-    'a repeated create for an existing goal refuses to rewrite spec v1',
+    'a repeated create for an existing goal refuses to rewrite spec v1, '
+    'and the guard runs INSIDE the creation transaction',
     () async {
+      // Two concurrent creates for the same id must serialize on the
+      // transaction — a preflight read outside it would let both pass and
+      // the loser rewrite the immutable spec v1.
+      final order = <String>[];
+      final txnSyncService = _OrderRecordingSyncService(order);
+      when(() => txnSyncService.upsertEntity(any())).thenAnswer(
+        (invocation) async {
+          upserts.add(
+            invocation.positionalArguments.first as AgentDomainEntity,
+          );
+        },
+      );
+      final txnService = GoalAgentService(
+        agentService: agentService,
+        repository: repository,
+        syncService: txnSyncService,
+        orchestrator: orchestrator,
+      );
       when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
-        (_) async => AgentDomainEntity.goalSpecHead(
-          id: goalSpecHeadId(agentId),
-          agentId: agentId,
-          versionId: '$agentId:spec-v1',
-          updatedAt: DateTime(2026),
-          vectorClock: null,
-        ),
+        (_) async {
+          order.add('guard');
+          return AgentDomainEntity.goalSpecHead(
+            id: goalSpecHeadId(agentId),
+            agentId: agentId,
+            versionId: '$agentId:spec-v1',
+            updatedAt: DateTime(2026),
+            vectorClock: null,
+          );
+        },
       );
       await expectLater(
-        () => service.createGoalAgent(
+        () => txnService.createGoalAgent(
           title: 'Gym 3×/week',
           statement: 'x',
           criteria: criteria,
@@ -154,7 +176,28 @@ void main() {
         ),
         throwsStateError,
       );
+      expect(order, ['transaction', 'guard']);
       expect(upserts, isEmpty);
+      verifyNever(
+        () => agentService.createAgent(
+          kind: any(named: 'kind'),
+          displayName: any(named: 'displayName'),
+          config: any(named: 'config'),
+          agentId: any(named: 'agentId'),
+        ),
+      );
     },
   );
+}
+
+class _OrderRecordingSyncService extends MockAgentSyncService {
+  _OrderRecordingSyncService(this.order);
+
+  final List<String> order;
+
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) {
+    order.add('transaction');
+    return action();
+  }
 }

--- a/test/features/goals/service/goal_agent_service_test.dart
+++ b/test/features/goals/service/goal_agent_service_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  setUpAll(() {
+    registerAllFallbackValues();
+    registerFallbackValue(
+      AgentSubscription(id: 'f', agentId: 'f', matchEntityIds: const {}),
+    );
+  });
+
+  const agentId = 'goal-agent-1';
+  const criteria = GoalCriterion.habit(
+    criterionId: 'gym',
+    habitId: 'gym-habit',
+    window: GoalWindow.calendarWeek(),
+    targetCount: 3,
+  );
+
+  late MockAgentService agentService;
+  late MockAgentSyncService syncService;
+  late MockWakeOrchestrator orchestrator;
+  late GoalAgentService service;
+  late List<AgentDomainEntity> upserts;
+
+  setUp(() {
+    agentService = MockAgentService();
+    syncService = MockAgentSyncService();
+    orchestrator = MockWakeOrchestrator();
+    service = GoalAgentService(
+      agentService: agentService,
+      syncService: syncService,
+      orchestrator: orchestrator,
+    );
+    upserts = [];
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    when(() => orchestrator.addSubscription(any())).thenReturn(null);
+    when(
+      () => agentService.createAgent(
+        kind: any(named: 'kind'),
+        displayName: any(named: 'displayName'),
+        config: any(named: 'config'),
+        agentId: any(named: 'agentId'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          AgentDomainEntity.agent(
+                id: agentId,
+                agentId: agentId,
+                kind: AgentKinds.goalAgent,
+                displayName: 'Gym 3×/week',
+                lifecycle: AgentLifecycle.active,
+                mode: AgentInteractionMode.autonomous,
+                allowedCategoryIds: const {},
+                currentStateId: '$agentId:state',
+                config: const AgentConfig(),
+                createdAt: DateTime(2026),
+                updatedAt: DateTime(2026),
+                vectorClock: null,
+              )
+              as AgentIdentityEntity,
+    );
+  });
+
+  test('invalid criteria never reach persistence', () async {
+    const doomed = GoalCriterion.allOf(criterionId: 'root', criteria: []);
+    await expectLater(
+      () => service.createGoalAgent(
+        title: 'Broken',
+        statement: 'x',
+        criteria: doomed,
+      ),
+      throwsArgumentError,
+    );
+    verifyNever(
+      () => agentService.createAgent(
+        kind: any(named: 'kind'),
+        displayName: any(named: 'displayName'),
+        config: any(named: 'config'),
+        agentId: any(named: 'agentId'),
+      ),
+    );
+    expect(upserts, isEmpty);
+  });
+
+  test('creation writes spec v1 + head + first cadence tick, then '
+      'subscribes to the goal signals', () async {
+    final identity = await service.createGoalAgent(
+      title: 'Gym 3×/week',
+      statement: 'Train at the station gym three times per week.',
+      criteria: criteria,
+      agentId: agentId,
+    );
+    expect(identity.kind, AgentKinds.goalAgent);
+
+    final version = upserts.whereType<GoalSpecVersionEntity>().single;
+    expect(version.version, 1);
+    expect(version.status, GoalSpecVersionStatus.active);
+    expect(version.authoredBy, 'user');
+    expect(version.criteria, criteria);
+
+    final head = upserts.whereType<GoalSpecHeadEntity>().single;
+    expect(head.id, goalSpecHeadId(agentId));
+    expect(head.versionId, version.id);
+
+    final cadence = upserts.whereType<ScheduledWakeEntity>().single;
+    expect(cadence.workspaceKey, goalCadenceWorkspaceKey);
+
+    final subscription =
+        verify(() => orchestrator.addSubscription(captureAny())).captured.single
+            as AgentSubscription;
+    expect(subscription.id, goalSignalSubscriptionId(agentId));
+    expect(subscription.agentId, agentId);
+    expect(subscription.matchEntityIds, {'gym-habit'});
+  });
+}

--- a/test/features/goals/service/goal_agent_service_test.dart
+++ b/test/features/goals/service/goal_agent_service_test.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
-import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -31,6 +31,7 @@ void main() {
   );
 
   late MockAgentService agentService;
+  late MockAgentRepository repository;
   late MockAgentSyncService syncService;
   late MockWakeOrchestrator orchestrator;
   late GoalAgentService service;
@@ -38,10 +39,13 @@ void main() {
 
   setUp(() {
     agentService = MockAgentService();
+    repository = MockAgentRepository();
     syncService = MockAgentSyncService();
     orchestrator = MockWakeOrchestrator();
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
     service = GoalAgentService(
       agentService: agentService,
+      repository: repository,
       syncService: syncService,
       orchestrator: orchestrator,
     );
@@ -128,4 +132,29 @@ void main() {
     expect(subscription.agentId, agentId);
     expect(subscription.matchEntityIds, {'gym-habit'});
   });
+
+  test(
+    'a repeated create for an existing goal refuses to rewrite spec v1',
+    () async {
+      when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+        (_) async => AgentDomainEntity.goalSpecHead(
+          id: goalSpecHeadId(agentId),
+          agentId: agentId,
+          versionId: '$agentId:spec-v1',
+          updatedAt: DateTime(2026),
+          vectorClock: null,
+        ),
+      );
+      await expectLater(
+        () => service.createGoalAgent(
+          title: 'Gym 3×/week',
+          statement: 'x',
+          criteria: criteria,
+          agentId: agentId,
+        ),
+        throwsStateError,
+      );
+      expect(upserts, isEmpty);
+    },
+  );
 }

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -49,6 +49,7 @@ void main() {
         agentServiceProvider.overrideWithValue(agentService),
         wakeOrchestratorProvider.overrideWithValue(MockWakeOrchestrator()),
         updateNotificationsProvider.overrideWithValue(updateNotifications),
+        domainLoggerProvider.overrideWithValue(MockDomainLogger()),
       ],
     );
     addTearDown(container.dispose);
@@ -101,15 +102,18 @@ void main() {
   test(
     'the sync listener starts on construction and feeds the dispatcher',
     () async {
+      final listed = Completer<void>();
+      when(
+        () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+      ).thenAnswer((_) async {
+        if (!listed.isCompleted) listed.complete();
+        return [];
+      });
       container.read(goalSignalSyncListenerProvider);
       syncStream.add({'anything'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      // Empty agent list → no dispatch, but the listener consumed the batch
-      // (listAgents was hit through the provider-wired dispatcher).
-      verify(
-        () => agentService.listAgents(lifecycle: AgentLifecycle.active),
-      ).called(1);
+      // Deterministic: resolves exactly when the provider-wired dispatcher
+      // reached the agent service, however many event-loop turns that took.
+      await listed.future;
     },
   );
 }

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
+import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:lotti/features/goals/state/goal_agent_providers.dart';
+import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
+import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  late StreamController<Set<String>> syncStream;
+  late MockAgentService agentService;
+  late MockAgentRepository repository;
+  late ProviderContainer container;
+
+  setUp(() {
+    syncStream = StreamController<Set<String>>.broadcast();
+    addTearDown(syncStream.close);
+    agentService = MockAgentService();
+    repository = MockAgentRepository();
+    final updateNotifications = MockUpdateNotifications();
+    when(
+      () => updateNotifications.syncUpdateStream,
+    ).thenAnswer((_) => syncStream.stream);
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => []);
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+
+    container = ProviderContainer(
+      overrides: [
+        journalDbProvider.overrideWithValue(MockJournalDb()),
+        agentRepositoryProvider.overrideWithValue(repository),
+        agentSyncServiceProvider.overrideWithValue(MockAgentSyncService()),
+        agentServiceProvider.overrideWithValue(agentService),
+        wakeOrchestratorProvider.overrideWithValue(MockWakeOrchestrator()),
+        updateNotificationsProvider.overrideWithValue(updateNotifications),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  test('every goal provider constructs against the shared agent runtime', () {
+    expect(container.read(goalSignalReaderProvider), isA<GoalSignalReader>());
+    expect(container.read(goalAgentPhaseAProvider), isA<GoalAgentPhaseA>());
+    expect(container.read(goalAgentServiceProvider), isA<GoalAgentService>());
+    expect(
+      container.read(goalRuntimeMaintenanceProvider),
+      isA<GoalRuntimeMaintenance>(),
+    );
+    expect(
+      container.read(goalSignalSyncDispatcherProvider),
+      isA<GoalSignalSyncDispatcher>(),
+    );
+  });
+
+  test('the runner map routes goal_agent wakes through Phase A', () async {
+    final runners = container.read(goalAgentWakeRunnersProvider);
+    expect(runners.keys, contains(AgentKinds.goalAgent));
+
+    // Invoking the closure exercises the wiring end to end: a goal agent
+    // without a spec head is Phase A's clean no-op.
+    final result = await runners[AgentKinds.goalAgent]!(
+      agentIdentity:
+          AgentDomainEntity.agent(
+                id: 'goal-x',
+                agentId: 'goal-x',
+                kind: AgentKinds.goalAgent,
+                displayName: 'x',
+                lifecycle: AgentLifecycle.active,
+                mode: AgentInteractionMode.autonomous,
+                allowedCategoryIds: const {},
+                currentStateId: 'goal-x:state',
+                config: const AgentConfig(),
+                createdAt: DateTime(2026),
+                updatedAt: DateTime(2026),
+                vectorClock: null,
+              )
+              as AgentIdentityEntity,
+      runKey: 'run-1',
+      triggerTokens: const {},
+      threadId: 'thread-1',
+    );
+    expect(result.success, isTrue);
+  });
+
+  test(
+    'the sync listener starts on construction and feeds the dispatcher',
+    () async {
+      container.read(goalSignalSyncListenerProvider);
+      syncStream.add({'anything'});
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      // Empty agent list → no dispatch, but the listener consumed the batch
+      // (listAgents was hit through the provider-wired dispatcher).
+      verify(
+        () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+      ).called(1);
+    },
+  );
+}

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -25,6 +28,8 @@ void main() {
   late StreamController<Set<String>> syncStream;
   late MockAgentService agentService;
   late MockAgentRepository repository;
+  late MockAgentSyncService syncService;
+  late MockJournalDb journalDb;
   late ProviderContainer container;
 
   setUp(() {
@@ -32,6 +37,8 @@ void main() {
     addTearDown(syncStream.close);
     agentService = MockAgentService();
     repository = MockAgentRepository();
+    syncService = MockAgentSyncService();
+    journalDb = MockJournalDb();
     final updateNotifications = MockUpdateNotifications();
     when(
       () => updateNotifications.syncUpdateStream,
@@ -43,9 +50,9 @@ void main() {
 
     container = ProviderContainer(
       overrides: [
-        journalDbProvider.overrideWithValue(MockJournalDb()),
+        journalDbProvider.overrideWithValue(journalDb),
         agentRepositoryProvider.overrideWithValue(repository),
-        agentSyncServiceProvider.overrideWithValue(MockAgentSyncService()),
+        agentSyncServiceProvider.overrideWithValue(syncService),
         agentServiceProvider.overrideWithValue(agentService),
         wakeOrchestratorProvider.overrideWithValue(MockWakeOrchestrator()),
         updateNotificationsProvider.overrideWithValue(updateNotifications),
@@ -97,6 +104,85 @@ void main() {
       threadId: 'thread-1',
     );
     expect(result.success, isTrue);
+  });
+
+  test('a local escalation nudges the scheduled-wake manager instead of '
+      'waiting out the hourly poll', () async {
+    const agentId = 'goal-esc';
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: 'Gym',
+        statement: 'x',
+        criteria: const GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: 'gym-habit',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+        createdAt: DateTime(2026),
+        vectorClock: null,
+      ),
+    );
+    when(
+      () => journalDb.getHabitCompletionsByHabitId(
+        habitId: any(named: 'habitId'),
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(() => syncService.upsertEntity(any())).thenAnswer((_) async {});
+    // The nudged manager runs one scan pass; an empty due list ends it.
+    when(
+      () => repository.getDueScheduledWakeRecords(any()),
+    ).thenAnswer((_) async => []);
+    when(
+      () => repository.getDueScheduledAgentStates(any()),
+    ).thenAnswer((_) async => []);
+
+    final result =
+        await container.read(
+          goalAgentWakeRunnersProvider,
+        )[AgentKinds.goalAgent]!(
+          agentIdentity:
+              AgentDomainEntity.agent(
+                    id: agentId,
+                    agentId: agentId,
+                    kind: AgentKinds.goalAgent,
+                    displayName: 'Gym',
+                    lifecycle: AgentLifecycle.active,
+                    mode: AgentInteractionMode.autonomous,
+                    allowedCategoryIds: const {},
+                    currentStateId: '$agentId:state',
+                    config: const AgentConfig(),
+                    createdAt: DateTime(2026),
+                    updatedAt: DateTime(2026),
+                    vectorClock: null,
+                  )
+                  as AgentIdentityEntity,
+          runKey: 'run-esc',
+          triggerTokens: const {'gym-habit'},
+          threadId: 'thread-esc',
+        );
+    expect(result.success, isTrue);
+
+    // First-ever evaluation is a transition, so Phase A armed an
+    // escalation and the provider-wired callback must have kicked the
+    // manager into an immediate scan pass.
+    await untilCalled(() => repository.getDueScheduledWakeRecords(any()));
   });
 
   test(

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -29,6 +29,26 @@ class _FakeReader extends GoalSignalReader {
   }) async => const GoalSignalWindow();
 }
 
+class _ThrowingThenRecordingPhaseA extends _RecordingPhaseA {
+  @override
+  Future<WakeResult> execute({
+    required AgentIdentityEntity agentIdentity,
+    required String runKey,
+    required Set<String> triggerTokens,
+    required String threadId,
+  }) {
+    if (agentIdentity.agentId == 'goal-broken') {
+      throw StateError('corrupt goal');
+    }
+    return super.execute(
+      agentIdentity: agentIdentity,
+      runKey: runKey,
+      triggerTokens: triggerTokens,
+      threadId: threadId,
+    );
+  }
+}
+
 class _RecordingPhaseA extends GoalAgentPhaseA {
   _RecordingPhaseA()
     : super(
@@ -192,6 +212,65 @@ void main() {
     controller.add({'cumulative_step_count'});
     await Future<void>.delayed(Duration.zero);
     expect(phaseA.calls, hasLength(1), reason: 'disposed = deaf');
+  });
+
+  test('one throwing goal cannot suppress evaluation of the next', () async {
+    final throwing = _ThrowingThenRecordingPhaseA();
+    final containedDispatcher = GoalSignalSyncDispatcher(
+      agentService: agentService,
+      repository: repository,
+      phaseA: throwing,
+    );
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer(
+      (_) async => [
+        identity('goal-broken', AgentKinds.goalAgent),
+        identity('goal-b', AgentKinds.goalAgent),
+      ],
+    );
+    stubSpec('goal-broken');
+    stubSpec('goal-b');
+
+    await containedDispatcher.dispatchBatch({'cumulative_step_count'});
+    expect(throwing.calls.map((c) => c.$1), ['goal-b']);
+  });
+
+  test('a stream error reaches the logger instead of ending evaluation '
+      'silently', () async {
+    final logger = MockDomainLogger();
+    when(
+      () => logger.error(
+        any(),
+        any<Object>(),
+        stackTrace: any(named: 'stackTrace'),
+        subDomain: any(named: 'subDomain'),
+        message: any(named: 'message'),
+      ),
+    ).thenReturn(null);
+    final controller = StreamController<Set<String>>.broadcast();
+    addTearDown(controller.close);
+    final updateNotifications = MockUpdateNotifications();
+    when(
+      () => updateNotifications.syncUpdateStream,
+    ).thenAnswer((_) => controller.stream);
+    GoalSignalSyncListener(
+      updateNotifications: updateNotifications,
+      dispatcher: dispatcher,
+      domainLogger: logger,
+    ).start();
+
+    controller.addError(StateError('stream broke'));
+    await Future<void>.delayed(Duration.zero);
+    verify(
+      () => logger.error(
+        any(),
+        any<Object>(),
+        stackTrace: any(named: 'stackTrace'),
+        subDomain: any(named: 'subDomain'),
+        message: any(named: 'message'),
+      ),
+    ).called(1);
   });
 
   test(

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/workflow/wake_result.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+class _FakeReader extends GoalSignalReader {
+  _FakeReader() : super(journalDb: MockJournalDb());
+
+  @override
+  Future<GoalSignalWindow> read({
+    required GoalCriterion criteria,
+    required DateTime reference,
+    int shortTermDays = 3,
+  }) async => const GoalSignalWindow();
+}
+
+class _RecordingPhaseA extends GoalAgentPhaseA {
+  _RecordingPhaseA()
+    : super(
+        repository: MockAgentRepository(),
+        syncService: MockAgentSyncService(),
+        signalReader: _FakeReader(),
+      );
+
+  final calls = <(String, Set<String>)>[];
+
+  @override
+  Future<WakeResult> execute({
+    required AgentIdentityEntity agentIdentity,
+    required String runKey,
+    required Set<String> triggerTokens,
+    required String threadId,
+  }) async {
+    calls.add((agentIdentity.agentId, triggerTokens));
+    return const WakeResult(success: true);
+  }
+}
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  const criteria = GoalCriterion.metric(
+    criterionId: 'steps',
+    dataType: 'cumulative_step_count',
+    window: GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: 10000,
+  );
+
+  AgentIdentityEntity identity(String id, String kind) =>
+      AgentDomainEntity.agent(
+            id: id,
+            agentId: id,
+            kind: kind,
+            displayName: id,
+            lifecycle: AgentLifecycle.active,
+            mode: AgentInteractionMode.autonomous,
+            allowedCategoryIds: const {},
+            currentStateId: '$id:state',
+            config: const AgentConfig(),
+            createdAt: DateTime(2026),
+            updatedAt: DateTime(2026),
+            vectorClock: null,
+          )
+          as AgentIdentityEntity;
+
+  late MockAgentService agentService;
+  late MockAgentRepository repository;
+  late _RecordingPhaseA phaseA;
+  late GoalSignalSyncDispatcher dispatcher;
+
+  void stubSpec(String agentId) {
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: agentId,
+        statement: 'x',
+        criteria: criteria,
+        createdAt: DateTime(2026),
+        vectorClock: null,
+      ),
+    );
+  }
+
+  setUp(() {
+    agentService = MockAgentService();
+    repository = MockAgentRepository();
+    phaseA = _RecordingPhaseA();
+    dispatcher = GoalSignalSyncDispatcher(
+      agentService: agentService,
+      repository: repository,
+      phaseA: phaseA,
+    );
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+  });
+
+  test('a synced batch touching a goal signal runs Phase A with the '
+      'intersection', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer(
+      (_) async => [
+        identity('goal-a', AgentKinds.goalAgent),
+        identity('task-1', AgentKinds.taskAgent),
+      ],
+    );
+    stubSpec('goal-a');
+
+    await dispatcher.dispatchBatch(
+      {'cumulative_step_count', 'unrelated-id'},
+    );
+
+    expect(phaseA.calls, hasLength(1));
+    expect(phaseA.calls.single.$1, 'goal-a');
+    expect(phaseA.calls.single.$2, {'cumulative_step_count'});
+  });
+
+  test('a batch with no goal signals dispatches nothing', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [identity('goal-a', AgentKinds.goalAgent)]);
+    stubSpec('goal-a');
+
+    await dispatcher.dispatchBatch({'some-task-id', 'HABIT_COMPLETION'});
+    expect(phaseA.calls, isEmpty);
+  });
+
+  test(
+    'failures are contained — a listAgents explosion never throws',
+    () async {
+      when(
+        () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+      ).thenThrow(StateError('db gone'));
+      await expectLater(
+        dispatcher.dispatchBatch({'cumulative_step_count'}),
+        completes,
+      );
+    },
+  );
+}

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
@@ -149,6 +151,40 @@ void main() {
 
     await dispatcher.dispatchBatch({'some-task-id', 'HABIT_COMPLETION'});
     expect(phaseA.calls, isEmpty);
+  });
+
+  test('the listener pumps synced batches, starts once, and stops on '
+      'dispose', () async {
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [identity('goal-a', AgentKinds.goalAgent)]);
+    stubSpec('goal-a');
+
+    final controller = StreamController<Set<String>>.broadcast();
+    addTearDown(controller.close);
+    final updateNotifications = MockUpdateNotifications();
+    when(
+      () => updateNotifications.syncUpdateStream,
+    ).thenAnswer((_) => controller.stream);
+
+    final listener =
+        GoalSignalSyncListener(
+            updateNotifications: updateNotifications,
+            dispatcher: dispatcher,
+          )
+          ..start()
+          // A second start must not double-subscribe.
+          ..start();
+
+    controller.add({'cumulative_step_count'});
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    expect(phaseA.calls, hasLength(1));
+
+    await listener.dispose();
+    controller.add({'cumulative_step_count'});
+    await Future<void>.delayed(Duration.zero);
+    expect(phaseA.calls, hasLength(1), reason: 'disposed = deaf');
   });
 
   test(

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -39,6 +39,10 @@ class _RecordingPhaseA extends GoalAgentPhaseA {
 
   final calls = <(String, Set<String>)>[];
 
+  /// Completed on every recorded call — deterministic synchronization for
+  /// listener tests (no event-loop-turn guessing).
+  Completer<void> nextCall = Completer<void>();
+
   @override
   Future<WakeResult> execute({
     required AgentIdentityEntity agentIdentity,
@@ -47,6 +51,9 @@ class _RecordingPhaseA extends GoalAgentPhaseA {
     required String threadId,
   }) async {
     calls.add((agentIdentity.agentId, triggerTokens));
+    final completer = nextCall;
+    nextCall = Completer<void>();
+    completer.complete();
     return const WakeResult(success: true);
   }
 }


### PR DESCRIPTION
PR 2 of the goal-agents phasing (design doc §8): the tier where ADR 0054's invariant becomes running code — **a tick that changes nothing costs €0 and writes no messages**. No LLM anywhere in this PR; Phase B is PR 3.

## What runs now

- **`GoalSignalReader`** — journal-backed daily aggregates with deliberately borrowed semantics: quantitative day totals use the health charts' per-type aggregation (`cumulative_step_count` is a running counter → day total is the daily **max**, matching the chart the user sees; unknown types fall back to a daily sum rather than silently reading as a tracker gap), habit days use the habits UI's latest-completion-per-day collapse with success-only counting, and day keys re-stamp the local calendar date as `dayUtc` to match `habits_controller` bucketing.
- **`GoalAgentPhaseA`** — one tick: spec head → re-arm the daily cadence wake (recurrence by re-arm, no schema change) → evaluate via the PR-0 evaluator → derive status with prior register rows feeding the grace check → upsert the evaluation-day `goalProgress` register (recompute-never-accumulate; `createdAt` preserved on same-day re-runs) → arm an immediate, lease-elected escalation wake **only on a status transition**. Until PR 3, an escalation firing re-runs this idempotent tier.
- **`GoalRuntimeMaintenance`** — startup subscription restore (per-goal leaf tokens, no global sentinels) and cadence self-healing in `beforeWakeScan`, each repair individually contained.
- **`GoalSignalSyncDispatcher`** — the sync blind-spot bridge (`synced_audio` pattern): synced signal batches run Phase A directly on receiving devices, so a desktop shows fresh registers for phone-imported steps; keyed registers make N devices converge; Phase B is never triggered from sync.
- **`GoalAgentService.createGoalAgent`** — validated spec v1 + head + first cadence tick in one transaction; the agent leaves creation live.

## The fallback regression test

`agent_wiring.dart` silently routes unregistered kinds to the task-agent workflow. The bootstrap now **merges** the Daily OS and Goals runner maps and maintenance lists, and `app_bootstrap_test.dart` pins: the `goal_agent` runner is registered, the merge kept `day_agent` intact (a replacement instead of a merge would silently unregister the other feature), and both hold in guest profiles.

## Tests

78 new/updated: reader bucketing semantics (daily-max proof, unknown-type fallback, success-only habits, range arithmetic), Phase A behavior (escalate on first evaluation and on transitions, €0 no-op on unchanged status, grace via prior rows, createdAt preservation, dangling-head failure), maintenance healing matrix, dispatcher matching/single-flight/containment, bootstrap pins. Full-repo analyzer clean.

No CHANGELOG entry (still headless — nothing user-visible).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added goal agents that evaluate quantitative data, habits, and measurable entries.
  * Goal agents create progress records, schedule recurring evaluations, and trigger status-change escalations.
  * Relevant data updates automatically prompt goal evaluations.
  * Added startup maintenance to restore subscriptions and repair missed schedules.
  * Added immediate scheduled-wake checks for newly triggered evaluations.
  * Added reliable goal creation with validation and duplicate protection.

* **Documentation**
  * Added documentation covering the goals runtime, evaluation flow, scheduling, and known limitations.

* **Tests**
  * Added comprehensive coverage for goal evaluation, scheduling, synchronization, maintenance, and agent creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->