### PR TITLE
fix: close goal banner snooze race gaps

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -503,6 +503,11 @@ flowchart TD
   watermarks merge losslessly on concurrent sync — the labeled ad library and
   its timing evidence must survive whole-row LWW. Concurrent snoozes for the
   same activation keep the later quiet deadline while retaining both events;
+  their staleness extensions merge by the later deadline so the selected
+  reveal cannot immediately disappear as stale. Successive snooze requests in
+  one model turn fold over the just-written row rather than the turn's initial
+  snapshot. Both the choice-time and requested-return offsets are retained, so
+  a daylight-saving transition cannot shift learned return-hour evidence;
   interaction-event ids deterministically de-duplicate the append-only
   histories across peers.
 - **Calendar arithmetic is component-based** (`DateTime(y, m, d ± n)`),
@@ -557,7 +562,10 @@ flowchart TD
   boundary, so expiry while the app is closed is handled without trusting a
   timer that did not run. Interaction writes return the exact persisted quiet
   deadline to optimistic local suppression, so a transaction crossing midnight
-  cannot extend a day dismissal into the following day. Synchronized snooze
+  cannot extend a day dismissal into the following day. That temporary local
+  suppression is activation-scoped: a concurrent re-run of the same row id is
+  immediately visible instead of inheriting the prior activation's quiet
+  interval. Synchronized snooze
   and day-dismissal histories accept only timestamps with explicit UTC markers
   or numeric offsets, keeping expiry and learned local-hour evidence
   replica-independent. `GoalFactsRenderer` summarizes duration, local start,

--- a/lib/classes/goal_nudge_models.dart
+++ b/lib/classes/goal_nudge_models.dart
@@ -115,8 +115,9 @@ abstract class GoalNudgeRating with _$GoalNudgeRating {
 ///
 /// The UTC instants preserve ordering and expiry semantics across devices.
 /// [utcOffsetMinutes] preserves the wall-clock context in which the user made
-/// the choice, so future timing analysis does not reinterpret an old snooze in
-/// the device's current timezone after travel or a daylight-saving change.
+/// the choice. [returnUtcOffsetMinutes] separately preserves the requested
+/// return wall time when the snooze crosses a daylight-saving boundary or was
+/// requested with another explicit offset.
 @freezed
 abstract class GoalNudgeSnooze with _$GoalNudgeSnooze {
   const factory GoalNudgeSnooze({
@@ -127,6 +128,8 @@ abstract class GoalNudgeSnooze with _$GoalNudgeSnooze {
     required GoalBannerSnoozeDuration duration,
     @JsonKey(fromJson: _decodePositiveMinutes) required int durationMinutes,
     @JsonKey(fromJson: _decodeUtcOffsetMinutes) required int utcOffsetMinutes,
+    @JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes)
+    int? returnUtcOffsetMinutes,
   }) = _GoalNudgeSnooze;
 
   const GoalNudgeSnooze._();
@@ -141,9 +144,10 @@ abstract class GoalNudgeSnooze with _$GoalNudgeSnooze {
       snoozedAt.toUtc().add(Duration(minutes: utcOffsetMinutes));
 
   /// The requested return time in the same recorded wall-clock convention as
-  /// [snoozedAtLocal].
-  DateTime get snoozedUntilLocal =>
-      snoozedUntil.toUtc().add(Duration(minutes: utcOffsetMinutes));
+  /// [snoozedAtLocal]. Older events fall back to the action-time offset.
+  DateTime get snoozedUntilLocal => snoozedUntil.toUtc().add(
+    Duration(minutes: returnUtcOffsetMinutes ?? utcOffsetMinutes),
+  );
 }
 
 /// One durable "dismiss for today" interaction for one banner activation.
@@ -195,6 +199,9 @@ int _decodeUtcOffsetMinutes(Object? raw) {
   }
   throw FormatException('utcOffsetMinutes outside -840..840: $raw');
 }
+
+int? _decodeOptionalUtcOffsetMinutes(Object? raw) =>
+    raw == null ? null : _decodeUtcOffsetMinutes(raw);
 
 /// Cross-field issues in a raw rating payload — what the per-field
 /// converters cannot see. Constructor assertions are deliberately NOT the

--- a/lib/classes/goal_nudge_models.freezed.dart
+++ b/lib/classes/goal_nudge_models.freezed.dart
@@ -569,7 +569,7 @@ as bool,
 /// @nodoc
 mixin _$GoalNudgeSnooze {
 
- String get id;@JsonKey(fromJson: _decodeActivation) int get activation; DateTime get snoozedAt; DateTime get snoozedUntil; GoalBannerSnoozeDuration get duration;@JsonKey(fromJson: _decodePositiveMinutes) int get durationMinutes;@JsonKey(fromJson: _decodeUtcOffsetMinutes) int get utcOffsetMinutes;
+ String get id;@JsonKey(fromJson: _decodeActivation) int get activation; DateTime get snoozedAt; DateTime get snoozedUntil; GoalBannerSnoozeDuration get duration;@JsonKey(fromJson: _decodePositiveMinutes) int get durationMinutes;@JsonKey(fromJson: _decodeUtcOffsetMinutes) int get utcOffsetMinutes;@JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes) int? get returnUtcOffsetMinutes;
 /// Create a copy of GoalNudgeSnooze
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -582,16 +582,16 @@ $GoalNudgeSnoozeCopyWith<GoalNudgeSnooze> get copyWith => _$GoalNudgeSnoozeCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalNudgeSnooze&&(identical(other.id, id) || other.id == id)&&(identical(other.activation, activation) || other.activation == activation)&&(identical(other.snoozedAt, snoozedAt) || other.snoozedAt == snoozedAt)&&(identical(other.snoozedUntil, snoozedUntil) || other.snoozedUntil == snoozedUntil)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.durationMinutes, durationMinutes) || other.durationMinutes == durationMinutes)&&(identical(other.utcOffsetMinutes, utcOffsetMinutes) || other.utcOffsetMinutes == utcOffsetMinutes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalNudgeSnooze&&(identical(other.id, id) || other.id == id)&&(identical(other.activation, activation) || other.activation == activation)&&(identical(other.snoozedAt, snoozedAt) || other.snoozedAt == snoozedAt)&&(identical(other.snoozedUntil, snoozedUntil) || other.snoozedUntil == snoozedUntil)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.durationMinutes, durationMinutes) || other.durationMinutes == durationMinutes)&&(identical(other.utcOffsetMinutes, utcOffsetMinutes) || other.utcOffsetMinutes == utcOffsetMinutes)&&(identical(other.returnUtcOffsetMinutes, returnUtcOffsetMinutes) || other.returnUtcOffsetMinutes == returnUtcOffsetMinutes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,activation,snoozedAt,snoozedUntil,duration,durationMinutes,utcOffsetMinutes);
+int get hashCode => Object.hash(runtimeType,id,activation,snoozedAt,snoozedUntil,duration,durationMinutes,utcOffsetMinutes,returnUtcOffsetMinutes);
 
 @override
 String toString() {
-  return 'GoalNudgeSnooze(id: $id, activation: $activation, snoozedAt: $snoozedAt, snoozedUntil: $snoozedUntil, duration: $duration, durationMinutes: $durationMinutes, utcOffsetMinutes: $utcOffsetMinutes)';
+  return 'GoalNudgeSnooze(id: $id, activation: $activation, snoozedAt: $snoozedAt, snoozedUntil: $snoozedUntil, duration: $duration, durationMinutes: $durationMinutes, utcOffsetMinutes: $utcOffsetMinutes, returnUtcOffsetMinutes: $returnUtcOffsetMinutes)';
 }
 
 
