### PR TITLE
feat(goals): bind a goal agent to the goal it coaches

### DIFF
--- a/lib/classes/goal_data.dart
+++ b/lib/classes/goal_data.dart
@@ -1,0 +1,83 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+
+part 'goal_data.freezed.dart';
+part 'goal_data.g.dart';
+
+/// Payload of a `JournalEntity.goal` — a long-term goal the user authored,
+/// and the container its check-ins hang from.
+///
+/// **Why this lives in the journal database.** A goal's criteria are written
+/// entirely in terms of other journal-side definitions: `habitId` names a
+/// `HabitDefinition`, `dataTypeId` a `MeasurableDataType`, `categoryId` a
+/// `CategoryDefinition`, `labelId` a `LabelDefinition`. Every referent of a
+/// goal is a definition in the journal database, which the backup catalog
+/// declares `required: true` and "the primary journal, task, definition, and
+/// link authority" — while the agent database it used to live in is
+/// `required: false`. A goal was the one member of its own family stored on
+/// the disposable side, so restoring a profile without the agent database
+/// silently lost goals the user had written. It no longer can.
+///
+/// The goal agent — the coach that evaluates this definition, keeps a
+/// standing report and speaks through banners — remains agent-side and
+/// optional, bound to this entry by an `AgentLink.agentGoal`, exactly as an
+/// event agent binds to its `JournalEvent`. Losing it costs the user their
+/// coach, never their goal or their check-ins.
+///
+/// **Two row shapes, one type.** A goal is one stable entry whose id never
+/// changes, so the links to its check-ins survive every revision of the
+/// criteria. Each revision additionally writes an immutable *snapshot* row
+/// carrying the criteria as they stood, with [snapshotOf] naming the goal it
+/// belongs to; [specVersionId] on the goal points at the snapshot standing
+/// for the current definition. Snapshots are what `goalProgress` registers and
+/// daily reflections pin themselves to, so a verdict passed under old criteria
+/// is never re-read as a judgement of the current ones.
+@freezed
+abstract class GoalData with _$GoalData {
+  const factory GoalData({
+    /// The goal's short name, as the user wrote it ("Blood pressure").
+    required String title,
+
+    /// The speakable form: "Average 10,000 steps a day over a rolling week."
+    required String statement,
+
+    /// The criteria tree success is defined in. Its leaves reference habit,
+    /// measurable, category and label definitions by their stable ids.
+    required GoalCriterion criteria,
+
+    /// Monotonic ordinal of the current definition, 1-based. Increments on
+    /// every accepted revision.
+    required int specVersion,
+
+    /// Id of the snapshot row holding this exact definition. Registers and
+    /// reflections pin to it, so their verdicts stay attributable to the
+    /// criteria that produced them.
+    required String specVersionId,
+
+    /// When the goal starts counting; null means "from creation".
+    DateTime? startDate,
+
+    /// Optional deadline. Once passed, the track policy resolves to
+    /// achieved/off-track instead of granting grace.
+    DateTime? targetDate,
+
+    /// Why this definition was chosen, when a revision recorded a reason.
+    String? rationale,
+
+    /// Set **only on an immutable spec snapshot**, naming the goal entry it
+    /// belongs to; null on the goal itself. Denormalized into the journal
+    /// row's `subtype` (the `HabitCompletionData.habitId` precedent) so a
+    /// goal's version history is an indexed `type + subtype` lookup rather
+    /// than a scan, and so a snapshot emits its goal as a precise wake token.
+    String? snapshotOf,
+  }) = _GoalData;
+
+  factory GoalData.fromJson(Map<String, dynamic> json) =>
+      _$GoalDataFromJson(json);
+}
+
+extension GoalDataExtension on GoalData {
+  /// Whether this row is an immutable record of a past or present definition
+  /// rather than the goal itself. Snapshots are never listed as goals.
+  bool get isSpecSnapshot => snapshotOf != null;
+}

