### PR TITLE
fix(goals): withhold ad tools the deterministic tier has already ruled out

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -192,6 +192,46 @@ surface to the user.
 scores are not comparable across it; a jump in those rows is the scorer, not
 the model. Cost, latency and the health-scenario rows are unaffected.
 
+## Blocked ad tools are withheld, not forbidden — 2026-08-17
+
+Ad over-creation was the largest failure mode of every model measured against
+this contract: all 73 `forbiddenToolCall` failures in a 10-sample two-model
+baseline involved `create_goal_ad` or `rerun_goal_ad`, 58% of all failures.
+Prompt wording could not fix it. Stating the prohibition as a closed list cut
+those failures 73 → 30 but made both models skip ads policy REQUIRES
+(`missingExpectedToolCall` 15 → 37, `cx_retire_then_rerun` 10/10 → 4/10);
+restoring the obligation swung it straight back. The two halves trade against
+each other and the net was a wash.
+
+The deterministic tier already knows the answer — `automaticGoalAdEligible`
+plus the dismissal cooldown — so `GoalAgentWorkflow` now withholds the ad
+tools on a scheduled wake that has ruled a banner out. A tool that is not on
+the wire cannot be called. The runner mirrors this via
+`GoalAgentEvalScenario.adToolsOffered`, so the eval measures the surface the
+app presents rather than a harder problem the runtime never poses.
+
+Two exceptions, both deliberate: the no-op scenario keeps the full surface
+because choosing silence while tools are available IS the measurement, and
+interactive wakes keep it because an explicit request overrides eligibility
+and cooldown (P5) — a judgment made during the turn, not one FACTS can
+precompute.
+
+| Model | Baseline | Withheld | `forbiddenToolCall` | Credits/goal-month | Wh/goal-month |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `glm-5.2` | 203/250 | 209/250 | 37 → 25 | 0.360 | 125.5 |
+| `qwen3.5-122b-a10b` | 171/250 | 200/250 | 36 → 7 | 0.057 | 71.9 |
+
+`gh_gym_pace` 2→10 and 4→10, `cx_dismiss_cooldown_no_ad` 2→10,
+`gp_recovering` 3→10, `gp_slightly_off` 4→10. The interactive half is
+untouched by design and remains the open half of the problem: 122b's
+`noOpViolated` (10/10 on `gp_noop`) is now its largest failure mode, and
+scoring here still counts tool-call ATTEMPTS — a workflow-level eval asserting
+persisted outcomes is the honest next step.
+
+Run-to-run variance was never quantified (the same contract was never run
+twice), so single-scenario moves of ±3 in this table are not interpretable;
+the category shifts and the 29-case total are far outside plausible noise.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -185,8 +185,18 @@ exactly when the model answers through the tool, so
 Two changes in `goal_agent_eval_runner.dart`: `reply_to_user` joins the
 tolerated set (the no-op scenario forbids every tool by name, so restraint is
 unaffected), and the prose checks — required terms and forbidden claims alike —
