### PR TITLE
fix(evals): stop the outcome eval passing wakes that persisted no report

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -82,9 +82,9 @@ Limitation, stated plainly: the tier-1 wake context is **authored** (a
 synthetic FACTS block), not produced by a real wake. The fixtures cross-check
 their deterministic arithmetic against the real evaluator and use the
 production prompt/tool contract, but the block itself is written by hand and
-can drift from what `GoalFactsRenderer` actually emits. Tier 2 closes that
-gap for its nine scenarios; the remaining seventeen still run on authored
-FACTS.
+can drift from what `GoalFactsRenderer` actually emits. Tier 2 does not
+re-implement any of these — its nine scenarios are new, built from entities —
+so all 26 tier-1 scenarios still run on authored FACTS.
 
 ### Tier 2 — what is measured
 
@@ -105,9 +105,9 @@ Pass/fail is over persisted entities:
 | `off_track_first_ad` | P5 | report + a newly authored banner |
 | `off_track_fresh_ad` | P6 | no second banner reaches the board |
 | `off_track_cooldown` | P5 | the same-day dismissal keeps the board quiet |
-| `recovering_retires_ad` | P7 | the stale scolding ends up retired |
-| `sparse_insufficient_data` | P8 | `insufficientData`, no banner |
-| `off_track_reuses_top_rated` | P13 | a re-run, not fresh copy |
+| `recovering_retires_ad` | P7 | the stale scolding is retired **and** a report lands |
+| `sparse_insufficient_data` | P8 | a report saying `insufficientData`, no banner |
+| `off_track_reuses_top_rated` | P13 | report + a re-run, not fresh copy |
 | `chat_question_on_track` | P10 | a reply the chat surface can render |
 
 Two of those are only meaningful at the outcome level. `forbidsNewAd` counts
@@ -522,30 +522,23 @@ mid-pep-talk. That LOWERS the reported score — 0.375 is the honest rate where
 
 ## Tier 2's first run finds a report-loss path — 2026-08-18
 
+> **Corrected 2026-08-18, later the same day.** The table first published here
+> read `27/27` and `18/27`. Both numbers were inflated by a scoring defect in
+> the harness — see "The first tier-2 table was inflated" below.
+> The corrected baseline is **33/54 and 39/54 across two runs**,
+> and report loss is not a glm-only problem. The mechanism described in this
+> section is unaffected and was confirmed by the corrected runs; only the
+> magnitudes were wrong, and they were wrong in the flattering direction.
+
 Nine scenarios, three samples each, two models. Tier 2's first live run, and
-it immediately found something no tier-1 run could have.
-
-| Scenario | Policy | deepseek-v4-flash-0731 | glm-5.2 |
-| --- | --- | ---: | ---: |
-| `ot_quiet_wake` | P2 | 3/3 | 3/3 |
-| `ot_transition_report` | P1 | 3/3 | 2/3 |
-| `off_track_first_ad` | P5 | 3/3 | **0/3** |
-| `off_track_fresh_ad` | P6 | 3/3 | **1/3** |
-| `off_track_cooldown` | P5 | 3/3 | **0/3** |
-| `recovering_retires_ad` | P7 | 3/3 | 3/3 |
-| `sparse_insufficient_data` | P8 | 3/3 | 3/3 |
-| `off_track_reuses_top_rated` | P13 | 3/3 | 3/3 |
-| `chat_question_on_track` | P10 | 3/3 | 3/3 |
-| **Total** | | **27/27** | **18/27** |
-
-Every one of glm-5.2's nine failures is the same category: `missingReport`.
-The wake persisted a banner, or nothing, and left the user with no standing
-report at all.
+it immediately found something no tier-1 run could have: nine failures, every
+one of them the same category — `missingReport`. The wake persisted a banner,
+or nothing, and left the user with no standing report at all.
 
 **Why.** All nine were refused by the deterministic guard, twice, and in
 eight of the nine the two refusals cite *different rules*:
 
-```
+```text
 1. "atRisk" is a status field value, not prose. Rewrite the visible text…
 2. the rolling standing must quote the FACTS aggregates verbatim —
    6000 is missing.
@@ -582,10 +575,9 @@ wrong number" into "no report at all", which is the worse failure.
    re-measuring before touching the retry budget.
 
 **Caveats.** Three samples per cell is thin — the tier-1 noise floor work is