--- a/lib/classes/goal_data.freezed.dart
+++ b/lib/classes/goal_data.freezed.dart
@@ -1,0 +1,355 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'goal_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GoalData {
+
+/// The goal's short name, as the user wrote it ("Blood pressure").
+ String get title;/// The speakable form: "Average 10,000 steps a day over a rolling week."
+ String get statement;/// The criteria tree success is defined in. Its leaves reference habit,
+/// measurable, category and label definitions by their stable ids.
+ GoalCriterion get criteria;/// Monotonic ordinal of the current definition, 1-based. Increments on
+/// every accepted revision.
+ int get specVersion;/// Id of the snapshot row holding this exact definition. Registers and
+/// reflections pin to it, so their verdicts stay attributable to the
+/// criteria that produced them.
+ String get specVersionId;/// When the goal starts counting; null means "from creation".
+ DateTime? get startDate;/// Optional deadline. Once passed, the track policy resolves to
+/// achieved/off-track instead of granting grace.
+ DateTime? get targetDate;/// Why this definition was chosen, when a revision recorded a reason.
+ String? get rationale;/// Set **only on an immutable spec snapshot**, naming the goal entry it
+/// belongs to; null on the goal itself. Denormalized into the journal
+/// row's `subtype` (the `HabitCompletionData.habitId` precedent) so a
+/// goal's version history is an indexed `type + subtype` lookup rather
+/// than a scan, and so a snapshot emits its goal as a precise wake token.
+ String? get snapshotOf;
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GoalDataCopyWith<GoalData> get copyWith => _$GoalDataCopyWithImpl<GoalData>(this as GoalData, _$identity);
+
+  /// Serializes this GoalData to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalData&&(identical(other.title, title) || other.title == title)&&(identical(other.statement, statement) || other.statement == statement)&&(identical(other.criteria, criteria) || other.criteria == criteria)&&(identical(other.specVersion, specVersion) || other.specVersion == specVersion)&&(identical(other.specVersionId, specVersionId) || other.specVersionId == specVersionId)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.targetDate, targetDate) || other.targetDate == targetDate)&&(identical(other.rationale, rationale) || other.rationale == rationale)&&(identical(other.snapshotOf, snapshotOf) || other.snapshotOf == snapshotOf));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,statement,criteria,specVersion,specVersionId,startDate,targetDate,rationale,snapshotOf);
+
+@override
+String toString() {
+  return 'GoalData(title: $title, statement: $statement, criteria: $criteria, specVersion: $specVersion, specVersionId: $specVersionId, startDate: $startDate, targetDate: $targetDate, rationale: $rationale, snapshotOf: $snapshotOf)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GoalDataCopyWith<$Res>  {
+  factory $GoalDataCopyWith(GoalData value, $Res Function(GoalData) _then) = _$GoalDataCopyWithImpl;
+@useResult
+$Res call({
+ String title, String statement, GoalCriterion criteria, int specVersion, String specVersionId, DateTime? startDate, DateTime? targetDate, String? rationale, String? snapshotOf
+});
+
+
+$GoalCriterionCopyWith<$Res> get criteria;
+
+}
+/// @nodoc
+class _$GoalDataCopyWithImpl<$Res>
+    implements $GoalDataCopyWith<$Res> {
+  _$GoalDataCopyWithImpl(this._self, this._then);
+
+  final GoalData _self;
+  final $Res Function(GoalData) _then;
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? statement = null,Object? criteria = null,Object? specVersion = null,Object? specVersionId = null,Object? startDate = freezed,Object? targetDate = freezed,Object? rationale = freezed,Object? snapshotOf = freezed,}) {
+  return _then(_self.copyWith(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,statement: null == statement ? _self.statement : statement // ignore: cast_nullable_to_non_nullable
+as String,criteria: null == criteria ? _self.criteria : criteria // ignore: cast_nullable_to_non_nullable
+as GoalCriterion,specVersion: null == specVersion ? _self.specVersion : specVersion // ignore: cast_nullable_to_non_nullable
+as int,specVersionId: null == specVersionId ? _self.specVersionId : specVersionId // ignore: cast_nullable_to_non_nullable
+as String,startDate: freezed == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,targetDate: freezed == targetDate ? _self.targetDate : targetDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,rationale: freezed == rationale ? _self.rationale : rationale // ignore: cast_nullable_to_non_nullable
+as String?,snapshotOf: freezed == snapshotOf ? _self.snapshotOf : snapshotOf // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalCriterionCopyWith<$Res> get criteria {
+  
+  return $GoalCriterionCopyWith<$Res>(_self.criteria, (value) {
+    return _then(_self.copyWith(criteria: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [GoalData].
+extension GoalDataPatterns on GoalData {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GoalData value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GoalData value)  $default,){
+final _that = this;
+switch (_that) {
+case _GoalData():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GoalData value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String statement,  GoalCriterion criteria,  int specVersion,  String specVersionId,  DateTime? startDate,  DateTime? targetDate,  String? rationale,  String? snapshotOf)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that.title,_that.statement,_that.criteria,_that.specVersion,_that.specVersionId,_that.startDate,_that.targetDate,_that.rationale,_that.snapshotOf);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String statement,  GoalCriterion criteria,  int specVersion,  String specVersionId,  DateTime? startDate,  DateTime? targetDate,  String? rationale,  String? snapshotOf)  $default,) {final _that = this;
+switch (_that) {
+case _GoalData():
+return $default(_that.title,_that.statement,_that.criteria,_that.specVersion,_that.specVersionId,_that.startDate,_that.targetDate,_that.rationale,_that.snapshotOf);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String statement,  GoalCriterion criteria,  int specVersion,  String specVersionId,  DateTime? startDate,  DateTime? targetDate,  String? rationale,  String? snapshotOf)?  $default,) {final _that = this;
+switch (_that) {
+case _GoalData() when $default != null:
+return $default(_that.title,_that.statement,_that.criteria,_that.specVersion,_that.specVersionId,_that.startDate,_that.targetDate,_that.rationale,_that.snapshotOf);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GoalData implements GoalData {
+  const _GoalData({required this.title, required this.statement, required this.criteria, required this.specVersion, required this.specVersionId, this.startDate, this.targetDate, this.rationale, this.snapshotOf});
+  factory _GoalData.fromJson(Map<String, dynamic> json) => _$GoalDataFromJson(json);
+
+/// The goal's short name, as the user wrote it ("Blood pressure").
+@override final  String title;
+/// The speakable form: "Average 10,000 steps a day over a rolling week."
+@override final  String statement;
+/// The criteria tree success is defined in. Its leaves reference habit,
+/// measurable, category and label definitions by their stable ids.
+@override final  GoalCriterion criteria;
+/// Monotonic ordinal of the current definition, 1-based. Increments on
+/// every accepted revision.
+@override final  int specVersion;
+/// Id of the snapshot row holding this exact definition. Registers and
+/// reflections pin to it, so their verdicts stay attributable to the
+/// criteria that produced them.
+@override final  String specVersionId;
+/// When the goal starts counting; null means "from creation".
+@override final  DateTime? startDate;
+/// Optional deadline. Once passed, the track policy resolves to
+/// achieved/off-track instead of granting grace.
+@override final  DateTime? targetDate;
+/// Why this definition was chosen, when a revision recorded a reason.
+@override final  String? rationale;
+/// Set **only on an immutable spec snapshot**, naming the goal entry it
+/// belongs to; null on the goal itself. Denormalized into the journal
+/// row's `subtype` (the `HabitCompletionData.habitId` precedent) so a
+/// goal's version history is an indexed `type + subtype` lookup rather
+/// than a scan, and so a snapshot emits its goal as a precise wake token.
+@override final  String? snapshotOf;
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GoalDataCopyWith<_GoalData> get copyWith => __$GoalDataCopyWithImpl<_GoalData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GoalDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GoalData&&(identical(other.title, title) || other.title == title)&&(identical(other.statement, statement) || other.statement == statement)&&(identical(other.criteria, criteria) || other.criteria == criteria)&&(identical(other.specVersion, specVersion) || other.specVersion == specVersion)&&(identical(other.specVersionId, specVersionId) || other.specVersionId == specVersionId)&&(identical(other.startDate, startDate) || other.startDate == startDate)&&(identical(other.targetDate, targetDate) || other.targetDate == targetDate)&&(identical(other.rationale, rationale) || other.rationale == rationale)&&(identical(other.snapshotOf, snapshotOf) || other.snapshotOf == snapshotOf));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,statement,criteria,specVersion,specVersionId,startDate,targetDate,rationale,snapshotOf);
+
+@override
+String toString() {
+  return 'GoalData(title: $title, statement: $statement, criteria: $criteria, specVersion: $specVersion, specVersionId: $specVersionId, startDate: $startDate, targetDate: $targetDate, rationale: $rationale, snapshotOf: $snapshotOf)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GoalDataCopyWith<$Res> implements $GoalDataCopyWith<$Res> {
+  factory _$GoalDataCopyWith(_GoalData value, $Res Function(_GoalData) _then) = __$GoalDataCopyWithImpl;
+@override @useResult
+$Res call({
+ String title, String statement, GoalCriterion criteria, int specVersion, String specVersionId, DateTime? startDate, DateTime? targetDate, String? rationale, String? snapshotOf
+});
+
+
+@override $GoalCriterionCopyWith<$Res> get criteria;
+
+}
+/// @nodoc
+class __$GoalDataCopyWithImpl<$Res>
+    implements _$GoalDataCopyWith<$Res> {
+  __$GoalDataCopyWithImpl(this._self, this._then);
+
+  final _GoalData _self;
+  final $Res Function(_GoalData) _then;
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? statement = null,Object? criteria = null,Object? specVersion = null,Object? specVersionId = null,Object? startDate = freezed,Object? targetDate = freezed,Object? rationale = freezed,Object? snapshotOf = freezed,}) {
+  return _then(_GoalData(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,statement: null == statement ? _self.statement : statement // ignore: cast_nullable_to_non_nullable
+as String,criteria: null == criteria ? _self.criteria : criteria // ignore: cast_nullable_to_non_nullable
+as GoalCriterion,specVersion: null == specVersion ? _self.specVersion : specVersion // ignore: cast_nullable_to_non_nullable
+as int,specVersionId: null == specVersionId ? _self.specVersionId : specVersionId // ignore: cast_nullable_to_non_nullable
+as String,startDate: freezed == startDate ? _self.startDate : startDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,targetDate: freezed == targetDate ? _self.targetDate : targetDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,rationale: freezed == rationale ? _self.rationale : rationale // ignore: cast_nullable_to_non_nullable
+as String?,snapshotOf: freezed == snapshotOf ? _self.snapshotOf : snapshotOf // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of GoalData
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalCriterionCopyWith<$Res> get criteria {
+  
+  return $GoalCriterionCopyWith<$Res>(_self.criteria, (value) {
+    return _then(_self.copyWith(criteria: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/classes/goal_data.g.dart
+++ b/lib/classes/goal_data.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'goal_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GoalData _$GoalDataFromJson(Map<String, dynamic> json) => _GoalData(
+  title: json['title'] as String,
+  statement: json['statement'] as String,
+  criteria: GoalCriterion.fromJson(json['criteria'] as Map<String, dynamic>),
+  specVersion: (json['specVersion'] as num).toInt(),
+  specVersionId: json['specVersionId'] as String,
+  startDate: json['startDate'] == null
+      ? null
+      : DateTime.parse(json['startDate'] as String),
+  targetDate: json['targetDate'] == null
+      ? null
+      : DateTime.parse(json['targetDate'] as String),
+  rationale: json['rationale'] as String?,
+  snapshotOf: json['snapshotOf'] as String?,
+);
+
+Map<String, dynamic> _$GoalDataToJson(_GoalData instance) => <String, dynamic>{
+  'title': instance.title,
+  'statement': instance.statement,
+  'criteria': instance.criteria,
+  'specVersion': instance.specVersion,
+  'specVersionId': instance.specVersionId,
+  'startDate': instance.startDate?.toIso8601String(),
+  'targetDate': instance.targetDate?.toIso8601String(),
+  'rationale': instance.rationale,
+  'snapshotOf': instance.snapshotOf,
+};

--- a/lib/classes/journal_entities.dart
+++ b/lib/classes/journal_entities.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/event_data.dart';
 import 'package:lotti/classes/geolocation.dart';
+import 'package:lotti/classes/goal_data.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/classes/rating_data.dart';
@@ -240,6 +241,16 @@ sealed class JournalEntity with _$JournalEntity {
     Geolocation? geolocation,
   }) = CheckInEntry;
 
+  /// A long-term goal the user authored, and the container its check-ins
+  /// hang from. Also the shape of each immutable spec snapshot — see
+  /// [GoalData.snapshotOf].
+  const factory JournalEntity.goal({
+    required Metadata meta,
+    required GoalData data,
+    EntryText? entryText,
+    Geolocation? geolocation,
+  }) = GoalEntry;
+
   factory JournalEntity.fromJson(Map<String, dynamic> json) =>
       _$JournalEntityFromJson(json);
 }
@@ -314,6 +325,14 @@ extension JournalEntityExtension on JournalEntity {
         ids
           ..add(checkIn.data.relationshipId)
           ..add(checkInNotification);
+
+      // A spec snapshot also wakes its goal: the version history is part of
+      // what the goal surface renders, so writing one must refresh the goal
+      // that owns it, not only the snapshot row.
+      case final GoalEntry goal:
+        ids
+          ..addAll([?goal.data.snapshotOf])
+          ..add(goalNotification);
     }
 
     return ids;

--- a/lib/classes/journal_entities.freezed.dart
+++ b/lib/classes/journal_entities.freezed.dart
@@ -1634,6 +1634,10 @@ JournalEntity _$JournalEntityFromJson(
           return CheckInEntry.fromJson(
             json
           );
+                case 'goal':
+          return GoalEntry.fromJson(
+            json
+          );
         
           default:
             throw CheckedFromJsonException(
@@ -1758,7 +1762,7 @@ extension JournalEntityPatterns on JournalEntity {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( JournalEntry value)?  journalEntry,TResult Function( JournalImage value)?  journalImage,TResult Function( JournalAudio value)?  journalAudio,TResult Function( Task value)?  task,TResult Function( JournalEvent value)?  event,TResult Function( ChecklistItem value)?  checklistItem,TResult Function( Checklist value)?  checklist,TResult Function( QuantitativeEntry value)?  quantitative,TResult Function( MeasurementEntry value)?  measurement,TResult Function( AiResponseEntry value)?  aiResponse,TResult Function( WorkoutEntry value)?  workout,TResult Function( HabitCompletionEntry value)?  habitCompletion,TResult Function( SurveyEntry value)?  survey,TResult Function( DayPlanEntry value)?  dayPlan,TResult Function( RatingEntry value)?  rating,TResult Function( ProjectEntry value)?  project,TResult Function( RelationshipEntry value)?  relationship,TResult Function( CheckInEntry value)?  checkIn,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( JournalEntry value)?  journalEntry,TResult Function( JournalImage value)?  journalImage,TResult Function( JournalAudio value)?  journalAudio,TResult Function( Task value)?  task,TResult Function( JournalEvent value)?  event,TResult Function( ChecklistItem value)?  checklistItem,TResult Function( Checklist value)?  checklist,TResult Function( QuantitativeEntry value)?  quantitative,TResult Function( MeasurementEntry value)?  measurement,TResult Function( AiResponseEntry value)?  aiResponse,TResult Function( WorkoutEntry value)?  workout,TResult Function( HabitCompletionEntry value)?  habitCompletion,TResult Function( SurveyEntry value)?  survey,TResult Function( DayPlanEntry value)?  dayPlan,TResult Function( RatingEntry value)?  rating,TResult Function( ProjectEntry value)?  project,TResult Function( RelationshipEntry value)?  relationship,TResult Function( CheckInEntry value)?  checkIn,TResult Function( GoalEntry value)?  goal,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
@@ -1779,7 +1783,8 @@ return dayPlan(_that);case RatingEntry() when rating != null:
 return rating(_that);case ProjectEntry() when project != null:
 return project(_that);case RelationshipEntry() when relationship != null:
 return relationship(_that);case CheckInEntry() when checkIn != null:
-return checkIn(_that);case _:
+return checkIn(_that);case GoalEntry() when goal != null:
+return goal(_that);case _:
   return orElse();
 
 }
@@ -1797,7 +1802,7 @@ return checkIn(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( JournalEntry value)  journalEntry,required TResult Function( JournalImage value)  journalImage,required TResult Function( JournalAudio value)  journalAudio,required TResult Function( Task value)  task,required TResult Function( JournalEvent value)  event,required TResult Function( ChecklistItem value)  checklistItem,required TResult Function( Checklist value)  checklist,required TResult Function( QuantitativeEntry value)  quantitative,required TResult Function( MeasurementEntry value)  measurement,required TResult Function( AiResponseEntry value)  aiResponse,required TResult Function( WorkoutEntry value)  workout,required TResult Function( HabitCompletionEntry value)  habitCompletion,required TResult Function( SurveyEntry value)  survey,required TResult Function( DayPlanEntry value)  dayPlan,required TResult Function( RatingEntry value)  rating,required TResult Function( ProjectEntry value)  project,required TResult Function( RelationshipEntry value)  relationship,required TResult Function( CheckInEntry value)  checkIn,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( JournalEntry value)  journalEntry,required TResult Function( JournalImage value)  journalImage,required TResult Function( JournalAudio value)  journalAudio,required TResult Function( Task value)  task,required TResult Function( JournalEvent value)  event,required TResult Function( ChecklistItem value)  checklistItem,required TResult Function( Checklist value)  checklist,required TResult Function( QuantitativeEntry value)  quantitative,required TResult Function( MeasurementEntry value)  measurement,required TResult Function( AiResponseEntry value)  aiResponse,required TResult Function( WorkoutEntry value)  workout,required TResult Function( HabitCompletionEntry value)  habitCompletion,required TResult Function( SurveyEntry value)  survey,required TResult Function( DayPlanEntry value)  dayPlan,required TResult Function( RatingEntry value)  rating,required TResult Function( ProjectEntry value)  project,required TResult Function( RelationshipEntry value)  relationship,required TResult Function( CheckInEntry value)  checkIn,required TResult Function( GoalEntry value)  goal,}){
 final _that = this;
 switch (_that) {
 case JournalEntry():
@@ -1818,7 +1823,8 @@ return dayPlan(_that);case RatingEntry():
 return rating(_that);case ProjectEntry():
 return project(_that);case RelationshipEntry():
 return relationship(_that);case CheckInEntry():
-return checkIn(_that);}
+return checkIn(_that);case GoalEntry():
+return goal(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -1832,7 +1838,7 @@ return checkIn(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( JournalEntry value)?  journalEntry,TResult? Function( JournalImage value)?  journalImage,TResult? Function( JournalAudio value)?  journalAudio,TResult? Function( Task value)?  task,TResult? Function( JournalEvent value)?  event,TResult? Function( ChecklistItem value)?  checklistItem,TResult? Function( Checklist value)?  checklist,TResult? Function( QuantitativeEntry value)?  quantitative,TResult? Function( MeasurementEntry value)?  measurement,TResult? Function( AiResponseEntry value)?  aiResponse,TResult? Function( WorkoutEntry value)?  workout,TResult? Function( HabitCompletionEntry value)?  habitCompletion,TResult? Function( SurveyEntry value)?  survey,TResult? Function( DayPlanEntry value)?  dayPlan,TResult? Function( RatingEntry value)?  rating,TResult? Function( ProjectEntry value)?  project,TResult? Function( RelationshipEntry value)?  relationship,TResult? Function( CheckInEntry value)?  checkIn,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( JournalEntry value)?  journalEntry,TResult? Function( JournalImage value)?  journalImage,TResult? Function( JournalAudio value)?  journalAudio,TResult? Function( Task value)?  task,TResult? Function( JournalEvent value)?  event,TResult? Function( ChecklistItem value)?  checklistItem,TResult? Function( Checklist value)?  checklist,TResult? Function( QuantitativeEntry value)?  quantitative,TResult? Function( MeasurementEntry value)?  measurement,TResult? Function( AiResponseEntry value)?  aiResponse,TResult? Function( WorkoutEntry value)?  workout,TResult? Function( HabitCompletionEntry value)?  habitCompletion,TResult? Function( SurveyEntry value)?  survey,TResult? Function( DayPlanEntry value)?  dayPlan,TResult? Function( RatingEntry value)?  rating,TResult? Function( ProjectEntry value)?  project,TResult? Function( RelationshipEntry value)?  relationship,TResult? Function( CheckInEntry value)?  checkIn,TResult? Function( GoalEntry value)?  goal,}){
 final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
@@ -1853,7 +1859,8 @@ return dayPlan(_that);case RatingEntry() when rating != null:
 return rating(_that);case ProjectEntry() when project != null:
 return project(_that);case RelationshipEntry() when relationship != null:
 return relationship(_that);case CheckInEntry() when checkIn != null:
-return checkIn(_that);case _:
+return checkIn(_that);case GoalEntry() when goal != null:
+return goal(_that);case _:
   return null;
 
 }
@@ -1870,7 +1877,7 @@ return checkIn(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,TResult Function( Metadata meta,  GoalData data,  EntryText? entryText,  Geolocation? geolocation)?  goal,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
 return journalEntry(_that.meta,_that.entryText,_that.geolocation);case JournalImage() when journalImage != null:
@@ -1890,7 +1897,8 @@ return dayPlan(_that.meta,_that.data,_that.entryText,_that.geolocation);case Rat
 return rating(_that.meta,_that.data,_that.entryText,_that.geolocation);case ProjectEntry() when project != null:
 return project(_that.meta,_that.data,_that.entryText,_that.geolocation);case RelationshipEntry() when relationship != null:
 return relationship(_that.meta,_that.data,_that.entryText,_that.geolocation);case CheckInEntry() when checkIn != null:
-return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
+return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case GoalEntry() when goal != null:
+return goal(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
   return orElse();
 
 }
@@ -1908,7 +1916,7 @@ return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)  journalEntry,required TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)  journalImage,required TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)  journalAudio,required TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)  task,required TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)  event,required TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)  checklistItem,required TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)  checklist,required TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)  quantitative,required TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)  measurement,required TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)  aiResponse,required TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)  workout,required TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)  habitCompletion,required TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)  survey,required TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)  dayPlan,required TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)  rating,required TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)  project,required TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)  relationship,required TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)  checkIn,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)  journalEntry,required TResult Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)  journalImage,required TResult Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)  journalAudio,required TResult Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)  task,required TResult Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)  event,required TResult Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)  checklistItem,required TResult Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)  checklist,required TResult Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)  quantitative,required TResult Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)  measurement,required TResult Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)  aiResponse,required TResult Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)  workout,required TResult Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)  habitCompletion,required TResult Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)  survey,required TResult Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)  dayPlan,required TResult Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)  rating,required TResult Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)  project,required TResult Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)  relationship,required TResult Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)  checkIn,required TResult Function( Metadata meta,  GoalData data,  EntryText? entryText,  Geolocation? geolocation)  goal,}) {final _that = this;
 switch (_that) {
 case JournalEntry():
 return journalEntry(_that.meta,_that.entryText,_that.geolocation);case JournalImage():
@@ -1928,7 +1936,8 @@ return dayPlan(_that.meta,_that.data,_that.entryText,_that.geolocation);case Rat
 return rating(_that.meta,_that.data,_that.entryText,_that.geolocation);case ProjectEntry():
 return project(_that.meta,_that.data,_that.entryText,_that.geolocation);case RelationshipEntry():
 return relationship(_that.meta,_that.data,_that.entryText,_that.geolocation);case CheckInEntry():
-return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);}
+return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case GoalEntry():
+return goal(_that.meta,_that.data,_that.entryText,_that.geolocation);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -1942,7 +1951,7 @@ return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult? Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult? Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult? Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult? Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult? Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult? Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult? Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult? Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult? Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult? Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult? Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult? Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult? Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult? Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult? Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult? Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult? Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( Metadata meta,  EntryText? entryText,  Geolocation? geolocation)?  journalEntry,TResult? Function( Metadata meta,  ImageData data,  EntryText? entryText,  Geolocation? geolocation)?  journalImage,TResult? Function( Metadata meta,  AudioData data,  EntryText? entryText,  Geolocation? geolocation)?  journalAudio,TResult? Function( Metadata meta,  TaskData data,  EntryText? entryText,  Geolocation? geolocation)?  task,TResult? Function( Metadata meta,  EventData data,  EntryText? entryText,  Geolocation? geolocation)?  event,TResult? Function( Metadata meta,  ChecklistItemData data,  EntryText? entryText,  Geolocation? geolocation)?  checklistItem,TResult? Function( Metadata meta,  ChecklistData data,  EntryText? entryText,  Geolocation? geolocation)?  checklist,TResult? Function( Metadata meta,  QuantitativeData data,  EntryText? entryText,  Geolocation? geolocation)?  quantitative,TResult? Function( Metadata meta,  MeasurementData data,  EntryText? entryText,  Geolocation? geolocation)?  measurement,TResult? Function( Metadata meta,  AiResponseData data,  EntryText? entryText,  Geolocation? geolocation)?  aiResponse,TResult? Function( Metadata meta,  WorkoutData data,  EntryText? entryText,  Geolocation? geolocation)?  workout,TResult? Function( Metadata meta,  HabitCompletionData data,  EntryText? entryText,  Geolocation? geolocation)?  habitCompletion,TResult? Function( Metadata meta,  SurveyData data,  EntryText? entryText,  Geolocation? geolocation)?  survey,TResult? Function( Metadata meta,  DayPlanData data,  EntryText? entryText,  Geolocation? geolocation)?  dayPlan,TResult? Function( Metadata meta,  RatingData data,  EntryText? entryText,  Geolocation? geolocation)?  rating,TResult? Function( Metadata meta,  ProjectData data,  EntryText? entryText,  Geolocation? geolocation)?  project,TResult? Function( Metadata meta,  RelationshipData data,  EntryText? entryText,  Geolocation? geolocation)?  relationship,TResult? Function( Metadata meta,  CheckInData data,  EntryText? entryText,  Geolocation? geolocation)?  checkIn,TResult? Function( Metadata meta,  GoalData data,  EntryText? entryText,  Geolocation? geolocation)?  goal,}) {final _that = this;
 switch (_that) {
 case JournalEntry() when journalEntry != null:
 return journalEntry(_that.meta,_that.entryText,_that.geolocation);case JournalImage() when journalImage != null:
@@ -1962,7 +1971,8 @@ return dayPlan(_that.meta,_that.data,_that.entryText,_that.geolocation);case Rat
 return rating(_that.meta,_that.data,_that.entryText,_that.geolocation);case ProjectEntry() when project != null:
 return project(_that.meta,_that.data,_that.entryText,_that.geolocation);case RelationshipEntry() when relationship != null:
 return relationship(_that.meta,_that.data,_that.entryText,_that.geolocation);case CheckInEntry() when checkIn != null:
-return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
+return checkIn(_that.meta,_that.data,_that.entryText,_that.geolocation);case GoalEntry() when goal != null:
+return goal(_that.meta,_that.data,_that.entryText,_that.geolocation);case _:
   return null;
 
 }
@@ -4108,6 +4118,127 @@ $MetadataCopyWith<$Res> get meta {
 $CheckInDataCopyWith<$Res> get data {
   
   return $CheckInDataCopyWith<$Res>(_self.data, (value) {
+    return _then(_self.copyWith(data: value));
+  });
+}/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EntryTextCopyWith<$Res>? get entryText {
+    if (_self.entryText == null) {
+    return null;
+  }
+
+  return $EntryTextCopyWith<$Res>(_self.entryText!, (value) {
+    return _then(_self.copyWith(entryText: value));
+  });
+}/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GeolocationCopyWith<$Res>? get geolocation {
+    if (_self.geolocation == null) {
+    return null;
+  }
+
+  return $GeolocationCopyWith<$Res>(_self.geolocation!, (value) {
+    return _then(_self.copyWith(geolocation: value));
+  });
+}
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class GoalEntry implements JournalEntity {
+  const GoalEntry({required this.meta, required this.data, this.entryText, this.geolocation, final  String? $type}): $type = $type ?? 'goal';
+  factory GoalEntry.fromJson(Map<String, dynamic> json) => _$GoalEntryFromJson(json);
+
+@override final  Metadata meta;
+ final  GoalData data;
+@override final  EntryText? entryText;
+@override final  Geolocation? geolocation;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GoalEntryCopyWith<GoalEntry> get copyWith => _$GoalEntryCopyWithImpl<GoalEntry>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GoalEntryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GoalEntry&&(identical(other.meta, meta) || other.meta == meta)&&(identical(other.data, data) || other.data == data)&&(identical(other.entryText, entryText) || other.entryText == entryText)&&(identical(other.geolocation, geolocation) || other.geolocation == geolocation));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,meta,data,entryText,geolocation);
+
+@override
+String toString() {
+  return 'JournalEntity.goal(meta: $meta, data: $data, entryText: $entryText, geolocation: $geolocation)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GoalEntryCopyWith<$Res> implements $JournalEntityCopyWith<$Res> {
+  factory $GoalEntryCopyWith(GoalEntry value, $Res Function(GoalEntry) _then) = _$GoalEntryCopyWithImpl;
+@override @useResult
+$Res call({
+ Metadata meta, GoalData data, EntryText? entryText, Geolocation? geolocation
+});
+
+
+@override $MetadataCopyWith<$Res> get meta;$GoalDataCopyWith<$Res> get data;@override $EntryTextCopyWith<$Res>? get entryText;@override $GeolocationCopyWith<$Res>? get geolocation;
+
+}
+/// @nodoc
+class _$GoalEntryCopyWithImpl<$Res>
+    implements $GoalEntryCopyWith<$Res> {
+  _$GoalEntryCopyWithImpl(this._self, this._then);
+
+  final GoalEntry _self;
+  final $Res Function(GoalEntry) _then;
+
+/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? meta = null,Object? data = null,Object? entryText = freezed,Object? geolocation = freezed,}) {
+  return _then(GoalEntry(
+meta: null == meta ? _self.meta : meta // ignore: cast_nullable_to_non_nullable
+as Metadata,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as GoalData,entryText: freezed == entryText ? _self.entryText : entryText // ignore: cast_nullable_to_non_nullable
+as EntryText?,geolocation: freezed == geolocation ? _self.geolocation : geolocation // ignore: cast_nullable_to_non_nullable
+as Geolocation?,
+  ));
+}
+
+/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$MetadataCopyWith<$Res> get meta {
+  
+  return $MetadataCopyWith<$Res>(_self.meta, (value) {
+    return _then(_self.copyWith(meta: value));
+  });
+}/// Create a copy of JournalEntity
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GoalDataCopyWith<$Res> get data {
+  
+  return $GoalDataCopyWith<$Res>(_self.data, (value) {
     return _then(_self.copyWith(data: value));
   });
 }/// Create a copy of JournalEntity

