### PR TITLE
fix(daily_os): stop the planner burning tokens on finished days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Goal-agent chat supports voice input.** The composer now has a microphone
   button that records, transcribes, and fills the text field.
 
+### Fixed
+- **The Daily OS planner no longer wakes for days that are already over.** The
+  planner kept one scheduled wake per day it had ever planned, and the finished
+  ones fired in bursts on every check — each a full model run that found nothing
+  to do and quietly re-scheduled itself, burning a large amount of inference for
+  no result. Wakes for a past day are now skipped before any model call, their
+  leftover schedules are cleared automatically, and the planner can no longer
+  schedule a new wake for a finished day.
+
 ## [1.0.7]
 ### Added
 - **Goal-agent criteria are ready for refinement.** Goal agents remain

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -43,6 +43,7 @@
     <release version="1.0.8" date="2026-08-12">
       <description>
         <p>Added: goal-agent chat supports voice input. The composer now has a microphone button that records, transcribes, and fills the text field.</p>
+        <p>Fixed: the Daily OS planner no longer wakes for days that are already over. Finished days kept firing full model runs that found nothing to do and re-scheduled themselves, burning inference for no result. Such wakes are now skipped before any model call, their leftover schedules are cleared automatically, and the planner can no longer schedule a new wake for a finished day.</p>
       </description>
     </release>
     <release version="1.0.7" date="2026-08-12">

--- a/lib/classes/day_agent_trigger_tokens.dart
+++ b/lib/classes/day_agent_trigger_tokens.dart
@@ -26,6 +26,15 @@ const dayAgentWorkspacePrefix = 'day:';
 /// Builds the wake-queue workspace key for the [dayId] day workspace.
 String dayAgentWorkspaceKey(String dayId) => '$dayAgentWorkspacePrefix$dayId';
 
+/// The `dayplan-…` id embedded in a `day:<dayId>` workspace key, or `null` when
+/// [workspaceKey] is not a day workspace (e.g. the coordinator digest lane
+/// `coordinator:digest`, which is deliberately not a `day:` partition).
+String? dayIdFromWorkspaceKey(String workspaceKey) =>
+    workspaceKey.startsWith(dayAgentWorkspacePrefix) &&
+        workspaceKey.length > dayAgentWorkspacePrefix.length
+    ? workspaceKey.substring(dayAgentWorkspacePrefix.length)
+    : null;
+
 /// Wake trigger token prefix that scopes a wake to a day workspace.
 ///
 /// `planning_day:<dayId>` is the authoritative day-workspace claim on a

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -687,13 +687,6 @@ class DayAgentService {
     return captureId;
   }
 
-  /// How many calendar days a per-day agent stays active past its own day.
-  ///
-  /// One, so it can wake the morning after and hand the coordinator anything
-  /// its day left unreported. After that the day is finished and there is
-  /// nothing for it to do on a timer.
-  static const dayAgentHandoverDays = 1;
-
   /// Stands down per-day agents whose day is over.
   ///
   /// **Why this exists.** A `day_agent:<dayId>` was created active and nothing
