### PR TITLE
fix(agents): make the wake-queue cancel button dismiss planner records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no result. Wakes for a past day are now skipped before any model call, their
   leftover schedules are cleared automatically, and the planner can no longer
   schedule a new wake for a finished day.
+- **The wake-queue cancel button now actually cancels.** Dismissing a scheduled
+  planner wake from the sidebar queue or the Wake Cycles page only cleared agent
+  state before, so the wake came back on the next check. It now removes the
+  underlying scheduled wake, so cancelling one makes it stay gone.
 
 ## [1.0.7]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -44,6 +44,7 @@
       <description>
         <p>Added: goal-agent chat supports voice input. The composer now has a microphone button that records, transcribes, and fills the text field.</p>
         <p>Fixed: the Daily OS planner no longer wakes for days that are already over. Finished days kept firing full model runs that found nothing to do and re-scheduled themselves, burning inference for no result. Such wakes are now skipped before any model call, their leftover schedules are cleared automatically, and the planner can no longer schedule a new wake for a finished day.</p>
+        <p>Fixed: the wake-queue cancel button now actually cancels. Dismissing a scheduled planner wake from the sidebar queue or the Wake Cycles page previously only cleared agent state, so the wake returned on the next check; it now removes the underlying scheduled wake so cancelling one makes it stay gone.</p>
       </description>
     </release>
     <release version="1.0.7" date="2026-08-12">

--- a/lib/features/agents/model/pending_wake_record.dart
+++ b/lib/features/agents/model/pending_wake_record.dart
@@ -21,12 +21,26 @@ class PendingWakeRecord {
     required this.type,
     required this.dueAt,
     this.subjectLabel,
+    this.recordId,
+    this.workspaceKey,
   });
 
   final AgentIdentityEntity agent;
   final AgentStateEntity state;
   final PendingWakeType type;
   final DateTime dueAt;
+
+  /// Id of the backing [ScheduledWakeEntity] for a workspace-scoped wake, or
+  /// `null` for a state-derived wake (`nextWakeAt` / `scheduledWakeAt`).
+  ///
+  /// Dismissing a workspace-scoped row must consume this record, not just clear
+  /// the agent state — see `AgentService.dismissScheduledWakeRecord`.
+  final String? recordId;
+
+  /// Wake-queue workspace key of the backing record (`day:<dayId>` for a
+  /// planner day pre-warm), so a dismiss can drop the matching queued job.
+  /// `null` for state-derived wakes.
+  final String? workspaceKey;
 
   /// Pre-resolved subject line for wakes whose subject is a workspace rather
   /// than a linked task/project — e.g. a planner day pre-warm sourced from a

--- a/lib/features/agents/service/agent_service.dart
+++ b/lib/features/agents/service/agent_service.dart
@@ -184,6 +184,44 @@ class AgentService {
     onPersistedStateChanged?.call(agentId);
   }
 
+  /// Dismiss a workspace-scoped scheduled-wake record so it neither fires nor
+  /// re-surfaces in the pending list.
+  ///
+  /// [clearScheduledWake] cannot remove these: a planner day pre-warm lives as
+  /// its own [ScheduledWakeEntity], not on `AgentState.scheduledWakeAt`. So the
+  /// cancel button on such a row must both (a) drop any job already queued for
+  /// the record's workspace and (b) consume the record — otherwise the
+  /// scheduled-wake manager re-fires it from the still-pending row on the next
+  /// scan, which is exactly why the button appeared to do nothing.
+  ///
+  /// The record is flipped to [ScheduledWakeStatus.consumed] rather than
+  /// hard-deleted so a peer's concurrent write converges via LWW instead of
+  /// resurrecting the row. A record already consumed (or raced away) needs only
+  /// the queue drop.
+  Future<void> dismissScheduledWakeRecord({
+    required String recordId,
+    required String agentId,
+    String? workspaceKey,
+  }) async {
+    // Drop the job already dequeued for this workspace so an in-flight burst
+    // stops now, not only on future scans.
+    orchestrator.cancelPendingWakes(agentId, workspaceKey: workspaceKey);
+
+    final entity = await repository.getEntity(recordId);
+    if (entity is ScheduledWakeEntity &&
+        entity.status == ScheduledWakeStatus.pending) {
+      final now = clock.now();
+      await syncService.upsertEntity(
+        entity.copyWith(
+          status: ScheduledWakeStatus.consumed,
+          consumedAt: now,
+          updatedAt: now,
+        ),
+      );
+    }
+    onPersistedStateChanged?.call(agentId);
+  }
+
   /// Transition agent to [AgentLifecycle.dormant] and unregister
   /// wake subscriptions.
   ///

