### PR TITLE
fix(evals): make the dialogue fixtures possible, and stop out-enforcing the runtime

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -190,8 +190,9 @@ read the reply rather than the bare assistant text.
 Both were tightened again the same day, after review of the merged change:
 the carrier is tolerated only where FACTS carry a pending user message (an
 unsolicited reply on a scheduled status wake is chat nobody asked for), at most
-one reply per exchange is allowed and nothing may precede it ("exactly once
-first", checkable via a per-exchange index on each recorded call), a blank or
+one reply per exchange is allowed (tracked by a per-exchange index on each
+recorded call, since a follow-up turn is a separate wake to the runtime), a
+blank or
 non-string `message` is `invalidToolArguments` as the runtime's `_handleReply`
 would reject it, and the prose checks take the surfaced reply in PRECEDENCE
 over assistant prose rather than concatenating both — mirroring

--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -351,6 +351,52 @@ the pass probability is a product of chances rather than a single draw.
   11.6x cost gap and the 28x energy gap are far outside it. DeepSeek versus GLM
   at +5 to +10 is about one sd — "at least as good", not "better".
 
+## The interactive ad bucket was mostly a fixture defect — 2026-08-17
+
+`forbiddenToolCall` — creating a banner where policy forbids one — was the
+largest failure class on this suite for every model. The tool-withholding gate
+fixed the scheduled half. The interactive half survived, and the reason was
+not the model.
+
+Six dialogue scenarios (`evo_*`, `wk_*`, `tone_roast_request`) set
+`lastReportStatus` while carrying an EMPTY `priorPeriodAttainments`. A goal
+with a previous report necessarily had previous periods, so those FACTS
+described a state the runtime cannot produce. `automaticGoalAdEligible` reads
+empty priors as a first evaluation, which earns a welcome banner (P4/P5) — so
+the deterministic tier said ads were permitted, the gate correctly offered the
+tools, the model correctly used them, and the scenario then scored it a
+violation.
+
+Giving those fixtures flat (non-declining, so the authored `trendWorsening`
+still holds) priors makes them internally consistent. Measured on
+`deepseek-v4-flash-0731`, ten samples:
+
+| | Baseline (5 runs) | Consistent priors (2 runs) |
+| --- | --- | --- |
+| Pass | 216.8/250 (0.867) | 243 and 244 /260 (0.935, 0.938) |
+| `forbiddenToolCall` | 21, 14, 14, 13, 15 | 0, 0 |
+
+**Read this as a measurement correction, not a model improvement.** Those
+failures were the eval feeding the runtime an impossible state and penalising
+the correct response to it. In production a real ongoing goal carries priors,
+the tier says ineligible, the gate withholds, and none of it arises.
+
+Two things did change for real. `ad_requested_while_ineligible` is new and
+covers P5 — an explicit request for a banner on a wake whose status blocks
+automatic ads — which nothing tested before; the runtime could have started
+refusing users who asked and no scenario would have noticed. And the
+classifier's reply-ORDERING rule is gone: `GoalAgentStrategy` enforces
+at-most-once per wake and says nothing about position, so requiring the reply
+to come first failed sequences production accepts. It had become the largest
+remaining failure category. A harness stricter than the code it measures is
+the same defect as one that is looser.
+
+Remaining failures are ~7-9 `missingAssistantContent` (mostly `evo_ambiguous`,
+where the model answers instead of asking the clarifying question) and ~5-7
+`missingRequiredReportContent` on the complex-health pair. Both are genuine
+model behaviour, and both sit in the high-variance scenarios, so more samples
+beat more fixes from here.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/lib/features/goals/workflow/goal_agent_contract.dart
+++ b/lib/features/goals/workflow/goal_agent_contract.dart
@@ -336,6 +336,15 @@ final List<AgentToolDefinition> goalAgentTools = [
           'type': 'string',
           'description': 'The complete concise reply shown to the user.',
         },
+        'userAskedForBanner': {
+          'type': 'boolean',
+          'description':
+              'True only when the pending message explicitly asks for a '
+              'banner or ad — in ANY language. Not for tone or style '
+              'preferences, not for questions about the goal. This is how a '
+              'request overrides the automatic banner rules, so a non-English '
+              'request is honored exactly like an English one.',
+        },
       },
       'required': ['message'],
     },

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -97,6 +97,7 @@ class GoalAgentStrategy extends ConversationStrategy
   Map<String, Object?>? _reportSections;
   String? _finalResponse;
   String? _replyToUser;
