### PR TITLE
test(evals): add a tier-2 goal eval that scores what the wake persisted

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -14,7 +14,33 @@ The contract now lives in
 `test/features/agents/eval/goal/support/goal_agent_spec.dart` re-exports it
 and keeps the policy matrix the scenarios are derived from.
 
-## What is measured
+## Two tiers
+
+There are two evals here, and they answer different questions. Their numbers
+are **not comparable** — do not put them in one table.
+
+| | Tier 1 — inference | Tier 2 — outcome |
+| --- | --- | --- |
+| Runner | `goal_agent_eval_runner.dart` | `goal_agent_outcome_eval.dart` |
+| Input | authored FACTS block | domain entities → real `GoalFactsRenderer` |
+| Under test | the model + the prompt/tool contract | the whole `GoalAgentWorkflow` |
+| Scored | tool calls attempted | entities persisted |
+| Strategy | records, accepts everything | the real `GoalAgentStrategy`, which rejects |
+| Retries | none | `_forceReport` / `_forceAd` / `_forceReply` all run |
+| Scenarios | 26, P1–P17 | 9, the rows where attempt ≠ outcome |
+| Cost | ~1 call per case | 1–3 calls per case |
+
+Tier 1 is the workhorse: cheap, broad, and every scenario is legible. But
+three production layers sit between a tool call and the user, and tier 1 is
+structurally blind to all of them — the FACTS are authored rather than
+rendered, nothing rejects a bad call, and nothing repairs a missing output.
+So a tier-1 failure can be a production success, and a tier-1 pass can
+persist nothing at all.
+
+Tier 2 exists to measure that gap, not to replace tier 1. It is deliberately
+narrow: nine scenarios over the policy rows where the two can disagree.
+
+### Tier 1 — what is measured
 
 Four behaviours, one scenario catalog
 (`goal_agent_eval_scenarios.dart`, ids in parentheses):
@@ -52,11 +78,57 @@ the medication habit is only 6/7. `signePrivateStrings` is the leakage
 inventory: private details deliberately present in the FACTS context that must
 never reach `create_goal_ad` arguments.
 
-Limitation, stated plainly: the wake context is **authored** (a synthetic
-FACTS block), not produced by a real wake over a real database. The fixtures
-cross-check their deterministic arithmetic against the real evaluator and use
-the production prompt/tool contract, but a future workflow-level eval should
-also build FACTS through `GoalAgentWorkflow` over a penguin fitness database.
+Limitation, stated plainly: the tier-1 wake context is **authored** (a
+synthetic FACTS block), not produced by a real wake. The fixtures cross-check
+their deterministic arithmetic against the real evaluator and use the
+production prompt/tool contract, but the block itself is written by hand and
+can drift from what `GoalFactsRenderer` actually emits. Tier 2 closes that
+gap for its nine scenarios; the remaining seventeen still run on authored
+FACTS.
+
+### Tier 2 — what is measured
+
+Nine scenarios (`goal_agent_outcome_eval_scenarios.dart`), each a goal world
+stated **only as evidence**: a `GoalSignalWindow`, the banners already on the
+board, and yesterday's period register. Status, attainment, trend, ad
+freshness, dismissal cooldown and reusability are all derived by production
+from that evidence — a tier-2 fixture structurally cannot claim a situation
+its own facts do not produce, which is the defect that cost two corrections
+in tier 1.
+
+Pass/fail is over persisted entities:
+
+| Scenario | Policy | Passes when |
+| --- | --- | --- |
+| `ot_quiet_wake` | P2 | nothing user-visible is written at all |
+| `ot_transition_report` | P1 | a report lands carrying the derived status |
+| `off_track_first_ad` | P5 | report + a newly authored banner |
+| `off_track_fresh_ad` | P6 | no second banner reaches the board |
+| `off_track_cooldown` | P5 | the same-day dismissal keeps the board quiet |
+| `recovering_retires_ad` | P7 | the stale scolding ends up retired |
+| `sparse_insufficient_data` | P8 | `insufficientData`, no banner |
+| `off_track_reuses_top_rated` | P13 | a re-run, not fresh copy |
+| `chat_question_on_track` | P10 | a reply the chat surface can render |
+
+Two of those are only meaningful at the outcome level. `forbidsNewAd` counts
+**re-runs as well as authored copy**, because the user cannot tell them apart
+and the cooldown does not either. And `expectsNoOutcome` is checked against
+`outcomeWrites` rather than every write: a scheduled wake persists its FACTS
+context row before inference starts and bills its tokens afterwards, so
+demanding a literally empty batch would fail every model for doing its
+bookkeeping.
+
+The tier's most useful output is the one that exists nowhere else: **every
+tool call the deterministic guard refused, with its reason.** A rejection is
+invisible to tier 1 (whose strategy accepts everything) and invisible in the
+final state (a repaired wake looks identical to one that got it right first
+time). A scenario that passes only after two refusals is paying three turns
+for one turn's work.
+
+Only one fake remains in the tier-2 stack: the signal reader. Everything
+downstream of it — Phase A, the renderer, the strategy, the forced retries,
+persistence — is production code. A future tier could replace that reader
+with a real penguin fitness database.
 
 ## Complex health results — 2026-08-13
 
@@ -448,6 +520,81 @@ loose form credited "Some days the win is just getting out the door?" buried
 mid-pep-talk. That LOWERS the reported score — 0.375 is the honest rate where
 0.525 was flattering — and it is the number to beat from here.
 
+## Tier 2's first run finds a report-loss path — 2026-08-18
+
+Nine scenarios, three samples each, two models. Tier 2's first live run, and
+it immediately found something no tier-1 run could have.
+
+| Scenario | Policy | deepseek-v4-flash-0731 | glm-5.2 |
+| --- | --- | ---: | ---: |
+| `ot_quiet_wake` | P2 | 3/3 | 3/3 |
+| `ot_transition_report` | P1 | 3/3 | 2/3 |
+| `off_track_first_ad` | P5 | 3/3 | **0/3** |
+| `off_track_fresh_ad` | P6 | 3/3 | **1/3** |
+| `off_track_cooldown` | P5 | 3/3 | **0/3** |
+| `recovering_retires_ad` | P7 | 3/3 | 3/3 |
+| `sparse_insufficient_data` | P8 | 3/3 | 3/3 |
+| `off_track_reuses_top_rated` | P13 | 3/3 | 3/3 |
+| `chat_question_on_track` | P10 | 3/3 | 3/3 |
+| **Total** | | **27/27** | **18/27** |
+
+Every one of glm-5.2's nine failures is the same category: `missingReport`.
+The wake persisted a banner, or nothing, and left the user with no standing
+report at all.
+
+**Why.** All nine were refused by the deterministic guard, twice, and in
+eight of the nine the two refusals cite *different rules*:
+
+```
+1. "atRisk" is a status field value, not prose. Rewrite the visible text…
+2. the rolling standing must quote the FACTS aggregates verbatim —
+   6000 is missing.
+```
+
+The model fixes what it was told, and trips the next rule on the way out.
+`GoalAgentWorkflow` allows exactly one forced report retry, so two attempts
+are all there are — and the wake ends with the report head unmoved.
+
+This is not a glm-only story. deepseek tripped the same aggregate rule 18
+times across its 27 cases; it simply had enough attempts left to recover.
+The rejection counts across both models:
+
+| Rule | deepseek | glm-5.2 |
+| --- | ---: | ---: |
+| rolling aggregate not quoted verbatim | 18 | 17 |
+| status value used as prose | 1 | 12 |
+| status field missing entirely | 1 | 2 |
+
+The aggregate rule (shipped in #3961, to stop models substituting the latest
+reading for the mean) is by a wide margin the most-tripped rule in the
+system. It is doing real work — but on a weaker model it converts "slightly
+wrong number" into "no report at all", which is the worse failure.
+
+**Two defects, both in production, not in the harness:**
+
+1. **The guard reports one violation at a time.** `_validateReport` returns
+   on the first failed check, so a report breaking two rules costs two round
+   trips to learn that. Collecting every violation into one rejection is
+   strictly better: same turn count, more information, and a converging model
+   needs one retry instead of two.
+2. **One forced retry is not enough when rejections are sequential.** Fixing
+   (1) mostly dissolves (2), which is the argument for fixing (1) first and
+   re-measuring before touching the retry budget.
+
+**Caveats.** Three samples per cell is thin — the tier-1 noise floor work is
+explicit that n=3 cannot rank two close models. It is enough here because the
+failures are not a scatter: they are one category, concentrated in one model,
+with a mechanism visible in the rejection log. The ranking claim
+("deepseek > glm") is weak at this n; the defect claim is not.
+
+Cost over the same run, and note this is per WAKE, not per call — a repaired
+wake pays for its retries:
+
+| Model | Cases | Credits | Credits/goal-month | Wh/goal-month |
+| --- | ---: | ---: | ---: | ---: |
+| `deepseek-v4-flash-0731` | 27 | 0.0113 | 0.0376 | 80.6 |
+| `glm-5.2` | 27 | 0.1421 | 0.4737 | 81.5 |
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:
@@ -525,6 +672,40 @@ fvm dart run tool/goal_agent_eval_report.dart eval_artifacts/goal_agent_*.json
 
 `qwen3.5-397b-a17b` is the optional ceiling probe — add it to
 `GOAL_AGENT_EVAL_MODELS` when a "how good can it get" reference is wanted.
+
+### Tier 2 (outcome eval)
+
+Separate driver, separate env vars — deliberately, so a tier-1 command line
+cannot silently launch the slower, more expensive tier.
+
+```bash
+LOTTI_GOAL_OUTCOME_EVAL_LIVE=1 \
+GOAL_AGENT_EVAL_API_KEY=$MELIOUS_API_KEY \
+GOAL_OUTCOME_EVAL_MODELS=deepseek-v4-flash-0731,glm-5.2 \
+GOAL_OUTCOME_EVAL_REPEATS=3 \
+fvm flutter test \
+  test/features/agents/eval/goal/goal_agent_outcome_eval_live_test.dart \
+  --tags eval-live
+```
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `GOAL_OUTCOME_EVAL_MODELS` | `glm-5.2` | comma-separated model list |
+| `GOAL_OUTCOME_EVAL_SCENARIOS` | all 9 | comma-separated scenario ids |
+| `GOAL_OUTCOME_EVAL_REPEATS` | `1` | samples per (model, scenario) |
+| `GOAL_OUTCOME_EVAL_JSON` / `_MARKDOWN` | temp dir | artifact paths |
+
+`REPEATS` is a first-class parameter rather than an outer loop because a
+single sample of a live model says almost nothing — see the noise floor
+above. Each sample bills under its own wake-run key, so a five-sample run
+does not attribute five wakes' credits to one case.
+
+Resolution goes through a **profile**, not the goal agent's built-in
+`glm-5.2` default: that default matches on `providerModelId` and can
+therefore only ever run one model, while a profile is how a real user points
+their goal agent somewhere else. Evaluating an arbitrary model means
+evaluating the profile path — which is the configured wake's own code path
+anyway.
 
 ## Methodology caveats
 

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -63,7 +63,7 @@ sources:
   - id: goal-agent-evals
     resource: ../../docs/evaluations/goal_agent_models/README.md
     title: Goal-agent model evaluation run book and results
-    last_modified: 2026-08-16
+    last_modified: 2026-08-18
   - id: tool-dispatcher
     resource: ../../lib/features/goals/workflow/goal_tool_dispatcher.dart
     title: GoalToolDispatcher — proposal persistence and spec revision routing
@@ -206,10 +206,15 @@ flowchart TD
   `rerun_goal_ad` from the tool list whenever the deterministic tier has already
   ruled a banner out — `automaticGoalAdEligible` false, or a dismissal cooldown
   active. A tool absent from the wire cannot be called, so the prohibition needs
-  no prompt compliance. Interactive wakes keep the full surface, because an
-  explicit request overrides eligibility and cooldown and that judgment happens
-  during the turn; the forced-ad repair path likewise receives every tool, since
-  it runs only where an ad is REQUIRED. The measurement that motivated this is
+  no prompt compliance. The override is keyed on the deterministic request
+  detector (`isExplicitGoalAdReplacementRequest`), not on "a message exists":
+  merely being spoken to is not a request for a banner, and treating it as one
+  left the ad tools on the wire for every dialogue turn — calls persistence
+  discards anyway, since `interactiveAdRequested` gates the write on the same
+  signal. A non-English request that the English heuristic misses is carried
+  instead as data, by `reply_to_user(userAskedForBanner: true)`. The forced-ad
+  repair path receives every tool, since it runs only where an ad is REQUIRED.
+  The measurement that motivated this is
   in `docs/evaluations/goal_agent_models/README.md`: prompt wording could only
   trade ad over-creation against skipping ads policy demands, because the model
   was being asked to re-derive a decision the runtime had already made.

