### PR TITLE
feat(goals): give a goal a journal-side entity

### DIFF
--- a/lib/classes/goal_data.dart
+++ b/lib/classes/goal_data.dart
@@ -1,0 +1,83 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+
+part 'goal_data.freezed.dart';
+part 'goal_data.g.dart';
+
+/// Payload of a `JournalEntity.goal` — a long-term goal the user authored,
+/// and the container its check-ins hang from.
+///
+/// **Why this lives in the journal database.** A goal's criteria are written
+/// entirely in terms of other journal-side definitions: `habitId` names a
+/// `HabitDefinition`, `dataTypeId` a `MeasurableDataType`, `categoryId` a
+/// `CategoryDefinition`, `labelId` a `LabelDefinition`. Every referent of a
+/// goal is a definition in the journal database, which the backup catalog
+/// declares `required: true` and "the primary journal, task, definition, and
+/// link authority" — while the agent database it used to live in is
+/// `required: false`. A goal was the one member of its own family stored on
+/// the disposable side, so restoring a profile without the agent database
+/// silently lost goals the user had written. It no longer can.
+///
+/// The goal agent — the coach that evaluates this definition, keeps a
+/// standing report and speaks through banners — remains agent-side and
+/// optional, bound to this entry by an `AgentLink.agentGoal`, exactly as an
+/// event agent binds to its `JournalEvent`. Losing it costs the user their
+/// coach, never their goal or their check-ins.
+///
+/// **Two row shapes, one type.** A goal is one stable entry whose id never
+/// changes, so the links to its check-ins survive every revision of the
+/// criteria. Each revision additionally writes an immutable *snapshot* row
+/// carrying the criteria as they stood, with [snapshotOf] naming the goal it
+/// belongs to; [specVersionId] on the goal points at the snapshot standing
+/// for the current definition. Snapshots are what `goalProgress` registers and
+/// daily reflections pin themselves to, so a verdict passed under old criteria
+/// is never re-read as a judgement of the current ones.
+@freezed
+abstract class GoalData with _$GoalData {
+  const factory GoalData({
+    /// The goal's short name, as the user wrote it ("Blood pressure").
+    required String title,
+
+    /// The speakable form: "Average 10,000 steps a day over a rolling week."
+    required String statement,
+
+    /// The criteria tree success is defined in. Its leaves reference habit,
+    /// measurable, category and label definitions by their stable ids.
+    required GoalCriterion criteria,
+
+    /// Monotonic ordinal of the current definition, 1-based. Increments on
+    /// every accepted revision.
+    required int specVersion,
+
+    /// Id of the snapshot row holding this exact definition. Registers and
+    /// reflections pin to it, so their verdicts stay attributable to the
+    /// criteria that produced them.
+    required String specVersionId,
+
+    /// When the goal starts counting; null means "from creation".
+    DateTime? startDate,
+
+    /// Optional deadline. Once passed, the track policy resolves to
+    /// achieved/off-track instead of granting grace.
+    DateTime? targetDate,
+
+    /// Why this definition was chosen, when a revision recorded a reason.
+    String? rationale,
+
+    /// Set **only on an immutable spec snapshot**, naming the goal entry it
+    /// belongs to; null on the goal itself. Denormalized into the journal
+    /// row's `subtype` (the `HabitCompletionData.habitId` precedent) so a
+    /// goal's version history is an indexed `type + subtype` lookup rather
+    /// than a scan, and so a snapshot emits its goal as a precise wake token.
+    String? snapshotOf,
+  }) = _GoalData;
+
+  factory GoalData.fromJson(Map<String, dynamic> json) =>
+      _$GoalDataFromJson(json);
+}
+
+extension GoalDataExtension on GoalData {
+  /// Whether this row is an immutable record of a past or present definition
+  /// rather than the goal itself. Snapshots are never listed as goals.
+  bool get isSpecSnapshot => snapshotOf != null;
+}