--- a/lib/classes/journal_entities.g.dart
+++ b/lib/classes/journal_entities.g.dart
@@ -536,3 +536,23 @@ Map<String, dynamic> _$CheckInEntryToJson(CheckInEntry instance) =>
       'geolocation': instance.geolocation,
       'runtimeType': instance.$type,
     };
+
+GoalEntry _$GoalEntryFromJson(Map<String, dynamic> json) => GoalEntry(
+  meta: Metadata.fromJson(json['meta'] as Map<String, dynamic>),
+  data: GoalData.fromJson(json['data'] as Map<String, dynamic>),
+  entryText: json['entryText'] == null
+      ? null
+      : EntryText.fromJson(json['entryText'] as Map<String, dynamic>),
+  geolocation: json['geolocation'] == null
+      ? null
+      : Geolocation.fromJson(json['geolocation'] as Map<String, dynamic>),
+  $type: json['runtimeType'] as String?,
+);
+
+Map<String, dynamic> _$GoalEntryToJson(GoalEntry instance) => <String, dynamic>{
+  'meta': instance.meta,
+  'data': instance.data,
+  'entryText': instance.entryText,
+  'geolocation': instance.geolocation,
+  'runtimeType': instance.$type,
+};

--- a/lib/database/conversions.dart
+++ b/lib/database/conversions.dart
@@ -23,6 +23,10 @@ JournalDbEntity toDbEntity(JournalEntity entity) {
     // Denormalized so "check-ins for relationship" is a plain indexed
     // type+subtype filter, the habitCompletion/habitId precedent.
     checkIn: (CheckInEntry entry) => entry.data.relationshipId,
+    // Empty on the goal itself, the owning goal id on a spec snapshot, so
+    // "this goal's version history" is an indexed type+subtype lookup and
+    // "every goal" is the rows with no subtype.
+    goal: (GoalEntry entry) => entry.data.snapshotOf ?? '',
     orElse: () => '',
   );
 