--- a/test/features/agents/eval/goal/goal_agent_outcome_eval_live_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_outcome_eval_live_test.dart
@@ -1,0 +1,175 @@
+@Tags(['eval-live'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/constants/provider_config.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/get_it.dart';
+
+import '../../../../helpers/fallbacks.dart';
+import '../../../ai_consumption/test_utils.dart';
+import 'support/goal_agent_outcome_eval.dart';
+import 'support/goal_agent_outcome_eval_scenarios.dart';
+
+/// Live goal-agent OUTCOME eval (tier 2).
+///
+/// Runs the real `GoalAgentWorkflow` against a live model and scores what it
+/// PERSISTED. Strategy rejections, forced retries and the persistence gates
+/// are all inside the measurement, so a case passes only if the user would
+/// actually have got the right thing — which is not the same question tier 1
+/// asks, and the numbers are not comparable with it.
+///
+/// Run book (full version in `docs/evaluations/goal_agent_models/README.md`):
+///
+///     LOTTI_GOAL_OUTCOME_EVAL_LIVE=1 \
+///     GOAL_AGENT_EVAL_API_KEY=$MELIOUS_API_KEY \
+///     GOAL_OUTCOME_EVAL_MODELS=deepseek-v4-flash-0731 \
+///     fvm flutter test test/features/agents/eval/goal/ \
+///       --tags eval-live --plain-name 'goal-agent outcome report'
+void main() {
+  test(
+    'writes a goal-agent outcome report',
+    () async {
+      // The test binding installs a mock HttpOverrides whose client fails
+      // every request — clear it so the eval reaches a real provider.
+      HttpOverrides.global = null;
+
+      registerAllFallbackValues();
+      final attribution = AiInteractionCaptureTestBench.create()..register();
+      addTearDown(attribution.unregister);
+      addTearDown(getIt.reset);
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final conversationSubscription = container.listen(
+        conversationRepositoryProvider,
+        (_, _) {},
+      );
+      addTearDown(conversationSubscription.close);
+      final cloudSubscription = container.listen(
+        cloudInferenceRepositoryProvider,
+        (_, _) {},
+      );
+      addTearDown(cloudSubscription.close);
+
+      final providerType = _providerType(
+        Platform.environment['GOAL_AGENT_EVAL_PROVIDER_TYPE'],
+      );
+      final provider = AiConfigInferenceProvider(
+        id: 'goal-outcome-eval-${providerType.name}',
+        name: 'Goal Outcome Eval (${providerType.name})',
+        baseUrl:
+            Platform.environment['GOAL_AGENT_EVAL_BASE_URL'] ??
+            ProviderConfig.defaultBaseUrls[providerType]!,
+        apiKey:
+            Platform.environment['GOAL_AGENT_EVAL_API_KEY'] ??
+            Platform.environment['MELIOUS_API_KEY'] ??
+            '',
+        inferenceProviderType: providerType,
+        createdAt: DateTime(2026, 8, 8),
+      );
+
+      final modelIds = _envList('GOAL_OUTCOME_EVAL_MODELS');
+      final requested = _envList('GOAL_OUTCOME_EVAL_SCENARIOS');
+      final repeats =
+          int.tryParse(
+            Platform.environment['GOAL_OUTCOME_EVAL_REPEATS'] ?? '',
+          ) ??
+          1;
+      final scenarios = requested.isEmpty
+          ? goalOutcomeEvalScenarios
+          : goalOutcomeEvalScenarios
+                .where((s) => requested.contains(s.id))
+                .toList(growable: false);
+      expect(
+        scenarios,
+        isNotEmpty,
+        reason: 'GOAL_OUTCOME_EVAL_SCENARIOS matched no scenario ids.',
+      );
+
+      final runner = GoalOutcomeEvalRunner(
+        provider: provider,
+        conversationRepository: container.read(
+          conversationRepositoryProvider.notifier,
+        ),
+        cloudInferenceRepository: container.read(
+          cloudInferenceRepositoryProvider,
+        ),
+        wakesPerDayAssumption:
+            int.tryParse(
+              Platform.environment['GOAL_AGENT_EVAL_WAKES_PER_DAY'] ?? '',
+            ) ??
+            3,
+        consumptionForWakeRunKey: (wakeRunKey) => attribution
+            .recordedInteractions
+            .where((event) => event.wakeRunKey == wakeRunKey)
+            .toList(growable: false),
+      );
+
+      final report = await runner.run(
+        modelIds: modelIds.isEmpty ? const ['glm-5.2'] : modelIds,
+        scenarios: scenarios,
+        repeats: repeats,
+      );
+
+      final tempDir = Directory.systemTemp.path;
+      final jsonPath =
+          Platform.environment['GOAL_OUTCOME_EVAL_JSON'] ??
+          '$tempDir/lotti-goal-outcome-eval.json';
+      final markdownPath =
+          Platform.environment['GOAL_OUTCOME_EVAL_MARKDOWN'] ??
+          '$tempDir/lotti-goal-outcome-eval.md';
+      _write(jsonPath, report.toPrettyJson());
+      _write(markdownPath, report.toMarkdown());
+
+      expect(report.results, isNotEmpty);
+      expect(File(markdownPath).existsSync(), isTrue);
+    },
+    skip: Platform.environment['LOTTI_GOAL_OUTCOME_EVAL_LIVE'] == '1'
+        ? null
+        : 'Set LOTTI_GOAL_OUTCOME_EVAL_LIVE=1 (and MELIOUS_API_KEY) to run '
+              'the live goal-agent outcome eval.',
+    timeout: Timeout(
+      Duration(
+        minutes:
+            int.tryParse(
+              Platform.environment['GOAL_AGENT_EVAL_TIMEOUT_MINUTES'] ?? '',
+            ) ??
+            30,
+      ),
+    ),
+  );
+}
+
+InferenceProviderType _providerType(String? name) {
+  if (name == null || name.trim().isEmpty) {
+    return InferenceProviderType.melious;
+  }
+  return InferenceProviderType.values.firstWhere(
+    (value) => value.name == name.trim(),
+    orElse: () => throw FormatException(
+      'Unknown GOAL_AGENT_EVAL_PROVIDER_TYPE "$name".',
+    ),
+  );
+}
+
+List<String> _envList(String name) {
+  final value = Platform.environment[name];
+  if (value == null || value.trim().isEmpty) return const [];
+  return value
+      .split(',')
+      .map((part) => part.trim())
+      .where((part) => part.isNotEmpty)
+      .toList(growable: false);
+}
+
+void _write(String path, String content) {
+  final file = File(path);
+  file.parent.createSync(recursive: true);
+  file.writeAsStringSync(content);
+}

--- a/test/features/agents/eval/goal/goal_agent_outcome_eval_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_outcome_eval_test.dart
@@ -1,0 +1,694 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/nudge_models.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/inference_usage.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_strategy.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import '../../../../helpers/fallbacks.dart';
+import '../../../../mocks/mocks.dart';
+import '../../workflow/task_agent_workflow_test_helpers.dart';
+import 'support/goal_agent_outcome_eval.dart';
+import 'support/goal_agent_outcome_eval_scenarios.dart';
+
+/// Offline coverage for the tier-2 bench.
+///
+/// The important half is the FIRST group. A tier-2 scenario never states its
+/// status — it states evidence, and production derives the rest. That is only
+/// an improvement over tier 1's authored FACTS if the derivation actually
+/// agrees with what the scenario's expectations assume, so every fixture is
+/// driven through the real workflow here and interrogated at the wire: what
+/// status did Phase A derive, and which tools were actually offered?
+///
+/// Both of tier 1's mirror-divergence bugs were exactly this failure — a
+/// fixture claiming a situation its own facts did not produce — and both were
+/// found by a live run rather than by a test.
+void main() {
+  final provider =
+      AiConfig.inferenceProvider(
+            id: 'outcome-eval-provider',
+            baseUrl: 'https://api.melious.ai/v1',
+            apiKey: 'key',
+            name: 'Melious',
+            createdAt: DateTime(2026),
+            inferenceProviderType: InferenceProviderType.melious,
+          )
+          as AiConfigInferenceProvider;
+
+  setUpAll(registerAllFallbackValues);
+
+  /// Runs one scenario with a scripted model turn and returns everything the
+  /// wire and the write batch saw.
+  Future<
+    ({
+      Map<String, Object?> facts,
+      List<String> toolNames,
+      GoalAgentEvalOutcome outcome,
+    })
+  >
+  drive(
+    GoalOutcomeEvalScenario scenario, {
+    List<ChatCompletionMessageToolCall> Function(int call)? toolCalls,
+    int maxDelegateCalls = 1,
+  }) async {
+    final manager = MockConversationManager();
+    when(() => manager.messages).thenReturn(const <ChatCompletionMessage>[]);
+    final conversationRepository = MockConversationRepository(manager)
+      ..maxDelegateCalls = maxDelegateCalls;
+    Map<String, Object?>? facts;
+    var toolNames = <String>[];
+    var call = 0;
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          call++;
+          if (call == 1) {
+            // The FACTS block is `prefix\n```json\n{...}\n``` `.
+            final json = message.substring(
+              message.indexOf('{'),
+              message.lastIndexOf('}') + 1,
+            );
+            facts = jsonDecode(json) as Map<String, Object?>;
+            toolNames = [for (final tool in tools!) tool.function.name];
+          }
+          final calls = toolCalls?.call(call) ?? const [];
+          if (calls.isNotEmpty) {
+            await (strategy! as GoalAgentStrategy).processToolCalls(
+              toolCalls: calls,
+              manager: manager,
+            );
+          }
+          return const InferenceUsage(inputTokens: 500, outputTokens: 80);
+        };
+
+    final runner = GoalOutcomeEvalRunner(
+      provider: provider,
+      conversationRepository: conversationRepository,
+      cloudInferenceRepository: MockCloudInferenceRepository(),
+    );
+    final result = await runner.runCase(
+      modelId: 'scripted',
+      scenario: scenario,
+    );
+    return (
+      facts: facts ?? const {},
+      toolNames: toolNames,
+      outcome: result.outcome,
+    );
+  }
+
+  ChatCompletionMessageToolCall toolCall(
+    String name,
+    Map<String, dynamic> args, {
+    String id = 'call-1',
+  }) => ChatCompletionMessageToolCall(
+    id: id,
+    type: ChatCompletionMessageToolCallType.function,
+    function: ChatCompletionMessageFunctionCall(
+      name: name,
+      arguments: jsonEncode(args),
+    ),
+  );
+
+  GoalTrackStatus statusOf(Map<String, Object?> facts) {
+    final evaluation = facts['evaluation']! as Map<String, Object?>;
+    return GoalTrackStatus.values.firstWhere(
+      (status) => status.name == evaluation['trackStatus'],
+    );
+  }
+
+  group('fixture honesty — the world each scenario actually builds', () {
+    // The status a scenario's expectations assume, stated once here so a
+    // fixture edit that changes the derived status fails loudly instead of
+    // quietly grading a different policy row.
+    const expectedStatus = {
+      'ot_quiet_wake': GoalTrackStatus.onTrack,
+      'ot_transition_report': GoalTrackStatus.onTrack,
+      'off_track_first_ad': GoalTrackStatus.offTrack,
+      'off_track_fresh_ad': GoalTrackStatus.offTrack,
+      'off_track_cooldown': GoalTrackStatus.offTrack,
+      'recovering_retires_ad': GoalTrackStatus.recovering,
+      'sparse_insufficient_data': GoalTrackStatus.insufficientData,
+      'off_track_reuses_top_rated': GoalTrackStatus.offTrack,
+      'chat_question_on_track': GoalTrackStatus.onTrack,
+    };
+
+    test('every scenario is covered by the status table', () {
+      expect(
+        goalOutcomeEvalScenarios.map((s) => s.id).toSet(),
+        expectedStatus.keys.toSet(),
+        reason: 'a new scenario must declare the status it means to exercise',
+      );
+    });
+
+    for (final scenario in goalOutcomeEvalScenarios) {
+      test(
+        '${scenario.id} derives ${expectedStatus[scenario.id]!.name}',
+        () async {
+          final driven = await drive(scenario);
+          expect(
+            statusOf(driven.facts),
+            expectedStatus[scenario.id],
+            reason:
+                'the evidence in ${scenario.id} must produce the status its '
+                'expectations are written against',
+          );
+        },
+      );
+    }
+
+    test('the ad surface is offered only where policy permits one', () async {
+      // The production gate, read at the wire rather than mirrored: ad tools
+      // ride on eligibility AND the absence of a same-day dismissal.
+      const offered = {
+        'ot_quiet_wake': false,
+        'ot_transition_report': false,
+        'off_track_first_ad': true,
+        'off_track_fresh_ad': true,
+        'off_track_cooldown': false,
+        'recovering_retires_ad': false,
+        'sparse_insufficient_data': false,
+        'off_track_reuses_top_rated': true,
+        'chat_question_on_track': false,
+      };
+      for (final scenario in goalOutcomeEvalScenarios) {
+        final driven = await drive(scenario);
+        expect(
+          driven.toolNames.contains(GoalAgentToolNames.createGoalAd),
+          offered[scenario.id],
+          reason: '${scenario.id}: create_goal_ad on the wire',
+        );
+        expect(
+          driven.toolNames.contains(GoalAgentToolNames.rerunGoalAd),
+          offered[scenario.id],
+          reason: '${scenario.id}: rerun_goal_ad on the wire',
+        );
+        // Everything else is always available — withholding is exactly two
+        // tools wide, and a wider cut would silently disable reporting.
+        expect(
+          driven.toolNames,
+          containsAll([
+            GoalAgentToolNames.updateGoalReport,
+            GoalAgentToolNames.retireGoalAd,
+            GoalAgentToolNames.replyToUser,
+          ]),
+          reason: '${scenario.id}: only the ad-creation pair may be withheld',
+        );
+      }
+    });
+
+    test('the cooldown scenario really is in cooldown', () async {
+      // Otherwise it would silently degrade into a duplicate of P5 and
+      // "no ad" would be measuring nothing.
+      final driven = await drive(
+        goalOutcomeScenarioById('off_track_cooldown'),
+      );
+      final ads = driven.facts['ads']! as Map<String, Object?>;
+      expect(ads['dismissalCooldownActive'], isTrue);
+    });
+
+    test('the reuse scenario really offers the ad it expects re-run', () async {
+      final driven = await drive(
+        goalOutcomeScenarioById('off_track_reuses_top_rated'),
+      );
+      final ads = driven.facts['ads']! as Map<String, Object?>;
+      expect(
+        [
+          for (final ad in ads['reusableTopRated']! as List)
+            (ad as Map<String, Object?>)['adId'],
+        ],
+        contains('ad-top-rated'),
+      );
+    });
+
+    test('the P6 scenario really has a fresh active banner', () async {
+      final driven = await drive(goalOutcomeScenarioById('off_track_fresh_ad'));
+      final ads = driven.facts['ads']! as Map<String, Object?>;
+      final active = (ads['active']! as List).cast<Map<String, Object?>>();
+      expect(active.single['adId'], 'ad-fresh');
+      expect(
+        active.single['fresh'],
+        isTrue,
+        reason: 'a stale banner would make a second ad legal, not forbidden',
+      );
+    });
+  });
+
+  group('outcome extraction reads the writes the way the app does', () {
+    test(
+      'a report and a banner are projected out of the write batch',
+      () async {
+        final driven = await drive(
+          goalOutcomeScenarioById('off_track_first_ad'),
+          toolCalls: (_) => [
+            toolCall(GoalAgentToolNames.updateGoalReport, {
+              'status': 'offTrack',
+              'oneLiner': 'Averaging 6000 of 10000 steps.',
+              'tldr': 'The rolling week slid well under target.',
+            }, id: 'call-a'),
+            toolCall(GoalAgentToolNames.createGoalAd, {
+              'headline': 'Your pedometer misses you.',
+              'tone': 'nudge',
+              'animation': 'steady',
+              'accent': 'tide',
+            }, id: 'call-b'),
+          ],
+        );
+        final outcome = driven.outcome;
+        expect(outcome.report?.provenance['trackStatus'], 'offTrack');
+        expect(outcome.reportText, contains('6000'));
+        expect(
+          outcome.newAds.single.brief.headline,
+          'Your pedometer misses you.',
+        );
+        expect(outcome.rerunAds, isEmpty);
+        expect(
+          classifyGoalAgentOutcome(
+            scenario: goalOutcomeScenarioById('off_track_first_ad'),
+            outcome: outcome,
+          ),
+          GoalOutcomeFailureCategory.none,
+        );
+      },
+    );
+
+    test('a re-run is not counted as newly authored copy', () async {
+      final driven = await drive(
+        goalOutcomeScenarioById('off_track_reuses_top_rated'),
+        toolCalls: (_) => [
+          toolCall(GoalAgentToolNames.rerunGoalAd, {
+            'adId': 'ad-top-rated',
+            'reason': 'proven copy',
+          }, id: 'call-a'),
+          toolCall(GoalAgentToolNames.updateGoalReport, {
+            'status': 'offTrack',
+            'oneLiner': 'Still behind.',
+            'tldr': 'The week is under target.',
+          }, id: 'call-b'),
+        ],
+      );
+      final outcome = driven.outcome;
+      expect(outcome.rerunAds.single.id, 'ad-top-rated');
+      expect(
+        outcome.newAds,
+        isEmpty,
+        reason: 'reuse costs nothing to author and must not read as creation',
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: goalOutcomeScenarioById('off_track_reuses_top_rated'),
+          outcome: outcome,
+        ),
+        GoalOutcomeFailureCategory.none,
+      );
+    });
+
+    test('a reply is read through the message → payload join', () async {
+      final driven = await drive(
+        goalOutcomeScenarioById('chat_question_on_track'),
+        toolCalls: (_) => [
+          toolCall(GoalAgentToolNames.replyToUser, {
+            'message': "You're at 11,000 a day — comfortably ahead.",
+          }),
+        ],
+      );
+      expect(
+        driven.outcome.visibleReply,
+        contains('comfortably ahead'),
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: goalOutcomeScenarioById('chat_question_on_track'),
+          outcome: driven.outcome,
+        ),
+        GoalOutcomeFailureCategory.none,
+      );
+    });
+
+    test(
+      'a refusal is captured with its reason, and the repair is too',
+      () async {
+        // The deterministic status is authoritative, so a report claiming
+        // `atRisk` where FACTS say `offTrack` is refused in-conversation. The
+        // wake then repairs and persists — which is exactly why the rejection
+        // must be recorded: the end state alone cannot tell a clean turn from
+        // one that cost three.
+        final driven = await drive(
+          goalOutcomeScenarioById('off_track_first_ad'),
+          maxDelegateCalls: 2,
+          toolCalls: (call) => call == 1
+              ? [
+                  toolCall(GoalAgentToolNames.updateGoalReport, {
+                    'status': 'atRisk',
+                    'oneLiner': 'Slightly behind.',
+                    'tldr': 'A bit under target.',
+                  }),
+                ]
+              : [
+                  toolCall(GoalAgentToolNames.updateGoalReport, {
+                    'status': 'offTrack',
+                    'oneLiner': 'Averaging 6000 of 10000 steps.',
+                    'tldr': 'The rolling week slid well under target.',
+                  }, id: 'call-b'),
+                ],
+        );
+        expect(
+          driven.outcome.rejections.single,
+          allOf(
+            contains(GoalAgentToolNames.updateGoalReport),
+            contains('offTrack'),
+          ),
+          reason: 'the refusal names the tool and the rule it broke',
+        );
+        expect(
+          driven.outcome.report,
+          isNotNull,
+          reason: 'the forced retry still had to land a report',
+        );
+      },
+    );
+
+    test('a quiet wake leaves bookkeeping but no outcome', () async {
+      final driven = await drive(goalOutcomeScenarioById('ot_quiet_wake'));
+      expect(
+        driven.outcome.writes,
+        isNotEmpty,
+        reason: 'the FACTS context row and usage row are always written',
+      );
+      expect(
+        driven.outcome.outcomeWrites,
+        isEmpty,
+        reason: 'nothing the user or the next wake can see',
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: goalOutcomeScenarioById('ot_quiet_wake'),
+          outcome: driven.outcome,
+        ),
+        GoalOutcomeFailureCategory.none,
+      );
+    });
+
+    test('a report on a quiet wake is the P2 failure', () async {
+      final driven = await drive(
+        goalOutcomeScenarioById('ot_quiet_wake'),
+        toolCalls: (_) => [
+          toolCall(GoalAgentToolNames.updateGoalReport, {
+            'status': 'onTrack',
+            'oneLiner': 'Still going well.',
+            'tldr': 'Nothing changed, but here is a report anyway.',
+          }),
+        ],
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: goalOutcomeScenarioById('ot_quiet_wake'),
+          outcome: driven.outcome,
+        ),
+        GoalOutcomeFailureCategory.writesOnNoOp,
+      );
+    });
+  });
+
+  group('the classifier names the first violated expectation', () {
+    GoalAgentEvalOutcome outcomeWith({
+      List<AgentDomainEntity> writes = const [],
+      bool succeeded = true,
+    }) => GoalAgentEvalOutcome(wakeSucceeded: succeeded, writes: writes);
+
+    AgentReportEntity report({
+      String status = 'offTrack',
+      String text = 'Averaging 6000 steps.',
+    }) =>
+        AgentDomainEntity.agentReport(
+              id: 'report-1',
+              agentId: goalOutcomeEvalAgentId,
+              scope: AgentReportScopes.current,
+              createdAt: goalOutcomeEvalNow,
+              vectorClock: null,
+              content: text,
+              provenance: {'trackStatus': status},
+            )
+            as AgentReportEntity;
+
+    GoalNudgeEntity ad({
+      NudgeStatus status = NudgeStatus.active,
+      int activationCount = 1,
+    }) => goalOutcomeEvalNudge(
+      id: 'ad-1',
+      agentId: goalOutcomeEvalAgentId,
+      status: status,
+      headline: 'Move.',
+      now: goalOutcomeEvalNow,
+      activationCount: activationCount,
+    );
+
+    const requiresReport = GoalOutcomeExpectation(requiresReport: true);
+    final base = goalOutcomeScenarioById('off_track_first_ad');
+
+    GoalOutcomeEvalScenario withExpectation(GoalOutcomeExpectation e) =>
+        GoalOutcomeEvalScenario(
+          id: base.id,
+          policyRuleId: base.policyRuleId,
+          statement: base.statement,
+          criteria: base.criteria,
+          window: base.window,
+          expectation: e,
+        );
+
+    test('a failed wake is never a policy verdict', () {
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(requiresReport),
+          outcome: outcomeWith(succeeded: false),
+        ),
+        GoalOutcomeFailureCategory.wakeFailed,
+      );
+    });
+
+    test('a missing report is named before its contents are graded', () {
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(
+              requiresReport: true,
+              requiredReportTermGroups: [
+                ['steps'],
+              ],
+            ),
+          ),
+          outcome: outcomeWith(),
+        ),
+        GoalOutcomeFailureCategory.missingReport,
+      );
+    });
+
+    test('a report contradicting the deterministic status fails', () {
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(
+              expectedReportStatus: GoalTrackStatus.offTrack,
+            ),
+          ),
+          outcome: outcomeWith(writes: [report(status: 'onTrack')]),
+        ),
+        GoalOutcomeFailureCategory.wrongReportStatus,
+      );
+    });
+
+    test('required report terms are synonym groups, not literals', () {
+      final scenario = withExpectation(
+        const GoalOutcomeExpectation(
+          requiredReportTermGroups: [
+            ['behind', 'under target', 'short of'],
+          ],
+        ),
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: scenario,
+          outcome: outcomeWith(
+            writes: [report(text: 'You are short of the weekly pace.')],
+          ),
+        ),
+        GoalOutcomeFailureCategory.none,
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: scenario,
+          outcome: outcomeWith(writes: [report(text: 'All good.')]),
+        ),
+        GoalOutcomeFailureCategory.missingReportContent,
+      );
+    });
+
+    test('a re-run counts as an ad appearing, and as no new copy', () {
+      // Both arms matter: the cooldown does not care which tool produced the
+      // banner, and P13 does care.
+      final rerun = outcomeWith(writes: [ad(activationCount: 3)]);
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(forbidsNewAd: true),
+          ),
+          outcome: rerun,
+        ),
+        GoalOutcomeFailureCategory.unexpectedAd,
+        reason: 'a re-run banner is just as loud as an authored one',
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(requiresNewAd: true),
+          ),
+          outcome: rerun,
+        ),
+        GoalOutcomeFailureCategory.missingAd,
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(requiresRerun: true),
+          ),
+          outcome: rerun,
+        ),
+        GoalOutcomeFailureCategory.none,
+      );
+    });
+
+    test('a retirement is required where the stale ad must go', () {
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(requiresRetirement: true),
+          ),
+          outcome: outcomeWith(),
+        ),
+        GoalOutcomeFailureCategory.missingRetirement,
+      );
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(requiresRetirement: true),
+          ),
+          outcome: outcomeWith(writes: [ad(status: NudgeStatus.retired)]),
+        ),
+        GoalOutcomeFailureCategory.none,
+      );
+    });
+
+    test('a reply that never persisted is a missing answer', () {
+      // The message row alone is not an answer: the chat surface renders the
+      // payload, so a row without one is a silent turn.
+      final orphaned =
+          AgentDomainEntity.agentMessage(
+                id: 'msg-1',
+                agentId: goalOutcomeEvalAgentId,
+                threadId: 'thread-1',
+                kind: AgentMessageKind.action,
+                createdAt: goalOutcomeEvalNow,
+                vectorClock: null,
+                contentEntryId: 'payload-missing',
+                metadata: const AgentMessageMetadata(
+                  toolName: AgentConversationToolNames.replyToUser,
+                ),
+              )
+              as AgentMessageEntity;
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(requiresReply: true),
+          ),
+          outcome: outcomeWith(writes: [orphaned]),
+        ),
+        GoalOutcomeFailureCategory.missingReply,
+      );
+    });
+  });
+
+  group('report', () {
+    GoalOutcomeEvalCaseResult caseResult({
+      required String modelId,
+      required GoalOutcomeEvalScenario scenario,
+      GoalOutcomeFailureCategory failure = GoalOutcomeFailureCategory.none,
+    }) => GoalOutcomeEvalCaseResult(
+      modelId: modelId,
+      scenario: scenario,
+      outcome: const GoalAgentEvalOutcome(wakeSucceeded: true, writes: []),
+      latencyMs: 1200,
+      failureCategory: failure,
+    );
+
+    test('the matrix and the shared cost table both render', () {
+      final scenario = goalOutcomeScenarioById('off_track_first_ad');
+      final report = GoalOutcomeEvalReport(
+        provider: provider,
+        modelIds: const ['deepseek-v4-flash-0731'],
+        scenarios: [scenario],
+        results: [
+          caseResult(modelId: 'deepseek-v4-flash-0731', scenario: scenario),
+        ],
+        wakesPerDayAssumption: 3,
+      );
+      final markdown = report.toMarkdown();
+      expect(markdown, contains('| off_track_first_ad | P5 | 1/1 |'));
+      // Cost degrades honestly through the shared renderer.
+      expect(markdown, contains('not reported'));
+      expect(markdown, contains('3 LLM wakes'));
+      // The tier warning must survive: these numbers are not tier 1's.
+      expect(markdown, contains('not comparable'));
+    });
+
+    test('a failure prints what persisted, not what was attempted', () {
+      final scenario = goalOutcomeScenarioById('ot_quiet_wake');
+      final report = GoalOutcomeEvalReport(
+        provider: provider,
+        modelIds: const ['glm-5.2'],
+        scenarios: [scenario],
+        results: [
+          caseResult(
+            modelId: 'glm-5.2',
+            scenario: scenario,
+            failure: GoalOutcomeFailureCategory.writesOnNoOp,
+          ),
+        ],
+        wakesPerDayAssumption: 3,
+      );
+      final markdown = report.toMarkdown();
+      expect(markdown, contains('ot_quiet_wake × `glm-5.2` — writesOnNoOp'));
+      expect(markdown, contains('Persisted: report=false'));
+    });
+
+    test('wake-run keys never collide with tier 1', () {
+      expect(
+        goalOutcomeEvalWakeRunKey('glm-5.2', 'off_track_first_ad'),
+        'goal-outcome-eval:off_track_first_ad:glm-5.2:0',
+      );
+      // Repeated samples must bill separately, or a five-sample run would
+      // attribute all five wakes' credits to one case.
+      expect(
+        goalOutcomeEvalWakeRunKey('glm-5.2', 'off_track_first_ad', sample: 4),
+        isNot(goalOutcomeEvalWakeRunKey('glm-5.2', 'off_track_first_ad')),
+      );
+    });
+  });
+}

