### PR TITLE
test(nav): cover the reserved bar gutter, hidden-bar focus and matcher catalogs

### DIFF
--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -168,10 +168,34 @@ transition even when its URL is correct — which is what the legacy
 
 # Chrome rules are pure functions of router state
 
-Mobile chrome decisions are derived, not stored. `settingsRouteHidesBottomNav`
-takes a `BeamLocation` and returns whether the bottom navigation bar should
-slide away, following one product rule: **menus keep the bar, terminal
-destinations take the bottom edge.**
+Mobile chrome decisions are derived, not stored. Four pure functions of router
+state decide what the bottom edge belongs to, following one product rule:
+**menus keep the bar, terminal destinations take the bottom edge.**
+
+| Predicate | Routes | Effect |
+| --- | --- | --- |
+| `isTaskDetailRoute` | `/tasks/<uuid>` | Bar **unmounted** — `TaskActionBar` replaces it outright |
+| `settingsRouteHidesBottomNav` | AI and Agents sections, sync/advanced leaves, entity editors | Bar **slides away** |
+| `projectsRouteHidesBottomNav` | `/projects/<id>` | Bar **slides away** |
+| `agentsRouteHidesBottomNav` | `/agents/create`, `/agents/details/<id>[/chat\|/edit]` | Bar **slides away** |
+
+Removal and slide-away differ on purpose: a page that docks its own bar can
+swap instantly, while a page that replaces the bar with nothing would read as a
+glitch, so the bar animates out and back instead.
+
+The predicates match **exact route shapes, not prefixes.** A malformed or
+restored URL like `/agents/details` with no id renders the plain list, and that
+list must keep its tab bar — so matching on the second path segment alone is a
+bug, not a shortcut.
+
+**Hiding the bar is only half of it.** Pages pad their content by
+`DesignSystemBottomNavigationBar.occupiedHeight`, so a hidden bar must also
+stop being reserved, or the page keeps a bar-sized empty gutter exactly where
+its own pinned surface was meant to dock. `_MobileNavOverlayHeightScope`
+therefore publishes `barDocked` alongside the indicator-row height, and
+`occupiedHeight` adds the bar's own height only when it is docked. The flag
+defaults to true when no scope exists, so a page rendered outside the shell
+(previews, widget tests) reserves room exactly as before.
 
 ```mermaid
 stateDiagram-v2
@@ -180,12 +204,15 @@ stateDiagram-v2
     BarHidden --> BarVisible: navigate back to a menu or list
     note right of BarVisible
       Settings root, menu hubs (advanced, sync,
-      definitions), entity list pages, conflicts list
+      definitions), entity list pages, conflicts list,
+      the Projects and Goal Agents list roots
     end note
     note right of BarHidden
       All of AI and Agents, every sync and advanced
       leaf, entity editors and create routes,
-      top-level leaves, conflict detail
+      top-level leaves, conflict detail,
+      project details, a goal agent's detail, chat,
+      create and edit pages
     end note
 ```
 

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -212,12 +212,14 @@ flowchart TD
   Update now, Skip once, and the persisted automatic-updates switch. The first
   tick of a day is not "new data" (the window slid), and identical
   recomputation keeps the report fresh.
-  Toggling that switch writes the identity through the sync service, which does
-  **not** notify on its own — only the wake path pings — so
-  `GoalAgentService.updateAutomaticUpdates` pings `UpdateNotifications` itself
-  after the transaction commits. Without it `agentIdentityProvider` keeps its
-  cached value and the switch renders the old state until the page is rebuilt
-  from scratch, which reads as a switch that does not work.
+  **A direct identity write must ping `UpdateNotifications` itself.**
+  `AgentSyncService.upsertEntity` does not notify; the wake path only appears
+  to, because `WakeOutputWriter` pings separately after its own commit. So a
+  user-initiated identity write — `GoalAgentService.updateAutomaticUpdates`
+  toggling that switch — pings after its transaction commits, or
+  `agentIdentityProvider` keeps its cached value and the switch renders the old
+  state until the page is rebuilt from scratch, which reads as a switch that
+  does not work.
 - **The deferred arm and its escalation commit in one transaction.** When the
   local countdown fires, its dedicated trigger re-enters Phase A and writes the
   current register together with a forced report-refresh escalation. The

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -11,7 +11,7 @@ sources:
   - id: goals-src
     resource: ../../lib/features/goals
     title: Goals feature source
