### PR TITLE
fix(goals): drop the percentage-scrubbing regex from the agents row

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -220,9 +220,10 @@ flowchart TD
   0.02 deadband — withheld when either register is insufficient-data, and only
   for rolling-window goals, since calendar/day windows reset attainment each
   period and a consecutive-register delta there is a boundary reset, not a
-  decline). Raw attainment percentages never reach the row — they stay in the
-  detail surfaces, and a report one-liner that leaks a percentage figure is
-  suppressed rather than rendered. A row whose per-agent
+  decline). The row shows a coarse chip rather than a raw attainment
+  percentage; the one-liner is the agent's own prose, so keeping percentages
+  out of it is a matter for the agent's instructions, not widget-level
+  filtering. A row whose per-agent
   health has not resolved shows no chip rather than a false "Not enough data",
   and the settled-empty state is a first-run explainer whose CTA is the sole
   creation affordance (the global FAB hides). The detail page

--- a/lib/features/goals/ui/pages/agents_page.dart
+++ b/lib/features/goals/ui/pages/agents_page.dart
@@ -143,18 +143,6 @@ class _FirstRunExplainer extends StatelessWidget {
   }
 }
 
-/// Matches a percentage figure like `64%`, `12.5 %` or the locale-formatted
-/// `12,5 %` (comma decimal separator).
-final _percentagePattern = RegExp(r'\d+(?:[.,]\d+)?\s*%');
-
-/// The list-summary contract is events-and-time language, never a percentage
-/// (handover 1c). Model-authored report one-liners are otherwise trusted
-/// prose; this is the display-side backstop that keeps a leaked figure off the
-/// row. The model prompt/`update_goal_report` contract is the real
-/// enforcement point.
-bool summaryHonorsNoPercentageContract(String summary) =>
-    !_percentagePattern.hasMatch(summary);
-
 class _GoalAgentRow extends ConsumerWidget {
   const _GoalAgentRow({required this.identity});
 
@@ -221,13 +209,12 @@ class _GoalAgentRow extends ConsumerWidget {
                           const _NeedsYouBadge(),
                       ],
                     ),
