### PR TITLE
fix: structure goal agent health reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Goal-agent health reports separate today's actions from rolling recovery.**
   When today's blood-pressure reading is on target, the agent now says logging
   is complete today, reports the rolling average and latest change separately,
-  and does not ask for another reading; lagging habits remain distinct actions.
+  and does not ask for another reading. Structured report sections keep latest
+  values, trends, coverage, and actions from being omitted, while explicit
+  current-day action items are accepted only for health criteria the app proves
+  remain loggable.
 
 ## [1.0.8]
 ### Added

--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -120,19 +120,35 @@ instruction.
 
 Fresh five-sample confirmation runs across P16 and P17 produced:
 
-| Structured-report model | Strict pass | Due-now violations | Mean input | Mean output | Credits | Wh |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `glm-5.2` | 10/10 | 0/10 | 4,261 | 797 | 0.0428 | 17.25 |
-| `muse-glimmer` | 10/10 | 0/10 | 4,583 | 2,182 | 0.0252 | 168.26 |
+| Structured-report model | Machine checks | Session semantic review | Due-now violations | Mean input | Mean output | Credits | Wh |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `glm-5.2` | 9/10 | 9/10 | 0/10 | 4,295 | 851 | 0.0448 | 20.67 |
+| `muse-glimmer` | 10/10 | 10/10 | 0/10 | 4,618 | 2,252 | 0.0254 | 171.20 |
 
-This moves Muse Glimmer from 1/10 to 10/10 on the complete complex-health
-contract, not merely the daily-action subset. It consistently bound 94 kg to
-weight, described the 129/94 → 125/84 improvement, called out sparse coverage,
-kept completed logging out of `now`, and isolated the 6/7 medication habit as
-future/ongoing focus. It is now adequate for these health scenarios. It is not
-yet a general Goal Agent default: its mean output remained about 2.7× GLM's and
-its provider-reported energy was about 9.8× higher, while the small scenario
-set says nothing about ads, revisions, dialogue, or no-op discipline.
+The two scores deliberately measure different things. Machine checks require
+the complete production report shape, exact values in the correct slots,
+sample counts, an empty `now` list, and absence of captured fabricated or
+current-action claims. They do not require mechanistic wording such as one of
+several synonyms for "on target" or "improving". The session review reads the
+captured prose for the actual conclusion, trend interpretation, and tone.
+
+Muse Glimmer reached the correct conclusion in all ten reviewed reports. It
+consistently bound 94 kg to weight, understood the 129/94 → 125/84 improvement,
+called out sparse coverage, kept completed logging out of `now`, and isolated
+the 6/7 medication habit as future or ongoing focus. GLM did the same in nine
+reports; one otherwise-correct report invented that a missed medication day
+"resets the full 7-day recovery window", although FACTS only supplied
+`daysToRecover: 1`. This is a factual overreach, not a harmless wording variant,
+so the captured claim is also retained as a deterministic regression check.
+
+Earlier strict iterations also caught one GLM report that encoded the report
+object as a JSON string and one that invented "Take BP medication today".
+Tightening the schema description and separating facts from typed actions
+removed both from the final sample, but the small run does not prove they are
+impossible. Muse is therefore adequate for these health scenarios, not yet a
+general Goal Agent default: its mean output remained about 2.6× GLM's and its
+provider-reported energy about 8.3× higher, while the small scenario set says
+nothing about ads, revisions, dialogue, or no-op discipline.
 
 The richer GLM input is about 7% larger than its baseline input. Follow-up
 token-saving experiments should preserve the winning semantics while testing:
@@ -145,7 +161,10 @@ token-saving experiments should preserve the winning semantics while testing:
 - whether summary fields such as `ratio` and `sampleCount` can be omitted when
   the exact series and deterministic status already carry the needed evidence.
 
-Raw run artifacts stay local under ignored `eval_artifacts/`; the scenario
+Raw run artifacts stay local under ignored `eval_artifacts/`. The final GLM
+sample came from the joint run ending `210834`; Muse's came from the Muse-only
+run ending `211212`. GLM's table result includes reclassification of the captured
+recovery-window fabrication against the committed regression check. The scenario
 catalog, objective classifier, and this run record are the reproducible source
 of truth committed to the repository.
 
@@ -227,11 +246,14 @@ fvm dart run tool/goal_agent_eval_report.dart eval_artifacts/goal_agent_*.json
 
 - **Samples are small.** 3 samples per cell is noise-level for anything but
   gross differences; treat single-cell flips as anecdotes, not signal.
-- **Objective checks only rank.** The classifier is deterministic
-  (tool calls, argument subsets, term groups, negation-aware claims from
-  the shared `eval_text_matchers.dart`). There is no LLM judge wired in
-  yet; if one is added, it is diagnostic only, never part of the pass/fail
-  gate (task-agent eval rule).
+- **Machine checks and prose review are separate.** The classifier is
+  deterministic (tool calls, complete shared report parsing, argument subsets,
+  values pinned to structured slots, and negation-aware forbidden claims from
+  `eval_text_matchers.dart`). It does not approximate semantic quality with an
+  expanding synonym list. Captured prose is reviewed separately for conclusions,
+  tone, and unsupported implications. There is no LLM judge wired in; if one is
+  added, it is diagnostic only, never part of the pass/fail gate (task-agent
+  eval rule).
 - **Be suspicious of scenarios all models pass or all models fail** — they
   usually measure the harness, not the model.
 - **Assert mutations via expected tool calls,** never by trusting report

--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -83,8 +83,9 @@ itself. The selected shape layers three deterministic hints instead:
   two exact observations with `latestChange`.
 - `evaluation.referenceIsCurrentDay` prevents delayed prior-day wakes from
   calling their historical evaluation "today".
-- The system contract defines those fields, while the `update_goal_report.tldr`
-  schema makes the daily-action distinction part of the required output.
+- The system contract defines those fields, while the original
+  `update_goal_report.tldr` description makes the daily-action distinction
+  part of the required output.
 
 With that shape, GLM 5.2 passed 10/10 fresh samples across both scenarios. It
 cited the latest values and aggregates correctly, described the improvement,
@@ -104,6 +105,34 @@ series, 5/10 explicitly described BP improvement, and 6/10 called out sparse
 coverage. Its higher token and provider-reported energy use also mean the lower
 credit price is not the same thing as lower resource use. These are tiny model
 samples, so the conclusion is a routing signal, not a benchmark claim.
+
+### Structured-report follow-up
+
+The free-form `tldr` remained an omission bottleneck for Muse Glimmer. Replacing
+it with five required report slots — evaluated-period state, rolling standing,
+latest change, coverage, and actions — changed the result materially. The app
+assembles those slots into the visible summary, so a fact cannot disappear in
+a second summarization pass. Actions are split into `now` and `later`; a `now`
+item must copy a criterion id from `healthLoggingNeededCriterionIds`, and the
+runtime discards any id that deterministic FACTS did not authorize. A rolling
+6/7 medication habit therefore cannot become an invented "take it today"
+instruction.
+
+Fresh five-sample confirmation runs across P16 and P17 produced:
+
+| Structured-report model | Strict pass | Due-now violations | Mean input | Mean output | Credits | Wh |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `glm-5.2` | 10/10 | 0/10 | 4,261 | 797 | 0.0428 | 17.25 |
+| `muse-glimmer` | 10/10 | 0/10 | 4,583 | 2,182 | 0.0252 | 168.26 |
+
+This moves Muse Glimmer from 1/10 to 10/10 on the complete complex-health
+contract, not merely the daily-action subset. It consistently bound 94 kg to
+weight, described the 129/94 → 125/84 improvement, called out sparse coverage,
+kept completed logging out of `now`, and isolated the 6/7 medication habit as
+future/ongoing focus. It is now adequate for these health scenarios. It is not
+yet a general Goal Agent default: its mean output remained about 2.7× GLM's and
+its provider-reported energy was about 9.8× higher, while the small scenario
+set says nothing about ads, revisions, dialogue, or no-op discipline.
 
 The richer GLM input is about 7% larger than its baseline input. Follow-up
 token-saving experiments should preserve the winning semantics while testing:

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -43,7 +43,7 @@
     <release version="1.0.9" date="2026-08-13">
       <description>
         <p>Changed: a design-panel polish pass across the goal-agent surfaces. The banner's Log today opens a one-tap logging sheet, day cells wear a dedicated success green with an inner dot for partial days, Restarting reads in blue, warning orange is reserved for genuine attention, the goal statement is labelled, phones get a persistent chat button, the Goal Agents list keeps one card silhouette with the week strip on the right on wide screens, day squares accept taps on a larger area, and chart target lines render at full strength.</p>
-        <p>Fixed: goal-agent health reports separate today's actions from rolling recovery. When today's blood-pressure reading is on target, the agent says logging is complete today, reports the rolling average and latest change separately, and does not ask for another reading; lagging habits remain distinct actions.</p>
+        <p>Fixed: goal-agent health reports separate today's actions from rolling recovery. When today's blood-pressure reading is on target, the agent says logging is complete today, reports the rolling average and latest change separately, and does not ask for another reading. Structured report sections keep latest values, trends, coverage, and actions from being omitted, while explicit current-day action items are accepted only for health criteria the app proves remain loggable.</p>
       </description>
     </release>
     <release version="1.0.8" date="2026-08-12">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -43,7 +43,7 @@
     <release version="1.0.9" date="2026-08-13">
       <description>
         <p>Changed: a design-panel polish pass across the goal-agent surfaces. The banner's Log today opens a one-tap logging sheet, day cells wear a dedicated success green with an inner dot for partial days, Restarting reads in blue, warning orange is reserved for genuine attention, the goal statement is labelled, phones get a persistent chat button, the Goal Agents list keeps one card silhouette with the week strip on the right on wide screens, day squares accept taps on a larger area, and chart target lines render at full strength.</p>
