### PR TITLE
fix: restore task search from focus mode

### DIFF
--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -325,7 +325,9 @@ On desktop, list focus mode conditionally adds the restore-list overlay inside
 a stable `Stack` parent. The task detail subtree never changes parent while the
 list hides or returns, preserving scroll position and other local widget state.
 The restore control remains distinct from Back, which continues to traverse the
-linked-task detail stack.
+linked-task detail stack. The desktop split also owns the primary search command:
+invoking it from the focused detail restores the offstage list, then delegates
+to the still-mounted tab to expand and focus task search on the next frame.
 
 When the expandable app bar has cover art, the whole artwork is an interactive
 image surface. A tap opens the same full-screen, zoomable viewer used by linked

--- a/lib/features/tasks/ui/pages/tasks_root_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_root_page.dart
@@ -5,6 +5,9 @@ import 'package:lotti/features/design_system/components/navigation/resizable_div
 import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/keyboard/domain/app_command.dart';
+import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
+import 'package:lotti/features/keyboard/ui/app_command_scope.dart';
 import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
@@ -24,11 +27,24 @@ import 'package:lotti/services/nav_service.dart';
 /// [DesktopDetailEmptyState] when nothing is selected. A selected task enables
 /// persisted focus mode, which keeps the list mounted offstage and exposes a
 /// separate restore action over every detail state.
