### PR TITLE
fix(goals): resolve goal edit mapping review follow-ups

### DIFF
--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -139,8 +139,10 @@ affordance. The automatic step count
 is an always-visible signal row rather than an intention-gated one, and an
 intention that names a health capability (blood pressure, weight) arrives
 with that signal pre-selected and seeded (130/80 mmHg, at-most), while a
-habit that merely names the same reading is demoted to an unchecked
-suggestion. Every signal is one kind of row in one signals card — provenance
+habit that is nothing but a record of that reading — its whole name is the
+reading's own words plus a measurement verb in the app's language, as in
+"Measure blood pressure" — is demoted to an unchecked suggestion. A signal
+the user deselects stays deselected across intention back-edits. Every signal is one kind of row in one signals card — provenance
 icon, plain-language subtitle, targets on the row's secondary line (blood
 pressure is a single row with paired systolic/diastolic inputs sharing one
 direction) — grouped as the user's signals above a Suggested caption, with

--- a/lib/features/goals/ui/pages/create_goal_agent_page.dart
+++ b/lib/features/goals/ui/pages/create_goal_agent_page.dart
@@ -92,6 +92,10 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
   final _categoryTimeTargets = <String, num?>{};
   final _categoryTimeDirections = <String, GoalDirection>{};
   final _suppressedCategoryTimeIds = <String>{};
+
+  /// Health signals the user explicitly deselected: an intention re-map may
+  /// still surface them as suggestions, but never re-seeds them selected.
+  final _suppressedHealthTypes = <String>{};
   List<HabitDefinition> _knownHabits = const [];
   List<MeasurableDataType> _knownMeasurables = const [];
   List<CategoryDefinition> _knownCategories = const [];
@@ -203,17 +207,38 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
     return distinctiveLabelWords.intersection(_words(intention)).isNotEmpty;
   }
 
-  /// Whether this habit's name names one of the intention-matched health
-  /// capabilities (e.g. a "Measure Blood Pressure" habit next to the
-  /// blood-pressure readings signal).
+  /// Bookkeeping verbs that don't make a habit more than a record of the
+  /// measurement it names ("Measure Blood Pressure", "Log weight").
+  static final Set<String> _measurementVerbs = {
+    'measure',
+    'track',
+    'log',
+    'check',
+    'record',
+    'monitor',
+    'take',
+  };
+
+  /// Whether this habit is a bookkeeping twin of an intention-matched
+  /// health capability: every distinctive word in its name is either part
+  /// of the health label or a measurement verb ("Measure Blood Pressure"
+  /// beside the blood-pressure readings signal). A habit that merely shares
+  /// one word with a label ("Weight training", "Pressure wash patio") is a
+  /// real habit and keeps its default selection.
   bool _overlapsMatchedHealthLabel(String habitName) {
     if (_matchedHealthTypes.isEmpty) return false;
     final habitWords = _words(
       _plainName(habitName),
     ).difference(_genericIntentionWords);
+    if (habitWords.isEmpty) return false;
     for (final dataType in _matchedHealthTypes) {
-      final label = _healthDimensionName(context, dataType);
-      if (_words(label).intersection(habitWords).isNotEmpty) return true;
+      final labelWords = _words(_healthDimensionName(context, dataType));
+      final leftover = habitWords
+          .difference(labelWords)
+          .difference(_measurementVerbs);
+      if (leftover.isEmpty && habitWords.intersection(labelWords).isNotEmpty) {
+        return true;
+      }
     }
     return false;
   }
@@ -225,6 +250,33 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       categories
           .map((category) => '${category.id}\u0000${category.name}')
           .join('\u0001');
+
+  /// Signals selected after the snapshot (via the picker) join the chosen
+  /// group for the lifetime of the current mapping-step entry, so
+  /// deselecting one leaves an unchecked row instead of deleting it.
+  void _appendSignalDescriptors(Iterable<String> healthDataTypes) {
+    final descriptors = <String>{
+      for (final dataType in healthDataTypes)
+        if (dataType == GoalHealthDataTypes.weight)
+          'weight'
+        else
+          'blood-pressure',
+    };
+    for (final descriptor in descriptors) {
+      if (!_chosenSignalOrder.contains(descriptor) &&
+          !_suggestedSignalOrder.contains(descriptor)) {
+        _chosenSignalOrder.add(descriptor);
+      }
+    }
+  }
+
+  void _appendHabitDescriptor(String habitId) {
+    final descriptor = 'habit:$habitId';
+    if (!_chosenSignalOrder.contains(descriptor) &&
+        !_suggestedSignalOrder.contains(descriptor)) {
+      _chosenSignalOrder.add(descriptor);
+    }
+  }
 
   void _snapshotSignalGroups() {
     final selectedHabitIds = _habitTargets.keys.toList();
@@ -308,8 +360,11 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
           ..add(GoalHealthDataTypes.bloodPressureDiastolic);
       }
       // The substance arrives selected: a blood-pressure intention watches
