### PR TITLE
test(evals): score the clarifying question where it has to be

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -398,6 +398,56 @@ where the model answers instead of asking the clarifying question) and ~5-7
 model behaviour, and both sit in the high-variance scenarios, so more samples
 beat more fixes from here.
 
+## Prompt edits need full-suite confirmation — 2026-08-18
+
+`evo_ambiguous` (vague musing: ask one clarifying question, do not propose)
+sat at 4-6/10. Reading the captured replies showed genuine model behaviour,
+not a harness artifact: warm coaching that never asks anything. The suspected
+cause was structural — "for vague musings, ask one clarifying question" lived
+inside rule 2, *Goal-change requests*, and a user sighing "this feels a bit
+much" never reads as a change request, so the model never reached the clause.
+
+Moving it into rule 1 produced a clean, large, targeted win. Measured on 40
+samples of that scenario alone (a cheap way to buy a real error bar):
+
+| Measure | Before | After | Delta (95% band) |
+| --- | ---: | ---: | --- |
+| any `?` anywhere | 0.525 | 0.900 | +0.375 (+/-0.181) |
+| question in the final quarter | 0.375 | 0.900 | +0.525 (+/-0.177) |
+
+Both cleared their bands, and loose and strict agreed afterwards — the
+questions had moved to the END of the reply, so it was not rhetorical-aside
+inflation.
+
+**The full suite then killed it.** Two runs each side:
+
+| | Before | After |
+| --- | --- | --- |
+| Total | 243, 244 /260 | 236, 231 /260 |
+| `evo_withdrawn` | 10, 10 | 3, 2 |
+| `forbiddenToolCall` | 0 | 15 |
+
+The change was reverted. The target gain did not even hold consistently
+(10 then 6) while `evo_withdrawn` collapsed in both runs and ad over-creation
+returned.
+
+**The lesson is about method, not this rule.** A targeted measurement flatters
+a prompt edit, because it measures the one place the edit was aimed and none
+of the places it leaks. This is the third prompt change in two days with a
+local win and distributed damage; the two structural fixes (withholding tools
+the deterministic tier has ruled out, enforcing the aggregates) had no such
+tail. At 3572 of 3600 characters this prompt is dense enough that moving text
+between precedence rules redistributes attention rather than adding a rule.
+
+**Rule: never accept a prompt edit on a targeted measurement. Confirm on the
+full suite, twice, both sides.**
+
+What was kept is the stricter check. `evo_ambiguous` now requires the question
+in the last sentence (`\?[^?]{0,60}$`) rather than a `?` anywhere, because the
+loose form credited "Some days the win is just getting out the door?" buried
+mid-pep-talk. That LOWERS the reported score — 0.375 is the honest rate where
+0.525 was flattering — and it is the number to beat from here.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -432,6 +432,44 @@ void main() {
       );
     });
 
