### PR TITLE
feat(goals): add voice input to goal agent chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8]
+### Added
+- **Goal-agent chat supports voice input.** The composer now has a microphone
+  button that records, transcribes, and fills the text field.
+
 ## [1.0.7]
 ### Added
 - **Goal-agent criteria are ready for refinement.** Goal agents remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent offers an editable record card; nothing is saved until it is approved,
   and accepted values use the normal measurement history with visible agent
   provenance.
+- **Goal-agent chat supports voice input.** The composer now has a microphone
+  button that records, transcribes, and fills the text field.
 
 ## [1.0.6]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,11 +40,15 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.8" date="2026-08-12">
+      <description>
+        <p>Added: goal-agent chat supports voice input. The composer now has a microphone button that records, transcribes, and fills the text field.</p>
+      </description>
+    </release>
     <release version="1.0.7" date="2026-08-12">
       <description>
         <p>Goal-agent criteria are ready for refinement. Goal agents remain configurable with linked habits and rolling seven-day step targets. Their evaluation foundation now preserves a separate accountable result for every configured criterion.</p>
         <p>Added: goal agents can combine linked measurables, habits, steps, weight and blood pressure through all, any, or at-least-N rules while preserving accountable evidence for every dimension. New and existing goals can set a direction and target for weight and separate systolic/diastolic blood-pressure observations. A sustained health trend projected to reach its target within four weeks is on track without being mislabeled as achieved. Goal details support separate daily Met/Mixed/Missed reflections and identify the dimension that needs attention. An explicit quantity for a linked measurable in goal chat now produces an editable approval card; accepted values use the normal measurement history and retain visible agent provenance.</p>
-        <p>Added: goal-agent chat supports voice input. The composer now has a microphone button that records, transcribes, and fills the text field.</p>
       </description>
     </release>
     <release version="1.0.6" date="2026-08-09">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -44,6 +44,7 @@
       <description>
         <p>Goal-agent criteria are ready for refinement. Goal agents remain configurable with linked habits and rolling seven-day step targets. Their evaluation foundation now preserves a separate accountable result for every configured criterion.</p>
         <p>Added: goal agents can combine linked measurables, habits, steps, weight and blood pressure through all, any, or at-least-N rules while preserving accountable evidence for every dimension. New and existing goals can set a direction and target for weight and separate systolic/diastolic blood-pressure observations. A sustained health trend projected to reach its target within four weeks is on track without being mislabeled as achieved. Goal details support separate daily Met/Mixed/Missed reflections and identify the dimension that needs attention. An explicit quantity for a linked measurable in goal chat now produces an editable approval card; accepted values use the normal measurement history and retain visible agent provenance.</p>
+        <p>Added: goal-agent chat supports voice input. The composer now has a microphone button that records, transcribes, and fills the text field.</p>
       </description>
     </release>
     <release version="1.0.6" date="2026-08-09">

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -581,6 +581,12 @@ flowchart TD
   mounted only for active goal agents. If the spec head moves while an
   interactive inference is running, output fencing fails the wake so the
   durable user turn remains retryable instead of completing without a reply.
+  The chat composer reuses the shared `chatRecorderControllerProvider` (the
+  same recorder the task-agent evolution chat uses) for voice input: a mic
+  trailing icon, waveform with cancel/stop, streaming partial transcript, and
+  auto-fill on completion. The recorder watch lives inside `_ChatComposer`
+  (a `ConsumerWidget`) so the 10 Hz amplitude stream rebuilds only the
+  composer subtree, not the full message list.
 - **Standing reports and governance remain visible.** The detail page always
   renders the report referenced by the authoritative current-scope report head;
   a delayed historical row cannot displace it merely by carrying a later local

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -5,7 +5,7 @@ description: Goal-driven agents — the deterministic Phase A tier evaluating cr
 resource: ../../lib/features/goals
 tags: [goals, agents, runtime, wake, evaluation]
 status: draft
-generated: { by: codex/gpt-5, at: 2026-08-11T01:43:18Z }
+generated: { by: codex/gpt-5, at: 2026-08-12T20:40:00Z }
 stale_after: 2027-02-22
 sources:
   - id: goals-src
@@ -64,6 +64,14 @@ sources:
     resource: ../../docs/adr/0054-deterministic-first-two-tier-wakes.md
     title: "ADR 0054: Deterministic-First Two-Tier Wakes"
     last_modified: 2026-08-08
+  - id: chat-composer
+    resource: ../../lib/features/agents/ui/chat/agent_chat_view.dart
+    title: AgentChatView — voice-enabled goal chat composer
+    last_modified: 2026-08-12
+  - id: recorder-controller
+    resource: ../../lib/features/ai_chat/ui/controllers/chat_recorder_controller.dart
+    title: ChatRecorderController — shared voice recorder
+    last_modified: 2026-08-12
 ---
 
 # Goal Agents — Runtime
@@ -587,6 +595,17 @@ flowchart TD
   auto-fill on completion. The recorder watch lives inside `_ChatComposer`
   (a `ConsumerWidget`) so the 10 Hz amplitude stream rebuilds only the
   composer subtree, not the full message list.
+
+  ```mermaid
+  stateDiagram-v2
+      [*] --> idle
+      idle --> recording: tap mic (no text)
+      recording --> processing: stop
+      recording --> idle: cancel
+      processing --> idle: transcript ready (auto-fills draft)
+      processing --> idle: error (localized toast)
+  ```
+
 - **Standing reports and governance remain visible.** The detail page always
   renders the report referenced by the authoritative current-scope report head;
   a delayed historical row cannot displace it merely by carrying a later local