-      // blood-pressure readings from the first render, not a checkbox.
+      // blood-pressure readings from the first render, not a checkbox —
+      // unless the user already deselected it once; an explicit choice
+      // survives intention back-edits as an unchecked suggestion.
       for (final dataType in _matchedHealthTypes) {
+        if (_suppressedHealthTypes.contains(dataType)) continue;
         _healthTargets.putIfAbsent(
           dataType,
           () => _defaultHealthTarget(dataType),
@@ -1013,6 +1068,7 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
                                             _rememberedHabitTargets[habitId] ??
                                             3,
                                       );
+                                      _appendHabitDescriptor(habitId);
                                     } else {
                                       final removed = _habitTargets.remove(
                                         habitId,
@@ -1056,6 +1112,7 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
                                   }),
                               onHealthSelected: (dataTypes) => setState(() {
                                 for (final dataType in dataTypes) {
+                                  _suppressedHealthTypes.remove(dataType);
                                   _healthTargets.putIfAbsent(
                                     dataType,
                                     () => _defaultHealthTarget(dataType),
@@ -1065,9 +1122,11 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
                                     () => GoalDirection.atMost,
                                   );
                                 }
+                                _appendSignalDescriptors(dataTypes);
                                 _validation = null;
                               }),
                               onHealthRemoved: (dataType) => setState(() {
+                                _suppressedHealthTypes.add(dataType);
                                 _healthTargets.remove(dataType);
                                 _healthDirections.remove(dataType);
                                 _validation = null;
@@ -1520,7 +1579,10 @@ class _MappingStep extends StatelessWidget {
       GoalHealthDataTypes.bloodPressureSystolic,
       GoalHealthDataTypes.bloodPressureDiastolic,
     ];
-    final selected = healthTargets.containsKey(types.first);
+    // A partial pair (an edited goal carrying only one reading) is still a
+    // selected blood-pressure signal: the row renders checked with the
+    // value it has, and deselecting removes whatever half is present.
+    final selected = types.any(healthTargets.containsKey);
     return Column(
       children: [
         DesignSystemSelectionRow(
@@ -1752,9 +1814,16 @@ class _MappingStep extends StatelessWidget {
       if (descriptor == 'weight') return _weightRow(context);
       if (descriptor == 'steps') return _stepsRow(context);
       final habitId = descriptor.substring('habit:'.length);
-      final known = visibleHabits.where((habit) => habit.id == habitId);
-      if (known.isEmpty) return null;
-      return _habitSignalRow(context, known.first);
+      // A descriptor in the frozen order renders as long as the habit is
+      // resolvable (or still selected under privacy): deselecting a
+      // picker-added habit leaves its unchecked row until step re-entry.
+      if (!habitsById.containsKey(habitId) && !selectedIds.contains(habitId)) {
+        return null;
+      }
+      return _habitSignalRow(
+        context,
+        (id: habitId, name: habitsById[habitId]?.name ?? habitId),
+      );
     }
 
     final knownDescriptors = {...chosenSignalOrder, ...suggestedSignalOrder};
@@ -2865,10 +2934,11 @@ class _ConfirmationStepState extends State<_ConfirmationStep> {
                       TextSpan(text: restatementParts.first),
                       TextSpan(
                         text: widget.signalDescription,
-                        style: TextStyle(
-                          color: tokens.colors.text.highEmphasis,
-                          fontWeight: tokens.typography.weight.semiBold,
-                        ),
+                        style: tokens.typography.styles.body.bodyMedium
+                            .copyWith(
+                              color: tokens.colors.text.highEmphasis,
+                              fontWeight: tokens.typography.weight.semiBold,
+                            ),
                       ),
                       for (final part in restatementParts.skip(1))
                         TextSpan(text: part),

--- a/lib/features/goals/ui/pages/create_goal_agent_page.dart
+++ b/lib/features/goals/ui/pages/create_goal_agent_page.dart
@@ -208,16 +208,20 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
   }
 
   /// Bookkeeping verbs that don't make a habit more than a record of the
-  /// measurement it names ("Measure Blood Pressure", "Log weight").
-  static final Set<String> _measurementVerbs = {
-    'measure',
-    'track',
-    'log',
-    'check',
-    'record',
-    'monitor',
-    'take',
-  };
+  /// measurement it names ("Measure Blood Pressure", "Gewicht messen").
+  ///
+  /// Habit names are written in the user's own language, so the forms come
+  /// from the catalog rather than a hardcoded English set: a German habit
+  /// has to be recognisable by German verbs. Each catalog carries the
+  /// inflections its language needs, comma-separated.
+  Set<String> _measurementVerbs(BuildContext context) => context
+      .messages
+      .goalFormMeasurementVerbs
+      .toLowerCase()
+      .split(',')
+      .map((verb) => verb.trim())
+      .where((verb) => verb.isNotEmpty)
+      .toSet();
 
   /// Whether this habit is a bookkeeping twin of an intention-matched
   /// health capability: every distinctive word in its name is either part
@@ -231,11 +235,12 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       _plainName(habitName),
     ).difference(_genericIntentionWords);
     if (habitWords.isEmpty) return false;
+    final measurementVerbs = _measurementVerbs(context);
     for (final dataType in _matchedHealthTypes) {
       final labelWords = _words(_healthDimensionName(context, dataType));
       final leftover = habitWords
           .difference(labelWords)
-          .difference(_measurementVerbs);
+          .difference(measurementVerbs);
       if (leftover.isEmpty && habitWords.intersection(labelWords).isNotEmpty) {
         return true;
       }
@@ -1616,7 +1621,13 @@ class _MappingStep extends StatelessWidget {
     final messages = context.messages;
     const systolic = GoalHealthDataTypes.bloodPressureSystolic;
     const diastolic = GoalHealthDataTypes.bloodPressureDiastolic;
-    final direction = healthDirections[systolic] ?? GoalDirection.atMost;
+    // One toggle drives both readings, so it has to read from whichever
+    // half a partial pair actually carries — an edited diastolic-only "at
+    // least" goal must not render as the default "at most".
+    final direction =
+        healthDirections[systolic] ??
+        healthDirections[diastolic] ??
+        GoalDirection.atMost;
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: kInlineTargetInputWidth),
       child: Column(
@@ -2504,9 +2515,10 @@ class _DimensionSourcePickerState extends State<_DimensionSourcePicker> {
       GoalHealthDataTypes.bloodPressureDiastolic,
     ];
     final weightSelected = _healthTypes.contains(GoalHealthDataTypes.weight);
-    final bloodPressureSelected = bloodPressureTypes.every(
-      _healthTypes.contains,
-    );
+    // The signal row treats a partial pair as selected; the picker has to
+    // agree, or tapping an apparently unchecked source would silently seed
+    // a default target for the reading the goal deliberately lacks.
+    final bloodPressureSelected = bloodPressureTypes.any(_healthTypes.contains);
     return SafeArea(
       child: Padding(
         padding: EdgeInsets.all(tokens.spacing.step5),

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2690,6 +2690,7 @@
   "goalFormMappingTitle": "Tohle můžu sledovat",
   "goalFormMeasurableCadence": "{measurableName}: {target} za válcovaný týden",
   "goalFormMeasurableSource": "Tvoje měřitelná veličina · {unitName}",
+  "goalFormMeasurementVerbs": "měřit,měří,měření,zaznamenat,zaznamenává,záznam,zapisovat,zapisuje,zápis,sledovat,sleduje,sledování,kontrolovat,kontroluje,kontrola,evidovat,eviduje,evidence",
   "goalFormNoHabits": "Zatím nejsou k dispozici žádné aktivní návyky.",
   "goalFormOpenHabits": "Nejdřív vytvořit návyk",
   "goalFormPersonaLabel": "Jméno agenta",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2940,6 +2940,7 @@
   "goalFormMappingTitle": "Her er det, jeg kan følge",
   "goalFormMeasurableCadence": "{measurableName}: {target} pr. rullende uge",
   "goalFormMeasurableSource": "Din målbare · {unitName}",
+  "goalFormMeasurementVerbs": "måle,måler,målt,måling,registrere,registrerer,registreret,registrering,notere,noterer,noteret,notat,tjekke,tjekker,tjekket,følge,følger,fulgt,overvåge,overvåger,overvåget",
   "goalFormNoHabits": "Der er endnu ingen aktive vaner.",
   "goalFormOpenHabits": "Opret en vane først",
   "goalFormPersonaLabel": "Agentens navn",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2683,6 +2683,7 @@
   "goalFormMappingTitle": "Das kann ich beobachten",
   "goalFormMeasurableCadence": "{measurableName}: {target} pro rollierende Woche",
   "goalFormMeasurableSource": "Deine Messgröße · {unitName}",
+  "goalFormMeasurementVerbs": "messen,misst,gemessen,messung,tracken,trackt,getrackt,tracking,notieren,notiert,notiz,protokollieren,protokolliert,protokoll,prüfen,prüft,geprüft,kontrollieren,kontrolliert,kontrolle,erfassen,erfasst,überwachen,überwacht,aufzeichnen,aufgezeichnet,dokumentieren,dokumentiert,eintragen,eingetragen",
   "goalFormNoHabits": "Es gibt noch keine aktiven Gewohnheiten.",
   "goalFormOpenHabits": "Erst eine Gewohnheit erstellen",
   "goalFormPersonaLabel": "Name des Agenten",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3747,6 +3747,7 @@
       }
     }
   },
+  "goalFormMeasurementVerbs": "measure,measures,measured,measuring,track,tracks,tracked,tracking,log,logs,logged,logging,check,checks,checked,checking,record,records,recorded,recording,monitor,monitors,monitored,monitoring,note,notes,noted,noting,take,takes,taking",
   "goalFormNoHabits": "No active habits are available yet.",
   "goalFormOpenHabits": "Create a habit first",
   "goalFormPersonaLabel": "Agent name",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2683,6 +2683,7 @@
   "goalFormMappingTitle": "Esto es lo que puedo observar",
   "goalFormMeasurableCadence": "{measurableName}: {target} por semana móvil",
   "goalFormMeasurableSource": "Tu medible · {unitName}",
+  "goalFormMeasurementVerbs": "medir,mide,medido,medición,registrar,registra,registrado,registro,anotar,anota,anotado,controlar,controla,controlado,control,revisar,revisa,revisado,monitorear,monitorea,monitoreado,seguir,sigue,seguimiento,tomar,toma",
   "goalFormNoHabits": "Aún no hay hábitos activos disponibles.",
   "goalFormOpenHabits": "Crear primero un hábito",
   "goalFormPersonaLabel": "Nombre del agente",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2683,6 +2683,7 @@
   "goalFormMappingTitle": "Voici ce que je peux observer",
   "goalFormMeasurableCadence": "{measurableName} : {target} par semaine glissante",
   "goalFormMeasurableSource": "Ta mesure · {unitName}",
+  "goalFormMeasurementVerbs": "mesurer,mesure,mesures,mesuré,suivre,suivi,suivis,noter,note,notes,noté,enregistrer,enregistre,enregistré,contrôler,contrôle,contrôlé,vérifier,vérifie,vérifié,surveiller,surveille,surveillé,relever,relevé",
   "goalFormNoHabits": "Aucune habitude active n’est encore disponible.",
   "goalFormOpenHabits": "Créer d’abord une habitude",
   "goalFormPersonaLabel": "Nom de l’agent",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2940,6 +2940,7 @@
   "goalFormMappingTitle": "Ecco cosa posso osservare",
   "goalFormMeasurableCadence": "{measurableName}: {target} per settimana continuativa",
   "goalFormMeasurableSource": "Il tuo misurabile · {unitName}",
+  "goalFormMeasurementVerbs": "misurare,misura,misurato,misurazione,registrare,registra,registrato,registrazione,annotare,annota,annotato,controllare,controlla,controllato,controllo,verificare,verifica,verificato,monitorare,monitora,monitorato,tracciare,traccia,tracciato",
   "goalFormNoHabits": "Non ci sono ancora abitudini attive.",
   "goalFormOpenHabits": "Crea prima un’abitudine",
   "goalFormPersonaLabel": "Nome dell’agente",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11131,6 +11131,12 @@ abstract class AppLocalizations {
   /// **'Your measurable · {unitName}'**
   String goalFormMeasurableSource(String unitName);
 
+  /// No description provided for @goalFormMeasurementVerbs.
+  ///
+  /// In en, this message translates to:
+  /// **'measure,measures,measured,measuring,track,tracks,tracked,tracking,log,logs,logged,logging,check,checks,checked,checking,record,records,recorded,recording,monitor,monitors,monitored,monitoring,note,notes,noted,noting,take,takes,taking'**
+  String get goalFormMeasurementVerbs;
+
   /// No description provided for @goalFormNoHabits.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6596,6 +6596,10 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'měřit,měří,měření,zaznamenat,zaznamenává,záznam,zapisovat,zapisuje,zápis,sledovat,sleduje,sledování,kontrolovat,kontroluje,kontrola,evidovat,eviduje,evidence';
+
+  @override
   String get goalFormNoHabits =>
       'Zatím nejsou k dispozici žádné aktivní návyky.';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6525,6 +6525,10 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'måle,måler,målt,måling,registrere,registrerer,registreret,registrering,notere,noterer,noteret,notat,tjekke,tjekker,tjekket,følge,følger,fulgt,overvåge,overvåger,overvåget';
+
+  @override
   String get goalFormNoHabits => 'Der er endnu ingen aktive vaner.';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6570,6 +6570,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'messen,misst,gemessen,messung,tracken,trackt,getrackt,tracking,notieren,notiert,notiz,protokollieren,protokolliert,protokoll,prüfen,prüft,geprüft,kontrollieren,kontrolliert,kontrolle,erfassen,erfasst,überwachen,überwacht,aufzeichnen,aufgezeichnet,dokumentieren,dokumentiert,eintragen,eingetragen';
+
+  @override
   String get goalFormNoHabits => 'Es gibt noch keine aktiven Gewohnheiten.';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6498,6 +6498,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'measure,measures,measured,measuring,track,tracks,tracked,tracking,log,logs,logged,logging,check,checks,checked,checking,record,records,recorded,recording,monitor,monitors,monitored,monitoring,note,notes,noted,noting,take,takes,taking';
+
+  @override
   String get goalFormNoHabits => 'No active habits are available yet.';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6616,6 +6616,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'medir,mide,medido,medición,registrar,registra,registrado,registro,anotar,anota,anotado,controlar,controla,controlado,control,revisar,revisa,revisado,monitorear,monitorea,monitoreado,seguir,sigue,seguimiento,tomar,toma';
+
+  @override
   String get goalFormNoHabits => 'Aún no hay hábitos activos disponibles.';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6632,6 +6632,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'mesurer,mesure,mesures,mesuré,suivre,suivi,suivis,noter,note,notes,noté,enregistrer,enregistre,enregistré,contrôler,contrôle,contrôlé,vérifier,vérifie,vérifié,surveiller,surveille,surveillé,relever,relevé';
+
+  @override
   String get goalFormNoHabits =>
       'Aucune habitude active n’est encore disponible.';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6611,6 +6611,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'misurare,misura,misurato,misurazione,registrare,registra,registrato,registrazione,annotare,annota,annotato,controllare,controlla,controllato,controllo,verificare,verifica,verificato,monitorare,monitora,monitorato,tracciare,traccia,tracciato';
+
+  @override
   String get goalFormNoHabits => 'Non ci sono ancora abitudini attive.';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6540,6 +6540,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'meten,meet,gemeten,meting,bijhouden,houdt,bijgehouden,noteren,noteert,genoteerd,notitie,registreren,registreert,geregistreerd,controleren,controleert,gecontroleerd,controle,checken,checkt,gecheckt,volgen,volgt,gevolgd';
+
+  @override
   String get goalFormNoHabits =>
       'Er zijn nog geen actieve gewoonten beschikbaar.';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6593,6 +6593,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'medir,mede,medido,medição,registar,regista,registado,registo,anotar,anota,anotado,controlar,controla,controlado,controlo,verificar,verifica,verificado,monitorizar,monitoriza,monitorizado,acompanhar,acompanha,acompanhamento,tomar,toma';
+
+  @override
   String get goalFormNoHabits => 'Ainda não há hábitos ativos disponíveis.';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6648,6 +6648,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'măsura,măsoară,măsurat,măsurare,înregistra,înregistrează,înregistrat,înregistrare,nota,notează,notat,verifica,verifică,verificat,monitoriza,monitorizează,monitorizat,urmări,urmărește,urmărit,consemna,consemnează,consemnat';
+
+  @override
   String get goalFormNoHabits => 'Nu există încă obiceiuri active disponibile.';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6532,6 +6532,10 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get goalFormMeasurementVerbs =>
+      'mäta,mäter,mätt,mätning,registrera,registrerar,registrerat,registrering,notera,noterar,noterat,anteckna,antecknar,antecknat,kolla,kollar,kollat,kontrollera,kontrollerar,kontrollerat,följa,följer,följt';
+
+  @override
   String get goalFormNoHabits => 'Det finns inga aktiva vanor ännu.';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2939,6 +2939,7 @@
   "goalFormMappingTitle": "Dit kan ik volgen",
   "goalFormMeasurableCadence": "{measurableName}: {target} per voortschrijdende week",
   "goalFormMeasurableSource": "Jouw meetbare · {unitName}",
+  "goalFormMeasurementVerbs": "meten,meet,gemeten,meting,bijhouden,houdt,bijgehouden,noteren,noteert,genoteerd,notitie,registreren,registreert,geregistreerd,controleren,controleert,gecontroleerd,controle,checken,checkt,gecheckt,volgen,volgt,gevolgd",
   "goalFormNoHabits": "Er zijn nog geen actieve gewoonten beschikbaar.",
   "goalFormOpenHabits": "Maak eerst een gewoonte",
   "goalFormPersonaLabel": "Naam van agent",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2939,6 +2939,7 @@
   "goalFormMappingTitle": "Eis o que consigo observar",
   "goalFormMeasurableCadence": "{measurableName}: {target} por semana contínua",
   "goalFormMeasurableSource": "Seu mensurável · {unitName}",
+  "goalFormMeasurementVerbs": "medir,mede,medido,medição,registar,regista,registado,registo,anotar,anota,anotado,controlar,controla,controlado,controlo,verificar,verifica,verificado,monitorizar,monitoriza,monitorizado,acompanhar,acompanha,acompanhamento,tomar,toma",
   "goalFormNoHabits": "Ainda não há hábitos ativos disponíveis.",
   "goalFormOpenHabits": "Criar primeiro um hábito",
   "goalFormPersonaLabel": "Nome do agente",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2683,6 +2683,7 @@
   "goalFormMappingTitle": "Iată ce pot urmări",
   "goalFormMeasurableCadence": "{measurableName}: {target} pe săptămână continuă",
   "goalFormMeasurableSource": "Măsurătoarea dvs. · {unitName}",
+  "goalFormMeasurementVerbs": "măsura,măsoară,măsurat,măsurare,înregistra,înregistrează,înregistrat,înregistrare,nota,notează,notat,verifica,verifică,verificat,monitoriza,monitorizează,monitorizat,urmări,urmărește,urmărit,consemna,consemnează,consemnat",
   "goalFormNoHabits": "Nu există încă obiceiuri active disponibile.",
   "goalFormOpenHabits": "Creați mai întâi un obicei",
   "goalFormPersonaLabel": "Numele agentului",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2940,6 +2940,7 @@
   "goalFormMappingTitle": "Det här kan jag följa",
   "goalFormMeasurableCadence": "{measurableName}: {target} per rullande vecka",
   "goalFormMeasurableSource": "Din mätbara · {unitName}",
+  "goalFormMeasurementVerbs": "mäta,mäter,mätt,mätning,registrera,registrerar,registrerat,registrering,notera,noterar,noterat,anteckna,antecknar,antecknat,kolla,kollar,kollat,kontrollera,kontrollerar,kontrollerat,följa,följer,följt",
   "goalFormNoHabits": "Det finns inga aktiva vanor ännu.",
   "goalFormOpenHabits": "Skapa en vana först",
   "goalFormPersonaLabel": "Agentens namn",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.10+4315
+version: 1.0.10+4316
 
 msix_config:
   display_name: LottiApp

--- a/test/features/goals/ui/pages/create_goal_agent_page_test.dart
+++ b/test/features/goals/ui/pages/create_goal_agent_page_test.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/categories/repository/categories_repository.dart'
 import 'package:lotti/features/categories/state/categories_list_controller.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/components/inputs/design_system_text_input.dart';
 import 'package:lotti/features/design_system/components/selection/design_system_selection_row.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
@@ -5149,6 +5150,191 @@ void main() {
         ),
         findsNothing,
       );
+    },
+  );
+
+  testWidgets(
+    'a German bookkeeping habit is demoted beside the weight signal',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      when(habitsRepository.watchHabitDefinitions).thenAnswer(
+        (_) => Stream.value([
+          _habit('wiegen', 'Gewicht messen'),
+          _habit('heben', 'Gewicht heben'),
+        ]),
+      );
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(),
+          overrides: overrides(),
+          locale: const Locale('de'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('goal-form-intention')),
+        'Gewicht verlieren',
+      );
+      await tester.tap(find.text('Weiter'));
+      await tester.pumpAndSettle();
+
+      // The readings signal arrives selected…
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(const ValueKey('goal-form-health-row-weight')),
+            )
+            .selected,
+        isTrue,
+      );
+      // …"Gewicht messen" is pure bookkeeping in German too, so it waits
+      // unchecked instead of duplicating the readings signal…
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(const ValueKey('goal-form-habit-wiegen')),
+            )
+            .selected,
+        isFalse,
+      );
+      expect(
+        tester.getRect(find.text('Vorgeschlagen')).top,
+        lessThan(
+          tester
+              .getRect(find.byKey(const ValueKey('goal-form-habit-wiegen')))
+              .top,
+        ),
+      );
+      // …while "Gewicht heben" has a real leftover word and stays selected.
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(const ValueKey('goal-form-habit-heben')),
+            )
+            .selected,
+        isTrue,
+      );
+    },
+  );
+
+  testWidgets(
+    'a diastolic-only goal renders its stored direction on the shared '
+    'blood-pressure toggle',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      const criteria = GoalCriterion.metric(
+        criterionId: 'bp-dia',
+        dataType: GoalHealthDataTypes.bloodPressureDiastolic,
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.dailySumThenAverage,
+        target: 82,
+        // Spelled out: the stored direction is what this test is about.
+        // ignore: avoid_redundant_argument_values
+        direction: GoalDirection.atLeast,
+      );
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(agentId: 'goal-1'),
+          overrides: overrides(editSpec: _spec(criteria: criteria)),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      // One toggle drives both readings, so it must read the direction off
+      // whichever half the partial pair actually carries.
+      expect(
+        tester
+            .widget<DsSegmentedToggle<GoalDirection>>(
+              find.byKey(
+                const ValueKey('goal-form-health-direction-blood-pressure'),
+              ),
+            )
+            .selected,
+        GoalDirection.atLeast,
+      );
+
+      // The stored direction survives the round trip to confirmation.
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      expect(
+        find.textContaining(
+          'Diastolic blood pressure: 7-day average At least 82 mmHg',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'the picker shows a diastolic-only goal as selected and deselects it',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      const criteria = GoalCriterion.metric(
+        criterionId: 'bp-dia',
+        dataType: GoalHealthDataTypes.bloodPressureDiastolic,
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.dailySumThenAverage,
+        target: 82,
+      );
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(agentId: 'goal-1'),
+          overrides: overrides(editSpec: _spec(criteria: criteria)),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('goal-form-add-signal')));
+      await tester.pumpAndSettle();
+      final source = find.byKey(
+        const ValueKey('goal-form-health-source-blood-pressure'),
+      );
+      // The picker agrees with the row: a partial pair reads as selected.
+      expect(
+        tester.widget<DesignSystemSelectionRow>(source).selected,
+        isTrue,
+      );
+
+      // Tapping therefore DESELECTS rather than seeding a systolic 130.
+      await tester.tap(source);
+      await tester.pump();
+      expect(
+        tester.widget<DesignSystemSelectionRow>(source).selected,
+        isFalse,
+      );
+      await tester.tap(find.byKey(const ValueKey('goal-form-picker-done')));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(
+                const ValueKey('goal-form-health-row-blood-pressure'),
+              ),
+            )
+            .selected,
+        isFalse,
+      );
+      for (final dataType in [
+        GoalHealthDataTypes.bloodPressureSystolic,
+        GoalHealthDataTypes.bloodPressureDiastolic,
+      ]) {
+        expect(
+          find.byKey(ValueKey('goal-form-health-target-$dataType')),
+          findsNothing,
+        );
+      }
+      expect(find.text('130'), findsNothing);
     },
   );
 }