--- a/lib/classes/goal_data.freezed.dart
+++ b/lib/classes/goal_data.freezed.dart
@@ -1,0 +1,355 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'goal_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GoalData {
+
+/// The goal's short name, as the user wrote it ("Blood pressure").
+ String get title;/// The speakable form: "Average 10,000 steps a day over a rolling week."
+ String get statement;/// The criteria tree success is defined in. Its leaves reference habit,
+/// measurable, category and label definitions by their stable ids.
+ GoalCriterion get criteria;/// Monotonic ordinal of the current definition, 1-based. Increments on
+/// every accepted revision.
+ int get specVersion;/// Id of the snapshot row holding this exact definition. Registers and
+/// reflections pin to it, so their verdicts stay attributable to the
+/// criteria that produced them.
+ String get specVersionId;/// When the goal starts counting; null means "from creation".
+ DateTime? get startDate;/// Optional deadline. Once passed, the track policy resolves to
+/// achieved/off-track instead of granting grace.
+ DateTime? get targetDate;/// Why this definition was chosen, when a revision recorded a reason.
+ String? get rationale;/// Set **only on an immutable spec snapshot**, naming the goal entry it
+/// belongs to; null on the goal itself. Denormalized into the journal
+/// row's `subtype` (the `HabitCompletionData.habitId` precedent) so a
+/// goal's version history is an indexed `type + subtype` lookup rather
+/// than a scan, and so a snapshot emits its goal as a precise wake token.
+ String? get snapshotOf;
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GoalDataCopyWith<GoalData> get copyWith => _$GoalDataCopyWithImpl<GoalData>(this as GoalData, _$identity);
+
+  /// Serializes this GoalData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalData&&(identical(other.title, title) || other.title == title)&&(identical(other.statement, statement) || other.statement == statement)&&(identical(other.criteria, criteria) || other.criteria == criteria)&&(identical(other.specVersion, specVersion) || other.specVersion == specVersion)&&(identical(other.specVersionId, specVersionId) || other.specVersionId == specVersionId)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.targetDate, targetDate) || other.targetDate == targetDate)&&(identical(other.rationale, rationale) || other.rationale == rationale)&&(identical(other.snapshotOf, snapshotOf) || other.snapshotOf == snapshotOf));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,statement,criteria,specVersion,specVersionId,startDate,targetDate,rationale,snapshotOf);
+
+@override
+String toString() {
+  return 'GoalData(title: $title, statement: $statement, criteria: $criteria, specVersion: $specVersion, specVersionId: $specVersionId, startDate: $startDate, targetDate: $targetDate, rationale: $rationale, snapshotOf: $snapshotOf)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GoalDataCopyWith<$Res>  {
+  factory $GoalDataCopyWith(GoalData value, $Res Function(GoalData) _then) = _$GoalDataCopyWithImpl;
+@useResult
+$Res call({
+ String title, String statement, GoalCriterion criteria, int specVersion, String specVersionId, DateTime? startDate, DateTime? targetDate, String? rationale, String? snapshotOf
+});
+
+
+$GoalCriterionCopyWith<$Res> get criteria;
+
+}
+/// @nodoc
+class _$GoalDataCopyWithImpl<$Res>
+    implements $GoalDataCopyWith<$Res> {
+  _$GoalDataCopyWithImpl(this._self, this._then);
+
+  final GoalData _self;
+  final $Res Function(GoalData) _then;
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? statement = null,Object? criteria = null,Object? specVersion = null,Object? specVersionId = null,Object? startDate = freezed,Object? targetDate = freezed,Object? rationale = freezed,Object? snapshotOf = freezed,}) {
+  return _then(_self.copyWith(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,statement: null == statement ? _self.statement : statement // ignore: cast_nullable_to_non_nullable
+as String,criteria: null == criteria ? _self.criteria : criteria // ignore: cast_nullable_to_non_nullable
+as GoalCriterion,specVersion: null == specVersion ? _self.specVersion : specVersion // ignore: cast_nullable_to_non_nullable
+as int,specVersionId: null == specVersionId ? _self.specVersionId : specVersionId // ignore: cast_nullable_to_non_nullable
+as String,startDate: freezed == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,targetDate: freezed == targetDate ? _self.targetDate : targetDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,rationale: freezed == rationale ? _self.rationale : rationale // ignore: cast_nullable_to_non_nullable
+as String?,snapshotOf: freezed == snapshotOf ? _self.snapshotOf : snapshotOf // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalCriterionCopyWith<$Res> get criteria {
+  
+  return $GoalCriterionCopyWith<$Res>(_self.criteria, (value) {
+    return _then(_self.copyWith(criteria: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [GoalData].
+extension GoalDataPatterns on GoalData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GoalData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GoalData value)  $default,){
+final _that = this;
+switch (_that) {
+case _GoalData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GoalData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String statement,  GoalCriterion criteria,  int specVersion,  String specVersionId,  DateTime? startDate,  DateTime? targetDate,  String? rationale,  String? snapshotOf)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that.title,_that.statement,_that.criteria,_that.specVersion,_that.specVersionId,_that.startDate,_that.targetDate,_that.rationale,_that.snapshotOf);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String statement,  GoalCriterion criteria,  int specVersion,  String specVersionId,  DateTime? startDate,  DateTime? targetDate,  String? rationale,  String? snapshotOf)  $default,) {final _that = this;
+switch (_that) {
+case _GoalData():
+return $default(_that.title,_that.statement,_that.criteria,_that.specVersion,_that.specVersionId,_that.startDate,_that.targetDate,_that.rationale,_that.snapshotOf);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String statement,  GoalCriterion criteria,  int specVersion,  String specVersionId,  DateTime? startDate,  DateTime? targetDate,  String? rationale,  String? snapshotOf)?  $default,) {final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that.title,_that.statement,_that.criteria,_that.specVersion,_that.specVersionId,_that.startDate,_that.targetDate,_that.rationale,_that.snapshotOf);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GoalData implements GoalData {
+  const _GoalData({required this.title, required this.statement, required this.criteria, required this.specVersion, required this.specVersionId, this.startDate, this.targetDate, this.rationale, this.snapshotOf});
+  factory _GoalData.fromJson(Map<String, dynamic> json) => _$GoalDataFromJson(json);
+
+/// The goal's short name, as the user wrote it ("Blood pressure").
+@override final  String title;
+/// The speakable form: "Average 10,000 steps a day over a rolling week."
+@override final  String statement;
+/// The criteria tree success is defined in. Its leaves reference habit,
+/// measurable, category and label definitions by their stable ids.
+@override final  GoalCriterion criteria;
+/// Monotonic ordinal of the current definition, 1-based. Increments on
+/// every accepted revision.
+@override final  int specVersion;
+/// Id of the snapshot row holding this exact definition. Registers and
+/// reflections pin to it, so their verdicts stay attributable to the
+/// criteria that produced them.
+@override final  String specVersionId;
+/// When the goal starts counting; null means "from creation".
+@override final  DateTime? startDate;
+/// Optional deadline. Once passed, the track policy resolves to
+/// achieved/off-track instead of granting grace.
+@override final  DateTime? targetDate;
+/// Why this definition was chosen, when a revision recorded a reason.
+@override final  String? rationale;
+/// Set **only on an immutable spec snapshot**, naming the goal entry it
+/// belongs to; null on the goal itself. Denormalized into the journal
+/// row's `subtype` (the `HabitCompletionData.habitId` precedent) so a
+/// goal's version history is an indexed `type + subtype` lookup rather
+/// than a scan, and so a snapshot emits its goal as a precise wake token.
+@override final  String? snapshotOf;
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GoalDataCopyWith<_GoalData> get copyWith => __$GoalDataCopyWithImpl<_GoalData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GoalDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GoalData&&(identical(other.title, title) || other.title == title)&&(identical(other.statement, statement) || other.statement == statement)&&(identical(other.criteria, criteria) || other.criteria == criteria)&&(identical(other.specVersion, specVersion) || other.specVersion == specVersion)&&(identical(other.specVersionId, specVersionId) || other.specVersionId == specVersionId)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.targetDate, targetDate) || other.targetDate == targetDate)&&(identical(other.rationale, rationale) || other.rationale == rationale)&&(identical(other.snapshotOf, snapshotOf) || other.snapshotOf == snapshotOf));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,statement,criteria,specVersion,specVersionId,startDate,targetDate,rationale,snapshotOf);
+
+@override
+String toString() {
+  return 'GoalData(title: $title, statement: $statement, criteria: $criteria, specVersion: $specVersion, specVersionId: $specVersionId, startDate: $startDate, targetDate: $targetDate, rationale: $rationale, snapshotOf: $snapshotOf)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GoalDataCopyWith<$Res> implements $GoalDataCopyWith<$Res> {
+  factory _$GoalDataCopyWith(_GoalData value, $Res Function(_GoalData) _then) = __$GoalDataCopyWithImpl;
+@override @useResult
+$Res call({
+ String title, String statement, GoalCriterion criteria, int specVersion, String specVersionId, DateTime? startDate, DateTime? targetDate, String? rationale, String? snapshotOf
+});
+
+
+@override $GoalCriterionCopyWith<$Res> get criteria;
+
+}
+/// @nodoc
+class __$GoalDataCopyWithImpl<$Res>
+    implements _$GoalDataCopyWith<$Res> {
+  __$GoalDataCopyWithImpl(this._self, this._then);
+
+  final _GoalData _self;
+  final $Res Function(_GoalData) _then;
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? statement = null,Object? criteria = null,Object? specVersion = null,Object? specVersionId = null,Object? startDate = freezed,Object? targetDate = freezed,Object? rationale = freezed,Object? snapshotOf = freezed,}) {
+  return _then(_GoalData(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,statement: null == statement ? _self.statement : statement // ignore: cast_nullable_to_non_nullable
+as String,criteria: null == criteria ? _self.criteria : criteria // ignore: cast_nullable_to_non_nullable
+as GoalCriterion,specVersion: null == specVersion ? _self.specVersion : specVersion // ignore: cast_nullable_to_non_nullable
+as int,specVersionId: null == specVersionId ? _self.specVersionId : specVersionId // ignore: cast_nullable_to_non_nullable
+as String,startDate: freezed == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,targetDate: freezed == targetDate ? _self.targetDate : targetDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,rationale: freezed == rationale ? _self.rationale : rationale // ignore: cast_nullable_to_non_nullable
+as String?,snapshotOf: freezed == snapshotOf ? _self.snapshotOf : snapshotOf // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalCriterionCopyWith<$Res> get criteria {
+  
+  return $GoalCriterionCopyWith<$Res>(_self.criteria, (value) {
+    return _then(_self.copyWith(criteria: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/classes/goal_data.g.dart
+++ b/lib/classes/goal_data.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'goal_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GoalData _$GoalDataFromJson(Map<String, dynamic> json) => _GoalData(
+  title: json['title'] as String,
+  statement: json['statement'] as String,
+  criteria: GoalCriterion.fromJson(json['criteria'] as Map<String, dynamic>),
+  specVersion: (json['specVersion'] as num).toInt(),
+  specVersionId: json['specVersionId'] as String,
+  startDate: json['startDate'] == null
+      ? null
+      : DateTime.parse(json['startDate'] as String),
+  targetDate: json['targetDate'] == null
+      ? null
+      : DateTime.parse(json['targetDate'] as String),
+  rationale: json['rationale'] as String?,
+  snapshotOf: json['snapshotOf'] as String?,
+);
+
+Map<String, dynamic> _$GoalDataToJson(_GoalData instance) => <String, dynamic>{
+  'title': instance.title,
+  'statement': instance.statement,
+  'criteria': instance.criteria,
+  'specVersion': instance.specVersion,
+  'specVersionId': instance.specVersionId,
+  'startDate': instance.startDate?.toIso8601String(),
+  'targetDate': instance.targetDate?.toIso8601String(),
+  'rationale': instance.rationale,
+  'snapshotOf': instance.snapshotOf,
+};

--- a/lib/classes/journal_entities.dart
+++ b/lib/classes/journal_entities.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/event_data.dart';
 import 'package:lotti/classes/geolocation.dart';
+import 'package:lotti/classes/goal_data.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/classes/rating_data.dart';
@@ -240,6 +241,16 @@ sealed class JournalEntity with _$JournalEntity {
     Geolocation? geolocation,
   }) = CheckInEntry;
 
+  /// A long-term goal the user authored, and the container its check-ins
+  /// hang from. Also the shape of each immutable spec snapshot — see
+  /// [GoalData.snapshotOf].
+  const factory JournalEntity.goal({
+    required Metadata meta,
+    required GoalData data,
+    EntryText? entryText,
+    Geolocation? geolocation,
+  }) = GoalEntry;
+
   factory JournalEntity.fromJson(Map<String, dynamic> json) =>
       _$JournalEntityFromJson(json);
 }
@@ -314,6 +325,14 @@ extension JournalEntityExtension on JournalEntity {
         ids
           ..add(checkIn.data.relationshipId)
           ..add(checkInNotification);
+
+      // A spec snapshot also wakes its goal: the version history is part of
+      // what the goal surface renders, so writing one must refresh the goal
+      // that owns it, not only the snapshot row.
+      case final GoalEntry goal:
+        ids
+          ..addAll([?goal.data.snapshotOf])
+          ..add(goalNotification);
     }
 
     return ids;

--- a/lib/classes/journal_entities.freezed.dart
+++ b/lib/classes/journal_entities.freezed.dart
@@ -1634,6 +1634,10 @@ JournalEntity _$JournalEntityFromJson(
           return CheckInEntry.fromJson(
             json
           );
+                case 'goal':
+          return GoalEntry.fromJson(
+            json
+          );
         
           default:
             throw CheckedFromJsonException(
@@ -1758,7 +1762,7 @@ extension JournalEntityPatterns on JournalEntity {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( JournalEntry value)?  journalEntry,TResult Function( JournalImage value)?  journalImage,TResult Function( JournalAudio value)?  journalAudio,TResult Function( Task value)?  task,TResult Function( JournalEvent value)?  event,TResult Function( ChecklistItem value)?  checklistItem,TResult Function( Checklist value)?  checklist,TResult Function( QuantitativeEntry value)?  quantitative,TResult Function( MeasurementEntry value)?  measurement,TResult Function( AiResponseEntry value)?  aiResponse,TResult Function( WorkoutEntry value)?  workout,TResult Function( HabitCompletionEntry value)?  habitCompletion,TResult Function( SurveyEntry value)?  survey,TResult Function( DayPlanEntry value)?  dayPlan,TResult Function( RatingEntry value)?  rating,TResult Function( ProjectEntry value)?  project,TResult Function( RelationshipEntry value)?  relationship,TResult Function( CheckInEntry value)?  checkIn,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( JournalEntry value)?  journalEntry,TResult Function( JournalImage value)?  journalImage,TResult Function( JournalAudio value)?  journalAudio,TResult Function( Task value)?  task,TResult Function( JournalEvent value)?  event,TResult Function( ChecklistItem value)?  checklistItem,TResult Function( Checklist value)?  checklist,TResult Function( QuantitativeEntry value)?  quantitative,TResult Function( MeasurementEntry value)?  measurement,TResult Function( AiResponseEntry value)?  aiResponse,TResult Function( WorkoutEntry value)?  workout,TResult Function( HabitCompletionEntry value)?  habitCompletion,TResult Function( SurveyEntry value)?  survey,TResult Function( DayPlanEntry value)?  dayPlan,TResult Function( RatingEntry value)?  rating,TResult Function( ProjectEntry value)?  project,TResult Function( RelationshipEntry value)?  relationship,TResult Function( CheckInEntry value)?  checkIn,TResult Function( GoalEntry value)?  goal,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
@@ -1779,7 +1783,8 @@ return dayPlan(_that);case RatingEntry() when rating != null:
 return rating(_that);case ProjectEntry() when project != null:
 return project(_that);case RelationshipEntry() when relationship != null:
 return relationship(_that);case CheckInEntry() when checkIn != null:
-return checkIn(_that);case _:
+return checkIn(_that);case GoalEntry() when goal != null:
+return goal(_that);case _:
   return orElse();
 
 }
@@ -1797,7 +1802,7 @@ return checkIn(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( JournalEntry value)  journalEntry,required TResult Function( JournalImage value)  journalImage,required TResult Function( JournalAudio value)  journalAudio,required TResult Function( Task value)  task,required TResult Function( JournalEvent value)  event,required TResult Function( ChecklistItem value)  checklistItem,required TResult Function( Checklist value)  checklist,required TResult Function( QuantitativeEntry value)  quantitative,required TResult Function( MeasurementEntry value)  measurement,required TResult Function( AiResponseEntry value)  aiResponse,required TResult Function( WorkoutEntry value)  workout,required TResult Function( HabitCompletionEntry value)  habitCompletion,required TResult Function( SurveyEntry value)  survey,required TResult Function( DayPlanEntry value)  dayPlan,required TResult Function( RatingEntry value)  rating,required TResult Function( ProjectEntry value)  project,required TResult Function( RelationshipEntry value)  relationship,required TResult Function( CheckInEntry value)  checkIn,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( JournalEntry value)  journalEntry,required TResult Function( JournalImage value)  journalImage,required TResult Function( JournalAudio value)  journalAudio,required TResult Function( Task value)  task,required TResult Function( JournalEvent value)  event,required TResult Function( ChecklistItem value)  checklistItem,required TResult Function( Checklist value)  checklist,required TResult Function( QuantitativeEntry value)  quantitative,required TResult Function( MeasurementEntry value)  measurement,required TResult Function( AiResponseEntry value)  aiResponse,required TResult Function( WorkoutEntry value)  workout,required TResult Function( HabitCompletionEntry value)  habitCompletion,required TResult Function( SurveyEntry value)  survey,required TResult Function( DayPlanEntry value)  dayPlan,required TResult Function( RatingEntry value)  rating,required TResult Function( ProjectEntry value)  project,required TResult Function( RelationshipEntry value)  relationship,required TResult Function( CheckInEntry value)  checkIn,required TResult Function( GoalEntry value)  goal,}){
 final _that = this;
 switch (_that) {
 case JournalEntry():
@@ -1818,7 +1823,8 @@ return dayPlan(_that);case RatingEntry():
 return rating(_that);case ProjectEntry():
 return project(_that);case RelationshipEntry():
 return relationship(_that);case CheckInEntry():
-return checkIn(_that);}
+return checkIn(_that);case GoalEntry():
+return goal(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -1832,7 +1838,7 @@ return checkIn(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( JournalEntry value)?  journalEntry,TResult? Function( JournalImage value)?  journalImage,TResult? Function( JournalAudio value)?  journalAudio,TResult? Function( Task value)?  task,TResult? Function( JournalEvent value)?  event,TResult? Function( ChecklistItem value)?  checklistItem,TResult? Function( Checklist value)?  checklist,TResult? Function( QuantitativeEntry value)?  quantitative,TResult? Function( MeasurementEntry value)?  measurement,TResult? Function( AiResponseEntry value)?  aiResponse,TResult? Function( WorkoutEntry value)?  workout,TResult? Function( HabitCompletionEntry value)?  habitCompletion,TResult? Function( SurveyEntry value)?  survey,TResult? Function( DayPlanEntry value)?  dayPlan,TResult? Function( RatingEntry value)?  rating,TResult? Function( ProjectEntry value)?  project,TResult? Function( RelationshipEntry value)?  relationship,TResult? Function( CheckInEntry value)?  checkIn,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( JournalEntry value)?  journalEntry,TResult? Function( JournalImage value)?  journalImage,TResult? Function( JournalAudio value)?  journalAudio,TResult? Function( Task value)?  task,TResult? Function( JournalEvent value)?  event,TResult? Function( ChecklistItem value)?  checklistItem,TResult? Function( Checklist value)?  checklist,TResult? Function( QuantitativeEntry value)?  quantitative,TResult? Function( MeasurementEntry value)?  measurement,TResult? Function( AiResponseEntry value)?  aiResponse,TResult? Function( WorkoutEntry value)?  workout,TResult? Function( HabitCompletionEntry value)?  habitCompletion,TResult? Function( SurveyEntry value)?  survey,TResult? Function( DayPlanEntry value)?  dayPlan,TResult? Function( RatingEntry value)?  rating,TResult? Function( ProjectEntry value)?  project,TResult? Function( RelationshipEntry value)?  relationship,TResult? Function( CheckInEntry value)?  checkIn,TResult? Function( GoalEntry value)?  goal,}){
 final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
@@ -1853,7 +1859,8 @@ return dayPlan(_that);case RatingEntry() when rating != null:
 return rating(_that);case ProjectEntry() when project != null:
 return project(_that);case RelationshipEntry() when relationship != null:
 return relationship(_that);case CheckInEntry() when checkIn != null:
-return checkIn(_that);case _:
+return checkIn(_that);case GoalEntry() when goal != null:
+return goal(_that);case _:
   return null;
 
 }
@@ -1870,7 +1877,7 @@ return checkIn(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,TResult Function( Metadata meta,  GoalData data,  EntryText? entryText,  Geolocation? geolocation)?  goal,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
 return journalEntry(_that.meta,_that.entryText,_that.geolocation);case JournalImage() when journalImage != null:
@@ -1890,7 +1897,8 @@ return dayPlan(_that.meta,_that.data,_that.entryText,_that.geolocation);case Rat
 return rating(_that.meta,_that.data,_that.entryText,_that.geolocation);case ProjectEntry() when project != null:
 return project(_that.meta,_that.data,_that.entryText,_that.geolocation);case RelationshipEntry() when relationship != null:
 return relationship(_that.meta,_that.data,_that.entryText,_that.geolocation);case CheckInEntry() when checkIn != null:
-return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
+return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case GoalEntry() when goal != null:
+return goal(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
   return orElse();
 
 }
@@ -1908,7 +1916,7 @@ return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)  journalEntry,required TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)  journalImage,required TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)  journalAudio,required TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)  task,required TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)  event,required TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)  checklistItem,required TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)  checklist,required TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)  quantitative,required TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)  measurement,required TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)  aiResponse,required TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)  workout,required TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)  habitCompletion,required TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)  survey,required TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)  dayPlan,required TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)  rating,required TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)  project,required TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)  relationship,required TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)  checkIn,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)  journalEntry,required TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)  journalImage,required TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)  journalAudio,required TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)  task,required TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)  event,required TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)  checklistItem,required TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)  checklist,required TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)  quantitative,required TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)  measurement,required TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)  aiResponse,required TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)  workout,required TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)  habitCompletion,required TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)  survey,required TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)  dayPlan,required TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)  rating,required TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)  project,required TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)  relationship,required TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)  checkIn,required TResult Function( Metadata meta,  GoalData data,  EntryText? entryText,  Geolocation? geolocation)  goal,}) {final _that = this;
 switch (_that) {
 case JournalEntry():
 return journalEntry(_that.meta,_that.entryText,_that.geolocation);case JournalImage():
@@ -1928,7 +1936,8 @@ return dayPlan(_that.meta,_that.data,_that.entryText,_that.geolocation);case Rat
 return rating(_that.meta,_that.data,_that.entryText,_that.geolocation);case ProjectEntry():
 return project(_that.meta,_that.data,_that.entryText,_that.geolocation);case RelationshipEntry():
 return relationship(_that.meta,_that.data,_that.entryText,_that.geolocation);case CheckInEntry():
-return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);}
+return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case GoalEntry():
+return goal(_that.meta,_that.data,_that.entryText,_that.geolocation);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -1942,7 +1951,7 @@ return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult? Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult? Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult? Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult? Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult? Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult? Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult? Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult? Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult? Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult? Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult? Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult? Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult? Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult? Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult? Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult? Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult? Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult? Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult? Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult? Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult? Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult? Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult? Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult? Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult? Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult? Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult? Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult? Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult? Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult? Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult? Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult? Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult? Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult? Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,TResult? Function( Metadata meta,  GoalData data,  EntryText? entryText,  Geolocation? geolocation)?  goal,}) {final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
 return journalEntry(_that.meta,_that.entryText,_that.geolocation);case JournalImage() when journalImage != null:
@@ -1962,7 +1971,8 @@ return dayPlan(_that.meta,_that.data,_that.entryText,_that.geolocation);case Rat
 return rating(_that.meta,_that.data,_that.entryText,_that.geolocation);case ProjectEntry() when project != null:
 return project(_that.meta,_that.data,_that.entryText,_that.geolocation);case RelationshipEntry() when relationship != null:
 return relationship(_that.meta,_that.data,_that.entryText,_that.geolocation);case CheckInEntry() when checkIn != null:
-return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
+return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case GoalEntry() when goal != null:
+return goal(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
   return null;
 
 }
@@ -4108,6 +4118,127 @@ $MetadataCopyWith<$Res> get meta {
 $CheckInDataCopyWith<$Res> get data {
   
   return $CheckInDataCopyWith<$Res>(_self.data, (value) {
+    return _then(_self.copyWith(data: value));
+  });
+}/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EntryTextCopyWith<$Res>? get entryText {
+    if (_self.entryText == null) {
+    return null;
+  }
+
+  return $EntryTextCopyWith<$Res>(_self.entryText!, (value) {
+    return _then(_self.copyWith(entryText: value));
+  });
+}/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GeolocationCopyWith<$Res>? get geolocation {
+    if (_self.geolocation == null) {
+    return null;
+  }
+
+  return $GeolocationCopyWith<$Res>(_self.geolocation!, (value) {
+    return _then(_self.copyWith(geolocation: value));
+  });
+}
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class GoalEntry implements JournalEntity {
+  const GoalEntry({required this.meta, required this.data, this.entryText, this.geolocation, final  String? $type}): $type = $type ?? 'goal';
+  factory GoalEntry.fromJson(Map<String, dynamic> json) => _$GoalEntryFromJson(json);
+
+@override final  Metadata meta;
+ final  GoalData data;
+@override final  EntryText? entryText;
+@override final  Geolocation? geolocation;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GoalEntryCopyWith<GoalEntry> get copyWith => _$GoalEntryCopyWithImpl<GoalEntry>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GoalEntryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalEntry&&(identical(other.meta, meta) || other.meta == meta)&&(identical(other.data, data) || other.data == data)&&(identical(other.entryText, entryText) || other.entryText == entryText)&&(identical(other.geolocation, geolocation) || other.geolocation == geolocation));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,meta,data,entryText,geolocation);
+
+@override
+String toString() {
+  return 'JournalEntity.goal(meta: $meta, data: $data, entryText: $entryText, geolocation: $geolocation)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GoalEntryCopyWith<$Res> implements $JournalEntityCopyWith<$Res> {
+  factory $GoalEntryCopyWith(GoalEntry value, $Res Function(GoalEntry) _then) = _$GoalEntryCopyWithImpl;
+@override @useResult
+$Res call({
+ Metadata meta, GoalData data, EntryText? entryText, Geolocation? geolocation
+});
+
+
+@override $MetadataCopyWith<$Res> get meta;$GoalDataCopyWith<$Res> get data;@override $EntryTextCopyWith<$Res>? get entryText;@override $GeolocationCopyWith<$Res>? get geolocation;
+
+}
+/// @nodoc
+class _$GoalEntryCopyWithImpl<$Res>
+    implements $GoalEntryCopyWith<$Res> {
+  _$GoalEntryCopyWithImpl(this._self, this._then);
+
+  final GoalEntry _self;
+  final $Res Function(GoalEntry) _then;
+
+/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? meta = null,Object? data = null,Object? entryText = freezed,Object? geolocation = freezed,}) {
+  return _then(GoalEntry(
+meta: null == meta ? _self.meta : meta // ignore: cast_nullable_to_non_nullable
+as Metadata,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as GoalData,entryText: freezed == entryText ? _self.entryText : entryText // ignore: cast_nullable_to_non_nullable
+as EntryText?,geolocation: freezed == geolocation ? _self.geolocation : geolocation // ignore: cast_nullable_to_non_nullable
+as Geolocation?,
+  ));
+}
+
+/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$MetadataCopyWith<$Res> get meta {
+  
+  return $MetadataCopyWith<$Res>(_self.meta, (value) {
+    return _then(_self.copyWith(meta: value));
+  });
+}/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalDataCopyWith<$Res> get data {
+  
+  return $GoalDataCopyWith<$Res>(_self.data, (value) {
     return _then(_self.copyWith(data: value));
   });
 }/// Create a copy of JournalEntity

