### PR TITLE
fix(goals): harden Phase A determinism (post-merge review of #3861)

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -70,7 +70,7 @@ flowchart TD
     EVAL --> REG[upsert goalProgress register\ngoal_progress:agent:evaluation-day\nrecompute, never accumulate]
     REG --> TRANS{status transitioned vs\nlast persisted status?}
     TRANS -- no --> DONE[return — the €0 no-op]
-    TRANS -- yes --> ESC[arm escalation wake\ngoal-escalation:periodKey,\nUTC deadline, lease-elected]
+    TRANS -- yes --> ESC[arm escalation wake\ngoal-escalation:periodKey,\nperiod-derived UTC deadline,\nlease-elected, same txn\nas the register]
     ESC --> NUDGE[nudge ScheduledWakeManager\nrequestCheck on arming device]
 ```
 
@@ -85,6 +85,14 @@ flowchart TD
 - **Transitions compare against the last persisted status** — today's own
   earlier row first, yesterday's otherwise — so an escalation wake that
   re-runs Phase A is a no-op, not a self-re-arming loop.
+- **The register and its escalation commit in one transaction.** A register
+  write acknowledging a transition without its escalation would be
+  permanent: the next run reads the new status as `previousStatus` and
+  never re-arms the missed Phase B wake. The escalation deadline is
+  derived from the period (its UTC day key), never from the arming
+  device's wall clock, so every device arming the same logical escalation
+  writes an identical record and the concurrent resolver's later-deadline
+  preference cannot resurrect a consumed wake.
 - **Grace history is a consecutive, same-spec-version streak**: prior-row
   collection stops at the first missing day and at the first row computed
   under a superseded spec version.

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -129,15 +129,26 @@ class GoalSignalReader {
         // Same display normalization as `aggregateNone`: percentage types
         // store fractions (body fat 0.18) but chart — and target — as 18.
         final multiplier = dataType.contains('PERCENTAGE') ? 100 : 1;
-        final latestFromByDay = <DateTime, DateTime>{};
+        final latestByDay = <DateTime, ({DateTime from, String id})>{};
         for (final entity in entities) {
           entity.maybeMap(
             quantitative: (quant) {
               final day = GoalWindow.dayUtc(quant.data.dateFrom);
-              final currentFrom = latestFromByDay[day];
-              if (currentFrom == null ||
-                  quant.data.dateFrom.isAfter(currentFrom)) {
-                latestFromByDay[day] = quant.data.dateFrom;
+              final current = latestByDay[day];
+              // Identical timestamps are broken by entity id: the query
+              // orders by date_from only, so relying on return order
+              // would let replicas pick different daily values from the
+              // same journal and diverge their registers.
+              final wins =
+                  current == null ||
+                  quant.data.dateFrom.isAfter(current.from) ||
+                  (quant.data.dateFrom.isAtSameMomentAs(current.from) &&
+                      quant.meta.id.compareTo(current.id) > 0);
+              if (wins) {
+                latestByDay[day] = (
+                  from: quant.data.dateFrom,
+                  id: quant.meta.id,
+                );
                 byDay[day] = quant.data.value * multiplier;
               }
             },

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -128,18 +128,24 @@ class GoalAgentPhaseA {
       shortTermAttainment: shortTerm,
     );
 
-    await _upsertRegister(
-      agentId: agentId,
-      version: version,
-      evaluation: evaluation,
-      facts: facts,
-      now: now,
-      periodKey: periodKey,
-      existing: existingToday is GoalProgressEntity ? existingToday : null,
-    );
-
+    // One transaction: a register write acknowledging the transition
+    // without its escalation would be permanent — the next run reads the
+    // new status as previousStatus and never re-arms the missed wake.
+    await _syncService.runInTransaction(() async {
+      await _upsertRegister(
+        agentId: agentId,
+        version: version,
+        evaluation: evaluation,
+        facts: facts,
+        now: now,
+        periodKey: periodKey,
+        existing: existingToday is GoalProgressEntity ? existingToday : null,
+      );
+      if (facts.needsEscalation) {
+        await _armEscalation(agentId, now, periodKey);
+      }
+    });
     if (facts.needsEscalation) {
-      await _armEscalation(agentId, now, periodKey);
       _onEscalationArmed?.call();
     }
 
@@ -240,7 +246,11 @@ class GoalAgentPhaseA {
 /// → re-arming overwrites (LWW) instead of accumulating.
 AgentDomainEntity goalCadenceWake(String agentId, DateTime now) {
   final today = DateTime(now.year, now.month, now.day, goalCadenceHour);
-  final next = now.isBefore(today) ? today : today.add(const Duration(days: 1));
+  // Calendar components, not a Duration: adding 24 elapsed hours across a
+  // DST transition would shift the fixed local cadence hour.
+  final next = now.isBefore(today)
+      ? today
+      : DateTime(now.year, now.month, now.day + 1, goalCadenceHour);
   return AgentDomainEntity.scheduledWake(
     id: scheduledWakeRecordId(agentId, workspaceKey: goalCadenceWorkspaceKey),
     agentId: agentId,
@@ -254,9 +264,16 @@ AgentDomainEntity goalCadenceWake(String agentId, DateTime now) {
 }
 
 /// An escalation wake due immediately, scoped to its evaluation period
-/// (see `_armEscalation`). The deadline is stored in UTC: it is an
-/// absolute moment a failover peer in another timezone must read
-/// correctly, unlike the cadence's deliberately local fixed hour.
+/// (see `_armEscalation`).
+///
+/// The deadline is DERIVED FROM THE PERIOD (its UTC day key), not from
+/// the arming instant: every device arming the same logical
+/// `(agentId, periodKey)` escalation must write an identical deadline.
+/// A wall-clock `now` would differ per device, and the scheduled-wake
+/// concurrent resolver prefers the later deadline as a newer wake window
+/// — letting a partitioned peer's pending copy resurrect an escalation
+/// another device already consumed. Midnight UTC is always in the past
+/// for the day being evaluated, so the wake is immediately due.
 AgentDomainEntity goalEscalationWake(
   String agentId,
   DateTime now,
@@ -267,7 +284,7 @@ AgentDomainEntity goalEscalationWake(
     workspaceKey: goalEscalationWorkspaceKey(periodKey),
   ),
   agentId: agentId,
-  scheduledAt: now.toUtc(),
+  scheduledAt: GoalWindow.dayUtc(now),
   status: ScheduledWakeStatus.pending,
   reason: WakeReason.scheduled.name,
   updatedAt: now,

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -261,6 +261,54 @@ void main() {
     );
   });
 
+  test('identical point-sample timestamps break the tie by entity id, '
+      'independent of query return order', () async {
+    const weight = GoalCriterion.metric(
+      criterionId: 'weight',
+      dataType: 'HealthDataType.WEIGHT',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.max,
+      target: 80,
+      direction: GoalDirection.atMost,
+    );
+    final at = DateTime(2026, 8, 8, 7);
+    JournalEntity sample(String id, num value) => JournalEntity.quantitative(
+      meta: meta(at, id: id),
+      data: QuantitativeData.discreteQuantityData(
+        dateFrom: at,
+        dateTo: at,
+        value: value,
+        dataType: 'HealthDataType.WEIGHT',
+        unit: 'kg',
+      ),
+    );
+    final a = sample('id-a', 81.2);
+    final b = sample('id-b', 79.4);
+
+    for (final rows in [
+      [a, b],
+      [b, a],
+    ]) {
+      when(
+        () => journalDb.getQuantitativeByType(
+          type: 'HealthDataType.WEIGHT',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => rows);
+      final window = await reader.read(criteria: weight, reference: reference);
+      expect(
+        window.quantitativeDailySums['HealthDataType.WEIGHT']![DateTime.utc(
+          2026,
+          8,
+          8,
+        )],
+        79.4,
+        reason: 'the greater id must win regardless of row order',
+      );
+    }
+  });
+
   test('percentage point samples are normalized to display units, '
       'matching the chart', () async {
     const bodyFat = GoalCriterion.metric(

--- a/test/features/goals/runtime/goal_agent_phase_a_test.dart
+++ b/test/features/goals/runtime/goal_agent_phase_a_test.dart
@@ -313,7 +313,51 @@ void main() {
     );
     expect(escalation.workspaceKey, 'goal-escalation:2026-08-08');
     expect(escalation.scheduledAt.isUtc, isTrue);
+    // Period-derived, never wall-clock: every device arming this logical
+    // escalation must write the IDENTICAL deadline, or the concurrent
+    // resolver's later-deadline preference resurrects consumed wakes.
+    expect(escalation.scheduledAt, DateTime.utc(2026, 8, 8));
   });
+
+  test(
+    'the register and its escalation land in ONE transaction — a '
+    'transition acknowledged without escalation would be permanent',
+    () async {
+      stubSpec();
+      final order = <String>[];
+      final txnSyncService = _OrderRecordingSyncService(order);
+      when(() => txnSyncService.upsertEntity(any())).thenAnswer(
+        (invocation) async {
+          final entity =
+              invocation.positionalArguments.first as AgentDomainEntity;
+          if (entity is GoalProgressEntity) order.add('register');
+          if (entity is ScheduledWakeEntity &&
+              isGoalEscalationWorkspace(entity.workspaceKey)) {
+            order.add('escalation');
+          }
+        },
+      );
+      final atomic = GoalAgentPhaseA(
+        repository: repository,
+        syncService: txnSyncService,
+        signalReader: _FakeSignalReader(onTrackSignals()),
+      );
+      await withClock(
+        fixedClock,
+        () => atomic.execute(
+          agentIdentity: identity,
+          runKey: 'run-1',
+          triggerTokens: const {},
+          threadId: 'thread-1',
+        ),
+      );
+      expect(
+        order,
+        ['transaction', 'register', 'escalation'],
+        reason: 'both writes must happen inside the same transaction',
+      );
+    },
+  );
 
   test('the escalation callback nudges the wake manager exactly when an '
       'escalation is armed', () async {
@@ -489,4 +533,16 @@ void main() {
     expect(register.createdAt, created);
     expect(register.updatedAt, now);
   });
+}
+
+class _OrderRecordingSyncService extends MockAgentSyncService {
+  _OrderRecordingSyncService(this.order);
+
+  final List<String> order;
+
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) {
+    order.add('transaction');
+    return action();
+  }
 }


### PR DESCRIPTION
Addresses the four findings of PR #3861's final Codex review ([review 4891308181](https://github.com/matthiasn/lotti/pull/3861#pullrequestreview-4891308181)), which landed after the merge. All four were real:

## P1 — register + escalation are now one transaction
If `_armEscalation` failed after the register upsert, the transition was acknowledged permanently: the next run read today's freshly persisted status as `previousStatus`, saw no transition, and the missed Phase B wake was never recreated. Both writes now commit in a single `runInTransaction`, and a test pins the ordering (transaction → register → escalation).

## P1 — escalation deadline is period-derived, not wall-clock
Two devices arming the same logical `(agentId, periodKey)` escalation while partitioned wrote different `scheduledAt` instants, and the scheduled-wake concurrent resolver prefers the later deadline — letting a delayed peer's pending copy resurrect an escalation another device already consumed. The deadline is now the period's UTC day key (midnight UTC, always in the past, so immediately due), identical on every device.

## P2 — cadence arithmetic is fully calendar-component
The one remaining `add(Duration(days: 1))` shifted the fixed 06:00 local cadence hour across DST transitions, contradicting the concept's stated invariant. Tomorrow is now built as `DateTime(y, m, d + 1, goalCadenceHour)`.

## P2 — same-timestamp point samples tie-break by entity id
The quantitative query orders by `date_from` only, so two samples with identical timestamps were resolved by DB return order — replicas that inserted the same synced rows in different orders could bucket different daily values and diverge their registers. Ties now break on `meta.id`, tested in both row orders.

The goals knowledge concept records the transactional invariant and the period-derived deadline.

No CHANGELOG entry: hardening of an unreleased runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daily goal progress now consistently uses the most recent sample, with deterministic tie-breaking when samples share a timestamp.
  * Escalation deadlines are now consistent across devices and derived from the goal period’s UTC date.
  * Daily schedules preserve the intended local time across daylight-saving changes.
  * Progress updates and escalation scheduling are saved together, preventing incomplete or duplicate escalation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->