--- a/test/features/goals/ui/pages/create_goal_agent_page_test.dart
+++ b/test/features/goals/ui/pages/create_goal_agent_page_test.dart
@@ -1806,8 +1806,13 @@ void main() {
     final gymRect = tester.getRect(gymRow);
     await tester.tapAt(Offset(gymRect.left + 40, gymRect.center.dy));
     await tester.pump();
-    // An unmatched habit's row disappears entirely on deselection.
-    expect(gymRow, findsNothing);
+    // The picker-added habit keeps its unchecked row for this step entry —
+    // only the cadence stepper leaves with the selection.
+    expect(gymRow, findsOneWidget);
+    expect(
+      tester.widget<DesignSystemSelectionRow>(gymRow).selected,
+      isFalse,
+    );
     expect(find.text('3×/week', skipOffstage: false), findsNothing);
   });
 
@@ -4041,8 +4046,20 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('goal-form-picker-done')));
     await tester.pumpAndSettle();
+    // The toggled-off signal keeps an unchecked row (frozen order) with no
+    // target controls.
+    final pageWeightRow = find.byKey(
+      const ValueKey('goal-form-health-row-weight'),
+    );
+    expect(pageWeightRow, findsOneWidget);
     expect(
-      find.byKey(const ValueKey('goal-form-health-row-weight')),
+      tester.widget<DesignSystemSelectionRow>(pageWeightRow).selected,
+      isFalse,
+    );
+    expect(
+      find.byKey(
+        const ValueKey('goal-form-health-target-HealthDataType.WEIGHT'),
+      ),
       findsNothing,
     );
   });
