### PR TITLE
chore: bump version to 1.0.11+4320

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.10+4319
+version: 1.0.11+4320
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Bumps the app version and build number for the next build.

1.0.10 is closed: its section in `CHANGELOG.md` and its `<release>` entry in `flatpak/com.matthiasn.lotti.metainfo.xml` are both complete. No `[1.0.11]` section is added here — there is nothing user-visible in this commit, and the next change that a user would notice creates it.

`pubspec.yaml` is the only file carrying the version; nothing else in the tree references it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.0.11 (build 4320).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->