### PR TITLE
fix(goals): let a chat request actually rewrite the standing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.10]
+### Fixed
+- **Asking the goal agent to change its report now changes it.** Telling the
+  agent in chat to make its report shorter, sectioned, or less repetitive used
+  to produce only a chat reply while the standing report stayed as it was. The
+  request now rewrites the report itself, and an explicit refusal to change it
+  is respected.
+
 ### Changed
 - **Goal agent pages get the whole screen on phones.** The bottom navigation
   bar slides away on a goal's detail page, its chat, and the create and edit

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -43,6 +43,7 @@
     <release version="1.0.10" date="2026-08-13">
       <description>
         <p>Changed: goal-agent banners now make Snooze the primary action, with 1, 3, 6, and 8 hour choices. Dismiss for today is a secondary option, banners return automatically after the chosen deadline or on the next local day even after an app restart, and durable snooze and dismissal timing history gives the goal agent evidence for choosing better initial display times.</p>
+        <p>Fixed: asking the goal agent in chat to change its report now changes it. Telling the agent to make its report shorter, sectioned, or less repetitive used to produce only a chat reply while the standing report stayed exactly as it was; the request now rewrites the report itself, and an explicit refusal to change it is respected.</p>
         <p>Changed: goal agent pages get the whole screen on phones. The bottom navigation bar slides away on a goal's detail page, its chat, and the create and edit wizards, the way it already does for project details, so the day sheet's record button and the wizard's Continue band dock at the bottom edge instead of sitting under the bar.</p>
         <p>Fixed: project agents no longer keep an empty daily 06:00 wake alive. Digest work is scheduled only after relevant project or linked-task activity, and existing dormant schedules disappear from the Wake tab on startup.</p>
       </description>

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -360,9 +360,19 @@ flowchart TD
   results and context-shape experiments live in the goal-agent eval run book.
   A wake with zero tool calls is legal (the no-op policy row) — the
   strategy never nags for output. Two deterministic exceptions are forced
-  with one pinned retry each: a transition/detail-refresh wake missing its
-  report, and policy row P5 (offTrack, no fresh ad, no cooldown) or an explicit
-  new-banner request missing its ad. A first evaluation that lands at risk is
+  with one pinned retry each: a wake missing its report where the status
+  transitioned, the detail page requested a refresh, **or the pending chat
+  message asked for the standing report itself to be rewritten**; and policy
+  row P5 (offTrack, no fresh ad, no cooldown) or an explicit new-banner
+  request missing its ad. The chat-rewrite path is deliberately NOT the
+  detail page's refresh token: that token also persists the derivation and
+  re-bases `previousStatus`, neither of which a rewrite of the standing text
+  may do. Its trigger mirrors the banner path — an English intent heuristic
+  over the pending message (plus a short affirmation following the agent's own
+  offer to rewrite), a matching FACTS-block instruction, and the model's own
+  tool call as the language-independent carrier — and an explicit refusal
+  ("don't make the report shorter") suppresses it, because forcing a rewrite
+  over a refusal destroys the report the user asked to keep. A first evaluation that lands at risk is
   also ad-eligible, so a newly created goal does not wait for a three-day trend
   before receiving its initial banner.
 - **Report freshness follows the durable standing head.** Producing report