-        <p>Fixed: goal-agent health reports separate today's actions from rolling recovery. When today's blood-pressure reading is on target, the agent says logging is complete today, reports the rolling average and latest change separately, and does not ask for another reading. Structured report sections keep latest values, trends, coverage, and actions from being omitted, while explicit current-day action items are accepted only for health criteria the app proves remain loggable.</p>
+        <p>Fixed: goal-agent health reports separate today's actions from rolling recovery. When today's blood-pressure reading is on target, the agent now says logging is complete today, reports the rolling average and latest change separately, and does not ask for another reading. Structured report sections keep latest values, trends, coverage, and actions from being omitted, while explicit current-day action items are accepted only for health criteria the app proves remain loggable.</p>
       </description>
     </release>
     <release version="1.0.8" date="2026-08-12">

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -330,6 +330,12 @@ flowchart TD
   copy says the evaluated day's logging is complete, describes any lagging
   rolling average separately, and does not ask for another reading. A delayed
   wake names the evaluated date and makes no claim about current-day actions.
+  `update_goal_report` collects evaluated-period state, rolling standing,
+  latest change, coverage, and actions as separate required slots; the strategy
+  assembles them into the persisted summary. Structured current actions carry a
+  criterion id and survive only when deterministic
+  `healthLoggingNeededCriterionIds` authorizes that id, so a lagging rolling
+  habit cannot create a current action item.
   Policy rows P16 and
   P17 regress this distinction with the six-dimensional BP fixture; model
   results and context-shape experiments live in the goal-agent eval run book.

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -332,10 +332,13 @@ flowchart TD
   wake names the evaluated date and makes no claim about current-day actions.
   `update_goal_report` collects evaluated-period state, rolling standing,
   latest change, coverage, and actions as separate required slots; the strategy
-  assembles them into the persisted summary. Structured current actions carry a
-  criterion id and survive only when deterministic
+  parses the same complete shape used by the eval classifier and assembles the
+  localized model-authored sentences without injecting English headings.
+  Evaluated-period and rolling-standing slots must be non-empty. Structured
+  current actions carry a criterion id and survive only when deterministic
   `healthLoggingNeededCriterionIds` authorizes that id, so a lagging rolling
-  habit cannot create a current action item.
+  habit cannot create a current action item; delayed overdue evaluations expose
+  no current-action ids at all.
   Policy rows P16 and
   P17 regress this distinction with the six-dimensional BP fixture; model
   results and context-shape experiments live in the goal-agent eval run book.

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -105,7 +105,13 @@ anchored to the same evaluation instant as the rolling aggregate. The latest
 sample also carries today's completion state and its direction since the
 previous sample, while a daily-action index keeps completed health logging
 separate from rolling habits that remain behind. Delayed prior-day wakes name
-their evaluated date instead of presenting it as today's state. Banner
+their evaluated date instead of presenting it as today's state. Standing
+reports use separate evaluated-period, rolling, change, coverage, and action
+slots that the app assembles into the visible summary. A structured current
+action is shown only when its criterion id appears in deterministic
+health-logging-needed guidance; a lagging rolling habit alone cannot create a
+"do this today" action item.
+Banner
 freshness hashes only those model-facing window samples, so older backfills do
 not invalidate copy that could not cite them. Goal Agents
 list rows share one silhouette — reserved week-strip footprint, shared trend

--- a/lib/features/goals/workflow/goal_agent_contract.dart
+++ b/lib/features/goals/workflow/goal_agent_contract.dart
@@ -45,6 +45,34 @@ final List<String> goalTrackStatusNames = [
   for (final status in GoalTrackStatus.values) status.name,
 ];
 
+/// Stable keys of the structured standing-report payload. The strategy
+/// renders these slots into the persisted user-visible summary in this order.
+abstract final class GoalReportSectionKeys {
+  static const currentPeriod = 'currentPeriod';
+  static const rollingWindow = 'rollingWindow';
+  static const latestChange = 'latestChange';
+  static const coverage = 'coverage';
+  static const nextActions = 'nextActions';
+
+  static const List<String> values = [
+    currentPeriod,
+    rollingWindow,
+    latestChange,
+    coverage,
+    nextActions,
+  ];
+}
+
+/// Keys that separate actions proven due in the evaluated period from later
+/// focus areas. This prevents a lagging rolling habit from becoming a false
+/// "do it today" instruction.
+abstract final class GoalReportActionKeys {
+  static const now = 'now';
+  static const later = 'later';
+
+  static const List<String> values = [now, later];
+}
+
 /// The system prompt. Deliberately lean (hard-capped at 3.2k chars by
 /// the offline test): the payload lesson from task-agent evals is that long
 /// prompts get skimmed, and every number the model needs arrives in the
@@ -157,21 +185,86 @@ final List<AgentToolDefinition> goalAgentTools = [
           'type': 'string',
           'description': 'One sentence a banner or list row can show.',
         },
-        'tldr': {
-          'type': 'string',
+        'report': {
+          'type': 'object',
           'description':
-              'Two to four sentences of current standing. When '
-              'todayGuidance lists completed health logging, say it is '
-              'complete today only when referenceIsCurrentDay; otherwise '
-              'name the evaluated date. Separate rolling averages and any '
-              'remaining actions.',
+              'Structured facts that the app assembles into the visible '
+              'standing summary. Keep each slot concise and do not repeat '
+              'the same fact across slots.',
+          'properties': {
+            GoalReportSectionKeys.currentPeriod: {
+              'type': 'string',
+              'description':
+                  'One concise sentence: what is complete versus loggable for '
+                  'evaluation.reference. Follow todayGuidance. For health, '
+                  'include each latest same-day value and whether it is on '
+                  'target. Say today only when referenceIsCurrentDay.',
+            },
+            GoalReportSectionKeys.rollingWindow: {
+              'type': 'string',
+              'description':
+                  'One concise sentence with rolling or calendar standing: '
+                  'aggregates, targets, and '
+                  'habit quotas. Never present an aggregate as a latest '
+                  'measurement.',
+            },
+            GoalReportSectionKeys.latestChange: {
+              'type': 'string',
+              'description':
+                  'One concise sentence: for every comparable health series, '
+                  'give exact latest and previous values plus latestChange. '
+                  'Empty when no comparable change exists.',
+            },
+            GoalReportSectionKeys.coverage: {
+              'type': 'string',
+              'description':
+                  'One concise sentence with sample counts, sparsity, or the '
+                  'specific insufficientData gap. Empty when not applicable.',
+            },
+            GoalReportSectionKeys.nextActions: {
+              'type': 'object',
+              'description':
+                  'Separate actions FACTS prove are due now from future or '
+                  'ongoing focus. A rollingHabitCriterionIdsBehind entry '
+                  'alone never proves an action is due today.',
+              'properties': {
+                GoalReportActionKeys.now: {
+                  'type': 'array',
+                  'description':
+                      'Actions explicitly proven due at evaluation.reference. '
+                      'criterionId must be copied from '
+                      'healthLoggingNeededCriterionIds. Use an empty list '
+                      'when FACTS do not identify one.',
+                  'items': {
+                    'type': 'object',
+                    'properties': {
+                      'criterionId': {'type': 'string'},
+                      'action': {'type': 'string'},
+                    },
+                    'required': ['criterionId', 'action'],
+                  },
+                },
+                GoalReportActionKeys.later: {
+                  'type': 'array',
+                  'description':
+                      'Future or ongoing focus, worded without claiming it is '
+                      'missing today.',
+                  'items': {'type': 'string'},
+                },
+              },
+              'required': GoalReportActionKeys.values,
+            },
+          },
+          'required': GoalReportSectionKeys.values,
         },
         'content': {
           'type': 'string',
-          'description': 'Optional longer narrative (markdown).',
+          'description':
+              'Optional longer markdown only for material detail absent from '
+              'report. Usually omit; never repeat the structured slots.',
         },
       },
