### PR TITLE
fix: refresh AI task taglines reliably

### DIFF
--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -510,6 +510,13 @@ because `notify` also feeds `localUpdateStream`, which drives wake
 orchestration and would let a wake re-trigger itself. Without that call the
 whole feature is invisible.
 
+The final report has the same post-commit requirement. `WakeOutputWriter`
+calls `UpdateNotifications.notifyUiOnly` only after the encompassing
+transaction succeeds, with the agent id, active task id and shared agent topic.
+Task headers and linked-task tagline batches therefore refresh immediately
+after a local wake publishes a report, without feeding the local
+wake-orchestration stream or exposing a report that later rolls back.
+
 The `incremental` flag separates the two modes. A mid-wake flush is narrow on
 purpose; the end-of-wake build is the only one allowed to reshape existing
 sets:

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -125,6 +125,9 @@ a single ellipsized line directly between the title and metadata. Its ink is
 `taskOneLinersProvider` batch and passes the results into both plain and typed
 rows. The batch watches the shared agent-update topic, so a local or synced
 report refreshes the card without one query and stream subscription per row.
+When the linked-id set changes, the widget retains the last resolved taglines
+for ids that remain in the card while the new batch key loads; added rows can
+arrive without a subtitle, but established rows never flash back to empty.
 Each compact text column becomes title plus one-line AI subtitle while the
 status remains on the trailing rail at the detail reading width; narrow rows
 prefix the status before the ellipsized summary so it cannot disappear behind

--- a/lib/features/agents/workflow/wake_output_writer.dart
+++ b/lib/features/agents/workflow/wake_output_writer.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/agents/workflow/task_agent_strategy.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:uuid/uuid.dart';
 
 /// Report details captured inside the wake transaction and returned to the