--- a/lib/features/agents/state/agent_pending_wake_providers.dart
+++ b/lib/features/agents/state/agent_pending_wake_providers.dart
@@ -95,6 +95,11 @@ final pendingWakeRecordsProvider = FutureProvider<List<PendingWakeRecord>>((
         type: PendingWakeType.scheduled,
         dueAt: record.scheduledAt,
         subjectLabel: _workspaceSubjectLabel(record.workspaceKey),
+        // Carry the record id + workspace so the row's cancel button can
+        // consume THIS record (not just the agent's state), which is what
+        // actually stops it re-firing on the next scan.
+        recordId: record.id,
+        workspaceKey: record.workspaceKey,
       ),
     );
   }

--- a/lib/features/agents/ui/pending_wakes/agent_pending_wakes_page.dart
+++ b/lib/features/agents/ui/pending_wakes/agent_pending_wakes_page.dart
@@ -250,6 +250,8 @@ AgentListRowData _vmToRow(PendingWakeVm vm, AppLocalizations messages) {
       dueAt: vm.dueAt,
       type: vm.type,
       agentId: vm.agentId,
+      recordId: vm.recordId,
+      workspaceKey: vm.workspaceKey,
     ),
     onTap: () => beamToNamed(agentInstanceRoute(vm.agentId)),
     sortAt: vm.dueAt,
@@ -281,11 +283,18 @@ class _PendingWakeTrailing extends ConsumerStatefulWidget {
     required this.dueAt,
     required this.type,
     required this.agentId,
+    this.recordId,
+    this.workspaceKey,
   });
 
   final DateTime dueAt;
   final PendingWakeType type;
   final String agentId;
+
+  /// Backing scheduled-wake record id for a workspace-scoped row; `null` for a
+  /// state-derived wake.
+  final String? recordId;
+  final String? workspaceKey;
 
   @override
   ConsumerState<_PendingWakeTrailing> createState() =>
@@ -299,11 +308,24 @@ class _PendingWakeTrailingState extends ConsumerState<_PendingWakeTrailing> {
     setState(() => _isDeleting = true);
     final service = ref.read(agentServiceProvider);
     try {
+      final recordId = widget.recordId;
       switch (widget.type) {
         case PendingWakeType.pending:
           service.cancelPendingWake(widget.agentId);
         case PendingWakeType.scheduled:
-          await service.clearScheduledWake(widget.agentId);
+          // A workspace-scoped wake is backed by a ScheduledWakeEntity, which
+          // clearScheduledWake cannot touch — consume the record itself so it
+          // stops re-firing. State-derived scheduled wakes still clear the
+          // agent's scheduledWakeAt.
+          if (recordId != null) {
+            await service.dismissScheduledWakeRecord(
+              recordId: recordId,
+              agentId: widget.agentId,
+              workspaceKey: widget.workspaceKey,
+            );
+          } else {
+            await service.clearScheduledWake(widget.agentId);
+          }
       }
     } catch (_) {
       if (!mounted) return;

--- a/lib/features/agents/ui/pending_wakes/pending_wake_view_model.dart
+++ b/lib/features/agents/ui/pending_wakes/pending_wake_view_model.dart
@@ -20,6 +20,8 @@ class PendingWakeVm {
     required this.kind,
     required this.type,
     required this.dueAt,
+    this.recordId,
+    this.workspaceKey,
   });
 
   /// Stable id, mirrors [PendingWakeRecord.id].
@@ -42,6 +44,15 @@ class PendingWakeVm {
   final String kind;
   final PendingWakeType type;
   final DateTime dueAt;
+
+  /// Backing `ScheduledWakeEntity` id for a workspace-scoped wake, or `null`
+  /// for a state-derived one. Mirrors [PendingWakeRecord.recordId] and lets the
+  /// row delete the record itself rather than only the agent state.
+  final String? recordId;
+
+  /// Workspace key of the backing record, so the delete can drop its queued
+  /// job. Mirrors [PendingWakeRecord.workspaceKey].
+  final String? workspaceKey;
 }
 
 /// All pending wake records joined with their resolved subject titles.
@@ -83,6 +94,8 @@ PendingWakeVm _toVm(PendingWakeRecord record, String? rawSubjectTitle) {
     kind: record.agent.kind,
     type: record.type,
     dueAt: record.dueAt,
+    recordId: record.recordId,
+    workspaceKey: record.workspaceKey,
   );
 }
 

