### PR TITLE
docs: close sync knowledge drift in auto-trigger, overview, receive-path

### DIFF
--- a/knowledge/features/sync/node-profiles-and-auto-trigger.md
+++ b/knowledge/features/sync/node-profiles-and-auto-trigger.md
@@ -85,7 +85,7 @@ sequenceDiagram
   participant Listener as SyncedAudioInferenceListener
   participant Disp as SyncedAudioInferenceDispatcher
   participant Runner as SkillInferenceRunner.runTranscription
-  participant Wake as WakeOrchestrator.enqueueManualWake
+  participant Wake as WakeOrchestrator.requestContentWake
 
   Mobile->>Matrix: JournalAudio (no transcript)
   Matrix-->>Apply: SyncJournalEntity event
@@ -98,7 +98,14 @@ sequenceDiagram
   Runner-->>Disp: transcript appended to entity (or runner returns silently)
   Disp->>Disp: reload entity, verify transcripts grew
   alt transcripts grew
-    Disp->>Wake: enqueueManualWake(reason: transcriptionComplete)
+    Disp->>Wake: requestContentWake(agentId, reason: transcriptionComplete)
+    Wake->>Wake: automatic updates enabled?
+    alt enabled
+      Wake-->>Disp: true (wake enqueued)
+    else disabled
+      Wake->>Wake: mark report stale, return false
+      Wake-->>Disp: false (marked stale, no wake)
+    end
   else no growth
     Disp->>Disp: skip wake (log only)
   end
@@ -141,8 +148,19 @@ contract:
     runner reaches step 15 with no transcript growth.
 15. Reload the entity. Skip the wake (log only) if `postCount <= priorCount` —
     a silent runner failure must not produce a misleading wake.
-16. Resolve the task agent and call `wakeOrchestrator.enqueueManualWake(reason:
-    WakeReason.transcriptionComplete.name)`.
+16. Resolve the task agent via `TaskAgentService.getTaskAgentForTask(linkedTaskId)`.
+    Skip the wake (log only) if no agent exists — the recording is still
+    transcribed, there is simply nothing to nudge.
+17. Call `wakeOrchestrator.requestContentWake(agentId, reason:
+    WakeReason.transcriptionComplete.name, triggerTokens: {linkedTaskId, id})`.
+    This is **not** an unconditional enqueue: `requestContentWake` honors the
+    per-agent automatic-updates opt-in. When the agent is in the orchestrator's
+    `_automaticUpdatesDisabledAgents` set, it only persists a report-stale
+    watermark (surfacing the manual "Wake agent" CTA) and returns `false`
+    **without enqueuing a wake** — so a synced-audio transcription never spends
+    tokens on an inference cycle the user has switched off. When automatic
+    updates are enabled, it delegates to `enqueueManualWake` with
+    `WakeInitiator.automation` and returns `true`.
 
 **`AutomaticPromptTrigger` is deliberately not on this path.** Its
 `ProfileAutomationService.tryTranscribe` re-enters the rank-ordered fallback that

--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -120,7 +120,8 @@ full journal, agent or attachment payloads.
 Pairing moves a **handover bundle** — homeserver, MXID, live password, room id,
 Base64url-encoded — from a device that already syncs to one that does not.
 `SyncBundleKind` decides what consuming it does: a `provisioned` bundle (minted
-by the CLI) rotates the account password and persists the new one; a `handover`
+by the provisioning service / admin UI, or by the CLI) rotates the account
+password and persists the new one; a `handover`
 bundle (minted by a peer) joins without rotating, so every peer shares one live
 credential. The controller's state transitions expose that distinction directly:
 a rotating bundle enters `rotatingPassword`, while a handover bundle proceeds
@@ -188,7 +189,7 @@ Five properties are deliberate:
   attaches itself, and everything written on it, to that stranger's account.
   Its copy names that consequence rather than stopping at "only use your own
   code".
-- **A first device skips the peer-only confirmation.** A CLI-minted
+- **A first device skips the peer-only confirmation.** A
   `provisioned` bundle normally establishes the account's only device. Once it
   decodes, `BundleImportWidget` starts configuration immediately because no
   peer exists to display a comparison code. A peer-minted `handover` bundle
@@ -250,7 +251,7 @@ Five properties are deliberate:
   handover produces a byte-identical one and cannot resolve a mismatch.
 
 **Configuring has two endings, and they are not interchangeable.**
-`ProvisioningState.ready` follows a CLI-minted `provisioned` bundle: the
+`ProvisioningState.ready` follows a `provisioned` bundle: the
 password has just been rotated and this is normally the *only* device on the
 account, so `_FirstDeviceView` says the account is set up and stops. There is
 no peer to run a SAS ceremony against and none to push settings from, so the
@@ -332,7 +333,8 @@ buttons.
 A failed connect distinguishes its remedies honestly: closing the inviting
 sheet does not revoke a code (`regenerateHandover()` re-serializes the
 persisted credential unchanged), but a rejected login usually means the code
-predates a password rotation — the first pairing from a CLI bundle rotates
+predates a password rotation — the first pairing from a `provisioned`
+bundle rotates
 it — or was mangled in transit, and both are fixed by a fresh code, never by
 re-attempting this one. So the bar's accent is *Enter a new code* (which
 resets `ProvisioningController` — the import page listens for the return to
