### PR TITLE
fix: preserve inline Markdown paste content

### DIFF
--- a/knowledge/features/journal/detail-and-saving.md
+++ b/knowledge/features/journal/detail-and-saving.md
@@ -52,7 +52,8 @@ flowchart TD
   Detect -->|no| Verbatim[Insert ordinary text unchanged]
   Detect -->|yes| Convert[delta_markdown converts to Delta]
   Convert --> Code[Restore inline code attributes]
-  Code --> Insert[Replace selection with rich Delta]
+  Code --> Fragment[Drop synthetic newline from inline fragments]
+  Fragment --> Insert[Replace selection with rich Delta]
 ```
 
 The syntax gate recognizes supported block constructs (ATX headings,
@@ -62,7 +63,15 @@ strikeout, code and links). It deliberately does not claim ordinary prose,
 converter supplies the same headings, emphasis, list, quote and custom divider
 representation already used when loading Markdown-only entries. Its decoder
 predates Flutter Quill's inline-code attribute, so paste protects code spans
-during conversion and restores them as `code: true` operations afterward.
+during conversion and restores them as `code: true` operations afterward,
+including spans whose longer delimiters contain shorter backtick runs. Quill's
+editor exposes three rendered heading sizes, so ATX levels four through six
+use the third heading style; fenced-code contents are never normalized as
+headings.
+Inline fragments shed only the converter's synthetic document newline, while
+explicit newlines and block-attributed newlines remain intact. Inline code
+normalizes line endings and CommonMark's optional single outer padding space,
+but preserves repeated spaces and tabs inside the code payload.
 
 # The state machine has two real states
 

--- a/lib/features/journal/ui/widgets/editor/editor_tools.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_tools.dart
@@ -12,10 +12,13 @@ import 'package:flutter_quill/quill_delta.dart';
 import 'package:lotti/classes/entry_text.dart';
 
 final _markdownBlockPattern = RegExp(
-  r'^(?: {0,3}#{1,3}[ \t]+| {0,3}>[ \t]?|'
+  r'^(?: {0,3}#{1,6}[ \t]+| {0,3}>[ \t]?|'
   r' {0,3}(?:[-+*]|\d+[.)])[ \t]+| {0,3}(?:`{3,}|~{3,}))',
   multiLine: true,
 );
