### PR TITLE
fix: keep slow wakes within active drain

### DIFF
--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -227,7 +227,9 @@ cannot release or abort the newer run that now owns the same agent lock. Each
 lease keeps its own progress time, so unrelated healthy wakes cannot hide a
 stalled slot by refreshing only the generation-wide clock. A healthy lease
 retained from a superseded generation is excluded from the replacement
-generation's stale calculation. A dequeued job also rechecks its drain
+generation's stale calculation, but every later scheduler pass evaluates it
+independently and releases it if its own progress becomes stale. A dequeued job
+also rechecks its drain
 generation after every pre-dispatch await. Before run-log insertion, a
 superseded drain returns the job to the queue and wakes the active scheduler;
 after insertion, it returns a persisted continuation that resumes the same run

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -243,10 +243,13 @@ may continue in the background; its eventual result is ignored by the drain.
 Workflows must therefore continue to treat late writes as normal database
 mutations that can produce a later notification.
 
-The scheduler only treats the surrounding drain as stale after **12 minutes**.
-That threshold deliberately exceeds the wake cap, leaving room for the bounded
-pre-wake hook and terminal status persistence so a valid slow wake cannot be
-superseded before its queued follow-up is dispatched.
+The scheduler only treats a drain as stale after **12 minutes without
+progress**. Dispatching or completing a wake resets that clock, so a healthy
+drain can process several slow wakes without being judged by its total age. If
+work remains queued, the one-minute safety net re-enters stale detection even
+while a drain is active; this recovers terminal persistence stalls without
+waiting for another enqueue. The threshold deliberately exceeds the wake cap,
+leaving room for the bounded pre-wake hook and terminal status persistence.
 
 # Completion signalling
 

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -222,13 +222,18 @@ Two independent limits apply:
 Each acquisition carries an ownership lease. Stale-drain recovery releases the
 superseded generation's leases before starting its replacement; late cleanup or
 timeout callbacks from the old generation cannot release or abort the newer
-run that now owns the same agent lock. A dequeued job also rechecks its drain
+run that now owns the same agent lock. Each lease keeps its own progress time,
+so unrelated healthy wakes cannot hide a stalled slot by refreshing only the
+generation-wide clock. A dequeued job also rechecks its drain
 generation after every pre-dispatch await. Before run-log insertion, a
 superseded drain returns the job to the queue and wakes the active scheduler;
 after insertion, it returns a persisted continuation that resumes the same run
 key without inserting a duplicate row. Drain-owned jobs remain visible to
 manual supersession and cancellation while outside the queue, so an obsolete
 older request is discarded rather than resurrected by a late continuation.
+Run-key history remains intact until both the visible queue and the drain-owned
+handoff set are empty, preventing restoration from duplicating an in-flight
+logical wake.
 
 Only the scheduler mutates `WakeQueue`, suppression state, throttle state and
 run-key history. Concurrent work begins only after a job has acquired its

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -219,6 +219,13 @@ Two independent limits apply:
 - **Per agent**: `WakeRunner` enforces single-flight, so two wakes for the same
   agent never overlap even when global capacity is free.
 
+Each acquisition carries an ownership lease. Stale-drain recovery releases the
+superseded generation's leases before starting its replacement; late cleanup or
+timeout callbacks from the old generation cannot release or abort the newer
+run that now owns the same agent lock. A dequeued job also rechecks its drain
+generation after every pre-dispatch await. If superseded, it releases any lease
+it acquired, returns the job to the queue, and wakes the active scheduler.
+
 Only the scheduler mutates `WakeQueue`, suppression state, throttle state and
 run-key history. Concurrent work begins only after a job has acquired its
 `WakeRunner` agent lock. Workflows and conversation managers are created per
@@ -248,8 +255,11 @@ progress**. Dispatching or completing a wake resets that clock, so a healthy
 drain can process several slow wakes without being judged by its total age. If
 work remains queued, the one-minute safety net re-enters stale detection even
 while a drain is active; this recovers terminal persistence stalls without
-waiting for another enqueue. The threshold deliberately exceeds the wake cap,
-leaving room for the bounded pre-wake hook and terminal status persistence.
+waiting for another enqueue. Recovery releases the superseded generation's
+runner leases before replacement dispatch, so a terminal status write cannot
+consume the only global slot indefinitely. The threshold deliberately exceeds
+the wake cap, leaving room for the bounded pre-wake hook and terminal status
+persistence.
 
 # Completion signalling
 

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -223,8 +223,12 @@ Each acquisition carries an ownership lease. Stale-drain recovery releases the
 superseded generation's leases before starting its replacement; late cleanup or
 timeout callbacks from the old generation cannot release or abort the newer
 run that now owns the same agent lock. A dequeued job also rechecks its drain
-generation after every pre-dispatch await. If superseded, it releases any lease
-it acquired, returns the job to the queue, and wakes the active scheduler.
+generation after every pre-dispatch await. Before run-log insertion, a
+superseded drain returns the job to the queue and wakes the active scheduler;
+after insertion, it returns a persisted continuation that resumes the same run
+key without inserting a duplicate row. Drain-owned jobs remain visible to
+manual supersession and cancellation while outside the queue, so an obsolete
+older request is discarded rather than resurrected by a late continuation.
 
 Only the scheduler mutates `WakeQueue`, suppression state, throttle state and
 run-key history. Concurrent work begins only after a job has acquired its
@@ -259,7 +263,9 @@ waiting for another enqueue. Recovery releases the superseded generation's
 runner leases before replacement dispatch, so a terminal status write cannot
 consume the only global slot indefinitely. The threshold deliberately exceeds
 the wake cap, leaving room for the bounded pre-wake hook and terminal status
-persistence.
+persistence. Progress is refreshed again immediately before the executor timer
+is armed, so pre-execution persistence and policy latency never shorten the
+executor's own ten-minute window.
 
 # Completion signalling
 

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -219,12 +219,15 @@ Two independent limits apply:
 - **Per agent**: `WakeRunner` enforces single-flight, so two wakes for the same
   agent never overlap even when global capacity is free.
 
-Each acquisition carries an ownership lease. Stale-drain recovery releases the
-superseded generation's leases before starting its replacement; late cleanup or
-timeout callbacks from the old generation cannot release or abort the newer
-run that now owns the same agent lock. Each lease keeps its own progress time,
-so unrelated healthy wakes cannot hide a stalled slot by refreshing only the
-generation-wide clock. A dequeued job also rechecks its drain
+Each acquisition carries an ownership lease. Stale-drain recovery releases
+only the superseded generation's individually stale leases before starting its
+replacement. Healthy concurrent leases retain their agent locks until their
+own executors settle, while late cleanup or timeout callbacks from a stale lease
+cannot release or abort the newer run that now owns the same agent lock. Each
+lease keeps its own progress time, so unrelated healthy wakes cannot hide a
+stalled slot by refreshing only the generation-wide clock. A healthy lease
+retained from a superseded generation is excluded from the replacement
+generation's stale calculation. A dequeued job also rechecks its drain
 generation after every pre-dispatch await. Before run-log insertion, a
 superseded drain returns the job to the queue and wakes the active scheduler;
 after insertion, it returns a persisted continuation that resumes the same run
@@ -264,13 +267,14 @@ progress**. Dispatching or completing a wake resets that clock, so a healthy
 drain can process several slow wakes without being judged by its total age. If
 work remains queued, the one-minute safety net re-enters stale detection even
 while a drain is active; this recovers terminal persistence stalls without
-waiting for another enqueue. Recovery releases the superseded generation's
-runner leases before replacement dispatch, so a terminal status write cannot
-consume the only global slot indefinitely. The threshold deliberately exceeds
-the wake cap, leaving room for the bounded pre-wake hook and terminal status
-persistence. Progress is refreshed again immediately before the executor timer
-is armed, so pre-execution persistence and policy latency never shorten the
-executor's own ten-minute window.
+waiting for another enqueue. Recovery releases each individually stale runner
+lease before replacement dispatch, so a terminal status write cannot consume a
+global slot indefinitely, but it preserves newer healthy leases from the same
+superseded generation. The threshold deliberately exceeds the wake cap, leaving
+room for the bounded pre-wake hook and terminal status persistence. Progress is
+refreshed again immediately before the executor timer is armed, so pre-execution
+persistence and policy latency never shorten the executor's own ten-minute
+window.
 
 # Completion signalling
 

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -243,6 +243,11 @@ may continue in the background; its eventual result is ignored by the drain.
 Workflows must therefore continue to treat late writes as normal database
 mutations that can produce a later notification.
 
+The scheduler only treats the surrounding drain as stale after **12 minutes**.
+That threshold deliberately exceeds the wake cap, leaving room for the bounded
+pre-wake hook and terminal status persistence so a valid slow wake cannot be
+superseded before its queued follow-up is dispatched.
+
 # Completion signalling
 
 `runCompletions` is a broadcast `Stream<WakeRunCompletion>` — one event per

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -213,7 +213,9 @@ extension WakeDrainEngine on WakeOrchestrator {
               return job.runKey;
             },
           );
-          _drainLastProgressAt = clock.now();
+          if (_drainGeneration == generation) {
+            _drainLastProgressAt = clock.now();
+          }
         }
 
         // Requeue skipped busy/throttled jobs before waiting. Active wakes use
@@ -246,7 +248,9 @@ extension WakeDrainEngine on WakeOrchestrator {
         );
         if (completedExecution != null) {
           await completedExecution;
-          _drainLastProgressAt = clock.now();
+          if (_drainGeneration == generation) {
+            _drainLastProgressAt = clock.now();
+          }
         }
       }
     } finally {

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -102,12 +102,66 @@ extension WakeDrainEngine on WakeOrchestrator {
     leases.forEach(runner.releaseLease);
   }
 
+  void _trackDrainOwnedJob(WakeJob job) {
+    _drainOwnedJobs[job.runKey] = job;
+  }
+
+  void _forgetDrainOwnedJob(WakeJob job) {
+    _drainOwnedJobs.remove(job.runKey);
+    _cancelledDrainOwnedRunReasons.remove(job.runKey);
+  }
+
+  String? _takeDrainOwnedCancellation(WakeJob job) {
+    final reason = _cancelledDrainOwnedRunReasons.remove(job.runKey);
+    if (reason != null) _drainOwnedJobs.remove(job.runKey);
+    return reason;
+  }
+
+  bool _discardCancelledDrainOwnedJob(
+    int generation,
+    WakeJob job, {
+    WakeRunnerLease? lease,
+  }) {
+    if (_takeDrainOwnedCancellation(job) == null) return false;
+    if (lease != null) _releaseDrainLease(generation, lease);
+    return true;
+  }
+
+  Future<void> _dropDrainOwnedJob(
+    WakeJob job, {
+    required String reason,
+    required bool emitUnpersistedCompletion,
+  }) async {
+    _forgetDrainOwnedJob(job);
+    if (_persistedWakeRunKeys.remove(job.runKey)) {
+      await _abortPersistedWake(
+        job,
+        reason: reason,
+        emitCompletion: true,
+      );
+    } else if (emitUnpersistedCompletion) {
+      _emitRunCompletion(
+        job,
+        WakeRunStatus.aborted,
+        error: StateError(reason),
+      );
+    }
+  }
+
   void _handOffSupersededJob(
     int generation,
     WakeJob job, {
     WakeRunnerLease? lease,
   }) {
+    if (_discardCancelledDrainOwnedJob(
+      generation,
+      job,
+      lease: lease,
+    )) {
+      return;
+    }
     if (lease != null) _releaseDrainLease(generation, lease);
+    _forgetDrainOwnedJob(job);
     queue.requeue(job);
     unawaited(processNext());
   }
@@ -161,20 +215,30 @@ extension WakeDrainEngine on WakeOrchestrator {
             },
           );
           if (job == null) break;
+          _trackDrainOwnedJob(job);
           inspectedJobs++;
 
           final wakeAllowed = await _wakeAllowedByCurrentPolicy(job);
+          if (_discardCancelledDrainOwnedJob(generation, job)) {
+            if (_drainGeneration != generation) return;
+            continue;
+          }
           if (_drainGeneration != generation) {
             _handOffSupersededJob(generation, job);
             return;
           }
           if (!wakeAllowed) {
+            const reason = 'wake dropped by current automation policy';
+            await _dropDrainOwnedJob(
+              job,
+              reason: reason,
+              emitUnpersistedCompletion: true,
+            );
             _log(
               'drain policy dropped automatic/disabled wake for '
               '${DomainLogger.sanitizeId(job.agentId)}',
               subDomain: 'drain',
             );
-            _emitRunCompletion(job, WakeRunStatus.aborted);
             continue;
           }
 
@@ -182,6 +246,14 @@ extension WakeDrainEngine on WakeOrchestrator {
             job.agentId,
             workspaceKey: job.workspaceKey,
           );
+          if (_discardCancelledDrainOwnedJob(
+            generation,
+            job,
+            lease: lease,
+          )) {
+            if (_drainGeneration != generation) return;
+            continue;
+          }
           if (_drainGeneration != generation) {
             _handOffSupersededJob(generation, job, lease: lease);
             return;
@@ -190,6 +262,7 @@ extension WakeDrainEngine on WakeOrchestrator {
             // Keep same-agent work queued while its active wake executes. The
             // active wake uses queue visibility to decide whether to arm its
             // existing follow-up throttle deadline.
+            _forgetDrainOwnedJob(job);
             deferred.add(job);
             continue;
           }
@@ -212,6 +285,11 @@ extension WakeDrainEngine on WakeOrchestrator {
                 'for ${DomainLogger.sanitizeId(job.agentId)}',
                 subDomain: 'drain',
               );
+              await _dropDrainOwnedJob(
+                job,
+                reason: 'wake dropped by suppression re-check',
+                emitUnpersistedCompletion: false,
+              );
               _releaseDrainLease(generation, lease);
               continue;
             }
@@ -225,6 +303,7 @@ extension WakeDrainEngine on WakeOrchestrator {
                 'for ${DomainLogger.sanitizeId(job.agentId)}',
                 subDomain: 'drain',
               );
+              _forgetDrainOwnedJob(job);
               _releaseDrainLease(generation, lease);
               deferred.add(job);
               continue;
