### PR TITLE
feat(goals): add tracked-time criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7]
+### Added
+- **Goal agents can reason about more than habits and steps.** Goal criteria can
+  now use any supported quantitative health signal, including sleep duration
+  and weight, user-defined measurable data, and time recorded against a
+  category. Category-time goals support both minimum and maximum durations and
+  optional recurring local-time bands, so an agent can watch goals such as
+  limiting coding after 22:00 while retaining the underlying session pattern
+  for grounded coaching. Multi-dimensional goals keep a separate accountable
+  result for every criterion, and agent-proposed changes still require the
+  user's approval.
+
 ## [1.0.6]
 ### Added
 - **Goal agents get their first visible surface (experimental).** Behind the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.7]
 ### Added
-- **Goal agents can reason about more than habits and steps.** Goal criteria can
-  now use any supported quantitative health signal, including sleep duration
-  and weight, user-defined measurable data, and time recorded against a
-  category. Category-time goals support both minimum and maximum durations and
-  optional recurring local-time bands, so an agent can watch goals such as
-  limiting coding after 22:00 while retaining the underlying session pattern
-  for grounded coaching. Multi-dimensional goals keep a separate accountable
-  result for every criterion, and agent-proposed changes still require the
-  user's approval.
+- **Goal-agent criteria are ready for refinement.** Goal agents remain
+  configurable with linked habits and rolling seven-day step targets. Their
+  evaluation foundation now preserves a separate accountable result for every
+  configured criterion.
 
 ## [1.0.6]
 ### Added

--- a/docs-site/metadata/surface-inventory.json
+++ b/docs-site/metadata/surface-inventory.json
@@ -1260,6 +1260,7 @@
         "/agents",
         "/agents/create",
         "/agents/details/:agentId",
+        "/agents/details/:agentId/edit",
         "/agents/details/:agentId/chat"
       ],
       "page": "ai-and-automation/goal-agents",

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,7 +42,7 @@
   <releases>
     <release version="1.0.7" date="2026-08-12">
       <description>
-        <p>Added: goal agents can reason about more than habits and steps. Goal criteria can now use any supported quantitative health signal, including sleep duration and weight, user-defined measurable data, and time recorded against a category. Category-time goals support both minimum and maximum durations and optional recurring local-time bands, so an agent can watch goals such as limiting coding after 22:00 while retaining the underlying session pattern for grounded coaching. Multi-dimensional goals keep a separate accountable result for every criterion, and agent-proposed changes still require the user's approval.</p>
+        <p>Added: goal agents remain configurable with linked habits and rolling seven-day step targets. Their evaluation foundation now preserves a separate accountable result for every configured criterion.</p>
       </description>
     </release>
     <release version="1.0.6" date="2026-08-09">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.7" date="2026-08-12">
+      <description>
+        <p>Added: goal agents can reason about more than habits and steps. Goal criteria can now use any supported quantitative health signal, including sleep duration and weight, user-defined measurable data, and time recorded against a category. Category-time goals support both minimum and maximum durations and optional recurring local-time bands, so an agent can watch goals such as limiting coding after 22:00 while retaining the underlying session pattern for grounded coaching. Multi-dimensional goals keep a separate accountable result for every criterion, and agent-proposed changes still require the user's approval.</p>
+      </description>
+    </release>
     <release version="1.0.6" date="2026-08-09">
       <description>
         <p>Changed: the Melious.ai profile now runs on GLM 5.2 and Kimi K3. Connecting a Melious key installs Kimi K3 alongside the models already offered, and the profile Lotti sets up for you binds GLM 5.2 for thinking, Kimi K3 for both high-end thinking and reading images, and Whisper Large v3 for transcription. Image generation stays on Flux 2 Klein 9B. An existing Melious profile moves to the same models on the next launch — unless you renamed it, described it, pinned it to a device or chose any model yourself, in which case it is left exactly as you set it. Voice capture that has no transcription model configured — onboarding's first task included — now also lands on Whisper Large v3 instead of the Voxtral chat path.</p>

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -19,7 +19,7 @@ sources:
   - id: signal-reader
     resource: ../../lib/features/goals/evaluation/goal_signal_reader.dart
     title: GoalSignalReader — journal-backed daily aggregates
-    last_modified: 2026-08-09
+    last_modified: 2026-08-12
   - id: evaluator
     resource: ../../lib/features/goals/evaluation/goal_progress_evaluator.dart
     title: GoalProgressEvaluator — pure criteria-tree fold
@@ -31,7 +31,11 @@ sources:
   - id: vocabulary
     resource: ../../lib/classes/goal_criterion.dart
     title: GoalCriterion tree (shared vocabulary in lib/classes)
-    last_modified: 2026-08-09
+    last_modified: 2026-08-12
+  - id: progress-vocabulary
+    resource: ../../lib/classes/goal_progress_models.dart
+    title: Persisted per-dimension progress vocabulary
+    last_modified: 2026-08-12
   - id: workflow
     resource: ../../lib/features/goals/workflow/goal_agent_workflow.dart
     title: GoalAgentWorkflow — the Phase B LLM tier
@@ -129,13 +133,44 @@ flowchart TD
 - **Grace history is a consecutive, same-spec-version streak**: prior-row
   collection stops at the first missing day and at the first row computed
   under a superseded spec version.
+- **Every criterion leaf is an accountable dimension.** A composite goal can
+  combine any number of titled metric, measurable, habit, or category-time
+  leaves through `allOf`, `anyOf`, or `atLeastCount`. Stable `criterionId`
+  values connect each leaf to its persisted `GoalCriterionProgress` result in
+  every period register: actual, target, ratio, satisfaction, sample count,
+  pace feasibility, and coverage remain inspectable instead of disappearing
+  into one overall score. The composite result controls goal health, while its
+  children retain the evidence for which dimension carried or missed it.
 - **Borrowed data semantics.** Quantitative day totals follow the health
   charts' per-type aggregation (`cumulative_step_count` day total is the
   daily max), point-sample types keep the day's latest sample, habit days
   follow the habits UI's latest-completion-per-day collapse with
-  success-only counting, and day keys re-stamp the local calendar date as
-  midnight UTC. The goal agent must never disagree with the chart the
-  user is looking at.
+  success-only counting, measurable leaves reuse their authored data-type ids,
+  and category time reuses the same category-attributed timer rows as Insights.
+  A category-time leaf can enforce an `atLeast` or `atMost` number of hours and
+  can clip every local day to an optional time band; a crossing band such as
+  `21:30 → 07:00` spans midnight. Day keys re-stamp the local calendar date as
+  midnight UTC. The goal agent must never disagree with the chart the user is
+  looking at.
+- **Pattern evidence is richer than the threshold.** Phase A reads only the
+  bounded evaluation/lookback range. When Phase B actually runs, the same
+  reader additionally passes every valid attributed session for a watched
+  category since the goal agent was created, including sessions outside an
+  optional cutoff band. The FACTS block exposes category, local start/end and
+  duration, so the coach can notice late-night or clustering patterns without
+  making every cheap signal tick scan the goal's lifetime. Those sessions are
+  evidence only: the model may discuss them but cannot replace the
+  deterministic per-dimension result.
+- **Subjective assessment is a separate governance layer.** Deterministic
+  `goalProgress` registers are recomputed from source and must never carry a
+  mutable opinion. A future daily-assessment register should therefore keep
+  user-authored ratings separate from agent suggestions. Direct user ratings
+  become approved assessments immediately; agent suggestions reuse the shared
+  `ChangeSet` and `ChangeDecision` path and become authoritative only after the
+  user confirms them. The assessment keys each rating by stable criterion id,
+  preserves proposal/decision provenance, and may add an overall reflection
+  without erasing any dimension's measured result. No producer for that
+  assessment register exists yet.
 - **Automatic Phase B is reachable only through the lease; direct chat and
   detail-page refreshes are explicit user wakes.** Sync-received signals run Phase A directly (the
   orchestrator deliberately listens local-only); automatic LLM-worthy work
@@ -446,6 +481,12 @@ flowchart TD
   repeatedly enqueueing work that the lifecycle guard would only discard.
   Goal-list rows and banner semantics resolve the active spec title; the
   identity display name remains the conversational persona used by chat.
+  The current form represents rolling habit quotas plus the supported steps
+  metric. A follow-up mapping surface must enumerate generic quantitative and
+  measurable types, category selection, `atLeast`/`atMost` tracked-hour
+  targets, and an optional local time band without hard-coding a health-data
+  catalog. A separate follow-up approval surface will render direct daily
+  dimension ratings and agent-proposed assessment change items.
 - **Conversation scope is the goal.** The contract identifies the agent as a
   dedicated coach rather than a general assistant. Coding, trivia and other
   unrelated requests receive a short purpose reminder and a redirect to the

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -154,13 +154,14 @@ flowchart TD
   looking at.
 - **Pattern evidence is richer than the threshold.** Phase A reads only the
   bounded evaluation/lookback range. When Phase B actually runs, the same
-  reader additionally passes every valid attributed session for a watched
+  reader additionally loads every valid attributed session for a watched
   category since the goal agent was created, including sessions outside an
-  optional cutoff band. The FACTS block exposes category, local start/end and
-  duration, so the coach can notice late-night or clustering patterns without
-  making every cheap signal tick scan the goal's lifetime. Those sessions are
-  evidence only: the model may discuss them but cannot replace the
-  deterministic per-dimension result.
+  optional cutoff band. FACTS summarizes the complete lifetime into bounded
+  local-hour and weekday distributions, then adds the 200 most recent raw
+  sessions with category, local start/end and duration. The coach can therefore
+  notice late-night or clustering patterns without allowing one current model
+  message to grow forever. Those signals are evidence only: the model may
+  discuss them but cannot replace the deterministic per-dimension result.
 - **Subjective assessment is a separate governance layer.** Deterministic
   `goalProgress` registers are recomputed from source and must never carry a
   mutable opinion. A future daily-assessment register should therefore keep

