### PR TITLE
fix: keep toast border above tone indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"3m AI time" is now "3m thinking"**, with a clearer explanation on hover.
 
 ### Fixed
+- **Toast borders follow their rounded corners cleanly.** Countdown and tone
+  indicator strips no longer paint over the toast outline at the left corners,
+  removing the doubled edge that was most visible at the top-left.
 - **The "At least N of M" stepper no longer closes the sheet.** Tapping plus
   or minus in "How this goal comes together" did change the count, but also
   dismissed the sheet with every tap; the stepper now adjusts the value on a

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,6 +42,7 @@
   <releases>
     <release version="1.0.10" date="2026-08-13">
       <description>
+        <p>Fixed: toast borders now follow their rounded corners cleanly. Countdown and tone indicator strips no longer paint over the outline at the left corners, removing the doubled edge that was most visible at the top-left.</p>
         <p>Changed: editing a goal is two steps, not three. The separate "What do you want to work toward?" page is gone from the edit flow - the statement is a single-line field at the top of the edit page with the suggestion chips right beneath it, and the step indicator now says so.</p>
         <p>Fixed: the plus and minus of the "At least N of M" rule changed the count but also dismissed the "How this goal comes together" sheet with every tap - the stepper now adjusts the count on a full-width control with proper touch targets, the sheet scrolls when space is tight, and it stays open until Done.</p>
         <p>Changed: the Goal Agents list reads at full size. The per-goal week strip drew 12px dots that were illegible at list scale; it now uses the same cell size as the detail page, and the chip row is reduced to the health chip, the trend chip and one badge - the "needs attention" pill appears only as a fallback while the agent has no one-liner yet.</p>

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -115,6 +115,12 @@ grouping is structural; keep a container when the fill is information. See
 [design tokens and theming](tokens-and-theming.md) for why the tint could not
 be expressed as a `colorScheme.*Container` either.
 
+`DesignSystemToast` clips its background, countdown bar, and leading tone
+gradient to one token-derived rounded outline, then paints the border in the
+foreground. The order is part of the component contract: both tone layers reach
+the interior edge of the curve, but neither can overpaint the outline and create
+a doubled or discontinuous corner.
+
 ## Beside the button tier: `DesignSystemIconAction`
 
 A glyph-only control for card headers and panel corners — the sync statistics

--- a/lib/features/design_system/components/toasts/design_system_toast.dart
+++ b/lib/features/design_system/components/toasts/design_system_toast.dart
@@ -164,9 +164,11 @@ class _DesignSystemToastState extends State<DesignSystemToast>
           : widget.title,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(spec.radius),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: spec.backgroundColor,
+        child: Container(
+          color: spec.backgroundColor,
+          // Tone strips are children of this surface. Keep the rounded border
+          // in the foreground so neither strip can overpaint its inner curve.
+          foregroundDecoration: BoxDecoration(
             border: Border.all(color: spec.borderColor),
             borderRadius: BorderRadius.circular(spec.radius),
           ),

--- a/test/features/design_system/components/toasts/design_system_toast_test.dart
+++ b/test/features/design_system/components/toasts/design_system_toast_test.dart
@@ -445,6 +445,34 @@ void main() {
     });
 
     group('countdown bar', () {
+      testWidgets('paints the rounded border above the tone strips', (
+        tester,
+      ) async {
+        await _pumpToast(
+          tester,
+          tone: DesignSystemToastTone.warning,
+          description: null,
+          countdownDuration: const Duration(seconds: 5),
+        );
+
+        final borderBox = tester
+            .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+            .singleWhere((widget) {
+              final decoration = widget.decoration;
+              return decoration is BoxDecoration && decoration.border != null;
+            });
+
+        expect(
+          borderBox.position,
+          DecorationPosition.foreground,
+          reason:
+              'the countdown and leading gradient must stay behind the '
+              'rounded border so they cannot overpaint either corner',
+        );
+
+        await tester.pump(const Duration(seconds: 6));
+      });
+
       testWidgets('renders a LinearProgressIndicator when countdown is set', (
         tester,
       ) async {


### PR DESCRIPTION
## Summary

- paint the rounded toast border above the countdown bar and leading tone gradient
- add a regression test for the border paint-order contract
- document the design-system invariant and update the 1.0.10 release notes

## Root cause

The outer `ClipRRect` kept the tone layers inside the toast, but the border itself was a background decoration. The countdown and leading gradient therefore painted over the stroke's inner rounded curve. The countdown bar made this look like a doubled or incorrectly clipped border, especially at the top-left corner.

Moving the border to `foregroundDecoration` keeps both tone layers beneath the outline while preserving the same token-derived radius and background.

## Screenshots

Dark-theme warning, success, and error countdown variants:

| Before | After |
| --- | --- |
| ![Toast borders before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/toast-border-clipping/e735beaf4a20d4f042b09f8e6bde32da5b7c7adc/before/toast_countdown_tones_before.png) | ![Toast borders after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/toast-border-clipping/e735beaf4a20d4f042b09f8e6bde32da5b7c7adc/after/toast_countdown_tones_after.png) |

## Validation

- `fvm flutter test test/features/design_system/components/toasts/design_system_toast_test.dart` — 26 tests passed
- targeted Flutter analyzer runs for the changed source and test — zero issues
- `make knowledge_check`
- `xmllint --noout flatpak/com.matthiasn.lotti.metainfo.xml`
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toast countdown and tone-indicator strips overlapping rounded toast borders.
  * Improved rendering consistency around toast corners.

* **Documentation**
  * Documented the toast border and clipping behavior.
  * Added release notes for version 1.0.10.

* **Tests**
  * Added coverage verifying correct toast border layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->