### PR TITLE
feat: surface AI task taglines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6]
+### Changed
+- **AI task summaries now look like AI content wherever you scan tasks.** The
+  agent's one-line take uses the AI accent in task lists, appears beneath linked
+  task titles, and sits between the title and status pills on task details, so
+  the same compact context is visible without opening the full AI summary card.
+
 ## [1.0.5]
 ### Changed
 - **The 1-on-1 with an agent now looks like one screen rather than several.**

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.6" date="2026-08-09">
+      <description>
+        <p>Changed: AI task summaries now look like AI content wherever you scan tasks. The agent's one-line take uses the AI accent in task lists, appears beneath linked task titles, and sits between the title and status pills on task details, so the same compact context is visible without opening the full AI summary card.</p>
+      </description>
+    </release>
     <release version="1.0.5" date="2026-08-07">
       <description>
         <p>Changed: the 1-on-1 with an agent now looks like one screen rather than several. The conversation home opened with a banner that repeated the page's own title, followed by a card headed "Current Proposal" in the state where no proposal exists, and a sentence printed twice on the same screen. It now leads with the one thing you can do, then what the agent has been doing since you last spoke, then what you decided last time, with past 1-on-1s visible without scrolling. The conversation itself no longer stretches its text the full width of a desktop window, the agent's replies are readable instead of sitting a shade above the background, and starting a session shows what is happening rather than a hairline spinner in the corner of an empty page. The wake-activity bars read as a chart rather than blurred lozenges, and their date labels thin out on a narrow screen instead of all shortening to "J…".</p>

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -121,10 +121,14 @@ pickers. When the task agent has published a one-liner, the header renders it as
 a single ellipsized line directly between the title and metadata. Its ink is
 `aiCard.accent`, matching the AI summary card instead of neutral task metadata.
 
-Linked-task rows watch the same provider for the other task. Their compact text
-column becomes title plus one-line AI subtitle while the status remains on the
-trailing rail at the detail reading width; narrow rows fold the status into the
-subtitle line. Both paths ellipsize rather than widening the card.
+`LinkedTasksWidget` resolves every linked task's one-liner through one
+`taskOneLinersProvider` batch and passes the results into both plain and typed
+rows. The batch watches the shared agent-update topic, so a local or synced
+report refreshes the card without one query and stream subscription per row.
+Each compact text column becomes title plus one-line AI subtitle while the
+status remains on the trailing rail at the detail reading width; narrow rows
+prefix the status before the ellipsized summary so it cannot disappear behind
+a long tagline.
 
 **Extended actions — share, speech modal — belong to the pinned app bar's
 `more_vert` button, not the header.** There is no ellipsis inside the header.
@@ -195,12 +199,15 @@ Three rules govern getting *out* of edit mode:
 
 ## The two-lane meta row
 
-The header body is Crumb → Title → Meta:
+The header body is Crumb → Title → AI one-liner → Meta:
 
 1. **Crumb** — `category / [project | No project]` separated by a literal `/`.
    No label chips here.
 2. **Title** — full width, tap to edit.
-3. **Meta** — a two-lane column.
+3. **AI one-liner** — an optional, single-line AI-accent summary. It preserves
+   the last value during background refresh and truncates rather than widening
+   the header.
+4. **Meta** — a two-lane column.
 
 **Without a category the crumb is one segment: `No category`.** A project is
 scoped to a category — `ProjectRepository.linkTaskToProject` refuses a

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -11,7 +11,7 @@ sources:
   - id: header
     resource: ../../../lib/features/tasks/ui/header
     title: Desktop task header
-    last_modified: 2026-08-03
+    last_modified: 2026-08-09
   - id: pages
     resource: ../../../lib/features/tasks/ui/pages
     title: TaskDetailsPage and TaskForm
@@ -114,9 +114,17 @@ text.
 # The header
 
 `DesktopTaskHeaderConnector` concentrates the whole metadata band. It watches
-`entryControllerProvider`, `projectForTaskProvider` and the labels stream, maps
-the task to an immutable `DesktopTaskHeaderData` plus a Riverpod-aware
-`estimateSlot`, and forwards callbacks to the existing modal pickers.
+`entryControllerProvider`, `projectForTaskProvider`, `taskOneLinerProvider` and
+the labels stream, maps the task to an immutable `DesktopTaskHeaderData` plus a
+Riverpod-aware `estimateSlot`, and forwards callbacks to the existing modal
+pickers. When the task agent has published a one-liner, the header renders it as
+a single ellipsized line directly between the title and metadata. Its ink is
+`aiCard.accent`, matching the AI summary card instead of neutral task metadata.
+
+Linked-task rows watch the same provider for the other task. Their compact text
+column becomes title plus one-line AI subtitle while the status remains on the
+trailing rail at the detail reading width; narrow rows fold the status into the
+subtitle line. Both paths ellipsize rather than widening the card.
 
 **Extended actions — share, speech modal — belong to the pinned app bar's
 `more_vert` button, not the header.** There is no ellipsis inside the header.

--- a/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
+++ b/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
@@ -267,9 +267,27 @@ extension _AgentHandlers on SyncEventProcessor {
           }
         }
       }