-class TasksRootPage extends ConsumerWidget {
+class TasksRootPage extends ConsumerStatefulWidget {
   const TasksRootPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TasksRootPage> createState() => _TasksRootPageState();
+}
+
+class _TasksRootPageState extends ConsumerState<TasksRootPage> {
+  final _tasksTabController = TasksTabPageController();
+
+  @override
+  void dispose() {
+    _tasksTabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     if (!isDesktopLayout(context)) {
       return const TasksTabPage();
     }
@@ -51,75 +67,85 @@ class TasksRootPage extends ConsumerWidget {
     final listPaneWidth = resolvedListPane.width;
     final paneController = ref.read(paneWidthControllerProvider.notifier);
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: TaskShowcasePalette.page(context),
-      ),
-      child: ValueListenableBuilder<List<String>>(
-        valueListenable: getIt<NavService>().desktopTaskDetailStack,
-        builder: (context, stack, _) {
-          final selectedTaskId = stack.isEmpty ? null : stack.last;
-          final canHideListPane = selectedTaskId != null;
-          final listPaneVisible =
-              !paneWidths.listPaneCollapsed || !canHideListPane;
-          final detailChild = selectedTaskId != null
-              ? TaskDetailsPage(
-                  key: ValueKey(selectedTaskId),
-                  taskId: selectedTaskId,
-                )
-              : DesktopDetailEmptyState(
-                  key: const ValueKey<String>(
-                    'tasks-root-empty-detail',
-                  ),
-                  message: context.messages.desktopEmptyStateSelectTask,
-                );
-
-          return ListDetailFocusTraversal(
-            debugLabel: 'tasks-split',
-            listPaneVisible: listPaneVisible,
-            canHideListPane: canHideListPane,
-            onListPaneVisibilityChanged: (visible) {
-              if (visible) {
-                paneController.expandListPane();
-              } else {
-                paneController.collapseListPane();
-              }
-            },
-            listPane: SizedBox(
-              width: listPaneWidth,
-              child: const TasksTabPage(),
-            ),
-            divider: ResizableDivider(
-              currentValue: listPaneWidth,
-              minValue: minListPaneWidth,
-              maxValue: maxListPaneWidth,
-              onDrag: resolvedListPane.onDrag,
-            ),
-            detailPane: _TasksDetailPane(
-              stackDepth: stack.length,
-              detail: AnimatedSwitcher(
-                // Fast cross-fade (200ms): stepping row-by-row through tasks is
-                // the split view's core interaction, and matches the logbook
-                // split so both panes feel identical.
-                duration: MotionDurations.short4,
-                switchInCurve: Curves.easeInOutCubic,
-                switchOutCurve: Curves.easeInOutCubic,
-                layoutBuilder: (currentChild, previousChildren) {
-                  return Stack(
-                    fit: StackFit.expand,
-                    children: <Widget>[
-                      ...previousChildren.map(
-                        (child) => ExcludeFocus(child: child),
-                      ),
-                      ?currentChild,
-                    ],
+    return AppCommandScope(
+      handlers: {
+        AppCommandId.focusSearch: AppCommandHandler(
+          invoke: (_) {
+            paneController.expandListPane();
+            _tasksTabController.focusSearch();
+          },
+        ),
+      },
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: TaskShowcasePalette.page(context),
+        ),
+        child: ValueListenableBuilder<List<String>>(
+          valueListenable: getIt<NavService>().desktopTaskDetailStack,
+          builder: (context, stack, _) {
+            final selectedTaskId = stack.isEmpty ? null : stack.last;
+            final canHideListPane = selectedTaskId != null;
+            final listPaneVisible =
+                !paneWidths.listPaneCollapsed || !canHideListPane;
+            final detailChild = selectedTaskId != null
+                ? TaskDetailsPage(
+                    key: ValueKey(selectedTaskId),
+                    taskId: selectedTaskId,
+                  )
+                : DesktopDetailEmptyState(
+                    key: const ValueKey<String>(
+                      'tasks-root-empty-detail',
+                    ),
+                    message: context.messages.desktopEmptyStateSelectTask,
                   );
-                },
-                child: detailChild,
+
+            return ListDetailFocusTraversal(
+              debugLabel: 'tasks-split',
+              listPaneVisible: listPaneVisible,
+              canHideListPane: canHideListPane,
+              onListPaneVisibilityChanged: (visible) {
+                if (visible) {
+                  paneController.expandListPane();
+                } else {
+                  paneController.collapseListPane();
+                }
+              },
+              listPane: SizedBox(
+                width: listPaneWidth,
+                child: TasksTabPage(controller: _tasksTabController),
               ),
-            ),
-          );
-        },
+              divider: ResizableDivider(
+                currentValue: listPaneWidth,
+                minValue: minListPaneWidth,
+                maxValue: maxListPaneWidth,
+                onDrag: resolvedListPane.onDrag,
+              ),
+              detailPane: _TasksDetailPane(
+                stackDepth: stack.length,
+                detail: AnimatedSwitcher(
+                  // Fast cross-fade (200ms): stepping row-by-row through tasks
+                  // is the split view's core interaction, and matches the
+                  // logbook split so both panes feel identical.
+                  duration: MotionDurations.short4,
+                  switchInCurve: Curves.easeInOutCubic,
+                  switchOutCurve: Curves.easeInOutCubic,
+                  layoutBuilder: (currentChild, previousChildren) {
+                    return Stack(
+                      fit: StackFit.expand,
+                      children: <Widget>[
+                        ...previousChildren.map(
+                          (child) => ExcludeFocus(child: child),
+                        ),
+                        ?currentChild,
+                      ],
+                    );
+                  },
+                  child: detailChild,
+                ),
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -54,6 +54,37 @@ typedef TasksTabCreateTaskCallback =
       TaskCreationFilterContext filterContext,
     );
 
+/// Bridges list-owned search UI to a parent desktop split command scope.
+///
+/// The task list remains mounted while focus mode hides it. A parent can use
+/// this controller to expand the list first, then ask the still-mounted tab to
+/// reveal and focus its search field without exposing the tab state's private
+/// focus and collapse controllers.
+class TasksTabPageController {
+  Object? _owner;
+  VoidCallback? _focusSearch;
+
+  /// Reveals and focuses task search when an attached tab is mounted.
+  void focusSearch() => _focusSearch?.call();
+
+  void _attach(Object owner, VoidCallback focusSearch) {
+    _owner = owner;
+    _focusSearch = focusSearch;
+  }
+
+  void _detach(Object owner) {
+    if (!identical(_owner, owner)) return;
+    _owner = null;
+    _focusSearch = null;
+  }
+
+  /// Detaches this bridge when its parent split is disposed.
+  void dispose() {
+    _owner = null;
+    _focusSearch = null;
+  }
+}
+
 /// Unambiguous active-filter values inherited by a task created from the task
 /// list.
 ///
@@ -105,9 +136,11 @@ class TasksTabPage extends ConsumerStatefulWidget {
   const TasksTabPage({
     super.key,
     this.onCreateTaskPressed,
+    this.controller,
   });
 
   final TasksTabCreateTaskCallback? onCreateTaskPressed;
+  final TasksTabPageController? controller;
 
   @override
   ConsumerState<TasksTabPage> createState() => _TasksTabPageState();
@@ -122,6 +155,15 @@ class _TasksTabPageState extends ConsumerState<TasksTabPage> {
     super.initState();
     _searchFocusNode.addListener(_onSearchFocusChanged);
     _collapseController.addListener(_onCollapseChanged);
+    widget.controller?._attach(this, _focusSearch);
+  }
+
+  @override
+  void didUpdateWidget(covariant TasksTabPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (identical(oldWidget.controller, widget.controller)) return;
+    oldWidget.controller?._detach(this);
+    widget.controller?._attach(this, _focusSearch);
   }
 
   void _onSearchFocusChanged() {
@@ -139,6 +181,7 @@ class _TasksTabPageState extends ConsumerState<TasksTabPage> {
 
   @override
   void dispose() {
+    widget.controller?._detach(this);
     _searchFocusNode
       ..removeListener(_onSearchFocusChanged)
       ..dispose();
@@ -146,6 +189,17 @@ class _TasksTabPageState extends ConsumerState<TasksTabPage> {
       ..removeListener(_onCollapseChanged)
       ..dispose();
     super.dispose();
+  }
+
+  void _focusSearch() {
+    _collapseController.expand();
+    // The field does not exist while the header is collapsed, and the entire
+    // tab can be offstage in desktop focus mode. Both the header expansion and
+    // the parent list restoration rebuild before this callback runs.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _searchFocusNode.requestFocus();
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
   }
 
   @override
@@ -183,17 +237,7 @@ class _TasksTabPageState extends ConsumerState<TasksTabPage> {
                 ),
           ),
           AppCommandId.focusSearch: AppCommandHandler(
-            invoke: (_) {
-              _collapseController.expand();
-              // The field does not exist while the header is collapsed, so
-              // focusing it in the same frame as the expand is a no-op — the
-              // shortcut would silently do nothing. Wait for the frame that
-              // rebuilds the expanded header, exactly as the compact bar's
-              // search affordance does.
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (mounted) _searchFocusNode.requestFocus();
-              });
-            },
+            invoke: (_) => _focusSearch(),
           ),
         },
         child: Scaffold(

--- a/test/features/tasks/ui/pages/tasks_root_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_root_page_test.dart
@@ -9,6 +9,9 @@ import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
 import 'package:lotti/features/journal/ui/pages/infinite_journal_page.dart';
+import 'package:lotti/features/keyboard/domain/app_command.dart';
+import 'package:lotti/features/keyboard/ui/app_command_controller.dart';
+import 'package:lotti/features/keyboard/ui/app_command_host.dart';
 import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_root_page.dart';
@@ -241,6 +244,76 @@ void main() {
       await tester.pumpAndSettle();
     },
   );
+
+  testWidgets('focus-search restores a hidden task list before focusing', (
+    tester,
+  ) async {
+    fakeController = FakeJournalPageController(state());
+
+    final navService = getIt<NavService>() as MockNavService;
+    final stackNotifier = ValueNotifier<List<String>>(<String>['task-42']);
+    addTearDown(stackNotifier.dispose);
+    when(
+      () => navService.desktopTaskDetailStack,
+    ).thenReturn(stackNotifier);
+
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        const AppCommandHost(
+          handlers: {},
+          platform: TargetPlatform.windows,
+          child: TasksRootPage(),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          journalPageScopeProvider.overrideWithValue(true),
+          journalPageControllerProvider(
+            true,
+          ).overrideWith(() => fakeController),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('tasks-hide-list-pane-expanded')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final taskSearch = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField && widget.focusNode?.debugLabel == 'tasks-search',
+      skipOffstage: false,
+    );
+    expect(taskSearch, findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is TextField &&
+            widget.focusNode?.debugLabel == 'tasks-search',
+      ),
+      findsNothing,
+    );
+
+    final detailContext = tester.element(find.byType(TaskDetailsPage));
+    final commandController = AppCommandControllerProvider.of(detailContext);
+    expect(
+      await commandController.invoke(detailContext, AppCommandId.focusSearch),
+      isTrue,
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(TasksRootPage)),
+    );
+    expect(
+      container.read(paneWidthControllerProvider).listPaneCollapsed,
+      isFalse,
+    );
+    expect(tester.widget<TextField>(taskSearch).focusNode?.hasFocus, isTrue);
+  });
 
   testWidgets(
     'wraps detail pane in AnimatedSwitcher and crossfades between tasks',

--- a/test/features/tasks/ui/pages/tasks_tab_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_tab_page_test.dart
@@ -199,6 +199,7 @@ void main() {
   Widget buildSubject({
     required JournalPageState state,
     TasksTabCreateTaskCallback? onCreateTaskPressed,
+    TasksTabPageController? controller,
     MediaQueryData? mediaQueryData,
   }) {
     fakeController = FakeJournalPageController(state);
@@ -209,6 +210,7 @@ void main() {
         platform: TargetPlatform.windows,
         child: TasksTabPage(
           onCreateTaskPressed: onCreateTaskPressed,
+          controller: controller,
         ),
       ),
       mediaQueryData: mediaQueryData,
@@ -324,6 +326,43 @@ void main() {
       tester.widget<TextField>(find.byType(TextField)).focusNode!.hasFocus,
       isTrue,
     );
+  });
+
+  testWidgets('external search bridge follows the attached tab controller', (
+    tester,
+  ) async {
+    final firstController = TasksTabPageController();
+    final secondController = TasksTabPageController();
+    addTearDown(firstController.dispose);
+    addTearDown(secondController.dispose);
+
+    await tester.pumpWidget(
+      buildSubject(state: state(), controller: firstController),
+    );
+    await tester.pump();
+
+    firstController.focusSearch();
+    await tester.pump();
+    await tester.pump();
+
+    TextField searchField() => tester.widget<TextField>(find.byType(TextField));
+    expect(searchField().focusNode?.hasFocus, isTrue);
+
+    searchField().focusNode?.unfocus();
+    await tester.pumpWidget(
+      buildSubject(state: state(), controller: secondController),
+    );
+    await tester.pump();
+
+    firstController.focusSearch();
+    await tester.pump();
+    await tester.pump();
+    expect(searchField().focusNode?.hasFocus, isFalse);
+
+    secondController.focusSearch();
+    await tester.pump();
+    await tester.pump();
+    expect(searchField().focusNode?.hasFocus, isTrue);
   });
 
   test('filter inheritance ignores empty and Unassigned selections', () {


### PR DESCRIPTION
## Summary
- keep the Tasks focus-search command available from the desktop detail pane
- restore the hidden list before delegating to the mounted task-list search controller
- preserve the existing list-local command behavior and add controller lifecycle coverage

Follow-up to #3933 and the late review finding in https://github.com/matthiasn/lotti/pull/3933#discussion_r3790116307.

## Verification
- targeted analyzer: clean
- `test/features/tasks/ui/pages/tasks_tab_page_test.dart`
- `test/features/tasks/ui/pages/tasks_root_page_test.dart`
- `make knowledge_check`
- regression test failed on `main` before the fix and passes with the fix

## Screenshots
No visual delta; this changes keyboard command routing only.