@@ -235,11 +314,24 @@ extension WakeDrainEngine on WakeOrchestrator {
           // for the task to have meaningful content before their first run.
           final shouldSkipForAwaitingContent =
               await _shouldSkipForAwaitingContent(job);
+          if (_discardCancelledDrainOwnedJob(
+            generation,
+            job,
+            lease: lease,
+          )) {
+            if (_drainGeneration != generation) return;
+            continue;
+          }
           if (_drainGeneration != generation) {
             _handOffSupersededJob(generation, job, lease: lease);
             return;
           }
           if (shouldSkipForAwaitingContent) {
+            await _dropDrainOwnedJob(
+              job,
+              reason: 'wake skipped while awaiting content',
+              emitUnpersistedCompletion: false,
+            );
             _releaseDrainLease(generation, lease);
             continue;
           }
@@ -256,6 +348,7 @@ extension WakeDrainEngine on WakeOrchestrator {
                   // but keep the scheduler resilient if an unexpected failure
                   // escapes that boundary (for example, a logging implementation
                   // throwing before `_executeJob` enters its outer try/finally).
+                  _forgetDrainOwnedJob(job);
                   _releaseDrainLease(generation, lease);
                   logError(
                     'unexpected wake execution failure for '
@@ -364,15 +457,24 @@ extension WakeDrainEngine on WakeOrchestrator {
     );
   }
 
-  /// Finalize a persisted wake that resumed after its drain was superseded.
-  Future<void> _finishSupersededWake(WakeJob job) async {
+  Future<void> _abortPersistedWake(
+    WakeJob job, {
+    required String reason,
+    required bool emitCompletion,
+  }) async {
     await _safeUpdateStatus(
       job.runKey,
       WakeRunStatus.aborted.name,
       completedAt: clock.now(),
-      errorMessage: 'superseded drain',
+      errorMessage: reason,
     );
-    _emitRunCompletion(job, WakeRunStatus.aborted);
+    if (emitCompletion) {
+      _emitRunCompletion(
+        job,
+        WakeRunStatus.aborted,
+        error: StateError(reason),
+      );
+    }
   }
 
   /// Execute a single wake job: persist → run executor → update status.
@@ -395,37 +497,52 @@ extension WakeDrainEngine on WakeOrchestrator {
     );
 
     try {
-      final entry = WakeRunLogData(
-        runKey: job.runKey,
-        agentId: job.agentId,
-        reason: job.reason,
-        reasonId: job.reasonId,
-        threadId: threadId,
-        status: WakeRunStatus.running.name,
-        createdAt: job.createdAt,
-        startedAt: clock.now(),
-      );
-
-      // Fix C: Log insertWakeRun failures at ERROR level.
-      try {
-        await repository.insertWakeRun(entry: entry);
-      } catch (e, s) {
-        logError(
-          'insertWakeRun failed for ${DomainLogger.sanitizeId(job.runKey)}',
-          error: e,
-          stackTrace: s,
+      final runAlreadyPersisted = _persistedWakeRunKeys.remove(job.runKey);
+      if (!runAlreadyPersisted) {
+        final entry = WakeRunLogData(
+          runKey: job.runKey,
+          agentId: job.agentId,
+          reason: job.reason,
+          reasonId: job.reasonId,
+          threadId: threadId,
+          status: WakeRunStatus.running.name,
+          createdAt: job.createdAt,
+          startedAt: clock.now(),
         );
-        _emitRunCompletion(job, WakeRunStatus.failed, error: e);
-        return;
+
+        // Fix C: Log insertWakeRun failures at ERROR level.
+        try {
+          await repository.insertWakeRun(entry: entry);
+        } catch (error, stackTrace) {
+          _forgetDrainOwnedJob(job);
+          logError(
+            'insertWakeRun failed for ${DomainLogger.sanitizeId(job.runKey)}',
+            error: error,
+            stackTrace: stackTrace,
+          );
+          _emitRunCompletion(job, WakeRunStatus.failed, error: error);
+          return;
+        }
       }
 
+      final postInsertCancellation = _takeDrainOwnedCancellation(job);
+      if (postInsertCancellation != null) {
+        await _abortPersistedWake(
+          job,
+          reason: postInsertCancellation,
+          emitCompletion: false,
+        );
+        return;
+      }
       if (_drainGeneration != generation) {
-        await _finishSupersededWake(job);
+        _persistedWakeRunKeys.add(job.runKey);
+        _handOffSupersededJob(generation, job, lease: lease);
         return;
       }
 
       final executor = wakeExecutor;
       if (executor == null) {
+        _forgetDrainOwnedJob(job);
         logError('no wakeExecutor set — marking run as failed');
         await _safeUpdateStatus(
           job.runKey,
@@ -461,21 +578,27 @@ extension WakeDrainEngine on WakeOrchestrator {
         }
       }
 
-      if (_drainGeneration != generation) {
-        await _finishSupersededWake(job);
-        return;
-      }
-
       // Policy may change while this job awaits runner acquisition, content
       // gating, run persistence, or the pre-wake hook. Re-read immediately
       // before executor setup so disabling automation cannot launch paid work
       // from a job that has already left the queue.
       final wakeAllowed = await _wakeAllowedByCurrentPolicy(job);
+      final finalPolicyCancellation = _takeDrainOwnedCancellation(job);
+      if (finalPolicyCancellation != null) {
+        await _abortPersistedWake(
+          job,
+          reason: finalPolicyCancellation,
+          emitCompletion: false,
+        );
+        return;
+      }
       if (_drainGeneration != generation) {
-        await _finishSupersededWake(job);
+        _persistedWakeRunKeys.add(job.runKey);
+        _handOffSupersededJob(generation, job, lease: lease);
         return;
       }
       if (!wakeAllowed) {
+        _forgetDrainOwnedJob(job);
         _log(
           'pre-execution policy dropped automatic/disabled wake for '
           '${DomainLogger.sanitizeId(job.agentId)}',
@@ -489,7 +612,11 @@ extension WakeDrainEngine on WakeOrchestrator {
         return;
       }
 
+      _forgetDrainOwnedJob(job);
       final startTime = clock.now();
+      if (_drainGeneration == generation) {
+        _drainLastProgressAt = startTime;
+      }
       Timer? timeoutTimer;
       try {
         // Pre-register suppression for the trigger tokens BEFORE executing.
@@ -688,31 +815,6 @@ extension WakeDrainEngine on WakeOrchestrator {
       }
     } finally {
       _releaseDrainLease(generation, lease);
-    }
-  }
-
-  /// Update wake run status, swallowing any DB errors so they don't escape
-  /// `_executeJob` / `_drain` / `processNext`.
-  Future<void> _safeUpdateStatus(
-    String runKey,
-    String status, {
-    DateTime? completedAt,
-    String? errorMessage,
-  }) async {
-    try {
-      await repository.updateWakeRunStatus(
-        runKey,
-        status,
-        completedAt: completedAt,
-        errorMessage: errorMessage,
-      );
-    } catch (e, s) {
-      logError(
-        'failed to update wake run status '
-        'for ${DomainLogger.sanitizeId(runKey)} to $status',
-        error: e,
-        stackTrace: s,
-      );
     }
   }
 

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -35,8 +35,11 @@ extension WakeDrainEngine on WakeOrchestrator {
           '(last progress ${stalledFor.inSeconds}s ago)',
           subDomain: 'drain',
         );
-        // Increment generation so the old drain's loop bails out.
+        // Increment generation so the old drain's loop bails out, then free
+        // only the runner slots owned by that superseded generation.
+        final staleGeneration = _drainGeneration;
         _drainGeneration++;
+        _releaseDrainGenerationLeases(staleGeneration);
         final wakeSignal = _drainWakeSignal;
         if (wakeSignal != null && !wakeSignal.isCompleted) {
           wakeSignal.complete();
@@ -78,6 +81,35 @@ extension WakeDrainEngine on WakeOrchestrator {
         _drainLastProgressAt = null;
       }
     }
+  }
+
+  void _trackDrainLease(int generation, WakeRunnerLease lease) {
+    (_drainLeasesByGeneration[generation] ??= <WakeRunnerLease>{}).add(lease);
+  }
+
+  void _releaseDrainLease(int generation, WakeRunnerLease lease) {
+    final leases = _drainLeasesByGeneration[generation];
+    leases?.remove(lease);
+    if (leases != null && leases.isEmpty) {
+      _drainLeasesByGeneration.remove(generation);
+    }
+    runner.releaseLease(lease);
+  }
+
+  void _releaseDrainGenerationLeases(int generation) {
+    final leases = _drainLeasesByGeneration.remove(generation);
+    if (leases == null) return;
+    leases.forEach(runner.releaseLease);
+  }
+
+  void _handOffSupersededJob(
+    int generation,
+    WakeJob job, {
+    WakeRunnerLease? lease,
+  }) {
+    if (lease != null) _releaseDrainLease(generation, lease);
+    queue.requeue(job);
+    unawaited(processNext());
   }
 
   /// Bounded dispatch pass: execute ready jobs up to the configured limit.
@@ -131,7 +163,12 @@ extension WakeDrainEngine on WakeOrchestrator {
           if (job == null) break;
           inspectedJobs++;
 
-          if (!await _wakeAllowedByCurrentPolicy(job)) {
+          final wakeAllowed = await _wakeAllowedByCurrentPolicy(job);
+          if (_drainGeneration != generation) {
+            _handOffSupersededJob(generation, job);
+            return;
+          }
+          if (!wakeAllowed) {
             _log(
               'drain policy dropped automatic/disabled wake for '
               '${DomainLogger.sanitizeId(job.agentId)}',
@@ -141,17 +178,22 @@ extension WakeDrainEngine on WakeOrchestrator {
             continue;
           }
 
-          final acquired = await runner.tryAcquire(
+          final lease = await runner.tryAcquireLease(
             job.agentId,
             workspaceKey: job.workspaceKey,
           );
-          if (!acquired) {
+          if (_drainGeneration != generation) {
+            _handOffSupersededJob(generation, job, lease: lease);
+            return;
+          }
+          if (lease == null) {
             // Keep same-agent work queued while its active wake executes. The
             // active wake uses queue visibility to decide whether to arm its
             // existing follow-up throttle deadline.
             deferred.add(job);
             continue;
           }
+          _trackDrainLease(generation, lease);
 
           // Re-check suppression and throttle for subscription jobs that were
           // enqueued during an agent's execution — before the throttle
@@ -170,7 +212,7 @@ extension WakeDrainEngine on WakeOrchestrator {
                 'for ${DomainLogger.sanitizeId(job.agentId)}',
                 subDomain: 'drain',
               );
-              runner.release(job.agentId);
+              _releaseDrainLease(generation, lease);
               continue;
             }
 
@@ -183,7 +225,7 @@ extension WakeDrainEngine on WakeOrchestrator {
                 'for ${DomainLogger.sanitizeId(job.agentId)}',
                 subDomain: 'drain',
               );
-              runner.release(job.agentId);
+              _releaseDrainLease(generation, lease);
               deferred.add(job);
               continue;
             }
@@ -191,28 +233,39 @@ extension WakeDrainEngine on WakeOrchestrator {
 
           // Content-gating: agents auto-assigned from category defaults wait
           // for the task to have meaningful content before their first run.
-          if (await _shouldSkipForAwaitingContent(job)) {
-            runner.release(job.agentId);
+          final shouldSkipForAwaitingContent =
+              await _shouldSkipForAwaitingContent(job);
+          if (_drainGeneration != generation) {
+            _handOffSupersededJob(generation, job, lease: lease);
+            return;
+          }
+          if (shouldSkipForAwaitingContent) {
+            _releaseDrainLease(generation, lease);
             continue;
           }
 
-          activeExecutions[job.runKey] = _executeJob(job).then(
-            (_) => job.runKey,
-            onError: (Object error, StackTrace stackTrace) {
-              // `_executeJob` owns its normal error boundary and lock release,
-              // but keep the scheduler resilient if an unexpected failure
-              // escapes that boundary (for example, a logging implementation
-              // throwing before `_executeJob` enters its outer try/finally).
-              runner.release(job.agentId);
-              logError(
-                'unexpected wake execution failure for '
-                '${DomainLogger.sanitizeId(job.runKey)}',
-                error: error,
-                stackTrace: stackTrace,
+          activeExecutions[job.runKey] =
+              _executeJob(
+                job,
+                lease: lease,
+                generation: generation,
+              ).then(
+                (_) => job.runKey,
+                onError: (Object error, StackTrace stackTrace) {
+                  // `_executeJob` owns its normal error boundary and lock release,
+                  // but keep the scheduler resilient if an unexpected failure
+                  // escapes that boundary (for example, a logging implementation
+                  // throwing before `_executeJob` enters its outer try/finally).
+                  _releaseDrainLease(generation, lease);
+                  logError(
+                    'unexpected wake execution failure for '
+                    '${DomainLogger.sanitizeId(job.runKey)}',
+                    error: error,
+                    stackTrace: stackTrace,
+                  );
+                  return job.runKey;
+                },
               );
-              return job.runKey;
-            },
-          );
           if (_drainGeneration == generation) {
             _drainLastProgressAt = clock.now();
           }
@@ -311,11 +364,26 @@ extension WakeDrainEngine on WakeOrchestrator {
     );
   }
 
+  /// Finalize a persisted wake that resumed after its drain was superseded.
+  Future<void> _finishSupersededWake(WakeJob job) async {
+    await _safeUpdateStatus(
+      job.runKey,
+      WakeRunStatus.aborted.name,
+      completedAt: clock.now(),
+      errorMessage: 'superseded drain',
+    );
+    _emitRunCompletion(job, WakeRunStatus.aborted);
+  }
+
   /// Execute a single wake job: persist → run executor → update status.
   ///
   /// All exceptions are caught and logged so that a single failing job does
   /// not abort the drain loop and starve other queued jobs.
-  Future<void> _executeJob(WakeJob job) async {
+  Future<void> _executeJob(
+    WakeJob job, {
+    required WakeRunnerLease lease,
+    required int generation,
+  }) async {
     final threadId = job.runKey;
 
     _log(
@@ -348,6 +416,11 @@ extension WakeDrainEngine on WakeOrchestrator {
           stackTrace: s,
         );
         _emitRunCompletion(job, WakeRunStatus.failed, error: e);
+        return;
+      }
+
+      if (_drainGeneration != generation) {
+        await _finishSupersededWake(job);
         return;
       }
 
@@ -388,11 +461,21 @@ extension WakeDrainEngine on WakeOrchestrator {
         }
       }
 
+      if (_drainGeneration != generation) {
+        await _finishSupersededWake(job);
+        return;
+      }
+
       // Policy may change while this job awaits runner acquisition, content
       // gating, run persistence, or the pre-wake hook. Re-read immediately
       // before executor setup so disabling automation cannot launch paid work
       // from a job that has already left the queue.
-      if (!await _wakeAllowedByCurrentPolicy(job)) {
+      final wakeAllowed = await _wakeAllowedByCurrentPolicy(job);
+      if (_drainGeneration != generation) {
+        await _finishSupersededWake(job);
+        return;
+      }
+      if (!wakeAllowed) {
         _log(
           'pre-execution policy dropped automatic/disabled wake for '
           '${DomainLogger.sanitizeId(job.agentId)}',
@@ -422,7 +505,7 @@ extension WakeDrainEngine on WakeOrchestrator {
         var timedOut = false;
         timeoutTimer = Timer(WakeOrchestrator.wakeRunMaxDuration, () {
           timedOut = true;
-          if (runner.abort(job.agentId)) {
+          if (runner.abortLease(lease)) {
             _log(
               'wake timed out after ${WakeOrchestrator.wakeRunMaxDuration.inSeconds}s '
               'for ${DomainLogger.sanitizeId(job.agentId)} — aborting',
@@ -445,7 +528,7 @@ extension WakeDrainEngine on WakeOrchestrator {
         // microtasks (e.g. `aborted` wins, then the executor finishes its
         // own then-handler before we reach the branch), which previously
         // misclassified an aborted run as `completed`.
-        final abortFuture = runner.abortFuture(job.agentId);
+        final abortFuture = lease.abortFuture;
         final completed = Completer<Map<String, VectorClock>?>();
         final aborted = Completer<void>();
         final abortSentinel = Object();
@@ -471,13 +554,11 @@ extension WakeDrainEngine on WakeOrchestrator {
           ),
         );
 
-        if (abortFuture != null) {
-          unawaited(
-            abortFuture.then((_) {
-              if (!aborted.isCompleted) aborted.complete();
-            }),
-          );
-        }
+        unawaited(
+          abortFuture.then((_) {
+            if (!aborted.isCompleted) aborted.complete();
+          }),
+        );
 
         final winner = await Future.any<Object?>([
           completed.future,
@@ -606,7 +687,7 @@ extension WakeDrainEngine on WakeOrchestrator {
         timeoutTimer?.cancel();
       }
     } finally {
-      runner.release(job.agentId);
+      _releaseDrainLease(generation, lease);
     }
   }
 

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -24,8 +24,9 @@ extension WakeDrainEngine on WakeOrchestrator {
   /// [WakeOrchestrator._drainTimeout], force-reset the guard to recover from
   /// a stuck drain while preserving healthy concurrent runner leases.
   Future<void> processNextImpl() async {
+    final now = clock.now();
+    _releaseStaleSupersededDrainLeases(now);
     if (_isDraining) {
-      final now = clock.now();
       var oldestProgressAt = _drainLastProgressAt;
       final activeGenerationLeases =
           _drainLeasesByGeneration[_drainGeneration] ?? const {};
@@ -121,6 +122,15 @@ extension WakeDrainEngine on WakeOrchestrator {
         .toList(growable: false);
     for (final lease in staleLeases) {
       _releaseDrainLease(generation, lease);
+    }
+  }
+
+  void _releaseStaleSupersededDrainLeases(DateTime now) {
+    final supersededGenerations = _drainLeasesByGeneration.keys
+        .where((generation) => generation != _drainGeneration)
+        .toList(growable: false);
+    for (final generation in supersededGenerations) {
+      _releaseStaleDrainLeases(generation, now);
     }
   }
 

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -25,11 +25,17 @@ extension WakeDrainEngine on WakeOrchestrator {
   /// a stuck drain.
   Future<void> processNextImpl() async {
     if (_isDraining) {
+      var oldestProgressAt = _drainLastProgressAt;
+      for (final progressAt in _drainLeaseProgressAt.values) {
+        if (oldestProgressAt == null || progressAt.isBefore(oldestProgressAt)) {
+          oldestProgressAt = progressAt;
+        }
+      }
       // Fix B: force-reset stale drain lock after timeout.
-      if (_drainLastProgressAt != null &&
-          clock.now().difference(_drainLastProgressAt!) >
+      if (oldestProgressAt != null &&
+          clock.now().difference(oldestProgressAt) >
               WakeOrchestrator._drainTimeout) {
-        final stalledFor = clock.now().difference(_drainLastProgressAt!);
+        final stalledFor = clock.now().difference(oldestProgressAt);
         _log(
           'force-resetting stale drain lock '
           '(last progress ${stalledFor.inSeconds}s ago)',
@@ -85,9 +91,11 @@ extension WakeDrainEngine on WakeOrchestrator {
 
   void _trackDrainLease(int generation, WakeRunnerLease lease) {
     (_drainLeasesByGeneration[generation] ??= <WakeRunnerLease>{}).add(lease);
+    _drainLeaseProgressAt[lease] = clock.now();
   }
 
   void _releaseDrainLease(int generation, WakeRunnerLease lease) {
+    _drainLeaseProgressAt.remove(lease);
     final leases = _drainLeasesByGeneration[generation];
     leases?.remove(lease);
     if (leases != null && leases.isEmpty) {
@@ -99,7 +107,9 @@ extension WakeDrainEngine on WakeOrchestrator {
   void _releaseDrainGenerationLeases(int generation) {
     final leases = _drainLeasesByGeneration.remove(generation);
     if (leases == null) return;
-    leases.forEach(runner.releaseLease);
+    leases
+      ..forEach(_drainLeaseProgressAt.remove)
+      ..forEach(runner.releaseLease);
   }
 
   void _trackDrainOwnedJob(WakeJob job) {
@@ -419,7 +429,9 @@ extension WakeDrainEngine on WakeOrchestrator {
       // Clear run-key history only when the queue is fully drained (no
       // deferred jobs left). This prevents stale keys from blocking future
       // wakes while avoiding premature clearing that could allow duplicates.
-      if (_drainGeneration == generation && queue.isEmpty) {
+      if (_drainGeneration == generation &&
+          queue.isEmpty &&
+          _drainOwnedJobs.isEmpty) {
         _log('run-key history cleared (queue empty)', subDomain: 'drain');
         queue.clearHistory();
       }
@@ -515,13 +527,16 @@ extension WakeDrainEngine on WakeOrchestrator {
         try {
           await repository.insertWakeRun(entry: entry);
         } catch (error, stackTrace) {
-          _forgetDrainOwnedJob(job);
+          final cancellation = _takeDrainOwnedCancellation(job);
           logError(
             'insertWakeRun failed for ${DomainLogger.sanitizeId(job.runKey)}',
             error: error,
             stackTrace: stackTrace,
           );
-          _emitRunCompletion(job, WakeRunStatus.failed, error: error);
+          if (cancellation == null) {
+            _forgetDrainOwnedJob(job);
+            _emitRunCompletion(job, WakeRunStatus.failed, error: error);
+          }
           return;
         }
       }
@@ -617,6 +632,9 @@ extension WakeDrainEngine on WakeOrchestrator {
       final startTime = clock.now();
       if (_drainGeneration == generation) {
         _drainLastProgressAt = startTime;
+        if (_drainLeaseProgressAt.containsKey(lease)) {
+          _drainLeaseProgressAt[lease] = startTime;
+        }
       }
       Timer? timeoutTimer;
       try {

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -20,17 +20,19 @@ extension WakeDrainEngine on WakeOrchestrator {
   /// When the queue becomes empty after processing, the seen-run-key history
   /// is cleared so that future notification batches can create new run keys.
   ///
-  /// Fix B: If a drain has been in progress for longer than [WakeOrchestrator._drainTimeout],
-  /// force-reset the guard to recover from a stuck drain.
+  /// Fix B: If a drain has made no progress for longer than
+  /// [WakeOrchestrator._drainTimeout], force-reset the guard to recover from
+  /// a stuck drain.
   Future<void> processNextImpl() async {
     if (_isDraining) {
       // Fix B: force-reset stale drain lock after timeout.
-      if (_drainStartedAt != null &&
-          clock.now().difference(_drainStartedAt!) >
+      if (_drainLastProgressAt != null &&
+          clock.now().difference(_drainLastProgressAt!) >
               WakeOrchestrator._drainTimeout) {
+        final stalledFor = clock.now().difference(_drainLastProgressAt!);
         _log(
           'force-resetting stale drain lock '
-          '(started ${clock.now().difference(_drainStartedAt!).inSeconds}s ago)',
+          '(last progress ${stalledFor.inSeconds}s ago)',
           subDomain: 'drain',
         );
         // Increment generation so the old drain's loop bails out.
@@ -40,7 +42,7 @@ extension WakeDrainEngine on WakeOrchestrator {
           wakeSignal.complete();
         }
         _isDraining = false;
-        _drainStartedAt = null;
+        _drainLastProgressAt = null;
       } else {
         _drainRequested = true;
         final wakeSignal = _drainWakeSignal;
@@ -52,7 +54,7 @@ extension WakeDrainEngine on WakeOrchestrator {
     }
 
     _isDraining = true;
-    _drainStartedAt = clock.now();
+    _drainLastProgressAt = clock.now();
     final myGeneration = _drainGeneration;
     _log(
       'drain started, queue.length=${queue.length}',
@@ -73,7 +75,7 @@ extension WakeDrainEngine on WakeOrchestrator {
       // Only clear the guard if we are still the active drain generation.
       if (_drainGeneration == myGeneration) {
         _isDraining = false;
-        _drainStartedAt = null;
+        _drainLastProgressAt = null;
       }
     }
   }
@@ -211,6 +213,7 @@ extension WakeDrainEngine on WakeOrchestrator {
               return job.runKey;
             },
           );
+          _drainLastProgressAt = clock.now();
         }
 
         // Requeue skipped busy/throttled jobs before waiting. Active wakes use
@@ -241,7 +244,10 @@ extension WakeDrainEngine on WakeOrchestrator {
         final completedExecution = activeExecutions.remove(
           completedRunKey as String,
         );
-        if (completedExecution != null) await completedExecution;
+        if (completedExecution != null) {
+          await completedExecution;
+          _drainLastProgressAt = clock.now();
+        }
       }
     } finally {
       final wakeSignal = ownedWakeSignal;

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -22,30 +22,35 @@ extension WakeDrainEngine on WakeOrchestrator {
   ///
   /// Fix B: If a drain has made no progress for longer than
   /// [WakeOrchestrator._drainTimeout], force-reset the guard to recover from
-  /// a stuck drain.
+  /// a stuck drain while preserving healthy concurrent runner leases.
   Future<void> processNextImpl() async {
     if (_isDraining) {
+      final now = clock.now();
       var oldestProgressAt = _drainLastProgressAt;
-      for (final progressAt in _drainLeaseProgressAt.values) {
+      final activeGenerationLeases =
+          _drainLeasesByGeneration[_drainGeneration] ?? const {};
+      for (final lease in activeGenerationLeases) {
+        final progressAt = _drainLeaseProgressAt[lease];
+        if (progressAt == null) continue;
         if (oldestProgressAt == null || progressAt.isBefore(oldestProgressAt)) {
           oldestProgressAt = progressAt;
         }
       }
       // Fix B: force-reset stale drain lock after timeout.
       if (oldestProgressAt != null &&
-          clock.now().difference(oldestProgressAt) >
-              WakeOrchestrator._drainTimeout) {
-        final stalledFor = clock.now().difference(oldestProgressAt);
+          now.difference(oldestProgressAt) > WakeOrchestrator._drainTimeout) {
+        final stalledFor = now.difference(oldestProgressAt);
         _log(
           'force-resetting stale drain lock '
           '(last progress ${stalledFor.inSeconds}s ago)',
           subDomain: 'drain',
         );
         // Increment generation so the old drain's loop bails out, then free
-        // only the runner slots owned by that superseded generation.
+        // only individually stale runner slots. Healthy concurrent executions
+        // keep their agent locks until their own futures settle.
         final staleGeneration = _drainGeneration;
         _drainGeneration++;
-        _releaseDrainGenerationLeases(staleGeneration);
+        _releaseStaleDrainLeases(staleGeneration, now);
         final wakeSignal = _drainWakeSignal;
         if (wakeSignal != null && !wakeSignal.isCompleted) {
           wakeSignal.complete();
@@ -104,12 +109,19 @@ extension WakeDrainEngine on WakeOrchestrator {
     runner.releaseLease(lease);
   }
 
-  void _releaseDrainGenerationLeases(int generation) {
-    final leases = _drainLeasesByGeneration.remove(generation);
+  void _releaseStaleDrainLeases(int generation, DateTime now) {
+    final leases = _drainLeasesByGeneration[generation];
     if (leases == null) return;
-    leases
-      ..forEach(_drainLeaseProgressAt.remove)
-      ..forEach(runner.releaseLease);
+    final staleLeases = leases
+        .where((lease) {
+          final progressAt = _drainLeaseProgressAt[lease];
+          return progressAt != null &&
+              now.difference(progressAt) > WakeOrchestrator._drainTimeout;
+        })
+        .toList(growable: false);
+    for (final lease in staleLeases) {
+      _releaseDrainLease(generation, lease);
+    }
   }
 
   void _trackDrainOwnedJob(WakeJob job) {

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -124,6 +124,7 @@ extension WakeDrainEngine on WakeOrchestrator {
   }) {
     if (_takeDrainOwnedCancellation(job) == null) return false;
     if (lease != null) _releaseDrainLease(generation, lease);
+    if (_drainGeneration != generation) unawaited(processNext());
     return true;
   }
 

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -443,8 +443,10 @@ class WakeOrchestrator with AgentErrorLogging {
   int _drainGeneration = 0;
 
   /// Maximum duration for a drain before it is considered stale and the
-  /// guard is force-reset.
-  static const _drainTimeout = Duration(minutes: 5);
+  /// guard is force-reset. This must remain longer than
+  /// [wakeRunMaxDuration], with headroom for the bounded pre-wake hook and
+  /// terminal status persistence, so a valid slow wake is never superseded.
+  static const _drainTimeout = Duration(minutes: 12);
 
   /// Safety-net periodic timer that catches any scenario where a deferred
   /// drain timer fails to fire (macOS App Nap, race conditions, etc.).

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -356,8 +356,15 @@ class WakeOrchestrator with AgentErrorLogging {
             WakeRunStatus.aborted.name,
             completedAt: clock.now(),
             errorMessage: reason,
+          ).then(
+            (_) => _emitRunCompletion(
+              job,
+              WakeRunStatus.aborted,
+              error: StateError(reason),
+            ),
           ),
         );
+        continue;
       }
       _emitRunCompletion(
         job,

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -444,8 +444,8 @@ class WakeOrchestrator with AgentErrorLogging {
   /// superseded and bail out.
   int _drainGeneration = 0;
 
-  /// Maximum duration for a drain before it is considered stale and the
-  /// guard is force-reset. This must remain longer than
+  /// Maximum interval without scheduler progress before a drain is considered
+  /// stale and the guard is force-reset. This must remain longer than
   /// [wakeRunMaxDuration], with headroom for the bounded pre-wake hook and
   /// terminal status persistence, so a valid slow wake is never superseded.
   static const _drainTimeout = Duration(minutes: 12);

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -434,8 +434,10 @@ class WakeOrchestrator with AgentErrorLogging {
   /// immediately instead of waiting behind an unrelated long inference.
   Completer<void>? _drainWakeSignal;
 
-  /// Timestamp when the current drain started, for stale-drain detection.
-  DateTime? _drainStartedAt;
+  /// Timestamp of the latest scheduler progress, for stale-drain detection.
+  /// Updated whenever a wake is dispatched or completes so a healthy drain
+  /// processing several slow wakes is not judged by its total lifetime.
+  DateTime? _drainLastProgressAt;
 
   /// Generation counter for drain cancellation. Incremented when a stale
   /// drain is force-reset so the old drain's loop can detect it was
@@ -449,7 +451,7 @@ class WakeOrchestrator with AgentErrorLogging {
   static const _drainTimeout = Duration(minutes: 12);
 
   /// Safety-net periodic timer that catches any scenario where a deferred
-  /// drain timer fails to fire (macOS App Nap, race conditions, etc.).
+  /// drain timer fails to fire or an active drain stops making progress.
   Timer? _safetyNetTimer;
 
   static const _restoredPendingWakeSubscriptionId = 'restored_pending_wake';
@@ -766,15 +768,15 @@ class WakeOrchestrator with AgentErrorLogging {
   /// Starts a periodic safety-net timer that ensures the queue is eventually
   /// drained even if a deferred drain timer fails to fire.
   ///
-  /// Only triggers [processNext] when the queue has pending jobs AND no
-  /// drain is currently in progress. We intentionally do NOT check
-  /// `_deferredDrainTimers.isEmpty` because a stale or cancelled timer
-  /// entry lingering in the map would permanently disable the safety net —
-  /// exactly the failure mode this mechanism is meant to recover from.
+  /// Triggers [processNext] whenever the queue has pending jobs. Re-entering
+  /// an active drain is intentional: it either wakes the healthy scheduler or
+  /// force-resets one whose last progress exceeded [_drainTimeout]. We do not
+  /// check `_deferredDrainTimers.isEmpty` because a stale or cancelled timer
+  /// entry lingering in the map would permanently disable the safety net.
   void _startSafetyNet() {
     _safetyNetTimer?.cancel();
     _safetyNetTimer = Timer.periodic(safetyNetInterval, (_) {
-      if (!queue.isEmpty && !_isDraining) {
+      if (!queue.isEmpty) {
         _log('safety-net drain: queue=${queue.length}');
         unawaited(processNext());
       }

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -328,15 +328,66 @@ class WakeOrchestrator with AgentErrorLogging {
     );
   }
 
+  List<WakeJob> _cancelDrainOwnedJobsWhere(
+    bool Function(WakeJob job) predicate, {
+    required String reason,
+  }) {
+    final cancelled = <WakeJob>[];
+    for (final job in _drainOwnedJobs.values) {
+      if (!predicate(job) ||
+          _cancelledDrainOwnedRunReasons.containsKey(job.runKey)) {
+        continue;
+      }
+      _cancelledDrainOwnedRunReasons[job.runKey] = reason;
+      cancelled.add(job);
+    }
+    return cancelled;
+  }
+
   void _emitRemovedRunCompletions(
     Iterable<WakeJob> jobs, {
     required String reason,
   }) {
     for (final job in jobs) {
+      if (_persistedWakeRunKeys.remove(job.runKey)) {
+        unawaited(
+          _safeUpdateStatus(
+            job.runKey,
+            WakeRunStatus.aborted.name,
+            completedAt: clock.now(),
+            errorMessage: reason,
+          ),
+        );
+      }
       _emitRunCompletion(
         job,
         WakeRunStatus.aborted,
         error: StateError(reason),
+      );
+    }
+  }
+
+  /// Update wake run status without letting persistence failures escape the
+  /// orchestrator's execution or cancellation paths.
+  Future<void> _safeUpdateStatus(
+    String runKey,
+    String status, {
+    DateTime? completedAt,
+    String? errorMessage,
+  }) async {
+    try {
+      await repository.updateWakeRunStatus(
+        runKey,
+        status,
+        completedAt: completedAt,
+        errorMessage: errorMessage,
+      );
+    } catch (error, stackTrace) {
+      logError(
+        'failed to update wake run status '
+        'for ${DomainLogger.sanitizeId(runKey)} to $status',
+        error: error,
+        stackTrace: stackTrace,
       );
     }
   }
@@ -451,6 +502,18 @@ class WakeOrchestrator with AgentErrorLogging {
   /// run for the same agent.
   final _drainLeasesByGeneration = <int, Set<WakeRunnerLease>>{};
 
+  /// Jobs temporarily owned by the drain while they are outside [queue] but
+  /// have not started executor work yet.
+  final _drainOwnedJobs = <String, WakeJob>{};
+
+  /// Cancellation reason for drain-owned jobs removed by a newer request or
+  /// explicit cancellation while an asynchronous pre-dispatch step was active.
+  final _cancelledDrainOwnedRunReasons = <String, String>{};
+
+  /// Run keys whose `wake_run_log` row already exists when stale recovery
+  /// returns their job to the queue.
+  final _persistedWakeRunKeys = <String>{};
+
   /// Maximum interval without scheduler progress before a drain is considered
   /// stale and the guard is force-reset. This must remain longer than
   /// [wakeRunMaxDuration], with headroom for the bounded pre-wake hook and
@@ -540,8 +603,13 @@ class WakeOrchestrator with AgentErrorLogging {
       agentId,
       (job) => job.initiator == WakeInitiator.automation,
     );
+    final owned = _cancelDrainOwnedJobsWhere(
+      (job) =>
+          job.agentId == agentId && job.initiator == WakeInitiator.automation,
+      reason: reason,
+    );
     _emitRemovedRunCompletions(
-      removed,
+      [...removed, ...owned],
       reason: reason,
     );
   }
@@ -824,13 +892,18 @@ class WakeOrchestrator with AgentErrorLogging {
     // per submission) opt out so a second submission in the same workspace
     // cannot drop the first's still-queued parse before it drains.
     if (supersede) {
+      const supersededReason = 'wake superseded by a newer manual request';
       final removed = queue.removeByAgent(
         agentId,
         workspaceKey: workspaceKey,
       );
+      final owned = _cancelDrainOwnedJobsWhere(
+        (job) => job.agentId == agentId && job.workspaceKey == workspaceKey,
+        reason: supersededReason,
+      );
       _emitRemovedRunCompletions(
-        removed,
-        reason: 'wake superseded by a newer manual request',
+        [...removed, ...owned],
+        reason: supersededReason,
       );
     }
 
@@ -868,16 +941,23 @@ class WakeOrchestrator with AgentErrorLogging {
     String? workspaceKey,
     bool allWorkspaces = false,
   }) {
+    const cancellationReason = 'wake cancelled before execution';
     final removed = queue.removeByAgent(
       agentId,
       workspaceKey: workspaceKey,
       allWorkspaces: allWorkspaces,
     );
-    _emitRemovedRunCompletions(
-      removed,
-      reason: 'wake cancelled before execution',
+    final owned = _cancelDrainOwnedJobsWhere(
+      (job) =>
+          job.agentId == agentId &&
+          (allWorkspaces || job.workspaceKey == workspaceKey),
+      reason: cancellationReason,
     );
-    return removed;
+    _emitRemovedRunCompletions(
+      [...removed, ...owned],
+      reason: cancellationReason,
+    );
+    return [...removed, ...owned];
   }
 
   /// Wake [agentId] for externally produced content (e.g. a completed audio

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -444,6 +444,13 @@ class WakeOrchestrator with AgentErrorLogging {
   /// superseded and bail out.
   int _drainGeneration = 0;
 
+  /// Runner leases owned by each drain generation.
+  ///
+  /// Stale recovery releases only the superseded generation's slots. Lease
+  /// identity ensures its late cleanup cannot release or abort a replacement
+  /// run for the same agent.
+  final _drainLeasesByGeneration = <int, Set<WakeRunnerLease>>{};
+
   /// Maximum interval without scheduler progress before a drain is considered
   /// stale and the guard is force-reset. This must remain longer than
   /// [wakeRunMaxDuration], with headroom for the bounded pre-wake hook and

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -497,9 +497,10 @@ class WakeOrchestrator with AgentErrorLogging {
 
   /// Runner leases owned by each drain generation.
   ///
-  /// Stale recovery releases only the superseded generation's slots. Lease
-  /// identity ensures its late cleanup cannot release or abort a replacement
-  /// run for the same agent.
+  /// Stale recovery releases only individually stale slots from the
+  /// superseded generation. Healthy slots retain ownership until completion,
+  /// and lease identity ensures late cleanup cannot release or abort a
+  /// replacement run for the same agent.
   final _drainLeasesByGeneration = <int, Set<WakeRunnerLease>>{};
 
   /// Latest meaningful progress for each active lease. Generation-wide

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -502,6 +502,10 @@ class WakeOrchestrator with AgentErrorLogging {
   /// run for the same agent.
   final _drainLeasesByGeneration = <int, Set<WakeRunnerLease>>{};
 
+  /// Latest meaningful progress for each active lease. Generation-wide
+  /// progress cannot let unrelated healthy wakes hide one stalled slot.
+  final _drainLeaseProgressAt = <WakeRunnerLease, DateTime>{};
+
   /// Jobs temporarily owned by the drain while they are outside [queue] but
   /// have not started executor work yet.
   final _drainOwnedJobs = <String, WakeJob>{};

--- a/lib/features/agents/wake/wake_runner.dart
+++ b/lib/features/agents/wake/wake_runner.dart
@@ -3,6 +3,27 @@ import 'dart:collection';
 
 import 'package:clock/clock.dart';
 
+/// Ownership token for one [WakeRunner] acquisition.
+///
+/// Lease-aware release and abort operations ignore tokens that no longer own
+/// the agent lock. This prevents a superseded wake from affecting a newer run
+/// for the same agent when its asynchronous cleanup resumes late.
+class WakeRunnerLease {
+  const WakeRunnerLease._({
+    required this.agentId,
+    required this._id,
+    required this.abortFuture,
+  });
+
+  /// Agent whose single-flight lock this lease owns.
+  final String agentId;
+
+  final int _id;
+
+  /// Completes when this specific run is aborted or released.
+  final Future<void> abortFuture;
+}
+
 /// Single-flight execution engine for agent wake runs.
 ///
 /// Ensures that at most one wake executes per agent at a time.  Each
@@ -13,6 +34,8 @@ class WakeRunner {
   final _activeStartedAt = <String, DateTime>{};
   final _activeWorkspaceKey = <String, String?>{};
   final _abortSignals = <String, Completer<void>>{};
+  final _activeLeaseIds = <String, int>{};
+  var _nextLeaseId = 0;
   late final UnmodifiableMapView<String, DateTime> _activeStartedAtView =
       UnmodifiableMapView(_activeStartedAt);
   final _runningController = StreamController<Set<String>>.broadcast();
@@ -33,13 +56,32 @@ class WakeRunner {
   /// [workspaceKeyFor] instead of treating any run of a shared agent as
   /// relevant to every workspace it might touch.
   Future<bool> tryAcquire(String agentId, {String? workspaceKey}) async {
-    if (_activeLocks.containsKey(agentId)) return false;
+    return (await tryAcquireLease(agentId, workspaceKey: workspaceKey)) != null;
+  }
+
+  /// Attempt to acquire [agentId] and return its ownership token.
+  ///
+  /// Unlike [tryAcquire], the returned lease lets asynchronous owners release
+  /// or abort only the run they acquired, even after stale recovery has
+  /// installed a replacement run for the same agent.
+  Future<WakeRunnerLease?> tryAcquireLease(
+    String agentId, {
+    String? workspaceKey,
+  }) async {
+    if (_activeLocks.containsKey(agentId)) return null;
     _activeLocks[agentId] = Completer<void>();
-    _abortSignals[agentId] = Completer<void>();
+    final abortSignal = Completer<void>();
+    _abortSignals[agentId] = abortSignal;
+    final leaseId = _nextLeaseId++;
+    _activeLeaseIds[agentId] = leaseId;
     _activeStartedAt[agentId] = clock.now();
     _activeWorkspaceKey[agentId] = workspaceKey;
     _runningController.add(activeAgentIds);
-    return true;
+    return WakeRunnerLease._(
+      agentId: agentId,
+      id: leaseId,
+      abortFuture: abortSignal.future,
+    );
   }
 
   /// Release the lock for [agentId] and complete any waiters.
@@ -53,9 +95,16 @@ class WakeRunner {
     lock.complete();
     _activeStartedAt.remove(agentId);
     _activeWorkspaceKey.remove(agentId);
+    _activeLeaseIds.remove(agentId);
     final abort = _abortSignals.remove(agentId);
     if (abort != null && !abort.isCompleted) abort.complete();
     _runningController.add(activeAgentIds);
+  }
+
+  /// Release [lease] only while it still owns its agent lock.
+  void releaseLease(WakeRunnerLease lease) {
+    if (_activeLeaseIds[lease.agentId] != lease._id) return;
+    release(lease.agentId);
   }
 
   /// Signal an abort for the in-flight run for [agentId].
@@ -69,6 +118,12 @@ class WakeRunner {
     if (abort == null || abort.isCompleted) return false;
     abort.complete();
     return true;
+  }
+
+  /// Abort [lease] only while it still owns its agent lock.
+  bool abortLease(WakeRunnerLease lease) {
+    if (_activeLeaseIds[lease.agentId] != lease._id) return false;
+    return abort(lease.agentId);
   }
 
   /// Future that completes when [agentId]'s in-flight run ends — either

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -237,6 +237,7 @@ void main() {
                   queue: stuckQueue,
                   runner: stuckRunner,
                   domainLogger: logger,
+                  maxConcurrentWakes: () => 2,
                   wakeExecutor: (agentId, runKey, triggers, threadId) {
                     executedAgentIds.add(agentId);
                     if (agentId == 'stuck-agent') {

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -6,72 +6,54 @@ void main() {
   // Owns stale-drain detection, force-reset recovery, and generation bail-out.
   group('WakeOrchestrator', () {
     group('stale drain recovery (Fix B)', () {
-      test('force-resets stale drain and new drain supersedes old one '
-          'via generation counter', () {
-        fakeAsync((async) {
-          final stuckCompleter = Completer<Map<String, VectorClock>?>();
-          final executedAgentIds = <String>[];
+      test(
+        'does not supersede a valid wake that outlives the old drain cap',
+        () {
+          fakeAsync((async) {
+            final slowCompleter = Completer<Map<String, VectorClock>?>();
+            final executedAgentIds = <String>[];
 
-          orchestrator
-            ..wakeExecutor = (agentId, runKey, triggers, threadId) {
-              executedAgentIds.add(agentId);
-              // First call hangs; subsequent ones complete immediately.
-              if (agentId == 'stuck-agent') return stuckCompleter.future;
-              return Future.value();
-            }
-            ..addSubscription(
-              makeSub(
-                id: 'sub-stuck',
-                agentId: 'stuck-agent',
-                matchEntityIds: {'entity-stuck'},
-              ),
-            )
-            ..addSubscription(
-              makeSub(
-                id: 'sub-ok',
-                agentId: 'ok-agent',
-                matchEntityIds: {'entity-ok'},
-              ),
+            orchestrator = WakeOrchestrator(
+              repository: mockRepository,
+              queue: queue,
+              runner: runner,
+              maxConcurrentWakes: () => 1,
+              wakeExecutor: (agentId, runKey, triggers, threadId) {
+                executedAgentIds.add(agentId);
+                if (agentId == 'slow-agent') return slowCompleter.future;
+                return Future.value();
+              },
             );
 
-          final controller = StreamController<Set<String>>.broadcast();
-          orchestrator.start(controller.stream);
+            orchestrator.enqueueManualWake(
+              agentId: 'slow-agent',
+              reason: 'manual',
+            );
+            async.flushMicrotasks();
+            expect(executedAgentIds, equals(['slow-agent']));
 
-          // Trigger the stuck agent — deferred drain starts after throttle.
-          emitAndDrain(async, controller, {'entity-stuck'});
+            // The wake is still valid but has outlived the old five-minute
+            // stale-drain threshold.
+            async
+              ..elapse(const Duration(minutes: 6))
+              ..flushMicrotasks();
 
-          // The executor is now awaiting the stuckCompleter.
-          expect(executedAgentIds, contains('stuck-agent'));
+            orchestrator.enqueueManualWake(
+              agentId: 'next-agent',
+              reason: 'manual',
+            );
+            async.flushMicrotasks();
+            expect(executedAgentIds, equals(['slow-agent']));
 
-          // Advance past the 5-minute drain timeout.
-          async
-            ..elapse(const Duration(minutes: 6))
-            ..flushMicrotasks();
-
-          // Now trigger ok-agent. processNext should detect the stale drain,
-          // force-reset it, and start a new drain for ok-agent.
-          emitAndDrain(async, controller, {'entity-ok'});
-
-          expect(executedAgentIds, contains('ok-agent'));
-
-          // Complete the stuck executor so the old drain can finish its
-          // finally block.
-          stuckCompleter.complete(null);
-          async.flushMicrotasks();
-
-          // The orchestrator should be in a clean state — not stuck.
-          // Verify by enqueuing another manual wake and seeing it execute.
-          executedAgentIds.clear();
-          orchestrator.enqueueManualWake(
-            agentId: 'ok-agent',
-            reason: 'test',
-          );
-          async.flushMicrotasks();
-          expect(executedAgentIds, contains('ok-agent'));
-
-          controller.close();
-        });
-      });
+            // Completing the valid wake must let its existing drain dispatch
+            // the queued follow-up immediately. A premature force-reset leaves
+            // next-agent queued until another scheduler trigger arrives.
+            slowCompleter.complete(null);
+            async.flushMicrotasks();
+            expect(executedAgentIds, equals(['slow-agent', 'next-agent']));
+          });
+        },
+      );
 
       test('does not force-reset when drain is within timeout window', () {
         fakeAsync((async) {
@@ -99,7 +81,7 @@ void main() {
           emitAndDrain(async, controller, {'entity-stuck'});
           expect(executionCount, 1);
 
-          // Advance 60 seconds — well within both the 5-minute drain
+          // Advance 60 seconds — well within both the 12-minute drain
           // stale-lock window and the per-cycle wakeRunMaxDuration cap, so
           // the stuck executor is still in flight.
           async.elapse(const Duration(seconds: 60));
@@ -127,74 +109,12 @@ void main() {
   });
 
   group('_drain(generation) bail-out', () {
-    test('old drain bails out when generation changes during iteration', () {
-      fakeAsync((async) {
-        final stuckCompleter = Completer<Map<String, VectorClock>?>();
-        final executedAgentIds = <String>[];
-
-        orchestrator
-          ..wakeExecutor = (agentId, runKey, triggers, threadId) {
-            executedAgentIds.add(agentId);
-            if (agentId == 'slow-agent') return stuckCompleter.future;
-            return Future.value();
-          }
-          ..addSubscription(
-            makeSub(
-              id: 'sub-slow',
-              agentId: 'slow-agent',
-              matchEntityIds: {'entity-slow'},
-            ),
-          )
-          ..addSubscription(
-            makeSub(
-              id: 'sub-ok',
-              agentId: 'ok-agent',
-              matchEntityIds: {'entity-ok'},
-            ),
-          );
-
-        final controller = StreamController<Set<String>>.broadcast();
-        orchestrator.start(controller.stream);
-
-        // Trigger slow-agent — drain starts, executor blocks.
-        emitAndDrain(async, controller, {'entity-slow'});
-        expect(executedAgentIds, contains('slow-agent'));
-
-        // Advance past the 5-minute drain timeout.
-        async
-          ..elapse(const Duration(minutes: 6))
-          ..flushMicrotasks();
-
-        // Trigger ok-agent — force-resets stale drain (increments
-        // generation) and starts a new drain.
-        emitAndDrain(async, controller, {'entity-ok'});
-        expect(executedAgentIds, contains('ok-agent'));
-
-        // Complete the stuck executor — the old _drain resumes, loops
-        // back to while(true), checks generation, and bails out via
-        // `if (_drainGeneration != generation) return`.
-        stuckCompleter.complete(null);
-        async.flushMicrotasks();
-
-        // Verify the orchestrator is in a clean state.
-        executedAgentIds.clear();
-        orchestrator.enqueueManualWake(
-          agentId: 'ok-agent',
-          reason: 'test',
-        );
-        async.flushMicrotasks();
-        expect(executedAgentIds, contains('ok-agent'));
-
-        controller.close();
-      });
-    });
-
     group('processNext stale-lock force-reset', () {
       // These tests drive the force-reset branch that the existing
       // "stale drain recovery" tests never reach: with a normally-completing
-      // abort path the stuck drain finishes at the 2-minute hard cap, so
+      // abort path the stuck drain finishes at the 10-minute hard cap, so
       // _isDraining is already false by the time a later processNext runs.
-      // To keep _isDraining stuck past the 5-minute _drainTimeout we hang the
+      // To keep _isDraining stuck past the 12-minute _drainTimeout we hang the
       // *aborted* status write, freezing _executeJob (and thus the drain)
       // inside _safeUpdateStatus.
       test(
@@ -301,8 +221,8 @@ void main() {
               ),
             ).called(1);
 
-            // Advance well past the 5-minute stale-drain timeout (total since
-            // drain start is now > 15 minutes).
+            // Advance well past the 12-minute stale-drain timeout (total since
+            // drain start is now > 16 minutes).
             async
               ..elapse(const Duration(minutes: 6))
               ..flushMicrotasks();

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -1,5 +1,28 @@
 import 'wake_orchestrator_test_harness.dart';
 
+class _AcquisitionGatedWakeRunner extends WakeRunner {
+  _AcquisitionGatedWakeRunner({
+    required this.gatedAgentId,
+    required this.gate,
+  });
+
+  final String gatedAgentId;
+  final Completer<void> gate;
+
+  @override
+  Future<WakeRunnerLease?> tryAcquireLease(
+    String agentId, {
+    String? workspaceKey,
+  }) async {
+    final lease = await super.tryAcquireLease(
+      agentId,
+      workspaceKey: workspaceKey,
+    );
+    if (agentId == gatedAgentId) await gate.future;
+    return lease;
+  }
+}
+
 void main() {
   configureWakeOrchestratorTestSuite();
 
@@ -110,6 +133,61 @@ void main() {
             executedAgentIds,
             equals(['first-agent', 'second-agent', 'next-agent']),
           );
+        });
+      });
+
+      test('starts the stale clock from the executor window', () {
+        fakeAsync((async) {
+          final finalPolicyGate = Completer<AgentDomainEntity?>();
+          final slowExecutionGate = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          var slowPolicyReads = 0;
+          when(() => mockRepository.getEntity(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            if (agentId == 'slow-agent' && ++slowPolicyReads == 2) {
+              return finalPolicyGate.future;
+            }
+            return Future.value();
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              if (agentId == 'slow-agent') return slowExecutionGate.future;
+              return Future.value();
+            },
+          );
+
+          orchestrator.enqueueManualWake(
+            agentId: 'slow-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, isEmpty);
+
+          // Pre-execution work consumes three minutes before the executor's
+          // separate ten-minute cap begins.
+          async.elapse(const Duration(minutes: 3));
+          finalPolicyGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['slow-agent']));
+
+          // The drain is 12.5 minutes old, but executor work has only used
+          // 9.5 minutes of its valid ten-minute window.
+          async.elapse(const Duration(minutes: 9, seconds: 30));
+          orchestrator.enqueueManualWake(
+            agentId: 'next-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['slow-agent']));
+
+          slowExecutionGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['slow-agent', 'next-agent']));
         });
       });
 
@@ -245,6 +323,331 @@ void main() {
           async.flushMicrotasks();
         });
       });
+
+      test('does not resurrect a drain-owned superseded manual wake', () {
+        fakeAsync((async) {
+          final policyLookupGate = Completer<AgentDomainEntity?>();
+          final executedRunKeys = <String>[];
+          final completions = <WakeRunCompletion>[];
+          when(() => mockRepository.getEntity('manual-agent')).thenAnswer(
+            (_) => policyLookupGate.future,
+          );
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+          final completionSub = orchestrator.runCompletions.listen(
+            completions.add,
+          );
+
+          final oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'manual-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          async.elapse(const Duration(minutes: 1));
+          final newRunKey = orchestrator.enqueueManualWake(
+            agentId: 'manual-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(
+            completions,
+            contains(
+              isA<WakeRunCompletion>()
+                  .having((item) => item.runKey, 'runKey', oldRunKey)
+                  .having(
+                    (item) => item.status,
+                    'status',
+                    WakeRunStatus.aborted,
+                  ),
+            ),
+          );
+
+          policyLookupGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedRunKeys, equals([newRunKey]));
+          expect(executedRunKeys, isNot(contains(oldRunKey)));
+
+          completionSub.cancel();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('releases and requeues work superseded during acquisition', () {
+        fakeAsync((async) {
+          final acquisitionGate = Completer<void>();
+          final contentGate = Completer<bool>();
+          final replacementGate = Completer<Map<String, VectorClock>?>();
+          final originalGate = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          final contentState = makeTestState(
+            id: 'state-acquisition-agent',
+            agentId: 'acquisition-agent',
+            awaitingContent: true,
+            slots: const AgentSlots(activeTaskId: 'task-acquisition'),
+          );
+          when(() => mockRepository.getAgentState(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            return Future.value(
+              agentId == 'acquisition-agent' ? contentState : null,
+            );
+          });
+          runner = _AcquisitionGatedWakeRunner(
+            gatedAgentId: 'acquisition-agent',
+            gate: acquisitionGate,
+          );
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            taskContentChecker: (taskId) => contentGate.future,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              if (agentId == 'acquisition-agent') return originalGate.future;
+              return replacementGate.future;
+            },
+          )..setAwaitingContent('acquisition-agent', awaiting: true);
+
+          orchestrator.enqueueManualWake(
+            agentId: 'acquisition-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(runner.isRunning('acquisition-agent'), isTrue);
+          expect(executedAgentIds, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, isEmpty);
+
+          acquisitionGate.complete();
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+          expect(runner.activeAgentIds, equals({'replacement-agent'}));
+
+          replacementGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          contentGate.complete(true);
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['replacement-agent', 'acquisition-agent']),
+          );
+
+          originalGate.complete(null);
+          async.flushMicrotasks();
+        });
+      });
+
+      test('releases and requeues work superseded during content gating', () {
+        fakeAsync((async) {
+          final contentGate = Completer<bool>();
+          final replacementGate = Completer<Map<String, VectorClock>?>();
+          final originalGate = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          final contentState = makeTestState(
+            id: 'state-content-agent',
+            agentId: 'content-agent',
+            awaitingContent: true,
+            slots: const AgentSlots(activeTaskId: 'task-content'),
+          );
+          when(() => mockRepository.getAgentState(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            return Future.value(
+              agentId == 'content-agent' ? contentState : null,
+            );
+          });
+
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            taskContentChecker: (taskId) => contentGate.future,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              if (agentId == 'content-agent') return originalGate.future;
+              return replacementGate.future;
+            },
+          )..setAwaitingContent('content-agent', awaiting: true);
+
+          orchestrator.enqueueManualWake(
+            agentId: 'content-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(runner.isRunning('content-agent'), isTrue);
+          expect(executedAgentIds, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          contentGate.complete(true);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          replacementGate.complete(null);
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['replacement-agent', 'content-agent']),
+          );
+
+          originalGate.complete(null);
+          async.flushMicrotasks();
+        });
+      });
+
+      test('resumes a persisted wake superseded during run insertion', () {
+        fakeAsync((async) {
+          final insertGate = Completer<void>();
+          final replacementGate = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          final wakeStartAgentIds = <String>[];
+          var insertAgentInsertCount = 0;
+          when(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          ).thenAnswer((call) async {
+            final entry = call.namedArguments[#entry] as WakeRunLogData;
+            if (entry.agentId == 'insert-agent') {
+              insertAgentInsertCount++;
+              await insertGate.future;
+            }
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            onWakeStart: (agentId, runKey, threadId) async {
+              wakeStartAgentIds.add(agentId);
+            },
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              return replacementGate.future;
+            },
+          );
+
+          orchestrator.enqueueManualWake(
+            agentId: 'insert-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+          expect(wakeStartAgentIds, equals(['replacement-agent']));
+
+          insertGate.complete();
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+          expect(wakeStartAgentIds, equals(['replacement-agent']));
+
+          replacementGate.complete(null);
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['replacement-agent', 'insert-agent']),
+          );
+          expect(
+            wakeStartAgentIds,
+            equals(['replacement-agent', 'insert-agent']),
+          );
+          expect(insertAgentInsertCount, 1);
+        });
+      });
+
+      test(
+        'resumes a persisted wake superseded during the final policy read',
+        () {
+          fakeAsync((async) {
+            final finalPolicyGate = Completer<AgentDomainEntity?>();
+            final replacementGate = Completer<Map<String, VectorClock>?>();
+            final executedAgentIds = <String>[];
+            var oldPolicyReads = 0;
+            var oldInsertCount = 0;
+            when(() => mockRepository.getEntity(any())).thenAnswer((call) {
+              final agentId = call.positionalArguments.first as String;
+              if (agentId == 'final-policy-agent' && ++oldPolicyReads == 2) {
+                return finalPolicyGate.future;
+              }
+              return Future.value();
+            });
+            when(
+              () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+            ).thenAnswer((call) async {
+              final entry = call.namedArguments[#entry] as WakeRunLogData;
+              if (entry.agentId == 'final-policy-agent') oldInsertCount++;
+            });
+            orchestrator = WakeOrchestrator(
+              repository: mockRepository,
+              queue: queue,
+              runner: runner,
+              maxConcurrentWakes: () => 1,
+              wakeExecutor: (agentId, runKey, triggers, threadId) {
+                executedAgentIds.add(agentId);
+                return replacementGate.future;
+              },
+            );
+
+            orchestrator.enqueueManualWake(
+              agentId: 'final-policy-agent',
+              reason: 'manual',
+            );
+            async.flushMicrotasks();
+            expect(oldPolicyReads, 2);
+            expect(executedAgentIds, isEmpty);
+
+            async.elapse(const Duration(minutes: 13));
+            orchestrator.enqueueManualWake(
+              agentId: 'replacement-agent',
+              reason: 'manual',
+            );
+            async.flushMicrotasks();
+            expect(executedAgentIds, equals(['replacement-agent']));
+
+            finalPolicyGate.complete(null);
+            async.flushMicrotasks();
+            expect(executedAgentIds, equals(['replacement-agent']));
+
+            replacementGate.complete(null);
+            async.flushMicrotasks();
+            expect(
+              executedAgentIds,
+              equals(['replacement-agent', 'final-policy-agent']),
+            );
+            expect(oldPolicyReads, 4);
+            expect(oldInsertCount, 1);
+          });
+        },
+      );
     });
   });
 

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -1506,9 +1506,11 @@ void main() {
       test('healthy concurrent wakes do not hide a stalled lease', () {
         fakeAsync((async) {
           final abortedStatusGate = Completer<void>();
+          final healthyExecutionGate = Completer<Map<String, VectorClock>?>();
           final executedAgentIds = <String>[];
           String? firstStuckRunKey;
           var stuckExecutionCount = 0;
+          var healthyExecutionCount = 0;
           when(
             () => mockRepository.updateWakeRunStatus(
               any(),
@@ -1534,6 +1536,9 @@ void main() {
               if (agentId == 'stuck-agent' && stuckExecutionCount++ == 0) {
                 return Completer<Map<String, VectorClock>?>().future;
               }
+              if (agentId == 'healthy-agent' && healthyExecutionCount++ == 0) {
+                return healthyExecutionGate.future;
+              }
               return Future.value();
             },
           );
@@ -1558,18 +1563,44 @@ void main() {
             equals(['stuck-agent', 'healthy-agent']),
           );
 
-          // The healthy completion refreshed generation-wide progress only
-          // two minutes ago, but the stuck lease has made no progress for
-          // more than the full twelve-minute recovery window.
+          // The healthy execution started only two minutes ago, but the stuck
+          // lease has made no progress for the full recovery window.
           async.elapse(const Duration(minutes: 2, milliseconds: 1));
           orchestrator.enqueueManualWake(
-            agentId: 'stuck-agent',
+            agentId: 'replacement-agent',
             reason: 'manual',
           );
           async.flushMicrotasks();
           expect(
             executedAgentIds,
-            equals(['stuck-agent', 'healthy-agent', 'stuck-agent']),
+            equals(['stuck-agent', 'healthy-agent', 'replacement-agent']),
+          );
+          expect(runner.isRunning('healthy-agent'), isTrue);
+
+          // Recovery frees the individually stale slot, but the healthy
+          // executor keeps its agent lock until its own future settles.
+          orchestrator.enqueueManualWake(
+            agentId: 'healthy-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['stuck-agent', 'healthy-agent', 'replacement-agent']),
+          );
+
+          healthyExecutionGate.complete(null);
+          async.flushMicrotasks();
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals([
+              'stuck-agent',
+              'healthy-agent',
+              'replacement-agent',
+              'healthy-agent',
+            ]),
           );
 
           abortedStatusGate.complete();

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -384,6 +384,230 @@ void main() {
         });
       });
 
+      test('cancels drain-owned automation before policy lookup completes', () {
+        fakeAsync((async) {
+          final policyLookupGate = Completer<AgentDomainEntity?>();
+          final executedRunKeys = <String>[];
+          final completions = <WakeRunCompletion>[];
+          when(() => mockRepository.getEntity('automation-agent')).thenAnswer(
+            (_) => policyLookupGate.future,
+          );
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+          final completionSub = orchestrator.runCompletions.listen(
+            completions.add,
+          );
+          final job = WakeJob(
+            runKey: 'owned-automation-run',
+            agentId: 'automation-agent',
+            reason: WakeReason.subscription.name,
+            initiator: WakeInitiator.automation,
+            triggerTokens: const {'project-1'},
+            createdAt: DateTime(2024, 3, 15),
+          );
+
+          queue.enqueue(job);
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          orchestrator.cancelPendingAutomaticWakes(job.agentId);
+          async.flushMicrotasks();
+          expect(
+            completions,
+            contains(
+              isA<WakeRunCompletion>()
+                  .having((item) => item.runKey, 'runKey', job.runKey)
+                  .having(
+                    (item) => item.status,
+                    'status',
+                    WakeRunStatus.aborted,
+                  ),
+            ),
+          );
+
+          policyLookupGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+          verifyNever(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          );
+
+          completionSub.cancel();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('cancels only the matching drain-owned workspace', () {
+        fakeAsync((async) {
+          final policyLookupGate = Completer<AgentDomainEntity?>();
+          final executedRunKeys = <String>[];
+          final completions = <WakeRunCompletion>[];
+          when(() => mockRepository.getEntity('workspace-agent')).thenAnswer(
+            (_) => policyLookupGate.future,
+          );
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+          final completionSub = orchestrator.runCompletions.listen(
+            completions.add,
+          );
+          final job = WakeJob(
+            runKey: 'owned-workspace-run',
+            agentId: 'workspace-agent',
+            workspaceKey: 'workspace-a',
+            reason: WakeReason.reanalysis.name,
+            initiator: WakeInitiator.user,
+            triggerTokens: const {},
+            createdAt: DateTime(2024, 3, 15),
+          );
+
+          queue.enqueue(job);
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          final removed = orchestrator.cancelPendingWakes(
+            job.agentId,
+            workspaceKey: job.workspaceKey,
+          );
+          async.flushMicrotasks();
+          expect(removed.map((item) => item.runKey), equals([job.runKey]));
+          expect(
+            completions,
+            contains(
+              isA<WakeRunCompletion>()
+                  .having((item) => item.runKey, 'runKey', job.runKey)
+                  .having(
+                    (item) => item.status,
+                    'status',
+                    WakeRunStatus.aborted,
+                  ),
+            ),
+          );
+
+          policyLookupGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          completionSub.cancel();
+          async.flushMicrotasks();
+        });
+      });
+
+      test('aborts a persisted handoff cancelled while queued', () {
+        fakeAsync((async) {
+          final finalPolicyGate = Completer<AgentDomainEntity?>();
+          final replacementExecutionGate =
+              Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          final completions = <WakeRunCompletion>[];
+          var handoffPolicyReads = 0;
+          when(() => mockRepository.getEntity(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            if (agentId == 'persisted-handoff-agent' &&
+                ++handoffPolicyReads == 2) {
+              return finalPolicyGate.future;
+            }
+            return Future.value();
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              if (agentId == 'replacement-agent') {
+                return replacementExecutionGate.future;
+              }
+              return Future.value();
+            },
+          );
+          final completionSub = orchestrator.runCompletions.listen(
+            completions.add,
+          );
+
+          final oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'persisted-handoff-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(handoffPolicyReads, 2);
+          expect(executedAgentIds, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          finalPolicyGate.complete(null);
+          async.flushMicrotasks();
+          expect(queue.hasQueuedJobFor('persisted-handoff-agent'), isTrue);
+
+          final removed = orchestrator.cancelPendingWakes(
+            'persisted-handoff-agent',
+            allWorkspaces: true,
+          );
+          async.flushMicrotasks();
+          expect(removed.map((job) => job.runKey), equals([oldRunKey]));
+          expect(
+            completions,
+            contains(
+              isA<WakeRunCompletion>()
+                  .having((item) => item.runKey, 'runKey', oldRunKey)
+                  .having(
+                    (item) => item.status,
+                    'status',
+                    WakeRunStatus.aborted,
+                  ),
+            ),
+          );
+          verify(
+            () => mockRepository.updateWakeRunStatus(
+              oldRunKey,
+              WakeRunStatus.aborted.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: 'wake cancelled before execution',
+            ),
+          ).called(1);
+          verify(
+            () => mockRepository.insertWakeRun(
+              entry: any(
+                named: 'entry',
+                that: isA<WakeRunLogData>().having(
+                  (entry) => entry.runKey,
+                  'runKey',
+                  oldRunKey,
+                ),
+              ),
+            ),
+          ).called(1);
+
+          replacementExecutionGate.complete(null);
+          completionSub.cancel();
+          async.flushMicrotasks();
+        });
+      });
+
       test('discards a superseded wake after stale acquisition', () {
         fakeAsync((async) {
           final acquisitionGate = Completer<void>();

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -55,6 +55,64 @@ void main() {
         },
       );
 
+      test('measures staleness from the latest sequential wake', () {
+        fakeAsync((async) {
+          final firstCompleter = Completer<Map<String, VectorClock>?>();
+          final secondCompleter = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              return switch (agentId) {
+                'first-agent' => firstCompleter.future,
+                'second-agent' => secondCompleter.future,
+                _ => Future.value(),
+              };
+            },
+          );
+
+          orchestrator.enqueueManualWake(
+            agentId: 'first-agent',
+            reason: 'manual',
+          );
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(minutes: 7))
+            ..flushMicrotasks();
+          orchestrator.enqueueManualWake(
+            agentId: 'second-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          firstCompleter.complete(null);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['first-agent', 'second-agent']));
+
+          // The drain is 13 minutes old, but its active wake only started six
+          // minutes ago and remains within the ten-minute execution cap.
+          async
+            ..elapse(const Duration(minutes: 6))
+            ..flushMicrotasks();
+          orchestrator.enqueueManualWake(
+            agentId: 'next-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+
+          secondCompleter.complete(null);
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['first-agent', 'second-agent', 'next-agent']),
+          );
+        });
+      });
+
       test('does not force-reset when drain is within timeout window', () {
         fakeAsync((async) {
           final stuckCompleter = Completer<Map<String, VectorClock>?>();
@@ -147,6 +205,7 @@ void main() {
             final abortedStatusGate = Completer<void>();
             final replacementDrainGate = Completer<Map<String, VectorClock>?>();
             final executedAgentIds = <String>[];
+            var stuckExecutionCount = 0;
 
             when(
               () => repo.insertWakeRun(entry: any(named: 'entry')),
@@ -181,9 +240,10 @@ void main() {
                   wakeExecutor: (agentId, runKey, triggers, threadId) {
                     executedAgentIds.add(agentId);
                     if (agentId == 'stuck-agent') {
-                      return Completer<Map<String, VectorClock>?>().future;
-                    }
-                    if (agentId == 'new-agent') {
+                      stuckExecutionCount++;
+                      if (stuckExecutionCount == 1) {
+                        return Completer<Map<String, VectorClock>?>().future;
+                      }
                       return replacementDrainGate.future;
                     }
                     return Future.value();
@@ -221,19 +281,22 @@ void main() {
               ),
             ).called(1);
 
-            // Advance well past the 12-minute stale-drain timeout (total since
-            // drain start is now > 16 minutes).
+            // Queue follow-up work before the drain becomes stale. The hung
+            // terminal status write cannot make progress, so the safety net
+            // must re-check and recover once the 12-minute threshold passes.
             async
-              ..elapse(const Duration(minutes: 6))
+              ..elapse(const Duration(minutes: 1))
+              ..flushMicrotasks();
+            stuck.enqueueManualWake(agentId: 'stuck-agent', reason: 'manual');
+            async.flushMicrotasks();
+            expect(executedAgentIds, equals(['stuck-agent']));
+
+            async
+              ..elapse(const Duration(minutes: 2))
               ..flushMicrotasks();
 
-            // A new wake for a different agent triggers processNext, which now
-            // detects the stale lock and force-resets it (lines 854-862).
-            stuck.enqueueManualWake(agentId: 'new-agent', reason: 'manual');
-            async.flushMicrotasks();
-
-            // Observable: the force-reset log fired and the new drain actually
-            // executed the new agent's job (proving _isDraining was cleared).
+            // Observable: the safety net re-entered processNext and fired the
+            // stale-lock recovery without needing another enqueue.
             verify(
               () => logger.log(
                 LogDomain.agentRuntime,
@@ -242,7 +305,7 @@ void main() {
                 level: any(named: 'level'),
               ),
             ).called(1);
-            expect(executedAgentIds, contains('new-agent'));
+            expect(executedAgentIds, equals(['stuck-agent']));
 
             // Now release the hung aborted write so the old (superseded) drain
             // resumes, observes the bumped generation, and bails out (line 883).
@@ -258,10 +321,17 @@ void main() {
               ),
             ).called(1);
 
-            // The replacement drain is still waiting on new-agent and has one
+            // The next safety-net tick dispatches the queued same-agent wake
+            // after the old drain releases its runner lock.
+            async
+              ..elapse(WakeOrchestrator.safetyNetInterval)
+              ..flushMicrotasks();
+            expect(executedAgentIds, equals(['stuck-agent', 'stuck-agent']));
+
+            // The replacement drain is still waiting on stuck-agent and has one
             // free global slot. Releasing the old drain must not clear the
             // replacement drain's wake signal, otherwise this newly queued
-            // agent would wait for new-agent despite the available capacity.
+            // agent would wait despite the available capacity.
             stuck.enqueueManualWake(agentId: 'third-agent', reason: 'manual');
             async.flushMicrotasks();
             expect(executedAgentIds, contains('third-agent'));

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -1,3 +1,5 @@
+import 'package:lotti/features/agents/wake/run_key_factory.dart';
+
 import 'wake_orchestrator_test_harness.dart';
 
 class _AcquisitionGatedWakeRunner extends WakeRunner {
@@ -799,6 +801,63 @@ void main() {
         });
       });
 
+      test('keeps an aborted outcome when cancelled insertion fails', () {
+        fakeAsync((async) {
+          final insertGate = Completer<void>();
+          final executedRunKeys = <String>[];
+          final completions = <WakeRunCompletion>[];
+          String? oldRunKey;
+          when(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          ).thenAnswer((call) async {
+            final entry = call.namedArguments[#entry] as WakeRunLogData;
+            if (entry.runKey == oldRunKey) {
+              await insertGate.future;
+              throw StateError('insert failed after cancellation');
+            }
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+          final completionSub = orchestrator.runCompletions.listen(
+            completions.add,
+          );
+
+          oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'failed-insert-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          async.elapse(const Duration(milliseconds: 1));
+          final newRunKey = orchestrator.enqueueManualWake(
+            agentId: 'failed-insert-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          insertGate.complete();
+          async.flushMicrotasks();
+
+          expect(executedRunKeys, equals([newRunKey]));
+          final oldCompletions = completions
+              .where((completion) => completion.runKey == oldRunKey)
+              .toList();
+          expect(oldCompletions, hasLength(1));
+          expect(oldCompletions.single.status, WakeRunStatus.aborted);
+
+          completionSub.cancel();
+          async.flushMicrotasks();
+        });
+      });
+
       test('aborts a manual wake superseded during final policy read', () {
         fakeAsync((async) {
           final finalPolicyGate = Completer<AgentDomainEntity?>();
@@ -962,6 +1021,82 @@ void main() {
 
           completionSub.cancel();
           async.flushMicrotasks();
+        });
+      });
+
+      test('deduplicates restoration while a stale handoff is owned', () {
+        fakeAsync((async) {
+          final policyGate = Completer<AgentDomainEntity?>();
+          final executedAgentIds = <String>[];
+          var restoredInsertCount = 0;
+          when(() => mockRepository.getEntity(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            if (agentId == 'restored-agent') return policyGate.future;
+            return Future.value();
+          });
+          when(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          ).thenAnswer((call) async {
+            final entry = call.namedArguments[#entry] as WakeRunLogData;
+            if (entry.agentId == 'restored-agent') restoredInsertCount++;
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              return Future.value();
+            },
+          );
+          final dueAt = clock.now().subtract(const Duration(minutes: 1));
+          const reasonId = 'restore-dedupe';
+          final restoredRunKey = RunKeyFactory.forSubscription(
+            agentId: 'restored-agent',
+            subscriptionId: reasonId,
+            batchTokens: const {},
+            wakeCounter: 0,
+            timestamp: dueAt,
+          );
+
+          orchestrator.restorePendingWake(
+            agentId: 'restored-agent',
+            dueAt: dueAt,
+            reasonId: reasonId,
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          expect(
+            queue.enqueue(
+              WakeJob(
+                runKey: restoredRunKey,
+                agentId: 'restored-agent',
+                reason: WakeReason.subscription.name,
+                triggerTokens: const {},
+                reasonId: reasonId,
+                createdAt: dueAt,
+              ),
+            ),
+            isFalse,
+          );
+          policyGate.complete(null);
+          async.flushMicrotasks();
+
+          expect(
+            executedAgentIds,
+            equals(['replacement-agent', 'restored-agent']),
+          );
+          expect(restoredInsertCount, 1);
         });
       });
     });
@@ -1143,6 +1278,80 @@ void main() {
           });
         },
       );
+
+      test('healthy concurrent wakes do not hide a stalled lease', () {
+        fakeAsync((async) {
+          final abortedStatusGate = Completer<void>();
+          final executedAgentIds = <String>[];
+          String? firstStuckRunKey;
+          var stuckExecutionCount = 0;
+          when(
+            () => mockRepository.updateWakeRunStatus(
+              any(),
+              any(),
+              completedAt: any(named: 'completedAt'),
+              errorMessage: any(named: 'errorMessage'),
+            ),
+          ).thenAnswer((call) async {
+            final runKey = call.positionalArguments.first as String;
+            final status = call.positionalArguments[1] as String;
+            if (runKey == firstStuckRunKey &&
+                status == WakeRunStatus.aborted.name) {
+              await abortedStatusGate.future;
+            }
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 2,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              if (agentId == 'stuck-agent' && stuckExecutionCount++ == 0) {
+                return Completer<Map<String, VectorClock>?>().future;
+              }
+              return Future.value();
+            },
+          );
+
+          firstStuckRunKey = orchestrator.enqueueManualWake(
+            agentId: 'stuck-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['stuck-agent']));
+
+          async
+            ..elapse(WakeOrchestrator.wakeRunMaxDuration)
+            ..flushMicrotasks();
+          orchestrator.enqueueManualWake(
+            agentId: 'healthy-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['stuck-agent', 'healthy-agent']),
+          );
+
+          // The healthy completion refreshed generation-wide progress only
+          // two minutes ago, but the stuck lease has made no progress for
+          // more than the full twelve-minute recovery window.
+          async.elapse(const Duration(minutes: 2, milliseconds: 1));
+          orchestrator.enqueueManualWake(
+            agentId: 'stuck-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['stuck-agent', 'healthy-agent', 'stuck-agent']),
+          );
+
+          abortedStatusGate.complete();
+          async.flushMicrotasks();
+        });
+      });
     });
   });
 }

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -515,6 +515,7 @@ void main() {
           final finalPolicyGate = Completer<AgentDomainEntity?>();
           final replacementExecutionGate =
               Completer<Map<String, VectorClock>?>();
+          final cancellationStatusGate = Completer<void>();
           final executedAgentIds = <String>[];
           final completions = <WakeRunCompletion>[];
           var handoffPolicyReads = 0;
@@ -547,6 +548,14 @@ void main() {
             agentId: 'persisted-handoff-agent',
             reason: 'manual',
           );
+          when(
+            () => mockRepository.updateWakeRunStatus(
+              oldRunKey,
+              WakeRunStatus.aborted.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: 'wake cancelled before execution',
+            ),
+          ).thenAnswer((_) => cancellationStatusGate.future);
           async.flushMicrotasks();
           expect(handoffPolicyReads, 2);
           expect(executedAgentIds, isEmpty);
@@ -571,14 +580,14 @@ void main() {
           expect(removed.map((job) => job.runKey), equals([oldRunKey]));
           expect(
             completions,
-            contains(
-              isA<WakeRunCompletion>()
-                  .having((item) => item.runKey, 'runKey', oldRunKey)
-                  .having(
-                    (item) => item.status,
-                    'status',
-                    WakeRunStatus.aborted,
-                  ),
+            isNot(
+              contains(
+                isA<WakeRunCompletion>().having(
+                  (item) => item.runKey,
+                  'runKey',
+                  oldRunKey,
+                ),
+              ),
             ),
           );
           verify(
@@ -589,6 +598,21 @@ void main() {
               errorMessage: 'wake cancelled before execution',
             ),
           ).called(1);
+
+          cancellationStatusGate.complete();
+          async.flushMicrotasks();
+          expect(
+            completions,
+            contains(
+              isA<WakeRunCompletion>()
+                  .having((item) => item.runKey, 'runKey', oldRunKey)
+                  .having(
+                    (item) => item.status,
+                    'status',
+                    WakeRunStatus.aborted,
+                  ),
+            ),
+          );
           verify(
             () => mockRepository.insertWakeRun(
               entry: any(
@@ -1506,9 +1530,11 @@ void main() {
       test('healthy concurrent wakes do not hide a stalled lease', () {
         fakeAsync((async) {
           final abortedStatusGate = Completer<void>();
+          final retainedStatusGate = Completer<void>();
           final healthyExecutionGate = Completer<Map<String, VectorClock>?>();
           final executedAgentIds = <String>[];
           String? firstStuckRunKey;
+          String? firstHealthyRunKey;
           var stuckExecutionCount = 0;
           var healthyExecutionCount = 0;
           when(
@@ -1524,6 +1550,10 @@ void main() {
             if (runKey == firstStuckRunKey &&
                 status == WakeRunStatus.aborted.name) {
               await abortedStatusGate.future;
+            }
+            if (runKey == firstHealthyRunKey &&
+                status == WakeRunStatus.aborted.name) {
+              await retainedStatusGate.future;
             }
           });
           orchestrator = WakeOrchestrator(
@@ -1553,7 +1583,7 @@ void main() {
           async
             ..elapse(WakeOrchestrator.wakeRunMaxDuration)
             ..flushMicrotasks();
-          orchestrator.enqueueManualWake(
+          firstHealthyRunKey = orchestrator.enqueueManualWake(
             agentId: 'healthy-agent',
             reason: 'manual',
           );
@@ -1589,8 +1619,20 @@ void main() {
             equals(['stuck-agent', 'healthy-agent', 'replacement-agent']),
           );
 
-          healthyExecutionGate.complete(null);
-          async.flushMicrotasks();
+          // The retained execution later times out and stalls in terminal
+          // persistence. A later scheduler pass must still release its old-
+          // generation lease and dispatch the queued same-agent follow-up.
+          async.elapse(
+            const Duration(minutes: 10, milliseconds: 1),
+          );
+          verify(
+            () => mockRepository.updateWakeRunStatus(
+              firstHealthyRunKey!,
+              WakeRunStatus.aborted.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: 'timeout',
+            ),
+          ).called(1);
           unawaited(orchestrator.processNext());
           async.flushMicrotasks();
           expect(
@@ -1603,6 +1645,8 @@ void main() {
             ]),
           );
 
+          retainedStatusGate.complete();
+          healthyExecutionGate.complete(null);
           abortedStatusGate.complete();
           async.flushMicrotasks();
         });

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -163,6 +163,88 @@ void main() {
           controller.close();
         });
       });
+
+      test('requeues work superseded during a policy lookup', () {
+        fakeAsync((async) {
+          final policyLookupGate = Completer<AgentDomainEntity?>();
+          final replacementExecutionGate =
+              Completer<Map<String, VectorClock>?>();
+          final originalExecutionGate = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          var activeExecutions = 0;
+          var maxActiveExecutions = 0;
+
+          when(() => mockRepository.getEntity(any())).thenAnswer((invocation) {
+            final agentId = invocation.positionalArguments.first as String;
+            if (agentId == 'policy-agent') return policyLookupGate.future;
+            return Future.value();
+          });
+
+          Future<Map<String, VectorClock>?> execute(
+            String agentId,
+            Completer<Map<String, VectorClock>?> gate,
+          ) async {
+            executedAgentIds.add(agentId);
+            activeExecutions++;
+            if (activeExecutions > maxActiveExecutions) {
+              maxActiveExecutions = activeExecutions;
+            }
+            try {
+              return await gate.future;
+            } finally {
+              activeExecutions--;
+            }
+          }
+
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              return switch (agentId) {
+                'policy-agent' => execute(agentId, originalExecutionGate),
+                _ => execute(agentId, replacementExecutionGate),
+              };
+            },
+          );
+
+          orchestrator.enqueueManualWake(
+            agentId: 'policy-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, isEmpty);
+
+          // Supersede the drain while its dequeued job is still awaiting the
+          // policy lookup, then occupy the only global execution slot.
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          // The stale continuation must hand its owned job back instead of
+          // acquiring a second runner slot from the old loop iteration.
+          policyLookupGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+          expect(maxActiveExecutions, 1);
+
+          replacementExecutionGate.complete(null);
+          async.flushMicrotasks();
+          expect(
+            executedAgentIds,
+            equals(['replacement-agent', 'policy-agent']),
+          );
+          expect(maxActiveExecutions, 1);
+
+          originalExecutionGate.complete(null);
+          async.flushMicrotasks();
+        });
+      });
     });
   });
 
@@ -176,7 +258,7 @@ void main() {
       // *aborted* status write, freezing _executeJob (and thus the drain)
       // inside _safeUpdateStatus.
       test(
-        'force-resets the stuck drain lock and the superseded drain bails out',
+        'releases the stale slot without releasing its replacement',
         () {
           fakeAsync((async) {
             final logger = MockDomainLogger();
@@ -237,7 +319,7 @@ void main() {
                   queue: stuckQueue,
                   runner: stuckRunner,
                   domainLogger: logger,
-                  maxConcurrentWakes: () => 2,
+                  maxConcurrentWakes: () => 1,
                   wakeExecutor: (agentId, runKey, triggers, threadId) {
                     executedAgentIds.add(agentId);
                     if (agentId == 'stuck-agent') {
@@ -306,10 +388,12 @@ void main() {
                 level: any(named: 'level'),
               ),
             ).called(1);
-            expect(executedAgentIds, equals(['stuck-agent']));
+            expect(executedAgentIds, equals(['stuck-agent', 'stuck-agent']));
+            expect(stuckRunner.isRunning('stuck-agent'), isTrue);
 
             // Now release the hung aborted write so the old (superseded) drain
-            // resumes, observes the bumped generation, and bails out (line 883).
+            // resumes and bails out. Its stale lease must not release the
+            // replacement wake's lock.
             abortedStatusGate.complete();
             async.flushMicrotasks();
 
@@ -321,24 +405,19 @@ void main() {
                 level: any(named: 'level'),
               ),
             ).called(1);
+            expect(stuckRunner.isRunning('stuck-agent'), isTrue);
 
-            // The next safety-net tick dispatches the queued same-agent wake
-            // after the old drain releases its runner lock.
-            async
-              ..elapse(WakeOrchestrator.safetyNetInterval)
-              ..flushMicrotasks();
-            expect(executedAgentIds, equals(['stuck-agent', 'stuck-agent']));
-
-            // The replacement drain is still waiting on stuck-agent and has one
-            // free global slot. Releasing the old drain must not clear the
-            // replacement drain's wake signal, otherwise this newly queued
-            // agent would wait despite the available capacity.
+            // Concurrency one remains enforced while the replacement runs.
             stuck.enqueueManualWake(agentId: 'third-agent', reason: 'manual');
             async.flushMicrotasks();
-            expect(executedAgentIds, contains('third-agent'));
+            expect(executedAgentIds, isNot(contains('third-agent')));
 
             replacementDrainGate.complete(null);
             async.flushMicrotasks();
+            expect(
+              executedAgentIds,
+              equals(['stuck-agent', 'stuck-agent', 'third-agent']),
+            );
 
             stuck.stop();
             controller.close();

--- a/test/features/agents/wake/wake_orchestrator_recovery_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_recovery_test.dart
@@ -382,6 +382,99 @@ void main() {
         });
       });
 
+      test('discards a superseded wake after stale acquisition', () {
+        fakeAsync((async) {
+          final acquisitionGate = Completer<void>();
+          final executedRunKeys = <String>[];
+          runner = _AcquisitionGatedWakeRunner(
+            gatedAgentId: 'acquisition-agent',
+            gate: acquisitionGate,
+          );
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+
+          final oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'acquisition-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(runner.isRunning('acquisition-agent'), isTrue);
+          expect(executedRunKeys, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          final newRunKey = orchestrator.enqueueManualWake(
+            agentId: 'acquisition-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          acquisitionGate.complete();
+          async.flushMicrotasks();
+          expect(executedRunKeys, equals([newRunKey]));
+          expect(executedRunKeys, isNot(contains(oldRunKey)));
+        });
+      });
+
+      test('discards a superseded wake after a stale content gate', () {
+        fakeAsync((async) {
+          final contentGate = Completer<bool>();
+          final executedRunKeys = <String>[];
+          final contentState = makeTestState(
+            id: 'state-content-cancel-agent',
+            agentId: 'content-cancel-agent',
+            awaitingContent: true,
+            slots: const AgentSlots(activeTaskId: 'task-content-cancel'),
+          );
+          when(() => mockRepository.getAgentState(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            return Future.value(
+              agentId == 'content-cancel-agent' ? contentState : null,
+            );
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            taskContentChecker: (taskId) => contentGate.future,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          )..setAwaitingContent('content-cancel-agent', awaiting: true);
+
+          final oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'content-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(runner.isRunning('content-cancel-agent'), isTrue);
+          expect(executedRunKeys, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          final newRunKey = orchestrator.enqueueManualWake(
+            agentId: 'content-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          contentGate.complete(true);
+          async.flushMicrotasks();
+          expect(executedRunKeys, equals([newRunKey]));
+          expect(executedRunKeys, isNot(contains(oldRunKey)));
+        });
+      });
+
       test('releases and requeues work superseded during acquisition', () {
         fakeAsync((async) {
           final acquisitionGate = Completer<void>();
@@ -648,6 +741,229 @@ void main() {
           });
         },
       );
+
+      test('aborts a manual wake superseded during run insertion', () {
+        fakeAsync((async) {
+          final insertGate = Completer<void>();
+          final executedRunKeys = <String>[];
+          String? oldRunKey;
+          var oldInsertCount = 0;
+          when(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          ).thenAnswer((call) async {
+            final entry = call.namedArguments[#entry] as WakeRunLogData;
+            if (entry.runKey == oldRunKey) {
+              oldInsertCount++;
+              await insertGate.future;
+            }
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+
+          oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'insert-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(oldInsertCount, 1);
+          expect(executedRunKeys, isEmpty);
+
+          async.elapse(const Duration(milliseconds: 1));
+          final newRunKey = orchestrator.enqueueManualWake(
+            agentId: 'insert-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          insertGate.complete();
+          async.flushMicrotasks();
+          expect(executedRunKeys, equals([newRunKey]));
+          expect(executedRunKeys, isNot(contains(oldRunKey)));
+          verify(
+            () => mockRepository.updateWakeRunStatus(
+              oldRunKey!,
+              WakeRunStatus.aborted.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: 'wake superseded by a newer manual request',
+            ),
+          ).called(1);
+        });
+      });
+
+      test('aborts a manual wake superseded during final policy read', () {
+        fakeAsync((async) {
+          final finalPolicyGate = Completer<AgentDomainEntity?>();
+          final executedRunKeys = <String>[];
+          var oldPolicyReads = 0;
+          when(() => mockRepository.getEntity(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            if (agentId == 'final-policy-cancel-agent' &&
+                ++oldPolicyReads == 2) {
+              return finalPolicyGate.future;
+            }
+            return Future.value();
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedRunKeys.add(runKey);
+              return Future.value();
+            },
+          );
+
+          final oldRunKey = orchestrator.enqueueManualWake(
+            agentId: 'final-policy-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(oldPolicyReads, 2);
+          expect(executedRunKeys, isEmpty);
+
+          async.elapse(const Duration(milliseconds: 1));
+          final newRunKey = orchestrator.enqueueManualWake(
+            agentId: 'final-policy-cancel-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedRunKeys, isEmpty);
+
+          finalPolicyGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedRunKeys, equals([newRunKey]));
+          expect(executedRunKeys, isNot(contains(oldRunKey)));
+          verify(
+            () => mockRepository.updateWakeRunStatus(
+              oldRunKey,
+              WakeRunStatus.aborted.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: 'wake superseded by a newer manual request',
+            ),
+          ).called(1);
+        });
+      });
+
+      test('aborts a persisted continuation rejected by current policy', () {
+        fakeAsync((async) {
+          final finalPolicyGate = Completer<AgentDomainEntity?>();
+          final replacementGate = Completer<Map<String, VectorClock>?>();
+          final executedAgentIds = <String>[];
+          final completions = <WakeRunCompletion>[];
+          final enabledIdentity = makeTestIdentity(
+            id: 'persisted-policy-agent',
+            agentId: 'persisted-policy-agent',
+            kind: 'project_agent',
+            config: const AgentConfig(automaticUpdatesEnabled: true),
+          );
+          final disabledIdentity = makeTestIdentity(
+            id: 'persisted-policy-agent',
+            agentId: 'persisted-policy-agent',
+            kind: 'project_agent',
+            config: const AgentConfig(automaticUpdatesEnabled: false),
+          );
+          var policyReads = 0;
+          var oldInsertCount = 0;
+          when(() => mockRepository.getEntity(any())).thenAnswer((call) {
+            final agentId = call.positionalArguments.first as String;
+            if (agentId != 'persisted-policy-agent') return Future.value();
+            policyReads++;
+            if (policyReads == 2) return finalPolicyGate.future;
+            return Future.value(
+              policyReads < 3 ? enabledIdentity : disabledIdentity,
+            );
+          });
+          when(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          ).thenAnswer((call) async {
+            final entry = call.namedArguments[#entry] as WakeRunLogData;
+            if (entry.agentId == 'persisted-policy-agent') oldInsertCount++;
+          });
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              executedAgentIds.add(agentId);
+              return replacementGate.future;
+            },
+          );
+          final completionSub = orchestrator.runCompletions.listen(
+            completions.add,
+          );
+
+          queue.enqueue(
+            WakeJob(
+              runKey: 'persisted-policy-run',
+              agentId: 'persisted-policy-agent',
+              reason: WakeReason.scheduled.name,
+              initiator: WakeInitiator.automation,
+              triggerTokens: const {},
+              createdAt: DateTime(2024, 3, 15),
+            ),
+          );
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+          expect(policyReads, 2);
+          expect(executedAgentIds, isEmpty);
+
+          async.elapse(const Duration(minutes: 13));
+          orchestrator.enqueueManualWake(
+            agentId: 'replacement-agent',
+            reason: 'manual',
+          );
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          finalPolicyGate.complete(enabledIdentity);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+
+          replacementGate.complete(null);
+          async.flushMicrotasks();
+          expect(executedAgentIds, equals(['replacement-agent']));
+          expect(policyReads, 3);
+          expect(oldInsertCount, 1);
+          expect(
+            completions,
+            contains(
+              isA<WakeRunCompletion>()
+                  .having(
+                    (item) => item.runKey,
+                    'runKey',
+                    'persisted-policy-run',
+                  )
+                  .having(
+                    (item) => item.status,
+                    'status',
+                    WakeRunStatus.aborted,
+                  ),
+            ),
+          );
+          verify(
+            () => mockRepository.updateWakeRunStatus(
+              'persisted-policy-run',
+              WakeRunStatus.aborted.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: 'wake dropped by current automation policy',
+            ),
+          ).called(1);
+
+          completionSub.cancel();
+          async.flushMicrotasks();
+        });
+      });
     });
   });
 

--- a/test/features/agents/wake/wake_runner_test.dart
+++ b/test/features/agents/wake/wake_runner_test.dart
@@ -53,6 +53,45 @@ void main() {
       });
     });
 
+    group('leases', () {
+      test('returns ownership only when the agent lock is available', () {
+        fakeAsync((async) {
+          late WakeRunnerLease? first;
+          late WakeRunnerLease? duplicate;
+          runner.tryAcquireLease('agent-1').then((value) => first = value);
+          async.flushMicrotasks();
+          runner.tryAcquireLease('agent-1').then((value) => duplicate = value);
+          async.flushMicrotasks();
+
+          expect(first, isNotNull);
+          expect(duplicate, isNull);
+          expect(first!.agentId, 'agent-1');
+        });
+      });
+
+      test('stale ownership cannot release or abort a replacement', () {
+        fakeAsync((async) {
+          late WakeRunnerLease first;
+          late WakeRunnerLease replacement;
+          runner.tryAcquireLease('agent-1').then((value) => first = value!);
+          async.flushMicrotasks();
+          runner.releaseLease(first);
+          runner
+              .tryAcquireLease('agent-1')
+              .then((value) => replacement = value!);
+          async.flushMicrotasks();
+
+          runner.releaseLease(first);
+          expect(runner.abortLease(first), isFalse);
+          expect(runner.isRunning('agent-1'), isTrue);
+
+          expect(runner.abortLease(replacement), isTrue);
+          runner.releaseLease(replacement);
+          expect(runner.isRunning('agent-1'), isFalse);
+        });
+      });
+    });
+
     group('release', () {
       test('removes lock so agent can be acquired again', () {
         fakeAsync((async) {


### PR DESCRIPTION
## Summary

- raise stale-drain recovery from 5 to 12 minutes so it remains above the new 10-minute wake execution cap
- add a regression test proving a valid six-minute wake keeps ownership of its drain and dispatches queued follow-up work immediately
- update wake-orchestration documentation and stale recovery test explanations

## Root cause

PR #3945 increased the per-wake execution cap to ten minutes but left the scheduler's stale-drain threshold at five minutes. New work arriving during a valid 5–10 minute inference could supersede the active drain. When the original inference then completed, its queued follow-up could be left waiting for a later scheduler trigger.

The completed review also reported a leaderboard separator mismatch, but the rebased and merged code already contains all 12 separator cells, so no report change is needed here.

## Validation

- regression test first failed against the merged implementation, then passed with this fix
- `fvm flutter test test/features/agents/wake/wake_orchestrator_recovery_test.dart --no-pub`
- `fvm flutter analyze --no-pub lib/features/agents/wake/wake_orchestrator.dart test/features/agents/wake/wake_orchestrator_recovery_test.dart`
- `make knowledge_check`
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wake operations now remain active based on recent progress, preventing valid long-running wakes from being reset prematurely.
  * Increased the inactivity threshold to 12 minutes.
  * Improved automatic recovery for stalled operations, including during processing and status updates.
  * Queued follow-up work continues dispatching during active operations.
  * Prevented superseded wakes from disrupting replacement runs or exceeding concurrency limits.
  * Improved requeueing, cancellation visibility, and duplicate prevention during recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->