@@ -103,6 +107,7 @@ JournalDbEntity toDbEntity(JournalEntity entity) {
       project: (_) => 'Project',
       relationship: (_) => 'Relationship',
       checkIn: (_) => 'CheckIn',
+      goal: (_) => 'Goal',
     ),
     subtype: subtype,
     serialized: json.encode(entity),

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -28,6 +28,7 @@ part 'database_config_flags.dart';
 part 'database_data_queries.dart';
 part 'database_definitions.dart';
 part 'database_entity_ops.dart';
+part 'database_goal_queries.dart';
 part 'database_insights_queries.dart';
 part 'database_journal_queries.dart';
 part 'database_links_ratings.dart';
@@ -118,6 +119,7 @@ class JournalDb extends _$JournalDb
         _JournalDbTaskQueries,
         _JournalDbTaskDueQueries,
         _JournalDbProjectQueries,
+        _JournalDbGoalQueries,
         _JournalDbRelationshipQueries,
         _JournalDbLinksRatings,
         _JournalDbDataQueries,

--- a/lib/database/database_goal_queries.dart
+++ b/lib/database/database_goal_queries.dart
@@ -1,0 +1,65 @@
+part of 'database.dart';
+
+/// Goal query surface for [JournalDb].
+///
+/// Goals and their immutable spec snapshots share the `Goal` row type and are
+/// told apart by the denormalized `subtype` column: empty on a goal, the owning
+/// goal's id on a snapshot (the habit-completion precedent, no schema change).
+/// Both queries therefore ride the existing `idx_journal_type_subtype` index.
+mixin _JournalDbGoalQueries on _$JournalDb, _JournalDbConfigFlags {
+  /// Every non-deleted goal, newest first. Spec snapshots are excluded — they
+  /// are the version history of a goal, not goals in their own right.
+  Future<List<GoalEntry>> getGoals() async {
+    final rows = await _queryWithPrivateFilter(
+      allPrivate: () => _goalRows().get(),
+      filtered: (statuses) => _goalRows(privateStatuses: statuses).get(),
+    );
+    return rows.map(fromDbEntity).whereType<GoalEntry>().toList();
+  }
+
+  /// The immutable spec snapshots belonging to [goalId], newest version first.
+  Future<List<GoalEntry>> getSpecSnapshotsForGoal(String goalId) async {
+    final rows = await _queryWithPrivateFilter(
+      allPrivate: () => _goalSnapshotRows(goalId).get(),
+      filtered: (statuses) =>
+          _goalSnapshotRows(goalId, privateStatuses: statuses).get(),
+    );
+    return rows.map(fromDbEntity).whereType<GoalEntry>().toList();
+  }
+
+  SimpleSelectStatement<Journal, JournalDbEntity> _goalRows({
+    List<bool>? privateStatuses,
+  }) {
+    return select(journal)
+      ..where((t) {
+        var predicate =
+            t.type.equals('Goal') &
+            // A goal carries no subtype; a snapshot carries its goal's id.
+            t.subtype.equals('') &
+            t.deleted.equals(false);
+        if (privateStatuses != null) {
+          predicate = predicate & t.private.isIn(privateStatuses);
+        }
+        return predicate;
+      })
+      ..orderBy([(t) => OrderingTerm.desc(t.dateFrom)]);
+  }
+
+  SimpleSelectStatement<Journal, JournalDbEntity> _goalSnapshotRows(
+    String goalId, {
+    List<bool>? privateStatuses,
+  }) {
+    return select(journal)
+      ..where((t) {
+        var predicate =
+            t.type.equals('Goal') &
+            t.subtype.equals(goalId) &
+            t.deleted.equals(false);
+        if (privateStatuses != null) {
+          predicate = predicate & t.private.isIn(privateStatuses);
+        }
+        return predicate;
+      })
+      ..orderBy([(t) => OrderingTerm.desc(t.dateFrom)]);
+  }
+}

--- a/lib/features/agents/database/agent_db_conversions.dart
+++ b/lib/features/agents/database/agent_db_conversions.dart
@@ -213,6 +213,7 @@ class AgentDbConversions {
       improverTarget: (l) => l.deletedAt,
       agentProject: (l) => l.deletedAt,
       agentEvent: (l) => l.deletedAt,
+      agentGoal: (l) => l.deletedAt,
       agentDay: (l) => l.deletedAt,
       soulAssignment: (l) => l.deletedAt,
     );
@@ -447,6 +448,7 @@ class AgentDbConversions {
       improverTarget: (_) => AgentLinkTypes.improverTarget,
       agentProject: (_) => AgentLinkTypes.agentProject,
       agentEvent: (_) => AgentLinkTypes.agentEvent,
+      agentGoal: (_) => AgentLinkTypes.agentGoal,
       agentDay: (_) => AgentLinkTypes.agentDay,
       soulAssignment: (_) => AgentLinkTypes.soulAssignment,
     );

--- a/lib/features/agents/model/agent_constants.dart
+++ b/lib/features/agents/model/agent_constants.dart
@@ -44,6 +44,7 @@ abstract final class AgentLinkTypes {
   static const agentProject = 'agent_project';
   static const agentDay = 'agent_day';
   static const agentEvent = 'agent_event';
+  static const agentGoal = 'agent_goal';
   static const soulAssignment = 'soul_assignment';
 }
 

--- a/lib/features/agents/model/agent_link.dart
+++ b/lib/features/agents/model/agent_link.dart
@@ -197,6 +197,23 @@ abstract class AgentLink with _$AgentLink {
     DateTime? deletedAt,
   }) = AgentEventLink;
 
+  /// Links a goal agent to the goal it coaches.
+  /// [fromId] = agent ID, [toId] = goal entry ID.
+  ///
+  /// The goal itself is a `JournalEntity.goal` in the journal database — the
+  /// store the backup catalog marks required — so this link points from the
+  /// disposable side at durable, user-authored content. Losing the agent
+  /// database costs the user their coach, never their goal or its check-ins.
+  const factory AgentLink.agentGoal({
+    required String id,
+    required String fromId,
+    required String toId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required VectorClock? vectorClock,
+    DateTime? deletedAt,
+  }) = AgentGoalLink;
+
   /// Links a day agent to the day it plans.
   /// [fromId] = agent ID, [toId] = day ID. Lets `slots.activeDayId` be derived
   /// from the synced log like the other active-slot links (State-as-Projection).
@@ -281,6 +298,7 @@ extension AgentLinkSoftDelete on AgentLink {
     improverTarget: (l) => l.copyWith(deletedAt: at, updatedAt: at),
     agentProject: (l) => l.copyWith(deletedAt: at, updatedAt: at),
     agentEvent: (l) => l.copyWith(deletedAt: at, updatedAt: at),
+    agentGoal: (l) => l.copyWith(deletedAt: at, updatedAt: at),
     agentDay: (l) => l.copyWith(deletedAt: at, updatedAt: at),
     soulAssignment: (l) => l.copyWith(deletedAt: at, updatedAt: at),
   );