-                    // Executive summary: the agent's standing one-liner,
-                    // events-and-time language, one line, never a percentage.
-                    // A model-authored one-liner that leaks a figure like
-                    // "64% of target" is suppressed rather than rendered — the
-                    // redesign removed percentages from this surface.
-                    if (health?.reportOneLiner case final String oneLiner
-                        when summaryHonorsNoPercentageContract(oneLiner)) ...[
+                    // Executive summary: the agent's standing one-liner —
+                    // events-and-time language, one line. Keeping percentages
+                    // out is a matter for the agent's own instructions (and a
+                    // conversation with it), not something worth policing in
+                    // the widget.
+                    if (health?.reportOneLiner case final String oneLiner) ...[
                       SizedBox(height: tokens.spacing.step1),
                       Text(
                         oneLiner,

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -1111,27 +1111,39 @@ void main() {
       return container.read(goalAgentHealthProvider(agentId).future);
     }
 
-    // allOf of two ROLLING children: the composite is sound → arrow up.
-    final rolling = await healthFor(
+    const rollingA = GoalCriterion.habit(
+      criterionId: 'a',
+      habitId: 'h-a',
+      window: GoalWindow.rollingDays(count: 7),
+      targetCount: 3,
+    );
+    const rollingB = GoalCriterion.habit(
+      criterionId: 'b',
+      habitId: 'h-b',
+      window: GoalWindow.rollingDays(count: 7),
+      targetCount: 3,
+    );
+
+    // Every composite flavour with all-rolling children is sound → arrow up.
+    // (Exercises the allOf / anyOf / atLeastCount arms of the soundness fold.)
+    for (final composite in <GoalCriterion>[
       const GoalCriterion.allOf(
         criterionId: 'root',
-        criteria: [
-          GoalCriterion.habit(
-            criterionId: 'a',
-            habitId: 'h-a',
-            window: GoalWindow.rollingDays(count: 7),
-            targetCount: 3,
-          ),
-          GoalCriterion.habit(
-            criterionId: 'b',
-            habitId: 'h-b',
-            window: GoalWindow.rollingDays(count: 7),
-            targetCount: 3,
-          ),
-        ],
+        criteria: [rollingA, rollingB],
       ),
-    );
-    expect(rolling.direction, GoalHealthDirection.up);
+      const GoalCriterion.anyOf(
+        criterionId: 'root',
+        criteria: [rollingA, rollingB],
+      ),
+      const GoalCriterion.atLeastCount(
+        criterionId: 'root',
+        successes: 1,
+        criteria: [rollingA, rollingB],
+      ),
+    ]) {
+      final rolling = await healthFor(composite);
+      expect(rolling.direction, GoalHealthDirection.up);
+    }
 
     // One CALENDAR child taints the composite → no arrow.
     final mixed = await healthFor(

--- a/test/features/goals/ui/pages/agents_page_test.dart
+++ b/test/features/goals/ui/pages/agents_page_test.dart
@@ -145,41 +145,34 @@ void main() {
     );
   });
 
-  testWidgets('a report one-liner that leaks a percentage is suppressed — the '
-      'row never renders a percentage on this surface', (tester) async {
+  testWidgets('the create FAB opens the creation flow, and a row opens that '
+      "agent's detail page", (tester) async {
+    final navigated = <String>[];
+    beamToNamedOverride = navigated.add;
+    addTearDown(() => beamToNamedOverride = null);
+
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         const AgentsPage(),
         overrides: [
           activeGoalAgentsProvider.overrideWith(
-            (ref) async => [
-              identity('goal-leak', 'Walk daily'),
-              identity('goal-clean', 'Sleep 8h'),
-            ],
+            (ref) async => [identity('goal-fit', 'Expedition fitness')],
           ),
-          goalAgentHealthProvider('goal-leak').overrideWith(
-            (ref) async => health(
-              trackStatus: GoalTrackStatus.offTrack,
-              // Locale comma decimal — must be caught too, not just `64%`.
-              reportOneLiner: 'Progress is 12,5 % of target this week.',
-            ),
-          ),
-          goalAgentHealthProvider('goal-clean').overrideWith(
-            (ref) async => health(
-              trackStatus: GoalTrackStatus.onTrack,
-              reportOneLiner: 'Seven solid nights running.',
-            ),
+          goalAgentHealthProvider('goal-fit').overrideWith(
+            (ref) async => health(trackStatus: GoalTrackStatus.onTrack),
           ),
         ],
       ),
     );
     await tester.pumpAndSettle();
-    // The leaked-percentage one-liner is withheld entirely — including the
-    // comma-decimal locale form...
-    expect(find.textContaining('12,5'), findsNothing);
-    expect(find.textContaining('% of target'), findsNothing);
-    // ...while a clean events-and-time one-liner still renders.
-    expect(find.text('Seven solid nights running.'), findsOneWidget);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    expect(navigated, ['/agents/create']);
+
+    await tester.tap(find.text('Expedition fitness'));
+    await tester.pump();
+    expect(navigated, ['/agents/create', '/agents/details/goal-fit']);
   });
 
   testWidgets('the settled-empty first-run screen hides the global create FAB '


### PR DESCRIPTION
Follow-up to #3879.

That PR added a display-time regex to the agents list that suppressed any report one-liner containing a `%`, to keep percentages off the redesigned surface. On reflection that was the wrong layer:

- **It polices LLM prose at the widget.** Locale forms (`12,5 %`), spelled-out "percent", `½`, etc. mean the pattern is always one phrasing behind — CodeRabbit already caught one gap.
- **It's heavy-handed** — one stray `%` discards an otherwise useful sentence.
- **It hides the real control.** The one-liner is the agent's own prose; whether percentages appear is a matter for the agent's report instructions (and a conversation with it), not a widget filter. We might deliberately *want* one there later.

This renders the one-liner as written and removes the regex + helper.

Also lands two coverage tests for the now-merged list that weren't in #3879 before it merged:
- the create FAB and a row tap route to `/agents/create` and `/agents/details/<id>`;
- the trend-soundness fold is exercised across all three composite flavours (allOf / anyOf / atLeastCount).

Docs: the goals concept no longer claims the one-liner is percentage-filtered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent report one-liners are now displayed whenever available, including text containing percentage figures.
  * Improved goal health direction handling for criteria based on rolling time windows.

* **Navigation**
  * The create-agent action now opens the agent creation page.
  * Selecting an agent goal now opens its details page.

* **Documentation**
  * Updated the Agents feature guidance to clarify how report wording handles attainment percentages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->