### PR TITLE
fix(flatpak): support sqlite3 3.5.1 offline build

### DIFF
--- a/.github/workflows/flatpak-foreign-deps.yml
+++ b/.github/workflows/flatpak-foreign-deps.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Validate Flutter pin guard
         run: python3 -m unittest check_flutter_pin_test
         working-directory: flatpak
+      - name: Check out pinned flatpak-flutter dependency database
+        run: |
+          set -euo pipefail
+          VERSION=$(awk -F'"' '/^FLATPAK_FLUTTER_VERSION=/ {print $2; exit}' flatpak/prepare_flathub_build.sh)
+          git clone --depth 1 --branch "$VERSION" \
+            https://github.com/TheAppgineer/flatpak-flutter.git \
+            flatpak/flatpak-flutter
+      - name: Validate foreign dependency selection guard
+        run: python3 -m unittest check_foreign_deps_test
+        working-directory: flatpak
       - name: Check Flathub manifest Flutter tag matches .fvmrc
         run: python3 flatpak/check_flutter_pin.py
       - name: Cache Pub Packages
@@ -46,4 +56,7 @@ jobs:
       - name: Get dependencies
         run: flutter pub get --enforce-lockfile
       - name: Validate Flatpak patches
-        run: python3 flatpak/check_foreign_deps.py
+        run: >-
+          python3 flatpak/check_foreign_deps.py
+          --bundled-foreign-deps
+          flatpak/flatpak-flutter/foreign_deps/foreign_deps.json

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -211,16 +211,22 @@ make check_flatpak_foreign_deps
 ```
 
 The check parses `pubspec.lock`, verifies that local overlay entries match the
-locked versions, and dry-runs every Flatpak patch against the actual Pub cache
-package directory. CI runs the same check for pull requests touching Flatpak or
-dependency files.
+locked versions, rejects version-sensitive native fallbacks selected from the
+pinned `flatpak-flutter` database, and dry-runs every Flatpak patch against the
+actual Pub cache package directory. CI runs the same check for pull requests
+touching Flatpak or dependency files. The prepare script also runs the fallback
+selection guard before manifest generation, when the merged tool database is
+available but the Pub cache may not be populated.
 
 Some upstream packages ship patched files with CRLF line endings. Keep those
 patches generated from the upstream file's real line endings so the Flathub
 builder's plain `patch -p1` invocation applies them.
 
-Current version-specific native patches include:
+Current version-specific native inputs and patches include:
 
+- `sqlite3 3.5.1`: preloads the hash-matched Linux library for each architecture
+  into the package hook's shared cache. This version validates and reuses an
+  existing matching library, so it needs no source patch.
 - `sqlite3_flutter_libs 0.5.42`: pins the SQLite archive hash so CMake uses the
   source downloaded during Flatpak's network-enabled source phase.
 - `objectbox_flutter_libs 5.3.1` and `5.3.2`: pins the per-architecture

--- a/flatpak/check_foreign_deps.py
+++ b/flatpak/check_foreign_deps.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
@@ -33,7 +34,25 @@ class PatchCheck:
     options: list[str]
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bundled-foreign-deps",
+        type=Path,
+        help=(
+            "flatpak-flutter foreign_deps.json to validate against the local "
+            "overlay"
+        ),
+    )
+    parser.add_argument(
+        "--selection-only",
+        action="store_true",
+        help="validate version selection without requiring a populated Pub cache",
+    )
+    args = parser.parse_args(argv)
+    if args.selection_only and args.bundled_foreign_deps is None:
+        parser.error("--selection-only requires --bundled-foreign-deps")
+
     repo_root = Path(__file__).resolve().parents[1]
     flatpak_dir = repo_root / "flatpak"
     pub_cache = Path(os.environ.get("PUB_CACHE", "~/.pub-cache")).expanduser()
@@ -43,7 +62,21 @@ def main() -> int:
     checks: list[PatchCheck] = []
 
     overlay_path = flatpak_dir / "flatpak_flutter_extra" / "foreign_deps.json"
+    overlay_data: dict[str, Any] = {}
     if overlay_path.exists():
+        overlay_data = _read_json_object(overlay_path)
+
+    if args.bundled_foreign_deps is not None:
+        bundled_data = _read_json_object(args.bundled_foreign_deps)
+        failures.extend(
+            validate_native_fallbacks(
+                bundled_foreign_deps=bundled_data,
+                overlay_foreign_deps=overlay_data,
+                locked_packages=locked_packages,
+            )
+        )
+
+    if overlay_path.exists() and not args.selection_only:
         checks.extend(
             _checks_from_versioned_foreign_deps(
                 overlay_path=overlay_path,
@@ -55,7 +88,7 @@ def main() -> int:
         )
 
     foreign_path = flatpak_dir / "foreign.json"
-    if foreign_path.exists():
+    if foreign_path.exists() and not args.selection_only:
         checks.extend(
             _checks_from_foreign_json(
                 foreign_path=foreign_path,
@@ -66,8 +99,9 @@ def main() -> int:
             )
         )
 
-    for check in checks:
-        failures.extend(_run_patch_check(check))
+    if not args.selection_only:
+        for check in checks:
+            failures.extend(_run_patch_check(check))
 
     if failures:
         print("Flatpak foreign dependency validation failed:", file=sys.stderr)
@@ -75,8 +109,83 @@ def main() -> int:
             print(f"- {failure}", file=sys.stderr)
         return 1
 
+    if args.selection_only:
+        print("Validated Flatpak foreign dependency version selection.")
+        return 0
+
     print(f"Validated {len(checks)} Flatpak foreign dependency patch(es).")
     return 0
+
+
+def validate_native_fallbacks(
+    *,
+    bundled_foreign_deps: dict[str, Any],
+    overlay_foreign_deps: dict[str, Any],
+    locked_packages: dict[str, LockedPackage],
+) -> list[str]:
+    """Reject version-sensitive native entries reused for newer packages.
+
+    ``flatpak-flutter`` deliberately selects the newest compatible entry when
+    it has no exact version. That is safe for nested tool patches such as the
+    shared cargokit patch, but package-root patches and prebuilt native files
+    are tied to the package's source layout and release artifacts.
+    """
+    merged: dict[str, Any] = {
+        name: dict(versions) if isinstance(versions, dict) else versions
+        for name, versions in bundled_foreign_deps.items()
+    }
+    for name, versions in overlay_foreign_deps.items():
+        if name.startswith("_") or not isinstance(versions, dict):
+            continue
+        existing = merged.setdefault(name, {})
+        if isinstance(existing, dict):
+            existing.update(versions)
+
+    failures: list[str] = []
+    for name, locked in locked_packages.items():
+        if locked.source != "hosted":
+            continue
+
+        versions = merged.get(name)
+        if not isinstance(versions, dict):
+            continue
+
+        selected = _flatpak_flutter_selected_version(
+            versions.keys(),
+            locked.version,
+        )
+        if selected is None or selected == locked.version:
+            continue
+
+        if _has_version_sensitive_native_sources(versions[selected]):
+            failures.append(
+                f"{name} is locked at {locked.version}, but flatpak-flutter "
+                f"would reuse the native package-root entry for {selected}; "
+                "add an exact foreign_deps overlay entry"
+            )
+
+    return failures
+
+
+def _has_version_sensitive_native_sources(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    manifest = entry.get("manifest")
+    if not isinstance(manifest, dict):
+        return False
+    sources = manifest.get("sources")
+    if not isinstance(sources, list):
+        return False
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        source_type = source.get("type")
+        if source_type in {"archive", "file"}:
+            return True
+        if source_type == "patch" and source.get("dest") == "$PUB_DEV":
+            return True
+    return False
 
 
 def _read_pubspec_lock(path: Path) -> dict[str, LockedPackage]:

--- a/flatpak/check_foreign_deps_test.py
+++ b/flatpak/check_foreign_deps_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Tests for Flatpak foreign-dependency validation."""
+
+from __future__ import annotations
+
+import unittest
+
+from check_foreign_deps import LockedPackage, validate_native_fallbacks
+
+
+class ValidateNativeFallbacksTest(unittest.TestCase):
+    def test_rejects_package_root_patch_reused_for_newer_locked_version(self):
+        bundled = {
+            "sqlite3": {
+                "2.9.4": {},
+                "3.0.0": {
+                    "manifest": {
+                        "sources": [
+                            {
+                                "type": "patch",
+                                "path": "sqlite3/assets.dart.patch",
+                                "dest": "$PUB_DEV",
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+        locked = {"sqlite3": LockedPackage(source="hosted", version="3.5.1")}
+
+        failures = validate_native_fallbacks(
+            bundled_foreign_deps=bundled,
+            overlay_foreign_deps={},
+            locked_packages=locked,
+        )
+
+        self.assertEqual(
+            failures,
+            [
+                "sqlite3 is locked at 3.5.1, but flatpak-flutter would reuse "
+                "the native package-root entry for 3.0.0; add an exact "
+                "foreign_deps overlay entry"
+            ],
+        )
+
+    def test_accepts_exact_overlay_for_locked_version(self):
+        bundled = {
+            "sqlite3": {
+                "3.0.0": {
+                    "manifest": {
+                        "sources": [
+                            {
+                                "type": "patch",
+                                "path": "sqlite3/assets.dart.patch",
+                                "dest": "$PUB_DEV",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        overlay = {"sqlite3": {"3.5.1": {"manifest": {"sources": []}}}}
+        locked = {"sqlite3": LockedPackage(source="hosted", version="3.5.1")}
+
+        self.assertEqual(
+            validate_native_fallbacks(
+                bundled_foreign_deps=bundled,
+                overlay_foreign_deps=overlay,
+                locked_packages=locked,
+            ),
+            [],
+        )
+
+    def test_allows_nested_tool_patch_to_follow_compatible_version(self):
+        bundled = {
+            "super_native_extensions": {
+                "0.8.24": {
+                    "manifest": {
+                        "sources": [
+                            {
+                                "type": "patch",
+                                "path": "cargokit/run_build_tool.sh.patch",
+                                "dest": "$PUB_DEV/cargokit",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        locked = {
+            "super_native_extensions": LockedPackage(
+                source="hosted",
+                version="0.9.1",
+            )
+        }
+
+        self.assertEqual(
+            validate_native_fallbacks(
+                bundled_foreign_deps=bundled,
+                overlay_foreign_deps={},
+                locked_packages=locked,
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/flatpak/flatpak_flutter_extra/foreign_deps.json
+++ b/flatpak/flatpak_flutter_extra/foreign_deps.json
@@ -1,5 +1,33 @@
 {
     "_comment": "Toolchain overlay: entries merged into the cloned flatpak-flutter's foreign_deps/foreign_deps.json by prepare_flathub_build.sh. Add new dependency versions here when pubspec.lock outpaces what flatpak-flutter ships. Submit upstream to https://github.com/TheAppgineer/flatpak-flutter when stable.",
+    "sqlite3": {
+        "3.5.1": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "file",
+                        "only-arches": [
+                            "x86_64"
+                        ],
+                        "url": "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.1/libsqlite3.x64.linux.so",
+                        "sha256": "b17729184e5a2818055ecbddd5ed6642521bfe6e56aafa472330e483c0e2e0d2",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/sqlite3/build/download-b1772918",
+                        "dest-filename": "libsqlite3.so"
+                    },
+                    {
+                        "type": "file",
+                        "only-arches": [
+                            "aarch64"
+                        ],
+                        "url": "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.1/libsqlite3.arm64.linux.so",
+                        "sha256": "7f0db19fdb987298ab8def51431aba5cec28a81685e8b62cebbc7402df090a16",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/sqlite3/build/download-7f0db19f",
+                        "dest-filename": "libsqlite3.so"
+                    }
+                ]
+            }
+        }
+    },
     "sqlite3_flutter_libs": {
         "0.5.42": {
             "manifest": {

--- a/flatpak/prepare_flathub_build.sh
+++ b/flatpak/prepare_flathub_build.sh
@@ -61,6 +61,13 @@ PY
   fi
 fi
 
+# Refuse version-sensitive native fallback entries before generating an
+# invalid manifest. This needs the merged flatpak-flutter database but not a
+# populated Pub cache, so it also runs in the release workflow.
+"$PYTHON" "$SCRIPT_DIR/check_foreign_deps.py" \
+  --bundled-foreign-deps "$TOOL_FOREIGN_DEPS/foreign_deps.json" \
+  --selection-only
+
 # Clean and create work dir
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR" "$OUTPUT_DIR"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.6+4302
+version: 1.0.6+4303
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
## Summary

- add an exact Flatpak overlay for sqlite3 3.5.1 using its per-architecture, hash-matched Linux binaries
- remove the need for the stale sqlite3 source patches by placing each binary directly in the hook cache directory expected by sqlite3 3.5.1
- reject version-sensitive native fallbacks selected from the pinned flatpak-flutter database before manifest generation
- run the new selection guard in CI and add focused Python regression tests
- bump the app build number from 4302 to 4303

## Root cause

The Flathub release generator pinned flatpak-flutter 0.11.0, whose bundled database has no exact sqlite3 3.5.1 entry. It therefore reused the 3.0.0 entry, including source patches and sqlite3 3.1.1 binaries. The generated `assets.dart.patch` no longer matched sqlite3 3.5.1 and failed in the Flathub aarch64 build.

## Validation

- `python3 -m unittest check_flutter_pin_test check_foreign_deps_test`
- `python3 check_foreign_deps.py --bundled-foreign-deps flatpak-flutter/foreign_deps/foreign_deps.json`
- `fvm flutter pub get --enforce-lockfile`
- `fvm flutter analyze --no-pub`
- `fvm dart format` across all tracked Dart files (0 changed)
- generated the offline manifest with flatpak-flutter 0.11.0 and asserted that both x86_64 and aarch64 use sqlite3 3.5.1 hash-derived cache paths with no sqlite3 package patches
- verified the downloaded sqlite3 3.5.1 binary hashes against the overlay values

The approximately 27,000-test Flutter suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flatpak dependency validation to detect incompatible native fallbacks and missing exact version overlays.
  * Added architecture-specific SQLite 3.5.1 fallback libraries for supported Linux builds.
  * Added an earlier dependency-selection check to prevent invalid Flatpak manifests.

* **Documentation**
  * Expanded Flatpak dependency-overlay guidance, validation details, and native input information.

* **Chores**
  * Updated the application build version to 1.0.6+4303.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->