-    last_modified: 2026-08-13
+    last_modified: 2026-08-14
   - id: phase-a
     resource: ../../lib/features/goals/runtime/goal_agent_phase_a.dart
     title: GoalAgentPhaseA — the deterministic tick
@@ -39,7 +39,7 @@ sources:
   - id: goal-service
     resource: ../../lib/features/goals/service/goal_agent_service.dart
     title: GoalAgentService — lifecycle, subscriptions and report automation
-    last_modified: 2026-08-13
+    last_modified: 2026-08-14
   - id: progress-vocabulary
     resource: ../../lib/classes/goal_progress_models.dart
     title: Persisted per-dimension progress vocabulary
@@ -47,11 +47,11 @@ sources:
   - id: workflow
     resource: ../../lib/features/goals/workflow/goal_agent_workflow.dart
     title: GoalAgentWorkflow — the Phase B LLM tier
-    last_modified: 2026-08-13
+    last_modified: 2026-08-14
   - id: contract
     resource: ../../lib/features/goals/workflow/goal_agent_contract.dart
     title: Goal-agent contract (eval-graduated prompt + tools)
-    last_modified: 2026-08-13
+    last_modified: 2026-08-14
   - id: strategy
     resource: ../../lib/features/goals/workflow/goal_agent_strategy.dart
     title: GoalAgentStrategy — Phase B conversation and tool dispatch
@@ -71,7 +71,7 @@ sources:
   - id: create-edit
     resource: ../../lib/features/goals/ui/pages/create_goal_agent_page.dart
     title: Goal create/edit flow — intention, observable mapping and confirmation
-    last_modified: 2026-08-12
+    last_modified: 2026-08-14
   - id: measurable-capture
     resource: ../../lib/features/goals/service/goal_measurable_capture_service.dart
     title: Approval-gated measurable capture from goal chat
@@ -91,11 +91,11 @@ sources:
   - id: chat-composer
     resource: ../../lib/features/agents/ui/chat/agent_chat_view.dart
     title: AgentChatView — voice-enabled goal chat composer
-    last_modified: 2026-08-12
+    last_modified: 2026-08-14
   - id: recorder-controller
     resource: ../../lib/features/ai_chat/ui/controllers/chat_recorder_controller.dart
     title: ChatRecorderController — shared voice recorder
-    last_modified: 2026-08-12
+    last_modified: 2026-08-14
 ---
 
 # Goal Agents — Runtime
@@ -212,6 +212,12 @@ flowchart TD
   Update now, Skip once, and the persisted automatic-updates switch. The first
   tick of a day is not "new data" (the window slid), and identical
   recomputation keeps the report fresh.
+  Toggling that switch writes the identity through the sync service, which does
+  **not** notify on its own — only the wake path pings — so
+  `GoalAgentService.updateAutomaticUpdates` pings `UpdateNotifications` itself
+  after the transaction commits. Without it `agentIdentityProvider` keeps its
+  cached value and the switch renders the old state until the page is rebuilt
+  from scratch, which reads as a switch that does not work.
 - **The deferred arm and its escalation commit in one transaction.** When the
   local countdown fires, its dedicated trigger re-enters Phase A and writes the
   current register together with a forced report-refresh escalation. The
@@ -751,8 +757,22 @@ flowchart TD
   `GoalAgentChatPane` beside detail. The mobile route mounts the composer only
   for an active goal identity, shows the coarse-health label (current state,
   never the aspiration statement) in its compact