+  var _bannerRequested = false;
   final _createdAds = <GoalAdRequest>[];
   final _rerunRequests = <GoalAdAction>[];
   final _retireRequests = <GoalAdAction>[];
@@ -114,6 +115,14 @@ class GoalAgentStrategy extends ConversationStrategy
   Map<String, Object?>? get reportSections => _reportSections;
   String? get finalResponse => _finalResponse;
   String? get replyToUser => _replyToUser;
+
+  /// Whether the reply declared that the pending message asked for a banner.
+  ///
+  /// The language-independent half of P5. The runtime's regex detector reads
+  /// English only, and the typed `create_goal_ad` call cannot carry the intent
+  /// on a wake whose tools were withheld, so the model states it as data and
+  /// the deterministic tier decides what to do with it.
+  bool get bannerRequested => _bannerRequested;
   bool get hasReport => _reportStatus != null;
   List<GoalAdRequest> get createdAds => List.unmodifiable(_createdAds);
   List<GoalAdAction> get rerunRequests => List.unmodifiable(_rerunRequests);
@@ -364,6 +373,7 @@ class GoalAgentStrategy extends ConversationStrategy
       return;
     }
     _replyToUser = message;
+    _bannerRequested = args['userAskedForBanner'] == true;
     await _accept(call, manager, 'Reply delivered.');
   }
 

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -514,16 +514,21 @@ class GoalAgentWorkflow with AgentErrorLogging {
         rethrowInferenceErrors: true,
       );
 
-      // The model's typed ad action is the language-independent intent
-      // carrier for interactive messages. The English heuristic above is a
-      // fast path that can force a forgotten action, but must not be the only
-      // way a localized explicit request bypasses automatic health/cooldown
-      // gates.
+      // Two language-independent intent carriers, because the English
+      // heuristic above must never be the only way a localized request
+      // bypasses the automatic health/cooldown gates.
+      //
+      // The typed ad action is one — but it cannot fire on a wake whose ad
+      // tools were withheld, which is exactly the ineligible interactive case
+      // the gate now covers. So the reply carries the intent as data instead:
+      // the model reads the message in the user's own language and says
+      // whether a banner was asked for, and the deterministic tier decides.
       userRequestedAd =
           userRequestedAd ||
           (pendingUserMessage != null &&
               (strategy.createdAds.isNotEmpty ||
-                  strategy.rerunRequests.isNotEmpty));
+                  strategy.rerunRequests.isNotEmpty)) ||
+          (pendingUserMessage != null && strategy.bannerRequested);
 
       // A transition or explicit detail-page refresh requires a report — one
       // pinned retry, then accept the partial wake. Ordinary automatic no-ops

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -355,23 +355,26 @@ void main() {
       );
     });
 
-    test('acting before answering breaks "exactly once first"', () {
+    test('acting before answering is not a violation the runtime makes', () {
+      // The contract says "reply first", but GoalAgentStrategy enforces only
+      // at-most-once. Scoring the order would fail sequences production
+      // accepts — the harness must not be stricter than the code it measures.
       expect(
         classifyGoalAgentResult(
-          scenario: scenarioById('evo_adjust_target'),
+          scenario: scenarioById('tone_roast_request'),
           toolCalls: [
             call(
-              GoalAgentToolNames.proposeGoalRevision,
-              '{"changes":{"targetValue":8000},"rationale":"user asked"}',
+              GoalAgentToolNames.recordGoalObservation,
+              '{"observation":"Wants roast tone in banners."}',
             ),
             call(
               GoalAgentToolNames.replyToUser,
-              '{"message":"Your goal is 10,000 steps per day; lowering it."}',
+              '{"message":"Noted — sharper next time."}',
             ),
           ],
           assistantContent: '',
         ),
-        GoalAgentEvalFailureCategory.unexpectedToolCall,
+        GoalAgentEvalFailureCategory.none,
       );
     });
 

--- a/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_scenarios_test.dart
@@ -663,20 +663,26 @@ void main() {
       }
     });
 
