### PR TITLE
feat(goals): the revision flow — approving a proposal mints the spec (PR 4)

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -150,9 +150,22 @@ flowchart TD
   don't count — the P14 swap stays legal), and for duplicate brief
   digests. Report prose passes `sanitizeAgentReportText`.
 - **The goal spec never mutates in a wake.** `propose_goal_revision`
-  lands as a pending ChangeSet for user approval (PR 4's flow mints the
-  version); ad state is validated in-conversation against the ids the
-  FACTS offered, and all outputs commit in one transaction.
+  lands as a pending ChangeSet for user approval; ad state is validated
+  in-conversation against the ids the FACTS offered, and all outputs
+  commit in one transaction.
+- **Revision is approval-gated and conservative.** Accepting the proposal
+  (`goalChangeSetConfirmationServiceProvider` → `GoalToolDispatcher` →
+  `GoalSpecRevisionService`) applies the changes to the criteria tree via
+  `applyGoalRevisionChanges` — which REJECTS anything ambiguous (two
+  candidate leaves and no name, unparseable period/cadence, free-form
+  `successCriteria` alone) rather than guessing — then supersedes the
+  current version, mints `v(n+1)` with full provenance (`authoredBy:
+  goal_agent`, `diffFromVersionId`, the proposal's rationale) and moves
+  the head in one transaction. Grace history resets naturally: Phase A's
+  prior-row streak breaks at the version change. After acceptance the
+  signal subscription re-registers from the NEW criteria; on other
+  devices the synced-in head triggers the same re-registration through
+  the sync processor's identity re-offer.
 - **Nudge accumulators are CRDTs.** Dismissal is terminal in the
   concurrent resolver, and exposure counters (per-host G-counters),
   rating histories and shown-at watermarks merge losslessly on concurrent

--- a/lib/features/agents/state/change_set_providers.dart
+++ b/lib/features/agents/state/change_set_providers.dart
@@ -111,6 +111,18 @@ eventPendingChangeSetsProvider = FutureProvider.autoDispose
       return deduplicateChangeSets(sets);
     });
 
+/// Pending change sets an agent targets at ITSELF (`taskId == agentId`) —
+/// the shape self-owned agents (goal agents today) use for proposals like
+/// spec revisions, where the agent is the subject being changed.
+final FutureProviderFamily<List<AgentDomainEntity>, String>
+selfTargetedPendingChangeSetsProvider = FutureProvider.autoDispose
+    .family<List<AgentDomainEntity>, String>((ref, agentId) async {
+      ref.watch(agentUpdateStreamProvider(agentId));
+      final repo = ref.watch(agentRepositoryProvider);
+      final sets = await repo.getPendingChangeSets(agentId, taskId: agentId);
+      return deduplicateChangeSets(sets);
+    });
+
 /// Event-scoped confirmation service. Confirmed event-agent proposals
 /// (currently just `suggest_follow_up_task`) are applied via
 /// [EventToolDispatcher]; rejection only records the decision.

