### PR TITLE
chore: upgrade Matrix and vodozemac

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -163,17 +163,17 @@ This file tells flatpak-flutter about plugins not in its built-in database.
 {
     "flutter_vodozemac": {
         "cargo_locks": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/rust"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.7.1/rust"
         ],
         "extra_pubspecs": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit/build_tool"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.7.1/cargokit/build_tool"
         ],
         "manifest": {
             "sources": [
                 {
                     "type": "patch",
                     "path": "cargokit/run_build_tool.sh.patch",
-                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit"
+                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.7.1/cargokit"
                 }
             ]
         }

--- a/flatpak/foreign.json
+++ b/flatpak/foreign.json
@@ -1,17 +1,17 @@
 {
     "flutter_vodozemac": {
         "cargo_locks": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/rust"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.7.1/rust"
         ],
         "extra_pubspecs": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit/build_tool"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.7.1/cargokit/build_tool"
         ],
         "manifest": {
             "sources": [
                 {
                     "type": "patch",
                     "path": "cargokit/run_build_tool.sh.patch",
-                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit"
+                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.7.1/cargokit"
                 }
             ]
         }

--- a/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
+++ b/lib/features/backup_restore/service/quiesced_profile_snapshot_service.dart
@@ -585,7 +585,7 @@ class QuiescedProfileSnapshotService {
         cause: error,
       );
     } finally {
-      database?.dispose();
+      database?.close();
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "57c62a6d85c39d2a8c984e3b73b29bf2775a865e690309405aeade647fb2184c"
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.4"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
@@ -337,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   collection:
     dependency: "direct main"
     description:
@@ -574,18 +582,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "3a3f1f6f905037d7426e4c445854139fd6a3d592135f7c96d7931682b73d16f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.3"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -937,10 +945,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "9375211fd7df9c070504ac4db7047c7fae857e238291433b770cfe696b5c357a"
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
       url: "https://pub.dev"
     source: hosted
-    version: "22.2.0"
+    version: "22.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -953,10 +961,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "945a438a4779f3aca3a948718d8a4048cbe9f9c8c797492c00abd5d39112bf37"
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "12.2.0"
   flutter_local_notifications_web:
     dependency: transitive
     description:
@@ -1085,10 +1093,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_rust_bridge
-      sha256: "37ef40bc6f863652e865f0b2563ea07f0d3c58d8efad803cc01933a4b2ee067e"
+      sha256: e87d6b9ee934dcd24a128ccb2bd91905d2d5fe5c06245d6a8f5477d4907a437a
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.12.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1109,10 +1117,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      sha256: "76fa9c841b3b1619fc5b5bc36efc7d158fa2356f223b6caeb1d0c80a54168546"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -1170,10 +1178,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_vodozemac
-      sha256: "4503bc4a33a5126539fe68eecbf736eafe412474874a2ebbfc94aef0b0d2e304"
+      sha256: "7e893533d757501eba4aedeecb54586ac2f3fa5e4f28de3e5723b383d5293d7e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1328,6 +1336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.3.1"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   html:
     dependency: transitive
     description:
@@ -1753,10 +1769,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: "25ab47abd6a98c5c1affd1c735b83dcd01844f49c60483d679ffb9463f0a3f61"
+      sha256: "9449c98ba2f8d5b72404ed41a03f3cb9942f691f2029b42b10f7fb86a570adfd"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "10.0.0"
   media_kit:
     dependency: "direct main"
     description:
@@ -1877,6 +1893,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.2"
   nested:
     dependency: transitive
     description:
@@ -2089,10 +2113,10 @@ packages:
     dependency: transitive
     description:
       name: photo_manager
-      sha256: "4f7de6c9778993c5c54cf1fb2eaa8d5c27c0771dc24a4dfca341aa81aef13fe1"
+      sha256: "2d00a785b501bf1e5f6180bbef772846e767be11d45d11112b63092ef54a419e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.0"
+    version: "3.12.0"
   photo_manager_image_provider:
     dependency: transitive
     description:
@@ -2373,6 +2397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   record_web:
     dependency: transitive
     description:
@@ -2711,10 +2743,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: "8d7b8749a516cbf6e9057f9b480b716ad14fc4f3d3873ca6938919cc626d9025"
+      sha256: "5ccd38136edb9beb3213f6927775d52db70dfdadcdb28dad1f625ca9f2b9824f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7+1"
+    version: "2.4.2"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -2735,10 +2767,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.1"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -2751,10 +2783,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:
@@ -3151,10 +3183,10 @@ packages:
     dependency: transitive
     description:
       name: vodozemac
-      sha256: bbe7dd31d7f623e2aeedb92e4b71a8b519e6109ce1e2911b5a220f6752b65cda
+      sha256: "7726f6c53bec7458b83820500b408a7d2d1804aae018c81bafae918d1a179313"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.7.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   flutter_riverpod: ^3.1.0
   flutter_secure_storage: ^10.0.0
   flutter_svg: ^2.2.4
-  flutter_vodozemac: ^0.6.0
+  flutter_vodozemac: ^0.7.1
   form_builder_validators: ^11.0.0
   formz: ^0.8.0
   freezed_annotation: ^3.1.0
@@ -84,7 +84,7 @@ dependencies:
   just_waveform: ^0.0.7
   latlong2: ^0.10.1
   location: ^9.0.0
-  matrix: ^8.1.0
+  matrix: ^10.0.0
   media_kit: ^1.0.2
   media_kit_libs_audio: ^1.0.7
   meta: ^1.12.0
@@ -110,7 +110,7 @@ dependencies:
   share_plus: ^12.0.0
   shared_preferences: ^2.3.2
   sqflite_common_ffi: ^2.3.3
-  sqlite3: ^2.4.5
+  sqlite3: ^3.5.1
   sqlite3_flutter_libs: ^0.5.42
   super_clipboard: ^0.9.1
   super_drag_and_drop: ^0.9.1

--- a/test/database/category_backfill_migration_test.dart
+++ b/test/database/category_backfill_migration_test.dart
@@ -131,7 +131,7 @@ void main() {
         );
         insertV42Entry(sqlite, id: 'uncategorized', columnCategory: '');
         sqlite.execute('PRAGMA user_version = 42');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v43.db');
         addTearDown(db.close);

--- a/test/database/database_migration_recent_test.dart
+++ b/test/database/database_migration_recent_test.dart
@@ -90,7 +90,7 @@ void main() {
         ['ordinary-entry', '{"data":{}}', 'JournalEntry'],
       )
       ..execute('PRAGMA user_version = 44')
-      ..dispose();
+      ..close();
 
     final db = JournalDb(overriddenFilename: 'v45.db');
     addTearDown(db.close);

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -97,7 +97,7 @@ void main() {
             "VALUES ('mig-task', '{}', 0, 0, 0, 0, 'Task', 1, 'OPEN')",
           )
           ..execute('PRAGMA user_version = 18')
-          ..dispose();
+          ..close();
 
         // Create the default-named db file so the pre-migration backup (which
         // copies `journalDbFileName` from the docs dir) succeeds, covering the

--- a/test/database/definition_indexes_migration_test.dart
+++ b/test/database/definition_indexes_migration_test.dart
@@ -63,7 +63,7 @@ void main() {
       _createV33DefinitionSchema(sqlite);
 
       sqlite.execute('PRAGMA user_version = 33');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = JournalDb(
         overriddenFilename: 'test_v34_definition_idx.db',
@@ -139,7 +139,7 @@ void main() {
         )
       ''');
         sqlite.execute('PRAGMA user_version = 33');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v34_definition_idx_existing.db',

--- a/test/database/due_at_migration_test.dart
+++ b/test/database/due_at_migration_test.dart
@@ -167,7 +167,7 @@ void main() {
       final sqlite = sqlite3.open(dbFile.path);
       createV40Schema(sqlite);
       sqlite.execute('PRAGMA user_version = 40');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = JournalDb(overriddenFilename: 'test_v41_column.db');
       addTearDown(db.close);
@@ -239,7 +239,7 @@ void main() {
         );
 
         sqlite.execute('PRAGMA user_version = 40');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v41_backfill.db');
         addTearDown(db.close);
@@ -275,7 +275,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV40Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 40');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v41_index.db');
         addTearDown(db.close);
@@ -296,7 +296,7 @@ void main() {
       final sqlite = sqlite3.open(dbFile.path);
       createV40Schema(sqlite);
       sqlite.execute('PRAGMA user_version = 40');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = JournalDb(overriddenFilename: 'test_v41_drop.db');
       addTearDown(db.close);
@@ -315,7 +315,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV40Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 40');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v41_plan.db');
         addTearDown(db.close);
@@ -356,7 +356,7 @@ void main() {
         due: DateTime.utc(2026, 5),
       );
       sqlite.execute('PRAGMA user_version = 40');
-      sqlite.dispose();
+      sqlite.close();
 
       // First open runs the migration.
       var db = JournalDb(overriddenFilename: 'test_v41_idempotent.db');

--- a/test/database/editor_db_query_test.dart
+++ b/test/database/editor_db_query_test.dart
@@ -399,7 +399,7 @@ void main() {
             'ON editor_drafts (created_at)',
           )
           ..execute('PRAGMA user_version = 1')
-          ..dispose();
+          ..close();
 
         final migratedDb = EditorDb(
           documentsDirectoryProvider: () async => tempDir,

--- a/test/database/labels_migration_test.dart
+++ b/test/database/labels_migration_test.dart
@@ -87,7 +87,7 @@ void main() {
       sqlite.execute('PRAGMA user_version = 25');
 
       // Close raw connection
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with JournalDb to trigger migration
       final db = JournalDb(overriddenFilename: 'test_v26.db');
@@ -141,7 +141,7 @@ void main() {
 
         // Set schema version to 26 without creating label tables
         sqlite.execute('PRAGMA user_version = 26');
-        sqlite.dispose();
+        sqlite.close();
 
         // Open with JournalDb to trigger migration
         final db = JournalDb(overriddenFilename: 'test_v27.db');
@@ -216,7 +216,7 @@ void main() {
 
       // Set schema version to 27
       sqlite.execute('PRAGMA user_version = 27');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with JournalDb to trigger migration
       final db = JournalDb(overriddenFilename: 'test_v28.db');
@@ -253,7 +253,7 @@ void main() {
       createJournalTable(sqlite, version: 25);
       createLinkedEntriesTableWithBuggyIndex(sqlite);
       sqlite.execute('PRAGMA user_version = 25');
-      sqlite.dispose();
+      sqlite.close();
 
       // First migration
       var db = JournalDb(overriddenFilename: 'test_idempotent.db');
@@ -330,7 +330,7 @@ void main() {
 
       createLinkedEntriesTableWithBuggyIndex(sqlite);
       sqlite.execute('PRAGMA user_version = 27');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with JournalDb to trigger migration
       final db = JournalDb(overriddenFilename: 'test_preserve.db');
@@ -420,7 +420,7 @@ void main() {
       createJournalTable(sqlite, version: 25);
       createLinkedEntriesTableWithBuggyIndex(sqlite);
       sqlite.execute('PRAGMA user_version = 25');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with JournalDb to trigger migration
       final db = JournalDb(overriddenFilename: 'test_empty.db');

--- a/test/database/linked_entries_index_migration_test.dart
+++ b/test/database/linked_entries_index_migration_test.dart
@@ -88,7 +88,7 @@ void main() {
 
       // Set user_version to 29 to trigger v30 migration
       sqlite.execute('PRAGMA user_version = 29');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with Drift to run migration
       final db = JournalDb(overriddenFilename: 'test_v30_linked_idx.db');

--- a/test/database/priority_migration_test.dart
+++ b/test/database/priority_migration_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       // Set user_version to 28 to trigger v29 migration
       sqlite.execute('PRAGMA user_version = 28');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with Drift to run migration
       final db = JournalDb(overriddenFilename: 'test_v29_priority.db');
@@ -135,7 +135,7 @@ void main() {
       ''');
 
         sqlite.execute('PRAGMA user_version = 32');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v33_due_idx.db');
         addTearDown(db.close);
@@ -168,7 +168,7 @@ void main() {
       createJournalTable(sqlite, version: 34);
 
       sqlite.execute('PRAGMA user_version = 34');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = JournalDb(overriddenFilename: 'test_v35_task_date_idx.db');
       addTearDown(db.close);
@@ -213,7 +213,7 @@ void main() {
       ''');
 
         sqlite.execute('PRAGMA user_version = 34');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v35_task_date_idx_existing.db',
@@ -246,7 +246,7 @@ void main() {
         createJournalTable(sqlite, version: 35);
 
         sqlite.execute('PRAGMA user_version = 35');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v36_journal_browse_idx.db',
@@ -294,7 +294,7 @@ void main() {
       ''');
 
         sqlite.execute('PRAGMA user_version = 35');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v36_journal_browse_idx_existing.db',
@@ -335,7 +335,7 @@ void main() {
       ''');
 
         sqlite.execute('PRAGMA user_version = 36');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v37_task_index_rebuild.db',
@@ -429,7 +429,7 @@ void main() {
       ''');
 
         sqlite.execute('PRAGMA user_version = 36');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v37_labeled_idx_existing.db',

--- a/test/database/sync_db_migration_test.dart
+++ b/test/database/sync_db_migration_test.dart
@@ -83,7 +83,7 @@ void main() {
         sqlite.execute('PRAGMA user_version = 1');
 
         // Close raw connection
-        sqlite.dispose();
+        sqlite.close();
 
         // Open with SyncDatabase to trigger migration
         final db = SyncDatabase(overriddenFilename: 'test_sync_v2.db');
@@ -234,7 +234,7 @@ void main() {
 
       _createOutboxV1(sqlite);
       sqlite.execute('PRAGMA user_version = 1');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with SyncDatabase to trigger migration
       final db = SyncDatabase(overriddenFilename: 'test_usage.db');
@@ -295,7 +295,7 @@ void main() {
         ''');
 
         sqlite.execute('PRAGMA user_version = 2');
-        sqlite.dispose();
+        sqlite.close();
 
         // Open with SyncDatabase to trigger the v2→v3→…→v24 migration.
         final db = SyncDatabase(overriddenFilename: 'test_sync_v3.db');
@@ -369,7 +369,7 @@ void main() {
       ''');
 
       sqlite.execute('PRAGMA user_version = 4');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with SyncDatabase to trigger v4→v5 migration
       final db = SyncDatabase(overriddenFilename: 'test_sync_v5.db');
@@ -416,7 +416,7 @@ void main() {
       ''');
 
       sqlite.execute('PRAGMA user_version = 5');
-      sqlite.dispose();
+      sqlite.close();
 
       // Open with SyncDatabase to trigger v5→v6 migration
       final db = SyncDatabase(overriddenFilename: 'test_sync_v6.db');
@@ -465,7 +465,7 @@ void main() {
       _createSyncSequenceLogV3(sqlite, withJsonPath: true);
       _createHostActivity(sqlite);
       sqlite.execute('PRAGMA user_version = 7');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = SyncDatabase(overriddenFilename: 'test_sync_v8.db');
 
@@ -505,7 +505,7 @@ void main() {
         _createSyncSequenceLogV3(sqlite);
         _createHostActivity(sqlite);
         sqlite.execute('PRAGMA user_version = 3');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v4.db');
 
@@ -569,7 +569,7 @@ void main() {
             ('host-1', 4, NULL, $agentEntity, 1, 1704067200, 1704067200)
         ''');
         sqlite.execute('PRAGMA user_version = 6');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v7.db');
 
@@ -614,7 +614,7 @@ void main() {
         _createSyncSequenceLogV3(sqlite, withJsonPath: true);
         _createHostActivity(sqlite);
         sqlite.execute('PRAGMA user_version = 11');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v12.db');
 
@@ -672,7 +672,7 @@ void main() {
         _createInboundEventQueueV13(sqlite);
         _createQueueMarkers(sqlite);
         sqlite.execute('PRAGMA user_version = 14');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v15_20.db');
 
@@ -763,7 +763,7 @@ void main() {
           'ON outbox (status, priority, created_at)',
         );
         sqlite.execute('PRAGMA user_version = 9');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v10.db');
 
@@ -841,7 +841,7 @@ void main() {
           'WHERE entry_id IS NOT NULL',
         );
         sqlite.execute('PRAGMA user_version = 10');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v11.db');
 
@@ -917,7 +917,7 @@ void main() {
         ''');
 
         sqlite.execute('PRAGMA user_version = 12');
-        sqlite.dispose();
+        sqlite.close();
 
         // Open with SyncDatabase to trigger the v12→v13→…→v24 migration.
         final db = SyncDatabase(overriddenFilename: 'test_sync_v13.db');
@@ -1000,7 +1000,7 @@ void main() {
         _createInboundEventQueueV13(sqlite);
         _createQueueMarkers(sqlite);
         sqlite.execute('PRAGMA user_version = 13');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v14.db');
 
@@ -1061,7 +1061,7 @@ void main() {
         );
         _createSyncSequenceLogV3(sqlite, withJsonPath: true);
         sqlite.execute('PRAGMA user_version = 20');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v21.db');
 
@@ -1152,7 +1152,7 @@ void main() {
         );
         _createSyncSequenceLogV3(sqlite, withJsonPath: true);
         sqlite.execute('PRAGMA user_version = 21');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v23_from_v21.db',
@@ -1221,7 +1221,7 @@ void main() {
             'WHERE status = 3',
           )
           ..execute('PRAGMA user_version = 21')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v22_reindex.db');
 
@@ -1260,7 +1260,7 @@ void main() {
         _createSyncSequenceLogV3(sqlite, withJsonPath: true);
         sqlite
           ..execute('PRAGMA user_version = 22')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v23_watermark.db',
@@ -1313,7 +1313,7 @@ void main() {
             )
           ''')
           ..execute('PRAGMA user_version = 23')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(overriddenFilename: 'test_sync_v24_burned.db');
 
@@ -1373,7 +1373,7 @@ void main() {
             'WHERE status IN (0, 3)',
           )
           ..execute('PRAGMA user_version = 24')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v25_outbox_id.db',
@@ -1412,7 +1412,7 @@ void main() {
         _createSyncSequenceLogV3(sqlite, withJsonPath: true);
         sqlite
           ..execute('PRAGMA user_version = 25')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v26_outbox_sent.db',
@@ -1452,7 +1452,7 @@ void main() {
         _createSyncSequenceLogV3(sqlite, withJsonPath: true);
         sqlite
           ..execute('PRAGMA user_version = 26')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v27_outbox_subject.db',
@@ -1503,7 +1503,7 @@ void main() {
             ) VALUES ('!room:example.org', '$anchor', 5000, 7)
           ''')
           ..execute('PRAGMA user_version = 27')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v28_resume_floor.db',
@@ -1552,7 +1552,7 @@ void main() {
         );
         sqlite3.open(dbFile.path)
           ..execute('PRAGMA user_version = 28')
-          ..dispose();
+          ..close();
 
         final db = SyncDatabase(
           overriddenFilename: 'test_sync_v29_onboarding.db',

--- a/test/database/task_indexes_v39_migration_test.dart
+++ b/test/database/task_indexes_v39_migration_test.dart
@@ -121,7 +121,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV38Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 38');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v39_due_open.db');
         addTearDown(db.close);
@@ -158,7 +158,7 @@ void main() {
       final sqlite = sqlite3.open(dbFile.path);
       createV38Schema(sqlite);
       sqlite.execute('PRAGMA user_version = 38');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = JournalDb(overriddenFilename: 'test_v39_status_private.db');
       addTearDown(db.close);
@@ -192,7 +192,7 @@ void main() {
           "AND task_status NOT IN ('DONE', 'REJECTED')",
         );
         sqlite.execute('PRAGMA user_version = 38');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v39_rerun.db');
         addTearDown(db.close);
@@ -215,7 +215,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV38Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 38');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v39_count_plan.db');
         addTearDown(db.close);
@@ -247,7 +247,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV38Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 38');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v39_due_plan.db');
         addTearDown(db.close);
@@ -282,7 +282,7 @@ void main() {
       final sqlite = sqlite3.open(dbFile.path);
       createV38Schema(sqlite);
       sqlite.execute('PRAGMA user_version = 43');
-      sqlite.dispose();
+      sqlite.close();
 
       final db = JournalDb(
         overriddenFilename: 'test_v44_task_priority_date.db',
@@ -318,7 +318,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV38Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 38');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(
           overriddenFilename: 'test_v44_task_priority_plan.db',
@@ -407,7 +407,7 @@ void main() {
         final sqlite = sqlite3.open(dbFile.path);
         createV38Schema(sqlite);
         sqlite.execute('PRAGMA user_version = 39');
-        sqlite.dispose();
+        sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v39_fallback.db');
         addTearDown(db.close);

--- a/test/features/agents/database/agent_database_test.dart
+++ b/test/features/agents/database/agent_database_test.dart
@@ -423,7 +423,7 @@ void main() {
 
         // Set schema version to 1
         rawDb.execute('PRAGMA user_version = 1');
-        rawDb.dispose();
+        rawDb.close();
 
         // Open with AgentDatabase to trigger v1→v2 migration
         final db = AgentDatabase(
@@ -541,7 +541,7 @@ void main() {
       ''');
 
       rawDb.execute('PRAGMA user_version = 2');
-      rawDb.dispose();
+      rawDb.close();
 
       // Open with AgentDatabase to trigger v2→v3 migration.
       final db = AgentDatabase(
@@ -689,7 +689,7 @@ void main() {
         ''');
 
       rawDb.execute('PRAGMA user_version = 2');
-      rawDb.dispose();
+      rawDb.close();
 
       // Migration should deduplicate before creating the index.
       final db = AgentDatabase(
@@ -795,7 +795,7 @@ void main() {
         ''');
 
       rawDb.execute('PRAGMA user_version = 3');
-      rawDb.dispose();
+      rawDb.close();
 
       final db = AgentDatabase(
         background: false,
@@ -925,7 +925,7 @@ void main() {
           ''');
 
         rawDb.execute('PRAGMA user_version = 4');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -1061,7 +1061,7 @@ void main() {
           ''');
 
         rawDb.execute('PRAGMA user_version = 5');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -1209,7 +1209,7 @@ void main() {
           )
         ''')
         ..execute('PRAGMA user_version = 8');
-      rawDb.dispose();
+      rawDb.close();
 
       final db = AgentDatabase(
         background: false,
@@ -1293,7 +1293,7 @@ void main() {
             'WHERE deleted_at IS NULL',
           )
           ..execute('PRAGMA user_version = 9');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -1432,7 +1432,7 @@ void main() {
             "'soul_assignment', 1, 1, '{}')",
           )
           ..execute('PRAGMA user_version = 10');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -1588,7 +1588,7 @@ void main() {
             )
           ''')
           ..execute('PRAGMA user_version = 12');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -1773,7 +1773,7 @@ void main() {
             )
           ''')
           ..execute('PRAGMA user_version = 13');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -1948,7 +1948,7 @@ void main() {
             )
           ''')
           ..execute('PRAGMA user_version = 14');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -2027,7 +2027,7 @@ void main() {
             )
           ''')
           ..execute('PRAGMA user_version = 15');
-        rawDb.dispose();
+        rawDb.close();
 
         final db = AgentDatabase(
           background: false,
@@ -2174,7 +2174,7 @@ void main() {
             ],
           )
           ..execute('PRAGMA user_version = 17')
-          ..dispose();
+          ..close();
 
         final db = AgentDatabase(
           background: false,
@@ -2283,7 +2283,7 @@ void main() {
         ..execute("INSERT INTO wake_run_log VALUES ('run-1', 1)")
         ..execute("INSERT INTO saga_log VALUES ('op-1', 'pending', 1, 1)")
         ..execute('PRAGMA user_version = 18')
-        ..dispose();
+        ..close();
 
       final db = AgentDatabase(
         background: false,

--- a/test/features/ai_consumption/database/consumption_database_test.dart
+++ b/test/features/ai_consumption/database/consumption_database_test.dart
@@ -64,7 +64,7 @@ void main() {
         )
       ''')
       ..execute('PRAGMA user_version = 1')
-      ..dispose();
+      ..close();
 
     final migrated = ConsumptionDatabase(
       background: false,

--- a/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
+++ b/test/features/backup_restore/service/quiesced_profile_snapshot_service_test.dart
@@ -48,7 +48,7 @@ void main() {
         reason: 'the fixture must exercise a database that was WAL-backed',
       );
     } finally {
-      database.dispose();
+      database.close();
     }
   }
 
@@ -472,7 +472,7 @@ void main() {
             'committed journal value',
           );
         } finally {
-          restoredJournal.dispose();
+          restoredJournal.close();
         }
 
         final manifestJson =
@@ -1216,7 +1216,7 @@ void main() {
                 try {
                   database.userVersion = 46;
                 } finally {
-                  database.dispose();
+                  database.close();
                 }
 
                 final manifestFile = File(
@@ -1270,7 +1270,7 @@ void main() {
         pageSize =
             database.select('PRAGMA page_size').single.values.single! as int;
       } finally {
-        database.dispose();
+        database.close();
       }
       final damagedBytes = journal.readAsBytesSync()..[pageSize] = 0;
       journal.writeAsBytesSync(damagedBytes, flush: true);


### PR DESCRIPTION
## Summary

- upgrade `matrix` from 8.1.0 to 10.0.0
- upgrade `flutter_vodozemac` from 0.6.0 to 0.7.1 (`vodozemac` 0.7.0 transitively)
- upgrade `sqlite3` and compatible Drift dependencies required by Matrix 10
- migrate SQLite cleanup calls from deprecated `dispose()` to `close()`
- update Flatpak foreign-dependency paths for `flutter_vodozemac 0.7.1`
- preserve the previously resolved minor dependency updates in `pubspec.lock`

## Impact

This keeps the Matrix encryption and sync stack current. There are no intended user-visible behavior changes.

## Validation

- `fvm dart format .`
- `fvm dart analyze` — no issues in the tracked repository
- targeted database, backup/restore, Matrix client/service/sender, and app bootstrap tests — 305 passed
- `make check_flatpak_foreign_deps` — all four native dependency patches validated
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. Integration checks and Codecov patch coverage will also be monitored through completion.