--- a/lib/classes/journal_entities.g.dart
+++ b/lib/classes/journal_entities.g.dart
@@ -536,3 +536,23 @@ Map<String, dynamic> _$CheckInEntryToJson(CheckInEntry instance) =>
       'geolocation': instance.geolocation,
       'runtimeType': instance.$type,
     };
+
+GoalEntry _$GoalEntryFromJson(Map<String, dynamic> json) => GoalEntry(
+  meta: Metadata.fromJson(json['meta'] as Map<String, dynamic>),
+  data: GoalData.fromJson(json['data'] as Map<String, dynamic>),
+  entryText: json['entryText'] == null
+      ? null
+      : EntryText.fromJson(json['entryText'] as Map<String, dynamic>),
+  geolocation: json['geolocation'] == null
+      ? null
+      : Geolocation.fromJson(json['geolocation'] as Map<String, dynamic>),
+  $type: json['runtimeType'] as String?,
+);
+
+Map<String, dynamic> _$GoalEntryToJson(GoalEntry instance) => <String, dynamic>{
+  'meta': instance.meta,
+  'data': instance.data,
+  'entryText': instance.entryText,
+  'geolocation': instance.geolocation,
+  'runtimeType': instance.$type,
+};

--- a/lib/database/conversions.dart
+++ b/lib/database/conversions.dart
@@ -23,6 +23,10 @@ JournalDbEntity toDbEntity(JournalEntity entity) {
     // Denormalized so "check-ins for relationship" is a plain indexed
     // type+subtype filter, the habitCompletion/habitId precedent.
     checkIn: (CheckInEntry entry) => entry.data.relationshipId,
+    // Empty on the goal itself, the owning goal id on a spec snapshot, so
+    // "this goal's version history" is an indexed type+subtype lookup and
+    // "every goal" is the rows with no subtype.
+    goal: (GoalEntry entry) => entry.data.snapshotOf ?? '',
     orElse: () => '',
   );
 
