### PR TITLE
fix(goals): accept a reader-formatted aggregate as quoting the aggregate

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -691,6 +691,80 @@ as the code it grades. The fixture-honesty tests caught status drift because
 they were written to; nothing was asserting that a passing case had actually
 been *asked* anything.
 
+## The report loss was a matcher bug — 2026-08-18
+
+The aggregate rule was not hard for models to satisfy. It was impossible.
+
+FACTS carry the rolling aggregate as a bare Dart number, `8600`. Dumping what
+models actually write into `rollingWindow` on live runs settles it in one
+look:
+
+```text
+deepseek/gp_on_track    Rolling 7-day average is 11,050 steps against a
+                        10,000 target.
+deepseek/gp_recovering  Rolling 7-day mean is 8,586 steps (86% of the
+                        10,000 target).
+glm-5.2/gp_recovering   Rolling 7-day mean is ~8,586 steps …
+deepseek/gh_complex     … systolic 127 (target ≤125), diastolic 89, weight 95
+```
+
+`_quotesNumber` required a digit-exact token, so **every four-digit aggregate
+failed and every three-digit one passed** — deterministically, both models,
+every sample. That is the whole pattern the tier-2 runs showed: the health
+goals (127, 95, 89) kept their reports and the step goals (6000, 8600, 11000)
+lost theirs. Probing the matcher directly:
+
+| what a report writes | old verdict |
+| --- | --- |
+| `Averaging 6000 steps a day` | pass |
+| `Averaging 6,000 steps a day` | **fail** |
+| `Averaging 6 000 steps a day` | **fail** |
+| `The 7-day average is 6000.` | **fail** |
+
+The last row is a separate plain bug: the lookahead treated a **sentence-ending
+period as a decimal point**, so any sentence ending on the number was refused.
+
+**The fix** tries the text both as written and with digit group separators
+removed (a `,`/`.`/space between a digit and exactly three more digits — two
+after it make it a decimal point, four make it neither), and only treats a
+trailing `.` as decimal when a digit follows. Trying *both* forms matters:
+normalization alone would collapse "weight 95 100" into "95100" and destroy a
+match the raw text already had.
+
+| | passes /54 | guard rejections | of those, the aggregate rule |
+| --- | ---: | ---: | ---: |
+| corrected baseline 1 | 33 | 63 | 45 |
+| corrected baseline 2 | 39 | 57 | 42 |
+| matcher fixed 1 | **53** | 19 | 5 |
+| matcher fixed 2 | **54** | 9 | 1 |
+
+Both models land at 27/27 or 26/27. No metric overlaps between conditions, so
+unlike the batching measurement this one does not need hedging: `+18/54` is
+far outside the noise floor, and the mechanism is directly observable in the
+rejection counts collapsing from 45/42 to 5/1.
+
+**What this reframes.** Most of what the previous two sections diagnosed as
+model failure and "report loss as the dominant failure mode" was self-inflicted
+by the guard added in #3961. The guard's *intent* was right — models really do
+substitute the latest reading for the mean — but its matcher punished correct,
+well-formatted prose, and one forced retry was never going to recover from a
+rule that cannot be satisfied. The batching fix remains correct and cheap, but
+with the matcher repaired its remaining contribution is small.
+
+**The lesson.** Three separate investigations here — a prompt-placement theory,
+a sequential-rejection theory, a retry-budget theory — all pointed at the model
+or the contract. None of them looked at whether the check itself was right. The
+question "would a correct answer pass this?" costs one probe and was never
+asked. It is now the first question, and the rejection log tier 2 records is
+what makes it cheap to ask.
+
+**Still open.** The check proves the aggregate *appears*, not that it is bound
+to the right series: a slot naming 95 as the target while stating 94 as the
+average still passes. Closing that means carrying the aggregates as typed
+per-series fields the app renders, instead of prose the model must echo and a
+regex must recover — which would delete this whole class of defect rather than
+repair it.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -351,17 +351,41 @@ class GoalAgentStrategy extends ConversationStrategy
   ///
   /// Substring matching passed the exact fabrication this check exists to
   /// catch: "127.85" contains "127", so a recomputed precision the FACTS
