### PR TITLE
fix(goals): isolate synced signal failures

### DIFF
--- a/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
+++ b/lib/features/goals/sync/goal_signal_sync_dispatcher.dart
@@ -67,7 +67,15 @@ class GoalSignalSyncDispatcher {
         final matched = await _matchedTokens(identity.agentId, tokens);
         if (matched.immediate.isEmpty && matched.stale.isEmpty) continue;
         if (matched.stale.isNotEmpty) {
-          await _agentService.markReportStale(identity.agentId);
+          try {
+            await _agentService.markReportStale(identity.agentId);
+          } catch (error, stackTrace) {
+            _log(
+              'marking goal report stale failed for one agent',
+              error,
+              stackTrace,
+            );
+          }
         }
         if (matched.immediate.isNotEmpty) {
           final runKey =

--- a/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
+++ b/test/features/goals/sync/goal_signal_sync_dispatcher_test.dart
@@ -248,6 +248,43 @@ void main() {
     expect(evaluated, ['goal-a'], reason: 'one batch emits one UI refresh');
   });
 
+  test('a stale-watermark failure does not suppress same-batch bounded '
+      'evaluation', () async {
+    const composite = GoalCriterion.allOf(
+      criterionId: 'mixed',
+      criteria: [
+        criteria,
+        GoalCriterion.categoryTime(
+          criterionId: 'coding-time',
+          categoryId: 'coding',
+          window: GoalWindow.day(),
+          aggregation: GoalAggregation.sum,
+          targetHours: 2,
+        ),
+      ],
+    );
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [identity('goal-a', AgentKinds.goalAgent)]);
+    stubSpec('goal-a', goalCriteria: composite);
+    when(
+      () => agentService.markReportStale('goal-a'),
+    ).thenThrow(StateError('stale write failed'));
+
+    await dispatcher.dispatchBatch({
+      'cumulative_step_count',
+      goalStaleSignalTriggerTokens(composite).first,
+    });
+
+    verify(() => agentService.markReportStale('goal-a')).called(1);
+    expect(phaseA.calls.single.$2, {'cumulative_step_count'});
+    expect(
+      evaluated,
+      ['goal-a'],
+      reason: 'bounded evidence remains independently actionable',
+    );
+  });
+
   test('the listener pumps synced batches, starts once, and stops on '
       'dispose', () async {
     when(


### PR DESCRIPTION
## Summary

- isolate synced category-time stale-watermark failures from bounded-signal Phase A evaluation
- preserve same-batch deterministic goal evaluation even when the stale marker cannot be persisted
- add a mutation-verified regression test for the mixed-signal failure path

Follow-up to #3892 for the remaining actionable CodeRabbit review finding embedded in its review summary.

## Verification

- `fvm dart analyze lib/features/goals/sync/goal_signal_sync_dispatcher.dart test/features/goals/sync/goal_signal_sync_dispatcher_test.dart`
- `fvm flutter test test/features/goals/sync/goal_signal_sync_dispatcher_test.dart`
- regression test fails with the isolation fix reverted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal synchronization so failures while marking a report stale no longer interrupt remaining processing.
  * Ensured other agents and related evaluations continue to be handled when one stale-report update fails.

* **Tests**
  * Added coverage to verify same-batch evaluations and notifications continue after a stale-report update error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->