@@ -103,6 +107,7 @@ JournalDbEntity toDbEntity(JournalEntity entity) {
       project: (_) => 'Project',
       relationship: (_) => 'Relationship',
       checkIn: (_) => 'CheckIn',
+      goal: (_) => 'Goal',
     ),
     subtype: subtype,
     serialized: json.encode(entity),

--- a/lib/features/journal/ui/widgets/list_cards/journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/journal_card.dart
@@ -295,6 +295,17 @@ class _EntryCardContent extends StatelessWidget {
         ),
         secondary: _contentRemainder(context, c.entryText),
       ),
+      // A goal is a container, not a journal moment: its home is the Goals
+      // tab, and its own detail surface is far richer than a list row. It is
+      // rendered here only so the switch stays exhaustive — the goal list
+      // query excludes spec snapshots, and goals themselves are not offered by
+      // the journal's entry-type filter.
+      final GoalEntry g => _scaffold(
+        context,
+        icon: Icons.flag_rounded,
+        iconColor: _categoryColor(context, item),
+        title: _titleText(context, g.data.title),
+      ),
     };
   }
 

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -115,6 +115,7 @@ const ratingNotification = 'RATING';
 const projectNotification = 'PROJECT';
 const relationshipNotification = 'RELATIONSHIP';
 const checkInNotification = 'CHECK_IN';