-  /// never carried scored as a faithful quote. Digits and decimal points on
-  /// either side disqualify a match, so 127 matches "127 mmHg" and "127," but
-  /// not "127.85" or "1127".
+  /// never carried scored as a faithful quote. A digit, or a decimal point
+  /// carrying digits, on either side disqualifies a match — so 127 matches
+  /// "127 mmHg" and "127," but not "127.85" or "1127".
+  ///
+  /// FACTS carry the aggregate as a bare Dart number (`8600`), while a report
+  /// writes it the way a reader expects to see it (`8,600`, or `8.600` in
+  /// German). Digit-exact matching therefore rejected every four-digit
+  /// aggregate from every evaluated model while passing every three-digit
+  /// one: the health goals passed and the step goals lost their reports
+  /// entirely. That is a matcher failure, not a model one, so the text is
+  /// tried BOTH as written and with digit group separators removed. Trying
+  /// both — rather than only the normalized form — means normalization can
+  /// never destroy a match the raw text already had ("weight 95 100" still
+  /// quotes 95).
   ///
   /// Known limit: this proves the aggregate APPEARS, not that it is bound to
   /// the right series. A slot naming 95 as the target while stating 94 as the
   /// average still passes. Closing that needs the aggregates carried as typed
   /// per-series fields rather than recovered from prose.
-  static bool _quotesNumber(String text, String value) => RegExp(
-    r'(?<![\d.])' + RegExp.escape(value) + r'(?![\d.])',
-  ).hasMatch(text);
+  static bool _quotesNumber(String text, String value) {
+    // A trailing `.` is sentence punctuation unless a digit follows: "the
+    // average is 8600." quotes 8600, "8600.5" does not.
+    final pattern = RegExp(
+      r'(?<!\d)(?<!\d\.)' + RegExp.escape(value) + r'(?!\d)(?!\.\d)',
+    );
+    return pattern.hasMatch(text) ||
+        pattern.hasMatch(text.replaceAll(_digitGroupSeparator, ''));
+  }
+
+  /// A digit group separator: a `,`, `.`, space or narrow/non-breaking space
+  /// between a digit and exactly three more digits. Two digits after it make
+  /// it a decimal point (`127.85`); four make it neither.
+  static final _digitGroupSeparator = RegExp(
+    '(?<=\\d)[,.\u00a0\u202f\u2009 ](?=\\d{3}(?!\\d))',
+  );
 
   Future<void> _handleReplyToUser(
     ChatCompletionMessageToolCall call,

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -620,6 +620,114 @@ void main() {
     },
   );
 