-  chat header, clears the overlaid navigation bar, and persists the detail
-  route after system/gesture back. `agentChatProjectionProvider`
+  chat header, and persists the detail
+  route after system/gesture back. **Every one of a goal's own pages — detail,
+  chat, create and edit — slides the mobile bottom nav away**
+  (`agentsRouteHidesBottomNav`; the `/agents` list root keeps it), because each
+  docks its own surface at the bottom edge: the day-assessment sheet's record
+  button and the wizards' pinned Continue band. Hiding the bar also stops it
+  being reserved, so those surfaces reach the edge instead of floating above a
+  bar-sized gutter — see
+  [navigation](../architecture/navigation.md#chrome-rules-are-pure-functions-of-router-state).
+  The visible reply list owns its measured heights
+  (`_AgentChatViewState._measuredHeights`, keyed by message id): a collapsible
+  reply's clamp is height-measured, `ListView.builder` disposes an item's State
+  once it leaves the cache extent, and an item that came back without its
+  measurement rendered full-height for one frame — which grew the content above
+  the viewport and made the list jump on every re-entry.
+  `agentChatProjectionProvider`
   filters and sorts the log first, retains the latest fifty durable visible
   candidates, and only then reads their payloads (no automatic `runKey`);
   projected turns are user messages and content-bearing `reply_to_user` actions;

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -97,6 +97,13 @@ concrete date in tooltip and outcome-menu header, and a blank habit day with
 a name-matching data observation recorded today offers a one-tap check-off.
 On the detail page the banner CTA opens a one-tap logging sheet
 (`GoalLogTodaySheet`) instead of navigating to the page it is on.
+On phones a goal's own pages — detail, chat, and the create and edit wizards —
+take the whole screen: the bottom navigation bar slides away, so the day
+sheet's record button and the wizards' Continue band dock at the bottom edge
+instead of sitting under it.
+Asking the agent in chat to change its report — shorter, sectioned, less
+repetitive — rewrites the standing report itself rather than only answering in
+chat, and an explicit refusal to change it is respected.
 Blood-pressure and weight headers quote the latest reading while their
 verdicts stay on the rolling-average target. When today's latest sample meets
 its target, the card celebrates that today's logging is on target even if the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.10+4318
+version: 1.0.10+4319
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -2655,9 +2655,23 @@ void main() {
               .first,
         );
 
+        // The bar's own ExcludeFocus, not the IndexedStack's per-tab one:
+        // `find.ancestor` walks outwards from the bar, and the tab barrier
+        // sits on a sibling subtree of the Positioned holding the bar.
+        ExcludeFocus excludeFocus() => tester.widget<ExcludeFocus>(
+          find
+              .ancestor(
+                of: find.byType(DesignSystemBottomNavigationBar),
+                matching: find.byType(ExcludeFocus),
+              )
+              .first,
+        );
+
         // The /agents list is a tab you navigate from, so it keeps the bar.
         expect(slide().offset, Offset.zero);
         expect(ignorePointer().ignoring, isFalse);
+        // A docked bar is a real destination: Tab must still reach its slots.
+        expect(excludeFocus().excluding, isFalse);
 
         // A goal's own page owns its bottom edge: the bar stays mounted so
         // the move can animate, but slides down and goes inert.
@@ -2666,6 +2680,9 @@ void main() {
         expect(find.byType(DesignSystemBottomNavigationBar), findsOneWidget);
         expect(slide().offset, const Offset(0, 1));
         expect(ignorePointer().ignoring, isTrue);
+        // Off-screen means out of keyboard traversal too, or Tab still lands
+        // on a slot and Enter navigates away from the page the user is on.
+        expect(excludeFocus().excluding, isTrue);
         await tester.pump(const Duration(milliseconds: 450));
 
         // The create wizard pins its own Continue band there too.
@@ -2673,6 +2690,7 @@ void main() {
         await tester.pump();
         expect(slide().offset, const Offset(0, 1));
         expect(ignorePointer().ignoring, isTrue);
+        expect(excludeFocus().excluding, isTrue);
         await tester.pump(const Duration(milliseconds: 450));
 
         // Popping back to the list slides the bar into place.
@@ -2680,6 +2698,7 @@ void main() {
         await tester.pump();
         expect(slide().offset, Offset.zero);
         expect(ignorePointer().ignoring, isFalse);
+        expect(excludeFocus().excluding, isFalse);
         await tester.pump(const Duration(milliseconds: 450));
 
         await tester.pumpWidget(const SizedBox.shrink());

--- a/test/l10n/goal_matcher_catalogs_test.dart
+++ b/test/l10n/goal_matcher_catalogs_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+
+/// Guards the two word lists the goal matcher parses out of the catalogs:
+/// `goalFormMeasurementVerbs` and `goalFormGenericIntentionWords`
+/// (`_catalogWords` in
+/// `lib/features/goals/ui/pages/create_goal_agent_page.dart`).
+///
+/// They are the only ARB entries that are not shown to anyone — they are
+/// data the matcher runs on — so a translator has no way to see that
+/// dropping the key, translating the commas into a sentence, or shipping a
+/// multi-word entry has silently disabled habit matching for that language.
+/// Nothing else in the suite would catch it either.
+void main() {
+  // Every shipped list is a couple of dozen inflections deep; the shortest
+  // today is 18 entries. Twelve is comfortably below that while still
+  // failing a stub, a truncation, or commas translated away into prose
+  // (which collapses the whole value into a single "entry").
+  const minimumEntries = 12;
+
+  // What `_words` can produce from user text: it replaces every
+  // non-letter/digit run with a space and splits on whitespace, so an entry
+  // carrying a space, a hyphen or an apostrophe can never match anything and
+  // is dead weight in the list.
+  final singleToken = RegExp(r'^[\p{L}\p{N}]+$', unicode: true);
+
+  final english = lookupAppLocalizations(const Locale('en'));
+
+  for (final locale in AppLocalizations.supportedLocales) {
+    final messages = lookupAppLocalizations(locale);
+    final catalogs = <String, String>{
+      'goalFormMeasurementVerbs': messages.goalFormMeasurementVerbs,
+      'goalFormGenericIntentionWords': messages.goalFormGenericIntentionWords,
+    };
+    final englishCatalogs = <String, String>{
+      'goalFormMeasurementVerbs': english.goalFormMeasurementVerbs,
+      'goalFormGenericIntentionWords': english.goalFormGenericIntentionWords,
+    };
+
+    group('goal matcher catalogs (${locale.toLanguageTag()})', () {
+      for (final entry in catalogs.entries) {
+        final key = entry.key;
+        final value = entry.value;
+
+        test('$key is a usable comma-separated word list', () {
+          expect(value.trim(), isNotEmpty, reason: '$key is empty in $locale');
+
+          final words = value.split(',');
+          expect(
+            words.length,
+            greaterThanOrEqualTo(minimumEntries),
+            reason:
+                '$key in $locale parses to ${words.length} entries — the '
+                'commas were probably translated away or the list truncated',
+          );
+
+          for (final word in words) {
+            expect(
+              word.trim(),
+              isNotEmpty,
+              reason: '$key in $locale has an empty entry (a stray comma)',
+            );
+            expect(
+              word,
+              word.trim(),
+              reason:
+                  '$key in $locale pads "$word" with whitespace; keep the '
+                  'list canonical so a diff shows real changes',
+            );
+            expect(
+              word,
+              matches(singleToken),
+              reason:
+                  '$key in $locale contains "$word", which is not a single '
+                  'word — the matcher tokenises user text on whitespace and '
+                  'punctuation, so this entry can never match',
+            );
+          }
+        });
+
+        // A key missing from a translated ARB is filled from the English
+        // template, which reads as a healthy list while matching nothing a
+        // user of that language ever writes.
+        if (locale.languageCode != 'en') {
+          test('$key is translated rather than the English fallback', () {
+            expect(
+              value,
+              isNot(englishCatalogs[key]),
+              reason:
+                  '$key in $locale is verbatim English — the key was likely '
+                  'dropped from app_${locale.languageCode}.arb',
+            );
+          });
+        }
+      }
+    });
+  }
+
+  // Deliberately not asserted: that entries are lowercase. `_catalogWords`
+  // lowercases the whole value before splitting, and the user's text is
+  // lowercased too, so an uppercase entry matches exactly as well — pinning
+  // the case would test the ARB's typography, not the matcher's behaviour.
+}

--- a/test/widgets/nav_bar/design_system_bottom_navigation_bar_test.dart
+++ b/test/widgets/nav_bar/design_system_bottom_navigation_bar_test.dart
@@ -260,5 +260,154 @@ void main() {
       await pump(0);
       expect(bottomPadding(), barOnly);
     });
+
+    testWidgets('occupiedHeight counts the bar only while it is docked', (
+      tester,
+    ) async {
+      const noInset = MediaQueryData(size: Size(390, 844));
+      const scopedChildKey = ValueKey('scoped-child');
+
+      Future<void> pump({required bool barDocked}) {
+        return tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            DesignSystemBottomNavigationOverlayHeight(
+              height: 24,
+              barDocked: barDocked,
+              child: const SizedBox.shrink(key: scopedChildKey),
+            ),
+            theme: DesignSystemTheme.light(),
+            mediaQueryData: noInset,
+          ),
+        );
+      }
+
+      double occupied() => DesignSystemBottomNavigationBar.occupiedHeight(
+        tester.element(find.byKey(scopedChildKey)),
+      );
+
+      await pump(barDocked: true);
+      final barHeight = DesignSystemFiveSlotNavBar.barHeight(
+        tester.element(find.byKey(scopedChildKey)),
+      );
+      // Guards the arithmetic below from passing on a zero-height bar.
+      expect(barHeight, greaterThan(0));
+      expect(
+        DesignSystemBottomNavigationOverlayHeight.barDockedOf(
+          tester.element(find.byKey(scopedChildKey)),
+        ),
+        isTrue,
+      );
+      final docked = occupied();
+      expect(docked, barHeight + 24);
+
+      // The bar has slid off-screen: it occupies nothing, so only the
+      // indicator row riding above it still counts. A page padding by this
+      // number must be left with no bar-sized gutter where its own pinned
+      // surface docks.
+      await pump(barDocked: false);
+      expect(
+        DesignSystemBottomNavigationOverlayHeight.barDockedOf(
+          tester.element(find.byKey(scopedChildKey)),
+        ),
+        isFalse,
+      );
+      final slidAway = occupied();
+      expect(slidAway, 24);
+      expect(docked - slidAway, barHeight);
+    });
+
+    testWidgets('reserves the bar where no scope publishes a docked state', (
+      tester,
+    ) async {
+      // Previews and widget tests render pages without the app shell, so
+      // `barDockedOf` defaults to docked and they reserve room exactly as
+      // they did before the flag existed.
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const SizedBox.shrink(),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: const MediaQueryData(size: Size(390, 844)),
+        ),
+      );
+
+      final context = tester.element(find.byType(Scaffold));
+      expect(
+        DesignSystemBottomNavigationOverlayHeight.barDockedOf(context),
+        isTrue,
+      );
+      expect(
+        DesignSystemBottomNavigationBar.occupiedHeight(context),
+        DesignSystemFiveSlotNavBar.barHeight(context),
+      );
+    });
+
+    testWidgets('FabPadding drops the bar gutter when the bar slides away', (
+      tester,
+    ) async {
+      Future<void> pump({required bool barDocked}) {
+        return tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            DesignSystemBottomNavigationOverlayHeight(
+              height: 24,
+              barDocked: barDocked,
+              child: const DesignSystemBottomNavigationFabPadding(
+                child: SizedBox.square(dimension: 56),
+              ),
+            ),
+            theme: DesignSystemTheme.light(),
+            mediaQueryData: const MediaQueryData(size: Size(390, 844)),
+          ),
+        );
+      }
+
+      double bottomPadding() {
+        final padding = tester.widget<Padding>(
+          find.descendant(
+            of: find.byType(DesignSystemBottomNavigationFabPadding),
+            matching: find.byType(Padding),
+          ),
+        );
+        return (padding.padding as EdgeInsets).bottom;
+      }
+
+      await pump(barDocked: true);
+      final barHeight = DesignSystemFiveSlotNavBar.barHeight(
+        tester.element(find.byType(DesignSystemBottomNavigationFabPadding)),
+      );
+      final docked = bottomPadding();
+      expect(docked, barHeight + 24);
+
+      // Flipping only the docked flag must reach dependents (it is the
+      // second half of updateShouldNotify) and shed exactly the bar.
+      await pump(barDocked: false);
+      expect(bottomPadding(), 24);
+      expect(docked - bottomPadding(), barHeight);
+    });
+
+    test('updateShouldNotify fires when only the docked flag flips', () {
+      const child = SizedBox.shrink();
+      const docked = DesignSystemBottomNavigationOverlayHeight(
+        height: 24,
+        child: child,
+      );
+      const slidAway = DesignSystemBottomNavigationOverlayHeight(
+        height: 24,
+        barDocked: false,
+        child: child,
+      );
+
+      expect(slidAway.updateShouldNotify(docked), isTrue);
+      expect(docked.updateShouldNotify(slidAway), isTrue);
+      // Neither field moved: dependents must not be rebuilt.
+      expect(
+        docked.updateShouldNotify(
+          const DesignSystemBottomNavigationOverlayHeight(
+            height: 24,
+            child: child,
+          ),
+        ),
+        isFalse,
+      );
+    });
   });
 }