+const goalNotification = 'GOAL';
 const categoriesNotification = 'CATEGORIES_CHANGED';
 const habitsNotification = 'HABITS_CHANGED';
 const dashboardsNotification = 'DASHBOARDS_CHANGED';

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -34,6 +34,7 @@ String folderForJournalEntity(JournalEntity journalEntity) {
     project: (_) => 'projects',
     relationship: (_) => 'relationships',
     checkIn: (_) => 'check_ins',
+    goal: (_) => 'goals',
   );
 }
 
@@ -57,6 +58,7 @@ String typeSuffix(JournalEntity journalEntity) {
     project: (_) => 'project',
     relationship: (_) => 'relationship',
     checkIn: (_) => 'check_in',
+    goal: (_) => 'goal',
   );
 }
 

--- a/test/classes/goal_data_test.dart
+++ b/test/classes/goal_data_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_data.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+
+/// A two-leaf criteria tree referencing a habit and a measurable data type —
+/// the two definition kinds a goal most commonly binds to. Used to prove the
+/// nested tree survives serialization rather than collapsing to its root.
+const _criteria = GoalCriterion.allOf(
+  criterionId: 'root',
+  criteria: [
+    GoalCriterion.habit(
+      criterionId: 'walk-daily',
+      habitId: 'habit-walk',
+      targetCount: 5,
+      window: GoalWindow.rollingDays(count: 7),
+    ),
+    GoalCriterion.measurable(
+      criterionId: 'systolic',
+      dataTypeId: 'measurable-systolic',
+      target: 130,
+      window: GoalWindow.rollingDays(count: 7),
+      aggregation: GoalAggregation.dailySumThenAverage,
+      direction: GoalDirection.atMost,
+    ),
+  ],
+);
+
+void main() {
+  group('GoalData', () {
+    test('round-trips through JSON with the criteria tree intact', () {
+      final data = GoalData(
+        title: 'Blood pressure',
+        statement: 'Average under 130 systolic over a rolling week.',
+        criteria: _criteria,
+        specVersion: 3,
+        specVersionId: 'snapshot-v3',
+        startDate: DateTime.utc(2026, 8, 3),
+        targetDate: DateTime.utc(2026, 12, 31),
+        rationale: 'Cardiologist asked for a three-month trend.',
+      );
+
+      final restored = GoalData.fromJson(
+        jsonDecode(jsonEncode(data)) as Map<String, dynamic>,
+      );
+
+      expect(restored, data);
+      // The tree specifically: a shallow copyWith-style comparison would pass
+      // even if the children were dropped, since equality is structural only
+      // when the children actually survive.
+      final root = restored.criteria as GoalCriterionAllOf;
+      expect(root.criteria, hasLength(2));
+      expect(
+        root.criteria.whereType<GoalCriterionHabit>().single.habitId,
+        'habit-walk',
+      );
+      expect(
+        root.criteria.whereType<GoalCriterionMeasurable>().single.dataTypeId,
+        'measurable-systolic',
+      );
+    });
+
+    test('a goal is not a snapshot; a snapshot names the goal it belongs to',
+        () {
+      const goal = GoalData(
+        title: 'Blood pressure',
+        statement: 'Average under 130 systolic over a rolling week.',
+        criteria: _criteria,
+        specVersion: 3,
+        specVersionId: 'snapshot-v3',
+      );
+      final snapshot = goal.copyWith(snapshotOf: 'goal-1');
+
+      expect(goal.snapshotOf, isNull);
+      expect(goal.isSpecSnapshot, isFalse);
+      expect(snapshot.isSpecSnapshot, isTrue);
+      expect(snapshot.snapshotOf, 'goal-1');
+    });
+
+    test('a serialized goal still resolves the definitions it references', () {
+      // The reason a goal belongs in the journal database at all: its
+      // referents are journal-side definitions. Resolve them from the
+      // ROUND-TRIPPED tree, so a serialization that silently dropped a
+      // criterion id fails here rather than at evaluation time.
+      final restored = GoalData.fromJson(
+        jsonDecode(
+          jsonEncode(
+            const GoalData(
+              title: 'Blood pressure',
+              statement: 'Average under 130 systolic over a rolling week.',
+              criteria: _criteria,
+              specVersion: 1,
+              specVersionId: 'snapshot-v1',
+            ),
+          ),
+        ) as Map<String, dynamic>,
+      );
+
+      expect(goalCriterionHabitIds(restored.criteria), {'habit-walk'});
+    });
+  });
+}