+  test('a reader-formatted aggregate still counts as quoting it', () async {
+    // FACTS carry a bare Dart number; a report writes the number the way a
+    // reader expects to see it. Digit-exact matching rejected EVERY
+    // four-digit aggregate from every evaluated model — "8,600" against
+    // 8600 — while passing every three-digit one, so the health goals
+    // passed and the step goals lost their reports entirely.
+    Future<bool> accepts(String rollingWindow, String aggregate) async {
+      final gated = GoalAgentStrategy(
+        syncService: syncService,
+        agentId: 'goal-1',
+        threadId: 'thread-1',
+        runKey: 'run-1',
+        knownAdIds: const {},
+        expectedRollingAggregates: [aggregate],
+      );
+      await gated.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              'status': 'offTrack',
+              'oneLiner': 'Behind.',
+              'report': {
+                'tldr': 'Behind on steps.',
+                'currentPeriod': 'Yesterday was light.',
+                'rollingWindow': rollingWindow,
+                'latestChange': 'Down on the week.',
+                'coverage': '7 days.',
+                'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+              },
+            },
+          ),
+        ],
+        manager: manager,
+      );
+      return gated.hasReport;
+    }
+
+    // What the models actually write, captured from live runs.
+    for (final written in [
+      'Rolling 7-day average is 8,600 steps against a 10,000 target.',
+      'Rolling 7-day mean is ~8,600 steps (attainment 0.86).',
+      // Locales that group with a period or a space.
+      'Der 7-Tage-Schnitt liegt bei 8.600 Schritten.',
+      'La moyenne sur 7 jours est de 8 600 pas.',
+      // The number ending the sentence: the trailing period is punctuation,
+      // not a decimal point, and rejecting it was a plain bug.
+      'The rolling seven-day average is 8600.',
+    ]) {
+      expect(
+        await accepts(written, '8600'),
+        isTrue,
+        reason: 'must accept: $written',
+      );
+    }
+
+    // And the fabrications this check exists for are still refused — the
+    // normalization must not buy acceptance with accuracy.
+    for (final fabricated in [
+      // A recomputed precision FACTS never carried.
+      'Rolling average 8600.42 steps.',
+      // A different number that merely contains the digits.
+      'Rolling average 18600 steps.',
+      // Grouped, but a different value.
+      'Rolling 7-day average is 8,700 steps.',
+    ]) {
+      expect(
+        await accepts(fabricated, '8600'),
+        isFalse,
+        reason: 'must refuse: $fabricated',
+      );
+    }
+  });
+
+  test('normalizing separators never destroys a raw match', () async {
+    // "weight 95 100" reads as two numbers; collapsing the space would hide
+    // the 95. The raw text is tried first for exactly this reason.
+    final gated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+      expectedRollingAggregates: const ['95'],
+    );
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {
+            'status': 'offTrack',
+            'oneLiner': 'Behind.',
+            'report': {
+              'tldr': 'Behind on weight.',
+              'currentPeriod': 'Weighed in today.',
+              'rollingWindow': 'Rolling weight 95 100 g above target.',
+              'latestChange': 'Down 1 kg.',
+              'coverage': '3 weigh-ins.',
+              'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+            },
+          },
+        ),
+      ],
+      manager: manager,
+    );
+    expect(gated.hasReport, isTrue);
+  });
+
   test('the reply carries a banner request in any language', () async {
     // The regex detector reads English only, and a wake whose ad tools were
     // withheld cannot carry the intent through a typed create_goal_ad call.


### PR DESCRIPTION
This is the answer to "why is the goal agent losing reports". Not the model, not the prompt, not the retry budget. **The guard was rejecting correct output.**

## The evidence

FACTS carry the rolling aggregate as a bare Dart number, `8600`. Here is what models actually write into `rollingWindow`, dumped from live runs of both:

```text
deepseek/gp_on_track    Rolling 7-day average is 11,050 steps against a 10,000 target.
deepseek/gp_recovering  Rolling 7-day mean is 8,586 steps (86% of the 10,000 target).
glm-5.2/gp_recovering   Rolling 7-day mean is ~8,586 steps (attainment 0.86).
deepseek/gh_complex     … systolic 127 (target ≤125), diastolic 89, weight 95 …
```

`_quotesNumber` required a digit-exact token, so **every four-digit aggregate failed and every three-digit one passed** — deterministically, both models, every sample. That is precisely the tier-2 pattern: health goals (127, 95, 89) kept their reports; step goals (6000, 8600, 11000) lost theirs.

Probing the matcher directly:

| what a report writes | old verdict |
| --- | --- |
| `Averaging 6000 steps a day` | pass |
| `Averaging 6,000 steps a day` | **fail** |
| `Averaging 6 000 steps a day` | **fail** |
| `The 7-day average is 6000.` | **fail** |

The last row is a separate plain bug: the lookahead treated a **sentence-ending period as a decimal point**, so any sentence ending on the number was refused.

## The fix

Try the text **both** as written and with digit group separators removed — a `,`, `.`, space or narrow/non-breaking space between a digit and *exactly three* more digits (two after it make it a decimal point, four make it neither). And treat a trailing `.` as decimal only when a digit follows.

Trying both forms rather than only the normalized one is load-bearing: normalization alone collapses `weight 95 100` into `95100` and destroys a match the raw text already had. There is a test for that.

**The anti-fabrication property is unchanged**, and tested: against `8600`, all of `8600.42` (recomputed precision), `18600` (different number containing the digits) and `8,700` (grouped but wrong) are still refused.

## Measurement

Full suite, twice each side, scored by the corrected classifier from #3967:

| | passes /54 | guard rejections | of those, the aggregate rule |
| --- | ---: | ---: | ---: |
| corrected baseline 1 | 33 | 63 | 45 |
| corrected baseline 2 | 39 | 57 | 42 |
| matcher fixed 1 | **53** | 19 | 5 |
| matcher fixed 2 | **54** | 9 | 1 |

Both models land at 27/27 or 26/27. **No metric overlaps between conditions**, so unlike the batching measurement this one needs no hedging: `+18/54` is far outside the noise floor, and the mechanism is directly visible in aggregate-rule rejections collapsing from 45/42 to 5/1.

## What this reframes

Most of what #3965 and #3967 diagnosed as model failure — "report loss is the dominant goal-agent failure mode" — was self-inflicted by the guard added in #3961. The guard's *intent* is right: models really do substitute the latest reading for the mean. But its matcher punished correct, well-formatted prose, and no retry budget recovers from a rule a correct answer cannot pass. The batching fix (#3966) remains correct and cheap; with the matcher repaired its remaining contribution is small.

Three separate investigations here — a prompt-placement theory, a sequential-rejection theory, a retry-budget theory — all pointed at the model or the contract. None asked whether the check itself was right. "Would a correct answer pass this?" costs one probe.

## Still open (not in this PR)

The check proves the aggregate *appears*, not that it is bound to the right series: a slot naming 95 as the target while stating 94 as the average still passes. Closing that means carrying aggregates as typed per-series fields the app renders, instead of prose the model must echo and a regex must recover — deleting the class rather than repairing it. Worth a separate design pass.

## Verification

- New tests cover the reader-formatted cases (`8,600`, German `8.600`, French `8 600`, sentence-final `8600.`), the fabrications that must still fail, and the raw-match-preservation case. **Re-run with the fix reverted: they fail.**
- 976 tests across `test/features/goals/` + `test/features/agents/eval/goal/` green
- `dart analyze` clean, `make knowledge_check` passes

No CHANGELOG entry: the guard this repairs landed in #3961 and has not shipped.