### PR DESCRIPTION
Test and documentation debt from #3919 and #3920 — three behaviours that shipped with no coverage, and the docs those PRs outdated.

### Tests

1. **The reserved bar gutter** (`barDocked`, previously zero test references). `occupiedHeight` adds the nav bar's own height only while the bar is docked; when it has slid away only the indicator-row overlay counts. That is what lets a goal agent page's pinned surface reach the bottom edge instead of floating above a bar-sized gap, and nothing asserted the arithmetic. Four tests: docked, slid away, no scope at all (the `?? true` fallback that keeps pages rendered outside the shell reserving room as before), and `updateShouldNotify` firing when only the flag flips.
2. **The hidden bar leaves keyboard traversal.** The existing "slides the bar away" tests assert the slide offset and pointer-ignoring; the `ExcludeFocus` added in the same review round was unasserted, and the file's other `ExcludeFocus` assertions are about inactive tabs in the IndexedStack — a different widget.
3. **The matcher's catalog word lists** (`goalFormMeasurementVerbs`, `goalFormGenericIntentionWords`) drive goal matching in eleven languages with no guard at all. A translator can break it silently by dropping the key, translating the commas away, or shipping an entry with a space in it. The new table test covers every supported locale and additionally fails a translated list that is byte-identical to English — which is exactly what a dropped key looks like after gen-l10n fills it from the template.