-now read assistant text plus every `reply_to_user.message`, which is the same
-surface to the user.
+read the reply rather than the bare assistant text.
+
+Both were tightened again the same day, after review of the merged change:
+the carrier is tolerated only where FACTS carry a pending user message (an
+unsolicited reply on a scheduled status wake is chat nobody asked for), at most
+one reply per exchange is allowed and nothing may precede it ("exactly once
+first", checkable via a per-exchange index on each recorded call), a blank or
+non-string `message` is `invalidToolArguments` as the runtime's `_handleReply`
+would reject it, and the prose checks take the surfaced reply in PRECEDENCE
+over assistant prose rather than concatenating both — mirroring
+`strategy.replyToUser ?? strategy.finalResponse`, under which assistant text is
+a hidden thought once a reply exists.
 
 **Results above this line predate the correction.** Dialogue and evolution
 scores are not comparable across it; a jump in those rows is the scorer, not
@@ -216,17 +226,57 @@ interactive wakes keep it because an explicit request overrides eligibility
 and cooldown (P5) — a judgment made during the turn, not one FACTS can
 precompute.
 
-| Model | Baseline | Withheld | `forbiddenToolCall` | Credits/goal-month | Wh/goal-month |
+| Model | Pre-gate | With gate | `forbiddenToolCall` | Credits/goal-month | Wh/goal-month |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `glm-5.2` | 203/250 | 209/250 | 37 → 25 | 0.360 | 125.5 |
-| `qwen3.5-122b-a10b` | 171/250 | 200/250 | 36 → 7 | 0.057 | 71.9 |
+| `glm-5.2` | 203/250 | 206/250 | 37 → 27 | 0.376 | 167.0 |
+| `qwen3.5-122b-a10b` | 171/250 | 174/250 | 36 → 22 | 0.057 | 67.4 |
 
-`gh_gym_pace` 2→10 and 4→10, `cx_dismiss_cooldown_no_ad` 2→10,
-`gp_recovering` 3→10, `gp_slightly_off` 4→10. The interactive half is
-untouched by design and remains the open half of the problem: 122b's
-`noOpViolated` (10/10 on `gp_noop`) is now its largest failure mode, and
-scoring here still counts tool-call ATTEMPTS — a workflow-level eval asserting
-persisted outcomes is the honest next step.
+**+3 per model, not the +29 first measured.** The first run of this change
+carried an eval-only bug: `adToolsOffered` dropped the `priors.isEmpty` branch
+of `automaticGoalAdEligible`, so a FIRST at-risk evaluation lost tools the
+runtime offers. That withheld ads on `gp_slightly_off` and `gh_gym_pace` —
+scenarios where over-creation is the very failure under measurement — and
+inflated the result. Two independent reviewers caught it. The rule now mirrors
+production exactly, and a property test asserts every atRisk/no-priors/no-trend
+scenario keeps its ad tools.
+
+The surviving wins are real and mechanical: `cx_dismiss_cooldown_no_ad` 2→10
+and `gp_recovering` 3→10 for qwen3.5-122b-a10b, both cases where the
+deterministic tier had already ruled the banner out.
+
+**The +3 is not a clean measurement of the gate.** That run also carried four
+scorer tightenings (pending-message gating, reply cardinality and ordering,
+payload validation, surfaced-reply precedence), so stricter scoring is mixed
+into the same delta — 122b's `unexpectedToolCall` (7) is the pending-message
+rule biting, and `ad_no_double` moved 10→3 in a scenario whose tool list never
+changed at all. Isolating the gate needs the corrected scorer run WITHOUT it,
+which has not been done.
+
+The case for the change does not rest on the delta: a tool that deterministic
+policy forbids should not be on the wire, and prompt wording provably could not
+achieve the same thing — it only traded ad over-creation against skipping ads
+policy demands.
+
+## Muse Glimmer across the full catalog — 2026-08-17
+
+The health-only runs above rated `muse-glimmer` highly and warned that the
+sample "says nothing about ads, revisions, dialogue, or no-op discipline."
+Measured across all 25 scenarios at 10 samples, it is last:
+
+| Model | Pass | Credits/goal-month | Wh/goal-month | Mean output | Mean latency |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `glm-5.2` | 206/250 (0.82) | 0.376 | 167.0 | 840 | 4.86s |
+| `qwen3.5-122b-a10b` | 174/250 (0.70) | 0.057 | 67.4 | 922 | 8.33s |
+| `muse-glimmer` | 151/250 (0.60) | 0.201 | 1921.8 | 1994 | 53.62s |
+
+Its failure mode is one-sided: **77 `missingExpectedToolCall`** — it writes
+prose instead of acting, scoring 0/10 on `ad_create_worsening`,
+`cx_retire_then_rerun`, `evo_adjust_target`, `evo_replace_metric`,
+`cx_gym_done_steps_collapse`, `gp_recovering`, `tone_roast_request` and
+`wk_mixed_musing_question`. Its provider-reported energy is 28x
+qwen3.5-122b-a10b's and 11x GLM's, and a 54-second mean wake is an order of
+magnitude off both. Cheap credits are not cheap resources (ADR 0058), and the
+earlier two-scenario result did not generalise.
 
 Run-to-run variance was never quantified (the same contract was never run
 twice), so single-scenario moves of ±3 in this table are not interpretable;

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -189,6 +189,18 @@ flowchart TD
   at risk on the initial/worsening path), that expiry re-arms the period's
   escalation so Phase B creates or reuses a replacement. Healthy expiry stays
   a EUR0 maintenance event.
+- **A blocked banner is unofferable, not merely forbidden.** Before the first
+  inference of a scheduled wake, `GoalAgentWorkflow` drops `create_goal_ad` and
+  `rerun_goal_ad` from the tool list whenever the deterministic tier has already
+  ruled a banner out — `automaticGoalAdEligible` false, or a dismissal cooldown
+  active. A tool absent from the wire cannot be called, so the prohibition needs
+  no prompt compliance. Interactive wakes keep the full surface, because an
+  explicit request overrides eligibility and cooldown and that judgment happens
+  during the turn; the forced-ad repair path likewise receives every tool, since
+  it runs only where an ad is REQUIRED. The measurement that motivated this is
+  in `docs/evaluations/goal_agent_models/README.md`: prompt wording could only
+  trade ad over-creation against skipping ads policy demands, because the model
+  was being asked to re-derive a decision the runtime had already made.
 - **Banners are dirty-tracked against their evidence.** Phase B stamps a
   `factsDigest` (coarse status plus each dimension's actual value and
   satisfaction plus a hash of the exact health timestamps and values that the

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -441,7 +441,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
       expectedStatus: facts.trackStatus,
     );
 
-    final tools = [
+    final allTools = [
       for (final tool in goalAgentTools)
         ChatCompletionTool(
           type: ChatCompletionToolType.function,
@@ -452,6 +452,30 @@ class GoalAgentWorkflow with AgentErrorLogging {
           ),
         ),
     ];
+
+    // A tool that is not on the wire cannot be called. The deterministic tier
+    // already decides whether a banner is permitted (`automaticGoalAdEligible`
+    // plus the dismissal cooldown), so on a scheduled wake that has ruled one
+    // out the ad tools are simply withheld rather than offered and forbidden
+    // in prose. Ad over-creation was the single largest failure mode across
+    // every evaluated model, and prompt wording could only trade it against
+    // skipping ads policy requires — withholding removes the choice.
+    //
+    // Interactive wakes keep the full surface: an explicit request overrides
+    // cooldown and eligibility (P5), and whether a message asks for a banner
+    // is a judgment made during the turn, not one FACTS can precompute.
+    final adToolsPermitted =
+        pendingUserMessage != null ||
+        (_adsEligible(facts, derivation.priors) &&
+            !_factsRenderer.dismissalCooldownActive(nudges, now));
+    final tools = adToolsPermitted
+        ? allTools
+        : [
+            for (final tool in allTools)
+              if (tool.function.name != GoalAgentToolNames.createGoalAd &&
+                  tool.function.name != GoalAgentToolNames.rerunGoalAd)
+                tool,
+          ];
     final inferenceRepo = CloudInferenceWrapper(
       cloudRepository: _cloudInferenceRepository,
       geminiThinkingMode: resolved.geminiThinkingMode,
@@ -538,7 +562,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
           conversationId: conversationId,
           resolved: resolved,
           inferenceRepo: inferenceRepo,
-          tools: tools,
+          // The full surface on purpose: this path runs only when the
+          // deterministic tier says an ad is REQUIRED, which is exactly the
+          // case the main turn's narrowing must not be able to veto.
+          tools: allTools,
           strategy: strategy,
           agentId: recordConsumption ? agentId : null,
           runKey: recordConsumption ? runKey : null,

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -303,6 +303,132 @@ void main() {
       );
     });
 