@@ -31,12 +32,13 @@ typedef WakeReportToEmbed = ({
 /// wake-completed milestone).
 ///
 /// Extracted from the Task Agent workflow into a standalone, independently
-/// testable collaborator. It depends only on an [AgentSyncService] for all
-/// sync-aware writes and an [AgentRepository] for the single read it needs
-/// (the current report head). Everything else a wake produced — the strategy,
-/// report fields, observations, retraction/change-set collaborators, the
-/// proposal ledger, the agent state, and the run identity — is passed in as
-/// data to [persist].
+/// testable collaborator. It depends on an [AgentSyncService] for all
+/// sync-aware writes, an [AgentRepository] for the single report-head read,
+/// and the registered [UpdateNotifications] service for a post-commit UI
+/// refresh when one is available.
+/// Everything else a wake produced — the strategy, report fields,
+/// observations, retraction/change-set collaborators, the proposal ledger,
+/// the agent state, and the run identity — is passed in as data to [persist].
 class WakeOutputWriter {
   /// Creates a writer bound to the sync write service and agent repository.
   ///
@@ -282,6 +284,13 @@ class WakeOutputWriter {
         runKey: runKey,
       );
     });
+    if (reportToEmbed != null && getIt.isRegistered<UpdateNotifications>()) {
+      getIt<UpdateNotifications>().notifyUiOnly({
+        agentId,
+        taskId,
+        agentNotification,
+      });
+    }
     if (reportToEmbed != null && attributionEnvelope != null) {
       await getIt<AiAttributionService>().finalize(attributionEnvelope);
     }

--- a/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_tasks_widget.dart
@@ -51,12 +51,14 @@ class LinkedTasksWidget extends ConsumerStatefulWidget {
 
 class _LinkedTasksWidgetState extends ConsumerState<LinkedTasksWidget> {
   bool _expanded = true;
+  Map<String, String> _lastOneLinersByTaskId = const {};
 
   @override
   void didUpdateWidget(LinkedTasksWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.taskId != widget.taskId) {
       _expanded = true;
+      _lastOneLinersByTaskId = const {};
     }
   }
 
@@ -77,13 +79,17 @@ class _LinkedTasksWidgetState extends ConsumerState<LinkedTasksWidget> {
       ...linkGroups.flat.map((entry) => entry.task.meta.id),
       ...linkGroups.typed.map((entry) => entry.task.meta.id),
     ];
-    final oneLinersByTaskId =
-        ref
-            .watch(
-              taskOneLinersProvider(TaskOneLinerRequest(linkedTaskIds)),
-            )
-            .value ??
-        const {};
+    final oneLiners = ref.watch(
+      taskOneLinersProvider(TaskOneLinerRequest(linkedTaskIds)),
+    );
+    if (oneLiners.value case final latest?) {
+      _lastOneLinersByTaskId = latest;
+    }
+    final oneLinersByTaskId = <String, String>{};
+    for (final taskId in linkedTaskIds) {
+      final oneLiner = _lastOneLinersByTaskId[taskId];
+      if (oneLiner != null) oneLinersByTaskId[taskId] = oneLiner;
+    }
 
     // Nothing to link to, nothing to show. On a first-run install this card
     // was a bordered box teaching a relationship feature that could not be

--- a/test/features/agents/workflow/wake_output_writer_test.dart
+++ b/test/features/agents/workflow/wake_output_writer_test.dart
@@ -12,6 +12,8 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
 import 'package:lotti/features/sync/g_counter.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:uuid/uuid.dart';
 
@@ -327,6 +329,25 @@ void main() {
       expect(result.reportContent, '# Status\nAll good.');
       expect(result.taskId, _taskId);
       expect(result.previousReportId, 'report-previous');
+    });
+
+    test('notifies task tagline providers after the report commits', () async {
+      when(
+        () => repo.getReportHead(_agentId, AgentReportScopes.current),
+      ).thenAnswer((_) async => null);
+      final notifications = MockUpdateNotifications();
+      getIt.registerSingleton<UpdateNotifications>(notifications);
+      addTearDown(() => getIt.unregister<UpdateNotifications>());
+
+      await run(reportContent: 'fresh report');
+
+      verify(
+        () => notifications.notifyUiOnly({
+          _agentId,
+          _taskId,
+          agentNotification,
+        }),
+      ).called(1);
     });
 
     test('mints a fresh head id when there is no existing head', () async {

--- a/test/features/tasks/ui/linked_tasks/linked_tasks_widget_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_tasks_widget_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +17,7 @@ import 'package:lotti/features/design_system/components/lists/design_system_list
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/state/linkable_tasks_controller.dart';
 import 'package:lotti/features/tasks/state/linked_tasks_controller.dart';
+import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
 import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_tasks_widget.dart';
@@ -32,6 +35,17 @@ import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
 import '../../../../test_utils/screenshot_harness.dart';
 import '../../../../widget_test_utils.dart';
+
+class _ControllableTaskLinkGroupsController extends TaskLinkGroupsController {
+  _ControllableTaskLinkGroupsController(this._initial);
+
+  final TaskLinkGroups _initial;
+
+  @override
+  Future<TaskLinkGroups> build() async => _initial;
+
+  void push(TaskLinkGroups groups) => state = AsyncData(groups);
+}
 
 void main() {
   final now = DateTime(2025, 12, 31, 12);
@@ -303,6 +317,79 @@ void main() {
 
       final row = tester.widget<LinkedTaskRow>(find.byType(LinkedTaskRow));
       expect(row.data.oneLiner, 'Ready for final review');
+    });
+
+    testWidgets('retains existing taglines while a changed link set reloads', (
+      tester,
+    ) async {
+      final firstTask = buildTask(id: 'task-2', title: 'Existing link');
+      final addedTask = buildTask(id: 'task-3', title: 'New link');
+      TaskLinkEntry entry(Task task) => TaskLinkEntry(
+        linkId: 'link-${task.id}',
+        task: task,
+        kind: TaskLinkKind.basic,
+        direction: TaskLinkDirection.outgoing,
+      );
+      final initialGroups = TaskLinkGroups(
+        flat: [entry(firstTask)],
+        typed: const [],
+      );
+      final refreshedGroups = TaskLinkGroups(
+        flat: [entry(firstTask), entry(addedTask)],
+        typed: const [],
+      );
+      final refreshedOneLiners = Completer<Map<String, String>>();
+      late _ControllableTaskLinkGroupsController groupsController;
+      final journalRepo = MockJournalRepository();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            linkableTasksOverride('task-main', exists: true),
+            linkedTasksControllerProvider(
+              'task-main',
+            ).overrideWith(LinkedTasksController.new),
+            taskLinkGroupsControllerProvider('task-main').overrideWith(
+              () => groupsController = _ControllableTaskLinkGroupsController(
+                initialGroups,
+              ),
+            ),
+            taskOneLinersProvider.overrideWith((ref, request) async {
+              if (request.taskIds.contains(addedTask.id)) {
+                return refreshedOneLiners.future;
+              }
+              return {firstTask.id: 'Established summary'};
+            }),
+            journalRepositoryProvider.overrideWithValue(journalRepo),
+          ],
+          child: const WidgetTestBench(
+            child: LinkedTasksWidget(taskId: 'task-main'),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      LinkedTaskRow rowFor(String taskId) => tester
+          .widgetList<LinkedTaskRow>(find.byType(LinkedTaskRow))
+          .singleWhere((row) => row.data.task.id == taskId);
+      expect(rowFor(firstTask.id).data.oneLiner, 'Established summary');
+
+      groupsController.push(refreshedGroups);
+      await tester.pump();
+
+      expect(rowFor(firstTask.id).data.oneLiner, 'Established summary');
+      expect(rowFor(addedTask.id).data.oneLiner, isNull);
+
+      refreshedOneLiners.complete({
+        firstTask.id: 'Updated summary',
+        addedTask.id: 'New summary',
+      });
+      await tester.pump();
+      await tester.pump();
+
+      expect(rowFor(firstTask.id).data.oneLiner, 'Updated summary');
+      expect(rowFor(addedTask.id).data.oneLiner, 'New summary');
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary
- notify task and agent UI listeners only after a locally generated AI report commits
- preserve established linked-task taglines while a changed task-id batch reloads
- document both refresh guarantees and add focused regression coverage

Follow-up to #3866, addressing the two late review findings that arrived after merge.

## Validation
- fvm flutter analyze on all changed Dart files
- targeted tests: wake_output_writer_test.dart and linked_tasks_widget_test.dart (47 passing)
- both new regression tests verified to fail with their respective production fix reverted
- focused LCOV confirms every new executable line is covered
- make knowledge_check
- git diff --check

## Screenshots
No visual output changed relative to #3866; this follow-up only fixes refresh behavior. The before/after screenshots attached to #3866 remain representative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task and linked-task views now refresh automatically after a report is successfully saved.
* **Bug Fixes**
  * Existing linked-task descriptions remain visible while refreshed data is loading.
  * Newly linked tasks display updated descriptions once loading completes.
* **Tests**
  * Added coverage for post-save UI refreshes and preserving linked-task descriptions during reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->