### PR TITLE
chore: release 1.0.10+4326

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.10+4325
+version: 1.0.10+4326
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
## Summary

- bump the build number to `1.0.10+4326`
- cut a fresh all-platform release containing the screenshot path repair from #3939 and the security/coverage follow-up from #3940

The existing `1.0.10+4325` tag was created before either fix merged and cannot be reused.

## Validation

- `make analyze`
- confirmed `1.0.10+4326` is not present in the remote tag set or GitHub releases

## Release plan

After merge, tag the merged commit as `1.0.10+4326`, push the tag, and monitor Android, iOS, macOS, Linux/Flatpak, Windows/Codemagic, and service release jobs.
