### PR TITLE
docs: close knowledge drift across goals, agents, daily_os, ai and tasks

### DIFF
--- a/knowledge/features/agents/overview.md
+++ b/knowledge/features/agents/overview.md
@@ -62,10 +62,14 @@ reads the journal on demand during a wake.
 | `event_agent` | `activeEventId` | `EventAgentWorkflow` | creation (content-gated), direct event edits |
 | `template_improver` | `activeTemplateId` | `ImproverAgentWorkflow` | scheduled ritual |
 | `day_agent` | day workspace (`day:<dayId>`), no single slot | `DayAgentWorkflow` | day-scoped pre-warms and capture wakes |
+| `goal_agent` | goal spec head (no single slot) | `GoalAgentWorkflow` | deterministic cadence, signal subscriptions, escalation wakes |
 
 The day agent is the single long-lived Daily OS planner (ADR 0022). Its workflow
 and service live in [`daily_os_next`](../daily_os_next/), not here — and
-**nothing in `features/agents` imports them.**
+**nothing in `features/agents` imports them.** The goal agent is the
+deterministic-first goal coach (ADRs 0053–0054); its workflow, evaluation and
+service live in [`goals`](../goals.md), also outside this tree, and it plugs in
+through the same registry mechanism as the day agent.
 
 ## How an owning feature plugs a kind in
 
@@ -175,6 +179,7 @@ arrives, so either sync ordering closes the snapshot-to-live-update gap.
 * [Project and event agents](project-and-event-agents.md) - the digest-shaped and recap-shaped variants.
 * [Templates, souls and evolution](templates-souls-evolution.md) - what an agent does versus who it is, and how both evolve.
 * [Persistence and sync](persistence-and-sync.md) - the `agent.sqlite` entity and link model, plus what syncs and what stays local.
+* [Projection kernel](projection.md) - the pure fold under the agent log, and the permutation-invariance proof that makes replay order irrelevant.
 * [UI surfaces](ui-surfaces.md) - the AI summary card, internals panel, settings tabs and sidebar.
 
 # Code reading guide

--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -43,7 +43,7 @@ sources:
   - id: entity-model
     resource: ../../../lib/features/agents/model/agent_domain_entity.dart
     title: AgentDomainEntity
-    last_modified: 2026-08-10
+    last_modified: 2026-08-12
   - id: db-conversions
     resource: ../../../lib/features/agents/database/agent_db_conversions.dart
     title: AgentDbConversions
@@ -75,6 +75,10 @@ sources:
     resource: ../../../docs/adr/0007-token-usage-wake-run-log-storage.md
     title: ADR 0007 — Token usage and wake run log storage
     last_modified: 2026-02-28
+  - id: adr-0053
+    resource: ../../../docs/adr/0053-goal-driven-agents-per-goal-producers.md
+    title: ADR 0053 — Goal-driven agents, per-goal producers
+    last_modified: 2026-08-08
 ---
 
 # One database, two shapes
@@ -110,6 +114,13 @@ that model.
 - Daily OS capture-pipeline and planning variants: `CaptureEntity`,
   `ParsedItemEntity`, `DayPlanEntity`, `DaySummaryEntity`, `DayDirectiveEntity`,
   `DayStatusEventEntity`, `WeekRollupEntity`.
+- Goal-agent variants (ADRs 0053–0058): `GoalSpecVersionEntity`,
+  `GoalSpecHeadEntity`, `GoalProgressEntity`, `GoalNudgeEntity`. The spec
+  version carries the immutable criteria tree; the head points at the active
+  version; the progress row is the deterministic per-period register; the nudge
+  is the banner ad with its CRDT exposure counters and rating history. All four
+  sync as agent-domain entities and validate through `GoalSpecValidator` at
+  every decode path.
 - `AgentUnknownEntity` — the forward-compat fallback for variants an older
   client cannot decode.
 
@@ -533,13 +544,15 @@ output, raw tool arguments, or arbitrary exception strings.
 The durable agent message log remains the memory and audit surface; it is never
 copied into runtime log files.
 
