### PR TITLE
fix(goals): dispatch signal wakes immediately, plus the UI design brief

### DIFF
--- a/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
+++ b/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
@@ -1,0 +1,414 @@
+# Goal Agents — UI Design Brief
+
+- Date: 2026-08-10 (revised same day: banner voice model, goal generality)
+- Status: Brief for design (no implementation decisions locked)
+- Audience: a designer picking up the whole feature surface, with no prior
+  context on this codebase
+
+## 1. What the feature is
+
+One durable, mostly dormant **agent per goal**. You tell it a goal ("walk more",
+"gym three times a week"). It watches the signals that goal depends on — habit
+completions, step counts — and speaks to you through short, model-authored
+**text banners** that appear where you already are. You can dismiss a banner,
+rate it, tap into a conversation with the agent, and change the goal by talking
+to it.
+
+Two properties are load-bearing and shape everything below:
+
+- **The banner is the agent's voice, not an alarm.** During an active period a
+  goal generally *has* a current message: "start the week strong" on Monday
+  morning, a nudge after a missed day, plain "you're at risk" language late in
+  a bad week, celebration when the target lands. Escalation lives in the copy
+  and tone — the banner's *presence* follows the rhythm of the period, not the
+  presence of trouble. Dismissal always quiets the goal for the rest of the
+  day, and that quiet is honoured absolutely.
+- **No generated imagery.** An earlier design generated an illustration per
+  nudge; that was removed on purpose (ADR 0058) because spending energy on
+  decoration was indefensible. **All personality must come from typography,
+  motion, colour and copy.** This is the central creative constraint of the
+  brief, not a limitation to work around.
+
+## 2. Honest state of things
+
+The backend is substantially built and well tested: entity model, CRDT merge
+rules, two-tier wake scheduling, LLM tier, revision flow. The UI is three
+screens that were built to make the backend visible, never designed:
+
+| Screen | File | Reality |
+|---|---|---|
+| Agents list | `lib/features/goals/ui/pages/agents_page.dart` | Flat cards: title, status chip, "55% of target", one-liner |
+| Create goal | `lib/features/goals/ui/pages/create_goal_agent_page.dart` | Name, statement, segmented type picker, target, habit checkboxes |
+| Goal detail | `lib/features/goals/ui/pages/goal_agent_detail_page.dart` | **Read-only.** Status, statement, banners, report, history |
+| Banner | `lib/features/goals/ui/goal_banner_card.dart` | Accent bar, headline, tagline, CTA, goal name, star, X |
+
+What does not exist at all:
+
+- **No conversation.** The detail page shows a read-only log with no composer.
+  "No conversations yet" is an empty log for a conversation there is no way to
+  start. This is the single largest gap against the original concept.
+- **No editing.** After creation the goal is immutable to its owner. You cannot
+  rename it, change the target, change the window, or add/remove a watched
+  habit. The only path to change is the agent proposing a revision you approve.
+- **No lifecycle controls.** No pause, no resume, **no delete**. A goal you
+  create is permanent.
+- **No cost or energy visibility**, despite that being an explicit product
+  promise ("what does my fitness agent cost per month" should be answerable).
+
+Known UI defects in what does exist, worth not reproducing:
+
+- The banner's CTA and goal-name row collide on phone (`Lace up now Expedition
+  fitness` runs together, the goal name truncates) and strand mid-card on
+  desktop.
+- The CTA is coloured text with no affordance — it looks pressable and isn't;
+  the whole card navigates instead.
+- Two always-present icon buttons take roughly a third of phone width and force
+  the headline to wrap; one of them disappears after rating, so the layout jumps.
+- Accent presets are a 4px bar plus a barely-tinted fill — the "personality"
+  the design is supposed to carry isn't visible.
+- The detail page is one flat `ListView` with no grouping; history rows put
+  status labels in a right-hand column that collides with wrapped headlines.
+
+Current-state screenshots can be regenerated at phone and desktop sizes with
+the `app-screenshots` skill. Images are never committed to this repo.
+
+## 3. Vocabulary the design has to express
+
+Status is being reworked in parallel (see §8). The design should express these
+states, in this vocabulary:
+
+| State | Meaning | Frequency |
+|---|---|---|
+| **On track** | Keeping up or better | Most of the time |
+| **Slipping** | Required daily rate just turned upward — still fully recoverable | Common, early, recoverable |
+| **At risk** | Every remaining day must land | Occasional |
+| **Off track** | Arithmetically out of road for this period | Rare |
+| **Achieved** | Target met for the period | Weekly-ish |
+| **Not enough data** | Signals too sparse to judge | Early days, broken imports |
+
+The underlying number is a **required rate**: `remaining ÷ creditable days
+left`. For "3× per week" it starts at 0.43. Do the habit and it falls; miss a
+day and it rises; at 1.0 every remaining day must land; above 1.0 the period is
+arithmetically gone. It has **two consumers**: the status shown on chips and
+lists, and the **register the agent writes its banner in** (encourage → nudge →
+at-risk → honest reset / celebrate). One source of truth, two voices.
+
+Note that percentage-of-target is actively misleading mid-period: 22% on a
+Monday morning is a good week, not a bad one. A design that shows *direction*
+(rate falling vs rising) tells the truth better than any static percentage.
+
+A second input runs alongside the rate: per-habit **reliability** — the
+habit's success record over trailing periods. It decides which habit earns the
+banner's attention (§5.D) and belongs in the progress visualisation too: a
+long-reliable habit and a chronically failing one should not look the same,
+even in the same week.
+
+## 4. Which goals can this coach? (scope of generality)
+
+Should the UX promise to monitor and improve **arbitrary** goals? Honest
+answer: **arbitrary intentions in, observable contracts out.** People think in
+intentions ("walk more", "get back in shape"), and the entry should accept them
+in the user's own words. But an agent can only *coach* what it can *observe*,
+and the design must keep that boundary legible instead of letting the agent
+pretend. Four tiers:
+
+1. **Signal-backed** (built today): habit completions, step counts, workouts,
+   measurables. The coaching loop closes with zero user effort — the agent
+   simply sees what happened. This is the core, and it should feel effortless.
+2. **Composable**: the criterion model already supports composites
+   (all-of / any-of / at-least-N) that the create form never exposes. The
+   design should assume goal *shapes* grow over time, not hard-code two forms.
+3. **Self-reported** (future, viable): goals observable only through the user
+   saying so — "worked on the novel today". Viable once conversation exists,
+   because a check-in answer becomes evidence. This is a *different UX
+   contract*: the agent's knowledge is only as fresh as the last conversation,
+   and the design must show that honestly ("last heard from you Tuesday")
+   rather than displaying confident staleness.
+4. **Unobservable**: "be more patient." No signal, no honest loop. The right
+   UX is **honest refusal at creation time**: the agent states what it would
+   need to watch and offers the nearest observable proxy — not acceptance
+   followed by hallucinated coaching.
+
+The recommended create flow follows from this: **intention first, mapping
+second, confirmation third.** The user states the goal in their own words (the
+statement is what the agent will later "speak"); the system maps it to
+observable criteria and *shows the mapping* ("I'll watch: Morning walk and
+Evening walk, three times each, Monday–Sunday"); the user confirms or adjusts.
+The visible mapping step is where honesty lives — and long-term, that mapping
+negotiation is the conversation surface's first real job.
+
+## 5. Surfaces to design
+
+Grouped by user job. Every surface needs phone and desktop, light and dark.
+
+### A. Getting in
+
+1. **First-run / feature explanation.** What a goal agent is, what it will do,
+   what it will cost, before the first one exists. Currently a single line of
+   text on an empty list.
+2. **Agents list.** The home of the feature. Per goal: name, state, direction
+   of travel, whether it needs the user (pending proposal, unread message).
+   Must scale from one goal to a dozen without becoming a wall. States: empty,
+   one, many, loading, background refresh, error.
+
+### B. Setting an intention
+
+3. **Create a goal.** Today it is a database row in a form. It should feel
+   like setting an intention, following §4: statement in the user's words →
+   visible mapping to what will be watched → confirmation. Progressive
+   disclosure for the mechanical parts (window, target, which habits count).
+   Two goal shapes exist today and more will follow — the shape picker needs
+   room to grow, and tier-4 goals need the honest-refusal path designed.
+4. **Edit a goal.** Same material, in an editing posture. Renaming,
+   retargeting, changing the window, adding or removing watched habits. Needs
+   to communicate that editing starts a new version of the goal rather than
+   rewriting history.
+
+### C. Living with it
+
+5. **Goal detail.** The agent's home. Should answer, in order: how am I doing,
+   what is the agent saying, what has it said before, what is it watching, and
+   what can I do about it. Currently an undifferentiated list.
+6. **Progress visualisation.** The most valuable missing piece. A habit-routine
+   goal is naturally a small grid — habits × days, one cell per creditable day.
+   A metric goal is a series against a target line. Both want to show direction
+   and the period boundary, not just a fill percentage. History across periods
+   matters too: this week versus the last several.
+7. **Report.** The agent's standing write-up — a one-line summary plus a longer
+   body. Needs a resting form that doesn't dominate and an expanded form.
+8. **Timeline / history.** Past banners with their outcomes (dismissed, expired,
+   retired, superseded), past reports, past goal versions. This is the durable
+   record and should be browsable over years.
+
+### D. The voice — banners
+
+This is the product. It is what a user experiences day to day, and under the
+voice model it is a **standing presence during an active period**, not an
+occasional alarm. The canonical weekly arc for a "3× per week" goal:
+
+| Moment | Situation | Register | Copy shape |
+|---|---|---|---|
+| Monday morning | fresh period | encourage | "Fresh week — nine sessions on the board. Take the first one today." |
+| Monday evening | strong day one | encourage/celebrate | "Two down on day one." |
+| Wednesday close | one habit untouched | nudge | "Four days left; the walks haven't started." |
+| Friday close | rate at 1.0 | at-risk | "Three walks, three days. All of them or it isn't." |
+| Saturday | rate above 1.0 | honest reset | "This week's gone for walks — Monday isn't." |
+| Sunday, target met | achieved | celebrate | An actual celebration. |
+
+The *current* banner supersedes the previous one — one standing message per
+goal, refreshed at meaningful moments, never a pile of stale alarms. The
+refresh rhythm is asymmetric: **a completion is acknowledged within seconds**
+(the check-off → fresh-copy loop is the feature's best moment), **a miss is
+judged only at day close** (a day isn't missed until it ends), and period
+boundaries open and close the week's arc.
+
+**The arc is a skeleton, not a script.** The banner is an editorial product:
+the agent says the *one most useful thing*, never an enumeration of everything
+left to do. Which habit earns the mention is **reliability-weighted**: a habit
+the user has hit for six straight weeks has earned silence until its pattern
+actually breaks, while a habit that failed the last two weeks gets named on
+Monday, by name, first. Dialogue reshapes it too — "I'm traveling until
+Thursday" should change both the copy and the timing of what's worth saying.
+(Per-habit trailing reliability is deterministically computable from persisted
+per-period results; dialogue hooks arrive with the conversation surface.) A
+Monday banner that lists nine sessions across three habits is a bug in voice,
+even when every word of it is true.
+
+9. **Banner card.** Content model: `headline` (always), `tagline` (optional),
+   `cta` (optional), the goal's name, plus a dismiss and a rate affordance. The
+   model also chooses presentation presets per banner:
+   - **Tone**: encourage, nudge, roast, celebrate — the registers of the arc
+     above. Default persona is "gently humorous, never shaming"; body-shaming
+     and guilt are out of bounds by contract.
+   - **Accent**: calm, ember, tide, neon, aurora — colour/energy families that
+     should be visibly different from one another and map to design-system
+     colours. The accents are energy, not status — so the **register should
+     tint the default**: a celebrate/on-track banner reads green-family at a
+     glance, before a word of it is read. Doing well deserves to be visible.
+   - **Animation**: steady, typewriter, pulse, wave, marquee, glitch. A fixed,
+     code-owned catalogue. Motion must respect reduced-motion settings and
+     degrade where fragment shaders are unavailable (shaders are disabled on
+     Linux). Cheesy is explicitly allowed — this is the one place the product
+     gets to have fun.
+10. **Placement: one rotating slot** (mechanics decided; surface set
+    recommended, not yet ratified). The slot is a **single fixed-height region
+    that cycles through all standing banners, ~15 seconds per tenure** — every
+    goal's voice gets screen time, the region never grows, and the exposure
+    metering that feeds the rating/reuse loop measures real tenure instead of
+    stack position. **Surface (decided): a persistent bottom dock at shell
+    level** — the "now playing" bar pattern. The voice is never buried in
+    scroll content: the dock anchors at the bottom of the content region
+    across the main working tabs (Tasks, Daily OS, Habits) with one shared
+    rotation state. On desktop it sits beside — not under — the navigation
+    sidebar, which keeps its full height. On mobile the exact position is
+    **TBD**; the leading candidate is directly above the bottom navigation
+    (mini-player position), and the design must resolve collisions with the
+    keyboard (the dock yields while typing), snackbars, and FABs. When
+    nothing is standing — everything dismissed, or nothing to say — the dock
+    collapses entirely; the disappearance is itself the feedback that
+    dismissal worked. The former in-content mounts (day page, habits page)
+    are removed. The old Daily-OS + Habits pair was an artefact of the alarm
+    era: it made the voice invisible to a tasks-first user and broke the
+    acknowledgment loop. Exclusions: Settings, Logbook; goal detail keeps its
+    own uncycled display. Dismissal removes the tenant globally. Named trade:
+    the voice is present during work-mode task triage — bounded by register,
+    cadence and one-swipe dismissal. Bonus: exposure metering simplifies and
+    gets more honest — a docked tenant is visible whenever the app is
+    foregrounded, so tenure ≈ real screen time, exactly what the rating/reuse
+    loop needs. Rules: the cycle pauses on hover/touch/open rating sheet;
+    freshly refreshed copy (a completion acknowledgment) jumps the queue;
+    dismissal removes that goal from rotation for the day and advances
+    immediately; dot indicators appear only with more than one tenant; a
+    banner plays its animation preset once per tenure and settles — one layer
+    of motion at a time, transition motion belongs to the slot. Goal detail
+    still shows that goal's banner alone, uncycled. Reduced motion: crossfade
+    transitions; whether auto-advance stops entirely is design's call
+    (auto-advancing content is a WCAG pause/stop/hide concern).
+11. **Dismiss.** Both an explicit control and swipe, on **any banner in any
+    register — congratulations are as dismissible as criticism.** Dismissal
+    quiets that goal for the rest of the day (statuses keep updating silently)
+    and removes it from the rotation, advancing to the next tenant. The agent
+    sees dismissal as a signal, but reads it by register: a dismissed roast may
+    mean "too pushy"; a dismissed celebration means "seen it, thanks" and must
+    not teach the agent to stop celebrating. The user should understand that
+    something happened — without a nagging confirmation.
+12. **Rating.** One rating opportunity per banner run, currently a modal sheet
+    with five stars and a skip. It feeds which lines of copy get reused. It
+    must be genuinely optional and never block dismissal.
+
+### E. Conversation — entirely unbuilt
+
+13. **Chat with the agent.** A durable, resumable conversation you return to,
+    not a session. Message list projecting stored agent messages, composer,
+    voice input (the app has a recorder-plus-transcription toolkit already),
+    a waiting/thinking state while a turn runs, error and retry, and pagination
+    for histories that will span years. Only user turns and the agent's replies
+    are shown; internal reasoning, tool calls and summaries stay hidden.
+14. **Entry points.** From a banner, from goal detail, from the list. Tapping a
+    banner should land in the conversation about *that* nudge.
+15. **In-conversation goal change.** When the agent proposes changing the goal,
+    the proposal should appear inline as something approvable, with a clear
+    before-and-after. Goal changes always require explicit approval — the agent
+    never silently moves its own goalposts.
+16. **Check-ins as evidence** (tier 3 of §4, future): the agent asks, the
+    answer is recorded as progress evidence. The design should anticipate chat
+    turns that *are* data entry, and staleness display when the agent hasn't
+    heard from the user.
+
+### F. Governance
+
+17. **Revision approval.** Agent-proposed goal changes as a readable diff.
+    Partially exists as a generic change-set card and looks like plumbing.
+18. **Version history.** How the goal has evolved and who authored each version.
+19. **Lifecycle.** Pause, resume, delete, with honest consequences (what happens
+    to history, to banners, to the schedule).
+20. **Cost and energy.** Per-goal spend and energy, surfaced without shame or
+    alarm. Every inference is already attributed per agent; the figures are
+    small (fractions of a cent per wake) and the design should make that
+    reassuring rather than hidden.
+
+## 6. Constraints
+
+**Platform.** Flutter, one codebase. Phone (390×844) and desktop (1280×800 and
+much wider) from the same widgets. Desktop is not a stretched phone — the
+banner at 1280px currently has an enormous dead centre.
+
+**Design system is mandatory.** Spacing, typography, colour, radii and elevation
+come from tokens. Raw numbers in `EdgeInsets`/`SizedBox`, literal `fontSize` or
+`fontWeight`, and one-off colours are not permitted. If a needed token doesn't
+exist, that's a conversation, not a local constant. Both light and dark themes
+are first-class.
+
+**Localisation.** Every fixed label ships in eleven catalogues, informal
+register (Romanian formal is the deliberate exception). **Agent-authored copy —
+headline, tagline, CTA — is generated content and is never localised**, so the
+design must hold text of unpredictable length and language, including long
+German compounds, without collapsing.
+
+**Accessibility.** Meaningful semantics on every interactive element, support for
+large text scaling without truncation or overflow, adequate touch targets, and
+reduced-motion honoured by every animation preset.
+
+**Never flash established UI.** Background refreshes (sync, database
+notifications) must preserve the last rendered content. Full-screen loading and
+empty states are for genuine first loads and deliberate navigation only.
+
+**Every surface needs its full state set**: first load, background refresh,
+empty, error, offline/stale, and — because this is a synced multi-device app —
+content that changes underneath the user while they are looking at it.
+
+## 7. What good looks like
+
+- A user can create, understand, correct, converse with, pause and delete a goal
+  without ever hitting a dead end.
+- The Monday banner feels like a coach showing up, not a system warning. Someone
+  should be willing to screenshot one.
+- Dismissal is respected instantly and visibly; the resulting quiet feels like
+  being listened to.
+- On a phone, the banner region is a guest, not an occupier — even when several
+  goals are active.
+- Nothing anywhere states a percentage that implies failure when the user is
+  doing fine.
+- The boundary of §4 stays legible: the user always knows what the agent can
+  see, and the agent never speaks with confidence about things it cannot.
+
+## 8. Being fixed in parallel — not design's problem
+
+- Status currently computes attainment against a full period's target with no
+  regard for elapsed time, so a good Monday reports "at risk" and every habit
+  reads "behind". Being replaced with the required-rate model in §3.
+- Banner eligibility is currently gated on the status ladder and, for at-risk
+  goals, on three weeks of declining attainment — so a banner cannot fire in a
+  goal's first week at all. Being replaced by the voice model: a standing
+  banner whose register follows the required rate; the trouble-gating layer is
+  deleted, not recalibrated.
+- The agent is passed habit identifiers rather than habit names, so its reports
+  say "Habit 1 / Habit 2 / Habit 3" instead of "Morning walk".
+
+Design should assume these are correct: statuses are truthful, the agent speaks
+at the week's rhythm in the right register, and it can name the things it is
+watching.
+
+## 9. Open questions for design to answer
+
+1. Does the agent have an identity — a name, a face, a voice — or is it an
+   ambient property of the goal? This affects the banner, the list and the whole
+   conversation surface.
+2. ~~The multi-goal Monday~~ — answered: a single rotating slot, ~15s per
+   tenure (§5.D.10). Remaining for design: the transition itself (slide vs
+   crossfade), the dot affordance, rotation *order* (round-robin vs
+   register-priority), and whether reduced-motion stops auto-advance.
+   The surface is settled — a persistent bottom dock at shell level
+   (§5.D.10); still TBD is the **mobile dock position** (above the bottom
+   nav is the leading candidate) and its keyboard/snackbar/FAB choreography.
+3. Copy refresh cadence is largely settled by an asymmetry: **completions are
+   acknowledged immediately** (the check-off → fresh-copy loop, seconds not
+   minutes, is the feature's best moment), while **misses are judged at day
+   close** (a day isn't missed until it ends) and periods at their boundary.
+   Bursts coalesce into one refresh; a dismissal's quiet window overrides
+   everything until tomorrow. Still open for design: whether an *intra-day*
+   miss-side nudge ("the evening is still yours") is welcome or intrusive.
+4. How far can the roast register go visually before the app feels like it is
+   mocking the user rather than teasing them?
+5. Where does conversation live: a pushed page, a sheet, or a peer of the goal
+   detail view?
+6. Does dismissing a banner mean "not now", "not today", or "not this one,
+   ever"? Today it means today. The design should make whichever answer we pick
+   legible without a confirmation dialog.
+7. How is a period boundary expressed? A week ending is the natural rhythm of
+   the whole feature and currently appears nowhere in the UI.
+
+## Related
+
+- `docs/adr/0053-goal-driven-agents-per-goal-producers.md` — one agent per goal
+- `docs/adr/0055-banner-nudge-attention-channel.md` — banners as the attention
+  channel; dismissal is data; staleness is a contract (its "never chide
+  succeeding users" gating is superseded by the voice model above, and its
+  bounded-stack presentation by the rotating slot of §5.D.10)
+- `docs/adr/0058-procedural-text-banners-no-generative-imagery.md` — why there
+  are no generated images, and where personality is expected to come from
+- `docs/implementation_plans/2026-08-08_goal_agents_design.md` — the original
+  system design
+- `docs/implementation_plans/2026-08-08_reusable_chat_interface_requirements.md`
+  — chat requirements, written but never built
+- `knowledge/features/goals.md` — runtime behaviour as built

--- a/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
+++ b/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
@@ -296,7 +296,7 @@ even when every word of it is true.
     stack position. **Surface (decided): a persistent bottom dock at shell
     level** — the "now playing" bar pattern. The voice is never buried in
     scroll content: the dock anchors at the bottom of the content region
-    across the main working tabs (Tasks, Daily OS, Habits) with one shared
+    across the main working tabs (Tasks, DailyOS, Habits) with one shared
     rotation state. On desktop it sits beside — not under — the navigation
     sidebar, which keeps its full height. On mobile the exact position is
     **TBD**; the leading candidate is directly above the bottom navigation

--- a/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
+++ b/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
@@ -74,28 +74,63 @@ the `app-screenshots` skill. Images are never committed to this repo.
 
 ## 3. Vocabulary the design has to express
 
-Status is being reworked in parallel (see §8). The design should express these
-states, in this vocabulary:
+Status is being reworked in parallel (see §8). Habit goals are evaluated over
+a **rolling window** — the trailing 7 days including today — never a calendar
+quota. A calendar week has two dead zones where effort stops mattering: once
+the target is arithmetically unreachable ("why walk on Saturday?") and once it
+is already met ("done till Monday"). A rolling window has neither: every
+action enters the window and counts for exactly seven days.
 
-| State | Meaning | Frequency |
+Two small numbers drive everything:
+
+- **deficit** = target − successes-in-window. Because at most one success per
+  day is creditable, the deficit IS the days-to-recovery: no state is ever
+  more than `target` days from healthy. "Haven't walked in a week" means
+  "three walking days from whole", not "this week is lost".
+- **buffer** = when at target, days until the oldest success ages out — the
+  internal direction signal that tells the agent *today* is worth mentioning.
+
+**The voice speaks in events and time; the UI speaks in numbers.** Deficit
+and buffer decide *when* the agent speaks and *how warmly* — they never enter
+a sentence as state. Ledger-talk ("you're at three", "2 of 3", "keeps you at
+three") assumes the reader tracks a running count against a threshold; nobody
+does. What is natural is observation and recency: "you've walked three times
+in the past week" (a trailing-week observation IS the rolling window, in
+ordinary English), "it's been five days since a walk", "a walk today keeps
+the momentum going". Counts as facts about what the user did are fine; counts
+as position-against-target belong to the chip and the progress grid. When the
+window slides and the count drops overnight, the grid shows a day slipping
+off the edge — the explanation is visual, not verbal.
+
+The health vocabulary the design expresses:
+
+| State | Meaning | Copy register |
 |---|---|---|
-| **On track** | Keeping up or better | Most of the time |
-| **Slipping** | Required daily rate just turned upward — still fully recoverable | Common, early, recoverable |
-| **At risk** | Every remaining day must land | Occasional |
-| **Off track** | Arithmetically out of road for this period | Rare |
-| **Achieved** | Target met for the period | Weekly-ish |
-| **Not enough data** | Signals too sparse to judge | Early days, broken imports |
+| **Healthy** | At rate (deficit 0, comfortable buffer) | celebrate / quiet confidence |
+| **Aging out** | At rate, but the oldest success expires imminently | gentle nudge |
+| **One away** | Deficit 1 | nudge — "one walk from whole" |
+| **Behind** | Deficit 2 … target−1 | firmer — "two days of walks gets you back" |
+| **Restarting** | Deficit = target (empty window) | **encourage** — a beginning, not a verdict |
+| **Not enough data** | Signals too sparse to judge | honest silence |
 
-The underlying number is a **required rate**: `remaining ÷ creditable days
-left`. For "3× per week" it starts at 0.43. Do the habit and it falls; miss a
-day and it rises; at 1.0 every remaining day must land; above 1.0 the period is
-arithmetically gone. It has **two consumers**: the status shown on chips and
-lists, and the **register the agent writes its banner in** (encourage → nudge →
-at-risk → honest reset / celebrate). One source of truth, two voices.
+Note the wrap-around: the *worst* state maps to the warmest register. There is
+no configuration of the numbers in which action is pointless, so the banner
+can always truthfully say "do it today and the number moves" — the property a
+quota model structurally cannot provide. There is no "off track" state.
 
-Note that percentage-of-target is actively misleading mid-period: 22% on a
-Monday morning is a good week, not a bad one. A design that shows *direction*
-(rate falling vs rising) tells the truth better than any static percentage.
+Chips and list labels use only the coarse states — Healthy / Behind /
+Restarting / Not enough data. The finer gradations ("aging out", deficit
+counts) drive copy and the progress grid, never labels: a chip that says
+"Aging out" is the same mechanism-leak as a banner that explains it.
+
+Deficit and buffer have **two consumers**: the health shown on chips and
+lists, and the register the agent writes in. One source of truth, two voices.
+Percentage-of-target is banned from surfaces: it is misleading mid-window and
+implies failure while the user is fine. Show distance-to-healthy and
+direction instead.
+
+(Metric goals — average steps over a rolling week — already live in this
+frame; this section brings habit routines into the same one.)
 
 A second input runs alongside the rate: per-habit **reliability** — the
 habit's success record over trailing periods. It decides which habit earns the
@@ -159,6 +194,13 @@ Grouped by user job. Every surface needs phone and desktop, light and dark.
    disclosure for the mechanical parts (window, target, which habits count).
    Two goal shapes exist today and more will follow — the shape picker needs
    room to grow, and tier-4 goals need the honest-refusal path designed.
+   **Counts are per habit**: gym 2× while morning exercises run 5× under the
+   same goal. The criterion model already carries a target per habit leaf —
+   the current form's single shared "times per week (each habit)" field is a
+   flattening artifact, not a constraint. One rolling window per goal;
+   per-habit counts within it. (Knock-on for §5.F: an agent-proposed cadence
+   revision must name WHICH habit it retargets, and the approval card must
+   show it — "Gym: 2× → 3×, others unchanged".)
 4. **Edit a goal.** Same material, in an editing posture. Renaming,
    retargeting, changing the window, adding or removing watched habits. Needs
    to communicate that editing starts a new version of the goal rather than
@@ -183,24 +225,30 @@ Grouped by user job. Every surface needs phone and desktop, light and dark.
 ### D. The voice — banners
 
 This is the product. It is what a user experiences day to day, and under the
-voice model it is a **standing presence during an active period**, not an
-occasional alarm. The canonical weekly arc for a "3× per week" goal:
+voice model it is a **standing presence**, not an occasional alarm. The
+canonical arc for a "3× per week (rolling)" goal:
 
-| Moment | Situation | Register | Copy shape |
+| Moment | Numbers (internal) | Register | Copy shape |
 |---|---|---|---|
-| Monday morning | fresh period | encourage | "Fresh week — nine sessions on the board. Take the first one today." |
-| Monday evening | strong day one | encourage/celebrate | "Two down on day one." |
-| Wednesday close | one habit untouched | nudge | "Four days left; the walks haven't started." |
-| Friday close | rate at 1.0 | at-risk | "Three walks, three days. All of them or it isn't." |
-| Saturday | rate above 1.0 | honest reset | "This week's gone for walks — Monday isn't." |
-| Sunday, target met | achieved | celebrate | An actual celebration. |
+| Empty window | deficit 3 | encourage | "Quiet week for walks — today's a good day to restart." |
+| After a check-off | deficit 2, moving | celebrate/encourage | "Back out there. Keep it going tomorrow." |
+| At rate | deficit 0 | quiet confidence | "Three walks this past week. That's the rhythm." |
+| Oldest success expiring | deficit 0, buffer 0 | gentle nudge | "A walk today keeps the momentum going." |
+| One short | deficit 1 | nudge | "It's been a few days — room for a walk today?" |
+| Sustained streak | weeks at rate | celebrate | "Three steady weeks of walking." (weekly recap rhythm) |
+
+The numbers column is internal — it selects the row, it never appears in the
+words (§3: events and time in the voice, numbers in the UI). Every row can
+truthfully imply "today's action matters" — there is no dead-week state.
 
 The *current* banner supersedes the previous one — one standing message per
 goal, refreshed at meaningful moments, never a pile of stale alarms. The
 refresh rhythm is asymmetric: **a completion is acknowledged within seconds**
 (the check-off → fresh-copy loop is the feature's best moment), **a miss is
-judged only at day close** (a day isn't missed until it ends), and period
-boundaries open and close the week's arc.
+judged only at day close** (a day isn't missed until it ends — and under the
+rolling window a "miss" is really a success aging out, §3). Status is rolling,
+but *ritual* keeps a weekly beat: a Monday kickoff and a weekly recap are
+rhythm moments for the voice, not arithmetic boundaries.
 
 **The arc is a skeleton, not a script.** The banner is an editorial product:
 the agent says the *one most useful thing*, never an enumeration of everything
@@ -354,20 +402,28 @@ content that changes underneath the user while they are looking at it.
 
 ## 8. Being fixed in parallel — not design's problem
 
-- Status currently computes attainment against a full period's target with no
-  regard for elapsed time, so a good Monday reports "at risk" and every habit
-  reads "behind". Being replaced with the required-rate model in §3.
+- Habit goals currently evaluate against a Mon–Sun calendar quota, computing
+  attainment against the full week's target with no regard for elapsed time —
+  a good Monday reports "at risk", every habit reads "behind", and a bad week
+  ends in an "arithmetically impossible" dead zone that advises against
+  exercising. Being replaced with the rolling-window deficit/buffer model of
+  §3 (the create form's habit shape moves to rolling-7; calendar-scoped
+  existing goals get migrated).
 - Banner eligibility is currently gated on the status ladder and, for at-risk
   goals, on three weeks of declining attainment — so a banner cannot fire in a
   goal's first week at all. Being replaced by the voice model: a standing
-  banner whose register follows the required rate; the trouble-gating layer is
-  deleted, not recalibrated.
+  banner whose register follows deficit and buffer; the trouble-gating layer
+  is deleted, not recalibrated.
 - The agent is passed habit identifiers rather than habit names, so its reports
   say "Habit 1 / Habit 2 / Habit 3" instead of "Morning walk".
+- A habit check-off used to sit behind the wake system's 120-second coalescing
+  window before the agent even recomputed; signal wakes now dispatch
+  immediately (fixed 2026-08-10), so design may assume the numbers react to a
+  tap in seconds.
 
-Design should assume these are correct: statuses are truthful, the agent speaks
-at the week's rhythm in the right register, and it can name the things it is
-watching.
+Design should assume these are correct: health is truthful and always
+actionable, the agent speaks in the right register within seconds of a
+completion, and it can name the things it is watching.
 
 ## 9. Open questions for design to answer
 

--- a/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
+++ b/docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md
@@ -181,8 +181,18 @@ Grouped by user job. Every surface needs phone and desktop, light and dark.
 1. **First-run / feature explanation.** What a goal agent is, what it will do,
    what it will cost, before the first one exists. Currently a single line of
    text on an empty list.
-2. **Agents list.** The home of the feature. Per goal: name, state, direction
-   of travel, whether it needs the user (pending proposal, unread message).
+2. **Agents list.** The home of the feature. Per goal: name, coarse health,
+   direction of travel, whether it needs the user (pending proposal, unread
+   message) — and an **executive summary**: the agent's standing one-liner,
+   one plain sentence per goal. It obeys the same language law as banners
+   (§3): events and time, never ledger states or percentages — "Three walks
+   this past week; the gym's been quiet since Tuesday", not "55% of target".
+   It is editorial, not exhaustive: it names the one thing that matters most
+   right now, reliability-weighted like the banner. It must never contradict
+   the chip beside it (both derive from the same facts) and it refreshes on
+   the voice's rhythm — completions reflected promptly, misses at day close.
+   (Wiring exists: the health projection already carries the report
+   one-liner; what's new is the language law and the freshness contract.)
    Must scale from one goal to a dozen without becoming a wall. States: empty,
    one, many, loading, background refresh, error.
 

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -132,13 +132,20 @@ scheduled project digest; task-agent subscriptions opt out, so child-entry and
 task-context updates refresh on the normal coalesced path.
 
 A subscription can instead opt **out of the window entirely** with
-`AgentSubscription.drainImmediately`: matches enqueue and dispatch at once, no
-deadline is armed (including the post-run follow-up deadline), and a stale
-hydrated deadline is cleared rather than honoured. Goal-agent signal
-subscriptions use this — a habit check-off is atomic evidence and the wake it
-triggers is the deterministic €0 Phase A tier, so deferral protects nothing
-and delays the user-visible acknowledgment. Bursts stay safe because the
-runner single-flights per agent and queued jobs merge tokens.
+`AgentSubscription.drainImmediately`: matches enqueue and dispatch once the
+whole batch has routed (never mid-loop — a second matching subscription must
+still find the job to merge into), no deadline is armed, and registering the
+subscription retires any persisted `nextWakeAt` left by the defer-first
+policy. The policy travels **on the queued job** (`WakeJob.drainImmediately`,
+upgraded monotonically on merge): the throttle is per-agent, so an agent
+holding both a deferred and an immediate subscription dispatches the
+immediate job past a deadline the deferred job still honours, and the
+post-run path arms the follow-up deadline only for deferred queued work.
+Goal-agent signal subscriptions use this — a habit check-off is atomic
+evidence and the wake it triggers is the deterministic €0 Phase A tier, so
+deferral protects nothing and delays the user-visible acknowledgment. Bursts
+stay safe because the runner single-flights per agent and queued jobs merge
+tokens.
 
 Manual wakes — `creation`, `reanalysis`, and scheduled jobs enqueued by
 `ScheduledWakeManager` — bypass subscription matching and the throttle.

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -5,13 +5,13 @@ description: How a local change becomes an agent wake — subscription matching,
 resource: ../../../lib/features/agents/wake
 tags: [agents, wake, scheduling, concurrency]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-25T23:30:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-10T16:30:00Z }
 stale_after: 2026-10-12
 sources:
   - id: wake
     resource: ../../../lib/features/agents/wake
     title: WakeOrchestrator, WakeQueue, WakeRunner, drain engine
-    last_modified: 2026-07-22
+    last_modified: 2026-08-10
   - id: enums
     resource: ../../../lib/features/agents/model/agent_enums.dart
     title: WakeReason

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -5,7 +5,7 @@ description: How a local change becomes an agent wake — subscription matching,
 resource: ../../../lib/features/agents/wake
 tags: [agents, wake, scheduling, concurrency]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-10T16:30:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-10T14:30:00Z }
 stale_after: 2026-10-12
 sources:
   - id: wake

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -131,6 +131,15 @@ Project-agent subscriptions use that path, so linked-task churn waits for the
 scheduled project digest; task-agent subscriptions opt out, so child-entry and
 task-context updates refresh on the normal coalesced path.
 
+A subscription can instead opt **out of the window entirely** with
+`AgentSubscription.drainImmediately`: matches enqueue and dispatch at once, no
+deadline is armed (including the post-run follow-up deadline), and a stale
+hydrated deadline is cleared rather than honoured. Goal-agent signal
+subscriptions use this — a habit check-off is atomic evidence and the wake it
+triggers is the deterministic €0 Phase A tier, so deferral protects nothing
+and delays the user-visible acknowledgment. Bursts stay safe because the
+runner single-flights per agent and queued jobs merge tokens.
+
 Manual wakes — `creation`, `reanalysis`, and scheduled jobs enqueued by
 `ScheduledWakeManager` — bypass subscription matching and the throttle.
 

--- a/lib/features/agents/wake/wake_batch_router.dart
+++ b/lib/features/agents/wake/wake_batch_router.dart
@@ -142,8 +142,15 @@ extension WakeBatchRouter on WakeOrchestrator {
 
       // 5. Throttle gate: when the agent is throttled (but not executing),
       //    merge tokens into the queued job or enqueue a new one so the
-      //    deferred drain timer can pick it up.
-      if (_isThrottled(sub.agentId)) {
+      //    deferred drain timer can pick it up. Immediate-drain
+      //    subscriptions clear the deadline instead — the only way one
+      //    exists for them is hydration of a pre-policy `nextWakeAt`, and
+      //    honouring it would defer exactly the wake this policy exists to
+      //    dispatch (the drain re-check also skips throttled agents, so a
+      //    stale deadline would strand the job).
+      if (sub.drainImmediately && _isThrottled(sub.agentId)) {
+        clearThrottle(sub.agentId);
+      } else if (_isThrottled(sub.agentId)) {
         final deadline = _throttle.deadlineFor(sub.agentId);
         final merged = queue.mergeTokens(
           sub.agentId,
@@ -206,6 +213,20 @@ extension WakeBatchRouter on WakeOrchestrator {
         isDirect: usesFastThrottle,
       )) {
         queue.enqueue(job);
+      }
+
+      // Immediate-drain subscriptions dispatch now: no deadline, no
+      // countdown. The evidence is atomic and the wake is cheap — see
+      // [AgentSubscription.drainImmediately].
+      if (sub.drainImmediately) {
+        _log(
+          'immediate drain for ${DomainLogger.sanitizeId(sub.agentId)}: '
+          'dispatching without throttle deadline, '
+          'triggers=${allMatched.map(DomainLogger.sanitizeId).join(',')}',
+          subDomain: 'defer',
+        );
+        unawaited(processNext());
+        continue;
       }
 
       // Awaiting-content agents (newly-created task agents on blank tasks)

--- a/lib/features/agents/wake/wake_batch_router.dart
+++ b/lib/features/agents/wake/wake_batch_router.dart
@@ -16,7 +16,15 @@ extension WakeBatchRouter on WakeOrchestrator {
     // immediate subscription's job synchronously, so a second subscription
     // matching the same batch would find nothing to merge into and enqueue
     // a duplicate — the agent would evaluate the same batch twice.
+    //
+    // Deadline arming is deferred to the same point: a deferred subscription
+    // whose tokens merged into a sibling's immediate job must not arm a
+    // deadline — the job dispatches this pass and leaves the queue empty, so
+    // nothing would ever clear that countdown. Deciding after the loop makes
+    // the outcome independent of subscription registration order.
     var immediateDrainRequested = false;
+    final immediateDrainAgents = <String>{};
+    final deadlineRequests = <String, DateTime?>{};
     for (final sub in _subscriptions) {
       // 1. Check whether any token matches the subscription's entity IDs.
       //    A "direct" match means the agent's own entity was edited
@@ -236,6 +244,7 @@ extension WakeBatchRouter on WakeOrchestrator {
           subDomain: 'defer',
         );
         immediateDrainRequested = true;
+        immediateDrainAgents.add(sub.agentId);
         continue;
       }
 
@@ -269,20 +278,41 @@ extension WakeBatchRouter on WakeOrchestrator {
       } else {
         morningDeadline = null;
       }
-      unawaited(
-        _setThrottleDeadline(sub.agentId, customDeadline: morningDeadline),
+      // Recorded, not armed — the decision happens after the loop. The
+      // fastest request wins when several subscriptions defer the same
+      // agent (null = the standard short window beats any morning slot).
+      deadlineRequests.update(
+        sub.agentId,
+        (existing) => existing == null || morningDeadline == null
+            ? null
+            : (morningDeadline.isBefore(existing) ? morningDeadline : existing),
+        ifAbsent: () => morningDeadline,
       );
 
       _log(
         'deferred wake for ${DomainLogger.sanitizeId(sub.agentId)}: '
-        '${morningDeadline == null ? 'drain scheduled in ${WakeOrchestrator.throttleWindow.inSeconds}s' : 'drain scheduled at $morningDeadline (morning)'}, '
+        '${morningDeadline == null ? 'drain requested in ${WakeOrchestrator.throttleWindow.inSeconds}s' : 'drain requested at $morningDeadline (morning)'}, '
         'reason=subscription, '
         'sub=${DomainLogger.sanitizeId(sub.id)}, '
         'triggers=${allMatched.map(DomainLogger.sanitizeId).join(',')}',
         subDomain: 'defer',
       );
     }
-    // One dispatch for the whole batch (see the loop-head comment).
+    // Arm the deferred deadlines first so other agents' queued jobs are
+    // throttled before the dispatch below can reach them — then one
+    // dispatch for the whole batch (see the loop-head comment).
+    deadlineRequests.forEach((agentId, customDeadline) {
+      if (immediateDrainAgents.contains(agentId)) {
+        _log(
+          'skipping deadline for ${DomainLogger.sanitizeId(agentId)}: '
+          'its tokens merged into an immediate job dispatching this batch — '
+          'arming would leave a countdown with no work behind it',
+          subDomain: 'defer',
+        );
+        return;
+      }
+      unawaited(_setThrottleDeadline(agentId, customDeadline: customDeadline));
+    });
     if (immediateDrainRequested) unawaited(processNext());
   }
 

--- a/lib/features/agents/wake/wake_batch_router.dart
+++ b/lib/features/agents/wake/wake_batch_router.dart
@@ -11,6 +11,12 @@ extension WakeBatchRouter on WakeOrchestrator {
       );
       return;
     }
+    // Immediate drains are collected and dispatched ONCE after the whole
+    // batch is routed: a mid-loop processNext() would dequeue the first
+    // immediate subscription's job synchronously, so a second subscription
+    // matching the same batch would find nothing to merge into and enqueue
+    // a duplicate — the agent would evaluate the same batch twice.
+    var immediateDrainRequested = false;
     for (final sub in _subscriptions) {
       // 1. Check whether any token matches the subscription's entity IDs.
       //    A "direct" match means the agent's own entity was edited
@@ -109,6 +115,7 @@ extension WakeBatchRouter on WakeOrchestrator {
           sub.agentId,
           allMatched,
           isDirect: usesFastThrottle,
+          markImmediate: sub.drainImmediately,
         );
         if (!merged) {
           final counter = _wakeCounters[sub.agentId] ?? 0;
@@ -128,6 +135,7 @@ extension WakeBatchRouter on WakeOrchestrator {
               reasonId: sub.id,
               createdAt: clock.now(),
               hasDirectMatch: usesFastThrottle,
+              drainImmediately: sub.drainImmediately,
             ),
           );
         }
@@ -203,6 +211,7 @@ extension WakeBatchRouter on WakeOrchestrator {
         reasonId: sub.id,
         createdAt: clock.now(),
         hasDirectMatch: usesFastThrottle,
+        drainImmediately: sub.drainImmediately,
       );
 
       // Attempt to merge tokens into an existing queued job for this agent
@@ -211,13 +220,14 @@ extension WakeBatchRouter on WakeOrchestrator {
         sub.agentId,
         allMatched,
         isDirect: usesFastThrottle,
+        markImmediate: sub.drainImmediately,
       )) {
         queue.enqueue(job);
       }
 
-      // Immediate-drain subscriptions dispatch now: no deadline, no
-      // countdown. The evidence is atomic and the wake is cheap — see
-      // [AgentSubscription.drainImmediately].
+      // Immediate-drain subscriptions dispatch after the batch finishes
+      // routing: no deadline, no countdown. The evidence is atomic and the
+      // wake is cheap — see [AgentSubscription.drainImmediately].
       if (sub.drainImmediately) {
         _log(
           'immediate drain for ${DomainLogger.sanitizeId(sub.agentId)}: '
@@ -225,7 +235,7 @@ extension WakeBatchRouter on WakeOrchestrator {
           'triggers=${allMatched.map(DomainLogger.sanitizeId).join(',')}',
           subDomain: 'defer',
         );
-        unawaited(processNext());
+        immediateDrainRequested = true;
         continue;
       }
 
@@ -272,6 +282,8 @@ extension WakeBatchRouter on WakeOrchestrator {
         subDomain: 'defer',
       );
     }
+    // One dispatch for the whole batch (see the loop-head comment).
+    if (immediateDrainRequested) unawaited(processNext());
   }
 
   /// Returns `true` when all [matchedTokens] are covered by the agent's

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -117,8 +117,12 @@ extension WakeDrainEngine on WakeOrchestrator {
                 candidate.agentId,
                 candidate.triggerTokens,
               );
+              // The throttle is per-agent but the drain policy is per-job:
+              // an immediate-drain job dispatches past a deadline that a
+              // deferred job for the SAME agent legitimately armed.
               return suppressed ||
                   preRegistered ||
+                  candidate.drainImmediately ||
                   !_isThrottled(candidate.agentId);
             },
           );
@@ -168,8 +172,9 @@ extension WakeDrainEngine on WakeOrchestrator {
             }
 
             // Throttled: defer the job so the deferred drain timer can pick
-            // it up after the throttle window expires.
-            if (_isThrottled(job.agentId)) {
+            // it up after the throttle window expires. Immediate-drain jobs
+            // ignore the agent-level deadline (see the candidate filter).
+            if (!job.drainImmediately && _isThrottled(job.agentId)) {
               _log(
                 'drain re-check: throttled=true '
                 'for ${DomainLogger.sanitizeId(job.agentId)}',
@@ -509,12 +514,15 @@ extension WakeDrainEngine on WakeOrchestrator {
               job.agentId,
               workspaceKey: job.workspaceKey,
             )) {
-          if (_drainsImmediately(job.agentId)) {
-            // Tokens that arrived during execution merged into a queued
-            // follow-up. An immediate-drain agent gets no follow-up
-            // countdown either — dispatch the merged job now.
-            unawaited(processNext());
-          } else {
+          // The policy lives on the queued jobs, not on the agent: a mixed
+          // queue (deferred follow-up beside an immediate one) arms the
+          // deadline for the deferred job AND dispatches the immediate one
+          // now — the job-level check in the candidate filter lets it pass
+          // the deadline the deferred job still honours.
+          if (queue.hasDeferredQueuedJobFor(
+            job.agentId,
+            workspaceKey: job.workspaceKey,
+          )) {
             final hasDirectQueued = queue.hasDirectQueuedJobFor(
               job.agentId,
               workspaceKey: job.workspaceKey,
@@ -529,6 +537,12 @@ extension WakeDrainEngine on WakeOrchestrator {
               job.agentId,
               customDeadline: morningDeadline,
             );
+          }
+          if (queue.hasImmediateQueuedJobFor(
+            job.agentId,
+            workspaceKey: job.workspaceKey,
+          )) {
+            unawaited(processNext());
           }
         }
       } catch (e) {

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -509,20 +509,27 @@ extension WakeDrainEngine on WakeOrchestrator {
               job.agentId,
               workspaceKey: job.workspaceKey,
             )) {
-          final hasDirectQueued = queue.hasDirectQueuedJobFor(
-            job.agentId,
-            workspaceKey: job.workspaceKey,
-          );
-          final morningDeadline = !hasDirectQueued
-              ? nextOccurrenceOf(
-                  clock.now(),
-                  hour: AgentSchedules.projectDailyDigestHour,
-                )
-              : null;
-          await _setThrottleDeadline(
-            job.agentId,
-            customDeadline: morningDeadline,
-          );
+          if (_drainsImmediately(job.agentId)) {
+            // Tokens that arrived during execution merged into a queued
+            // follow-up. An immediate-drain agent gets no follow-up
+            // countdown either — dispatch the merged job now.
+            unawaited(processNext());
+          } else {
+            final hasDirectQueued = queue.hasDirectQueuedJobFor(
+              job.agentId,
+              workspaceKey: job.workspaceKey,
+            );
+            final morningDeadline = !hasDirectQueued
+                ? nextOccurrenceOf(
+                    clock.now(),
+                    hour: AgentSchedules.projectDailyDigestHour,
+                  )
+                : null;
+            await _setThrottleDeadline(
+              job.agentId,
+              customDeadline: morningDeadline,
+            );
+          }
         }
       } catch (e) {
         _suppression.clearPreRegistered(job.agentId);

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -31,6 +31,7 @@ class AgentSubscription {
     required this.matchEntityIds,
     this.predicate,
     this.deferPropagatedMatches = true,
+    this.drainImmediately = false,
   });
 
   /// Unique subscription identifier (stable across restarts).
@@ -54,6 +55,20 @@ class AgentSubscription {
   /// subscriptions disable it: child-entry/task-context changes should update
   /// the task agent on the normal coalesced wake path.
   final bool deferPropagatedMatches;
+
+  /// Whether matches dispatch immediately instead of defer-first behind the
+  /// 120-second coalescing window.
+  ///
+  /// The window exists for wakes that cost real inference money on evidence
+  /// that arrives in incomplete bursts (a task being edited). Goal-agent
+  /// signal subscriptions set this: their evidence is atomic (a habit
+  /// check-off IS the complete fact) and the triggered work is the
+  /// deterministic €0 Phase A tier, so deferral protects nothing and delays
+  /// the user-visible acknowledgment of their own action by two minutes.
+  /// Bursts stay safe without the window — the runner single-flights per
+  /// agent and queued jobs merge tokens, so N rapid check-offs collapse into
+  /// at most one follow-up run.
+  final bool drainImmediately;
 }
 
 /// Checks whether a content-gated entity (by ID) has the content the agent is
@@ -501,6 +516,14 @@ class WakeOrchestrator with AgentErrorLogging {
   bool _isThrottled(String agentId) {
     return _throttle.isThrottled(agentId);
   }
+
+  /// Whether [agentId] holds a subscription that opted into immediate
+  /// dispatch ([AgentSubscription.drainImmediately]). Consulted wherever a
+  /// throttle deadline would otherwise be armed on the agent's behalf — an
+  /// immediate-drain agent must never grow a countdown, including the
+  /// post-run follow-up arming in the drain engine.
+  bool _drainsImmediately(String agentId) =>
+      _subscriptions.any((s) => s.agentId == agentId && s.drainImmediately);
 
   /// Set the throttle deadline for [agentId] and persist it to the agent's
   /// state entity via `nextWakeAt`.

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -425,6 +425,13 @@ class WakeOrchestrator with AgentErrorLogging {
     } else {
       _subscriptions.add(sub);
     }
+    // An immediate-drain agent must never sit behind a countdown, including
+    // a `nextWakeAt` persisted before the policy existed (or before this
+    // subscription switched to it). Registration is the reliable moment to
+    // retire it: startup hydration may never load the deadline into the
+    // coordinator, leaving a stale countdown row in the pending-wakes UI
+    // that no in-memory check would ever clear.
+    if (sub.drainImmediately) clearThrottle(sub.agentId);
   }
 
   /// Remove all subscriptions for [agentId] and clean up internal state.
@@ -516,14 +523,6 @@ class WakeOrchestrator with AgentErrorLogging {
   bool _isThrottled(String agentId) {
     return _throttle.isThrottled(agentId);
   }
-
-  /// Whether [agentId] holds a subscription that opted into immediate
-  /// dispatch ([AgentSubscription.drainImmediately]). Consulted wherever a
-  /// throttle deadline would otherwise be armed on the agent's behalf — an
-  /// immediate-drain agent must never grow a countdown, including the
-  /// post-run follow-up arming in the drain engine.
-  bool _drainsImmediately(String agentId) =>
-      _subscriptions.any((s) => s.agentId == agentId && s.drainImmediately);
 
   /// Set the throttle deadline for [agentId] and persist it to the agent's
   /// state entity via `nextWakeAt`.

--- a/lib/features/agents/wake/wake_queue.dart
+++ b/lib/features/agents/wake/wake_queue.dart
@@ -11,6 +11,7 @@ class WakeJob {
     this.reasonId,
     this.workspaceKey,
     this.hasDirectMatch = true,
+    this.drainImmediately = false,
     WakeInitiator? initiator,
   }) : initiator =
            initiator ??
@@ -68,6 +69,15 @@ class WakeJob {
   /// pending propagated-only job that picks up a fresh direct edit no
   /// longer fires at next 06:00 as if it were still propagated-only.
   bool hasDirectMatch;
+
+  /// `true` when a match from an immediate-drain subscription
+  /// (`AgentSubscription.drainImmediately`) contributed to this job. The
+  /// throttle is per-agent, so an agent holding both a deferred and an
+  /// immediate subscription needs the policy ON THE JOB: the drain engine
+  /// dispatches an immediate job past the agent's deadline while a deferred
+  /// job queued alongside it keeps waiting. [WakeQueue.mergeTokens] upgrades
+  /// this monotonically, mirroring [hasDirectMatch].
+  bool drainImmediately;
 }
 
 /// In-memory FIFO queue with run-key deduplication.
@@ -118,16 +128,22 @@ class WakeQueue {
   ///
   /// Returns `true` when a matching job was found and updated, `false`
   /// otherwise.
+  /// When [markImmediate] is `true`, also upgrades the job's
+  /// [WakeJob.drainImmediately] — an immediate-drain match coalescing onto a
+  /// deferred job must not wait out that job's window. Monotonic, like the
+  /// [isDirect] upgrade.
   bool mergeTokens(
     String agentId,
     Set<String> tokens, {
     String? workspaceKey,
     bool isDirect = false,
+    bool markImmediate = false,
   }) {
     for (final job in _queue) {
       if (job.agentId == agentId && job.workspaceKey == workspaceKey) {
         job.triggerTokens.addAll(tokens);
         if (isDirect) job.hasDirectMatch = true;
+        if (markImmediate) job.drainImmediately = true;
         return true;
       }
     }
@@ -152,6 +168,28 @@ class WakeQueue {
   bool hasQueuedJobFor(String agentId, {String? workspaceKey}) => _queue.any(
     (job) => job.agentId == agentId && job.workspaceKey == workspaceKey,
   );
+
+  /// Whether a queued job for [agentId] in [workspaceKey] carries the
+  /// immediate-drain policy — the post-run path dispatches these at once
+  /// instead of arming a follow-up deadline.
+  bool hasImmediateQueuedJobFor(String agentId, {String? workspaceKey}) =>
+      _queue.any(
+        (job) =>
+            job.agentId == agentId &&
+            job.workspaceKey == workspaceKey &&
+            job.drainImmediately,
+      );
+
+  /// Whether a queued job for [agentId] in [workspaceKey] does NOT carry the
+  /// immediate-drain policy — such a job still deserves its follow-up
+  /// deadline even when an immediate job sits beside it in the queue.
+  bool hasDeferredQueuedJobFor(String agentId, {String? workspaceKey}) =>
+      _queue.any(
+        (job) =>
+            job.agentId == agentId &&
+            job.workspaceKey == workspaceKey &&
+            !job.drainImmediately,
+      );
 
   /// Remove queued jobs for [agentId] and return them.
   ///

--- a/lib/features/goals/service/goal_agent_service.dart
+++ b/lib/features/goals/service/goal_agent_service.dart
@@ -149,7 +149,10 @@ class GoalAgentService {
 
   /// Evidence-triggered wakes: the goal agent listens to exactly the
   /// signals its criteria reference — leaf dataTypes, habitIds and
-  /// measurable ids — never a global sentinel.
+  /// measurable ids — never a global sentinel. `drainImmediately`: a habit
+  /// check-off is atomic evidence and Phase A is €0, so the wake dispatches
+  /// now — the user's tap is acknowledged in seconds, not after the
+  /// 120-second coalescing window built for costly task-agent wakes.
   void registerSignalSubscription(String agentId, GoalCriterion criteria) {
     _orchestrator.addSubscription(
       AgentSubscription(
@@ -157,6 +160,7 @@ class GoalAgentService {
         agentId: agentId,
         matchEntityIds: goalSignalTriggerTokens(criteria),
         deferPropagatedMatches: false,
+        drainImmediately: true,
       ),
     );
   }

--- a/test/features/agents/wake/wake_orchestrator_test_helpers.dart
+++ b/test/features/agents/wake/wake_orchestrator_test_helpers.dart
@@ -17,6 +17,7 @@ AgentSubscription makeSub({
   Set<String> matchEntityIds = const {'entity-1'},
   bool Function(Set<String> tokens)? predicate,
   bool deferPropagatedMatches = true,
+  bool drainImmediately = false,
 }) {
   return AgentSubscription(
     id: id,
@@ -24,6 +25,7 @@ AgentSubscription makeSub({
     matchEntityIds: matchEntityIds,
     predicate: predicate,
     deferPropagatedMatches: deferPropagatedMatches,
+    drainImmediately: drainImmediately,
   );
 }
 

--- a/test/features/agents/wake/wake_orchestrator_throttle_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_throttle_test.dart
@@ -233,6 +233,135 @@ void main() {
         });
       });
 
+      test('a deferred sibling matching the same batch does not arm a '
+          'deadline for the immediate job it merged into', () {
+        fakeAsync((async) {
+          var executionCount = 0;
+          final state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(),
+                    updatedAt: clock.now(),
+                    vectorClock: null,
+                  )
+                  as AgentStateEntity;
+
+          // Immediate registered FIRST, deferred second; both match the
+          // one batch. The deferred sibling's tokens merge into the
+          // immediate job, which dispatches and empties the queue — an
+          // armed deadline would be a countdown with no work behind it,
+          // and nothing would ever clear it.
+          orchestrator
+            ..addSubscription(
+              makeSub(drainImmediately: true, matchEntityIds: {'entity-1'}),
+            )
+            ..addSubscription(
+              makeSub(
+                id: 'sub-deferred',
+                matchEntityIds: {'entity-1', 'entity-2'},
+                deferPropagatedMatches: false,
+              ),
+            )
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+              executionCount++;
+              return null;
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+          when(
+            () => mockRepository.upsertEntity(any()),
+          ).thenAnswer((_) async {});
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          emitTokens(async, controller, {'entity-1'});
+          expect(executionCount, 1);
+
+          // No persisted countdown may survive a batch whose only job
+          // dispatched immediately.
+          verifyNever(
+            () => mockRepository.upsertEntity(
+              any(
+                that: isA<AgentStateEntity>().having(
+                  (s) => s.nextWakeAt,
+                  'nextWakeAt',
+                  isNotNull,
+                ),
+              ),
+            ),
+          );
+
+          controller.close();
+        });
+      });
+
+      test('the deferred-first registration order arms no deadline either — '
+          'the decision is order-independent', () {
+        fakeAsync((async) {
+          var executionCount = 0;
+          final state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(),
+                    updatedAt: clock.now(),
+                    vectorClock: null,
+                  )
+                  as AgentStateEntity;
+
+          orchestrator
+            ..addSubscription(
+              makeSub(
+                id: 'sub-deferred',
+                matchEntityIds: {'entity-1'},
+                deferPropagatedMatches: false,
+              ),
+            )
+            ..addSubscription(
+              makeSub(
+                id: 'sub-immediate',
+                drainImmediately: true,
+                matchEntityIds: {'entity-1'},
+              ),
+            )
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+              executionCount++;
+              return null;
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+          when(
+            () => mockRepository.upsertEntity(any()),
+          ).thenAnswer((_) async {});
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          emitTokens(async, controller, {'entity-1'});
+          expect(executionCount, 1);
+
+          verifyNever(
+            () => mockRepository.upsertEntity(
+              any(
+                that: isA<AgentStateEntity>().having(
+                  (s) => s.nextWakeAt,
+                  'nextWakeAt',
+                  isNotNull,
+                ),
+              ),
+            ),
+          );
+
+          controller.close();
+        });
+      });
+
       test('a deferred subscription of the same agent keeps its follow-up '
           'window — the immediate policy is per job, not per agent', () {
         fakeAsync((async) {

--- a/test/features/agents/wake/wake_orchestrator_throttle_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_throttle_test.dart
@@ -85,6 +85,124 @@ void main() {
         });
       });
     });
+    group('immediate drain (drainImmediately subscriptions)', () {
+      test('dispatches without the 120s defer-first window — the wake runs '
+          'on flushMicrotasks alone', () {
+        fakeAsync((async) {
+          var executionCount = 0;
+
+          orchestrator
+            ..addSubscription(makeSub(drainImmediately: true))
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+              executionCount++;
+              return null;
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          // No async.elapse: a defer-first subscription would sit behind
+          // the 120s deadline here (see the deferred-drain group above).
+          emitTokens(async, controller, {'entity-1'});
+          expect(executionCount, 1);
+
+          controller.close();
+        });
+      });
+
+      test('a stale hydrated deadline is cleared instead of stranding the '
+          'wake behind a countdown', () {
+        fakeAsync((async) {
+          var executionCount = 0;
+
+          orchestrator
+            ..addSubscription(makeSub(drainImmediately: true))
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+              executionCount++;
+              return null;
+            }
+            // Hydration of a pre-policy `nextWakeAt` arms a real deadline.
+            ..setThrottleDeadline(
+              'agent-1',
+              clock.now().add(WakeOrchestrator.throttleWindow),
+            );
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          emitTokens(async, controller, {'entity-1'});
+          expect(
+            executionCount,
+            1,
+            reason:
+                'the stale deadline must be cleared, not honoured — '
+                'the drain re-check skips throttled agents, so honouring '
+                'it would strand the job',
+          );
+
+          controller.close();
+        });
+      });
+
+      test('a burst during execution merges and the follow-up runs without '
+          'a post-run countdown', () {
+        fakeAsync((async) {
+          final gate = Completer<Map<String, VectorClock>?>();
+          var executionCount = 0;
+
+          orchestrator
+            ..addSubscription(
+              makeSub(
+                matchEntityIds: {'entity-1', 'entity-2'},
+                drainImmediately: true,
+              ),
+            )
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) {
+              executionCount++;
+              if (executionCount == 1) return gate.future;
+              return Future.value();
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          // First check-off dispatches immediately.
+          emitTokens(async, controller, {'entity-1'});
+          expect(executionCount, 1);
+
+          // Second check-off lands while the first wake is executing —
+          // single-flight queues it for the drain re-check.
+          emitTokens(async, controller, {'entity-2'});
+          expect(executionCount, 1);
+
+          // First wake completes with no recorded mutations. The post-run
+          // path must dispatch the merged follow-up NOW instead of arming
+          // the 120s follow-up deadline task agents get.
+          gate.complete(null);
+          async.flushMicrotasks();
+          expect(
+            executionCount,
+            2,
+            reason: 'the follow-up job must not wait out a countdown',
+          );
+
+          controller.close();
+        });
+      });
+    });
+
     group('throttle gate', () {
       glados.Glados(
         glados.any.pendingWakeRestoreScenario,

--- a/test/features/agents/wake/wake_orchestrator_throttle_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_throttle_test.dart
@@ -152,6 +152,146 @@ void main() {
         });
       });
 
+      test('registering an immediate-drain subscription retires a deadline '
+          'persisted under the old defer-first policy', () {
+        fakeAsync((async) {
+          // The upgrade scenario: `nextWakeAt` was persisted by the old
+          // defer-first policy and hydration never loaded it into the
+          // coordinator. No notification arrives — an idle goal would show
+          // the stale countdown row forever unless registration clears it.
+          final state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(),
+                    updatedAt: clock.now(),
+                    vectorClock: null,
+                    nextWakeAt: clock.now().add(
+                      WakeOrchestrator.throttleWindow,
+                    ),
+                  )
+                  as AgentStateEntity;
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+          when(
+            () => mockRepository.upsertEntity(any()),
+          ).thenAnswer((_) async {});
+
+          orchestrator.addSubscription(makeSub(drainImmediately: true));
+          async.flushMicrotasks();
+
+          final upserted = verify(
+            () => mockRepository.upsertEntity(captureAny()),
+          ).captured.whereType<AgentStateEntity>().last;
+          expect(
+            upserted.nextWakeAt,
+            isNull,
+            reason: 'registration alone must wipe the durable countdown',
+          );
+        });
+      });
+
+      test('one batch matching two immediate subscriptions of the same '
+          'agent coalesces into a single wake', () {
+        fakeAsync((async) {
+          var executionCount = 0;
+          final seenTriggers = <Set<String>>[];
+
+          orchestrator
+            ..addSubscription(
+              makeSub(drainImmediately: true, matchEntityIds: {'entity-1'}),
+            )
+            ..addSubscription(
+              makeSub(
+                id: 'sub-2',
+                drainImmediately: true,
+                matchEntityIds: {'entity-2'},
+              ),
+            )
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+              executionCount++;
+              seenTriggers.add(triggers);
+              return null;
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          // Both subscriptions match the SAME batch. A mid-loop dispatch
+          // would dequeue the first job before the second subscription
+          // routes, duplicating the evaluation of one database batch.
+          emitTokens(async, controller, {'entity-1', 'entity-2'});
+          expect(executionCount, 1);
+          expect(seenTriggers.single, containsAll(['entity-1', 'entity-2']));
+
+          controller.close();
+        });
+      });
+
+      test('a deferred subscription of the same agent keeps its follow-up '
+          'window — the immediate policy is per job, not per agent', () {
+        fakeAsync((async) {
+          final gate = Completer<Map<String, VectorClock>?>();
+          var executionCount = 0;
+
+          // One agent, two subscriptions with opposite policies.
+          orchestrator
+            ..addSubscription(
+              makeSub(drainImmediately: true, matchEntityIds: {'entity-1'}),
+            )
+            ..addSubscription(
+              makeSub(
+                id: 'sub-deferred',
+                matchEntityIds: {'entity-2'},
+                deferPropagatedMatches: false,
+              ),
+            )
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) {
+              executionCount++;
+              if (executionCount == 1) return gate.future;
+              return Future.value();
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          // Immediate wake starts.
+          emitTokens(async, controller, {'entity-1'});
+          expect(executionCount, 1);
+
+          // The DEFERRED subscription matches while the agent is running —
+          // its follow-up job must wait out the normal window after the
+          // wake completes, not ride the other subscription's policy.
+          emitTokens(async, controller, {'entity-2'});
+          gate.complete(null);
+          async.flushMicrotasks();
+          expect(
+            executionCount,
+            1,
+            reason:
+                'the deferred follow-up must not dispatch immediately '
+                'just because a sibling subscription drains immediately',
+          );
+
+          // After the window, the deferred job drains normally.
+          async
+            ..elapse(WakeOrchestrator.throttleWindow)
+            ..flushMicrotasks();
+          expect(executionCount, 2);
+
+          controller.close();
+        });
+      });
+
       test('a burst during execution merges and the follow-up runs without '
           'a post-run countdown', () {
         fakeAsync((async) {

--- a/test/features/agents/wake/wake_orchestrator_throttle_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_throttle_test.dart
@@ -472,6 +472,57 @@ void main() {
       });
     });
 
+    group('batch deadline decision', () {
+      test('two digest-deferred subscriptions of one agent coalesce to a '
+          'single morning deadline — and neither dispatches early', () {
+        fakeAsync((async) {
+          var executionCount = 0;
+
+          // Both subscriptions keep the default deferPropagatedMatches and
+          // match only propagated tokens, so each requests the next-06:00
+          // slot; the second request exercises the keep-the-earlier
+          // tie-break in the post-loop decision.
+          orchestrator
+            ..addSubscription(makeSub(matchEntityIds: {'entity-1'}))
+            ..addSubscription(
+              makeSub(id: 'sub-2', matchEntityIds: {'entity-1', 'entity-2'}),
+            )
+            ..wakeExecutor = (agentId, runKey, triggers, threadId) async {
+              executionCount++;
+              return null;
+            };
+
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Set<String>>.broadcast();
+          orchestrator.start(controller.stream);
+
+          emitTokens(async, controller, {
+            propagatedNotification('entity-1'),
+            propagatedNotification('entity-2'),
+          });
+
+          // The short window passing proves the morning slot won — a fast
+          // deadline here would mean the digest policy was dropped in the
+          // post-loop coalescing.
+          async
+            ..elapse(WakeOrchestrator.throttleWindow * 2)
+            ..flushMicrotasks();
+          expect(executionCount, 0);
+
+          // Past the morning slot the single coalesced job drains once.
+          async
+            ..elapse(const Duration(hours: 25))
+            ..flushMicrotasks();
+          expect(executionCount, 1);
+
+          controller.close();
+        });
+      });
+    });
+
     group('throttle gate', () {
       glados.Glados(
         glados.any.pendingWakeRestoreScenario,

--- a/test/features/agents/wake/wake_queue_test.dart
+++ b/test/features/agents/wake/wake_queue_test.dart
@@ -22,6 +22,7 @@ void main() {
     String? workspaceKey,
     DateTime? createdAt,
     WakeInitiator? initiator,
+    bool drainImmediately = false,
   }) {
     return WakeJob(
       runKey: runKey,
@@ -32,6 +33,7 @@ void main() {
       workspaceKey: workspaceKey,
       createdAt: createdAt ?? testDate,
       initiator: initiator,
+      drainImmediately: drainImmediately,
     );
   }
 
@@ -466,6 +468,51 @@ void main() {
           );
         },
       );
+    });
+
+    group('immediate-drain job policy', () {
+      test('hasImmediateQueuedJobFor and hasDeferredQueuedJobFor split a '
+          'mixed queue by job policy, not by agent', () {
+        queue
+          ..enqueue(makeJob(runKey: 'a', drainImmediately: true))
+          ..enqueue(makeJob(runKey: 'b'));
+
+        expect(queue.hasImmediateQueuedJobFor('agent-1'), isTrue);
+        expect(queue.hasDeferredQueuedJobFor('agent-1'), isTrue);
+
+        // Workspace scoping matches the other predicates.
+        expect(
+          queue.hasImmediateQueuedJobFor('agent-1', workspaceKey: 'day:x'),
+          isFalse,
+        );
+      });
+
+      test('an immediate-only queue reports no deferred job — the post-run '
+          'path must not arm a countdown for it', () {
+        queue.enqueue(makeJob(runKey: 'a', drainImmediately: true));
+
+        expect(queue.hasImmediateQueuedJobFor('agent-1'), isTrue);
+        expect(queue.hasDeferredQueuedJobFor('agent-1'), isFalse);
+      });
+
+      test('mergeTokens(markImmediate) upgrades a deferred job monotonically '
+          '— a later deferred merge cannot downgrade it', () {
+        queue.enqueue(makeJob(runKey: 'a'));
+        expect(queue.hasImmediateQueuedJobFor('agent-1'), isFalse);
+
+        expect(
+          queue.mergeTokens('agent-1', {'tok-b'}, markImmediate: true),
+          isTrue,
+        );
+        expect(queue.hasImmediateQueuedJobFor('agent-1'), isTrue);
+
+        expect(queue.mergeTokens('agent-1', {'tok-c'}), isTrue);
+        expect(
+          queue.hasImmediateQueuedJobFor('agent-1'),
+          isTrue,
+          reason: 'the upgrade is monotonic, like hasDirectMatch',
+        );
+      });
     });
 
     glados.Glados(

--- a/test/features/goals/service/goal_agent_service_test.dart
+++ b/test/features/goals/service/goal_agent_service_test.dart
@@ -146,6 +146,11 @@ void main() {
     expect(subscription.id, goalSignalSubscriptionId(agentId));
     expect(subscription.agentId, agentId);
     expect(subscription.matchEntityIds, {'gym-habit'});
+    // A habit check-off is atomic evidence and Phase A is €0: the wake
+    // dispatches immediately instead of sitting behind the task-agent
+    // 120-second coalescing window (the user's tap must be acknowledged
+    // in seconds).
+    expect(subscription.drainImmediately, isTrue);
   });
 
   test('removeSignalSubscriptions drops the agent from the orchestrator', () {


### PR DESCRIPTION
## What

Two things riding together out of today's dogfooding session:

### Immediate signal wakes

A habit check-off parked the goal agent's evidence wake behind the wake
orchestrator's defer-first **120-second** coalescing window — the user tapped,
and the chip/registers stayed stale for two minutes (with a visible countdown
in the wake queue). That window exists for task agents, where evidence arrives
in incomplete editing bursts and each wake used to cost real inference money.
Neither holds on the goal path: a check-off is atomic evidence, and the wake it
triggers is the deterministic €0 Phase A tier.

`AgentSubscription` gains `drainImmediately`:

- matches enqueue and dispatch at once — no deadline armed, no countdown;
- the post-run follow-up deadline is skipped too (a burst's merged follow-up
  job dispatches immediately after the running wake completes);
- a stale hydrated deadline (pre-policy `nextWakeAt`) is cleared rather than
  honoured — the drain re-check skips throttled agents, so honouring it would
  strand the job.

Goal signal subscriptions opt in. Bursts stay safe: the runner single-flights
per agent and queued jobs merge tokens, so N rapid check-offs collapse into at
most one follow-up run. Task/project agent behaviour is unchanged (default
remains defer-first).

Three regression tests cover the dispatch path, the stale-deadline path, and
the burst path — each verified to fail with the fix reverted. The
wake-orchestration knowledge concept documents the new policy.

### Goal agents UI design brief

`docs/implementation_plans/2026-08-10_goal_agents_ui_design_brief.md` — the
full design handover produced from today's session: the banner as the agent's
standing voice rather than an alarm, editorial selection, the rolling-window
health model (deficit/buffer, no dead-week state), events-and-time copy
language, the rotating bottom-dock placement, per-habit counts, and the honest
inventory of what the visible layer still lacks (edit/delete/pause,
conversation, progress visualisation, cost visibility).

## Why now

Dogfooding the flag-gated feature surfaced that the two-minute lag makes the
core loop — act, be acknowledged — feel broken. This is the smallest
self-contained piece of the larger fix list; the rolling evaluator, create-form
default, and facts enrichment follow separately.

## Testing

- `wake_orchestrator_throttle_test.dart` — 3 new tests (fail on revert)
- full orchestrator test family green (146 tests)
- `goal_agent_service_test.dart` asserts the opt-in on the registered
  subscription
- analyzer zero issues; `make knowledge_check` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Goal-agent signal events now trigger processing immediately, reducing delays after relevant activity.
  - Bursts of incoming activity continue to be combined safely while processing is underway.

- **Bug Fixes**
  - Stale deferred wake-ups are cleared so queued work is not unnecessarily delayed.
  - Immediate processing no longer creates an additional post-run countdown.
  - Immediate and deferred work now maintain the correct scheduling behavior when merged.

- **Documentation**
  - Added a comprehensive design brief covering goal-agent experiences, progress views, notifications, accessibility, localization, and future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->