--- a/lib/features/agents/ui/chat/agent_chat_view.dart
+++ b/lib/features/agents/ui/chat/agent_chat_view.dart
@@ -244,17 +244,6 @@ class _AgentChatViewState extends ConsumerState<AgentChatView> {
           draft: widget.draft,
           onDraftChanged: widget.onDraftChanged,
           onSend: widget.onSend,
-          recorderState: ref.watch(chatRecorderControllerProvider),
-          onStartRecording: () =>
-              ref.read(chatRecorderControllerProvider.notifier).start(),
-          onCancelRecording: () =>
-              ref.read(chatRecorderControllerProvider.notifier).cancel(),
-          onStopRecording: () => ref
-              .read(chatRecorderControllerProvider.notifier)
-              .stopAndTranscribe(),
-          normalizedAmplitudes: ref
-              .read(chatRecorderControllerProvider.notifier)
-              .getNormalizedAmplitudeHistory(),
         ),
       ],
     );
@@ -267,7 +256,10 @@ class _AgentChatViewState extends ConsumerState<AgentChatView> {
 /// infrastructure. Idle shows a text field with a mic/send trailing icon;
 /// recording shows the waveform with cancel/stop; processing shows the
 /// streaming partial transcript.
-class _ChatComposer extends StatelessWidget {
+///
+/// Watches [chatRecorderControllerProvider] internally so the 10 Hz amplitude
+/// stream rebuilds only this subtree, not the full message list above.
+class _ChatComposer extends ConsumerWidget {
   const _ChatComposer({
     required this.controller,
     required this.agentName,
@@ -275,11 +267,6 @@ class _ChatComposer extends StatelessWidget {
     required this.draft,
     required this.onDraftChanged,
     required this.onSend,
-    required this.recorderState,
-    required this.onStartRecording,
-    required this.onCancelRecording,
-    required this.onStopRecording,
-    required this.normalizedAmplitudes,
   });
 
   final TextEditingController controller;
@@ -288,15 +275,11 @@ class _ChatComposer extends StatelessWidget {
   final String draft;
   final ValueChanged<String> onDraftChanged;
   final VoidCallback onSend;
-  final ChatRecorderState recorderState;
-  final VoidCallback onStartRecording;
-  final VoidCallback onCancelRecording;
-  final VoidCallback onStopRecording;
-  final List<double> normalizedAmplitudes;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
+    final recorderState = ref.watch(chatRecorderControllerProvider);
     final status = recorderState.status;
 
     return DecoratedBox(
@@ -310,9 +293,14 @@ class _ChatComposer extends StatelessWidget {
         padding: EdgeInsets.all(tokens.spacing.step4),
         child: switch (status) {
           ChatRecorderStatus.recording => _RecordingControls(
-            amplitudes: normalizedAmplitudes,
-            onCancel: onCancelRecording,
-            onStop: onStopRecording,
+            amplitudes: ref
+                .read(chatRecorderControllerProvider.notifier)
+                .getNormalizedAmplitudeHistory(),
+            onCancel: () =>
+                ref.read(chatRecorderControllerProvider.notifier).cancel(),
+            onStop: () => ref
+                .read(chatRecorderControllerProvider.notifier)
+                .stopAndTranscribe(),
           ),
           ChatRecorderStatus.processing => _TranscriptionProgress(
             partialTranscript: recorderState.partialTranscript ?? '',
@@ -324,7 +312,8 @@ class _ChatComposer extends StatelessWidget {
             draft: draft,
             onDraftChanged: onDraftChanged,
             onSend: onSend,
-            onStartRecording: onStartRecording,
+            onStartRecording: () =>
+                ref.read(chatRecorderControllerProvider.notifier).start(),
           ),
         },
       ),
@@ -475,7 +464,7 @@ class _TranscriptionProgress extends StatelessWidget {
                 width: tokens.spacing.step6,
                 height: tokens.spacing.step6,
                 child: CircularProgressIndicator(
-                  strokeWidth: 2,
+                  strokeWidth: BorderWidths.emphasis,
                   color: tokens.colors.interactive.enabled,
                 ),
               ),

--- a/lib/features/agents/ui/chat/agent_chat_view.dart
+++ b/lib/features/agents/ui/chat/agent_chat_view.dart
@@ -313,11 +313,9 @@ class _ChatComposer extends StatelessWidget {
             onCancel: onCancelRecording,
             onStop: onStopRecording,
           ),
-          ChatRecorderStatus.processing
-              when recorderState.partialTranscript != null =>
-            _TranscriptionProgress(
-              partialTranscript: recorderState.partialTranscript!,
-            ),
+          ChatRecorderStatus.processing => _TranscriptionProgress(
+            partialTranscript: recorderState.partialTranscript ?? '',
+          ),
           _ => _IdleComposer(
             controller: controller,
             agentName: agentName,
@@ -325,7 +323,6 @@ class _ChatComposer extends StatelessWidget {
             draft: draft,
             onDraftChanged: onDraftChanged,
             onSend: onSend,
-            isProcessing: status == ChatRecorderStatus.processing,
             onStartRecording: onStartRecording,
           ),
         },
@@ -342,7 +339,6 @@ class _IdleComposer extends StatelessWidget {
     required this.draft,
     required this.onDraftChanged,
     required this.onSend,
-    required this.isProcessing,
     required this.onStartRecording,
   });
 
@@ -352,14 +348,13 @@ class _IdleComposer extends StatelessWidget {
   final String draft;
   final ValueChanged<String> onDraftChanged;
   final VoidCallback onSend;
-  final bool isProcessing;
   final VoidCallback onStartRecording;
 
   @override
   Widget build(BuildContext context) {
     final hasText = draft.trim().isNotEmpty;
     final canSend = hasText && !isSending;
-    final canRecord = !isSending && !isProcessing && !hasText;
+    final canRecord = !isSending && !hasText;
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
@@ -371,7 +366,7 @@ class _IdleComposer extends StatelessWidget {
             helperText: isSending
                 ? context.messages.goalChatResponding(agentName)
                 : null,
-            enabled: !isSending && !isProcessing,
+            enabled: !isSending,
             textCapitalization: TextCapitalization.sentences,
             trailingIcon: hasText
                 ? Icons.send_rounded
@@ -449,7 +444,7 @@ class _TranscriptionProgress extends StatelessWidget {
               color: tokens.colors.background.level02,
               borderRadius: BorderRadius.circular(tokens.radii.l),
             ),
-            constraints: const BoxConstraints(maxHeight: 48),
+            constraints: BoxConstraints(maxHeight: tokens.spacing.step9),
             child: SingleChildScrollView(
               reverse: true,
               child: Text(
@@ -505,6 +500,7 @@ class _CircleIconButton extends StatelessWidget {
     return Semantics(
       button: true,
       label: tooltip,
+      onTap: onPressed,
       child: ExcludeSemantics(
         child: Tooltip(
           message: tooltip,

--- a/lib/features/agents/ui/chat/agent_chat_view.dart
+++ b/lib/features/agents/ui/chat/agent_chat_view.dart
@@ -3,8 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/agents/state/agent_chat_projection.dart';
 import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
+import 'package:lotti/features/ai_chat/ui/controllers/chat_recorder_controller.dart';
+import 'package:lotti/features/ai_chat/ui/widgets/waveform_bars.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/inputs/design_system_text_input.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -45,6 +49,7 @@ class AgentChatView extends ConsumerStatefulWidget {
 class _AgentChatViewState extends ConsumerState<AgentChatView> {
   late final TextEditingController _controller;
   final _scrollController = ScrollController();
+  late final ProviderSubscription<ChatRecorderState> _recorderSubscription;
   String? _lastMessageId;
   bool _wasSending = false;
 
@@ -53,6 +58,43 @@ class _AgentChatViewState extends ConsumerState<AgentChatView> {
     super.initState();
     _controller = TextEditingController(text: widget.draft);
     _wasSending = widget.isSending;
+    _recorderSubscription = ref.listenManual<ChatRecorderState>(
+      chatRecorderControllerProvider,
+      (previous, next) {
+        final error = next.error?.trim();
+        if (error != null &&
+            error.isNotEmpty &&
+            error != previous?.error &&
+            mounted) {
+          context.showToast(
+            tone: DesignSystemToastTone.error,
+            title: context.messages.commonError,
+            description: error,
+            duration: const Duration(seconds: 8),
+            replaceCurrent: true,
+          );
+          Future.microtask(() {
+            if (mounted) {
+              ref.read(chatRecorderControllerProvider.notifier).clearResult();
+            }
+          });
+          return;
+        }
+        if (next.transcript != null &&
+            next.transcript != previous?.transcript) {
+          if (!mounted) return;
+          final transcript = next.transcript!.trim();
+          if (transcript.isNotEmpty) {
+            _controller.text = transcript;
+            _controller.selection = TextSelection.collapsed(
+              offset: _controller.text.length,
+            );
+            widget.onDraftChanged(transcript);
+          }
+          ref.read(chatRecorderControllerProvider.notifier).clearResult();
+        }
+      },
+    );
   }
 
   @override
@@ -73,6 +115,7 @@ class _AgentChatViewState extends ConsumerState<AgentChatView> {
   void dispose() {
     _controller.dispose();
     _scrollController.dispose();
+    _recorderSubscription.close();
     super.dispose();
   }
 
@@ -193,36 +236,298 @@ class _AgentChatViewState extends ConsumerState<AgentChatView> {
               ],
             ),
           ),
-        DecoratedBox(
-          decoration: BoxDecoration(
-            color: tokens.colors.background.level01,
-            border: Border(
-              top: BorderSide(color: tokens.colors.decorative.level01),
-            ),
+        _ChatComposer(
+          controller: _controller,
+          agentName: widget.agentName,
+          isSending: widget.isSending,
+          draft: widget.draft,
+          onDraftChanged: widget.onDraftChanged,
+          onSend: widget.onSend,
+          recorderState: ref.watch(chatRecorderControllerProvider),
+          onStartRecording: () =>
+              ref.read(chatRecorderControllerProvider.notifier).start(),
+          onCancelRecording: () =>
+              ref.read(chatRecorderControllerProvider.notifier).cancel(),
+          onStopRecording: () => ref
+              .read(chatRecorderControllerProvider.notifier)
+              .stopAndTranscribe(),
+          normalizedAmplitudes: ref
+              .read(chatRecorderControllerProvider.notifier)
+              .getNormalizedAmplitudeHistory(),
+        ),
+      ],
+    );
+  }
+}
+
+/// Voice-enabled composer for the agent chat. Reuses the shared
+/// [chatRecorderControllerProvider] — the same recorder the evolution chat
+/// uses — so transcription, error toasts, and the waveform are shared
+/// infrastructure. Idle shows a text field with a mic/send trailing icon;
+/// recording shows the waveform with cancel/stop; processing shows the
+/// streaming partial transcript.
+class _ChatComposer extends StatelessWidget {
+  const _ChatComposer({
+    required this.controller,
+    required this.agentName,
+    required this.isSending,
+    required this.draft,
+    required this.onDraftChanged,
+    required this.onSend,
+    required this.recorderState,
+    required this.onStartRecording,
+    required this.onCancelRecording,
+    required this.onStopRecording,
+    required this.normalizedAmplitudes,
+  });
+
+  final TextEditingController controller;
+  final String agentName;
+  final bool isSending;
+  final String draft;
+  final ValueChanged<String> onDraftChanged;
+  final VoidCallback onSend;
+  final ChatRecorderState recorderState;
+  final VoidCallback onStartRecording;
+  final VoidCallback onCancelRecording;
+  final VoidCallback onStopRecording;
+  final List<double> normalizedAmplitudes;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final status = recorderState.status;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tokens.colors.background.level01,
+        border: Border(
+          top: BorderSide(color: tokens.colors.decorative.level01),
+        ),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.step4),
+        child: switch (status) {
+          ChatRecorderStatus.recording => _RecordingControls(
+            amplitudes: normalizedAmplitudes,
+            onCancel: onCancelRecording,
+            onStop: onStopRecording,
           ),
-          child: Padding(
-            padding: EdgeInsets.all(tokens.spacing.step4),
-            child: DesignSystemTextInput(
-              controller: _controller,
-              hintText: context.messages.goalChatPlaceholder(widget.agentName),
-              helperText: widget.isSending
-                  ? context.messages.goalChatResponding(widget.agentName)
-                  : null,
-              enabled: !widget.isSending,
-              textCapitalization: TextCapitalization.sentences,
-              trailingIcon: Icons.send_rounded,
-              onTrailingIconTap: widget.draft.trim().isEmpty
-                  ? null
-                  : widget.onSend,
-              trailingIconTooltip: context.messages.chatInputSendTooltip,
-              onChanged: widget.onDraftChanged,
-              onSubmitted: (_) {
-                if (widget.draft.trim().isNotEmpty) widget.onSend();
-              },
+          ChatRecorderStatus.processing
+              when recorderState.partialTranscript != null =>
+            _TranscriptionProgress(
+              partialTranscript: recorderState.partialTranscript!,
             ),
+          _ => _IdleComposer(
+            controller: controller,
+            agentName: agentName,
+            isSending: isSending,
+            draft: draft,
+            onDraftChanged: onDraftChanged,
+            onSend: onSend,
+            isProcessing: status == ChatRecorderStatus.processing,
+            onStartRecording: onStartRecording,
+          ),
+        },
+      ),
+    );
+  }
+}
+
+class _IdleComposer extends StatelessWidget {
+  const _IdleComposer({
+    required this.controller,
+    required this.agentName,
+    required this.isSending,
+    required this.draft,
+    required this.onDraftChanged,
+    required this.onSend,
+    required this.isProcessing,
+    required this.onStartRecording,
+  });
+
+  final TextEditingController controller;
+  final String agentName;
+  final bool isSending;
+  final String draft;
+  final ValueChanged<String> onDraftChanged;
+  final VoidCallback onSend;
+  final bool isProcessing;
+  final VoidCallback onStartRecording;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasText = draft.trim().isNotEmpty;
+    final canSend = hasText && !isSending;
+    final canRecord = !isSending && !isProcessing && !hasText;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Expanded(
+          child: DesignSystemTextInput(
+            controller: controller,
+            hintText: context.messages.goalChatPlaceholder(agentName),
+            helperText: isSending
+                ? context.messages.goalChatResponding(agentName)
+                : null,
+            enabled: !isSending && !isProcessing,
+            textCapitalization: TextCapitalization.sentences,
+            trailingIcon: hasText
+                ? Icons.send_rounded
+                : (canRecord ? Icons.mic_rounded : null),
+            onTrailingIconTap: hasText
+                ? (canSend ? onSend : null)
+                : (canRecord ? onStartRecording : null),
+            trailingIconTooltip: hasText
+                ? context.messages.chatInputSendTooltip
+                : (canRecord ? context.messages.chatInputRecordVoice : null),
+            onChanged: onDraftChanged,
+            onSubmitted: (_) {
+              if (draft.trim().isNotEmpty) onSend();
+            },
           ),
         ),
       ],
+    );
+  }
+}
+
+class _RecordingControls extends StatelessWidget {
+  const _RecordingControls({
+    required this.amplitudes,
+    required this.onCancel,
+    required this.onStop,
+  });
+
+  final List<double> amplitudes;
+  final VoidCallback onCancel;
+  final VoidCallback onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Row(
+      children: [
+        Expanded(
+          child: WaveformBars(amplitudesNormalized: amplitudes),
+        ),
+        SizedBox(width: tokens.spacing.step3),
+        _CircleIconButton(
+          icon: Icons.close_rounded,
+          onPressed: onCancel,
+          tooltip: context.messages.chatInputCancelRecording,
+        ),
+        SizedBox(width: tokens.spacing.step2),
+        _CircleIconButton(
+          icon: Icons.stop_rounded,
+          onPressed: onStop,
+          tooltip: context.messages.chatInputStopTranscribe,
+        ),
+      ],
+    );
+  }
+}
+
+class _TranscriptionProgress extends StatelessWidget {
+  const _TranscriptionProgress({required this.partialTranscript});
+
+  final String partialTranscript;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Row(
+      children: [
+        Expanded(
+          child: Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: tokens.spacing.step4,
+              vertical: tokens.spacing.step3,
+            ),
+            decoration: BoxDecoration(
+              color: tokens.colors.background.level02,
+              borderRadius: BorderRadius.circular(tokens.radii.l),
+            ),
+            constraints: const BoxConstraints(maxHeight: 48),
+            child: SingleChildScrollView(
+              reverse: true,
+              child: Text(
+                partialTranscript,
+                style: tokens.typography.styles.body.bodyMedium.copyWith(
+                  color: tokens.colors.text.mediumEmphasis,
+                ),
+              ),
+            ),
+          ),
+        ),
+        SizedBox(width: tokens.spacing.step3),
+        SizedBox.square(
+          dimension: tokens.spacing.step8,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox(
+                width: tokens.spacing.step6,
+                height: tokens.spacing.step6,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: tokens.colors.interactive.enabled,
+                ),
+              ),
+              Icon(
+                Icons.mic_rounded,
+                size: IconSizes.s,
+                color: tokens.colors.interactive.enabled,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CircleIconButton extends StatelessWidget {
+  const _CircleIconButton({
+    required this.icon,
+    required this.onPressed,
+    required this.tooltip,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final String tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Semantics(
+      button: true,
+      label: tooltip,
+      child: ExcludeSemantics(
+        child: Tooltip(
+          message: tooltip,
+          excludeFromSemantics: true,
+          child: Container(
+            width: tokens.spacing.step8,
+            height: tokens.spacing.step8,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: tokens.colors.interactive.enabled,
+            ),
+            child: IconButton(
+              onPressed: onPressed,
+              icon: Icon(
+                icon,
+                size: IconSizes.s,
+                color: tokens.colors.text.onInteractiveAlert,
+              ),
+              padding: EdgeInsets.zero,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/agents/ui/chat/agent_chat_view.dart
+++ b/lib/features/agents/ui/chat/agent_chat_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/agents/state/agent_chat_projection.dart';
@@ -69,7 +70,7 @@ class _AgentChatViewState extends ConsumerState<AgentChatView> {
           context.showToast(
             tone: DesignSystemToastTone.error,
             title: context.messages.commonError,
-            description: error,
+            description: context.messages.chatInputRecordingFailed,
             duration: const Duration(seconds: 8),
             replaceCurrent: true,
           );
@@ -402,24 +403,32 @@ class _RecordingControls extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    return Row(
-      children: [
-        Expanded(
-          child: WaveformBars(amplitudesNormalized: amplitudes),
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): onCancel,
+      },
+      child: Focus(
+        autofocus: true,
+        child: Row(
+          children: [
+            Expanded(
+              child: WaveformBars(amplitudesNormalized: amplitudes),
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            _CircleIconButton(
+              icon: Icons.close_rounded,
+              onPressed: onCancel,
+              tooltip: context.messages.chatInputCancelRecording,
+            ),
+            SizedBox(width: tokens.spacing.step2),
+            _CircleIconButton(
+              icon: Icons.stop_rounded,
+              onPressed: onStop,
+              tooltip: context.messages.chatInputStopTranscribe,
+            ),
+          ],
         ),
-        SizedBox(width: tokens.spacing.step3),
-        _CircleIconButton(
-          icon: Icons.close_rounded,
-          onPressed: onCancel,
-          tooltip: context.messages.chatInputCancelRecording,
-        ),
-        SizedBox(width: tokens.spacing.step2),
-        _CircleIconButton(
-          icon: Icons.stop_rounded,
-          onPressed: onStop,
-          tooltip: context.messages.chatInputStopTranscribe,
-        ),
-      ],
+      ),
     );
   }
 }
@@ -506,8 +515,8 @@ class _CircleIconButton extends StatelessWidget {
           message: tooltip,
           excludeFromSemantics: true,
           child: Container(
-            width: tokens.spacing.step8,
-            height: tokens.spacing.step8,
+            width: TapTargets.minimum,
+            height: TapTargets.minimum,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               color: tokens.colors.interactive.enabled,

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -133,12 +133,10 @@ ages out while the goal still qualifies for automatic copy, the next
 deterministic tick expires it and re-arms Phase B for a replacement; healthy
 expiry remains model-free. The desktop banner tenant fills the dock's available
 width.
-Voice input in the goal chat composer reuses the shared
-`chatRecorderControllerProvider` — the same recorder the task-agent
-evolution chat uses — with a mic trailing icon, waveform with cancel/stop,
-streaming partial transcript, and auto-fill on completion. Paging beyond the
-newest fifty visible turns, search, and inline nudge cards remain later
-conversation increments; the plan of record is
+Voice input in the goal chat composer lets the user record, transcribe,
+and fill the text field from speech. Paging beyond the newest fifty visible
+turns, search, and inline nudge cards remain later conversation increments;
+the plan of record is
 `docs/implementation_plans/2026-08-08_goal_agents_design.md`.
 
 Runtime map: [knowledge/features/goals.md](../../../knowledge/features/goals.md).

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -133,8 +133,12 @@ ages out while the goal still qualifies for automatic copy, the next
 deterministic tick expires it and re-arms Phase B for a replacement; healthy
 expiry remains model-free. The desktop banner tenant fills the dock's available
 width.
-Voice, paging beyond the newest fifty visible turns, search, and inline nudge
-cards remain later conversation increments; the plan of record is
+Voice input in the goal chat composer reuses the shared
+`chatRecorderControllerProvider` — the same recorder the task-agent
+evolution chat uses — with a mic trailing icon, waveform with cancel/stop,
+streaming partial transcript, and auto-fill on completion. Paging beyond the
+newest fifty visible turns, search, and inline nudge cards remain later
+conversation increments; the plan of record is
 `docs/implementation_plans/2026-08-08_goal_agents_design.md`.
 
 Runtime map: [knowledge/features/goals.md](../../../knowledge/features/goals.md).

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1379,6 +1379,7 @@
   "chatInputHintSelectModel": "Vyberte model pro zahájení chatu",
   "chatInputListening": "Naslouchám...",
   "chatInputNoAudioRecorded": "Nebyl nahrán žádný zvuk. Zkus to znovu.",
+  "chatInputRecordingFailed": "Nahrávání selhalo. Zkus to znovu.",
   "chatInputPleaseWait": "Čekejte prosím...",
   "chatInputProcessing": "Zpracování...",
   "chatInputRecordVoice": "Nahrát hlasovou zprávu",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1553,6 +1553,7 @@
   "chatInputPleaseWait": "Vent venligst...",
   "chatInputProcessing": "Behandler...",
   "chatInputRecordVoice": "Optag talebesked",
+  "chatInputRecordingFailed": "Optagelse mislykkedes. Prøv igen.",
   "chatInputSendTooltip": "Send besked",
   "chatInputStopRealtime": "Stop live-transskriptionen",
   "chatInputStopTranscribe": "Stop og transskribér",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1372,6 +1372,7 @@
   "chatInputHintSelectModel": "Wähle ein Modell zum Chatten",
   "chatInputListening": "Hört zu...",
   "chatInputNoAudioRecorded": "Es wurde kein Audio aufgenommen. Versuch es noch einmal.",
+  "chatInputRecordingFailed": "Aufnahme fehlgeschlagen. Bitte erneut versuchen.",
   "chatInputPleaseWait": "Bitte warten...",
   "chatInputProcessing": "Verarbeitung...",
   "chatInputRecordVoice": "Sprachnachricht aufnehmen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1883,6 +1883,7 @@
   "chatInputHintSelectModel": "Select a model to start chatting",
   "chatInputListening": "Listening...",
   "chatInputNoAudioRecorded": "No audio was recorded. Try again.",
+  "chatInputRecordingFailed": "Recording failed. Please try again.",
   "chatInputPleaseWait": "Please wait...",
   "chatInputProcessing": "Processing...",
   "chatInputRecordVoice": "Record voice message",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1372,6 +1372,7 @@
   "chatInputHintSelectModel": "Selecciona un modelo para empezar a chatear",
   "chatInputListening": "Escuchando...",
   "chatInputNoAudioRecorded": "No se ha grabado audio. Inténtalo de nuevo.",
+  "chatInputRecordingFailed": "Error de grabación. Inténtalo de nuevo.",
   "chatInputPleaseWait": "Espera...",
   "chatInputProcessing": "Procesando...",
   "chatInputRecordVoice": "Grabar mensaje de voz",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1372,6 +1372,7 @@
   "chatInputHintSelectModel": "Choisis un modèle pour commencer à discuter",
   "chatInputListening": "Écoute en cours...",
   "chatInputNoAudioRecorded": "Aucun son n'a été enregistré. Réessaie.",
+  "chatInputRecordingFailed": "Échec de l'enregistrement. Veuillez réessayer.",
   "chatInputPleaseWait": "Patiente un instant...",
   "chatInputProcessing": "Traitement...",
   "chatInputRecordVoice": "Enregistrer un message vocal",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1372,7 +1372,7 @@
   "chatInputHintSelectModel": "Choisis un modèle pour commencer à discuter",
   "chatInputListening": "Écoute en cours...",
   "chatInputNoAudioRecorded": "Aucun son n'a été enregistré. Réessaie.",
-  "chatInputRecordingFailed": "Échec de l'enregistrement. Veuillez réessayer.",
+  "chatInputRecordingFailed": "Échec de l'enregistrement. Réessaie.",
   "chatInputPleaseWait": "Patiente un instant...",
   "chatInputProcessing": "Traitement...",
   "chatInputRecordVoice": "Enregistrer un message vocal",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1553,6 +1553,7 @@
   "chatInputPleaseWait": "Ti prego, aspetta...",
   "chatInputProcessing": "Elaborazione...",
   "chatInputRecordVoice": "Messaggio vocale registrato",
+  "chatInputRecordingFailed": "Registrazione fallita. Riprova.",
   "chatInputSendTooltip": "Invia messaggio",
   "chatInputStopRealtime": "Stop trascrizione live",
   "chatInputStopTranscribe": "Fermati e trascrivi",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5178,6 +5178,12 @@ abstract class AppLocalizations {
   /// **'No audio was recorded. Try again.'**
   String get chatInputNoAudioRecorded;
 
+  /// No description provided for @chatInputRecordingFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording failed. Please try again.'**
+  String get chatInputRecordingFailed;
+
   /// No description provided for @chatInputPleaseWait.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3102,6 +3102,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Nebyl nahrán žádný zvuk. Zkus to znovu.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Čekejte prosím...';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3102,7 +3102,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Nebyl nahrán žádný zvuk. Zkus to znovu.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed => 'Nahrávání selhalo. Zkus to znovu.';
 
   @override
   String get chatInputPleaseWait => 'Čekejte prosím...';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3061,6 +3061,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Vent venligst...';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3061,7 +3061,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed => 'Optagelse mislykkedes. Prøv igen.';
 
   @override
   String get chatInputPleaseWait => 'Vent venligst...';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3086,6 +3086,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Es wurde kein Audio aufgenommen. Versuch es noch einmal.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Bitte warten...';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3086,7 +3086,8 @@ class AppLocalizationsDe extends AppLocalizations {
       'Es wurde kein Audio aufgenommen. Versuch es noch einmal.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed =>
+      'Aufnahme fehlgeschlagen. Bitte erneut versuchen.';
 
   @override
   String get chatInputPleaseWait => 'Bitte warten...';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3046,6 +3046,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Please wait...';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3101,6 +3101,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se ha grabado audio. Inténtalo de nuevo.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Espera...';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3101,7 +3101,8 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se ha grabado audio. Inténtalo de nuevo.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed =>
+      'Error de grabación. Inténtalo de nuevo.';
 
   @override
   String get chatInputPleaseWait => 'Espera...';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3106,7 +3106,8 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aucun son n\'a été enregistré. Réessaie.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed =>
+      'Échec de l\'enregistrement. Veuillez réessayer.';
 
   @override
   String get chatInputPleaseWait => 'Patiente un instant...';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3106,6 +3106,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aucun son n\'a été enregistré. Réessaie.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Patiente un instant...';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3107,7 +3107,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get chatInputRecordingFailed =>
-      'Échec de l\'enregistrement. Veuillez réessayer.';
+      'Échec de l\'enregistrement. Réessaie.';
 
   @override
   String get chatInputPleaseWait => 'Patiente un instant...';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3102,7 +3102,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed => 'Registrazione fallita. Riprova.';
 
   @override
   String get chatInputPleaseWait => 'Ti prego, aspetta...';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3102,6 +3102,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Ti prego, aspetta...';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3071,6 +3071,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Wacht even...';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3071,7 +3071,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed => 'Opname mislukt. Probeer het opnieuw.';
 
   @override
   String get chatInputPleaseWait => 'Wacht even...';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3091,6 +3091,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Por favor, espere...';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3091,7 +3091,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed => 'Falha na gravação. Tente novamente.';
 
   @override
   String get chatInputPleaseWait => 'Por favor, espere...';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3112,6 +3112,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu s-a înregistrat niciun sunet. Încercați din nou.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Așteaptă...';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3113,7 +3113,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get chatInputRecordingFailed =>
-      'Înregistrarea a eșuat. Te rog să încerci din nou.';
+      'Înregistrarea a eșuat. Vă rugăm să încercați din nou.';
 
   @override
   String get chatInputPleaseWait => 'Așteaptă...';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3112,7 +3112,8 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu s-a înregistrat niciun sunet. Încercați din nou.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed =>
+      'Înregistrarea a eșuat. Te rog să încerci din nou.';
 
   @override
   String get chatInputPleaseWait => 'Așteaptă...';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3069,6 +3069,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
+  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+
+  @override
   String get chatInputPleaseWait => 'Vänta, snälla...';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3069,7 +3069,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chatInputNoAudioRecorded => 'No audio was recorded. Try again.';
 
   @override
-  String get chatInputRecordingFailed => 'Recording failed. Please try again.';
+  String get chatInputRecordingFailed =>
+      'Inspelningen misslyckades. Försök igen.';
 
   @override
   String get chatInputPleaseWait => 'Vänta, snälla...';

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1552,6 +1552,7 @@
   "chatInputPleaseWait": "Wacht even...",
   "chatInputProcessing": "Bezig met verwerken...",
   "chatInputRecordVoice": "Voicemail opnemen",
+  "chatInputRecordingFailed": "Opname mislukt. Probeer het opnieuw.",
   "chatInputSendTooltip": "Bericht versturen",
   "chatInputStopRealtime": "Stop live transcriptie",
   "chatInputStopTranscribe": "Stoppen en transcriberen",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1552,6 +1552,7 @@
   "chatInputPleaseWait": "Por favor, espere...",
   "chatInputProcessing": "Processando...",
   "chatInputRecordVoice": "Gravar mensagem de voz",
+  "chatInputRecordingFailed": "Falha na gravação. Tente novamente.",
   "chatInputSendTooltip": "Enviar mensagem",
   "chatInputStopRealtime": "Interromper a transcrição ao vivo",
   "chatInputStopTranscribe": "Pare e transcreva",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1372,6 +1372,7 @@
   "chatInputHintSelectModel": "Selectați un model pentru a începe conversația",
   "chatInputListening": "Ascultă...",
   "chatInputNoAudioRecorded": "Nu s-a înregistrat niciun sunet. Încercați din nou.",
+  "chatInputRecordingFailed": "Înregistrarea a eșuat. Te rog să încerci din nou.",
   "chatInputPleaseWait": "Așteaptă...",
   "chatInputProcessing": "Se procesează...",
   "chatInputRecordVoice": "Înregistrați un mesaj vocal",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1372,7 +1372,7 @@
   "chatInputHintSelectModel": "Selectați un model pentru a începe conversația",
   "chatInputListening": "Ascultă...",
   "chatInputNoAudioRecorded": "Nu s-a înregistrat niciun sunet. Încercați din nou.",
-  "chatInputRecordingFailed": "Înregistrarea a eșuat. Te rog să încerci din nou.",
+  "chatInputRecordingFailed": "Înregistrarea a eșuat. Vă rugăm să încercați din nou.",
   "chatInputPleaseWait": "Așteaptă...",
   "chatInputProcessing": "Se procesează...",
   "chatInputRecordVoice": "Înregistrați un mesaj vocal",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1553,6 +1553,7 @@
   "chatInputPleaseWait": "Vänta, snälla...",
   "chatInputProcessing": "Bearbetar...",
   "chatInputRecordVoice": "Spela in röstmeddelande",
+  "chatInputRecordingFailed": "Inspelningen misslyckades. Försök igen.",
   "chatInputSendTooltip": "Skicka meddelande",
   "chatInputStopRealtime": "Stoppa livetranskriptionen",
   "chatInputStopTranscribe": "Stoppa och transkribera",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.7+4304
+version: 1.0.8+4305
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/ui/chat/agent_chat_view_test.dart
+++ b/test/features/agents/ui/chat/agent_chat_view_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/agents/state/agent_chat_projection.dart';
 import 'package:lotti/features/agents/ui/chat/agent_chat_view.dart';
 import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
 import 'package:lotti/features/ai_chat/ui/controllers/chat_recorder_controller.dart';
+import 'package:lotti/features/ai_chat/ui/widgets/waveform_bars.dart';
 
 import '../../../../widget_test_utils.dart';
 import '../evolution/widgets/evolution_recorder_test_utils.dart';
@@ -472,6 +473,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      expect(find.byType(WaveformBars), findsOneWidget);
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
       expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
       expect(find.byType(TextField), findsNothing);
@@ -622,6 +624,148 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
       expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets('shows progress indicator when processing with no partial', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => ProcessingTestController(partialTranscript: null),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets('a transcription error shows a toast and clears the error', (
+      tester,
+    ) async {
+      late TranscriptEmittingController controller;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => controller = TranscriptEmittingController(),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.emitError('Microphone permission denied');
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        find.textContaining('Microphone permission denied'),
+        findsOneWidget,
+      );
+      expect(controller.clearResultCalls, greaterThan(0));
+    });
+
+    testWidgets('an empty transcript is not written to the draft', (
+      tester,
+    ) async {
+      var draft = '';
+      late TranscriptEmittingController controller;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          StatefulBuilder(
+            builder: (context, setState) => Scaffold(
+              body: AgentChatView(
+                agentId: 'goal-1',
+                agentName: 'Juno',
+                draft: draft,
+                isSending: false,
+                onDraftChanged: (v) => setState(() => draft = v),
+                onSend: () {},
+                onRetry: () {},
+              ),
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => controller = TranscriptEmittingController(),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.emitTranscript('   ');
+      await tester.pumpAndSettle();
+
+      expect(draft, '');
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+    });
+
+    testWidgets('mic button is hidden while sending', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: true,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              ChatRecorderController.new,
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.mic_rounded), findsNothing);
+      expect(find.byIcon(Icons.send_rounded), findsNothing);
     });
   });
 }

--- a/test/features/agents/ui/chat/agent_chat_view_test.dart
+++ b/test/features/agents/ui/chat/agent_chat_view_test.dart
@@ -4,8 +4,10 @@ import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/features/agents/state/agent_chat_projection.dart';
 import 'package:lotti/features/agents/ui/chat/agent_chat_view.dart';
 import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
+import 'package:lotti/features/ai_chat/ui/controllers/chat_recorder_controller.dart';
 
 import '../../../../widget_test_utils.dart';
+import '../evolution/widgets/evolution_recorder_test_utils.dart';
 
 void main() {
   testWidgets('the visible message footer follows locale word order', (
@@ -327,5 +329,299 @@ void main() {
 
     expect(find.textContaining('Message 0'), findsOneWidget);
     expect(find.textContaining('Message 29'), findsNothing);
+  });
+
+  group('voice input', () {
+    testWidgets('shows a mic button when idle with no text', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              ChatRecorderController.new,
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.send_rounded), findsNothing);
+    });
+
+    testWidgets('shows send when text is present and mic when cleared', (
+      tester,
+    ) async {
+      var draft = '';
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          StatefulBuilder(
+            builder: (context, setState) => Scaffold(
+              body: AgentChatView(
+                agentId: 'goal-1',
+                agentName: 'Juno',
+                draft: draft,
+                isSending: false,
+                onDraftChanged: (v) => setState(() => draft = v),
+                onSend: () {},
+                onRetry: () {},
+              ),
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              ChatRecorderController.new,
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.send_rounded), findsNothing);
+
+      await tester.enterText(find.byType(TextField), 'Hello');
+      await tester.pump();
+
+      expect(find.byIcon(Icons.send_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.mic_rounded), findsNothing);
+
+      await tester.enterText(find.byType(TextField), '');
+      await tester.pump();
+
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.send_rounded), findsNothing);
+    });
+
+    testWidgets('tapping the mic starts recording', (tester) async {
+      var startCalled = false;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => IdleCallbackController(
+                onStartCalled: () => startCalled = true,
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.mic_rounded));
+      await tester.pump();
+
+      expect(startCalled, isTrue);
+    });
+
+    testWidgets('shows waveform and cancel/stop while recording', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              RecordingTestController.new,
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.close_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets('cancel button calls the recorder', (tester) async {
+      var cancelCalled = false;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => RecordingCallbackController(
+                onCancelCalled: () => cancelCalled = true,
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close_rounded));
+      await tester.pump();
+      expect(cancelCalled, isTrue);
+
+      // The controller transitions to idle, so the mic reappears.
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+    });
+
+    testWidgets('stop button calls the recorder', (tester) async {
+      var stopCalled = false;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => RecordingCallbackController(
+                onStopCalled: () => stopCalled = true,
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.stop_rounded));
+      await tester.pump();
+      expect(stopCalled, isTrue);
+    });
+
+    testWidgets('a finished transcript fills the text field', (tester) async {
+      var draft = '';
+      late TranscriptEmittingController controller;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          StatefulBuilder(
+            builder: (context, setState) => Scaffold(
+              body: AgentChatView(
+                agentId: 'goal-1',
+                agentName: 'Juno',
+                draft: draft,
+                isSending: false,
+                onDraftChanged: (v) => setState(() => draft = v),
+                onSend: () {},
+                onRetry: () {},
+              ),
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => controller = TranscriptEmittingController(),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.emitTranscript('I walked this morning.');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller?.text,
+        'I walked this morning.',
+      );
+      expect(draft, 'I walked this morning.');
+      expect(find.byIcon(Icons.send_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows partial transcript while processing', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Scaffold(
+            body: AgentChatView(
+              agentId: 'goal-1',
+              agentName: 'Juno',
+              draft: '',
+              isSending: false,
+              onDraftChanged: (_) {},
+              onSend: () {},
+              onRetry: () {},
+            ),
+          ),
+          overrides: [
+            agentChatProjectionProvider(
+              'goal-1',
+            ).overrideWith((ref) async => const []),
+            chatRecorderControllerProvider.overrideWith(
+              () => ProcessingTestController(
+                partialTranscript: 'Transcribing audio…',
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Transcribing audio…'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+    });
   });
 }

--- a/test/features/agents/ui/chat/agent_chat_view_test.dart
+++ b/test/features/agents/ui/chat/agent_chat_view_test.dart
@@ -693,7 +693,7 @@ void main() {
       await tester.pump();
 
       expect(
-        find.textContaining('Microphone permission denied'),
+        find.textContaining('Recording failed'),
         findsOneWidget,
       );
       expect(controller.clearResultCalls, greaterThan(0));
@@ -735,6 +735,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(draft, '');
+      expect(controller.clearResultCalls, greaterThan(0));
       expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary

- Adds voice input to the goal agent chat composer, reusing the shared `chatRecorderControllerProvider` already used by the evolution chat
- Idle with no text → mic trailing icon (tap to start recording); idle with text → send icon
- Recording → waveform bars + cancel (X) / stop buttons
- Processing → streaming partial transcript with a spinner + mic icon
- Finished transcript → auto-fills the text field and switches to send
- Transcription errors surface as localized design-system toasts
- Uses design-system tokens throughout (colors, spacing, radii, typography); reuses the shared `WaveformBars` widget

## Context

The goal agent chat (`AgentChatView`) was text-only — the handover design (§1f) specifies a mic button that records, transcribes, and fills the text field. The shared recorder infrastructure (`ChatRecorderController`, `chatRecorderControllerProvider`, `WaveformBars`) already existed and was used by the task-agent evolution chat (`EvolutionMessageInput`). This PR wires that same infrastructure into the goal agent chat.

## Screenshots

### Mobile

| Before | After |
|---|---|
| ![Mobile before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/goal-agent-voice-input/d68566e54b04f7bcb614d14c6dbcec24a88579cd/before/goal_chat_mobile.png) | ![Mobile after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/goal-agent-voice-input/d68566e54b04f7bcb614d14c6dbcec24a88579cd/after/goal_chat_mobile.png) |

### Desktop

| Before | After |
|---|---|
| ![Desktop before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/goal-agent-voice-input/d68566e54b04f7bcb614d14c6dbcec24a88579cd/before/goal_chat_desktop.png) | ![Desktop after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/goal-agent-voice-input/d68566e54b04f7bcb614d14c6dbcec24a88579cd/after/goal_chat_desktop.png) |

## Validation

- `fvm dart analyze` on both files: no issues
- `fvm flutter test test/features/agents/ui/chat/agent_chat_view_test.dart`: **19 passed** (7 existing + 12 new voice input tests)
- New tests cover: mic button visibility, send/mic switching, tapping mic starts recording, waveform + cancel/stop while recording, cancel and stop button callbacks, transcript fills text field, partial transcript while processing, processing with null partial, error toast, empty transcript, mic hidden while sending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added voice input to goal-agent chat.
  - Record audio, view waveform feedback, cancel or stop recording, and transcribe speech into the message field.
  - Partial transcripts appear during processing, with completed transcripts added automatically.
- **Bug Fixes**
  - Added clear feedback when recording fails, including retry guidance.
- **Localization**
  - Recording error messages are now available in supported languages.
- **Tests**
  - Added coverage for recording, transcription, processing, errors, and sending states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->