--- a/lib/features/agents/ui/sidebar_wake_queue.dart
+++ b/lib/features/agents/ui/sidebar_wake_queue.dart
@@ -375,11 +375,23 @@ class _WakeRowState extends ConsumerState<_WakeRow> {
     setState(() => _cancelling = true);
     final service = ref.read(agentServiceProvider);
     try {
+      final recordId = widget.record.recordId;
       switch (widget.record.type) {
         case PendingWakeType.pending:
           service.cancelPendingWake(widget.record.agent.agentId);
         case PendingWakeType.scheduled:
-          await service.clearScheduledWake(widget.record.agent.agentId);
+          // A workspace-scoped wake (planner day pre-warm) is backed by a
+          // ScheduledWakeEntity; consume it so it stops re-firing, since
+          // clearScheduledWake only clears the agent's scheduledWakeAt.
+          if (recordId != null) {
+            await service.dismissScheduledWakeRecord(
+              recordId: recordId,
+              agentId: widget.record.agent.agentId,
+              workspaceKey: widget.record.workspaceKey,
+            );
+          } else {
+            await service.clearScheduledWake(widget.record.agent.agentId);
+          }
       }
     } catch (_) {
       // Service swallows; the provider refresh reflects whatever the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.8+4306
+version: 1.0.8+4307
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/service/agent_service_test.dart
+++ b/test/features/agents/service/agent_service_test.dart
@@ -704,6 +704,90 @@ void main() {
       });
     });
 