--- a/lib/features/goals/workflow/goal_agent_contract.dart
+++ b/lib/features/goals/workflow/goal_agent_contract.dart
@@ -182,10 +182,16 @@ String? _requiredReportString(Object? value) {
 String? _optionalReportString(Object? value) =>
     value is String ? value.trim() : null;
 
-/// The system prompt. Deliberately lean (hard-capped at 3.2k chars by
+/// The system prompt. Deliberately lean (hard-capped at 3.6k chars by
 /// the offline test): the payload lesson from task-agent evals is that long
 /// prompts get skimmed, and every number the model needs arrives in the
 /// wake FACTS block, not here.
+///
+/// The ceiling is a discipline, not a model limit — it exists so growth is
+/// argued rather than accreted. It moved from 3.2k when the standing-report
+/// rule was added: the FACTS block can only carry a rule to the turns whose
+/// English heuristic fires, so a rule that must hold in every language and
+/// every turn belongs here.
 const goalAgentSystemPrompt = '''
 You are the dedicated coach for exactly one user goal, not a general assistant.
 Discuss only its evidence, progress, criteria, banners, and proposed changes.
@@ -235,6 +241,9 @@ Act in this order of precedence:
    images. Include no personal data: names, life numbers, locations, or health.
 4. Status reporting: when FACTS say the track status or period changed
    materially, call update_goal_report with the FACTS status.
+   The report is STORED: reply_to_user never changes it. When the user asks
+   for the report itself to change (shorter, sectioned, less repetitive), call
+   update_goal_report in the SAME turn with the full rewrite.
 5. Nothing material changed: call no tools and write nothing.
 
 Use record_goal_observation only for novel facts worth remembering for years,

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -221,6 +221,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
     // standing text, not a re-derivation of the evidence.
     final userRequestedReport = isExplicitGoalReportUpdateRequest(
       pendingUserMessage,
+      previousAssistantMessage: previousAssistantMessage,
     );
 
     final head = await _repository.getEntity(goalSpecHeadId(agentId));
@@ -1815,17 +1816,41 @@ bool isExplicitGoalAdReplacementRequest(
 /// same text they complained about. Like the ad heuristic this is an English
 /// fast path that forces a forgotten tool call; the language-independent
 /// carrier is the model choosing `update_goal_report` itself, which the
-/// system prompt now asks for explicitly.
-bool isExplicitGoalReportUpdateRequest(String? message) {
+/// system prompt asks for explicitly.
+bool isExplicitGoalReportUpdateRequest(
+  String? message, {
+  String? previousAssistantMessage,
+}) {
   if (message == null) return false;
   final normalized = message.toLowerCase().trim();
+  // "Yes, please" after the agent offers to rewrite the report is the same
+  // request in its most common form; the offer is the only place the subject
+  // is named, exactly as the banner path treats an affirmation.
+  if (_isShortGoalAdAffirmation(normalized) &&
+      _offersGoalReportRewrite(previousAssistantMessage)) {
+    return true;
+  }
   final mentionsReport = RegExp(
     r'\b(?:report|summary|write[-\s]?up)\b',
   ).hasMatch(normalized);
   if (!mentionsReport) return false;
+  // A question ABOUT the report is not a request to rewrite it. Leading
+  // interrogatives only: "can/could/would you shorten it" are requests, and
+  // they are deliberately not in this set.
+  final asksAboutReport = RegExp(
+    r'^(?:how|what|why|when|where|which|who)\b',
+  ).hasMatch(normalized);
+  if (asksAboutReport) return false;
+  // Negation binds loosely in real messages — "don't want you to change the
+  // report", "please don't make the report shorter" — so any negation ahead
+  // of a change word within the same clause declines the rewrite. Forcing a
+  // rewrite against an explicit refusal overwrites a report the user asked
+  // to keep, which is worse than missing an implicit request.
   final declinesChange = RegExp(
-    r"\b(?:don't|dont|do not|never)\s+"
-    r'(?:change|update|rewrite|restructure|touch|shorten)\b',
+    r"\b(?:don't|dont|do not|never|no\s+need\s+to|rather\s+not|"
+    r'stop|leave|keep)\b[^.!?]{0,60}\b(?:change|update|rewrite|rewriting|'
+    'restructure|touch|shorten|shorter|concise|condense|trim|tighten|'
+    r'split|format|structure|improve|less|make|alone|as\s+is)\b',
   ).hasMatch(normalized);
   if (declinesChange) return false;
   return RegExp(
@@ -1834,6 +1859,22 @@ bool isExplicitGoalReportUpdateRequest(String? message) {
     r'update|refresh|change|improve|less)\b|'
     r'\bwall\s+of\s+text\b|'
     r'\bbreak\s+(?:it|this|that|the\s+report)?\s*up\b',
+  ).hasMatch(normalized);
+}
+
+/// Whether the agent's previous visible reply OFFERED to rewrite the standing
+/// report, which is what makes a bare "yes" a rewrite request.
+bool _offersGoalReportRewrite(String? message) {
+  if (message == null) return false;
+  final normalized = message.toLowerCase();
+  if (!RegExp(r'\b(?:report|summary|write[-\s]?up)\b').hasMatch(normalized)) {
+    return false;
+  }
+  return RegExp(
+    r"\b(?:if\s+you(?:'d|\s+would)?\s+(?:like|want)|want\s+me\s+to|"
+    r'would\s+you\s+like|shall\s+i|should\s+i|say\s+the\s+word|'
+    r'i\s+can\s+(?:rewrite|restructure|shorten|split|reformat)|'
+    r'let\s+me\s+(?:rewrite|restructure|shorten|split|reformat))\b',
   ).hasMatch(normalized);
 }
 

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -215,6 +215,13 @@ class GoalAgentWorkflow with AgentErrorLogging {
       pendingUserMessage,
       previousAssistantMessage: previousAssistantMessage,
     );
+    // A chat request to change the report is as binding as the detail page's
+    // refresh token, but must not take the token's other effects (persisting
+    // the derivation, re-basing previousStatus) — it is a rewrite of the
+    // standing text, not a re-derivation of the evidence.
+    final userRequestedReport = isExplicitGoalReportUpdateRequest(
+      pendingUserMessage,
+    );
 
     final head = await _repository.getEntity(goalSpecHeadId(agentId));
     if (head is! GoalSpecHeadEntity) {
@@ -347,6 +354,13 @@ class GoalAgentWorkflow with AgentErrorLogging {
           'EVIDENCE CHANGED. Update the standing report from the '
           'authoritative FACTS.';
     }
+    if (userRequestedReport) {
+      factsBlock =
+          '$factsBlock\n\nUSER EXPLICITLY ASKED FOR THE STANDING REPORT TO '
+          'CHANGE. Call update_goal_report in this turn with the full '
+          'rewritten report honouring their instruction; replying without it '
+          'leaves the report they complained about untouched.';
+    }
     if (userRequestedAd) {
       factsBlock =
           '$factsBlock\n\nUSER EXPLICITLY REQUESTED A NEW BANNER AD. This '
@@ -471,7 +485,8 @@ class GoalAgentWorkflow with AgentErrorLogging {
       // A transition or explicit detail-page refresh requires a report — one
       // pinned retry, then accept the partial wake. Ordinary automatic no-ops
       // remain legal and free of forced output.
-      if ((facts.statusTransitioned || reportRefresh) && !strategy.hasReport) {
+      if ((facts.statusTransitioned || reportRefresh || userRequestedReport) &&
+          !strategy.hasReport) {
         final retryUsage = await _forceReport(
           conversationId: conversationId,
           resolved: resolved,
@@ -481,7 +496,20 @@ class GoalAgentWorkflow with AgentErrorLogging {
           agentId: recordConsumption ? agentId : null,
           runKey: recordConsumption ? runKey : null,
           threadId: recordConsumption ? threadId : null,
-          userRequestedRefresh: reportRefresh,
+          // Say which of the three reasons forced this, so the retry cannot
+          // describe a habit-day edit the user never made.
+          instruction: userRequestedReport
+              ? 'The user asked in chat for the standing report itself to '
+                    'change. Call update_goal_report now with the full '
+                    'rewritten report honouring their instruction, keeping '
+                    'every value faithful to the FACTS block.'
+              : reportRefresh
+              ? 'The user explicitly requested a standing-report refresh '
+                    'after editing a habit day. Call update_goal_report now '
+                    'with the status and current evidence from the FACTS '
+                    'block.'
+              : 'The track status changed this wake. Call update_goal_report '
+                    'now with the status from the FACTS block.',
         );
         if (retryUsage != null) {
           usage = usage == null ? retryUsage : usage.merge(retryUsage);
@@ -1017,17 +1045,12 @@ class GoalAgentWorkflow with AgentErrorLogging {
     required String? agentId,
     required String? runKey,
     required String? threadId,
-    required bool userRequestedRefresh,
+    required String instruction,
   }) async {
     try {
       return await _conversationRepository.sendMessage(
         conversationId: conversationId,
-        message: userRequestedRefresh
-            ? 'The user explicitly requested a standing-report refresh after '
-                  'editing a habit day. Call update_goal_report now with the '
-                  'status and current evidence from the FACTS block.'
-            : 'The track status changed this wake. Call update_goal_report '
-                  'now with the status from the FACTS block.',
+        message: instruction,
         model: resolved.modelId,
         provider: resolved.provider,
         inferenceRepo: inferenceRepo,
@@ -1782,6 +1805,36 @@ bool isExplicitGoalAdReplacementRequest(
       qualifiedRequest ||
       requestsBanner ||
       reportsMissingBanner;
+}
+
+/// True when a chat message asks for the STANDING REPORT itself to change —
+/// shorter, restructured, sectioned, less repetitive — rather than asking a
+/// question about the goal.
+///
+/// The report is a stored artifact: a reply alone leaves the user reading the
+/// same text they complained about. Like the ad heuristic this is an English
+/// fast path that forces a forgotten tool call; the language-independent
+/// carrier is the model choosing `update_goal_report` itself, which the
+/// system prompt now asks for explicitly.
+bool isExplicitGoalReportUpdateRequest(String? message) {
+  if (message == null) return false;
+  final normalized = message.toLowerCase().trim();
+  final mentionsReport = RegExp(
+    r'\b(?:report|summary|write[-\s]?up)\b',
+  ).hasMatch(normalized);
+  if (!mentionsReport) return false;
+  final declinesChange = RegExp(
+    r"\b(?:don't|dont|do not|never)\s+"
+    r'(?:change|update|rewrite|restructure|touch|shorten)\b',
+  ).hasMatch(normalized);
+  if (declinesChange) return false;
+  return RegExp(
+    r'\b(?:rewrite|rewrote|restructure|reorganise|reorganize|shorten|shorter|'
+    'concise|condense|trim|tighten|split|bullets?|sections?|format|structure|'
+    r'update|refresh|change|improve|less)\b|'
+    r'\bwall\s+of\s+text\b|'
+    r'\bbreak\s+(?:it|this|that|the\s+report)?\s*up\b',
+  ).hasMatch(normalized);
 }
 
 bool _isShortGoalAdAffirmation(String message) => RegExp(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.10+4317
+version: 1.0.10+4318
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
@@ -647,9 +647,10 @@ void main() {
 
     test('system prompt stays lean', () {
       // The payload lesson: a bloated prompt gets skimmed. Budget grew with
-      // the judgment tier (composite targeting, cooldown, roast bounds) —
-      // still a hard ceiling, revisit any growth past it.
-      expect(goalAgentSystemPrompt.length, lessThan(3200));
+      // the judgment tier (composite targeting, cooldown, roast bounds) and
+      // again with the standing-report rule — still a hard ceiling, revisit
+      // any growth past it.
+      expect(goalAgentSystemPrompt.length, lessThan(3600));
       expect(goalAgentSystemPrompt, contains('insufficientData'));
       expect(goalAgentSystemPrompt, contains('rerun_goal_ad'));
       expect(goalAgentSystemPrompt, contains('snooze_goal_ad'));

--- a/test/features/goals/workflow/goal_agent_contract_test.dart
+++ b/test/features/goals/workflow/goal_agent_contract_test.dart
@@ -7,8 +7,11 @@ import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 void main() {
   test('the prompt stays under the eval-enforced hard cap', () {
     // The payload lesson: long prompts get skimmed. The eval suite pins
-    // the same bound; this pins it for the production import path.
-    expect(goalAgentSystemPrompt.length, lessThan(3200));
+    // the same bound; this pins it for the production import path. The
+    // ceiling is a discipline rather than a model limit — moved to 3.6k with
+    // the standing-report rule, which has to hold in every language and so
+    // cannot live in the per-wake FACTS block.
+    expect(goalAgentSystemPrompt.length, lessThan(3600));
     expect(
       goalAgentSystemPrompt,
       contains('explicitly asks for another ad'),

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -307,6 +307,108 @@ void main() {
     },
   );
 
+  test('a short affirmation counts only after an offer to rewrite the '
+      'report', () {
+    const offer = 'I can rewrite the report into sections if you like.';
+    const question = 'Want me to shorten the report?';
+    for (final affirmation in ['yes please', 'do it', 'go ahead', 'sure']) {
+      expect(
+        isExplicitGoalReportUpdateRequest(
+          affirmation,
+          previousAssistantMessage: offer,
+        ),
+        isTrue,
+        reason: '"$affirmation" after an offer is the same request',
+      );
+      expect(
+        isExplicitGoalReportUpdateRequest(
+          affirmation,
+          previousAssistantMessage: question,
+        ),
+        isTrue,
+      );
+      // With no prior turn the subject is simply unknown.
+      expect(isExplicitGoalReportUpdateRequest(affirmation), isFalse);
+    }
+
+    // An offer about the BANNER must not turn "yes" into a report rewrite.
+    expect(
+      isExplicitGoalReportUpdateRequest(
+        'yes please',
+        previousAssistantMessage:
+            "If you'd like a fresh banner right now, just say the word.",
+      ),
+      isFalse,
+    );
+    // Merely mentioning the report is not offering to change it.
+    expect(
+      isExplicitGoalReportUpdateRequest(
+        'yes',
+        previousAssistantMessage:
+            'Your report shows two walks logged this week.',
+      ),
+      isFalse,
+    );
+    // A non-affirmation with an offer standing still needs its own intent.
+    expect(
+      isExplicitGoalReportUpdateRequest(
+        'how did I do yesterday?',
+        previousAssistantMessage: offer,
+      ),
+      isFalse,
+    );
+  });
+
+  test('questions about the report are not requests to rewrite it', () {
+    for (final question in [
+      'how do I update the report?',
+      'what does the report say about steps?',
+      'why is the report so long?',
+      'when was the summary last updated?',
+      'which sections does the report have?',
+    ]) {
+      expect(
+        isExplicitGoalReportUpdateRequest(question),
+        isFalse,
+        reason: '"$question" asks about the report, it does not change it',
+      );
+    }
+
+    // Modal requests only LOOK like questions — they are instructions.
+    for (final request in [
+      'can you shorten the report?',
+      'could you restructure the summary?',
+      'would you split the report into sections?',
+    ]) {
+      expect(
+        isExplicitGoalReportUpdateRequest(request),
+        isTrue,
+        reason: '"$request" is a request, not a question',
+      );
+    }
+  });
+
+  test('an explicit refusal never forces a rewrite', () {
+    // The asymmetry that matters: forcing a rewrite over a refusal destroys
+    // the report the user asked to keep, while missing an implicit request
+    // only leaves them to ask again.
+    for (final decline in [
+      "I don't want you to change the report",
+      "please don't make the report shorter",
+      'leave the report as is',
+      'no need to rewrite the summary',
+      'do not touch the report',
+      "I'd rather not change the write-up",
+      'keep the report as is',
+    ]) {
+      expect(
+        isExplicitGoalReportUpdateRequest(decline),
+        isFalse,
+        reason: '"$decline" declines the rewrite',
+      );
+    }
+  });
+
   test('report update intent needs a report noun AND a change intent', () {
     // Positives: the wording the user actually reports with.
     expect(
@@ -4460,34 +4562,34 @@ void main() {
     );
     // Let a forced retry through if one fires — otherwise the fake caps
     // delegate calls at one and this test could not see the bug it guards.
-    conversationRepository.maxDelegateCalls = 3;
-    conversationRepository.sendMessageDelegate =
-        ({
-          required conversationId,
-          required message,
-          required model,
-          required provider,
-          required inferenceRepo,
-          tools,
-          toolChoice,
-          temperature = 0.7,
-          strategy,
-        }) async {
-          // ignore: avoid_print
-          expect(
-            message,
-            isNot(contains('USER EXPLICITLY ASKED FOR THE STANDING REPORT')),
-          );
-          await (strategy! as GoalAgentStrategy).processToolCalls(
-            toolCalls: [
-              toolCall(GoalAgentToolNames.replyToUser, {
-                'message': 'You are two walks in this week.',
-              }),
-            ],
-            manager: conversationManager,
-          );
-          return null;
-        };
+    conversationRepository
+      ..maxDelegateCalls = 3
+      ..sendMessageDelegate =
+          ({
+            required conversationId,
+            required message,
+            required model,
+            required provider,
+            required inferenceRepo,
+            tools,
+            toolChoice,
+            temperature = 0.7,
+            strategy,
+          }) async {
+            expect(
+              message,
+              isNot(contains('USER EXPLICITLY ASKED FOR THE STANDING REPORT')),
+            );
+            await (strategy! as GoalAgentStrategy).processToolCalls(
+              toolCalls: [
+                toolCall(GoalAgentToolNames.replyToUser, {
+                  'message': 'You are two walks in this week.',
+                }),
+              ],
+              manager: conversationManager,
+            );
+            return null;
+          };
 
     final result = await withClock(
       fixedClock,
@@ -4508,4 +4610,174 @@ void main() {
     );
     expect(upserts.whereType<AgentReportEntity>(), isEmpty);
   });
+
+  test(
+    'a bare "yes" after the agent offers a rewrite forces the report',
+    () async {
+      // The most common form of the original bug: the agent offers, the user
+      // says "yes", and only the previous turn names the subject.
+      stubSpec();
+      stubGlmResolution();
+      when(
+        () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+      ).thenAnswer(
+        (_) async => AgentDomainEntity.goalProgress(
+          id: goalProgressId(agentId, '2026-08-08'),
+          agentId: agentId,
+          periodKey: '2026-08-08',
+          trackStatus: GoalTrackStatus.insufficientData,
+          attainment: 0,
+          dataCoverage: 0,
+          satisfied: false,
+          specVersionId: '$agentId:spec-v1',
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: null,
+        ),
+      );
+      conversationRepository.maxDelegateCalls = 2;
+      var calls = 0;
+      String? forcedInstruction;
+      conversationRepository.sendMessageDelegate =
+          ({
+            required conversationId,
+            required message,
+            required model,
+            required provider,
+            required inferenceRepo,
+            tools,
+            toolChoice,
+            temperature = 0.7,
+            strategy,
+          }) async {
+            calls += 1;
+            if (calls == 1) {
+              expect(
+                message,
+                contains(
+                  'USER EXPLICITLY ASKED FOR THE STANDING REPORT TO '
+                  'CHANGE',
+                ),
+              );
+              await (strategy! as GoalAgentStrategy).processToolCalls(
+                toolCalls: [
+                  toolCall(GoalAgentToolNames.replyToUser, {
+                    'message': 'On it.',
+                  }),
+                ],
+                manager: conversationManager,
+              );
+              return null;
+            }
+            forcedInstruction = message;
+            await (strategy! as GoalAgentStrategy).processToolCalls(
+              toolCalls: [
+                toolCall(GoalAgentToolNames.updateGoalReport, {
+                  'status': 'insufficientData',
+                  'oneLiner': 'Split into three short sections.',
+                  'tldr': 'Rewritten as offered.',
+                }),
+              ],
+              manager: conversationManager,
+            );
+            return null;
+          };
+
+      final result = await withClock(
+        fixedClock,
+        () => workflow.execute(
+          agentIdentity: identity,
+          runKey: 'chat-run',
+          triggerTokens: const {},
+          threadId: 'chat',
+          pendingUserMessage: 'yes please',
+          previousAssistantMessage:
+              'I can rewrite the report into sections if you like.',
+        ),
+      );
+
+      expect(result.success, isTrue);
+      expect(result.reportUpdated, isTrue);
+      expect(calls, 2, reason: 'primary turn plus exactly one forced retry');
+      expect(forcedInstruction, contains('asked in chat'));
+      expect(
+        upserts.whereType<AgentReportEntity>().single.oneLiner,
+        'Split into three short sections.',
+      );
+    },
+  );
+
+  test(
+    'a bare "yes" with no standing offer does not force the report',
+    () async {
+      stubSpec();
+      stubGlmResolution();
+      when(
+        () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+      ).thenAnswer(
+        (_) async => AgentDomainEntity.goalProgress(
+          id: goalProgressId(agentId, '2026-08-08'),
+          agentId: agentId,
+          periodKey: '2026-08-08',
+          trackStatus: GoalTrackStatus.insufficientData,
+          attainment: 0,
+          dataCoverage: 0,
+          satisfied: false,
+          specVersionId: '$agentId:spec-v1',
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: null,
+        ),
+      );
+      conversationRepository
+        ..maxDelegateCalls = 3
+        ..sendMessageDelegate =
+            ({
+              required conversationId,
+              required message,
+              required model,
+              required provider,
+              required inferenceRepo,
+              tools,
+              toolChoice,
+              temperature = 0.7,
+              strategy,
+            }) async {
+              expect(
+                message,
+                isNot(
+                  contains('USER EXPLICITLY ASKED FOR THE STANDING REPORT'),
+                ),
+              );
+              await (strategy! as GoalAgentStrategy).processToolCalls(
+                toolCalls: [
+                  toolCall(GoalAgentToolNames.replyToUser, {
+                    'message': 'Happy to help — what would you like?',
+                  }),
+                ],
+                manager: conversationManager,
+              );
+              return null;
+            };
+
+      final result = await withClock(
+        fixedClock,
+        () => workflow.execute(
+          agentIdentity: identity,
+          runKey: 'chat-run',
+          triggerTokens: const {},
+          threadId: 'chat',
+          pendingUserMessage: 'yes please',
+        ),
+      );
+
+      expect(result.success, isTrue);
+      expect(
+        conversationRepository.sendMessageDelegateCallCount,
+        1,
+        reason: 'an affirmation with no offer names no subject',
+      );
+      expect(upserts.whereType<AgentReportEntity>(), isEmpty);
+    },
+  );
 }

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -307,6 +307,56 @@ void main() {
     },
   );
 
+  test('report update intent needs a report noun AND a change intent', () {
+    // Positives: the wording the user actually reports with.
+    expect(
+      isExplicitGoalReportUpdateRequest(
+        'make the report less of a wall of text',
+      ),
+      isTrue,
+    );
+    expect(
+      isExplicitGoalReportUpdateRequest('can you shorten the summary'),
+      isTrue,
+    );
+    expect(
+      isExplicitGoalReportUpdateRequest(
+        'restructure the report into sections',
+      ),
+      isTrue,
+    );
+    expect(
+      isExplicitGoalReportUpdateRequest('please break the report up a bit'),
+      isTrue,
+    );
+    expect(
+      isExplicitGoalReportUpdateRequest('rewrite the write-up more concise'),
+      isTrue,
+    );
+
+    // A question about the report is not a request to change it.
+    expect(
+      isExplicitGoalReportUpdateRequest('how is the report looking?'),
+      isFalse,
+    );
+    // An explicit decline must never force a rewrite.
+    expect(
+      isExplicitGoalReportUpdateRequest("don't change the report"),
+      isFalse,
+    );
+    expect(
+      isExplicitGoalReportUpdateRequest('do not rewrite the summary'),
+      isFalse,
+    );
+    // Change intent aimed at something that is not the report.
+    expect(
+      isExplicitGoalReportUpdateRequest('shorten the banner'),
+      isFalse,
+    );
+    expect(isExplicitGoalReportUpdateRequest(null), isFalse);
+    expect(isExplicitGoalReportUpdateRequest('   '), isFalse);
+  });
+
   setUp(() {
     repository = MockAgentRepository();
     syncService = MockAgentSyncService();
@@ -4281,5 +4331,181 @@ void main() {
       DateTime.utc(2026, 8, 6, 23, 59, 59),
       reason: 'UTC, so period order is timezone-independent across devices',
     );
+  });
+
+  test('a chat request to change the report forces one pinned '
+      'update_goal_report retry that names the chat rewrite', () async {
+    // The reported bug: the model answers in chat, promises a better report,
+    // and the stored report is never touched. Nothing but the detail page's
+    // refresh token used to force the tool call.
+    stubSpec();
+    stubGlmResolution();
+    // A chat wake re-bases previousStatus to the PRIOR DAY's row (only the
+    // detail-page refresh token reads today's), so the prior day is what has
+    // to match for `statusTransitioned` to be false — otherwise a missing
+    // baseline forces the report on its own and this test proves nothing.
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-08'),
+        agentId: agentId,
+        periodKey: '2026-08-08',
+        trackStatus: GoalTrackStatus.insufficientData,
+        attainment: 0,
+        dataCoverage: 0,
+        satisfied: false,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: now,
+        updatedAt: now,
+        vectorClock: null,
+      ),
+    );
+    conversationRepository.maxDelegateCalls = 2;
+    var calls = 0;
+    String? forcedInstruction;
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          calls += 1;
+          if (calls == 1) {
+            // The FACTS block spells the requirement out to the model.
+            expect(
+              message,
+              contains(
+                'USER EXPLICITLY ASKED FOR THE STANDING REPORT TO '
+                'CHANGE',
+              ),
+            );
+            // The model replies and forgets the tool — the whole bug.
+            await (strategy! as GoalAgentStrategy).processToolCalls(
+              toolCalls: [
+                toolCall(GoalAgentToolNames.replyToUser, {
+                  'message': "Sure — I'll tighten it up.",
+                }),
+              ],
+              manager: conversationManager,
+            );
+            return null;
+          }
+          forcedInstruction = message;
+          expect(
+            [for (final tool in tools!) tool.function.name],
+            [GoalAgentToolNames.updateGoalReport],
+          );
+          expect(toolChoice, isNotNull);
+          await (strategy! as GoalAgentStrategy).processToolCalls(
+            toolCalls: [
+              toolCall(GoalAgentToolNames.updateGoalReport, {
+                'status': 'insufficientData',
+                'oneLiner': 'Three short sections instead of one block.',
+                'tldr': 'Rewritten shorter, as asked.',
+              }),
+            ],
+            manager: conversationManager,
+          );
+          return null;
+        };
+
+    final result = await withClock(
+      fixedClock,
+      () => workflow.execute(
+        agentIdentity: identity,
+        runKey: 'chat-run',
+        triggerTokens: const {},
+        threadId: 'chat',
+        pendingUserMessage: 'Please make the report less of a wall of text.',
+      ),
+    );
+
+    expect(result.success, isTrue);
+    expect(result.reportUpdated, isTrue);
+    expect(calls, 2, reason: 'primary turn plus exactly one forced retry');
+    // The retry must name the real reason: the old bool made a chat rewrite
+    // claim the user had edited a habit day.
+    expect(forcedInstruction, contains('asked in chat'));
+    expect(forcedInstruction, isNot(contains('editing a habit day')));
+    final report = upserts.whereType<AgentReportEntity>().single;
+    expect(report.oneLiner, 'Three short sections instead of one block.');
+  });
+
+  test('an ordinary chat question does not force a report', () async {
+    stubSpec();
+    stubGlmResolution();
+    when(
+      () => repository.getEntity(goalProgressId(agentId, '2026-08-08')),
+    ).thenAnswer(
+      (_) async => AgentDomainEntity.goalProgress(
+        id: goalProgressId(agentId, '2026-08-08'),
+        agentId: agentId,
+        periodKey: '2026-08-08',
+        trackStatus: GoalTrackStatus.insufficientData,
+        attainment: 0,
+        dataCoverage: 0,
+        satisfied: false,
+        specVersionId: '$agentId:spec-v1',
+        createdAt: now,
+        updatedAt: now,
+        vectorClock: null,
+      ),
+    );
+    // Let a forced retry through if one fires — otherwise the fake caps
+    // delegate calls at one and this test could not see the bug it guards.
+    conversationRepository.maxDelegateCalls = 3;
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          // ignore: avoid_print
+          expect(
+            message,
+            isNot(contains('USER EXPLICITLY ASKED FOR THE STANDING REPORT')),
+          );
+          await (strategy! as GoalAgentStrategy).processToolCalls(
+            toolCalls: [
+              toolCall(GoalAgentToolNames.replyToUser, {
+                'message': 'You are two walks in this week.',
+              }),
+            ],
+            manager: conversationManager,
+          );
+          return null;
+        };
+
+    final result = await withClock(
+      fixedClock,
+      () => workflow.execute(
+        agentIdentity: identity,
+        runKey: 'chat-run',
+        triggerTokens: const {},
+        threadId: 'chat',
+        pendingUserMessage: 'How is the report looking?',
+      ),
+    );
+
+    expect(result.success, isTrue);
+    expect(
+      conversationRepository.sendMessageDelegateCallCount,
+      1,
+      reason: 'a question must not force a standing-report rewrite',
+    );
+    expect(upserts.whereType<AgentReportEntity>(), isEmpty);
   });
 }


### PR DESCRIPTION
Asking the goal agent in chat to change its report — "make it less of a wall of text" — only ever produced a chat reply. The agent would agree, describe the better structure, and the standing report stayed exactly as it was.

### Why

A chat message already runs a full wake (`GoalChatService.retryMessage` → manual wake, `WakeReason.userMessage`), and the workflow already exposes `update_goal_report`. Nothing connected a chat request to it:

- `reportRefresh` is set only by a trigger token the detail page attaches to its own refresh action.
- The forced-report retry fires only on `facts.statusTransitioned || reportRefresh`.
- So a chat rewrite request hits neither gate, and `reply_to_user` is the only tool the turn needs.

Banners never had this problem because they carry both halves: an explicit-request heuristic (`isExplicitGoalAdReplacementRequest`) and a pinned `_forceAd` retry. Reports had neither.

### The change

1. `isExplicitGoalReportUpdateRequest` — requires a report noun (`report`, `summary`, `write-up`) **and** a change intent (`rewrite`, `restructure`, `shorten`, `concise`, `sections`, `bullets`, `wall of text`, …), and returns false for declines like "don't change the report". Same shape as the banner heuristic, including its limitation: it is an English fast path, and the language-independent carrier stays the model calling the tool itself.
2. `userRequestedReport` is derived in `execute` and kept deliberately **separate** from `reportRefresh`. That token also persists the derivation and re-bases `previousStatus`; a rewrite of the standing text must do neither.
3. The FACTS block gains an explicit instruction when the flag is set, mirroring the banner instruction.
4. The forced-report gate becomes `statusTransitioned || reportRefresh || userRequestedReport`, and `_forceReport` takes an `instruction` string instead of a bool — the old bool made a chat rewrite tell the model the user had "edited a habit day", which was simply false.

### The prompt ceiling, lifted on purpose

The rule's natural home is the system prompt, which sat at a 3.2k hard cap asserted in two places. That cap is a **discipline, not a model limit**: it exists so prompt growth is argued rather than accreted, after task-agent evals showed that long prompts get skimmed and because every number the model needs arrives in the per-wake FACTS block instead.

This rule is worth the argument. The FACTS block can only carry an instruction to the turns whose English heuristic fires, so a rule that has to hold in **every language and every turn** belongs in the prompt. The ceiling moves to 3.6k in both assertion sites, with the reasoning recorded at each; the prompt lands at 3391 chars, so the ceiling stays a real constraint rather than a formality. The live eval harness (`goal_agent_eval_live_test.dart`, opt-in against a real provider) remains the empirical check on whether prompt growth costs adherence.

Build number bumped to `1.0.10+4318`. Tests are in flight and will be pushed onto this branch.