@@ -4293,12 +4310,15 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('goal-form-picker-done')));
       await tester.pumpAndSettle();
 
-      // Every toggled-off dimension left no card behind on the page.
+      // The toggled-off blood-pressure signal keeps an unchecked row in the
+      // frozen order; the category and measurable cards leave entirely.
+      final bpRow = find.byKey(
+        const ValueKey('goal-form-health-row-blood-pressure'),
+      );
+      expect(bpRow, findsOneWidget);
       expect(
-        find.byKey(
-          const ValueKey('goal-form-health-row-blood-pressure'),
-        ),
-        findsNothing,
+        tester.widget<DesignSystemSelectionRow>(bpRow).selected,
+        isFalse,
       );
       expect(
         find.byKey(
@@ -4832,6 +4852,302 @@ void main() {
       expect(
         signalSpan.style?.color,
         dsTokensLight.colors.text.highEmphasis,
+      );
+      // The emphasized span derives from the bodyMedium token, not a raw
+      // TextStyle that would drop the typeface metrics.
+      expect(
+        signalSpan.style?.fontSize,
+        dsTokensLight.typography.styles.body.bodyMedium.fontSize,
+      );
+    },
+  );
+
+  testWidgets(
+    'an edited goal with only a diastolic reading renders a checked '
+    'blood-pressure row',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      const criteria = GoalCriterion.metric(
+        criterionId: 'bp-dia',
+        dataType: GoalHealthDataTypes.bloodPressureDiastolic,
+        window: GoalWindow.rollingDays(count: 7),
+        aggregation: GoalAggregation.dailySumThenAverage,
+        target: 82,
+      );
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(agentId: 'goal-1'),
+          overrides: overrides(editSpec: _spec(criteria: criteria)),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      // A partial pair is still a selected signal: checked, carrying the
+      // one value it has.
+      final row = find.byKey(
+        const ValueKey('goal-form-health-row-blood-pressure'),
+      );
+      expect(
+        tester.widget<DesignSystemSelectionRow>(row).selected,
+        isTrue,
+      );
+      String targetText(String dataType) => tester
+          .widget<EditableText>(
+            find.descendant(
+              of: find.byKey(ValueKey('goal-form-health-target-$dataType')),
+              matching: find.byType(EditableText),
+            ),
+          )
+          .controller
+          .text;
+      expect(targetText(GoalHealthDataTypes.bloodPressureDiastolic), '82');
+      expect(targetText(GoalHealthDataTypes.bloodPressureSystolic), isEmpty);
+
+      // Deselecting removes whatever half of the pair is present.
+      await tester.tap(find.text('Blood Pressure'));
+      await tester.pump();
+      expect(
+        tester.widget<DesignSystemSelectionRow>(row).selected,
+        isFalse,
+      );
+      expect(
+        find.byKey(
+          const ValueKey(
+            'goal-form-health-target-HealthDataType.BLOOD_PRESSURE_DIASTOLIC',
+          ),
+        ),
+        findsNothing,
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pump();
+      expect(
+        find.text(
+          'Choose at least one signal the agent can actually observe.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'only bookkeeping-twin habits are demoted beside a health signal',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      when(habitsRepository.watchHabitDefinitions).thenAnswer(
+        (_) => Stream.value([
+          _habit('wt', 'Weight training'),
+          _habit('logw', 'Log weight'),
+        ]),
+      );
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(),
+          overrides: overrides(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('goal-form-intention')),
+        'lose weight',
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      // The readings signal arrives selected…
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(const ValueKey('goal-form-health-row-weight')),
+            )
+            .selected,
+        isTrue,
+      );
+      // …"Weight training" is a real habit that shares a word with the
+      // label, so it keeps its default selection…
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(const ValueKey('goal-form-habit-wt')),
+            )
+            .selected,
+        isTrue,
+      );
+      // …while "Log weight" is pure bookkeeping and waits unchecked.
+      expect(
+        tester
+            .widget<DesignSystemSelectionRow>(
+              find.byKey(const ValueKey('goal-form-habit-logw')),
+            )
+            .selected,
+        isFalse,
+      );
+    },
+  );
+
+  testWidgets(
+    'a deselected health signal survives an intention re-map unseeded',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(),
+          overrides: overrides(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('goal-form-intention')),
+        'Keep my blood pressure under control',
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      final row = find.byKey(
+        const ValueKey('goal-form-health-row-blood-pressure'),
+      );
+      expect(
+        tester.widget<DesignSystemSelectionRow>(row).selected,
+        isTrue,
+      );
+      await tester.tap(find.text('Blood Pressure'));
+      await tester.pump();
+
+      // A changed intention re-maps, but the explicit deselection survives
+      // as an unchecked suggestion instead of being re-seeded.
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('goal-form-intention')),
+        'Keep my blood pressure under control every single morning',
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      expect(row, findsOneWidget);
+      expect(
+        tester.widget<DesignSystemSelectionRow>(row).selected,
+        isFalse,
+      );
+
+      // An explicit re-select clears the suppression and re-seeds…
+      await tester.tap(find.text('Blood Pressure'));
+      await tester.pump();
+      expect(
+        tester
+            .widget<EditableText>(
+              find.descendant(
+                of: find.byKey(
+                  const ValueKey(
+                    'goal-form-health-target-'
+                    'HealthDataType.BLOOD_PRESSURE_SYSTOLIC',
+                  ),
+                ),
+                matching: find.byType(EditableText),
+              ),
+            )
+            .controller
+            .text,
+        '130',
+      );
+
+      // …and the next re-map keeps it selected.
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('goal-form-intention')),
+        'Keep my blood pressure under control before breakfast',
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget<DesignSystemSelectionRow>(row).selected,
+        isTrue,
+      );
+    },
+  );
+
+  testWidgets(
+    'deselected picker-added signals keep their unchecked rows until '
+    're-entry',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 1800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(),
+          overrides: overrides(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('goal-form-intention')),
+        'Track my week',
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('goal-form-add-signal')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('goal-form-picker-habit-run')),
+      );
+      await tester.pump();
+      await tester.tap(
+        find.byKey(const ValueKey('goal-form-health-source-weight')),
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('goal-form-picker-done')));
+      await tester.pumpAndSettle();
+
+      final runRow = find.byKey(const ValueKey('goal-form-habit-run'));
+      final weightRow = find.byKey(
+        const ValueKey('goal-form-health-row-weight'),
+      );
+      expect(
+        tester.widget<DesignSystemSelectionRow>(runRow).selected,
+        isTrue,
+      );
+      expect(
+        tester.widget<DesignSystemSelectionRow>(weightRow).selected,
+        isTrue,
+      );
+
+      // Deselecting a picker-added habit leaves its unchecked row in place
+      // (tap the row's own title — the derived goal name is also "Run").
+      await tester.tap(
+        find.descendant(of: runRow, matching: find.text('Run')),
+      );
+      await tester.pump();
+      expect(runRow, findsOneWidget);
+      expect(
+        tester.widget<DesignSystemSelectionRow>(runRow).selected,
+        isFalse,
+      );
+      expect(
+        find.byKey(const ValueKey('goal-form-increase-run')),
+        findsNothing,
+      );
+
+      // Same for a picker-added health signal.
+      await tester.tap(find.text('Weight'));
+      await tester.pump();
+      expect(weightRow, findsOneWidget);
+      expect(
+        tester.widget<DesignSystemSelectionRow>(weightRow).selected,
+        isFalse,
+      );
+      expect(
+        find.byKey(
+          const ValueKey('goal-form-health-target-HealthDataType.WEIGHT'),
+        ),
+        findsNothing,
       );
     },
   );