+    group('dismissScheduledWakeRecord', () {
+      ScheduledWakeEntity pendingRecord({
+        ScheduledWakeStatus status = ScheduledWakeStatus.pending,
+      }) =>
+          AgentDomainEntity.scheduledWake(
+                id: 'wake-rec-1',
+                agentId: 'daily_os_planner',
+                scheduledAt: kAgentTestDate.add(const Duration(hours: 1)),
+                status: status,
+                reason: 'scheduled',
+                updatedAt: kAgentTestDate,
+                vectorClock: null,
+                triggerTokens: const ['planning_day:dayplan-2026-07-14'],
+                workspaceKey: 'day:dayplan-2026-07-14',
+              )
+              as ScheduledWakeEntity;
+
+      test('consumes the record and drops its queued job', () async {
+        when(
+          () => mockOrchestrator.cancelPendingWakes(
+            'daily_os_planner',
+            workspaceKey: 'day:dayplan-2026-07-14',
+          ),
+        ).thenReturn(const []);
+        when(
+          () => mockRepository.getEntity('wake-rec-1'),
+        ).thenAnswer((_) async => pendingRecord());
+
+        await service.dismissScheduledWakeRecord(
+          recordId: 'wake-rec-1',
+          agentId: 'daily_os_planner',
+          workspaceKey: 'day:dayplan-2026-07-14',
+        );
+
+        // The queued job is dropped so an in-flight burst stops now…
+        verify(
+          () => mockOrchestrator.cancelPendingWakes(
+            'daily_os_planner',
+            workspaceKey: 'day:dayplan-2026-07-14',
+          ),
+        ).called(1);
+        // …and the record is consumed so the manager cannot re-fire it.
+        final written =
+            verify(
+                  () => mockSyncService.upsertEntity(captureAny()),
+                ).captured.single
+                as ScheduledWakeEntity;
+        expect(written.id, 'wake-rec-1');
+        expect(written.status, ScheduledWakeStatus.consumed);
+        expect(written.consumedAt, isNotNull);
+        expect(notifiedAgentIds, ['daily_os_planner']);
+      });
+
+      test('drops the queued job but writes nothing when already '
+          'consumed', () async {
+        // A record that already fired must not be re-written (the pending-list
+        // refresh + queue drop are enough), or an LWW race could resurrect it.
+        when(
+          () => mockOrchestrator.cancelPendingWakes(
+            'daily_os_planner',
+            workspaceKey: 'day:dayplan-2026-07-14',
+          ),
+        ).thenReturn(const []);
+        when(() => mockRepository.getEntity('wake-rec-1')).thenAnswer(
+          (_) async => pendingRecord(status: ScheduledWakeStatus.consumed),
+        );
+
+        await service.dismissScheduledWakeRecord(
+          recordId: 'wake-rec-1',
+          agentId: 'daily_os_planner',
+          workspaceKey: 'day:dayplan-2026-07-14',
+        );
+
+        verify(
+          () => mockOrchestrator.cancelPendingWakes(
+            'daily_os_planner',
+            workspaceKey: 'day:dayplan-2026-07-14',
+          ),
+        ).called(1);
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+        expect(notifiedAgentIds, ['daily_os_planner']);
+      });
+    });
+
     group('pauseAgent', () {
       glados.Glados(
         glados.any.agentLifecycleScenario,

--- a/test/features/agents/state/agent_pending_wake_providers_test.dart
+++ b/test/features/agents/state/agent_pending_wake_providers_test.dart
@@ -735,6 +735,11 @@ void main() {
         expect(record.dueAt, dueAt);
         // `day:<dayId>` workspace → the day id is the subject label.
         expect(record.subjectLabel, 'dayplan-2026-06-08');
+        // The backing record id + workspace ride along so the row's cancel
+        // button can consume THIS record and drop its queued job — without
+        // them the button only clears agent state and the wake re-fires.
+        expect(record.recordId, 'sched-1');
+        expect(record.workspaceKey, 'day:dayplan-2026-06-08');
 
         // The planner's state carries no wake field of its own — its wake
         // lives on the ScheduledWakeEntity — so it only survives the SQL

--- a/test/features/agents/ui/pending_wakes/agent_pending_wakes_page_test.dart
+++ b/test/features/agents/ui/pending_wakes/agent_pending_wakes_page_test.dart
@@ -26,12 +26,17 @@ PendingWakeRecord _record({
   required DateTime dueAt,
   String kind = AgentKinds.taskAgent,
   AgentSlots slots = const AgentSlots(),
+  String? recordId,
+  String? workspaceKey,
 }) {
   final state = makeTestState(
     agentId: agentId,
     slots: slots,
     nextWakeAt: type == PendingWakeType.pending ? dueAt : null,
-    scheduledWakeAt: type == PendingWakeType.scheduled ? dueAt : null,
+    // A record-backed wake carries its due time on the record, not on state.
+    scheduledWakeAt: type == PendingWakeType.scheduled && recordId == null
+        ? dueAt
+        : null,
   );
   return PendingWakeRecord(
     agent: makeTestIdentity(
@@ -42,6 +47,9 @@ PendingWakeRecord _record({
     state: state,
     type: type,
     dueAt: dueAt,
+    subjectLabel: workspaceKey == null ? null : 'dayplan-2026-06-08',
+    recordId: recordId,
+    workspaceKey: workspaceKey,
   );
 }
 
@@ -365,6 +373,55 @@ void main() {
         await tester.pump();
 
         verify(() => mockService.clearScheduledWake('agent-2')).called(1);
+      });
+    },
+  );
+
+  testWidgets(
+    'delete button dismisses the record for a workspace-scoped wake',
+    (tester) async {
+      // A planner day pre-warm is backed by a ScheduledWakeEntity;
+      // clearScheduledWake cannot remove it, so the row must dismiss the
+      // record itself (and drop its queued job) or the wake re-fires.
+      final mockService = MockAgentService();
+      when(
+        () => mockService.dismissScheduledWakeRecord(
+          recordId: 'sched-1',
+          agentId: 'daily_os_planner',
+          workspaceKey: 'day:dayplan-2026-06-08',
+        ),
+      ).thenAnswer((_) async {});
+
+      final now = DateTime(2026, 3, 31, 9);
+      await withClock(Clock(() => now), () async {
+        await pumpPage(
+          tester,
+          records: [
+            _record(
+              agentId: 'daily_os_planner',
+              displayName: 'Shepherd',
+              kind: AgentKinds.dayAgent,
+              type: PendingWakeType.scheduled,
+              dueAt: now.add(const Duration(minutes: 5)),
+              recordId: 'sched-1',
+              workspaceKey: 'day:dayplan-2026-06-08',
+            ),
+          ],
+          agentService: mockService,
+        );
+
+        await tester.tap(find.byIcon(Icons.delete_outline_rounded));
+        await tester.pump();
+        await tester.pump();
+
+        verify(
+          () => mockService.dismissScheduledWakeRecord(
+            recordId: 'sched-1',
+            agentId: 'daily_os_planner',
+            workspaceKey: 'day:dayplan-2026-06-08',
+          ),
+        ).called(1);
+        verifyNever(() => mockService.clearScheduledWake(any()));
       });
     },
   );

--- a/test/features/agents/ui/sidebar_wake_queue_test.dart
+++ b/test/features/agents/ui/sidebar_wake_queue_test.dart
@@ -28,6 +28,8 @@ void main() {
     required String displayName,
     required Duration eta,
     PendingWakeType type = PendingWakeType.pending,
+    String? recordId,
+    String? workspaceKey,
   }) {
     return PendingWakeRecord(
       agent: makeTestIdentity(
@@ -38,6 +40,9 @@ void main() {
       state: makeTestState(agentId: agentId),
       type: type,
       dueAt: fixedNow.add(eta),
+      subjectLabel: workspaceKey == null ? null : 'dayplan-2026-06-08',
+      recordId: recordId,
+      workspaceKey: workspaceKey,
     );
   }
 
@@ -571,6 +576,59 @@ void main() {
         () => agentService.clearScheduledWake('agent-scheduled'),
       ).called(1);
       verifyNever(() => agentService.cancelPendingWake(any()));
+    },
+  );
+
+  testWidgets(
+    'tapping the trailing × on a workspace-scoped wake dismisses the record',
+    (tester) async {
+      // A planner day pre-warm is backed by a ScheduledWakeEntity; the ×
+      // must dismiss that record (and drop its queued job), not just clear
+      // the agent state, or the wake re-fires on the next scan.
+      final agentService = MockAgentService();
+      when(
+        () => agentService.dismissScheduledWakeRecord(
+          recordId: 'sched-1',
+          agentId: 'daily_os_planner',
+          workspaceKey: 'day:dayplan-2026-06-08',
+        ),
+      ).thenAnswer((_) async {});
+
+      await withClock(Clock.fixed(fixedNow), () async {
+        await tester.pumpWidget(
+          buildSubject(
+            [
+              makeWake(
+                agentId: 'daily_os_planner',
+                displayName: 'Shepherd',
+                eta: const Duration(minutes: 30),
+                type: PendingWakeType.scheduled,
+                recordId: 'sched-1',
+                workspaceKey: 'day:dayplan-2026-06-08',
+              ),
+            ],
+            agentService: agentService,
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+      });
+
+      final element = tester.element(find.byType(SidebarWakeQueue));
+      await tester.tap(
+        find.byTooltip(element.messages.sidebarWakesCancelTooltip),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      verify(
+        () => agentService.dismissScheduledWakeRecord(
+          recordId: 'sched-1',
+          agentId: 'daily_os_planner',
+          workspaceKey: 'day:dayplan-2026-06-08',
+        ),
+      ).called(1);
+      verifyNever(() => agentService.clearScheduledWake(any()));
     },
   );
 


### PR DESCRIPTION
## The bug

The × / trash affordance on a **scheduled** wake — in the sidebar wake queue and on the Wake Cycles page — called `clearScheduledWake(agentId)`, which only nulls `AgentState.scheduledWakeAt`. But a planner day pre-warm doesn't live there: it's its own workspace-scoped `ScheduledWakeEntity`. So the record survived, the `ScheduledWakeManager` re-fired it from the still-pending row on the next scan, and **the button appeared to do nothing** — the wake just came back.

(Surfaced during the P0 token-burn investigation in #3897: the runaway planner had ~30 record-backed queued wakes that the cancel button couldn't clear.)

## The fix

- Thread the backing **record id + workspace key** through `PendingWakeRecord` → `PendingWakeVm` → the trailing cancel widgets.
- Add `AgentService.dismissScheduledWakeRecord({recordId, agentId, workspaceKey})`: it **consumes the record** (flips it to `consumed`, LWW-safe — not a hard delete) **and drops any job already queued** for that workspace, so an in-flight burst stops immediately, not just on future scans.
- Both surfaces (sidebar `SidebarWakeQueue` and the `AgentPendingWakesPage`) route a **record-backed** row's cancel through it; state-derived scheduled wakes keep the existing `clearScheduledWake` path.

## Relationship to #3897
Complementary. #3897 (merged) stops the planner *creating* runaway records and auto-reaps stale ones. This PR makes the *manual* cancel button work for any record-backed wake — the user can now clear a queued planner wake by hand and have it stay gone.

## Tests
- `AgentService.dismissScheduledWakeRecord`: consumes a pending record + drops its queued job; and, when the record already fired, drops the job but writes nothing (no LWW resurrection).
- Provider: the backing record id + workspace key now ride along on workspace-scoped `PendingWakeRecord`s.
- Widget (both surfaces): tapping × on a record-backed row calls `dismissScheduledWakeRecord` (not `clearScheduledWake`); the existing state-derived tests still assert the `clearScheduledWake` path.

Analyzer clean; the four affected suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelling a scheduled planner wake from the sidebar or Wake Cycles page now removes the underlying scheduled wake.
  * Cancelled wakes no longer reappear in the queue.
  * Existing state-based wake cancellation behavior remains unchanged.

* **Release**
  * Updated the application to version 1.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->