+      // Task-scoped report consumers subscribe to the task ID, not the agent
+      // ID. Resolve active task links so a report or report-head received from
+      // another device refreshes an already-open header and task list.
+      final reportTaskIds = <String>{};
+      if (resolvedEntity is AgentReportEntity ||
+          resolvedEntity is AgentReportHeadEntity) {
+        final taskLinks = await agentRepository!.getLinksFrom(
+          resolvedEntity.agentId,
+          type: 'agent_task',
+        );
+        reportTaskIds.addAll(
+          taskLinks
+              .whereType<AgentTaskLink>()
+              .where((link) => link.deletedAt == null)
+              .map((link) => link.toId),
+        );
+      }
       _updateNotifications.notify(
         {
           resolvedEntity.agentId,
+          ...reportTaskIds,
           // Include templateId so template-level aggregate providers
           // refresh when token usage or reports arrive from other devices.
           if (resolvedEntity is WakeTokenUsageEntity &&

--- a/lib/features/tasks/state/task_one_liner_provider.dart
+++ b/lib/features/tasks/state/task_one_liner_provider.dart
@@ -1,6 +1,32 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/services/db_notification.dart';
+
+/// Stable, de-duplicated task IDs for one batched one-liner lookup.
+@immutable
+class TaskOneLinerRequest {
+  factory TaskOneLinerRequest(Iterable<String> taskIds) {
+    final sortedIds = taskIds.toSet().toList()..sort();
+    return TaskOneLinerRequest._(List.unmodifiable(sortedIds));
+  }
+
+  const TaskOneLinerRequest._(this.taskIds);
+
+  final List<String> taskIds;
+
+  static const _equality = ListEquality<String>();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TaskOneLinerRequest && _equality.equals(taskIds, other.taskIds);
+
+  @override
+  int get hashCode => _equality.hash(taskIds);
+}
 
 /// Fetches the AI-generated one-liner subtitle for a task from its agent
 /// report.
@@ -22,4 +48,35 @@ Future<String?> taskOneLiner(Ref ref, String taskId) async {
     return oneLiner;
   }
   return null;
+}
+
+/// Fetches one-liners for a complete linked-task card in one repository call.
+///
+/// The shared agent notification refreshes the single batch when any report
+/// changes, avoiding one database lookup and one stream subscription per row.
+final FutureProviderFamily<Map<String, String>, TaskOneLinerRequest>
+taskOneLinersProvider = FutureProvider.autoDispose
+    .family<Map<String, String>, TaskOneLinerRequest>(
+      taskOneLiners,
+      name: 'taskOneLinersProvider',
+    );
+Future<Map<String, String>> taskOneLiners(
+  Ref ref,
+  TaskOneLinerRequest request,
+) async {
+  if (request.taskIds.isEmpty) return const {};
+
+  ref.watch(agentUpdateStreamProvider(agentNotification));
+  final repository = ref.watch(agentRepositoryProvider);
+  final reports = await repository.getLatestTaskReportsForTaskIds(
+    request.taskIds,
+  );
+  final oneLiners = <String, String>{};
+  for (final taskId in request.taskIds) {
+    final oneLiner = reports[taskId]?.oneLiner?.trim();
+    if (oneLiner != null && oneLiner.isNotEmpty) {
+      oneLiners[taskId] = oneLiner;
+    }
+  }
+  return Map.unmodifiable(oneLiners);
 }

--- a/lib/features/tasks/ui/header/desktop_task_header.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header.dart
@@ -60,6 +60,7 @@ class DesktopTaskHeaderData {
     this.project,
     this.category,
     this.dueDate,
+    this.oneLiner,
     this.labels = const [],
   });
 
@@ -69,6 +70,7 @@ class DesktopTaskHeaderData {
   final DesktopTaskHeaderProject? project;
   final DesktopTaskHeaderCategory? category;
   final DesktopTaskHeaderDueDate? dueDate;
+  final String? oneLiner;
   final List<LabelDefinition> labels;
 }
 
@@ -80,7 +82,8 @@ class DesktopTaskHeaderData {
 ///    "where am I?" info out of the chip soup.
 /// 2. **Title** — heading-3 with an always-shown small edit pencil to its
 ///    right; tap toggles the inline editor.
-/// 3. **Meta row** — pill chips for the *actionable* metadata (priority, due,
+/// 3. **AI one-liner** — optional accent-colored task-agent context.
+/// 4. **Meta row** — pill chips for the *actionable* metadata (priority, due,
 ///    estimate, labels) followed by the status select pinned to the right
 ///    edge of the row.
 class DesktopTaskHeader extends StatefulWidget {
@@ -278,6 +281,18 @@ class _DesktopTaskHeaderState extends State<DesktopTaskHeader> {
             SizedBox(height: crumbGap),
           ],
           _buildTitleLine(context),
+          if (widget.data.oneLiner case final oneLiner?
+              when oneLiner.isNotEmpty) ...[
+            SizedBox(height: tokens.spacing.step2),
+            Text(
+              oneLiner,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: tokens.typography.styles.body.bodySmall.copyWith(
+                color: tokens.colors.aiCard.accent,
+              ),
+            ),
+          ],
           SizedBox(height: metaGap),
           MetaRow(
             priority: widget.data.priority,

--- a/lib/features/tasks/ui/header/desktop_task_header_connector.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_connector.dart
@@ -18,6 +18,7 @@ import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
 import 'package:lotti/features/projects/ui/widgets/project_selection_modal_content.dart';
 import 'package:lotti/features/tasks/state/task_blockers_controller.dart';
+import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header_meta.dart';
@@ -65,8 +66,11 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
 
     final projectAsync = ref.watch(projectForTaskProvider(taskId));
     final project = projectAsync.asData?.value;
+    // `.value` preserves the established tagline while a background refresh
+    // reloads the provider, avoiding a one-line header reflow.
+    final oneLiner = ref.watch(taskOneLinerProvider(taskId)).value;
 
-    final data = _buildData(context, task, project);
+    final data = _buildData(context, task, project, oneLiner);
     final controller = ref.read(entryControllerProvider(taskId).notifier);
     final categoryId = task.meta.categoryId;
 
@@ -112,6 +116,7 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
     BuildContext context,
     Task task,
     ProjectEntry? project,
+    String? oneLiner,
   ) {
     final cache = getIt<EntitiesCacheService>();
     final categoryId = task.meta.categoryId;
@@ -161,6 +166,7 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
             ),
       category: category,
       dueDate: dueDate,
+      oneLiner: oneLiner,
       labels: labels,
     );
   }

--- a/lib/features/tasks/ui/linked_tasks/linked_task_row.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_task_row.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/link_created_feedback.dart';
 import 'package:lotti/features/tasks/ui/utils.dart';
 import 'package:lotti/features/tasks/util/task_navigation.dart';
@@ -57,9 +55,10 @@ const double _trailingStatusMinRowWidth = 520;
 /// Deliberately just the task — direction and relationship kind are stated by
 /// the section header the row sits under, never repeated per row.
 class LinkedTaskRowData {
-  const LinkedTaskRowData({required this.task});
+  const LinkedTaskRowData({required this.task, this.oneLiner});
 
   final Task task;
+  final String? oneLiner;
 }
 
 /// A single row in the linked-tasks card: status glyph, title, optional AI
@@ -67,7 +66,7 @@ class LinkedTaskRowData {
 /// buttons (manage mode, only for whichever of [onEdit]/[onUnlink] is
 /// supplied). Shared by the flat plain-link list and the typed relationship
 /// sections — one template for every row on the card.
-class LinkedTaskRow extends ConsumerWidget {
+class LinkedTaskRow extends StatelessWidget {
   const LinkedTaskRow({
     required this.data,
     required this.manageMode,
@@ -100,12 +99,10 @@ class LinkedTaskRow extends ConsumerWidget {
   final Future<int> Function()? onUnlink;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final task = data.task;
-    // Keep the last summary painted while its report refreshes so a database
-    // notification cannot collapse and re-expand the row.
-    final oneLiner = ref.watch(taskOneLinerProvider(task.id)).value;
+    final oneLiner = data.oneLiner;
     final hasOneLiner = oneLiner != null && oneLiner.isNotEmpty;
 
     final showActions = manageMode && (onEdit != null || onUnlink != null);
@@ -148,19 +145,19 @@ class LinkedTaskRow extends ConsumerWidget {
               : statusLabel,
           subtitleSpans: hasOneLiner
               ? [
+                  if (!wideEnoughForTrailingStatus)
+                    TextSpan(
+                      text: '$statusLabel · ',
+                      style: tokens.typography.styles.others.caption.copyWith(
+                        color: tokens.colors.text.lowEmphasis,
+                      ),
+                    ),
                   TextSpan(
                     text: oneLiner,
                     style: tokens.typography.styles.others.caption.copyWith(
                       color: tokens.colors.aiCard.accent,
                     ),
                   ),
-                  if (!wideEnoughForTrailingStatus)
-                    TextSpan(
-                      text: ' · $statusLabel',
-                      style: tokens.typography.styles.others.caption.copyWith(
-                        color: tokens.colors.text.lowEmphasis,
-                      ),
-                    ),
                 ]
               : null,
           // The list item's default subtitle ink is medium, which on the

--- a/lib/features/tasks/ui/linked_tasks/linked_task_row.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_task_row.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/link_created_feedback.dart';
 import 'package:lotti/features/tasks/ui/utils.dart';
 import 'package:lotti/features/tasks/util/task_navigation.dart';
@@ -60,12 +62,12 @@ class LinkedTaskRowData {
   final Task task;
 }
 
-/// A single row in the linked-tasks card: status glyph, title, and either a
-/// chevron (browse mode) or edit/unlink buttons (manage mode, only for
-/// whichever of [onEdit]/[onUnlink] is supplied). Shared by the flat
-/// plain-link list and the typed relationship sections — one template for
-/// every row on the card.
-class LinkedTaskRow extends StatelessWidget {
+/// A single row in the linked-tasks card: status glyph, title, optional AI
+/// one-liner subtitle, and either a chevron (browse mode) or edit/unlink
+/// buttons (manage mode, only for whichever of [onEdit]/[onUnlink] is
+/// supplied). Shared by the flat plain-link list and the typed relationship
+/// sections — one template for every row on the card.
+class LinkedTaskRow extends ConsumerWidget {
   const LinkedTaskRow({
     required this.data,
     required this.manageMode,
@@ -98,9 +100,13 @@ class LinkedTaskRow extends StatelessWidget {
   final Future<int> Function()? onUnlink;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
     final task = data.task;
+    // Keep the last summary painted while its report refreshes so a database
+    // notification cannot collapse and re-expand the row.
+    final oneLiner = ref.watch(taskOneLinerProvider(task.id)).value;
+    final hasOneLiner = oneLiner != null && oneLiner.isNotEmpty;
 
     final showActions = manageMode && (onEdit != null || onUnlink != null);
     final statusLabel = taskLabelFromStatusString(
@@ -125,16 +131,38 @@ class LinkedTaskRow extends StatelessWidget {
           title: task.data.title,
           titleMaxLines: 2,
           size: DesignSystemListItemSize.small,
-          semanticsLabel: '${task.data.title}, $statusLabel',
+          semanticsLabel: [
+            task.data.title,
+            if (hasOneLiner) oneLiner,
+            statusLabel,
+          ].join(', '),
           leading: StatusGlyph(status: task.data.status),
-          // Status as a trailing anchor rather than a second line: it keeps the
-          // row one line tall, and on a wide detail pane it stops the trailing
-          // affordance floating alone at the far edge of an otherwise empty row.
+          // At the detail reading width, status remains the trailing anchor so
+          // it does not compete with the AI subtitle. Narrow rows fold it into
+          // that same ellipsized subtitle line instead of crowding the title.
           // Kept in manage mode too: curating links is exactly when knowing a
-          // blocker is already Done matters most, and dropping it there cost
-          // the row its second type level during the one task it serves.
+          // blocker is already Done matters most.
           //
-          subtitle: wideEnoughForTrailingStatus ? null : statusLabel,
+          subtitle: hasOneLiner || wideEnoughForTrailingStatus
+              ? null
+              : statusLabel,
+          subtitleSpans: hasOneLiner
+              ? [
+                  TextSpan(
+                    text: oneLiner,
+                    style: tokens.typography.styles.others.caption.copyWith(
+                      color: tokens.colors.aiCard.accent,
+                    ),
+                  ),
+                  if (!wideEnoughForTrailingStatus)
+                    TextSpan(
+                      text: ' · $statusLabel',
+                      style: tokens.typography.styles.others.caption.copyWith(
+                        color: tokens.colors.text.lowEmphasis,
+                      ),
+                    ),
+                ]
+              : null,
           // The list item's default subtitle ink is medium, which on the
           // narrow layout tied the status with the section eyebrow grouping it
           // and flattened the three roles the wide layout ranks.

--- a/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/tasks/state/linkable_tasks_controller.dart';
 import 'package:lotti/features/tasks/state/linked_tasks_controller.dart';
 import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
+import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/edit_link_type_modal.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/link_created_feedback.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/link_task_modal.dart';
@@ -72,6 +73,17 @@ class _LinkedTasksWidgetState extends ConsumerState<LinkedTasksWidget> {
     // have no links" CTA on the first open of every task that has some.
     final resolved = groupsAsync.hasValue || groupsAsync.hasError;
     final hasLinks = linkGroups.totalCount > 0;
+    final linkedTaskIds = [
+      ...linkGroups.flat.map((entry) => entry.task.meta.id),
+      ...linkGroups.typed.map((entry) => entry.task.meta.id),
+    ];
+    final oneLinersByTaskId =
+        ref
+            .watch(
+              taskOneLinersProvider(TaskOneLinerRequest(linkedTaskIds)),
+            )
+            .value ??
+        const {};
 
     // Nothing to link to, nothing to show. On a first-run install this card
     // was a bordered box teaching a relationship feature that could not be
@@ -84,7 +96,12 @@ class _LinkedTasksWidgetState extends ConsumerState<LinkedTasksWidget> {
     if (!hasLinks && !canLink) return const SizedBox.shrink();
 
     final flatRows = linkGroups.flat
-        .map((entry) => LinkedTaskRowData(task: entry.task))
+        .map(
+          (entry) => LinkedTaskRowData(
+            task: entry.task,
+            oneLiner: oneLinersByTaskId[entry.task.meta.id],
+          ),
+        )
         .toList();
 
     final tokens = context.designTokens;
@@ -138,6 +155,7 @@ class _LinkedTasksWidgetState extends ConsumerState<LinkedTasksWidget> {
                   TaskRelationshipSections(
                     taskId: taskId,
                     manageMode: uiState.manageMode,
+                    oneLinersByTaskId: oneLinersByTaskId,
                   ),
                 if (linkGroups.typed.isNotEmpty && flatRows.isNotEmpty)
                   const DesignSystemDivider(),

--- a/lib/features/tasks/ui/linked_tasks/task_relationship_sections.dart
+++ b/lib/features/tasks/ui/linked_tasks/task_relationship_sections.dart
@@ -63,11 +63,13 @@ class TaskRelationshipSections extends ConsumerWidget {
   const TaskRelationshipSections({
     required this.taskId,
     required this.manageMode,
+    this.oneLinersByTaskId = const {},
     super.key,
   });
 
   final String taskId;
   final bool manageMode;
+  final Map<String, String> oneLinersByTaskId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -143,7 +145,10 @@ class TaskRelationshipSections extends ConsumerWidget {
       for (final entry in sections[s].entries) {
         children.add(
           LinkedTaskRow(
-            data: LinkedTaskRowData(task: entry.task),
+            data: LinkedTaskRowData(
+              task: entry.task,
+              oneLiner: oneLinersByTaskId[entry.task.meta.id],
+            ),
             manageMode: manageMode,
             onEdit: () => EditLinkTypeModal.show(
               context: context,

--- a/lib/features/tasks/ui/widgets/task_browse_list_item_rows.dart
+++ b/lib/features/tasks/ui/widgets/task_browse_list_item_rows.dart
@@ -253,7 +253,7 @@ class TaskRowContent extends ConsumerWidget {
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   style: tokens.typography.styles.others.caption.copyWith(
-                    color: TaskShowcasePalette.lowText(context),
+                    color: tokens.colors.aiCard.accent,
                   ),
                 ),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.5+4298
+version: 1.0.6+4299
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -46,6 +46,12 @@ void main() {
       when(() => mockAgentRepo.getLinkById(any())).thenAnswer(
         (_) async => null,
       );
+      when(
+        () => mockAgentRepo.getLinksFrom(
+          any(),
+          type: any(named: 'type'),
+        ),
+      ).thenAnswer((_) async => const []);
       processor.agentRepository = mockAgentRepo;
     });
 
@@ -830,11 +836,37 @@ void main() {
         agentEntity: entity,
         status: SyncEntryStatus.update,
       );
+      final taskLink = AgentLink.agentTask(
+        id: 'agent-task-link',
+        fromId: 'agent-1',
+        toId: 'task-1',
+        createdAt: DateTime(2024, 3, 15),
+        updatedAt: DateTime(2024, 3, 15),
+        vectorClock: null,
+      );
+      final deletedTaskLink = AgentLink.agentTask(
+        id: 'deleted-agent-task-link',
+        fromId: 'agent-1',
+        toId: 'deleted-task',
+        createdAt: DateTime(2024, 3, 15),
+        updatedAt: DateTime(2024, 3, 15),
+        vectorClock: null,
+        deletedAt: DateTime(2024, 3, 16),
+      );
+      when(
+        () => mockAgentRepo.getLinksFrom('agent-1', type: 'agent_task'),
+      ).thenAnswer((_) async => [taskLink, deletedTaskLink]);
       when(() => event.text).thenReturn(encodeMessage(message));
 
       await processor.process(event: event, journalDb: journalDb);
 
       verify(() => mockAgentRepo.upsertEntity(entity)).called(1);
+      verify(
+        () => updateNotifications.notify(
+          {'agent-1', 'task-1', 'AGENT_CHANGED'},
+          fromSync: true,
+        ),
+      ).called(1);
     });
 
     test('processes agent report head entity', () async {
@@ -851,11 +883,28 @@ void main() {
         agentEntity: entity,
         status: SyncEntryStatus.update,
       );
+      final taskLink = AgentLink.agentTask(
+        id: 'agent-task-link',
+        fromId: 'agent-1',
+        toId: 'task-1',
+        createdAt: DateTime(2024, 3, 15),
+        updatedAt: DateTime(2024, 3, 15),
+        vectorClock: null,
+      );
+      when(
+        () => mockAgentRepo.getLinksFrom('agent-1', type: 'agent_task'),
+      ).thenAnswer((_) async => [taskLink]);
       when(() => event.text).thenReturn(encodeMessage(message));
 
       await processor.process(event: event, journalDb: journalDb);
 
       verify(() => mockAgentRepo.upsertEntity(entity)).called(1);
+      verify(
+        () => updateNotifications.notify(
+          {'agent-1', 'task-1', 'AGENT_CHANGED'},
+          fromSync: true,
+        ),
+      ).called(1);
     });
 
     test(

--- a/test/features/tasks/state/task_one_liner_provider_test.dart
+++ b/test/features/tasks/state/task_one_liner_provider_test.dart
@@ -178,4 +178,91 @@ void main() {
       expect(result, 'Building REST API endpoints');
     });
   });
+
+  group('taskOneLinersProvider', () {
+    late MockAgentRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockAgentRepository();
+    });
+
+    ProviderContainer createContainer() {
+      final container = ProviderContainer(
+        overrides: [
+          agentRepositoryProvider.overrideWithValue(mockRepository),
+          agentUpdateStreamProvider.overrideWith(
+            (ref, agentId) => const Stream<Set<String>>.empty(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('de-duplicates and sorts IDs for a stable family key', () {
+      final first = TaskOneLinerRequest(
+        const ['task-b', 'task-a', 'task-b'],
+      );
+      final second = TaskOneLinerRequest(const ['task-a', 'task-b']);
+
+      expect(first.taskIds, ['task-a', 'task-b']);
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+    });
+
+    test(
+      'fetches all task reports once and keeps non-empty taglines',
+      () async {
+        final request = TaskOneLinerRequest(const ['task-b', 'task-a']);
+        when(
+          () => mockRepository.getLatestTaskReportsForTaskIds([
+            'task-a',
+            'task-b',
+          ]),
+        ).thenAnswer(
+          (_) async => {
+            'task-a': AgentReportEntity(
+              id: 'report-a',
+              agentId: 'agent-a',
+              scope: 'current',
+              createdAt: DateTime(2024, 3, 15),
+              vectorClock: null,
+              oneLiner: '  Ready for review  ',
+            ),
+            'task-b': AgentReportEntity(
+              id: 'report-b',
+              agentId: 'agent-b',
+              scope: 'current',
+              createdAt: DateTime(2024, 3, 15),
+              vectorClock: null,
+              oneLiner: '   ',
+            ),
+          },
+        );
+
+        final result = await createContainer().read(
+          taskOneLinersProvider(request).future,
+        );
+
+        expect(result, const {'task-a': 'Ready for review'});
+        verify(
+          () => mockRepository.getLatestTaskReportsForTaskIds([
+            'task-a',
+            'task-b',
+          ]),
+        ).called(1);
+      },
+    );
+
+    test('an empty request performs no repository lookup', () async {
+      final result = await createContainer().read(
+        taskOneLinersProvider(TaskOneLinerRequest(const [])).future,
+      );
+
+      expect(result, isEmpty);
+      verifyNever(
+        () => mockRepository.getLatestTaskReportsForTaskIds(any()),
+      );
+    });
+  });
 }

--- a/test/features/tasks/ui/header/desktop_task_header_connector_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_connector_test.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
 import 'package:lotti/features/projects/ui/widgets/project_selection_modal_content.dart';
 import 'package:lotti/features/tasks/model/task_progress_state.dart';
+import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header_connector.dart';
@@ -245,6 +246,7 @@ void main() {
     ProjectEntry? project,
     List<LabelDefinition> labels = const [],
     TaskProgressState? progress,
+    String? oneLiner,
     Locale locale = const Locale('en'),
   }) {
     return ProviderScope(
@@ -258,6 +260,9 @@ void main() {
         ),
         taskProgressControllerProvider(task.id).overrideWith(
           () => _FakeTaskProgressController(progress),
+        ),
+        taskOneLinerProvider.overrideWith(
+          (ref, taskId) async => oneLiner,
         ),
       ],
       child: MaterialApp(
@@ -288,6 +293,19 @@ void main() {
 
       expect(find.byType(DesktopTaskHeader), findsOneWidget);
       expect(find.text('Test Task'), findsOneWidget);
+    });
+
+    testWidgets('passes the task AI one-liner into the header', (tester) async {
+      const oneLiner = 'Final review is waiting on the payment provider';
+      final task = buildTask();
+
+      await tester.pumpWidget(
+        pumpConnector(task: task, oneLiner: oneLiner),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text(oneLiner), findsOneWidget);
     });
 
     testWidgets('formats due dates for the active German locale', (

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -98,6 +98,7 @@ LabelDefinition _label({
 
 DesktopTaskHeaderData _fixture({
   String title = 'Payment confirmation',
+  String? oneLiner,
   TaskPriority priority = TaskPriority.p1High,
   TaskStatus? status,
   DesktopTaskHeaderProject? project,
@@ -108,6 +109,7 @@ DesktopTaskHeaderData _fixture({
   final createdAt = DateTime.utc(2026);
   return DesktopTaskHeaderData(
     title: title,
+    oneLiner: oneLiner,
     priority: priority,
     status:
         status ??
@@ -166,6 +168,37 @@ String _priorityLabel(TaskPriority priority) => switch (priority) {
 
 void main() {
   group('DesktopTaskHeader — content + layout', () {
+    testWidgets('shows the AI one-liner between title and metadata', (
+      tester,
+    ) async {
+      const oneLiner = 'Settlement is ready for final verification';
+      await _pumpDesktop(
+        tester,
+        DesktopTaskHeader(
+          data: _fixture(oneLiner: oneLiner),
+          onTitleSaved: (_) {},
+        ),
+      );
+
+      final summary = tester.widget<Text>(find.text(oneLiner));
+      final context = tester.element(find.text(oneLiner));
+      expect(summary.style?.color, context.designTokens.colors.aiCard.accent);
+      expect(summary.maxLines, 1);
+      expect(summary.overflow, TextOverflow.ellipsis);
+
+      final textOrder = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((text) => text.data)
+          .where(
+            (text) =>
+                text == 'Payment confirmation' ||
+                text == oneLiner ||
+                text == 'Open',
+          )
+          .toList();
+      expect(textOrder, ['Payment confirmation', oneLiner, 'Open']);
+    });
+
     testWidgets(
       'renders title, classification line, metadata line and no ellipsis',
       (tester) async {

--- a/test/features/tasks/ui/linked_tasks/linked_task_row_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_task_row_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -26,8 +25,9 @@ void main() {
     await getIt.reset();
   });
 
-  LinkedTaskRowData buildRowData() => LinkedTaskRowData(
+  LinkedTaskRowData buildRowData({String? oneLiner}) => LinkedTaskRowData(
     task: TestTaskFactory.create(id: 'other-task', title: 'Other Task'),
+    oneLiner: oneLiner,
   );
 
   group('LinkedTaskRow', () {
@@ -62,13 +62,8 @@ void main() {
             width: 500,
             height: 800,
           ),
-          overrides: [
-            taskOneLinerProvider.overrideWith(
-              (ref, taskId) async => oneLiner,
-            ),
-          ],
           child: LinkedTaskRow(
-            data: buildRowData(),
+            data: buildRowData(oneLiner: oneLiner),
             manageMode: false,
           ),
         ),
@@ -82,7 +77,7 @@ void main() {
       );
       final richText = tester.widget<RichText>(oneLinerText);
       final rootSpan = richText.text as TextSpan;
-      final summarySpan = rootSpan.children!.first as TextSpan;
+      final summarySpan = rootSpan.children!.last as TextSpan;
       final context = tester.element(find.byType(LinkedTaskRow));
       final textPainter = TextPainter(
         text: richText.text,
@@ -92,7 +87,7 @@ void main() {
       )..layout(maxWidth: tester.getSize(oneLinerText).width);
 
       expect(summarySpan.text, oneLiner);
-      expect(rootSpan.toPlainText(), '$oneLiner · Open');
+      expect(rootSpan.toPlainText(), 'Open · $oneLiner');
       expect(
         summarySpan.style?.color,
         context.designTokens.colors.aiCard.accent,

--- a/test/features/tasks/ui/linked_tasks/linked_task_row_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_task_row_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -49,6 +50,46 @@ void main() {
         expect(find.byType(SvgPicture), findsNothing);
       },
     );
+
+    testWidgets('renders the AI one-liner in accent ink with ellipsis', (
+      tester,
+    ) async {
+      const oneLiner =
+          'A deliberately long AI summary that cannot fit in this linked row';
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: [
+            taskOneLinerProvider.overrideWith(
+              (ref, taskId) async => oneLiner,
+            ),
+          ],
+          child: SizedBox(
+            width: 540,
+            child: LinkedTaskRow(
+              data: buildRowData(),
+              manageMode: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final richText = tester.widget<RichText>(
+        find.text(oneLiner, findRichText: true),
+      );
+      final rootSpan = richText.text as TextSpan;
+      final summarySpan = rootSpan.children!.first as TextSpan;
+      final context = tester.element(find.byType(LinkedTaskRow));
+
+      expect(summarySpan.text, oneLiner);
+      expect(
+        summarySpan.style?.color,
+        context.designTokens.colors.aiCard.accent,
+      );
+      expect(richText.maxLines, 1);
+      expect(richText.overflow, TextOverflow.ellipsis);
+    });
 
     testWidgets(
       'shows the plain chevron in manage mode when onUnlink is null',

--- a/test/features/tasks/ui/linked_tasks/linked_task_row_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_task_row_test.dart
@@ -58,37 +58,48 @@ void main() {
           'A deliberately long AI summary that cannot fit in this linked row';
       await tester.pumpWidget(
         WidgetTestBench(
+          surfaceConstraints: const BoxConstraints.tightFor(
+            width: 500,
+            height: 800,
+          ),
           overrides: [
             taskOneLinerProvider.overrideWith(
               (ref, taskId) async => oneLiner,
             ),
           ],
-          child: SizedBox(
-            width: 540,
-            child: LinkedTaskRow(
-              data: buildRowData(),
-              manageMode: false,
-            ),
+          child: LinkedTaskRow(
+            data: buildRowData(),
+            manageMode: false,
           ),
         ),
       );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      final richText = tester.widget<RichText>(
-        find.text(oneLiner, findRichText: true),
+      final oneLinerText = find.byWidgetPredicate(
+        (widget) =>
+            widget is RichText && widget.text.toPlainText().contains(oneLiner),
       );
+      final richText = tester.widget<RichText>(oneLinerText);
       final rootSpan = richText.text as TextSpan;
       final summarySpan = rootSpan.children!.first as TextSpan;
       final context = tester.element(find.byType(LinkedTaskRow));
+      final textPainter = TextPainter(
+        text: richText.text,
+        textDirection: TextDirection.ltr,
+        maxLines: richText.maxLines,
+        ellipsis: '…',
+      )..layout(maxWidth: tester.getSize(oneLinerText).width);
 
       expect(summarySpan.text, oneLiner);
+      expect(rootSpan.toPlainText(), '$oneLiner · Open');
       expect(
         summarySpan.style?.color,
         context.designTokens.colors.aiCard.accent,
       );
       expect(richText.maxLines, 1);
       expect(richText.overflow, TextOverflow.ellipsis);
+      expect(textPainter.didExceedMaxLines, isTrue);
     });
 
     testWidgets(

--- a/test/features/tasks/ui/linked_tasks/linked_tasks_widget_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_tasks_widget_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/design_system/components/lists/design_system_list
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/state/linkable_tasks_controller.dart';
 import 'package:lotti/features/tasks/state/linked_tasks_controller.dart';
+import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_tasks_widget.dart';
 import 'package:lotti/features/tasks/ui/utils.dart';
@@ -169,6 +170,7 @@ void main() {
     List<Override> extraOverrides = const [],
     List<EntryLink> extraTypedLinks = const [],
     List<Task> extraTypedTasks = const [],
+    Map<String, String> oneLinersByTaskId = const {},
     // Defaults to "the app has other tasks", the world every case below the
     // first-run ones lives in. False is the fresh-install state where the
     // card must not render at all.
@@ -190,6 +192,16 @@ void main() {
             manageMode
                 ? () => MockLinkedTasksControllerManageMode('task-main')
                 : LinkedTasksController.new,
+          ),
+          taskOneLinersProvider.overrideWith(
+            (ref, request) async {
+              final result = <String, String>{};
+              for (final taskId in request.taskIds) {
+                final oneLiner = oneLinersByTaskId[taskId];
+                if (oneLiner != null) result[taskId] = oneLiner;
+              }
+              return result;
+            },
           ),
           journalRepositoryProvider.overrideWithValue(journalRepo),
           ...extraOverrides,
@@ -279,6 +291,20 @@ void main() {
   });
 
   group('LinkedTasksWidget rendering', () {
+    testWidgets('passes one batched tagline result into the matching row', (
+      tester,
+    ) async {
+      await pumpWidget(
+        tester,
+        incoming: [],
+        outgoing: [buildTask(id: 'task-2', title: 'Linked task')],
+        oneLinersByTaskId: const {'task-2': 'Ready for final review'},
+      );
+
+      final row = tester.widget<LinkedTaskRow>(find.byType(LinkedTaskRow));
+      expect(row.data.oneLiner, 'Ready for final review');
+    });
+
     testWidgets(
       'the header sits nearer the content it labels than the card edge',
       (tester) async {

--- a/test/features/tasks/ui/linked_tasks/task_relationship_sections_test.dart
+++ b/test/features/tasks/ui/linked_tasks/task_relationship_sections_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/task_relationship_sections.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -58,6 +59,7 @@ void main() {
     WidgetTester tester,
     TaskLinkGroups groups, {
     bool manageMode = false,
+    Map<String, String> oneLinersByTaskId = const {},
   }) async {
     final journalRepo = MockJournalRepository();
     when(
@@ -87,6 +89,7 @@ void main() {
           child: TaskRelationshipSections(
             taskId: anchorTaskId,
             manageMode: manageMode,
+            oneLinersByTaskId: oneLinersByTaskId,
           ),
         ),
       ),
@@ -97,6 +100,29 @@ void main() {
   }
 
   group('TaskRelationshipSections', () {
+    testWidgets('passes the batched one-liner into its linked row', (
+      tester,
+    ) async {
+      await pumpSections(
+        tester,
+        TaskLinkGroups(
+          flat: const [],
+          typed: [
+            entry(
+              id: 'blocker',
+              title: 'Blocker Task',
+              kind: TaskLinkKind.blocks,
+              direction: TaskLinkDirection.incoming,
+            ),
+          ],
+        ),
+        oneLinersByTaskId: const {'blocker': 'Unblocks the launch review'},
+      );
+
+      final row = tester.widget<LinkedTaskRow>(find.byType(LinkedTaskRow));
+      expect(row.data.oneLiner, 'Unblocks the launch review');
+    });
+
     testWidgets('renders nothing when there are no typed relationships', (
       tester,
     ) async {

--- a/test/features/tasks/ui/widgets/task_browse_list_item_meta_test.dart
+++ b/test/features/tasks/ui/widgets/task_browse_list_item_meta_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
 import 'package:lotti/features/tasks/model/task_progress_state.dart';
 import 'package:lotti/features/tasks/state/task_live_data_provider.dart';
@@ -357,6 +358,11 @@ void main() {
 
       expect(find.text('Task With Summary'), findsOneWidget);
       expect(find.text('Implementing OAuth2 flow'), findsOneWidget);
+      final oneLiner = tester.widget<Text>(
+        find.text('Implementing OAuth2 flow'),
+      );
+      final context = tester.element(find.text('Implementing OAuth2 flow'));
+      expect(oneLiner.style?.color, context.designTokens.colors.aiCard.accent);
     });
 
     testWidgets('does not render one-liner when provider returns null', (

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -379,6 +379,26 @@ void main() {
         linkedTo: any(named: 'linkedTo'),
       ),
     ).thenAnswer((_) async => []);
+    when(
+      () => journalRepository.getTypedLinksForTaskIds(
+        {manualOrbitalHabitatTaskId},
+        linkTypes: any(named: 'linkTypes'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        EntryLink.basic(
+          id: 'link-habitat-feeder',
+          fromId: manualOrbitalHabitatTaskId,
+          toId: manualFishFeederTaskId,
+          createdAt: manualDemoNow.subtract(const Duration(days: 2)),
+          updatedAt: manualDemoNow.subtract(const Duration(days: 2)),
+          vectorClock: null,
+        ),
+      ],
+    );
+    when(
+      () => journalRepository.getJournalEntitiesByIds({manualFishFeederTaskId}),
+    ).thenAnswer((_) async => [world.fishFeederTask]);
 
     when(() => entitiesCache.sortedCategories).thenReturn([world.category]);
     when(() => entitiesCache.sortedLabels).thenReturn(world.labels);
@@ -604,6 +624,30 @@ void main() {
           find.text(
             _t('Pre-launch checks', 'Checks vor dem Start'),
           ),
+        );
+        _expectVisible(
+          tester,
+          device,
+          find
+              .text(
+                _t(
+                  'Pressure stable · 37 penguins accounted for',
+                  'Druck stabil · 37 Pinguine vollzählig',
+                ),
+              )
+              .last,
+        );
+        _expectVisible(
+          tester,
+          device,
+          find
+              .text(
+                _t(
+                  'Feeder calibration blocks the habitat demo',
+                  'Futterautomat-Kalibrierung blockiert die Habitat-Demo',
+                ),
+              )
+              .last,
         );
         await captureScreenshot(
           tester,

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -1127,6 +1127,24 @@ Future<void> _pumpTaskSurface(
   final taskAgentState = _manualTaskAgentState(
     automaticUpdates: automaticUpdates,
   );
+  String oneLinerFor(String taskId) => switch (taskId) {
+    final id when id == manualOrbitalHabitatTaskId => _t(
+      'Pressure stable · 37 penguins accounted for',
+      'Druck stabil · 37 Pinguine vollzählig',
+    ),
+    final id when id == manualFishFeederTaskId => _t(
+      'Feeder calibration blocks the habitat demo',
+      'Futterautomat-Kalibrierung blockiert die Habitat-Demo',
+    ),
+    final id when id == manualSardineCargoTaskId => _t(
+      'Europa cold-chain manifest ready to reconcile',
+      'Europa-Kühlkettenmanifest bereit zum Abgleich',
+    ),
+    _ => _t(
+      'Awaiting an answer from orbital transport counsel',
+      'Warte auf Antwort der orbitalen Transportrechtsberatung',
+    ),
+  };
 
   await withClock(Clock.fixed(manualDemoNow), () async {
     await primeManualDemoCoverArt(
@@ -1165,23 +1183,12 @@ Future<void> _pumpTaskSurface(
               (ref, taskId) async => tasksById[taskId],
             ),
             taskOneLinerProvider.overrideWith(
-              (ref, taskId) async => switch (taskId) {
-                final id when id == manualOrbitalHabitatTaskId => _t(
-                  'Pressure stable · 37 penguins accounted for',
-                  'Druck stabil · 37 Pinguine vollzählig',
-                ),
-                final id when id == manualFishFeederTaskId => _t(
-                  'Feeder calibration blocks the habitat demo',
-                  'Futterautomat-Kalibrierung blockiert die Habitat-Demo',
-                ),
-                final id when id == manualSardineCargoTaskId => _t(
-                  'Europa cold-chain manifest ready to reconcile',
-                  'Europa-Kühlkettenmanifest bereit zum Abgleich',
-                ),
-                _ => _t(
-                  'Awaiting an answer from orbital transport counsel',
-                  'Warte auf Antwort der orbitalen Transportrechtsberatung',
-                ),
+              (ref, taskId) async => oneLinerFor(taskId),
+            ),
+            taskOneLinersProvider.overrideWith(
+              (ref, request) async => {
+                for (final taskId in request.taskIds)
+                  taskId: oneLinerFor(taskId),
               },
             ),
             hasAvailableSkillsProvider((

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -1071,11 +1071,16 @@ void main() {
         final messages = AppLocalizations.of(
           tester.element(find.byType(TaskDetailsPage)),
         )!;
-        // The modal's title dropped the trailing ellipsis: the action label
-        // (linkExistingTask) stays on the trigger button underneath, while
-        // the sheet itself is titled linkExistingTaskTitle.
+        // Match the modal's route heading rather than every visible copy of
+        // the localized text. Some catalogs intentionally use the same copy
+        // for the underlying trigger and the sheet title.
         expect(
-          find.text(messages.linkExistingTaskTitle),
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.header == true &&
+                widget.properties.label == messages.linkExistingTaskTitle,
+          ),
           findsOneWidget,
         );
         expect(

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -637,18 +637,24 @@ void main() {
               )
               .last,
         );
-        _expectVisible(
-          tester,
-          device,
-          find
-              .text(
-                _t(
-                  'Feeder calibration blocks the habitat demo',
-                  'Futterautomat-Kalibrierung blockiert die Habitat-Demo',
-                ),
-              )
-              .last,
-        );
+        // The phone capture is intentionally anchored on the page header;
+        // its linked-task rows are below the viewport. The desktop capture
+        // scrolls the whole task form into view and therefore proves both AI
+        // subtitle surfaces in one frame.
+        if (!device.isPhone) {
+          _expectVisible(
+            tester,
+            device,
+            find
+                .text(
+                  _t(
+                    'Feeder calibration blocks the habitat demo',
+                    'Futterautomat-Kalibrierung blockiert die Habitat-Demo',
+                  ),
+                )
+                .last,
+          );
+        }
         await captureScreenshot(
           tester,
           'task_detail_${viewport}_$theme',


### PR DESCRIPTION
## Summary

- surface each task agent's one-line summary beneath linked-task titles
- use the existing `aiCard.accent` token for task-list, linked-task, and detail-header taglines
- keep summaries stable during provider reloads and ellipsize constrained rows
- bump the app to `1.0.6+4299` with matching CHANGELOG and Flatpak release metadata
- batch linked-task tagline reads, refresh open surfaces after synced reports, and keep narrow-row statuses visible
- extend the deterministic task screenshot fixture and focused widget coverage

## Why

Task taglines were already useful in task cards, but neutral ink made them indistinguishable from ordinary metadata. Linked-task rows and the detail header did not expose the same compact AI context at all. This makes the agent-authored opinion visually consistent with the existing AI summary card wherever tasks are scanned.

## Screenshots

### Task list column

| Before | After |
| --- | --- |
| ![Task list before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/ai-task-taglines/1eca00272aa27f3cb6bd31ff4414df8b3d86896a/before/task_workspace_desktop_dark.png) | ![Task list after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/ai-task-taglines/1eca00272aa27f3cb6bd31ff4414df8b3d86896a/after/task_workspace_desktop_dark.png) |

### Task detail header and linked tasks

| Before | After |
| --- | --- |
| ![Task detail before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/ai-task-taglines/1eca00272aa27f3cb6bd31ff4414df8b3d86896a/before/task_detail_desktop_dark.png) | ![Task detail after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/ai-task-taglines/1eca00272aa27f3cb6bd31ff4414df8b3d86896a/after/task_detail_desktop_dark.png) |

## Validation

- `fvm dart format .`
- focused tests for the five touched production/test areas: 163 tests passed
- screenshot harness captures for desktop task workspace and task detail
- targeted Flutter analysis over all touched Dart files: zero issues
- `make knowledge_check`: 93 concepts and 476 Mermaid diagrams passed
- regression assertions were rerun with the production fix reverted and failed as expected, then passed after restoration

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. Codecov's patch report is treated as the authoritative patch-coverage result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI-generated task summaries now appear across task lists, task details, and linked-task titles.
  - Task headers display summaries with AI-accent styling and single-line ellipsis handling.
  - Linked tasks show summaries alongside status information, adapting to available space.

- **Bug Fixes**
  - Improved summary visibility and layout across desktop, narrow, and linked-task views.

- **Documentation**
  - Updated feature documentation and release information for version 1.0.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->