@@ -411,7 +413,7 @@ goes through one private setter, so no path can change it without emitting.
 
 The SDK's `KeyVerification.isDone` is `canceled || state in {error, done}` —
 true for a ceremony that was refused just as loudly as for one that verified
-(matrix 8.1.0, `encryption/utils/key_verification.dart`). Every SDK path that
+(matrix 10.0.0, `encryption/utils/key_verification.dart`). Every SDK path that
 sets `error` also sets `canceled`, so failure is not separable from
 cancellation; there are two terminal outcomes, not three.
 

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -156,10 +156,10 @@ window, so anchoring there would skip it.
 
 **The zero cache limit was required by Matrix SDK 7.0.0**, and has not been
 re-verified since; `pubspec.yaml` now pins
-`matrix: ^8.1.0`, and four in-code comments still name 7.0.0
+`matrix: ^10.0.0`, and four in-code comments still name 7.0.0
 (`bootstrap_forward_strategy.dart`, `bootstrap_backward_strategy.dart`, and twice
 in `queue_pipeline_coordinator.dart`). Treat the workaround as load-bearing until
-someone re-checks it on 8.x — not as a fact about the pinned version. Without it,
+someone re-checks it — not as a fact about the pinned version. Without it,
 an
 anchor already present in the SDK database suppresses the context request,
 leaves the timeline without a forward token, and can make a reconnect

--- a/knowledge/features/sync/sequence-and-backfill.md
+++ b/knowledge/features/sync/sequence-and-backfill.md
@@ -28,6 +28,10 @@ sources:
     resource: ../../../lib/features/sync/matrix/sync_event_processor_notification_handlers.dart
     title: Notification receive and sequence mapping
     last_modified: 2026-08-06
+  - id: consumption-receive
+    resource: ../../../lib/features/sync/matrix/sync_event_processor_consumption_handlers.dart
+    title: Consumption-event receive and sequence mapping
+    last_modified: 2026-07-05
   - id: backfill-response
     resource: ../../../lib/features/sync/backfill/backfill_response_handler.dart
     title: Backfill payload proof and response handling

--- a/knowledge/features/sync/vector-clocks-and-conflicts.md
+++ b/knowledge/features/sync/vector-clocks-and-conflicts.md
@@ -24,6 +24,10 @@ sources:
     resource: ../../../lib/features/sync/ui/widgets/conflicts/entry_field_diff.dart
     title: computeEntryDiff
     last_modified: 2026-06-20
+  - id: agent-resolver
+    resource: ../../../lib/features/agents/sync/agent_concurrent_resolver.dart
+    title: AgentConcurrentResolver — resolveConcurrent and mergeAgentStateCounters
+    last_modified: 2026-08-12
 ---
 
 # What a vector clock is here


### PR DESCRIPTION
## Summary

Audit of the sync feature concepts against source found 8 gaps across 5 concept files — a wrong method name, a missing behavioral gate, stale version pins, and missing source provenance. All fixes validated clean.

## Changes

### `node-profiles-and-auto-trigger.md` (3 fixes — most important)
- **Wrong method name** — the eligibility list and Mermaid sequence diagram said `enqueueManualWake`. The actual code calls `requestContentWake` — a distinct method that delegates to `enqueueManualWake` only when automatic updates are enabled.
- **Missing automatic-updates opt-in** — the doc implied synced-audio transcription unconditionally triggers a wake. The actual `requestContentWake` honors the per-agent opt-out: for disabled agents it only persists a report-stale watermark (surfacing the manual CTA) and returns `false` **without enqueuing a wake**. This behavioral gate is now documented in step 17 and the sequence diagram's `alt`/`else` branches.
- **Missing step 17** — the code resolves the task agent via `TaskAgentService.getTaskAgentForTask` and skips the wake entirely if no agent exists. The documented eligibility list ended at step 16.

### `overview.md` (2 fixes)
- **Stale CLI-minted wording** — four occurrences of "CLI-minted" / "CLI bundle" for `provisioned` bundles replaced with `provisioned` bundle or "provisioning service / admin UI, or by the CLI" (#3844 added the provisioning service and React admin UI as the tracked minting path).
- **Matrix version** — `8.1.0` → `10.0.0` (#3873 bumped the SDK two majors).

### `receive-path.md` (1 fix)
- **Matrix version pin** — `matrix: ^8.1.0` → `matrix: ^10.0.0` (#3873). The surrounding caution ("not re-verified since 7.0.0", "treat as load-bearing") is still accurate and more pertinent.

### `vector-clocks-and-conflicts.md` (1 fix)
- **Missing source** — added `agent_concurrent_resolver.dart` to `sources:` frontmatter. The "Agent state converges" section names the file and describes `mergeAgentStateCounters` with specific counters, but the file was absent from provenance.

### `sequence-and-backfill.md` (1 fix)
- **Missing source** — added `sync_event_processor_consumption_handlers.dart` to `sources:` frontmatter, for parity with the other three receive handlers (journal, agent, notification) already listed.

## Validation

```
make okf_check      → OKF 0.2: checked 93 concepts — 0 error(s), 0 warning(s)
make knowledge_check → mermaid: parsed 478 block(s) — 0 failed, 0 unclosed
```

## Verified accurate (no changes needed)

`index.md`, `message-model.md`, `send-path.md`, `sequence-and-backfill.md` (prose), `vector-clocks-and-conflicts.md` (prose) — all current.

No code changes — documentation only.