-For the seven runtime and workflow classes that share `AgentErrorLogging`
+For the runtime and workflow classes that share `AgentErrorLogging`
 (`agents/util/agent_error_logging.dart`), the rule is enforced in one place: its
 no-logger fallback passes `error.runtimeType` to `developer.log`, never the error
 object. That mixin replaced a byte-identical copy of the method in each class, so
-the rule can no longer be upheld in six places and broken in the seventh.
+the rule can no longer be upheld in some places and broken in others.
 `DayAgentWorkflow` deliberately does not adopt it — its logger is non-nullable
 and it has no fallback branch at all — so it carries the rule on its own.
+`GoalAgentWorkflow` (in `features/goals`) does adopt it, so the mixin is no
+longer exclusive to `features/agents`.
 
 # AI consumption provenance
 

--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -36,6 +36,18 @@ sources:
     resource: ../../../docs/adr/0052-agent-directive-constitution.md
     title: ADR 0052 — An agent's constitution is code, not an evolvable directive
     last_modified: 2026-08-08
+  - id: adr-0051
+    resource: ../../../docs/adr/0051-agenda-gated-tool-exposure.md
+    title: ADR 0051 — Gate tool exposure on what the wake already knows
+    last_modified: 2026-08-08
+  - id: tool-gate
+    resource: ../../../lib/features/agents/tools/task_agent_tool_gate.dart
+    title: TaskAgentWakeFacts / visibleTaskAgentToolNames — the per-wake tool gate
+    last_modified: 2026-08-08
+  - id: staged-exposure
+    resource: ../../../lib/features/agents/tools/task_agent_staged_tool_exposure.dart
+    title: TaskAgentStagedToolExposure — withhold update_report from turn one
+    last_modified: 2026-08-08
 ---
 
 # Creation
@@ -396,6 +408,72 @@ For the exact Melious `mistral-small-4-119b-instruct` executor:
   stays accurate.
 
 # Tool policy
+
+The tool list a wake advertises is **not a constant**. Two complementary
+mechanisms narrow it behind the `narrowToolSurface` flag (off by default,
+additive): a per-wake **fact gate** that drops tools the wake cannot legitimately
+use, and a **staged exposure** that withholds `update_report` from the opening
+turn. With the flag off, `TaskAgentWakeFacts.permissive` and a single fixed tool
+list reproduce today's behaviour exactly, so both can be evaluated side by side
+before either becomes default (ADR 0051).
+
+## Agenda-gated exposure (ADR 0051)
+
+`visibleTaskAgentToolNames(TaskAgentWakeFacts)` drops a tool when the fact that
+makes it usable is absent. `_resolveWakeFacts` computes each fact from state the
+wake already loads — no extra inference turn, inverting the rejected "ask the
+model what it intends" design whose arithmetic doubled input to save a fraction
+of the payload.
+
+| Tool | Withheld when |
+|-----|---------------|
+| `update_checklist_items` | the task has no checklist items |
+| `update_running_timer` | no timer is running **for this task** (a timer on another task reaches the prompt only as an opaque range, so there is no id to update — offering the tool would invite a hallucinated one) |
+| `update_time_entry` | the task has no editable time records |
+| `assign_task_labels` | no label definitions exist for the category |
+| `retract_suggestions` | the proposal ledger holds no open proposals |
+| `resolve_attention_request` | this agent holds no active attention claim on the task |
+
+Tools with no precondition — `set_task_title`, `update_task_estimate`,
+`update_task_due_date`, `update_task_priority`, `set_task_status`,
+`set_task_language`, `add_multiple_checklist_items`, `create_follow_up_task`,
+`link_task`, `record_observations`, `request_attention`,
+`migrate_checklist_items` — are always offered. `migrate_checklist_items` is
+only meaningful after `create_follow_up_task`, but that happens mid-wake and
+the tool list is fixed for the turn, so it cannot be gated on it.
+
+Every fact defaults to **permissive**: a caller that has not been taught to
+compute one gets the tool, so adding a gate can never silently remove a
+capability from a wake that was not updated. A gate has to be asked for.
+
+`hasNewerContentThanReport` is deliberately left permissive in `_resolveWakeFacts`.
+A note that arrives saying nothing new is still newer than the report, and
+whether its content matters is a judgement the timestamps cannot make, so gating
+`update_report` on it would withhold the tool from wakes that genuinely need it.
+`update_report` is narrowed by the **staged exposure** below instead — a
+structural fix that does not require the app to judge materiality.
+
+## Staged exposure
+
+`TaskAgentStagedToolExposure` withholds `update_report` from the **opening
+turn** only, so the wake does the work before it reports on it. The shipped
+directive is evidence-first — establish what changed, then report it — and a
+model that can publish on turn one can satisfy the wake protocol before looking
+at anything; weaker models do exactly that. From the second turn onward the
+full list is advertised, so nothing is permanently unreachable and a wake can
+always finish its report. `record_observations` is deliberately *not* withheld:
+observations are the agent's private notes for later wakes, and a model that
+wants to note something on its first turn should be able to.
+
+A wake with genuinely nothing to do is unaffected: finishing with a plain-text
+note and no tool call is available on the first turn and is still the correct
+ending. The one case that pays a turn is a report-only wake, where nothing needs
+changing but the report does — that model must wait for turn two to publish.
+Whether that trade is worth it is a measurement, not an assumption, which is
+why both mechanisms sit behind `narrowToolSurface` rather than shipping on by
+default.
+
+## Locally short-circuited tools
 
 Four tools are short-circuited **locally** in `TaskAgentStrategy` and never reach
 `AgentToolExecutor`: `update_report`, `record_observations`,

