### PR TITLE
fix: align goal health evidence snapshots

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -237,7 +237,10 @@ flowchart TD
   `latest` repeats the newest reading with deterministic `onTarget` and
   `isToday` flags relative to that evaluation day. Future samples and samples
   outside the criterion window are excluded. A delayed escalation therefore
-  cannot slide its raw evidence beyond the aggregate it explains. Phase B can
+  evaluates at the final representable microsecond before the encoded day's
+  next local midnight: fractional-second samples at the boundary remain in the
+  period, while its raw evidence cannot slide beyond the aggregate it explains.
+  Phase B can
   describe the latest reading, direction and sparsity without inventing an
   intermediate measured value or overflowing a provider context; high-volume
   quantitative types such as steps remain aggregate-only.

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -170,12 +170,15 @@ flowchart TD
   a EUR0 maintenance event.
 - **Banners are dirty-tracked against their evidence.** Phase B stamps a
   `factsDigest` (coarse status plus each dimension's actual value and
-  satisfaction plus a hash of exact health timestamps and values,
+  satisfaction plus a hash of the exact health timestamps and values that the
+  criterion's authored window can render at that evaluation reference,
   `goalFactsDigest`) into every minted or re-run banner's provenance. Phase A's
   sweep — which runs after derivation for exactly this reason — expires an
   active banner whose stamped digest no longer matches the current derivation,
   so a banner quoting "129/94" dies when a new reading or same-value backfill
-  lands, and the expiry re-arms the escalation for replacement copy. Health
+  lands inside that model-facing window, and the expiry re-arms the escalation
+  for replacement copy. A prior-period backfill that FACTS cannot expose leaves
+  valid copy alone. Health
   signal subscriptions also advance the standing-report stale watermark
   directly because the persisted progress register intentionally contains
   aggregates rather than the full raw series.
@@ -187,7 +190,7 @@ flowchart TD
   stamp existed keep deadline-only expiry.
 - **The report is dirty-tracked against the register.** When a tick's
   derivation differs from today's already-persisted register row
-  (`goalRegisterDigest` vs `goalFactsDigest`), Phase A advances the durable
+  (`goalRegisterDigest` vs `goalAggregateFactsDigest`), Phase A advances the durable
   report-stale watermark through the orchestrator — the detail page shows
   the out-of-date badge and the Update now CTA even though no status
   transitioned. The first tick of a day is not "new data" (the window slid),
@@ -238,6 +241,11 @@ flowchart TD
   describe the latest reading, direction and sparsity without inventing an
   intermediate measured value or overflowing a provider context; high-volume
   quantitative types such as steps remain aggregate-only.
+  The journal query may reach the next local midnight for complete historical
+  days, but the reader clips both quantitative aggregation and raw observations
+  to the captured evaluation instant before either projection is built. A
+  concurrent same-day write therefore appears in both representations on the
+  next wake, never in only one side of the current FACTS.
 - **Health level trends can be green before the threshold is crossed.** Weight
   and systolic/diastolic blood-pressure leaves use their latest observation per
   day and a rolling seven-day average. An unmet leaf with at least four sampled

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -97,7 +97,9 @@ target, the card celebrates that today's logging is on target even if the
 rolling average still needs recovery; an over-target rolling average remains
 actionable when today has not been measured. Agent FACTS carry the newest 100
 exact samples per supported health criterion plus total and omitted counts,