@@ -602,7 +602,7 @@ abstract mixin class $GoalNudgeSnoozeCopyWith<$Res>  {
   factory $GoalNudgeSnoozeCopyWith(GoalNudgeSnooze value, $Res Function(GoalNudgeSnooze) _then) = _$GoalNudgeSnoozeCopyWithImpl;
 @useResult
 $Res call({
- String id,@JsonKey(fromJson: _decodeActivation) int activation, DateTime snoozedAt, DateTime snoozedUntil, GoalBannerSnoozeDuration duration,@JsonKey(fromJson: _decodePositiveMinutes) int durationMinutes,@JsonKey(fromJson: _decodeUtcOffsetMinutes) int utcOffsetMinutes
+ String id,@JsonKey(fromJson: _decodeActivation) int activation, DateTime snoozedAt, DateTime snoozedUntil, GoalBannerSnoozeDuration duration,@JsonKey(fromJson: _decodePositiveMinutes) int durationMinutes,@JsonKey(fromJson: _decodeUtcOffsetMinutes) int utcOffsetMinutes,@JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes) int? returnUtcOffsetMinutes
 });
 
 
@@ -619,7 +619,7 @@ class _$GoalNudgeSnoozeCopyWithImpl<$Res>
 
 /// Create a copy of GoalNudgeSnooze
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activation = null,Object? snoozedAt = null,Object? snoozedUntil = null,Object? duration = null,Object? durationMinutes = null,Object? utcOffsetMinutes = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activation = null,Object? snoozedAt = null,Object? snoozedUntil = null,Object? duration = null,Object? durationMinutes = null,Object? utcOffsetMinutes = null,Object? returnUtcOffsetMinutes = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,activation: null == activation ? _self.activation : activation // ignore: cast_nullable_to_non_nullable
@@ -628,7 +628,8 @@ as DateTime,snoozedUntil: null == snoozedUntil ? _self.snoozedUntil : snoozedUnt
 as DateTime,duration: null == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
 as GoalBannerSnoozeDuration,durationMinutes: null == durationMinutes ? _self.durationMinutes : durationMinutes // ignore: cast_nullable_to_non_nullable
 as int,utcOffsetMinutes: null == utcOffsetMinutes ? _self.utcOffsetMinutes : utcOffsetMinutes // ignore: cast_nullable_to_non_nullable
-as int,
+as int,returnUtcOffsetMinutes: freezed == returnUtcOffsetMinutes ? _self.returnUtcOffsetMinutes : returnUtcOffsetMinutes // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -713,10 +714,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(fromJson: _decodeActivation)  int activation,  DateTime snoozedAt,  DateTime snoozedUntil,  GoalBannerSnoozeDuration duration, @JsonKey(fromJson: _decodePositiveMinutes)  int durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes)  int utcOffsetMinutes)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(fromJson: _decodeActivation)  int activation,  DateTime snoozedAt,  DateTime snoozedUntil,  GoalBannerSnoozeDuration duration, @JsonKey(fromJson: _decodePositiveMinutes)  int durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes)  int utcOffsetMinutes, @JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes)  int? returnUtcOffsetMinutes)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GoalNudgeSnooze() when $default != null:
-return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_that.duration,_that.durationMinutes,_that.utcOffsetMinutes);case _:
+return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_that.duration,_that.durationMinutes,_that.utcOffsetMinutes,_that.returnUtcOffsetMinutes);case _:
   return orElse();
 
 }
@@ -734,10 +735,10 @@ return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(fromJson: _decodeActivation)  int activation,  DateTime snoozedAt,  DateTime snoozedUntil,  GoalBannerSnoozeDuration duration, @JsonKey(fromJson: _decodePositiveMinutes)  int durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes)  int utcOffsetMinutes)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(fromJson: _decodeActivation)  int activation,  DateTime snoozedAt,  DateTime snoozedUntil,  GoalBannerSnoozeDuration duration, @JsonKey(fromJson: _decodePositiveMinutes)  int durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes)  int utcOffsetMinutes, @JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes)  int? returnUtcOffsetMinutes)  $default,) {final _that = this;
 switch (_that) {
 case _GoalNudgeSnooze():
-return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_that.duration,_that.durationMinutes,_that.utcOffsetMinutes);case _:
+return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_that.duration,_that.durationMinutes,_that.utcOffsetMinutes,_that.returnUtcOffsetMinutes);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -754,10 +755,10 @@ return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(fromJson: _decodeActivation)  int activation,  DateTime snoozedAt,  DateTime snoozedUntil,  GoalBannerSnoozeDuration duration, @JsonKey(fromJson: _decodePositiveMinutes)  int durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes)  int utcOffsetMinutes)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(fromJson: _decodeActivation)  int activation,  DateTime snoozedAt,  DateTime snoozedUntil,  GoalBannerSnoozeDuration duration, @JsonKey(fromJson: _decodePositiveMinutes)  int durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes)  int utcOffsetMinutes, @JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes)  int? returnUtcOffsetMinutes)?  $default,) {final _that = this;
 switch (_that) {
 case _GoalNudgeSnooze() when $default != null:
-return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_that.duration,_that.durationMinutes,_that.utcOffsetMinutes);case _:
+return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_that.duration,_that.durationMinutes,_that.utcOffsetMinutes,_that.returnUtcOffsetMinutes);case _:
   return null;
 
 }
@@ -769,7 +770,7 @@ return $default(_that.id,_that.activation,_that.snoozedAt,_that.snoozedUntil,_th
 @JsonSerializable()
 
 class _GoalNudgeSnooze extends GoalNudgeSnooze {
-  const _GoalNudgeSnooze({required this.id, @JsonKey(fromJson: _decodeActivation) required this.activation, required this.snoozedAt, required this.snoozedUntil, required this.duration, @JsonKey(fromJson: _decodePositiveMinutes) required this.durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes) required this.utcOffsetMinutes}): super._();
+  const _GoalNudgeSnooze({required this.id, @JsonKey(fromJson: _decodeActivation) required this.activation, required this.snoozedAt, required this.snoozedUntil, required this.duration, @JsonKey(fromJson: _decodePositiveMinutes) required this.durationMinutes, @JsonKey(fromJson: _decodeUtcOffsetMinutes) required this.utcOffsetMinutes, @JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes) this.returnUtcOffsetMinutes}): super._();
   factory _GoalNudgeSnooze.fromJson(Map<String, dynamic> json) => _$GoalNudgeSnoozeFromJson(json);
 
 @override final  String id;
@@ -779,6 +780,7 @@ class _GoalNudgeSnooze extends GoalNudgeSnooze {
 @override final  GoalBannerSnoozeDuration duration;
 @override@JsonKey(fromJson: _decodePositiveMinutes) final  int durationMinutes;
 @override@JsonKey(fromJson: _decodeUtcOffsetMinutes) final  int utcOffsetMinutes;
+@override@JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes) final  int? returnUtcOffsetMinutes;
 
 /// Create a copy of GoalNudgeSnooze
 /// with the given fields replaced by the non-null parameter values.