--- a/lib/classes/goal_criterion.dart
+++ b/lib/classes/goal_criterion.dart
@@ -83,6 +83,10 @@ sealed class GoalCriterion with _$GoalCriterion {
   /// Model-facing wake facts may also include the underlying sessions for
   /// coaching-pattern analysis, but their deterministic result remains the
   /// authoritative measured outcome.
+  ///
+  /// [aggregation] remains hour-valued: `sum`, `dailySumThenAverage`, and `max`
+  /// are valid. `count` is rejected because it counts active days and cannot be
+  /// compared honestly with [targetHours].
   const factory GoalCriterion.categoryTime({
     required String criterionId,
     required String categoryId,

--- a/lib/classes/goal_criterion.dart
+++ b/lib/classes/goal_criterion.dart
@@ -6,6 +6,24 @@ import 'package:lotti/classes/goal_window.dart';
 part 'goal_criterion.freezed.dart';
 part 'goal_criterion.g.dart';
 
+/// A recurring local-time slice applied independently to every calendar day.
+///
+/// Minutes are counted from local midnight. A range whose start is later than
+/// its end crosses midnight: `21:30 → 07:00` includes late evening and the
+/// following early-morning band. All-day category time uses no range rather
+/// than encoding `00:00 → 00:00`, keeping equal endpoints invalid and
+/// unambiguous.
+@freezed
+abstract class GoalDailyTimeRange with _$GoalDailyTimeRange {
+  const factory GoalDailyTimeRange({
+    required int startMinute,
+    required int endMinute,
+  }) = _GoalDailyTimeRange;
+
+  factory GoalDailyTimeRange.fromJson(Map<String, dynamic> json) =>
+      _$GoalDailyTimeRangeFromJson(json);
+}
+
 /// The criteria tree a goal's success is defined in.
 ///
 /// Leaves bind a measurable signal to a windowed target; composites combine
@@ -19,9 +37,11 @@ part 'goal_criterion.g.dart';
 /// [GoalCriterion.fromAutoCompleteRule] imports one as a seed instead.
 @freezed
 sealed class GoalCriterion with _$GoalCriterion {
-  /// A health/quantitative target: "daily step sums, averaged over a rolling
-  /// 7 days, at least 10,000". [dataType] is the journal quantitative data
-  /// type string (e.g. `cumulative_step_count`).
+  /// A health/quantitative dimension: "daily step totals, averaged over a
+  /// rolling 7 days, at least 10,000". [dataType] is the journal quantitative
+  /// data type string (for example `cumulative_step_count`, sleep duration, or
+  /// weight). The health data type's configured daily aggregation is applied
+  /// first; [aggregation] then combines those daily values across [window].
   const factory GoalCriterion.metric({
     required String criterionId,
     required String dataType,
@@ -42,8 +62,8 @@ sealed class GoalCriterion with _$GoalCriterion {
     String? title,
   }) = GoalCriterionHabit;
 
-  /// A measurable-data-type target, same shape as [GoalCriterion.metric] but
-  /// keyed by the `MeasurableDataType` id.
+  /// A user-defined measurable-data dimension, same shape as
+  /// [GoalCriterion.metric] but keyed by the `MeasurableDataType` id.
   const factory GoalCriterion.measurable({
     required String criterionId,
     required String dataTypeId,
@@ -53,6 +73,26 @@ sealed class GoalCriterion with _$GoalCriterion {
     @Default(GoalDirection.atLeast) GoalDirection direction,
     String? title,
   }) = GoalCriterionMeasurable;
+
+  /// A tracked-time dimension attributed to [categoryId], measured in hours.
+  ///
+  /// [dailyTimeRange] optionally restricts the evidence to a recurring local
+  /// time band. This makes both amount goals ("at most 8 hours of coding in a
+  /// rolling week") and timing goals ("no coding from 21:30 to 07:00") honest
+  /// first-class criteria over the same journal time entries used by Insights.
+  /// Model-facing wake facts may also include the underlying sessions for
+  /// coaching-pattern analysis, but their deterministic result remains the
+  /// authoritative measured outcome.
+  const factory GoalCriterion.categoryTime({
+    required String criterionId,
+    required String categoryId,
+    required GoalWindow window,
+    required GoalAggregation aggregation,
+    required num targetHours,
+    @Default(GoalDirection.atMost) GoalDirection direction,
+    GoalDailyTimeRange? dailyTimeRange,
+    String? title,
+  }) = GoalCriterionCategoryTime;
 
   /// All children must be satisfied; attainment is their mean.
   const factory GoalCriterion.allOf({

--- a/lib/classes/goal_criterion.freezed.dart
+++ b/lib/classes/goal_criterion.freezed.dart
@@ -11,6 +11,272 @@ part of 'goal_criterion.dart';
 
 // dart format off
 T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GoalDailyTimeRange {
+
+ int get startMinute; int get endMinute;
+/// Create a copy of GoalDailyTimeRange
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GoalDailyTimeRangeCopyWith<GoalDailyTimeRange> get copyWith => _$GoalDailyTimeRangeCopyWithImpl<GoalDailyTimeRange>(this as GoalDailyTimeRange, _$identity);
+
+  /// Serializes this GoalDailyTimeRange to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalDailyTimeRange&&(identical(other.startMinute, startMinute) || other.startMinute == startMinute)&&(identical(other.endMinute, endMinute) || other.endMinute == endMinute));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,startMinute,endMinute);
+
+@override
+String toString() {
+  return 'GoalDailyTimeRange(startMinute: $startMinute, endMinute: $endMinute)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GoalDailyTimeRangeCopyWith<$Res>  {
+  factory $GoalDailyTimeRangeCopyWith(GoalDailyTimeRange value, $Res Function(GoalDailyTimeRange) _then) = _$GoalDailyTimeRangeCopyWithImpl;
+@useResult
+$Res call({
+ int startMinute, int endMinute
+});
+
+
+
+
+}
+/// @nodoc
+class _$GoalDailyTimeRangeCopyWithImpl<$Res>
+    implements $GoalDailyTimeRangeCopyWith<$Res> {
+  _$GoalDailyTimeRangeCopyWithImpl(this._self, this._then);
+
+  final GoalDailyTimeRange _self;
+  final $Res Function(GoalDailyTimeRange) _then;
+
+/// Create a copy of GoalDailyTimeRange
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? startMinute = null,Object? endMinute = null,}) {
+  return _then(_self.copyWith(
+startMinute: null == startMinute ? _self.startMinute : startMinute // ignore: cast_nullable_to_non_nullable
+as int,endMinute: null == endMinute ? _self.endMinute : endMinute // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GoalDailyTimeRange].
+extension GoalDailyTimeRangePatterns on GoalDailyTimeRange {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GoalDailyTimeRange value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GoalDailyTimeRange() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GoalDailyTimeRange value)  $default,){
+final _that = this;
+switch (_that) {
+case _GoalDailyTimeRange():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GoalDailyTimeRange value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GoalDailyTimeRange() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int startMinute,  int endMinute)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GoalDailyTimeRange() when $default != null:
+return $default(_that.startMinute,_that.endMinute);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int startMinute,  int endMinute)  $default,) {final _that = this;
+switch (_that) {
+case _GoalDailyTimeRange():
+return $default(_that.startMinute,_that.endMinute);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int startMinute,  int endMinute)?  $default,) {final _that = this;
+switch (_that) {
+case _GoalDailyTimeRange() when $default != null:
+return $default(_that.startMinute,_that.endMinute);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GoalDailyTimeRange implements GoalDailyTimeRange {
+  const _GoalDailyTimeRange({required this.startMinute, required this.endMinute});
+  factory _GoalDailyTimeRange.fromJson(Map<String, dynamic> json) => _$GoalDailyTimeRangeFromJson(json);
+
+@override final  int startMinute;
+@override final  int endMinute;
+
+/// Create a copy of GoalDailyTimeRange
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GoalDailyTimeRangeCopyWith<_GoalDailyTimeRange> get copyWith => __$GoalDailyTimeRangeCopyWithImpl<_GoalDailyTimeRange>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GoalDailyTimeRangeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GoalDailyTimeRange&&(identical(other.startMinute, startMinute) || other.startMinute == startMinute)&&(identical(other.endMinute, endMinute) || other.endMinute == endMinute));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,startMinute,endMinute);
+
+@override
+String toString() {
+  return 'GoalDailyTimeRange(startMinute: $startMinute, endMinute: $endMinute)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GoalDailyTimeRangeCopyWith<$Res> implements $GoalDailyTimeRangeCopyWith<$Res> {
+  factory _$GoalDailyTimeRangeCopyWith(_GoalDailyTimeRange value, $Res Function(_GoalDailyTimeRange) _then) = __$GoalDailyTimeRangeCopyWithImpl;
+@override @useResult
+$Res call({
+ int startMinute, int endMinute
+});
+
+
+
+
+}
+/// @nodoc
+class __$GoalDailyTimeRangeCopyWithImpl<$Res>
+    implements _$GoalDailyTimeRangeCopyWith<$Res> {
+  __$GoalDailyTimeRangeCopyWithImpl(this._self, this._then);
+
+  final _GoalDailyTimeRange _self;
+  final $Res Function(_GoalDailyTimeRange) _then;
+
+/// Create a copy of GoalDailyTimeRange
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? startMinute = null,Object? endMinute = null,}) {
+  return _then(_GoalDailyTimeRange(
+startMinute: null == startMinute ? _self.startMinute : startMinute // ignore: cast_nullable_to_non_nullable
+as int,endMinute: null == endMinute ? _self.endMinute : endMinute // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
 GoalCriterion _$GoalCriterionFromJson(
   Map<String, dynamic> json
 ) {
@@ -25,6 +291,10 @@ GoalCriterion _$GoalCriterionFromJson(
           );
                 case 'measurable':
           return GoalCriterionMeasurable.fromJson(
+            json
+          );
+                case 'categoryTime':
+          return GoalCriterionCategoryTime.fromJson(
             json
           );
                 case 'allOf':
@@ -129,13 +399,14 @@ extension GoalCriterionPatterns on GoalCriterion {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GoalCriterionMetric value)?  metric,TResult Function( GoalCriterionHabit value)?  habit,TResult Function( GoalCriterionMeasurable value)?  measurable,TResult Function( GoalCriterionAllOf value)?  allOf,TResult Function( GoalCriterionAnyOf value)?  anyOf,TResult Function( GoalCriterionAtLeastCount value)?  atLeastCount,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( GoalCriterionMetric value)?  metric,TResult Function( GoalCriterionHabit value)?  habit,TResult Function( GoalCriterionMeasurable value)?  measurable,TResult Function( GoalCriterionCategoryTime value)?  categoryTime,TResult Function( GoalCriterionAllOf value)?  allOf,TResult Function( GoalCriterionAnyOf value)?  anyOf,TResult Function( GoalCriterionAtLeastCount value)?  atLeastCount,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case GoalCriterionMetric() when metric != null:
 return metric(_that);case GoalCriterionHabit() when habit != null:
 return habit(_that);case GoalCriterionMeasurable() when measurable != null:
-return measurable(_that);case GoalCriterionAllOf() when allOf != null:
+return measurable(_that);case GoalCriterionCategoryTime() when categoryTime != null:
+return categoryTime(_that);case GoalCriterionAllOf() when allOf != null:
 return allOf(_that);case GoalCriterionAnyOf() when anyOf != null:
 return anyOf(_that);case GoalCriterionAtLeastCount() when atLeastCount != null:
 return atLeastCount(_that);case _:
@@ -156,13 +427,14 @@ return atLeastCount(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GoalCriterionMetric value)  metric,required TResult Function( GoalCriterionHabit value)  habit,required TResult Function( GoalCriterionMeasurable value)  measurable,required TResult Function( GoalCriterionAllOf value)  allOf,required TResult Function( GoalCriterionAnyOf value)  anyOf,required TResult Function( GoalCriterionAtLeastCount value)  atLeastCount,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( GoalCriterionMetric value)  metric,required TResult Function( GoalCriterionHabit value)  habit,required TResult Function( GoalCriterionMeasurable value)  measurable,required TResult Function( GoalCriterionCategoryTime value)  categoryTime,required TResult Function( GoalCriterionAllOf value)  allOf,required TResult Function( GoalCriterionAnyOf value)  anyOf,required TResult Function( GoalCriterionAtLeastCount value)  atLeastCount,}){
 final _that = this;
 switch (_that) {
 case GoalCriterionMetric():
 return metric(_that);case GoalCriterionHabit():
 return habit(_that);case GoalCriterionMeasurable():
-return measurable(_that);case GoalCriterionAllOf():
+return measurable(_that);case GoalCriterionCategoryTime():
+return categoryTime(_that);case GoalCriterionAllOf():
 return allOf(_that);case GoalCriterionAnyOf():
 return anyOf(_that);case GoalCriterionAtLeastCount():
 return atLeastCount(_that);}
@@ -179,13 +451,14 @@ return atLeastCount(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GoalCriterionMetric value)?  metric,TResult? Function( GoalCriterionHabit value)?  habit,TResult? Function( GoalCriterionMeasurable value)?  measurable,TResult? Function( GoalCriterionAllOf value)?  allOf,TResult? Function( GoalCriterionAnyOf value)?  anyOf,TResult? Function( GoalCriterionAtLeastCount value)?  atLeastCount,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( GoalCriterionMetric value)?  metric,TResult? Function( GoalCriterionHabit value)?  habit,TResult? Function( GoalCriterionMeasurable value)?  measurable,TResult? Function( GoalCriterionCategoryTime value)?  categoryTime,TResult? Function( GoalCriterionAllOf value)?  allOf,TResult? Function( GoalCriterionAnyOf value)?  anyOf,TResult? Function( GoalCriterionAtLeastCount value)?  atLeastCount,}){
 final _that = this;
 switch (_that) {
 case GoalCriterionMetric() when metric != null:
 return metric(_that);case GoalCriterionHabit() when habit != null:
 return habit(_that);case GoalCriterionMeasurable() when measurable != null:
-return measurable(_that);case GoalCriterionAllOf() when allOf != null:
+return measurable(_that);case GoalCriterionCategoryTime() when categoryTime != null:
+return categoryTime(_that);case GoalCriterionAllOf() when allOf != null:
 return allOf(_that);case GoalCriterionAnyOf() when anyOf != null:
 return anyOf(_that);case GoalCriterionAtLeastCount() when atLeastCount != null:
 return atLeastCount(_that);case _:
@@ -205,12 +478,13 @@ return atLeastCount(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String criterionId,  String dataType,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  metric,TResult Function( String criterionId,  String habitId,  GoalWindow window,  int targetCount,  String? title)?  habit,TResult Function( String criterionId,  String dataTypeId,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  measurable,TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  allOf,TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  anyOf,TResult Function( String criterionId,  List<GoalCriterion> criteria,  int successes,  String? title)?  atLeastCount,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String criterionId,  String dataType,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  metric,TResult Function( String criterionId,  String habitId,  GoalWindow window,  int targetCount,  String? title)?  habit,TResult Function( String criterionId,  String dataTypeId,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  measurable,TResult Function( String criterionId,  String categoryId,  GoalWindow window,  GoalAggregation aggregation,  num targetHours,  GoalDirection direction,  GoalDailyTimeRange? dailyTimeRange,  String? title)?  categoryTime,TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  allOf,TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  anyOf,TResult Function( String criterionId,  List<GoalCriterion> criteria,  int successes,  String? title)?  atLeastCount,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case GoalCriterionMetric() when metric != null:
 return metric(_that.criterionId,_that.dataType,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionHabit() when habit != null:
 return habit(_that.criterionId,_that.habitId,_that.window,_that.targetCount,_that.title);case GoalCriterionMeasurable() when measurable != null:
-return measurable(_that.criterionId,_that.dataTypeId,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionAllOf() when allOf != null:
+return measurable(_that.criterionId,_that.dataTypeId,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionCategoryTime() when categoryTime != null:
+return categoryTime(_that.criterionId,_that.categoryId,_that.window,_that.aggregation,_that.targetHours,_that.direction,_that.dailyTimeRange,_that.title);case GoalCriterionAllOf() when allOf != null:
 return allOf(_that.criterionId,_that.criteria,_that.title);case GoalCriterionAnyOf() when anyOf != null:
 return anyOf(_that.criterionId,_that.criteria,_that.title);case GoalCriterionAtLeastCount() when atLeastCount != null:
 return atLeastCount(_that.criterionId,_that.criteria,_that.successes,_that.title);case _:
@@ -231,12 +505,13 @@ return atLeastCount(_that.criterionId,_that.criteria,_that.successes,_that.title
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String criterionId,  String dataType,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)  metric,required TResult Function( String criterionId,  String habitId,  GoalWindow window,  int targetCount,  String? title)  habit,required TResult Function( String criterionId,  String dataTypeId,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)  measurable,required TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)  allOf,required TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)  anyOf,required TResult Function( String criterionId,  List<GoalCriterion> criteria,  int successes,  String? title)  atLeastCount,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String criterionId,  String dataType,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)  metric,required TResult Function( String criterionId,  String habitId,  GoalWindow window,  int targetCount,  String? title)  habit,required TResult Function( String criterionId,  String dataTypeId,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)  measurable,required TResult Function( String criterionId,  String categoryId,  GoalWindow window,  GoalAggregation aggregation,  num targetHours,  GoalDirection direction,  GoalDailyTimeRange? dailyTimeRange,  String? title)  categoryTime,required TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)  allOf,required TResult Function( String criterionId,  List<GoalCriterion> criteria,  String? title)  anyOf,required TResult Function( String criterionId,  List<GoalCriterion> criteria,  int successes,  String? title)  atLeastCount,}) {final _that = this;
 switch (_that) {
 case GoalCriterionMetric():
 return metric(_that.criterionId,_that.dataType,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionHabit():
 return habit(_that.criterionId,_that.habitId,_that.window,_that.targetCount,_that.title);case GoalCriterionMeasurable():
-return measurable(_that.criterionId,_that.dataTypeId,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionAllOf():
+return measurable(_that.criterionId,_that.dataTypeId,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionCategoryTime():
+return categoryTime(_that.criterionId,_that.categoryId,_that.window,_that.aggregation,_that.targetHours,_that.direction,_that.dailyTimeRange,_that.title);case GoalCriterionAllOf():
 return allOf(_that.criterionId,_that.criteria,_that.title);case GoalCriterionAnyOf():
 return anyOf(_that.criterionId,_that.criteria,_that.title);case GoalCriterionAtLeastCount():
 return atLeastCount(_that.criterionId,_that.criteria,_that.successes,_that.title);}
@@ -253,12 +528,13 @@ return atLeastCount(_that.criterionId,_that.criteria,_that.successes,_that.title
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String criterionId,  String dataType,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  metric,TResult? Function( String criterionId,  String habitId,  GoalWindow window,  int targetCount,  String? title)?  habit,TResult? Function( String criterionId,  String dataTypeId,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  measurable,TResult? Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  allOf,TResult? Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  anyOf,TResult? Function( String criterionId,  List<GoalCriterion> criteria,  int successes,  String? title)?  atLeastCount,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String criterionId,  String dataType,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  metric,TResult? Function( String criterionId,  String habitId,  GoalWindow window,  int targetCount,  String? title)?  habit,TResult? Function( String criterionId,  String dataTypeId,  GoalWindow window,  GoalAggregation aggregation,  num target,  GoalDirection direction,  String? title)?  measurable,TResult? Function( String criterionId,  String categoryId,  GoalWindow window,  GoalAggregation aggregation,  num targetHours,  GoalDirection direction,  GoalDailyTimeRange? dailyTimeRange,  String? title)?  categoryTime,TResult? Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  allOf,TResult? Function( String criterionId,  List<GoalCriterion> criteria,  String? title)?  anyOf,TResult? Function( String criterionId,  List<GoalCriterion> criteria,  int successes,  String? title)?  atLeastCount,}) {final _that = this;
 switch (_that) {
 case GoalCriterionMetric() when metric != null:
 return metric(_that.criterionId,_that.dataType,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionHabit() when habit != null:
 return habit(_that.criterionId,_that.habitId,_that.window,_that.targetCount,_that.title);case GoalCriterionMeasurable() when measurable != null:
-return measurable(_that.criterionId,_that.dataTypeId,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionAllOf() when allOf != null:
+return measurable(_that.criterionId,_that.dataTypeId,_that.window,_that.aggregation,_that.target,_that.direction,_that.title);case GoalCriterionCategoryTime() when categoryTime != null:
+return categoryTime(_that.criterionId,_that.categoryId,_that.window,_that.aggregation,_that.targetHours,_that.direction,_that.dailyTimeRange,_that.title);case GoalCriterionAllOf() when allOf != null:
 return allOf(_that.criterionId,_that.criteria,_that.title);case GoalCriterionAnyOf() when anyOf != null:
 return anyOf(_that.criterionId,_that.criteria,_that.title);case GoalCriterionAtLeastCount() when atLeastCount != null:
 return atLeastCount(_that.criterionId,_that.criteria,_that.successes,_that.title);case _:
@@ -543,6 +819,114 @@ $GoalWindowCopyWith<$Res> get window {
   
   return $GoalWindowCopyWith<$Res>(_self.window, (value) {
     return _then(_self.copyWith(window: value));
+  });
+}
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class GoalCriterionCategoryTime extends GoalCriterion {
+  const GoalCriterionCategoryTime({required this.criterionId, required this.categoryId, required this.window, required this.aggregation, required this.targetHours, this.direction = GoalDirection.atMost, this.dailyTimeRange, this.title, final  String? $type}): $type = $type ?? 'categoryTime',super._();
+  factory GoalCriterionCategoryTime.fromJson(Map<String, dynamic> json) => _$GoalCriterionCategoryTimeFromJson(json);
+
+@override final  String criterionId;
+ final  String categoryId;
+ final  GoalWindow window;
+ final  GoalAggregation aggregation;
+ final  num targetHours;
+@JsonKey() final  GoalDirection direction;
+ final  GoalDailyTimeRange? dailyTimeRange;
+@override final  String? title;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of GoalCriterion
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GoalCriterionCategoryTimeCopyWith<GoalCriterionCategoryTime> get copyWith => _$GoalCriterionCategoryTimeCopyWithImpl<GoalCriterionCategoryTime>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GoalCriterionCategoryTimeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalCriterionCategoryTime&&(identical(other.criterionId, criterionId) || other.criterionId == criterionId)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.window, window) || other.window == window)&&(identical(other.aggregation, aggregation) || other.aggregation == aggregation)&&(identical(other.targetHours, targetHours) || other.targetHours == targetHours)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.dailyTimeRange, dailyTimeRange) || other.dailyTimeRange == dailyTimeRange)&&(identical(other.title, title) || other.title == title));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,criterionId,categoryId,window,aggregation,targetHours,direction,dailyTimeRange,title);
+
+@override
+String toString() {
+  return 'GoalCriterion.categoryTime(criterionId: $criterionId, categoryId: $categoryId, window: $window, aggregation: $aggregation, targetHours: $targetHours, direction: $direction, dailyTimeRange: $dailyTimeRange, title: $title)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GoalCriterionCategoryTimeCopyWith<$Res> implements $GoalCriterionCopyWith<$Res> {
+  factory $GoalCriterionCategoryTimeCopyWith(GoalCriterionCategoryTime value, $Res Function(GoalCriterionCategoryTime) _then) = _$GoalCriterionCategoryTimeCopyWithImpl;
+@override @useResult
+$Res call({
+ String criterionId, String categoryId, GoalWindow window, GoalAggregation aggregation, num targetHours, GoalDirection direction, GoalDailyTimeRange? dailyTimeRange, String? title
+});
+
+
+$GoalWindowCopyWith<$Res> get window;$GoalDailyTimeRangeCopyWith<$Res>? get dailyTimeRange;
+
+}
+/// @nodoc
+class _$GoalCriterionCategoryTimeCopyWithImpl<$Res>
+    implements $GoalCriterionCategoryTimeCopyWith<$Res> {
+  _$GoalCriterionCategoryTimeCopyWithImpl(this._self, this._then);
+
+  final GoalCriterionCategoryTime _self;
+  final $Res Function(GoalCriterionCategoryTime) _then;
+
+/// Create a copy of GoalCriterion
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? criterionId = null,Object? categoryId = null,Object? window = null,Object? aggregation = null,Object? targetHours = null,Object? direction = null,Object? dailyTimeRange = freezed,Object? title = freezed,}) {
+  return _then(GoalCriterionCategoryTime(
+criterionId: null == criterionId ? _self.criterionId : criterionId // ignore: cast_nullable_to_non_nullable
+as String,categoryId: null == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
+as String,window: null == window ? _self.window : window // ignore: cast_nullable_to_non_nullable
+as GoalWindow,aggregation: null == aggregation ? _self.aggregation : aggregation // ignore: cast_nullable_to_non_nullable
+as GoalAggregation,targetHours: null == targetHours ? _self.targetHours : targetHours // ignore: cast_nullable_to_non_nullable
+as num,direction: null == direction ? _self.direction : direction // ignore: cast_nullable_to_non_nullable
+as GoalDirection,dailyTimeRange: freezed == dailyTimeRange ? _self.dailyTimeRange : dailyTimeRange // ignore: cast_nullable_to_non_nullable
+as GoalDailyTimeRange?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of GoalCriterion
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalWindowCopyWith<$Res> get window {
+  
+  return $GoalWindowCopyWith<$Res>(_self.window, (value) {
+    return _then(_self.copyWith(window: value));
+  });
+}/// Create a copy of GoalCriterion
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalDailyTimeRangeCopyWith<$Res>? get dailyTimeRange {
+    if (_self.dailyTimeRange == null) {
+    return null;
+  }
+
+  return $GoalDailyTimeRangeCopyWith<$Res>(_self.dailyTimeRange!, (value) {
+    return _then(_self.copyWith(dailyTimeRange: value));
   });
 }
 }

--- a/lib/classes/goal_criterion.g.dart
+++ b/lib/classes/goal_criterion.g.dart
@@ -6,6 +6,18 @@ part of 'goal_criterion.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+_GoalDailyTimeRange _$GoalDailyTimeRangeFromJson(Map<String, dynamic> json) =>
+    _GoalDailyTimeRange(
+      startMinute: (json['startMinute'] as num).toInt(),
+      endMinute: (json['endMinute'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$GoalDailyTimeRangeToJson(_GoalDailyTimeRange instance) =>
+    <String, dynamic>{
+      'startMinute': instance.startMinute,
+      'endMinute': instance.endMinute,
+    };
+
 GoalCriterionMetric _$GoalCriterionMetricFromJson(Map<String, dynamic> json) =>
     GoalCriterionMetric(
       criterionId: json['criterionId'] as String,
@@ -89,6 +101,40 @@ Map<String, dynamic> _$GoalCriterionMeasurableToJson(
   'aggregation': _$GoalAggregationEnumMap[instance.aggregation]!,
   'target': instance.target,
   'direction': _$GoalDirectionEnumMap[instance.direction]!,
+  'title': instance.title,
+  'runtimeType': instance.$type,
+};
+
+GoalCriterionCategoryTime _$GoalCriterionCategoryTimeFromJson(
+  Map<String, dynamic> json,
+) => GoalCriterionCategoryTime(
+  criterionId: json['criterionId'] as String,
+  categoryId: json['categoryId'] as String,
+  window: GoalWindow.fromJson(json['window'] as Map<String, dynamic>),
+  aggregation: $enumDecode(_$GoalAggregationEnumMap, json['aggregation']),
+  targetHours: json['targetHours'] as num,
+  direction:
+      $enumDecodeNullable(_$GoalDirectionEnumMap, json['direction']) ??
+      GoalDirection.atMost,
+  dailyTimeRange: json['dailyTimeRange'] == null
+      ? null
+      : GoalDailyTimeRange.fromJson(
+          json['dailyTimeRange'] as Map<String, dynamic>,
+        ),
+  title: json['title'] as String?,
+  $type: json['runtimeType'] as String?,
+);
+
+Map<String, dynamic> _$GoalCriterionCategoryTimeToJson(
+  GoalCriterionCategoryTime instance,
+) => <String, dynamic>{
+  'criterionId': instance.criterionId,
+  'categoryId': instance.categoryId,
+  'window': instance.window,
+  'aggregation': _$GoalAggregationEnumMap[instance.aggregation]!,
+  'targetHours': instance.targetHours,
+  'direction': _$GoalDirectionEnumMap[instance.direction]!,
+  'dailyTimeRange': instance.dailyTimeRange,
   'title': instance.title,
   'runtimeType': instance.$type,
 };

--- a/lib/classes/goal_spec_validator.dart
+++ b/lib/classes/goal_spec_validator.dart
@@ -42,6 +42,20 @@ abstract final class GoalSpecValidator {
         _windowJsonIssues(json['window'], '$path.window', issues);
       case 'metric' || 'measurable':
         _windowJsonIssues(json['window'], '$path.window', issues);
+      case 'categoryTime':
+        _windowJsonIssues(json['window'], '$path.window', issues);
+        final dailyTimeRange = json['dailyTimeRange'];
+        if (dailyTimeRange is Map<String, dynamic>) {
+          for (final key in ['startMinute', 'endMinute']) {
+            final value = dailyTimeRange[key];
+            if (value is num && value % 1 != 0) {
+              issues.add(
+                '$path.dailyTimeRange.$key: $value is fractional and would '
+                'be silently truncated to ${value.toInt()}',
+              );
+            }
+          }
+        }
       case 'atLeastCount':
         requireIntegral('successes');
         _recurse(json, path, issues);
@@ -125,6 +139,32 @@ abstract final class GoalSpecValidator {
           issues.add('$id: targetCount must be at least 1, was $targetCount');
         }
         _requirePositiveRollingCount(id, window, issues);
+      case GoalCriterionCategoryTime(
+        :final categoryId,
+        :final targetHours,
+        :final window,
+        :final dailyTimeRange,
+      ):
+        _requireIdentifier(id, 'categoryId', categoryId, issues);
+        _requireFiniteTarget(id, targetHours, issues);
+        if (targetHours < 0) {
+          issues.add(
+            '$id: targetHours must not be negative, was $targetHours',
+          );
+        }
+        _requirePositiveRollingCount(id, window, issues);
+        if (dailyTimeRange case final range?) {
+          _requireMinuteOfDay(id, 'startMinute', range.startMinute, issues);
+          _requireMinuteOfDay(id, 'endMinute', range.endMinute, issues);
+          if (range.startMinute == range.endMinute &&
+              range.startMinute >= 0 &&
+              range.startMinute < Duration.minutesPerDay) {
+            issues.add(
+              '$id: daily time range endpoints must differ; omit the range '
+              'to measure the full day',
+            );
+          }
+        }
       case GoalCriterionAllOf(:final criteria) ||
           GoalCriterionAnyOf(:final criteria):
         if (criteria.isEmpty) {
@@ -172,6 +212,19 @@ abstract final class GoalSpecValidator {
   ) {
     if (target is double && !target.isFinite) {
       issues.add('$id: target must be finite, was $target');
+    }
+  }
+
+  static void _requireMinuteOfDay(
+    String id,
+    String field,
+    int minute,
+    List<String> issues,
+  ) {
+    if (minute < 0 || minute >= Duration.minutesPerDay) {
+      issues.add(
+        '$id: $field must be between 0 and 1439, was $minute',
+      );
     }
   }
 

--- a/lib/classes/goal_spec_validator.dart
+++ b/lib/classes/goal_spec_validator.dart
@@ -1,4 +1,5 @@
 import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/classes/goal_window.dart';
 
 /// Validates goal criteria before persistence and before evaluation
@@ -143,6 +144,7 @@ abstract final class GoalSpecValidator {
         :final categoryId,
         :final targetHours,
         :final window,
+        :final aggregation,
         :final dailyTimeRange,
       ):
         _requireIdentifier(id, 'categoryId', categoryId, issues);
@@ -150,6 +152,12 @@ abstract final class GoalSpecValidator {
         if (targetHours < 0) {
           issues.add(
             '$id: targetHours must not be negative, was $targetHours',
+          );
+        }
+        if (aggregation == GoalAggregation.count) {
+          issues.add(
+            '$id: count aggregation uses day units and is invalid for an '
+            'hour target',
           );
         }
         _requirePositiveRollingCount(id, window, issues);

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -17,6 +17,10 @@ today:
 - `evaluation/` — `GoalProgressEvaluator`, a pure fold over a
   `GoalSignalWindow` of daily aggregates, and `GoalTrackPolicy`, which turns
   attainment, pace, grace, and data coverage into a `GoalTrackStatus`.
+  Quantitative and user-defined measurable leaves share the existing journal
+  ingestion paths; category-time leaves reuse Insights attribution, support
+  minimum/maximum hours and optional local time bands, and give Phase B the
+  bounded raw session evidence needed to discuss timing patterns.
 - `GoalSpecValidator` (in `lib/classes/goal_spec_validator.dart`, beside
   the vocabulary it validates) — the decode-boundary gate, invoked from
   `AgentDomainEntity.fromJson` so every path (Matrix sync, storage reads)
@@ -31,6 +35,12 @@ synced-signal dispatcher, `service/` transactional goal creation, and
 agent runtime (merged in `app_bootstrap.dart`). Persistence entities live
 on `AgentDomainEntity` (`goalSpecVersion`/`goalSpecHead`/`goalProgress`/
 `goalNudge`) with `GoalSpecValidator` gating every decode path.
+Each goal-progress period retains one `GoalCriterionProgress` result per stable
+criterion id, so multi-dimensional goals remain accountable beneath the
+composite health result. Subjective daily ratings are deliberately not written
+into those recomputed rows: direct user assessments and agent-proposed
+assessments require a separate approval-aware register, with agent proposals
+reusing the existing ChangeSet/ChangeDecision flow.
 
 The LLM tier (Phase B) runs too: `workflow/` holds the lease-elected
 escalation workflow, its code-owned contract, the tool dispatcher, and the

--- a/lib/features/goals/evaluation/goal_progress_evaluator.dart
+++ b/lib/features/goals/evaluation/goal_progress_evaluator.dart
@@ -77,6 +77,26 @@ class GoalProgressEvaluator {
           range.end,
         );
         return _leafRatio(series, aggregation, target, direction);
+      case GoalCriterionCategoryTime(
+        :final criterionId,
+        :final aggregation,
+        :final targetHours,
+        :final direction,
+      ):
+        final range = window.periodRange(reference);
+        final series = _zeroFilledCategoryTime(
+          signals: signals,
+          criterionId: criterionId,
+          range: range,
+          reference: reference,
+        );
+        return _leafRatio(
+          series,
+          aggregation,
+          targetHours,
+          direction,
+          countPositiveValues: true,
+        );
       case GoalCriterionHabit(
         :final habitId,
         :final window,
@@ -179,6 +199,28 @@ class GoalProgressEvaluator {
           target: target,
           direction: direction,
         ),
+      GoalCriterionCategoryTime(
+        :final criterionId,
+        :final window,
+        :final aggregation,
+        :final targetHours,
+        :final direction,
+      ) =>
+        _metricLeaf(
+          criterionId: criterionId,
+          series: _zeroFilledCategoryTime(
+            signals: signals,
+            criterionId: criterionId,
+            range: window.periodRange(reference),
+            reference: reference,
+          ),
+          window: window,
+          reference: reference,
+          aggregation: aggregation,
+          target: targetHours,
+          direction: direction,
+          countPositiveValues: true,
+        ),
       GoalCriterionHabit(
         :final criterionId,
         :final habitId,
@@ -236,9 +278,14 @@ class GoalProgressEvaluator {
     required GoalAggregation aggregation,
     required num target,
     required GoalDirection direction,
+    bool countPositiveValues = false,
   }) {
     final sampleCount = series.length;
-    final actual = _aggregate(series, aggregation);
+    final actual = _aggregate(
+      series,
+      aggregation,
+      countPositiveValues: countPositiveValues,
+    );
     final double ratio;
     final bool satisfied;
     if (sampleCount == 0) {
@@ -264,6 +311,33 @@ class GoalProgressEvaluator {
       ),
       coverage: coverage,
     );
+  }
+
+  /// Time entries are the user's explicit ledger: within that ledger, no row
+  /// for a category/day means zero tracked time, not a broken sensor. Filling
+  /// elapsed days makes an at-most-zero curfew evaluable while the UI and
+  /// prompts remain honest that only tracked time counts.
+  Map<DateTime, num> _zeroFilledCategoryTime({
+    required GoalSignalWindow signals,
+    required String criterionId,
+    required ({DateTime start, DateTime end}) range,
+    required DateTime reference,
+  }) {
+    final today = GoalWindow.dayUtc(reference);
+    final end = range.end.isBefore(today) ? range.end : today;
+    final recorded = signals.categoryTimeInRange(
+      criterionId,
+      range.start,
+      end,
+    );
+    return {
+      for (
+        var day = range.start;
+        !day.isAfter(end);
+        day = day.add(const Duration(days: 1))
+      )
+        day: recorded[day] ?? 0,
+    };
   }
 
   _NodeOutcome _habitLeaf({
@@ -541,7 +615,11 @@ class GoalProgressEvaluator {
     return sawFalse ? false : null;
   }
 
-  num _aggregate(Map<DateTime, num> series, GoalAggregation aggregation) {
+  num _aggregate(
+    Map<DateTime, num> series,
+    GoalAggregation aggregation, {
+    bool countPositiveValues = false,
+  }) {
     if (series.isEmpty) return 0;
     switch (aggregation) {
       case GoalAggregation.dailySumThenAverage:
@@ -549,7 +627,9 @@ class GoalProgressEvaluator {
       case GoalAggregation.sum:
         return series.values.reduce((a, b) => a + b);
       case GoalAggregation.count:
-        return series.length;
+        return countPositiveValues
+            ? series.values.where((value) => value > 0).length
+            : series.length;
       case GoalAggregation.max:
         return series.values.reduce(math.max);
     }
@@ -588,11 +668,16 @@ double _leafRatio(
   Map<DateTime, num> series,
   GoalAggregation aggregation,
   num target,
-  GoalDirection direction,
-) {
+  GoalDirection direction, {
+  bool countPositiveValues = false,
+}) {
   if (series.isEmpty) return 0;
   const evaluator = GoalProgressEvaluator();
-  final actual = evaluator._aggregate(series, aggregation);
+  final actual = evaluator._aggregate(
+    series,
+    aggregation,
+    countPositiveValues: countPositiveValues,
+  );
   final (ratio, _) = evaluator._compare(actual, target, direction);
   return ratio;
 }

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -6,6 +6,9 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/features/dashboards/config/dashboard_health_config.dart';
 import 'package:lotti/features/dashboards/state/health_data.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/insights/logic/time_bucketing.dart';
+import 'package:lotti/features/insights/model/insights_models.dart';
+import 'package:lotti/services/db_notification.dart';
 
 /// Reads the journal into a [GoalSignalWindow] for one criteria tree —
 /// the seam between the pure evaluator and the database (Phase A of
@@ -25,6 +28,9 @@ import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 ///   ([GoalWindow.dayUtc] over `meta.dateFrom`), matching the `ymd`
 ///   bucketing of `habits_controller` — a calendar-date key, not a
 ///   timezone conversion.
+/// - Category-time leaves reuse Insights' category attribution and interval
+///   union rules. Overlapping timers in one category count once, while an
+///   optional daily time range clips the absolute spans in local time.
 class GoalSignalReader {
   const GoalSignalReader({required this._journalDb});
 
@@ -32,11 +38,15 @@ class GoalSignalReader {
 
   /// Loads every signal series the [criteria] tree needs to be evaluated
   /// at [reference], covering the widest leaf window plus the short-term
-  /// trend lookback.
+  /// trend lookback. When [categorySessionEvidenceStart] is supplied, raw
+  /// watched-category sessions extend back to that instant without widening
+  /// the deterministic criterion's authored evaluation window.
   Future<GoalSignalWindow> read({
     required GoalCriterion criteria,
     required DateTime reference,
     int shortTermDays = 3,
+    bool includeCategoryTimeSessions = true,
+    DateTime? categorySessionEvidenceStart,
   }) async {
     final needs = _SignalNeeds()..collect(criteria);
     final rangeStart = _rangeStart(criteria, reference, shortTermDays);
@@ -110,13 +120,172 @@ class GoalSignalReader {
       measurables[dataTypeId] = byDay;
     }
 
+    final categoryTime = <String, Map<DateTime, num>>{};
+    final categoryTimeSessions = <String, List<GoalCategoryTimeSession>>{};
+    DateTime? categoryTimeEvidenceStart;
+    if (needs.categoryTimeCriteria.isNotEmpty) {
+      final requestedEvidenceStart = categorySessionEvidenceStart ?? rangeStart;
+      final evidenceStart = requestedEvidenceStart.isAfter(rangeEnd)
+          ? rangeEnd
+          : requestedEvidenceStart;
+      if (includeCategoryTimeSessions) {
+        categoryTimeEvidenceStart = evidenceStart;
+      }
+      final queryStart =
+          includeCategoryTimeSessions && evidenceStart.isBefore(rangeStart)
+          ? evidenceStart
+          : rangeStart;
+      final rows = await _journalDb.insightsTimeRows(
+        start: queryStart,
+        end: rangeEnd,
+      );
+      final watchedCategoryIds = {
+        for (final criterion in needs.categoryTimeCriteria)
+          criterion.categoryId,
+      };
+      if (includeCategoryTimeSessions) {
+        for (final row in rows) {
+          final categoryId = row.categoryId;
+          final dateFrom = row.dateFrom.isBefore(evidenceStart)
+              ? evidenceStart
+              : row.dateFrom;
+          final dateTo = row.dateTo.isAfter(rangeEnd) ? rangeEnd : row.dateTo;
+          if (categoryId == null ||
+              !watchedCategoryIds.contains(categoryId) ||
+              !dateTo.isAfter(dateFrom)) {
+            continue;
+          }
+          categoryTimeSessions
+              .putIfAbsent(categoryId, () => [])
+              .add(
+                GoalCategoryTimeSession(
+                  categoryId: categoryId,
+                  dateFrom: dateFrom,
+                  dateTo: dateTo,
+                ),
+              );
+        }
+        for (final sessions in categoryTimeSessions.values) {
+          sessions.sort((a, b) => a.dateFrom.compareTo(b.dateFrom));
+        }
+      }
+      for (final criterion in needs.categoryTimeCriteria) {
+        categoryTime[criterion.criterionId] = _bucketCategoryTime(
+          rows: rows,
+          criterion: criterion,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        );
+      }
+    }
+
     return GoalSignalWindow(
       quantitativeDailySums: quantitative,
       habitSuccessesByDay: habits,
       habitCompletionsByDay: habitCompletions,
       measurableDailySums: measurables,
+      categoryTimeDailyHours: categoryTime,
+      categoryTimeSessionsByCategory: categoryTimeSessions,
+      categoryTimeEvidenceStart: categoryTimeEvidenceStart,
+      categoryTimeEvidenceEnd:
+          needs.categoryTimeCriteria.isEmpty || !includeCategoryTimeSessions
+          ? null
+          : rangeEnd,
     );
   }
+
+  Map<DateTime, num> _bucketCategoryTime({
+    required List<InsightsTimeRowRecord> rows,
+    required GoalCriterionCategoryTime criterion,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) {
+    final intervalsByDay = <DateTime, List<TimeInterval>>{};
+    for (final row in rows) {
+      if (row.categoryId != criterion.categoryId) continue;
+      final start = row.dateFrom.isBefore(rangeStart)
+          ? rangeStart
+          : row.dateFrom;
+      final end = row.dateTo.isAfter(rangeEnd) ? rangeEnd : row.dateTo;
+      if (!end.isAfter(start)) continue;
+
+      for (final segment in splitByLocalDay(start, end)) {
+        final day = GoalWindow.dayUtc(segment.start);
+        final clipped = _clipToDailyTimeRange(
+          segment,
+          criterion.dailyTimeRange,
+        );
+        if (clipped.isNotEmpty) {
+          intervalsByDay.putIfAbsent(day, () => []).addAll(clipped);
+        }
+      }
+    }
+
+    final hoursByDay = <DateTime, num>{};
+    for (final entry in intervalsByDay.entries) {
+      final seconds = intervalSeconds(mergeIntervals(entry.value));
+      if (seconds > 0) {
+        hoursByDay[entry.key] = seconds / Duration.secondsPerHour;
+      }
+    }
+    return hoursByDay;
+  }
+
+  List<TimeInterval> _clipToDailyTimeRange(
+    TimeInterval segment,
+    GoalDailyTimeRange? timeRange,
+  ) {
+    if (timeRange == null) return [segment];
+    final day = segment.start.isUtc
+        ? DateTime.utc(
+            segment.start.year,
+            segment.start.month,
+            segment.start.day,
+          )
+        : DateTime(
+            segment.start.year,
+            segment.start.month,
+            segment.start.day,
+          );
+    final nextDay = nextLocalMidnight(day);
+    final windows = timeRange.startMinute < timeRange.endMinute
+        ? [
+            (
+              start: _atMinuteOfDay(day, timeRange.startMinute),
+              end: _atMinuteOfDay(day, timeRange.endMinute),
+            ),
+          ]
+        : [
+            (start: day, end: _atMinuteOfDay(day, timeRange.endMinute)),
+            (start: _atMinuteOfDay(day, timeRange.startMinute), end: nextDay),
+          ];
+
+    final clipped = <TimeInterval>[];
+    for (final window in windows) {
+      final start = segment.start.isAfter(window.start)
+          ? segment.start
+          : window.start;
+      final end = segment.end.isBefore(window.end) ? segment.end : window.end;
+      if (end.isAfter(start)) clipped.add(TimeInterval(start, end));
+    }
+    return clipped;
+  }
+
+  DateTime _atMinuteOfDay(DateTime day, int minute) => day.isUtc
+      ? DateTime.utc(
+          day.year,
+          day.month,
+          day.day,
+          minute ~/ Duration.minutesPerHour,
+          minute % Duration.minutesPerHour,
+        )
+      : DateTime(
+          day.year,
+          day.month,
+          day.day,
+          minute ~/ Duration.minutesPerHour,
+          minute % Duration.minutesPerHour,
+        );
 
   /// One deterministic value per day, honoring the health config's
   /// per-type aggregation:
@@ -192,7 +361,8 @@ class GoalSignalReader {
       switch (criterion) {
         case GoalCriterionMetric(:final window) ||
             GoalCriterionMeasurable(:final window) ||
-            GoalCriterionHabit(:final window):
+            GoalCriterionHabit(:final window) ||
+            GoalCriterionCategoryTime(:final window):
           // One extra period back so the policy's prior-attainment grace
           // check can be computed from the same window.
           final start = window.periodRange(reference).start;
@@ -215,13 +385,21 @@ class GoalSignalReader {
 /// The notification tokens a goal's criteria tree subscribes to: leaf
 /// `dataType` strings (quantitative entries notify with their dataType),
 /// `habitId`s (habit completions notify with their habitId) and
-/// measurable `dataTypeId`s (measurements notify with theirs).
+/// measurable `dataTypeId`s (measurements notify with theirs). Category-time
+/// leaves subscribe to the broad journal/link/task/category tokens because
+/// any of those mutations can alter tracked duration or category attribution.
 Set<String> goalSignalTriggerTokens(GoalCriterion criteria) {
   final needs = _SignalNeeds()..collect(criteria);
   return {
     ...needs.quantitativeTypes,
     ...needs.habitIds,
     ...needs.measurableTypeIds,
+    if (needs.categoryTimeCriteria.isNotEmpty) ...{
+      textEntryNotification,
+      linkNotification,
+      taskNotification,
+      categoriesNotification,
+    },
   };
 }
 
@@ -229,6 +407,7 @@ class _SignalNeeds {
   final quantitativeTypes = <String>{};
   final habitIds = <String>{};
   final measurableTypeIds = <String>{};
+  final categoryTimeCriteria = <GoalCriterionCategoryTime>[];
 
   void collect(GoalCriterion criterion) {
     switch (criterion) {
@@ -238,6 +417,8 @@ class _SignalNeeds {
         habitIds.add(habitId);
       case GoalCriterionMeasurable(:final dataTypeId):
         measurableTypeIds.add(dataTypeId);
+      case final GoalCriterionCategoryTime categoryTime:
+        categoryTimeCriteria.add(categoryTime);
       case GoalCriterionAllOf(:final criteria) ||
           GoalCriterionAnyOf(:final criteria) ||
           GoalCriterionAtLeastCount(:final criteria):

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/insights/logic/time_bucketing.dart';
 import 'package:lotti/features/insights/model/insights_models.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/time_service.dart';
 
 /// Reads the journal into a [GoalSignalWindow] for one criteria tree —
 /// the seam between the pure evaluator and the database (Phase A of
@@ -32,9 +33,13 @@ import 'package:lotti/services/db_notification.dart';
 ///   union rules. Overlapping timers in one category count once, while an
 ///   optional daily time range clips the absolute spans in local time.
 class GoalSignalReader {
-  const GoalSignalReader({required this._journalDb});
+  const GoalSignalReader({
+    required this._journalDb,
+    this._timeService,
+  });
 
   final JournalDb _journalDb;
+  final TimeService? _timeService;
 
   /// Loads every signal series the [criteria] tree needs to be evaluated
   /// at [reference], covering the widest leaf window plus the short-term
@@ -139,6 +144,24 @@ class GoalSignalReader {
         start: queryStart,
         end: rangeEnd,
       );
+      final activeTimerRow = await _activeTimerRow(reference);
+      if (activeTimerRow != null &&
+          activeTimerRow.dateTo.isAfter(queryStart) &&
+          activeTimerRow.dateFrom.isBefore(rangeEnd)) {
+        // The persisted row for a running timer has a stale zero-length end
+        // and is normally absent from Insights. If it was saved while still
+        // running, replace that stale prefix rather than duplicating the raw
+        // evidence; interval union keeps deterministic totals honest either
+        // way, but the model-facing session list must remain one session.
+        rows
+          ..removeWhere(
+            (row) =>
+                row.categoryId == activeTimerRow.categoryId &&
+                row.dateFrom == activeTimerRow.dateFrom,
+          )
+          ..add(activeTimerRow)
+          ..sort((a, b) => a.dateFrom.compareTo(b.dateFrom));
+      }
       final watchedCategoryIds = {
         for (final criterion in needs.categoryTimeCriteria)
           criterion.categoryId,
@@ -191,6 +214,36 @@ class GoalSignalReader {
           needs.categoryTimeCriteria.isEmpty || !includeCategoryTimeSessions
           ? null
           : rangeEnd,
+    );
+  }
+
+  Future<InsightsTimeRowRecord?> _activeTimerRow(DateTime reference) async {
+    final timeService = _timeService;
+    final current = timeService?.getCurrent();
+    if (current is! JournalEntry) return null;
+
+    final linked = timeService?.linkedFrom;
+    final needsPrivateFlag =
+        current.meta.private == true || linked?.meta.private == true;
+    final showPrivate =
+        !needsPrivateFlag || await _journalDb.getConfigFlag('private');
+    if (current.meta.private == true && !showPrivate) return null;
+
+    final linkedCategory = linked?.meta.private == true && !showPrivate
+        ? null
+        : linked?.meta.categoryId;
+    final categoryId = linkedCategory?.trim().isNotEmpty == true
+        ? linkedCategory
+        : current.meta.categoryId;
+    if (categoryId == null || categoryId.trim().isEmpty) return null;
+
+    final persistedEnd = current.meta.dateTo;
+    final dateTo = persistedEnd.isAfter(reference) ? persistedEnd : reference;
+    if (!dateTo.isAfter(current.meta.dateFrom)) return null;
+    return (
+      dateFrom: current.meta.dateFrom,
+      dateTo: dateTo,
+      categoryId: categoryId,
     );
   }
 
@@ -399,6 +452,7 @@ Set<String> goalSignalTriggerTokens(GoalCriterion criteria) {
       linkNotification,
       taskNotification,
       categoriesNotification,
+      privateToggleNotification,
     },
   };
 }

--- a/lib/features/goals/evaluation/goal_signal_window.dart
+++ b/lib/features/goals/evaluation/goal_signal_window.dart
@@ -1,6 +1,23 @@
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/goal_window.dart';
 
+/// One category-attributed tracked-time session exposed as evidence to the
+/// goal agent. It is deliberately not a success verdict: the deterministic
+/// evaluator and, later, a user-approved daily assessment own that decision.
+class GoalCategoryTimeSession {
+  const GoalCategoryTimeSession({
+    required this.categoryId,
+    required this.dateFrom,
+    required this.dateTo,
+  });
+
+  final String categoryId;
+  final DateTime dateFrom;
+  final DateTime dateTo;
+
+  Duration get duration => dateTo.difference(dateFrom);
+}
+
 /// The pre-fetched daily aggregates a goal evaluation runs over.
 ///
 /// This value object is the seam between the pure evaluator and whatever
@@ -18,6 +35,10 @@ class GoalSignalWindow {
     this.habitSuccessesByDay = const {},
     this.habitCompletionsByDay = const {},
     this.measurableDailySums = const {},
+    this.categoryTimeDailyHours = const {},
+    this.categoryTimeSessionsByCategory = const {},
+    this.categoryTimeEvidenceStart,
+    this.categoryTimeEvidenceEnd,
   });
 
   /// Journal quantitative data: data type string → day key → sum of that
@@ -36,6 +57,24 @@ class GoalSignalWindow {
 
   /// Measurable data: `MeasurableDataType` id → day key → daily sum.
   final Map<String, Map<DateTime, num>> measurableDailySums;
+
+  /// Tracked category time: category-time criterion id → day key → hours.
+  ///
+  /// This map is criterion-scoped rather than category-scoped because two
+  /// leaves may watch the same category through different local-time bands.
+  final Map<String, Map<DateTime, num>> categoryTimeDailyHours;
+
+  /// Every valid tracked-time session attributed to a watched category in
+  /// the reader's evidence range. Sessions remain unfiltered by a criterion's
+  /// optional daily time band so the agent can discuss patterns outside the
+  /// strict threshold while never redefining the computed verdict.
+  final Map<String, List<GoalCategoryTimeSession>>
+  categoryTimeSessionsByCategory;
+
+  /// Inclusive query start and exclusive query end for category session
+  /// evidence. Null when the criteria tree watches no category time.
+  final DateTime? categoryTimeEvidenceStart;
+  final DateTime? categoryTimeEvidenceEnd;
 
   /// Daily sums for [dataType] restricted to [start]..[end] (inclusive).
   Map<DateTime, num> quantitativeInRange(
@@ -57,6 +96,13 @@ class GoalSignalWindow {
     DateTime start,
     DateTime end,
   ) => _inRange(measurableDailySums[dataTypeId], start, end);
+
+  /// Tracked hours for category-time [criterionId] in [start]..[end].
+  Map<DateTime, num> categoryTimeInRange(
+    String criterionId,
+    DateTime start,
+    DateTime end,
+  ) => _inRange(categoryTimeDailyHours[criterionId], start, end);
 
   static Map<DateTime, V> _inRange<V>(
     Map<DateTime, V>? series,

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -96,6 +96,7 @@ class GoalAgentPhaseA {
       agentId: agentId,
       version: version,
       now: now,
+      includeCategoryTimeSessions: false,
     );
     final facts = derivation.facts;
     final periodKey = derivation.periodKey;
@@ -222,11 +223,15 @@ class GoalAgentPhaseA {
     required String agentId,
     required GoalSpecVersionEntity version,
     required DateTime now,
+    bool includeCategoryTimeSessions = true,
+    DateTime? categorySessionEvidenceStart,
   }) async {
     final signals = await _signalReader.read(
       criteria: version.criteria,
       reference: now,
       shortTermDays: _policy.shortTermDays,
+      includeCategoryTimeSessions: includeCategoryTimeSessions,
+      categorySessionEvidenceStart: categorySessionEvidenceStart,
     );
     final evaluation = _evaluator.evaluate(version.criteria, signals, now);
     final shortTerm = _evaluator.shortTermAttainment(
@@ -266,6 +271,9 @@ class GoalAgentPhaseA {
         previousStatus: previousStatus,
         evaluation: evaluation,
         shortTermAttainment: shortTerm,
+        categoryTimeSessionsByCategory: signals.categoryTimeSessionsByCategory,
+        categoryTimeEvidenceStart: signals.categoryTimeEvidenceStart,
+        categoryTimeEvidenceEnd: signals.categoryTimeEvidenceEnd,
       ),
       periodKey: periodKey,
       priors: priors,

--- a/lib/features/goals/runtime/goal_wake_facts.dart
+++ b/lib/features/goals/runtime/goal_wake_facts.dart
@@ -1,6 +1,7 @@
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 
 /// Whether three consecutive attainment points are strictly worsening.
 /// [priorAttainments] is ordered most-recent-first.
@@ -36,6 +37,9 @@ class GoalWakeFacts {
     required this.evaluation,
     this.previousStatus,
     this.shortTermAttainment,
+    this.categoryTimeSessionsByCategory = const {},
+    this.categoryTimeEvidenceStart,
+    this.categoryTimeEvidenceEnd,
   });
 
   /// Policy-derived status for the evaluation day.
@@ -47,6 +51,14 @@ class GoalWakeFacts {
 
   final GoalEvaluation evaluation;
   final double? shortTermAttainment;
+
+  /// Session-level evidence for model pattern analysis. These observations do
+  /// not override [evaluation]; a future governed daily assessment can turn a
+  /// model suggestion into a user-approved outcome.
+  final Map<String, List<GoalCategoryTimeSession>>
+  categoryTimeSessionsByCategory;
+  final DateTime? categoryTimeEvidenceStart;
+  final DateTime? categoryTimeEvidenceEnd;
 
   /// Whether the status changed against the last persisted register row.
   /// A first-ever evaluation counts as a transition (there is a new fact

--- a/lib/features/goals/service/goal_revision_apply.dart
+++ b/lib/features/goals/service/goal_revision_apply.dart
@@ -34,7 +34,7 @@ class GoalRevisionRejected extends GoalRevisionResult {
 /// goal's criteria, and it runs on user approval, so anything ambiguous is
 /// rejected with a reason instead of guessed at:
 ///
-/// - `targetValue` / `period` bind to exactly one metric-or-measurable
+/// - `targetValue` / `period` bind to exactly one numeric
 ///   leaf: the only such leaf, or the one whose `criterionId` or dataType
 ///   matches `metric`. Two candidates and no disambiguator → rejected.
 /// - `cadence` binds to exactly one habit leaf and must parse to a
@@ -79,6 +79,7 @@ GoalRevisionResult applyGoalRevisionChanges({
         (c) => switch (c) {
           GoalCriterionMetric() => c.copyWith(target: targetValue),
           GoalCriterionMeasurable() => c.copyWith(target: targetValue),
+          GoalCriterionCategoryTime() => c.copyWith(targetHours: targetValue),
           _ => c,
         },
       );
@@ -98,6 +99,7 @@ GoalRevisionResult applyGoalRevisionChanges({
         (c) => switch (c) {
           GoalCriterionMetric() => c.copyWith(window: window),
           GoalCriterionMeasurable() => c.copyWith(window: window),
+          GoalCriterionCategoryTime() => c.copyWith(window: window),
           _ => c,
         },
       );
@@ -193,13 +195,15 @@ GoalRevisionResult applyGoalRevisionChanges({
   return GoalRevisionApplied(criteria: revised, changeSummaries: summaries);
 }
 
-/// The single metric/measurable leaf a quantitative change binds to, or
+/// The single numeric leaf a quantitative change binds to, or
 /// null when the binding is ambiguous.
 GoalCriterion? _resolveQuantitativeLeaf(GoalCriterion root, Object? metric) {
   final leaves = <GoalCriterion>[];
   void visit(GoalCriterion c) {
     switch (c) {
-      case GoalCriterionMetric() || GoalCriterionMeasurable():
+      case GoalCriterionMetric() ||
+          GoalCriterionMeasurable() ||
+          GoalCriterionCategoryTime():
         leaves.add(c);
       case GoalCriterionAllOf(:final criteria) ||
           GoalCriterionAnyOf(:final criteria) ||
@@ -223,6 +227,8 @@ GoalCriterion? _resolveQuantitativeLeaf(GoalCriterion root, Object? metric) {
                 dataType.toLowerCase() == needle,
               GoalCriterionMeasurable(:final dataTypeId) =>
                 dataTypeId.toLowerCase() == needle,
+              GoalCriterionCategoryTime(:final categoryId) =>
+                categoryId.toLowerCase() == needle,
               _ => false,
             },
       )
@@ -233,6 +239,7 @@ GoalCriterion? _resolveQuantitativeLeaf(GoalCriterion root, Object? metric) {
 num _leafTarget(GoalCriterion leaf) => switch (leaf) {
   GoalCriterionMetric(:final target) => target,
   GoalCriterionMeasurable(:final target) => target,
+  GoalCriterionCategoryTime(:final targetHours) => targetHours,
   _ => 0,
 };
 
@@ -246,7 +253,9 @@ List<GoalCriterionHabit> _habitLeaves(GoalCriterion root) {
           GoalCriterionAnyOf(:final criteria) ||
           GoalCriterionAtLeastCount(:final criteria):
         criteria.forEach(visit);
-      case GoalCriterionMetric() || GoalCriterionMeasurable():
+      case GoalCriterionMetric() ||
+          GoalCriterionMeasurable() ||
+          GoalCriterionCategoryTime():
         break;
     }
   }

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -522,7 +522,8 @@ typedef GoalAgentHealth = ({
 bool _attainmentTrendIsSound(GoalCriterion criterion) => switch (criterion) {
   GoalCriterionMetric(:final window) ||
   GoalCriterionMeasurable(:final window) ||
-  GoalCriterionHabit(:final window) => window is GoalWindowRollingDays,
+  GoalCriterionHabit(:final window) ||
+  GoalCriterionCategoryTime(:final window) => window is GoalWindowRollingDays,
   GoalCriterionAllOf(:final criteria) ||
   GoalCriterionAnyOf(:final criteria) ||
   GoalCriterionAtLeastCount(:final criteria) => criteria.every(

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -31,16 +31,23 @@ import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
 import 'package:lotti/features/goals/workflow/goal_tool_dispatcher.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
 import 'package:lotti/services/db_notification.dart' show agentNotification;
 import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/time_service.dart';
 import 'package:lotti/utils/consts.dart';
 
 /// Goal-agent runtime wiring (the Daily OS plug-in pattern: providers live
 /// in the owning feature; `features/agents` never imports goals).
 
 final goalSignalReaderProvider = Provider<GoalSignalReader>(
-  (ref) => GoalSignalReader(journalDb: ref.watch(journalDbProvider)),
+  (ref) => GoalSignalReader(
+    journalDb: ref.watch(journalDbProvider),
+    timeService: getIt.isRegistered<TimeService>()
+        ? getIt<TimeService>()
+        : null,
+  ),
   name: 'goalSignalReaderProvider',
 );
 

--- a/lib/features/goals/state/goal_progress_view.dart
+++ b/lib/features/goals/state/goal_progress_view.dart
@@ -169,7 +169,9 @@ bool _criterionCompletedOnDay(
   // verdict: a rolling habit contributes when it was completed on this day.
   GoalCriterionHabit(:final habitId) =>
     (signals.habitSuccessesByDay[habitId]?[day] ?? 0) > 0,
-  GoalCriterionMetric() || GoalCriterionMeasurable() =>
+  GoalCriterionMetric() ||
+  GoalCriterionMeasurable() ||
+  GoalCriterionCategoryTime() =>
     const GoalProgressEvaluator().evaluate(criterion, signals, day).satisfied,
   GoalCriterionAllOf(criteria: final children) => children.every(
     (child) => _criterionCompletedOnDay(child, signals, day),
@@ -200,6 +202,7 @@ GoalProgressView buildGoalProgressView({
   final habitLeaves = <GoalCriterionHabit>[];
   final metricLeaves = <GoalCriterionMetric>[];
   final measurableLeaves = <GoalCriterionMeasurable>[];
+  final categoryTimeLeaves = <GoalCriterionCategoryTime>[];
 
   void visit(GoalCriterion criterion) {
     switch (criterion) {
@@ -209,6 +212,8 @@ GoalProgressView buildGoalProgressView({
         metricLeaves.add(metric);
       case final GoalCriterionMeasurable measurable:
         measurableLeaves.add(measurable);
+      case final GoalCriterionCategoryTime categoryTime:
+        categoryTimeLeaves.add(categoryTime);
       case GoalCriterionAllOf(criteria: final children):
         children.forEach(visit);
       case GoalCriterionAnyOf(criteria: final children):
@@ -260,6 +265,12 @@ GoalProgressView buildGoalProgressView({
           signals: signals,
           reference: reference,
         ),
+      for (final categoryTime in categoryTimeLeaves)
+        _categoryTimeProgressView(
+          categoryTime: categoryTime,
+          signals: signals,
+          reference: reference,
+        ),
     ],
   );
 }
@@ -302,6 +313,25 @@ GoalMetricProgressView _measurableProgressView({
   reference: reference,
 );
 
+GoalMetricProgressView _categoryTimeProgressView({
+  required GoalCriterionCategoryTime categoryTime,
+  required GoalSignalWindow signals,
+  required DateTime reference,
+}) => _numericProgressView(
+  criterion: categoryTime,
+  name: categoryTime.title?.trim().isNotEmpty == true
+      ? categoryTime.title!.trim()
+      : categoryTime.categoryId,
+  target: categoryTime.targetHours,
+  window: categoryTime.window,
+  direction: categoryTime.direction,
+  aggregation: categoryTime.aggregation,
+  dailyValues: signals.categoryTimeDailyHours[categoryTime.criterionId],
+  signals: signals,
+  reference: reference,
+  zeroIsObserved: true,
+);
+
 GoalMetricProgressView _numericProgressView({
   required GoalCriterion criterion,
   required String name,
@@ -312,8 +342,10 @@ GoalMetricProgressView _numericProgressView({
   required Map<DateTime, num>? dailyValues,
   required GoalSignalWindow signals,
   required DateTime reference,
+  bool zeroIsObserved = false,
 }) {
   final range = window.periodRange(reference);
+  final today = GoalWindow.dayUtc(reference);
   return GoalMetricProgressView(
     name: name,
     target: target,
@@ -329,7 +361,9 @@ GoalMetricProgressView _numericProgressView({
         GoalProgressDay(
           day: day,
           value: dailyValues?[day] ?? 0,
-          isObserved: dailyValues?.containsKey(day) ?? false,
+          isObserved:
+              (dailyValues?.containsKey(day) ?? false) ||
+              (zeroIsObserved && !day.isAfter(today)),
           targetSatisfied: const GoalProgressEvaluator()
               .evaluate(criterion, signals, day)
               .satisfied,
@@ -434,7 +468,9 @@ goalAgentProgressViewProvider = FutureProvider.autoDispose
         switch (criterion) {
           case GoalCriterionHabit(:final habitId):
             habitIds.add(habitId);
-          case GoalCriterionMetric() || GoalCriterionMeasurable():
+          case GoalCriterionMetric() ||
+              GoalCriterionMeasurable() ||
+              GoalCriterionCategoryTime():
             return;
           case GoalCriterionAllOf(criteria: final children):
             children.forEach(collect);

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -256,6 +256,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
       agentId: agentId,
       version: version,
       now: reference,
+      categorySessionEvidenceStart: agentIdentity.createdAt,
     );
     // Phase A persisted the transition's register row BEFORE arming this
     // wake, so re-deriving sees the new status as previousStatus and the
@@ -278,6 +279,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
               : derivation.priors.firstOrNull?.trackStatus),
       evaluation: derivation.facts.evaluation,
       shortTermAttainment: derivation.facts.shortTermAttainment,
+      categoryTimeSessionsByCategory:
+          derivation.facts.categoryTimeSessionsByCategory,
+      categoryTimeEvidenceStart: derivation.facts.categoryTimeEvidenceStart,
+      categoryTimeEvidenceEnd: derivation.facts.categoryTimeEvidenceEnd,
     );
 
     // Spec-scoped like the persistence snapshot: an old-spec fresh

--- a/lib/features/goals/workflow/goal_facts_renderer.dart
+++ b/lib/features/goals/workflow/goal_facts_renderer.dart
@@ -24,11 +24,11 @@ const goalReusableMinMeanRating = 4.0;
 ///
 /// The output shape is EXACTLY the one the eval fixtures validated
 /// model-against-model (`goal_agent_eval_fixtures.dart`): a labelled JSON
-/// fence with `goal` / `evaluation` / `reporting` / `ads` / `personaTone`
-/// / `unansweredUserMessages` / `observations` sections. Every number is
-/// pre-computed here — the prompt instructs the model to restate, never
-/// derive, so this renderer is the single place the model's worldview is
-/// assembled.
+/// fence with `goal` / `evaluation` / optional raw `signals` / `reporting` /
+/// `ads` / `personaTone` / `unansweredUserMessages` / `observations`
+/// sections. Every verdict is pre-computed here — the prompt instructs the
+/// model to restate, never derive, so this renderer is the single place the
+/// model's worldview is assembled.
 class GoalFactsRenderer {
   const GoalFactsRenderer();
 
@@ -95,6 +95,26 @@ class GoalFactsRenderer {
         ),
         'priorPeriodAttainments': priorAttainments,
       },
+      if (facts.categoryTimeSessionsByCategory.isNotEmpty)
+        'signals': {
+          'categoryTimeEvidenceStart': facts.categoryTimeEvidenceStart
+              ?.toIso8601String(),
+          'categoryTimeEvidenceEnd': facts.categoryTimeEvidenceEnd
+              ?.toIso8601String(),
+          'categoryTimeSessions': [
+            for (final sessions in facts.categoryTimeSessionsByCategory.values)
+              for (final session in sessions)
+                {
+                  'categoryId': session.categoryId,
+                  'startedAtLocal': session.dateFrom.toIso8601String(),
+                  'endedAtLocal': session.dateTo.toIso8601String(),
+                  'durationMinutes': session.duration.inMinutes,
+                },
+          ],
+          'interpretationPolicy':
+              'session evidence may inform coaching patterns; it does not '
+              'override deterministic criterion results',
+        },
       'reporting': {
         'materialChangeSinceLastReport': facts.statusTransitioned,
         'lastReportStatus': facts.previousStatus?.name,
@@ -203,6 +223,7 @@ Map<String, Object?> criterionJson(GoalCriterion criterion) =>
     switch (criterion) {
       GoalCriterionMetric() => {
         'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
         'metric': criterion.dataType,
         'aggregation': criterion.aggregation.name,
         'window': _windowLabel(criterion.window),
@@ -211,28 +232,48 @@ Map<String, Object?> criterionJson(GoalCriterion criterion) =>
       },
       GoalCriterionHabit() => {
         'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
         'habit': criterion.habitId,
         'window': _windowLabel(criterion.window),
         'targetCount': criterion.targetCount,
       },
       GoalCriterionMeasurable() => {
         'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
         'measurable': criterion.dataTypeId,
         'aggregation': criterion.aggregation.name,
         'window': _windowLabel(criterion.window),
         'target': criterion.target,
         'direction': criterion.direction.name,
       },
+      GoalCriterionCategoryTime() => {
+        'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
+        'categoryTime': criterion.categoryId,
+        'aggregation': criterion.aggregation.name,
+        'window': _windowLabel(criterion.window),
+        'targetHours': criterion.targetHours,
+        'direction': criterion.direction.name,
+        if (criterion.dailyTimeRange case final range?)
+          'dailyTimeRange': {
+            'startMinute': range.startMinute,
+            'endMinute': range.endMinute,
+          },
+        'evidence': 'tracked Lotti time entries only',
+      },
       GoalCriterionAllOf() => {
         'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
         'allOf': [for (final c in criterion.criteria) criterionJson(c)],
       },
       GoalCriterionAnyOf() => {
         'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
         'anyOf': [for (final c in criterion.criteria) criterionJson(c)],
       },
       GoalCriterionAtLeastCount() => {
         'criterionId': criterion.criterionId,
+        if (criterion.title != null) 'title': criterion.title,
         'atLeast': criterion.successes,
         'of': [for (final c in criterion.criteria) criterionJson(c)],
       },

--- a/lib/features/goals/workflow/goal_facts_renderer.dart
+++ b/lib/features/goals/workflow/goal_facts_renderer.dart
@@ -5,6 +5,7 @@ import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_nudge_models.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 
 // The dismissal quiet window is the REST OF THE LOCAL CALENDAR DAY (see
@@ -19,6 +20,10 @@ const goalAdFreshFor = Duration(hours: 48);
 /// Minimum mean rating for a retired ad to be offered for zero-cost
 /// re-run (policy row P13).
 const goalReusableMinMeanRating = 4.0;
+
+/// Maximum number of raw category sessions included in one model message.
+/// The complete lifetime remains represented by the bounded summaries below.
+const goalCategorySessionEvidenceLimit = 200;
 
 /// Renders the deterministic FACTS block for one Phase B wake.
 ///
@@ -48,6 +53,16 @@ class GoalFactsRenderer {
     final priorAttainments = [
       for (final row in priorRegisters) row.attainment,
     ];
+    final categorySessions = [
+      for (final sessions in facts.categoryTimeSessionsByCategory.values)
+        ...sessions,
+    ]..sort((a, b) => a.dateFrom.compareTo(b.dateFrom));
+    final recentCategorySessions =
+        categorySessions.length <= goalCategorySessionEvidenceLimit
+        ? categorySessions
+        : categorySessions.sublist(
+            categorySessions.length - goalCategorySessionEvidenceLimit,
+          );
 
     return _factsBlock({
       'generatedAt': now.toUtc().toIso8601String(),
@@ -101,19 +116,25 @@ class GoalFactsRenderer {
               ?.toIso8601String(),
           'categoryTimeEvidenceEnd': facts.categoryTimeEvidenceEnd
               ?.toIso8601String(),
+          'categoryTimeSessionCount': categorySessions.length,
+          'categoryTimeSessionsOmitted':
+              categorySessions.length - recentCategorySessions.length,
+          'categoryTimeLifetimeSummary': _categoryTimeLifetimeSummary(
+            facts.categoryTimeSessionsByCategory,
+          ),
           'categoryTimeSessions': [
-            for (final sessions in facts.categoryTimeSessionsByCategory.values)
-              for (final session in sessions)
-                {
-                  'categoryId': session.categoryId,
-                  'startedAtLocal': session.dateFrom.toIso8601String(),
-                  'endedAtLocal': session.dateTo.toIso8601String(),
-                  'durationMinutes': session.duration.inMinutes,
-                },
+            for (final session in recentCategorySessions)
+              {
+                'categoryId': session.categoryId,
+                'startedAtLocal': session.dateFrom.toIso8601String(),
+                'endedAtLocal': session.dateTo.toIso8601String(),
+                'durationMinutes': session.duration.inMinutes,
+              },
           ],
           'interpretationPolicy':
-              'session evidence may inform coaching patterns; it does not '
-              'override deterministic criterion results',
+              'lifetime summaries and recent session evidence may inform '
+              'coaching patterns; they do not override deterministic '
+              'criterion results',
         },
       'reporting': {
         'materialChangeSinceLastReport': facts.statusTransitioned,
@@ -135,6 +156,54 @@ class GoalFactsRenderer {
       'unansweredUserMessages': unansweredUserMessages,
       'observations': observations,
     });
+  }
+
+  List<Map<String, Object>> _categoryTimeLifetimeSummary(
+    Map<String, List<GoalCategoryTimeSession>> sessionsByCategory,
+  ) {
+    final categoryIds = sessionsByCategory.keys.toList()..sort();
+    return [
+      for (final categoryId in categoryIds)
+        _categorySummary(
+          categoryId,
+          sessionsByCategory[categoryId] ?? const [],
+        ),
+    ];
+  }
+
+  Map<String, Object> _categorySummary(
+    String categoryId,
+    List<GoalCategoryTimeSession> sessions,
+  ) {
+    final minutesByLocalHour = List<int>.filled(24, 0);
+    final minutesByLocalWeekday = List<int>.filled(7, 0);
+    var totalMinutes = 0;
+    for (final session in sessions) {
+      totalMinutes += session.duration.inMinutes;
+      var cursor = session.dateFrom;
+      while (cursor.isBefore(session.dateTo)) {
+        final nextHour = DateTime(
+          cursor.year,
+          cursor.month,
+          cursor.day,
+          cursor.hour + 1,
+        );
+        final segmentEnd = nextHour.isBefore(session.dateTo)
+            ? nextHour
+            : session.dateTo;
+        final minutes = segmentEnd.difference(cursor).inMinutes;
+        minutesByLocalHour[cursor.hour] += minutes;
+        minutesByLocalWeekday[cursor.weekday - DateTime.monday] += minutes;
+        cursor = segmentEnd;
+      }
+    }
+    return {
+      'categoryId': categoryId,
+      'sessionCount': sessions.length,
+      'totalMinutes': totalMinutes,
+      'minutesByLocalHour': minutesByLocalHour,
+      'minutesByLocalWeekday': minutesByLocalWeekday,
+    };
   }
 
   /// Worsening means: strictly declining attainment over today plus at

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.6+4303
+version: 1.0.7+4304
 
 msix_config:
   display_name: LottiApp

--- a/test/classes/goal_criterion_test.dart
+++ b/test/classes/goal_criterion_test.dart
@@ -219,4 +219,25 @@ void main() {
     );
     expect(decoded, criterion);
   });
+
+  test('category time round trip preserves a cross-midnight band', () {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'late-coding',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.rollingDays(count: 7),
+      aggregation: GoalAggregation.sum,
+      targetHours: 0,
+      dailyTimeRange: GoalDailyTimeRange(
+        startMinute: 21 * 60 + 30,
+        endMinute: 7 * 60,
+      ),
+      title: 'Late vibe coding',
+    );
+
+    final decoded = GoalCriterion.fromJson(
+      jsonDecode(jsonEncode(criterion)) as Map<String, dynamic>,
+    );
+
+    expect(decoded, criterion);
+  });
 }

--- a/test/classes/goal_spec_validator_test.dart
+++ b/test/classes/goal_spec_validator_test.dart
@@ -199,6 +199,24 @@ void main() {
       );
     });
 
+    test('category time rejects an empty daily time band', () {
+      const criterion = GoalCriterion.categoryTime(
+        criterionId: 'late-coding',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.day(),
+        aggregation: GoalAggregation.sum,
+        targetHours: 0,
+        dailyTimeRange: GoalDailyTimeRange(
+          startMinute: 22 * 60,
+          endMinute: 22 * 60,
+        ),
+      );
+
+      final issues = GoalSpecValidator.criterionIssues(criterion);
+
+      expect(issues.single, contains('endpoints must differ'));
+    });
+
     test('an empty atLeastCount reports childlessness, not a quota', () {
       const empty = GoalCriterion.atLeastCount(
         criterionId: 'root',

--- a/test/classes/goal_spec_validator_test.dart
+++ b/test/classes/goal_spec_validator_test.dart
@@ -152,6 +152,53 @@ void main() {
       expect(issues, anyElement(contains('water: rolling window')));
     });
 
+    test('category time validates category, target and daily time band', () {
+      const bad = GoalCriterion.categoryTime(
+        criterionId: 'late-coding',
+        categoryId: '  ',
+        window: GoalWindow.rollingDays(count: 0),
+        aggregation: GoalAggregation.sum,
+        targetHours: -1,
+        dailyTimeRange: GoalDailyTimeRange(
+          startMinute: 1440,
+          endMinute: 1440,
+        ),
+      );
+
+      final issues = GoalSpecValidator.criterionIssues(bad);
+
+      expect(issues, hasLength(5));
+      expect(issues, anyElement(contains('categoryId must not be blank')));
+      expect(issues, anyElement(contains('targetHours must not be negative')));
+      expect(issues, anyElement(contains('rolling window')));
+      expect(issues, anyElement(contains('startMinute')));
+      expect(issues, anyElement(contains('endMinute')));
+    });
+
+    test('category time raw JSON rejects fractional time-band minutes', () {
+      const criterion = GoalCriterion.categoryTime(
+        criterionId: 'late-coding',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 0,
+        dailyTimeRange: GoalDailyTimeRange(
+          startMinute: 1290,
+          endMinute: 420,
+        ),
+      );
+      final json = jsonOf(criterion);
+      (json['dailyTimeRange'] as Map<String, dynamic>)['startMinute'] = 1290.5;
+
+      final issues = GoalSpecValidator.criterionJsonIssues(json);
+
+      expect(issues.single, contains('dailyTimeRange.startMinute'));
+      expect(
+        () => GoalSpecValidator.decodeValidated(json),
+        throwsFormatException,
+      );
+    });
+
     test('an empty atLeastCount reports childlessness, not a quota', () {
       const empty = GoalCriterion.atLeastCount(
         criterionId: 'root',

--- a/test/classes/goal_spec_validator_test.dart
+++ b/test/classes/goal_spec_validator_test.dart
@@ -217,6 +217,20 @@ void main() {
       expect(issues.single, contains('endpoints must differ'));
     });
 
+    test('category time rejects day-count aggregation for hour targets', () {
+      const criterion = GoalCriterion.categoryTime(
+        criterionId: 'coding-days',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.count,
+        targetHours: 2,
+      );
+
+      final issues = GoalSpecValidator.criterionIssues(criterion);
+
+      expect(issues.single, contains('count aggregation uses day units'));
+    });
+
     test('an empty atLeastCount reports childlessness, not a quota', () {
       const empty = GoalCriterion.atLeastCount(
         criterionId: 'root',

--- a/test/features/goals/evaluation/goal_progress_evaluator_test.dart
+++ b/test/features/goals/evaluation/goal_progress_evaluator_test.dart
@@ -190,6 +190,145 @@ void main() {
     });
   });
 
+  group('category time leaf', () {
+    const weeklyCap = GoalCriterion.categoryTime(
+      criterionId: 'coding-cap',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.rollingDays(count: 7),
+      aggregation: GoalAggregation.sum,
+      targetHours: 6,
+    );
+
+    test('sums tracked hours and applies an at-most cap', () {
+      final under = evaluator.evaluate(
+        weeklyCap,
+        GoalSignalWindow(
+          categoryTimeDailyHours: {
+            'coding-cap': {d(7): 2.25, d(8): 3.5},
+          },
+        ),
+        saturday,
+      );
+      expect(under.results['coding-cap']!.actual, 5.75);
+      expect(under.satisfied, isTrue);
+      expect(under.dataCoverage, 1);
+
+      final over = evaluator.evaluate(
+        weeklyCap,
+        GoalSignalWindow(
+          categoryTimeDailyHours: {
+            'coding-cap': {d(6): 2, d(7): 2, d(8): 3},
+          },
+        ),
+        saturday,
+      );
+      expect(over.results['coding-cap']!.actual, 7);
+      expect(over.satisfied, isFalse);
+      expect(over.attainment, closeTo(6 / 7, 1e-9));
+    });
+
+    test('at-least and at-most thresholds include the exact boundary', () {
+      const minimum = GoalCriterion.categoryTime(
+        criterionId: 'creative-minimum',
+        categoryId: 'creative-work',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 4,
+        direction: GoalDirection.atLeast,
+      );
+      final exactSignals = GoalSignalWindow(
+        categoryTimeDailyHours: {
+          'creative-minimum': {d(7): 1.5, d(8): 2.5},
+          'coding-cap': {d(7): 1.5, d(8): 4.5},
+        },
+      );
+
+      expect(
+        evaluator.evaluate(minimum, exactSignals, saturday).satisfied,
+        isTrue,
+      );
+      expect(
+        evaluator.evaluate(weeklyCap, exactSignals, saturday).satisfied,
+        isTrue,
+      );
+
+      final below = evaluator.evaluate(
+        minimum,
+        GoalSignalWindow(
+          categoryTimeDailyHours: {
+            'creative-minimum': {d(8): 3.99},
+          },
+        ),
+        saturday,
+      );
+      expect(below.satisfied, isFalse);
+    });
+
+    test(
+      'count aggregation counts days with tracked time, not zero-filled days',
+      () {
+        const activeDays = GoalCriterion.categoryTime(
+          criterionId: 'coding-days',
+          categoryId: 'vibe-coding',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.count,
+          targetHours: 2,
+          direction: GoalDirection.atLeast,
+        );
+        final evaluation = evaluator.evaluate(
+          activeDays,
+          GoalSignalWindow(
+            categoryTimeDailyHours: {
+              'coding-days': {d(6): 0.5, d(8): 2},
+            },
+          ),
+          saturday,
+        );
+
+        expect(evaluation.results['coding-days']!.actual, 2);
+        expect(evaluation.satisfied, isTrue);
+      },
+    );
+
+    test('no matching tracked time is a real zero, not missing telemetry', () {
+      const curfew = GoalCriterion.categoryTime(
+        criterionId: 'late-coding',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 0,
+        dailyTimeRange: GoalDailyTimeRange(
+          startMinute: 1290,
+          endMinute: 420,
+        ),
+      );
+
+      final evaluation = evaluator.evaluate(
+        curfew,
+        const GoalSignalWindow(),
+        saturday,
+      );
+
+      expect(evaluation.results['late-coding']!.actual, 0);
+      expect(evaluation.results['late-coding']!.sampleCount, 7);
+      expect(evaluation.dataCoverage, 1);
+      expect(evaluation.satisfied, isTrue);
+    });
+
+    test('short-term attainment re-windows the same category series', () {
+      final signals = GoalSignalWindow(
+        categoryTimeDailyHours: {
+          'coding-cap': {d(6): 1, d(7): 1, d(8): 1},
+        },
+      );
+
+      expect(
+        evaluator.shortTermAttainment(weeklyCap, signals, saturday),
+        1,
+      );
+    });
+  });
+
   group('habit leaf', () {
     const gym = GoalCriterion.habit(
       criterionId: 'gym',

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -768,6 +768,45 @@ void main() {
     );
   });
 
+  test('a same-day UTC band clips tracked time to both endpoints', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'workday-coding',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 8,
+      dailyTimeRange: GoalDailyTimeRange(
+        startMinute: 9 * 60,
+        endMinute: 17 * 60,
+      ),
+    );
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        (
+          dateFrom: DateTime.utc(2026, 8, 8, 8),
+          dateTo: DateTime.utc(2026, 8, 8, 18),
+          categoryId: 'vibe-coding',
+        ),
+      ],
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: DateTime.utc(2026, 8, 8, 20),
+    );
+
+    expect(
+      window.categoryTimeDailyHours['workday-coding'],
+      {DateTime.utc(2026, 8, 8): 8},
+      reason: 'only the authored 09:00–17:00 UTC band should count',
+    );
+  });
+
   test(
     'category time subscribes to every mutation that can change attribution',
     () {

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,6 +14,7 @@ import '../../../mocks/mocks.dart';
 
 void main() {
   late MockJournalDb journalDb;
+  late MockTimeService timeService;
   late GoalSignalReader reader;
 
   final reference = DateTime(2026, 8, 8, 14, 30);
@@ -60,7 +62,13 @@ void main() {
 
   setUp(() {
     journalDb = MockJournalDb();
-    reader = GoalSignalReader(journalDb: journalDb);
+    timeService = MockTimeService();
+    when(timeService.getCurrent).thenReturn(null);
+    when(() => timeService.linkedFrom).thenReturn(null);
+    reader = GoalSignalReader(
+      journalDb: journalDb,
+      timeService: timeService,
+    );
     when(
       () => journalDb.getQuantitativeByType(
         type: any(named: 'type'),
@@ -562,6 +570,152 @@ void main() {
     },
   );
 
+  test('category time includes the active linked-task timer', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'coding-cap',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 2,
+    );
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(
+      () => journalDb.getConfigFlag('private'),
+    ).thenAnswer((_) async => false);
+    final startedAt = DateTime(2026, 8, 8, 22);
+    final running = JournalEntity.journalEntry(
+      meta: Metadata(
+        id: 'running',
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        dateFrom: startedAt,
+        dateTo: startedAt,
+        categoryId: 'entry-category',
+      ),
+    );
+    final linkedTask = JournalEntity.task(
+      meta: Metadata(
+        id: 'task',
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        dateFrom: startedAt,
+        dateTo: startedAt,
+        categoryId: 'vibe-coding',
+      ),
+      data: TaskData(
+        status: TaskStatus.open(
+          id: 'status',
+          createdAt: startedAt,
+          utcOffset: 0,
+        ),
+        dateFrom: startedAt,
+        dateTo: startedAt,
+        statusHistory: const [],
+        title: 'Coding',
+      ),
+    );
+    when(timeService.getCurrent).thenReturn(running);
+    when(() => timeService.linkedFrom).thenReturn(linkedTask);
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: DateTime(2026, 8, 8, 23, 30),
+    );
+
+    expect(
+      window.categoryTimeDailyHours['coding-cap'],
+      {DateTime.utc(2026, 8, 8): 1.5},
+    );
+    expect(
+      window.categoryTimeSessionsByCategory['vibe-coding']?.single.dateTo,
+      DateTime(2026, 8, 8, 23, 30),
+      reason: 'the in-memory timer endpoint must advance beyond persisted data',
+    );
+  });
+
+  test('a hidden private active timer contributes no category time', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'coding-cap',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 2,
+    );
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(
+      () => journalDb.getConfigFlag('private'),
+    ).thenAnswer((_) async => false);
+    final startedAt = DateTime(2026, 8, 8, 22);
+    when(timeService.getCurrent).thenReturn(
+      JournalEntity.journalEntry(
+        meta: Metadata(
+          id: 'private-running',
+          createdAt: startedAt,
+          updatedAt: startedAt,
+          dateFrom: startedAt,
+          dateTo: startedAt,
+          categoryId: 'vibe-coding',
+          private: true,
+        ),
+      ),
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: DateTime(2026, 8, 8, 23),
+    );
+
+    expect(window.categoryTimeDailyHours['coding-cap'], isEmpty);
+    verify(() => journalDb.getConfigFlag('private')).called(1);
+  });
+
+  test('an unadvanced active timer remains zero-duration evidence', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'coding-cap',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 2,
+    );
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer((_) async => []);
+    final startedAt = DateTime(2026, 8, 8, 22);
+    when(timeService.getCurrent).thenReturn(
+      JournalEntity.journalEntry(
+        meta: Metadata(
+          id: 'just-started',
+          createdAt: startedAt,
+          updatedAt: startedAt,
+          dateFrom: startedAt,
+          dateTo: startedAt,
+          categoryId: 'vibe-coding',
+        ),
+      ),
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: startedAt,
+    );
+
+    expect(window.categoryTimeDailyHours['coding-cap'], isEmpty);
+    expect(window.categoryTimeSessionsByCategory, isEmpty);
+  });
+
   test(
     'category session evidence spans goal lifetime without widening evaluation',
     () async {
@@ -825,6 +979,7 @@ void main() {
           linkNotification,
           taskNotification,
           categoriesNotification,
+          privateToggleNotification,
         },
       );
     },

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -513,4 +514,280 @@ void main() {
     ).captured;
     expect(captured.single, DateTime(2026, 7, 26));
   });
+
+  test(
+    'category time reuses Insights union semantics for all-day totals',
+    () async {
+      const criterion = GoalCriterion.categoryTime(
+        criterionId: 'coding-cap',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 8,
+      );
+      when(
+        () => journalDb.insightsTimeRows(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          (
+            dateFrom: DateTime(2026, 8, 8, 18),
+            dateTo: DateTime(2026, 8, 8, 20),
+            categoryId: 'vibe-coding',
+          ),
+          (
+            dateFrom: DateTime(2026, 8, 8, 19),
+            dateTo: DateTime(2026, 8, 8, 21),
+            categoryId: 'vibe-coding',
+          ),
+          (
+            dateFrom: DateTime(2026, 8, 8, 17),
+            dateTo: DateTime(2026, 8, 8, 22),
+            categoryId: 'other',
+          ),
+        ],
+      );
+
+      final window = await reader.read(
+        criteria: criterion,
+        reference: reference,
+      );
+
+      expect(
+        window.categoryTimeDailyHours['coding-cap'],
+        {DateTime.utc(2026, 8, 8): 3},
+      );
+    },
+  );
+
+  test(
+    'category session evidence spans goal lifetime without widening evaluation',
+    () async {
+      const criterion = GoalCriterion.categoryTime(
+        criterionId: 'coding-today',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.day(),
+        aggregation: GoalAggregation.sum,
+        targetHours: 2,
+      );
+      when(
+        () => journalDb.insightsTimeRows(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          (
+            dateFrom: DateTime(2026, 8),
+            dateTo: DateTime(2026, 8, 1, 1),
+            categoryId: 'vibe-coding',
+          ),
+          (
+            dateFrom: DateTime(2026, 8, 8, 10),
+            dateTo: DateTime(2026, 8, 8, 11, 30),
+            categoryId: 'vibe-coding',
+          ),
+        ],
+      );
+
+      final window = await reader.read(
+        criteria: criterion,
+        reference: reference,
+        categorySessionEvidenceStart: DateTime(2026, 8),
+      );
+
+      final captured = verify(
+        () => journalDb.insightsTimeRows(
+          start: captureAny(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).captured;
+      expect(captured.single, DateTime(2026, 8));
+      expect(
+        window.categoryTimeSessionsByCategory['vibe-coding'],
+        hasLength(2),
+      );
+      expect(window.categoryTimeEvidenceStart, DateTime(2026, 8));
+      expect(
+        window.categoryTimeDailyHours['coding-today'],
+        {DateTime.utc(2026, 8, 8): 1.5},
+        reason: 'historical pattern evidence must not alter the authored day',
+      );
+    },
+  );
+
+  test(
+    'sleep duration uses the health pipeline minutes-to-hours semantics',
+    () async {
+      const sleep = GoalCriterion.metric(
+        criterionId: 'sleep',
+        dataType: 'HealthDataType.SLEEP_ASLEEP',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.dailySumThenAverage,
+        target: 7.5,
+      );
+      when(
+        () => journalDb.getQuantitativeByType(
+          type: 'HealthDataType.SLEEP_ASLEEP',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          JournalEntity.quantitative(
+            meta: meta(DateTime(2026, 8, 8, 7)),
+            data: QuantitativeData.discreteQuantityData(
+              dateFrom: DateTime(2026, 8, 8, 7),
+              dateTo: DateTime(2026, 8, 8, 7),
+              value: 300,
+              dataType: 'HealthDataType.SLEEP_ASLEEP',
+              unit: 'min',
+            ),
+          ),
+          JournalEntity.quantitative(
+            meta: meta(DateTime(2026, 8, 8, 8)),
+            data: QuantitativeData.discreteQuantityData(
+              dateFrom: DateTime(2026, 8, 8, 8),
+              dateTo: DateTime(2026, 8, 8, 8),
+              value: 150,
+              dataType: 'HealthDataType.SLEEP_ASLEEP',
+              unit: 'min',
+            ),
+          ),
+        ],
+      );
+
+      final window = await reader.read(criteria: sleep, reference: reference);
+
+      expect(
+        window.quantitativeDailySums['HealthDataType.SLEEP_ASLEEP'],
+        {DateTime.utc(2026, 8, 8): 7.5},
+      );
+    },
+  );
+
+  test('cross-midnight category band clips each local day precisely', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'late-coding',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.rollingDays(count: 7),
+      aggregation: GoalAggregation.sum,
+      targetHours: 0,
+      dailyTimeRange: GoalDailyTimeRange(
+        startMinute: 21 * 60 + 30,
+        endMinute: 7 * 60,
+      ),
+    );
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        (
+          dateFrom: DateTime(2026, 8, 7, 20),
+          dateTo: DateTime(2026, 8, 8, 8),
+          categoryId: 'vibe-coding',
+        ),
+        (
+          dateFrom: DateTime(2026, 8, 8, 12),
+          dateTo: DateTime(2026, 8, 8, 13),
+          categoryId: 'vibe-coding',
+        ),
+      ],
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: reference,
+    );
+
+    expect(
+      window.categoryTimeDailyHours['late-coding'],
+      {
+        DateTime.utc(2026, 8, 7): 2.5,
+        DateTime.utc(2026, 8, 8): 7,
+      },
+    );
+    final sessions =
+        window.categoryTimeSessionsByCategory['vibe-coding'] ?? const [];
+    expect(sessions, hasLength(2));
+    expect(sessions.first.dateFrom, DateTime(2026, 8, 7, 20));
+    expect(sessions.last.dateFrom, DateTime(2026, 8, 8, 12));
+    expect(
+      window.categoryTimeDailyHours['late-coding']![DateTime.utc(2026, 8, 8)],
+      7,
+      reason:
+          'the model sees the midday session, but the curfew does not count it',
+    );
+  });
+
+  test('a cutoff is half-open: time ending at 22:00 is allowed', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'after-ten',
+      categoryId: 'screen-time',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 0,
+      dailyTimeRange: GoalDailyTimeRange(
+        startMinute: 22 * 60,
+        endMinute: 0,
+      ),
+    );
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        (
+          dateFrom: DateTime(2026, 8, 8, 21),
+          dateTo: DateTime(2026, 8, 8, 22),
+          categoryId: 'screen-time',
+        ),
+        (
+          dateFrom: DateTime(2026, 8, 8, 22),
+          dateTo: DateTime(2026, 8, 8, 22, 30),
+          categoryId: 'screen-time',
+        ),
+      ],
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: reference,
+    );
+
+    expect(
+      window.categoryTimeDailyHours['after-ten'],
+      {DateTime.utc(2026, 8, 8): 0.5},
+    );
+  });
+
+  test(
+    'category time subscribes to every mutation that can change attribution',
+    () {
+      const criterion = GoalCriterion.categoryTime(
+        criterionId: 'coding-cap',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 8,
+      );
+
+      expect(
+        goalSignalTriggerTokens(criterion),
+        {
+          textEntryNotification,
+          linkNotification,
+          taskNotification,
+          categoriesNotification,
+        },
+      );
+    },
+  );
 }

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -570,7 +570,7 @@ void main() {
     },
   );
 
-  test('category time includes the active linked-task timer', () async {
+  test('category time replaces a persisted active timer prefix', () async {
     const criterion = GoalCriterion.categoryTime(
       criterionId: 'coding-cap',
       categoryId: 'vibe-coding',
@@ -578,16 +578,24 @@ void main() {
       aggregation: GoalAggregation.sum,
       targetHours: 2,
     );
+    final startedAt = DateTime(2026, 8, 8, 22);
     when(
       () => journalDb.insightsTimeRows(
         start: any(named: 'start'),
         end: any(named: 'end'),
       ),
-    ).thenAnswer((_) async => []);
+    ).thenAnswer(
+      (_) async => [
+        (
+          dateFrom: startedAt,
+          dateTo: DateTime(2026, 8, 8, 22, 15),
+          categoryId: 'vibe-coding',
+        ),
+      ],
+    );
     when(
       () => journalDb.getConfigFlag('private'),
     ).thenAnswer((_) async => false);
-    final startedAt = DateTime(2026, 8, 8, 22);
     final running = JournalEntity.journalEntry(
       meta: Metadata(
         id: 'running',
@@ -630,6 +638,11 @@ void main() {
     expect(
       window.categoryTimeDailyHours['coding-cap'],
       {DateTime.utc(2026, 8, 8): 1.5},
+    );
+    expect(
+      window.categoryTimeSessionsByCategory['vibe-coding'],
+      hasLength(1),
+      reason: 'the persisted timer prefix must not duplicate raw evidence',
     );
     expect(
       window.categoryTimeSessionsByCategory['vibe-coding']?.single.dateTo,

--- a/test/features/goals/evaluation/goal_signal_window_test.dart
+++ b/test/features/goals/evaluation/goal_signal_window_test.dart
@@ -14,6 +14,20 @@ void main() {
     measurableDailySums: {
       'water-id': {d(2): 1500},
     },
+    categoryTimeDailyHours: {
+      'late-coding': {d(2): 0.5, d(4): 1.25},
+    },
+    categoryTimeSessionsByCategory: {
+      'coding': [
+        GoalCategoryTimeSession(
+          categoryId: 'coding',
+          dateFrom: DateTime(2026, 8, 2, 21, 45),
+          dateTo: DateTime(2026, 8, 2, 23, 15),
+        ),
+      ],
+    },
+    categoryTimeEvidenceStart: DateTime(2026, 8),
+    categoryTimeEvidenceEnd: DateTime(2026, 8, 6),
   );
 
   test('range queries are inclusive of both endpoints', () {
@@ -47,5 +61,21 @@ void main() {
     expect(window.habitSuccessesInRange('gym-habit', d(4), d(6)), {d(5): 2});
     expect(window.measurableInRange('water-id', d(2), d(2)), {d(2): 1500});
     expect(window.measurableInRange('water-id', d(3), d(9)), isEmpty);
+  });
+
+  test('category-time dimensions are criterion-scoped and range-filtered', () {
+    expect(window.categoryTimeInRange('late-coding', d(2), d(3)), {
+      d(2): 0.5,
+    });
+    expect(window.categoryTimeInRange('unknown', d(1), d(31)), isEmpty);
+  });
+
+  test('category session evidence retains exact timing and query bounds', () {
+    final session = window.categoryTimeSessionsByCategory['coding']!.single;
+
+    expect(session.categoryId, 'coding');
+    expect(session.duration, const Duration(minutes: 90));
+    expect(window.categoryTimeEvidenceStart, DateTime(2026, 8));
+    expect(window.categoryTimeEvidenceEnd, DateTime(2026, 8, 6));
   });
 }

--- a/test/features/goals/runtime/goal_agent_phase_a_test.dart
+++ b/test/features/goals/runtime/goal_agent_phase_a_test.dart
@@ -29,6 +29,8 @@ class _FakeSignalReader extends GoalSignalReader {
     required GoalCriterion criteria,
     required DateTime reference,
     int shortTermDays = 3,
+    bool includeCategoryTimeSessions = true,
+    DateTime? categorySessionEvidenceStart,
   }) async => window;
 }
 
@@ -156,6 +158,43 @@ void main() {
             staleAt: DateTime(2026, 8, 7, 9),
           )
           as GoalNudgeEntity;
+
+  test(
+    'wake facts retain category sessions for model pattern analysis',
+    () async {
+      stubSpec();
+      final session = GoalCategoryTimeSession(
+        categoryId: 'vibe-coding',
+        dateFrom: DateTime(2026, 8, 7, 23),
+        dateTo: DateTime(2026, 8, 8, 1),
+      );
+      final signals = GoalSignalWindow(
+        quantitativeDailySums: onTrackSignals().quantitativeDailySums,
+        categoryTimeSessionsByCategory: {
+          'vibe-coding': [session],
+        },
+        categoryTimeEvidenceStart: DateTime(2026, 8, 2),
+        categoryTimeEvidenceEnd: DateTime(2026, 8, 9),
+      );
+
+      final derivation = await withClock(
+        fixedClock,
+        () => phaseA(signals).deriveWakeFacts(
+          agentId: agentId,
+          version: specVersion as GoalSpecVersionEntity,
+          now: now,
+          categorySessionEvidenceStart: DateTime(2026, 8, 2),
+        ),
+      );
+
+      expect(
+        derivation.facts.categoryTimeSessionsByCategory['vibe-coding']?.single,
+        session,
+      );
+      expect(derivation.facts.categoryTimeEvidenceStart, DateTime(2026, 8, 2));
+      expect(derivation.facts.categoryTimeEvidenceEnd, DateTime(2026, 8, 9));
+    },
+  );
 
   GoalProgressEntity progressRow({
     required String periodKey,

--- a/test/features/goals/service/goal_revision_apply_test.dart
+++ b/test/features/goals/service/goal_revision_apply_test.dart
@@ -267,6 +267,51 @@ void main() {
     expect(revised.window, const GoalWindow.rollingDays(count: 3));
   });
 
+  test(
+    'category time takes target and period changes and binds by category',
+    () {
+      const categoryTime = GoalCriterion.categoryTime(
+        criterionId: 'late-coding',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 0,
+        dailyTimeRange: GoalDailyTimeRange(
+          startMinute: 21 * 60 + 30,
+          endMinute: 7 * 60,
+        ),
+      );
+      const composite = GoalCriterion.allOf(
+        criterionId: 'detox',
+        criteria: [steps, categoryTime],
+      );
+
+      final result = applied(
+        applyGoalRevisionChanges(
+          criteria: composite,
+          changes: {
+            'metric': 'vibe-coding',
+            'targetValue': 1.5,
+            'period': 'rolling 14 days',
+          },
+        ),
+      );
+      final revised = result.criteria as GoalCriterionAllOf;
+      final time = revised.criteria.last as GoalCriterionCategoryTime;
+      expect(time.targetHours, 1.5);
+      expect(time.window, const GoalWindow.rollingDays(count: 14));
+      expect(
+        time.dailyTimeRange,
+        const GoalDailyTimeRange(
+          startMinute: 21 * 60 + 30,
+          endMinute: 7 * 60,
+        ),
+        reason: 'changing the cap must preserve the authored daily band',
+      );
+      expect((revised.criteria.first as GoalCriterionMetric).target, 10000);
+    },
+  );
+
   test('two habit leaves make a cadence change ambiguous — rejected', () {
     const twoGyms = GoalCriterion.anyOf(
       criterionId: 'either-gym',

--- a/test/features/goals/service/goal_revision_apply_test.dart
+++ b/test/features/goals/service/goal_revision_apply_test.dart
@@ -312,6 +312,31 @@ void main() {
     },
   );
 
+  test('a category-time sibling does not make habit cadence ambiguous', () {
+    const categoryTime = GoalCriterion.categoryTime(
+      criterionId: 'late-coding',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 0,
+    );
+    const composite = GoalCriterion.allOf(
+      criterionId: 'balanced-day',
+      criteria: [gym, categoryTime],
+    );
+
+    final result = applied(
+      applyGoalRevisionChanges(
+        criteria: composite,
+        changes: {'cadence': 2},
+      ),
+    );
+    final revised = result.criteria as GoalCriterionAllOf;
+
+    expect((revised.criteria.first as GoalCriterionHabit).targetCount, 2);
+    expect(revised.criteria.last, categoryTime);
+  });
+
   test('two habit leaves make a cadence change ambiguous — rejected', () {
     const twoGyms = GoalCriterion.anyOf(
       criterionId: 'either-gym',

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -29,12 +29,15 @@ import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/services/time_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -47,7 +50,11 @@ void main() {
   late MockUpdateNotifications updateNotifications;
   late ProviderContainer container;
 
-  setUp(() {
+  setUp(() async {
+    await setUpTestGetIt(
+      additionalSetup: () =>
+          getIt.registerSingleton<TimeService>(MockTimeService()),
+    );
     syncStream = StreamController<Set<String>>.broadcast();
     addTearDown(syncStream.close);
     agentService = MockAgentService();
@@ -96,6 +103,7 @@ void main() {
     );
     addTearDown(container.dispose);
   });
+  tearDown(tearDownTestGetIt);
 
   AgentIdentityEntity goalIdentity(String id) =>
       AgentDomainEntity.agent(

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -150,6 +150,40 @@ void main() {
     expect(view.compactWindow[5], isFalse);
   });
 
+  test('category time projects tracked hours and treats an empty elapsed day '
+      'as an observed zero', () {
+    final view = buildGoalProgressView(
+      criteria: const GoalCriterion.categoryTime(
+        criterionId: 'late-coding',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.sum,
+        targetHours: 0,
+        title: 'Late vibe coding',
+      ),
+      signals: GoalSignalWindow(
+        categoryTimeDailyHours: {
+          'late-coding': {day(1): 0.75},
+        },
+      ),
+      reference: today,
+    );
+
+    final metric = view.metric!;
+    expect(metric.name, 'Late vibe coding');
+    expect(metric.target, 0);
+    expect(metric.direction, GoalDirection.atMost);
+    expect(metric.days[5].value, 0.75);
+    expect(metric.days[5].isObserved, isTrue);
+    expect(metric.days.last.value, 0);
+    expect(metric.days.last.isObserved, isTrue);
+    expect(
+      view.compactWindow,
+      [true, true, true, true, true, false, false],
+      reason: 'a late session keeps the rolling at-most-zero window failed',
+    );
+  });
+
   test('sum and count metrics compare the aggregated rolling period', () {
     GoalProgressView build(GoalAggregation aggregation) =>
         buildGoalProgressView(

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -184,6 +184,22 @@ void main() {
     );
   });
 
+  test('category time falls back to its category identifier when untitled', () {
+    final view = buildGoalProgressView(
+      criteria: const GoalCriterion.categoryTime(
+        criterionId: 'coding-cap',
+        categoryId: 'vibe-coding',
+        window: GoalWindow.day(),
+        aggregation: GoalAggregation.sum,
+        targetHours: 2,
+      ),
+      signals: const GoalSignalWindow(),
+      reference: today,
+    );
+
+    expect(view.metric?.name, 'vibe-coding');
+  });
+
   test('sum and count metrics compare the aggregated rolling period', () {
     GoalProgressView build(GoalAggregation aggregation) =>
         buildGoalProgressView(

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -26,6 +26,8 @@ class _FakeReader extends GoalSignalReader {
     required GoalCriterion criteria,
     required DateTime reference,
     int shortTermDays = 3,
+    bool includeCategoryTimeSessions = true,
+    DateTime? categorySessionEvidenceStart,
   }) async => const GoalSignalWindow();
 }
 

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -44,6 +44,8 @@ class _FakeReader extends GoalSignalReader {
     required GoalCriterion criteria,
     required DateTime reference,
     int shortTermDays = 3,
+    bool includeCategoryTimeSessions = true,
+    DateTime? categorySessionEvidenceStart,
   }) async => window;
 }
 

--- a/test/features/goals/workflow/goal_facts_renderer_test.dart
+++ b/test/features/goals/workflow/goal_facts_renderer_test.dart
@@ -404,6 +404,52 @@ void main() {
       expect(session['endedAtLocal'], '2026-08-09T01:45:00.000');
       expect(session['durationMinutes'], 150);
       expect(session.containsKey('satisfied'), isFalse);
+      final summary =
+          (signals['categoryTimeLifetimeSummary'] as List).single
+              as Map<String, dynamic>;
+      expect(summary['sessionCount'], 1);
+      expect(summary['totalMinutes'], 150);
+      final minutesByHour = summary['minutesByLocalHour'] as List;
+      expect(minutesByHour[23], 45);
+      expect(minutesByHour[0], 60);
+      expect(minutesByHour[1], 45);
     },
   );
+
+  test('lifetime category evidence keeps a bounded recent raw sample', () {
+    final sessions = [
+      for (var index = 0; index < 205; index++)
+        GoalCategoryTimeSession(
+          categoryId: 'vibe-coding',
+          dateFrom: DateTime(2026).add(Duration(hours: index)),
+          dateTo: DateTime(2026).add(
+            Duration(hours: index, minutes: 30),
+          ),
+        ),
+    ];
+
+    final json = renderedJson(
+      wakeFacts: facts(
+        categoryTimeSessions: {'vibe-coding': sessions},
+        categoryTimeEvidenceStart: DateTime(2026),
+        categoryTimeEvidenceEnd: DateTime(2026, 8, 10),
+      ),
+    );
+    final signals = json['signals'] as Map<String, dynamic>;
+
+    expect(signals['categoryTimeSessionCount'], 205);
+    expect(signals['categoryTimeSessionsOmitted'], 5);
+    expect(signals['categoryTimeSessions'], hasLength(200));
+    final recent = signals['categoryTimeSessions'] as List;
+    expect(
+      (recent.first as Map<String, dynamic>)['startedAtLocal'],
+      sessions[5].dateFrom.toIso8601String(),
+      reason: 'the bounded sample must retain the most recent raw sessions',
+    );
+    final summary =
+        (signals['categoryTimeLifetimeSummary'] as List).single
+            as Map<String, dynamic>;
+    expect(summary['sessionCount'], 205);
+    expect(summary['totalMinutes'], 205 * 30);
+  });
 }

--- a/test/features/goals/workflow/goal_facts_renderer_test.dart
+++ b/test/features/goals/workflow/goal_facts_renderer_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/goal_nudge_models.dart';
 import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 import 'package:lotti/features/goals/workflow/goal_facts_renderer.dart';
 
@@ -42,6 +43,9 @@ void main() {
     GoalTrackStatus? previous = GoalTrackStatus.atRisk,
     int? deficit,
     int? buffer,
+    Map<String, List<GoalCategoryTimeSession>> categoryTimeSessions = const {},
+    DateTime? categoryTimeEvidenceStart,
+    DateTime? categoryTimeEvidenceEnd,
   }) => GoalWakeFacts(
     trackStatus: status,
     previousStatus: previous,
@@ -65,6 +69,9 @@ void main() {
       },
     ),
     shortTermAttainment: 0.5,
+    categoryTimeSessionsByCategory: categoryTimeSessions,
+    categoryTimeEvidenceStart: categoryTimeEvidenceStart,
+    categoryTimeEvidenceEnd: categoryTimeEvidenceEnd,
   );
 
   GoalNudgeEntity nudge({
@@ -336,4 +343,67 @@ void main() {
       isEmpty,
     );
   });
+
+  test(
+    'criterionJson labels tracked category time and its local daily band',
+    () {
+      final json = criterionJson(
+        const GoalCriterion.categoryTime(
+          criterionId: 'late-coding',
+          categoryId: 'vibe-coding',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.sum,
+          targetHours: 0,
+          title: 'Late-night coding',
+          dailyTimeRange: GoalDailyTimeRange(
+            startMinute: 21 * 60 + 30,
+            endMinute: 7 * 60,
+          ),
+        ),
+      );
+
+      expect(json['categoryTime'], 'vibe-coding');
+      expect(json['title'], 'Late-night coding');
+      expect(json['targetHours'], 0);
+      expect(json['direction'], 'atMost');
+      expect(json['evidence'], 'tracked Lotti time entries only');
+      expect(json['dailyTimeRange'], {
+        'startMinute': 21 * 60 + 30,
+        'endMinute': 7 * 60,
+      });
+    },
+  );
+
+  test(
+    'category session evidence exposes local timing without deciding success',
+    () {
+      final json = renderedJson(
+        wakeFacts: facts(
+          categoryTimeSessions: {
+            'vibe-coding': [
+              GoalCategoryTimeSession(
+                categoryId: 'vibe-coding',
+                dateFrom: DateTime(2026, 8, 8, 23, 15),
+                dateTo: DateTime(2026, 8, 9, 1, 45),
+              ),
+            ],
+          },
+          categoryTimeEvidenceStart: DateTime(2026, 8, 2),
+          categoryTimeEvidenceEnd: DateTime(2026, 8, 10),
+        ),
+      );
+
+      final signals = json['signals'] as Map<String, dynamic>;
+      expect(signals['categoryTimeEvidenceStart'], '2026-08-02T00:00:00.000');
+      expect(signals['categoryTimeEvidenceEnd'], '2026-08-10T00:00:00.000');
+      final session =
+          (signals['categoryTimeSessions'] as List).single
+              as Map<String, dynamic>;
+      expect(session['categoryId'], 'vibe-coding');
+      expect(session['startedAtLocal'], '2026-08-08T23:15:00.000');
+      expect(session['endedAtLocal'], '2026-08-09T01:45:00.000');
+      expect(session['durationMinutes'], 150);
+      expect(session.containsKey('satisfied'), isFalse);
+    },
+  );
 }


### PR DESCRIPTION
## What changed

- add a serialized `categoryTime` goal criterion with minimum/maximum hour targets and optional recurring local-time bands
- reuse Insights category attribution and interval-union semantics for tracked-time evaluation
- support midnight-crossing cutoffs such as 21:30–07:00 with half-open boundaries
- retain watched-category session history from goal creation for model-side pattern coaching while keeping deterministic evaluation window-scoped
- surface titled per-dimension criteria and raw session evidence in authoritative goal FACTS
- extend revision, progress, provider, validation, and presentation folds for the new criterion
- document multi-dimensional accountability and the follow-up daily assessment design, with agent suggestions reusing ChangeSet/ChangeDecision approval
- prepare the intentional `1.0.7+4304` release bump with matching CHANGELOG and Flatpak metadata

## Why

Goal agents need flexible signals beyond linked habits: sleep and other quantitative data already use the generic metric path, custom measurements use the measurable path, and category-attributed tracked time needed a first-class criterion. This enables goals such as minimum focused work, maximum vibe-coding time, or no tracked screen-time after a local cutoff without creating a parallel telemetry pipeline.

Each criterion leaf remains an accountable dimension with its own persisted result. Raw category sessions are evidence for coaching patterns only and never override deterministic outcomes.

## Validation

- focused Flutter tests for every touched source path passed
- affected signal/runtime/workflow tests rerun after the lifetime-evidence refinement: 104 passed
- coverage follow-up adds UTC same-day clipping, empty-band validation, mixed habit/category revision, and untitled-category presentation tests: 73 focused tests passed
- targeted Dart analyzer: zero issues
- `make knowledge_check`: 93 OKF concepts and 476 Mermaid blocks passed

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in ten shards. Codecov is the authoritative patch-coverage result.

## Follow-up UI

The create/edit UI still represents rolling habit quotas and the supported steps metric. A follow-up will add generic quantitative/measurable selection, category-time min/max configuration, optional local-time bands, and daily per-dimension self/agent assessments using the existing approval surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category-based tracked-time goals with minimum or maximum duration targets and recurring local-time ranges.
  * Added support for linked habits and rolling seven-day step targets.
  * Added progress tracking for quantitative signals and user-defined measurable data.
  * Multi-criterion goals now retain separate accountable results for each criterion.
  * Agent-proposed goal changes continue to require user approval.

* **Documentation**
  * Updated release notes and goal documentation for version 1.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->