-explicit that n=3 cannot rank two close models. It is enough here because the
-failures are not a scatter: they are one category, concentrated in one model,
-with a mechanism visible in the rejection log. The ranking claim
-("deepseek > glm") is weak at this n; the defect claim is not.
+explicit that n=3 cannot rank two close models. The defect claim survives that
+because the failures are one category with a mechanism visible in the
+rejection log. The *ranking* claim did not survive: see the correction below.
 
 Cost over the same run, and note this is per WAKE, not per call — a repaired
 wake pays for its retries:
@@ -603,7 +595,11 @@ A single violation reads exactly as it always did; only the multiple case
 gains an envelope.
 
 Measured the way the rule two sections up demands — full suite, twice, both
-sides:
+sides. **The pass columns below are superseded** — they were scored by the
+classifier defect described in the next section, and the fix needs
+re-measuring against the corrected 33/39 baseline. The rejection and
+mechanism columns are unaffected, since they were read from the rejection log
+rather than from pass totals:
 
 | | passes /54 | guard rejections | failures where the retry tripped a NEW rule |
 | --- | ---: | ---: | ---: |
@@ -633,6 +629,67 @@ is missing, and still does not quote it. Worth attacking next, and worth
 attacking as a contract problem (is the `rollingWindow` slot asking for
 something models can reliably produce?) rather than by widening the retry
 budget.
+
+## The first tier-2 table was inflated — 2026-08-18
+
+Review of the tier-2 PR found two scoring defects, and correcting them moves
+the numbers a long way in the unflattering direction. Recording it here at
+length because the failure is instructive: a brand-new harness, built
+specifically to stop fixtures from claiming what their facts do not support,
+shipped with fixtures claiming what their facts did not support.
+
+**Defect 1 — a status expectation that no report satisfied.**
+`classifyGoalAgentOutcome` checked `expectedReportStatus` only when
+`outcome.report != null`. A wake that persisted *no report at all* therefore
+passed a scenario whose entire point was what the report must say. The fix is
+structural rather than per-scenario: pinning the status now *implies*
+requiring the report, because "the report must say `insufficientData`" cannot
+be satisfied by silence.
+
+**Defect 2 — a P8 fixture that never posed its question.**
+`sparse_insufficient_data` gave yesterday's register the *same*
+`insufficientData` status as today. No transition, therefore no forced report,
+therefore a quiet wake was correct restraint (P2) — the scenario was a second
+no-op test wearing P8's label, and all six cases per run "passed" by doing
+nothing. Yesterday is now `onTrack`, so the tracker gap is new and the wake
+owes an explanation.
+
+Two more scenarios were simply missing `requiresReport`: `recovering_retires_ad`
+(P7 is "retire *and* report", and offTrack → recovering is a transition) and
+`off_track_reuses_top_rated` (same evidence as P5, so the same transition and
+the same duty; only the ad decision differs).
+
+**The corrected baseline**, same code, same models, same three samples, run
+twice:
+
+| | deepseek-v4-flash-0731 | glm-5.2 | total |
+| --- | ---: | ---: | ---: |
+| as first published | 27/27 | 18/27 | 45/54 |
+| corrected, run 1 | 19/27 | 14/27 | **33/54** |
+| corrected, run 2 | 22/27 | 17/27 | **39/54** |
+
+**Every** newly-exposed failure is `missingReport`. That changes the finding's
+shape in two ways:
+
+- **Report loss is the dominant goal-agent failure mode, not a glm quirk.**
+  The original "deepseek 27/27" was an artifact of scenarios that never asked
+  for a report. Corrected, deepseek loses the report in 5–8 of 27 wakes.
+- **It is spread across every scenario that owes a report**, worst on P7
+  (4–6 of 6) and P13 (3–4 of 6), not concentrated in the ad rows.
+
+**What this invalidates.** Every tier-2 total published before this correction,
+including the before/after table for the batched-rejection change — that fix
+must be re-measured against the 33/39 baseline. The *mechanism* claims are
+unaffected: rejection counts and the sequential-rules pattern were read from
+the rejection log, not from pass totals.
+
+**The lesson, which is not a new one.** A vacuous pass is invisible in a green
+matrix — 3/3 looks identical whether it was earned or never asked for. The
+existing testing convention says every test must assert something meaningful;
+this is the eval-harness form of that rule, and the harness needed it as much
+as the code it grades. The fixture-honesty tests caught status drift because
+they were written to; nothing was asserting that a passing case had actually
+been *asked* anything.
 
 ## Cost and latency
 