--- a/lib/features/goals/service/goal_revision_apply.dart
+++ b/lib/features/goals/service/goal_revision_apply.dart
@@ -65,9 +65,11 @@ GoalRevisionResult applyGoalRevisionChanges({
       );
     }
     if (targetValue != null) {
-      if (targetValue is! num || !targetValue.isFinite || targetValue <= 0) {
+      // Zero is legal (an atMost-0 goal); only negative and non-finite
+      // values are outside the creation-time domain.
+      if (targetValue is! num || !targetValue.isFinite || targetValue < 0) {
         return GoalRevisionRejected(
-          'targetValue must be a positive number, got "$targetValue"',
+          'targetValue must be a non-negative number, got "$targetValue"',
         );
       }
       final before = _leafTarget(leaf);
@@ -135,6 +137,14 @@ GoalRevisionResult applyGoalRevisionChanges({
       '(free-form successCriteria alone cannot rewrite the criteria)',
     );
   }
+  if (revised == criteria) {
+    // A stale proposal restating the current values must not supersede
+    // the spec: an equivalent v(n+1) would still reset the same-version
+    // grace history for no actual change.
+    return const GoalRevisionRejected(
+      'the proposal restates the current criteria — nothing would change',
+    );
+  }
   return GoalRevisionApplied(criteria: revised, changeSummaries: summaries);
 }
 
@@ -147,8 +157,12 @@ GoalWindow? parseGoalWindowPhrase(String phrase) {
   }
   final rolling = RegExp(r'rolling\s+(\d+)\s+days?').firstMatch(normalized);
   if (rolling != null) {
-    final count = int.parse(rolling.group(1)!);
-    return count > 0 ? GoalWindow.rollingDays(count: count) : null;
+    // tryParse: model-authored digits can overflow a 64-bit int, and this
+    // parser's contract is null for unusable input, never a throw.
+    final count = int.tryParse(rolling.group(1)!);
+    return count != null && count > 0
+        ? GoalWindow.rollingDays(count: count)
+        : null;
   }
   if (normalized.contains('calendar week') ||
       normalized == 'week' ||
@@ -167,10 +181,14 @@ int? _parseCadenceCount(Object? cadence) {
   if (cadence is num) {
     return cadence % 1 == 0 && cadence > 0 ? cadence.toInt() : null;
   }
-  final match = RegExp(r'^\s*(\d+)\s*(x|times)?').firstMatch('$cadence');
+  // Anchored end to end: '3.5' or '3 bananas' must reject, not silently
+  // truncate to 3 — this runs on the approval-time mutation path.
+  final match = RegExp(
+    r'^\s*(\d+)\s*(x|times(\s+per\s+\w+)?)?\s*$',
+  ).firstMatch('$cadence');
   if (match == null) return null;
-  final count = int.parse(match.group(1)!);
-  return count > 0 ? count : null;
+  final count = int.tryParse(match.group(1)!);
+  return count != null && count > 0 ? count : null;
 }
 
 /// The single metric/measurable leaf a quantitative change binds to, or

--- a/lib/features/goals/service/goal_revision_apply.dart
+++ b/lib/features/goals/service/goal_revision_apply.dart
@@ -1,0 +1,258 @@
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_window.dart';
+
+/// The result of applying a `propose_goal_revision` changes payload to a
+/// criteria tree: either a revised tree plus a human summary of what
+/// changed, or a rejection reason the approval surface can show.
+sealed class GoalRevisionResult {
+  const GoalRevisionResult();
+}
+
+class GoalRevisionApplied extends GoalRevisionResult {
+  const GoalRevisionApplied({
+    required this.criteria,
+    required this.changeSummaries,
+  });
+
+  final GoalCriterion criteria;
+
+  /// One line per applied field, e.g. `target: 10000 → 8000`.
+  final List<String> changeSummaries;
+}
+
+class GoalRevisionRejected extends GoalRevisionResult {
+  const GoalRevisionRejected(this.reason);
+
+  final String reason;
+}
+
+/// Applies the model-proposed `changes` map (the `propose_goal_revision`
+/// tool contract: `metric`, `targetValue`, `period`, `cadence`,
+/// `successCriteria`) to [criteria].
+///
+/// Deliberately conservative — this is the ONLY path that ever rewrites a
+/// goal's criteria, and it runs on user approval, so anything ambiguous is
+/// rejected with a reason instead of guessed at:
+///
+/// - `targetValue` / `period` bind to exactly one metric-or-measurable
+///   leaf: the only such leaf, or the one whose `criterionId` or dataType
+///   matches `metric`. Two candidates and no disambiguator → rejected.
+/// - `cadence` binds to exactly one habit leaf and must parse to a
+///   positive whole count (`3`, `"3"`, `"3x"`, `"3 times per week"`).
+/// - `period` accepts the FACTS vocabulary: `day`, `rolling N days`,
+///   `calendar week`, `calendar month` (case-insensitive, tolerant of
+///   surrounding words like "window").
+/// - `successCriteria` alone never rewrites the tree — free-form intent
+///   belongs in a conversation, not a silent structural guess; it is
+///   rejected unless another applicable field carries the change.
+GoalRevisionResult applyGoalRevisionChanges({
+  required GoalCriterion criteria,
+  required Map<String, dynamic> changes,
+}) {
+  final summaries = <String>[];
+  var revised = criteria;
+
+  final targetValue = changes['targetValue'];
+  final period = changes['period'];
+  final cadence = changes['cadence'];
+
+  if (targetValue != null || period != null) {
+    final leaf = _resolveQuantitativeLeaf(revised, changes['metric']);
+    if (leaf == null) {
+      return const GoalRevisionRejected(
+        'the proposal does not identify a single measurable criterion — '
+        'ask the agent (or the user) to name the criterion to change',
+      );
+    }
+    if (targetValue != null) {
+      if (targetValue is! num || !targetValue.isFinite || targetValue <= 0) {
+        return GoalRevisionRejected(
+          'targetValue must be a positive number, got "$targetValue"',
+        );
+      }
+      final before = _leafTarget(leaf);
+      revised = _mapLeaf(
+        revised,
+        leaf.criterionId,
+        (c) => switch (c) {
+          GoalCriterionMetric() => c.copyWith(target: targetValue),
+          GoalCriterionMeasurable() => c.copyWith(target: targetValue),
+          _ => c,
+        },
+      );
+      summaries.add('target: $before → $targetValue');
+    }
+    if (period != null) {
+      final window = parseGoalWindowPhrase('$period');
+      if (window == null) {
+        return GoalRevisionRejected(
+          'unrecognized period "$period" — expected day, rolling N days, '
+          'calendar week or calendar month',
+        );
+      }
+      revised = _mapLeaf(
+        revised,
+        leaf.criterionId,
+        (c) => switch (c) {
+          GoalCriterionMetric() => c.copyWith(window: window),
+          GoalCriterionMeasurable() => c.copyWith(window: window),
+          _ => c,
+        },
+      );
+      summaries.add('window: $period');
+    }
+  }
+
+  if (cadence != null) {
+    final habits = _habitLeaves(revised);
+    if (habits.length != 1) {
+      return GoalRevisionRejected(
+        habits.isEmpty
+            ? 'the goal has no habit criterion for a cadence change'
+            : 'the goal has ${habits.length} habit criteria — the proposal '
+                  'must identify which one',
+      );
+    }
+    final count = _parseCadenceCount(cadence);
+    if (count == null) {
+      return GoalRevisionRejected(
+        'unrecognized cadence "$cadence" — expected a positive count like '
+        '"3" or "3 times per week"',
+      );
+    }
+    final before = habits.single.targetCount;
+    revised = _mapLeaf(
+      revised,
+      habits.single.criterionId,
+      (c) => c is GoalCriterionHabit ? c.copyWith(targetCount: count) : c,
+    );
+    summaries.add('cadence: $before → $count per window');
+  }
+
+  if (summaries.isEmpty) {
+    return const GoalRevisionRejected(
+      'the proposal carries no applicable structural change '
+      '(free-form successCriteria alone cannot rewrite the criteria)',
+    );
+  }
+  return GoalRevisionApplied(criteria: revised, changeSummaries: summaries);
+}
+
+/// Parses the FACTS window vocabulary into a [GoalWindow].
+GoalWindow? parseGoalWindowPhrase(String phrase) {
+  final normalized = phrase.toLowerCase().trim();
+  if (RegExp(r'^(per\s+)?day(\b|$)').hasMatch(normalized) ||
+      normalized == 'daily') {
+    return const GoalWindow.day();
+  }
+  final rolling = RegExp(r'rolling\s+(\d+)\s+days?').firstMatch(normalized);
+  if (rolling != null) {
+    final count = int.parse(rolling.group(1)!);
+    return count > 0 ? GoalWindow.rollingDays(count: count) : null;
+  }
+  if (normalized.contains('calendar week') ||
+      normalized == 'week' ||
+      normalized == 'weekly') {
+    return const GoalWindow.calendarWeek();
+  }
+  if (normalized.contains('calendar month') ||
+      normalized == 'month' ||
+      normalized == 'monthly') {
+    return const GoalWindow.calendarMonth();
+  }
+  return null;
+}
+
+int? _parseCadenceCount(Object? cadence) {
+  if (cadence is num) {
+    return cadence % 1 == 0 && cadence > 0 ? cadence.toInt() : null;
+  }
+  final match = RegExp(r'^\s*(\d+)\s*(x|times)?').firstMatch('$cadence');
+  if (match == null) return null;
+  final count = int.parse(match.group(1)!);
+  return count > 0 ? count : null;
+}
+
+/// The single metric/measurable leaf a quantitative change binds to, or
+/// null when the binding is ambiguous.
+GoalCriterion? _resolveQuantitativeLeaf(GoalCriterion root, Object? metric) {
+  final leaves = <GoalCriterion>[];
+  void visit(GoalCriterion c) {
+    switch (c) {
+      case GoalCriterionMetric() || GoalCriterionMeasurable():
+        leaves.add(c);
+      case GoalCriterionAllOf(:final criteria) ||
+          GoalCriterionAnyOf(:final criteria) ||
+          GoalCriterionAtLeastCount(:final criteria):
+        criteria.forEach(visit);
+      case GoalCriterionHabit():
+        break;
+    }
+  }
+
+  visit(root);
+  if (leaves.length == 1) return leaves.single;
+  if (metric is! String || metric.isEmpty) return null;
+  final needle = metric.toLowerCase();
+  final matches = leaves
+      .where(
+        (leaf) =>
+            leaf.criterionId.toLowerCase() == needle ||
+            switch (leaf) {
+              GoalCriterionMetric(:final dataType) =>
+                dataType.toLowerCase() == needle,
+              GoalCriterionMeasurable(:final dataTypeId) =>
+                dataTypeId.toLowerCase() == needle,
+              _ => false,
+            },
+      )
+      .toList();
+  return matches.length == 1 ? matches.single : null;
+}
+
+num _leafTarget(GoalCriterion leaf) => switch (leaf) {
+  GoalCriterionMetric(:final target) => target,
+  GoalCriterionMeasurable(:final target) => target,
+  _ => 0,
+};
+
+List<GoalCriterionHabit> _habitLeaves(GoalCriterion root) {
+  final leaves = <GoalCriterionHabit>[];
+  void visit(GoalCriterion c) {
+    switch (c) {
+      case GoalCriterionHabit():
+        leaves.add(c);
+      case GoalCriterionAllOf(:final criteria) ||
+          GoalCriterionAnyOf(:final criteria) ||
+          GoalCriterionAtLeastCount(:final criteria):
+        criteria.forEach(visit);
+      case GoalCriterionMetric() || GoalCriterionMeasurable():
+        break;
+    }
+  }
+
+  visit(root);
+  return leaves;
+}
+
+/// Rebuilds the tree with [transform] applied to the node whose
+/// criterionId is [criterionId]; composites are rebuilt structurally.
+GoalCriterion _mapLeaf(
+  GoalCriterion node,
+  String criterionId,
+  GoalCriterion Function(GoalCriterion) transform,
+) {
+  if (node.criterionId == criterionId) return transform(node);
+  return switch (node) {
+    GoalCriterionAllOf(:final criteria) => node.copyWith(
+      criteria: [for (final c in criteria) _mapLeaf(c, criterionId, transform)],
+    ),
+    GoalCriterionAnyOf(:final criteria) => node.copyWith(
+      criteria: [for (final c in criteria) _mapLeaf(c, criterionId, transform)],
+    ),
+    GoalCriterionAtLeastCount(:final criteria) => node.copyWith(
+      criteria: [for (final c in criteria) _mapLeaf(c, criterionId, transform)],
+    ),
+    _ => node,
+  };
+}

--- a/lib/features/goals/service/goal_spec_revision_service.dart
+++ b/lib/features/goals/service/goal_spec_revision_service.dart
@@ -54,6 +54,51 @@ class GoalSpecRevisionService {
     required String rationale,
     String? sourceThreadId,
   }) async {
+    final now = clock.now();
+    // Everything — reads included — runs inside the serialized
+    // transaction: two near-simultaneous acceptances reading the head
+    // BEFORE their transactions would both allocate spec-v(n+1) and the
+    // later commit would silently swallow the earlier user-approved
+    // revision.
+    try {
+      return await _syncService.runInTransaction(
+        () => _reviseInTransaction(
+          agentId: agentId,
+          changes: changes,
+          rationale: rationale,
+          sourceThreadId: sourceThreadId,
+          now: now,
+        ),
+      );
+    } catch (error) {
+      // The transaction's database writes can be durable even when a
+      // deferred post-commit step (the sync outbox flush) rethrows. If
+      // the head already moved to the version this call was minting, the
+      // revision IS committed — reporting failure would let a retry mint
+      // a second version on top of it.
+      final head = await _repository.getEntity(goalSpecHeadId(agentId));
+      if (head is GoalSpecHeadEntity) {
+        final version = await _repository.getEntity(head.versionId);
+        if (version is GoalSpecVersionEntity &&
+            version.authoredBy == AgentKinds.goalAgent &&
+            version.createdAt == now) {
+          return GoalSpecRevisionMinted(
+            version: version,
+            changeSummaries: const ['(committed before a sync error)'],
+          );
+        }
+      }
+      rethrow;
+    }
+  }
+
+  Future<GoalSpecRevisionOutcome> _reviseInTransaction({
+    required String agentId,
+    required Map<String, dynamic> changes,
+    required String rationale,
+    required String? sourceThreadId,
+    required DateTime now,
+  }) async {
     final head = await _repository.getEntity(goalSpecHeadId(agentId));
     if (head is! GoalSpecHeadEntity) {
       return const GoalSpecRevisionRefused(
@@ -82,9 +127,17 @@ class GoalSpecRevisionService {
       );
     }
 
-    final now = clock.now();
     final nextVersion = current.version + 1;
     final versionId = '$agentId:spec-v$nextVersion';
+    final existing = await _repository.getEntity(versionId);
+    if (existing != null) {
+      // The successor id already exists: another acceptance won the race
+      // within this id space. Refuse rather than overwrite provenance.
+      return GoalSpecRevisionRefused(
+        'a concurrent revision already minted $versionId — re-approve '
+        'against the new head if the change is still wanted',
+      );
+    }
     final minted =
         AgentDomainEntity.goalSpecVersion(
               id: versionId,
@@ -105,15 +158,13 @@ class GoalSpecRevisionService {
             )
             as GoalSpecVersionEntity;
 
-    await _syncService.runInTransaction(() async {
-      await _syncService.upsertEntity(
-        current.copyWith(status: GoalSpecVersionStatus.superseded),
-      );
-      await _syncService.upsertEntity(minted);
-      await _syncService.upsertEntity(
-        head.copyWith(versionId: versionId, updatedAt: now),
-      );
-    });
+    await _syncService.upsertEntity(
+      current.copyWith(status: GoalSpecVersionStatus.superseded),
+    );
+    await _syncService.upsertEntity(minted);
+    await _syncService.upsertEntity(
+      head.copyWith(versionId: versionId, updatedAt: now),
+    );
 
     return GoalSpecRevisionMinted(
       version: minted,

--- a/lib/features/goals/service/goal_spec_revision_service.dart
+++ b/lib/features/goals/service/goal_spec_revision_service.dart
@@ -1,0 +1,123 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_spec_validator.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/goals/service/goal_revision_apply.dart';
+
+/// The outcome of a user-approved goal revision.
+sealed class GoalSpecRevisionOutcome {
+  const GoalSpecRevisionOutcome();
+}
+
+class GoalSpecRevisionMinted extends GoalSpecRevisionOutcome {
+  const GoalSpecRevisionMinted({
+    required this.version,
+    required this.changeSummaries,
+  });
+
+  /// The freshly minted ACTIVE spec version.
+  final GoalSpecVersionEntity version;
+  final List<String> changeSummaries;
+}
+
+class GoalSpecRevisionRefused extends GoalSpecRevisionOutcome {
+  const GoalSpecRevisionRefused(this.reason);
+
+  final String reason;
+}
+
+/// Mints a new goal spec version from an APPROVED `propose_goal_revision`
+/// ChangeSet item and moves the head — the ONLY path that ever changes a
+/// goal after creation (ADR 0053: the coach never quietly moves its own
+/// goalposts; the user's approval is what runs this).
+///
+/// The soul-version-ops pattern: everything in one transaction — supersede
+/// the current version, mint `version + 1` with full provenance
+/// (`authoredBy: goal_agent`, `diffFromVersionId`, the proposal's
+/// rationale), move the deterministic head. Grace history resets
+/// naturally: Phase A's prior-row collection breaks at the version change.
+class GoalSpecRevisionService {
+  GoalSpecRevisionService({
+    required this._repository,
+    required this._syncService,
+  });
+
+  final AgentRepository _repository;
+  final AgentSyncService _syncService;
+
+  Future<GoalSpecRevisionOutcome> reviseFromProposal({
+    required String agentId,
+    required Map<String, dynamic> changes,
+    required String rationale,
+    String? sourceThreadId,
+  }) async {
+    final head = await _repository.getEntity(goalSpecHeadId(agentId));
+    if (head is! GoalSpecHeadEntity) {
+      return const GoalSpecRevisionRefused(
+        'the goal no longer exists (no spec head)',
+      );
+    }
+    final current = await _repository.getEntity(head.versionId);
+    if (current is! GoalSpecVersionEntity) {
+      return GoalSpecRevisionRefused(
+        'spec head ${head.versionId} points at nothing',
+      );
+    }
+
+    final applied = applyGoalRevisionChanges(
+      criteria: current.criteria,
+      changes: changes,
+    );
+    if (applied is GoalRevisionRejected) {
+      return GoalSpecRevisionRefused(applied.reason);
+    }
+    final revised = (applied as GoalRevisionApplied).criteria;
+    final issues = GoalSpecValidator.criterionIssues(revised);
+    if (issues.isNotEmpty) {
+      return GoalSpecRevisionRefused(
+        'the revised criteria fail validation: ${issues.join('; ')}',
+      );
+    }
+
+    final now = clock.now();
+    final nextVersion = current.version + 1;
+    final versionId = '$agentId:spec-v$nextVersion';
+    final minted =
+        AgentDomainEntity.goalSpecVersion(
+              id: versionId,
+              agentId: agentId,
+              version: nextVersion,
+              status: GoalSpecVersionStatus.active,
+              authoredBy: AgentKinds.goalAgent,
+              title: current.title,
+              statement: current.statement,
+              criteria: revised,
+              createdAt: now,
+              vectorClock: null,
+              sourceSessionId: sourceThreadId,
+              diffFromVersionId: current.id,
+              startDate: current.startDate,
+              targetDate: current.targetDate,
+              rationale: rationale,
+            )
+            as GoalSpecVersionEntity;
+
+    await _syncService.runInTransaction(() async {
+      await _syncService.upsertEntity(
+        current.copyWith(status: GoalSpecVersionStatus.superseded),
+      );
+      await _syncService.upsertEntity(minted);
+      await _syncService.upsertEntity(
+        head.copyWith(versionId: versionId, updatedAt: now),
+      );
+    });
+
+    return GoalSpecRevisionMinted(
+      version: minted,
+      changeSummaries: applied.changeSummaries,
+    );
+  }
+}

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
@@ -10,8 +12,12 @@ import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
+import 'package:lotti/features/goals/service/goal_spec_revision_service.dart';
 import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
+import 'package:lotti/features/goals/workflow/goal_tool_dispatcher.dart';
+import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
 
 /// Goal-agent runtime wiring (the Daily OS plug-in pattern: providers live
@@ -130,3 +136,49 @@ final goalSignalSyncListenerProvider = Provider<GoalSignalSyncListener>(
   },
   name: 'goalSignalSyncListenerProvider',
 );
+
+/// Revision minting for accepted `propose_goal_revision` proposals.
+final goalSpecRevisionServiceProvider = Provider<GoalSpecRevisionService>(
+  (ref) => GoalSpecRevisionService(
+    repository: ref.watch(agentRepositoryProvider),
+    syncService: ref.watch(agentSyncServiceProvider),
+  ),
+  name: 'goalSpecRevisionServiceProvider',
+);
+
+/// Goal-scoped confirmation service: accepting a revision proposal mints
+/// the new spec version and moves the head via [GoalToolDispatcher];
+/// rejection only records the decision. After a confirmed revision the
+/// runtime re-registers the goal's signal subscriptions — the criteria
+/// may now reference different signals.
+final goalChangeSetConfirmationServiceProvider =
+    Provider<ChangeSetConfirmationService>(
+      (ref) => ChangeSetConfirmationService(
+        syncService: ref.watch(agentSyncServiceProvider),
+        toolDispatcher: GoalToolDispatcher(
+          revisionService: ref.watch(goalSpecRevisionServiceProvider),
+        ).dispatch,
+        labelsRepository: ref.watch(labelsRepositoryProvider),
+        domainLogger: ref.watch(domainLoggerProvider),
+        onConfirmedDecision:
+            ({required changeSet, required item, required decision}) async {
+              if (item.toolName != GoalAgentToolNames.proposeGoalRevision) {
+                return;
+              }
+              final repository = ref.read(agentRepositoryProvider);
+              final head = await repository.getEntity(
+                goalSpecHeadId(changeSet.agentId),
+              );
+              if (head is! GoalSpecHeadEntity) return;
+              final version = await repository.getEntity(head.versionId);
+              if (version is! GoalSpecVersionEntity) return;
+              ref
+                  .read(goalAgentServiceProvider)
+                  .registerSignalSubscription(
+                    changeSet.agentId,
+                    version.criteria,
+                  );
+            },
+      ),
+      name: 'goalChangeSetConfirmationServiceProvider',
+    );

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
 import 'package:lotti/features/goals/workflow/goal_tool_dispatcher.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/services/domain_logging.dart';
 
 /// Goal-agent runtime wiring (the Daily OS plug-in pattern: providers live
 /// in the owning feature; `features/agents` never imports goals).
@@ -169,9 +170,27 @@ final goalChangeSetConfirmationServiceProvider =
               final head = await repository.getEntity(
                 goalSpecHeadId(changeSet.agentId),
               );
-              if (head is! GoalSpecHeadEntity) return;
-              final version = await repository.getEntity(head.versionId);
-              if (version is! GoalSpecVersionEntity) return;
+              final version = head is GoalSpecHeadEntity
+                  ? await repository.getEntity(head.versionId)
+                  : null;
+              if (version is! GoalSpecVersionEntity) {
+                // A confirmed revision whose head/version cannot be read
+                // back leaves the runtime subscribed to the OLD criteria
+                // until restart — visible, not silent.
+                ref
+                    .read(domainLoggerProvider)
+                    .error(
+                      LogDomain.agentRuntime,
+                      StateError(
+                        'goal spec unreadable after confirmed revision',
+                      ),
+                      subDomain: 'goalRevision',
+                      message:
+                          'signal re-registration skipped for '
+                          '${changeSet.agentId}',
+                    );
+                return;
+              }
               ref
                   .read(goalAgentServiceProvider)
                   .registerSignalSubscription(

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -172,6 +172,11 @@ class GoalAgentWorkflow with AgentErrorLogging {
 
     final resolved = await _resolveModel(agentIdentity);
     if (resolved == null) {
+      // The escalation record is already consumed and Phase A will not
+      // re-arm this transition — a temporarily unconfigured provider must
+      // not orphan the period. The retry costs €0 until resolution works
+      // (this guard aborts before any inference).
+      await _rearmEscalation(agentId, derivation.periodKey, triggerTokens, now);
       return const WakeResult(
         success: false,
         error: 'no inference provider resolves for the goal agent',
@@ -229,6 +234,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
       geminiThinkingMode: resolved.geminiThinkingMode,
     );
     final recordConsumption = canRecordAgentConsumption;
+    var outputsCommitted = false;
 
     try {
       var usage = await _conversationRepository.sendMessage(
@@ -269,9 +275,8 @@ class GoalAgentWorkflow with AgentErrorLogging {
       // Policy row P5 is deterministic: offTrack + no fresh active ad +
       // no cooldown REQUIRES an ad, and no later wake will re-arm this
       // escalation (the status already persisted). One pinned retry.
-      if (_adRequired(facts, nudges, strategy, now) &&
-          strategy.createdAds.isEmpty &&
-          strategy.rerunRequests.isEmpty) {
+      if (_adRequired(facts, derivation.priors, nudges, strategy, now) &&
+          !_hasViableAdAction(strategy, nudges)) {
         final retryUsage = await _forceAd(
           conversationId: conversationId,
           resolved: resolved,
@@ -305,6 +310,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
         derivation: derivation,
         now: now,
       );
+      outputsCommitted = true;
       if (!attributionFinalized && recordConsumption) {
         // No report → no output carrier: close the wake's attribution
         // session explicitly or it looks perpetually in-flight in the
@@ -317,22 +323,32 @@ class GoalAgentWorkflow with AgentErrorLogging {
         );
       }
 
+      // Bookkeeping, contained: a failed usage row must not fail (or
+      // re-run!) a wake whose outputs already committed.
       if (usage != null && usage.hasData) {
-        await _syncService.upsertEntity(
-          AgentDomainEntity.wakeTokenUsage(
-            id: _uuid.v4(),
-            agentId: agentId,
-            runKey: runKey,
-            threadId: threadId,
-            modelId: resolved.modelId,
-            createdAt: now,
-            vectorClock: null,
-            inputTokens: usage.inputTokens,
-            outputTokens: usage.outputTokens,
-            thoughtsTokens: usage.thoughtsTokens,
-            cachedInputTokens: usage.cachedInputTokens,
-          ),
-        );
+        try {
+          await _syncService.upsertEntity(
+            AgentDomainEntity.wakeTokenUsage(
+              id: _uuid.v4(),
+              agentId: agentId,
+              runKey: runKey,
+              threadId: threadId,
+              modelId: resolved.modelId,
+              createdAt: now,
+              vectorClock: null,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              thoughtsTokens: usage.thoughtsTokens,
+              cachedInputTokens: usage.cachedInputTokens,
+            ),
+          );
+        } catch (error, stackTrace) {
+          logError(
+            'failed to persist wake token usage',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
       }
 
       return const WakeResult(success: true);
@@ -355,47 +371,79 @@ class GoalAgentWorkflow with AgentErrorLogging {
       }
       // The escalation record was consumed before this workflow ran, and
       // Phase A will not re-arm it (the transitioned status is already
-      // persisted) — a transient failure must not orphan the period.
-      // The re-arm carries a LATER deadline, which is the resolver's
-      // supported reschedule-beats-consume path; outputs are idempotent
-      // (deterministic report head, digest-deduped ads).
-      try {
-        await _syncService.upsertEntity(
-          AgentDomainEntity.scheduledWake(
-            id: scheduledWakeRecordId(
-              agentId,
-              workspaceKey: goalEscalationWorkspaceKey(derivation.periodKey),
-            ),
-            agentId: agentId,
-            scheduledAt: now.toUtc(),
-            status: ScheduledWakeStatus.pending,
-            reason: WakeReason.scheduled.name,
-            updatedAt: now,
-            vectorClock: null,
-            workspaceKey: goalEscalationWorkspaceKey(derivation.periodKey),
-            triggerTokens: [for (final token in triggerTokens) token],
-          ),
-        );
-      } catch (rearmError, rearmStack) {
-        logError(
-          'failed to re-arm escalation after wake failure',
-          error: rearmError,
-          stackTrace: rearmStack,
+      // persisted) — a transient failure must not orphan the period. But
+      // ONLY when the outputs never committed: a post-commit bookkeeping
+      // failure re-armed would re-bill the wake and duplicate its
+      // UUID-keyed outputs.
+      if (!outputsCommitted) {
+        await _rearmEscalation(
+          agentId,
+          derivation.periodKey,
+          triggerTokens,
+          now,
         );
       }
       return WakeResult(success: false, error: error.toString());
     }
   }
 
-  /// Policy row P5's deterministic precondition: offTrack, no fresh
-  /// active ad surviving this wake's retires, and no dismissal cooldown.
+  /// Re-arms the period's escalation with a LATER deadline — the
+  /// resolver's supported reschedule-beats-consume path. Contained: a
+  /// failed re-arm is logged, never masks the original failure.
+  Future<void> _rearmEscalation(
+    String agentId,
+    String periodKey,
+    Set<String> triggerTokens,
+    DateTime now,
+  ) async {
+    try {
+      await _syncService.upsertEntity(
+        AgentDomainEntity.scheduledWake(
+          id: scheduledWakeRecordId(
+            agentId,
+            workspaceKey: goalEscalationWorkspaceKey(periodKey),
+          ),
+          agentId: agentId,
+          scheduledAt: now.toUtc(),
+          status: ScheduledWakeStatus.pending,
+          reason: WakeReason.scheduled.name,
+          updatedAt: now,
+          vectorClock: null,
+          workspaceKey: goalEscalationWorkspaceKey(periodKey),
+          triggerTokens: [for (final token in triggerTokens) token],
+        ),
+      );
+    } catch (error, stackTrace) {
+      logError(
+        'failed to re-arm escalation after wake failure',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  /// Whether the deterministic facts permit ad activity at all: offTrack
+  /// always; atRisk only on a worsening trend (policy rows P4/P5). Every
+  /// other status forbids ads — succeeding, recovering or data-gapped
+  /// users are never chided.
+  bool _adsEligible(GoalWakeFacts facts, List<GoalProgressEntity> priors) =>
+      facts.trackStatus == GoalTrackStatus.offTrack ||
+      (facts.trackStatus == GoalTrackStatus.atRisk &&
+          _factsRenderer.trendWorsening(facts.evaluation.attainment, [
+            for (final row in priors) row.attainment,
+          ]));
+
+  /// The deterministic ad requirement (policy rows P4/P5): an eligible
+  /// status, no fresh active ad surviving this wake's retires, and no
+  /// dismissal cooldown.
   bool _adRequired(
     GoalWakeFacts facts,
+    List<GoalProgressEntity> priors,
     List<GoalNudgeEntity> nudges,
     GoalAgentStrategy strategy,
     DateTime now,
   ) {
-    if (facts.trackStatus != GoalTrackStatus.offTrack) return false;
+    if (!_adsEligible(facts, priors)) return false;
     if (_factsRenderer.dismissalCooldownActive(nudges, now)) return false;
     final retired = {for (final action in strategy.retireRequests) action.adId};
     final freshActive = nudges.any(
@@ -405,6 +453,21 @@ class GoalAgentWorkflow with AgentErrorLogging {
           now.difference(n.activatedAt ?? n.createdAt) < goalAdFreshFor,
     );
     return !freshActive;
+  }
+
+  /// Whether the strategy holds an ad action that will actually SURVIVE
+  /// the persistence guards: any create, or a rerun whose target really
+  /// is a retired row — a rerun of a stale-but-active ad would be
+  /// rejected at persistence and must not satisfy the requirement.
+  bool _hasViableAdAction(
+    GoalAgentStrategy strategy,
+    List<GoalNudgeEntity> nudges,
+  ) {
+    if (strategy.createdAds.isNotEmpty) return true;
+    final byId = {for (final nudge in nudges) nudge.id: nudge};
+    return strategy.rerunRequests.any(
+      (action) => byId[action.adId]?.status == GoalNudgeStatus.retired,
+    );
   }
 
   Future<InferenceUsage?> _forceAd({
@@ -456,6 +519,25 @@ class GoalAgentWorkflow with AgentErrorLogging {
     }
   }
 
+  /// The head's LWW timestamp: the period's last instant when the period
+  /// is already over, the wall clock otherwise — so concurrent heads from
+  /// different overdue periods resolve by PERIOD under generic LWW.
+  DateTime _headTimestamp(String periodKey, DateTime now) {
+    final periodEnd = _periodEnd(periodKey);
+    if (periodEnd == null) return now;
+    return periodEnd.isBefore(now) ? periodEnd : now;
+  }
+
+  DateTime? _periodEnd(String periodKey) {
+    final parts = periodKey.split('-');
+    if (parts.length != 3) return null;
+    final year = int.tryParse(parts[0]);
+    final month = int.tryParse(parts[1]);
+    final day = int.tryParse(parts[2]);
+    if (year == null || month == null || day == null) return null;
+    return DateTime(year, month, day, 23, 59, 59);
+  }
+
   /// The instant the derivation evaluates at: the escalation's encoded
   /// day when that day is already over (evaluated at its last hour, so
   /// the whole day's data is in range), otherwise now. Day keys are
@@ -464,13 +546,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
     if (periodKey == null) return now;
     final today = const GoalWindow.day().periodKey(now);
     if (periodKey.compareTo(today) >= 0) return now;
-    final parts = periodKey.split('-');
-    if (parts.length != 3) return now;
-    final year = int.tryParse(parts[0]);
-    final month = int.tryParse(parts[1]);
-    final day = int.tryParse(parts[2]);
-    if (year == null || month == null || day == null) return now;
-    return DateTime(year, month, day, 23, 59, 59);
+    return _periodEnd(periodKey) ?? now;
   }
 
   /// glm-5.2 on Melious is the validated default (the model the eval
@@ -723,7 +799,12 @@ class GoalAgentWorkflow with AgentErrorLogging {
               agentId: agentId,
               scope: AgentReportScopes.current,
               reportId: reportId,
-              updatedAt: now,
+              // Stamped with the PERIOD's end (not the wall clock) for
+              // overdue periods: two devices lease-elected onto different
+              // overdue periods write concurrent head versions, and LWW
+              // on this timestamp then prefers the NEWER period no matter
+              // which device finished last.
+              updatedAt: _headTimestamp(derivation.periodKey, now),
               vectorClock: null,
             ),
           );
@@ -754,6 +835,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
         nudges,
         now,
       );
+      // The authoritative status permits ads only for offTrack or a
+      // worsening atRisk (P4/P5) — an imperfect model response must not
+      // chide a succeeding, recovering or data-gapped user.
+      final adsEligible = _adsEligible(derivation.facts, derivation.priors);
       // P6: a fresh active ad blocks a second one. Ads retired in THIS
       // wake don't count — the retire+create swap (P14) stays legal.
       final retiredNow = {
@@ -766,6 +851,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
             now.difference(n.activatedAt ?? n.createdAt) < goalAdFreshFor,
       );
       for (final action in strategy.rerunRequests) {
+        if (!adsEligible) {
+          logError('rerun suppressed: status does not permit ads');
+          continue;
+        }
         if (cooldownActive) {
           logError('rerun suppressed: dismissal cooldown active');
           continue;
@@ -799,6 +888,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
         for (final nudge in nudges) nudge.briefDigest,
       };
       for (final request in strategy.createdAds) {
+        if (!adsEligible) {
+          logError('ad creation suppressed: status does not permit ads');
+          continue;
+        }
         if (cooldownActive) {
           logError('ad creation suppressed: dismissal cooldown active');
           continue;
@@ -807,7 +900,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
           logError('ad creation suppressed: a fresh active ad exists');
           continue;
         }
-        final digest = goalBriefDigest(request.brief);
+        // Weaker models echo FACTS ids into copy; the banner renders
+        // this text verbatim, so it gets the same sanitizer as reports.
+        final brief = _sanitizeBrief(request.brief);
+        final digest = goalBriefDigest(brief);
         if (!seenDigests.add(digest)) {
           logError('ad creation skipped: duplicate brief digest');
           continue;
@@ -818,7 +914,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
             id: _uuid.v4(),
             agentId: agentId,
             status: GoalNudgeStatus.active,
-            brief: request.brief,
+            brief: brief,
             briefDigest: digest,
             createdAt: now,
             updatedAt: now,
@@ -916,6 +1012,15 @@ class GoalAgentWorkflow with AgentErrorLogging {
     return attributionFinalized;
   }
 }
+
+/// The report sanitizer applied to every copy field a banner renders.
+GoalNudgeBrief _sanitizeBrief(GoalNudgeBrief brief) => brief.copyWith(
+  headline: sanitizeAgentReportText(brief.headline),
+  tagline: brief.tagline == null
+      ? null
+      : sanitizeAgentReportText(brief.tagline!),
+  cta: brief.cta == null ? null : sanitizeAgentReportText(brief.cta!),
+);
 
 /// Near-duplicate dedupe key over the banner copy: the same words with
 /// different presets are the same ad.

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -278,6 +278,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
       if (_adRequired(facts, derivation.priors, nudges, strategy, now) &&
           !_hasViableAdAction(strategy, nudges)) {
         final retryUsage = await _forceAd(
+          facts: facts,
           conversationId: conversationId,
           resolved: resolved,
           inferenceRepo: inferenceRepo,
@@ -387,9 +388,11 @@ class GoalAgentWorkflow with AgentErrorLogging {
     }
   }
 
-  /// Re-arms the period's escalation with a LATER deadline — the
-  /// resolver's supported reschedule-beats-consume path. Contained: a
-  /// failed re-arm is logged, never masks the original failure.
+  /// Re-arms the period's escalation as pending, due at the current
+  /// instant — a strictly later deadline than the consumed record's, so
+  /// this is the resolver's supported reschedule-beats-consume path.
+  /// Contained: a failed re-arm is logged, never masks the original
+  /// failure.
   Future<void> _rearmEscalation(
     String agentId,
     String periodKey,
@@ -471,6 +474,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
   }
 
   Future<InferenceUsage?> _forceAd({
+    required GoalWakeFacts facts,
     required String conversationId,
     required ({
       String modelId,
@@ -489,9 +493,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
       return await _conversationRepository.sendMessage(
         conversationId: conversationId,
         message:
-            'The goal is offTrack with no active banner and no cooldown — '
-            'an ad is REQUIRED (policy). Call create_goal_ad now (or '
-            'rerun_goal_ad if the FACTS offered a reusable one).',
+            'The goal is ${facts.trackStatus.name} with no active banner '
+            'and no cooldown — an ad is REQUIRED (policy). Call '
+            'create_goal_ad now (or rerun_goal_ad if the FACTS offered a '
+            'reusable one).',
         model: resolved.modelId,
         provider: resolved.provider,
         inferenceRepo: inferenceRepo,
@@ -523,19 +528,33 @@ class GoalAgentWorkflow with AgentErrorLogging {
   /// is already over, the wall clock otherwise — so concurrent heads from
   /// different overdue periods resolve by PERIOD under generic LWW.
   DateTime _headTimestamp(String periodKey, DateTime now) {
-    final periodEnd = _periodEnd(periodKey);
-    if (periodEnd == null) return now;
+    // UTC, deliberately: this timestamp exists to give concurrent heads
+    // from different devices a PERIOD-based LWW order, and a local
+    // constructor would map the same period key to different instants
+    // across timezones — an eastern device's older period could outrank
+    // a western device's newer one.
+    final parts = _periodParts(periodKey);
+    if (parts == null) return now;
+    final periodEnd = DateTime.utc(parts.$1, parts.$2, parts.$3, 23, 59, 59);
     return periodEnd.isBefore(now) ? periodEnd : now;
   }
 
+  /// The evaluation instant for an overdue period — LOCAL wall clock,
+  /// unlike [_headTimestamp]: signal queries and day keys are local.
   DateTime? _periodEnd(String periodKey) {
+    final parts = _periodParts(periodKey);
+    if (parts == null) return null;
+    return DateTime(parts.$1, parts.$2, parts.$3, 23, 59, 59);
+  }
+
+  (int, int, int)? _periodParts(String periodKey) {
     final parts = periodKey.split('-');
     if (parts.length != 3) return null;
     final year = int.tryParse(parts[0]);
     final month = int.tryParse(parts[1]);
     final day = int.tryParse(parts[2]);
     if (year == null || month == null || day == null) return null;
-    return DateTime(year, month, day, 23, 59, 59);
+    return (year, month, day);
   }
 
   /// The instant the derivation evaluates at: the escalation's encoded
@@ -978,6 +997,9 @@ class GoalAgentWorkflow with AgentErrorLogging {
                     'args': {
                       'changes': proposal.changes,
                       'rationale': proposal.rationale,
+                      // Provenance for the minted version: the wake
+                      // conversation that proposed this revision.
+                      'sourceThreadId': threadId,
                     },
                   },
               ],

--- a/lib/features/goals/workflow/goal_tool_dispatcher.dart
+++ b/lib/features/goals/workflow/goal_tool_dispatcher.dart
@@ -45,11 +45,13 @@ class GoalToolDispatcher {
     }
     final rationaleValue = args['rationale'];
     final rationale = rationaleValue is String ? rationaleValue.trim() : '';
+    final sourceThreadId = args['sourceThreadId'];
 
     final outcome = await _revisionService.reviseFromProposal(
       agentId: agentId,
       changes: changes,
       rationale: rationale,
+      sourceThreadId: sourceThreadId is String ? sourceThreadId : null,
     );
     return switch (outcome) {
       GoalSpecRevisionMinted(:final version, :final changeSummaries) =>

--- a/lib/features/goals/workflow/goal_tool_dispatcher.dart
+++ b/lib/features/goals/workflow/goal_tool_dispatcher.dart
@@ -1,0 +1,70 @@
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/goals/service/goal_spec_revision_service.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
+
+/// Applies ACCEPTED goal change-set items (the `EventToolDispatcher`
+/// shape): the confirmation service persists the decision, then hands the
+/// item here. One case today — `propose_goal_revision`, whose acceptance
+/// mints a new spec version and moves the head.
+///
+/// Refusals return `success: false` so the proposal stays unresolved
+/// instead of half-applying (the accept-after-delete posture).
+class GoalToolDispatcher {
+  GoalToolDispatcher({required this._revisionService});
+
+  final GoalSpecRevisionService _revisionService;
+
+  Future<ToolExecutionResult> dispatch(
+    String toolName,
+    Map<String, dynamic> args,
+    String agentId,
+  ) async {
+    switch (toolName) {
+      case GoalAgentToolNames.proposeGoalRevision:
+        return _handleProposeGoalRevision(args, agentId);
+      default:
+        return ToolExecutionResult(
+          success: false,
+          output: 'Unknown tool: $toolName',
+          errorMessage: 'Tool $toolName is not registered for the Goal Agent',
+        );
+    }
+  }
+
+  Future<ToolExecutionResult> _handleProposeGoalRevision(
+    Map<String, dynamic> args,
+    String agentId,
+  ) async {
+    final changes = args['changes'];
+    if (changes is! Map<String, dynamic> || changes.isEmpty) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: the proposal carries no changes object',
+        errorMessage: 'Missing changes',
+      );
+    }
+    final rationaleValue = args['rationale'];
+    final rationale = rationaleValue is String ? rationaleValue.trim() : '';
+
+    final outcome = await _revisionService.reviseFromProposal(
+      agentId: agentId,
+      changes: changes,
+      rationale: rationale,
+    );
+    return switch (outcome) {
+      GoalSpecRevisionMinted(:final version, :final changeSummaries) =>
+        ToolExecutionResult(
+          success: true,
+          output:
+              'Goal revised to v${version.version}: '
+              '${changeSummaries.join(', ')}',
+          mutatedEntityId: version.id,
+        ),
+      GoalSpecRevisionRefused(:final reason) => ToolExecutionResult(
+        success: false,
+        output: 'Error: $reason',
+        errorMessage: reason,
+      ),
+    };
+  }
+}

--- a/test/features/agents/state/change_set_providers_test.dart
+++ b/test/features/agents/state/change_set_providers_test.dart
@@ -292,6 +292,45 @@ void main() {
     });
   });
 
+  group('selfTargetedPendingChangeSetsProvider', () {
+    test('fetches change sets the agent targets at itself and deduplicates '
+        'them', () async {
+      final updateController = StreamController<Set<String>>.broadcast();
+      addTearDown(updateController.close);
+      final container = ProviderContainer(
+        overrides: [
+          agentRepositoryProvider.overrideWithValue(mockRepository),
+          agentUpdateStreamProvider(
+            'goal-1',
+          ).overrideWith((ref) => updateController.stream),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final older = makeTestChangeSet(
+        id: 'cs-old',
+        agentId: 'goal-1',
+        taskId: 'goal-1',
+        createdAt: DateTime(2026, 8, 9),
+      );
+      final newer = makeTestChangeSet(
+        id: 'cs-new',
+        agentId: 'goal-1',
+        taskId: 'goal-1',
+        createdAt: DateTime(2026, 8, 10),
+      );
+      when(
+        () => mockRepository.getPendingChangeSets('goal-1', taskId: 'goal-1'),
+      ).thenAnswer((_) async => [newer, older]);
+
+      final result = await container.read(
+        selfTargetedPendingChangeSetsProvider('goal-1').future,
+      );
+      // Identical pending items → the duplicate collapses to the newest.
+      expect(result, [newer]);
+    });
+  });
+
   group('eventPendingChangeSetsProvider', () {
     test('returns empty list when no agent exists for event', () async {
       final container = createEventAgentContainer(

--- a/test/features/goals/service/goal_revision_apply_test.dart
+++ b/test/features/goals/service/goal_revision_apply_test.dart
@@ -154,8 +154,9 @@ void main() {
     );
   });
 
-  test('invalid target values are rejected', () {
-    for (final bad in ['8000', -1, 0, double.nan]) {
+  test('invalid target values are rejected; zero is legal (atMost-0 '
+      'goals exist)', () {
+    for (final bad in ['8000', -1, double.nan]) {
       expect(
         rejected(
           applyGoalRevisionChanges(
@@ -163,9 +164,65 @@ void main() {
             changes: {'targetValue': bad},
           ),
         ),
-        contains('targetValue must be a positive number'),
+        contains('targetValue must be a non-negative number'),
       );
     }
+    final zeroed = applied(
+      applyGoalRevisionChanges(criteria: steps, changes: {'targetValue': 0}),
+    );
+    expect((zeroed.criteria as GoalCriterionMetric).target, 0);
+  });
+
+  test('a proposal restating the current values is a rejected no-op — it '
+      'must not reset the grace history', () {
+    expect(
+      rejected(
+        applyGoalRevisionChanges(
+          criteria: steps,
+          changes: {'targetValue': 10000},
+        ),
+      ),
+      contains('restates the current criteria'),
+    );
+  });
+
+  test('cadence strings with trailing garbage are rejected, not '
+      'truncated', () {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'fit',
+      criteria: [steps, gym],
+    );
+    for (final bad in ['3.5', '3 bananas', '3x weekly-ish']) {
+      expect(
+        rejected(
+          applyGoalRevisionChanges(
+            criteria: composite,
+            changes: {'cadence': bad},
+          ),
+        ),
+        contains('unrecognized cadence'),
+      );
+    }
+  });
+
+  test('absurdly long digit runs reject instead of throwing', () {
+    expect(
+      parseGoalWindowPhrase('rolling 99999999999999999999999 days'),
+      isNull,
+    );
+    const composite = GoalCriterion.allOf(
+      criterionId: 'fit',
+      criteria: [steps, gym],
+    );
+    expect(
+      rejected(
+        applyGoalRevisionChanges(
+          criteria: composite,
+          changes: {'cadence': '99999999999999999999999'},
+        ),
+      ),
+      contains('unrecognized cadence'),
+    );
   });
 
   test('successCriteria alone never rewrites the tree', () {

--- a/test/features/goals/service/goal_revision_apply_test.dart
+++ b/test/features/goals/service/goal_revision_apply_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/goals/service/goal_revision_apply.dart';
+
+void main() {
+  const steps = GoalCriterion.metric(
+    criterionId: 'steps',
+    dataType: 'cumulative_step_count',
+    window: GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: 10000,
+  );
+  const gym = GoalCriterion.habit(
+    criterionId: 'gym',
+    habitId: 'gym-habit',
+    window: GoalWindow.calendarWeek(),
+    targetCount: 3,
+  );
+  const water = GoalCriterion.measurable(
+    criterionId: 'water',
+    dataTypeId: 'water-id',
+    window: GoalWindow.day(),
+    aggregation: GoalAggregation.sum,
+    target: 2000,
+  );
+
+  GoalRevisionApplied applied(GoalRevisionResult result) {
+    expect(result, isA<GoalRevisionApplied>(), reason: '$result');
+    return result as GoalRevisionApplied;
+  }
+
+  String rejected(GoalRevisionResult result) {
+    expect(result, isA<GoalRevisionRejected>(), reason: '$result');
+    return (result as GoalRevisionRejected).reason;
+  }
+
+  test('a target change on a single-leaf goal binds without naming it', () {
+    final result = applied(
+      applyGoalRevisionChanges(
+        criteria: steps,
+        changes: {'targetValue': 8000},
+      ),
+    );
+    expect((result.criteria as GoalCriterionMetric).target, 8000);
+    expect(result.changeSummaries, ['target: 10000 → 8000']);
+  });
+
+  test('inside a composite, the metric field disambiguates by criterionId '
+      'or dataType — and only the named leaf changes', () {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'fit',
+      criteria: [steps, water, gym],
+    );
+    for (final metric in ['steps', 'CUMULATIVE_STEP_COUNT']) {
+      final result = applied(
+        applyGoalRevisionChanges(
+          criteria: composite,
+          changes: {'metric': metric, 'targetValue': 12000},
+        ),
+      );
+      final revised = result.criteria as GoalCriterionAllOf;
+      expect(
+        (revised.criteria[0] as GoalCriterionMetric).target,
+        12000,
+      );
+      expect((revised.criteria[1] as GoalCriterionMeasurable).target, 2000);
+      expect((revised.criteria[2] as GoalCriterionHabit).targetCount, 3);
+    }
+  });
+
+  test('two quantitative leaves and no metric name → rejected, never '
+      'guessed', () {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'fit',
+      criteria: [steps, water],
+    );
+    expect(
+      rejected(
+        applyGoalRevisionChanges(
+          criteria: composite,
+          changes: {'targetValue': 12000},
+        ),
+      ),
+      contains('does not identify a single measurable criterion'),
+    );
+  });
+
+  test('period phrases parse the FACTS vocabulary; garbage is rejected', () {
+    expect(parseGoalWindowPhrase('day'), const GoalWindow.day());
+    expect(parseGoalWindowPhrase('daily'), const GoalWindow.day());
+    expect(
+      parseGoalWindowPhrase('Rolling 14 days'),
+      const GoalWindow.rollingDays(count: 14),
+    );
+    expect(
+      parseGoalWindowPhrase('calendar week (Mon-Sun)'),
+      const GoalWindow.calendarWeek(),
+    );
+    expect(parseGoalWindowPhrase('monthly'), const GoalWindow.calendarMonth());
+    expect(parseGoalWindowPhrase('fortnight'), isNull);
+
+    final result = applied(
+      applyGoalRevisionChanges(
+        criteria: steps,
+        changes: {'period': 'rolling 14 days'},
+      ),
+    );
+    expect(
+      (result.criteria as GoalCriterionMetric).window,
+      const GoalWindow.rollingDays(count: 14),
+    );
+    expect(
+      rejected(
+        applyGoalRevisionChanges(
+          criteria: steps,
+          changes: {'period': 'fortnight'},
+        ),
+      ),
+      contains('unrecognized period'),
+    );
+  });
+
+  test('cadence binds to the single habit leaf and parses count phrases', () {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'fit',
+      criteria: [steps, gym],
+    );
+    for (final cadence in [4, '4', '4x', '4 times per week']) {
+      final result = applied(
+        applyGoalRevisionChanges(
+          criteria: composite,
+          changes: {'cadence': cadence},
+        ),
+      );
+      final revised = result.criteria as GoalCriterionAllOf;
+      expect((revised.criteria[1] as GoalCriterionHabit).targetCount, 4);
+    }
+    expect(
+      rejected(
+        applyGoalRevisionChanges(
+          criteria: composite,
+          changes: {'cadence': 'whenever'},
+        ),
+      ),
+      contains('unrecognized cadence'),
+    );
+    expect(
+      rejected(
+        applyGoalRevisionChanges(criteria: steps, changes: {'cadence': 3}),
+      ),
+      contains('no habit criterion'),
+    );
+  });
+
+  test('invalid target values are rejected', () {
+    for (final bad in ['8000', -1, 0, double.nan]) {
+      expect(
+        rejected(
+          applyGoalRevisionChanges(
+            criteria: steps,
+            changes: {'targetValue': bad},
+          ),
+        ),
+        contains('targetValue must be a positive number'),
+      );
+    }
+  });
+
+  test('successCriteria alone never rewrites the tree', () {
+    expect(
+      rejected(
+        applyGoalRevisionChanges(
+          criteria: steps,
+          changes: {'successCriteria': 'just feel better about walking'},
+        ),
+      ),
+      contains('no applicable structural change'),
+    );
+  });
+
+  test('target and cadence apply together across a composite', () {
+    const composite = GoalCriterion.atLeastCount(
+      criterionId: 'two-of',
+      successes: 2,
+      criteria: [steps, gym, water],
+    );
+    final result = applied(
+      applyGoalRevisionChanges(
+        criteria: composite,
+        changes: {'metric': 'steps', 'targetValue': 9000, 'cadence': 2},
+      ),
+    );
+    final revised = result.criteria as GoalCriterionAtLeastCount;
+    expect((revised.criteria[0] as GoalCriterionMetric).target, 9000);
+    expect((revised.criteria[1] as GoalCriterionHabit).targetCount, 2);
+    expect(result.changeSummaries, hasLength(2));
+  });
+
+  test('a measurable leaf takes target and period changes too', () {
+    final result =
+        applyGoalRevisionChanges(
+              criteria: water,
+              changes: {'targetValue': 2500, 'period': 'rolling 3 days'},
+            )
+            as GoalRevisionApplied;
+    final revised = result.criteria as GoalCriterionMeasurable;
+    expect(revised.target, 2500);
+    expect(revised.window, const GoalWindow.rollingDays(count: 3));
+  });
+
+  test('two habit leaves make a cadence change ambiguous — rejected', () {
+    const twoGyms = GoalCriterion.anyOf(
+      criterionId: 'either-gym',
+      criteria: [
+        gym,
+        GoalCriterion.habit(
+          criterionId: 'home-gym',
+          habitId: 'home-gym-habit',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 2,
+        ),
+      ],
+    );
+    final result = applyGoalRevisionChanges(
+      criteria: twoGyms,
+      changes: {'cadence': 4},
+    );
+    expect(
+      (result as GoalRevisionRejected).reason,
+      contains('2 habit criteria'),
+    );
+  });
+
+  test('the rewrite recurses through anyOf composites', () {
+    const nested = GoalCriterion.anyOf(
+      criterionId: 'either',
+      criteria: [steps],
+    );
+    final result =
+        applyGoalRevisionChanges(
+              criteria: nested,
+              changes: {'targetValue': 9000},
+            )
+            as GoalRevisionApplied;
+    final revised = result.criteria as GoalCriterionAnyOf;
+    expect((revised.criteria.single as GoalCriterionMetric).target, 9000);
+  });
+}

--- a/test/features/goals/service/goal_spec_revision_service_test.dart
+++ b/test/features/goals/service/goal_spec_revision_service_test.dart
@@ -1,0 +1,218 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/goals/service/goal_spec_revision_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  const agentId = 'goal-1';
+  final now = DateTime(2026, 8, 10, 9);
+  final fixedClock = Clock.fixed(now);
+
+  const criteria = GoalCriterion.metric(
+    criterionId: 'steps',
+    dataType: 'cumulative_step_count',
+    window: GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: 10000,
+  );
+
+  late MockAgentRepository repository;
+  late MockAgentSyncService syncService;
+  late List<AgentDomainEntity> upserts;
+  late GoalSpecRevisionService service;
+
+  setUp(() {
+    repository = MockAgentRepository();
+    syncService = MockAgentSyncService();
+    upserts = [];
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    service = GoalSpecRevisionService(
+      repository: repository,
+      syncService: syncService,
+    );
+  });
+
+  void stubSpec({int version = 1}) {
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v$version',
+        updatedAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v$version')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v$version',
+        agentId: agentId,
+        version: version,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: 'Steps',
+        statement: 'Average 10,000 steps per day.',
+        criteria: criteria,
+        createdAt: DateTime(2026, 8),
+        vectorClock: null,
+        startDate: DateTime(2026, 8),
+      ),
+    );
+  }
+
+  test('an approved proposal supersedes v1, mints v2 with provenance, and '
+      'moves the head — in one transaction', () async {
+    stubSpec();
+    final outcome = await withClock(
+      fixedClock,
+      () => service.reviseFromProposal(
+        agentId: agentId,
+        changes: {'targetValue': 8000},
+        rationale: 'user asked to ease off after the injury',
+      ),
+    );
+
+    expect(outcome, isA<GoalSpecRevisionMinted>());
+    final minted = (outcome as GoalSpecRevisionMinted).version;
+    expect(minted.id, '$agentId:spec-v2');
+    expect(minted.version, 2);
+    expect(minted.status, GoalSpecVersionStatus.active);
+    expect(minted.authoredBy, AgentKinds.goalAgent);
+    expect(minted.diffFromVersionId, '$agentId:spec-v1');
+    expect(minted.rationale, 'user asked to ease off after the injury');
+    expect((minted.criteria as GoalCriterionMetric).target, 8000);
+    expect(
+      minted.startDate,
+      DateTime(2026, 8),
+      reason: 'dates carry over — a revision is not a restart',
+    );
+    expect(outcome.changeSummaries, ['target: 10000 → 8000']);
+
+    final superseded = upserts.whereType<GoalSpecVersionEntity>().singleWhere(
+      (v) => v.id == '$agentId:spec-v1',
+    );
+    expect(superseded.status, GoalSpecVersionStatus.superseded);
+    final head = upserts.whereType<GoalSpecHeadEntity>().single;
+    expect(head.id, goalSpecHeadId(agentId));
+    expect(head.versionId, '$agentId:spec-v2');
+    expect(head.updatedAt, now);
+  });
+
+  test('refusals: missing head, dangling head, inapplicable changes — '
+      'nothing is written', () async {
+    // No head at all.
+    var outcome = await service.reviseFromProposal(
+      agentId: agentId,
+      changes: {'targetValue': 8000},
+      rationale: 'r',
+    );
+    expect(
+      (outcome as GoalSpecRevisionRefused).reason,
+      contains('no spec head'),
+    );
+
+    // Dangling head.
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: 'missing',
+        updatedAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+    outcome = await service.reviseFromProposal(
+      agentId: agentId,
+      changes: {'targetValue': 8000},
+      rationale: 'r',
+    );
+    expect(
+      (outcome as GoalSpecRevisionRefused).reason,
+      contains('points at nothing'),
+    );
+
+    // Inapplicable proposal.
+    stubSpec();
+    outcome = await service.reviseFromProposal(
+      agentId: agentId,
+      changes: {'successCriteria': 'be happier'},
+      rationale: 'r',
+    );
+    expect(
+      (outcome as GoalSpecRevisionRefused).reason,
+      contains('no applicable structural change'),
+    );
+
+    expect(upserts, isEmpty, reason: 'a refusal must write nothing');
+  });
+
+  test('a revision over an already-corrupt tree fails validation and '
+      'refuses to mint', () async {
+    // Duplicate criterionIds (e.g. a bad sync from an old peer): the
+    // revision applies structurally, but the validator must veto the mint.
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: 'Steps',
+        statement: 'x',
+        criteria: const GoalCriterion.allOf(
+          criterionId: 'steps',
+          criteria: [criteria],
+        ),
+        createdAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+    final outcome = await service.reviseFromProposal(
+      agentId: agentId,
+      changes: {'targetValue': 8000},
+      rationale: 'r',
+    );
+    expect(
+      (outcome as GoalSpecRevisionRefused).reason,
+      contains('fail validation'),
+    );
+    expect(upserts, isEmpty);
+  });
+
+  test('version numbers keep counting past v2', () async {
+    stubSpec(version: 4);
+    final outcome = await withClock(
+      fixedClock,
+      () => service.reviseFromProposal(
+        agentId: agentId,
+        changes: {'period': 'rolling 14 days'},
+        rationale: 'longer horizon',
+      ),
+    );
+    expect(
+      (outcome as GoalSpecRevisionMinted).version.id,
+      '$agentId:spec-v5',
+    );
+  });
+}

--- a/test/features/goals/service/goal_spec_revision_service_test.dart
+++ b/test/features/goals/service/goal_spec_revision_service_test.dart
@@ -160,8 +160,10 @@ void main() {
 
   test('a revision over an already-corrupt tree fails validation and '
       'refuses to mint', () async {
-    // Duplicate criterionIds (e.g. a bad sync from an old peer): the
-    // revision applies structurally, but the validator must veto the mint.
+    // Duplicate criterionIds on two OTHER leaves (e.g. a bad sync from an
+    // old peer): the target change on the unique steps leaf is a REAL
+    // structural change, so the apply step succeeds — proving it is the
+    // validator, not an apply no-op, that vetoes the mint.
     when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
       (_) async => AgentDomainEntity.goalSpecHead(
         id: goalSpecHeadId(agentId),
@@ -181,8 +183,22 @@ void main() {
         title: 'Steps',
         statement: 'x',
         criteria: const GoalCriterion.allOf(
-          criterionId: 'steps',
-          criteria: [criteria],
+          criterionId: 'root',
+          criteria: [
+            criteria,
+            GoalCriterion.habit(
+              criterionId: 'dup',
+              habitId: 'gym-a',
+              window: GoalWindow.calendarWeek(),
+              targetCount: 3,
+            ),
+            GoalCriterion.habit(
+              criterionId: 'dup',
+              habitId: 'gym-b',
+              window: GoalWindow.calendarWeek(),
+              targetCount: 2,
+            ),
+          ],
         ),
         createdAt: DateTime(2026, 8),
         vectorClock: null,
@@ -190,7 +206,7 @@ void main() {
     );
     final outcome = await service.reviseFromProposal(
       agentId: agentId,
-      changes: {'targetValue': 8000},
+      changes: {'metric': 'steps', 'targetValue': 8000},
       rationale: 'r',
     );
     expect(
@@ -215,4 +231,132 @@ void main() {
       '$agentId:spec-v5',
     );
   });
+
+  test('reads happen INSIDE the transaction, and a successor id that '
+      'already exists refuses instead of overwriting provenance', () async {
+    final order = <String>[];
+    final txnSyncService = _OrderRecordingSyncService(order);
+    when(() => txnSyncService.upsertEntity(any())).thenAnswer((
+      invocation,
+    ) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    final txnService = GoalSpecRevisionService(
+      repository: repository,
+      syncService: txnSyncService,
+    );
+    stubSpec();
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer((
+      _,
+    ) async {
+      order.add('read-head');
+      return AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026, 8),
+        vectorClock: null,
+      );
+    });
+    // The successor already exists: a concurrent acceptance won.
+    when(() => repository.getEntity('$agentId:spec-v2')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v2',
+        agentId: agentId,
+        version: 2,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: AgentKinds.goalAgent,
+        title: 'Steps',
+        statement: 'x',
+        criteria: criteria,
+        createdAt: DateTime(2026, 8, 10, 8),
+        vectorClock: null,
+      ),
+    );
+
+    final outcome = await txnService.reviseFromProposal(
+      agentId: agentId,
+      changes: {'targetValue': 8000},
+      rationale: 'r',
+    );
+    expect(
+      (outcome as GoalSpecRevisionRefused).reason,
+      contains('concurrent revision already minted'),
+    );
+    expect(upserts, isEmpty);
+    expect(
+      order.first,
+      'transaction',
+      reason: 'the head read must be serialized by the transaction',
+    );
+  });
+
+  test('a post-commit sync failure is reconciled: the head already moved '
+      'to the minted version, so the approval is reported as committed — '
+      'a retry must not mint twice', () async {
+    stubSpec();
+    final failing = _CommitThenThrowSyncService();
+    when(() => failing.upsertEntity(any())).thenAnswer((invocation) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    final service = GoalSpecRevisionService(
+      repository: repository,
+      syncService: failing,
+    );
+    // After the (durable) writes, the repository serves the moved head.
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async =>
+          upserts.whereType<GoalSpecHeadEntity>().lastOrNull ??
+          AgentDomainEntity.goalSpecHead(
+                id: goalSpecHeadId(agentId),
+                agentId: agentId,
+                versionId: '$agentId:spec-v1',
+                updatedAt: DateTime(2026, 8),
+                vectorClock: null,
+              )
+              as GoalSpecHeadEntity,
+    );
+    when(() => repository.getEntity('$agentId:spec-v2')).thenAnswer(
+      (_) async => upserts
+          .whereType<GoalSpecVersionEntity>()
+          .where((v) => v.id == '$agentId:spec-v2')
+          .lastOrNull,
+    );
+
+    final outcome = await withClock(
+      fixedClock,
+      () => service.reviseFromProposal(
+        agentId: agentId,
+        changes: {'targetValue': 8000},
+        rationale: 'r',
+      ),
+    );
+    expect(outcome, isA<GoalSpecRevisionMinted>());
+    expect(
+      (outcome as GoalSpecRevisionMinted).version.id,
+      '$agentId:spec-v2',
+    );
+  });
+}
+
+class _OrderRecordingSyncService extends MockAgentSyncService {
+  _OrderRecordingSyncService(this.order);
+
+  final List<String> order;
+
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) {
+    order.add('transaction');
+    return action();
+  }
+}
+
+/// Runs the transaction body (writes land) and THEN throws — the durable
+/// commit + failed outbox flush shape.
+class _CommitThenThrowSyncService extends MockAgentSyncService {
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) async {
+    await action();
+    throw StateError('outbox flush failed');
+  }
 }

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -438,4 +438,104 @@ void main() {
     expect(subscription.agentId, agentId);
     expect(subscription.matchEntityIds, {'gym-habit'});
   });
+
+  test('a confirmed revision whose spec cannot be read back logs the '
+      'skipped re-registration instead of failing silently', () async {
+    const agentId = 'goal-gone';
+    final logger = container.read(domainLoggerProvider) as MockDomainLogger;
+    when(
+      () => logger.error(
+        any(),
+        any<Object>(),
+        stackTrace: any(named: 'stackTrace'),
+        subDomain: any(named: 'subDomain'),
+        message: any(named: 'message'),
+      ),
+    ).thenReturn(null);
+    final upserted = <AgentDomainEntity>[];
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserted.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    when(() => syncService.repository).thenReturn(repository);
+
+    // The head is readable for the mint, then gone for the hook's
+    // read-back (e.g. clobbered by a concurrent sync apply).
+    var headReads = 0;
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer((
+      _,
+    ) async {
+      headReads++;
+      if (headReads > 1) return null;
+      return AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026, 8),
+        vectorClock: null,
+      );
+    });
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: 'Gym',
+        statement: 'x',
+        criteria: const GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: 'gym-habit',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+        createdAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+
+    final changeSet =
+        AgentDomainEntity.changeSet(
+              id: 'cs-2',
+              agentId: agentId,
+              taskId: agentId,
+              threadId: 'thread-1',
+              runKey: 'run-1',
+              status: ChangeSetStatus.pending,
+              items: const [
+                ChangeItem(
+                  toolName: GoalAgentToolNames.proposeGoalRevision,
+                  args: {
+                    'changes': {'cadence': 4},
+                    'rationale': 'step it up',
+                  },
+                  humanSummary: 'Raise the cadence to 4',
+                ),
+              ],
+              createdAt: DateTime(2026, 8, 10),
+              vectorClock: null,
+            )
+            as ChangeSetEntity;
+    when(() => repository.getEntity('cs-2')).thenAnswer((_) async => changeSet);
+
+    final orchestrator =
+        container.read(wakeOrchestratorProvider) as MockWakeOrchestrator;
+    final service = container.read(goalChangeSetConfirmationServiceProvider);
+    final result = await service.confirmItem(changeSet, 0);
+    expect(result.success, isTrue);
+
+    verify(
+      () => logger.error(
+        any(),
+        any<Object>(),
+        stackTrace: any(named: 'stackTrace'),
+        subDomain: 'goalRevision',
+        message: any(
+          named: 'message',
+          that: contains('re-registration skipped'),
+        ),
+      ),
+    ).called(1);
+    verifyNever(() => orchestrator.addSubscription(any()));
+  });
 }

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -10,7 +10,9 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
@@ -20,6 +22,8 @@ import 'package:lotti/features/goals/runtime/goal_runtime_maintenance.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
+import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
 import 'package:mocktail/mocktail.dart';
 
@@ -66,6 +70,7 @@ void main() {
         agentRepositoryProvider.overrideWithValue(repository),
         agentSyncServiceProvider.overrideWithValue(syncService),
         agentServiceProvider.overrideWithValue(agentService),
+        labelsRepositoryProvider.overrideWithValue(MockLabelsRepository()),
         wakeOrchestratorProvider.overrideWithValue(MockWakeOrchestrator()),
         updateNotificationsProvider.overrideWithValue(updateNotifications),
         domainLoggerProvider.overrideWithValue(MockDomainLogger()),
@@ -314,4 +319,123 @@ void main() {
       await listed.future;
     },
   );
+
+  test('accepting a revision proposal end-to-end: decision persisted, v2 '
+      'minted, head moved, and the signal subscription re-registered from '
+      'the NEW criteria', () async {
+    const agentId = 'goal-rev';
+    final changeSet =
+        AgentDomainEntity.changeSet(
+              id: 'cs-1',
+              agentId: agentId,
+              taskId: agentId,
+              threadId: 'thread-1',
+              runKey: 'run-1',
+              status: ChangeSetStatus.pending,
+              items: const [
+                ChangeItem(
+                  toolName: GoalAgentToolNames.proposeGoalRevision,
+                  args: {
+                    'changes': {'targetValue': 8000},
+                    'rationale': 'ease off',
+                  },
+                  humanSummary: 'Lower the target to 8000',
+                ),
+              ],
+              createdAt: DateTime(2026, 8, 10),
+              vectorClock: null,
+            )
+            as ChangeSetEntity;
+
+    final upserted = <AgentDomainEntity>[];
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserted.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    when(() => syncService.repository).thenReturn(repository);
+    final orchestrator =
+        container.read(wakeOrchestratorProvider) as MockWakeOrchestrator;
+    when(() => orchestrator.addSubscription(any())).thenReturn(null);
+
+    final headV1 =
+        AgentDomainEntity.goalSpecHead(
+              id: goalSpecHeadId(agentId),
+              agentId: agentId,
+              versionId: '$agentId:spec-v1',
+              updatedAt: DateTime(2026, 8),
+              vectorClock: null,
+            )
+            as GoalSpecHeadEntity;
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      // The confirmation hook re-reads the head AFTER the mint: serve the
+      // freshest head that has been written, v1 before.
+      (_) async =>
+          upserted.whereType<GoalSpecHeadEntity>().lastOrNull ?? headV1,
+    );
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: 'Gym',
+        statement: 'x',
+        criteria: const GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: 'gym-habit',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+        createdAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v2')).thenAnswer(
+      (_) async => upserted
+          .whereType<GoalSpecVersionEntity>()
+          .where((v) => v.id == '$agentId:spec-v2')
+          .lastOrNull,
+    );
+    when(() => repository.getEntity('cs-1')).thenAnswer((_) async => changeSet);
+
+    final service = container.read(goalChangeSetConfirmationServiceProvider);
+    // A habit goal can't take targetValue — use cadence instead so the
+    // revision is applicable.
+    final applicable = changeSet.copyWith(
+      items: const [
+        ChangeItem(
+          toolName: GoalAgentToolNames.proposeGoalRevision,
+          args: {
+            'changes': {'cadence': 4},
+            'rationale': 'step it up',
+          },
+          humanSummary: 'Raise the cadence to 4',
+        ),
+      ],
+    );
+    when(
+      () => repository.getEntity('cs-1'),
+    ).thenAnswer((_) async => applicable);
+
+    final result = await service.confirmItem(applicable, 0);
+    expect(result.success, isTrue, reason: result.errorMessage ?? '');
+    expect(result.mutatedEntityId, '$agentId:spec-v2');
+
+    final minted = upserted.whereType<GoalSpecVersionEntity>().singleWhere(
+      (v) => v.id == '$agentId:spec-v2',
+    );
+    expect((minted.criteria as GoalCriterionHabit).targetCount, 4);
+    final head = upserted.whereType<GoalSpecHeadEntity>().last;
+    expect(head.versionId, '$agentId:spec-v2');
+
+    final decision = upserted.whereType<ChangeDecisionEntity>().single;
+    expect(decision.verdict, ChangeDecisionVerdict.confirmed);
+
+    // The hook re-registered the subscription from the NEW criteria.
+    final subscription =
+        verify(() => orchestrator.addSubscription(captureAny())).captured.last
+            as AgentSubscription;
+    expect(subscription.agentId, agentId);
+    expect(subscription.matchEntityIds, {'gym-habit'});
+  });
 }

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -1739,6 +1739,13 @@ void main() {
           strategy,
         }) async {
           callTools.add([for (final t in tools!) t.function.name]);
+          if (callTools.length == 2) {
+            expect(
+              message,
+              contains('The goal is offTrack'),
+              reason: 'the forced-ad prompt names the ACTUAL status',
+            );
+          }
           if (callTools.length == 1) {
             // The model reports but "forgets" the required ad.
             await (strategy! as GoalAgentStrategy).processToolCalls(
@@ -2207,6 +2214,10 @@ void main() {
       ),
     );
     final head = upserts.whereType<AgentReportHeadEntity>().single;
-    expect(head.updatedAt, DateTime(2026, 8, 6, 23, 59, 59));
+    expect(
+      head.updatedAt,
+      DateTime.utc(2026, 8, 6, 23, 59, 59),
+      reason: 'UTC, so period order is timezone-independent across devices',
+    );
   });
 }

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -20,6 +20,7 @@ import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dar
 import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_strategy.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
@@ -72,6 +73,24 @@ GoalAgentWorkflow _offTrackWorkflow(
   cloudInferenceRepository: cloudInferenceRepository,
   aiConfigRepository: aiConfigRepository,
 );
+
+Future<GoalWakeDerivation> _offTrackDerivation(
+  MockAgentRepository repository,
+  GoalSpecVersionEntity version,
+  DateTime now,
+) => GoalAgentPhaseA(
+  repository: repository,
+  syncService: MockAgentSyncService(),
+  signalReader: _FakeReader(
+    GoalSignalWindow(
+      quantitativeDailySums: {
+        'cumulative_step_count': {
+          for (var day = 3; day <= 9; day++) DateTime.utc(2026, 8, day): 6000,
+        },
+      },
+    ),
+  ),
+).deriveWakeFacts(agentId: version.agentId, version: version, now: now);
 
 void _stubBadPrior(
   MockAgentRepository repository,
@@ -292,6 +311,14 @@ void main() {
       'usage — all attributed to glm-5.2', () async {
     stubSpec();
     stubGlmResolution();
+    workflow = _offTrackWorkflow(
+      repository,
+      syncService,
+      conversationRepository,
+      cloudInferenceRepository,
+      aiConfigRepository,
+    );
+    _stubBadPrior(repository, agentId, now);
     conversationRepository.sendMessageDelegate =
         ({
           required conversationId,
@@ -312,13 +339,13 @@ void main() {
           await (strategy! as GoalAgentStrategy).processToolCalls(
             toolCalls: [
               toolCall(GoalAgentToolNames.updateGoalReport, {
-                'status': 'insufficientData',
-                'oneLiner': 'No step data this window.',
-                'tldr': 'The tracker went quiet; nothing to judge yet.',
+                'status': 'offTrack',
+                'oneLiner': 'Averaging 6k of 10k steps.',
+                'tldr': 'The rolling week slid well under target.',
               }, id: 'call-a'),
               toolCall(GoalAgentToolNames.createGoalAd, {
                 'headline': 'Your pedometer misses you.',
-                'tone': 'encourage',
+                'tone': 'nudge',
                 'animation': 'steady',
                 'accent': 'tide',
               }, id: 'call-b'),
@@ -341,8 +368,8 @@ void main() {
     expect(userMessages, hasLength(1), reason: 'the FACTS blob is inspectable');
 
     final report = upserts.whereType<AgentReportEntity>().single;
-    expect(report.tldr, 'The tracker went quiet; nothing to judge yet.');
-    expect(report.provenance['trackStatus'], 'insufficientData');
+    expect(report.tldr, 'The rolling week slid well under target.');
+    expect(report.provenance['trackStatus'], 'offTrack');
     final head = upserts.whereType<AgentReportHeadEntity>().single;
     expect(head.reportId, report.id);
 
@@ -477,6 +504,7 @@ void main() {
     );
 
     stubSpec();
+    _stubBadPrior(repository, agentId, now);
     await withClock(
       fixedClock,
       () async {
@@ -488,11 +516,7 @@ void main() {
           runKey: 'run-1',
           threadId: 'thread-1',
           strategy: strategy,
-          derivation: await GoalAgentPhaseA(
-            repository: repository,
-            syncService: MockAgentSyncService(),
-            signalReader: _FakeReader(),
-          ).deriveWakeFacts(agentId: agentId, version: version!, now: now),
+          derivation: await _offTrackDerivation(repository, version!, now),
           now: now,
         );
       },
@@ -524,6 +548,7 @@ void main() {
       'observation payload resolution, thought + observation persistence, '
       'and retry-usage merging', () async {
     stubSpec();
+    _stubBadPrior(repository, agentId, now);
     final profileIdentity = makeTestIdentity(
       id: agentId,
       agentId: agentId,
@@ -627,6 +652,13 @@ void main() {
         content: 'Re-running the proven banner.',
       ),
     ]);
+    workflow = _offTrackWorkflow(
+      repository,
+      syncService,
+      conversationRepository,
+      cloudInferenceRepository,
+      aiConfigRepository,
+    );
 
     conversationRepository.maxDelegateCalls = 2;
     var calls = 0;
@@ -660,13 +692,13 @@ void main() {
             );
             return const InferenceUsage(inputTokens: 800, outputTokens: 90);
           }
-          // Forced retry (first evaluation transitions): publish the report.
+          // Forced retry (the transition wake missed its report).
           await (strategy! as GoalAgentStrategy).processToolCalls(
             toolCalls: [
               toolCall(GoalAgentToolNames.updateGoalReport, {
-                'status': 'insufficientData',
-                'oneLiner': 'No data.',
-                'tldr': 'Quiet tracker.',
+                'status': 'offTrack',
+                'oneLiner': 'Behind.',
+                'tldr': 'The week slid under target.',
               }),
             ],
             manager: conversationManager,
@@ -946,6 +978,32 @@ void main() {
     () async {
       stubSpec();
       stubGlmResolution();
+      workflow = _offTrackWorkflow(
+        repository,
+        syncService,
+        conversationRepository,
+        cloudInferenceRepository,
+        aiConfigRepository,
+      );
+      // Prior bad day under the SAME (old) spec version → grace exhausted
+      // → offTrack, so the ad is policy-eligible.
+      when(
+        () => repository.getEntity(goalProgressId(agentId, '2026-08-05')),
+      ).thenAnswer(
+        (_) async => AgentDomainEntity.goalProgress(
+          id: goalProgressId(agentId, '2026-08-05'),
+          agentId: agentId,
+          periodKey: '2026-08-05',
+          trackStatus: GoalTrackStatus.atRisk,
+          attainment: 0.6,
+          dataCoverage: 1,
+          satisfied: false,
+          specVersionId: '$agentId:spec-v0',
+          createdAt: DateTime(2026, 8, 5),
+          updatedAt: DateTime(2026, 8, 5),
+          vectorClock: null,
+        ),
+      );
       // The old period's register was computed under a superseded spec —
       // the wake must be judged against THAT version, not today's head.
       when(
@@ -1002,13 +1060,13 @@ void main() {
             await (strategy! as GoalAgentStrategy).processToolCalls(
               toolCalls: [
                 toolCall(GoalAgentToolNames.updateGoalReport, {
-                  'status': 'insufficientData',
-                  'oneLiner': 'No data.',
-                  'tldr': 'Quiet tracker.',
+                  'status': 'offTrack',
+                  'oneLiner': 'Behind on the old spec.',
+                  'tldr': 'That week slid under target.',
                 }, id: 'call-a'),
                 toolCall(GoalAgentToolNames.createGoalAd, {
                   'headline': 'Late but not forgotten.',
-                  'tone': 'encourage',
+                  'tone': 'nudge',
                   'animation': 'steady',
                 }, id: 'call-b'),
               ],
@@ -1083,14 +1141,15 @@ void main() {
     }
 
     stubSpec();
+    _stubBadPrior(repository, agentId, now);
     final version =
         await repository.getEntity('$agentId:spec-v1')
             as GoalSpecVersionEntity?;
-    final derivation = await GoalAgentPhaseA(
-      repository: repository,
-      syncService: MockAgentSyncService(),
-      signalReader: _FakeReader(),
-    ).deriveWakeFacts(agentId: agentId, version: version!, now: now);
+    final derivation = await _offTrackDerivation(
+      repository,
+      version!,
+      now,
+    );
 
     // Cooldown: the model ignored dismissalCooldownActive — persistence
     // must still hold the 24h quiet contract, for creates AND reruns.
@@ -1546,14 +1605,11 @@ void main() {
     ).thenAnswer((_) async => [activeRow('ad-live')]);
 
     stubSpec();
+    _stubBadPrior(repository, agentId, now);
     final version =
         await repository.getEntity('$agentId:spec-v1')
             as GoalSpecVersionEntity?;
-    final derivation = await GoalAgentPhaseA(
-      repository: repository,
-      syncService: MockAgentSyncService(),
-      signalReader: _FakeReader(),
-    ).deriveWakeFacts(agentId: agentId, version: version!, now: now);
+    final derivation = await _offTrackDerivation(repository, version!, now);
 
     Future<GoalAgentStrategy> strategyWith(
       List<ChatCompletionMessageToolCall> calls,
@@ -1865,5 +1921,220 @@ void main() {
     final result = await run();
     expect(result.success, isFalse);
     expect(result.error, contains('provider melted'));
+  });
+
+  test('persistOutputs: an ineligible status suppresses ads, an atRisk '
+      'worsening trend permits them, and banner copy is sanitized', () async {
+    stubSpec();
+    final version =
+        await repository.getEntity('$agentId:spec-v1')
+            as GoalSpecVersionEntity?;
+    when(
+      () => repository.getEntitiesByAgentId(
+        agentId,
+        type: AgentEntityTypes.goalNudge,
+      ),
+    ).thenAnswer((_) async => []);
+
+    Future<GoalAgentStrategy> creating(String headline) async {
+      final strategy = GoalAgentStrategy(
+        syncService: syncService,
+        agentId: agentId,
+        threadId: 'thread-1',
+        runKey: 'run-1',
+        knownAdIds: const {},
+      );
+      await strategy.processToolCalls(
+        toolCalls: [
+          toolCall(GoalAgentToolNames.createGoalAd, {
+            'headline': headline,
+            'tone': 'nudge',
+            'animation': 'pulse',
+          }),
+        ],
+        manager: conversationManager,
+      );
+      return strategy;
+    }
+
+    // insufficientData (default fake reader): the model's ad is refused.
+    await withClock(
+      fixedClock,
+      () async => workflow.persistOutputs(
+        agentId: agentId,
+        runKey: 'run-1',
+        threadId: 'thread-1',
+        strategy: await creating('No data, but here is a banner anyway.'),
+        derivation: await GoalAgentPhaseA(
+          repository: repository,
+          syncService: MockAgentSyncService(),
+          signalReader: _FakeReader(),
+        ).deriveWakeFacts(agentId: agentId, version: version!, now: now),
+        now: now,
+      ),
+    );
+    expect(upserts.whereType<GoalNudgeEntity>(), isEmpty);
+
+    // atRisk with a strictly worsening trend (good prior days, bad today):
+    // eligible — and the persisted copy is sanitized.
+    for (final (period, attainment) in [
+      ('2026-08-08', 0.85),
+      ('2026-08-07', 0.9),
+    ]) {
+      when(
+        () => repository.getEntity(goalProgressId(agentId, period)),
+      ).thenAnswer(
+        (_) async => AgentDomainEntity.goalProgress(
+          id: goalProgressId(agentId, period),
+          agentId: agentId,
+          periodKey: period,
+          trackStatus: GoalTrackStatus.onTrack,
+          attainment: attainment,
+          dataCoverage: 1,
+          satisfied: true,
+          specVersionId: '$agentId:spec-v1',
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: null,
+        ),
+      );
+    }
+    final atRisk = await _offTrackDerivation(repository, version!, now);
+    expect(atRisk.facts.trackStatus, GoalTrackStatus.atRisk);
+    await withClock(
+      fixedClock,
+      () async => workflow.persistOutputs(
+        agentId: agentId,
+        runKey: 'run-1',
+        threadId: 'thread-1',
+        strategy: await creating(
+          'Lace up (id: 123e4567-e89b-12d3-a456-426614174000)',
+        ),
+        derivation: atRisk,
+        now: now,
+      ),
+    );
+    final nudge = upserts.whereType<GoalNudgeEntity>().single;
+    expect(nudge.brief.headline, 'Lace up');
+    expect(nudge.briefDigest, goalBriefDigest(nudge.brief));
+  });
+
+  test('an unresolvable provider re-arms the escalation — configuring it '
+      'later must retry the period', () async {
+    stubSpec();
+    when(
+      () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+    ).thenAnswer((_) async => []);
+    final result = await run();
+    expect(result.success, isFalse);
+    final rearmed = upserts.whereType<ScheduledWakeEntity>().singleWhere(
+      (w) => isGoalEscalationWorkspace(w.workspaceKey),
+    );
+    expect(rearmed.status, ScheduledWakeStatus.pending);
+  });
+
+  test('a bookkeeping failure after committed outputs neither fails the '
+      'wake nor re-arms the escalation', () async {
+    stubSpec();
+    stubGlmResolution();
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      final entity = invocation.positionalArguments.first as AgentDomainEntity;
+      if (entity is WakeTokenUsageEntity) throw StateError('outbox rejected');
+      upserts.add(entity);
+    });
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          await (strategy! as GoalAgentStrategy).processToolCalls(
+            toolCalls: [
+              toolCall(GoalAgentToolNames.updateGoalReport, {
+                'status': 'insufficientData',
+                'oneLiner': 'No data.',
+                'tldr': 'Quiet tracker.',
+              }),
+            ],
+            manager: conversationManager,
+          );
+          return const InferenceUsage(inputTokens: 100, outputTokens: 10);
+        };
+    final result = await run();
+    expect(
+      result.success,
+      isTrue,
+      reason:
+          'outputs committed — bookkeeping '
+          'must not fail the wake',
+    );
+    expect(upserts.whereType<AgentReportEntity>(), hasLength(1));
+    expect(
+      upserts.whereType<ScheduledWakeEntity>().where(
+        (w) => isGoalEscalationWorkspace(w.workspaceKey),
+      ),
+      isEmpty,
+      reason: 'no re-arm: the wake must not be re-billed',
+    );
+  });
+
+  test('an overdue period stamps the head with the PERIOD end, so '
+      'cross-device LWW orders concurrent heads by period', () async {
+    final strategy = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: agentId,
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+    );
+    await strategy.processToolCalls(
+      toolCalls: [
+        toolCall(GoalAgentToolNames.updateGoalReport, {
+          'status': 'insufficientData',
+          'oneLiner': 'Old period.',
+          'tldr': 'Overdue evaluation.',
+        }),
+      ],
+      manager: conversationManager,
+    );
+    when(
+      () => repository.getEntitiesByAgentId(
+        agentId,
+        type: AgentEntityTypes.goalNudge,
+      ),
+    ).thenAnswer((_) async => []);
+    stubSpec();
+    final version =
+        await repository.getEntity('$agentId:spec-v1')
+            as GoalSpecVersionEntity?;
+    final oldDerivation =
+        await GoalAgentPhaseA(
+          repository: repository,
+          syncService: MockAgentSyncService(),
+          signalReader: _FakeReader(),
+        ).deriveWakeFacts(
+          agentId: agentId,
+          version: version!,
+          now: DateTime(2026, 8, 6, 23),
+        );
+    await withClock(
+      fixedClock,
+      () => workflow.persistOutputs(
+        agentId: agentId,
+        runKey: 'run-1',
+        threadId: 'thread-1',
+        strategy: strategy,
+        derivation: oldDerivation,
+        now: now,
+      ),
+    );
+    final head = upserts.whereType<AgentReportHeadEntity>().single;
+    expect(head.updatedAt, DateTime(2026, 8, 6, 23, 59, 59));
   });
 }

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -1936,7 +1936,10 @@ void main() {
       ),
     ).thenAnswer((_) async => []);
 
-    Future<GoalAgentStrategy> creating(String headline) async {
+    Future<GoalAgentStrategy> creatingWithTagline(
+      String headline, [
+      String? tagline,
+    ]) async {
       final strategy = GoalAgentStrategy(
         syncService: syncService,
         agentId: agentId,
@@ -1948,6 +1951,7 @@ void main() {
         toolCalls: [
           toolCall(GoalAgentToolNames.createGoalAd, {
             'headline': headline,
+            'tagline': ?tagline,
             'tone': 'nudge',
             'animation': 'pulse',
           }),
@@ -1956,6 +1960,72 @@ void main() {
       );
       return strategy;
     }
+
+    Future<GoalAgentStrategy> creating(String headline) =>
+        creatingWithTagline(headline);
+
+    // insufficientData (default fake reader): the model's ad is refused —
+    // and a rerun of a retired library ad is refused the same way.
+    final retiredLibraryAd =
+        AgentDomainEntity.goalNudge(
+              id: 'ad-lib',
+              agentId: agentId,
+              status: GoalNudgeStatus.retired,
+              brief: const GoalNudgeBrief(
+                headline: 'old',
+                tone: GoalNudgeTone.nudge,
+                animation: GoalBannerAnimation.steady,
+              ),
+              briefDigest: 'd-lib',
+              createdAt: DateTime(2026, 8),
+              updatedAt: DateTime(2026, 8),
+              vectorClock: null,
+            )
+            as GoalNudgeEntity;
+    when(
+      () => repository.getEntitiesByAgentId(
+        agentId,
+        type: AgentEntityTypes.goalNudge,
+      ),
+    ).thenAnswer((_) async => [retiredLibraryAd]);
+    final rerunning = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: agentId,
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {'ad-lib'},
+    );
+    await rerunning.processToolCalls(
+      toolCalls: [
+        toolCall(GoalAgentToolNames.rerunGoalAd, {
+          'adId': 'ad-lib',
+          'reason': 'bring it back',
+        }),
+      ],
+      manager: conversationManager,
+    );
+    await withClock(
+      fixedClock,
+      () async => workflow.persistOutputs(
+        agentId: agentId,
+        runKey: 'run-1',
+        threadId: 'thread-1',
+        strategy: rerunning,
+        derivation: await GoalAgentPhaseA(
+          repository: repository,
+          syncService: MockAgentSyncService(),
+          signalReader: _FakeReader(),
+        ).deriveWakeFacts(agentId: agentId, version: version!, now: now),
+        now: now,
+      ),
+    );
+    expect(upserts.whereType<GoalNudgeEntity>(), isEmpty);
+    when(
+      () => repository.getEntitiesByAgentId(
+        agentId,
+        type: AgentEntityTypes.goalNudge,
+      ),
+    ).thenAnswer((_) async => []);
 
     // insufficientData (default fake reader): the model's ad is refused.
     await withClock(
@@ -2007,8 +2077,9 @@ void main() {
         agentId: agentId,
         runKey: 'run-1',
         threadId: 'thread-1',
-        strategy: await creating(
+        strategy: await creatingWithTagline(
           'Lace up (id: 123e4567-e89b-12d3-a456-426614174000)',
+          'Six quiet days (123e4567-e89b-12d3-a456-426614174000)',
         ),
         derivation: atRisk,
         now: now,
@@ -2016,6 +2087,7 @@ void main() {
     );
     final nudge = upserts.whereType<GoalNudgeEntity>().single;
     expect(nudge.brief.headline, 'Lace up');
+    expect(nudge.brief.tagline, 'Six quiet days');
     expect(nudge.briefDigest, goalBriefDigest(nudge.brief));
   });
 

--- a/test/features/goals/workflow/goal_tool_dispatcher_test.dart
+++ b/test/features/goals/workflow/goal_tool_dispatcher_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/goals/service/goal_spec_revision_service.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
+import 'package:lotti/features/goals/workflow/goal_tool_dispatcher.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  const agentId = 'goal-1';
+  late MockAgentRepository repository;
+  late MockAgentSyncService syncService;
+  late List<AgentDomainEntity> upserts;
+  late GoalToolDispatcher dispatcher;
+
+  setUp(() {
+    repository = MockAgentRepository();
+    syncService = MockAgentSyncService();
+    upserts = [];
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      upserts.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    dispatcher = GoalToolDispatcher(
+      revisionService: GoalSpecRevisionService(
+        repository: repository,
+        syncService: syncService,
+      ),
+    );
+  });
+
+  void stubSpec() {
+    when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: '$agentId:spec-v1',
+        updatedAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+    when(() => repository.getEntity('$agentId:spec-v1')).thenAnswer(
+      (_) async => AgentDomainEntity.goalSpecVersion(
+        id: '$agentId:spec-v1',
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: 'Steps',
+        statement: 'Average 10,000 steps per day.',
+        criteria: const GoalCriterion.metric(
+          criterionId: 'steps',
+          dataType: 'cumulative_step_count',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          target: 10000,
+        ),
+        createdAt: DateTime(2026, 8),
+        vectorClock: null,
+      ),
+    );
+  }
+
+  test(
+    'an accepted revision mints the version and reports what changed',
+    () async {
+      stubSpec();
+      final result = await dispatcher.dispatch(
+        GoalAgentToolNames.proposeGoalRevision,
+        {
+          'changes': {'targetValue': 8000},
+          'rationale': 'ease off',
+        },
+        agentId,
+      );
+      expect(result.success, isTrue);
+      expect(result.mutatedEntityId, '$agentId:spec-v2');
+      expect(result.output, contains('Goal revised to v2'));
+      expect(result.output, contains('target: 10000 → 8000'));
+      expect(
+        upserts.whereType<GoalSpecHeadEntity>().single.versionId,
+        '$agentId:spec-v2',
+      );
+    },
+  );
+
+  test('a refusal keeps the proposal unresolved — success false, nothing '
+      'written', () async {
+    stubSpec();
+    final result = await dispatcher.dispatch(
+      GoalAgentToolNames.proposeGoalRevision,
+      {
+        'changes': {'period': 'fortnight'},
+        'rationale': 'r',
+      },
+      agentId,
+    );
+    expect(result.success, isFalse);
+    expect(result.errorMessage, contains('unrecognized period'));
+    expect(upserts, isEmpty);
+  });
+
+  test('missing changes and unknown tools are rejected', () async {
+    final noChanges = await dispatcher.dispatch(
+      GoalAgentToolNames.proposeGoalRevision,
+      {'rationale': 'r'},
+      agentId,
+    );
+    expect(noChanges.success, isFalse);
+    expect(noChanges.errorMessage, 'Missing changes');
+
+    final unknown = await dispatcher.dispatch('made_up_tool', {}, agentId);
+    expect(unknown.success, isFalse);
+    expect(unknown.errorMessage, contains('not registered'));
+  });
+}

--- a/test/features/goals/workflow/goal_tool_dispatcher_test.dart
+++ b/test/features/goals/workflow/goal_tool_dispatcher_test.dart
@@ -78,11 +78,20 @@ void main() {
         {
           'changes': {'targetValue': 8000},
           'rationale': 'ease off',
+          'sourceThreadId': 'thread-42',
         },
         agentId,
       );
       expect(result.success, isTrue);
       expect(result.mutatedEntityId, '$agentId:spec-v2');
+      expect(
+        upserts
+            .whereType<GoalSpecVersionEntity>()
+            .singleWhere((v) => v.id == '$agentId:spec-v2')
+            .sourceSessionId,
+        'thread-42',
+        reason: 'the proposing conversation stays auditable on the version',
+      );
       expect(result.output, contains('Goal revised to v2'));
       expect(result.output, contains('target: 10000 → 8000'));
       expect(


### PR DESCRIPTION
PR 4 of the goal-agents build: the goal-evolution loop closes. A `propose_goal_revision` ChangeSet queued by a Phase B wake can now be **accepted**, and acceptance is the only path that ever changes a goal after creation — the coach never quietly moves its own goalposts (ADR 0053).

## What lands

**`applyGoalRevisionChanges` (pure, exhaustively tested).** Applies the proposal's `changes` map (`metric` / `targetValue` / `period` / `cadence`) to the criteria tree. Deliberately conservative: two candidate leaves without a disambiguating name, unparseable period/cadence phrases, or free-form `successCriteria` alone are **rejected with a reason** instead of guessed at. Period parsing speaks the FACTS vocabulary (`day`, `rolling N days`, `calendar week`, `calendar month`).

**`GoalSpecRevisionService`** — the soul-version-ops pattern, one transaction: supersede the current version, mint `v(n+1)` with full provenance (`authoredBy: goal_agent`, `diffFromVersionId`, the proposal's rationale; start/target dates carry over — a revision is not a restart), move the deterministic head. Grace history resets naturally: Phase A's prior-row streak breaks at the version change. A revision over an already-corrupt tree is vetoed by `GoalSpecValidator` before anything is written.

**`GoalToolDispatcher`** (the `EventToolDispatcher` shape): refusals return `success: false` so the proposal stays unresolved rather than half-applying.

**Wiring**: `goalChangeSetConfirmationServiceProvider` reuses the generic `ChangeSetConfirmationService` — decision persistence, item-status derivation and resolution notifications come free. The `onConfirmedDecision` hook re-registers the goal's signal subscription from the **new** criteria; on other devices the synced-in head triggers the same re-registration through the sync processor's identity re-offer (shipped in PR 3). `selfTargetedPendingChangeSetsProvider` (kind-agnostic, in agents) is the pending-proposals query for PR 5's approval surface.

**Also carried in this branch** (first commit): the post-merge Codex review fixes of #3863 — status-gated ad writes (incl. the atRisk-worsening P4 requirement), viable-action check for the forced ad retry, sanitized banner copy, resolution-failure re-arm, `outputsCommitted` guard against re-billing, and period-stamped report heads for cross-device LWW ordering. All nine threads on #3863 are replied and point here.

## Verification

- End-to-end accept test: decision persisted, v2 minted, head moved, subscription re-registered from the new criteria — through the real `ChangeSetConfirmationService`.
- 232 tests green across goals, change-set providers, eval-offline and bootstrap suites; analyzer clean repo-wide; zero uncovered lines in `lib/features/goals`; `make knowledge_check` passes (concept records the revision invariant).

No CHANGELOG entry: still headless — no user-visible surface until PR 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for proposing and approving goal revisions, including target, period, cadence, and criteria updates.
  * Approved changes now create versioned goal specifications with history and provenance.
  * Updated goal subscriptions automatically use revised criteria across devices.
  * Added handling for pending self-targeted change proposals.

* **Bug Fixes**
  * Improved goal wake retries, escalation re-arming, ad eligibility, report timing, and banner sanitization.
  * Invalid, ambiguous, or unsupported goal changes are now rejected safely.

* **Tests**
  * Expanded coverage for goal revisions, approvals, workflow retries, advertising behavior, and tool validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->