--- a/test/database/conversions_test.dart
+++ b/test/database/conversions_test.dart
@@ -446,6 +446,7 @@ void main() {
         project: (_) => throw StateError('unexpected variant'),
         relationship: (_) => throw StateError('unexpected variant'),
         checkIn: (_) => throw StateError('unexpected variant'),
+        goal: (_) => throw StateError('unexpected variant'),
       );
     }
 


### PR DESCRIPTION
Stacked PR **1 of 3** · base: `main`

Gives a goal a journal-side entity, so the thing the user authored stops living
only in the agent database.

## Why

`profile_backup_catalog.dart` states the repository's own position:

| Store | `required` | Rationale (verbatim) |
|---|---|---|
| `journal` | **`true`** | "Primary journal, task, definition, and **link authority**." |
| `agents` | `false` | "Owns agent state, history, proposals, and observations." |

Restoring a profile without the agent database is therefore a supported state —
but a goal existed *only* there, so that restore silently lost goals the user
had written.

A goal is also the odd one out in its own family. Its criteria are written
entirely in terms of journal-side definitions: `habitId` names a
`HabitDefinition`, `dataTypeId` a `MeasurableDataType`, `categoryId` a
`CategoryDefinition`, `labelId` a `LabelDefinition`. Every referent of a goal
already lives in the journal database; only the goal itself did not.

## What

- `GoalData` — title, statement, criteria, `specVersion`/`specVersionId`,
  start/target dates, rationale, and `snapshotOf`.
- `JournalEntity.goal` → `GoalEntry`, stored in the `journal` table. Serialized
  payload, so **no schema migration**.
- Two row shapes, one type: a goal carries no `subtype`; an immutable spec
  snapshot carries its goal's id (the `HabitCompletionData.habitId` /
  `CheckInData.relationshipId` precedent), so version history rides the existing
  `idx_journal_type_subtype` index.
- `affectedIds` emits the owning goal for a snapshot, so writing one refreshes
  the goal that owns it.
- Sync sidecar folder/type names for the new variant.

## Why the goal row is stable

A goal is one entry whose id never changes, so links from its check-ins survive
every revision of the criteria. Each revision writes a separate immutable
snapshot row instead of mutating the goal — which is what keeps `specVersionId`
resolvable for the registers and reflections pinned to it.

## Not in this PR

Agent↔goal linking (PR 2), the repository (PR 3), dual-write at the spec-minting
seams, and the backfill for existing goals. Nothing reads `GoalEntry` yet.

Refs `lotti3-aa4`.