--- a/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_eval_runner.dart
@@ -20,6 +20,7 @@ import 'package:openai_dart/openai_dart.dart';
 import '../../../../ai/eval/support/eval_text_matchers.dart';
 import 'goal_agent_eval_scenarios.dart';
 import 'goal_agent_spec.dart';
+import 'goal_eval_cost_table.dart';
 
 const goalAgentEvalKind = 'lotti.goalAgentInferenceEvalReport';
 
@@ -75,7 +76,7 @@ enum GoalAgentEvalFailureCategory {
 }
 
 /// One (model, scenario) outcome.
-class GoalAgentEvalCaseResult {
+class GoalAgentEvalCaseResult implements GoalEvalCostCase {
   const GoalAgentEvalCaseResult({
     required this.modelId,
     required this.scenario,
@@ -91,6 +92,7 @@ class GoalAgentEvalCaseResult {
     this.errorMessage,
   });
 
+  @override
   final String modelId;
   final GoalAgentEvalScenario scenario;
   final List<GoalAgentEvalToolCall> toolCalls;
@@ -99,7 +101,9 @@ class GoalAgentEvalCaseResult {
   final String assistantContent;
   final int latencyMs;
   final GoalAgentEvalFailureCategory failureCategory;
+  @override
   final int? inputTokens;
+  @override
   final int? outputTokens;
   final int? thoughtsTokens;
   final int? cachedInputTokens;
@@ -114,6 +118,7 @@ class GoalAgentEvalCaseResult {
   /// Total reported energy for this case in watt-hours, or null when the
   /// provider sent no energy data. The "my fitness agent costs N Wh/month"
   /// number starts here (ADR 0058 Decision 4).
+  @override
   double? get energyWh {
     final values = consumption
         .map((e) => e.energyKwh)
@@ -124,6 +129,7 @@ class GoalAgentEvalCaseResult {
 
   /// Total billed credits for this case, or null when nothing was reported.
   /// Never zero-defaulted: a missing bill is not a free run.
+  @override
   double? get credits {
     final values = consumption
         .map((e) => e.credits)
@@ -247,66 +253,13 @@ class GoalAgentEvalReport {
       }
     }
 
-    buffer
-      ..writeln('## Cost (observed, not a target)')
-      ..writeln()
-      ..writeln(
-        '| Model | Cases | In | Out | Credits | Credits/goal-month* | '
-        'Wh | Wh/goal-month* |',
-      )
-      ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
-    for (final modelId in modelIds) {
-      final cases = results.where((r) => r.modelId == modelId).toList();
-      final inTokens = cases.fold<int>(
-        0,
-        (sum, r) => sum + (r.inputTokens ?? 0),
-      );
-      final outTokens = cases.fold<int>(
-        0,
-        (sum, r) => sum + (r.outputTokens ?? 0),
-      );
-      final creditValues = cases
-          .map((r) => r.credits)
-          .whereType<double>()
-          .toList();
-      final credits = creditValues.isEmpty
-          ? null
-          : creditValues.reduce((a, b) => a + b);
-      // Per-month figures divide by REPORTED cases only: missing telemetry
-      // must widen uncertainty, never masquerade as zero cost.
-      final perGoalMonth = credits == null
-          ? null
-          : credits / creditValues.length * wakesPerDayAssumption * 30;
-      final energyValues = cases
-          .map((r) => r.energyWh)
-          .whereType<double>()
-          .toList();
-      final energyWh = energyValues.isEmpty
-          ? null
-          : energyValues.reduce((a, b) => a + b);
-      final energyPerGoalMonth = energyWh == null
-          ? null
-          : energyWh / energyValues.length * wakesPerDayAssumption * 30;
-      buffer.writeln(
-        '| `$modelId` | ${cases.length} | $inTokens | $outTokens | '
-        '${credits?.toStringAsFixed(4) ?? 'not reported'} | '
-        '${perGoalMonth?.toStringAsFixed(4) ?? 'not reported'} | '
-        '${energyWh?.toStringAsFixed(2) ?? 'not reported'} | '
-        '${energyPerGoalMonth?.toStringAsFixed(1) ?? 'not reported'} |',
-      );
-    }
-    buffer
-      ..writeln()
-      ..writeln(
-        '*Extrapolation assumes $wakesPerDayAssumption LLM wakes '
-        'per goal per day — a printed assumption, not a measurement — '
-        'and divide by cases that actually reported the figure: missing '
-        'telemetry widens uncertainty, it is never counted as zero. '
-        'Credits and energy are Melious-reported; "not reported" means '
-        'the provider sent no data, never that the run was free. Banner '
-        'creation itself (ADR 0058) adds no image inference on top of '
-        'the Phase B text turn.',
-      );
+    buffer.write(
+      renderGoalEvalCostTable(
+        modelIds: modelIds,
+        cases: results,
+        wakesPerDayAssumption: wakesPerDayAssumption,
+      ),
+    );
     return buffer.toString();
   }
 }

--- a/test/features/agents/eval/goal/support/goal_agent_outcome_eval.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_outcome_eval.dart
@@ -1,0 +1,961 @@
+/// Tier 2 of the goal-agent eval: score what the wake PERSISTED, not what
+/// the model attempted.
+///
+/// Tier 1 (`goal_agent_eval_runner.dart`) sends a hand-authored FACTS block
+/// straight to a model and grades the tool calls that come back. It is cheap,
+/// fast and every scenario is legible — but three whole layers of production
+/// sit between a tool call and the user, and tier 1 cannot see any of them:
+///
+///  1. **The FACTS are authored.** Production renders them from domain
+///     entities via `GoalFactsRenderer`. A fixture that drifts from the
+///     renderer measures a prompt the app never sends.
+///  2. **The strategy rejects.** `GoalAgentStrategy` refuses a report that
+///     contradicts the deterministic status, an aggregate the FACTS never
+///     carried, an ad id that was never offered. Tier 1's recording strategy
+///     accepts everything.
+///  3. **The workflow repairs.** `_forceReport`, `_forceAd` and `_forceReply`
+///     re-ask when a required output is missing, and persistence discards ads
+///     on turns that did not request one. A tier-1 "failure" may be a
+///     production success, and a tier-1 "pass" may persist nothing at all.
+///
+/// So this tier runs the real [GoalAgentWorkflow] against a live model over a
+/// world built from real entities, and grades the writes. The two tiers'
+/// numbers are NOT comparable — tier 1 scores attempts, tier 2 scores
+/// outcomes — and that gap is the measurement, not a defect.
+library;
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/nudge_models.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai_consumption/model/ai_consumption_event.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../../mocks/mocks.dart';
+import '../../../../ai/eval/support/eval_text_matchers.dart';
+import '../../../test_data/entity_factories.dart';
+import 'goal_eval_cost_table.dart';
+
+const goalAgentOutcomeEvalKind = 'lotti.goalAgentOutcomeEvalReport';
+
+/// The agent, period and clock every tier-2 scenario shares. Fixed so a
+/// scenario's evidence days and its escalation period cannot drift apart.
+const goalOutcomeEvalAgentId = 'goal-eval-agent';
+const goalOutcomeEvalPeriodKey = '2026-08-09';
+final goalOutcomeEvalNow = DateTime(2026, 8, 9, 12);
+
+/// What the wake was allowed, required and forbidden to leave behind.
+///
+/// Every field is a policy row restated over persisted entities. A `null`
+/// or `false` field is not an expectation — it is silence, and silence must
+/// never fail a case.
+class GoalOutcomeExpectation {
+  const GoalOutcomeExpectation({
+    this.expectsNoOutcome = false,
+    this.requiresReport = false,
+    this.expectedReportStatus,
+    this.requiresNewAd = false,
+    this.forbidsNewAd = false,
+    this.requiresRerun = false,
+    this.requiresRetirement = false,
+    this.requiredReportTermGroups = const [],
+    this.forbiddenReportTerms = const [],
+    this.requiresReply = false,
+    this.requiredReplyPatterns = const [],
+    this.forbiddenReplyClaims = const [],
+  });
+
+  /// P2: a wake with nothing to say must leave nothing behind.
+  ///
+  /// Checked against [GoalAgentEvalOutcome.outcomeWrites], not every write:
+  /// a scheduled wake persists its FACTS context row before inference even
+  /// starts, and bills its tokens afterwards, so demanding a literally empty
+  /// batch would fail every model for doing its bookkeeping. What must be
+  /// empty is what the user or the next wake can see.
+  final bool expectsNoOutcome;
+
+  final bool requiresReport;
+
+  /// The deterministic tier's status, which the persisted report's
+  /// provenance must carry. `GoalAgentStrategy` already rejects a
+  /// contradicting claim in-conversation; this proves the rejection held all
+  /// the way to the write.
+  final GoalTrackStatus? expectedReportStatus;
+
+  /// A newly authored banner (activation 1). Distinct from [requiresRerun],
+  /// which reuses proven copy at zero authoring cost.
+  final bool requiresNewAd;
+
+  /// No banner may be *activated* this wake — neither authored nor re-run.
+  /// This is the outcome-level form of "ad over-creation", and unlike tier 1
+  /// it is blind to attempts persistence would have discarded anyway.
+  final bool forbidsNewAd;
+
+  final bool requiresRerun;
+
+  /// A stale banner must end the wake retired.
+  final bool requiresRetirement;
+
+  /// Each group is a synonym set: the report must contain at least one term
+  /// from every group.
+  final List<List<String>> requiredReportTermGroups;
+  final List<String> forbiddenReportTerms;
+
+  /// Interactive turns only: the user must actually get an answer.
+  final bool requiresReply;
+  final List<String> requiredReplyPatterns;
+  final List<String> forbiddenReplyClaims;
+}
+
+/// A tier-2 scenario: a goal world expressed in domain entities, so the FACTS
+/// the model reads are rendered by production rather than authored here.
+class GoalOutcomeEvalScenario {
+  const GoalOutcomeEvalScenario({
+    required this.id,
+    required this.policyRuleId,
+    required this.statement,
+    required this.criteria,
+    required this.window,
+    required this.expectation,
+    this.title = 'Goal',
+    this.nudges,
+    this.priorRegisters,
+    this.pendingUserMessage,
+    this.previousAssistantMessage,
+    this.triggerTokens = const {
+      'goal-escalation:$goalOutcomeEvalPeriodKey',
+    },
+  });
+
+  final String id;
+
+  /// The row of `goalAgentPolicyMatrix` this scenario instantiates.
+  final String policyRuleId;
+  final String title;
+  final String statement;
+  final GoalCriterion criteria;
+
+  /// The evidence Phase A derives from — the ONLY place a scenario states
+  /// what happened. Status, attainment and trend all follow from it.
+  final GoalSignalWindow window;
+
+  /// Banners already on the board, built against the run's clock so
+  /// freshness, cooldown and reusability resolve the way they would live.
+  final List<GoalNudgeEntity> Function(String agentId, DateTime now)? nudges;
+
+  /// Prior period registers keyed by period key, for scenarios whose policy
+  /// depends on trend rather than on today alone.
+  final Map<String, GoalProgressEntity> Function(String agentId, DateTime now)?
+  priorRegisters;
+
+  final String? pendingUserMessage;
+  final String? previousAssistantMessage;
+  final Set<String> triggerTokens;
+
+  final GoalOutcomeExpectation expectation;
+}
+
+enum GoalOutcomeFailureCategory {
+  none,
+  inferenceError,
+  wakeFailed,
+  writesOnNoOp,
+  missingReport,
+  wrongReportStatus,
+  missingReportContent,
+  forbiddenReportContent,
+  missingAd,
+  unexpectedAd,
+  missingRerun,
+  missingRetirement,
+  missingReply,
+  missingReplyContent,
+  forbiddenReplyClaim,
+}
+
+/// Everything one wake left behind, projected out of the captured upserts.
+class GoalAgentEvalOutcome {
+  const GoalAgentEvalOutcome({
+    required this.wakeSucceeded,
+    required this.writes,
+    this.wakeError,
+  });
+
+  final bool wakeSucceeded;
+  final String? wakeError;
+  final List<AgentDomainEntity> writes;
+
+  AgentReportEntity? get report =>
+      writes.whereType<AgentReportEntity>().lastOrNull;
+
+  /// Every value the persisted report exposes to the user, joined — the
+  /// report is graded as the user reads it, not field by field.
+  String get reportText {
+    final entity = report;
+    if (entity == null) return '';
+    return [
+      entity.oneLiner,
+      entity.tldr,
+      entity.content,
+    ].whereType<String>().where((part) => part.trim().isNotEmpty).join('\n');
+  }
+
+  List<GoalNudgeEntity> get nudgeWrites =>
+      writes.whereType<GoalNudgeEntity>().toList(growable: false);
+
+  /// The writes that constitute an OUTCOME — what the user or a later wake
+  /// can see. Everything a wake persists regardless of what it decided is
+  /// excluded by construction:
+  ///
+  ///  * the FACTS context row (`system` message) and its payload — inspectable
+  ///    provenance, written before inference even starts;
+  ///  * the final-prose `thought` row and its payload — never surfaced;
+  ///  * `WakeTokenUsageEntity` — cost bookkeeping.
+  ///
+  /// A report, a report head, a banner, an observation, a proposal or a
+  /// user-visible reply all survive the filter, which is what makes
+  /// [GoalOutcomeExpectation.expectsNoOutcome] a real claim rather than a
+  /// tautology.
+  List<AgentDomainEntity> get outcomeWrites {
+    final bookkeepingPayloadIds = {
+      for (final message in writes.whereType<AgentMessageEntity>())
+        if (message.kind == AgentMessageKind.system ||
+            message.kind == AgentMessageKind.thought)
+          ?message.contentEntryId,
+    };
+    return [
+      for (final write in writes)
+        if (write is! WakeTokenUsageEntity)
+          if (!(write is AgentMessageEntity &&
+              (write.kind == AgentMessageKind.system ||
+                  write.kind == AgentMessageKind.thought)))
+            if (!(write is AgentMessagePayloadEntity &&
+                bookkeepingPayloadIds.contains(write.id)))
+              write,
+    ];
+  }
+
+  /// Banners this wake put in front of the user. Both arms of "an ad
+  /// appeared" — freshly authored copy and a re-run of proven copy — because
+  /// the user cannot tell them apart and the cooldown does not either.
+  List<GoalNudgeEntity> get activatedAds => nudgeWrites
+      .where((n) => n.status == NudgeStatus.active)
+      .toList(growable: false);
+
+  List<GoalNudgeEntity> get newAds =>
+      activatedAds.where((n) => n.activationCount <= 1).toList(growable: false);
+
+  List<GoalNudgeEntity> get rerunAds =>
+      activatedAds.where((n) => n.activationCount > 1).toList(growable: false);
+
+  List<GoalNudgeEntity> get retiredAds => nudgeWrites
+      .where((n) => n.status == NudgeStatus.retired)
+      .toList(growable: false);
+
+  /// Every tool call the deterministic guard refused, as `tool: reason`.
+  ///
+  /// This is the tier's most useful diagnostic and it exists nowhere else: a
+  /// rejection is invisible to tier 1 (whose strategy accepts everything) and
+  /// invisible in the final state (a repaired wake looks identical to one
+  /// that got it right first time). A scenario that passes only after two
+  /// refusals is paying for three turns to do one turn's work, and a
+  /// scenario that fails after two refusals shows exactly which rule the
+  /// model could not satisfy.
+  List<String> get rejections => [
+    for (final message in writes.whereType<AgentMessageEntity>())
+      if (message.kind == AgentMessageKind.toolResult)
+        if (message.metadata.errorMessage case final String error)
+          '${message.metadata.toolName}: ${error.split('\n').first}',
+  ];
+
+  /// The reply as the chat surface will render it: the `reply_to_user`
+  /// action row's payload text. Read through the same message→payload join
+  /// the projection uses, so a reply that persisted without its payload
+  /// counts as no reply — which is what the user would see.
+  String? get visibleReply {
+    final action = writes
+        .whereType<AgentMessageEntity>()
+        .where(
+          (m) =>
+              m.kind == AgentMessageKind.action &&
+              m.metadata.toolName == AgentConversationToolNames.replyToUser,
+        )
+        .lastOrNull;
+    final payloadId = action?.contentEntryId;
+    if (payloadId == null) return null;
+    final payload = writes
+        .whereType<AgentMessagePayloadEntity>()
+        .where((p) => p.id == payloadId)
+        .lastOrNull;
+    final text = payload?.content['text'];
+    return text is String && text.trim().isNotEmpty ? text : null;
+  }
+
+  Map<String, Object?> toJson() => {
+    'wakeSucceeded': wakeSucceeded,
+    'wakeError': wakeError,
+    'reportText': reportText,
+    'reportStatus': report?.provenance['trackStatus'],
+    'newAdHeadlines': [for (final ad in newAds) ad.brief.headline],
+    'rerunAdIds': [for (final ad in rerunAds) ad.id],
+    'retiredAdIds': [for (final ad in retiredAds) ad.id],
+    'visibleReply': visibleReply,
+    'rejections': rejections,
+    // Message rows carry their kind: "six AgentMessageEntity" says nothing
+    // about what a wake did, while "six observations" or "six actions" is a
+    // diagnosis.
+    'outcomeWrites': [
+      for (final write in outcomeWrites)
+        if (write is AgentMessageEntity)
+          'AgentMessage(${write.kind.name}'
+              '${write.metadata.toolName == null ? '' : ':${write.metadata.toolName}'})'
+        else
+          write.runtimeType.toString(),
+    ],
+  };
+}
+
+/// Deterministic outcome classifier — first violated expectation names the
+/// failure, same discipline as tier 1.
+GoalOutcomeFailureCategory classifyGoalAgentOutcome({
+  required GoalOutcomeEvalScenario scenario,
+  required GoalAgentEvalOutcome outcome,
+}) {
+  if (!outcome.wakeSucceeded) return GoalOutcomeFailureCategory.wakeFailed;
+  final expectation = scenario.expectation;
+
+  // The no-op row is checked first and across every outcome kind, not just
+  // banners: a wake that "did nothing" while advancing the report head did
+  // not do nothing.
+  if (expectation.expectsNoOutcome && outcome.outcomeWrites.isNotEmpty) {
+    return GoalOutcomeFailureCategory.writesOnNoOp;
+  }
+
+  if (expectation.requiresReport && outcome.report == null) {
+    return GoalOutcomeFailureCategory.missingReport;
+  }
+  final expectedStatus = expectation.expectedReportStatus;
+  if (expectedStatus != null &&
+      outcome.report != null &&
+      outcome.report!.provenance['trackStatus'] != expectedStatus.name) {
+    return GoalOutcomeFailureCategory.wrongReportStatus;
+  }
+
+  final reportText = outcome.reportText;
+  if (expectation.requiredReportTermGroups.any(
+    (group) => !containsAnyEvalTerm(reportText, group),
+  )) {
+    return GoalOutcomeFailureCategory.missingReportContent;
+  }
+  if (expectation.forbiddenReportTerms.any(
+    (term) => reportText.toLowerCase().contains(term.toLowerCase()),
+  )) {
+    return GoalOutcomeFailureCategory.forbiddenReportContent;
+  }
+
+  if (expectation.forbidsNewAd && outcome.activatedAds.isNotEmpty) {
+    return GoalOutcomeFailureCategory.unexpectedAd;
+  }
+  if (expectation.requiresNewAd && outcome.newAds.isEmpty) {
+    return GoalOutcomeFailureCategory.missingAd;
+  }
+  if (expectation.requiresRerun && outcome.rerunAds.isEmpty) {
+    return GoalOutcomeFailureCategory.missingRerun;
+  }
+  if (expectation.requiresRetirement && outcome.retiredAds.isEmpty) {
+    return GoalOutcomeFailureCategory.missingRetirement;
+  }
+
+  final reply = outcome.visibleReply;
+  if (expectation.requiresReply && (reply == null || reply.trim().isEmpty)) {
+    return GoalOutcomeFailureCategory.missingReply;
+  }
+  if (reply != null) {
+    if (expectation.requiredReplyPatterns.any(
+      (pattern) => !RegExp(
+        pattern,
+        caseSensitive: false,
+        multiLine: true,
+      ).hasMatch(reply.trimRight()),
+    )) {
+      return GoalOutcomeFailureCategory.missingReplyContent;
+    }
+    if (expectation.forbiddenReplyClaims.any(
+      (claim) => containsAffirmativeReportClaim(reply, claim),
+    )) {
+      return GoalOutcomeFailureCategory.forbiddenReplyClaim;
+    }
+  }
+
+  return GoalOutcomeFailureCategory.none;
+}
+
+/// One (model, scenario) tier-2 outcome.
+class GoalOutcomeEvalCaseResult implements GoalEvalCostCase {
+  const GoalOutcomeEvalCaseResult({
+    required this.modelId,
+    required this.scenario,
+    required this.outcome,
+    required this.latencyMs,
+    required this.failureCategory,
+    this.inputTokens,
+    this.outputTokens,
+    this.consumption = const [],
+    this.errorMessage,
+  });
+
+  @override
+  final String modelId;
+  final GoalOutcomeEvalScenario scenario;
+  final GoalAgentEvalOutcome outcome;
+  final int latencyMs;
+  final GoalOutcomeFailureCategory failureCategory;
+  @override
+  final int? inputTokens;
+  @override
+  final int? outputTokens;
+  final List<AiConsumptionEvent> consumption;
+  final String? errorMessage;
+
+  bool get passed => failureCategory == GoalOutcomeFailureCategory.none;
+
+  @override
+  double? get credits {
+    final values = consumption.map((e) => e.credits).whereType<double>();
+    return values.isEmpty ? null : values.reduce((a, b) => a + b);
+  }
+
+  @override
+  double? get energyWh {
+    final values = consumption.map((e) => e.energyKwh).whereType<double>();
+    return values.isEmpty ? null : values.reduce((a, b) => a + b) * 1000;
+  }
+
+  Map<String, Object?> toJson() => {
+    'modelId': modelId,
+    'scenarioId': scenario.id,
+    'policyRuleId': scenario.policyRuleId,
+    'latencyMs': latencyMs,
+    'failureCategory': failureCategory.name,
+    'passed': passed,
+    'inputTokens': inputTokens,
+    'outputTokens': outputTokens,
+    'credits': credits,
+    'energyWh': energyWh,
+    'outcome': outcome.toJson(),
+    'errorMessage': errorMessage,
+  };
+}
+
+/// The tier-2 report. Same cost table as tier 1 (shared, not copied); the
+/// failure section prints persisted entities rather than tool calls, because
+/// that is what this tier can actually testify about.
+class GoalOutcomeEvalReport {
+  const GoalOutcomeEvalReport({
+    required this.provider,
+    required this.modelIds,
+    required this.scenarios,
+    required this.results,
+    required this.wakesPerDayAssumption,
+  });
+
+  final AiConfigInferenceProvider provider;
+  final List<String> modelIds;
+  final List<GoalOutcomeEvalScenario> scenarios;
+  final List<GoalOutcomeEvalCaseResult> results;
+  final int wakesPerDayAssumption;
+
+  Map<String, Object?> toJson() => {
+    'kind': goalAgentOutcomeEvalKind,
+    'provider': {
+      'id': provider.id,
+      'type': provider.inferenceProviderType.name,
+      'baseUrl': provider.baseUrl,
+    },
+    'modelIds': modelIds,
+    'wakesPerDayAssumption': wakesPerDayAssumption,
+    'scenarioIds': [for (final scenario in scenarios) scenario.id],
+    'results': [for (final result in results) result.toJson()],
+  };
+
+  String toPrettyJson() => const JsonEncoder.withIndent('  ').convert(toJson());
+
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('# Goal-agent OUTCOME eval (tier 2)')
+      ..writeln()
+      ..writeln(
+        'Scores what the real `GoalAgentWorkflow` PERSISTED — not what the '
+        'model attempted. Strategy rejections, forced retries and the '
+        'persistence gates are all inside the measurement, so these numbers '
+        'are not comparable with the tier-1 inference eval.',
+      )
+      ..writeln()
+      ..writeln('Provider: `${provider.baseUrl}`.')
+      ..writeln()
+      ..writeln('## Scenario × model matrix')
+      ..writeln()
+      ..writeln('| Scenario | Policy | ${modelIds.join(' | ')} |')
+      ..writeln('| --- | --- |${' ---: |' * modelIds.length}');
+    for (final scenario in scenarios) {
+      final cells = modelIds.map((modelId) {
+        final cases = results.where(
+          (r) => r.modelId == modelId && r.scenario.id == scenario.id,
+        );
+        if (cases.isEmpty) return '—';
+        return '${cases.where((r) => r.passed).length}/${cases.length}';
+      });
+      buffer.writeln(
+        '| ${scenario.id} | ${scenario.policyRuleId} | ${cells.join(' | ')} |',
+      );
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('## Failures')
+      ..writeln();
+    final failures = results.where((r) => !r.passed).toList();
+    if (failures.isEmpty) buffer.writeln('None.');
+    for (final failure in failures) {
+      buffer
+        ..writeln(
+          '### ${failure.scenario.id} × `${failure.modelId}` — '
+          '${failure.failureCategory.name}',
+        )
+        ..writeln()
+        ..writeln(
+          'Persisted: report=${failure.outcome.report != null}, '
+          'newAds=${failure.outcome.newAds.length}, '
+          'reruns=${failure.outcome.rerunAds.length}, '
+          'retired=${failure.outcome.retiredAds.length}, '
+          'reply=${failure.outcome.visibleReply != null}',
+        )
+        ..writeln();
+      if (failure.outcome.rejections.isNotEmpty) {
+        buffer.writeln('Refused by the deterministic guard:');
+        for (final rejection in failure.outcome.rejections) {
+          buffer.writeln('- $rejection');
+        }
+        buffer.writeln();
+      }
+      if (failure.errorMessage != null) {
+        buffer
+          ..writeln('Error: ${failure.errorMessage}')
+          ..writeln();
+      }
+    }
+
+    buffer.write(
+      renderGoalEvalCostTable(
+        modelIds: modelIds,
+        cases: results,
+        wakesPerDayAssumption: wakesPerDayAssumption,
+      ),
+    );
+    return buffer.toString();
+  }
+}
+
+/// A signal reader that answers with the scenario's window. The only fake in
+/// the tier-2 stack: everything downstream of it — Phase A, the renderer, the
+/// strategy, persistence — is the production code.
+class GoalOutcomeEvalSignalReader extends GoalSignalReader {
+  GoalOutcomeEvalSignalReader(this.window) : super(journalDb: MockJournalDb());
+
+  final GoalSignalWindow window;
+
+  @override
+  Future<GoalSignalWindow> read({
+    required GoalCriterion criteria,
+    required DateTime reference,
+    int shortTermDays = 3,
+    bool includeTimeEntryEvidence = true,
+    DateTime? timeEntryEvidenceStart,
+    DateTime? timeEntryEndExclusive,
+  }) async => window;
+}
+
+/// Wake-run key for one tier-2 case — the consumption-event join key.
+///
+/// Distinct from tier 1's prefix so a mixed session cannot cross-attribute
+/// cost, and carrying the sample index so repeated runs of one scenario bill
+/// separately instead of collapsing onto one key.
+String goalOutcomeEvalWakeRunKey(
+  String modelId,
+  String scenarioId, {
+  int sample = 0,
+}) => 'goal-outcome-eval:$scenarioId:$modelId:$sample';
+
+/// Builds the world for one scenario and runs the REAL workflow over it.
+class GoalOutcomeEvalRunner {
+  GoalOutcomeEvalRunner({
+    required this.provider,
+    required this.conversationRepository,
+    required this.cloudInferenceRepository,
+    this.wakesPerDayAssumption = 3,
+    this.consumptionForWakeRunKey,
+  });
+
+  final AiConfigInferenceProvider provider;
+  final ConversationRepository conversationRepository;
+  final CloudInferenceRepository cloudInferenceRepository;
+  final int wakesPerDayAssumption;
+  final List<AiConsumptionEvent> Function(String wakeRunKey)?
+  consumptionForWakeRunKey;
+
+  /// Runs every (model, scenario) pair [repeats] times.
+  ///
+  /// Repeats are a first-class parameter rather than an outer loop because a
+  /// single sample of a live model says almost nothing: the tier-1 noise
+  /// floor over five identical runs was wide enough to swallow most of the
+  /// differences that looked meaningful at n=1.
+  Future<GoalOutcomeEvalReport> run({
+    required List<String> modelIds,
+    required List<GoalOutcomeEvalScenario> scenarios,
+    int repeats = 1,
+  }) async {
+    final results = <GoalOutcomeEvalCaseResult>[];
+    for (final modelId in modelIds) {
+      for (var sample = 0; sample < repeats; sample++) {
+        for (final scenario in scenarios) {
+          results.add(
+            await runCase(
+              modelId: modelId,
+              scenario: scenario,
+              sample: sample,
+            ),
+          );
+        }
+      }
+    }
+    return GoalOutcomeEvalReport(
+      provider: provider,
+      modelIds: modelIds,
+      scenarios: scenarios,
+      results: results,
+      wakesPerDayAssumption: wakesPerDayAssumption,
+    );
+  }
+
+  Future<GoalOutcomeEvalCaseResult> runCase({
+    required String modelId,
+    required GoalOutcomeEvalScenario scenario,
+    int sample = 0,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    final wakeRunKey = goalOutcomeEvalWakeRunKey(
+      modelId,
+      scenario.id,
+      sample: sample,
+    );
+    final bench = buildGoalOutcomeEvalBench(
+      scenario: scenario,
+      modelId: modelId,
+      provider: provider,
+      conversationRepository: conversationRepository,
+      cloudInferenceRepository: cloudInferenceRepository,
+    );
+
+    GoalAgentEvalOutcome outcome;
+    String? errorMessage;
+    try {
+      final result = await withClock(
+        Clock.fixed(goalOutcomeEvalNow),
+        () => bench.workflow.execute(
+          agentIdentity: bench.identity,
+          runKey: wakeRunKey,
+          triggerTokens: scenario.triggerTokens,
+          threadId: 'thread-${scenario.id}',
+          pendingUserMessage: scenario.pendingUserMessage,
+          previousAssistantMessage: scenario.previousAssistantMessage,
+        ),
+      );
+      outcome = GoalAgentEvalOutcome(
+        wakeSucceeded: result.success,
+        writes: bench.writes,
+        wakeError: result.error,
+      );
+      errorMessage = result.error;
+    } catch (error) {
+      // A thrown wake is not a policy failure — it is a broken run, and
+      // conflating the two would let an outage read as a model regression.
+      return GoalOutcomeEvalCaseResult(
+        modelId: modelId,
+        scenario: scenario,
+        outcome: GoalAgentEvalOutcome(
+          wakeSucceeded: false,
+          writes: bench.writes,
+          wakeError: error.toString(),
+        ),
+        latencyMs: stopwatch.elapsedMilliseconds,
+        failureCategory: GoalOutcomeFailureCategory.inferenceError,
+        consumption: consumptionForWakeRunKey?.call(wakeRunKey) ?? const [],
+        errorMessage: error.toString(),
+      );
+    }
+
+    final consumption =
+        consumptionForWakeRunKey?.call(wakeRunKey) ??
+        const <AiConsumptionEvent>[];
+    final usage = bench.writes.whereType<WakeTokenUsageEntity>().toList();
+    return GoalOutcomeEvalCaseResult(
+      modelId: modelId,
+      scenario: scenario,
+      outcome: outcome,
+      latencyMs: stopwatch.elapsedMilliseconds,
+      failureCategory: classifyGoalAgentOutcome(
+        scenario: scenario,
+        outcome: outcome,
+      ),
+      inputTokens: usage.isEmpty
+          ? null
+          : usage.fold<int>(0, (sum, u) => sum + (u.inputTokens ?? 0)),
+      outputTokens: usage.isEmpty
+          ? null
+          : usage.fold<int>(0, (sum, u) => sum + (u.outputTokens ?? 0)),
+      consumption: consumption,
+      errorMessage: errorMessage,
+    );
+  }
+}
+
+/// The assembled world for one scenario: the workflow under test, the
+/// identity that wakes it, and the list every write lands in.
+typedef GoalOutcomeEvalBench = ({
+  GoalAgentWorkflow workflow,
+  AgentIdentityEntity identity,
+  List<AgentDomainEntity> writes,
+  MockAgentRepository repository,
+});
+
+/// Stubs the repository so the goal world of [scenario] exists, and wires a
+/// real [GoalAgentWorkflow] over it.
+///
+/// Shared by the live runner and the offline tests: the offline tests drive
+/// the same bench with a scripted conversation repository, so the fixtures
+/// themselves are covered in CI without a network call.
+GoalOutcomeEvalBench buildGoalOutcomeEvalBench({
+  required GoalOutcomeEvalScenario scenario,
+  required String modelId,
+  required AiConfigInferenceProvider provider,
+  required ConversationRepository conversationRepository,
+  required CloudInferenceRepository cloudInferenceRepository,
+}) {
+  const agentId = goalOutcomeEvalAgentId;
+  final now = goalOutcomeEvalNow;
+  final repository = MockAgentRepository();
+  final syncService = MockAgentSyncService();
+  final aiConfigRepository = MockAiConfigRepository();
+  final writes = <AgentDomainEntity>[];
+
+  // Resolution goes through a PROFILE, not the goal agent's built-in
+  // `glm-5.2` default. The default branch matches on `providerModelId`, so it
+  // can only ever run one model — while a profile is exactly how a real user
+  // points their goal agent somewhere else. Evaluating an arbitrary model
+  // therefore means evaluating the profile path, which is the configured
+  // wake's own code path anyway.
+  const modelConfigId = 'goal-outcome-eval-model';
+  const profileId = 'goal-outcome-eval-profile';
+  final model =
+      AiConfig.model(
+            id: modelConfigId,
+            name: modelId,
+            providerModelId: modelId,
+            inferenceProviderId: provider.id,
+            createdAt: DateTime(2026),
+            inputModalities: const [Modality.text],
+            outputModalities: const [Modality.text],
+            isReasoningModel: true,
+            supportsFunctionCalling: true,
+            description: 'tier-2 eval model',
+          )
+          as AiConfigModel;
+  when(
+    () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+  ).thenAnswer((_) async => [model]);
+  when(
+    () => aiConfigRepository.getConfigById(provider.id),
+  ).thenAnswer((_) async => provider);
+  when(() => aiConfigRepository.getConfigById(modelConfigId)).thenAnswer(
+    (_) async => model,
+  );
+  when(() => aiConfigRepository.getConfigById(profileId)).thenAnswer(
+    (_) async =>
+        AiConfig.inferenceProfile(
+              id: profileId,
+              name: 'Goal outcome eval',
+              createdAt: DateTime(2026),
+              thinkingModelId: modelConfigId,
+            )
+            as AiConfigInferenceProfile,
+  );
+
+  const specVersionId = '$agentId:spec-v1';
+  final priorRegisters =
+      scenario.priorRegisters?.call(agentId, now) ??
+      const <String, GoalProgressEntity>{};
+
+  when(() => repository.getEntity(any<String>())).thenAnswer((
+    invocation,
+  ) async {
+    final id = invocation.positionalArguments.first as String;
+    if (id == goalSpecHeadId(agentId)) {
+      return AgentDomainEntity.goalSpecHead(
+        id: goalSpecHeadId(agentId),
+        agentId: agentId,
+        versionId: specVersionId,
+        updatedAt: DateTime(2026),
+        vectorClock: null,
+      );
+    }
+    if (id == specVersionId) {
+      return AgentDomainEntity.goalSpecVersion(
+        id: specVersionId,
+        agentId: agentId,
+        version: 1,
+        status: GoalSpecVersionStatus.active,
+        authoredBy: 'user',
+        title: scenario.title,
+        statement: scenario.statement,
+        criteria: scenario.criteria,
+        createdAt: DateTime(2026),
+        vectorClock: null,
+      );
+    }
+    for (final entry in priorRegisters.entries) {
+      if (id == goalProgressId(agentId, entry.key)) return entry.value;
+    }
+    return null;
+  });
+
+  when(
+    () => repository.getEntitiesByAgentId(
+      agentId,
+      type: AgentEntityTypes.goalNudge,
+    ),
+  ).thenAnswer(
+    (_) async => scenario.nudges?.call(agentId, now) ?? <GoalNudgeEntity>[],
+  );
+  when(
+    () => repository.getMessagesByKind(
+      agentId,
+      AgentMessageKind.observation,
+      limit: any<int>(named: 'limit'),
+    ),
+  ).thenAnswer((_) async => <AgentMessageEntity>[]);
+  when(
+    () => repository.getReportHead(agentId, AgentReportScopes.current),
+  ).thenAnswer((_) async => null);
+  when(
+    () => repository.getLatestReport(agentId, AgentReportScopes.current),
+  ).thenAnswer((_) async => null);
+  when(() => syncService.upsertEntity(any<AgentDomainEntity>())).thenAnswer((
+    invocation,
+  ) async {
+    writes.add(invocation.positionalArguments.first as AgentDomainEntity);
+  });
+
+  final workflow = GoalAgentWorkflow(
+    repository: repository,
+    syncService: syncService,
+    phaseA: GoalAgentPhaseA(
+      repository: repository,
+      syncService: syncService,
+      signalReader: GoalOutcomeEvalSignalReader(scenario.window),
+    ),
+    conversationRepository: conversationRepository,
+    cloudInferenceRepository: cloudInferenceRepository,
+    aiConfigRepository: aiConfigRepository,
+  );
+
+  return (
+    workflow: workflow,
+    identity: makeTestIdentity(
+      id: agentId,
+      agentId: agentId,
+      kind: AgentKinds.goalAgent,
+      config: const AgentConfig(profileId: profileId),
+    ),
+    writes: writes,
+    repository: repository,
+  );
+}
+
+/// Builds a banner row for a scenario's starting board.
+GoalNudgeEntity goalOutcomeEvalNudge({
+  required String id,
+  required String agentId,
+  required NudgeStatus status,
+  required String headline,
+  required DateTime now,
+  NudgeTone tone = NudgeTone.nudge,
+  Duration age = const Duration(hours: 2),
+  Duration? staleIn = goalAdLifetime,
+  int activationCount = 1,
+  DateTime? dismissedAt,
+  DateTime? retiredAt,
+  List<NudgeRating> ratings = const [],
+}) {
+  final brief = NudgeBrief(
+    headline: headline,
+    tone: tone,
+    animation: NudgeBannerAnimation.steady,
+  );
+  final createdAt = now.subtract(age);
+  return AgentDomainEntity.goalNudge(
+        id: id,
+        agentId: agentId,
+        status: status,
+        brief: brief,
+        briefDigest: goalBriefDigest(brief),
+        createdAt: createdAt,
+        updatedAt: createdAt,
+        vectorClock: null,
+        // Spec-scoped exactly the way the workflow filters: a row whose
+        // origin names another version is invisible to the wake.
+        provenance: {'specVersionId': '$agentId:spec-v1'},
+        activationCount: activationCount,
+        activatedAt: status == NudgeStatus.active ? createdAt : null,
+        staleAt: staleIn == null ? null : createdAt.add(staleIn),
+        dismissedAt: dismissedAt,
+        retiredAt: retiredAt,
+        ratings: ratings,
+      )
+      as GoalNudgeEntity;
+}
+
+/// Builds a prior period register — the trend a policy row reads.
+GoalProgressEntity goalOutcomeEvalRegister({
+  required String agentId,
+  required String periodKey,
+  required GoalTrackStatus trackStatus,
+  required double attainment,
+  required DateTime now,
+}) =>
+    AgentDomainEntity.goalProgress(
+          id: goalProgressId(agentId, periodKey),
+          agentId: agentId,
+          periodKey: periodKey,
+          trackStatus: trackStatus,
+          attainment: attainment,
+          dataCoverage: 1,
+          satisfied: false,
+          specVersionId: '$agentId:spec-v1',
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: null,
+        )
+        as GoalProgressEntity;

--- a/test/features/agents/eval/goal/support/goal_agent_outcome_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_outcome_eval_scenarios.dart
@@ -1,0 +1,293 @@
+/// The tier-2 scenario catalog: goal worlds expressed in domain entities.
+///
+/// Each scenario states only its EVIDENCE — the signal window, the banners
+/// already on the board, the prior period registers. Status, attainment,
+/// trend, freshness, cooldown and reusability are all derived by production
+/// from that evidence, which is the point: a tier-1 fixture can claim a
+/// status its FACTS never justify, and this tier structurally cannot.
+///
+/// The set is deliberately small. It covers the policy rows where an
+/// *attempt* and an *outcome* can disagree — forced retries, strategy
+/// rejections, withheld tools and the persistence gates — rather than
+/// re-running tier 1's breadth through a slower harness.
+library;
+
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/classes/nudge_models.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+
+import 'goal_agent_outcome_eval.dart';
+
+/// The steps goal every scenario varies. One criterion on purpose: tier 2
+/// measures the wake's machinery, and a composite tree would put the
+/// evaluator's arithmetic in the way of that.
+const goalOutcomeEvalSteps = GoalCriterion.metric(
+  criterionId: 'steps',
+  dataType: 'cumulative_step_count',
+  window: GoalWindow.rollingDays(count: 7),
+  aggregation: GoalAggregation.dailySumThenAverage,
+  target: 10000,
+);
+
+const _statement = 'Average 10,000 steps per day.';
+
+/// A uniform seven-day window at [perDay] steps. Attainment is then simply
+/// `perDay / 10000`, so a scenario's intended status is legible from the
+/// number alone — and the offline test asserts the derivation agrees.
+GoalSignalWindow _uniform(int perDay) => GoalSignalWindow(
+  quantitativeDailySums: {
+    'cumulative_step_count': {
+      for (var day = 3; day <= 9; day++) DateTime.utc(2026, 8, day): perDay,
+    },
+  },
+);
+
+/// Behind over the week but back at pace for the trailing three days — the
+/// shape `GoalTrackPolicy` reads as `recovering`.
+final _recoveringWindow = GoalSignalWindow(
+  quantitativeDailySums: {
+    'cumulative_step_count': {
+      for (var day = 3; day <= 6; day++) DateTime.utc(2026, 8, day): 3000,
+      for (var day = 7; day <= 9; day++) DateTime.utc(2026, 8, day): 11000,
+    },
+  },
+);
+
+/// Two days of readings in a seven-day window: coverage below the policy's
+/// floor, which is `insufficientData` and never a guilt trip.
+final _sparseWindow = GoalSignalWindow(
+  quantitativeDailySums: {
+    'cumulative_step_count': {
+      DateTime.utc(2026, 8, 8): 9000,
+      DateTime.utc(2026, 8, 9): 9500,
+    },
+  },
+);
+
+/// Yesterday's register, which is what makes a trend. `offTrack` needs a bad
+/// prior period; a matching prior is what makes a wake a genuine no-op.
+Map<String, GoalProgressEntity> Function(String, DateTime) _yesterday(
+  GoalTrackStatus status,
+  double attainment,
+) =>
+    (agentId, now) => {
+      '2026-08-08': goalOutcomeEvalRegister(
+        agentId: agentId,
+        periodKey: '2026-08-08',
+        trackStatus: status,
+        attainment: attainment,
+        now: now,
+      ),
+    };
+
+/// The tier-2 catalog.
+final goalOutcomeEvalScenarios = <GoalOutcomeEvalScenario>[
+  // ── P2: the no-op discriminator ────────────────────────────────────────
+  // On track yesterday, on track today, nothing to say. Tier 1 grades this
+  // by counting tool calls; here it is the stronger claim that the wake left
+  // NOTHING behind — no report, no head advance, no banner.
+  GoalOutcomeEvalScenario(
+    id: 'ot_quiet_wake',
+    policyRuleId: 'P2',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(11000),
+    priorRegisters: _yesterday(GoalTrackStatus.onTrack, 1.1),
+    expectation: const GoalOutcomeExpectation(expectsNoOutcome: true),
+  ),
+
+  // ── P1: a transition owes a report ─────────────────────────────────────
+  // Yesterday at risk, today on track. `statusTransitioned` makes the report
+  // mandatory, so this case also exercises `_forceReport`: a model that
+  // simply answers in prose is repaired into a persisted report, and tier 1
+  // would have scored the same turn a miss.
+  GoalOutcomeEvalScenario(
+    id: 'ot_transition_report',
+    policyRuleId: 'P1',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(11000),
+    priorRegisters: _yesterday(GoalTrackStatus.atRisk, 0.85),
+    expectation: const GoalOutcomeExpectation(
+      requiresReport: true,
+      expectedReportStatus: GoalTrackStatus.onTrack,
+      forbidsNewAd: true,
+    ),
+  ),
+
+  // ── P5: off track with a clear board owes a banner ──────────────────────
+  // The only row where an ad is REQUIRED, and the one `_forceAd` exists for.
+  GoalOutcomeEvalScenario(
+    id: 'off_track_first_ad',
+    policyRuleId: 'P5',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(6000),
+    priorRegisters: _yesterday(GoalTrackStatus.atRisk, 0.6),
+    expectation: const GoalOutcomeExpectation(
+      requiresReport: true,
+      expectedReportStatus: GoalTrackStatus.offTrack,
+      requiresNewAd: true,
+    ),
+  ),
+
+  // ── P6: a fresh banner is already doing this job ───────────────────────
+  // Ad tools are on the wire here (off track IS eligible), so this measures
+  // restraint under temptation rather than a withheld surface — and it
+  // measures it at the board, where a second banner would actually shout.
+  GoalOutcomeEvalScenario(
+    id: 'off_track_fresh_ad',
+    policyRuleId: 'P6',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(6000),
+    priorRegisters: _yesterday(GoalTrackStatus.atRisk, 0.6),
+    nudges: (agentId, now) => [
+      goalOutcomeEvalNudge(
+        id: 'ad-fresh',
+        agentId: agentId,
+        status: NudgeStatus.active,
+        headline: 'Your pedometer misses you.',
+        now: now,
+      ),
+    ],
+    expectation: const GoalOutcomeExpectation(
+      requiresReport: true,
+      forbidsNewAd: true,
+    ),
+  ),
+
+  // ── The dismissal cooldown, end to end ─────────────────────────────────
+  // Off track — so policy would otherwise REQUIRE an ad — but the user
+  // dismissed one today. The deterministic tier withholds the ad tools
+  // entirely, and this case proves the quiet actually reaches the board
+  // rather than being argued for in the prompt.
+  GoalOutcomeEvalScenario(
+    id: 'off_track_cooldown',
+    policyRuleId: 'P5',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(6000),
+    priorRegisters: _yesterday(GoalTrackStatus.atRisk, 0.6),
+    nudges: (agentId, now) => [
+      goalOutcomeEvalNudge(
+        id: 'ad-dismissed-today',
+        agentId: agentId,
+        status: NudgeStatus.dismissed,
+        headline: 'Ten thousand steps is a walk, not a marathon.',
+        now: now,
+        age: const Duration(hours: 4),
+        dismissedAt: now.subtract(const Duration(hours: 4)),
+      ),
+    ],
+    expectation: const GoalOutcomeExpectation(
+      requiresReport: true,
+      forbidsNewAd: true,
+    ),
+  ),
+
+  // ── P7: recovering retires the stale scolding ──────────────────────────
+  GoalOutcomeEvalScenario(
+    id: 'recovering_retires_ad',
+    policyRuleId: 'P7',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _recoveringWindow,
+    priorRegisters: _yesterday(GoalTrackStatus.offTrack, 0.4),
+    nudges: (agentId, now) => [
+      goalOutcomeEvalNudge(
+        id: 'ad-stale-behind',
+        agentId: agentId,
+        status: NudgeStatus.active,
+        headline: "You're well behind this week.",
+        now: now,
+        age: const Duration(days: 4),
+      ),
+    ],
+    expectation: const GoalOutcomeExpectation(
+      requiresRetirement: true,
+      forbidsNewAd: true,
+    ),
+  ),
+
+  // ── P8: a data gap is not a failure ────────────────────────────────────
+  GoalOutcomeEvalScenario(
+    id: 'sparse_insufficient_data',
+    policyRuleId: 'P8',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _sparseWindow,
+    priorRegisters: _yesterday(GoalTrackStatus.insufficientData, 0),
+    expectation: const GoalOutcomeExpectation(
+      expectedReportStatus: GoalTrackStatus.insufficientData,
+      forbidsNewAd: true,
+    ),
+  ),
+
+  // ── P13: reuse beats authoring ─────────────────────────────────────────
+  // Off track with no active banner but a proven retired one on the shelf.
+  // `rerun_goal_ad` costs nothing to author; a fresh `create_goal_ad` is the
+  // wrong outcome even though it also puts a banner on the board.
+  GoalOutcomeEvalScenario(
+    id: 'off_track_reuses_top_rated',
+    policyRuleId: 'P13',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(6000),
+    priorRegisters: _yesterday(GoalTrackStatus.atRisk, 0.6),
+    nudges: (agentId, now) => [
+      goalOutcomeEvalNudge(
+        id: 'ad-top-rated',
+        agentId: agentId,
+        status: NudgeStatus.retired,
+        headline: 'The couch will still be there afterwards.',
+        now: now,
+        age: const Duration(days: 12),
+        retiredAt: now.subtract(const Duration(days: 5)),
+        ratings: [
+          NudgeRating(
+            activation: 1,
+            ratedAt: now.subtract(const Duration(days: 6)),
+            rating: 5,
+          ),
+        ],
+      ),
+    ],
+    expectation: const GoalOutcomeExpectation(requiresRerun: true),
+  ),
+
+  // ── P10: dialogue first, and the user must actually get an answer ──────
+  // On track, so the ad tools are withheld — the interactive-and-ineligible
+  // combination that used to leave them on the wire for every chat turn.
+  // The pass condition is a persisted, user-visible reply.
+  GoalOutcomeEvalScenario(
+    id: 'chat_question_on_track',
+    policyRuleId: 'P10',
+    title: 'Steps',
+    statement: _statement,
+    criteria: goalOutcomeEvalSteps,
+    window: _uniform(11000),
+    priorRegisters: _yesterday(GoalTrackStatus.onTrack, 1.1),
+    pendingUserMessage: 'How am I doing on steps this week?',
+    triggerTokens: const {'goal-chat'},
+    expectation: const GoalOutcomeExpectation(
+      requiresReply: true,
+      forbidsNewAd: true,
+    ),
+  ),
+];
+
+/// Lookup by id, for the offline tests and `GOAL_OUTCOME_EVAL_SCENARIOS`.
+GoalOutcomeEvalScenario goalOutcomeScenarioById(String id) =>
+    goalOutcomeEvalScenarios.firstWhere((scenario) => scenario.id == id);

--- a/test/features/agents/eval/goal/support/goal_eval_cost_table.dart
+++ b/test/features/agents/eval/goal/support/goal_eval_cost_table.dart
@@ -1,0 +1,94 @@
+/// The cost table both goal-agent eval tiers report through.
+///
+/// Extracted rather than copied: the "missing telemetry widens uncertainty,
+/// it is never counted as zero" rule is the whole point of the table, and two
+/// implementations of it would eventually publish two different €/goal-month
+/// figures for the same run.
+library;
+
+/// The cost surface a case must expose to appear in the table. Both
+/// `GoalAgentEvalCaseResult` (tier 1, scores tool calls) and
+/// `GoalOutcomeEvalCaseResult` (tier 2, scores persisted outcomes) implement
+/// it, so a model's cost is quoted the same way whichever tier measured it.
+abstract class GoalEvalCostCase {
+  String get modelId;
+  int? get inputTokens;
+  int? get outputTokens;
+
+  /// Billed credits, or null when the provider reported none. Never
+  /// zero-defaulted: a missing bill is not a free run.
+  double? get credits;
+
+  /// Reported energy in watt-hours, or null when none was reported.
+  double? get energyWh;
+}
+
+/// Renders the shared cost table, including the €/goal-month and Wh/goal-month
+/// extrapolations and the paragraph that prints their assumption.
+String renderGoalEvalCostTable({
+  required List<String> modelIds,
+  required List<GoalEvalCostCase> cases,
+  required int wakesPerDayAssumption,
+}) {
+  final buffer = StringBuffer()
+    ..writeln('## Cost (observed, not a target)')
+    ..writeln()
+    ..writeln(
+      '| Model | Cases | In | Out | Credits | Credits/goal-month* | '
+      'Wh | Wh/goal-month* |',
+    )
+    ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+  for (final modelId in modelIds) {
+    final modelCases = cases.where((c) => c.modelId == modelId).toList();
+    final inTokens = modelCases.fold<int>(
+      0,
+      (sum, c) => sum + (c.inputTokens ?? 0),
+    );
+    final outTokens = modelCases.fold<int>(
+      0,
+      (sum, c) => sum + (c.outputTokens ?? 0),
+    );
+    final creditValues = modelCases
+        .map((c) => c.credits)
+        .whereType<double>()
+        .toList();
+    final credits = creditValues.isEmpty
+        ? null
+        : creditValues.reduce((a, b) => a + b);
+    // Per-month figures divide by REPORTED cases only: missing telemetry
+    // must widen uncertainty, never masquerade as zero cost.
+    final perGoalMonth = credits == null
+        ? null
+        : credits / creditValues.length * wakesPerDayAssumption * 30;
+    final energyValues = modelCases
+        .map((c) => c.energyWh)
+        .whereType<double>()
+        .toList();
+    final energyWh = energyValues.isEmpty
+        ? null
+        : energyValues.reduce((a, b) => a + b);
+    final energyPerGoalMonth = energyWh == null
+        ? null
+        : energyWh / energyValues.length * wakesPerDayAssumption * 30;
+    buffer.writeln(
+      '| `$modelId` | ${modelCases.length} | $inTokens | $outTokens | '
+      '${credits?.toStringAsFixed(4) ?? 'not reported'} | '
+      '${perGoalMonth?.toStringAsFixed(4) ?? 'not reported'} | '
+      '${energyWh?.toStringAsFixed(2) ?? 'not reported'} | '
+      '${energyPerGoalMonth?.toStringAsFixed(1) ?? 'not reported'} |',
+    );
+  }
+  buffer
+    ..writeln()
+    ..writeln(
+      '*Extrapolation assumes $wakesPerDayAssumption LLM wakes '
+      'per goal per day — a printed assumption, not a measurement — '
+      'and divide by cases that actually reported the figure: missing '
+      'telemetry widens uncertainty, it is never counted as zero. '
+      'Credits and energy are Melious-reported; "not reported" means '
+      'the provider sent no data, never that the run was free. Banner '
+      'creation itself (ADR 0058) adds no image inference on top of '
+      'the Phase B text turn.',
+    );
+  return buffer.toString();
+}


### PR DESCRIPTION
## Why

The goal-agent inference eval grades **tool calls**. Three production layers sit between a tool call and the user, and it is structurally blind to all of them:

1. **The FACTS are authored.** Production renders them from domain entities via `GoalFactsRenderer`. A fixture that drifts from the renderer measures a prompt the app never sends — twice this session that drift produced a wrong conclusion.
2. **The strategy rejects.** `GoalAgentStrategy` refuses a report contradicting the deterministic status, an aggregate the FACTS never carried, an ad id that was never offered. The eval's recording strategy accepts everything.
3. **The workflow repairs.** `_forceReport` / `_forceAd` / `_forceReply` re-ask when a required output is missing, and persistence discards ads on turns that did not request one.

So a tier-1 failure can be a production success, and a tier-1 pass can persist nothing at all. The README has named this gap as future work since the harness was written.

## What

Tier 2 runs the real `GoalAgentWorkflow` against a live model over a world built from domain entities, and grades the **writes**.

- **9 scenarios**, chosen for the policy rows where an attempt and an outcome can disagree (P1, P2, P5, P6, P7, P8, P10, P13, and the dismissal cooldown).
- A scenario states **only its evidence** — a `GoalSignalWindow`, the banners already on the board, yesterday's period register. Status, attainment, trend, freshness, cooldown and reusability are all derived by production, so a tier-2 fixture cannot claim a situation its own facts do not produce.
- The offline tests drive **every** fixture through the real workflow and assert the derived status *and* which tools were actually put on the wire. That check is the one tier 1 lacked.
- Only one fake remains in the stack: the signal reader. Phase A, the renderer, the strategy, the forced retries and persistence are all production code.

Two outcome-level distinctions that only exist at this tier: `forbidsNewAd` counts **re-runs as well as authored copy** (the user cannot tell them apart and neither does the cooldown), and `expectsNoOutcome` is checked against outcome writes rather than every write, since a scheduled wake always persists its FACTS row and bills its tokens.

The most useful output is the **rejection log** — every call the deterministic guard refused, with its reason. Invisible to tier 1, and invisible in the final state, because a repaired wake looks identical to one that got it right first time.

The cost table is **extracted and shared** by both tiers rather than copied: two implementations of "missing telemetry widens uncertainty, it is never zero" would eventually publish two different €/goal-month figures for one run.

## What the first run found

9 scenarios × 3 samples × 2 models:

| | deepseek-v4-flash-0731 | glm-5.2 |
|---|---:|---:|
| Total | **27/27** | **18/27** |
| `off_track_first_ad` (P5) | 3/3 | 0/3 |
| `off_track_cooldown` | 3/3 | 0/3 |
| `off_track_fresh_ad` (P6) | 3/3 | 1/3 |

All nine glm-5.2 failures are `missingReport` — the wake left a banner, or nothing, and **no standing report at all**. The rejection log shows why: two refusals per wake, citing *different rules* in eight of the nine.

```
1. "atRisk" is a status field value, not prose. Rewrite the visible text…
2. the rolling standing must quote the FACTS aggregates verbatim — 6000 is missing.
```

The model fixes what it was told and trips the next rule on the way out. The workflow allows exactly one forced report retry, so two attempts are all there are.

Not a glm-only story — deepseek tripped the same aggregate rule 18 times across its 27 cases and simply had attempts left to recover:

| Rule | deepseek | glm-5.2 |
|---|---:|---:|
| rolling aggregate not quoted verbatim | 18 | 17 |
| status value used as prose | 1 | 12 |
| status field missing entirely | 1 | 2 |

That aggregate rule (#3961, to stop models substituting the latest reading for the mean) is now the most-tripped rule in the system. It is doing real work, but on a weaker model it converts "slightly wrong number" into "no report", which is the worse failure.

**Production follow-up, deliberately not in this PR:** `_validateReport` returns on the first failed check, so a report breaking two rules costs two round trips to learn that. Collecting every violation into one rejection is strictly better — same turn count, more information, one retry instead of two — and should be measured before anyone touches the retry budget.

## Caveats stated plainly

Three samples per cell is thin; the noise-floor work in the README is explicit that n=3 cannot rank two close models. The **ranking** claim is weak at this n. The **defect** claim is not: the failures are one category, concentrated in one model, with a mechanism visible in the rejection log.

## Also

Corrects `knowledge/features/goals.md`, which still claimed interactive wakes keep the full ad surface. Untrue since the withholding change — the gate keys on the deterministic request detector, not on "a message exists".

No CHANGELOG entry: test-harness and docs only, nothing a user sees at runtime.

## Verification

- 89 tests in `test/features/agents/eval/goal/`, 225 across that plus `test/features/goals/workflow/` — all green
- `dart analyze` clean on `test/features/agents/eval/` and `lib/features/goals/`
- `make knowledge_check` passes
- Tier-1 report tests pass unchanged after the cost-table extraction, which is the proof it was behaviour-preserving

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for two evaluation tiers, including scope, scenarios, pass criteria, run commands, and recorded results.
  * Clarified ad-tool handling and banner-request behavior.

* **Tests**
  * Added offline and live evaluations covering goal outcomes, reports, ads, repairs, replies, and persisted results.
  * Added configurable model, scenario, repeat, timeout, and artifact controls.

* **Reporting**
  * Added shared cost reporting with token, credit, energy, and projection details.
  * Improved visibility into validation failures and incomplete recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->