### PR DESCRIPTION
Follow-up to #3914: the five review comments that arrived after it was merged, each with a regression test that fails without its fix.

### Fixes

1. **A partial blood-pressure pair renders as a selected signal.** An edited goal carrying only one of the two readings showed an unchecked row with no controls, so the value it already had was invisible and unreachable. The row is selected when *either* reading is present, shows the value it has, and deselecting removes whatever half exists.
2. **Only bookkeeping twins are demoted beside a health signal.** The demotion rule matched any shared word, so "Weight training" was demoted next to the weight readings signal. A habit is now demoted only when its whole name is the health label plus a measurement verb (measure/track/log/check/record/monitor/take) — "Log weight" demotes, "Weight training" stays a real habit.
3. **An explicit health deselection survives an intention back-edit.** Re-mapping re-seeded the readings the user had just removed. Deselected health types are remembered and return as unchecked suggestions; selecting one again clears the memory and re-seeds its default target.
4. **Picker-added signals keep their row after deselection.** A signal added through the picker vanished the moment it was unticked, so undoing a misclick meant reopening the picker. Picker additions now join the frozen chosen-signal order for the lifetime of the step, leaving an unchecked row behind.
5. **The confirmation recap's emphasis comes from a typography token.** The emphasized signal span used a raw `TextStyle`, which dropped the body size in the middle of a sentence.

