### PR TITLE
fix: stop recurring empty project-agent wakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across app restarts, and durable snooze and dismissal timing history gives
   the goal agent evidence for choosing better initial display times.
 
+### Fixed
+- **Project agents no longer keep an empty daily 06:00 wake alive.** Their
+  digest wake is now scheduled only after relevant project or linked-task
+  activity, while direct edits and manual refreshes still wake them promptly.
+  Existing dormant schedules are removed from the Wake tab on startup.
+
 ## [1.0.9]
 ### Added
 - **An explicit goal-name field in the goal editor.** The goal's name is a

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -44,6 +44,7 @@
       <description>
         <p>Changed: goal-agent banners now make Snooze the primary action, with 1, 3, 6, and 8 hour choices. Dismiss for today is a secondary option, banners return automatically after the chosen deadline or on the next local day even after an app restart, and durable snooze and dismissal timing history gives the goal agent evidence for choosing better initial display times.</p>
         <p>Changed: goal agent pages get the whole screen on phones. The bottom navigation bar slides away on a goal's detail page, its chat, and the create and edit wizards, the way it already does for project details, so the day sheet's record button and the wizard's Continue band dock at the bottom edge instead of sitting under the bar.</p>
+        <p>Fixed: project agents no longer keep an empty daily 06:00 wake alive. Digest work is scheduled only after relevant project or linked-task activity, and existing dormant schedules disappear from the Wake tab on startup.</p>
       </description>
     </release>
     <release version="1.0.9" date="2026-08-13">

--- a/knowledge/features/agents/project-and-event-agents.md
+++ b/knowledge/features/agents/project-and-event-agents.md
@@ -19,7 +19,7 @@ sources:
   - id: project-service
     resource: ../../../lib/features/agents/service/project_agent_service.dart
     title: ProjectAgentService (creation and announcement)
-    last_modified: 2026-07-26
+    last_modified: 2026-08-14
   - id: event-service
     resource: ../../../lib/features/agents/service/event_agent_service.dart
     title: EventAgentService (creation, content gate and announcement)
@@ -42,13 +42,12 @@ expensive and useless.
 2. Validates the template is a project-agent template.
 3. Creates identity and state.
 4. Sets `slots.activeProjectId`.
-5. Schedules the first digest for **tomorrow's local 06:00** —
-   `nextLocalDayAtTime` always rolls forward a full day, even if today's 06:00
-   has not yet passed.
+5. Leaves `scheduledWakeAt` unset: a project agent is dormant unless work is
+   observed.
 6. Creates `agent_project` and `template_assignment` links.
 7. Announces itself (see below).
-8. Registers a **direct project-edit** subscription.
-9. Enqueues a creation wake.
+8. Registers the project subscription.
+9. Enqueues the explicit creation wake.
 
 ## Announcing a newly created agent
 
@@ -81,31 +80,41 @@ id through it. Task agents solve the same problem one layer up, by calling
 
 ```mermaid
 stateDiagram-v2
-  [*] --> Scheduled: project agent created
-  Scheduled --> WakingNow: creation wake
-  Scheduled --> WakingNow: manual reanalysis
-  Scheduled --> WakingNow: direct project edit
-  Scheduled --> PendingActivity: linked task or project activity
-  PendingActivity --> WakingNow: scheduled digest becomes due
-  Scheduled --> SkipAndReschedule: scheduled digest due with no pending activity
-  SkipAndReschedule --> Scheduled
-  WakingNow --> Scheduled: state updated after wake
+  [*] --> Dormant: project agent created
+  Dormant --> WakingNow: creation wake or manual reanalysis
+  Dormant --> ShortDelay: direct project edit
+  Dormant --> MorningDigest: linked task or propagated project activity
+  ShortDelay --> WakingNow: coalescing deadline reached
+  MorningDigest --> WakingNow: next local 06:00 reached
+  WakingNow --> Dormant: no newer activity
+  WakingNow --> MorningDigest: newer activity queued during wake
+  LegacyDailySchedule --> Dormant: cleanup with no activity
+  LegacyDailySchedule --> WakingNow: pending activity still exists
 ```
 
-- **Linked-task churn** never wakes the agent directly. `ProjectActivityMonitor`
-  listens to `localUpdateStream`, resolves affected project ids, and sets
-  `slots.pendingProjectActivityAt` on the project agent state. The digest picks
-  it up later.
-- **Direct project edits** are different: the service registers a direct project
-  notification token, so an explicit edit to the project entity wakes the agent
-  immediately through the orchestrator.
+- **Linked-task churn** does not wake the agent immediately.
+  `ProjectActivityMonitor` listens to `localUpdateStream`, resolves affected
+  project ids, and sets `slots.pendingProjectActivityAt`. The project
+  subscription persists `nextWakeAt` for the next local 06:00 and reconstructs
+  that queued wake after a restart.
+- **Direct project edits** use the same subscription but take the short
+  coalescing path, so an explicit project edit does not wait until morning.
+- **Explicit requests** (`creation` and manual `reanalysis`) bypass the
+  subscription throttle and enqueue immediately.
 