@@ -717,10 +710,8 @@ class DayAgentService {
   Future<int> retirePastDayAgents() async {
     // Calendar arithmetic, not a 24-hour subtraction: across a DST change a
     // fixed Duration does not reliably land on the previous calendar date.
-    final today = localDay(clock.now());
-    final cutoff = dayAgentIdForDate(
-      DateTime(today.year, today.month, today.day - dayAgentHandoverDays),
-    );
+    // Shares the one currency cutoff with the wake gate and the record reaper.
+    final cutoff = dayAgentIdForDate(plannerWakeCurrencyCutoff(clock.now()));
     final active = await agentService.listAgents(
       lifecycle: AgentLifecycle.active,
     );
@@ -772,6 +763,65 @@ class DayAgentService {
     // Surfaces watching lifecycle refresh on this, as they do for every other
     // identity mutation in this service.
     onPersistedStateChanged?.call(agent.agentId);
+  }
+
+  /// Consumes the coordinator's day-scoped scheduled-wake records whose day
+  /// workspace is already finished (older than [plannerWakeCurrencyCutoff]).
+  ///
+  /// **Why this exists.** [retirePastDayAgents] retires per-day *identities*,
+  /// but the long-lived coordinator (`dailyOsPlannerAgentId`) is not one — it
+  /// stays active forever. Every `set_next_wake` it runs persists one pending
+  /// [ScheduledWakeEntity] keyed by `day:<dayId>` workspace, so the coordinator
+  /// accumulated one record per day it ever planned with nothing to expire the
+  /// past-day ones. Because the due query is purely time-based, all of them
+  /// came due together on every scan and each fired a full planner inference
+  /// that found the day finished and re-scheduled itself. Consuming the stale
+  /// records here stops that burst at its source and drains the backlog that
+  /// built up before this guard existed.
+  ///
+  /// Scoped tightly: only `pending` records owned by the coordinator whose
+  /// workspace is a `day:<dayId>` partition strictly before the cutoff. The
+  /// coordinator's single digest lane (`coordinator:digest`) is not a `day:`
+  /// workspace, so it is never touched, and per-day agents' own records are
+  /// handled by retirement. `consumed`, not deleted, so a peer's concurrent
+  /// flip converges via LWW instead of resurrecting the row.
+  Future<int> expireStalePlannerWakeRecords() async {
+    final now = clock.now();
+    final pending = await repository.getPendingScheduledWakeRecords();
+    var expired = 0;
+    for (final record in pending) {
+      if (record.agentId != dailyOsPlannerAgentId) continue;
+      final dayId = dayIdFromWorkspaceKey(record.workspaceKey ?? '');
+      if (dayId == null || !isStalePlannerDay(dayId, now)) continue;
+      try {
+        await syncService.upsertEntity(
+          record.copyWith(
+            status: ScheduledWakeStatus.consumed,
+            consumedAt: now,
+            updatedAt: now,
+          ),
+        );
+        onPersistedStateChanged?.call(record.agentId);
+        expired++;
+      } catch (e, s) {
+        domainLogger.error(
+          LogDomain.agentRuntime,
+          e,
+          message:
+              'failed to expire stale planner wake record '
+              '${DomainLogger.sanitizeId(record.id)}',
+          stackTrace: s,
+        );
+      }
+    }
+    if (expired > 0) {
+      domainLogger.log(
+        LogDomain.agentRuntime,
+        'expired $expired stale planner wake record(s)',
+        subDomain: 'lifecycle',
+      );
+    }
+    return expired;
   }
 
   /// Restore in-memory runtime state for active day agents at app startup.

--- a/lib/features/daily_os_next/agents/state/daily_os_runtime_maintenance.dart
+++ b/lib/features/daily_os_next/agents/state/daily_os_runtime_maintenance.dart
@@ -38,6 +38,22 @@ class DailyOsRuntimeMaintenance implements AgentRuntimeMaintenance {
         stackTrace: s,
       );
     }
+    // The coordinator is never retired (it is not a per-day identity), so its
+    // day-scoped scheduled-wake records for finished days are expired here.
+    // Without this, every past day the singleton planner ever planned holds a
+    // pending record that fires a full inference on each scan and re-arms
+    // itself — the token-burn loop. Contained like the retirement above: a
+    // failure must not stop the wakes that are genuinely due.
+    try {
+      await dayAgents.expireStalePlannerWakeRecords();
+    } catch (e, s) {
+      domainLogger?.error(
+        LogDomain.agentRuntime,
+        e,
+        message: 'failed to expire stale planner wake records before wake scan',
+        stackTrace: s,
+      );
+    }
     // The digest bootstrap can arm a record for an already-past slot when a run
     // was interrupted, which only fires promptly if it exists before the scan.
     try {

--- a/lib/features/daily_os_next/agents/workflow/day_agent_tool_handlers.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_tool_handlers.dart
@@ -196,6 +196,23 @@ extension DayAgentToolHandlers on DayAgentWorkflow {
     }
 
     final now = clock.now();
+
+    // Currency guard (token-burn fix): never re-arm a wake for a day workspace
+    // that is already finished. `dayId` here is the wake's own workspace, so a
+    // wake operating on a past day cannot resurrect its just-consumed past-day
+    // record and re-enter the burn loop. Complements the pre-inference gate in
+    // `_execute`: that stops a stale wake before it runs; this stops a running
+    // wake (e.g. one that crossed a midnight boundary mid-run) from seeding the
+    // next one.
+    if (isStalePlannerDay(dayId, now)) {
+      return DayAgentToolResult(
+        success: false,
+        output:
+            'Error: cannot schedule a wake for "$dayId" — that day is already '
+            'finished. Only the current or upcoming day may be pre-warmed.',
+      );
+    }
+
     final earliestAllowed = now.add(DayAgentWorkflow.minScheduledWakeLeadTime);
     if (scheduledAt.isBefore(earliestAllowed)) {
       return DayAgentToolResult(

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -336,6 +336,33 @@ class DayAgentWorkflow {
       triggerTokens: triggerTokens,
     );
 
+    // Stale-day gate (token-burn fix). A background `planning_day` wake for a
+    // day already past the handover cutoff has no actionable work — the day is
+    // finished. Short-circuit HERE, before assembling the ~200K-token day
+    // context or calling the model, and without re-arming: the scheduled-wake
+    // record that fired this wake was already consumed by the wake manager, so
+    // returning success simply lets it rest. This is the pattern the singleton
+    // planner accumulated one record per past day of — each firing a full
+    // inference that concluded "nothing to do" and re-scheduled itself.
+    //
+    // Excluded, deliberately: digest wakes (the coordinator's live cadence,
+    // re-anchored to today upstream), drafting and refine wakes (user-initiated
+    // on a current day), and capture-submitted wakes (`isDayTokenWake` is false
+    // — their day comes from the capture, which the user just recorded). Only a
+    // bare, day-token scheduled wake for a finished day is waste.
+    if (isDayTokenWake &&
+        !wakeContext.isDigestWake &&
+        !wakeContext.isDraftingWake &&
+        !wakeContext.isRefineWake &&
+        isStalePlannerDay(resolvedDayId, now)) {
+      _log(
+        'skipped stale planning_day wake for $resolvedDayId — day finished, '
+        'no inference',
+        subDomain: 'execute',
+      );
+      return const WakeResult(success: true);
+    }
+
     final observations = await agentRepository.getMessagesByKind(
       agentId,
       AgentMessageKind.observation,

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
@@ -718,6 +718,39 @@ DateTime? dateFromDayId(String dayId) {
   return DateTime.tryParse(dayId.substring(prefix.length));
 }
 
+/// How many calendar days a Daily OS day workspace stays plannable past its own
+/// date. One: the day itself, plus the morning-after handover — after that the
+/// day is finished and there is nothing for a background wake to do on a timer.
+///
+/// The single source of truth for the retirement cutoff (`retirePastDayAgents`),
+/// the stale-record reaper (`expireStalePlannerWakeRecords`), the pre-inference
+/// wake gate, and the `set_next_wake` currency guard. All four must agree, or a
+/// wake the reaper leaves alive could fire an inference the gate then wastes.
+const dayAgentHandoverDays = 1;
+
+/// The oldest local calendar date a Daily OS planner wake may still act on:
+/// today minus [dayAgentHandoverDays]. A `dayplan-…` workspace strictly before
+/// this is finished; its background wakes must neither run an inference nor be
+/// re-armed.
+DateTime plannerWakeCurrencyCutoff(DateTime now) {
+  final today = localDay(now);
+  return DateTime(today.year, today.month, today.day - dayAgentHandoverDays);
+}
+
+/// Whether [dayId] is a `dayplan-…` workspace already older than the planner's
+/// currency cutoff at [now] — a finished day whose scheduled planner wakes are
+/// pure token waste.
+///
+/// A non-day id (the coordinator digest lane, a malformed key) is never stale
+/// here: staleness is a claim about a resolved calendar day, and callers gate
+/// those cases separately. Drafting/refine/digest/capture wakes are likewise
+/// excluded at their call sites — this is the calendar test alone.
+bool isStalePlannerDay(String dayId, DateTime now) {
+  final date = dateFromDayId(dayId);
+  if (date == null) return false;
+  return date.isBefore(plannerWakeCurrencyCutoff(now));
+}
+
 /// Extracts the `text` field from a message payload, falling back to
 /// `(no content)` when the payload is absent or carries no text.
 String extractPayloadText(AgentMessagePayloadEntity? payload) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.8+4305
+version: 1.0.8+4306
 
 msix_config:
   display_name: LottiApp

--- a/test/classes/day_agent_trigger_tokens_test.dart
+++ b/test/classes/day_agent_trigger_tokens_test.dart
@@ -24,6 +24,19 @@ void main() {
       );
     });
 
+    test('dayIdFromWorkspaceKey inverts dayAgentWorkspaceKey', () {
+      const dayId = 'dayplan-2026-05-25';
+      expect(dayIdFromWorkspaceKey(dayAgentWorkspaceKey(dayId)), dayId);
+    });
+
+    test('dayIdFromWorkspaceKey returns null for a non-day workspace', () {
+      // The coordinator digest lane is deliberately not a `day:` partition, so
+      // the record reaper must not read a day out of it.
+      expect(dayIdFromWorkspaceKey(coordinatorDigestWorkspaceKey), isNull);
+      expect(dayIdFromWorkspaceKey('day:'), isNull);
+      expect(dayIdFromWorkspaceKey(''), isNull);
+    });
+
     test('dayAgentRefineToken prefixes the day id', () {
       expect(
         dayAgentRefineToken('dayplan-2026-05-25'),

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -1929,6 +1929,138 @@ void main() {
     }
   });
 
+  group('expireStalePlannerWakeRecords', () {
+    // The always-active coordinator arms one pending scheduled-wake record per
+    // day it plans; nothing retired the past-day ones (retirement only touches
+    // per-day *identities*), so they piled up and all fired together on every
+    // scan. This reaper consumes the finished-day ones at their source.
+    ScheduledWakeEntity plannerDayWake(
+      String dayId, {
+      String? owner,
+    }) =>
+        AgentDomainEntity.scheduledWake(
+              id: scheduledWakeRecordId(
+                owner ?? dailyOsPlannerAgentId,
+                workspaceKey: dayAgentWorkspaceKey(dayId),
+              ),
+              agentId: owner ?? dailyOsPlannerAgentId,
+              scheduledAt: DateTime(2026, 5, 25, 22, 30),
+              status: ScheduledWakeStatus.pending,
+              reason: WakeReason.scheduled.name,
+              updatedAt: now,
+              vectorClock: null,
+              triggerTokens: [dayAgentPlanningDayToken(dayId)],
+              workspaceKey: dayAgentWorkspaceKey(dayId),
+            )
+            as ScheduledWakeEntity;
+
+    ScheduledWakeEntity digestLaneWake() =>
+        AgentDomainEntity.scheduledWake(
+              id: scheduledWakeRecordId(
+                dailyOsPlannerAgentId,
+                workspaceKey: coordinatorDigestWorkspaceKey,
+              ),
+              agentId: dailyOsPlannerAgentId,
+              scheduledAt: DateTime(2026, 5, 20, 6),
+              status: ScheduledWakeStatus.pending,
+              reason: dayAgentDigestReason,
+              updatedAt: now,
+              vectorClock: null,
+              triggerTokens: [dayAgentDigestToken('dayplan-2026-05-20')],
+              workspaceKey: coordinatorDigestWorkspaceKey,
+            )
+            as ScheduledWakeEntity;
+
+    test(
+      'consumes only the coordinator day records for finished days',
+      () async {
+        // today = 2026-05-25, handover cutoff = 2026-05-24. Only days strictly
+        // before the cutoff are finished.
+        final stale = plannerDayWake('dayplan-2026-05-20');
+        final records = <ScheduledWakeEntity>[
+          stale,
+          // Today and the handover day are still live — never touched.
+          plannerDayWake('dayplan-2026-05-25'),
+          plannerDayWake('dayplan-2026-05-24'),
+          // The digest lane is not a `day:` workspace — never touched.
+          digestLaneWake(),
+          // A per-day agent's own stale record — retirement's job, not ours.
+          plannerDayWake(
+            'dayplan-2026-05-19',
+            owner: perDayAgentId('dayplan-2026-05-19'),
+          ),
+        ];
+        when(
+          () => repository.getPendingScheduledWakeRecords(),
+        ).thenAnswer((_) async => records);
+
+        final expired = await withClock(
+          Clock.fixed(now),
+          service.expireStalePlannerWakeRecords,
+        );
+
+        expect(expired, 1);
+        final written = verify(
+          () => syncService.upsertEntity(captureAny()),
+        ).captured.whereType<ScheduledWakeEntity>().toList();
+        // Exactly the one finished-day coordinator record, flipped consumed.
+        expect(written, hasLength(1));
+        expect(written.single.id, stale.id);
+        expect(written.single.status, ScheduledWakeStatus.consumed);
+        expect(written.single.consumedAt, now);
+        expect(changedTokens, contains(dailyOsPlannerAgentId));
+      },
+    );
+
+    test('writes nothing when no record is for a finished day', () async {
+      when(() => repository.getPendingScheduledWakeRecords()).thenAnswer(
+        (_) async => [
+          plannerDayWake('dayplan-2026-05-25'),
+          digestLaneWake(),
+        ],
+      );
+
+      expect(
+        await withClock(
+          Clock.fixed(now),
+          service.expireStalePlannerWakeRecords,
+        ),
+        0,
+      );
+      verifyNever(() => syncService.upsertEntity(any()));
+    });
+
+    test('logs and continues when consuming a record throws', () async {
+      when(() => repository.getPendingScheduledWakeRecords()).thenAnswer(
+        (_) async => [plannerDayWake('dayplan-2026-05-20')],
+      );
+      when(() => syncService.upsertEntity(any())).thenThrow(
+        StateError('wake write failed'),
+      );
+
+      // A write failure is contained, not propagated: it must not strand the
+      // wake scan that runs right after this reaper.
+      expect(
+        await withClock(
+          Clock.fixed(now),
+          service.expireStalePlannerWakeRecords,
+        ),
+        0,
+      );
+      verify(
+        () => domainLogger.error(
+          any(),
+          any(),
+          message: any(
+            named: 'message',
+            that: contains('expire stale planner wake record'),
+          ),
+          stackTrace: any(named: 'stackTrace'),
+        ),
+      ).called(1);
+    });
+  });
+
   group('retirePastDayAgents', () {
     // A day that is over must not hold a live agent: nothing retired them, so
     // the active set grew by one per day of use and every one was re-hydrated

--- a/test/features/daily_os_next/agents/state/daily_os_runtime_maintenance_test.dart
+++ b/test/features/daily_os_next/agents/state/daily_os_runtime_maintenance_test.dart
@@ -27,6 +27,11 @@ void main() {
         stackTrace: any<StackTrace?>(named: 'stackTrace'),
       ),
     ).thenAnswer((_) {});
+    // beforeWakeScan runs three contained repairs; default them all to succeed
+    // so each test overrides only the one it exercises.
+    when(dayAgents.retirePastDayAgents).thenAnswer((_) async => 0);
+    when(dayAgents.expireStalePlannerWakeRecords).thenAnswer((_) async => 0);
+    when(dayAgents.ensureCoordinatorDigestWake).thenAnswer((_) async {});
     maintenance = DailyOsRuntimeMaintenance(
       dayAgents: dayAgents,
       domainLogger: logger,
@@ -58,16 +63,23 @@ void main() {
       );
     });
 
-    test('runs retirement and the digest repair, in that order', () async {
+    test('runs retirement, the reaper and the digest repair, in that '
+        'order', () async {
       when(dayAgents.retirePastDayAgents).thenAnswer((_) async => 2);
+      when(
+        dayAgents.expireStalePlannerWakeRecords,
+      ).thenAnswer((_) async => 3);
       when(dayAgents.ensureCoordinatorDigestWake).thenAnswer((_) async {});
 
       await maintenance.beforeWakeScan();
 
       // Order matters: retirement decides which agents may still wake, so it
-      // must settle before the digest repair arms a record.
+      // must settle before the digest repair arms a record. The reaper runs
+      // between them — it targets the coordinator's records, which retirement
+      // never touches.
       verifyInOrder([
         dayAgents.retirePastDayAgents,
+        dayAgents.expireStalePlannerWakeRecords,
         dayAgents.ensureCoordinatorDigestWake,
       ]);
       verifyNever(
@@ -98,6 +110,28 @@ void main() {
             LogDomain.agentRuntime,
             any<Object>(),
             message: 'failed to retire past day agents before wake scan',
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'contains a reaper failure and still repairs the digest',
+      () async {
+        when(
+          dayAgents.expireStalePlannerWakeRecords,
+        ).thenThrow(StateError('reaper boom'));
+
+        await maintenance.beforeWakeScan();
+
+        verify(dayAgents.ensureCoordinatorDigestWake).called(1);
+        verify(
+          () => logger.error(
+            LogDomain.agentRuntime,
+            any<Object>(),
+            message:
+                'failed to expire stale planner wake records before wake scan',
             stackTrace: any<StackTrace?>(named: 'stackTrace'),
           ),
         ).called(1);

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_models_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_models_test.dart
@@ -962,6 +962,44 @@ void main() {
       );
     });
   });
+
+  group('planner wake currency', () {
+    test('the handover window is one day', () {
+      expect(dayAgentHandoverDays, 1);
+    });
+
+    test(
+      'the cutoff is today minus the handover window, at local midnight',
+      () {
+        expect(
+          plannerWakeCurrencyCutoff(DateTime(2026, 8, 12, 23, 8)),
+          DateTime(2026, 8, 11),
+        );
+      },
+    );
+
+    test('today and the handover day are not stale; older days are', () {
+      final now = DateTime(2026, 8, 12, 23, 8);
+      // Today's own workspace is always current.
+      expect(isStalePlannerDay('dayplan-2026-08-12', now), isFalse);
+      // Yesterday is the handover day — still allowed one wake.
+      expect(isStalePlannerDay('dayplan-2026-08-11', now), isFalse);
+      // The day before the handover is finished — the misfire boundary.
+      expect(isStalePlannerDay('dayplan-2026-08-10', now), isTrue);
+      // Weeks-stale days (as seen in the runaway) are stale.
+      expect(isStalePlannerDay('dayplan-2026-07-14', now), isTrue);
+      // A future pre-warm is never stale.
+      expect(isStalePlannerDay('dayplan-2026-08-13', now), isFalse);
+    });
+
+    test('a non-dayplan id is never treated as a stale day', () {
+      // Staleness is a claim about a resolved calendar day; the digest lane and
+      // malformed keys are gated by their callers, not here.
+      final now = DateTime(2026, 8, 12);
+      expect(isStalePlannerDay('coordinator:digest', now), isFalse);
+      expect(isStalePlannerDay('not-a-day', now), isFalse);
+    });
+  });
 }
 
 CreateChatCompletionStreamResponse _thinkingChunk(String model) =>

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_persistence_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_persistence_test.dart
@@ -330,6 +330,37 @@ void main() {
       expect(upsertedEntities.whereType<ScheduledWakeEntity>(), isEmpty);
     });
 
+    test('refuses to re-arm a wake for a finished day', () async {
+      // Currency guard (token-burn fix), defence-in-depth behind the
+      // pre-inference gate. A refine wake bypasses that gate (mode wakes are
+      // user-initiated), so if it ran on a stale day and the model tried to
+      // schedule the next wake, set_next_wake must still refuse — otherwise the
+      // finished-day record would resurrect itself and re-enter the burn loop.
+      const staleDay = 'dayplan-2026-05-10';
+      conversationRepository.toolCalls = [
+        toolCall(
+          name: DayAgentToolNames.setNextWake,
+          args: const {
+            'at': '2026-05-26T08:30:00',
+            'reason': 'Re-arm the finished day.',
+          },
+        ),
+      ];
+
+      final result = await execute(
+        workflow(),
+        triggerTokens: {dayAgentRefineToken(staleDay)},
+      );
+
+      expect(result.success, isTrue);
+      expect(
+        conversationRepository.toolResponses.single,
+        contains('that day is already finished'),
+      );
+      // No record was armed — the loop cannot restart.
+      expect(upsertedEntities.whereType<ScheduledWakeEntity>(), isEmpty);
+    });
+
     test(
       'returns a tool error when state disappears during scheduling',
       () async {

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -289,4 +289,53 @@ void main() {
       );
     });
   });
+
+  // The token-burn fix. The singleton planner accumulated one scheduled-wake
+  // record per past day; each fired a full ~200K-token wake that found the day
+  // finished and re-armed itself. This gate stops that wake before any context
+  // is assembled or the model is called.
+  group('stale-day wake gate', () {
+    test(
+      'skips a background planning_day wake for a finished day with no '
+      'inference and no re-arm',
+      () async {
+        // now = 2026-05-25; handover cutoff = 2026-05-24. This day is weeks
+        // stale — exactly the dayplan-2026-07-14…08-10 records in the runaway.
+        final result = await execute(
+          workflow(),
+          triggerTokens: {dayAgentPlanningDayToken('dayplan-2026-05-10')},
+        );
+
+        // The record that fired this wake was already consumed by the wake
+        // manager, so success simply lets it rest — no failure, no retry.
+        expect(result.success, isTrue);
+        // The whole point: the model was never called…
+        expect(conversationRepository.sendMessageCalls, isEmpty);
+        expect(conversationRepository.lastUserMessage, isNull);
+        // …and nothing was written, so no next wake was armed.
+        expect(upsertedEntities, isEmpty);
+      },
+    );
+
+    test('still runs the handover (yesterday) wake', () async {
+      // Yesterday is inside the handover window, so the wake must proceed to
+      // inference rather than be gated. Stub the day-scoped reads for it.
+      const yesterday = 'dayplan-2026-05-24';
+      when(
+        () => repository.getCaptureEventMetaForDay(
+          agentId: agentId,
+          dayId: yesterday,
+        ),
+      ).thenAnswer((_) async => const []);
+
+      final result = await execute(
+        workflow(),
+        triggerTokens: {dayAgentPlanningDayToken(yesterday)},
+      );
+
+      expect(result.success, isTrue);
+      // It reached the model — the gate did not fire on the handover day.
+      expect(conversationRepository.sendMessageCalls, isNotEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## The bug (P0 — active token spend)

The long-lived Daily OS planner (`daily_os_planner`, shown as *Shepherd*) was billing a large amount of inference for no result — bursts of 7–13 full wakes within a couple of minutes, each shipping ~200K tokens of context.

**Root cause.** The architecture moved from per-day agent identities to one always-active singleton planner, but the cleanup machinery did not move with it:

1. `set_next_wake` persists one `ScheduledWakeEntity` per day, keyed deterministically by `day:<dayId>` workspace. The singleton plans many days → **one pending record per day it ever planned** (weeks of `dayplan-*` records).
2. **Nothing expired the past-day records.** `retirePastDayAgents` only stands down per-day *identities*; the coordinator is never one. (Confirmed in the runtime logs: `retired` = 0 on every day.)
3. `getDueScheduledWakeRecords` is purely time-based, so on each scan **all stale records came due at once** (logs: `23:08:01 … 13 scheduled-wake record(s) fired` → 13 serial `planning_day` wakes over ~2.5 min).
4. Each wake reached the workflow, which validated only that the day *parsed* — **no currency gate** — assembled full context, and called the model. The model found nothing to do and called `set_next_wake`, which re-armed the same past-day record. Resurrected → due again → burned again.

## The fix (three defenses, one shared cutoff = today − 1-day handover)

- **Pre-inference gate** (`DayAgentWorkflow._execute`): a background `planning_day` wake for a finished day returns *before* assembling context or calling the model, and does not re-arm. Digest / drafting / refine / capture wakes are excluded.
- **`set_next_wake` currency guard**: the planner can no longer schedule a wake for a day that is already over — a wake that slips the gate cannot reseed the loop.
- **Stale-record reaper** (`expireStalePlannerWakeRecords`, wired into `beforeWakeScan`): consumes the coordinator's day-scoped records for finished days, draining the backlog that already accumulated on the next scan.

Project- and goal-agent timers (`Hb4all`, `Orga`, `goal-cadence`) are untouched — the fix is scoped to the `daily_os_planner` day path, and yesterday's legitimate handover wake still runs.

## Tests
- Pure cutoff/staleness helpers and workspace-key inverse (boundary cases incl. today, handover day, weeks-stale, future).
- Gate: a stale `planning_day` wake completes with **no model call and no writes**; the handover (yesterday) wake still reaches inference.
- Guard: a wake for a finished day is refused, no record armed (reachable via a refine wake that bypasses the gate).
- Reaper: consumes only finished-day coordinator records (leaves today, handover, the digest lane, and per-day agents' own records); contains a write failure.
- Maintenance wiring: reaper runs between retirement and the digest repair, and its failure is contained.

Analyzer clean; targeted suites green.

## Note
Build number bump (`+4306`) was made by the maintainer and is intended.

Follow-up in this PR: the sidebar wake-queue X/trash buttons don't currently cancel queued wakes — fixing next so the running instance can be cleared manually.