### PR TITLE
fix(goals): tell the report every rule it broke, not just the first

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -595,6 +595,45 @@ wake pays for its retries:
 | `deepseek-v4-flash-0731` | 27 | 0.0113 | 0.0376 | 80.6 |
 | `glm-5.2` | 27 | 0.1421 | 0.4737 | 81.5 |
 
+## Batching the guard's rejections — 2026-08-18
+
+The fix for the above: `_validateReport` collects **every** rule the report
+broke and reports them in one rejection, instead of returning on the first.
+A single violation reads exactly as it always did; only the multiple case
+gains an envelope.
+
+Measured the way the rule two sections up demands — full suite, twice, both
+sides:
+
+| | passes /54 | guard rejections | failures where the retry tripped a NEW rule |
+| --- | ---: | ---: | ---: |
+| baseline run 1 | 45 | 51 | 9 |
+| baseline run 2 | 47 | 50 | 5 |
+| batched run 1 | 52 | 43 | 1 |
+| batched run 2 | 49 | 45 | 2 |
+
+**What the numbers support.** The targeted mechanism moved and stayed moved:
+failures where the one forced retry trips a rule the first attempt was never
+told about fell from 9/5 to 1/2. Total guard rejections fell ~12%. The
+batched envelope fires in roughly one rejection in five, so it is doing work
+rather than sitting behind an unreachable branch.
+
+**What they do not support.** The headline `+4.5/54` is two runs a side with
+a within-condition spread of 2–3 — quote it as a direction, not a
+measurement. A first pass that compared one run a side read `+7` and was
+flattering itself; this is exactly the trap the two-sided rule exists for.
+Per model: glm-5.2 carries essentially all of the movement (18/22 → 26/24),
+while deepseek is flat (27/25 → 26/25) because it rarely broke two rules in
+one call to begin with.
+
+**What is left.** With the sequential-rule failures gone, the residual
+failures are the *same* rule tripped twice — nearly always the rolling
+aggregate. That is a different defect: the model is told exactly which number
+is missing, and still does not quote it. Worth attacking next, and worth
+attacking as a contract problem (is the `rollingWindow` slot asking for
+something models can reliably produce?) rather than by widening the retry
+budget.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -230,19 +230,27 @@ class GoalAgentStrategy extends ConversationStrategy
     final tldr = hasStructuredReport
         ? structured?.tldr ?? ''
         : _trimmed(args['tldr']);