--- a/knowledge/features/agents/ui-surfaces.md
+++ b/knowledge/features/agents/ui-surfaces.md
@@ -467,7 +467,7 @@ shell on narrow layouts.
 
 ## History sections and reload behaviour
 
-Four list sections on the template and soul detail pages read a
+Five list sections on the template and soul detail pages read a
 `FutureProvider.autoDispose.family`:
 
 | Section | Provider | Reloads while open? |
@@ -476,6 +476,14 @@ Four list sections on the template and soul detail pages read a
 | Soul → Info → Soul Evolution History | `soulEvolutionSessionHistoryProvider` | yes — every soul write |
 | Template → Reports tab | `templateRecentReportsProvider` | yes, but only on some events |
 | Template → Stats → Version History | `templateVersionHistoryProvider` | no |
+| Template → Instances | `templateInstanceOverviewProvider` | yes — on the shared agent-update topic |
+
+The Template Instances section (added in #3855) renders one row per running
+agent created from the template, with its task title, status, and the latest
+report one-liner. It is wired into the template detail page through
+`agent_template_detail_sections.dart` and backed by the
+`TemplateInstanceOverview` model and `templateInstanceOverviewProvider` in
+`state/template_query_providers.dart`.
 
 `agentUpdateStreamProvider(id)` filters `UpdateNotifications.updateStream` down
 to sets *containing* `id`. Soul sections are well served: soul entities carry

--- a/knowledge/features/ai/model-evaluation.md
+++ b/knowledge/features/ai/model-evaluation.md
@@ -141,16 +141,19 @@ than treated as universal model rankings.
   used all three allowed attempts.
 
 Direct review found Qwen's final reports **richer and more natural**, while the
-Mistral route stayed more compact and conservative. These results support the
-Qwen default and retain Mistral as a selectable alternative. They do **not** prove
-GLM 5.2 parity or unrestricted reliability on arbitrary user histories.
+Mistral route stayed more compact and conservative. These results supported the
+Qwen default at the time of the run. They do **not** prove GLM 5.2 parity or
+unrestricted reliability on arbitrary user histories.
 
-`qwen3.5-122b-a10b` is part of the curated Melious catalog and is the seeded
-thinking default. Existing untouched Melious profiles migrate from Mistral
-thinking to Qwen when the provider-owned Qwen row exists; the profile stores the
-applied seed generation, so the migration runs once and a later deliberate switch
-back to Mistral is preserved. Mistral remains in the image-recognition slot
-because this Qwen endpoint is text-only.
+`qwen3.5-122b-a10b` is part of the curated Melious catalog. The shipped
+thinking default has since moved to **GLM 5.2**, with **Kimi K3** for high-end
+thinking and image recognition, and Whisper Large v3 for transcription (see
+[seeding and lifecycle](seeding-and-lifecycle.md) for the current seed and the
+generation-2 migration). Existing untouched Melious profiles migrate through
+that generation boundary; the profile stores the applied seed generation, so
+each migration runs once and a later deliberate switch is preserved. The Qwen
+evaluation remains the record of why the task-agent report contract was shaped
+this way; it is no longer a statement about the shipped model.
 
 The resulting shipped routing is described in
 [task agents](../agents/task-agents.md).

--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -20,6 +20,14 @@ sources:
     resource: ../../../pubspec.yaml
     title: Shader and native dependency registration
     last_modified: 2026-07-26
+  - id: known-models
+    resource: ../../../lib/features/ai/util/known_models.dart
+    title: Known model constants and the curated static catalog
+    last_modified: 2026-08-12
+  - id: known-models-data
+    resource: ../../../lib/features/ai/util/known_models_data.dart
+    title: The meliousModels catalog entries
+    last_modified: 2026-08-12
 ---
 
 # One facade, two collaborators
@@ -139,9 +147,9 @@ untouched rather than writing zeros.
 
 A small curated static catalog exists for immediate setup before live-catalog
 rows are installed: `deepseek-v4-pro`, `glm-5.2`, `gemma-4-26b-a4b`,
-`minimax-m2.7`, `mistral-small-4-119b-instruct`, `qwen3.5-122b-a10b`,
-`deepseek-v4-flash`, `flux-2-klein-9b`, `voxtral-small-24b-2507`,
-`whisper-large-v3`, `whisper-large-v3-turbo`.
+`kimi-k3`, `minimax-m2.7`, `mistral-small-4-119b-instruct`,
+`qwen3.5-122b-a10b`, `deepseek-v4-flash`, `flux-2-klein-9b`,
+`voxtral-small-24b-2507`, `whisper-large-v3`, `whisper-large-v3-turbo`.
 
 ## Gemini
 

--- a/knowledge/features/daily_os_next/coordination-protocol.md
+++ b/knowledge/features/daily_os_next/coordination-protocol.md
@@ -11,7 +11,11 @@ sources:
   - id: agents
     resource: ../../../lib/features/daily_os_next/agents
     title: Directive, status and digest services
-    last_modified: 2026-08-03
+    last_modified: 2026-08-07
+  - id: runtime-maintenance
+    resource: ../../../lib/features/daily_os_next/agents/state/daily_os_runtime_maintenance.dart
+    title: DailyOsRuntimeMaintenance — the beforeWakeScan contributor
+    last_modified: 2026-08-07
   - id: adr-0032
     resource: ../../../docs/adr/0032-hierarchical-day-agent-coordination.md
     title: ADR 0032 — Hierarchical day-agent coordination
@@ -46,13 +50,20 @@ lifecycle**: a finished day still holding a deadline is otherwise due on every
 tick, forever.
 
 Retirement runs **ahead of every due-record pass**, not only at start-up. It is
-wired into `ScheduledWakeManager.beforeCheck`, which the manager awaits at the
-top of each `_checkAndEnqueue` — the immediate one in `start()` and every
-hourly tick after it. Ordering is the whole point: a finished agent is still
-`active` until the pass runs, so retiring afterwards would let it fire on the
-very tick that was about to retire it. Covering the ticks and not just start-up
-is what catches a desktop session left open across the handover boundary, where
-the boundary arrives on a tick and no relaunch ever comes.
+wired into `ScheduledWakeManager.beforeCheck` through the shared
+`AgentRuntimeMaintenance` registry (ADR of #3836):
+`DailyOsRuntimeMaintenance` (`agents/state/daily_os_runtime_maintenance.dart`)
+implements the `AgentRuntimeMaintenance` interface, is registered in
+`agentRuntimeMaintenanceProvider`, and the wake manager calls
+`beforeWakeScan()` on every contributor at the top of each `_checkAndEnqueue`
+— the immediate one in `start()` and every hourly tick after it. That
+indirection is what lets `features/agents` call the pre-check without importing
+this feature; the composition root wires the contributor in. Ordering is the
+whole point: a finished agent is still `active` until the pass runs, so
+retiring afterwards would let it fire on the very tick that was about to retire
+it. Covering the ticks and not just start-up is what catches a desktop session
+left open across the handover boundary, where the boundary arrives on a tick
+and no relaunch ever comes.
 
 The repair repeats if it crosses local midnight. Retirement's cutoff is a
 calendar date while the due query reads the clock *after* the repair, so a pass

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -32,6 +32,10 @@ sources:
     resource: ../../lib/classes/goal_criterion.dart
     title: GoalCriterion tree (shared vocabulary in lib/classes)
     last_modified: 2026-08-12
+  - id: trigger-tokens
+    resource: ../../lib/classes/goal_trigger_tokens.dart
+    title: Goal trigger tokens — cadence, escalation, baseline, report-refresh
+    last_modified: 2026-08-12
   - id: progress-vocabulary
     resource: ../../lib/classes/goal_progress_models.dart
     title: Persisted per-dimension progress vocabulary
@@ -43,7 +47,19 @@ sources:
   - id: contract
     resource: ../../lib/features/goals/workflow/goal_agent_contract.dart
     title: Goal-agent contract (eval-graduated prompt + tools)
-    last_modified: 2026-08-11
+    last_modified: 2026-08-12
+  - id: strategy
+    resource: ../../lib/features/goals/workflow/goal_agent_strategy.dart
+    title: GoalAgentStrategy — Phase B conversation and tool dispatch
+    last_modified: 2026-08-12
+  - id: facts-renderer
+    resource: ../../lib/features/goals/workflow/goal_facts_renderer.dart
+    title: GoalFactsRenderer — the JSON fence Phase B consumes
+    last_modified: 2026-08-12
+  - id: tool-dispatcher
+    resource: ../../lib/features/goals/workflow/goal_tool_dispatcher.dart
+    title: GoalToolDispatcher — proposal persistence and spec revision routing
+    last_modified: 2026-08-12
   - id: create-edit
     resource: ../../lib/features/goals/ui/pages/create_goal_agent_page.dart
     title: Goal create/edit flow — intention, observable mapping and confirmation
@@ -128,7 +144,7 @@ flowchart TD
     USERWAKE --> PB
     REFREG --> PB
     PB --> FACTS[GoalFactsRenderer\nJSON fence: goal, evaluation,\nreporting, ads, personaTone]
-    FACTS --> CONV[one bounded conversation\nglm-5.2 default, profile override,\ntemperature 0, 7-tool contract]
+    FACTS --> CONV[one bounded conversation\nglm-5.2 default, profile override,\ntemperature 0, 8-tool contract]
     CONV --> OUT[one transaction:\nreport+head, goalNudge writes,\nobservations, revision ChangeSet,\nvisible reply_to_user carrier]
     OUT --> FRESH{current report head advanced\nand no watched timer active?}
     FRESH -- yes --> REPORTDONE[clear report-stale watermark]
@@ -345,7 +361,15 @@ flowchart TD
   inactive details hide the approval card as well. After acceptance the
   signal subscription re-registers from the NEW criteria; on other
   devices the synced-in head triggers the same re-registration through
-  the sync processor's identity re-offer.
+  the sync processor's identity re-offer. A revision also retires the
+  superseded goal's whole ad surface and pending inference in the same
+  transaction: every non-terminal nudge (`draft`, `ready`, `active`,
+  `retired`) moves to `superseded` — `retired` rows are the reuse library
+  (`reusableTopRated`), so a top-rated ad written for the old target cannot
+  be re-activated beside the revised statement — and every pending
+  `goal-escalation` wake is consumed, so a wake armed under the old spec
+  cannot later spend inference on a transition the new goal never made.
+  The immediate post-acceptance evaluation re-arms anything genuinely due.
 - **Owner edits are versioned, never in-place.** The explicit edit route uses
   `GoalSpecRevisionService.reviseFromOwner` with the complete user-authored
   title, intention, persona name and criteria tree. It serializes against the

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -28,6 +28,26 @@ sources:
     resource: ../../../assets/design_system/tokens.json
     title: aiCard and proposalKind tokens
     last_modified: 2026-07-26
+  - id: compact-app-bar
+    resource: ../../../lib/features/tasks/ui/task_compact_app_bar.dart
+    title: TaskCompactAppBar
+    last_modified: 2026-08-12
+  - id: expandable-app-bar
+    resource: ../../../lib/features/tasks/ui/task_expandable_app_bar.dart
+    title: TaskExpandableAppBar
+    last_modified: 2026-08-12
+  - id: cover-art
+    resource: ../../../lib/features/tasks/ui/cover_art_background.dart
+    title: CoverArtBackground and the full-screen viewer
+    last_modified: 2026-08-12
+  - id: one-liner
+    resource: ../../../lib/features/tasks/state/task_one_liner_provider.dart
+    title: taskOneLinerProvider and taskOneLinersProvider
+    last_modified: 2026-08-12
+  - id: scroll-stability
+    resource: ../../../lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
+    title: TaskScrollStabilityScope and ViewportStableScrollController
+    last_modified: 2026-08-12
 ---
 
 # Band order
@@ -138,7 +158,7 @@ meaning is available from the glyph tooltip on hover or long press and remains
 part of the row's accessibility label, instead of consuming inline text space.
 
 **Extended actions — share, speech modal — belong to the pinned app bar's
-`more_vert` button, not the header.** There is no ellipsis inside the header.
+`more_horiz` button, not the header.** There is no ellipsis inside the header.
 
 ## Title states
 
@@ -296,7 +316,10 @@ crumb segments. The page owns the gutter (see above).
 
 `TaskCompactAppBar` and `TaskExpandableAppBar` surface the task title in
 `subtitle2` once the scroll offset passes a threshold, so the title stays visible
-as the header scrolls away.
+as the header scrolls away. Both app bars also carry a desktop-only
+knowledge-graph entry point (`Icons.hub_outlined` → `TaskKnowledgeGraphPage`,
+gated by `knowledgeGraphEntryPointEnabledProvider`), so the graph is one tap
+from the task without competing for header space on mobile.
 
 When the expandable app bar has cover art, the whole artwork is an interactive
 image surface. A tap opens the same full-screen, zoomable viewer used by linked


### PR DESCRIPTION
## Summary

A systematic audit of the past 7 days of work (66 commits) against the `knowledge/` bundle found 16 substantive documentation gaps across 8 concept files — factual errors, behavioral gaps, and missing source provenance. This PR closes all of them.

## What was audited

Every concept file under `knowledge/features/` for **goals**, **agents**, **daily_os_next**, **ai**, and **tasks** was read in full and compared against its source code, with source-path resolution and spot-checks of key claims.

## Changes by feature

### Goals (`knowledge/features/goals.md`)
- **8-tool contract** — corrected `7-tool contract` → `8-tool contract` in the runtime flow diagram. The contract exports 8 tools (`reply_to_user`, `update_goal_report`, `create_goal_ad`, `rerun_goal_ad`, `retire_goal_ad`, `snooze_goal_ad`, `propose_goal_revision_v2`, `record_goal_observation`). The count was bumped 6→7 in #3883 but `snooze_goal_ad` had already been added in #3877.
- **Revision terminal-supersedes nudges + consumes escalation wakes** — `_mintRevision` in `goal_spec_revision_service.dart:354-401` supersedes every non-terminal nudge (including the `retired` reuse library) and consumes pending `goal-escalation` wakes in the same transaction as the version mint. This load-bearing behavior was undocumented.
- **`goal_trigger_tokens.dart`** — added to `sources:` frontmatter (the wake-routing vocabulary referenced throughout the diagrams: cadence, escalation, baseline, report-refresh).
- **3 missing workflow sources** (from the earlier gap-3 fix) — added `goal_agent_strategy.dart`, `goal_facts_renderer.dart`, `goal_tool_dispatcher.dart`; corrected stale `contract` `last_modified`.

### Agents (`knowledge/features/agents/`)
- **`overview.md`** — added `goal_agent` (the 6th agent kind, ADR 0053) to the kinds table with its slot, workflow, and trigger shape; added the missing `projection.md` link to the Concepts list.
- **`persistence-and-sync.md`** — added the four goal entity variants (`GoalSpecVersionEntity`, `GoalSpecHeadEntity`, `GoalProgressEntity`, `GoalNudgeEntity`) to the Entities list with their roles and sync/validation notes; cited ADR 0053; replaced the hard "seven classes" count for `AgentErrorLogging` with a general statement noting `GoalAgentWorkflow` also adopts the mixin.
- **`task-agents.md`** — added ADR 0051 and the two implementation files (`task_agent_tool_gate.dart`, `task_agent_staged_tool_exposure.dart`) to `sources:`; inserted the **Agenda-gated exposure** and **Staged exposure** subsections at the top of "Tool policy" (from the earlier gap-1 fix).
- **`ui-surfaces.md`** — added the **Template Instances** section (#3855) as the 5th row in the history-sections table, with prose describing `templateInstanceOverviewProvider`, `TemplateInstanceOverview`, and the wiring.

### Daily OS (`knowledge/features/daily_os_next/coordination-protocol.md`)
- **`AgentRuntimeMaintenance` registry** — rewrote the "Retirement runs ahead of every due-record pass" paragraph to describe the indirection introduced by #3836: `DailyOsRuntimeMaintenance` implements the shared interface, registered in `agentRuntimeMaintenanceProvider`, called via `beforeWakeScan()`. Added `daily_os_runtime_maintenance.dart` to `sources:`.

### AI (`knowledge/features/ai/`)
- **`model-evaluation.md`** — rewrote the shipped-default conclusion. The Qwen evaluation is now framed as the historical record, not the shipped default. The shipped default has moved to GLM 5.2 thinking + Kimi K3 high-end/vision + Whisper Large v3 transcription (per #3878), with a forward link to `seeding-and-lifecycle.md`.
- **`provider-routing.md`** — added `kimi-k3` to the curated static-catalog list (now 12 models, matching `meliousModels`); added `known_models.dart` and `known_models_data.dart` to `sources:`.

### Tasks (`knowledge/features/tasks/detail-composition.md`)
- **Glyph name** — corrected `more_vert` → `more_horiz` (the actual icon in both `TaskCompactAppBar` and `TaskExpandableAppBar`).
- **Knowledge-graph app-bar entry** — added the desktop-only `Icons.hub_outlined` → `TaskKnowledgeGraphPage` entry point (#3816) to the app-bar description.
- **6 missing source paths** — added `task_compact_app_bar.dart`, `task_expandable_app_bar.dart`, `cover_art_background.dart`, `task_one_liner_provider.dart`, `viewport_stable_animated_size.dart` to the `sources:` frontmatter.

## Validation

```
make okf_check      → OKF 0.2: checked 93 concepts — 0 error(s), 0 warning(s)
make knowledge_check → mermaid: parsed 478 block(s) — 0 failed, 0 unclosed
```

## What was verified accurate (no changes needed)

- `agents/wake-orchestration.md`, `agents/projection.md`, `agents/project-and-event-agents.md`
- `daily_os_next/agent-identities.md` (frontmatter already updated to moved `lib/classes/` paths), `dependency-aware-planning.md`, `evaluation.md`, `processing-outbox.md`, `ui-surfaces.md`
- `ai/seeding-and-lifecycle.md` (fully reflects KIMI K3), `ai/execution-paths.md` (coding-prompt `generateWithImages` described), `ai/overview.md`, `ai/profile-resolution.md`, `ai/conversations-and-tools.md`, `ai/embeddings-and-search.md`, `ai/attribution.md`, `ai/activity-visualization.md`, `ai/settings-ui.md`
- `tasks/index.md`, `tasks/overview.md`, `tasks/data-model.md`, `tasks/checklists.md`, `tasks/relationships.md`

No code changes — documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for goal-based agents, persistence, synchronization, tool availability, and agent history views.
  - Clarified current AI model recommendations, model catalog information, and profile migration behavior.
  - Updated Goals documentation with revised tool workflows, triggers, and acceptance behavior.
  - Documented runtime coordination and maintenance behavior, including startup and scheduled checks.
  - Added task interface guidance for compact/expanded app bars, cover-art viewing, scrolling, and desktop knowledge-graph access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->