+final _unsupportedAtxHeadingPattern = RegExp(r'^( {0,3})#{4,6}([ \t]+)');
+final _markdownFenceLinePattern = RegExp('^ {0,3}(`{3,}|~{3,})');
+final _lineEndingPattern = RegExp('\r\n|\n|\r');
 final _markdownHorizontalRulePattern = RegExp(
   r'^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})$',
   multiLine: true,
@@ -30,7 +33,9 @@ final _markdownInlinePattern = RegExp(
 final _markdownItalicPattern = RegExp(
   r'(?<![\w\\])[*_](?=\S)[^*_\n]+(?<=\S)[*_](?!\w)',
 );
-final _inlineCodePattern = RegExp(r'(?<!\\)(`+)([^`\n]+?)\1');
+final _inlineCodePattern = RegExp(
+  r'(?<![`\\])(`+)(?!`)([^\n]*?)(?<!`)\1(?!`)',
+);
 
 /// The current document of `controller` as a Quill [Delta].
 Delta deltaFromController(QuillController controller) {
@@ -114,11 +119,13 @@ bool containsMarkdownFormatting(String text) =>
 Delta? markdownDeltaForPaste(String text) {
   if (!containsMarkdownFormatting(text)) return null;
 
-  final protected = _protectInlineCode(text);
+  final normalizedHeadings = _normalizeAtxHeadingLevels(text);
+  final protected = _protectInlineCode(normalizedHeadings);
   final encoded = markdownToDelta(protected.markdown);
   final decoded = jsonDecode(encoded) as List<dynamic>;
   final delta = Delta.fromJson(decoded);
-  return _restoreInlineCode(delta, protected.inlineCodeByToken);
+  final restored = _restoreInlineCode(delta, protected.inlineCodeByToken);
+  return _withoutSyntheticInlineTerminalNewline(restored, text);
 }
 
 /// Inserts Markdown-looking [plainText] at the current selection.
@@ -172,14 +179,74 @@ String? handlePlainTextMarkdownPaste(
 }
 
 String _normalizeInlineCode(String code) {
-  final normalizedWhitespace = code.replaceAll(RegExp(r'\s+'), ' ');
-  if (normalizedWhitespace.length > 2 &&
-      normalizedWhitespace.startsWith(' ') &&
-      normalizedWhitespace.endsWith(' ') &&
-      normalizedWhitespace.trim().isNotEmpty) {
-    return normalizedWhitespace.substring(1, normalizedWhitespace.length - 1);
+  final normalizedLineEndings = code
+      .replaceAll('\r\n', '\n')
+      .replaceAll('\r', '\n');
+  if (normalizedLineEndings.length > 2 &&
+      normalizedLineEndings.startsWith(' ') &&
+      normalizedLineEndings.endsWith(' ') &&
+      normalizedLineEndings.trim().isNotEmpty) {
+    return normalizedLineEndings.substring(
+      1,
+      normalizedLineEndings.length - 1,
+    );
   }
-  return normalizedWhitespace;
+  return normalizedLineEndings;
+}
+
+String _normalizeAtxHeadingLevels(String markdown) {
+  String? fenceCharacter;
+  var fenceLength = 0;
+
+  return markdown.splitMapJoin(
+    _lineEndingPattern,
+    onMatch: (match) => match.group(0)!,
+    onNonMatch: (line) {
+      final fenceMatch = _markdownFenceLinePattern.firstMatch(line);
+      if (fenceMatch != null) {
+        final fence = fenceMatch.group(1)!;
+        if (fenceCharacter == null) {
+          fenceCharacter = fence[0];
+          fenceLength = fence.length;
+        } else if (fence[0] == fenceCharacter &&
+            fence.length >= fenceLength &&
+            line.substring(fenceMatch.end).trim().isEmpty) {
+          fenceCharacter = null;
+          fenceLength = 0;
+        }
+        return line;
+      }
+      if (fenceCharacter != null) return line;
+
+      return line.replaceFirstMapped(
+        _unsupportedAtxHeadingPattern,
+        (match) => '${match.group(1)}###${match.group(2)}',
+      );
+    },
+  );
+}
+
+Delta _withoutSyntheticInlineTerminalNewline(Delta delta, String markdown) {
+  if (markdown.contains('\n') ||
+      markdown.contains('\r') ||
+      _markdownBlockPattern.hasMatch(markdown) ||
+      _markdownHorizontalRulePattern.hasMatch(markdown)) {
+    return delta;
+  }
+
+  final operations = delta.toList();
+  // `markdownToDelta` always returns a document Delta, so detected Markdown
+  // always has at least its terminal newline operation here.
+  final last = operations.last;
+  if (last.value != '\n' || (last.attributes?.isNotEmpty ?? false)) {
+    return delta;
+  }
+
+  final trimmed = Delta();
+  for (final operation in operations.take(operations.length - 1)) {
+    trimmed.insert(operation.value, operation.attributes);
+  }
+  return trimmed;
 }
 
 Delta _restoreInlineCode(Delta delta, Map<String, String> inlineCodeByToken) {

--- a/test/features/journal/ui/widgets/editor/editor_tools_test.dart
+++ b/test/features/journal/ui/widgets/editor/editor_tools_test.dart
@@ -138,6 +138,7 @@ Done ✅'''
     test('detects supported Markdown without claiming ordinary text', () {
       const markdownCases = [
         '# Heading',
+        '###### Compact heading',
         'A **bold** word',
         'Use `code` here',
         '> Quote',
@@ -226,7 +227,7 @@ Done ✅'''
       );
 
       expect(replacement, isEmpty);
-      expect(controller.document.toPlainText(), 'before bold\n after\n');
+      expect(controller.document.toPlainText(), 'before bold after\n');
       expect(
         controller.document.toDelta().toList().any(
           (operation) =>
@@ -237,7 +238,87 @@ Done ✅'''
       );
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 12),
+        const TextSelection.collapsed(offset: 11),
+      );
+    });
+
+    test('removes only a synthetic unformatted terminal newline', () {
+      final inlineDelta = markdownDeltaForPaste('**bold**')!;
+      final explicitNewlineDelta = markdownDeltaForPaste('**bold**\n')!;
+      final headingDelta = markdownDeltaForPaste('# Heading')!;
+      final horizontalRuleDelta = markdownDeltaForPaste('---')!;
+
+      expect(inlineDelta.toList().last.value, 'bold');
+      expect(explicitNewlineDelta.toList().last.value, '\n');
+      expect(headingDelta.toList().last.value, '\n');
+      expect(
+        headingDelta.toList().last.attributes,
+        containsPair('header', 1),
+      );
+      expect(
+        horizontalRuleDelta.toList().any(
+          (operation) =>
+              operation.data is Map<String, dynamic> &&
+              (operation.data! as Map<String, dynamic>)['divider'] == 'hr',
+        ),
+        isTrue,
+      );
+    });
+
+    test('preserves interior whitespace and trims one code-span pad', () {
+      final delta = markdownDeltaForPaste(
+        'Use `alpha  beta\tgamma` and ` padded `.',
+      )!;
+      final codeValues = delta
+          .toList()
+          .where((operation) => operation.attributes?['code'] == true)
+          .map((operation) => operation.value)
+          .toList();
+
+      expect(codeValues, ['alpha  beta\tgamma', 'padded']);
+    });
+
+    test('converts ATX heading levels four through six as headings', () {
+      for (var level = 4; level <= 6; level++) {
+        final marker = List.filled(level, '#').join();
+        final delta = markdownDeltaForPaste('$marker Details')!;
+
+        expect(delta.toList().last.value, '\n');
+        expect(
+          delta.toList().last.attributes,
+          containsPair('header', 3),
+          reason: 'ATX level $level uses Quill’s smallest heading style',
+        );
+      }
+    });
+
+    test('does not normalize heading markers inside fenced code', () {
+      final delta = markdownDeltaForPaste('```\n#### literal code\n```')!;
+
+      expect(
+        Document.fromDelta(delta).toPlainText(),
+        contains('#### literal code'),
+      );
+    });
+
+    test('allows shorter backtick runs inside longer code spans', () {
+      final delta = markdownDeltaForPaste('Use ``a ` b`` here')!;
+      final operations = delta.toList();
+
+      expect(
+        operations.any(
+          (operation) =>
+              operation.value == 'a ` b' &&
+              operation.attributes?['code'] == true,
+        ),
+        isTrue,
+      );
+      expect(
+        operations
+            .map((operation) => operation.value)
+            .whereType<String>()
+            .join(),
+        isNot(contains('``')),
       );
     });
 


### PR DESCRIPTION
## Summary

- keep single-line inline Markdown inside the surrounding paragraph when pasted
- preserve repeated spaces and tabs inside inline-code payloads
- support shorter backtick runs inside longer inline-code delimiters
- recognize ATX heading levels four through six, using Quill's third heading style
- retain explicit newlines and block-level Markdown boundaries

## Context

Follow-up to #3934, addressing all six unresolved inline review threads left as that PR was merged. Two reviewers independently identified the paragraph-break and code-whitespace problems; the remaining findings cover higher ATX heading levels and longer code-span delimiters.

`delta_markdown` emits a terminal document newline even for an inline fragment such as `**bold**`. Inserting that Delta into a selection split the surrounding sentence into two paragraphs. The paste converter now removes only that synthetic newline for single-line inline fragments; explicit line endings and block constructs remain unchanged.

Inline-code restoration previously collapsed all whitespace with `\s+`. It now normalizes line endings and removes CommonMark's optional single outer padding space while retaining interior spaces and tabs exactly.

No new changelog entry is added because this tightens the Markdown paste behavior introduced in #3934 before release.

## Verification

- `fvm flutter test test/features/journal/ui/widgets/editor/editor_tools_test.dart` — 21 passed
- `FLUTTER='fvm flutter' ./tool/analyze.sh` — no issues
- `make knowledge_check` — 93 concepts valid; 480 Mermaid blocks parsed
- both new regressions were confirmed to fail on merged `main` before implementation
- the approximately 27,000-test full suite and patch coverage are intentionally delegated to CI's 10 shards

## Screenshots

| Before | After |
| --- | --- |
| ![Inline Markdown creates an unintended line break before the fix](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/markdown-paste-followup/30fdbc6c2ed4c44ee2c1a65361bea9f7933984d4/before/markdown_inline_paste_before.png) | ![Inline Markdown remains in the surrounding sentence after the fix](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/markdown-paste-followup/30fdbc6c2ed4c44ee2c1a65361bea9f7933984d4/after/markdown_inline_paste_after.png) |