--- a/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_eval_runner_test.dart
@@ -904,7 +904,7 @@ void main() {
       expect(markdown, isNot(contains('13.5')));
       expect(markdown, contains('0.1800'));
       expect(markdown, isNot(contains('0.0900')));
-      expect(markdown, contains('divide by cases that actually reported'));
+      expect(markdown, contains('divides by cases that actually reported'));
     });
 
     test('case json round-trips the consumption events', () {

--- a/test/features/agents/eval/goal/goal_agent_outcome_eval_live_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_outcome_eval_live_test.dart
@@ -41,8 +41,11 @@ void main() {
 
       registerAllFallbackValues();
       final attribution = AiInteractionCaptureTestBench.create()..register();
-      addTearDown(attribution.unregister);
+      // Registration order is load-bearing: tear-downs run in reverse, so
+      // `unregister` must be registered LAST to run BEFORE `getIt.reset`
+      // pulls the registrations out from under it.
       addTearDown(getIt.reset);
+      addTearDown(attribution.unregister);
 
       final container = ProviderContainer();
       addTearDown(container.dispose);
@@ -60,16 +63,28 @@ void main() {
       final providerType = _providerType(
         Platform.environment['GOAL_AGENT_EVAL_PROVIDER_TYPE'],
       );
+      // Fail loudly on a missing key. Falling back to an empty string makes
+      // every case an `inferenceError`, and since the test only asserts the
+      // report is non-empty, a run that authenticated nowhere would still go
+      // green and produce a report full of zeros.
+      final apiKey =
+          Platform.environment['GOAL_AGENT_EVAL_API_KEY'] ??
+          Platform.environment['MELIOUS_API_KEY'] ??
+          '';
+      expect(
+        apiKey,
+        isNotEmpty,
+        reason:
+            'Set GOAL_AGENT_EVAL_API_KEY (or MELIOUS_API_KEY) — an empty key '
+            'produces a full report of authentication failures.',
+      );
       final provider = AiConfigInferenceProvider(
         id: 'goal-outcome-eval-${providerType.name}',
         name: 'Goal Outcome Eval (${providerType.name})',
         baseUrl:
             Platform.environment['GOAL_AGENT_EVAL_BASE_URL'] ??
             ProviderConfig.defaultBaseUrls[providerType]!,
-        apiKey:
-            Platform.environment['GOAL_AGENT_EVAL_API_KEY'] ??
-            Platform.environment['MELIOUS_API_KEY'] ??
-            '',
+        apiKey: apiKey,
         inferenceProviderType: providerType,
         createdAt: DateTime(2026, 8, 8),
       );

--- a/test/features/agents/eval/goal/goal_agent_outcome_eval_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_outcome_eval_test.dart
@@ -501,6 +501,38 @@ void main() {
       );
     });
 
+    test('pinning the status also requires the report to exist', () {
+      // The vacuous pass this harness shipped with: the status check ran only
+      // when a report existed, so a wake that persisted NOTHING satisfied a
+      // scenario whose whole point was what the report must say. Six of six
+      // P8 cases per run "passed" that way.
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(
+              expectedReportStatus: GoalTrackStatus.insufficientData,
+            ),
+          ),
+          outcome: outcomeWith(),
+        ),
+        GoalOutcomeFailureCategory.missingReport,
+        reason: 'silence cannot satisfy "the report must say X"',
+      );
+      // And a banner alone is still not a report — the exact shape the live
+      // runs produced.
+      expect(
+        classifyGoalAgentOutcome(
+          scenario: withExpectation(
+            const GoalOutcomeExpectation(
+              expectedReportStatus: GoalTrackStatus.offTrack,
+            ),
+          ),
+          outcome: outcomeWith(writes: [ad()]),
+        ),
+        GoalOutcomeFailureCategory.missingReport,
+      );
+    });
+
     test('a report contradicting the deterministic status fails', () {
       expect(
         classifyGoalAgentOutcome(

--- a/test/features/agents/eval/goal/support/goal_agent_outcome_eval.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_outcome_eval.dart
@@ -87,12 +87,15 @@ class GoalOutcomeExpectation {
   /// empty is what the user or the next wake can see.
   final bool expectsNoOutcome;
 
+  /// A standing report must land. Implied by [expectedReportStatus], so a
+  /// scenario pinning the status does not need to set both.
   final bool requiresReport;
 
   /// The deterministic tier's status, which the persisted report's
   /// provenance must carry. `GoalAgentStrategy` already rejects a
   /// contradicting claim in-conversation; this proves the rejection held all
-  /// the way to the write.
+  /// the way to the write. Requiring the report is part of the claim: "the
+  /// report must say insufficientData" cannot be satisfied by no report.
   final GoalTrackStatus? expectedReportStatus;
 
   /// A newly authored banner (activation 1). Distinct from [requiresRerun],
@@ -344,12 +347,17 @@ GoalOutcomeFailureCategory classifyGoalAgentOutcome({
     return GoalOutcomeFailureCategory.writesOnNoOp;
   }
 
-  if (expectation.requiresReport && outcome.report == null) {
+  // Pinning the status IMPLIES requiring the report. Checking the status
+  // only when a report exists let a wake that persisted nothing at all pass
+  // a scenario whose whole point was what the report must say — the exact
+  // vacuous pass the testing conventions warn about, and it inflated the
+  // first published tier-2 numbers before review caught it.
+  final expectedStatus = expectation.expectedReportStatus;
+  if ((expectation.requiresReport || expectedStatus != null) &&
+      outcome.report == null) {
     return GoalOutcomeFailureCategory.missingReport;
   }
-  final expectedStatus = expectation.expectedReportStatus;
   if (expectedStatus != null &&
-      outcome.report != null &&
       outcome.report!.provenance['trackStatus'] != expectedStatus.name) {
     return GoalOutcomeFailureCategory.wrongReportStatus;
   }

--- a/test/features/agents/eval/goal/support/goal_agent_outcome_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_outcome_eval_scenarios.dart
@@ -214,6 +214,10 @@ final goalOutcomeEvalScenarios = <GoalOutcomeEvalScenario>[
       ),
     ],
     expectation: const GoalOutcomeExpectation(
+      // P7 is "retire_goal_ad + update_goal_report", and offTrack → recovering
+      // is a status transition, so the report is mandatory rather than
+      // incidental — the wake must say why the scolding went away.
+      requiresReport: true,
       requiresRetirement: true,
       forbidsNewAd: true,
     ),
@@ -227,7 +231,10 @@ final goalOutcomeEvalScenarios = <GoalOutcomeEvalScenario>[
     statement: _statement,
     criteria: goalOutcomeEvalSteps,
     window: _sparseWindow,
-    priorRegisters: _yesterday(GoalTrackStatus.insufficientData, 0),
+    // Yesterday was fine, the tracker gap is new. A same-status prior would
+    // have made this a no-op wake owing nothing, so the scenario would have
+    // graded restraint while claiming to grade P8.
+    priorRegisters: _yesterday(GoalTrackStatus.onTrack, 1.1),
     expectation: const GoalOutcomeExpectation(
       expectedReportStatus: GoalTrackStatus.insufficientData,
       forbidsNewAd: true,
@@ -264,7 +271,12 @@ final goalOutcomeEvalScenarios = <GoalOutcomeEvalScenario>[
         ],
       ),
     ],
-    expectation: const GoalOutcomeExpectation(requiresRerun: true),
+    // Same evidence as P5, so the same transition, so the same report duty —
+    // only the ad decision differs.
+    expectation: const GoalOutcomeExpectation(
+      requiresReport: true,
+      requiresRerun: true,
+    ),
   ),
 
   // ── P10: dialogue first, and the user must actually get an answer ──────

--- a/test/features/agents/eval/goal/support/goal_eval_cost_table.dart
+++ b/test/features/agents/eval/goal/support/goal_eval_cost_table.dart
@@ -83,7 +83,7 @@ String renderGoalEvalCostTable({
     ..writeln(
       '*Extrapolation assumes $wakesPerDayAssumption LLM wakes '
       'per goal per day — a printed assumption, not a measurement — '
-      'and divide by cases that actually reported the figure: missing '
+      'and divides by cases that actually reported the figure: missing '
       'telemetry widens uncertainty, it is never counted as zero. '
       'Credits and energy are Melious-reported; "not reported" means '
       'the provider sent no data, never that the run was free. Banner '


### PR DESCRIPTION
Addresses review on #3965 (merged). Two of the comments were **scoring defects that inflated the published numbers**, so this is a correction, not a cleanup.

## The defects

**1. A status expectation that silence satisfied.** `classifyGoalAgentOutcome` checked `expectedReportStatus` only when `outcome.report != null`. A wake that persisted **no report at all** therefore passed a scenario whose entire point was what the report must say. Fixed structurally rather than per-scenario: pinning the status now *implies* requiring the report, because "the report must say `insufficientData`" cannot be satisfied by nothing. (Codex P2)

**2. A P8 fixture that never posed its question.** `sparse_insufficient_data` gave yesterday's register the *same* `insufficientData` status as today. No transition → no forced report → a quiet wake was correct restraint (P2). The scenario was a second no-op test wearing P8's label, and all six cases per run "passed" by doing nothing. Yesterday is now `onTrack`, so the tracker gap is new and the wake owes an explanation. (Codex P2)

Two more scenarios were missing `requiresReport` outright: `recovering_retires_ad` (P7 is "retire *and* report", and offTrack → recovering is a transition) and `off_track_reuses_top_rated` (same evidence as P5, so the same transition and the same duty — only the ad decision differs).

## What it costs

| | deepseek-v4-flash-0731 | glm-5.2 | total |
| --- | ---: | ---: | ---: |
| as published in #3965 | 27/27 | 18/27 | 45/54 |
| corrected, run 1 | 19/27 | 14/27 | **33/54** |
| corrected, run 2 | 22/27 | 17/27 | **39/54** |

Same code, same models, same three samples, run twice. **Every** newly-exposed failure is `missingReport`, which changes the finding's shape:

- **Report loss is the dominant goal-agent failure mode, not a glm quirk.** The "deepseek 27/27" headline was an artifact of scenarios that never asked for a report; corrected, deepseek loses the report in 5–8 of 27 wakes.
- **It is spread across every scenario that owes a report** — worst on P7 (4–6 of 6) and P13 (3–4 of 6) — not concentrated in the ad rows as #3965 concluded.

**This invalidates every tier-2 total published so far, including the before/after table in #3966.** That fix must be re-measured against the 33/39 baseline; I'll do that once this lands. The *mechanism* claims in both PRs are unaffected — rejection counts and the sequential-rules pattern were read from the rejection log, not from pass totals.

## Also from review

- The live test **fails fast on a missing API key** instead of reporting a full matrix of authentication failures as though it were data (the test only asserted the report was non-empty, so an unauthenticated run went green). (CodeRabbit)
- Tear-downs registered so `attribution.unregister` runs **before** `getIt.reset` pulls its registrations out from under it — `addTearDown` runs in reverse. (CodeRabbit)
- The "remaining seventeen still run on authored FACTS" claim was wrong: tier 2 re-implements none of tier 1, so all 26 still do. (CodeRabbit)
- `divide` → `divides` in the cost-table paragraph, which is published verbatim in every eval report. (CodeRabbit)
- MD040 language on the quoted-rejections fence. (CodeRabbit)

## The lesson, recorded in the README

A vacuous pass is invisible in a green matrix — `3/3` looks identical whether it was earned or never asked for. A harness built specifically to stop fixtures claiming what their facts do not support shipped with fixtures claiming what their facts did not support. The fixture-honesty tests caught *status* drift because they were written to; nothing asserted that a passing case had actually been asked anything.

## Verification

- New classifier test: a pinned status with no report is `missingReport`, and a banner alone is not a report. **Re-run with the fix reverted: it fails.**
- 90 tests in `test/features/agents/eval/goal/` green, `dart analyze` clean, `make knowledge_check` passes
- Two fresh live runs produced the corrected table above

No CHANGELOG entry: eval harness and docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected evaluation handling when required reports are missing, including cases with only an ad recorded.
  - Improved validation for report status transitions and sparse-data scenarios.
  - Fixed test setup checks to provide clearer errors when required API credentials are unavailable.
- **Documentation**
  - Updated evaluation guidance, scenarios, baselines, failure distributions, and cost-table explanations to reflect corrected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->