-    test('restraint and interactive wakes keep the whole surface', () {
+    test('restraint and explicit ad requests keep the whole surface', () {
       // Withholding must never be what makes the no-op wake quiet: choosing
       // silence with every tool available IS the measurement.
       final noOp = goalAgentEvalScenarios.singleWhere((s) => s.id == 'gp_noop');
       expect(noOp.adToolsOffered, isTrue);
-      // An explicit request overrides eligibility and cooldown (P5), and that
-      // judgment happens during the turn — so pending-message wakes keep the
-      // ad tools even when the deterministic status alone would block them.
-      final cooldownChat = goalAgentEvalScenarios.singleWhere(
-        (s) => s.id == 'tone_roast_request',
+      // P5 is keyed on the deterministic request detector, not on "a message
+      // exists" — being spoken to is not asking for a banner. A wake whose
+      // status blocks automatic ads still gets the tools when the user asks.
+      final requested = goalAgentEvalScenarios.singleWhere(
+        (s) => s.id == 'ad_requested_while_ineligible',
       );
-      expect(cooldownChat.hasPendingUserMessage, isTrue);
-      expect(cooldownChat.adToolsOffered, isTrue);
-      // ...while the same block on a scheduled wake does withhold them.
+      expect(requested.hasPendingUserMessage, isTrue);
+      expect(requested.adToolsOffered, isTrue);
+      // ...while an ordinary dialogue turn on the same blocked status does not.
+      final chatting = goalAgentEvalScenarios.singleWhere(
+        (s) => s.id == 'wk_mixed_musing_question',
+      );
+      expect(chatting.hasPendingUserMessage, isTrue);
+      expect(chatting.adToolsOffered, isFalse);
+      // And a scheduled wake in cooldown stays blocked.
       final scheduled = goalAgentEvalScenarios.singleWhere(
         (s) => s.id == 'cx_dismiss_cooldown_no_ad',
       );

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -447,8 +447,9 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
       return GoalAgentEvalFailureCategory.invalidToolArguments;
     }
   }
-  // Cardinality only, deliberately: `GoalAgentStrategy` rejects a SECOND
-  // reply per wake and nothing else, so that is what the eval mirrors.
+  // Cardinality only, deliberately. `GoalAgentStrategy` rejects a SECOND
+  // reply and nothing else; a scenario's follow-up turns are separate wakes
+  // to the runtime, so the eval mirrors that as one reply PER EXCHANGE.
   //
   // An earlier revision also required the reply to be the first call of its
   // exchange, reading the contract's "exactly once first" as an ordering

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -447,19 +447,19 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
       return GoalAgentEvalFailureCategory.invalidToolArguments;
     }
   }
+  // Cardinality only, deliberately: `GoalAgentStrategy` rejects a SECOND
+  // reply per wake and nothing else, so that is what the eval mirrors.
+  //
+  // An earlier revision also required the reply to be the first call of its
+  // exchange, reading the contract's "exactly once first" as an ordering
+  // rule. The runtime does not enforce it, the user reads the same answer
+  // either way, and it became the largest single failure category — scoring
+  // models for a sequence production accepts. Stricter than the code under
+  // test is the same defect as looser; both measure the harness.
   final exchangesWithReplies = <int>{};
   for (final reply in replies) {
-    // "Exactly once first": at most one reply per wake, and nothing may
-    // precede it in that exchange — a proposal authored before the user has
-    // been answered is the tool-discipline failure this measures.
     if (!exchangesWithReplies.add(reply.exchangeIndex)) {
       return GoalAgentEvalFailureCategory.toolCallOverBudget;
-    }
-    final firstOfExchange = toolCalls.firstWhere(
-      (call) => call.exchangeIndex == reply.exchangeIndex,
-    );
-    if (firstOfExchange.name != GoalAgentToolNames.replyToUser) {
-      return GoalAgentEvalFailureCategory.unexpectedToolCall;
     }
   }
 

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -919,6 +919,12 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       trackStatus: GoalTrackStatus.atRisk,
       materialChange: false,
       lastReportStatus: GoalTrackStatus.atRisk.name,
+      // Both halves of the override at once: the status blocks automatic ads
+      // AND a dismissal is in force. Testing only the status half would let a
+      // regression that stopped explicit requests from bypassing cooldown
+      // (`cooldownBlocksAds`) pass unnoticed, since the only other cooldown
+      // scenario is a scheduled wake asserting the block holds.
+      dismissalCooldownActive: true,
       unansweredUserMessages: const [_msgBannerRequest],
     ),
     expectedToolCalls: const [

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -240,6 +240,9 @@ const _obsKnee =
 const _obsShoreCount =
     'Shore count at Colony 7 runs behind schedule; '
     'colleague Marit Halvorsen covers the evening shift.';
+const _msgBannerRequest =
+    'Nothing on my home screen lately — give me a new banner '
+    'to push me this week.';
 const _msgRoastRequest =
     'Honestly these ad visuals are getting a bit '
     'bland. Roast me a little next time — I can take it.';
@@ -510,6 +513,15 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     facts: buildStepsFacts(
       dailySteps: gSlightlyOffSteps,
       attainment: gSlightlyOffAttainment,
+      // An ongoing goal: it has a lastReportStatus, so it necessarily had
+      // prior evaluated periods. Leaving these empty told the deterministic
+      // tier this was a FIRST evaluation, which earns a welcome banner and
+      // put the ad tools on the wire for every dialogue turn. Flat, not
+      // declining, so the authored trendWorsening stays false.
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
       trackStatus: GoalTrackStatus.atRisk,
       lastReportStatus: GoalTrackStatus.onTrack.name,
       unansweredUserMessages: const [
@@ -532,6 +544,15 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     facts: buildStepsFacts(
       dailySteps: gSlightlyOffSteps,
       attainment: gSlightlyOffAttainment,
+      // An ongoing goal: it has a lastReportStatus, so it necessarily had
+      // prior evaluated periods. Leaving these empty told the deterministic
+      // tier this was a FIRST evaluation, which earns a welcome banner and
+      // put the ad tools on the wire for every dialogue turn. Flat, not
+      // declining, so the authored trendWorsening stays false.
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
       trackStatus: GoalTrackStatus.atRisk,
       materialChange: false,
       lastReportStatus: GoalTrackStatus.atRisk.name,
@@ -580,6 +601,15 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     facts: buildStepsFacts(
       dailySteps: gSlightlyOffSteps,
       attainment: gSlightlyOffAttainment,
+      // An ongoing goal: it has a lastReportStatus, so it necessarily had
+      // prior evaluated periods. Leaving these empty told the deterministic
+      // tier this was a FIRST evaluation, which earns a welcome banner and
+      // put the ad tools on the wire for every dialogue turn. Flat, not
+      // declining, so the authored trendWorsening stays false.
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
       trackStatus: GoalTrackStatus.atRisk,
       materialChange: false,
       lastReportStatus: GoalTrackStatus.atRisk.name,
@@ -603,6 +633,15 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     facts: buildStepsFacts(
       dailySteps: gSlightlyOffSteps,
       attainment: gSlightlyOffAttainment,
+      // An ongoing goal: it has a lastReportStatus, so it necessarily had
+      // prior evaluated periods. Leaving these empty told the deterministic
+      // tier this was a FIRST evaluation, which earns a welcome banner and
+      // put the ad tools on the wire for every dialogue turn. Flat, not
+      // declining, so the authored trendWorsening stays false.
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
       trackStatus: GoalTrackStatus.atRisk,
       materialChange: false,
       lastReportStatus: GoalTrackStatus.atRisk.name,
@@ -824,6 +863,15 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     facts: buildStepsFacts(
       dailySteps: gSlightlyOffSteps,
       attainment: gSlightlyOffAttainment,
+      // An ongoing goal: it has a lastReportStatus, so it necessarily had
+      // prior evaluated periods. Leaving these empty told the deterministic
+      // tier this was a FIRST evaluation, which earns a welcome banner and
+      // put the ad tools on the wire for every dialogue turn. Flat, not
+      // declining, so the authored trendWorsening stays false.
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
       trackStatus: GoalTrackStatus.atRisk,
       materialChange: false,
       lastReportStatus: GoalTrackStatus.atRisk.name,
@@ -850,6 +898,37 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       ..._adCreationToolNames,
     ],
     maxToolCallCounts: const {GoalAgentToolNames.recordGoalObservation: 1},
+  ),
+  // P5: an explicit request overrides eligibility and cooldown. Nothing else
+  // covers it — every other interactive scenario is ordinary conversation —
+  // so without this the runtime could withhold the ad tools from a user who
+  // asked for a banner and no scenario would notice.
+  GoalAgentEvalScenario(
+    id: 'ad_requested_while_ineligible',
+    policyRuleId: 'P5',
+    description:
+        'The user asks for a banner on a wake whose status blocks automatic '
+        'ads: the request wins, and the copy still reflects reality.',
+    facts: buildStepsFacts(
+      dailySteps: gSlightlyOffSteps,
+      attainment: gSlightlyOffAttainment,
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
+      trackStatus: GoalTrackStatus.atRisk,
+      materialChange: false,
+      lastReportStatus: GoalTrackStatus.atRisk.name,
+      unansweredUserMessages: const [_msgBannerRequest],
+    ),
+    expectedToolCalls: const [
+      GoalAgentExpectedToolCall(GoalAgentToolNames.createGoalAd),
+    ],
+    maxToolCallCounts: const {GoalAgentToolNames.createGoalAd: 1},
+    forbiddenToolNames: const [GoalAgentToolNames.proposeGoalRevision],
+    forbiddenToolArgumentTerms: {
+      GoalAgentToolNames.createGoalAd: signePrivateStrings,
+    },
   ),
   GoalAgentEvalScenario(
     id: 'tone_roast_ad',
@@ -891,6 +970,15 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
     facts: buildStepsFacts(
       dailySteps: gSlightlyOffSteps,
       attainment: gSlightlyOffAttainment,
+      // An ongoing goal: it has a lastReportStatus, so it necessarily had
+      // prior evaluated periods. Leaving these empty told the deterministic
+      // tier this was a FIRST evaluation, which earns a welcome banner and
+      // put the ad tools on the wire for every dialogue turn. Flat, not
+      // declining, so the authored trendWorsening stays false.
+      priorPeriodAttainments: const [
+        gSlightlyOffAttainment,
+        gSlightlyOffAttainment,
+      ],
       trackStatus: GoalTrackStatus.atRisk,
       materialChange: false,
       lastReportStatus: GoalTrackStatus.atRisk.name,

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -486,6 +486,59 @@ void main() {
     },
   );
 
+  test('the reply carries a banner request in any language', () async {
+    // The regex detector reads English only, and a wake whose ad tools were
+    // withheld cannot carry the intent through a typed create_goal_ad call.
+    // Without this the German request below would silently get no banner.
+    await strategy.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.replyToUser,
+          args: {
+            'message': 'Alles klar — ein neues Banner kommt.',
+            'userAskedForBanner': true,
+          },
+        ),
+      ],
+      manager: manager,
+    );
+    expect(strategy.bannerRequested, isTrue);
+    expect(strategy.replyToUser, 'Alles klar — ein neues Banner kommt.');
+  });
+
+  test('an ordinary reply declares no banner request', () async {
+    // Absent and false must both mean "not asked": the flag may only ever
+    // widen what the deterministic tier permits, never by omission.
+    await strategy.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.replyToUser,
+          args: {'message': 'Du liegst diese Woche knapp darunter.'},
+        ),
+      ],
+      manager: manager,
+    );
+    expect(strategy.bannerRequested, isFalse);
+
+    final explicitFalse = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+    );
+    await explicitFalse.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.replyToUser,
+          args: {'message': 'Noch nicht.', 'userAskedForBanner': false},
+        ),
+      ],
+      manager: manager,
+    );
+    expect(explicitFalse.bannerRequested, isFalse);
+  });
+
   test('a report with no aggregates to quote is left alone', () async {
     // An empty window has no mean, and an insufficientData report names the
     // gap. Demanding a number there would force the model to invent one.


### PR DESCRIPTION
## The interactive ad failures were a fixture defect

`forbiddenToolCall` — creating a banner where policy forbids one — has been the largest failure class on this suite for every model measured. #3958's tool-withholding gate fixed the scheduled half. The interactive half survived, and **the cause was not the model.**

Six dialogue scenarios (`evo_*`, `wk_*`, `tone_roast_request`) set `lastReportStatus` while carrying an **empty `priorPeriodAttainments`**. A goal with a previous report necessarily had previous periods, so those FACTS describe a state the runtime cannot produce.

`automaticGoalAdEligible` reads empty priors as a *first evaluation*, which earns a welcome banner (P4/P5). So the deterministic tier said ads were permitted → the gate correctly offered the tools → the model correctly used them → the scenario scored it a violation. Every layer behaved correctly except the input.

## Result

`deepseek-v4-flash-0731`, 10 samples:

| | Baseline (5 runs) | Consistent priors (2 runs) |
| --- | --- | --- |
| Pass | 216.8/250 (0.867) | **243 and 244 /260** (0.935, 0.938) |
| `forbiddenToolCall` | 21, 14, 14, 13, 15 | **0, 0** |

**This is a measurement correction, not a model improvement.** The eval was feeding the runtime an impossible state and penalising the correct response to it. In production a real ongoing goal carries priors, the tier says ineligible, the gate withholds, and none of this arises. The README says so explicitly, so the 7-point jump is not mistaken later for the agent getting better.

## Two things that are real

**`ad_requested_while_ineligible` (new, P5).** An explicit request for a banner on a wake whose status blocks automatic ads. Nothing covered this — every other interactive scenario is ordinary conversation — so the runtime could have started refusing users who asked and no scenario would have noticed. It is the regression this change could plausibly cause, so it is guarded before shipping, not after. Scores 8/10.

**The reply-ordering rule is removed.** I added it from review feedback on #3958, reading the contract's "exactly once first" as an ordering requirement. `GoalAgentStrategy` enforces at-most-once per wake and says *nothing* about position, so the check failed sequences production accepts — 9 × `tone_roast_request` and 2 × the new scenario, the largest remaining failure category. Cardinality is kept; position is not. **A harness stricter than the code it measures is the same defect as one that is looser**, and this is the third mirror-divergence found tonight (after `reply_to_user` being scored unexpected, and the missing `priors.isEmpty` branch).

## What remains

~7–9 `missingAssistantContent` (mostly `evo_ambiguous`, where the model answers instead of asking the clarifying question) and ~5–7 `missingRequiredReportContent` on the complex-health pair. Both are genuine model behaviour, and both sit in the high-variance scenarios documented in #3961 — so more samples beat more fixes from here.

192 tests green, analyzer clean, `make knowledge_check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected evaluation scenarios that incorrectly treated valid ad requests as failures.
  * Explicit banner or ad requests now receive appropriate handling, including localized requests, even when automatic ads are ineligible.
  * Goal observations can be recorded before a user reply when permitted.
  * Removed unnecessary ordering restrictions on tool calls.
  * Clarified validation for reply frequency and payload content.

* **Documentation**
  * Updated evaluation documentation with revised results, scenario coverage, fixture corrections, and remaining model-response limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->