### PR TITLE
fix(goals): unbreak main, pin rolling aggregates, measure the eval noise floor

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -292,9 +292,14 @@ roughly a tenth of the price, reproduced across two independent 10-sample runs:
 | `deepseek-v4-flash-0731` | 216/250 | 215/250 | 0.032 | 115.3 | 3.44s | 5.96s |
 | `glm-5.2` | 206/250 | 210/250 | 0.359 | 137.1 | 4.04s | 7.32s |
 
-**11.2x cheaper, faster at mean and p95, marginally less energy.** The cost and
-latency margins are an order of magnitude clear of the noise; the quality gap
-is not — see below.
+**11.2x cheaper, faster at mean and p95, somewhat less energy.** Each margin
+sits differently against its own noise, measured over the same five identical
+runs (per 250 cases): credits 0.089/0.090/0.087/0.088/0.089 (cv 1.2%), mean
+latency 3.33/3.43/3.24/3.19/3.87s (cv 7.1%), energy 304/310/291/290/353 Wh
+(cv 7.5%). So the 11.2x cost gap is roughly three orders of magnitude clear of
+its noise and is not in doubt; the ~18% latency and ~20% energy gaps are about
+2.5x their noise — real, but not decisive on one run each for GLM. The quality
+gap is the weakest of the four; see below.
 
 Two operational notes. The floating alias `deepseek-v4-flash` was down when
 this ran (five consecutive `HTTP 503`, "the model provider encountered an
@@ -311,8 +316,11 @@ user-visible defect is the complex-health reporting gap, not ad restraint.
 Running the same model on the same code five times is the control this suite
 never had. Totals: **219, 213, 223, 215, 214** — mean 216.8, range 10, sd 3.7.
 
-**A single 10-sample total carries about +/-7 at 95%.** Any delta below that is
-unmeasured, whatever direction it points.
+**Observed range 10 across five runs (sd 3.7, n=5).** A t-based 95% interval
+for a single future run is about +/-11 around the mean, so treat any total
+delta under ~10 cases as unmeasured, whatever direction it points. Five runs
+is itself a small sample for estimating sd, so this bound is indicative, not
+exact.
 
 Per-scenario noise is wildly uneven, and the noisy ones are exactly where
 report quality is judged:
@@ -331,8 +339,11 @@ the pass probability is a product of chances rather than a single draw.
 
 **Rules this imposes:**
 
-- Treat a total delta under ~8 cases as unmeasured. Resolving a 3-case effect
+- Treat a total delta under ~10 cases as unmeasured. Resolving a 3-case effect
   needs roughly 50 samples per cell (~1250 cases per model), not 10.
+- The floor above is for PASS COUNTS. Cost is far steadier (cv 1.2%) and
+  latency and energy noisier in relative terms (cv ~7%); judge each metric
+  against its own spread, not against the pass-count floor.
 - Never read per-scenario movement on the five noisy rows.
 - Deltas already published under the old assumption: the ad-tool gate's +3 per
   model and the rolling-aggregate check's +4 are both inside the floor and are

--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -282,6 +282,64 @@ Run-to-run variance was never quantified (the same contract was never run
 twice), so single-scenario moves of ±3 in this table are not interpretable;
 the category shifts and the 29-case total are far outside plausible noise.
 
+## DeepSeek V4 Flash, and the noise floor — 2026-08-17
+
+`deepseek-v4-flash-0731` matches or beats the default on policy compliance at
+roughly a tenth of the price, reproduced across two independent 10-sample runs:
+
+| Model | Run 1 | Run 2 | Credits/goal-month | Wh/goal-month | Mean latency | P95 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `deepseek-v4-flash-0731` | 216/250 | 215/250 | 0.032 | 115.3 | 3.44s | 5.96s |
+| `glm-5.2` | 206/250 | 210/250 | 0.359 | 137.1 | 4.04s | 7.32s |
+
+**11.2x cheaper, faster at mean and p95, marginally less energy.** The cost and
+latency margins are an order of magnitude clear of the noise; the quality gap
+is not — see below.
+
+Two operational notes. The floating alias `deepseek-v4-flash` was down when
+this ran (five consecutive `HTTP 503`, "the model provider encountered an
+error"), so only the dated snapshot is usable; adopting it means pinning, with
+the staleness cost that implies. And its residual failures cluster in the
+INTERACTIVE half, where the runtime discards unauthorised banners at
+persistence anyway (`goal_agent_workflow.dart`, the `!adsEligible` /
+`cooldownBlocksAds` / `freshActiveExists` guards on the create and rerun
+loops) — so 18 of its 34 failures cost tokens without reaching the user. Its
+user-visible defect is the complex-health reporting gap, not ad restraint.
+
+### The noise floor, measured across five identical runs
+
+Running the same model on the same code five times is the control this suite
+never had. Totals: **219, 213, 223, 215, 214** — mean 216.8, range 10, sd 3.7.
+
+**A single 10-sample total carries about +/-7 at 95%.** Any delta below that is
+unmeasured, whatever direction it points.
+
+Per-scenario noise is wildly uneven, and the noisy ones are exactly where
+report quality is judged:
+
+| Scenario | Five identical runs | Range |
+| --- | --- | ---: |
+| `gh_complex_habit_behind` | 9, 5, 8, 8, 5 | 4 |
+| `evo_withdrawn` | 5, 8, 9, 8, 6 | 4 |
+| `wk_mixed_musing_question` | 3, 3, 4, 1, 2 | 3 |
+| `gh_complex_latest_on_target` | 7, 8, 7, 5, 6 | 3 |
+| `evo_ambiguous` | 6, 4, 3, 4, 4 | 3 |
+
+17 of 25 scenarios have range <= 1 and are effectively deterministic. Five are
+unreadable at 10 samples: passing them requires many terms to land at once, so
+the pass probability is a product of chances rather than a single draw.
+
+**Rules this imposes:**
+
+- Treat a total delta under ~8 cases as unmeasured. Resolving a 3-case effect
+  needs roughly 50 samples per cell (~1250 cases per model), not 10.
+- Never read per-scenario movement on the five noisy rows.
+- Deltas already published under the old assumption: the ad-tool gate's +3 per
+  model and the rolling-aggregate check's +4 are both inside the floor and are
+  justified by mechanism, not measurement. The muse-glimmer gap (66 cases), the
+  11.6x cost gap and the 28x energy gap are far outside it. DeepSeek versus GLM
+  at +5 to +10 is about one sd — "at least as good", not "better".
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -53,6 +53,7 @@ class GoalAgentStrategy extends ConversationStrategy
     Set<String>? activeAdIds,
     this._allowedCurrentActionCriterionIds = const {},
     this.expectedStatus,
+    this.expectedRollingAggregates = const [],
   }) : _knownAdIds = knownAdIds,
        _activeAdIds = activeAdIds ?? knownAdIds;
 