-      'required': ['status', 'oneLiner', 'tldr'],
+      'required': ['status', 'oneLiner', 'report'],
     },
   ),
   AgentToolDefinition(

--- a/lib/features/goals/workflow/goal_agent_contract.dart
+++ b/lib/features/goals/workflow/goal_agent_contract.dart
@@ -73,6 +73,115 @@ abstract final class GoalReportActionKeys {
   static const List<String> values = [now, later];
 }
 
+/// One model-authored action whose current-period visibility is gated by
+/// deterministic FACTS before persistence.
+class GoalReportCurrentAction {
+  const GoalReportCurrentAction({
+    required this.criterionId,
+    required this.action,
+  });
+
+  final String criterionId;
+  final String action;
+}
+
+/// Parsed form of the structured standing report shared by production and
+/// the inference eval classifier, so provider schema compliance is tested
+/// against the same completeness rules the runtime enforces.
+class GoalStructuredReport {
+  const GoalStructuredReport({
+    required this.currentPeriod,
+    required this.rollingWindow,
+    required this.latestChange,
+    required this.coverage,
+    required this.now,
+    required this.later,
+  });
+
+  final String currentPeriod;
+  final String rollingWindow;
+  final String latestChange;
+  final String coverage;
+  final List<GoalReportCurrentAction> now;
+  final List<String> later;
+
+  static GoalStructuredReport? tryParse(Object? value) {
+    if (value is! Map<String, dynamic>) return null;
+    final currentPeriod = _requiredReportString(
+      value[GoalReportSectionKeys.currentPeriod],
+    );
+    final rollingWindow = _requiredReportString(
+      value[GoalReportSectionKeys.rollingWindow],
+    );
+    final latestChange = _optionalReportString(
+      value[GoalReportSectionKeys.latestChange],
+    );
+    final coverage = _optionalReportString(
+      value[GoalReportSectionKeys.coverage],
+    );
+    final actions = value[GoalReportSectionKeys.nextActions];
+    if (currentPeriod == null ||
+        rollingWindow == null ||
+        latestChange == null ||
+        coverage == null ||
+        actions is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final rawNow = actions[GoalReportActionKeys.now];
+    final rawLater = actions[GoalReportActionKeys.later];
+    if (rawNow is! List<dynamic> || rawLater is! List<dynamic>) return null;
+    final now = <GoalReportCurrentAction>[];
+    for (final item in rawNow) {
+      if (item is! Map<String, dynamic>) return null;
+      final criterionId = _requiredReportString(item['criterionId']);
+      final action = _requiredReportString(item['action']);
+      if (criterionId == null || action == null) return null;
+      now.add(
+        GoalReportCurrentAction(criterionId: criterionId, action: action),
+      );
+    }
+    final later = <String>[];
+    for (final item in rawLater) {
+      final action = _requiredReportString(item);
+      if (action == null) return null;
+      later.add(action);
+    }
+
+    return GoalStructuredReport(
+      currentPeriod: currentPeriod,
+      rollingWindow: rollingWindow,
+      latestChange: latestChange,
+      coverage: coverage,
+      now: now,
+      later: later,
+    );
+  }
+
+  /// Composes model-authored localized sentences without injecting English
+  /// headings. Only explicitly authorized current actions are included.
+  String visibleSummary({
+    required Set<String> allowedCurrentActionCriterionIds,
+  }) => [
+    currentPeriod,
+    rollingWindow,
+    if (latestChange.isNotEmpty) latestChange,
+    if (coverage.isNotEmpty) coverage,
+    for (final item in now)
+      if (allowedCurrentActionCriterionIds.contains(item.criterionId))
+        item.action,
+    ...later,
+  ].join('\n\n');
+}
+
+String? _requiredReportString(Object? value) {
+  final trimmed = _optionalReportString(value);
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+String? _optionalReportString(Object? value) =>
+    value is String ? value.trim() : null;
+
 /// The system prompt. Deliberately lean (hard-capped at 3.2k chars by
 /// the offline test): the payload lesson from task-agent evals is that long
 /// prompts get skimmed, and every number the model needs arrives in the
@@ -95,8 +204,8 @@ Health checklist:
   nothing about the current day.
 - `latestChange` is previous-to-latest only. `towardTarget` means improvement
   since the previous reading, not a stable trend.
-- A rolling habit below target is behind, not proof today's completion is
-  missing. Never invent which day was missed.
+- Put current instructions only in authorized nextActions.now;
+  nextActions.later never says today/now.
 
 Act in this order of precedence:
 1. Unanswered user message: call reply_to_user exactly once first. When asked,
@@ -189,8 +298,10 @@ final List<AgentToolDefinition> goalAgentTools = [
           'type': 'object',
           'description':
               'Structured facts that the app assembles into the visible '
-              'standing summary. Keep each slot concise and do not repeat '
-              'the same fact across slots.',
+              'standing summary. Prose slots are facts only; put every '
+              'instruction in nextActions. Keep each slot concise and do '
+              'not repeat the same fact across slots. Return a JSON object, '
+              'never an encoded JSON string.',
           'properties': {
             GoalReportSectionKeys.currentPeriod: {
               'type': 'string',
@@ -248,7 +359,8 @@ final List<AgentToolDefinition> goalAgentTools = [
                   'type': 'array',
                   'description':
                       'Future or ongoing focus, worded without claiming it is '
-                      'missing today.',
+                      'missing today. Never say today or now, and never '
+                      'instruct current-period completion.',
                   'items': {'type': 'string'},
                 },
               },

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -46,6 +46,7 @@ class GoalAgentStrategy extends ConversationStrategy
     required this.runKey,
     required Set<String> knownAdIds,
     Set<String>? activeAdIds,
+    this._allowedCurrentActionCriterionIds = const {},
     this.expectedStatus,
   }) : _knownAdIds = knownAdIds,
        _activeAdIds = activeAdIds ?? knownAdIds;
@@ -68,6 +69,11 @@ class GoalAgentStrategy extends ConversationStrategy
   /// this subset; reusable or retired library entries remain valid rerun
   /// targets but cannot be hidden from a surface where they are not shown.
   final Set<String> _activeAdIds;
+
+  /// Criterion ids deterministic FACTS explicitly mark actionable at the
+  /// evaluation reference. Other model-authored current actions are dropped
+  /// before the report becomes user-visible.
+  final Set<String> _allowedCurrentActionCriterionIds;
 
   /// The deterministic track status of this wake's FACTS. The contract
   /// declares it authoritative, so a report claiming any other status is
@@ -194,15 +200,22 @@ class GoalAgentStrategy extends ConversationStrategy
         .where((s) => s.name == statusRaw)
         .firstOrNull;
     final oneLiner = _trimmed(args['oneLiner']);
-    final tldr = _trimmed(args['tldr']);
+    final hasStructuredReport = args.containsKey('report');
+    final structuredTldr = _composeStructuredReport(args['report']);
+    final tldr = hasStructuredReport
+        ? structuredTldr ?? ''
+        : _trimmed(args['tldr']);
     if (status == null || oneLiner.isEmpty || tldr.isEmpty) {
       await _reject(
         call: call,
         manager: manager,
-        error:
-            'Error: update_goal_report needs status (one of '
-            '${goalTrackStatusNames.join('|')}), a non-empty oneLiner and '
-            'a non-empty tldr.',
+        error: hasStructuredReport
+            ? 'Error: update_goal_report needs status (one of '
+                  '${goalTrackStatusNames.join('|')}), a non-empty oneLiner '
+                  'and a complete structured report.'
+            : 'Error: update_goal_report needs status (one of '
+                  '${goalTrackStatusNames.join('|')}), a non-empty oneLiner '
+                  'and a non-empty tldr.',
       );
       return;
     }
@@ -220,7 +233,10 @@ class GoalAgentStrategy extends ConversationStrategy
     _reportOneLiner = oneLiner;
     _reportTldr = tldr;
     final content = _trimmed(args['content']);
-    _reportContent = content.isEmpty ? null : content;
+    // Structured reports are already the complete visible narrative. Ignore
+    // duplicated free-form content so it cannot reintroduce an action that
+    // the deterministic current-action filter removed.
+    _reportContent = hasStructuredReport || content.isEmpty ? null : content;
     await _accept(call, manager, 'Goal report updated.');
   }
 
@@ -419,6 +435,57 @@ class GoalAgentStrategy extends ConversationStrategy
     }
     _observations.add(ObservationRecord(text: note));
     await _accept(call, manager, 'Observation recorded.');
+  }
+
+  String? _composeStructuredReport(Object? value) {
+    if (value is! Map<String, dynamic>) return null;
+    final paragraphKeys = [
+      GoalReportSectionKeys.currentPeriod,
+      GoalReportSectionKeys.rollingWindow,
+      GoalReportSectionKeys.latestChange,
+      GoalReportSectionKeys.coverage,
+    ];
+    if (paragraphKeys.any((key) => value[key] is! String)) return null;
+    final rawActions = value[GoalReportSectionKeys.nextActions];
+    if (rawActions is! Map<String, dynamic>) {
+      return null;
+    }
+    final now = _currentActionList(rawActions[GoalReportActionKeys.now]);
+    final later = _stringList(rawActions[GoalReportActionKeys.later]);
+    if (now == null || later == null) return null;
+
+    final paragraphs = [
+      for (final key in paragraphKeys)
+        if (_trimmed(value[key]).isNotEmpty) _trimmed(value[key]),
+    ];
+    if (now.isNotEmpty) paragraphs.add('Now: ${now.join(' ')}');
+    if (later.isNotEmpty) paragraphs.add('Next: ${later.join(' ')}');
+    return paragraphs.join('\n\n');
+  }
+
+  List<String>? _stringList(Object? value) {
+    if (value is! List<dynamic> || value.any((item) => item is! String)) {
+      return null;
+    }
+    return [
+      for (final item in value)
+        if (_trimmed(item).isNotEmpty) _trimmed(item),
+    ];
+  }
+
+  List<String>? _currentActionList(Object? value) {
+    if (value is! List<dynamic>) return null;
+    final actions = <String>[];
+    for (final item in value) {
+      if (item is! Map<String, dynamic>) return null;
+      final criterionId = _trimmed(item['criterionId']);
+      final action = _trimmed(item['action']);
+      if (criterionId.isEmpty || action.isEmpty) return null;
+      if (_allowedCurrentActionCriterionIds.contains(criterionId)) {
+        actions.add(action);
+      }
+    }
+    return actions;
   }
 
   String _trimmed(Object? value) => value is String ? value.trim() : '';

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -71,8 +71,8 @@ class GoalAgentStrategy extends ConversationStrategy
   final Set<String> _activeAdIds;
 
   /// Criterion ids deterministic FACTS explicitly mark actionable at the
-  /// evaluation reference. Other model-authored current actions are dropped
-  /// before the report becomes user-visible.
+  /// evaluation reference. Explicit structured current-action items with any
+  /// other id are dropped before the report becomes user-visible.
   final Set<String> _allowedCurrentActionCriterionIds;
 
   /// The deterministic track status of this wake's FACTS. The contract