+    // Every rule the report broke, not just the first one.
+    //
+    // These checks used to return on the first failure, which cost one round
+    // trip per rule to discover: the model would fix what it was told and
+    // trip the next rule on the way out. A wake gets exactly one forced
+    // report retry, so two sequentially-reported violations were enough to
+    // end it with no standing report at all — the outcome eval found this
+    // happening on 8 of one model's 9 failures, and the same rules were being
+    // tripped (and recovered from) by every other model too. Reporting them
+    // together costs nothing and lets one retry fix everything.
+    final problems = <String>[];
     if (status == null || oneLiner.isEmpty || tldr.isEmpty) {
-      await _reject(
-        call: call,
-        manager: manager,
-        error: hasStructuredReport
-            ? 'Error: update_goal_report needs status (one of '
+      problems.add(
+        hasStructuredReport
+            ? 'update_goal_report needs status (one of '
                   '${goalTrackStatusNames.join('|')}), a non-empty oneLiner '
                   'and a complete structured report.'
-            : 'Error: update_goal_report needs status (one of '
+            : 'update_goal_report needs status (one of '
                   '${goalTrackStatusNames.join('|')}), a non-empty oneLiner '
                   'and a non-empty tldr.',
       );
-      return;
     }
     // The prompt tells the model that status names are field values, never
     // prose. That instruction is the only thing standing between a weaker
@@ -265,25 +273,19 @@ class GoalAgentStrategy extends ConversationStrategy
       content,
     ]);
     if (tokenInProse != null) {
-      await _reject(
-        call: call,
-        manager: manager,
-        error:
-            'Error: "$tokenInProse" is a status field value, not prose. '
-            "Rewrite the visible text in the user's language and call "
-            'update_goal_report again.',
+      problems.add(
+        '"$tokenInProse" is a status field value, not prose. '
+        "Rewrite the visible text in the user's language and call "
+        'update_goal_report again.',
       );
-      return;
     }
-    if (expectedStatus != null && status != expectedStatus) {
-      await _reject(
-        call: call,
-        manager: manager,
-        error:
-            'Error: the FACTS trackStatus is "${expectedStatus!.name}" and '
-            'it is authoritative — use it verbatim.',
+    // Only meaningful once a status parsed at all; otherwise the missing-field
+    // problem above already says everything there is to say.
+    if (status != null && expectedStatus != null && status != expectedStatus) {
+      problems.add(
+        'the FACTS trackStatus is "${expectedStatus!.name}" and '
+        'it is authoritative — use it verbatim.',
       );
-      return;
     }
     // The rolling standing slot exists to state the deterministic aggregate.
     // Models substitute the LATEST reading for it — reporting a 7-day mean
@@ -296,17 +298,28 @@ class GoalAgentStrategy extends ConversationStrategy
           .where((value) => !_quotesNumber(structured.rollingWindow, value))
           .toList();
       if (missing.isNotEmpty) {
-        await _reject(
-          call: call,
-          manager: manager,
-          error:
-              'Error: the rolling standing must quote the FACTS aggregates '
-              'verbatim — ${missing.join(', ')} '
-              '${missing.length == 1 ? 'is' : 'are'} missing. Use the '
-              'aggregate, never the latest reading, and never recompute it.',
+        problems.add(
+          'the rolling standing must quote the FACTS aggregates '
+          'verbatim — ${missing.join(', ')} '
+          '${missing.length == 1 ? 'is' : 'are'} missing. Use the '
+          'aggregate, never the latest reading, and never recompute it.',
         );
-        return;
       }
+    }
+    if (problems.isNotEmpty) {
+      await _reject(
+        call: call,
+        manager: manager,
+        // A single problem reads exactly as it always did; only the multiple
+        // case gains an envelope, and it says "all of them" because a retry
+        // that fixes one is what put us here.
+        error: problems.length == 1
+            ? 'Error: ${problems.single}'
+            : 'Error: update_goal_report broke ${problems.length} rules — '
+                  'fix all of them in one call. '
+                  '${[for (final (i, p) in problems.indexed) '${i + 1}) $p'].join(' ')}',
+      );
+      return;
     }
     _reportStatus = status;
     _reportOneLiner = oneLiner;

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -379,6 +379,140 @@ void main() {
     expect(gated.reportStatus, GoalTrackStatus.offTrack);
   });
 
+  test('a report breaking several rules is told about all of them', () async {
+    // Sequential rejection cost one round trip per rule: the model fixed
+    // what it was told and tripped the next rule on the way out. A wake gets
+    // exactly ONE forced report retry, so two rules reported one at a time
+    // ended the wake with no standing report at all — which the outcome eval
+    // caught happening on 8 of one model's 9 failures.
+    final gated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+      expectedStatus: GoalTrackStatus.offTrack,
+      expectedRollingAggregates: const ['6000'],
+    );
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {
+            // Three rules at once: a status contradicting FACTS, a status
+            // token used as prose, and a rolling standing that never quotes
+            // the deterministic aggregate.
+            'status': 'atRisk',
+            'oneLiner': 'The goal is atRisk this week.',
+            'report': {
+              'tldr': 'Slightly behind.',
+              'currentPeriod': 'Around 6.4k yesterday.',
+              'rollingWindow': 'Averaging about 6.5k steps a day.',
+              'latestChange': 'Down from last week.',
+              'coverage': '7 days.',
+              'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+            },
+          },
+        ),
+      ],
+      manager: manager,
+    );
+
+    expect(gated.hasReport, isFalse);
+    final refusal = rejection();
+    expect(refusal, contains('broke 3 rules'));
+    expect(refusal, contains('fix all of them in one call'));
+    // Each rule named, so one retry can satisfy every one of them.
+    expect(refusal, contains('is a status field value, not prose'));
+    expect(refusal, contains('the FACTS trackStatus is "offTrack"'));
+    expect(refusal, contains('6000 is missing'));
+    // Numbered, because an unstructured concatenation of three sentences is
+    // what the model has to act on.
+    expect(refusal, contains('1)'));
+    expect(refusal, contains('3)'));
+
+    // And the corrected report — every rule honoured at once — lands.
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {
+            'status': 'offTrack',
+            'oneLiner': 'Well under the daily target.',
+            'report': {
+              'tldr': 'Behind on steps.',
+              'currentPeriod': 'Around 6.4k yesterday.',
+              'rollingWindow': 'Averaging 6000 steps a day against 10000.',
+              'latestChange': 'Down from last week.',
+              'coverage': '7 days.',
+              'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+            },
+          },
+        ),
+      ],
+      manager: manager,
+    );
+    expect(gated.reportStatus, GoalTrackStatus.offTrack);
+  });
+
+  test('a single broken rule reads exactly as it always did', () async {
+    // The envelope is for the multiple case only: one problem must not gain
+    // a "broke 1 rules" preamble.
+    final gated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+      expectedStatus: GoalTrackStatus.offTrack,
+    );
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {
+            'status': 'atRisk',
+            'oneLiner': 'Slightly behind.',
+            'tldr': 'A little under target.',
+          },
+        ),
+      ],
+      manager: manager,
+    );
+    expect(
+      rejection(),
+      'Error: the FACTS trackStatus is "offTrack" and it is authoritative '
+      '— use it verbatim.',
+    );
+  });
+
+  test('a missing status does not also report a status mismatch', () async {
+    // "needs status" and "the status is wrong" are the same defect stated
+    // twice; reporting both would make the model hunt for a second problem
+    // that does not exist.
+    final gated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+      expectedStatus: GoalTrackStatus.offTrack,
+    );
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {'oneLiner': 'Behind.', 'tldr': 'Behind on steps.'},
+        ),
+      ],
+      manager: manager,
+    );
+    final refusal = rejection();
+    expect(refusal, contains('needs status'));
+    expect(refusal, isNot(contains('broke')));
+    expect(refusal, isNot(contains('authoritative')));
+  });
+
   test('a rolling standing quoting the latest reading instead of the '
       'aggregate is rejected', () async {
     // Every evaluated model substitutes the latest weigh-in for the 7-day


### PR DESCRIPTION
**Stacked on #3965** (the tier-2 outcome eval that found this). Review that first; this PR's diff against it is 1 production file + its tests + a README section.

## The defect

`_validateReport` returned on the first failed check. A report breaking two rules therefore cost **two round trips** to discover that — the model fixes what it was told and trips the next rule on the way out:

```
attempt 1 → "atRisk" is a status field value, not prose.
retry     → the rolling standing must quote the FACTS aggregates
            verbatim — 6000 is missing.
```

`GoalAgentWorkflow` allows exactly **one** forced report retry. So two sequentially-reported violations end the wake with no standing report at all: the user keeps the banner and loses the report explaining it.

The tier-2 outcome eval caught this on **8 of glm-5.2's 9 failures**. It is not a glm-only story — deepseek tripped the same rules 18 times across 27 cases and simply had attempts left to recover.

## The fix

Collect every violated rule and report them together. Costs nothing: same turn count, strictly more information, and a converging model needs one retry instead of two.

- A **single** violation reads byte-identically to before — no `broke 1 rules` preamble. Every existing rejection test passes unchanged, which is the evidence.
- A missing `status` suppresses the status-mismatch check, since "needs status" and "the status is wrong" are the same defect stated twice.

## Measurement

Full suite, twice each side — the rule this repo learned the hard way two PRs ago:

| | passes /54 | guard rejections | failures where the retry tripped a NEW rule |
| --- | ---: | ---: | ---: |
| baseline run 1 | 45 | 51 | 9 |
| baseline run 2 | 47 | 50 | 5 |
| batched run 1 | 52 | 43 | 1 |
| batched run 2 | 49 | 45 | 2 |

**Supported:** the targeted mechanism moved and stayed moved (9/5 → 1/2). Total guard rejections down ~12%. The batched envelope fires in roughly one rejection in five, so it is not sitting behind an unreachable branch.

**Not supported:** the headline `+4.5/54` is two runs a side with a within-condition spread of 2–3 — a direction, not a measurement. A first pass comparing one run a side read `+7` and was flattering itself. Per model, glm-5.2 carries essentially all the movement (18/22 → 26/24) while deepseek is flat (27/25 → 26/25), which is consistent with the mechanism: deepseek rarely broke two rules in one call.

**What is left:** with the sequential-rule failures gone, the residual failures are the *same* rule tripped twice — nearly always the rolling aggregate. Different defect, worth attacking as a contract question (is the `rollingWindow` slot asking for something models can reliably produce?) rather than by widening the retry budget.

## Verification

- New test asserts all three rules are named in one rejection, numbered, and that the corrected report then lands. **Re-run with the fix reverted: it fails.**
- Two characterization tests pin the unchanged single-violation behaviour — these pass with or without the fix by design, guarding against an envelope leaking onto the single case.
- 973 tests across `test/features/goals/` + `test/features/agents/eval/goal/` green
- `dart analyze` clean, `make knowledge_check` passes

No CHANGELOG entry: the guard this repairs landed in #3961 and has not shipped, so there is no released behaviour to describe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goal report validation now identifies and displays multiple issues in a single response.
  * Combined feedback includes numbered corrections, helping address all detected problems in one retry.
  * Single validation errors retain their existing message format.
  * Missing status information no longer produces an unrelated status-mismatch error.

* **Documentation**
  * Added evaluation results covering validation feedback, retry behavior, and remaining limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->