-anchored to the same evaluation day as the rolling aggregate.
+anchored to the same evaluation instant as the rolling aggregate. Banner
+freshness hashes only those model-facing window samples, so older backfills do
+not invalidate copy that could not cite them.
 Typed dimension cards preserve the evaluator's configured aggregation
 rather than treating every daily contribution as a standalone target;
 composite details retain every metric and measurable leaf that contributes to

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -75,11 +75,19 @@ class GoalSignalReader {
     final quantitative = <String, Map<DateTime, num>>{};
     final quantitativeObservations = <String, List<GoalMetricObservation>>{};
     for (final dataType in needs.quantitativeTypes) {
-      final entities = await _journalDb.getQuantitativeByType(
+      final queriedEntities = await _journalDb.getQuantitativeByType(
         type: dataType,
         rangeStart: rangeStart,
         rangeEnd: rangeEnd,
       );
+      // The query intentionally reaches the next local midnight so completed
+      // historical days retain their final hour. A live wake can receive a
+      // row written after it captured [reference] while this await is in
+      // flight, though. Clip once here so deterministic aggregates and the
+      // parallel exact series describe the same snapshot.
+      final entities = queriedEntities
+          .where((entity) => !entity.meta.dateFrom.isAfter(reference))
+          .toList(growable: false);
       quantitative[dataType] = _bucketQuantitative(entities, dataType);
       if (GoalHealthDataTypes.supported.contains(dataType)) {
         quantitativeObservations[dataType] = _rawQuantitativeObservations(

--- a/lib/features/goals/runtime/goal_agent_phase_a.dart
+++ b/lib/features/goals/runtime/goal_agent_phase_a.dart
@@ -118,7 +118,13 @@ class GoalAgentPhaseA {
       agentId,
       now,
       activeVersionId: version.id,
-      currentFactsDigest: replacementEligible ? goalFactsDigest(facts) : null,
+      currentFactsDigest: replacementEligible
+          ? goalFactsDigest(
+              facts,
+              criteria: version.criteria,
+              evaluationReference: now,
+            )
+          : null,
     );
     final needsEscalation =
         facts.needsEscalation || (activeAdExpired && replacementEligible);

--- a/lib/features/goals/runtime/goal_wake_facts.dart
+++ b/lib/features/goals/runtime/goal_wake_facts.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart' show sha1;
+import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 
 /// Whether three consecutive attainment points are strictly worsening.
 /// [priorAttainments] is ordered most-recent-first.
@@ -85,6 +88,67 @@ String _healthEvidenceDigest(
   return sha1.convert(utf8.encode(evidence.join('|'))).toString();
 }
 
+/// Exact observations that one health criterion can expose to inference.
+///
+/// Keeping this projection shared by rendering and freshness guarantees that
+/// a prior-period backfill cannot stale copy when it is absent from FACTS.
+List<GoalMetricObservation> goalHealthObservationsForCriterion({
+  required GoalCriterionMetric metric,
+  required GoalWakeFacts facts,
+  required DateTime evaluationReference,
+}) {
+  if (!GoalHealthDataTypes.supported.contains(metric.dataType)) {
+    return const [];
+  }
+  final range = metric.window.periodRange(evaluationReference);
+  final candidates =
+      facts.quantitativeObservationsByType[metric.dataType] ??
+      const <GoalMetricObservation>[];
+  return <GoalMetricObservation>[
+    for (final observation in candidates)
+      if (!GoalWindow.dayUtc(observation.recordedAt).isBefore(range.start) &&
+          !GoalWindow.dayUtc(observation.recordedAt).isAfter(range.end) &&
+          !observation.recordedAt.isAfter(evaluationReference))
+        observation,
+  ]..sort((a, b) {
+    final byTime = a.recordedAt.compareTo(b.recordedAt);
+    return byTime != 0 ? byTime : a.tieBreaker.compareTo(b.tieBreaker);
+  });
+}
+
+Map<String, List<GoalMetricObservation>> _renderedHealthEvidence({
+  required GoalCriterion criteria,
+  required GoalWakeFacts facts,
+  required DateTime evaluationReference,
+}) {
+  final evidence = <String, List<GoalMetricObservation>>{};
+
+  void visit(GoalCriterion criterion) {
+    switch (criterion) {
+      case final GoalCriterionMetric metric
+          when GoalHealthDataTypes.supported.contains(metric.dataType):
+        evidence['${metric.criterionId}:${metric.dataType}'] =
+            goalHealthObservationsForCriterion(
+              metric: metric,
+              facts: facts,
+              evaluationReference: evaluationReference,
+            );
+      case GoalCriterionAllOf(:final criteria) ||
+          GoalCriterionAnyOf(:final criteria) ||
+          GoalCriterionAtLeastCount(:final criteria):
+        criteria.forEach(visit);
+      case GoalCriterionMetric() ||
+          GoalCriterionHabit() ||
+          GoalCriterionMeasurable() ||
+          GoalCriterionCategoryTime():
+        break;
+    }
+  }
+
+  visit(criteria);
+  return evidence;
+}
+
 /// Deterministic fingerprint of every fact that can shape banner copy: the
 /// aggregate register evidence plus exact model-facing health observations.
 ///
@@ -92,9 +156,19 @@ String _healthEvidenceDigest(
 /// staleness sweep compares it against the current derivation, so a banner
 /// quoting evidence that has since changed is recognized as data-stale even
 /// when a backfill leaves the daily aggregate unchanged.
-String goalFactsDigest(GoalWakeFacts facts) {
+String goalFactsDigest(
+  GoalWakeFacts facts, {
+  required GoalCriterion criteria,
+  required DateTime evaluationReference,
+}) {
   final aggregate = goalAggregateFactsDigest(facts);
-  final health = _healthEvidenceDigest(facts.quantitativeObservationsByType);
+  final health = _healthEvidenceDigest(
+    _renderedHealthEvidence(
+      criteria: criteria,
+      facts: facts,
+      evaluationReference: evaluationReference,
+    ),
+  );
   return health.isEmpty ? aggregate : '$aggregate|health=$health';
 }
 

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -872,9 +872,9 @@ class GoalAgentWorkflow with AgentErrorLogging {
   /// The evaluation instant for an overdue period — LOCAL wall clock,
   /// unlike [_headTimestamp]: signal queries and day keys are local.
   DateTime? _periodEnd(String periodKey) {
-    final parts = _periodParts(periodKey);
-    if (parts == null) return null;
-    return DateTime(parts.$1, parts.$2, parts.$3, 23, 59, 59);
+    return _periodEndExclusive(periodKey)?.subtract(
+      const Duration(microseconds: 1),
+    );
   }
 
   /// Exclusive local end of an encoded day, preserving the final second.

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -563,6 +563,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
           strategy: strategy,
           derivation: derivation,
           now: now,
+          evaluationReference: reference,
           escalationBaseline: goalEscalationBaselineFromTriggerTokens(
             triggerTokens,
           ),
@@ -1126,11 +1127,13 @@ class GoalAgentWorkflow with AgentErrorLogging {
     required GoalAgentStrategy strategy,
     required GoalWakeDerivation derivation,
     required DateTime now,
+    DateTime? evaluationReference,
     String? escalationBaseline,
     bool replyToUser = false,
     bool userRequestedAd = false,
     String? adCreationDiscriminator,
   }) async {
+    final factsReference = evaluationReference ?? now;
     final reportId = strategy.hasReport ? _uuid.v4() : null;
     final attributionEnvelope = await prepareAgentReportAttribution(
       runKey: runKey,
@@ -1513,7 +1516,11 @@ class GoalAgentWorkflow with AgentErrorLogging {
               // Re-stamp the evidence fingerprint: the re-run is a fresh
               // acknowledgment of the CURRENT facts, so later Phase A
               // sweeps must compare against this wake's derivation.
-              'factsDigest': goalFactsDigest(derivation.facts),
+              'factsDigest': goalFactsDigest(
+                derivation.facts,
+                criteria: derivation.version.criteria,
+                evaluationReference: factsReference,
+              ),
             },
           ),
         );
@@ -1600,7 +1607,11 @@ class GoalAgentWorkflow with AgentErrorLogging {
             // data-stale once new evidence changes the derivation.
             provenance: {
               'specVersionId': derivation.version.id,
-              'factsDigest': goalFactsDigest(derivation.facts),
+              'factsDigest': goalFactsDigest(
+                derivation.facts,
+                criteria: derivation.version.criteria,
+                evaluationReference: factsReference,
+              ),
             },
           ),
         );

--- a/lib/features/goals/workflow/goal_facts_renderer.dart
+++ b/lib/features/goals/workflow/goal_facts_renderer.dart
@@ -201,23 +201,11 @@ class GoalFactsRenderer {
     required DateTime evaluationReference,
   }) {
     if (!GoalHealthDataTypes.supported.contains(metric.dataType)) return null;
-    final range = metric.window.periodRange(evaluationReference);
-    final candidates =
-        facts.quantitativeObservationsByType[metric.dataType] ??
-        const <GoalMetricObservation>[];
-    final observations =
-        <GoalMetricObservation>[
-          for (final observation in candidates)
-            if (!GoalWindow.dayUtc(
-                  observation.recordedAt,
-                ).isBefore(range.start) &&
-                !GoalWindow.dayUtc(observation.recordedAt).isAfter(range.end) &&
-                !observation.recordedAt.isAfter(evaluationReference))
-              observation,
-        ]..sort((a, b) {
-          final byTime = a.recordedAt.compareTo(b.recordedAt);
-          return byTime != 0 ? byTime : a.tieBreaker.compareTo(b.tieBreaker);
-        });
+    final observations = goalHealthObservationsForCriterion(
+      metric: metric,
+      facts: facts,
+      evaluationReference: evaluationReference,
+    );
     final latest = observations.lastOrNull;
     final emittedObservations =
         observations.length <= goalHealthObservationEvidenceLimit

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.8+4310
+version: 1.0.8+4311
 
 msix_config:
   display_name: LottiApp

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -168,10 +168,10 @@ void main() {
             ),
           ),
           JournalEntity.quantitative(
-            meta: meta(DateTime(2026, 8, 8, 18)),
+            meta: meta(DateTime(2026, 8, 8, 13)),
             data: QuantitativeData.discreteQuantityData(
-              dateFrom: DateTime(2026, 8, 8, 18),
-              dateTo: DateTime(2026, 8, 8, 18),
+              dateFrom: DateTime(2026, 8, 8, 13),
+              dateTo: DateTime(2026, 8, 8, 13),
               value: 1400,
               dataType: 'custom_rowing_meters',
               unit: 'm',
@@ -234,69 +234,73 @@ void main() {
     },
   );
 
-  test("point-sample types (aggregation none) keep the day's LATEST "
-      'sample', () async {
-    const weight = GoalCriterion.metric(
-      criterionId: 'weight',
-      dataType: 'HealthDataType.WEIGHT',
-      window: GoalWindow.day(),
-      aggregation: GoalAggregation.max,
-      target: 80,
-      direction: GoalDirection.atMost,
-    );
-    JournalEntity sample(DateTime at, num value) => JournalEntity.quantitative(
-      meta: meta(at),
-      data: QuantitativeData.discreteQuantityData(
-        dateFrom: at,
-        dateTo: at,
-        value: value,
+  test(
+    'point-sample aggregate and raw evidence share the evaluation cutoff',
+    () async {
+      const weight = GoalCriterion.metric(
+        criterionId: 'weight',
         dataType: 'HealthDataType.WEIGHT',
-        unit: 'kg',
-      ),
-    );
-    when(
-      () => journalDb.getQuantitativeByType(
-        type: 'HealthDataType.WEIGHT',
-        rangeStart: any(named: 'rangeStart'),
-        rangeEnd: any(named: 'rangeEnd'),
-      ),
-    ).thenAnswer(
-      // Newest-first, like the real query: without deterministic
-      // reduction the OLDEST sample would win the day-keyed map.
-      (_) async => [
-        sample(DateTime(2026, 8, 8, 21), 79.4),
-        sample(DateTime(2026, 8, 8, 7), 81.2),
-        // Defensive: a stray non-quantitative row is skipped, not bucketed.
-        measurement(DateTime(2026, 8, 8, 12), 1),
-      ],
-    );
+        window: GoalWindow.day(),
+        aggregation: GoalAggregation.max,
+        target: 80,
+        direction: GoalDirection.atMost,
+      );
+      JournalEntity sample(DateTime at, num value) =>
+          JournalEntity.quantitative(
+            meta: meta(at),
+            data: QuantitativeData.discreteQuantityData(
+              dateFrom: at,
+              dateTo: at,
+              value: value,
+              dataType: 'HealthDataType.WEIGHT',
+              unit: 'kg',
+            ),
+          );
+      when(
+        () => journalDb.getQuantitativeByType(
+          type: 'HealthDataType.WEIGHT',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        // Newest-first, like the real query: without deterministic
+        // reduction the OLDEST sample would win the day-keyed map.
+        (_) async => [
+          // This row arrived after the wake captured its reference. Neither the
+          // deterministic aggregate nor the exact model evidence may include it.
+          sample(DateTime(2026, 8, 8, 21), 79.4),
+          sample(DateTime(2026, 8, 8, 7), 81.2),
+          // Defensive: a stray non-quantitative row is skipped, not bucketed.
+          measurement(DateTime(2026, 8, 8, 12), 1),
+        ],
+      );
 
-    final window = await reader.read(criteria: weight, reference: reference);
-    expect(
-      window.quantitativeDailySums['HealthDataType.WEIGHT']![DateTime.utc(
-        2026,
-        8,
-        8,
-      )],
-      79.4,
-    );
-    final observations =
-        window.quantitativeObservationsByType['HealthDataType.WEIGHT']!;
-    expect(
-      observations.map((observation) => observation.recordedAt),
-      [DateTime(2026, 8, 8, 7), DateTime(2026, 8, 8, 21)],
-      reason: 'the agent needs every ordered raw sample, not the daily fold',
-    );
-    expect(observations.map((observation) => observation.value), [81.2, 79.4]);
-    expect(
-      observations.map((observation) => observation.tieBreaker),
-      [
-        'e-${DateTime(2026, 8, 8, 7).millisecondsSinceEpoch}',
-        'e-${DateTime(2026, 8, 8, 21).millisecondsSinceEpoch}',
-      ],
-      reason: 'equal timestamps need a stable replica-independent ordering',
-    );
-  });
+      final window = await reader.read(criteria: weight, reference: reference);
+      expect(
+        window.quantitativeDailySums['HealthDataType.WEIGHT']![DateTime.utc(
+          2026,
+          8,
+          8,
+        )],
+        81.2,
+      );
+      final observations =
+          window.quantitativeObservationsByType['HealthDataType.WEIGHT']!;
+      expect(
+        observations.map((observation) => observation.recordedAt),
+        [DateTime(2026, 8, 8, 7)],
+        reason: 'both representations stop at the captured reference instant',
+      );
+      expect(observations.map((observation) => observation.value), [81.2]);
+      expect(
+        observations.map((observation) => observation.tieBreaker),
+        [
+          'e-${DateTime(2026, 8, 8, 7).millisecondsSinceEpoch}',
+        ],
+        reason: 'equal timestamps need a stable replica-independent ordering',
+      );
+    },
+  );
 
   test('identical point-sample timestamps break the tie by entity id, '
       'independent of query return order', () async {

--- a/test/features/goals/runtime/goal_wake_facts_test.dart
+++ b/test/features/goals/runtime/goal_wake_facts_test.dart
@@ -1,11 +1,23 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 
 void main() {
+  const criteria = GoalCriterion.metric(
+    criterionId: 'health-weight',
+    dataType: GoalHealthDataTypes.weight,
+    window: GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: 88,
+    direction: GoalDirection.atMost,
+  );
+  final reference = DateTime(2026, 8, 9, 12);
+
   GoalWakeFacts facts(List<GoalMetricObservation> observations) =>
       GoalWakeFacts(
         trackStatus: GoalTrackStatus.atRisk,
@@ -63,14 +75,141 @@ void main() {
       reason: 'the persisted aggregate did not change',
     );
     expect(
-      goalFactsDigest(backfilled),
-      isNot(goalFactsDigest(original)),
+      goalFactsDigest(
+        backfilled,
+        criteria: criteria,
+        evaluationReference: reference,
+      ),
+      isNot(
+        goalFactsDigest(
+          original,
+          criteria: criteria,
+          evaluationReference: reference,
+        ),
+      ),
       reason: 'banner copy can describe timestamps and sparsity',
     );
     expect(
-      goalFactsDigest(reordered),
-      goalFactsDigest(original),
+      goalFactsDigest(
+        reordered,
+        criteria: criteria,
+        evaluationReference: reference,
+      ),
+      goalFactsDigest(
+        original,
+        criteria: criteria,
+        evaluationReference: reference,
+      ),
       reason: 'query order cannot create replica-specific freshness',
     );
   });
+
+  test(
+    'exact digest ignores prior-period samples absent from rendered facts',
+    () {
+      final current = facts([
+        GoalMetricObservation(
+          recordedAt: DateTime(2026, 8, 8, 8),
+          value: 88,
+        ),
+      ]);
+      final withPriorPeriodBackfill = facts([
+        GoalMetricObservation(
+          recordedAt: DateTime(2026, 8, 2, 8),
+          value: 91,
+        ),
+        ...current.quantitativeObservationsByType[GoalHealthDataTypes.weight]!,
+      ]);
+
+      expect(
+        goalFactsDigest(
+          withPriorPeriodBackfill,
+          criteria: criteria,
+          evaluationReference: reference,
+        ),
+        goalFactsDigest(
+          current,
+          criteria: criteria,
+          evaluationReference: reference,
+        ),
+        reason: 'banner freshness must hash only model-facing window evidence',
+      );
+    },
+  );
+
+  test(
+    'composite freshness visits nested health and ignores non-health leaves',
+    () {
+      const composite = GoalCriterion.allOf(
+        criterionId: 'root',
+        criteria: [
+          GoalCriterion.metric(
+            criterionId: 'steps',
+            dataType: 'cumulative_step_count',
+            window: GoalWindow.day(),
+            aggregation: GoalAggregation.sum,
+            target: 10000,
+          ),
+          GoalCriterion.habit(
+            criterionId: 'habit',
+            habitId: 'meds',
+            window: GoalWindow.day(),
+            targetCount: 1,
+          ),
+          GoalCriterion.measurable(
+            criterionId: 'water',
+            dataTypeId: 'water-id',
+            window: GoalWindow.day(),
+            aggregation: GoalAggregation.sum,
+            target: 2000,
+          ),
+          GoalCriterion.categoryTime(
+            criterionId: 'sleep',
+            categoryId: 'sleep-id',
+            window: GoalWindow.day(),
+            aggregation: GoalAggregation.sum,
+            targetHours: 8,
+          ),
+          GoalCriterion.anyOf(
+            criterionId: 'health-choice',
+            criteria: [
+              GoalCriterion.atLeastCount(
+                criterionId: 'health-count',
+                successes: 1,
+                criteria: [criteria],
+              ),
+            ],
+          ),
+        ],
+      );
+      final original = facts([
+        GoalMetricObservation(
+          recordedAt: DateTime(2026, 8, 8, 8),
+          value: 88,
+        ),
+      ]);
+      final changed = facts([
+        GoalMetricObservation(
+          recordedAt: DateTime(2026, 8, 8, 8),
+          value: 87,
+        ),
+      ]);
+
+      expect(
+        goalFactsDigest(
+          changed,
+          criteria: composite,
+          evaluationReference: reference,
+        ),
+        isNot(
+          goalFactsDigest(
+            original,
+            criteria: composite,
+            evaluationReference: reference,
+          ),
+        ),
+        reason: 'only the nested model-facing health series changes the digest',
+      );
+    },
+  );
 }

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -662,6 +662,10 @@ void main() {
                     value: 90,
                   ),
                   GoalMetricObservation(
+                    recordedAt: DateTime(2026, 8, 8, 23, 59, 59, 500),
+                    value: 89,
+                  ),
+                  GoalMetricObservation(
                     recordedAt: DateTime(2026, 8, 9, 8),
                     value: 88,
                   ),
@@ -690,11 +694,16 @@ void main() {
             expect(message, contains('"healthSeries"'));
             expect(
               message,
-              contains('"reference": "2026-08-08T23:59:59.000"'),
+              contains('"reference": "2026-08-08T23:59:59.999999"'),
             );
             expect(
               message,
               contains('"recordedAt": "2026-08-08T08:00:00.000"'),
+            );
+            expect(
+              message,
+              contains('"recordedAt": "2026-08-08T23:59:59.500"'),
+              reason: 'the completed day includes its final fractional second',
             );
             expect(
               message,


### PR DESCRIPTION
## What changed

- clip queried quantitative rows to the wake’s captured evaluation instant before building either daily aggregates or exact observations
- share one health-window projection between FACTS rendering and banner freshness
- hash only exact samples that a criterion can actually render, so prior-period backfills do not expire still-valid banner copy
- pass the delayed wake’s evaluation reference through banner persistence
- bump only the build number from `4310` to `4311`; version `1.0.8` is unchanged

## Why

Follow-up to #3905. Two post-merge review findings exposed consistency edges:

1. a same-day health write landing while the journal query was in flight could influence `actual` while being absent from `healthSeries`;
2. the reader deliberately carries a prior period for policy evaluation, but freshness hashed those extra samples even though FACTS filtered them out.

The result could be unexplained aggregates or unnecessary banner replacement inference. This PR makes aggregate evidence, model-facing evidence, and freshness use the same reference/window boundaries.

## Validation

- regression tests were run against the merged behavior first and failed
- 123 focused tests pass across signal reading, wake facts, Phase A, FACTS rendering, and workflow persistence
- changed executable production lines have local coverage; no new uncovered lines
- targeted Flutter analyzer: zero issues
- `make knowledge_check`: 93 concepts and 478 Mermaid blocks validated
- `git diff --check`

This is an internal consistency fix with no visual change, so no new screenshot pair is needed.