### PR TITLE
fix(goals): harden tracked-time evaluation

### DIFF
--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,7 +42,7 @@
   <releases>
     <release version="1.0.7" date="2026-08-12">
       <description>
-        <p>Added: goal agents remain configurable with linked habits and rolling seven-day step targets. Their evaluation foundation now preserves a separate accountable result for every configured criterion.</p>
+        <p>Goal-agent criteria are ready for refinement. Goal agents remain configurable with linked habits and rolling seven-day step targets. Their evaluation foundation now preserves a separate accountable result for every configured criterion.</p>
       </description>
     </release>
     <release version="1.0.6" date="2026-08-09">

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -149,19 +149,25 @@ flowchart TD
   and category time reuses the same category-attributed timer rows as Insights.
   A category-time leaf can enforce an `atLeast` or `atMost` number of hours and
   can clip every local day to an optional time band; a crossing band such as
-  `21:30 → 07:00` spans midnight. Day keys re-stamp the local calendar date as
-  midnight UTC. The goal agent must never disagree with the chart the user is
-  looking at.
+  `21:30 → 07:00` spans midnight. Evaluation clips the current day at the
+  evaluation instant, so future-dated entries never count as time already
+  tracked. A live timer resolves category attribution through the same linked-
+  task query as Insights and replaces its persisted prefix by entry id. Day
+  keys re-stamp the local calendar date as midnight UTC. The goal agent must
+  never disagree with the chart the user is looking at.
 - **Pattern evidence is richer than the threshold.** Phase A reads only the
   bounded evaluation/lookback range. When Phase B actually runs, the same
   reader additionally loads every valid attributed session for a watched
   category since the goal agent was created, including sessions outside an
-  optional cutoff band. FACTS summarizes the complete lifetime into bounded
+  optional cutoff band. FACTS unions overlaps per category and preserves
+  sub-minute precision while summarizing the complete lifetime into bounded
   local-hour and weekday distributions, then adds the 200 most recent raw
-  sessions with category, local start/end and duration. The coach can therefore
-  notice late-night or clustering patterns without allowing one current model
-  message to grow forever. Those signals are evidence only: the model may
-  discuss them but cannot replace the deterministic per-dimension result.
+  sessions with category, local start/end and duration. The raw session count
+  remains available separately from the unioned duration. The coach can
+  therefore notice late-night or clustering patterns without allowing one
+  current model message to grow forever. Those signals are evidence only: the
+  model may discuss them but cannot replace the deterministic per-dimension
+  result.
 - **Subjective assessment is a separate governance layer.** Deterministic
   `goalProgress` registers are recomputed from source and must never carry a
   mutable opinion. A future daily-assessment register should therefore keep
@@ -488,6 +494,13 @@ flowchart TD
   targets, and an optional local time band without hard-coding a health-data
   catalog. A separate follow-up approval surface will render direct daily
   dimension ratings and agent-proposed assessment change items.
+- **Tracked time invalidates without churning wakes.** Category-time leaves
+  observe the journal, link, task, category and privacy notifications used by
+  Insights, but those mutations only advance the durable report-stale
+  watermark. They do not queue Phase A or inference for every timer edit. The
+  existing 06:00 cadence evaluates accumulated changes automatically, while
+  Update now remains the explicit immediate path. Habit and measured-data
+  signals stay immediate because each write is a bounded observation.
 - **Conversation scope is the goal.** The contract identifies the agent as a
   dedicated coach rather than a general assistant. Coding, trivia and other
   unrelated requests receive a short purpose reminder and a redirect to the

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -84,6 +84,7 @@ flowchart TD
         STORE --> USERWAKE[manual userMessage wake\nmessage id trigger token]
         DAYEDIT[Goal detail day cell\nsuccess or missed] --> HABITWRITE[existing habit completion\npersistence path]
         HABITWRITE --> SIG
+        REFRESH[Update now\ngoal-report-refresh] --> REFREG[persist deterministic register\nwithout duplicate escalation]
     end
     ORCH --> PA[GoalAgentPhaseA.execute]
     DISP --> SYNCROUTE{bounded signal or\ncategory-time mutation?}
@@ -103,9 +104,13 @@ flowchart TD
     ROUTE -- no --> PA
     ROUTE -- yes --> PB[GoalAgentWorkflow — Phase B\nsame derivation as Phase A]
     USERWAKE --> PB
+    REFREG --> PB
     PB --> FACTS[GoalFactsRenderer\nJSON fence: goal, evaluation,\nreporting, ads, personaTone]
     FACTS --> CONV[one bounded conversation\nglm-5.2 default, profile override,\ntemperature 0, 7-tool contract]
     CONV --> OUT[one transaction:\nreport+head, goalNudge writes,\nobservations, revision ChangeSet,\nvisible reply_to_user carrier]