Revert-checked: reverting the `occupiedHeight`/`updateShouldNotify` fix fails three of the four new tests (the fourth pins the fallback that must not change, and passes either way by design), and removing `ExcludeFocus` fails the goal-agent test. Item 3 has no fix to revert, so it was mutation-checked against the generated German getter instead — a comma-less value and an English-verbatim value each fail.

165 tests green across the three files, analyzer clean.

### Documentation

- `knowledge/architecture/navigation.md` documented only `settingsRouteHidesBottomNav`. It now carries all four chrome predicates, the difference between unmounting the bar and sliding it away, the exact-shape matching rule, and the reserved-height consequence.
- `knowledge/features/goals.md` still said the mobile chat route "clears the overlaid navigation bar" — the bar is no longer there on any of a goal's pages. Also records two invariants that lived only in commit messages: the list-owned reply heights that keep the chat from jumping, and why the automatic-updates toggle must ping `UpdateNotifications` itself.
- `lib/features/goals/README.md` gains the two user-visible behaviours; source dates bumped for the seven entries whose files changed.

### Findings, no action taken

`_words` drops user tokens shorter than three characters, so short catalog entries — Danish `og`/`år`, Spanish `y`, Italian `e`, Romanian `pe`/`zi` — can never match anything and are dead weight in several generic-intention lists. Harmless, and removing them is an ARB change rather than a test one, so it is left for a deliberate follow-up rather than folded in here.

Build number bumped to `1.0.10+4319`. No CHANGELOG entry: tests and documentation only, nothing a user sees at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Goal detail, chat, creation, and editing screens now use the full phone display, with bottom navigation hidden and action controls docked at the screen edge.
  - Chat requests to change report styling now update the active report; refusals leave it unchanged.

- **Bug Fixes**
  - Improved mobile navigation visibility and keyboard-focus behavior across projects, agents, and goal workflows.
  - Prevented layout jumps when collapsible chat replies are loaded or restored.

- **Documentation**
  - Updated navigation and goals documentation to reflect the latest mobile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->