+    test('a rhetorical aside is not a clarifying question', () {
+      // The vague-musing scenario wants the agent to ASK something. A loose
+      // "contains ?" credited pep talk with a rhetorical question buried in
+      // the middle: over 40 samples the loose form scored 0.525 where the
+      // question actually landed at the end only 0.375 of the time.
+      final scenario = scenarioById('evo_ambiguous');
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Some days the win is just getting out the door? '
+              'Totally normal. A short walk after dinner, parking farther '
+              'out, taking the stairs. Small wins stack. You have got this."}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.missingAssistantContent,
+      );
+      // Ending on the question is what the policy asks for.
+      expect(
+        classifyGoalAgentResult(
+          scenario: scenario,
+          toolCalls: [
+            call(
+              GoalAgentToolNames.replyToUser,
+              '{"message":"Totally fair — some weeks it is a lot. '
+              'What is making it feel heavy right now?"}',
+            ),
+          ],
+          assistantContent: '',
+        ),
+        GoalAgentEvalFailureCategory.none,
+      );
+    });
+
     test('reuse scenario fails a model that regenerates instead', () {
       final category = classifyGoalAgentResult(
         scenario: scenarioById('ad_reuse_top_rated'),

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -576,6 +576,15 @@ GoalAgentEvalFailureCategory classifyGoalAgentResult({
   )) {
     return GoalAgentEvalFailureCategory.missingAssistantContent;
   }
+  if (scenario.requiredAssistantContentPatterns.any(
+    (pattern) => !RegExp(
+      pattern,
+      caseSensitive: false,
+      multiLine: true,
+    ).hasMatch(userVisibleText.trimRight()),
+  )) {
+    return GoalAgentEvalFailureCategory.missingAssistantContent;
+  }
   if (scenario.forbiddenAssistantContentClaims.any(
     (claim) => containsAffirmativeReportClaim(userVisibleText, claim),
   )) {

--- a/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_scenarios.dart
@@ -47,6 +47,7 @@ class GoalAgentEvalScenario {
     this.requiredToolArgumentTermGroups = const {},
     this.forbiddenToolArgumentTerms = const {},
     this.requiredAssistantContentTermGroups = const [],
+    this.requiredAssistantContentPatterns = const [],
     this.forbiddenAssistantContentClaims = const [],
     this.maxToolCallCounts = const {},
   });
@@ -176,6 +177,12 @@ class GoalAgentEvalScenario {
 
   /// Term groups that must appear in plain assistant text (dialogue).
   final List<List<String>> requiredAssistantContentTermGroups;
+
+  /// Regexes the visible reply must match. Term groups are substring checks,
+  /// which cannot express WHERE something appears — and for a clarifying
+  /// question that is the whole point: a rhetorical aside mid-pep-talk is not
+  /// the model asking the user anything.
+  final List<String> requiredAssistantContentPatterns;
 
   /// Claims that must not be affirmatively asserted in assistant text.
   final List<String> forbiddenAssistantContentClaims;
@@ -621,9 +628,12 @@ final goalAgentEvalScenarios = <GoalAgentEvalScenario>[
       GoalAgentToolNames.proposeGoalRevision,
       ..._adCreationToolNames,
     ],
-    requiredAssistantContentTermGroups: const [
-      ['?'],
-    ],
+    // A question at the END of the reply, not any question mark anywhere: the
+    // loose check credited "Some days the win is just getting out the door?"
+    // inside a pep talk. Measured over 40 samples the two differ sharply —
+    // 0.525 loose against 0.375 strict — so the loose form was overstating
+    // how often the agent actually asks.
+    requiredAssistantContentPatterns: const [r'\?[^?]{0,60}$'],
   ),
   GoalAgentEvalScenario(
     id: 'evo_withdrawn',


### PR DESCRIPTION
## What changed

`evo_ambiguous` asks the agent to meet a vague musing with a clarifying question. The check was `?` **anywhere** in the reply, which credited a rhetorical aside buried mid-pep-talk:

> "Some days the win is just getting out the door? Totally normal. A short walk after dinner, parking farther out, taking the stairs. Small wins stack. You've got this. 💪"

Over 40 samples the loose form scored **0.525** where the question actually landed at the end only **0.375** of the time. It now requires the question in the last sentence (`\?[^?]{0,60}$`).

**This lowers the reported number, which is the point.** 0.375 is the honest rate; 0.525 was flattering.

## The prompt fix that motivated it was reverted

Reading the captured replies showed genuine model behaviour, not a harness artifact — warm coaching that never asks anything. The suspected cause was structural: *"for vague musings, ask one clarifying question"* lived inside rule 2, **Goal-change requests**, and a user sighing "this feels a bit much" never reads as a change request, so the model never reached the clause.

Moving it into rule 1 looked excellent on a targeted 40-sample measurement:

| Measure | Before | After | Δ (95% band) |
| --- | ---: | ---: | --- |
| any `?` | 0.525 | 0.900 | +0.375 (±0.181) |
| question at the end | 0.375 | 0.900 | +0.525 (±0.177) |

Both cleared their bands, and loose and strict **agreed** afterwards — the questions had moved to the end, so it wasn't rhetorical inflation.

Then the full suite killed it. Two runs each side:

| | Before | After |
| --- | --- | --- |
| Total | 243, 244 /260 | **236, 231** /260 |
| `evo_withdrawn` | 10, 10 | **3, 2** |
| `forbiddenToolCall` | 0 | **15** |

The target gain didn't even hold consistently (10 then 6) while `evo_withdrawn` collapsed in both runs and ad over-creation returned. Reverted; prompt is back to 3572 chars.

## The part worth keeping

**A targeted measurement flatters a prompt edit** — it measures the one place the edit was aimed and none of the places it leaks. This is the third prompt change with a local win and distributed damage, where both structural fixes this week (withholding tools the deterministic tier has ruled out; enforcing the aggregates) had no such tail. At 3572 of 3600 characters this prompt is dense enough that moving text between precedence rules redistributes attention rather than adding a rule.

**Rule now in the eval README: never accept a prompt edit on a targeted measurement. Confirm on the full suite, twice, both sides.**

195 tests green, analyzer clean, `make knowledge_check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved evaluation checks to distinguish genuine clarification questions from rhetorical questions.
  * Added support for validating required response content using case-insensitive, multi-line patterns.
  * Updated ambiguous-goal evaluations to require a question near the end of the response.

* **Documentation**
  * Documented the prompt-edit experiment and its evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->