-## The cheap skip
+## Dormant-by-default scheduling
 
-If a scheduled digest is due, a report already exists, and
-`pendingProjectActivityAt` is still `null`, the workflow rolls `scheduledWakeAt`
-forward and **skips the model call entirely**. That is the mechanism keeping
-project agents digest-shaped rather than reactive.
+Project agents do not own a recurring `scheduledWakeAt`. Meaningful local
+activity creates the event-driven `nextWakeAt`; after a successful wake the
+orchestrator clears it when no follow-up remains. Consequently the Wake tab
+contains a project-agent row only while actual queued work exists.
+
+Older installations can still contain the former daily schedule. Startup
+restoration clears it immediately when `pendingProjectActivityAt` is null, and
+`ScheduledWakeManager` applies the same cleanup if an overdue row wins the
+startup race. If pending activity exists, the legacy row may fire once as a
+migration safety net; every successful workflow run clears `scheduledWakeAt`
+instead of rolling it forward.
 
 During the final state transition, `pendingProjectActivityAt` is cleared **only
 when no newer activity arrived during the wake**. If fresh activity lands
@@ -115,11 +124,13 @@ summary is stale again.
 ## Wake flow
 
 `ProjectAgentWorkflow.execute()` loads state and resolves `activeProjectId`,
-checks whether a due scheduled wake can be skipped cheaply, loads the project
+retires a dormant legacy scheduled wake before inference, loads the project
 entity and prior observations, resolves template/version and inference profile,
 builds linked-task context **including task-agent reports**, runs the
 conversation with `ProjectAgentStrategy`, and persists token usage, final
 thought, report, observations, deferred change set and updated state.
+Successful persistence clears the legacy `scheduledWakeAt` and clears
+`pendingProjectActivityAt` only when no newer activity arrived during the wake.
 
 Project reports follow the same inline task-link contract as task reports: when
 linked-task context includes a task id, the report may point at `/tasks/<taskId>`

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -11,7 +11,7 @@ sources:
   - id: wake
     resource: ../../../lib/features/agents/wake
     title: WakeOrchestrator, WakeQueue, WakeRunner, drain engine
-    last_modified: 2026-08-10
+    last_modified: 2026-08-14
   - id: enums
     resource: ../../../lib/features/agents/model/agent_enums.dart
     title: WakeReason
@@ -130,6 +130,13 @@ A subscription can opt into daily-digest deferral for propagated-only matches.
 Project-agent subscriptions use that path, so linked-task churn waits for the
 scheduled project digest; task-agent subscriptions opt out, so child-entry and
 task-context updates refresh on the normal coalesced path.
+
+That deferred subscription job is the project agent's only normal clock-based
+wake. Project agents start with no `scheduledWakeAt`; local project activity
+creates `nextWakeAt` only while a queued job exists, direct project edits use
+the shorter coalescing deadline, and manual requests bypass throttling. The
+scheduled-wake manager only recognizes state-level project schedules as legacy:
+it clears dormant ones instead of rolling them to another day.
 
 A subscription can instead opt **out of the window entirely** with
 `AgentSubscription.drainImmediately`: matches enqueue and dispatch once the

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -25,9 +25,9 @@ applied until the user confirms it.
   marked out of date and an *Update now* button appears.
 - **Withdraws its own stale suggestions.** When a proposal no longer makes sense,
   the agent retracts it rather than leaving it in the list.
-- **Summarizes at other scopes too.** A project agent writes a daily digest
-  across a project's tasks; an event agent writes a recap of a trip or gathering
-  from its photos and notes; the Daily OS planner plans a day.
+- **Summarizes at other scopes too.** A project agent refreshes its digest after
+  relevant project or linked-task activity; an event agent writes a recap of a
+  trip or gathering from its photos and notes; the Daily OS planner plans a day.
 - **Learns from feedback.** Agents periodically hold a "one-on-one" — a
   conversation where the user's accumulated feedback is reviewed and the agent's
   own instructions are revised, with every change approved by the user first.

--- a/lib/features/agents/service/project_activity_monitor.dart
+++ b/lib/features/agents/service/project_activity_monitor.dart
@@ -12,11 +12,11 @@ import 'package:lotti/services/domain_logging.dart';
 
 /// Tracks local project-linked activity and marks project summaries stale.
 ///
