### PR TITLE
fix(evals): stop scoring the contract-mandated reply as an unexpected call

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -168,6 +168,30 @@ recovery-window fabrication against the committed regression check. The scenario
 catalog, objective classifier, and this run record are the reproducible source
 of truth committed to the repository.
 
+## Scorer correction — 2026-08-16
+
+The classifier scored `reply_to_user` as an unexpected tool call. That tool is
+part of the shipped contract, the runner offers it to the model, and the system
+prompt orders "unanswered user message → call reply_to_user exactly once
+first". Every dialogue scenario was therefore unpassable by a model that obeyed
+the contract: in a 3-sample GLM 5.2 baseline, 14 of 28 failures were this
+artifact alone, and `evo_*`, `wk_*` and `tone_roast_request` scored 0/3 across
+the board — the "all models fail" smell this README warns about.
+
+Compounding it, the prose assertions read bare assistant text, which is empty
+exactly when the model answers through the tool, so
+`requiredAssistantContentTermGroups` failed even once the call was tolerated.
+
+Two changes in `goal_agent_eval_runner.dart`: `reply_to_user` joins the
+tolerated set (the no-op scenario forbids every tool by name, so restraint is
+unaffected), and the prose checks — required terms and forbidden claims alike —
+now read assistant text plus every `reply_to_user.message`, which is the same
+surface to the user.
+
+**Results above this line predate the correction.** Dialogue and evolution
+scores are not comparable across it; a jump in those rows is the scorer, not
+the model. Cost, latency and the health-scenario rows are unaffected.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -230,6 +230,79 @@ void main() {
       );
     });
 
