### PR TITLE
fix: deduplicate goal banner snooze evidence

### DIFF
--- a/lib/features/agents/sync/agent_concurrent_resolver.dart
+++ b/lib/features/agents/sync/agent_concurrent_resolver.dart
@@ -429,6 +429,9 @@ int _compareGoalNudgeSnoozes(GoalNudgeSnooze a, GoalNudgeSnooze b) {
   if (byMinutes != 0) return byMinutes;
   final byOffset = a.utcOffsetMinutes.compareTo(b.utcOffsetMinutes);
   if (byOffset != 0) return byOffset;
+  final byReturnOffsetPresence = (a.returnUtcOffsetMinutes == null ? 1 : 0)
+      .compareTo(b.returnUtcOffsetMinutes == null ? 1 : 0);
+  if (byReturnOffsetPresence != 0) return byReturnOffsetPresence;
   return (a.returnUtcOffsetMinutes ?? a.utcOffsetMinutes).compareTo(
     b.returnUtcOffsetMinutes ?? b.utcOffsetMinutes,
   );

--- a/lib/features/goals/logic/goal_banner_snooze.dart
+++ b/lib/features/goals/logic/goal_banner_snooze.dart
@@ -58,7 +58,7 @@ Map<String, String> _legacyQuietDeadline(
 DateTime _staleAtAfterQuietPeriod(DateTime until) =>
     until.toUtc().add(goalBannerLifetime);
 
-/// Applies a durable snooze while preserving an append-only timing event.
+/// Applies a durable snooze while preserving unique append-only timing events.
 GoalNudgeEntity snoozeGoalBannerEntity({
   required GoalNudgeEntity nudge,
   required DateTime now,
@@ -66,6 +66,7 @@ GoalNudgeEntity snoozeGoalBannerEntity({
   required String eventId,
   int? returnUtcOffsetMinutes,
 }) {
+  if (nudge.snoozeHistory.any((event) => event.id == eventId)) return nudge;
   final exactDuration = until.toUtc().difference(now.toUtc());
   if (exactDuration <= Duration.zero) {
     throw ArgumentError.value(until, 'until', 'must be in the future');

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -387,12 +387,19 @@ class GoalAgentStrategy extends ConversationStrategy
       );
       return;
     }
-    _snoozeRequests.add((
+    final request = (
       adId: adId,
       until: until,
       returnUtcOffsetMinutes: returnUtcOffsetMinutes,
       reason: reason,
-    ));
+    );
+    final alreadyRequested = _snoozeRequests.any(
+      (existing) =>
+          existing.adId == request.adId &&
+          existing.until == request.until &&
+          existing.returnUtcOffsetMinutes == request.returnUtcOffsetMinutes,
+    );
+    if (!alreadyRequested) _snoozeRequests.add(request);
     await _accept(
       call,
       manager,

--- a/test/features/agents/sync/agent_concurrent_resolver_merge_test.dart
+++ b/test/features/agents/sync/agent_concurrent_resolver_merge_test.dart
@@ -915,7 +915,22 @@ void main() {
       final laterReturnOffset = baseline.copyWith(
         returnUtcOffsetMinutes: 180,
       );
-      expect(selected(laterReturnOffset, baseline), baseline);
+      expect(selected(laterReturnOffset, baseline), laterReturnOffset);
+
+      final explicitReturnOffset = baseline.copyWith(
+        returnUtcOffsetMinutes: baseline.utcOffsetMinutes,
+      );
+      expect(
+        selected(baseline, explicitReturnOffset),
+        explicitReturnOffset,
+        reason: 'explicit offset evidence must beat a legacy absent value',
+      );
+
+      expect(
+        selected(laterReturnOffset, explicitReturnOffset),
+        explicitReturnOffset,
+        reason: 'two explicit offsets retain their numeric total order',
+      );
     });
 
     test('unions day-dismissal history by id and converges on conflicting '

--- a/test/features/goals/logic/goal_banner_snooze_test.dart
+++ b/test/features/goals/logic/goal_banner_snooze_test.dart
@@ -150,6 +150,27 @@ void main() {
     },
   );
 
+  test('reapplying the same snooze event is idempotent', () {
+    final now = DateTime.utc(2026, 8, 11, 10);
+    final until = DateTime.utc(2026, 8, 11, 13);
+    final first = snoozeGoalBannerEntity(
+      nudge: makeGoalNudge(),
+      now: now,
+      until: until,
+      eventId: 'snooze-1',
+    );
+
+    final repeated = snoozeGoalBannerEntity(
+      nudge: first,
+      now: now,
+      until: until,
+      eventId: 'snooze-1',
+    );
+
+    expect(repeated.snoozeHistory, first.snoozeHistory);
+    expect(repeated.snoozeHistory, hasLength(1));
+  });
+
   test('a zero or negative snooze interval is rejected', () {
     final now = DateTime.utc(2026, 8, 11, 10);
     for (final until in [now, now.subtract(const Duration(minutes: 1))]) {

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -410,6 +410,37 @@ void main() {
     expect(request.reason, 'user asked for tomorrow morning');
   });
 
+  test('identical snooze requests are accumulated only once', () async {
+    final now = DateTime.utc(2026, 8, 11, 12);
+    await withClock(
+      Clock.fixed(now),
+      () => strategy.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.snoozeGoalAd,
+            args: {
+              'adId': 'ad-known',
+              'until': '2026-08-12T08:30:00+02:00',
+              'reason': 'first request',
+            },
+          ),
+          _call(
+            name: GoalAgentToolNames.snoozeGoalAd,
+            args: {
+              'adId': 'ad-known',
+              'until': '2026-08-12T08:30:00+02:00',
+              'reason': 'repeated request',
+            },
+          ),
+        ],
+        manager: manager,
+      ),
+    );
+
+    expect(strategy.snoozeRequests, hasLength(1));
+    expect(strategy.snoozeRequests.single.reason, 'first request');
+  });
+
   test(
     'snooze rejects offsets outside the DateTime timezone contract',
     () async {


### PR DESCRIPTION
## Summary

- prefer explicit return-time offset evidence when concurrent snooze-event copies differ only by legacy nullability
- deduplicate identical same-turn snooze tool requests before persistence
- make snooze-event appends idempotent by event ID for retry safety
- add regression coverage for both late review findings from #3915

## Validation

- `make analyze`
- 62 targeted tests across the concurrent resolver, snooze model helper, and goal-agent strategy
- `fvm dart format` on all six changed Dart files
- `git diff --check`

Follow-up to #3915.