-/// Project agents do not wake immediately on task/project notifications
-/// anymore. Instead, this monitor listens to the local update stream, resolves
-/// whether an affected project has a provisioned project agent, and persists a
-/// pending activity marker on the agent state. The scheduled 06:00 wake later
-/// decides whether to spend tokens on a fresh report.
+/// Linked-task activity does not wake project agents immediately. This monitor
+/// listens to the local update stream, resolves whether an affected project has
+/// a provisioned agent, and persists a pending activity marker. In parallel,
+/// the project subscription queues that work for the next local 06:00; direct
+/// project edits take the subscription's short coalescing path instead.
 class ProjectActivityMonitor with AgentErrorLogging {
   ProjectActivityMonitor({
     required this._notifications,

--- a/lib/features/agents/service/project_agent_service.dart
+++ b/lib/features/agents/service/project_agent_service.dart
@@ -8,7 +8,6 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart'
     show AgentLifecycle, AgentTemplateKind, WakeReason;
 import 'package:lotti/features/agents/model/agent_link.dart';
-import 'package:lotti/features/agents/model/agent_time_utils.dart';
 import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
@@ -108,10 +107,6 @@ class ProjectAgentService {
       final now = clock.now();
       final updatedState = state.copyWith(
         slots: state.slots.copyWith(activeProjectId: projectId),
-        scheduledWakeAt: nextLocalDayAtTime(
-          now,
-          hour: AgentSchedules.projectDailyDigestHour,
-        ),
         updatedAt: now,
       );
       await syncService.upsertEntity(updatedState);
@@ -253,7 +248,9 @@ class ProjectAgentService {
     for (final agent in projectAgents) {
       try {
         final links = linksByAgentId[agent.agentId] ?? const <AgentLink>[];
-        final state = statesByAgentId[agent.agentId];
+        final state = await _retireDormantDailySchedule(
+          statesByAgentId[agent.agentId],
+        );
         _hydrateThrottleDeadlineFromState(agent.agentId, state);
         for (final link in links) {
           _registerProjectSubscription(agent.agentId, link.toId);
@@ -296,6 +293,37 @@ class ProjectAgentService {
         matchEntityIds: {projectEntityUpdateNotification(projectId)},
       ),
     );
+  }
+
+  /// Removes the legacy always-on daily digest from an idle project agent.
+  ///
+  /// Project updates already persist an event-driven subscription wake in
+  /// `nextWakeAt`. Retaining a separate `scheduledWakeAt` when there is no
+  /// pending project activity only keeps a meaningless 06:00 row alive in the
+  /// Wake tab. A schedule that still has pending activity is left intact as a
+  /// one-time migration safety net and is retired by the next successful wake.
+  Future<AgentStateEntity?> _retireDormantDailySchedule(
+    AgentStateEntity? state,
+  ) async {
+    if (state == null ||
+        state.scheduledWakeAt == null ||
+        state.slots.pendingProjectActivityAt != null) {
+      return state;
+    }
+
+    final updatedState = state.copyWith(
+      scheduledWakeAt: null,
+      updatedAt: clock.now(),
+    );
+    await syncService.upsertEntity(updatedState);
+    onPersistedStateChanged?.call(state.agentId);
+    domainLogger?.log(
+      LogDomain.agentRuntime,
+      'retired dormant daily schedule for '
+      '${DomainLogger.sanitizeId(state.agentId)}',
+      subDomain: 'restore',
+    );
+    return updatedState;
   }
 
   void _hydrateThrottleDeadlineFromState(

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -382,8 +382,8 @@ ScheduledWakeManager scheduledWakeManager(Ref ref) {
   return manager;
 }
 
-/// Tracks local project/task changes and marks project reports stale without
-/// waking the project agent immediately.
+/// Tracks local project/task changes and marks project reports stale while the
+/// project subscription chooses the appropriate short or morning wake delay.
 final projectActivityMonitorProvider = Provider<ProjectActivityMonitor>(
   projectActivityMonitor,
   name: 'projectActivityMonitorProvider',

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -21,12 +21,12 @@ class _HandledCheckSequence {
 }
 
 /// Manages scheduled wakes for agents that need to wake on a time-based
-/// schedule (e.g., daily project digests, weekly one-on-one rituals).
+/// schedule (e.g., weekly one-on-one rituals).
 ///
 /// On startup and then hourly, queries for agents with overdue
-/// `scheduledWakeAt`. Dormant project agents (no pending activity since
-/// last report) are fast-forwarded to the next future time slot without
-/// executing, avoiding unnecessary LLM calls after prolonged app absence.
+/// `scheduledWakeAt`. Legacy project schedules with no pending activity are
+/// retired instead of advanced, because project work is now scheduled by
+/// update-driven subscription wakes.
 /// Non-project agents (e.g., improver agents) are always enqueued.
 class ScheduledWakeManager with AgentErrorLogging {
   ScheduledWakeManager({
@@ -237,7 +237,7 @@ class ScheduledWakeManager with AgentErrorLogging {
       if (generation != _generation) return;
 
       var enqueued = 0;
-      var fastForwarded = 0;
+      var retired = 0;
       var skippedArchived = 0;
 
       for (final state in dueStates) {
@@ -264,9 +264,9 @@ class ScheduledWakeManager with AgentErrorLogging {
             continue;
           }
 
-          if (_canFastForward(state)) {
-            await _fastForwardSchedule(state, now);
-            fastForwarded++;
+          if (_shouldRetireDormantProjectSchedule(state)) {
+            await _retireDormantProjectSchedule(state, now);
+            retired++;
             continue;
           }
 
@@ -293,7 +293,7 @@ class ScheduledWakeManager with AgentErrorLogging {
       if (dueStates.isNotEmpty || recordsEnqueued > 0) {
         _log(
           'processed ${dueStates.length} due agents: '
-          '$enqueued enqueued, $fastForwarded fast-forwarded, '
+          '$enqueued enqueued, $retired dormant schedules retired, '
           '$skippedArchived archived skipped; '
           '$recordsEnqueued scheduled-wake record(s) fired',
         );
@@ -570,53 +570,31 @@ class ScheduledWakeManager with AgentErrorLogging {
     );
   }
 
-  /// Whether this agent can be fast-forwarded instead of fully woken.
-  /// Only applies to project agents (identified by `activeProjectId`)
-  /// that have been woken before and have no pending activity.
-  bool _canFastForward(AgentStateEntity state) {
+  /// Whether this legacy project schedule should be retired without a wake.
+  bool _shouldRetireDormantProjectSchedule(AgentStateEntity state) {
     final isProjectAgent = state.slots.activeProjectId != null;
     if (!isProjectAgent) return false;
 
     final hasPendingActivity = state.slots.pendingProjectActivityAt != null;
-    return !hasPendingActivity && state.lastWakeAt != null;
+    return !hasPendingActivity;
   }
 
-  /// Advance `scheduledWakeAt` to the next future time slot without
-  /// executing a full wake cycle. Used for dormant project agents with
-  /// no pending activity — avoids unnecessary LLM calls.
-  Future<void> _fastForwardSchedule(
+  /// Clear an obsolete project `scheduledWakeAt` without executing a wake.
+  Future<void> _retireDormantProjectSchedule(
     AgentStateEntity state,
     DateTime now,
   ) async {
-    final scheduled = state.scheduledWakeAt!;
-    var nextWake = DateTime(
-      now.year,
-      now.month,
-      now.day,
-      scheduled.hour,
-      scheduled.minute,
-    );
-    if (!nextWake.isAfter(now)) {
-      nextWake = DateTime(
-        now.year,
-        now.month,
-        now.day + 1,
-        scheduled.hour,
-        scheduled.minute,
-      );
-    }
-
     await _syncService.upsertEntity(
       state.copyWith(
-        scheduledWakeAt: nextWake,
+        scheduledWakeAt: null,
         updatedAt: now,
       ),
     );
     onPersistedStateChanged?.call(state.agentId);
 
     _log(
-      'fast-forwarded ${DomainLogger.sanitizeId(state.agentId)} '
-      'to $nextWake (no pending activity)',
+      'retired dormant project schedule for '
+      '${DomainLogger.sanitizeId(state.agentId)}',
     );
   }
 

--- a/lib/features/agents/workflow/project_agent_execute.dart
+++ b/lib/features/agents/workflow/project_agent_execute.dart
@@ -74,7 +74,6 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
 
     final scheduledWakeWasDue =
         state.scheduledWakeAt != null && !state.scheduledWakeAt!.isAfter(now);
-    final shouldInitializeSchedule = state.scheduledWakeAt == null;
 
     // 2a. Capture this wake's project-linked journal entries into the log
     // (ADR 0020) — same substrate and renderer as the task agent (only
@@ -463,13 +462,6 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
         }
 
         // Update state.
-        final nextScheduledWakeAt =
-            scheduledWakeWasDue || shouldInitializeSchedule
-            ? nextLocalDayAtTime(
-                now,
-                hour: AgentSchedules.projectDailyDigestHour,
-              )
-            : latestState.scheduledWakeAt;
         final latestPendingActivityAt =
             latestState.slots.pendingProjectActivityAt;
         final nextPendingActivityAt =
@@ -487,7 +479,9 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
               pendingProjectActivityAt: nextPendingActivityAt,
             ),
             lastWakeAt: now,
-            scheduledWakeAt: nextScheduledWakeAt,
+            // Project work is scheduled by update-driven subscription wakes.
+            // Any state-level daily schedule is legacy and must not recur.
+            scheduledWakeAt: null,
             updatedAt: now,
             consecutiveFailureCount: 0,
             wakeCounter: latestState.wakeCounter.increment(hostId),

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -5,7 +5,6 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/agents/model/agent_time_utils.dart';
 import 'package:lotti/features/agents/model/project_agent_report_contract.dart';
 import 'package:lotti/features/agents/service/agent_log_llm_summarizer.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
@@ -135,10 +134,7 @@ class ProjectAgentWorkflow with AgentErrorLogging {
       await syncService.upsertEntity(
         state.copyWith(
           lastWakeAt: now,
-          scheduledWakeAt: nextLocalDayAtTime(
-            now,
-            hour: AgentSchedules.projectDailyDigestHour,
-          ),
+          scheduledWakeAt: null,
           updatedAt: now,
           consecutiveFailureCount: 0,
           wakeCounter: state.wakeCounter.increment(hostId),
@@ -157,7 +153,7 @@ class ProjectAgentWorkflow with AgentErrorLogging {
     onPersistedStateChanged?.call(state.agentId);
 
     _log(
-      'scheduled wake skipped: no pending project activity',
+      'retired legacy scheduled wake: no pending project activity',
       subDomain: 'execute',
     );
   }

--- a/test/features/agents/service/project_agent_service_test.dart
+++ b/test/features/agents/service/project_agent_service_test.dart
@@ -389,7 +389,7 @@ void main() {
         );
         expect(
           updatedState.scheduledWakeAt,
-          DateTime(2026, 3, 21, 6),
+          isNull,
           reason: '$scenario',
         );
 
@@ -528,7 +528,7 @@ void main() {
       });
 
       test(
-        'initializes the next daily digest at 06:00 on the next day',
+        'starts stale without a recurring daily digest schedule',
         () async {
           final identity = makeIdentity();
           final template = makeTestTemplate(
@@ -577,7 +577,7 @@ void main() {
             () => mockSyncService.upsertEntity(captureAny()),
           ).captured;
           final updatedState = stateCalls.first as AgentStateEntity;
-          expect(updatedState.scheduledWakeAt, DateTime(2026, 3, 21, 6));
+          expect(updatedState.scheduledWakeAt, isNull);
         },
       );
 
@@ -1034,6 +1034,116 @@ void main() {
                   as List<String>;
           expect(requestedAgentIds, ['pa-1']);
           verifyNever(() => mockRepository.getAgentState('pa-1'));
+        },
+      );
+
+      test(
+        'clears a legacy daily schedule when no project activity is pending',
+        () async {
+          final projectAgent = makeIdentity(agentId: 'pa-dormant');
+          final link = AgentLink.agentProject(
+            id: 'link-dormant',
+            fromId: 'pa-dormant',
+            toId: 'project-dormant',
+            createdAt: kAgentTestDate,
+            updatedAt: kAgentTestDate,
+            vectorClock: null,
+          );
+          final legacySchedule = DateTime(2026, 3, 23, 6);
+          final state = makeState(
+            id: 'state-pa-dormant',
+            agentId: 'pa-dormant',
+            activeProjectId: 'project-dormant',
+          ).copyWith(scheduledWakeAt: legacySchedule);
+
+          when(
+            () => mockAgentService.listAgents(
+              lifecycle: AgentLifecycle.active,
+            ),
+          ).thenAnswer((_) async => [projectAgent]);
+          when(
+            () => mockRepository.getAgentStatesByAgentIds(['pa-dormant']),
+          ).thenAnswer((_) async => {'pa-dormant': state});
+          when(
+            () => mockRepository.getLinksFromMultiple(
+              ['pa-dormant'],
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'pa-dormant': [link],
+            },
+          );
+
+          await withClock(Clock.fixed(DateTime(2026, 3, 22, 10)), () {
+            return service.restoreSubscriptions();
+          });
+
+          final repaired =
+              verify(
+                    () => mockSyncService.upsertEntity(captureAny()),
+                  ).captured.single
+                  as AgentStateEntity;
+          expect(repaired.scheduledWakeAt, isNull);
+          expect(repaired.slots.pendingProjectActivityAt, isNull);
+          expect(repaired.updatedAt, DateTime(2026, 3, 22, 10));
+          expect(notifiedAgentIds, ['pa-dormant']);
+          verifyNever(
+            () => mockOrchestrator.restorePendingWake(
+              agentId: any(named: 'agentId'),
+              dueAt: any(named: 'dueAt'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'retains a legacy schedule while project activity is pending',
+        () async {
+          final projectAgent = makeIdentity(agentId: 'pa-active');
+          final link = AgentLink.agentProject(
+            id: 'link-active',
+            fromId: 'pa-active',
+            toId: 'project-active',
+            createdAt: kAgentTestDate,
+            updatedAt: kAgentTestDate,
+            vectorClock: null,
+          );
+          final pendingAt = DateTime(2026, 3, 22, 9);
+          final state =
+              makeState(
+                id: 'state-pa-active',
+                agentId: 'pa-active',
+                activeProjectId: 'project-active',
+              ).copyWith(
+                slots: AgentSlots(
+                  activeProjectId: 'project-active',
+                  pendingProjectActivityAt: pendingAt,
+                ),
+                scheduledWakeAt: DateTime(2026, 3, 23, 6),
+              );
+
+          when(
+            () => mockAgentService.listAgents(lifecycle: AgentLifecycle.active),
+          ).thenAnswer((_) async => [projectAgent]);
+          when(
+            () => mockRepository.getAgentStatesByAgentIds(['pa-active']),
+          ).thenAnswer((_) async => {'pa-active': state});
+          when(
+            () => mockRepository.getLinksFromMultiple(
+              ['pa-active'],
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer(
+            (_) async => {
+              'pa-active': [link],
+            },
+          );
+
+          await service.restoreSubscriptions();
+
+          verifyNever(() => mockSyncService.upsertEntity(any()));
+          verify(() => mockOrchestrator.addSubscription(any())).called(1);
         },
       );
 

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -33,8 +33,8 @@ enum _GeneratedScheduledWakeTimeSlot {
 
 enum _GeneratedScheduledWakeFailureSlot {
   none,
-  firstFastForward,
-  everyFastForward,
+  firstRetirement,
+  everyRetirement,
 }
 
 enum _GeneratedScheduledWakeManagerOperationKind { start, stop, tick }
@@ -50,10 +50,11 @@ class _GeneratedScheduledWakeSpec {
   final _GeneratedScheduledWakeStateKind kind;
   final _GeneratedScheduledWakeTimeSlot timeSlot;
 
-  bool get expectsFastForward =>
+  bool get expectsRetirement =>
+      kind == _GeneratedScheduledWakeStateKind.projectNeverWoken ||
       kind == _GeneratedScheduledWakeStateKind.projectDormant;
 
-  bool get expectsEnqueue => !expectsFastForward;
+  bool get expectsEnqueue => !expectsRetirement;
 
   DateTime get scheduledWakeAt {
     final (hour, minute) = switch (timeSlot) {
@@ -64,27 +65,6 @@ class _GeneratedScheduledWakeSpec {
       _GeneratedScheduledWakeTimeSlot.endOfDay => (23, 55),
     };
     return DateTime(2026, 5, 17, hour, minute);
-  }
-
-  DateTime expectedFastForwardWakeAt(DateTime now) {
-    final scheduled = scheduledWakeAt;
-    var nextWake = DateTime(
-      now.year,
-      now.month,
-      now.day,
-      scheduled.hour,
-      scheduled.minute,
-    );
-    if (!nextWake.isAfter(now)) {
-      nextWake = DateTime(
-        now.year,
-        now.month,
-        now.day + 1,
-        scheduled.hour,
-        scheduled.minute,
-      );
-    }
-    return nextWake;
   }
 
   AgentStateEntity toState(int index) {
@@ -138,17 +118,17 @@ class _GeneratedScheduledWakeBatchScenario {
   final List<_GeneratedScheduledWakeSpec> specs;
   final _GeneratedScheduledWakeFailureSlot failureSlot;
 
-  Set<String> failingFastForwardAgentIds(List<AgentStateEntity> states) {
-    final fastForwardIds = <String>[
+  Set<String> failingRetirementAgentIds(List<AgentStateEntity> states) {
+    final retirementIds = <String>[
       for (var i = 0; i < specs.length; i++)
-        if (specs[i].expectsFastForward) states[i].agentId,
+        if (specs[i].expectsRetirement) states[i].agentId,
     ];
     return switch (failureSlot) {
       _GeneratedScheduledWakeFailureSlot.none => const <String>{},
-      _GeneratedScheduledWakeFailureSlot.firstFastForward =>
-        fastForwardIds.isEmpty ? const <String>{} : {fastForwardIds.first},
-      _GeneratedScheduledWakeFailureSlot.everyFastForward =>
-        fastForwardIds.toSet(),
+      _GeneratedScheduledWakeFailureSlot.firstRetirement =>
+        retirementIds.isEmpty ? const <String>{} : {retirementIds.first},
+      _GeneratedScheduledWakeFailureSlot.everyRetirement =>
+        retirementIds.toSet(),
     };
   }
 
@@ -344,7 +324,7 @@ void main() {
       glados.any.scheduledWakeBatchScenario,
       glados.ExploreConfig(numRuns: 180),
     ).test(
-      'matches generated due-batch enqueue and fast-forward semantics',
+      'matches generated due-batch enqueue and retirement semantics',
       (
         scenario,
       ) {
@@ -352,13 +332,13 @@ void main() {
           for (final (index, spec) in scenario.specs.indexed)
             spec.toState(index),
         ];
-        final failingFastForwardIds = scenario.failingFastForwardAgentIds(
+        final failingRetirementIds = scenario.failingRetirementAgentIds(
           states,
         );
         final generatedRepository = MockAgentRepository();
         final generatedOrchestrator = MockWakeOrchestrator();
         final generatedSyncService = MockAgentSyncService();
-        final attemptedFastForwardWrites = <AgentStateEntity>[];
+        final attemptedRetirementWrites = <AgentStateEntity>[];
         final notifiedAgentIds = <String>[];
 
         fakeAsync((async) {
@@ -370,7 +350,7 @@ void main() {
               () => generatedRepository.getDueScheduledWakeRecords(any()),
             ).thenAnswer((_) async => []);
             // Every generated agent is live, so the lifecycle guard passes and
-            // the enqueue/fast-forward model is exercised unchanged.
+            // the enqueue/retirement model is exercised unchanged.
             when(
               () => generatedRepository.getEntity(any()),
             ).thenAnswer((_) async => makeTestIdentity());
@@ -379,8 +359,8 @@ void main() {
             ) async {
               final entity =
                   invocation.positionalArguments.single as AgentStateEntity;
-              attemptedFastForwardWrites.add(entity);
-              if (failingFastForwardIds.contains(entity.agentId)) {
+              attemptedRetirementWrites.add(entity);
+              if (failingRetirementIds.contains(entity.agentId)) {
                 throw StateError('generated sync failure');
               }
             });
@@ -398,12 +378,12 @@ void main() {
               for (var i = 0; i < scenario.specs.length; i++)
                 if (scenario.specs[i].expectsEnqueue) states[i].agentId,
             ];
-            final expectedFastForwardIds = <String>[
+            final expectedRetirementIds = <String>[
               for (var i = 0; i < scenario.specs.length; i++)
-                if (scenario.specs[i].expectsFastForward) states[i].agentId,
+                if (scenario.specs[i].expectsRetirement) states[i].agentId,
             ];
-            final expectedNotifiedIds = expectedFastForwardIds
-                .where((agentId) => !failingFastForwardIds.contains(agentId))
+            final expectedNotifiedIds = expectedRetirementIds
+                .where((agentId) => !failingRetirementIds.contains(agentId))
                 .toList();
 
             if (expectedEnqueuedIds.isEmpty) {
@@ -428,23 +408,13 @@ void main() {
             }
 
             expect(
-              attemptedFastForwardWrites.map((state) => state.agentId).toList(),
-              expectedFastForwardIds,
+              attemptedRetirementWrites.map((state) => state.agentId).toList(),
+              expectedRetirementIds,
               reason: '$scenario',
             );
 
-            for (final write in attemptedFastForwardWrites) {
-              final index = states.indexWhere(
-                (state) => state.agentId == write.agentId,
-              );
-              expect(index, isNonNegative, reason: '$scenario');
-              expect(
-                write.scheduledWakeAt,
-                scenario.specs[index].expectedFastForwardWakeAt(
-                  _generatedScheduledWakeNow,
-                ),
-                reason: '$scenario',
-              );
+            for (final write in attemptedRetirementWrites) {
+              expect(write.scheduledWakeAt, isNull, reason: '$scenario');
               expect(write.updatedAt, _generatedScheduledWakeNow);
             }
 
@@ -1776,7 +1746,7 @@ void main() {
       });
     });
 
-    test('fast-forwards dormant project agents without enqueuing a wake', () {
+    test('clears dormant project schedules without enqueuing a wake', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final pastSchedule = DateTime(2024, 3, 13, 6);
       final dormantState = makeTestState(
@@ -1809,7 +1779,7 @@ void main() {
                     () => syncService.upsertEntity(captureAny()),
                   ).captured.single
                   as AgentStateEntity;
-          expect(captured.scheduledWakeAt, DateTime(2024, 3, 16, 6));
+          expect(captured.scheduledWakeAt, isNull);
 
           manager.stop();
         });
@@ -1817,7 +1787,7 @@ void main() {
     });
 
     test(
-      'enqueues never-woken project agents even without pending activity',
+      'clears never-woken project schedules without pending activity',
       () {
         final now = DateTime(2024, 3, 15, 10, 30);
         final pastSchedule = DateTime(2024, 3, 14, 6);
@@ -1836,12 +1806,18 @@ void main() {
             final manager = createAndStart();
             async.flushMicrotasks();
 
-            verify(
+            verifyNever(
               () => orchestrator.enqueueManualWake(
                 agentId: kTestAgentId,
                 reason: WakeReason.scheduled.name,
               ),
-            ).called(1);
+            );
+            final captured =
+                verify(
+                      () => syncService.upsertEntity(captureAny()),
+                    ).captured.single
+                    as AgentStateEntity;
+            expect(captured.scheduledWakeAt, isNull);
 
             manager.stop();
           });
@@ -1849,7 +1825,7 @@ void main() {
       },
     );
 
-    test('mixed batch: fast-forwards dormant, enqueues active', () {
+    test('mixed batch: retires dormant schedule and enqueues active', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final pastSchedule = DateTime(2024, 3, 13, 6);
 
@@ -1900,7 +1876,7 @@ void main() {
             ),
           );
 
-          // Dormant agent fast-forwarded via syncService.
+          // Dormant schedule retired via syncService.
           verify(() => syncService.upsertEntity(any())).called(1);
 
           manager.stop();
@@ -1908,7 +1884,7 @@ void main() {
       });
     });
 
-    test('fast-forward fires onPersistedStateChanged callback', () {
+    test('schedule retirement fires onPersistedStateChanged callback', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final dormantState = makeTestState(
         scheduledWakeAt: DateTime(2024, 3, 13, 6),
@@ -2006,9 +1982,7 @@ void main() {
         });
       },
     );
-    test('fast-forward preserves agent schedule hour and keeps today slot', () {
-      // now is 5:00 AM, schedule was for 9:00 AM two days ago.
-      // Fast-forward should schedule for TODAY at 9:00 AM, not tomorrow.
+    test('schedule retirement does not preserve a custom legacy hour', () {
       final now = DateTime(2024, 3, 15, 5);
       final pastSchedule = DateTime(2024, 3, 13, 9);
       final dormantState = makeTestState(
@@ -2034,8 +2008,7 @@ void main() {
                     () => syncService.upsertEntity(captureAny()),
                   ).captured.single
                   as AgentStateEntity;
-          // Today at 9:00 AM, not tomorrow.
-          expect(captured.scheduledWakeAt, DateTime(2024, 3, 15, 9));
+          expect(captured.scheduledWakeAt, isNull);
 
           manager.stop();
         });

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -686,7 +686,7 @@ void main() {
             () => mockSyncService.upsertEntity(captureAny()),
           ).captured;
           final updatedState = captured.single as AgentStateEntity;
-          expect(updatedState.scheduledWakeAt, DateTime(2026, 3, 21, 6));
+          expect(updatedState.scheduledWakeAt, isNull);
           expect(updatedState.slots.lastDailyWakeAt, isNull);
           // The dormant skip is a successful no-op wake — the failure
           // streak must reset alongside the reschedule.
@@ -751,7 +751,7 @@ void main() {
       );
 
       test(
-        'rolls forward the daily digest schedule when the scheduled wake is due',
+        'retires the legacy daily digest schedule after processing activity',
         () async {
           final testDate = DateTime(2026, 3, 20, 6, 30);
           final dueState = makeTestState(
@@ -781,7 +781,7 @@ void main() {
             () => mockSyncService.upsertEntity(captureAny()),
           ).captured;
           final updatedState = captured.whereType<AgentStateEntity>().last;
-          expect(updatedState.scheduledWakeAt, DateTime(2026, 3, 21, 6));
+          expect(updatedState.scheduledWakeAt, isNull);
           expect(updatedState.slots.lastDailyWakeAt, testDate);
           expect(updatedState.slots.pendingProjectActivityAt, isNull);
           // A due scheduled wake advances both watermarks → exactly those two
@@ -797,7 +797,7 @@ void main() {
       );
 
       test(
-        'keeps the future digest schedule and clears pending activity on non-due wakes',
+        'retires a future legacy digest schedule after a non-due wake',
         () async {
           final testDate = DateTime(2026, 3, 20, 9);
           final futureSchedule = DateTime(2026, 3, 21, 6);
@@ -828,7 +828,7 @@ void main() {
             () => mockSyncService.upsertEntity(captureAny()),
           ).captured;
           final updatedState = captured.whereType<AgentStateEntity>().last;
-          expect(updatedState.scheduledWakeAt, futureSchedule);
+          expect(updatedState.scheduledWakeAt, isNull);
           expect(updatedState.slots.lastDailyWakeAt, isNull);
           expect(updatedState.slots.pendingProjectActivityAt, isNull);
           // A non-due wake advances lastWakeAt but not lastDailyWakeAt →


### PR DESCRIPTION
## Summary

- default project agents to a dormant, non-recurring wake state
- retire legacy `scheduledWakeAt` rows when no project activity is pending
- keep project-agent work event-driven through persisted subscription wakes
- preserve manual scheduling, explicit reanalysis, and scheduled-wake deletion
- document the wake lifecycle and update release metadata

## Root cause

Project-agent creation initialized `scheduledWakeAt` to the next local 06:00. Successful project-agent wakes rolled that value forward every day, while `ScheduledWakeManager` fast-forwarded dormant rows to the next 06:00 instead of removing them.

The supplied runtime logs show the resulting persistent churn:

- 2026-08-12: 25 due project-agent states, 1 enqueued and 24 fast-forwarded with no pending activity
- 2026-08-13: the same 24 dormant states were fast-forwarded again, with no state-based project-agent wake enqueued

Most existing rows therefore caused scheduler/UI churn rather than inference, but never-woken idle agents could still be enqueued because the old fast-forward guard required a previous wake.

## Behavior after this change

New project agents have no recurring `scheduledWakeAt`. Relevant project or linked-task updates mark `pendingProjectActivityAt` and use the existing persisted subscription `nextWakeAt` path. Direct project edits use the short coalescing deadline; creation and explicit reanalysis wake immediately.

Startup restoration clears legacy dormant schedules immediately. The hourly manager applies the same repair to overdue rows. If a legacy schedule still has pending work, it remains as a one-time migration safety net and is cleared after the successful wake instead of recurring.

No visual widget code changed; the Wake tab now reflects the corrected underlying schedule state.

## Validation

- `fvm flutter test --no-pub` on the five affected service/workflow/scheduler/provider test files: 197 tests passed
- `fvm flutter analyze --no-pub`: no issues
- `make knowledge_check`: 93 OKF concepts valid; 479 Mermaid blocks parsed
- `xmllint --noout flatpak/com.matthiasn.lotti.metainfo.xml`
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.