+    OUT --> FRESH{current report head advanced\nand no watched timer active?}
+    FRESH -- yes --> REPORTDONE[clear report-stale watermark]
+    FRESH -- no --> STAY[keep report stale]
 ```
 
 ## Invariants
@@ -192,8 +197,10 @@ flowchart TD
   source exists before enqueue, the wake bypasses throttling, and no chat UI
   owns an inference loop. A successful exact-day habit edit also enqueues a
   workspace-scoped `goal-report-refresh` wake; its workspace does not supersede
-  the ordinary subscription wake, and it routes to Phase B to refresh the
-  standing report even when the coarse status did not change.
+  the ordinary subscription wake. It first persists the deterministic register
+  from the same derivation snapshot without arming a duplicate escalation, then
+  routes to Phase B to refresh the standing report even when the coarse status
+  did not change.
 - **Phase B re-derives, never trusts.** The workflow calls the same
   `deriveWakeFacts` Phase A used to arm the escalation and renders every
   number into the FACTS block; the prompt forbids the model to recompute.
@@ -204,6 +211,12 @@ flowchart TD
   new-banner request missing its ad. A first evaluation that lands at risk is
   also ad-eligible, so a newly created goal does not wait for a three-day trend
   before receiving its initial banner.
+- **Report freshness follows the durable standing head.** Producing report
+  material or writing a historical report row is insufficient: the shared
+  drain clears the stale watermark only when this wake actually advances the
+  current report head. A report that includes a watched category timer's live
+  elapsed prefix also remains stale, because in-memory timer ticks continue
+  changing evidence without journal notifications.
 - **The escalation carries its own baseline and period.** The wake record
   encodes the PRE-transition status as a `goal-baseline:<status>` trigger
   token (Phase A's register write hides it from any re-derivation, and a

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -77,6 +77,7 @@ the rollout flag.
 flowchart TD
     subgraph triggers [Triggers — every device]
         SIG[localUpdateStream signals\nleaf dataTypes, habitIds,\nmeasurable ids] --> ORCH[WakeOrchestrator\nsubscription match]
+        LOCALTIME[local category-time mutation] --> STALE[advance report-stale watermark\nno wake]
         SYNC[syncUpdateStream] --> DISP[GoalSignalSyncDispatcher]
         CAD[cadence ScheduledWakeEntity\nworkspace goal-cadence,\ndaily at 06:00 local] --> MGR[ScheduledWakeManager]
         CHAT[Goal chat composer] --> STORE[persist user message + payload]
@@ -85,7 +86,9 @@ flowchart TD
         HABITWRITE --> SIG
     end
     ORCH --> PA[GoalAgentPhaseA.execute]
-    DISP --> PA
+    DISP --> SYNCROUTE{bounded signal or\ncategory-time mutation?}
+    SYNCROUTE -- bounded --> PA
+    SYNCROUTE -- category time --> STALE
     MGR --> PA
     PA --> HEAD[spec head → active version\nno head = clean no-op]
     HEAD --> REARM[re-arm cadence\nrecurrence by re-arm]
@@ -179,10 +182,12 @@ flowchart TD
   without erasing any dimension's measured result. No producer for that
   assessment register exists yet.
 - **Automatic Phase B is reachable only through the lease; direct chat and
-  detail-page refreshes are explicit user wakes.** Sync-received signals run Phase A directly (the
-  orchestrator deliberately listens local-only); automatic LLM-worthy work
-  becomes a `goal-escalation:<periodKey>` scheduled wake whose lease election
-  picks exactly one device. A durable source chat turn instead carries a
+  detail-page refreshes are explicit user wakes.** The orchestrator listens
+  local-only. On sync, bounded habit/measured signals run Phase A directly,
+  while category-time mutations only advance the receiving agent's durable
+  report-stale watermark. Automatic LLM-worthy work becomes a
+  `goal-escalation:<periodKey>` scheduled wake whose lease election picks
+  exactly one device. A durable source chat turn instead carries a
   `goal-chat-message:<messageId>` trigger on a manual `userMessage` wake. The
   source exists before enqueue, the wake bypasses throttling, and no chat UI
   owns an inference loop. A successful exact-day habit edit also enqueues a
@@ -208,7 +213,9 @@ flowchart TD
   period never advances the current report head. A failed Phase B wake
   re-arms its escalation with a later deadline (the resolver's supported
   reschedule-beats-consume path), so a transient failure cannot orphan
-  the period.
+  the period. Completed historical periods read category time through the next
+  local midnight as an exclusive bound, so their final second is not lost;
+  live periods remain clipped at the evaluation instant.
 - **Ad contracts are enforced at persistence, not just in the prompt.**
   `persistOutputs` re-reads the nudge rows (a dismissal during inference
   must count), and suppresses creates/re-runs during the same-day dismissal
@@ -499,8 +506,13 @@ flowchart TD
   Insights, but those mutations only advance the durable report-stale
   watermark. They do not queue Phase A or inference for every timer edit. The
   existing 06:00 cadence evaluates accumulated changes automatically, while
-  Update now remains the explicit immediate path. Habit and measured-data
-  signals stay immediate because each write is a bounded observation.
+  Update now remains the explicit immediate report path. A deterministic
+  cadence pass may refresh progress registers but does not clear the stale
+  badge unless a report-producing wake durably replaces the standing report.
+  Synced category-time journal facts re-advance the watermark on their receiving
+  device, including when they arrive after an earlier Update now. Habit and
+  measured-data signals stay immediate because each write is a bounded
+  observation.
 - **Conversation scope is the goal.** The contract identifies the agent as a
   dedicated coach rather than a general assistant. Coding, trivia and other
   unrelated requests receive a short purpose reminder and a redirect to the

--- a/lib/database/database_insights_queries.dart
+++ b/lib/database/database_insights_queries.dart
@@ -3,10 +3,30 @@ part of 'database.dart';
 /// One slim time row for the Insights time-analysis dashboard: the absolute
 /// time span plus the resolved category id (`null` = uncategorized).
 typedef InsightsTimeRowRecord = ({
+  String entryId,
   DateTime dateFrom,
   DateTime dateTo,
   String? categoryId,
 });
+
+const _insightsResolvedCategorySql = '''
+  COALESCE(
+    (
+      SELECT t.category
+      FROM linked_entries le
+      INNER JOIN journal t ON t.id = le.from_id
+      WHERE le.to_id = j.id
+        AND COALESCE(le.hidden, FALSE) = FALSE
+        AND t.type = 'Task'
+        AND t.deleted = FALSE
+        AND t.category != ''
+        AND COALESCE(t.private, FALSE) IN (FALSE, pf.visible)
+      ORDER BY t.date_from DESC, t.id
+      LIMIT 1
+    ),
+    NULLIF(j.category, '')
+  )
+''';
 
 /// Insights query surface for [JournalDb]: lean duration aggregation rows.
 mixin _JournalDbInsightsQueries on _$JournalDb {
@@ -55,24 +75,10 @@ mixin _JournalDbInsightsQueries on _$JournalDb {
           ) AS visible
         )
         SELECT
+          j.id AS entry_id,
           j.date_from AS date_from,
           j.date_to AS date_to,
-          COALESCE(
-            (
-              SELECT t.category
-              FROM linked_entries le
-              INNER JOIN journal t ON t.id = le.from_id
-              WHERE le.to_id = j.id
-                AND COALESCE(le.hidden, FALSE) = FALSE
-                AND t.type = 'Task'
-                AND t.deleted = FALSE
-                AND t.category != ''
-                AND COALESCE(t.private, FALSE) IN (FALSE, pf.visible)
-              ORDER BY t.date_from DESC, t.id
-              LIMIT 1
-            ),
-            NULLIF(j.category, '')
-          ) AS category_id
+          $_insightsResolvedCategorySql AS category_id
         FROM journal j INDEXED BY idx_journal_insights_time
         CROSS JOIN private_flag pf
         WHERE j.type = 'JournalEntry'
@@ -90,10 +96,39 @@ mixin _JournalDbInsightsQueries on _$JournalDb {
     return [
       for (final row in rows)
         (
+          entryId: row.read<String>('entry_id'),
           dateFrom: row.read<DateTime>('date_from'),
           dateTo: row.read<DateTime>('date_to'),
           categoryId: row.read<String?>('category_id'),
         ),
     ];
+  }
+
+  /// Resolves one time entry's category with the exact task-link precedence
+  /// and privacy rules used by [insightsTimeRows]. Unlike the range query,
+  /// this deliberately accepts a zero-duration entry so a live timer can be
+  /// attributed before it has a persisted end time.
+  Future<String?> insightsTimeCategoryForEntry(String entryId) async {
+    final rows = await customSelect(
+      '''
+        WITH private_flag AS (
+          SELECT COALESCE(
+            (SELECT status FROM config_flags WHERE name = 'private'),
+            FALSE
+          ) AS visible
+        )
+        SELECT $_insightsResolvedCategorySql AS category_id
+        FROM journal j
+        CROSS JOIN private_flag pf
+        WHERE j.id = ?
+          AND j.type = 'JournalEntry'
+          AND j.deleted = FALSE
+          AND COALESCE(j.private, FALSE) IN (FALSE, pf.visible)
+        LIMIT 1
+      ''',
+      variables: [Variable<String>(entryId)],
+      readsFrom: {journal, linkedEntries, configFlags},
+    ).get();
+    return rows.isEmpty ? null : rows.single.read<String?>('category_id');
   }
 }

--- a/lib/features/agents/service/agent_service.dart
+++ b/lib/features/agents/service/agent_service.dart
@@ -164,6 +164,10 @@ class AgentService {
   bool abortRunningWake(String agentId) =>
       orchestrator.abortRunningWake(agentId);
 
+  /// Marks the standing report stale without scheduling inference.
+  Future<void> markReportStale(String agentId) =>
+      orchestrator.markReportStale(agentId);
+
   /// Remove a persisted scheduled wake from the agent state.
   Future<void> clearScheduledWake(String agentId) async {
     final state = await repository.getAgentState(agentId);

--- a/lib/features/agents/state/agent_wiring.dart
+++ b/lib/features/agents/state/agent_wiring.dart
@@ -114,7 +114,12 @@ void wireWakeExecutor(
         extraTokens: triggers,
       );
 
-      return result.mutatedEntries;
+      return identity.kind == AgentKinds.goalAgent
+          ? WakeExecutorResult(
+              result.mutatedEntries,
+              reportUpdated: result.reportUpdated,
+            )
+          : result.mutatedEntries;
     }
 
     // Default: task agent workflow.

--- a/lib/features/agents/wake/wake_batch_router.dart
+++ b/lib/features/agents/wake/wake_batch_router.dart
@@ -76,6 +76,16 @@ extension WakeBatchRouter on WakeOrchestrator {
       final predicate = sub.predicate;
       if (predicate != null && !predicate(allMatched)) continue;
 
+      if (sub.reportStaleOnly) {
+        _scheduleReportStale(sub.agentId, clock.now());
+        _log(
+          'marked report stale without scheduling a wake for '
+          '${DomainLogger.sanitizeId(sub.agentId)}',
+          subDomain: 'stale',
+        );
+        continue;
+      }
+
       // Automatic inference is opt-in, but observation is not. Disabled task
       // agents keep their subscriptions and persist a stale watermark instead
       // of queueing a wake. While a manual wake is running, retain the existing

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -502,7 +502,11 @@ extension WakeDrainEngine on WakeOrchestrator {
         );
         _emitRunCompletion(job, WakeRunStatus.completed);
 
-        await _markReportFresh(job.agentId, refreshStartedAt: startTime);
+        final reportUpdated =
+            mutated is! WakeExecutorResult || mutated.reportUpdated;
+        if (reportUpdated) {
+          await _markReportFresh(job.agentId, refreshStartedAt: startTime);
+        }
 
         // Only arm a follow-up throttle deadline when work remains queued;
         // otherwise the persisted `nextWakeAt` surfaces in the Wake Cycles

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
@@ -114,6 +115,21 @@ typedef WakeExecutor =
       Set<String> triggers,
       String threadId,
     );
+
+/// Backward-compatible executor payload with report-refresh metadata.
+///
+/// The suppression contract historically returned only mutated entity clocks.
+/// Keeping this as a map preserves that contract while allowing owning agent
+/// features to say that a successful maintenance wake did not replace their
+/// standing report.
+class WakeExecutorResult extends UnmodifiableMapView<String, VectorClock> {
+  WakeExecutorResult(
+    super.map, {
+    required this.reportUpdated,
+  });
+
+  final bool reportUpdated;
+}
 
 /// Returns the current global limit for simultaneously executing wake cycles.
 typedef MaxConcurrentWakes = int Function();
@@ -798,6 +814,19 @@ class WakeOrchestrator with AgentErrorLogging {
     );
     return true;
   }
+
+  /// Persists a report-stale watermark without queueing a wake.
+  ///
+  /// Sync-side signal dispatchers use this when high-frequency evidence
+  /// arrives after a prior refresh. The write shares the same per-agent
+  /// serialization as notification-driven stale/fresh updates.
+  Future<void> markReportStale(
+    String agentId, {
+    DateTime? occurredAt,
+  }) => _serializeFreshnessWrite(
+    agentId,
+    () => _persistReportStale(agentId, occurredAt ?? clock.now()),
+  );
 
   // ── Internal notification handling ─────────────────────────────────────────
 

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -32,6 +32,7 @@ class AgentSubscription {
     this.predicate,
     this.deferPropagatedMatches = true,
     this.drainImmediately = false,
+    this.reportStaleOnly = false,
   });
 
   /// Unique subscription identifier (stable across restarts).
@@ -69,6 +70,13 @@ class AgentSubscription {
   /// agent and queued jobs merge tokens, so N rapid check-offs collapse into
   /// at most one follow-up run.
   final bool drainImmediately;
+
+  /// Whether matching evidence should only mark the persisted report stale.
+  ///
+  /// This keeps high-frequency observational signals visible to the user
+  /// without turning every mutation into agent work. The agent's scheduled
+  /// cadence or an explicit manual refresh consumes the accumulated changes.
+  final bool reportStaleOnly;
 }
 
 /// Checks whether a content-gated entity (by ID) has the content the agent is

--- a/lib/features/agents/workflow/wake_result.dart
+++ b/lib/features/agents/workflow/wake_result.dart
@@ -5,6 +5,7 @@ class WakeResult {
   const WakeResult({
     required this.success,
     this.mutatedEntries = const {},
+    this.reportUpdated = false,
     this.error,
   });
 
@@ -14,6 +15,14 @@ class WakeResult {
   /// Map of journal entity IDs mutated during this wake to their post-mutation
   /// vector clocks. Used by the orchestrator for self-notification suppression.
   final Map<String, VectorClock> mutatedEntries;
+
+  /// Whether this wake durably replaced the agent's standing report.
+  ///
+  /// Deterministic maintenance wakes can succeed and update derived state
+  /// without producing prose. The shared wake runtime uses this distinction
+  /// to keep an existing report visibly stale until a report-producing wake
+  /// completes.
+  final bool reportUpdated;
 
   /// Error description when [success] is false.
   final String? error;

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -20,7 +20,10 @@ today:
   Quantitative and user-defined measurable leaves share the existing journal
   ingestion paths; category-time leaves reuse Insights attribution, support
   minimum/maximum hours and optional local time bands, and give Phase B the
-  bounded raw session evidence needed to discuss timing patterns.
+  bounded raw session evidence needed to discuss timing patterns. Tracked-time
+  mutations mark the standing report out of date without waking the agent for
+  every timer edit; the daily cadence or Update now consumes the accumulated
+  evidence. Habit and measured-data observations remain immediate.
 - `GoalSpecValidator` (in `lib/classes/goal_spec_validator.dart`, beside
   the vocabulary it validates) — the decode-boundary gate, invoked from
   `AgentDomainEntity.fromJson` so every path (Matrix sync, storage reads)

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -22,8 +22,10 @@ today:
   minimum/maximum hours and optional local time bands, and give Phase B the
   bounded raw session evidence needed to discuss timing patterns. Tracked-time
   mutations mark the standing report out of date without waking the agent for
-  every timer edit; the daily cadence or Update now consumes the accumulated
-  evidence. Habit and measured-data observations remain immediate.
+  every timer edit; the daily cadence consumes accumulated evidence into the
+  deterministic progress register, while only a report-producing transition
+  or Update now clears the stale report. Habit and measured-data observations
+  remain immediate.
 - `GoalSpecValidator` (in `lib/classes/goal_spec_validator.dart`, beside
   the vocabulary it validates) — the decode-boundary gate, invoked from
   `AgentDomainEntity.fromJson` so every path (Matrix sync, storage reads)

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -24,8 +24,10 @@ today:
   mutations mark the standing report out of date without waking the agent for
   every timer edit; the daily cadence consumes accumulated evidence into the
   deterministic progress register, while only a report-producing transition
-  or Update now clears the stale report. Habit and measured-data observations
-  remain immediate.
+  or Update now can clear the stale report. Update now first refreshes the
+  deterministic register from the same evidence snapshot used for prose, and a
+  report rendered while a watched timer is still running remains stale until a
+  settled wake. Habit and measured-data observations remain immediate.
 - `GoalSpecValidator` (in `lib/classes/goal_spec_validator.dart`, beside
   the vocabulary it validates) — the decode-boundary gate, invoked from
   `AgentDomainEntity.fromJson` so every path (Matrix sync, storage reads)

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -135,6 +135,7 @@ class GoalSignalReader {
     final categoryTime = <String, Map<DateTime, num>>{};
     final categoryTimeSessions = <String, List<GoalCategoryTimeSession>>{};
     DateTime? categoryTimeEvidenceStart;
+    var hasActiveCategoryTimer = false;
     if (needs.categoryTimeCriteria.isNotEmpty) {
       final requestedEvidenceStart = categorySessionEvidenceStart ?? rangeStart;
       final evidenceStart = requestedEvidenceStart.isAfter(rangeEnd)
@@ -171,6 +172,9 @@ class GoalSignalReader {
         for (final criterion in needs.categoryTimeCriteria)
           criterion.categoryId,
       };
+      hasActiveCategoryTimer =
+          activeTimerRow != null &&
+          watchedCategoryIds.contains(activeTimerRow.categoryId);
       if (includeCategoryTimeSessions) {
         for (final row in rows) {
           final categoryId = row.categoryId;
@@ -221,6 +225,7 @@ class GoalSignalReader {
           needs.categoryTimeCriteria.isEmpty || !includeCategoryTimeSessions
           ? null
           : categoryTimeEnd,
+      hasActiveCategoryTimer: hasActiveCategoryTimer,
     );
   }
 
@@ -244,7 +249,6 @@ class GoalSignalReader {
 
     final persistedEnd = current.meta.dateTo;
     final dateTo = persistedEnd.isAfter(reference) ? persistedEnd : reference;
-    if (!dateTo.isAfter(current.meta.dateFrom)) return null;
     return (
       entryId: current.meta.id,
       dateFrom: current.meta.dateFrom,

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -63,6 +63,7 @@ class GoalSignalReader {
       reference.month,
       reference.day + 1,
     );
+    final categoryTimeEnd = reference.isBefore(rangeEnd) ? reference : rangeEnd;
 
     final quantitative = <String, Map<DateTime, num>>{};
     for (final dataType in needs.quantitativeTypes) {
@@ -142,12 +143,12 @@ class GoalSignalReader {
           : rangeStart;
       final rows = await _journalDb.insightsTimeRows(
         start: queryStart,
-        end: rangeEnd,
+        end: categoryTimeEnd,
       );
       final activeTimerRow = await _activeTimerRow(reference);
       if (activeTimerRow != null &&
           activeTimerRow.dateTo.isAfter(queryStart) &&
-          activeTimerRow.dateFrom.isBefore(rangeEnd)) {
+          activeTimerRow.dateFrom.isBefore(categoryTimeEnd)) {
         // The persisted row for a running timer has a stale zero-length end
         // and is normally absent from Insights. If it was saved while still
         // running, replace that stale prefix rather than duplicating the raw
@@ -155,9 +156,7 @@ class GoalSignalReader {
         // way, but the model-facing session list must remain one session.
         rows
           ..removeWhere(
-            (row) =>
-                row.categoryId == activeTimerRow.categoryId &&
-                row.dateFrom == activeTimerRow.dateFrom,
+            (row) => row.entryId == activeTimerRow.entryId,
           )
           ..add(activeTimerRow)
           ..sort((a, b) => a.dateFrom.compareTo(b.dateFrom));
@@ -172,7 +171,9 @@ class GoalSignalReader {
           final dateFrom = row.dateFrom.isBefore(evidenceStart)
               ? evidenceStart
               : row.dateFrom;
-          final dateTo = row.dateTo.isAfter(rangeEnd) ? rangeEnd : row.dateTo;
+          final dateTo = row.dateTo.isAfter(categoryTimeEnd)
+              ? categoryTimeEnd
+              : row.dateTo;
           if (categoryId == null ||
               !watchedCategoryIds.contains(categoryId) ||
               !dateTo.isAfter(dateFrom)) {
@@ -197,7 +198,7 @@ class GoalSignalReader {
           rows: rows,
           criterion: criterion,
           rangeStart: rangeStart,
-          rangeEnd: rangeEnd,
+          rangeEnd: categoryTimeEnd,
         );
       }
     }
@@ -213,7 +214,7 @@ class GoalSignalReader {
       categoryTimeEvidenceEnd:
           needs.categoryTimeCriteria.isEmpty || !includeCategoryTimeSessions
           ? null
-          : rangeEnd,
+          : categoryTimeEnd,
     );
   }
 
@@ -222,18 +223,16 @@ class GoalSignalReader {
     final current = timeService?.getCurrent();
     if (current is! JournalEntry) return null;
 
-    final linked = timeService?.linkedFrom;
-    final needsPrivateFlag =
-        current.meta.private == true || linked?.meta.private == true;
+    final needsPrivateFlag = current.meta.private == true;
     final showPrivate =
         !needsPrivateFlag || await _journalDb.getConfigFlag('private');
     if (current.meta.private == true && !showPrivate) return null;
 
-    final linkedCategory = linked?.meta.private == true && !showPrivate
-        ? null
-        : linked?.meta.categoryId;
-    final categoryId = linkedCategory?.trim().isNotEmpty == true
-        ? linkedCategory
+    final resolvedCategory = await _journalDb.insightsTimeCategoryForEntry(
+      current.meta.id,
+    );
+    final categoryId = resolvedCategory?.trim().isNotEmpty == true
+        ? resolvedCategory
         : current.meta.categoryId;
     if (categoryId == null || categoryId.trim().isEmpty) return null;
 
@@ -241,6 +240,7 @@ class GoalSignalReader {
     final dateTo = persistedEnd.isAfter(reference) ? persistedEnd : reference;
     if (!dateTo.isAfter(current.meta.dateFrom)) return null;
     return (
+      entryId: current.meta.id,
       dateFrom: current.meta.dateFrom,
       dateTo: dateTo,
       categoryId: categoryId,
@@ -454,6 +454,33 @@ Set<String> goalSignalTriggerTokens(GoalCriterion criteria) {
       categoriesNotification,
       privateToggleNotification,
     },
+  };
+}
+
+/// Goal signals that should immediately run the deterministic evaluator.
+///
+/// Habit and measured-value writes are complete, bounded observations. A
+/// category-time mutation is intentionally excluded because tracked sessions
+/// can update frequently; those signals use [goalStaleSignalTriggerTokens].
+Set<String> goalImmediateSignalTriggerTokens(GoalCriterion criteria) {
+  final needs = _SignalNeeds()..collect(criteria);
+  return {
+    ...needs.quantitativeTypes,
+    ...needs.habitIds,
+    ...needs.measurableTypeIds,
+  };
+}
+
+/// High-frequency goal signals that invalidate the report without waking it.
+Set<String> goalStaleSignalTriggerTokens(GoalCriterion criteria) {
+  final needs = _SignalNeeds()..collect(criteria);
+  if (needs.categoryTimeCriteria.isEmpty) return const {};
+  return const {
+    textEntryNotification,
+    linkNotification,
+    taskNotification,
+    categoriesNotification,
+    privateToggleNotification,
   };
 }
 

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -45,13 +45,16 @@ class GoalSignalReader {
   /// at [reference], covering the widest leaf window plus the short-term
   /// trend lookback. When [categorySessionEvidenceStart] is supplied, raw
   /// watched-category sessions extend back to that instant without widening
-  /// the deterministic criterion's authored evaluation window.
+  /// the deterministic criterion's authored evaluation window. A completed
+  /// historical period may supply [categoryTimeEndExclusive] as the following
+  /// local midnight; live periods default to clipping at [reference].
   Future<GoalSignalWindow> read({
     required GoalCriterion criteria,
     required DateTime reference,
     int shortTermDays = 3,
     bool includeCategoryTimeSessions = true,
     DateTime? categorySessionEvidenceStart,
+    DateTime? categoryTimeEndExclusive,
   }) async {
     final needs = _SignalNeeds()..collect(criteria);
     final rangeStart = _rangeStart(criteria, reference, shortTermDays);
@@ -63,7 +66,10 @@ class GoalSignalReader {
       reference.month,
       reference.day + 1,
     );
-    final categoryTimeEnd = reference.isBefore(rangeEnd) ? reference : rangeEnd;
+    final requestedCategoryTimeEnd = categoryTimeEndExclusive ?? reference;
+    final categoryTimeEnd = requestedCategoryTimeEnd.isBefore(rangeEnd)
+        ? requestedCategoryTimeEnd
+        : rangeEnd;
 
     final quantitative = <String, Map<DateTime, num>>{};
     for (final dataType in needs.quantitativeTypes) {
@@ -433,28 +439,6 @@ class GoalSignalReader {
     // Back to local wall-clock for the DB range query.
     return DateTime(earliest.year, earliest.month, earliest.day);
   }
-}
-
-/// The notification tokens a goal's criteria tree subscribes to: leaf
-/// `dataType` strings (quantitative entries notify with their dataType),
-/// `habitId`s (habit completions notify with their habitId) and
-/// measurable `dataTypeId`s (measurements notify with theirs). Category-time
-/// leaves subscribe to the broad journal/link/task/category tokens because
-/// any of those mutations can alter tracked duration or category attribution.
-Set<String> goalSignalTriggerTokens(GoalCriterion criteria) {
-  final needs = _SignalNeeds()..collect(criteria);
-  return {
-    ...needs.quantitativeTypes,
-    ...needs.habitIds,
-    ...needs.measurableTypeIds,
-    if (needs.categoryTimeCriteria.isNotEmpty) ...{
-      textEntryNotification,
-      linkNotification,
-      taskNotification,
-      categoriesNotification,
-      privateToggleNotification,
-    },
-  };
 }
 
 /// Goal signals that should immediately run the deterministic evaluator.

--- a/lib/features/goals/evaluation/goal_signal_window.dart
+++ b/lib/features/goals/evaluation/goal_signal_window.dart
@@ -39,6 +39,7 @@ class GoalSignalWindow {
     this.categoryTimeSessionsByCategory = const {},
     this.categoryTimeEvidenceStart,
     this.categoryTimeEvidenceEnd,
+    this.hasActiveCategoryTimer = false,
   });
 
   /// Journal quantitative data: data type string → day key → sum of that
@@ -75,6 +76,13 @@ class GoalSignalWindow {
   /// evidence. Null when the criteria tree watches no category time.
   final DateTime? categoryTimeEvidenceStart;
   final DateTime? categoryTimeEvidenceEnd;
+
+  /// Whether a currently running timer contributes to a watched category.
+  ///
+  /// A report rendered from the current elapsed prefix must remain stale:
+  /// in-memory timer ticks do not emit journal mutations, so the evidence can
+  /// keep changing after the report is written.
+  final bool hasActiveCategoryTimer;
 
   /// Daily sums for [dataType] restricted to [start]..[end] (inclusive).
   Map<DateTime, num> quantitativeInRange(

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -99,48 +99,65 @@ class GoalAgentPhaseA {
       includeCategoryTimeSessions: false,
     );
     final facts = derivation.facts;
-    final periodKey = derivation.periodKey;
-    final existingToday = derivation.existingToday;
-    final evaluation = facts.evaluation;
     final needsEscalation =
         facts.needsEscalation ||
         (activeAdExpired && automaticGoalAdEligible(facts, derivation.priors));
 
-    // One transaction: a register write acknowledging the transition
-    // without its escalation would be permanent — the next run reads the
-    // new status as previousStatus and never re-arms the missed wake.
+    final persisted = await persistDerivation(
+      agentId: agentId,
+      derivation: derivation,
+      now: now,
+      armEscalation: needsEscalation,
+    );
+    if (needsEscalation && persisted) {
+      _onEscalationArmed?.call();
+    }
+
+    return const WakeResult(success: true);
+  }
+
+  /// Persists one already-derived deterministic register snapshot.
+  ///
+  /// The explicit report-refresh path uses this without arming another Phase
+  /// B wake, so **Update now** advances health/register surfaces from the same
+  /// evidence snapshot that its prose report describes. Returns false when a
+  /// concurrent revision or deletion fences the write.
+  Future<bool> persistDerivation({
+    required String agentId,
+    required GoalWakeDerivation derivation,
+    required DateTime now,
+    bool armEscalation = false,
+  }) async {
     var fenced = false;
     await _syncService.runInTransaction(() async {
-      // A revision committing after this wake read the head must fence
-      // BOTH writes: a v1 register would overwrite the day's row under
-      // the new spec, and a v1 escalation would arm an old-target Phase
-      // B wake after the revision's sweep already cleaned up.
+      // A revision committing after derivation must fence BOTH writes: an old
+      // register would overwrite today's row under the new spec, and an old
+      // escalation would arm Phase B after the revision sweep already ran.
       final headNow = await _repository.getEntity(goalSpecHeadId(agentId));
-      // A MISSING head means the goal was hard-deleted mid-wake:
-      // recreating the register or an escalation would sync rows back
-      // out after the user requested permanent deletion.
-      if (headNow is! GoalSpecHeadEntity || headNow.versionId != version.id) {
+      if (headNow is! GoalSpecHeadEntity ||
+          headNow.versionId != derivation.version.id) {
         fenced = true;
         return;
       }
       await _upsertRegister(
         agentId: agentId,
-        version: version,
-        evaluation: evaluation,
-        facts: facts,
+        version: derivation.version,
+        evaluation: derivation.facts.evaluation,
+        facts: derivation.facts,
         now: now,
-        periodKey: periodKey,
-        existing: existingToday,
+        periodKey: derivation.periodKey,
+        existing: derivation.existingToday,
       );
-      if (needsEscalation) {
-        await _armEscalation(agentId, now, periodKey, facts.previousStatus);
+      if (armEscalation) {
+        await _armEscalation(
+          agentId,
+          now,
+          derivation.periodKey,
+          derivation.facts.previousStatus,
+        );
       }
     });
-    if (needsEscalation && !fenced) {
-      _onEscalationArmed?.call();
-    }
-
-    return const WakeResult(success: true);
+    return !fenced;
   }
 
   /// The render-side staleness filter hides an overdue ad immediately,
@@ -276,6 +293,7 @@ class GoalAgentPhaseA {
         categoryTimeSessionsByCategory: signals.categoryTimeSessionsByCategory,
         categoryTimeEvidenceStart: signals.categoryTimeEvidenceStart,
         categoryTimeEvidenceEnd: signals.categoryTimeEvidenceEnd,
+        hasActiveCategoryTimer: signals.hasActiveCategoryTimer,
       ),
       periodKey: periodKey,
       priors: priors,

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -225,6 +225,7 @@ class GoalAgentPhaseA {
     required DateTime now,
     bool includeCategoryTimeSessions = true,
     DateTime? categorySessionEvidenceStart,
+    DateTime? categoryTimeEndExclusive,
   }) async {
     final signals = await _signalReader.read(
       criteria: version.criteria,
@@ -232,6 +233,7 @@ class GoalAgentPhaseA {
       shortTermDays: _policy.shortTermDays,
       includeCategoryTimeSessions: includeCategoryTimeSessions,
       categorySessionEvidenceStart: categorySessionEvidenceStart,
+      categoryTimeEndExclusive: categoryTimeEndExclusive,
     );
     final evaluation = _evaluator.evaluate(version.criteria, signals, now);
     final shortTerm = _evaluator.shortTermAttainment(

--- a/lib/features/goals/runtime/goal_wake_facts.dart
+++ b/lib/features/goals/runtime/goal_wake_facts.dart
@@ -40,6 +40,7 @@ class GoalWakeFacts {
     this.categoryTimeSessionsByCategory = const {},
     this.categoryTimeEvidenceStart,
     this.categoryTimeEvidenceEnd,
+    this.hasActiveCategoryTimer = false,
   });
 
   /// Policy-derived status for the evaluation day.
@@ -59,6 +60,10 @@ class GoalWakeFacts {
   categoryTimeSessionsByCategory;
   final DateTime? categoryTimeEvidenceStart;
   final DateTime? categoryTimeEvidenceEnd;
+
+  /// Whether the category-time snapshot contains a still-running timer.
+  /// Reports built from this prefix remain stale until a later settled wake.
+  final bool hasActiveCategoryTimer;
 
   /// Whether the status changed against the last persisted register row.
   /// A first-ever evaluation counts as a transition (there is a new fact

--- a/lib/features/goals/service/goal_agent_service.dart
+++ b/lib/features/goals/service/goal_agent_service.dart
@@ -176,25 +176,43 @@ class GoalAgentService {
     );
   }
 
-  /// Evidence-triggered wakes: the goal agent listens to exactly the
-  /// signals its criteria reference — leaf dataTypes, habitIds and
-  /// measurable ids — never a global sentinel. `drainImmediately`: a habit
-  /// check-off is atomic evidence and Phase A is €0, so the wake dispatches
-  /// now — the user's tap is acknowledged in seconds, not after the
-  /// 120-second coalescing window built for costly task-agent wakes.
+  /// Observes exactly the signals referenced by the goal criteria.
+  ///
+  /// Bounded habit and measured-data writes immediately run the deterministic
+  /// evaluator. Category-time activity is high-frequency and instead marks
+  /// the report stale; the daily cadence or Update now consumes those changes.
   void registerSignalSubscription(String agentId, GoalCriterion criteria) {
-    _orchestrator.addSubscription(
-      AgentSubscription(
-        id: goalSignalSubscriptionId(agentId),
-        agentId: agentId,
-        matchEntityIds: goalSignalTriggerTokens(criteria),
-        deferPropagatedMatches: false,
-        drainImmediately: true,
-      ),
-    );
+    _orchestrator.removeSubscriptions(agentId);
+    final immediateTokens = goalImmediateSignalTriggerTokens(criteria);
+    if (immediateTokens.isNotEmpty) {
+      _orchestrator.addSubscription(
+        AgentSubscription(
+          id: goalSignalSubscriptionId(agentId),
+          agentId: agentId,
+          matchEntityIds: immediateTokens,
+          deferPropagatedMatches: false,
+          drainImmediately: true,
+        ),
+      );
+    }
+    final staleTokens = goalStaleSignalTriggerTokens(criteria);
+    if (staleTokens.isNotEmpty) {
+      _orchestrator.addSubscription(
+        AgentSubscription(
+          id: goalStaleSignalSubscriptionId(agentId),
+          agentId: agentId,
+          matchEntityIds: staleTokens,
+          reportStaleOnly: true,
+        ),
+      );
+    }
   }
 }
 
 /// Stable subscription id, so repeated `restoreSubscriptions` replace
 /// instead of accumulate.
 String goalSignalSubscriptionId(String agentId) => '${agentId}_goal_signals';
+
+/// Stable id for category-time observation that marks the report stale.
+String goalStaleSignalSubscriptionId(String agentId) =>
+    '${agentId}_goal_stale_signals';

--- a/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
+++ b/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
@@ -115,7 +115,13 @@ class GoalSignalSyncDispatcher {
       if (tokens.contains(agentId) &&
           await _registerMisaligned(agentId, version.id))
         goalSpecHeadId(agentId),
-      ...goalSignalTriggerTokens(version.criteria).intersection(tokens),
+      // Category-time mutations are high-frequency observations. Their
+      // source device persists the shared report-stale watermark, so a
+      // receiving device must not turn the same mutation into another Phase A
+      // run. Bounded signals remain immediate on every device.
+      ...goalImmediateSignalTriggerTokens(
+        version.criteria,
+      ).intersection(tokens),
     };
   }
 

--- a/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
+++ b/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
@@ -14,12 +14,13 @@ import 'package:lotti/services/domain_logging.dart';
 /// Bridges the sync blind spot for goal signals (ADR 0054 Decision 4).
 ///
 /// `WakeOrchestrator` deliberately listens to `localUpdateStream` only —
-/// synced writes must not wake LLM tiers. But goal *Phase A* is
-/// deterministic and idempotent (keyed registers), so a desktop receiving
-/// phone-imported steps runs the €0 tier directly and converges instead of
-/// showing stale registers. Phase B is never triggered from here: if
-/// Phase A finds an LLM-worthy transition it arms the escalation wake, and
-/// the scheduled-wake manager's lease election picks exactly one device.
+/// synced writes must not wake LLM tiers. Bounded observations run goal
+/// *Phase A* directly because it is deterministic and idempotent (keyed
+/// registers). High-frequency category-time mutations only advance the
+/// receiving agent's report-stale watermark; cadence or Update now consumes
+/// them later. Phase B is never triggered from here: if Phase A finds an
+/// LLM-worthy transition it arms the escalation wake, and the scheduled-wake
+/// manager's lease election picks exactly one device.
 class GoalSignalSyncDispatcher {
   GoalSignalSyncDispatcher({
     required this._agentService,
@@ -43,9 +44,11 @@ class GoalSignalSyncDispatcher {
   /// concurrent evaluations of the same goal.
   final _inFlight = <String>{};
 
-  /// Runs Phase A for every goal agent whose signal tokens intersect the
-  /// synced batch. Never throws; each agent is contained individually so
-  /// one corrupt goal cannot suppress updates for unrelated goals.
+  /// Applies every goal agent's matching synced-signal policy.
+  ///
+  /// Bounded signals run Phase A; category-time signals mark the report stale
+  /// without a wake. Never throws: each agent is contained individually so one
+  /// corrupt goal cannot suppress updates for unrelated goals.
   Future<void> dispatchBatch(Set<String> tokens) async {
     final List<AgentIdentityEntity> agents;
     try {
@@ -62,17 +65,22 @@ class GoalSignalSyncDispatcher {
       _inFlight.add(identity.agentId);
       try {
         final matched = await _matchedTokens(identity.agentId, tokens);
-        if (matched.isEmpty) continue;
-        final runKey =
-            'goal-sync:${identity.agentId}:'
-            '${clock.now().millisecondsSinceEpoch}';
-        await _phaseA.execute(
-          agentIdentity: identity,
-          runKey: runKey,
-          triggerTokens: matched,
-          threadId: runKey,
-        );
-        _onAgentEvaluated?.call(identity.agentId);
+        if (matched.immediate.isEmpty && matched.stale.isEmpty) continue;
+        if (matched.stale.isNotEmpty) {
+          await _agentService.markReportStale(identity.agentId);
+        }
+        if (matched.immediate.isNotEmpty) {
+          final runKey =
+              'goal-sync:${identity.agentId}:'
+              '${clock.now().millisecondsSinceEpoch}';
+          await _phaseA.execute(
+            agentIdentity: identity,
+            runKey: runKey,
+            triggerTokens: matched.immediate,
+            threadId: runKey,
+          );
+          _onAgentEvaluated?.call(identity.agentId);
+        }
       } catch (error, stackTrace) {
         _log(
           'goal signal sync dispatch failed for one agent',
@@ -94,15 +102,17 @@ class GoalSignalSyncDispatcher {
     );
   }
 
-  Future<Set<String>> _matchedTokens(
+  Future<_GoalSignalMatches> _matchedTokens(
     String agentId,
     Set<String> tokens,
   ) async {
     final head = await _repository.getEntity(goalSpecHeadId(agentId));
-    if (head is! GoalSpecHeadEntity) return const {};
+    if (head is! GoalSpecHeadEntity) return const _GoalSignalMatches();
     final version = await _repository.getEntity(head.versionId);
-    if (version is! GoalSpecVersionEntity) return const {};
-    return {
+    if (version is! GoalSpecVersionEntity) {
+      return const _GoalSignalMatches();
+    }
+    final immediate = {
       // A synced HEAD is itself a signal: after disconnected approvals
       // settle, the register may have resolved to the other version —
       // one immediate €0 recompute realigns health with the standing
@@ -115,14 +125,19 @@ class GoalSignalSyncDispatcher {
       if (tokens.contains(agentId) &&
           await _registerMisaligned(agentId, version.id))
         goalSpecHeadId(agentId),
-      // Category-time mutations are high-frequency observations. Their
-      // source device persists the shared report-stale watermark, so a
-      // receiving device must not turn the same mutation into another Phase A
-      // run. Bounded signals remain immediate on every device.
+      // Category-time mutations are high-frequency observations. They never
+      // run Phase A here; the separate stale intersection below advances the
+      // receiving device's watermark so late journal delivery cannot leave a
+      // newly refreshed report looking current. Bounded signals remain
+      // immediate on every device.
       ...goalImmediateSignalTriggerTokens(
         version.criteria,
       ).intersection(tokens),
     };
+    final stale = goalStaleSignalTriggerTokens(
+      version.criteria,
+    ).intersection(tokens);
+    return _GoalSignalMatches(immediate: immediate, stale: stale);
   }
 
   /// Whether the newest progress register was computed under a version
@@ -141,6 +156,16 @@ class GoalSignalSyncDispatcher {
     final latest = registers.firstOrNull;
     return latest != null && latest.specVersionId != versionId;
   }
+}
+
+class _GoalSignalMatches {
+  const _GoalSignalMatches({
+    this.immediate = const {},
+    this.stale = const {},
+  });
+
+  final Set<String> immediate;
+  final Set<String> stale;
 }
 
 /// App-lifetime subscription pumping synced batches into the dispatcher

--- a/lib/features/goals/ui/pages/goal_agent_detail_page.dart
+++ b/lib/features/goals/ui/pages/goal_agent_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/agents/ui/agent_internals_panel.dart';
 import 'package:lotti/features/agents/ui/change_set_summary_card.dart';
 import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
+import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
@@ -41,6 +42,7 @@ class GoalAgentDetailPage extends ConsumerWidget {
     final tokens = context.designTokens;
     final identityAsync = ref.watch(agentIdentityProvider(agentId));
     final healthAsync = ref.watch(goalAgentHealthProvider(agentId));
+    final agentState = ref.watch(agentStateProvider(agentId)).value;
     // Stale-while-revalidate: `.value` keeps the last render across
     // background reloads; only a load that has never produced data gets
     // the spinner. An errored load must not claim "no report yet".
@@ -192,6 +194,8 @@ class GoalAgentDetailPage extends ConsumerWidget {
           healthAsync: healthAsync,
           nudges: nudges,
           report: latestReport,
+          reportIsStale:
+              agentState is AgentStateEntity && agentState.isReportStale,
           canRefresh: isActive,
         ),
         SizedBox(height: tokens.spacing.cardItemSpacing),
@@ -323,6 +327,7 @@ class _AgentSayingSection extends ConsumerWidget {
     required this.healthAsync,
     required this.nudges,
     required this.report,
+    required this.reportIsStale,
     required this.canRefresh,
   });
 
@@ -330,6 +335,7 @@ class _AgentSayingSection extends ConsumerWidget {
   final AsyncValue<GoalAgentHealth> healthAsync;
   final List<GoalBannerEntry> nudges;
   final AgentReportEntity? report;
+  final bool reportIsStale;
   final bool canRefresh;
 
   @override
@@ -341,14 +347,28 @@ class _AgentSayingSection extends ConsumerWidget {
     final header = Row(
       children: [
         Expanded(
-          child: Text(
-            context.messages.goalDetailSayingTitle,
-            style: tokens.typography.styles.others.caption.copyWith(
-              color: tokens.colors.alert.warning.ink,
-            ),
+          child: Wrap(
+            spacing: tokens.spacing.step3,
+            runSpacing: tokens.spacing.step1,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                context.messages.goalDetailSayingTitle,
+                style: tokens.typography.styles.others.caption.copyWith(
+                  color: tokens.colors.alert.warning.ink,
+                ),
+              ),
+              if (reportIsStale && (report != null || oneLiner != null))
+                DesignSystemBadge.outlined(
+                  label: context.messages.taskAgentStatusOutOfDate,
+                  tone: DesignSystemBadgeTone.warning,
+                  semanticLabel: context.messages.taskAgentReportOutdatedTitle,
+                ),
+            ],
           ),
         ),
-        if (canRefresh)
+        if (canRefresh) ...[
+          SizedBox(width: tokens.spacing.step2),
           DesignSystemButton(
             label: context.messages.taskAgentUpdateNow,
             onPressed: () => ref
@@ -359,6 +379,7 @@ class _AgentSayingSection extends ConsumerWidget {
             leadingIcon: Icons.refresh_rounded,
             isLoading: isRefreshing,
           ),
+        ],
       ],
     );
     final reportCard = _GoalReportCard(

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -227,6 +227,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
     final escalationPeriod = goalEscalationPeriodFromTriggerTokens(
       triggerTokens,
     );
+    final overdueEscalation = _isPastPeriod(escalationPeriod, now);
     final reference = _escalationReference(escalationPeriod, now);
     // A delayed escalation may outlive a spec revision: the period's
     // register row records the version that actually armed the wake, and
@@ -257,6 +258,9 @@ class GoalAgentWorkflow with AgentErrorLogging {
       version: version,
       now: reference,
       categorySessionEvidenceStart: agentIdentity.createdAt,
+      categoryTimeEndExclusive: overdueEscalation
+          ? _periodEndExclusive(escalationPeriod!)
+          : null,
     );
     // Phase A persisted the transition's register row BEFORE arming this
     // wake, so re-deriving sees the new status as previousStatus and the
@@ -597,7 +601,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
         }
       }
 
-      return const WakeResult(success: true);
+      return WakeResult(
+        success: true,
+        reportUpdated: strategy.hasReport,
+      );
     } catch (error, stackTrace) {
       _domainLogger?.error(
         LogDomain.agentWorkflow,
@@ -839,6 +846,13 @@ class GoalAgentWorkflow with AgentErrorLogging {
     return DateTime(parts.$1, parts.$2, parts.$3, 23, 59, 59);
   }
 
+  /// Exclusive local end of an encoded day, preserving the final second.
+  DateTime? _periodEndExclusive(String periodKey) {
+    final parts = _periodParts(periodKey);
+    if (parts == null) return null;
+    return DateTime(parts.$1, parts.$2, parts.$3 + 1);
+  }
+
   (int, int, int)? _periodParts(String periodKey) {
     final parts = periodKey.split('-');
     if (parts.length != 3) return null;
@@ -855,10 +869,13 @@ class GoalAgentWorkflow with AgentErrorLogging {
   /// lexically ordered, so a plain string compare detects a past period.
   DateTime _escalationReference(String? periodKey, DateTime now) {
     if (periodKey == null) return now;
-    final today = const GoalWindow.day().periodKey(now);
-    if (periodKey.compareTo(today) >= 0) return now;
+    if (!_isPastPeriod(periodKey, now)) return now;
     return _periodEnd(periodKey) ?? now;
   }
+
+  bool _isPastPeriod(String? periodKey, DateTime now) =>
+      periodKey != null &&
+      periodKey.compareTo(const GoalWindow.day().periodKey(now)) < 0;
 
   /// glm-5.2 on Melious is the validated default (the model the eval
   /// matrix proved the contract against); an AI profile on the agent's

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -64,6 +64,20 @@ String _goalAgentReplyPayloadId(String agentId, String runKey) =>
 /// How many recent observations feed the FACTS block.
 const goalObservationLookback = 12;
 
+/// Durable outcomes from a goal wake's transactional output batch.
+class GoalOutputPersistenceResult {
+  const GoalOutputPersistenceResult({
+    required this.attributionFinalized,
+    required this.reportHeadAdvanced,
+  });
+
+  /// Whether report-backed AI attribution has a durable carrier.
+  final bool attributionFinalized;
+
+  /// Whether this wake replaced the report selected by the current head.
+  final bool reportHeadAdvanced;
+}
+
 /// Phase B of the goal-agent wake (ADR 0054): the lease-elected LLM tier.
 ///
 /// Runs only when an escalation wake fires (the router keys on the
@@ -262,6 +276,14 @@ class GoalAgentWorkflow with AgentErrorLogging {
           ? _periodEndExclusive(escalationPeriod!)
           : null,
     );
+    if (reportRefresh) {
+      final persisted = await _phaseA.persistDerivation(
+        agentId: agentId,
+        derivation: derivation,
+        now: now,
+      );
+      if (!persisted) return const WakeResult(success: true);
+    }
     // Phase A persisted the transition's register row BEFORE arming this
     // wake, so re-deriving sees the new status as previousStatus and the
     // transition vanishes. The wake record carries the PRE-transition
@@ -287,6 +309,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
           derivation.facts.categoryTimeSessionsByCategory,
       categoryTimeEvidenceStart: derivation.facts.categoryTimeEvidenceStart,
       categoryTimeEvidenceEnd: derivation.facts.categoryTimeEvidenceEnd,
+      hasActiveCategoryTimer: derivation.facts.hasActiveCategoryTimer,
     );
 
     // Spec-scoped like the persistence snapshot: an old-spec fresh
@@ -319,8 +342,9 @@ class GoalAgentWorkflow with AgentErrorLogging {
         : '$renderedFacts\n\nPENDING USER MESSAGE:\n$pendingUserMessage';
     if (reportRefresh) {
       factsBlock =
-          '$factsBlock\n\nUSER REQUESTED REPORT REFRESH AFTER A HABIT EDIT. '
-          'Update the standing report from the authoritative FACTS.';
+          '$factsBlock\n\nUSER REQUESTED REPORT REFRESH AFTER WATCHED '
+          'EVIDENCE CHANGED. Update the standing report from the '
+          'authoritative FACTS.';
     }
     if (userRequestedAd) {
       factsBlock =
@@ -527,8 +551,9 @@ class GoalAgentWorkflow with AgentErrorLogging {
       }
 
       var attributionFinalized = false;
+      var reportHeadAdvanced = false;
       try {
-        attributionFinalized = await persistOutputs(
+        final persistence = await persistOutputs(
           agentId: agentId,
           runKey: runKey,
           threadId: threadId,
@@ -544,6 +569,8 @@ class GoalAgentWorkflow with AgentErrorLogging {
               ? null
               : 'chat:$chatMessageId',
         );
+        attributionFinalized = persistence.attributionFinalized;
+        reportHeadAdvanced = persistence.reportHeadAdvanced;
         outputsCommitted = true;
       } catch (error, stackTrace) {
         final replyCommitted =
@@ -603,7 +630,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
 
       return WakeResult(
         success: true,
-        reportUpdated: strategy.hasReport,
+        reportUpdated: reportHeadAdvanced && !facts.hasActiveCategoryTimer,
       );
     } catch (error, stackTrace) {
       _domainLogger?.error(
@@ -1085,11 +1112,11 @@ class GoalAgentWorkflow with AgentErrorLogging {
   /// directly to pin the ad-state guards (dismissal-terminal defense,
   /// rerun-requires-retired) that the in-conversation validation makes
   /// hard to reach through the loop.
-  /// Returns whether the wake's attribution envelope was finalized (a
-  /// report existed and the projection landed) — the caller terminalizes
-  /// the session as carrierless otherwise.
+  /// Returns the durable report-carrier and standing-head outcomes. The caller
+  /// terminalizes attribution without a carrier and only clears report
+  /// staleness when the current head actually advanced.
   @visibleForTesting
-  Future<bool> persistOutputs({
+  Future<GoalOutputPersistenceResult> persistOutputs({
     required String agentId,
     required String runKey,
     required String threadId,
@@ -1107,6 +1134,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
       reportId: reportId,
     );
     var attributionFinalized = false;
+    var reportHeadAdvanced = false;
     var fenced = false;
 
     await _syncService.runInTransaction(() async {
@@ -1299,6 +1327,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
               vectorClock: null,
             ),
           );
+          reportHeadAdvanced = true;
         }
       }
 
@@ -1651,7 +1680,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
           'interactive goal turn was fenced by a concurrent spec revision',
         );
       }
-      return false;
+      return const GoalOutputPersistenceResult(
+        attributionFinalized: false,
+        reportHeadAdvanced: false,
+      );
     }
 
     // Finalize AFTER the transaction: the projection must never describe
@@ -1671,7 +1703,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
         attributionFinalized = true;
       }
     }
-    return attributionFinalized;
+    return GoalOutputPersistenceResult(
+      attributionFinalized: attributionFinalized,
+      reportHeadAdvanced: reportHeadAdvanced,
+    );
   }
 }
 

--- a/lib/features/goals/workflow/goal_facts_renderer.dart
+++ b/lib/features/goals/workflow/goal_facts_renderer.dart
@@ -7,6 +7,8 @@ import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
+import 'package:lotti/features/insights/logic/time_bucketing.dart';
+import 'package:lotti/features/insights/model/insights_models.dart';
 
 // The dismissal quiet window is the REST OF THE LOCAL CALENDAR DAY (see
 // `GoalFactsRenderer.dismissalCooldownActive`): a rolling duration would
@@ -128,7 +130,7 @@ class GoalFactsRenderer {
                 'categoryId': session.categoryId,
                 'startedAtLocal': session.dateFrom.toIso8601String(),
                 'endedAtLocal': session.dateTo.toIso8601String(),
-                'durationMinutes': session.duration.inMinutes,
+                'durationMinutes': _minutes(session.duration.inSeconds),
               },
           ],
           'interpretationPolicy':
@@ -175,36 +177,46 @@ class GoalFactsRenderer {
     String categoryId,
     List<GoalCategoryTimeSession> sessions,
   ) {
-    final minutesByLocalHour = List<int>.filled(24, 0);
-    final minutesByLocalWeekday = List<int>.filled(7, 0);
-    var totalMinutes = 0;
-    for (final session in sessions) {
-      totalMinutes += session.duration.inMinutes;
-      var cursor = session.dateFrom;
-      while (cursor.isBefore(session.dateTo)) {
+    final secondsByLocalHour = List<int>.filled(24, 0);
+    final secondsByLocalWeekday = List<int>.filled(7, 0);
+    final merged = mergeIntervals([
+      for (final session in sessions)
+        TimeInterval(session.dateFrom, session.dateTo),
+    ]);
+    var totalSeconds = 0;
+    for (final interval in merged) {
+      totalSeconds += interval.duration.inSeconds;
+      var cursor = interval.start;
+      while (cursor.isBefore(interval.end)) {
         final nextHour = DateTime(
           cursor.year,
           cursor.month,
           cursor.day,
           cursor.hour + 1,
         );
-        final segmentEnd = nextHour.isBefore(session.dateTo)
+        final segmentEnd = nextHour.isBefore(interval.end)
             ? nextHour
-            : session.dateTo;
-        final minutes = segmentEnd.difference(cursor).inMinutes;
-        minutesByLocalHour[cursor.hour] += minutes;
-        minutesByLocalWeekday[cursor.weekday - DateTime.monday] += minutes;
+            : interval.end;
+        final seconds = segmentEnd.difference(cursor).inSeconds;
+        secondsByLocalHour[cursor.hour] += seconds;
+        secondsByLocalWeekday[cursor.weekday - DateTime.monday] += seconds;
         cursor = segmentEnd;
       }
     }
     return {
       'categoryId': categoryId,
       'sessionCount': sessions.length,
-      'totalMinutes': totalMinutes,
-      'minutesByLocalHour': minutesByLocalHour,
-      'minutesByLocalWeekday': minutesByLocalWeekday,
+      'totalMinutes': _minutes(totalSeconds),
+      'minutesByLocalHour': [
+        for (final seconds in secondsByLocalHour) _minutes(seconds),
+      ],
+      'minutesByLocalWeekday': [
+        for (final seconds in secondsByLocalWeekday) _minutes(seconds),
+      ],
     };
   }
+
+  double _minutes(int seconds) => seconds / Duration.secondsPerMinute;
 
   /// Worsening means: strictly declining attainment over today plus at
   /// least two prior periods (three data points, each below the one

--- a/test/database/database_insights_queries_test.dart
+++ b/test/database/database_insights_queries_test.dart
@@ -197,6 +197,7 @@ void main() {
         );
 
         expect(rows, hasLength(1));
+        expect(rows.single.entryId, 'entry-1');
         expect(rows.single.dateFrom, DateTime(2024, 3, 1, 9));
         expect(rows.single.dateTo, DateTime(2024, 3, 1, 10, 30));
         expect(rows.single.categoryId, 'cat-own');
@@ -279,6 +280,41 @@ void main() {
       expect(rows, hasLength(1));
       expect(rows.single.categoryId, 'cat-b');
     });
+
+    test(
+      'live zero-duration attribution uses the same latest-task rule',
+      () async {
+        await db.updateJournalEntity(
+          buildTask(
+            id: 'task-a',
+            at: DateTime(2024, 3),
+            categoryId: 'cat-a',
+          ),
+        );
+        await db.updateJournalEntity(
+          buildTask(
+            id: 'task-b',
+            at: DateTime(2024, 3, 2),
+            categoryId: 'cat-b',
+          ),
+        );
+        await db.updateJournalEntity(
+          buildTimeEntry(
+            id: 'running',
+            dateFrom: DateTime(2024, 3, 3, 9),
+            dateTo: DateTime(2024, 3, 3, 9),
+            categoryId: 'entry-category',
+          ),
+        );
+        await link(fromId: 'task-a', toId: 'running');
+        await link(fromId: 'task-b', toId: 'running');
+
+        expect(
+          await db.insightsTimeCategoryForEntry('running'),
+          'cat-b',
+        );
+      },
+    );
 
     test('hidden links and deleted tasks do not steal attribution', () async {
       await db.updateJournalEntity(

--- a/test/features/agents/service/agent_service_test.dart
+++ b/test/features/agents/service/agent_service_test.dart
@@ -659,6 +659,18 @@ void main() {
       );
     });
 
+    group('markReportStale', () {
+      test('delegates to the no-wake watermark path', () async {
+        when(
+          () => mockOrchestrator.markReportStale('agent-1'),
+        ).thenAnswer((_) async {});
+
+        await service.markReportStale('agent-1');
+
+        verify(() => mockOrchestrator.markReportStale('agent-1')).called(1);
+      });
+    });
+
     group('clearScheduledWake', () {
       test('persists state with scheduledWakeAt cleared', () async {
         final state = makeTestState(

--- a/test/features/agents/state/agent_wiring_test.dart
+++ b/test/features/agents/state/agent_wiring_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
 import 'package:lotti/features/agents/state/agent_wiring.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
@@ -24,6 +25,7 @@ void main() {
     late MockWakeOrchestrator orchestrator;
     late MockUpdateNotifications notifications;
     late ProviderContainer container;
+    late Map<String, AgentWakeRunner> contributedRunners;
 
     setUp(() {
       agentService = MockAgentService();
@@ -32,6 +34,7 @@ void main() {
       templateService = MockAgentTemplateService();
       orchestrator = MockWakeOrchestrator();
       notifications = MockUpdateNotifications();
+      contributedRunners = {};
 
       // The orchestrator stores whatever executor is wired into a real field.
       WakeExecutor? wired;
@@ -53,6 +56,7 @@ void main() {
           agentServiceProvider.overrideWithValue(agentService),
           eventAgentWorkflowProvider.overrideWithValue(eventWorkflow),
           agentTemplateServiceProvider.overrideWithValue(templateService),
+          agentWakeRunnersProvider.overrideWithValue(contributedRunners),
         ],
       );
       addTearDown(container.dispose);
@@ -226,5 +230,43 @@ void main() {
         ),
       );
     });
+
+    test(
+      'goal runner preserves whether the standing report was updated',
+      () async {
+        when(() => agentService.getAgent('goal-1')).thenAnswer(
+          (_) async => makeTestIdentity(
+            id: 'goal-1',
+            agentId: 'goal-1',
+            kind: AgentKinds.goalAgent,
+          ),
+        );
+        contributedRunners[AgentKinds.goalAgent] =
+            ({
+              required agentIdentity,
+              required runKey,
+              required triggerTokens,
+              required threadId,
+            }) async => const WakeResult(
+              success: true,
+              mutatedEntries: {
+                'progress-1': VectorClock({'host-a': 1}),
+              },
+            );
+
+        final result = await wire()(
+          'goal-1',
+          'run-key',
+          const {},
+          'thread',
+        );
+
+        expect(result, {
+          'progress-1': const VectorClock({'host-a': 1}),
+        });
+        expect(result, isA<WakeExecutorResult>());
+        expect((result! as WakeExecutorResult).reportUpdated, isFalse);
+      },
+    );
   });
 }

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -490,6 +490,55 @@ void main() {
       );
 
       test(
+        'successful maintenance wake keeps a standing report stale when no '
+        'report was produced',
+        () async {
+          final staleAt = DateTime(2026, 7, 16, 8, 59);
+          final wakeAt = DateTime(2026, 7, 16, 9);
+          var state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(activeTaskId: 'entity-1'),
+                    updatedAt: staleAt,
+                    vectorClock: null,
+                    reportStaleAt: staleAt,
+                  )
+                  as AgentStateEntity;
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            syncEntityWriter: (entity) async {
+              state = entity as AgentStateEntity;
+            },
+            wakeExecutor: (_, _, _, _) async => WakeExecutorResult(
+              const {},
+              reportUpdated: false,
+            ),
+          );
+          queue.enqueue(
+            WakeJob(
+              runKey: 'maintenance-only',
+              agentId: 'agent-1',
+              reason: WakeReason.scheduled.name,
+              triggerTokens: const {},
+              createdAt: wakeAt,
+            ),
+          );
+
+          await withClock(Clock.fixed(wakeAt), orchestrator.processNext);
+
+          expect(state.reportFreshAt, isNull);
+          expect(state.reportStaleAt, staleAt);
+          expect(state.isReportStale, isTrue);
+        },
+      );
+
+      test(
         'change observed during a manual wake remains stale afterward',
         () async {
           final refreshStartedAt = DateTime(2026, 7, 16, 9);

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -257,6 +257,47 @@ void main() {
       );
 
       test(
+        'a stale-only subscription persists freshness without queueing work',
+        () async {
+          final signalAt = DateTime(2026, 8, 12, 18, 30);
+          var state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(activeTaskId: 'entity-1'),
+                    updatedAt: DateTime(2026, 8, 12, 18),
+                    vectorClock: null,
+                    reportFreshAt: DateTime(2026, 8, 12, 18, 15),
+                  )
+                  as AgentStateEntity;
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            syncEntityWriter: (entity) async {
+              state = entity as AgentStateEntity;
+            },
+          )..addSubscription(makeSub(reportStaleOnly: true));
+          final controller = StreamController<Set<String>>.broadcast();
+
+          await withClock(Clock.fixed(signalAt), () async {
+            await orchestrator.start(controller.stream);
+            controller.add({'entity-1'});
+            await pumpEventQueue();
+          });
+
+          expect(queue.isEmpty, isTrue);
+          expect(state.reportStaleAt, signalAt);
+          expect(state.reportFreshAt, DateTime(2026, 8, 12, 18, 15));
+          expect(state.isReportStale, isTrue);
+          await controller.close();
+        },
+      );
+
+      test(
         'a failed stale-watermark write is contained and reported',
         () async {
           // The watermark is a hint that the report has drifted, not the report

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -298,6 +298,45 @@ void main() {
       );
 
       test(
+        'markReportStale persists the supplied evidence-arrival timestamp '
+        'without queueing work',
+        () async {
+          final signalAt = DateTime(2026, 8, 12, 18, 30);
+          var state =
+              AgentDomainEntity.agentState(
+                    id: 'state-1',
+                    agentId: 'agent-1',
+                    slots: const AgentSlots(activeTaskId: 'entity-1'),
+                    updatedAt: DateTime(2026, 8, 12, 18),
+                    vectorClock: null,
+                    reportFreshAt: DateTime(2026, 8, 12, 18, 15),
+                  )
+                  as AgentStateEntity;
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => state);
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            syncEntityWriter: (entity) async {
+              state = entity as AgentStateEntity;
+            },
+          );
+
+          await orchestrator.markReportStale(
+            'agent-1',
+            occurredAt: signalAt,
+          );
+
+          expect(queue.isEmpty, isTrue);
+          expect(state.reportStaleAt, signalAt);
+          expect(state.reportFreshAt, DateTime(2026, 8, 12, 18, 15));
+          expect(state.isReportStale, isTrue);
+        },
+      );
+
+      test(
         'a failed stale-watermark write is contained and reported',
         () async {
           // The watermark is a hint that the report has drifted, not the report

--- a/test/features/agents/wake/wake_orchestrator_test_helpers.dart
+++ b/test/features/agents/wake/wake_orchestrator_test_helpers.dart
@@ -18,6 +18,7 @@ AgentSubscription makeSub({
   bool Function(Set<String> tokens)? predicate,
   bool deferPropagatedMatches = true,
   bool drainImmediately = false,
+  bool reportStaleOnly = false,
 }) {
   return AgentSubscription(
     id: id,
@@ -26,6 +27,7 @@ AgentSubscription makeSub({
     predicate: predicate,
     deferPropagatedMatches: deferPropagatedMatches,
     drainImmediately: drainImmediately,
+    reportStaleOnly: reportStaleOnly,
   );
 }
 

--- a/test/features/agents/workflow/wake_result_test.dart
+++ b/test/features/agents/workflow/wake_result_test.dart
@@ -16,6 +16,7 @@ void main() {
       expect(result.mutatedEntries, {
         'entity-1': const VectorClock({'host-a': 1}),
       });
+      expect(result.reportUpdated, isFalse);
       expect(result.error, isNull);
     });
 
@@ -28,9 +29,10 @@ void main() {
     });
 
     test('defaults mutatedEntries to empty map', () {
-      const result = WakeResult(success: true);
+      const result = WakeResult(success: true, reportUpdated: true);
 
       expect(result.mutatedEntries, isEmpty);
+      expect(result.reportUpdated, isTrue);
       expect(result.error, isNull);
     });
   });

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -774,6 +774,7 @@ void main() {
       contains(DateTime(2026, 8, 8, 23, 30)),
       reason: 'the in-memory timer endpoint must advance beyond persisted data',
     );
+    expect(window.hasActiveCategoryTimer, isTrue);
   });
 
   test('a hidden private active timer contributes no category time', () async {
@@ -814,6 +815,7 @@ void main() {
     );
 
     expect(window.categoryTimeDailyHours['coding-cap'], isEmpty);
+    expect(window.hasActiveCategoryTimer, isFalse);
     verify(() => journalDb.getConfigFlag('private')).called(1);
   });
 
@@ -849,6 +851,8 @@ void main() {
       criteria: criterion,
       reference: startedAt,
     );
+
+    expect(window.hasActiveCategoryTimer, isTrue);
 
     expect(window.categoryTimeDailyHours['coding-cap'], isEmpty);
     expect(window.categoryTimeSessionsByCategory, isEmpty);

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -65,6 +65,9 @@ void main() {
     timeService = MockTimeService();
     when(timeService.getCurrent).thenReturn(null);
     when(() => timeService.linkedFrom).thenReturn(null);
+    when(
+      () => journalDb.insightsTimeCategoryForEntry(any()),
+    ).thenAnswer((_) async => null);
     reader = GoalSignalReader(
       journalDb: journalDb,
       timeService: timeService,
@@ -541,16 +544,19 @@ void main() {
       ).thenAnswer(
         (_) async => [
           (
+            entryId: 'coding-a',
             dateFrom: DateTime(2026, 8, 8, 18),
             dateTo: DateTime(2026, 8, 8, 20),
             categoryId: 'vibe-coding',
           ),
           (
+            entryId: 'coding-b',
             dateFrom: DateTime(2026, 8, 8, 19),
             dateTo: DateTime(2026, 8, 8, 21),
             categoryId: 'vibe-coding',
           ),
           (
+            entryId: 'other',
             dateFrom: DateTime(2026, 8, 8, 17),
             dateTo: DateTime(2026, 8, 8, 22),
             categoryId: 'other',
@@ -560,7 +566,7 @@ void main() {
 
       final window = await reader.read(
         criteria: criterion,
-        reference: reference,
+        reference: DateTime(2026, 8, 8, 22),
       );
 
       expect(
@@ -569,6 +575,60 @@ void main() {
       );
     },
   );
+
+  test('category time excludes entries after the evaluation instant', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'coding-cap',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 2,
+    );
+    final reference = DateTime(2026, 8, 8, 12);
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        (
+          entryId: 'spans-now',
+          dateFrom: DateTime(2026, 8, 8, 11),
+          dateTo: DateTime(2026, 8, 8, 13),
+          categoryId: 'vibe-coding',
+        ),
+        (
+          entryId: 'future',
+          dateFrom: DateTime(2026, 8, 8, 13),
+          dateTo: DateTime(2026, 8, 8, 14),
+          categoryId: 'vibe-coding',
+        ),
+      ],
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: reference,
+    );
+
+    final queryEnd = verify(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: captureAny(named: 'end'),
+      ),
+    ).captured.single;
+    expect(queryEnd, reference);
+    expect(
+      window.categoryTimeDailyHours['coding-cap'],
+      {DateTime.utc(2026, 8, 8): 1},
+    );
+    expect(
+      window.categoryTimeSessionsByCategory['vibe-coding']?.single.dateTo,
+      reference,
+    );
+    expect(window.categoryTimeEvidenceEnd, reference);
+  });
 
   test('category time replaces a persisted active timer prefix', () async {
     const criterion = GoalCriterion.categoryTime(
@@ -587,8 +647,15 @@ void main() {
     ).thenAnswer(
       (_) async => [
         (
+          entryId: 'running',
           dateFrom: startedAt,
           dateTo: DateTime(2026, 8, 8, 22, 15),
+          categoryId: 'vibe-coding',
+        ),
+        (
+          entryId: 'unrelated-same-start',
+          dateFrom: startedAt,
+          dateTo: DateTime(2026, 8, 8, 22, 30),
           categoryId: 'vibe-coding',
         ),
       ],
@@ -613,7 +680,7 @@ void main() {
         updatedAt: startedAt,
         dateFrom: startedAt,
         dateTo: startedAt,
-        categoryId: 'vibe-coding',
+        categoryId: 'wrong-linked-category',
       ),
       data: TaskData(
         status: TaskStatus.open(
@@ -629,6 +696,9 @@ void main() {
     );
     when(timeService.getCurrent).thenReturn(running);
     when(() => timeService.linkedFrom).thenReturn(linkedTask);
+    when(
+      () => journalDb.insightsTimeCategoryForEntry('running'),
+    ).thenAnswer((_) async => 'vibe-coding');
 
     final window = await reader.read(
       criteria: criterion,
@@ -641,12 +711,16 @@ void main() {
     );
     expect(
       window.categoryTimeSessionsByCategory['vibe-coding'],
-      hasLength(1),
-      reason: 'the persisted timer prefix must not duplicate raw evidence',
+      hasLength(2),
+      reason:
+          'the persisted timer prefix is replaced by id without deleting an '
+          'unrelated session that happens to share its start and category',
     );
     expect(
-      window.categoryTimeSessionsByCategory['vibe-coding']?.single.dateTo,
-      DateTime(2026, 8, 8, 23, 30),
+      window.categoryTimeSessionsByCategory['vibe-coding']?.map(
+        (session) => session.dateTo,
+      ),
+      contains(DateTime(2026, 8, 8, 23, 30)),
       reason: 'the in-memory timer endpoint must advance beyond persisted data',
     );
   });
@@ -747,11 +821,13 @@ void main() {
       ).thenAnswer(
         (_) async => [
           (
+            entryId: 'old-session',
             dateFrom: DateTime(2026, 8),
             dateTo: DateTime(2026, 8, 1, 1),
             categoryId: 'vibe-coding',
           ),
           (
+            entryId: 'current-session',
             dateFrom: DateTime(2026, 8, 8, 10),
             dateTo: DateTime(2026, 8, 8, 11, 30),
             categoryId: 'vibe-coding',
@@ -855,11 +931,13 @@ void main() {
     ).thenAnswer(
       (_) async => [
         (
+          entryId: 'overnight',
           dateFrom: DateTime(2026, 8, 7, 20),
           dateTo: DateTime(2026, 8, 8, 8),
           categoryId: 'vibe-coding',
         ),
         (
+          entryId: 'midday',
           dateFrom: DateTime(2026, 8, 8, 12),
           dateTo: DateTime(2026, 8, 8, 13),
           categoryId: 'vibe-coding',
@@ -912,11 +990,13 @@ void main() {
     ).thenAnswer(
       (_) async => [
         (
+          entryId: 'allowed',
           dateFrom: DateTime(2026, 8, 8, 21),
           dateTo: DateTime(2026, 8, 8, 22),
           categoryId: 'screen-time',
         ),
         (
+          entryId: 'prohibited',
           dateFrom: DateTime(2026, 8, 8, 22),
           dateTo: DateTime(2026, 8, 8, 22, 30),
           categoryId: 'screen-time',
@@ -926,7 +1006,7 @@ void main() {
 
     final window = await reader.read(
       criteria: criterion,
-      reference: reference,
+      reference: DateTime(2026, 8, 8, 23),
     );
 
     expect(
@@ -955,6 +1035,7 @@ void main() {
     ).thenAnswer(
       (_) async => [
         (
+          entryId: 'workday',
           dateFrom: DateTime.utc(2026, 8, 8, 8),
           dateTo: DateTime.utc(2026, 8, 8, 18),
           categoryId: 'vibe-coding',
@@ -975,7 +1056,7 @@ void main() {
   });
 
   test(
-    'category time subscribes to every mutation that can change attribution',
+    'category time uses stale-only triggers for attribution changes',
     () {
       const criterion = GoalCriterion.categoryTime(
         criterionId: 'coding-cap',
@@ -995,6 +1076,38 @@ void main() {
           privateToggleNotification,
         },
       );
+      expect(goalImmediateSignalTriggerTokens(criterion), isEmpty);
+      expect(
+        goalStaleSignalTriggerTokens(criterion),
+        goalSignalTriggerTokens(criterion),
+      );
     },
   );
+
+  test('bounded observations stay on the immediate trigger path', () {
+    const criterion = GoalCriterion.allOf(
+      criterionId: 'bounded',
+      criteria: [
+        GoalCriterion.habit(
+          criterionId: 'walk',
+          habitId: 'walk-habit',
+          window: GoalWindow.day(),
+          targetCount: 1,
+        ),
+        GoalCriterion.metric(
+          criterionId: 'steps',
+          dataType: 'HealthDataType.STEPS',
+          window: GoalWindow.day(),
+          aggregation: GoalAggregation.sum,
+          target: 10000,
+        ),
+      ],
+    );
+
+    expect(
+      goalImmediateSignalTriggerTokens(criterion),
+      {'walk-habit', 'HealthDataType.STEPS'},
+    );
+    expect(goalStaleSignalTriggerTokens(criterion), isEmpty);
+  });
 }

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -456,7 +456,10 @@ void main() {
       ],
     );
     expect(
-      goalSignalTriggerTokens(composite),
+      {
+        ...goalImmediateSignalTriggerTokens(composite),
+        ...goalStaleSignalTriggerTokens(composite),
+      },
       {'cumulative_step_count', 'gym-habit', 'water-id'},
     );
   });
@@ -628,6 +631,54 @@ void main() {
       reference,
     );
     expect(window.categoryTimeEvidenceEnd, reference);
+  });
+
+  test('a completed historical day uses the next midnight as its exclusive '
+      'category-time endpoint', () async {
+    const criterion = GoalCriterion.categoryTime(
+      criterionId: 'coding-cap',
+      categoryId: 'vibe-coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 2,
+    );
+    final reference = DateTime(2026, 8, 8, 23, 59, 59);
+    final endExclusive = DateTime(2026, 8, 9);
+    when(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        (
+          entryId: 'final-second',
+          dateFrom: reference,
+          dateTo: endExclusive,
+          categoryId: 'vibe-coding',
+        ),
+      ],
+    );
+
+    final window = await reader.read(
+      criteria: criterion,
+      reference: reference,
+      categoryTimeEndExclusive: endExclusive,
+    );
+
+    final queryEnd = verify(
+      () => journalDb.insightsTimeRows(
+        start: any(named: 'start'),
+        end: captureAny(named: 'end'),
+      ),
+    ).captured.single;
+    expect(queryEnd, endExclusive);
+    expect(
+      window.categoryTimeSessionsByCategory['vibe-coding']?.single.dateTo,
+      endExclusive,
+      reason: 'the final second belongs to the completed period',
+    );
+    expect(window.categoryTimeEvidenceEnd, endExclusive);
   });
 
   test('category time replaces a persisted active timer prefix', () async {
@@ -1066,21 +1117,15 @@ void main() {
         targetHours: 8,
       );
 
-      expect(
-        goalSignalTriggerTokens(criterion),
-        {
-          textEntryNotification,
-          linkNotification,
-          taskNotification,
-          categoriesNotification,
-          privateToggleNotification,
-        },
-      );
+      const expected = {
+        textEntryNotification,
+        linkNotification,
+        taskNotification,
+        categoriesNotification,
+        privateToggleNotification,
+      };
       expect(goalImmediateSignalTriggerTokens(criterion), isEmpty);
-      expect(
-        goalStaleSignalTriggerTokens(criterion),
-        goalSignalTriggerTokens(criterion),
-      );
+      expect(goalStaleSignalTriggerTokens(criterion), expected);
     },
   );
 

--- a/test/features/goals/evaluation/goal_signal_window_test.dart
+++ b/test/features/goals/evaluation/goal_signal_window_test.dart
@@ -28,6 +28,7 @@ void main() {
     },
     categoryTimeEvidenceStart: DateTime(2026, 8),
     categoryTimeEvidenceEnd: DateTime(2026, 8, 6),
+    hasActiveCategoryTimer: true,
   );
 
   test('range queries are inclusive of both endpoints', () {
@@ -77,5 +78,6 @@ void main() {
     expect(session.duration, const Duration(minutes: 90));
     expect(window.categoryTimeEvidenceStart, DateTime(2026, 8));
     expect(window.categoryTimeEvidenceEnd, DateTime(2026, 8, 6));
+    expect(window.hasActiveCategoryTimer, isTrue);
   });
 }

--- a/test/features/goals/runtime/goal_agent_phase_a_test.dart
+++ b/test/features/goals/runtime/goal_agent_phase_a_test.dart
@@ -31,6 +31,7 @@ class _FakeSignalReader extends GoalSignalReader {
     int shortTermDays = 3,
     bool includeCategoryTimeSessions = true,
     DateTime? categorySessionEvidenceStart,
+    DateTime? categoryTimeEndExclusive,
   }) async => window;
 }
 

--- a/test/features/goals/runtime/goal_runtime_maintenance_test.dart
+++ b/test/features/goals/runtime/goal_runtime_maintenance_test.dart
@@ -207,6 +207,8 @@ void main() {
             as AgentSubscription;
     expect(subscription.agentId, 'goal-a');
     expect(subscription.matchEntityIds, {'gym-habit'});
+    verify(() => orchestrator.removeSubscriptions('goal-a')).called(1);
+    clearInteractions(orchestrator);
 
     await maintenance.onIdentityReceived(
       goalIdentity('task-1', kind: AgentKinds.taskAgent),

--- a/test/features/goals/service/goal_agent_service_test.dart
+++ b/test/features/goals/service/goal_agent_service_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -165,6 +166,41 @@ void main() {
   test('removeSignalSubscriptions drops the agent from the orchestrator', () {
     when(() => orchestrator.removeSubscriptions(any())).thenReturn(null);
     service.removeSignalSubscriptions(agentId);
+    verify(() => orchestrator.removeSubscriptions(agentId)).called(1);
+  });
+
+  test('category time marks the report stale while bounded signals wake', () {
+    const categoryTime = GoalCriterion.categoryTime(
+      criterionId: 'coding-time',
+      categoryId: 'coding',
+      window: GoalWindow.rollingDays(count: 7),
+      targetHours: 10,
+      aggregation: GoalAggregation.sum,
+    );
+    const mixed = GoalCriterion.allOf(
+      criterionId: 'balanced',
+      criteria: [criteria, categoryTime],
+    );
+
+    service.registerSignalSubscription(agentId, mixed);
+
+    final subscriptions = verify(
+      () => orchestrator.addSubscription(captureAny()),
+    ).captured.cast<AgentSubscription>();
+    final immediate = subscriptions.singleWhere(
+      (subscription) => subscription.id == goalSignalSubscriptionId(agentId),
+    );
+    expect(immediate.matchEntityIds, {'gym-habit'});
+    expect(immediate.drainImmediately, isTrue);
+    expect(immediate.reportStaleOnly, isFalse);
+
+    final stale = subscriptions.singleWhere(
+      (subscription) =>
+          subscription.id == goalStaleSignalSubscriptionId(agentId),
+    );
+    expect(stale.matchEntityIds, goalStaleSignalTriggerTokens(categoryTime));
+    expect(stale.drainImmediately, isFalse);
+    expect(stale.reportStaleOnly, isTrue);
     verify(() => orchestrator.removeSubscriptions(agentId)).called(1);
   });
 

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -234,6 +234,7 @@ void main() {
         limit: any(named: 'limit'),
       ),
     ).thenAnswer((_) async => []);
+    when(() => syncService.upsertEntity(any())).thenAnswer((_) async {});
 
     final runner = container.read(
       goalAgentWakeRunnersProvider,
@@ -264,7 +265,6 @@ void main() {
 
     // The same wake without the escalation token stays on the €0 tier and
     // succeeds without any inference plumbing.
-    when(() => syncService.upsertEntity(any())).thenAnswer((_) async {});
     when(
       () => repository.getDueScheduledWakeRecords(any()),
     ).thenAnswer((_) async => []);

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -28,6 +28,7 @@ class _FakeReader extends GoalSignalReader {
     int shortTermDays = 3,
     bool includeCategoryTimeSessions = true,
     DateTime? categorySessionEvidenceStart,
+    DateTime? categoryTimeEndExclusive,
   }) async => const GoalSignalWindow();
 }
 
@@ -156,6 +157,9 @@ void main() {
       onAgentEvaluated: evaluated.add,
     );
     when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+    when(
+      () => agentService.markReportStale(any()),
+    ).thenAnswer((_) async {});
   });
 
   test('a synced batch touching a goal signal runs Phase A with the '
@@ -210,7 +214,38 @@ void main() {
     await dispatcher.dispatchBatch(goalStaleSignalTriggerTokens(categoryTime));
 
     expect(phaseA.calls, isEmpty);
-    expect(evaluated, isEmpty);
+    verify(() => agentService.markReportStale('goal-a')).called(1);
+    expect(evaluated, isEmpty, reason: 'no Phase A projection was written');
+  });
+
+  test('a mixed synced batch marks category evidence stale and evaluates '
+      'bounded evidence once', () async {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'mixed',
+      criteria: [
+        criteria,
+        GoalCriterion.categoryTime(
+          criterionId: 'coding-time',
+          categoryId: 'coding',
+          window: GoalWindow.day(),
+          aggregation: GoalAggregation.sum,
+          targetHours: 2,
+        ),
+      ],
+    );
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [identity('goal-a', AgentKinds.goalAgent)]);
+    stubSpec('goal-a', goalCriteria: composite);
+
+    await dispatcher.dispatchBatch({
+      'cumulative_step_count',
+      goalStaleSignalTriggerTokens(composite).first,
+    });
+
+    verify(() => agentService.markReportStale('goal-a')).called(1);
+    expect(phaseA.calls.single.$2, {'cumulative_step_count'});
+    expect(evaluated, ['goal-a'], reason: 'one batch emits one UI refresh');
   });
 
   test('the listener pumps synced batches, starts once, and stops on '

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -113,7 +113,10 @@ void main() {
   late _RecordingPhaseA phaseA;
   late GoalSignalSyncDispatcher dispatcher;
 
-  void stubSpec(String agentId) {
+  void stubSpec(
+    String agentId, {
+    GoalCriterion goalCriteria = criteria,
+  }) {
     when(() => repository.getEntity(goalSpecHeadId(agentId))).thenAnswer(
       (_) async => AgentDomainEntity.goalSpecHead(
         id: goalSpecHeadId(agentId),
@@ -132,7 +135,7 @@ void main() {
         authoredBy: 'user',
         title: agentId,
         statement: 'x',
-        criteria: criteria,
+        criteria: goalCriteria,
         createdAt: DateTime(2026),
         vectorClock: null,
       ),
@@ -189,6 +192,25 @@ void main() {
 
     await dispatcher.dispatchBatch({'some-task-id', 'HABIT_COMPLETION'});
     expect(phaseA.calls, isEmpty);
+  });
+
+  test('synced category-time churn waits for the scheduled cadence', () async {
+    const categoryTime = GoalCriterion.categoryTime(
+      criterionId: 'coding-time',
+      categoryId: 'coding',
+      window: GoalWindow.day(),
+      aggregation: GoalAggregation.sum,
+      targetHours: 2,
+    );
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [identity('goal-a', AgentKinds.goalAgent)]);
+    stubSpec('goal-a', goalCriteria: categoryTime);
+
+    await dispatcher.dispatchBatch(goalStaleSignalTriggerTokens(categoryTime));
+
+    expect(phaseA.calls, isEmpty);
+    expect(evaluated, isEmpty);
   });
 
   test('the listener pumps synced batches, starts once, and stops on '

--- a/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
+++ b/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
@@ -211,11 +211,25 @@ void main() {
             'goal-1',
           ).overrideWith((ref) async => {}),
           agentReportProvider('goal-1').overrideWith((ref) async => null),
+          agentStateProvider('goal-1').overrideWith(
+            (ref) async =>
+                AgentDomainEntity.agentState(
+                      id: 'goal-1:state',
+                      agentId: 'goal-1',
+                      slots: const AgentSlots(),
+                      updatedAt: DateTime(2026, 8, 12, 18, 30),
+                      vectorClock: null,
+                      reportFreshAt: DateTime(2026, 8, 12, 18),
+                      reportStaleAt: DateTime(2026, 8, 12, 18, 30),
+                    )
+                    as AgentStateEntity,
+          ),
         ],
       ),
     );
     await tester.pumpAndSettle();
     expect(find.text('Seven for seven. Keep coasting.'), findsOneWidget);
+    expect(find.text('Out of date'), findsOneWidget);
     expect(find.textContaining('No report yet'), findsNothing);
   });
 

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -1073,9 +1073,66 @@ void main() {
     );
 
     expect(result.success, isTrue);
+    expect(result.reportUpdated, isTrue);
     expect(calls, 2, reason: 'primary turn plus one forced report tool turn');
+    final progress = upserts.whereType<GoalProgressEntity>().single;
+    expect(progress.periodKey, '2026-08-09');
+    expect(progress.specVersionId, '$agentId:spec-v1');
     final report = upserts.whereType<AgentReportEntity>().single;
     expect(report.oneLiner, 'The edited day is accounted for.');
+  });
+
+  test('a report rendered while a watched category timer is active remains '
+      'stale even after its standing head advances', () async {
+    stubSpec();
+    stubGlmResolution();
+    workflow = GoalAgentWorkflow(
+      repository: repository,
+      syncService: syncService,
+      phaseA: GoalAgentPhaseA(
+        repository: repository,
+        syncService: syncService,
+        signalReader: _FakeReader(
+          const GoalSignalWindow(hasActiveCategoryTimer: true),
+        ),
+      ),
+      conversationRepository: conversationRepository,
+      cloudInferenceRepository: cloudInferenceRepository,
+      aiConfigRepository: aiConfigRepository,
+    );
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          await (strategy! as GoalAgentStrategy).processToolCalls(
+            toolCalls: [
+              toolCall(GoalAgentToolNames.updateGoalReport, {
+                'status': 'insufficientData',
+                'oneLiner': 'Coding is still in progress.',
+                'tldr': 'The running timer can still change this result.',
+              }),
+            ],
+            manager: conversationManager,
+          );
+          return null;
+        };
+
+    final result = await run(
+      triggerTokens: const {goalReportRefreshTriggerToken},
+    );
+
+    expect(result.success, isTrue);
+    expect(result.reportUpdated, isFalse);
+    expect(upserts.whereType<GoalProgressEntity>(), hasLength(1));
+    expect(upserts.whereType<AgentReportHeadEntity>(), hasLength(1));
   });
 
   test('persistOutputs: retire is dismissal-terminal-safe, rerun requires a '
@@ -1944,7 +2001,8 @@ void main() {
       ),
     );
 
-    expect(finalized, isFalse);
+    expect(finalized.attributionFinalized, isFalse);
+    expect(finalized.reportHeadAdvanced, isFalse);
     // The conversation's own message trail (thought/action/toolResult)
     // already landed while the model ran — the fence stops the OUTPUTS:
     // no report, no head move, no banner.
@@ -2096,7 +2154,7 @@ void main() {
       manager: conversationManager,
     );
 
-    await withClock(
+    final persistence = await withClock(
       fixedClock,
       () => workflow.persistOutputs(
         agentId: agentId,
@@ -2108,6 +2166,7 @@ void main() {
       ),
     );
 
+    expect(persistence.reportHeadAdvanced, isFalse);
     expect(
       upserts.whereType<AgentReportEntity>(),
       hasLength(1),
@@ -3207,7 +3266,7 @@ void main() {
           version: version!,
           now: DateTime(2026, 8, 6, 23),
         );
-    await withClock(
+    final persistence = await withClock(
       fixedClock,
       () => workflow.persistOutputs(
         agentId: agentId,
@@ -3219,6 +3278,7 @@ void main() {
       ),
     );
     // The report row itself lands (history), but the head stays put.
+    expect(persistence.reportHeadAdvanced, isFalse);
     expect(upserts.whereType<AgentReportEntity>(), hasLength(1));
     expect(upserts.whereType<AgentReportHeadEntity>(), isEmpty);
   });

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -46,6 +46,7 @@ class _FakeReader extends GoalSignalReader {
     int shortTermDays = 3,
     bool includeCategoryTimeSessions = true,
     DateTime? categorySessionEvidenceStart,
+    DateTime? categoryTimeEndExclusive,
   }) async => window;
 }
 
@@ -954,6 +955,7 @@ void main() {
       );
 
       expect(result.success, isTrue);
+      expect(result.reportUpdated, isTrue);
       final replacement = upserts.whereType<GoalNudgeEntity>().single;
       expect(replacement.status, GoalNudgeStatus.active);
       expect(replacement.brief.headline, 'Zeit, wieder loszulegen.');
@@ -1562,6 +1564,11 @@ void main() {
 
     final result = await run();
     expect(result.success, isTrue);
+    expect(
+      result.reportUpdated,
+      isFalse,
+      reason: 'a successful inference turn did not replace the report',
+    );
     verify(
       () => attribution.prepareCompletion(
         attributionId: any(named: 'attributionId'),

--- a/test/features/goals/workflow/goal_facts_renderer_test.dart
+++ b/test/features/goals/workflow/goal_facts_renderer_test.dart
@@ -416,6 +416,72 @@ void main() {
     },
   );
 
+  test('lifetime category summaries union overlapping raw sessions', () {
+    final json = renderedJson(
+      wakeFacts: facts(
+        categoryTimeSessions: {
+          'vibe-coding': [
+            GoalCategoryTimeSession(
+              categoryId: 'vibe-coding',
+              dateFrom: DateTime(2026, 8, 8, 9),
+              dateTo: DateTime(2026, 8, 8, 10, 30),
+            ),
+            GoalCategoryTimeSession(
+              categoryId: 'vibe-coding',
+              dateFrom: DateTime(2026, 8, 8, 9, 30),
+              dateTo: DateTime(2026, 8, 8, 11),
+            ),
+          ],
+        },
+      ),
+    );
+
+    final signals = json['signals'] as Map<String, dynamic>;
+    expect(signals['categoryTimeSessionCount'], 2);
+    expect(signals['categoryTimeSessions'], hasLength(2));
+    final summary =
+        (signals['categoryTimeLifetimeSummary'] as List).single
+            as Map<String, dynamic>;
+    expect(summary['sessionCount'], 2, reason: 'raw evidence stays auditable');
+    expect(
+      summary['totalMinutes'],
+      120,
+      reason: 'the 09:30–10:30 overlap must count only once',
+    );
+    final minutesByHour = summary['minutesByLocalHour'] as List;
+    expect(minutesByHour[9], 60);
+    expect(minutesByHour[10], 60);
+  });
+
+  test('category summaries preserve seconds across local-hour splits', () {
+    final json = renderedJson(
+      wakeFacts: facts(
+        categoryTimeSessions: {
+          'vibe-coding': [
+            GoalCategoryTimeSession(
+              categoryId: 'vibe-coding',
+              dateFrom: DateTime(2026, 8, 8, 9, 59, 30),
+              dateTo: DateTime(2026, 8, 8, 10, 0, 30),
+            ),
+          ],
+        },
+      ),
+    );
+
+    final signals = json['signals'] as Map<String, dynamic>;
+    final raw =
+        (signals['categoryTimeSessions'] as List).single
+            as Map<String, dynamic>;
+    expect(raw['durationMinutes'], 1);
+    final summary =
+        (signals['categoryTimeLifetimeSummary'] as List).single
+            as Map<String, dynamic>;
+    expect(summary['totalMinutes'], 1);
+    final minutesByHour = summary['minutesByLocalHour'] as List;
+    expect(minutesByHour[9], 0.5);
+    expect(minutesByHour[10], 0.5);
+  });
+
   test('lifetime category evidence keeps a bounded recent raw sample', () {
     final sessions = [
       for (var index = 0; index < 205; index++)


### PR DESCRIPTION
## Summary

- keep high-frequency category-time edits observable without waking the goal agent on every timer mutation: they now advance the durable report-stale watermark, while the existing daily cadence and **Update now** consume accumulated changes
- make category-time evaluation agree with Insights by clipping the current day at the evaluation instant, resolving live timer attribution through the same linked-task query, and replacing persisted timer prefixes by entry ID
- union overlapping lifetime sessions and preserve sub-minute precision in the Phase B evidence summary
- surface an **Out of date** badge beside an established stale goal report on mobile and desktop
- align the Flatpak 1.0.7 release text with the changelog

This is a focused follow-up to #3891 and addresses the remaining review findings from that merged model/runtime PR.

## Root cause

Category-time criteria originally shared the immediate wake subscription used by bounded habit and measured-data observations. That made timer churn too eager. Live timers also used mutable in-memory link attribution and a category/start-time deduplication heuristic, while lifetime summaries summed raw rows after flooring each segment to whole minutes. Together those choices could produce unnecessary wakes, inconsistent attribution, dropped same-start entries, future-time inclusion, and inflated or truncated evidence totals.

## Validation

- `fvm dart analyze` on all touched Dart and test files: no issues
- targeted Flutter tests for the database query, wake orchestrator, signal reader, goal service/providers/sync, goal detail page, and FACTS renderer: **142 passed**
- mutation-checked each new regression test against the reverted production behavior
- `make knowledge_check`: 93 OKF concepts and 477 Mermaid blocks validated
- mobile and desktop screenshot harness captures passed on both base and head

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. Codecov is the authoritative patch-coverage result.

## Screenshots

### Mobile — stale report affordance

| Before | After |
|---|---|
| ![Mobile before](https://raw.githubusercontent.com/matthiasn/lotti-docs/6324c2b867bfd8f7470c46796051422814549634/pr-screenshots/goal-time-followups/before/goal_report_stale_mobile_dark.png) | ![Mobile after](https://raw.githubusercontent.com/matthiasn/lotti-docs/6324c2b867bfd8f7470c46796051422814549634/pr-screenshots/goal-time-followups/after/goal_report_stale_mobile_dark.png) |

### Desktop — stale report affordance

| Before | After |
|---|---|
| ![Desktop before](https://raw.githubusercontent.com/matthiasn/lotti-docs/6324c2b867bfd8f7470c46796051422814549634/pr-screenshots/goal-time-followups/before/goal_report_stale_desktop_dark.png) | ![Desktop after](https://raw.githubusercontent.com/matthiasn/lotti-docs/6324c2b867bfd8f7470c46796051422814549634/pr-screenshots/goal-time-followups/after/goal_report_stale_desktop_dark.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goal reports now indicate when their data is out of date.
  * Goal time tracking better handles active timers, privacy settings, midnight boundaries, and overlapping sessions.
  * Category-time evidence preserves precise durations and avoids double-counting activity.
* **Bug Fixes**
  * Improved category attribution, including for zero-duration entries.
  * Prevented frequent tracking updates from triggering unnecessary immediate evaluations.
* **Documentation**
  * Updated goal and release documentation to explain time evaluation and report freshness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->