@@ -438,54 +438,9 @@ class GoalAgentStrategy extends ConversationStrategy
   }
 
   String? _composeStructuredReport(Object? value) {
-    if (value is! Map<String, dynamic>) return null;
-    final paragraphKeys = [
-      GoalReportSectionKeys.currentPeriod,
-      GoalReportSectionKeys.rollingWindow,
-      GoalReportSectionKeys.latestChange,
-      GoalReportSectionKeys.coverage,
-    ];
-    if (paragraphKeys.any((key) => value[key] is! String)) return null;
-    final rawActions = value[GoalReportSectionKeys.nextActions];
-    if (rawActions is! Map<String, dynamic>) {
-      return null;
-    }
-    final now = _currentActionList(rawActions[GoalReportActionKeys.now]);
-    final later = _stringList(rawActions[GoalReportActionKeys.later]);
-    if (now == null || later == null) return null;
-
-    final paragraphs = [
-      for (final key in paragraphKeys)
-        if (_trimmed(value[key]).isNotEmpty) _trimmed(value[key]),
-    ];
-    if (now.isNotEmpty) paragraphs.add('Now: ${now.join(' ')}');
-    if (later.isNotEmpty) paragraphs.add('Next: ${later.join(' ')}');
-    return paragraphs.join('\n\n');
-  }
-
-  List<String>? _stringList(Object? value) {
-    if (value is! List<dynamic> || value.any((item) => item is! String)) {
-      return null;
-    }
-    return [
-      for (final item in value)
-        if (_trimmed(item).isNotEmpty) _trimmed(item),
-    ];
-  }
-
-  List<String>? _currentActionList(Object? value) {
-    if (value is! List<dynamic>) return null;
-    final actions = <String>[];
-    for (final item in value) {
-      if (item is! Map<String, dynamic>) return null;
-      final criterionId = _trimmed(item['criterionId']);
-      final action = _trimmed(item['action']);
-      if (criterionId.isEmpty || action.isEmpty) return null;
-      if (_allowedCurrentActionCriterionIds.contains(criterionId)) {
-        actions.add(action);
-      }
-    }
-    return actions;
+    return GoalStructuredReport.tryParse(value)?.visibleSummary(
+      allowedCurrentActionCriterionIds: _allowedCurrentActionCriterionIds,
+    );
   }
 
   String _trimmed(Object? value) => value is String ? value.trim() : '';

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -412,6 +412,12 @@ class GoalAgentWorkflow with AgentErrorLogging {
       runKey: runKey,
       knownAdIds: knownAdIds,
       activeAdIds: activeAdIds,
+      allowedCurrentActionCriterionIds: _factsRenderer
+          .healthLoggingNeededCriterionIds(
+            criteria: version.criteria,
+            facts: facts,
+            evaluationReference: reference,
+          ),
       // The deterministic status is authoritative: a report claiming
       // anything else is rejected in-conversation.
       expectedStatus: facts.trackStatus,

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -412,12 +412,13 @@ class GoalAgentWorkflow with AgentErrorLogging {
       runKey: runKey,
       knownAdIds: knownAdIds,
       activeAdIds: activeAdIds,
-      allowedCurrentActionCriterionIds: _factsRenderer
-          .healthLoggingNeededCriterionIds(
-            criteria: version.criteria,
-            facts: facts,
-            evaluationReference: reference,
-          ),
+      allowedCurrentActionCriterionIds: overdueEscalation
+          ? const {}
+          : _factsRenderer.healthLoggingNeededCriterionIds(
+              criteria: version.criteria,
+              facts: facts,
+              evaluationReference: reference,
+            ),
       // The deterministic status is authoritative: a report claiming
       // anything else is rejected in-conversation.
       expectedStatus: facts.trackStatus,

--- a/lib/features/goals/workflow/goal_facts_renderer.dart
+++ b/lib/features/goals/workflow/goal_facts_renderer.dart
@@ -298,7 +298,11 @@ class GoalFactsRenderer {
     required DateTime evaluationReference,
   }) {
     final healthLoggingComplete = <String>[];
-    final healthLoggingNeeded = <String>[];
+    final healthLoggingNeeded = _healthLoggingNeededCriterionIds(
+      metrics: criteria.metrics,
+      facts: facts,
+      evaluationReference: evaluationReference,
+    ).toList();
     for (final entry in criteria.metrics.entries) {
       final metric = entry.value;
       if (!GoalHealthDataTypes.supported.contains(metric.dataType)) continue;
@@ -312,12 +316,6 @@ class GoalFactsRenderer {
           _isToday(latest.recordedAt, evaluationReference) &&
           _meetsTarget(latest.value, metric.target, metric.direction)) {
         healthLoggingComplete.add(entry.key);
-      } else if (latest == null ||
-          !_isToday(latest.recordedAt, evaluationReference)) {
-        final result = facts.evaluation.results[entry.key];
-        if (result != null && !result.satisfied) {
-          healthLoggingNeeded.add(entry.key);
-        }
       }
     }
     final rollingHabitsBehind = <String>[
@@ -331,6 +329,42 @@ class GoalFactsRenderer {
       'healthLoggingNeededCriterionIds': healthLoggingNeeded..sort(),
       'rollingHabitCriterionIdsBehind': rollingHabitsBehind..sort(),
     };
+  }
+
+  /// Health criteria whose latest observation is absent for the evaluated
+  /// day while their rolling result remains unsatisfied. Reports may turn
+  /// only these criterion ids into current-period actions.
+  Set<String> healthLoggingNeededCriterionIds({
+    required GoalCriterion criteria,
+    required GoalWakeFacts facts,
+    required DateTime evaluationReference,
+  }) => _healthLoggingNeededCriterionIds(
+    metrics: _leafCriteriaById(criteria).metrics,
+    facts: facts,
+    evaluationReference: evaluationReference,
+  );
+
+  Set<String> _healthLoggingNeededCriterionIds({
+    required Map<String, GoalCriterionMetric> metrics,
+    required GoalWakeFacts facts,
+    required DateTime evaluationReference,
+  }) {
+    final needed = <String>{};
+    for (final entry in metrics.entries) {
+      final metric = entry.value;
+      if (!GoalHealthDataTypes.supported.contains(metric.dataType)) continue;
+      final observations = goalHealthObservationsForCriterion(
+        metric: metric,
+        facts: facts,
+        evaluationReference: evaluationReference,
+      );
+      final latest = observations.lastOrNull;
+      if (latest == null || !_isToday(latest.recordedAt, evaluationReference)) {
+        final result = facts.evaluation.results[entry.key];
+        if (result != null && !result.satisfied) needed.add(entry.key);
+      }
+    }
+    return needed;
   }
 
   String _healthTodayStatus({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.9+4313
+version: 1.0.9+4314
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -258,6 +258,7 @@ void main() {
         final scenario = scenarioById('gh_complex_latest_on_target');
         const correctReport =
             '{"status":"insufficientData",'
+            '"report":{"nextActions":{"now":[],"later":[]}},'
             '"oneLiner":"Today is logged and done: the latest 125/84 is on '
             'target.",'
             '"tldr":"Only two readings make the series sparse, but BP improved '
@@ -277,6 +278,7 @@ void main() {
 
         const fabricatedLatest =
             '{"status":"insufficientData",'
+            '"report":{"nextActions":{"now":[],"later":[]}},'
             '"oneLiner":"Today is logged and done: the latest 125/84 is on '
             'target.",'
             '"tldr":"BP improved from 129/94 to 125/84. Rolling averages are '
@@ -295,6 +297,7 @@ void main() {
 
         const trendMissing =
             '{"status":"insufficientData",'
+            '"report":{"nextActions":{"now":[],"later":[]}},'
             '"oneLiner":"Today is logged and done: 125/84 is on target.", '
             '"tldr":"The readings were 129/94 and 125/84. Rolling averages '
             'are 127 and 89. Weight readings were 96 and 94 with an average '
@@ -316,6 +319,7 @@ void main() {
       final scenario = scenarioById('gh_complex_habit_behind');
       const correctReport =
           '{"status":"insufficientData",'
+          '"report":{"nextActions":{"now":[],"later":[]}},'
           '"oneLiner":"The latest 125/84 is in range and BP logging is '
           'complete for today.", '
           '"tldr":"The two readings are still sparse. BP improved since the '
@@ -335,6 +339,7 @@ void main() {
 
       const repeatsMeasurement =
           '{"status":"insufficientData",'
+          '"report":{"nextActions":{"now":[],"later":[]}},'
           '"oneLiner":"The latest 125/84 is in range and BP logging is '
           'complete for today.", '
           '"tldr":"Two readings are sparse. BP improved since the previous '
@@ -354,6 +359,7 @@ void main() {
 
       const inventsMissedWeekday =
           '{"status":"insufficientData",'
+          '"report":{"nextActions":{"now":[],"later":[]}},'
           '"oneLiner":"The latest 125/84 is in range and BP logging is '
           'complete for today.", '
           '"tldr":"Two readings are sparse. BP improved since the previous '
@@ -365,6 +371,49 @@ void main() {
           scenario: scenario,
           toolCalls: [
             call(GoalAgentToolNames.updateGoalReport, inventsMissedWeekday),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.forbiddenReportContent,
+      );
+
+      const inventsActionDueNow =
+          '{"status":"insufficientData", '
+          '"report":{"nextActions":{"now":["Take medication"], '
+          '"later":[]}},'
+          '"oneLiner":"The latest 125/84 is in range and BP logging is '
+          'complete for today.", '
+          '"tldr":"Two readings are sparse. BP improved since the previous '
+          'reading, while rolling averages remain 127 and 89. BP meds are '
+          '6/7 and behind. Weight improved to 94 kg with an average of 95."}';
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(GoalAgentToolNames.updateGoalReport, inventsActionDueNow),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.argumentMismatch,
+      );
+
+      const inventsMedicationDueToday =
+          '{"status":"insufficientData",'
+          '"report":{"nextActions":{"now":[],"later":[]}},'
+          '"oneLiner":"The latest 125/84 is in range and BP logging is '
+          'complete for today.", '
+          '"tldr":"Two readings are sparse. BP improved since the previous '
+          'reading, while rolling averages remain 127 and 89. BP meds are '
+          '6/7 and behind. Weight improved to 94 kg with an average of 95. '
+          'Take BP medication today."}';
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(
+              GoalAgentToolNames.updateGoalReport,
+              inventsMedicationDueToday,
+            ),
           ],
           assistantContent: '',
         ),

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -14,6 +16,25 @@ void main() {
 
   GoalAgentEvalToolCall call(String name, String argumentsJson) =>
       GoalAgentEvalToolCall(name: name, argumentsJson: argumentsJson);
+
+  String healthReport({
+    required String currentPeriod,
+    required String rollingWindow,
+    required String latestChange,
+    required String coverage,
+    List<Object?> now = const [],
+    List<Object?> later = const [],
+  }) => jsonEncode({
+    'status': 'insufficientData',
+    'oneLiner': currentPeriod,
+    'report': {
+      'currentPeriod': currentPeriod,
+      'rollingWindow': rollingWindow,
+      'latestChange': latestChange,
+      'coverage': coverage,
+      'nextActions': {'now': now, 'later': later},
+    },
+  });
 
   group('classifyGoalAgentResult', () {
     test('a correct on-track wake passes', () {
@@ -256,15 +277,18 @@ void main() {
       'complex health report distinguishes exact readings from averages',
       () {
         final scenario = scenarioById('gh_complex_latest_on_target');
-        const correctReport =
-            '{"status":"insufficientData",'
-            '"report":{"nextActions":{"now":[],"later":[]}},'
-            '"oneLiner":"Today is logged and done: the latest 125/84 is on '
-            'target.",'
-            '"tldr":"Only two readings make the series sparse, but BP improved '
-            'from 129/94 to 125/84. The rolling averages remain 127 and 89. '
-            'Weight also improved from 96 to the latest 94 kg, while its average '
-            'is 95."}';
+        final correctReport = healthReport(
+          currentPeriod:
+              'Today is logged and done: the latest 125/84 is on target, '
+              'and weight was logged today at 94 kg.',
+          rollingWindow:
+              'The rolling averages remain 127 and 89, while weight averages '
+              '95.',
+          latestChange:
+              'BP improved from 129/94 to 125/84, and weight improved from '
+              '95 to 94 kg.',
+          coverage: 'Only two BP and three weight readings make data sparse.',
+        );
         expect(
           classifyGoalAgentResult(
             scenario: scenario,
@@ -276,14 +300,17 @@ void main() {
           GoalAgentEvalFailureCategory.none,
         );
 
-        const fabricatedLatest =
-            '{"status":"insufficientData",'
-            '"report":{"nextActions":{"now":[],"later":[]}},'
-            '"oneLiner":"Today is logged and done: the latest 125/84 is on '
-            'target.",'
-            '"tldr":"BP improved from 129/94 to 125/84. Rolling averages are '
-            '127 and 89. Weight improved from 96 to 94 kg with an average of 95. '
-            'Current blood pressure is 127/89. Two readings are sparse."}';
+        final fabricatedLatest = healthReport(
+          currentPeriod:
+              'Today is logged and done: the latest 125/84 is on target, but '
+              'current blood pressure is 127/89. Weight is 94 kg.',
+          rollingWindow:
+              'Rolling averages are 127 and 89, and weight averages 95.',
+          latestChange:
+              'BP improved from 129/94 to 125/84. Weight improved from 95 to '
+              '94 kg.',
+          coverage: 'Two BP and three weight readings are sparse.',
+        );
         expect(
           classifyGoalAgentResult(
             scenario: scenario,
@@ -295,18 +322,23 @@ void main() {
           GoalAgentEvalFailureCategory.forbiddenReportContent,
         );
 
-        const trendMissing =
-            '{"status":"insufficientData",'
-            '"report":{"nextActions":{"now":[],"later":[]}},'
-            '"oneLiner":"Today is logged and done: 125/84 is on target.", '
-            '"tldr":"The readings were 129/94 and 125/84. Rolling averages '
-            'are 127 and 89. Weight readings were 96 and 94 with an average '
-            'of 95. Only two readings make the series sparse."}';
+        final previousReadingsMissing = healthReport(
+          currentPeriod:
+              'Today is logged and done: 125/84 is on target and weight is '
+              '94 kg.',
+          rollingWindow:
+              'Rolling averages are 127 and 89, and weight averages 95.',
+          latestChange: 'Latest BP is 125/84 and latest weight is 94.',
+          coverage: 'Only two readings make the series sparse.',
+        );
         expect(
           classifyGoalAgentResult(
             scenario: scenario,
             toolCalls: [
-              call(GoalAgentToolNames.updateGoalReport, trendMissing),
+              call(
+                GoalAgentToolNames.updateGoalReport,
+                previousReadingsMissing,
+              ),
             ],
             assistantContent: '',
           ),
@@ -317,15 +349,18 @@ void main() {
 
     test('complex health habit report isolates the action still due', () {
       final scenario = scenarioById('gh_complex_habit_behind');
-      const correctReport =
-          '{"status":"insufficientData",'
-          '"report":{"nextActions":{"now":[],"later":[]}},'
-          '"oneLiner":"The latest 125/84 is in range and BP logging is '
-          'complete for today.", '
-          '"tldr":"The two readings are still sparse. BP improved since the '
-          'previous reading, while the rolling averages remain 127 and 89. '
-          'BP meds are 6/7, so that separate habit is behind after one missed '
-          'day. Weight improved to 94 kg with a rolling average of 95."}';
+      final correctReport = healthReport(
+        currentPeriod:
+            'The latest 125/84 is in range and BP logging is complete for '
+            'today; weight was logged today at 94 kg.',
+        rollingWindow:
+            'Rolling averages remain 127 and 89; BP meds are 6/7 and behind, '
+            'while weight averages 95.',
+        latestChange:
+            'BP improved from 129/94 to 125/84 and weight improved from 95 to '
+            '94 kg.',
+        coverage: 'The two BP and three weight readings are still sparse.',
+      );
       expect(
         classifyGoalAgentResult(
           scenario: scenario,
@@ -337,15 +372,20 @@ void main() {
         GoalAgentEvalFailureCategory.none,
       );
 
-      const repeatsMeasurement =
-          '{"status":"insufficientData",'
-          '"report":{"nextActions":{"now":[],"later":[]}},'
-          '"oneLiner":"The latest 125/84 is in range and BP logging is '
-          'complete for today.", '
-          '"tldr":"Two readings are sparse. BP improved since the previous '
-          'reading, while rolling averages remain 127 and 89. BP meds are '
-          '6/7 after a missed day. Weight improved to 94 kg with an average of '
-          '95. Measure blood pressure again."}';
+      final repeatsMeasurement = healthReport(
+        currentPeriod:
+            'The latest 125/84 is in range and BP logging is complete for '
+            'today; weight is 94 kg.',
+        rollingWindow:
+            'Rolling averages remain 127 and 89; BP meds are 6/7 after a '
+            'missed day, and weight averages 95.',
+        latestChange:
+            'BP improved from 129/94 to 125/84 and weight improved from 95 to '
+            '94 kg.',
+        coverage:
+            'Two BP and three weight readings are sparse. Measure blood '
+            'pressure again.',
+      );
       expect(
         classifyGoalAgentResult(
           scenario: scenario,
@@ -357,15 +397,18 @@ void main() {
         GoalAgentEvalFailureCategory.forbiddenReportContent,
       );
 
-      const inventsMissedWeekday =
-          '{"status":"insufficientData",'
-          '"report":{"nextActions":{"now":[],"later":[]}},'
-          '"oneLiner":"The latest 125/84 is in range and BP logging is '
-          'complete for today.", '
-          '"tldr":"Two readings are sparse. BP improved since the previous '
-          'reading, while rolling averages remain 127 and 89. BP meds are '
-          '6/7 and behind because Monday was missed. Weight improved to 94 kg '
-          'with an average of 95."}';
+      final inventsMissedWeekday = healthReport(
+        currentPeriod:
+            'The latest 125/84 is in range and BP logging is complete for '
+            'today; weight is 94 kg.',
+        rollingWindow:
+            'Rolling averages remain 127 and 89; BP meds are 6/7 and behind '
+            'because Monday was missed, while weight averages 95.',
+        latestChange:
+            'BP improved from 129/94 to 125/84 and weight improved from 95 to '
+            '94 kg.',
+        coverage: 'Two BP and three weight readings are sparse.',
+      );
       expect(
         classifyGoalAgentResult(
           scenario: scenario,
@@ -377,15 +420,19 @@ void main() {
         GoalAgentEvalFailureCategory.forbiddenReportContent,
       );
 
-      const inventsActionDueNow =
-          '{"status":"insufficientData", '
-          '"report":{"nextActions":{"now":["Take medication"], '
-          '"later":[]}},'
-          '"oneLiner":"The latest 125/84 is in range and BP logging is '
-          'complete for today.", '
-          '"tldr":"Two readings are sparse. BP improved since the previous '
-          'reading, while rolling averages remain 127 and 89. BP meds are '
-          '6/7 and behind. Weight improved to 94 kg with an average of 95."}';
+      final inventsActionDueNow = healthReport(
+        currentPeriod:
+            'The latest 125/84 is in range and BP logging is complete for '
+            'today; weight is 94 kg.',
+        rollingWindow:
+            'Rolling averages remain 127 and 89; BP meds are 6/7 and behind, '
+            'while weight averages 95.',
+        latestChange:
+            'BP improved from 129/94 to 125/84 and weight improved from 95 to '
+            '94 kg.',
+        coverage: 'Two BP and three weight readings are sparse.',
+        now: const ['Take medication'],
+      );
       expect(
         classifyGoalAgentResult(
           scenario: scenario,
@@ -397,15 +444,19 @@ void main() {
         GoalAgentEvalFailureCategory.argumentMismatch,
       );
 
-      const inventsMedicationDueToday =
-          '{"status":"insufficientData",'
-          '"report":{"nextActions":{"now":[],"later":[]}},'
-          '"oneLiner":"The latest 125/84 is in range and BP logging is '
-          'complete for today.", '
-          '"tldr":"Two readings are sparse. BP improved since the previous '
-          'reading, while rolling averages remain 127 and 89. BP meds are '
-          '6/7 and behind. Weight improved to 94 kg with an average of 95. '
-          'Take BP medication today."}';
+      final inventsMedicationDueToday = healthReport(
+        currentPeriod:
+            'The latest 125/84 is in range and BP logging is complete for '
+            'today; weight is 94 kg.',
+        rollingWindow:
+            'Rolling averages remain 127 and 89; BP meds are 6/7 and behind, '
+            'while weight averages 95.',
+        latestChange:
+            'BP improved from 129/94 to 125/84 and weight improved from 95 to '
+            '94 kg.',
+        coverage: 'Two BP and three weight readings are sparse.',
+        later: const ['Take BP medication today.'],
+      );
       expect(
         classifyGoalAgentResult(
           scenario: scenario,
@@ -418,6 +469,77 @@ void main() {
           assistantContent: '',
         ),
         GoalAgentEvalFailureCategory.forbiddenReportContent,
+      );
+
+      final inventsRecoveryReset = healthReport(
+        currentPeriod:
+            'The latest 125/84 is in range and BP logging is complete for '
+            'today; weight is 94 kg.',
+        rollingWindow:
+            'Rolling averages remain 127 and 89; BP meds are 6/7 and one '
+            'missed day resets the full 7-day recovery window. Weight '
+            'averages 95.',
+        latestChange:
+            'BP improved from 129/94 to 125/84 and weight improved from 95 to '
+            '94 kg.',
+        coverage: 'Two BP and three weight readings are sparse.',
+      );
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(GoalAgentToolNames.updateGoalReport, inventsRecoveryReset),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.forbiddenReportContent,
+      );
+    });
+
+    test('complex health eval rejects an incomplete structured report', () {
+      final scenario = scenarioById('gh_complex_latest_on_target');
+      const incomplete =
+          '{"status":"insufficientData","oneLiner":"125/84 on target", '
+          '"report":{"nextActions":{"now":[],"later":[]}},'
+          '"tldr":"129/94 improved to 125/84; rolling 127/89; weight 94 '
+          'and average 95; two readings are sparse and logging complete."}';
+
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(GoalAgentToolNames.updateGoalReport, incomplete),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.argumentMismatch,
+      );
+    });
+
+    test('complex health machine checks do not grade semantic wording', () {
+      final scenario = scenarioById('gh_complex_latest_on_target');
+      final terseButStructurallyGrounded = healthReport(
+        currentPeriod: 'Current observations: 125, 84, and 94.',
+        rollingWindow: 'Window aggregates: 127, 89, and 95.',
+        latestChange: '129→125; 94→84; 95→94.',
+        coverage: 'BP samples: 2. Weight samples: 3.',
+      );
+
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(
+              GoalAgentToolNames.updateGoalReport,
+              terseButStructurallyGrounded,
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.none,
+        reason:
+            'trend direction, daily-status meaning, and tone are reviewed '
+            'semantically from captured artifacts',
       );
     });
   });

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -449,16 +449,36 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
     }
     if (expected.expectedArgumentsSubset.isNotEmpty &&
         !matching.any(
-          (call) => _containsExpectedValues(
-            call.jsonObjectArguments ?? const {},
-            expected.expectedArgumentsSubset,
-          ),
+          (call) {
+            final arguments = call.jsonObjectArguments ?? const {};
+            if (!_containsExpectedValues(
+              arguments,
+              expected.expectedArgumentsSubset,
+            )) {
+              return false;
+            }
+            return expected.name != GoalAgentToolNames.updateGoalReport ||
+                !expected.expectedArgumentsSubset.containsKey('report') ||
+                GoalStructuredReport.tryParse(arguments['report']) != null;
+          },
         )) {
       return GoalAgentEvalFailureCategory.argumentMismatch;
     }
   }
 
-  final reportText = _latestReportArguments(toolCalls)?.toLowerCase() ?? '';
+  final structuredReport = _latestStructuredReport(toolCalls);
+  for (final entry in scenario.requiredStructuredReportTermGroups.entries) {
+    final sectionText = _structuredReportSectionText(
+      structuredReport,
+      entry.key,
+    );
+    if (sectionText == null ||
+        entry.value.any((group) => !containsAnyEvalTerm(sectionText, group))) {
+      return GoalAgentEvalFailureCategory.missingRequiredReportContent;
+    }
+  }
+
+  final reportText = _latestReportText(toolCalls).toLowerCase();
   if (scenario.requiredReportTermGroups.any(
     (group) => !containsAnyEvalTerm(reportText, group),
   )) {
@@ -513,14 +533,53 @@ String _argumentsFor(List<GoalAgentEvalToolCall> toolCalls, String name) =>
         .map((call) => call.argumentsJson)
         .join('\n');
 
-String? _latestReportArguments(List<GoalAgentEvalToolCall> toolCalls) {
+String _latestReportText(List<GoalAgentEvalToolCall> toolCalls) {
   for (final call in toolCalls.reversed) {
     if (call.name == GoalAgentToolNames.updateGoalReport) {
-      return call.argumentsJson;
+      final arguments = call.jsonObjectArguments;
+      final structured = GoalStructuredReport.tryParse(arguments?['report']);
+      if (structured == null) return call.argumentsJson;
+      final summary = structured.visibleSummary(
+        allowedCurrentActionCriterionIds: {
+          for (final action in structured.now) action.criterionId,
+        },
+      );
+      final oneLiner = arguments?['oneLiner'];
+      return oneLiner is String && oneLiner.trim().isNotEmpty
+          ? '${oneLiner.trim()}\n\n$summary'
+          : summary;
+    }
+  }
+  return '';
+}
+
+GoalStructuredReport? _latestStructuredReport(
+  List<GoalAgentEvalToolCall> toolCalls,
+) {
+  for (final call in toolCalls.reversed) {
+    if (call.name == GoalAgentToolNames.updateGoalReport) {
+      return GoalStructuredReport.tryParse(
+        call.jsonObjectArguments?['report'],
+      );
     }
   }
   return null;
 }
+
+String? _structuredReportSectionText(
+  GoalStructuredReport? report,
+  String key,
+) => switch ((report, key)) {
+  (final GoalStructuredReport value, GoalReportSectionKeys.currentPeriod) =>
+    value.currentPeriod,
+  (final GoalStructuredReport value, GoalReportSectionKeys.rollingWindow) =>
+    value.rollingWindow,
+  (final GoalStructuredReport value, GoalReportSectionKeys.latestChange) =>
+    value.latestChange,
+  (final GoalStructuredReport value, GoalReportSectionKeys.coverage) =>
+    value.coverage,
+  _ => null,
+};
 
 bool _containsExpectedValues(
   Map<String, dynamic> actual,

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -37,6 +37,7 @@ class GoalAgentEvalScenario {
     this.forbiddenToolNames = const [],
     this.expectsNoToolCalls = false,
     this.requiredReportTermGroups = const [],
+    this.requiredStructuredReportTermGroups = const {},
     this.forbiddenReportTerms = const [],
     this.forbiddenReportClaims = const [],
     this.forbiddenReportPatterns = const [],
@@ -70,6 +71,12 @@ class GoalAgentEvalScenario {
   /// Term groups that must appear in the final `update_goal_report` call
   /// (any member of a group satisfies it).
   final List<List<String>> requiredReportTermGroups;
+
+  /// Machine-checkable term groups pinned to a specific structured report
+  /// slot. Semantic conclusions such as tone, improvement, and whether the
+  /// wording celebrates today's result are reviewed from captured outputs,
+  /// not approximated with an ever-growing synonym list.
+  final Map<String, List<List<String>>> requiredStructuredReportTermGroups;
   final List<String> forbiddenReportTerms;
 
   /// Claims that must not be *affirmatively asserted* in the report
@@ -840,58 +847,29 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       ),
     ],
     forbiddenToolNames: _adCreationToolNames,
-    requiredReportTermGroups: const [
-      ['125'],
-      ['84'],
-      ['127'],
-      ['89'],
-      ['average', 'rolling'],
-      ['on target', 'in range', 'within target'],
-      [
-        'improv',
-        'downward',
-        'lower',
-        'declin',
-        'toward target',
-        'towardtarget',
-        'right direction',
-        'trending down',
-        'dropped',
-        'down from',
-        'moving toward',
-        'moved toward',
+    requiredStructuredReportTermGroups: const {
+      GoalReportSectionKeys.currentPeriod: [
+        ['125'],
+        ['84'],
+        ['94'],
       ],
-      [
-        'done for today',
-        'logging is complete',
-        'logging complete',
-        'logged today',
-        'today is logged',
-        'logged and done',
-        'nothing more',
+      GoalReportSectionKeys.rollingWindow: [
+        ['127'],
+        ['89'],
+        ['95'],
       ],
-      [
-        'weight 94',
-        '94 kg',
-        'weight was logged today at 94',
-        'weight was measured today at 94',
-        'weight today is 94',
-        'weight today at 94',
+      GoalReportSectionKeys.latestChange: [
+        ['129'],
+        ['125'],
+        ['94'],
+        ['84'],
+        ['95'],
       ],
-      ['95'],
-      ['weight'],
-      [
-        'sparse',
-        'limited data',
-        'low data',
-        'few readings',
-        'insufficient',
-        'two readings',
-        '2 readings',
-        'data coverage',
-        'too few',
+      GoalReportSectionKeys.coverage: [
+        ['2', 'two'],
+        ['3', 'three'],
       ],
-    ],
+    },
     forbiddenReportClaims: const [
       'latest systolic is 127',
       'systolic is at 127',
@@ -928,72 +906,31 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       ),
     ],
     forbiddenToolNames: _adCreationToolNames,
-    requiredReportTermGroups: const [
-      ['125'],
-      ['84'],
-      ['127'],
-      ['89'],
-      ['average', 'rolling'],
-      ['on target', 'in range', 'within target'],
-      [
-        'done for today',
-        'logging is complete',
-        'logging complete',
-        'logged today',
-        'is logged',
-        'nothing more',
+    forbiddenReportTerms: const ['resets the full 7-day recovery window'],
+    requiredStructuredReportTermGroups: const {
+      GoalReportSectionKeys.currentPeriod: [
+        ['125'],
+        ['84'],
+        ['94'],
       ],
-      ['6/7', '6 of 7', 'six of seven'],
-      ['med', 'medication'],
-      [
-        'behind',
-        'missed',
-        'missing',
-        'short',
-        'not met',
-        "isn't met",
-        'not satisfied',
-        'lag',
-        'below target',
-        'need more',
-        'reach 7',
-        'reach the 7',
-        'rebuild',
-        'gap',
+      GoalReportSectionKeys.rollingWindow: [
+        ['127'],
+        ['89'],
+        ['95'],
+        ['6/7', '6 of 7', 'six of seven'],
       ],
-      [
-        'improv',
-        'downward',
-        'lower',
-        'declin',
-        'toward target',
-        'towardtarget',
-        'moving toward',
-        'moved toward',
-        'down from',
+      GoalReportSectionKeys.latestChange: [
+        ['129'],
+        ['125'],
+        ['94'],
+        ['84'],
+        ['95'],
       ],
-      [
-        'weight 94',
-        '94 kg',
-        'weight was logged today at 94',
-        'weight was measured today at 94',
-        'weight today is 94',
-        'weight today at 94',
+      GoalReportSectionKeys.coverage: [
+        ['2', 'two'],
+        ['3', 'three'],
       ],
-      ['95'],
-      ['weight'],
-      [
-        'sparse',
-        'limited data',
-        'low data',
-        'few readings',
-        'insufficient',
-        'two readings',
-        '2 readings',
-        'data coverage',
-        'too few',
-      ],
-    ],
+    },
     forbiddenReportClaims: const [
       'measure blood pressure again',
       'take another blood pressure reading',

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -831,7 +831,12 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     expectedToolCalls: const [
       GoalAgentExpectedToolCall(
         GoalAgentToolNames.updateGoalReport,
-        expectedArgumentsSubset: {'status': 'insufficientData'},
+        expectedArgumentsSubset: {
+          'status': 'insufficientData',
+          'report': {
+            'nextActions': {'now': <Object?>[]},
+          },
+        },
       ),
     ],
     forbiddenToolNames: _adCreationToolNames,
@@ -848,6 +853,7 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
         'lower',
         'declin',
         'toward target',
+        'towardtarget',
         'right direction',
         'trending down',
         'dropped',
@@ -858,12 +864,20 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       [
         'done for today',
         'logging is complete',
+        'logging complete',
         'logged today',
         'today is logged',
         'logged and done',
         'nothing more',
       ],
-      ['weight 94', '94 kg'],
+      [
+        'weight 94',
+        '94 kg',
+        'weight was logged today at 94',
+        'weight was measured today at 94',
+        'weight today is 94',
+        'weight today at 94',
+      ],
       ['95'],
       ['weight'],
       [
@@ -874,6 +888,8 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
         'insufficient',
         'two readings',
         '2 readings',
+        'data coverage',
+        'too few',
       ],
     ],
     forbiddenReportClaims: const [
@@ -903,7 +919,12 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     expectedToolCalls: const [
       GoalAgentExpectedToolCall(
         GoalAgentToolNames.updateGoalReport,
-        expectedArgumentsSubset: {'status': 'insufficientData'},
+        expectedArgumentsSubset: {
+          'status': 'insufficientData',
+          'report': {
+            'nextActions': {'now': <Object?>[]},
+          },
+        },
       ),
     ],
     forbiddenToolNames: _adCreationToolNames,
@@ -914,21 +935,51 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       ['89'],
       ['average', 'rolling'],
       ['on target', 'in range', 'within target'],
-      ['done for today', 'logging is complete', 'logged today', 'nothing more'],
+      [
+        'done for today',
+        'logging is complete',
+        'logging complete',
+        'logged today',
+        'is logged',
+        'nothing more',
+      ],
       ['6/7', '6 of 7', 'six of seven'],
       ['med', 'medication'],
-      ['behind', 'missed', 'missing', 'short', 'not met', "isn't met"],
+      [
+        'behind',
+        'missed',
+        'missing',
+        'short',
+        'not met',
+        "isn't met",
+        'not satisfied',
+        'lag',
+        'below target',
+        'need more',
+        'reach 7',
+        'reach the 7',
+        'rebuild',
+        'gap',
+      ],
       [
         'improv',
         'downward',
         'lower',
         'declin',
         'toward target',
+        'towardtarget',
         'moving toward',
         'moved toward',
         'down from',
       ],
-      ['weight 94', '94 kg'],
+      [
+        'weight 94',
+        '94 kg',
+        'weight was logged today at 94',
+        'weight was measured today at 94',
+        'weight today is 94',
+        'weight today at 94',
+      ],
       ['95'],
       ['weight'],
       [
@@ -939,6 +990,8 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
         'insufficient',
         'two readings',
         '2 readings',
+        'data coverage',
+        'too few',
       ],
     ],
     forbiddenReportClaims: const [
@@ -954,6 +1007,8 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     forbiddenReportPatterns: const [
       r'\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b.{0,40}\b(?:missed|missing|skipped|forgot|not taken)\b',
       r'\b(?:missed|missing|skipped|forgot|not taken)\b.{0,40}\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b',
+      r'\b(?:take|log|record|complete)\b.{0,50}\b(?:meds?|medication|dose)\b.{0,50}\btoday\b',
+      r'\btoday\b.{0,50}\b(?:take|log|record|complete)\b.{0,50}\b(?:meds?|medication|dose)\b',
     ],
   ),
 ];

--- a/test/features/goals/workflow/goal_agent_contract_test.dart
+++ b/test/features/goals/workflow/goal_agent_contract_test.dart
@@ -66,9 +66,50 @@ void main() {
     );
     final properties =
         reportTool.parameters['properties'] as Map<String, dynamic>;
+    final required = reportTool.parameters['required'] as List<dynamic>;
+    final report = properties['report'] as Map<String, dynamic>;
+    final reportProperties = report['properties'] as Map<String, dynamic>;
     expect(
-      (properties['tldr'] as Map<String, dynamic>)['description'],
-      contains('todayGuidance lists completed health logging'),
+      required,
+      containsAll(['status', 'oneLiner', 'report']),
+    );
+    expect(
+      report['required'],
+      GoalReportSectionKeys.values,
+    );
+    expect(
+      reportProperties.keys,
+      containsAll(GoalReportSectionKeys.values),
+    );
+    expect(
+      (reportProperties[GoalReportSectionKeys.currentPeriod]
+          as Map<String, dynamic>)['description'],
+      contains('todayGuidance'),
+    );
+    expect(
+      (reportProperties[GoalReportSectionKeys.latestChange]
+          as Map<String, dynamic>)['description'],
+      contains('exact latest'),
+    );
+    expect(
+      (reportProperties[GoalReportSectionKeys.nextActions]
+          as Map<String, dynamic>)['type'],
+      'object',
+    );
+    expect(
+      (reportProperties[GoalReportSectionKeys.nextActions]
+          as Map<String, dynamic>)['required'],
+      GoalReportActionKeys.values,
+    );
+    final actionProperties =
+        (reportProperties[GoalReportSectionKeys.nextActions]
+                as Map<String, dynamic>)['properties']
+            as Map<String, dynamic>;
+    expect(
+      ((actionProperties[GoalReportActionKeys.now]
+              as Map<String, dynamic>)['items']
+          as Map<String, dynamic>)['required'],
+      ['criterionId', 'action'],
     );
   });
 

--- a/test/features/goals/workflow/goal_agent_contract_test.dart
+++ b/test/features/goals/workflow/goal_agent_contract_test.dart
@@ -132,4 +132,78 @@ void main() {
       [for (final v in GoalNudgeTone.values) v.name],
     );
   });
+
+  group('GoalStructuredReport', () {
+    Map<String, Object?> validReport() => {
+      'currentPeriod': 'Logging is complete today.',
+      'rollingWindow': 'The rolling average remains above target.',
+      'latestChange': '',
+      'coverage': '',
+      'nextActions': {
+        'now': [
+          {'criterionId': 'health-weight', 'action': 'Log weight.'},
+        ],
+        'later': ['Keep the weekly habit moving.'],
+      },
+    };
+
+    test(
+      'parses complete reports and gates current actions when composing',
+      () {
+        final report = GoalStructuredReport.tryParse(validReport());
+
+        expect(report, isNotNull);
+        expect(
+          report!.visibleSummary(
+            allowedCurrentActionCriterionIds: const {'health-weight'},
+          ),
+          'Logging is complete today.\n\n'
+          'The rolling average remains above target.\n\n'
+          'Log weight.\n\n'
+          'Keep the weekly habit moving.',
+        );
+        expect(
+          report.visibleSummary(
+            allowedCurrentActionCriterionIds: const {},
+          ),
+          isNot(contains('Log weight.')),
+        );
+      },
+    );
+
+    test('rejects empty required standing sections', () {
+      for (final key in ['currentPeriod', 'rollingWindow']) {
+        final value = validReport()..[key] = '  ';
+        expect(
+          GoalStructuredReport.tryParse(value),
+          isNull,
+          reason: key,
+        );
+      }
+    });
+
+    test('rejects missing, mistyped, and empty action fields', () {
+      final malformed = [
+        validReport()..remove('coverage'),
+        validReport()..['latestChange'] = 7,
+        validReport()..['nextActions'] = 'later',
+        validReport()
+          ..['nextActions'] = {
+            'now': [
+              {'criterionId': '', 'action': 'Log weight.'},
+            ],
+            'later': <Object?>[],
+          },
+        validReport()
+          ..['nextActions'] = {
+            'now': <Object?>[],
+            'later': [''],
+          },
+      ];
+
+      for (final value in malformed) {
+        expect(GoalStructuredReport.tryParse(value), isNull, reason: '$value');
+      }
+    });
+  });
 }

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -158,7 +158,7 @@ void main() {
         'Rolling averages remain above target at 127/89.\n\n'
         'Blood pressure improved from 129/94 to 125/84.\n\n'
         'Two readings make the series sparse.\n\n'
-        'Next: Keep taking the medication tomorrow.',
+        'Keep taking the medication tomorrow.',
       );
       expect(strategy.reportContent, isNull);
     },
@@ -207,10 +207,44 @@ void main() {
         manager: manager,
       );
 
-      expect(gated.reportTldr, contains('Now: Log weight today.'));
+      expect(gated.reportTldr, contains('Log weight today.'));
       expect(gated.reportTldr, isNot(contains('Take medication today.')));
     },
   );
+
+  test('structured report rejects empty current or rolling standing', () async {
+    for (final emptyKey in ['currentPeriod', 'rollingWindow']) {
+      await strategy.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              'status': 'offTrack',
+              'oneLiner': 'Behind.',
+              'report': {
+                'currentPeriod': emptyKey == 'currentPeriod'
+                    ? ''
+                    : 'Nothing completed.',
+                'rollingWindow': emptyKey == 'rollingWindow'
+                    ? ''
+                    : 'The rolling window is behind.',
+                'latestChange': '',
+                'coverage': '',
+                'nextActions': {
+                  'now': <Object>[],
+                  'later': ['Keep going.'],
+                },
+              },
+            },
+          ),
+        ],
+        manager: manager,
+      );
+
+      expect(strategy.hasReport, isFalse, reason: emptyKey);
+      expect(rejection(), contains('structured report'));
+    }
+  });
 
   test(
     'structured report rejects malformed next actions without a fallback',

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -121,6 +121,125 @@ void main() {
     expect(strategy.reportContent, isNull);
   });
 
+  test(
+    'structured report sections become the persisted visible summary',
+    () async {
+      await strategy.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              'status': 'insufficientData',
+              'oneLiner': 'Today is handled; the rolling window still lags.',
+              'report': {
+                'currentPeriod':
+                    'Blood pressure logging is complete today at 125/84.',
+                'rollingWindow':
+                    'Rolling averages remain above target at 127/89.',
+                'latestChange':
+                    'Blood pressure improved from 129/94 to 125/84.',
+                'coverage': 'Two readings make the series sparse.',
+                'nextActions': {
+                  'now': <Object>[],
+                  'later': ['Keep taking the medication tomorrow.'],
+                },
+              },
+              'content': 'Take medication today.',
+            },
+          ),
+        ],
+        manager: manager,
+      );
+
+      expect(strategy.hasReport, isTrue);
+      expect(
+        strategy.reportTldr,
+        'Blood pressure logging is complete today at 125/84.\n\n'
+        'Rolling averages remain above target at 127/89.\n\n'
+        'Blood pressure improved from 129/94 to 125/84.\n\n'
+        'Two readings make the series sparse.\n\n'
+        'Next: Keep taking the medication tomorrow.',
+      );
+      expect(strategy.reportContent, isNull);
+    },
+  );
+
+  test(
+    'only deterministically allowed current actions become visible',
+    () async {
+      final gated = GoalAgentStrategy(
+        syncService: syncService,
+        agentId: 'goal-1',
+        threadId: 'thread-1',
+        runKey: 'run-1',
+        knownAdIds: const {},
+        allowedCurrentActionCriterionIds: const {'health-weight'},
+      );
+      await gated.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              'status': 'insufficientData',
+              'oneLiner': 'One measurement remains.',
+              'report': {
+                'currentPeriod': 'Weight is not measured today.',
+                'rollingWindow': 'The rolling weight average is above target.',
+                'latestChange': '',
+                'coverage': 'Today is missing from the series.',
+                'nextActions': {
+                  'now': [
+                    {
+                      'criterionId': 'health-weight',
+                      'action': 'Log weight today.',
+                    },
+                    {
+                      'criterionId': 'habit-bp-meds',
+                      'action': 'Take medication today.',
+                    },
+                  ],
+                  'later': <Object>[],
+                },
+              },
+            },
+          ),
+        ],
+        manager: manager,
+      );
+
+      expect(gated.reportTldr, contains('Now: Log weight today.'));
+      expect(gated.reportTldr, isNot(contains('Take medication today.')));
+    },
+  );
+
+  test(
+    'structured report rejects malformed next actions without a fallback',
+    () async {
+      await strategy.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              'status': 'offTrack',
+              'oneLiner': 'Behind.',
+              'report': {
+                'currentPeriod': 'Nothing completed.',
+                'rollingWindow': 'The rolling window is behind.',
+                'latestChange': '',
+                'coverage': '',
+                'nextActions': 'Walk tomorrow',
+              },
+            },
+          ),
+        ],
+        manager: manager,
+      );
+
+      expect(strategy.hasReport, isFalse);
+      expect(rejection(), contains('structured report'));
+    },
+  );
+
   test('a report status contradicting the deterministic FACTS is '
       'rejected — the computed status is authoritative', () async {
     final gated = GoalAgentStrategy(

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -639,7 +639,20 @@ void main() {
         target: 88,
         direction: GoalDirection.atMost,
       );
-      stubSpec(criteria: weight);
+      const systolic = GoalCriterion.metric(
+        criterionId: 'health-systolic',
+        dataType: GoalHealthDataTypes.bloodPressureSystolic,
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.dailySumThenAverage,
+        target: 125,
+        direction: GoalDirection.atMost,
+      );
+      stubSpec(
+        criteria: const GoalCriterion.allOf(
+          criterionId: 'health-composite',
+          criteria: [weight, systolic],
+        ),
+      );
       stubGlmResolution();
       workflow = GoalAgentWorkflow(
         repository: repository,
@@ -711,12 +724,35 @@ void main() {
             );
             expect(message, contains('"onTarget": false'));
             expect(message, contains('"isToday": true'));
+            expect(
+              message,
+              contains(
+                '"healthLoggingNeededCriterionIds": [\n'
+                '        "health-systolic"',
+              ),
+              reason: 'the historical gap is real for its evaluated day',
+            );
             await (strategy! as GoalAgentStrategy).processToolCalls(
               toolCalls: [
                 toolCall(GoalAgentToolNames.updateGoalReport, {
                   'status': 'insufficientData',
                   'oneLiner': 'The delayed report matches its encoded day.',
-                  'tldr': 'Only observations through August 8 are included.',
+                  'report': {
+                    'currentPeriod':
+                        'Only observations through August 8 are included.',
+                    'rollingWindow': 'The historical window lacks systolic BP.',
+                    'latestChange': '',
+                    'coverage': 'Systolic coverage is missing.',
+                    'nextActions': {
+                      'now': [
+                        {
+                          'criterionId': 'health-systolic',
+                          'action': 'Measure blood pressure now.',
+                        },
+                      ],
+                      'later': <Object?>[],
+                    },
+                  },
                 }),
               ],
               manager: conversationManager,
@@ -729,10 +765,9 @@ void main() {
       );
 
       expect(result.success, isTrue);
-      expect(
-        upserts.whereType<AgentReportEntity>().single.tldr,
-        'Only observations through August 8 are included.',
-      );
+      final tldr = upserts.whereType<AgentReportEntity>().single.tldr;
+      expect(tldr, contains('Only observations through August 8'));
+      expect(tldr, isNot(contains('Measure blood pressure now')));
     },
   );
 

--- a/test/features/goals/workflow/goal_facts_renderer_test.dart
+++ b/test/features/goals/workflow/goal_facts_renderer_test.dart
@@ -557,6 +557,71 @@ void main() {
     },
   );
 
+  test('current report actions expose only unmeasured health criteria', () {
+    const criteria = GoalCriterion.allOf(
+      criterionId: 'health-routine',
+      criteria: [
+        GoalCriterion.metric(
+          criterionId: 'health-weight',
+          dataType: GoalHealthDataTypes.weight,
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          target: 88,
+          direction: GoalDirection.atMost,
+        ),
+        GoalCriterion.habit(
+          criterionId: 'habit-bp-meds',
+          habitId: 'habit-bp-meds',
+          window: GoalWindow.rollingDays(count: 7),
+          targetCount: 7,
+        ),
+      ],
+    );
+    final wakeFacts = GoalWakeFacts(
+      trackStatus: GoalTrackStatus.insufficientData,
+      evaluation: const GoalEvaluation(
+        attainment: 0.9,
+        satisfied: false,
+        dataCoverage: 1 / 7,
+        results: {
+          'health-weight': GoalCriterionResult(
+            criterionId: 'health-weight',
+            actual: 95,
+            target: 88,
+            ratio: 88 / 95,
+            satisfied: false,
+            sampleCount: 1,
+          ),
+          'habit-bp-meds': GoalCriterionResult(
+            criterionId: 'habit-bp-meds',
+            actual: 6,
+            target: 7,
+            ratio: 6 / 7,
+            satisfied: false,
+            sampleCount: 6,
+          ),
+        },
+      ),
+      quantitativeObservationsByType: {
+        GoalHealthDataTypes.weight: [
+          GoalMetricObservation(
+            recordedAt: DateTime(2026, 8, 8, 8),
+            value: 95,
+          ),
+        ],
+      },
+    );
+
+    expect(
+      renderer.healthLoggingNeededCriterionIds(
+        criteria: criteria,
+        facts: wakeFacts,
+        evaluationReference: DateTime(2026, 8, 9, 12),
+      ),
+      {'health-weight'},
+    );
+  });
+
   test('health evidence keeps the newest bounded sample and omitted count', () {
     const criteria = GoalCriterion.metric(
       criterionId: 'health-weight',


### PR DESCRIPTION
## What changed

- replace the free-form Goal Agent report TLDR with required evaluated-period, rolling-window, latest-change, coverage, and action slots
- parse the complete report shape in one shared production/eval validator; reject blank current-period and rolling-window sections
- split actions into `now` and `later`, with current actions carrying a criterion ID
- accept a structured current action only when deterministic Goal FACTS prove that health criterion still needs logging at the evaluation reference
- expose no current action IDs for delayed overdue evaluations
- assemble localized model-authored sentences without hard-coded English headings
- grade exact facts and structure mechanically while reviewing conclusions and tone semantically from captured outputs
- bump the build number from 4313 to 4314 without changing the version

## Why

Muse Glimmer understood individual parts of the richer health time series, but a free-form TLDR let it omit facts or turn a rolling 6/7 medication habit into a false “take it today” instruction. Required semantic slots make omission harder, and the runtime criterion-ID guard prevents an explicit unauthorized current action from reaching the visible report.

The eval had also become overfitted to wording. The classifier now checks the complete runtime schema, exact values in the correct slots, sample counts, empty due-now actions, and captured factual/action regressions. Natural wording such as whether the model says “on target”, “in range”, or something equally clear is judged from the run artifacts in the evaluation session.

## Eval results

Five samples per model across the two complex 3-habit × 3-health-metric scenarios:

| Model | Machine checks | Session semantic review | Due-now violations | Mean input | Mean output | Credits | Provider-reported Wh |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| GLM 5.2 | 9/10 | 9/10 | 0/10 | 4,295 | 851 | 0.0448 | 20.67 |
| Muse Glimmer | 10/10 | 10/10 | 0/10 | 4,618 | 2,252 | 0.0254 | 171.20 |

Muse consistently reached the intended conclusion: today’s 125/84 BP is complete and on target, the 127/89 rolling averages remain behind, weight improved to 94 while averaging 95, coverage is sparse, and the 6/7 medication habit is future/ongoing focus rather than a fabricated action due today.

One GLM report invented that a missed medication day “resets the full 7-day recovery window”; FACTS only supplied `daysToRecover: 1`. Earlier iterations also exposed one encoded-JSON report and one false “Take BP medication today” action. The final prompt/schema removed those latter failures from the confirmation sample.

Muse is viable for these health scenarios, but not yet a general default: output is about 2.6× GLM and reported energy about 8.3× higher, and these scenarios do not cover ads, revisions, dialogue, or no-op discipline.

## Validation

- targeted analyzer: zero warnings or infos
- 147 targeted tests covering the changed workflow, schema, facts renderer, and eval harness: pass
- regression mutations: report completeness, current-action filtering, historical action suppression, and eval/runtime shape drift each fail when their fix is reverted
- `make knowledge_check`: pass (93 concepts and all Mermaid validation)
- Flatpak metainfo XML validation: pass
- `git diff --check`: pass
- patch coverage on the previous revision: 100%; replacement CI is running for the review commit

The full suite is intentionally delegated to CI, where it runs in 10 shards. This changes report generation and validation rather than a visual widget, so no screenshot pair applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal reports now separate current-period status, rolling progress, latest changes, data coverage, and recommended actions.
  * Current-day actions appear only when additional health logging is needed; outdated habits no longer create “do this today” prompts.
  * Delayed wake information now identifies the evaluated date.

* **Bug Fixes**
  * On-target blood-pressure readings no longer trigger unnecessary repeat measurements.
  * Health-report summaries now provide clearer, more accurate progress and coverage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->