--- a/lib/features/agents/model/agent_link.freezed.dart
+++ b/lib/features/agents/model/agent_link.freezed.dart
@@ -75,6 +75,10 @@ AgentLink _$AgentLinkFromJson(
           return AgentEventLink.fromJson(
             json
           );
+                case 'agentGoal':
+          return AgentGoalLink.fromJson(
+            json
+          );
                 case 'agentDay':
           return AgentDayLink.fromJson(
             json
@@ -175,7 +179,7 @@ extension AgentLinkPatterns on AgentLink {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( BasicAgentLink value)?  basic,TResult Function( AgentStateLink value)?  agentState,TResult Function( MessagePrevLink value)?  messagePrev,TResult Function( MessagePayloadLink value)?  messagePayload,TResult Function( ToolEffectLink value)?  toolEffect,TResult Function( AgentTaskLink value)?  agentTask,TResult Function( CaptureToParsedItemLink value)?  captureToParsedItem,TResult Function( ParsedItemToTaskLink value)?  parsedItemToTask,TResult Function( CaptureToPlanLink value)?  captureToPlan,TResult Function( AttentionRequestEvidenceLink value)?  attentionRequestEvidence,TResult Function( AttentionAwardRequestLink value)?  attentionAwardRequest,TResult Function( AttentionAwardPlanLink value)?  attentionAwardPlan,TResult Function( TemplateAssignmentLink value)?  templateAssignment,TResult Function( ImproverTargetLink value)?  improverTarget,TResult Function( AgentProjectLink value)?  agentProject,TResult Function( AgentEventLink value)?  agentEvent,TResult Function( AgentDayLink value)?  agentDay,TResult Function( SoulAssignmentLink value)?  soulAssignment,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( BasicAgentLink value)?  basic,TResult Function( AgentStateLink value)?  agentState,TResult Function( MessagePrevLink value)?  messagePrev,TResult Function( MessagePayloadLink value)?  messagePayload,TResult Function( ToolEffectLink value)?  toolEffect,TResult Function( AgentTaskLink value)?  agentTask,TResult Function( CaptureToParsedItemLink value)?  captureToParsedItem,TResult Function( ParsedItemToTaskLink value)?  parsedItemToTask,TResult Function( CaptureToPlanLink value)?  captureToPlan,TResult Function( AttentionRequestEvidenceLink value)?  attentionRequestEvidence,TResult Function( AttentionAwardRequestLink value)?  attentionAwardRequest,TResult Function( AttentionAwardPlanLink value)?  attentionAwardPlan,TResult Function( TemplateAssignmentLink value)?  templateAssignment,TResult Function( ImproverTargetLink value)?  improverTarget,TResult Function( AgentProjectLink value)?  agentProject,TResult Function( AgentEventLink value)?  agentEvent,TResult Function( AgentGoalLink value)?  agentGoal,TResult Function( AgentDayLink value)?  agentDay,TResult Function( SoulAssignmentLink value)?  soulAssignment,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case BasicAgentLink() when basic != null:
@@ -194,7 +198,8 @@ return attentionAwardPlan(_that);case TemplateAssignmentLink() when templateAssi
 return templateAssignment(_that);case ImproverTargetLink() when improverTarget != null:
 return improverTarget(_that);case AgentProjectLink() when agentProject != null:
 return agentProject(_that);case AgentEventLink() when agentEvent != null:
-return agentEvent(_that);case AgentDayLink() when agentDay != null:
+return agentEvent(_that);case AgentGoalLink() when agentGoal != null:
+return agentGoal(_that);case AgentDayLink() when agentDay != null:
 return agentDay(_that);case SoulAssignmentLink() when soulAssignment != null:
 return soulAssignment(_that);case _:
   return orElse();
@@ -214,7 +219,7 @@ return soulAssignment(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( BasicAgentLink value)  basic,required TResult Function( AgentStateLink value)  agentState,required TResult Function( MessagePrevLink value)  messagePrev,required TResult Function( MessagePayloadLink value)  messagePayload,required TResult Function( ToolEffectLink value)  toolEffect,required TResult Function( AgentTaskLink value)  agentTask,required TResult Function( CaptureToParsedItemLink value)  captureToParsedItem,required TResult Function( ParsedItemToTaskLink value)  parsedItemToTask,required TResult Function( CaptureToPlanLink value)  captureToPlan,required TResult Function( AttentionRequestEvidenceLink value)  attentionRequestEvidence,required TResult Function( AttentionAwardRequestLink value)  attentionAwardRequest,required TResult Function( AttentionAwardPlanLink value)  attentionAwardPlan,required TResult Function( TemplateAssignmentLink value)  templateAssignment,required TResult Function( ImproverTargetLink value)  improverTarget,required TResult Function( AgentProjectLink value)  agentProject,required TResult Function( AgentEventLink value)  agentEvent,required TResult Function( AgentDayLink value)  agentDay,required TResult Function( SoulAssignmentLink value)  soulAssignment,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( BasicAgentLink value)  basic,required TResult Function( AgentStateLink value)  agentState,required TResult Function( MessagePrevLink value)  messagePrev,required TResult Function( MessagePayloadLink value)  messagePayload,required TResult Function( ToolEffectLink value)  toolEffect,required TResult Function( AgentTaskLink value)  agentTask,required TResult Function( CaptureToParsedItemLink value)  captureToParsedItem,required TResult Function( ParsedItemToTaskLink value)  parsedItemToTask,required TResult Function( CaptureToPlanLink value)  captureToPlan,required TResult Function( AttentionRequestEvidenceLink value)  attentionRequestEvidence,required TResult Function( AttentionAwardRequestLink value)  attentionAwardRequest,required TResult Function( AttentionAwardPlanLink value)  attentionAwardPlan,required TResult Function( TemplateAssignmentLink value)  templateAssignment,required TResult Function( ImproverTargetLink value)  improverTarget,required TResult Function( AgentProjectLink value)  agentProject,required TResult Function( AgentEventLink value)  agentEvent,required TResult Function( AgentGoalLink value)  agentGoal,required TResult Function( AgentDayLink value)  agentDay,required TResult Function( SoulAssignmentLink value)  soulAssignment,}){
 final _that = this;
 switch (_that) {
 case BasicAgentLink():
@@ -233,7 +238,8 @@ return attentionAwardPlan(_that);case TemplateAssignmentLink():
 return templateAssignment(_that);case ImproverTargetLink():
 return improverTarget(_that);case AgentProjectLink():
 return agentProject(_that);case AgentEventLink():
-return agentEvent(_that);case AgentDayLink():
+return agentEvent(_that);case AgentGoalLink():
+return agentGoal(_that);case AgentDayLink():
 return agentDay(_that);case SoulAssignmentLink():
 return soulAssignment(_that);case _:
   throw StateError('Unexpected subclass');
@@ -252,7 +258,7 @@ return soulAssignment(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( BasicAgentLink value)?  basic,TResult? Function( AgentStateLink value)?  agentState,TResult? Function( MessagePrevLink value)?  messagePrev,TResult? Function( MessagePayloadLink value)?  messagePayload,TResult? Function( ToolEffectLink value)?  toolEffect,TResult? Function( AgentTaskLink value)?  agentTask,TResult? Function( CaptureToParsedItemLink value)?  captureToParsedItem,TResult? Function( ParsedItemToTaskLink value)?  parsedItemToTask,TResult? Function( CaptureToPlanLink value)?  captureToPlan,TResult? Function( AttentionRequestEvidenceLink value)?  attentionRequestEvidence,TResult? Function( AttentionAwardRequestLink value)?  attentionAwardRequest,TResult? Function( AttentionAwardPlanLink value)?  attentionAwardPlan,TResult? Function( TemplateAssignmentLink value)?  templateAssignment,TResult? Function( ImproverTargetLink value)?  improverTarget,TResult? Function( AgentProjectLink value)?  agentProject,TResult? Function( AgentEventLink value)?  agentEvent,TResult? Function( AgentDayLink value)?  agentDay,TResult? Function( SoulAssignmentLink value)?  soulAssignment,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( BasicAgentLink value)?  basic,TResult? Function( AgentStateLink value)?  agentState,TResult? Function( MessagePrevLink value)?  messagePrev,TResult? Function( MessagePayloadLink value)?  messagePayload,TResult? Function( ToolEffectLink value)?  toolEffect,TResult? Function( AgentTaskLink value)?  agentTask,TResult? Function( CaptureToParsedItemLink value)?  captureToParsedItem,TResult? Function( ParsedItemToTaskLink value)?  parsedItemToTask,TResult? Function( CaptureToPlanLink value)?  captureToPlan,TResult? Function( AttentionRequestEvidenceLink value)?  attentionRequestEvidence,TResult? Function( AttentionAwardRequestLink value)?  attentionAwardRequest,TResult? Function( AttentionAwardPlanLink value)?  attentionAwardPlan,TResult? Function( TemplateAssignmentLink value)?  templateAssignment,TResult? Function( ImproverTargetLink value)?  improverTarget,TResult? Function( AgentProjectLink value)?  agentProject,TResult? Function( AgentEventLink value)?  agentEvent,TResult? Function( AgentGoalLink value)?  agentGoal,TResult? Function( AgentDayLink value)?  agentDay,TResult? Function( SoulAssignmentLink value)?  soulAssignment,}){
 final _that = this;
 switch (_that) {
 case BasicAgentLink() when basic != null:
@@ -271,7 +277,8 @@ return attentionAwardPlan(_that);case TemplateAssignmentLink() when templateAssi
 return templateAssignment(_that);case ImproverTargetLink() when improverTarget != null:
 return improverTarget(_that);case AgentProjectLink() when agentProject != null:
 return agentProject(_that);case AgentEventLink() when agentEvent != null:
-return agentEvent(_that);case AgentDayLink() when agentDay != null:
+return agentEvent(_that);case AgentGoalLink() when agentGoal != null:
+return agentGoal(_that);case AgentDayLink() when agentDay != null:
 return agentDay(_that);case SoulAssignmentLink() when soulAssignment != null:
 return soulAssignment(_that);case _:
   return null;
@@ -290,7 +297,7 @@ return soulAssignment(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  basic,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentState,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  messagePrev,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  String? contentEntryId,  DateTime? sourceCreatedAt,  DateTime? deletedAt)?  messagePayload,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  toolEffect,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentTask,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToParsedItem,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  parsedItemToTask,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToPlan,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionRequestEvidence,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardRequest,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardPlan,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  templateAssignment,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  improverTarget,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentProject,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentEvent,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentDay,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  soulAssignment,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  basic,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentState,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  messagePrev,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  String? contentEntryId,  DateTime? sourceCreatedAt,  DateTime? deletedAt)?  messagePayload,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  toolEffect,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentTask,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToParsedItem,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  parsedItemToTask,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToPlan,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionRequestEvidence,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardRequest,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardPlan,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  templateAssignment,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  improverTarget,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentProject,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentEvent,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentGoal,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentDay,TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  soulAssignment,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case BasicAgentLink() when basic != null:
 return basic(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentStateLink() when agentState != null:
@@ -308,7 +315,8 @@ return attentionAwardPlan(_that.id,_that.fromId,_that.toId,_that.createdAt,_that
 return templateAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case ImproverTargetLink() when improverTarget != null:
 return improverTarget(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentProjectLink() when agentProject != null:
 return agentProject(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentEventLink() when agentEvent != null:
-return agentEvent(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentDayLink() when agentDay != null:
+return agentEvent(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentGoalLink() when agentGoal != null:
+return agentGoal(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentDayLink() when agentDay != null:
 return agentDay(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case SoulAssignmentLink() when soulAssignment != null:
 return soulAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case _:
   return orElse();
@@ -328,7 +336,7 @@ return soulAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.upd
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  basic,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentState,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  messagePrev,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  String? contentEntryId,  DateTime? sourceCreatedAt,  DateTime? deletedAt)  messagePayload,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  toolEffect,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentTask,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  captureToParsedItem,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  parsedItemToTask,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  captureToPlan,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  attentionRequestEvidence,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  attentionAwardRequest,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  attentionAwardPlan,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  templateAssignment,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  improverTarget,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentProject,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentEvent,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentDay,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  soulAssignment,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  basic,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentState,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  messagePrev,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  String? contentEntryId,  DateTime? sourceCreatedAt,  DateTime? deletedAt)  messagePayload,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  toolEffect,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentTask,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  captureToParsedItem,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  parsedItemToTask,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  captureToPlan,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  attentionRequestEvidence,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  attentionAwardRequest,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  attentionAwardPlan,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  templateAssignment,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  improverTarget,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentProject,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentEvent,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentGoal,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  agentDay,required TResult Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)  soulAssignment,}) {final _that = this;
 switch (_that) {
 case BasicAgentLink():
 return basic(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentStateLink():
@@ -346,7 +354,8 @@ return attentionAwardPlan(_that.id,_that.fromId,_that.toId,_that.createdAt,_that
 return templateAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case ImproverTargetLink():
 return improverTarget(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentProjectLink():
 return agentProject(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentEventLink():
-return agentEvent(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentDayLink():
+return agentEvent(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentGoalLink():
+return agentGoal(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentDayLink():
 return agentDay(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case SoulAssignmentLink():
 return soulAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case _:
   throw StateError('Unexpected subclass');
@@ -365,7 +374,7 @@ return soulAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.upd
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  basic,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentState,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  messagePrev,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  String? contentEntryId,  DateTime? sourceCreatedAt,  DateTime? deletedAt)?  messagePayload,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  toolEffect,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentTask,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToParsedItem,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  parsedItemToTask,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToPlan,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionRequestEvidence,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardRequest,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardPlan,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  templateAssignment,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  improverTarget,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentProject,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentEvent,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentDay,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  soulAssignment,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  basic,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentState,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  messagePrev,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  String? contentEntryId,  DateTime? sourceCreatedAt,  DateTime? deletedAt)?  messagePayload,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  toolEffect,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentTask,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToParsedItem,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  parsedItemToTask,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  captureToPlan,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionRequestEvidence,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardRequest,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  attentionAwardPlan,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  templateAssignment,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  improverTarget,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentProject,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentEvent,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentGoal,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  agentDay,TResult? Function( String id,  String fromId,  String toId,  DateTime createdAt,  DateTime updatedAt,  VectorClock? vectorClock,  DateTime? deletedAt)?  soulAssignment,}) {final _that = this;
 switch (_that) {
 case BasicAgentLink() when basic != null:
 return basic(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentStateLink() when agentState != null:
@@ -383,7 +392,8 @@ return attentionAwardPlan(_that.id,_that.fromId,_that.toId,_that.createdAt,_that
 return templateAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case ImproverTargetLink() when improverTarget != null:
 return improverTarget(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentProjectLink() when agentProject != null:
 return agentProject(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentEventLink() when agentEvent != null:
-return agentEvent(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentDayLink() when agentDay != null:
+return agentEvent(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentGoalLink() when agentGoal != null:
+return agentGoal(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case AgentDayLink() when agentDay != null:
 return agentDay(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case SoulAssignmentLink() when soulAssignment != null:
 return soulAssignment(_that.id,_that.fromId,_that.toId,_that.createdAt,_that.updatedAt,_that.vectorClock,_that.deletedAt);case _:
   return null;
@@ -1743,6 +1753,91 @@ class _$AgentEventLinkCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? deletedAt = freezed,}) {
   return _then(AgentEventLink(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
+as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,vectorClock: freezed == vectorClock ? _self.vectorClock : vectorClock // ignore: cast_nullable_to_non_nullable
+as VectorClock?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class AgentGoalLink implements AgentLink {
+  const AgentGoalLink({required this.id, required this.fromId, required this.toId, required this.createdAt, required this.updatedAt, required this.vectorClock, this.deletedAt, final  String? $type}): $type = $type ?? 'agentGoal';
+  factory AgentGoalLink.fromJson(Map<String, dynamic> json) => _$AgentGoalLinkFromJson(json);
+
+@override final  String id;
+@override final  String fromId;
+@override final  String toId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  VectorClock? vectorClock;
+@override final  DateTime? deletedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of AgentLink
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AgentGoalLinkCopyWith<AgentGoalLink> get copyWith => _$AgentGoalLinkCopyWithImpl<AgentGoalLink>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AgentGoalLinkToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AgentGoalLink&&(identical(other.id, id) || other.id == id)&&(identical(other.fromId, fromId) || other.fromId == fromId)&&(identical(other.toId, toId) || other.toId == toId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,fromId,toId,createdAt,updatedAt,vectorClock,deletedAt);
+
+@override
+String toString() {
+  return 'AgentLink.agentGoal(id: $id, fromId: $fromId, toId: $toId, createdAt: $createdAt, updatedAt: $updatedAt, vectorClock: $vectorClock, deletedAt: $deletedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AgentGoalLinkCopyWith<$Res> implements $AgentLinkCopyWith<$Res> {
+  factory $AgentGoalLinkCopyWith(AgentGoalLink value, $Res Function(AgentGoalLink) _then) = _$AgentGoalLinkCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String fromId, String toId, DateTime createdAt, DateTime updatedAt, VectorClock? vectorClock, DateTime? deletedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$AgentGoalLinkCopyWithImpl<$Res>
+    implements $AgentGoalLinkCopyWith<$Res> {
+  _$AgentGoalLinkCopyWithImpl(this._self, this._then);
+
+  final AgentGoalLink _self;
+  final $Res Function(AgentGoalLink) _then;
+
+/// Create a copy of AgentLink
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? fromId = null,Object? toId = null,Object? createdAt = null,Object? updatedAt = null,Object? vectorClock = freezed,Object? deletedAt = freezed,}) {
+  return _then(AgentGoalLink(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,fromId: null == fromId ? _self.fromId : fromId // ignore: cast_nullable_to_non_nullable
 as String,toId: null == toId ? _self.toId : toId // ignore: cast_nullable_to_non_nullable

--- a/lib/features/agents/model/agent_link.g.dart
+++ b/lib/features/agents/model/agent_link.g.dart
@@ -472,6 +472,34 @@ Map<String, dynamic> _$AgentEventLinkToJson(AgentEventLink instance) =>
       'runtimeType': instance.$type,
     };
 
+AgentGoalLink _$AgentGoalLinkFromJson(Map<String, dynamic> json) =>
+    AgentGoalLink(
+      id: json['id'] as String,
+      fromId: json['fromId'] as String,
+      toId: json['toId'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      vectorClock: json['vectorClock'] == null
+          ? null
+          : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
+      deletedAt: json['deletedAt'] == null
+          ? null
+          : DateTime.parse(json['deletedAt'] as String),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$AgentGoalLinkToJson(AgentGoalLink instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'fromId': instance.fromId,
+      'toId': instance.toId,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'vectorClock': instance.vectorClock,
+      'deletedAt': instance.deletedAt?.toIso8601String(),
+      'runtimeType': instance.$type,
+    };
+
 AgentDayLink _$AgentDayLinkFromJson(Map<String, dynamic> json) => AgentDayLink(
   id: json['id'] as String,
   fromId: json['fromId'] as String,

--- a/lib/features/goals/model/goal_entry_ids.dart
+++ b/lib/features/goals/model/goal_entry_ids.dart
@@ -1,0 +1,31 @@
+/// Deterministic identity inputs for the journal-side goal rows.
+///
+/// Derivation, not allocation, is the point. The backfill that gives an
+/// existing goal agent its journal entry runs on **every device that syncs
+/// that agent**, independently and without coordination. Minting random ids
+/// would have each device create its own row for the same goal, and sync would
+/// faithfully replicate all of them. Seeding the id from something the devices
+/// already agree on means they write the *same* row, and last-writer-wins
+/// merges it instead of duplicating it.
+///
+/// These return the **input string** for
+/// `PersistenceLogic.createMetadata(uuidV5Input:)`, which is the repository's
+/// existing deduplication mechanism (`MetadataService.generateId` hashes it
+/// into a UUID v5). Deliberately not a second id scheme of its own — the
+/// prefixes below are what keep the two families from colliding.
+library;
+
+/// Identity input for the goal coached by [agentId].
+///
+/// The agent id is the one identifier every device shares for a goal before
+/// the journal entry exists, which is what makes it the correct seed.
+String goalEntryUuidV5Input(String agentId) => 'goal:$agentId';
+
+/// Identity input for the immutable snapshot of one spec version.
+///
+/// Seeded with the agent-side `goalSpecVersion` id (`<agentId>:spec-v<n>`),
+/// which is already unique and immutable, so re-running the backfill
+/// re-derives the same snapshot rather than appending a duplicate of a version
+/// that has not changed.
+String goalSpecSnapshotUuidV5Input(String specVersionId) =>
+    'goal-spec:$specVersionId';

--- a/lib/features/goals/repository/goal_repository.dart
+++ b/lib/features/goals/repository/goal_repository.dart
@@ -1,0 +1,163 @@
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/logic/services/metadata_service.dart';
+
+/// Journal-side persistence for goals: the durable, user-authored half of a
+/// goal, independent of whether its coaching agent still exists.
+///
+/// Every write here is **idempotent by construction**. Both entry points are
+/// reached from paths that legitimately run more than once — the startup
+/// backfill on every device that syncs a goal, and goal creation retried after
+/// a deferred outbox flush failed — so the ids are derived (see
+/// [goalEntryUuidV5Input]) and an existing row is updated rather than
+/// duplicated.
+class GoalRepository {
+  GoalRepository({
+    required this._journalDb,
+    required this._persistenceLogic,
+    required this._metadataService,
+  });
+
+  final JournalDb _journalDb;
+  final PersistenceLogic _persistenceLogic;
+
+  /// Used only for its pure [MetadataService.generateId]. Resolving an id has
+  /// to stay free of side effects: `createMetadata` reserves AND commits a
+  /// vector-clock counter, so computing an id through it — just to look the
+  /// row up and find it already there — would burn a counter on every startup
+  /// backfill, on every device.
+  final MetadataService _metadataService;
+
+  /// The goal coached by [agentId], or null when it has no journal entry yet.
+  Future<GoalEntry?> getGoalForAgent(String agentId) async {
+    final id = _metadataService.generateId(
+      uuidV5Input: goalEntryUuidV5Input(agentId),
+    );
+    final entity = await _journalDb.journalEntityById(id);
+    return entity is GoalEntry && !entity.isDeleted ? entity : null;
+  }
+
+  /// Every goal, newest first. Spec snapshots are excluded.
+  Future<List<GoalEntry>> getGoals() => _journalDb.getGoals();
+
+  /// The immutable spec snapshots of [goalId], newest version first.
+  Future<List<GoalEntry>> getSpecSnapshots(String goalId) =>
+      _journalDb.getSpecSnapshotsForGoal(goalId);
+
+  /// Writes (or refreshes) the stable goal row for [agentId] and returns it.
+  ///
+  /// The row's id never changes across revisions, so links from its check-ins
+  /// survive every change to the criteria — which is the reason the version
+  /// history lives in separate snapshot rows rather than in this one.
+  Future<GoalEntry?> upsertGoal({
+    required String agentId,
+    required String title,
+    required String statement,
+    required GoalCriterion criteria,
+    required int specVersion,
+    required String specVersionId,
+    DateTime? startDate,
+    DateTime? targetDate,
+    String? rationale,
+    String? categoryId,
+  }) async {
+    final data = GoalData(
+      title: title,
+      statement: statement,
+      criteria: criteria,
+      specVersion: specVersion,
+      specVersionId: specVersionId,
+      startDate: startDate,
+      targetDate: targetDate,
+      rationale: rationale,
+    );
+    return _upsert(
+      uuidV5Input: goalEntryUuidV5Input(agentId),
+      data: data,
+      categoryId: categoryId,
+      // The goal's own start is its position in time, so it sorts among the
+      // user's entries where they would look for it rather than at whatever
+      // moment the backfill happened to run.
+      dateFrom: startDate,
+    );
+  }
+
+  /// Writes the immutable snapshot of one spec version, if it is not already
+  /// stored, and returns it.
+  ///
+  /// Never rewrites an existing snapshot: a version is immutable by
+  /// definition, and a re-run that "refreshed" one would silently rewrite
+  /// history that registers and reflections are pinned to.
+  Future<GoalEntry?> ensureSpecSnapshot({
+    required String goalId,
+    required String specVersionId,
+    required String title,
+    required String statement,
+    required GoalCriterion criteria,
+    required int specVersion,
+    required DateTime createdAt,
+    DateTime? startDate,
+    DateTime? targetDate,
+    String? rationale,
+    String? categoryId,
+  }) async {
+    final id = _metadataService.generateId(
+      uuidV5Input: goalSpecSnapshotUuidV5Input(specVersionId),
+    );
+    final existing = await _journalDb.journalEntityById(id);
+    if (existing is GoalEntry) return existing;
+
+    return _upsert(
+      uuidV5Input: goalSpecSnapshotUuidV5Input(specVersionId),
+      data: GoalData(
+        title: title,
+        statement: statement,
+        criteria: criteria,
+        specVersion: specVersion,
+        specVersionId: specVersionId,
+        startDate: startDate,
+        targetDate: targetDate,
+        rationale: rationale,
+        snapshotOf: goalId,
+      ),
+      categoryId: categoryId,
+      // A snapshot is dated when the version was authored, so the history
+      // reads in the order the goal actually changed.
+      dateFrom: createdAt,
+    );
+  }
+
+  Future<GoalEntry?> _upsert({
+    required String uuidV5Input,
+    required GoalData data,
+    String? categoryId,
+    DateTime? dateFrom,
+  }) async {
+    // Look the row up by its DERIVED id first. Creating metadata up front to
+    // learn the id would commit a vector-clock counter every time an existing
+    // goal was merely refreshed.
+    final id = _metadataService.generateId(uuidV5Input: uuidV5Input);
+    final existing = await _journalDb.journalEntityById(id);
+
+    if (existing is GoalEntry) {
+      final updatedMeta = await _persistenceLogic.updateMetadata(existing.meta);
+      final updated = existing.copyWith(meta: updatedMeta, data: data);
+      final saved = await _persistenceLogic.updateDbEntity(updated);
+      return (saved ?? false) ? updated : null;
+    }
+
+    final meta = await _persistenceLogic.createMetadata(
+      uuidV5Input: uuidV5Input,
+      categoryId: categoryId,
+      dateFrom: dateFrom,
+      dateTo: dateFrom,
+    );
+    final created = JournalEntity.goal(meta: meta, data: data) as GoalEntry;
+    final saved = await _persistenceLogic.createDbEntity(created);
+    return (saved ?? false) ? created : null;
+  }
+}

--- a/lib/features/journal/ui/widgets/list_cards/journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/journal_card.dart
@@ -295,6 +295,17 @@ class _EntryCardContent extends StatelessWidget {
         ),
         secondary: _contentRemainder(context, c.entryText),
       ),
+      // A goal is a container, not a journal moment: its home is the Goals
+      // tab, and its own detail surface is far richer than a list row. It is
+      // rendered here only so the switch stays exhaustive — the goal list
+      // query excludes spec snapshots, and goals themselves are not offered by
+      // the journal's entry-type filter.
+      final GoalEntry g => _scaffold(
+        context,
+        icon: Icons.flag_rounded,
+        iconColor: _categoryColor(context, item),
+        title: _titleText(context, g.data.title),
+      ),
     };
   }
 

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -115,6 +115,7 @@ const ratingNotification = 'RATING';
 const projectNotification = 'PROJECT';
 const relationshipNotification = 'RELATIONSHIP';
 const checkInNotification = 'CHECK_IN';
+const goalNotification = 'GOAL';
 const categoriesNotification = 'CATEGORIES_CHANGED';
 const habitsNotification = 'HABITS_CHANGED';
 const dashboardsNotification = 'DASHBOARDS_CHANGED';

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -34,6 +34,7 @@ String folderForJournalEntity(JournalEntity journalEntity) {
     project: (_) => 'projects',
     relationship: (_) => 'relationships',
     checkIn: (_) => 'check_ins',
+    goal: (_) => 'goals',
   );
 }
 
@@ -57,6 +58,7 @@ String typeSuffix(JournalEntity journalEntity) {
     project: (_) => 'project',
     relationship: (_) => 'relationship',
     checkIn: (_) => 'check_in',
+    goal: (_) => 'goal',
   );
 }
 

--- a/test/classes/goal_data_test.dart
+++ b/test/classes/goal_data_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_data.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+
+/// A two-leaf criteria tree referencing a habit and a measurable data type —
+/// the two definition kinds a goal most commonly binds to. Used to prove the
+/// nested tree survives serialization rather than collapsing to its root.
+const _criteria = GoalCriterion.allOf(
+  criterionId: 'root',
+  criteria: [
+    GoalCriterion.habit(
+      criterionId: 'walk-daily',
+      habitId: 'habit-walk',
+      targetCount: 5,
+      window: GoalWindow.rollingDays(count: 7),
+    ),
+    GoalCriterion.measurable(
+      criterionId: 'systolic',
+      dataTypeId: 'measurable-systolic',
+      target: 130,
+      window: GoalWindow.rollingDays(count: 7),
+      aggregation: GoalAggregation.dailySumThenAverage,
+      direction: GoalDirection.atMost,
+    ),
+  ],
+);
+
+void main() {
+  group('GoalData', () {
+    test('round-trips through JSON with the criteria tree intact', () {
+      final data = GoalData(
+        title: 'Blood pressure',
+        statement: 'Average under 130 systolic over a rolling week.',
+        criteria: _criteria,
+        specVersion: 3,
+        specVersionId: 'snapshot-v3',
+        startDate: DateTime.utc(2026, 8, 3),
+        targetDate: DateTime.utc(2026, 12, 31),
+        rationale: 'Cardiologist asked for a three-month trend.',
+      );
+
+      final restored = GoalData.fromJson(
+        jsonDecode(jsonEncode(data)) as Map<String, dynamic>,
+      );
+
+      expect(restored, data);
+      // The tree specifically: a shallow copyWith-style comparison would pass
+      // even if the children were dropped, since equality is structural only
+      // when the children actually survive.
+      final root = restored.criteria as GoalCriterionAllOf;
+      expect(root.criteria, hasLength(2));
+      expect(
+        root.criteria.whereType<GoalCriterionHabit>().single.habitId,
+        'habit-walk',
+      );
+      expect(
+        root.criteria.whereType<GoalCriterionMeasurable>().single.dataTypeId,
+        'measurable-systolic',
+      );
+    });
+
+    test('a goal is not a snapshot; a snapshot names the goal it belongs to',
+        () {
+      const goal = GoalData(
+        title: 'Blood pressure',
+        statement: 'Average under 130 systolic over a rolling week.',
+        criteria: _criteria,
+        specVersion: 3,
+        specVersionId: 'snapshot-v3',
+      );
+      final snapshot = goal.copyWith(snapshotOf: 'goal-1');
+
+      expect(goal.snapshotOf, isNull);
+      expect(goal.isSpecSnapshot, isFalse);
+      expect(snapshot.isSpecSnapshot, isTrue);
+      expect(snapshot.snapshotOf, 'goal-1');
+    });
+
+    test('a serialized goal still resolves the definitions it references', () {
+      // The reason a goal belongs in the journal database at all: its
+      // referents are journal-side definitions. Resolve them from the
+      // ROUND-TRIPPED tree, so a serialization that silently dropped a
+      // criterion id fails here rather than at evaluation time.
+      final restored = GoalData.fromJson(
+        jsonDecode(
+          jsonEncode(
+            const GoalData(
+              title: 'Blood pressure',
+              statement: 'Average under 130 systolic over a rolling week.',
+              criteria: _criteria,
+              specVersion: 1,
+              specVersionId: 'snapshot-v1',
+            ),
+          ),
+        ) as Map<String, dynamic>,
+      );
+
+      expect(goalCriterionHabitIds(restored.criteria), {'habit-walk'});
+    });
+  });
+}

--- a/test/database/conversions_test.dart
+++ b/test/database/conversions_test.dart
@@ -446,6 +446,7 @@ void main() {
         project: (_) => throw StateError('unexpected variant'),
         relationship: (_) => throw StateError('unexpected variant'),
         checkIn: (_) => throw StateError('unexpected variant'),
+        goal: (_) => throw StateError('unexpected variant'),
       );
     }
 

--- a/test/features/agents/database/agent_db_conversions_test.dart
+++ b/test/features/agents/database/agent_db_conversions_test.dart
@@ -1008,6 +1008,41 @@ void main() {
       expect(result.softDeleted(updatedAt).deletedAt, updatedAt);
     });
 
+    test('fromLinkRow roundtrips agentGoal links', () {
+      final link = model.AgentLink.agentGoal(
+        id: 'link-agent-goal',
+        fromId: 'agent-001',
+        toId: 'goal-entry-001',
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        vectorClock: null,
+      );
+      final companion = AgentDbConversions.toLinkCompanion(link);
+
+      // The type column is what `getLinksFrom(agentId, type:)` filters on, so
+      // a wrong discriminator would silently return no goal for an agent that
+      // has one.
+      expect(companion.type.value, AgentLinkTypes.agentGoal);
+
+      final row = AgentLink(
+        id: 'link-agent-goal',
+        fromId: 'agent-001',
+        toId: 'goal-entry-001',
+        type: AgentLinkTypes.agentGoal,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        serialized: companion.serialized.value,
+        schemaVersion: 1,
+      );
+
+      final result = AgentDbConversions.fromLinkRow(row);
+
+      expect(result, isA<model.AgentGoalLink>());
+      expect(result.fromId, 'agent-001');
+      expect(result.toId, 'goal-entry-001');
+      expect(result.softDeleted(updatedAt).deletedAt, updatedAt);
+    });
+
     test('fromLinkRow roundtrips captureToPlan link', () {
       final link = model.AgentLink.captureToPlan(
         id: 'link-capture-plan',

--- a/test/features/goals/model/goal_entry_ids_test.dart
+++ b/test/features/goals/model/goal_entry_ids_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+
+void main() {
+  group('goal identity inputs', () {
+    test('are stable for the same subject', () {
+      // The whole point: every device derives the same input, so the backfill
+      // converges on one row instead of one row per device.
+      expect(goalEntryUuidV5Input('agent-1'), goalEntryUuidV5Input('agent-1'));
+      expect(
+        goalSpecSnapshotUuidV5Input('agent-1:spec-v1'),
+        goalSpecSnapshotUuidV5Input('agent-1:spec-v1'),
+      );
+    });
+
+    test('separate distinct subjects', () {
+      expect(
+        goalEntryUuidV5Input('agent-1'),
+        isNot(goalEntryUuidV5Input('agent-2')),
+      );
+      expect(
+        goalSpecSnapshotUuidV5Input('agent-1:spec-v1'),
+        isNot(goalSpecSnapshotUuidV5Input('agent-1:spec-v2')),
+      );
+    });
+
+    test('cannot collide across the two families', () {
+      // A goal and a snapshot are different rows. Without distinct prefixes an
+      // agent id and a version id that happened to match would derive the same
+      // journal id, and the snapshot would overwrite its own goal.
+      expect(
+        goalEntryUuidV5Input('collide'),
+        isNot(goalSpecSnapshotUuidV5Input('collide')),
+      );
+    });
+  });
+}

--- a/test/features/goals/repository/goal_repository_test.dart
+++ b/test/features/goals/repository/goal_repository_test.dart
@@ -1,0 +1,259 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_data.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+import 'package:lotti/features/goals/repository/goal_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  final testDate = DateTime(2026, 8, 18, 10, 30);
+
+  const criteria = GoalCriterion.habit(
+    criterionId: 'walk-daily',
+    habitId: 'habit-walk',
+    targetCount: 5,
+    window: GoalWindow.rollingDays(count: 7),
+  );
+
+  late MockJournalDb mockDb;
+  late MockPersistenceLogic mockPersistence;
+  late MockMetadataService mockMetadata;
+  late GoalRepository repository;
+
+  Metadata meta(String id) => Metadata(
+    id: id,
+    createdAt: testDate,
+    updatedAt: testDate,
+    dateFrom: testDate,
+    dateTo: testDate,
+  );
+
+  GoalEntry goalEntry({
+    required String id,
+    String title = 'Walk more',
+    int specVersion = 1,
+    String specVersionId = 'agent-1:spec-v1',
+    String? snapshotOf,
+  }) => GoalEntry(
+    meta: meta(id),
+    data: GoalData(
+      title: title,
+      statement: 'Walk on five days a week.',
+      criteria: criteria,
+      specVersion: specVersion,
+      specVersionId: specVersionId,
+      snapshotOf: snapshotOf,
+    ),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(goalEntry(id: 'fallback'));
+    registerFallbackValue(meta('fallback'));
+  });
+
+  setUp(() {
+    mockDb = MockJournalDb();
+    mockPersistence = MockPersistenceLogic();
+    mockMetadata = MockMetadataService();
+    repository = GoalRepository(
+      journalDb: mockDb,
+      persistenceLogic: mockPersistence,
+      metadataService: mockMetadata,
+    );
+
+    // Mirrors MetadataService.generateId closely enough to distinguish the
+    // two id families without reimplementing UUID v5.
+    when(
+      () => mockMetadata.generateId(uuidV5Input: any(named: 'uuidV5Input')),
+    ).thenAnswer(
+      (invocation) =>
+          'derived:${invocation.namedArguments[#uuidV5Input] as String}',
+    );
+  });
+
+  group('getGoalForAgent', () {
+    test('resolves the goal through the derived id', () async {
+      final expectedId = 'derived:${goalEntryUuidV5Input('agent-1')}';
+      final entry = goalEntry(id: expectedId);
+      when(
+        () => mockDb.journalEntityById(expectedId),
+      ).thenAnswer((_) async => entry);
+
+      expect(await repository.getGoalForAgent('agent-1'), entry);
+      verify(() => mockDb.journalEntityById(expectedId)).called(1);
+    });
+
+    test('returns null for a soft-deleted goal', () async {
+      final expectedId = 'derived:${goalEntryUuidV5Input('agent-1')}';
+      final deleted = GoalEntry(
+        meta: meta(expectedId).copyWith(deletedAt: testDate),
+        data: goalEntry(id: expectedId).data,
+      );
+      when(
+        () => mockDb.journalEntityById(expectedId),
+      ).thenAnswer((_) async => deleted);
+
+      expect(await repository.getGoalForAgent('agent-1'), isNull);
+    });
+  });
+
+  group('upsertGoal', () {
+    test('creates the goal when no row exists yet', () async {
+      when(() => mockDb.journalEntityById(any())).thenAnswer((_) async => null);
+      when(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((_) async => meta('new-goal'));
+      when(() => mockPersistence.createDbEntity(any())).thenAnswer(
+        (_) async => true,
+      );
+
+      final created = await repository.upsertGoal(
+        agentId: 'agent-1',
+        title: 'Walk more',
+        statement: 'Walk on five days a week.',
+        criteria: criteria,
+        specVersion: 1,
+        specVersionId: 'agent-1:spec-v1',
+      );
+
+      expect(created, isNotNull);
+      expect(created!.data.title, 'Walk more');
+      expect(created.data.snapshotOf, isNull, reason: 'a goal is not a snapshot');
+      verify(() => mockPersistence.createDbEntity(any())).called(1);
+      verifyNever(() => mockPersistence.updateDbEntity(any()));
+    });
+
+    test('updates in place rather than duplicating an existing goal', () async {
+      // The backfill runs on every device, every launch. A second run must
+      // refresh the row it already wrote, never append another goal.
+      final existingId = 'derived:${goalEntryUuidV5Input('agent-1')}';
+      when(
+        () => mockDb.journalEntityById(existingId),
+      ).thenAnswer((_) async => goalEntry(id: existingId, title: 'Old title'));
+      when(
+        () => mockPersistence.updateMetadata(any()),
+      ).thenAnswer((_) async => meta(existingId));
+      when(() => mockPersistence.updateDbEntity(any())).thenAnswer(
+        (_) async => true,
+      );
+
+      final updated = await repository.upsertGoal(
+        agentId: 'agent-1',
+        title: 'New title',
+        statement: 'Walk on five days a week.',
+        criteria: criteria,
+        specVersion: 2,
+        specVersionId: 'agent-1:spec-v2',
+      );
+
+      expect(updated!.meta.id, existingId, reason: 'identity must not move');
+      expect(updated.data.title, 'New title');
+      expect(updated.data.specVersion, 2);
+      verify(() => mockPersistence.updateDbEntity(any())).called(1);
+      // Creating metadata reserves AND commits a vector-clock counter, so the
+      // refresh path must never touch it.
+      verifyNever(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      );
+    });
+
+    test('returns null when the write fails', () async {
+      when(() => mockDb.journalEntityById(any())).thenAnswer((_) async => null);
+      when(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((_) async => meta('new-goal'));
+      when(
+        () => mockPersistence.createDbEntity(any()),
+      ).thenAnswer((_) async => false);
+
+      expect(
+        await repository.upsertGoal(
+          agentId: 'agent-1',
+          title: 'Walk more',
+          statement: 'Walk on five days a week.',
+          criteria: criteria,
+          specVersion: 1,
+          specVersionId: 'agent-1:spec-v1',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('ensureSpecSnapshot', () {
+    test('never rewrites a snapshot that already exists', () async {
+      // A spec version is immutable, and registers and reflections are pinned
+      // to it. Refreshing one would rewrite history they point at.
+      final snapshotId =
+          'derived:${goalSpecSnapshotUuidV5Input('agent-1:spec-v1')}';
+      final existing = goalEntry(id: snapshotId, snapshotOf: 'goal-1');
+      when(
+        () => mockDb.journalEntityById(snapshotId),
+      ).thenAnswer((_) async => existing);
+
+      final result = await repository.ensureSpecSnapshot(
+        goalId: 'goal-1',
+        specVersionId: 'agent-1:spec-v1',
+        title: 'Rewritten title',
+        statement: 'Rewritten statement.',
+        criteria: criteria,
+        specVersion: 1,
+        createdAt: testDate,
+      );
+
+      expect(result, existing);
+      verifyNever(() => mockPersistence.updateDbEntity(any()));
+      verifyNever(() => mockPersistence.createDbEntity(any()));
+    });
+
+    test('writes a snapshot that names its goal', () async {
+      when(() => mockDb.journalEntityById(any())).thenAnswer((_) async => null);
+      when(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((_) async => meta('snapshot-1'));
+      when(() => mockPersistence.createDbEntity(any())).thenAnswer(
+        (_) async => true,
+      );
+
+      final snapshot = await repository.ensureSpecSnapshot(
+        goalId: 'goal-1',
+        specVersionId: 'agent-1:spec-v1',
+        title: 'Walk more',
+        statement: 'Walk on five days a week.',
+        criteria: criteria,
+        specVersion: 1,
+        createdAt: testDate,
+      );
+
+      // `snapshotOf` is what the subtype column carries, which is what makes
+      // version history an indexed lookup and keeps snapshots out of the goal
+      // list.
+      expect(snapshot!.data.snapshotOf, 'goal-1');
+      expect(snapshot.data.isSpecSnapshot, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Stacked PR **2 of 3** · base: `feat/goal-journal-entity`

Binds a goal agent to the goal it coaches.

`AgentLink.agentGoal` (`fromId` = agent id, `toId` = goal entry id) is the exact
sibling of `AgentEventLink`, `AgentProjectLink` and `AgentDayLink` — an agent
pointing at the journal entity it works on.

The direction matters: the link lives on the **disposable** side and points at
durable, user-authored content. Losing the agent database costs the user their
coach, never their goal.

- `AgentLink.agentGoal` union member + `softDeleted` arm
- `AgentLinkTypes.agentGoal`
- `agent_db_conversions.dart` — the two exhaustive `map()` arms

No behaviour change: nothing writes the link yet.

Refs `lotti3-aa4`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for journal goals, including titles, criteria, dates, rationale, versions, and immutable specification snapshots.
  - Added goal persistence, retrieval, updates, and snapshot creation.
  - Added links between goals and agents.
  - Added goal notifications and dedicated goal file organization.
  - Goals now appear as flagged cards in journal views.

- **Bug Fixes**
  - Added filtering for deleted and private goals.

- **Tests**
  - Added coverage for goal serialization, persistence, snapshots, identifiers, and agent links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->