### Tests

`create_goal_agent_page_test.dart` 83 → 87 tests (four new, one extended); `goal_form_mapping_test.dart` re-run unchanged. Local lcov intersected with this PR's added lines is empty — full patch coverage. Each new test was re-run with its fix reverted and fails.

Three pre-existing tests pinned the old "deselected picker signal disappears" behavior and now assert the row persists unchecked with its controls gone.

No CHANGELOG entry: these correct behavior introduced by #3914 earlier today, and the existing entries describe the intended behavior these fixes restore.

---

### Second commit: review round on this PR

Three Codex P2 findings, each with a revert-verified regression test (90 tests in the page suite, patch coverage complete):

1. **The bookkeeping verbs are localized.** They were a hardcoded English set, so the demotion never fired outside English — a German user saw both the weight signal and a duplicate "Gewicht messen" habit selected. The forms now come from a new `goalFormMeasurementVerbs` catalog key, added to all eleven translated catalogs (`en_GB` inherits from `en`).
2. **A partial blood-pressure pair keeps its stored direction.** The shared toggle read only the systolic direction, so a diastolic-only "at least" goal rendered as the default "at most" while saving "at least". It now falls back to whichever half exists.
3. **The picker agrees with the row on partial pairs.** The picker still used `every`, so the same signal showed unchecked there and a tap silently seeded a default 130 for the missing reading. It uses `any`, matching the row.

Also bumps the build number to `1.0.10+4316` and corrects the goals README, which described the demotion by the over-broad rule this PR narrows.

Known adjacent gap, deliberately not fixed here: `_genericIntentionWords` is still an English-only stop-word list, so a German habit with extra generic words ("Gewicht jeden Tag messen") keeps them as leftovers and escapes demotion. It shifts match sensitivity rather than producing a contradictory selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved goal creation suggestions for health measurements, including blood pressure and weight.
  * Preserves deselected health signals and newly added habits during goal setup.
  * Supports partial blood-pressure targets while retaining measurement direction.
  * Added measurement terminology across supported languages.

* **Bug Fixes**
  * Improved habit-to-health matching and suggestion grouping.
  * Updated confirmation summary typography.
  * Incremented the application build version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->