+    test('the contract-mandated reply carrier is not an unexpected call', () {
+      // The shipped contract orders "unanswered user message → call
+      // reply_to_user exactly once first", and the eval offers the tool.
+      // Scoring that reply as unexpected made every dialogue scenario
+      // unpassable and hid real model differences behind a harness artifact.
+      final category = classifyGoalAgentResult(
+        scenario: scenarioById('evo_adjust_target'),
+        toolCalls: [
+          call(
+            GoalAgentToolNames.replyToUser,
+            '{"message":"Your goal is 10,000 steps per day; I can lower it."}',
+          ),
+          call(
+            GoalAgentToolNames.proposeGoalRevision,
+            '{"changes":{"targetValue":8000},"rationale":"user asked"}',
+          ),
+        ],
+        assistantContent: '',
+      );
+      expect(category, GoalAgentEvalFailureCategory.none);
+    });
+
+    test('the reply carrier counts as text the user actually reads', () {
+      final scenario = scenarioById('wk_dialogue_over_report');
+      // Restating the goal inside reply_to_user is the contract-shaped way
+      // to answer, so it must satisfy the prose requirement...
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Your goal is an average of 10,000 steps per day '
+              'over a rolling 7-day window."}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.none,
+      );
+      // ...and a reply that omits the restatement must still fail, or the
+      // check would pass on the mere presence of a reply.
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"All good, keep it up!"}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.missingAssistantContent,
+      );
+    });
+
+    test('tolerating the reply carrier leaves no-op restraint intact', () {
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenarioById('gp_noop'),
+          toolCalls: [
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Nothing changed since the last wake."}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.noOpViolated,
+      );
+    });
+
     test('reuse scenario fails a model that regenerates instead', () {
       final category = classifyGoalAgentResult(
         scenario: scenarioById('ad_reuse_top_rated'),

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -423,11 +423,18 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
   // always tolerated unless explicitly forbidden — the policy regulates
   // them by situation, and over-reporting is measured by the no-op and
   // budget checks, not by this allow-list.
+  //
+  // `reply_to_user` is tolerated for the same reason it is not optional:
+  // the shipped contract orders "unanswered user message → call
+  // reply_to_user exactly once first". Scoring the contract-mandated reply
+  // as an unexpected call made every dialogue scenario unpassable. The
+  // no-op scenario forbids every tool by name, so restraint is unaffected.
   final allowedNames = {
     for (final expected in scenario.expectedToolCalls) expected.name,
     GoalAgentToolNames.updateGoalReport,
     GoalAgentToolNames.recordGoalObservation,
     GoalAgentToolNames.retireGoalAd,
+    GoalAgentToolNames.replyToUser,
   }..removeAll(scenario.forbiddenToolNames);
   if (toolCalls.any((call) => !allowedNames.contains(call.name))) {
     return GoalAgentEvalFailureCategory.unexpectedToolCall;
@@ -513,18 +520,40 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
     }
   }
 
+  final userVisibleText = _userVisibleText(assistantContent, toolCalls);
   if (scenario.requiredAssistantContentTermGroups.any(
-    (group) => !containsAnyEvalTerm(assistantContent, group),
+    (group) => !containsAnyEvalTerm(userVisibleText, group),
   )) {
     return GoalAgentEvalFailureCategory.missingAssistantContent;
   }
   if (scenario.forbiddenAssistantContentClaims.any(
-    (claim) => containsAffirmativeReportClaim(assistantContent, claim),
+    (claim) => containsAffirmativeReportClaim(userVisibleText, claim),
   )) {
     return GoalAgentEvalFailureCategory.forbiddenAssistantClaim;
   }
 
   return GoalAgentEvalFailureCategory.none;
+}
+
+/// Everything the user actually reads this turn.
+///
+/// Under the shipped contract a dialogue turn answers through
+/// `reply_to_user`, so bare assistant text is empty exactly when the model
+/// obeyed the contract. Asserting prose against assistant text alone
+/// therefore measured the harness; the reply argument is the same surface
+/// to the user and belongs in both the required and forbidden checks.
+String _userVisibleText(
+  String assistantContent,
+  List<GoalAgentEvalToolCall> toolCalls,
+) {
+  final parts = [
+    if (assistantContent.isNotEmpty) assistantContent,
+    for (final call in toolCalls)
+      if (call.name == GoalAgentToolNames.replyToUser)
+        if (call.jsonObjectArguments?['message'] case final String message)
+          if (message.isNotEmpty) message,
+  ];
+  return parts.join('\n');
 }
 
 String _argumentsFor(List<GoalAgentEvalToolCall> toolCalls, String name) =>


### PR DESCRIPTION
## Problem

The goal-agent eval classifier tolerated `update_goal_report`, `record_goal_observation` and `retire_goal_ad`, but not `reply_to_user` — even though that tool ships in `goal_agent_contract.dart`, is offered to the model by the runner, and is what the system prompt orders first whenever there is an unanswered user message:

> Unanswered user message: call reply_to_user exactly once first.

So a model that followed the shipped contract was scored `unexpectedToolCall`.

This surfaced while running a live glm-5.2 baseline: **14 of 28 failures were this artifact alone**, and every `evo_*`, `wk_*` and `tone_roast_request` scenario sat at 0/3. That is exactly the smell this suite's own README warns about — *"be suspicious of scenarios all models fail; they usually measure the harness."* The entire dialogue/evolution half of the catalog was unpassable by construction.

The prose assertions had drifted the same way. `assistantContent` collects bare assistant text, which is empty *precisely when* the model answers through `reply_to_user` (verified: 0 characters in `evo_adjust_target`, `evo_replace_metric`, `wk_dialogue_over_report`, `tone_roast_request`, `wk_mixed_musing_question`). So `requiredAssistantContentTermGroups` failed even once the call itself was tolerated.

`reply_to_user` entered the contract in #3883, which touched the scenarios but not the scorer.

## Change

In `goal_agent_eval_runner.dart`:

- `reply_to_user` joins the tolerated set. The no-op scenario forbids every tool *by name*, so `gp_noop` restraint — the cheapest discriminator in the suite — is unaffected.
- Required and forbidden prose checks now read assistant text **plus every `reply_to_user.message`**, which is the same surface to the user.

## Tests

Three tests added. With the fix reverted, the two that pin it fail (`unexpectedToolCall` instead of `none`, and the missing-restatement case); the third is a deliberate guard that must pass both ways, confirming no-op discipline did not loosen. The prose test asserts both directions — a reply that omits the restatement still fails, so the check cannot pass on the mere presence of a reply.

Analyzer clean; 50/50 offline eval self-tests green.

## Note for reviewers

Dialogue and evolution scores are **not comparable across this change** — a jump in those rows is the scorer, not the model. The eval README records this under a dated "Scorer correction" section. Cost, latency and the health-scenario rows are unaffected.

No CHANGELOG entry: test/eval-harness only, nothing user-visible.