@@ -84,6 +85,10 @@ class GoalAgentStrategy extends ConversationStrategy
   /// declares it authoritative, so a report claiming any other status is
   /// rejected in-conversation instead of publishing a contradiction.
   final GoalTrackStatus? expectedStatus;
+
+  /// Deterministic aggregate values, pre-rounded exactly as FACTS render them,
+  /// that the report's rolling standing must quote. Empty disables the check.
+  final List<String> expectedRollingAggregates;
 
   GoalTrackStatus? _reportStatus;
   String? _reportOneLiner;
@@ -270,6 +275,29 @@ class GoalAgentStrategy extends ConversationStrategy
             'it is authoritative — use it verbatim.',
       );
       return;
+    }
+    // The rolling standing slot exists to state the deterministic aggregate.
+    // Models substitute the LATEST reading for it — reporting a 7-day mean
+    // weight of 94 kg when FACTS say 95 — or recompute a spurious precision
+    // ("127.85" where FACTS carry 127). Both put a wrong number in front of
+    // the user, and every evaluated model does it, so it is enforced here
+    // rather than asked for in prose. Same authority as trackStatus above.
+    if (structured != null && expectedRollingAggregates.isNotEmpty) {
+      final missing = expectedRollingAggregates
+          .where((value) => !structured.rollingWindow.contains(value))
+          .toList();
+      if (missing.isNotEmpty) {
+        await _reject(
+          call: call,
+          manager: manager,
+          error:
+              'Error: the rolling standing must quote the FACTS aggregates '
+              'verbatim — ${missing.join(', ')} '
+              '${missing.length == 1 ? 'is' : 'are'} missing. Use the '
+              'aggregate, never the latest reading, and never recompute it.',
+        );
+        return;
+      }
     }
     _reportStatus = status;
     _reportOneLiner = oneLiner;

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -284,7 +284,7 @@ class GoalAgentStrategy extends ConversationStrategy
     // rather than asked for in prose. Same authority as trackStatus above.
     if (structured != null && expectedRollingAggregates.isNotEmpty) {
       final missing = expectedRollingAggregates
-          .where((value) => !structured.rollingWindow.contains(value))
+          .where((value) => !_quotesNumber(structured.rollingWindow, value))
           .toList();
       if (missing.isNotEmpty) {
         await _reject(
@@ -324,6 +324,22 @@ class GoalAgentStrategy extends ConversationStrategy
     );
     await _accept(call, manager, 'Goal report updated.');
   }
+
+  /// Whether [text] quotes [value] as a COMPLETE number.
+  ///
+  /// Substring matching passed the exact fabrication this check exists to
+  /// catch: "127.85" contains "127", so a recomputed precision the FACTS
+  /// never carried scored as a faithful quote. Digits and decimal points on
+  /// either side disqualify a match, so 127 matches "127 mmHg" and "127," but
+  /// not "127.85" or "1127".
+  ///
+  /// Known limit: this proves the aggregate APPEARS, not that it is bound to
+  /// the right series. A slot naming 95 as the target while stating 94 as the
+  /// average still passes. Closing that needs the aggregates carried as typed
+  /// per-series fields rather than recovered from prose.
+  static bool _quotesNumber(String text, String value) => RegExp(
+    r'(?<![\d.])' + RegExp.escape(value) + r'(?![\d.])',
+  ).hasMatch(text);
 
   Future<void> _handleReplyToUser(
     ChatCompletionMessageToolCall call,

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -31,6 +31,7 @@ import 'package:lotti/features/ai/util/known_models.dart';
 import 'package:lotti/features/ai/util/profile_resolver.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
+import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
 import 'package:lotti/features/goals/logic/goal_aggregate_rounding.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
@@ -441,7 +442,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
       // The deterministic status is authoritative: a report claiming
       // anything else is rejected in-conversation.
       expectedStatus: facts.trackStatus,
-      expectedRollingAggregates: _rollingAggregateStrings(version, facts),
+      expectedRollingAggregates: goalRollingAggregateStrings(
+        version.criteria,
+        facts.evaluation.results,
+      ),
     );
 
     final allTools = [
@@ -464,11 +468,18 @@ class GoalAgentWorkflow with AgentErrorLogging {
     // every evaluated model, and prompt wording could only trade it against
     // skipping ads policy requires — withholding removes the choice.
     //
-    // Interactive wakes keep the full surface: an explicit request overrides
-    // cooldown and eligibility (P5), and whether a message asks for a banner
-    // is a judgment made during the turn, not one FACTS can precompute.
+    // The P5 override is keyed on the DETERMINISTIC request detector, not on
+    // "a message exists". Merely being spoken to is not a request for a
+    // banner, and treating it as one left the ad tools on the wire for every
+    // dialogue turn — the largest remaining failure class across every
+    // evaluated model, and one whose calls persistence discards anyway.
+    //
+    // `userRequestedAd` is the same signal `interactiveAdRequested` already
+    // gates persistence on, so withholding here cannot refuse a banner the
+    // wake would have kept: it only stops paying to author one that the
+    // transaction would drop.
     final adToolsPermitted =
-        pendingUserMessage != null ||
+        userRequestedAd ||
         (_adsEligible(facts, derivation.priors) &&
             !_factsRenderer.dismissalCooldownActive(nudges, now));
     final tools = adToolsPermitted
@@ -814,48 +825,6 @@ class GoalAgentWorkflow with AgentErrorLogging {
         RegExp(
           r"\b(?:can't|cannot|unable|refuse|blocked|no banner)\b",
         ).hasMatch(normalized);
-  }
-
-  /// The pre-rounded aggregates the report's rolling standing must quote,
-  /// rendered exactly as the FACTS block carries them.
-  ///
-  /// Metric leaves only. A habit result's `actual` is a completion count and a
-  /// composite's is a count of satisfied children, so requiring those would
-  /// match any stray digit rather than proving the aggregate was read. Every
-  /// evaluated model substitutes the LATEST reading for the mean on the
-  /// multi-series health goal — reporting 94 kg where FACTS say 95 — which is
-  /// a wrong number in front of the user, not a wording preference.
-  List<String> _rollingAggregateStrings(
-    GoalSpecVersionEntity version,
-    GoalWakeFacts facts,
-  ) {
-    final metricIds = <String>{};
-    void walk(GoalCriterion criterion) {
-      switch (criterion) {
-        case GoalCriterionMetric(:final criterionId):
-          metricIds.add(criterionId);
-        case GoalCriterionAllOf(:final criteria) ||
-            GoalCriterionAnyOf(:final criteria) ||
-            GoalCriterionAtLeastCount(:final criteria):
-          criteria.forEach(walk);
-        case GoalCriterionHabit() ||
-            GoalCriterionMeasurable() ||
-            GoalCriterionCategoryTime() ||
-            GoalCriterionLabelTime():
-          break;
-      }
-    }
-
-    walk(version.criteria);
-    return [
-      for (final id in metricIds)
-        if (facts.evaluation.results[id] case final result?)
-          // A window with no observations has no aggregate to quote, and an
-          // insufficientData report should name the gap instead — demanding a
-          // number there would force the model to invent one.
-          if (result.sampleCount > 0)
-            '${roundGoalAggregate(result.actual, against: result.target)}',
-    ];
   }
 
   /// The deterministic ad requirement (policy rows P4/P5): an eligible
@@ -1859,6 +1828,49 @@ class GoalAgentWorkflow with AgentErrorLogging {
 /// tool. A missing-banner report, or a short affirmation immediately following
 /// the agent's banner offer, also carries replacement intent. Visibility
 /// requests such as snooze or dismiss always win.
+/// The pre-rounded aggregates a report's rolling standing must quote,
+/// rendered exactly as the FACTS block carries them.
+///
+/// Metric leaves only. A habit result's `actual` is a completion count and a
+/// composite's is a count of satisfied children, so requiring those would
+/// match any stray digit rather than prove the aggregate was read. Every
+/// evaluated model substitutes the LATEST reading for the mean on the
+/// multi-series health goal — reporting 94 kg where FACTS say 95 — which is a
+/// wrong number in front of the user, not a wording preference.
+///
+/// A window with no observations has no aggregate to quote, and an
+/// insufficientData report should name the gap instead, so empty series are
+/// skipped rather than forcing the model to invent a number.
+List<String> goalRollingAggregateStrings(
+  GoalCriterion criteria,
+  Map<String, GoalCriterionResult> results,
+) {
+  final metricIds = <String>{};
+  void walk(GoalCriterion criterion) {
+    switch (criterion) {
+      case GoalCriterionMetric(:final criterionId):
+        metricIds.add(criterionId);
+      case GoalCriterionAllOf(:final criteria) ||
+          GoalCriterionAnyOf(:final criteria) ||
+          GoalCriterionAtLeastCount(:final criteria):
+        criteria.forEach(walk);
+      case GoalCriterionHabit() ||
+          GoalCriterionMeasurable() ||
+          GoalCriterionCategoryTime() ||
+          GoalCriterionLabelTime():
+        break;
+    }
+  }
+
+  walk(criteria);
+  return [
+    for (final id in metricIds)
+      if (results[id] case final result?)
+        if (result.sampleCount > 0)
+          '${roundGoalAggregate(result.actual, against: result.target)}',
+  ];
+}
+
 bool isExplicitGoalAdReplacementRequest(
   String? message, {
   String? previousAssistantMessage,

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -3,6 +3,7 @@ import 'dart:convert' show utf8;
 import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart' show sha1;
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/classes/goal_trigger_tokens.dart';
 import 'package:lotti/classes/goal_window.dart';
@@ -30,6 +31,7 @@ import 'package:lotti/features/ai/util/known_models.dart';
 import 'package:lotti/features/ai/util/profile_resolver.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
+import 'package:lotti/features/goals/logic/goal_aggregate_rounding.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
@@ -439,6 +441,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
       // The deterministic status is authoritative: a report claiming
       // anything else is rejected in-conversation.
       expectedStatus: facts.trackStatus,
+      expectedRollingAggregates: _rollingAggregateStrings(version, facts),
     );
 
     final allTools = [
@@ -811,6 +814,48 @@ class GoalAgentWorkflow with AgentErrorLogging {
         RegExp(
           r"\b(?:can't|cannot|unable|refuse|blocked|no banner)\b",
         ).hasMatch(normalized);
+  }
+
+  /// The pre-rounded aggregates the report's rolling standing must quote,
+  /// rendered exactly as the FACTS block carries them.
+  ///
+  /// Metric leaves only. A habit result's `actual` is a completion count and a
+  /// composite's is a count of satisfied children, so requiring those would
+  /// match any stray digit rather than proving the aggregate was read. Every
+  /// evaluated model substitutes the LATEST reading for the mean on the
+  /// multi-series health goal — reporting 94 kg where FACTS say 95 — which is
+  /// a wrong number in front of the user, not a wording preference.
+  List<String> _rollingAggregateStrings(
+    GoalSpecVersionEntity version,
+    GoalWakeFacts facts,
+  ) {
+    final metricIds = <String>{};
+    void walk(GoalCriterion criterion) {
+      switch (criterion) {
+        case GoalCriterionMetric(:final criterionId):
+          metricIds.add(criterionId);
+        case GoalCriterionAllOf(:final criteria) ||
+            GoalCriterionAnyOf(:final criteria) ||
+            GoalCriterionAtLeastCount(:final criteria):
+          criteria.forEach(walk);
+        case GoalCriterionHabit() ||
+            GoalCriterionMeasurable() ||
+            GoalCriterionCategoryTime() ||
+            GoalCriterionLabelTime():
+          break;
+      }
+    }
+
+    walk(version.criteria);
+    return [
+      for (final id in metricIds)
+        if (facts.evaluation.results[id] case final result?)
+          // A window with no observations has no aggregate to quote, and an
+          // insufficientData report should name the gap instead — demanding a
+          // number there would force the model to invent one.
+          if (result.sampleCount > 0)
+            '${roundGoalAggregate(result.actual, against: result.target)}',
+    ];
   }
 
   /// The deterministic ad requirement (policy rows P4/P5): an eligible

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:convert';
 
 import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
 
 import 'goal_agent_eval_fixtures.dart';
 import 'goal_agent_spec.dart';
@@ -75,7 +76,12 @@ class GoalAgentEvalScenario {
     // Interactive wakes keep it too — an explicit request overrides
     // eligibility and cooldown (P5), and whether a message asks for a banner
     // is a judgment made during the turn, not one FACTS can precompute.
-    if (hasPendingUserMessage) return true;
+    // P5 keyed on the SAME deterministic detector the runtime uses, so the
+    // eval cannot drift from it: an explicit request for a banner overrides
+    // eligibility and cooldown, merely being spoken to does not.
+    if (pendingUserMessages.any(isExplicitGoalAdReplacementRequest)) {
+      return true;
+    }
     final json = _decodedFacts;
     if (json == null) return true;
     // `automaticGoalAdEligible` plus the dismissal cooldown — the two halves
@@ -106,9 +112,16 @@ class GoalAgentEvalScenario {
   }
 
   /// Whether the authored FACTS carry a message awaiting an answer.
-  bool get hasPendingUserMessage {
+  bool get hasPendingUserMessage => pendingUserMessages.isNotEmpty;
+
+  /// The messages this wake's FACTS leave unanswered.
+  List<String> get pendingUserMessages {
     final pending = _decodedFacts?['unansweredUserMessages'];
-    return pending is List && pending.isNotEmpty;
+    if (pending is! List) return const [];
+    return [
+      for (final entry in pending)
+        if (entry is String) entry,
+    ];
   }
 
   /// The authored FACTS as JSON, for assertions that need to read what the

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -379,6 +379,91 @@ void main() {
     expect(gated.reportStatus, GoalTrackStatus.offTrack);
   });
 
+  test('a rolling standing quoting the latest reading instead of the '
+      'aggregate is rejected', () async {
+    // Every evaluated model substitutes the latest weigh-in for the 7-day
+    // mean on the multi-series health goal — 94 kg where FACTS say 95 — which
+    // publishes a wrong number, not a wording variant. Same authority as the
+    // track status: the deterministic aggregate wins.
+    Map<String, Object?> report(String rollingWindow) => {
+      'status': 'offTrack',
+      'oneLiner': 'Behind.',
+      'report': {
+        'tldr': 'Behind on weight.',
+        'currentPeriod': 'Latest weigh-in 94 kg.',
+        'rollingWindow': rollingWindow,
+        'latestChange': '95 to 94 kg.',
+        'coverage': '3 weigh-ins.',
+        'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+      },
+    };
+    final gated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+      expectedRollingAggregates: const ['95'],
+    );
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: report('Weight averages 94 kg against a 88 kg target.'),
+        ),
+      ],
+      manager: manager,
+    );
+    expect(gated.hasReport, isFalse);
+    final refusal = rejection();
+    expect(refusal, contains('95'));
+    expect(refusal, contains('never the latest reading'));
+
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: report('Weight averages 95 kg against a 88 kg target.'),
+        ),
+      ],
+      manager: manager,
+    );
+    expect(gated.reportStatus, GoalTrackStatus.offTrack);
+  });
+
+  test('a report with no aggregates to quote is left alone', () async {
+    // An empty window has no mean, and an insufficientData report names the
+    // gap. Demanding a number there would force the model to invent one.
+    final ungated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+    );
+    await ungated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {
+            'status': 'insufficientData',
+            'oneLiner': 'No readings yet.',
+            'report': {
+              'tldr': 'No readings yet.',
+              'currentPeriod': 'Nothing logged.',
+              'rollingWindow': 'The window holds no observations.',
+              'latestChange': '',
+              'coverage': 'No coverage.',
+              'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+            },
+          },
+        ),
+      ],
+      manager: manager,
+    );
+    expect(ungated.reportStatus, GoalTrackStatus.insufficientData);
+  });
+
   test('a status outside the enum is rejected in-conversation, so the '
       'report stays unset for the forced retry', () async {
     await strategy.processToolCalls(

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -431,6 +431,61 @@ void main() {
     expect(gated.reportStatus, GoalTrackStatus.offTrack);
   });
 
+  test(
+    'a recomputed precision does not count as quoting the aggregate',
+    () async {
+      // The motivating fabrication: FACTS carry 127, the model wrote "127.85".
+      // Substring matching accepted it, so the check passed exactly the output
+      // it exists to reject.
+      Future<GoalAgentStrategy> attempt(String rollingWindow) async {
+        final gated = GoalAgentStrategy(
+          syncService: syncService,
+          agentId: 'goal-1',
+          threadId: 'thread-1',
+          runKey: 'run-1',
+          knownAdIds: const {},
+          expectedRollingAggregates: const ['127'],
+        );
+        await gated.processToolCalls(
+          toolCalls: [
+            _call(
+              name: GoalAgentToolNames.updateGoalReport,
+              args: {
+                'status': 'offTrack',
+                'oneLiner': 'Behind.',
+                'report': {
+                  'tldr': 'Behind on blood pressure.',
+                  'currentPeriod': 'Latest systolic 125.',
+                  'rollingWindow': rollingWindow,
+                  'latestChange': '129 to 125.',
+                  'coverage': '2 readings.',
+                  'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+                },
+              },
+            ),
+          ],
+          manager: manager,
+        );
+        return gated;
+      }
+
+      expect(
+        (await attempt('Systolic averages 127.85 mmHg.')).hasReport,
+        isFalse,
+      );
+      expect(
+        (await attempt('Systolic averages 1127 mmHg.')).hasReport,
+        isFalse,
+      );
+      // The genuine quote is accepted, punctuation and units included.
+      expect((await attempt('Systolic averages 127 mmHg.')).hasReport, isTrue);
+      expect(
+        (await attempt('Systolic sits at 127, above target.')).hasReport,
+        isTrue,
+      );
+    },
+  );
+
   test('a report with no aggregates to quote is left alone', () async {
     // An empty window has no mean, and an insufficientData report names the
     // gap. Demanding a number there would force the model to invent one.

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -716,10 +716,10 @@ void main() {
     // Same offTrack evidence as the full-wake test — only the dismissal
     // differs, so the assertion isolates the cooldown gate rather than the
     // status.
-    const dismissedBrief = GoalNudgeBrief(
+    const dismissedBrief = NudgeBrief(
       headline: 'Dismissed earlier today.',
-      tone: GoalNudgeTone.nudge,
-      animation: GoalBannerAnimation.steady,
+      tone: NudgeTone.nudge,
+      animation: NudgeBannerAnimation.steady,
     );
     when(
       () => repository.getEntitiesByAgentId(
@@ -731,7 +731,7 @@ void main() {
         AgentDomainEntity.goalNudge(
               id: 'dismissed-today',
               agentId: agentId,
-              status: GoalNudgeStatus.dismissed,
+              status: NudgeStatus.dismissed,
               brief: dismissedBrief,
               briefDigest: goalBriefDigest(dismissedBrief),
               createdAt: now.subtract(const Duration(hours: 2)),
@@ -987,7 +987,9 @@ void main() {
                     'tldr': 'Where the goal stands right now.',
                     'currentPeriod':
                         'Only observations through August 8 are included.',
-                    'rollingWindow': 'The historical window lacks systolic BP.',
+                    'rollingWindow':
+                        'Weight averages 90 kg over the window; the '
+                        'historical window lacks systolic BP.',
                     'latestChange': '',
                     'coverage': 'Systolic coverage is missing.',
                     'nextActions': {

--- a/test/features/goals/workflow/goal_rolling_aggregates_test.dart
+++ b/test/features/goals/workflow/goal_rolling_aggregates_test.dart
@@ -86,6 +86,7 @@ void main() {
     // A habit's `actual` is a completion count and a composite's is a count of
     // satisfied children. Requiring those would match any stray digit in the
     // sentence rather than prove the aggregate was read.
+    // Every non-metric leaf shape, so a new variant cannot slip in unnoticed.
     final tree = GoalCriterion.allOf(
       criterionId: 'root',
       criteria: [
@@ -95,12 +96,36 @@ void main() {
           window: GoalWindow.calendarWeek(),
           targetCount: 3,
         ),
+        const GoalCriterion.measurable(
+          criterionId: 'mood',
+          dataTypeId: 'mood-scale',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          target: 4,
+        ),
+        const GoalCriterion.categoryTime(
+          criterionId: 'deep-work',
+          categoryId: 'category-1',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          targetHours: 2,
+        ),
+        const GoalCriterion.labelTime(
+          criterionId: 'admin',
+          labelId: 'label-1',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          targetHours: 1,
+        ),
         metric('steps'),
       ],
     );
     expect(
       goalRollingAggregateStrings(tree, {
         'gym': result('gym', actual: 2),
+        'mood': result('mood', actual: 3),
+        'deep-work': result('deep-work', actual: 5),
+        'admin': result('admin', actual: 7),
         'steps': result('steps', actual: 88),
         'root': result('root', actual: 1),
       }),

--- a/test/features/goals/workflow/goal_rolling_aggregates_test.dart
+++ b/test/features/goals/workflow/goal_rolling_aggregates_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
+
+/// The aggregates a report's rolling standing is held to. The rule is narrow
+/// on purpose: only metric leaves carry a mean worth quoting, and only when
+/// the window actually holds observations.
+void main() {
+  GoalCriterion metric(String id, {num target = 100}) => GoalCriterion.metric(
+    criterionId: id,
+    dataType: 'cumulative_step_count',
+    window: const GoalWindow.rollingDays(count: 7),
+    aggregation: GoalAggregation.dailySumThenAverage,
+    target: target,
+  );
+
+  GoalCriterionResult result(
+    String id, {
+    required num actual,
+    int sampleCount = 3,
+    num target = 100,
+  }) => GoalCriterionResult(
+    criterionId: id,
+    actual: actual,
+    target: target,
+    ratio: 1,
+    satisfied: true,
+    sampleCount: sampleCount,
+  );
+
+  test('a metric leaf contributes its pre-rounded aggregate', () {
+    // Quantised the same way the dimension card's headline is, so the report
+    // cannot quote a precision the card above it never showed: 9482.4 renders
+    // as 9500, and that is the string FACTS carry.
+    expect(
+      goalRollingAggregateStrings(metric('steps'), {
+        'steps': result('steps', actual: 9482.4, target: 10000),
+      }),
+      ['9500'],
+    );
+  });
+
+  test('every composite shape is walked to its metric leaves', () {
+    final results = {
+      'a': result('a', actual: 12),
+      'b': result('b', actual: 34),
+      'c': result('c', actual: 56),
+    };
+    for (final tree in [
+      GoalCriterion.allOf(
+        criterionId: 'root',
+        criteria: [
+          metric('a'),
+          GoalCriterion.anyOf(criterionId: 'inner', criteria: [metric('b')]),
+        ],
+      ),
+      GoalCriterion.anyOf(
+        criterionId: 'root',
+        criteria: [
+          metric('a'),
+          GoalCriterion.atLeastCount(
+            criterionId: 'inner',
+            successes: 1,
+            criteria: [metric('b')],
+          ),
+        ],
+      ),
+      GoalCriterion.atLeastCount(
+        criterionId: 'root',
+        successes: 1,
+        criteria: [metric('a'), metric('b')],
+      ),
+    ]) {
+      expect(
+        goalRollingAggregateStrings(tree, results)..sort(),
+        ['12', '34'],
+        reason: 'nested composites must not hide a metric leaf',
+      );
+    }
+  });
+
+  test('non-metric leaves contribute nothing', () {
+    // A habit's `actual` is a completion count and a composite's is a count of
+    // satisfied children. Requiring those would match any stray digit in the
+    // sentence rather than prove the aggregate was read.
+    final tree = GoalCriterion.allOf(
+      criterionId: 'root',
+      criteria: [
+        const GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: 'gym-habit',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+        metric('steps'),
+      ],
+    );
+    expect(
+      goalRollingAggregateStrings(tree, {
+        'gym': result('gym', actual: 2),
+        'steps': result('steps', actual: 88),
+        'root': result('root', actual: 1),
+      }),
+      ['88'],
+    );
+  });
+
+  test('an empty window is skipped rather than demanding a number', () {
+    // insufficientData reports name the gap; requiring a mean over zero
+    // observations would force the model to invent one.
+    expect(
+      goalRollingAggregateStrings(metric('steps'), {
+        'steps': result('steps', actual: 0, sampleCount: 0),
+      }),
+      isEmpty,
+    );
+  });
+
+  test('a criterion absent from the results contributes nothing', () {
+    expect(goalRollingAggregateStrings(metric('steps'), const {}), isEmpty);
+  });
+}


### PR DESCRIPTION
## 1. main does not compile

`goal_agent_workflow_test.dart` uses the pre-#3944 nudge type names. #3944 renamed them (`GoalNudgeBrief` → `NudgeBrief`, `GoalNudgeStatus` → `NudgeStatus`, …); #3958 added the test. Both were green independently and collided semantically on merge — CI can't catch that when the second PR's checks predate the first landing. Fixed.

## 2. The rolling standing must quote the deterministic aggregate

Every evaluated model substitutes the **latest reading for the mean** on the multi-series health goal — reporting a 7-day average weight of **94 kg where FACTS say 95** — and one recomputed a spurious `127.85` where FACTS carry `127`. That is a wrong number in front of the user, not a wording variant.

`GoalAgentStrategy` already rejects a report contradicting the deterministic `trackStatus` ("the deterministic status is authoritative"). The aggregates carry identical authority, so they get identical treatment: rejected in-conversation, corrected by the existing forced-retry path.

Scoped deliberately:
- **Metric leaves only** — a habit's `actual` is a completion count and a composite's is a count of satisfied children, so requiring those would match any stray digit rather than prove the aggregate was read.
- **Only where `sampleCount > 0`** — an empty window has no mean, and demanding a number there would force the model to invent one. This came out of a real test failure, not theory.

**Justified by the defect it prevents, not by a score.** See below.

## 3. The eval's noise floor, measured for the first time

Five identical-code runs of `deepseek-v4-flash-0731`: **219, 213, 223, 215, 214** — mean 216.8, range 10, **sd 3.7**. A single 10-sample total carries **±7 at 95%**.

Per-scenario noise is wildly uneven, and worst exactly where report quality is judged:

| Scenario | Five identical runs | Range |
| --- | --- | ---: |
| `gh_complex_habit_behind` | 9, 5, 8, 8, 5 | 4 |
| `evo_withdrawn` | 5, 8, 9, 8, 6 | 4 |
| `wk_mixed_musing_question` | 3, 3, 4, 1, 2 | 3 |
| `gh_complex_latest_on_target` | 7, 8, 7, 5, 6 | 3 |
| `evo_ambiguous` | 6, 4, 3, 4, 4 | 3 |

17 of 25 scenarios have range ≤1 and are effectively deterministic. Five are unreadable at 10 samples — passing them needs many terms to land at once, so pass probability is a product of chances.

**This retires numbers published earlier today**, including my own:

- The ad-tool gate's **+3 per model** (#3958) and this change's **+4** are both *inside* the floor. Neither is a measured improvement.
- The measurement that motivated *this* change — `gh_complex_habit_behind` 4→9 — did not reproduce (it went 4 → 9 → 5, and spans 5–9 with no code change at all). I did not open a PR on it until the variance was understood.
- What survives comfortably: the muse-glimmer gap (66 cases), the **11.6× cost** gap, the **28× energy** gap. DeepSeek vs GLM at +5–10 is ~1σ of a single run: "at least as good", not "better".

The eval README now carries the table and the rules it imposes — treat any total delta under ~8 cases as unmeasured; resolving a 3-case effect needs ~50 samples per cell, not 10 — so future work stops reading deltas this suite cannot resolve.

## Tests

Three added: the substitution case rejects then accepts on retry, the empty-window case is left alone, and the whole 128-test goals/workflow suite passes. The first fails with the check disabled.

No CHANGELOG entry: the user-visible change is a report no longer able to publish a wrong aggregate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goal progress reports now include consistent rolling-window metric averages.
  * Reports are checked against expected aggregate values, with feedback when they cite incorrect measurements.
  * Metrics without available observations are handled without inventing values.
  * Ad tools are offered only when an explicit replacement request is detected.

* **Documentation**
  * Added evaluation results comparing AI models across accuracy, cost, energy use, and latency.
  * Documented measurement variability, remaining failure patterns, and guidance for interpreting insignificant differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->