+    test(
+      'an unsolicited reply on a scheduled wake is chat nobody asked for',
+      () {
+        // The tool description scopes the carrier to a PENDING USER MESSAGE and
+        // the runtime only arms the reply path for an interactive wake, so
+        // tolerating it everywhere would pass a status wake that opened a chat.
+        final scheduled = scenarioById('gp_on_track');
+        expect(scheduled.hasPendingUserMessage, isFalse);
+        expect(
+          classifyGoalAgentResult(
+            scenario: scheduled,
+            toolCalls: [
+              call(
+                GoalAgentToolNames.updateGoalReport,
+                '{"status":"onTrack","oneLiner":"Cruising at 11k.", '
+                '"tldr":"Comfortably above target all week."}',
+              ),
+              call(
+                GoalAgentToolNames.replyToUser,
+                '{"message":"Just checking in on your steps!"}',
+              ),
+            ],
+            assistantContent: '',
+          ),
+          GoalAgentEvalFailureCategory.unexpectedToolCall,
+        );
+      },
+    );
+
+    test('a second reply in one wake is over budget', () {
+      // GoalAgentStrategy rejects it outright with "may be called at most
+      // once per wake"; the eval must not score what the runtime refuses.
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenarioById('wk_dialogue_over_report'),
+          toolCalls: [
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Your goal is an average of 10,000 steps per day '
+              'over a rolling 7-day window."}',
+            ),
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Anything else?"}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.toolCallOverBudget,
+      );
+    });
+
+    test('acting before answering breaks "exactly once first"', () {
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenarioById('evo_adjust_target'),
+          toolCalls: [
+            call(
+              GoalAgentToolNames.proposeGoalRevision,
+              '{"changes":{"targetValue":8000},"rationale":"user asked"}',
+            ),
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Your goal is 10,000 steps per day; lowering it."}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.unexpectedToolCall,
+      );
+    });
+
+    test('a reply payload the runtime would refuse is invalid', () {
+      for (final arguments in [
+        '{}',
+        '{"message":7}',
+        '{"message":"   "}',
+      ]) {
+        expect(
+          classifyGoalAgentResult(
+            scenario: scenarioById('tone_roast_request'),
+            toolCalls: [
+              call(GoalAgentToolNames.replyToUser, arguments),
+              call(
+                GoalAgentToolNames.recordGoalObservation,
+                '{"observation":"Wants roast tone in banners."}',
+              ),
+            ],
+            assistantContent: '',
+          ),
+          GoalAgentEvalFailureCategory.invalidToolArguments,
+          reason: 'no visible answer is delivered by $arguments',
+        );
+      }
+    });
+
+    test('the surfaced reply is scored, not the hidden thought', () {
+      final scenario = scenarioById('wk_dialogue_over_report');
+      // Production persists `replyToUser ?? finalResponse`, so assistant prose
+      // is invisible once a reply exists: it must not rescue a reply that
+      // omits the restatement...
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(GoalAgentToolNames.replyToUser, '{"message":"All good!"}'),
+          ],
+          assistantContent:
+              'Your goal is an average of 10,000 steps per day over a '
+              'rolling 7-day window.',
+        ),
+        GoalAgentEvalFailureCategory.missingAssistantContent,
+      );
+      // ...and with no reply at all, bare prose is still what the user reads.
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: const [],
+          assistantContent:
+              'Your goal is an average of 10,000 steps per day over a '
+              'rolling 7-day window.',
+        ),
+        GoalAgentEvalFailureCategory.none,
+      );
+    });
+
     test('reuse scenario fails a model that regenerates instead', () {
       final category = classifyGoalAgentResult(
         scenario: scenarioById('ad_reuse_top_rated'),

--- a/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
@@ -632,6 +632,37 @@ void main() {
       }
     });
 
+    test('a first at-risk evaluation still earns its welcome banner', () {
+      // `automaticGoalAdEligible` permits an ad for an atRisk goal with no
+      // prior periods even absent a worsening trend. An eval gate that
+      // required the trend would withhold tools the runtime offers — and
+      // would flatter every model on precisely the scenarios where ad
+      // over-creation is the failure under measurement.
+      final firstAtRisk = goalAgentEvalScenarios.where((scenario) {
+        final evaluation = scenario.factsJson?['evaluation'];
+        if (evaluation is! Map) return false;
+        final verdict = evaluation['composite'] is Map
+            ? evaluation['composite'] as Map
+            : evaluation;
+        final priors = verdict['priorPeriodAttainments'];
+        return verdict['trackStatus'] == GoalTrackStatus.atRisk.name &&
+            verdict['trendWorsening3PlusDays'] != true &&
+            (priors is! List || priors.isEmpty);
+      }).toList();
+      expect(
+        firstAtRisk,
+        isNotEmpty,
+        reason: 'no scenario exercises the first-evaluation branch',
+      );
+      for (final scenario in firstAtRisk) {
+        expect(
+          scenario.adToolsOffered,
+          isTrue,
+          reason: '${scenario.id} is eligible under automaticGoalAdEligible',
+        );
+      }
+    });
+
     test('restraint and interactive wakes keep the whole surface', () {
       // Withholding must never be what makes the no-op wake quiet: choosing
       // silence with every tool available IS the measurement.

--- a/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
@@ -610,6 +610,49 @@ void main() {
       }
     });
 
+    test('a scenario is never asked for an ad tool it is not handed', () {
+      // The runner mirrors the runtime's pre-turn narrowing, so a withheld
+      // tool is unreachable. If a scenario expected one, it would fail on
+      // every model for a reason the model cannot influence — the exact
+      // "measures the harness, not the model" trap this suite warns about.
+      for (final scenario in goalAgentEvalScenarios) {
+        if (scenario.adToolsOffered) continue;
+        expect(
+          scenario.expectedToolCalls.map((call) => call.name),
+          isNot(
+            anyElement(
+              anyOf(
+                GoalAgentToolNames.createGoalAd,
+                GoalAgentToolNames.rerunGoalAd,
+              ),
+            ),
+          ),
+          reason: '${scenario.id} expects an ad tool the wake withholds',
+        );
+      }
+    });
+
+    test('restraint and interactive wakes keep the whole surface', () {
+      // Withholding must never be what makes the no-op wake quiet: choosing
+      // silence with every tool available IS the measurement.
+      final noOp = goalAgentEvalScenarios.singleWhere((s) => s.id == 'gp_noop');
+      expect(noOp.adToolsOffered, isTrue);
+      // An explicit request overrides eligibility and cooldown (P5), and that
+      // judgment happens during the turn — so pending-message wakes keep the
+      // ad tools even when the deterministic status alone would block them.
+      final cooldownChat = goalAgentEvalScenarios.singleWhere(
+        (s) => s.id == 'tone_roast_request',
+      );
+      expect(cooldownChat.hasPendingUserMessage, isTrue);
+      expect(cooldownChat.adToolsOffered, isTrue);
+      // ...while the same block on a scheduled wake does withhold them.
+      final scheduled = goalAgentEvalScenarios.singleWhere(
+        (s) => s.id == 'cx_dismiss_cooldown_no_ad',
+      );
+      expect(scheduled.hasPendingUserMessage, isFalse);
+      expect(scheduled.adToolsOffered, isFalse);
+    });
+
     test('no-op scenario forbids the entire tool surface', () {
       final noop = goalAgentEvalScenarios.singleWhere(
         (s) => s.expectsNoToolCalls,

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -28,10 +28,17 @@ class GoalAgentEvalToolCall {
   const GoalAgentEvalToolCall({
     required this.name,
     required this.argumentsJson,
+    this.exchangeIndex = 0,
   });
 
   final String name;
   final String argumentsJson;
+
+  /// Which user turn produced this call. The contract's "exactly once first"
+  /// is a per-wake rule, so cardinality and position are only meaningful
+  /// within one exchange — a flattened list cannot tell a second reply from
+  /// the legitimate reply to a follow-up message.
+  final int exchangeIndex;
 
   Map<String, dynamic>? get jsonObjectArguments {
     try {
@@ -45,6 +52,7 @@ class GoalAgentEvalToolCall {
   Map<String, Object?> toJson() => {
     'name': name,
     'argumentsJson': argumentsJson,
+    'exchangeIndex': exchangeIndex,
   };
 }
 
@@ -309,8 +317,14 @@ class GoalAgentEvalReport {
 /// harness measure something the app never does).
 class GoalAgentEvalStrategy extends ConversationStrategy {
   final _toolCalls = <GoalAgentEvalToolCall>[];
+  var _exchangeIndex = 0;
 
   List<GoalAgentEvalToolCall> get toolCalls => List.unmodifiable(_toolCalls);
+
+  /// Called by the runner before each user turn, so per-wake rules stay
+  /// per-wake across a multi-turn scenario.
+  // ignore: use_setters_to_change_properties
+  void beginExchange(int index) => _exchangeIndex = index;
 
   static final Set<String> _knownToolNames = {
     for (final tool in goalAgentTools) tool.name,
@@ -325,6 +339,7 @@ class GoalAgentEvalStrategy extends ConversationStrategy {
       final recorded = GoalAgentEvalToolCall(
         name: call.function.name,
         argumentsJson: call.function.arguments,
+        exchangeIndex: _exchangeIndex,
       );
       _toolCalls.add(recorded);
       manager.addToolResponse(
@@ -419,6 +434,35 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
     return GoalAgentEvalFailureCategory.forbiddenToolCall;
   }
 
+  // The reply carrier's own contract, enforced the way the runtime enforces
+  // it rather than merely tolerated. `GoalAgentStrategy` rejects a blank
+  // message and any second reply in a wake, so a payload the runtime would
+  // refuse must not score as a delivered answer here.
+  final replies = toolCalls
+      .where((call) => call.name == GoalAgentToolNames.replyToUser)
+      .toList();
+  for (final reply in replies) {
+    final message = reply.jsonObjectArguments?['message'];
+    if (message is! String || message.trim().isEmpty) {
+      return GoalAgentEvalFailureCategory.invalidToolArguments;
+    }
+  }
+  final exchangesWithReplies = <int>{};
+  for (final reply in replies) {
+    // "Exactly once first": at most one reply per wake, and nothing may
+    // precede it in that exchange — a proposal authored before the user has
+    // been answered is the tool-discipline failure this measures.
+    if (!exchangesWithReplies.add(reply.exchangeIndex)) {
+      return GoalAgentEvalFailureCategory.toolCallOverBudget;
+    }
+    final firstOfExchange = toolCalls.firstWhere(
+      (call) => call.exchangeIndex == reply.exchangeIndex,
+    );
+    if (firstOfExchange.name != GoalAgentToolNames.replyToUser) {
+      return GoalAgentEvalFailureCategory.unexpectedToolCall;
+    }
+  }
+
   // Tools outside expected ∪ tolerated: reporting and observations are
   // always tolerated unless explicitly forbidden — the policy regulates
   // them by situation, and over-reporting is measured by the no-op and
@@ -427,14 +471,19 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
   // `reply_to_user` is tolerated for the same reason it is not optional:
   // the shipped contract orders "unanswered user message → call
   // reply_to_user exactly once first". Scoring the contract-mandated reply
-  // as an unexpected call made every dialogue scenario unpassable. The
-  // no-op scenario forbids every tool by name, so restraint is unaffected.
+  // as an unexpected call made every dialogue scenario unpassable.
+  //
+  // Tolerated only where the contract actually calls for it, though: the
+  // tool description says "call exactly once when FACTS contain a PENDING
+  // USER MESSAGE", and the runtime only arms the reply path for an
+  // interactive wake. An unsolicited reply on a scheduled status wake is
+  // chat the user never asked for, and stays an unexpected call.
   final allowedNames = {
     for (final expected in scenario.expectedToolCalls) expected.name,
     GoalAgentToolNames.updateGoalReport,
     GoalAgentToolNames.recordGoalObservation,
     GoalAgentToolNames.retireGoalAd,
-    GoalAgentToolNames.replyToUser,
+    if (scenario.hasPendingUserMessage) GoalAgentToolNames.replyToUser,
   }..removeAll(scenario.forbiddenToolNames);
   if (toolCalls.any((call) => !allowedNames.contains(call.name))) {
     return GoalAgentEvalFailureCategory.unexpectedToolCall;
@@ -535,25 +584,25 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
   return GoalAgentEvalFailureCategory.none;
 }
 
-/// Everything the user actually reads this turn.
+/// Exactly what the user reads this turn — the SURFACED text, not every
+/// string the model produced.
 ///
-/// Under the shipped contract a dialogue turn answers through
-/// `reply_to_user`, so bare assistant text is empty exactly when the model
-/// obeyed the contract. Asserting prose against assistant text alone
-/// therefore measured the harness; the reply argument is the same surface
-/// to the user and belongs in both the required and forbidden checks.
+/// The runtime persists `strategy.replyToUser ?? strategy.finalResponse`:
+/// when a reply carrier exists it wins outright and the bare assistant prose
+/// stays a hidden thought. Concatenating both let hidden text satisfy a
+/// requirement the visible answer missed — and let a forbidden claim the user
+/// never saw fail an otherwise clean reply. Precedence, not union.
 String _userVisibleText(
   String assistantContent,
   List<GoalAgentEvalToolCall> toolCalls,
 ) {
-  final parts = [
-    if (assistantContent.isNotEmpty) assistantContent,
+  final replies = [
     for (final call in toolCalls)
       if (call.name == GoalAgentToolNames.replyToUser)
         if (call.jsonObjectArguments?['message'] case final String message)
-          if (message.isNotEmpty) message,
+          if (message.trim().isNotEmpty) message,
   ];
-  return parts.join('\n');
+  return replies.isEmpty ? assistantContent : replies.join('\n');
 }
 
 String _argumentsFor(List<GoalAgentEvalToolCall> toolCalls, String name) =>
@@ -714,16 +763,23 @@ class GoalAgentInferenceEvalRunner {
           model: modelId,
           provider: provider,
           inferenceRepo: inferenceRepository,
+          // Mirrors `GoalAgentWorkflow`: a wake whose deterministic tier has
+          // ruled out a banner is never handed the ad-creation tools, so the
+          // eval measures the surface the app actually presents rather than a
+          // harder problem the runtime never poses.
           tools: [
             for (final tool in goalAgentTools)
-              ChatCompletionTool(
-                type: ChatCompletionToolType.function,
-                function: FunctionObject(
-                  name: tool.name,
-                  description: tool.description,
-                  parameters: tool.parameters,
+              if (scenario.adToolsOffered ||
+                  (tool.name != GoalAgentToolNames.createGoalAd &&
+                      tool.name != GoalAgentToolNames.rerunGoalAd))
+                ChatCompletionTool(
+                  type: ChatCompletionToolType.function,
+                  function: FunctionObject(
+                    name: tool.name,
+                    description: tool.description,
+                    parameters: tool.parameters,
+                  ),
                 ),
-              ),
           ],
           temperature: temperature,
           strategy: strategy,
@@ -738,8 +794,10 @@ class GoalAgentInferenceEvalRunner {
         }
       }
 
+      strategy.beginExchange(0);
       await exchange(scenario.facts);
-      for (final followUp in scenario.followUpUserMessages) {
+      for (final (index, followUp) in scenario.followUpUserMessages.indexed) {
+        strategy.beginExchange(index + 1);
         await exchange(followUp);
       }
 

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -2,6 +2,8 @@
 /// `goalAgentPolicyMatrix` — every scenario names the policy rule it tests.
 library;
 
+import 'dart:convert';
+
 import 'package:lotti/classes/goal_enums.dart';
 
 import 'goal_agent_eval_fixtures.dart';
@@ -56,6 +58,60 @@ class GoalAgentEvalScenario {
 
   /// The FACTS block sent as the wake's user message.
   final String facts;
+
+  /// Whether `GoalAgentWorkflow` would hand this wake the ad-creation tools.
+  ///
+  /// Mirrors the production gate: the runtime withholds `create_goal_ad` and
+  /// `rerun_goal_ad` on a scheduled wake whose deterministic tier has already
+  /// ruled a banner out, and keeps the full surface on an interactive wake
+  /// because an explicit request overrides eligibility and cooldown (P5).
+  /// Read from the authored FACTS so the eval cannot claim a narrowing the
+  /// shipped runtime would not perform.
+  bool get adToolsOffered {
+    // Restraint scenarios keep the full surface: choosing silence while every
+    // tool is available IS the behaviour under test, and withholding would
+    // make the no-op wake prove nothing.
+    if (expectsNoToolCalls) return true;
+    // Interactive wakes keep it too — an explicit request overrides
+    // eligibility and cooldown (P5), and whether a message asks for a banner
+    // is a judgment made during the turn, not one FACTS can precompute.
+    if (hasPendingUserMessage) return true;
+    final json = _decodedFacts;
+    if (json == null) return true;
+    // `automaticGoalAdEligible` plus the dismissal cooldown — the two halves
+    // of the runtime's pre-turn gate. Deliberately NOT the fresh-active-ad
+    // check: a retire during the turn can clear that, which is why production
+    // leaves it to `_adRequired` after the fact.
+    final ads = json['ads'];
+    if (ads is Map && ads['dismissalCooldownActive'] == true) return false;
+    final evaluation = json['evaluation'];
+    if (evaluation is! Map) return true;
+    // Composite goals nest the rolled-up verdict under `composite`; simple
+    // ones carry it flat. Reading only the flat shape silently withheld the
+    // ad tools from every composite scenario, including the retire-then-rerun
+    // flows that REQUIRE a replacement banner.
+    final composite = evaluation['composite'];
+    final verdict = composite is Map ? composite : evaluation;
+    final status = verdict['trackStatus'];
+    if (status == GoalTrackStatus.offTrack.name) return true;
+    return status == GoalTrackStatus.atRisk.name &&
+        verdict['trendWorsening3PlusDays'] == true;
+  }
+
+  /// Whether the authored FACTS carry a message awaiting an answer.
+  bool get hasPendingUserMessage {
+    final pending = _decodedFacts?['unansweredUserMessages'];
+    return pending is List && pending.isNotEmpty;
+  }
+
+  Map<String, dynamic>? get _decodedFacts {
+    const prefix = '```json\n';
+    final start = facts.indexOf(prefix);
+    final end = facts.lastIndexOf('\n```');
+    if (start < 0 || end <= start) return null;
+    final decoded = jsonDecode(facts.substring(start + prefix.length, end));
+    return decoded is Map<String, dynamic> ? decoded : null;
+  }
 
   /// Additional user turns sent after the model's first response — the
   /// multi-turn dialogue scenarios (each entry is one further exchange).

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -94,8 +94,15 @@ class GoalAgentEvalScenario {
     final verdict = composite is Map ? composite : evaluation;
     final status = verdict['trackStatus'];
     if (status == GoalTrackStatus.offTrack.name) return true;
-    return status == GoalTrackStatus.atRisk.name &&
-        verdict['trendWorsening3PlusDays'] == true;
+    if (status != GoalTrackStatus.atRisk.name) return false;
+    // `automaticGoalAdEligible` is `atRisk && (priors.isEmpty || worsening)`:
+    // the first evaluation of a new goal earns a welcome banner even without
+    // a worsening trend. Dropping that branch withheld tools the runtime
+    // offers, which would flatter every model on exactly the scenarios where
+    // over-creation is the failure being measured.
+    if (verdict['trendWorsening3PlusDays'] == true) return true;
+    final priors = verdict['priorPeriodAttainments'];
+    return priors is! List || priors.isEmpty;
   }
 
   /// Whether the authored FACTS carry a message awaiting an answer.
@@ -103,6 +110,10 @@ class GoalAgentEvalScenario {
     final pending = _decodedFacts?['unansweredUserMessages'];
     return pending is List && pending.isNotEmpty;
   }
+
+  /// The authored FACTS as JSON, for assertions that need to read what the
+  /// wake actually carries rather than restate it.
+  Map<String, dynamic>? get factsJson => _decodedFacts;
 
   Map<String, dynamic>? get _decodedFacts {
     const prefix = '```json\n';

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -696,6 +696,98 @@ void main() {
     expect(conversationRepository.sendMessageDelegateCallCount, 2);
   });
 
+  test('a scheduled wake whose ads are deterministically blocked is not even '
+      'offered the ad tools', () async {
+    // Ad over-creation was the largest failure mode of every model evaluated
+    // against this contract, and prompt wording could only trade it against
+    // skipping ads policy requires. The deterministic tier already knows the
+    // answer, so the tools come off the wire: an unofferable tool cannot be
+    // called, whatever the model infers from prose.
+    stubSpec();
+    stubGlmResolution();
+    workflow = _offTrackWorkflow(
+      repository,
+      syncService,
+      conversationRepository,
+      cloudInferenceRepository,
+      aiConfigRepository,
+    );
+    _stubBadPrior(repository, agentId, now);
+    // Same offTrack evidence as the full-wake test — only the dismissal
+    // differs, so the assertion isolates the cooldown gate rather than the
+    // status.
+    const dismissedBrief = GoalNudgeBrief(
+      headline: 'Dismissed earlier today.',
+      tone: GoalNudgeTone.nudge,
+      animation: GoalBannerAnimation.steady,
+    );
+    when(
+      () => repository.getEntitiesByAgentId(
+        agentId,
+        type: AgentEntityTypes.goalNudge,
+      ),
+    ).thenAnswer(
+      (_) async => [
+        AgentDomainEntity.goalNudge(
+              id: 'dismissed-today',
+              agentId: agentId,
+              status: GoalNudgeStatus.dismissed,
+              brief: dismissedBrief,
+              briefDigest: goalBriefDigest(dismissedBrief),
+              createdAt: now.subtract(const Duration(hours: 2)),
+              updatedAt: now.subtract(const Duration(hours: 1)),
+              vectorClock: null,
+              dismissedAt: now.subtract(const Duration(hours: 1)),
+            )
+            as GoalNudgeEntity,
+      ],
+    );
+
+    List<String>? handedOver;
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          handedOver ??= [
+            for (final tool in tools ?? const <ChatCompletionTool>[])
+              tool.function.name,
+          ];
+          await (strategy! as GoalAgentStrategy).processToolCalls(
+            toolCalls: [
+              toolCall(GoalAgentToolNames.updateGoalReport, {
+                'status': 'offTrack',
+                'oneLiner': 'Averaging 6k of 10k steps.',
+                'tldr': 'The rolling week slid well under target.',
+              }, id: 'call-a'),
+            ],
+            manager: conversationManager,
+          );
+          return const InferenceUsage(inputTokens: 900, outputTokens: 120);
+        };
+
+    final result = await run();
+    expect(result.success, isTrue);
+    expect(
+      handedOver,
+      isNot(contains(GoalAgentToolNames.createGoalAd)),
+      reason: 'a dismissal blocks automatic ads for the calendar day',
+    );
+    expect(handedOver, isNot(contains(GoalAgentToolNames.rerunGoalAd)));
+    // Only the two ad tools come off: withholding must not quietly shrink the
+    // surface that makes a wake useful.
+    expect(handedOver, contains(GoalAgentToolNames.updateGoalReport));
+    expect(handedOver, contains(GoalAgentToolNames.retireGoalAd));
+    expect(handedOver, hasLength(goalAgentTools.length - 2));
+  });
+
   test('a full wake persists FACTS, report + head, the new ad, and token '
       'usage — all attributed to glm-5.2', () async {
     stubSpec();


### PR DESCRIPTION
## The problem

Ad over-creation was the largest failure mode of every model measured against the goal-agent contract. In a 10-sample, two-model baseline (500 cases), **all 73 `forbiddenToolCall` failures involved `create_goal_ad` or `rerun_goal_ad` — 58% of all failures.**

The main wake turn (`goal_agent_workflow.dart:444`) handed over the entire tool surface unconditionally, every wake, regardless of status, cooldown, staleness or health gates — all of which the deterministic tier has already computed. We opened the door, then spent prompt budget asking the model not to walk through it.

Notably, the workflow *already* narrows tool lists with `toolChoice` in three repair paths (`:860`, `:1062`, `:1119`) — but only ever to **force** a tool, never to withhold one.

## Why not fix the prompt

I tried, and measured it. Two 10-sample runs per wording:

| Wording | Total failures | `forbiddenToolCall` | `missingExpectedToolCall` |
| --- | ---: | ---: | ---: |
| baseline | 126 | 73 | 15 |
| closed list ("ONLY when a/b/c") | 94 | 30 | 37 |
| required + forbidden | 127 | 61 | 22 |

The halves **trade against each other**. Emphasising the prohibition made both models skip ads policy requires — glm-5.2 lost `cx_retire_then_rerun` 10/10 → 4/10, which in product terms is a nudge that silently never appears. Restoring the obligation swung it back. Net: a wash. The prompt edit and the ceiling raise it needed were reverted.

## The change

`automaticGoalAdEligible` + `dismissalCooldownActive` already decide this. The main turn now omits the ad tools when a scheduled wake has ruled a banner out — a tool that is not on the wire cannot be called.

`_forceAd` gets `allTools` on purpose: it runs only when the deterministic tier says an ad is **required**, which is exactly the case the narrowing must not veto.

Two deliberate exceptions:
- **Interactive wakes** keep the full surface — an explicit request overrides eligibility and cooldown (P5), and whether a message asks for a banner is a judgment made during the turn, not one FACTS can precompute.
- **The no-op scenario** keeps it too — choosing silence while every tool is available *is* the measurement.

The eval mirrors the runtime through `GoalAgentEvalScenario.adToolsOffered`, so it measures the surface the app presents rather than a harder problem the runtime never poses. A self-test asserts that no withheld scenario expects an ad tool, which would otherwise manufacture cases no model could pass.

## Result

| Model | Pre-gate | With gate | `forbiddenToolCall` | Credits/goal-month | Wh/goal-month |
| --- | ---: | ---: | ---: | ---: | ---: |
| `glm-5.2` | 203/250 (0.81) | **206/250 (0.82)** | 37 → 27 | 0.376 | 167.0 |
| `qwen3.5-122b-a10b` | 171/250 (0.68) | **174/250 (0.70)** | 36 → 22 | 0.057 | 67.4 |

**Correction:** this PR originally claimed +29 for qwen3.5-122b-a10b. That was wrong, and the reviewers found why — see the review section below. Re-measured with the mirror corrected, the gate is worth **+3 per model**. The surviving wins are `cx_dismiss_cooldown_no_ad` 2→10 and `gp_recovering` 3→10, both wakes the deterministic tier had already ruled out.

**The +3 is not a clean measurement of the gate either.** The same run carries the four scorer tightenings, so stricter scoring is mixed into the delta — 122b's `unexpectedToolCall` (7) is the new pending-message rule, and `ad_no_double` moved 10→3 in a scenario whose tool list never changed. Isolating the gate needs the corrected scorer run *without* it, which I have not done.

So the case rests on the mechanism, not the number: a tool that deterministic policy forbids should not be on the wire, and prompt wording provably cannot achieve the same thing — it only trades ad over-creation against skipping ads policy demands.

## Also: the four review findings from #3957

They landed unaddressed when that PR merged, so they are folded in here — each with a regression test verified against a reverted fix:

1. `reply_to_user` is tolerated only where FACTS carry a pending message (an unsolicited reply on a scheduled wake is chat nobody asked for).
2. A second reply in a wake is over budget, and one that follows another call breaks "exactly once first" — both checkable now that each recorded call carries a per-exchange index.
3. A blank or non-string `message` is `invalidToolArguments`, matching `_handleReply`'s rejection.
4. Prose checks score the **surfaced** reply instead of concatenating hidden assistant prose, matching `strategy.replyToUser ?? strategy.finalResponse`.

## Limits, stated plainly

- Scoring still counts tool-call **attempts**, not persisted outcomes. A workflow-level eval asserting what actually got written is the honest next step.
- The **interactive half is untouched by design** — `tone_roast_request` and the `evo_*` ad failures (~37 cases) remain.
- **Run-to-run variance was never quantified** (the same contract was never run twice), so single-scenario moves of ±3 are not interpretable. The category shifts and the 29-case total are far outside plausible noise.
- 122b's `noOpViolated` (10/10 on `gp_noop`) is now its largest failure mode and is unrelated to this change.

No CHANGELOG entry: no user-visible behaviour change beyond banners no longer appearing where policy already forbade them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled goal-agent wakes now omit ad-creation tools when ads are ineligible or within a dismissal cooldown.
  * Interactive wakes and mandatory ad retries retain the full available tool set.
  * Evaluation scenarios now support richer eligibility and pending-message checks.
  * Added expanded evaluation results and reporting for ad-tool behavior and model performance.

* **Bug Fixes**
  * Improved handling and validation of user-facing replies, including ordering, uniqueness, and malformed responses.
  * Evaluation scoring now prioritizes the reply shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Review round 1 — all four addressed

**Both bots flagged the same P1, and it was real.** `adToolsOffered` dropped the `priors.isEmpty` branch of `automaticGoalAdEligible`, so a first at-risk evaluation lost tools production offers. It withheld ads on `gp_slightly_off` and `gh_gym_pace` — the scenarios where over-creation is the failure being measured — and inflated the headline. Fixed to mirror production exactly, re-measured, numbers above corrected. A property test now scans the catalog for every atRisk/no-priors/no-trend scenario and asserts each keeps its ad tools, so a future fixture is covered without anyone remembering.

**Documented the gate** in `knowledge/features/goals.md` as a runtime invariant (Codex, per AGENTS.md).

**Corrected the scorer section** in the eval README: it still described concatenating assistant prose with every reply, which this PR replaced with precedence plus pending-message gating (CodeRabbit).

**Declined one:** CodeRabbit reads the `2026-08-17` heading as future-dated relative to August 16. The date is correct — the session crossed midnight — so it stands.

## Also measured: muse-glimmer

Full catalog, 10 samples, since the README's earlier praise came from two health scenarios and explicitly warned it said "nothing about ads, revisions, dialogue, or no-op discipline":

| Model | Pass | Credits/goal-month | Wh/goal-month | Mean output | Mean latency |
| --- | ---: | ---: | ---: | ---: | ---: |
| `glm-5.2` | 206/250 (0.82) | 0.376 | 167.0 | 840 | 4.86s |
| `qwen3.5-122b-a10b` | 174/250 (0.70) | 0.057 | 67.4 | 922 | 8.33s |
| `muse-glimmer` | 151/250 (0.60) | 0.201 | **1921.8** | 1994 | 53.62s |

Last on quality, **28× 122b's energy**, and a 54-second mean wake. Failure mode is one-sided — **77 `missingExpectedToolCall`**, prose instead of action, with 0/10 on eight scenarios including `cx_retire_then_rerun` and `evo_adjust_target`. It does not generalise from the health sample.