@@ -793,16 +795,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GoalNudgeSnooze&&(identical(other.id, id) || other.id == id)&&(identical(other.activation, activation) || other.activation == activation)&&(identical(other.snoozedAt, snoozedAt) || other.snoozedAt == snoozedAt)&&(identical(other.snoozedUntil, snoozedUntil) || other.snoozedUntil == snoozedUntil)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.durationMinutes, durationMinutes) || other.durationMinutes == durationMinutes)&&(identical(other.utcOffsetMinutes, utcOffsetMinutes) || other.utcOffsetMinutes == utcOffsetMinutes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GoalNudgeSnooze&&(identical(other.id, id) || other.id == id)&&(identical(other.activation, activation) || other.activation == activation)&&(identical(other.snoozedAt, snoozedAt) || other.snoozedAt == snoozedAt)&&(identical(other.snoozedUntil, snoozedUntil) || other.snoozedUntil == snoozedUntil)&&(identical(other.duration, duration) || other.duration == duration)&&(identical(other.durationMinutes, durationMinutes) || other.durationMinutes == durationMinutes)&&(identical(other.utcOffsetMinutes, utcOffsetMinutes) || other.utcOffsetMinutes == utcOffsetMinutes)&&(identical(other.returnUtcOffsetMinutes, returnUtcOffsetMinutes) || other.returnUtcOffsetMinutes == returnUtcOffsetMinutes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,activation,snoozedAt,snoozedUntil,duration,durationMinutes,utcOffsetMinutes);
+int get hashCode => Object.hash(runtimeType,id,activation,snoozedAt,snoozedUntil,duration,durationMinutes,utcOffsetMinutes,returnUtcOffsetMinutes);
 
 @override
 String toString() {
-  return 'GoalNudgeSnooze(id: $id, activation: $activation, snoozedAt: $snoozedAt, snoozedUntil: $snoozedUntil, duration: $duration, durationMinutes: $durationMinutes, utcOffsetMinutes: $utcOffsetMinutes)';
+  return 'GoalNudgeSnooze(id: $id, activation: $activation, snoozedAt: $snoozedAt, snoozedUntil: $snoozedUntil, duration: $duration, durationMinutes: $durationMinutes, utcOffsetMinutes: $utcOffsetMinutes, returnUtcOffsetMinutes: $returnUtcOffsetMinutes)';
 }
 
 
@@ -813,7 +815,7 @@ abstract mixin class _$GoalNudgeSnoozeCopyWith<$Res> implements $GoalNudgeSnooze
   factory _$GoalNudgeSnoozeCopyWith(_GoalNudgeSnooze value, $Res Function(_GoalNudgeSnooze) _then) = __$GoalNudgeSnoozeCopyWithImpl;
 @override @useResult
 $Res call({
- String id,@JsonKey(fromJson: _decodeActivation) int activation, DateTime snoozedAt, DateTime snoozedUntil, GoalBannerSnoozeDuration duration,@JsonKey(fromJson: _decodePositiveMinutes) int durationMinutes,@JsonKey(fromJson: _decodeUtcOffsetMinutes) int utcOffsetMinutes
+ String id,@JsonKey(fromJson: _decodeActivation) int activation, DateTime snoozedAt, DateTime snoozedUntil, GoalBannerSnoozeDuration duration,@JsonKey(fromJson: _decodePositiveMinutes) int durationMinutes,@JsonKey(fromJson: _decodeUtcOffsetMinutes) int utcOffsetMinutes,@JsonKey(fromJson: _decodeOptionalUtcOffsetMinutes) int? returnUtcOffsetMinutes
 });
 
 
@@ -830,7 +832,7 @@ class __$GoalNudgeSnoozeCopyWithImpl<$Res>
 
 /// Create a copy of GoalNudgeSnooze
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activation = null,Object? snoozedAt = null,Object? snoozedUntil = null,Object? duration = null,Object? durationMinutes = null,Object? utcOffsetMinutes = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activation = null,Object? snoozedAt = null,Object? snoozedUntil = null,Object? duration = null,Object? durationMinutes = null,Object? utcOffsetMinutes = null,Object? returnUtcOffsetMinutes = freezed,}) {
   return _then(_GoalNudgeSnooze(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,activation: null == activation ? _self.activation : activation // ignore: cast_nullable_to_non_nullable
@@ -839,7 +841,8 @@ as DateTime,snoozedUntil: null == snoozedUntil ? _self.snoozedUntil : snoozedUnt
 as DateTime,duration: null == duration ? _self.duration : duration // ignore: cast_nullable_to_non_nullable
 as GoalBannerSnoozeDuration,durationMinutes: null == durationMinutes ? _self.durationMinutes : durationMinutes // ignore: cast_nullable_to_non_nullable
 as int,utcOffsetMinutes: null == utcOffsetMinutes ? _self.utcOffsetMinutes : utcOffsetMinutes // ignore: cast_nullable_to_non_nullable
-as int,
+as int,returnUtcOffsetMinutes: freezed == returnUtcOffsetMinutes ? _self.returnUtcOffsetMinutes : returnUtcOffsetMinutes // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/lib/classes/goal_nudge_models.g.dart
+++ b/lib/classes/goal_nudge_models.g.dart
@@ -80,6 +80,9 @@ _GoalNudgeSnooze _$GoalNudgeSnoozeFromJson(Map<String, dynamic> json) =>
       ),
       durationMinutes: _decodePositiveMinutes(json['durationMinutes']),
       utcOffsetMinutes: _decodeUtcOffsetMinutes(json['utcOffsetMinutes']),
+      returnUtcOffsetMinutes: _decodeOptionalUtcOffsetMinutes(
+        json['returnUtcOffsetMinutes'],
+      ),
     );
 
 Map<String, dynamic> _$GoalNudgeSnoozeToJson(_GoalNudgeSnooze instance) =>
@@ -91,6 +94,7 @@ Map<String, dynamic> _$GoalNudgeSnoozeToJson(_GoalNudgeSnooze instance) =>
       'duration': _$GoalBannerSnoozeDurationEnumMap[instance.duration]!,
       'durationMinutes': instance.durationMinutes,
       'utcOffsetMinutes': instance.utcOffsetMinutes,
+      'returnUtcOffsetMinutes': instance.returnUtcOffsetMinutes,
     };
 
 const _$GoalBannerSnoozeDurationEnumMap = {

--- a/lib/features/agents/model/agent_domain_entity.freezed.dart
+++ b/lib/features/agents/model/agent_domain_entity.freezed.dart
@@ -4329,11 +4329,11 @@ class GoalNudgeEntity implements AgentDomainEntity {
 /// visible again when this instant is no longer on the reading device's
 /// local calendar day.
  final  DateTime? dismissedForDayAt;
-/// Append-only day-dismissal evidence. Current visibility reads
-/// [dismissedForDayAt]; future timing analysis reads this history.
+/// Append-only day-dismissal evidence. Current visibility reads the latest
+/// day-dismissal instant above; future timing analysis reads this history.
  final  List<GoalNudgeDayDismissal> _dismissalHistory;
-/// Append-only day-dismissal evidence. Current visibility reads
-/// [dismissedForDayAt]; future timing analysis reads this history.
+/// Append-only day-dismissal evidence. Current visibility reads the latest
+/// day-dismissal instant above; future timing analysis reads this history.
 @JsonKey() List<GoalNudgeDayDismissal> get dismissalHistory {
   if (_dismissalHistory is EqualUnmodifiableListView) return _dismissalHistory;
   // ignore: implicit_dynamic_type

--- a/lib/features/agents/sync/agent_concurrent_resolver.dart
+++ b/lib/features/agents/sync/agent_concurrent_resolver.dart
@@ -375,6 +375,12 @@ GoalNudgeEntity mergeGoalNudgeAccumulators({
       if (event.snoozedUntil == snoozedUntil) effectiveSnooze = event;
     }
   }
+  final activationCount = local.activationCount > incoming.activationCount
+      ? local.activationCount
+      : incoming.activationCount;
+  final mergedStaleAt = sameActivation
+      ? _latestInstant(local.staleAt, incoming.staleAt)
+      : winner.staleAt;
   return winner.copyWith(
     // The merged row observed BOTH branches, so its clock must be their
     // join: keeping only the winner's clock would let that device's next
@@ -388,15 +394,14 @@ GoalNudgeEntity mergeGoalNudgeAccumulators({
     snoozedUntil: snoozedUntil,
     lastSnoozeDuration: effectiveSnooze?.duration ?? winner.lastSnoozeDuration,
     dismissalHistory: mergedDismissals,
+    staleAt: mergedStaleAt,
     dismissedForDayAt: sameActivation
         ? _latestInstant(
             local.dismissedForDayAt,
             incoming.dismissedForDayAt,
           )
         : winner.dismissedForDayAt,
-    activationCount: local.activationCount > incoming.activationCount
-        ? local.activationCount
-        : incoming.activationCount,
+    activationCount: activationCount,
     firstShownAt: _earliestInstant(local.firstShownAt, incoming.firstShownAt),
     lastShownAt: _latestInstant(local.lastShownAt, incoming.lastShownAt),
   );
@@ -422,7 +427,11 @@ int _compareGoalNudgeSnoozes(GoalNudgeSnooze a, GoalNudgeSnooze b) {
   if (byDuration != 0) return byDuration;
   final byMinutes = a.durationMinutes.compareTo(b.durationMinutes);
   if (byMinutes != 0) return byMinutes;
-  return a.utcOffsetMinutes.compareTo(b.utcOffsetMinutes);
+  final byOffset = a.utcOffsetMinutes.compareTo(b.utcOffsetMinutes);
+  if (byOffset != 0) return byOffset;
+  return (a.returnUtcOffsetMinutes ?? a.utcOffsetMinutes).compareTo(
+    b.returnUtcOffsetMinutes ?? b.utcOffsetMinutes,
+  );
 }
 
 DateTime? _earliestInstant(DateTime? a, DateTime? b) {

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -176,7 +176,8 @@ restarts. Every snooze and day dismissal appends its activation, local offset,
 start, and requested return boundary; snoozes also preserve the selected or
 exact duration. The FACTS renderer gives the agent bounded timing summaries so
 repeated snooze-return and dismissal hours can inform future initial display
-times. Chat can also snooze the current banner until any requested future time;
+times without shifting a requested return across timezone or daylight-saving
+boundaries. Chat can also snooze the current banner until any requested future time;
 the just-committed snooze is suppressed locally while its durable projection
 reloads. Dismissal cooldown applies to automatic banners only: a direct request
 for a banner, a missing-banner report, or a short affirmative reply to the

--- a/lib/features/goals/logic/goal_banner_snooze.dart
+++ b/lib/features/goals/logic/goal_banner_snooze.dart
@@ -64,6 +64,7 @@ GoalNudgeEntity snoozeGoalBannerEntity({
   required DateTime now,
   required DateTime until,
   required String eventId,
+  int? returnUtcOffsetMinutes,
 }) {
   final exactDuration = until.toUtc().difference(now.toUtc());
   if (exactDuration <= Duration.zero) {
@@ -78,6 +79,8 @@ GoalNudgeEntity snoozeGoalBannerEntity({
     duration: goalBannerSnoozeDurationFor(exactDuration),
     durationMinutes: durationMinutes,
     utcOffsetMinutes: now.timeZoneOffset.inMinutes,
+    returnUtcOffsetMinutes:
+        returnUtcOffsetMinutes ?? until.timeZoneOffset.inMinutes,
   );
   final staleAfterSnooze = _staleAtAfterQuietPeriod(until);
   return nudge.copyWith(

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -403,11 +403,14 @@ final FutureProvider<List<AgentIdentityEntity>> activeGoalAgentsProvider =
 /// active-banner projection has reloaded. Banner surfaces subtract these ids
 /// from retained data, so a background refresh cannot flash the old active row
 /// throughout its quiet interval. Each deadline removes itself on time.
-class LocallySnoozedNudgeDeadlines extends Notifier<Map<String, DateTime>> {
+typedef GoalBannerLocalSuppression = ({int activation, DateTime until});
+
+class LocallySnoozedNudgeDeadlines
+    extends Notifier<Map<String, GoalBannerLocalSuppression>> {
   final _timers = <String, Timer>{};
 
   @override
-  Map<String, DateTime> build() {
+  Map<String, GoalBannerLocalSuppression> build() {
     ref.onDispose(() {
       for (final timer in _timers.values) {
         timer.cancel();
@@ -416,11 +419,11 @@ class LocallySnoozedNudgeDeadlines extends Notifier<Map<String, DateTime>> {
     return const {};
   }
 
-  void add(String id, DateTime until) {
+  void add(String id, int activation, DateTime until) {
     final now = clock.now();
     if (!until.isAfter(now)) return;
     _timers[id]?.cancel();
-    state = {...state, id: until};
+    state = {...state, id: (activation: activation, until: until)};
     _timers[id] = Timer(until.difference(now), () {
       _timers.remove(id);
       state = Map.of(state)..remove(id);
@@ -428,9 +431,15 @@ class LocallySnoozedNudgeDeadlines extends Notifier<Map<String, DateTime>> {
   }
 }
 
-final NotifierProvider<LocallySnoozedNudgeDeadlines, Map<String, DateTime>>
+final NotifierProvider<
+  LocallySnoozedNudgeDeadlines,
+  Map<String, GoalBannerLocalSuppression>
+>
 locallySnoozedNudgeDeadlinesProvider =
-    NotifierProvider<LocallySnoozedNudgeDeadlines, Map<String, DateTime>>(
+    NotifierProvider<
+      LocallySnoozedNudgeDeadlines,
+      Map<String, GoalBannerLocalSuppression>
+    >(
       LocallySnoozedNudgeDeadlines.new,
       name: 'locallySnoozedNudgeDeadlinesProvider',
     );

--- a/lib/features/goals/state/goal_chat_controller.dart
+++ b/lib/features/goals/state/goal_chat_controller.dart
@@ -146,7 +146,7 @@ class GoalChatController extends Notifier<GoalChatComposerState> {
         if (nudge.status == GoalNudgeStatus.active &&
             until != null &&
             until.isAfter(now)) {
-          local.add(nudge.id, until);
+          local.add(nudge.id, nudge.activationCount, until);
         }
       }
     } on Object {

--- a/lib/features/goals/ui/goal_banner_actions.dart
+++ b/lib/features/goals/ui/goal_banner_actions.dart
@@ -132,7 +132,7 @@ Future<bool> showGoalBannerSnoozeSheet(
 
   container
       .read(locallySnoozedNudgeDeadlinesProvider.notifier)
-      .add(entry.nudge.id, hiddenUntil);
+      .add(entry.nudge.id, entry.nudge.activationCount, hiddenUntil);
   container.invalidate(activeGoalNudgesProvider);
   return true;
 }

--- a/lib/features/goals/ui/goal_banner_dock.dart
+++ b/lib/features/goals/ui/goal_banner_dock.dart
@@ -37,17 +37,24 @@ double _textBlockHeight(TextStyle style, int lines, TextScaler scaler) {
 /// shell lane that reserves space for it.
 List<GoalBannerEntry> visibleGoalBannerEntries({
   required Iterable<GoalBannerEntry>? entries,
-  required Map<String, DateTime> locallySnoozedDeadlines,
+  required Map<String, GoalBannerLocalSuppression> locallySnoozedDeadlines,
   DateTime? now,
 }) {
   final instant = now ?? clock.now();
+  bool isLocallySuppressed(GoalBannerEntry entry) {
+    final suppression = locallySnoozedDeadlines[entry.nudge.id];
+    return suppression != null &&
+        suppression.activation == entry.nudge.activationCount &&
+        suppression.until.isAfter(instant);
+  }
+
   return [
     for (final entry in entries ?? const <GoalBannerEntry>[])
       if ((entry.nudge.staleAt == null ||
               instant.isBefore(entry.nudge.staleAt!)) &&
           !goalBannerIsSnoozed(entry.nudge, instant) &&
           !goalBannerIsDismissedForDay(entry.nudge, instant) &&
-          locallySnoozedDeadlines[entry.nudge.id]?.isAfter(instant) != true)
+          !isLocallySuppressed(entry))
         entry,
   ];
 }

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -19,7 +19,12 @@ typedef GoalAdRequest = ({GoalNudgeBrief brief, String? reasonSummary});
 typedef GoalAdAction = ({String adId, String reason});
 
 /// A request to hide one active banner until an exact future instant.
-typedef GoalAdSnooze = ({String adId, DateTime until, String reason});
+typedef GoalAdSnooze = ({
+  String adId,
+  DateTime until,
+  int returnUtcOffsetMinutes,
+  String reason,
+});
 
 /// A revision proposal accumulated from `propose_goal_revision_v2`.
 typedef GoalRevisionProposal = ({
@@ -355,9 +360,13 @@ class GoalAgentStrategy extends ConversationStrategy
     final until = hasExplicitOffset
         ? DateTime.tryParse(untilText)?.toUtc()
         : null;
+    final returnUtcOffsetMinutes = hasExplicitOffset
+        ? _iso8601UtcOffsetMinutes(untilText)
+        : null;
     if (adId.isEmpty ||
         reason.isEmpty ||
         until == null ||
+        returnUtcOffsetMinutes == null ||
         !until.isAfter(clock.now().toUtc())) {
       await _reject(
         call: call,
@@ -378,12 +387,30 @@ class GoalAgentStrategy extends ConversationStrategy
       );
       return;
     }
-    _snoozeRequests.add((adId: adId, until: until, reason: reason));
+    _snoozeRequests.add((
+      adId: adId,
+      until: until,
+      returnUtcOffsetMinutes: returnUtcOffsetMinutes,
+      reason: reason,
+    ));
     await _accept(
       call,
       manager,
       'Ad snoozed until ${until.toIso8601String()}.',
     );
+  }
+
+  int? _iso8601UtcOffsetMinutes(String value) {
+    if (value.endsWith('Z') || value.endsWith('z')) return 0;
+    final match = RegExp(r'([+-])(\d{2}):?(\d{2})$').firstMatch(value);
+    if (match == null) return null;
+    final hours = int.parse(match.group(2)!);
+    final minutes = int.parse(match.group(3)!);
+    if (hours > 14 || minutes > 59 || (hours == 14 && minutes != 0)) {
+      return null;
+    }
+    final absolute = hours * 60 + minutes;
+    return match.group(1) == '-' ? -absolute : absolute;
   }
 
   Future<void> _handleProposeRevision(

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -1200,18 +1200,22 @@ class GoalAgentWorkflow with AgentErrorLogging {
       for (final action in strategy.snoozeRequests) {
         final nudge = byId[action.adId];
         if (nudge == null || nudge.status != GoalNudgeStatus.active) continue;
-        await _syncService.upsertEntity(
-          snoozeGoalBannerEntity(
-            nudge: nudge,
-            now: now,
-            until: action.until,
-            eventId: const Uuid().v5(
-              Namespace.url.value,
-              'lotti://goal-agent/${nudge.id}/snooze/$runKey/'
-              '${action.until.toUtc().toIso8601String()}',
-            ),
+        final updated = snoozeGoalBannerEntity(
+          nudge: nudge,
+          now: now,
+          until: action.until,
+          returnUtcOffsetMinutes: action.returnUtcOffsetMinutes,
+          eventId: const Uuid().v5(
+            Namespace.url.value,
+            'lotti://goal-agent/${nudge.id}/snooze/$runKey/'
+            '${action.until.toUtc().toIso8601String()}',
           ),
         );
+        await _syncService.upsertEntity(updated);
+        // A single model turn may request several successive quiet deadlines
+        // for one banner. Fold each write into the next so no append-only event
+        // is overwritten by the transaction's original snapshot.
+        byId[action.adId] = updated;
       }
 
       // Interactive replies are explicit reply_to_user action rows so the

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2571,7 +2571,6 @@
   "goalAttainmentLabel": "{percent} % cíle",
   "goalBannerActionFailed": "To se neuložilo — zkus to prosím znovu.",
   "goalBannerDismissForDay": "Skrýt na dnešek",
-  "goalBannerDismissTooltip": "Zavřít",
   "goalBannerRateTooltip": "Ohodnotit tento banner",
   "goalBannerRatingSkip": "Přeskočit",
   "goalBannerRatingTitle": "Jaký byl tento banner?",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2821,7 +2821,6 @@
   "goalAttainmentLabel": "{percent} % af målet",
   "goalBannerActionFailed": "Det blev ikke gemt — prøv venligst igen.",
   "goalBannerDismissForDay": "Skjul resten af dagen",
-  "goalBannerDismissTooltip": "Afvis",
   "goalBannerRateTooltip": "Bedøm dette banner",
   "goalBannerRatingSkip": "Spring over",
   "goalBannerRatingTitle": "Hvordan var dette banner?",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2564,7 +2564,6 @@
   "goalAttainmentLabel": "{percent} % des Ziels",
   "goalBannerActionFailed": "Das wurde nicht gespeichert — bitte versuch es noch einmal.",
   "goalBannerDismissForDay": "Für heute ausblenden",
-  "goalBannerDismissTooltip": "Ausblenden",
   "goalBannerRateTooltip": "Dieses Banner bewerten",
   "goalBannerRatingSkip": "Überspringen",
   "goalBannerRatingTitle": "Wie fandest du dieses Banner?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3305,10 +3305,6 @@
   "@goalBannerDismissForDay": {
     "description": "De-emphasized action that hides a goal-agent banner until the next local day."
   },
-  "goalBannerDismissTooltip": "Dismiss",
-  "@goalBannerDismissTooltip": {
-    "description": "Tooltip of the X button on a goal banner; dismissing starts a 24h quiet window."
-  },
   "goalBannerRateTooltip": "Rate this banner",
   "goalBannerRatingSkip": "Skip",
   "@goalBannerRatingSkip": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -60,7 +60,6 @@
   "fileMenuNewTask": "Task",
   "fileMenuTitle": "File",
   "goalAttainmentLabel": "{percent}% of target",
-  "goalBannerDismissTooltip": "Dismiss",
   "goalBannerRatingSkip": "Skip",
   "goalBannerRatingTitle": "How was this banner?",
   "goalBannerSemanticLabel": "Goal banner for {goalTitle}",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2564,7 +2564,6 @@
   "goalAttainmentLabel": "{percent} % del objetivo",
   "goalBannerActionFailed": "Eso no se guardó; inténtalo de nuevo.",
   "goalBannerDismissForDay": "Ocultar por hoy",
-  "goalBannerDismissTooltip": "Descartar",
   "goalBannerRateTooltip": "Valorar este banner",
   "goalBannerRatingSkip": "Omitir",
   "goalBannerRatingTitle": "¿Qué te pareció este banner?",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2564,7 +2564,6 @@
   "goalAttainmentLabel": "{percent} % de l’objectif",
   "goalBannerActionFailed": "Ça n'a pas été enregistré — réessaie, s'il te plaît.",
   "goalBannerDismissForDay": "Masquer pour aujourd’hui",
-  "goalBannerDismissTooltip": "Ignorer",
   "goalBannerRateTooltip": "Noter cette bannière",
   "goalBannerRatingSkip": "Passer",
   "goalBannerRatingTitle": "Tu as trouvé cette bannière comment ?",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2821,7 +2821,6 @@
   "goalAttainmentLabel": "{percent}% dell’obiettivo",
   "goalBannerActionFailed": "Non è stato salvato: riprova per favore.",
   "goalBannerDismissForDay": "Nascondi per oggi",
-  "goalBannerDismissTooltip": "Ignora",
   "goalBannerRateTooltip": "Valuta questo banner",
   "goalBannerRatingSkip": "Salta",
   "goalBannerRatingTitle": "Com’era questo banner?",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10397,12 +10397,6 @@ abstract class AppLocalizations {
   /// **'Dismiss for today'**
   String get goalBannerDismissForDay;
 
-  /// Tooltip of the X button on a goal banner; dismissing starts a 24h quiet window.
-  ///
-  /// In en, this message translates to:
-  /// **'Dismiss'**
-  String get goalBannerDismissTooltip;
-
   /// No description provided for @goalBannerRateTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6124,9 +6124,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get goalBannerDismissForDay => 'Skrýt na dnešek';
 
   @override
-  String get goalBannerDismissTooltip => 'Zavřít';
-
-  @override
   String get goalBannerRateTooltip => 'Ohodnotit tento banner';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6060,9 +6060,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get goalBannerDismissForDay => 'Skjul resten af dagen';
 
   @override
-  String get goalBannerDismissTooltip => 'Afvis';
-
-  @override
   String get goalBannerRateTooltip => 'Bedøm dette banner';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6101,9 +6101,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get goalBannerDismissForDay => 'Für heute ausblenden';
 
   @override
-  String get goalBannerDismissTooltip => 'Ausblenden';
-
-  @override
   String get goalBannerRateTooltip => 'Dieses Banner bewerten';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6031,9 +6031,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get goalBannerDismissForDay => 'Dismiss for today';
 
   @override
-  String get goalBannerDismissTooltip => 'Dismiss';
-
-  @override
   String get goalBannerRateTooltip => 'Rate this banner';
 
   @override
@@ -12987,9 +12984,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String goalAttainmentLabel(int percent) {
     return '$percent% of target';
   }
-
-  @override
-  String get goalBannerDismissTooltip => 'Dismiss';
 
   @override
   String get goalBannerRatingSkip => 'Skip';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6139,9 +6139,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get goalBannerDismissForDay => 'Ocultar por hoy';
 
   @override
-  String get goalBannerDismissTooltip => 'Descartar';
-
-  @override
   String get goalBannerRateTooltip => 'Valorar este banner';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6155,9 +6155,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get goalBannerDismissForDay => 'Masquer pour aujourd’hui';
 
   @override
-  String get goalBannerDismissTooltip => 'Ignorer';
-
-  @override
   String get goalBannerRateTooltip => 'Noter cette bannière';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6134,9 +6134,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get goalBannerDismissForDay => 'Nascondi per oggi';
 
   @override
-  String get goalBannerDismissTooltip => 'Ignora';
-
-  @override
   String get goalBannerRateTooltip => 'Valuta questo banner';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6079,9 +6079,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get goalBannerDismissForDay => 'Voor vandaag verbergen';
 
   @override
-  String get goalBannerDismissTooltip => 'Verbergen';
-
-  @override
   String get goalBannerRateTooltip => 'Beoordeel deze banner';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6116,9 +6116,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get goalBannerDismissForDay => 'Ocultar por hoje';
 
   @override
-  String get goalBannerDismissTooltip => 'Dispensar';
-
-  @override
   String get goalBannerRateTooltip => 'Avaliar este banner';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6159,9 +6159,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get goalBannerDismissForDay => 'Ascundeți pentru azi';
 
   @override
-  String get goalBannerDismissTooltip => 'Închideți';
-
-  @override
   String get goalBannerRateTooltip => 'Evaluați acest banner';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6065,9 +6065,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get goalBannerDismissForDay => 'Dölj resten av dagen';
 
   @override
-  String get goalBannerDismissTooltip => 'Avfärda';
-
-  @override
   String get goalBannerRateTooltip => 'Betygsätt den här bannern';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2820,7 +2820,6 @@
   "goalAttainmentLabel": "{percent}% van het doel",
   "goalBannerActionFailed": "Dat is niet opgeslagen — probeer het opnieuw.",
   "goalBannerDismissForDay": "Voor vandaag verbergen",
-  "goalBannerDismissTooltip": "Verbergen",
   "goalBannerRateTooltip": "Beoordeel deze banner",
   "goalBannerRatingSkip": "Overslaan",
   "goalBannerRatingTitle": "Wat vond je van deze banner?",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2820,7 +2820,6 @@
   "goalAttainmentLabel": "{percent}% da meta",
   "goalBannerActionFailed": "Isso não foi salvo — tente novamente.",
   "goalBannerDismissForDay": "Ocultar por hoje",
-  "goalBannerDismissTooltip": "Dispensar",
   "goalBannerRateTooltip": "Avaliar este banner",
   "goalBannerRatingSkip": "Ignorar",
   "goalBannerRatingTitle": "O que achaste deste banner?",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2564,7 +2564,6 @@
   "goalAttainmentLabel": "{percent}% din obiectiv",
   "goalBannerActionFailed": "Nu s-a salvat — vă rugăm să încercați din nou.",
   "goalBannerDismissForDay": "Ascundeți pentru azi",
-  "goalBannerDismissTooltip": "Închideți",
   "goalBannerRateTooltip": "Evaluați acest banner",
   "goalBannerRatingSkip": "Omiteți",
   "goalBannerRatingTitle": "Cum vi s-a părut acest banner?",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2821,7 +2821,6 @@
   "goalAttainmentLabel": "{percent} % av målet",
   "goalBannerActionFailed": "Det sparades inte — försök igen.",
   "goalBannerDismissForDay": "Dölj resten av dagen",
-  "goalBannerDismissTooltip": "Avfärda",
   "goalBannerRateTooltip": "Betygsätt den här bannern",
   "goalBannerRatingSkip": "Hoppa över",
   "goalBannerRatingTitle": "Vad tyckte du om den här bannern?",

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -1397,7 +1397,7 @@ void main() {
         final container = ProviderScope.containerOf(pageContext, listen: false);
         container
             .read(locallySnoozedNudgeDeadlinesProvider.notifier)
-            .add(nudge.id, DateTime.utc(2099));
+            .add(nudge.id, nudge.activationCount, DateTime.utc(2099));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
 

--- a/test/classes/goal_nudge_models_test.dart
+++ b/test/classes/goal_nudge_models_test.dart
@@ -46,6 +46,7 @@ void main() {
       duration: GoalBannerSnoozeDuration.threeHours,
       durationMinutes: 180,
       utcOffsetMinutes: 120,
+      returnUtcOffsetMinutes: 180,
     );
 
     final decoded = GoalNudgeSnooze.fromJson(
@@ -54,7 +55,12 @@ void main() {
 
     expect(decoded, event);
     expect(decoded.snoozedAtLocal, DateTime.utc(2026, 8, 13, 12));
-    expect(decoded.snoozedUntilLocal, DateTime.utc(2026, 8, 13, 15));
+    expect(decoded.snoozedUntilLocal, DateTime.utc(2026, 8, 13, 16));
+    expect(
+      decoded.copyWith(returnUtcOffsetMinutes: null).snoozedUntilLocal,
+      DateTime.utc(2026, 8, 13, 15),
+      reason: 'older events retain their action-offset interpretation',
+    );
   });
 
   test('GoalNudgeSnooze rejects invalid duration and timezone evidence', () {

--- a/test/features/agents/sync/agent_concurrent_resolver_merge_test.dart
+++ b/test/features/agents/sync/agent_concurrent_resolver_merge_test.dart
@@ -18,6 +18,7 @@ void main() {
     int activationCount = 1,
     DateTime? firstShownAt,
     DateTime? lastShownAt,
+    DateTime? staleAt,
     DateTime? snoozedUntil,
     GoalBannerSnoozeDuration? lastSnoozeDuration,
     List<GoalNudgeSnooze> snoozeHistory = const [],
@@ -43,6 +44,7 @@ void main() {
             activationCount: activationCount,
             firstShownAt: firstShownAt,
             lastShownAt: lastShownAt,
+            staleAt: staleAt,
             snoozedUntil: snoozedUntil,
             lastSnoozeDuration: lastSnoozeDuration,
             snoozeHistory: snoozeHistory,
@@ -822,6 +824,7 @@ void main() {
           snoozedUntil: short.snoozedUntil,
           lastSnoozeDuration: short.duration,
           snoozeHistory: [short],
+          staleAt: DateTime.utc(2026, 8, 14, 11),
         );
         final incoming = goalNudge(
           status: GoalNudgeStatus.active,
@@ -829,6 +832,7 @@ void main() {
           lastSnoozeDuration: long.duration,
           snoozeHistory: [long],
           dismissedForDayAt: DateTime.utc(2026, 8, 13, 11),
+          staleAt: DateTime.utc(2026, 8, 16, 17),
         );
 
         final ab = mergeGoalNudgeAccumulators(
@@ -849,6 +853,11 @@ void main() {
         expect(ab.snoozedUntil, long.snoozedUntil);
         expect(ab.lastSnoozeDuration, GoalBannerSnoozeDuration.eightHours);
         expect(ab.dismissedForDayAt, DateTime.utc(2026, 8, 13, 11));
+        expect(
+          ab.staleAt,
+          DateTime.utc(2026, 8, 16, 17),
+          reason: 'the selected later reveal keeps its branch lifetime',
+        );
         expect(ab.snoozeHistory, ba.snoozeHistory);
         expect(ab.snoozedUntil, ba.snoozedUntil);
       },
@@ -902,6 +911,11 @@ void main() {
 
       final laterOffset = baseline.copyWith(utcOffsetMinutes: 180);
       expect(selected(laterOffset, baseline), baseline);
+
+      final laterReturnOffset = baseline.copyWith(
+        returnUtcOffsetMinutes: 180,
+      );
+      expect(selected(laterReturnOffset, baseline), baseline);
     });
 
     test('unions day-dismissal history by id and converges on conflicting '

--- a/test/features/goals/logic/goal_banner_snooze_test.dart
+++ b/test/features/goals/logic/goal_banner_snooze_test.dart
@@ -138,6 +138,10 @@ void main() {
       expect(snoozed.snoozedUntil, until);
       expect(snoozed.lastSnoozeDuration, GoalBannerSnoozeDuration.threeHours);
       expect(snoozed.snoozeHistory.single.durationMinutes, 180);
+      expect(
+        snoozed.snoozeHistory.single.returnUtcOffsetMinutes,
+        until.timeZoneOffset.inMinutes,
+      );
       expect(snoozed.staleAt, DateTime.utc(2026, 8, 14, 13));
       expect(snoozed.provenance, {
         'specVersionId': 'spec-1',

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -1611,10 +1611,13 @@ void main() {
       withClock(Clock(() => start.add(async.elapsed)), () {
         container
             .read(locallySnoozedNudgeDeadlinesProvider.notifier)
-            .add('ad-1', start.add(const Duration(minutes: 15)));
+            .add('ad-1', 1, start.add(const Duration(minutes: 15)));
 
         expect(container.read(locallySnoozedNudgeDeadlinesProvider), {
-          'ad-1': start.add(const Duration(minutes: 15)),
+          'ad-1': (
+            activation: 1,
+            until: start.add(const Duration(minutes: 15)),
+          ),
         });
         async.elapse(const Duration(minutes: 15));
         expect(container.read(locallySnoozedNudgeDeadlinesProvider), isEmpty);

--- a/test/features/goals/state/goal_chat_controller_test.dart
+++ b/test/features/goals/state/goal_chat_controller_test.dart
@@ -308,7 +308,7 @@ void main() {
     await withClock(Clock.fixed(now), controller.send);
 
     expect(container.read(locallySnoozedNudgeDeadlinesProvider), {
-      'snoozed': until,
+      'snoozed': (activation: 1, until: until),
     });
   });
 }

--- a/test/features/goals/ui/goal_banner_actions_test.dart
+++ b/test/features/goals/ui/goal_banner_actions_test.dart
@@ -131,7 +131,7 @@ void main() {
       expect(result, isTrue);
       expect(
         containerOf(ctx).read(locallySnoozedNudgeDeadlinesProvider)['ad-1'],
-        persistedDeadline,
+        (activation: 1, until: persistedDeadline),
       );
       verify(
         () => interactions.snooze(
@@ -154,7 +154,7 @@ void main() {
       expect(await resultFuture, isTrue);
       expect(
         containerOf(ctx).read(locallySnoozedNudgeDeadlinesProvider)['ad-1'],
-        persistedDeadline,
+        (activation: 1, until: persistedDeadline),
       );
       verify(
         () => interactions.dismissForDay('ad-1', forActivation: 1),

--- a/test/features/goals/ui/goal_banner_dock_test.dart
+++ b/test/features/goals/ui/goal_banner_dock_test.dart
@@ -170,6 +170,28 @@ void main() {
     expect(visible.map((entry) => entry.nudge.id), ['visible']);
   });
 
+  test('local suppression never hides a newer activation of the same row', () {
+    final now = DateTime.utc(2026, 8, 11, 12);
+    final visible = visibleGoalBannerEntries(
+      entries: [
+        entry(
+          id: 'rerun',
+          headline: 'Fresh activation',
+          activationCount: 2,
+        ),
+      ],
+      locallySnoozedDeadlines: {
+        'rerun': (
+          activation: 1,
+          until: now.add(const Duration(hours: 12)),
+        ),
+      },
+      now: now,
+    );
+
+    expect(visible.map((entry) => entry.nudge.id), ['rerun']);
+  });
+
   testWidgets('a single tenant just sits: no dots, no auto-advance after '
       'a full tenure', (tester) async {
     await pumpDock(tester, [entry(id: 'a', headline: 'Only voice')]);
@@ -888,7 +910,7 @@ void main() {
 
     container
         .read(locallySnoozedNudgeDeadlinesProvider.notifier)
-        .add('a', DateTime.utc(2099));
+        .add('a', 1, DateTime.utc(2099));
     await settleTransition(tester);
 
     expect(find.text('Quiet now'), findsNothing);

--- a/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
+++ b/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
@@ -512,7 +512,11 @@ void main() {
     );
     container
         .read(locallySnoozedNudgeDeadlinesProvider.notifier)
-        .add('ad-goal-1-The stairs filed a complaint.', DateTime.utc(2099));
+        .add(
+          'ad-goal-1-The stairs filed a complaint.',
+          1,
+          DateTime.utc(2099),
+        );
     await tester.pump();
 
     expect(find.byType(GoalBannerCard), findsNWidgets(2));

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -406,8 +406,34 @@ void main() {
     final request = strategy.snoozeRequests.single;
     expect(request.adId, 'ad-known');
     expect(request.until, DateTime.utc(2026, 8, 12, 6, 30));
+    expect(request.returnUtcOffsetMinutes, 120);
     expect(request.reason, 'user asked for tomorrow morning');
   });
+
+  test(
+    'snooze rejects offsets outside the DateTime timezone contract',
+    () async {
+      await withClock(
+        Clock.fixed(DateTime.utc(2026, 8, 11, 12)),
+        () => strategy.processToolCalls(
+          toolCalls: [
+            _call(
+              name: GoalAgentToolNames.snoozeGoalAd,
+              args: {
+                'adId': 'ad-known',
+                'until': '2026-08-12T08:30:00+14:30',
+                'reason': 'invalid offset',
+              },
+            ),
+          ],
+          manager: manager,
+        ),
+      );
+
+      expect(strategy.snoozeRequests, isEmpty);
+      expect(rejection(), contains('ISO 8601'));
+    },
+  );
 
   test('snooze rejects future timestamps without an explicit offset', () async {
     await withClock(

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -1392,6 +1392,11 @@ void main() {
           'until': '2099-08-12T08:30:00Z',
           'reason': 'keep the longer lifetime',
         }, id: 'c8'),
+        toolCall(GoalAgentToolNames.snoozeGoalAd, {
+          'adId': 'ad-snooze',
+          'until': '2099-08-12T11:30:00+02:00',
+          'reason': 'follow-up timing choice in the same turn',
+        }, id: 'c9'),
       ],
       manager: conversationManager,
     );
@@ -1419,7 +1424,7 @@ void main() {
     // The dismissed ad was NOT retired (terminal), the missing ad was
     // skipped, the active ad was NOT re-run but WAS retired; the retired
     // ad was re-run.
-    expect(written, hasLength(4));
+    expect(written, hasLength(5));
     final retired = written.singleWhere((n) => n.id == 'ad-active');
     expect(retired.status, GoalNudgeStatus.retired);
     expect(retired.provenance['retireReason'], 'quota completed');
@@ -1434,24 +1439,25 @@ void main() {
     expect(rerun.snoozedUntil, isNull);
     expect(rerun.lastSnoozeDuration, isNull);
     expect(rerun.dismissedForDayAt, isNull);
-    final snoozed = written.singleWhere((n) => n.id == 'ad-snooze');
+    final snoozed = written.lastWhere((n) => n.id == 'ad-snooze');
     expect(snoozed.status, GoalNudgeStatus.active);
     expect(
       snoozed.snoozedUntil,
-      DateTime.utc(2099, 8, 12, 8, 30),
+      DateTime.utc(2099, 8, 12, 9, 30),
     );
     expect(
       snoozed.lastSnoozeDuration,
       GoalBannerSnoozeDuration.custom,
     );
-    expect(snoozed.snoozeHistory, hasLength(1));
+    expect(snoozed.snoozeHistory, hasLength(2));
     expect(
-      snoozed.snoozeHistory.single.snoozedUntil,
-      DateTime.utc(2099, 8, 12, 8, 30),
+      snoozed.snoozeHistory.last.snoozedUntil,
+      DateTime.utc(2099, 8, 12, 9, 30),
     );
+    expect(snoozed.snoozeHistory.last.returnUtcOffsetMinutes, 120);
     expect(
       snoozed.staleAt,
-      DateTime.utc(2099, 8, 12, 8, 30).add(goalAdLifetime),
+      DateTime.utc(2099, 8, 12, 9, 30).add(goalAdLifetime),
       reason: 'the banner must remain live after its snooze expires',
     );
     final longLived = written.singleWhere((n) => n.id == 'ad-snooze-long');

--- a/test/features/goals/workflow/goal_facts_renderer_test.dart
+++ b/test/features/goals/workflow/goal_facts_renderer_test.dart
@@ -844,6 +844,7 @@ void main() {
       String id, {
       required int startHourUtc,
       required int durationHours,
+      int returnUtcOffsetMinutes = 120,
     }) => GoalNudgeSnooze(
       id: id,
       activation: 1,
@@ -859,6 +860,7 @@ void main() {
       ),
       durationMinutes: durationHours * 60,
       utcOffsetMinutes: 120,
+      returnUtcOffsetMinutes: returnUtcOffsetMinutes,
     );
     final json = renderedJson(
       nudges: [
@@ -866,7 +868,12 @@ void main() {
           id: 'ad-history',
           status: GoalNudgeStatus.retired,
           snoozeHistory: [
-            event('s1', startHourUtc: 8, durationHours: 3),
+            event(
+              's1',
+              startHourUtc: 8,
+              durationHours: 3,
+              returnUtcOffsetMinutes: 180,
+            ),
             event('s2', startHourUtc: 9, durationHours: 1),
             event('s3', startHourUtc: 12, durationHours: 3),
           ],
@@ -886,7 +893,7 @@ void main() {
     final returnHours =
         behavior['countByRequestedReturnLocalHour'] as List<dynamic>;
     expect(returnHours[12], 1);
-    expect(returnHours[13], 1);
+    expect(returnHours[14], 1);
     expect(returnHours[17], 1);
     final recent = (behavior['recent'] as List<dynamic>)
         .cast<Map<String, dynamic>>();


### PR DESCRIPTION
## Summary

Second follow-up to #3911 and #3912, covering the five review findings that arrived after the first follow-up was already prepared.

- scope optimistic local suppression to the banner activation so a concurrent re-run is immediately visible
- fold repeated `snooze_goal_ad` requests over the just-written row, preserving every append-only event
- merge `staleAt` across concurrent snoozes so the selected reveal deadline retains its promised lifetime
- persist the requested-return UTC offset separately from the action-time offset for DST/timezone-correct timing evidence
- remove the obsolete direct-dismiss tooltip from every ARB catalog and regenerate localization output

## Validation

- `make analyze` — no issues
- 342 focused tests across the touched model, sync, state, workflow, UI, detail, and shell files — passed
- `make knowledge_check` — 93 concepts valid; 479 Mermaid blocks parsed
- `make l10n` and `make sort_arb_files` — completed
- `git diff --check` — passed

## Review context

This PR addresses the remaining unresolved inline threads on #3911. Each thread will be replied to individually and resolved after this PR is linked.