### PR TITLE
feat(goals): add journal-side persistence for goals and spec snapshots

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -28,6 +28,7 @@ part 'database_config_flags.dart';
 part 'database_data_queries.dart';
 part 'database_definitions.dart';
 part 'database_entity_ops.dart';
+part 'database_goal_queries.dart';
 part 'database_insights_queries.dart';
 part 'database_journal_queries.dart';
 part 'database_links_ratings.dart';
@@ -118,6 +119,7 @@ class JournalDb extends _$JournalDb
         _JournalDbTaskQueries,
         _JournalDbTaskDueQueries,
         _JournalDbProjectQueries,
+        _JournalDbGoalQueries,
         _JournalDbRelationshipQueries,
         _JournalDbLinksRatings,
         _JournalDbDataQueries,

--- a/lib/database/database_goal_queries.dart
+++ b/lib/database/database_goal_queries.dart
@@ -1,0 +1,65 @@
+part of 'database.dart';
+
+/// Goal query surface for [JournalDb].
+///
+/// Goals and their immutable spec snapshots share the `Goal` row type and are
+/// told apart by the denormalized `subtype` column: empty on a goal, the owning
+/// goal's id on a snapshot (the habit-completion precedent, no schema change).
+/// Both queries therefore ride the existing `idx_journal_type_subtype` index.
+mixin _JournalDbGoalQueries on _$JournalDb, _JournalDbConfigFlags {
+  /// Every non-deleted goal, newest first. Spec snapshots are excluded — they
+  /// are the version history of a goal, not goals in their own right.
+  Future<List<GoalEntry>> getGoals() async {
+    final rows = await _queryWithPrivateFilter(
+      allPrivate: () => _goalRows().get(),
+      filtered: (statuses) => _goalRows(privateStatuses: statuses).get(),
+    );
+    return rows.map(fromDbEntity).whereType<GoalEntry>().toList();
+  }
+
+  /// The immutable spec snapshots belonging to [goalId], newest version first.
+  Future<List<GoalEntry>> getSpecSnapshotsForGoal(String goalId) async {
+    final rows = await _queryWithPrivateFilter(
+      allPrivate: () => _goalSnapshotRows(goalId).get(),
+      filtered: (statuses) =>
+          _goalSnapshotRows(goalId, privateStatuses: statuses).get(),
+    );
+    return rows.map(fromDbEntity).whereType<GoalEntry>().toList();
+  }
+
+  SimpleSelectStatement<Journal, JournalDbEntity> _goalRows({
+    List<bool>? privateStatuses,
+  }) {
+    return select(journal)
+      ..where((t) {
+        var predicate =
+            t.type.equals('Goal') &
+            // A goal carries no subtype; a snapshot carries its goal's id.
+            t.subtype.equals('') &
+            t.deleted.equals(false);
+        if (privateStatuses != null) {
+          predicate = predicate & t.private.isIn(privateStatuses);
+        }
+        return predicate;
+      })
+      ..orderBy([(t) => OrderingTerm.desc(t.dateFrom)]);
+  }
+
+  SimpleSelectStatement<Journal, JournalDbEntity> _goalSnapshotRows(
+    String goalId, {
+    List<bool>? privateStatuses,
+  }) {
+    return select(journal)
+      ..where((t) {
+        var predicate =
+            t.type.equals('Goal') &
+            t.subtype.equals(goalId) &
+            t.deleted.equals(false);
+        if (privateStatuses != null) {
+          predicate = predicate & t.private.isIn(privateStatuses);
+        }
+        return predicate;
+      })
+      ..orderBy([(t) => OrderingTerm.desc(t.dateFrom)]);
+  }
+}

--- a/lib/features/goals/model/goal_entry_ids.dart
+++ b/lib/features/goals/model/goal_entry_ids.dart
@@ -1,0 +1,31 @@
+/// Deterministic identity inputs for the journal-side goal rows.
+///
+/// Derivation, not allocation, is the point. The backfill that gives an
+/// existing goal agent its journal entry runs on **every device that syncs
+/// that agent**, independently and without coordination. Minting random ids
+/// would have each device create its own row for the same goal, and sync would
+/// faithfully replicate all of them. Seeding the id from something the devices
+/// already agree on means they write the *same* row, and last-writer-wins
+/// merges it instead of duplicating it.
+///
+/// These return the **input string** for
+/// `PersistenceLogic.createMetadata(uuidV5Input:)`, which is the repository's
+/// existing deduplication mechanism (`MetadataService.generateId` hashes it
+/// into a UUID v5). Deliberately not a second id scheme of its own — the
+/// prefixes below are what keep the two families from colliding.
+library;
+
+/// Identity input for the goal coached by [agentId].
+///
+/// The agent id is the one identifier every device shares for a goal before
+/// the journal entry exists, which is what makes it the correct seed.
+String goalEntryUuidV5Input(String agentId) => 'goal:$agentId';
+
+/// Identity input for the immutable snapshot of one spec version.
+///
+/// Seeded with the agent-side `goalSpecVersion` id (`<agentId>:spec-v<n>`),
+/// which is already unique and immutable, so re-running the backfill
+/// re-derives the same snapshot rather than appending a duplicate of a version
+/// that has not changed.
+String goalSpecSnapshotUuidV5Input(String specVersionId) =>
+    'goal-spec:$specVersionId';

--- a/lib/features/goals/repository/goal_repository.dart
+++ b/lib/features/goals/repository/goal_repository.dart
@@ -1,0 +1,163 @@
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/logic/services/metadata_service.dart';
+
+/// Journal-side persistence for goals: the durable, user-authored half of a
+/// goal, independent of whether its coaching agent still exists.
+///
+/// Every write here is **idempotent by construction**. Both entry points are
+/// reached from paths that legitimately run more than once — the startup
+/// backfill on every device that syncs a goal, and goal creation retried after
+/// a deferred outbox flush failed — so the ids are derived (see
+/// [goalEntryUuidV5Input]) and an existing row is updated rather than
+/// duplicated.
+class GoalRepository {
+  GoalRepository({
+    required this._journalDb,
+    required this._persistenceLogic,
+    required this._metadataService,
+  });
+
+  final JournalDb _journalDb;
+  final PersistenceLogic _persistenceLogic;
+
+  /// Used only for its pure [MetadataService.generateId]. Resolving an id has
+  /// to stay free of side effects: `createMetadata` reserves AND commits a
+  /// vector-clock counter, so computing an id through it — just to look the
+  /// row up and find it already there — would burn a counter on every startup
+  /// backfill, on every device.
+  final MetadataService _metadataService;
+
+  /// The goal coached by [agentId], or null when it has no journal entry yet.
+  Future<GoalEntry?> getGoalForAgent(String agentId) async {
+    final id = _metadataService.generateId(
+      uuidV5Input: goalEntryUuidV5Input(agentId),
+    );
+    final entity = await _journalDb.journalEntityById(id);
+    return entity is GoalEntry && !entity.isDeleted ? entity : null;
+  }
+
+  /// Every goal, newest first. Spec snapshots are excluded.
+  Future<List<GoalEntry>> getGoals() => _journalDb.getGoals();
+
+  /// The immutable spec snapshots of [goalId], newest version first.
+  Future<List<GoalEntry>> getSpecSnapshots(String goalId) =>
+      _journalDb.getSpecSnapshotsForGoal(goalId);
+
+  /// Writes (or refreshes) the stable goal row for [agentId] and returns it.
+  ///
+  /// The row's id never changes across revisions, so links from its check-ins
+  /// survive every change to the criteria — which is the reason the version
+  /// history lives in separate snapshot rows rather than in this one.
+  Future<GoalEntry?> upsertGoal({
+    required String agentId,
+    required String title,
+    required String statement,
+    required GoalCriterion criteria,
+    required int specVersion,
+    required String specVersionId,
+    DateTime? startDate,
+    DateTime? targetDate,
+    String? rationale,
+    String? categoryId,
+  }) async {
+    final data = GoalData(
+      title: title,
+      statement: statement,
+      criteria: criteria,
+      specVersion: specVersion,
+      specVersionId: specVersionId,
+      startDate: startDate,
+      targetDate: targetDate,
+      rationale: rationale,
+    );
+    return _upsert(
+      uuidV5Input: goalEntryUuidV5Input(agentId),
+      data: data,
+      categoryId: categoryId,
+      // The goal's own start is its position in time, so it sorts among the
+      // user's entries where they would look for it rather than at whatever
+      // moment the backfill happened to run.
+      dateFrom: startDate,
+    );
+  }
+
+  /// Writes the immutable snapshot of one spec version, if it is not already
+  /// stored, and returns it.
+  ///
+  /// Never rewrites an existing snapshot: a version is immutable by
+  /// definition, and a re-run that "refreshed" one would silently rewrite
+  /// history that registers and reflections are pinned to.
+  Future<GoalEntry?> ensureSpecSnapshot({
+    required String goalId,
+    required String specVersionId,
+    required String title,
+    required String statement,
+    required GoalCriterion criteria,
+    required int specVersion,
+    required DateTime createdAt,
+    DateTime? startDate,
+    DateTime? targetDate,
+    String? rationale,
+    String? categoryId,
+  }) async {
+    final id = _metadataService.generateId(
+      uuidV5Input: goalSpecSnapshotUuidV5Input(specVersionId),
+    );
+    final existing = await _journalDb.journalEntityById(id);
+    if (existing is GoalEntry) return existing;
+
+    return _upsert(
+      uuidV5Input: goalSpecSnapshotUuidV5Input(specVersionId),
+      data: GoalData(
+        title: title,
+        statement: statement,
+        criteria: criteria,
+        specVersion: specVersion,
+        specVersionId: specVersionId,
+        startDate: startDate,
+        targetDate: targetDate,
+        rationale: rationale,
+        snapshotOf: goalId,
+      ),
+      categoryId: categoryId,
+      // A snapshot is dated when the version was authored, so the history
+      // reads in the order the goal actually changed.
+      dateFrom: createdAt,
+    );
+  }
+
+  Future<GoalEntry?> _upsert({
+    required String uuidV5Input,
+    required GoalData data,
+    String? categoryId,
+    DateTime? dateFrom,
+  }) async {
+    // Look the row up by its DERIVED id first. Creating metadata up front to
+    // learn the id would commit a vector-clock counter every time an existing
+    // goal was merely refreshed.
+    final id = _metadataService.generateId(uuidV5Input: uuidV5Input);
+    final existing = await _journalDb.journalEntityById(id);
+
+    if (existing is GoalEntry) {
+      final updatedMeta = await _persistenceLogic.updateMetadata(existing.meta);
+      final updated = existing.copyWith(meta: updatedMeta, data: data);
+      final saved = await _persistenceLogic.updateDbEntity(updated);
+      return (saved ?? false) ? updated : null;
+    }
+
+    final meta = await _persistenceLogic.createMetadata(
+      uuidV5Input: uuidV5Input,
+      categoryId: categoryId,
+      dateFrom: dateFrom,
+      dateTo: dateFrom,
+    );
+    final created = JournalEntity.goal(meta: meta, data: data) as GoalEntry;
+    final saved = await _persistenceLogic.createDbEntity(created);
+    return (saved ?? false) ? created : null;
+  }
+}

--- a/test/features/goals/model/goal_entry_ids_test.dart
+++ b/test/features/goals/model/goal_entry_ids_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+
+void main() {
+  group('goal identity inputs', () {
+    test('are stable for the same subject', () {
+      // The whole point: every device derives the same input, so the backfill
+      // converges on one row instead of one row per device.
+      expect(goalEntryUuidV5Input('agent-1'), goalEntryUuidV5Input('agent-1'));
+      expect(
+        goalSpecSnapshotUuidV5Input('agent-1:spec-v1'),
+        goalSpecSnapshotUuidV5Input('agent-1:spec-v1'),
+      );
+    });
+
+    test('separate distinct subjects', () {
+      expect(
+        goalEntryUuidV5Input('agent-1'),
+        isNot(goalEntryUuidV5Input('agent-2')),
+      );
+      expect(
+        goalSpecSnapshotUuidV5Input('agent-1:spec-v1'),
+        isNot(goalSpecSnapshotUuidV5Input('agent-1:spec-v2')),
+      );
+    });
+
+    test('cannot collide across the two families', () {
+      // A goal and a snapshot are different rows. Without distinct prefixes an
+      // agent id and a version id that happened to match would derive the same
+      // journal id, and the snapshot would overwrite its own goal.
+      expect(
+        goalEntryUuidV5Input('collide'),
+        isNot(goalSpecSnapshotUuidV5Input('collide')),
+      );
+    });
+  });
+}

--- a/test/features/goals/repository/goal_repository_test.dart
+++ b/test/features/goals/repository/goal_repository_test.dart
@@ -1,0 +1,259 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_data.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+import 'package:lotti/features/goals/repository/goal_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  final testDate = DateTime(2026, 8, 18, 10, 30);
+
+  const criteria = GoalCriterion.habit(
+    criterionId: 'walk-daily',
+    habitId: 'habit-walk',
+    targetCount: 5,
+    window: GoalWindow.rollingDays(count: 7),
+  );
+
+  late MockJournalDb mockDb;
+  late MockPersistenceLogic mockPersistence;
+  late MockMetadataService mockMetadata;
+  late GoalRepository repository;
+
+  Metadata meta(String id) => Metadata(
+    id: id,
+    createdAt: testDate,
+    updatedAt: testDate,
+    dateFrom: testDate,
+    dateTo: testDate,
+  );
+
+  GoalEntry goalEntry({
+    required String id,
+    String title = 'Walk more',
+    int specVersion = 1,
+    String specVersionId = 'agent-1:spec-v1',
+    String? snapshotOf,
+  }) => GoalEntry(
+    meta: meta(id),
+    data: GoalData(
+      title: title,
+      statement: 'Walk on five days a week.',
+      criteria: criteria,
+      specVersion: specVersion,
+      specVersionId: specVersionId,
+      snapshotOf: snapshotOf,
+    ),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(goalEntry(id: 'fallback'));
+    registerFallbackValue(meta('fallback'));
+  });
+
+  setUp(() {
+    mockDb = MockJournalDb();
+    mockPersistence = MockPersistenceLogic();
+    mockMetadata = MockMetadataService();
+    repository = GoalRepository(
+      journalDb: mockDb,
+      persistenceLogic: mockPersistence,
+      metadataService: mockMetadata,
+    );
+
+    // Mirrors MetadataService.generateId closely enough to distinguish the
+    // two id families without reimplementing UUID v5.
+    when(
+      () => mockMetadata.generateId(uuidV5Input: any(named: 'uuidV5Input')),
+    ).thenAnswer(
+      (invocation) =>
+          'derived:${invocation.namedArguments[#uuidV5Input] as String}',
+    );
+  });
+
+  group('getGoalForAgent', () {
+    test('resolves the goal through the derived id', () async {
+      final expectedId = 'derived:${goalEntryUuidV5Input('agent-1')}';
+      final entry = goalEntry(id: expectedId);
+      when(
+        () => mockDb.journalEntityById(expectedId),
+      ).thenAnswer((_) async => entry);
+
+      expect(await repository.getGoalForAgent('agent-1'), entry);
+      verify(() => mockDb.journalEntityById(expectedId)).called(1);
+    });
+
+    test('returns null for a soft-deleted goal', () async {
+      final expectedId = 'derived:${goalEntryUuidV5Input('agent-1')}';
+      final deleted = GoalEntry(
+        meta: meta(expectedId).copyWith(deletedAt: testDate),
+        data: goalEntry(id: expectedId).data,
+      );
+      when(
+        () => mockDb.journalEntityById(expectedId),
+      ).thenAnswer((_) async => deleted);
+
+      expect(await repository.getGoalForAgent('agent-1'), isNull);
+    });
+  });
+
+  group('upsertGoal', () {
+    test('creates the goal when no row exists yet', () async {
+      when(() => mockDb.journalEntityById(any())).thenAnswer((_) async => null);
+      when(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((_) async => meta('new-goal'));
+      when(() => mockPersistence.createDbEntity(any())).thenAnswer(
+        (_) async => true,
+      );
+
+      final created = await repository.upsertGoal(
+        agentId: 'agent-1',
+        title: 'Walk more',
+        statement: 'Walk on five days a week.',
+        criteria: criteria,
+        specVersion: 1,
+        specVersionId: 'agent-1:spec-v1',
+      );
+
+      expect(created, isNotNull);
+      expect(created!.data.title, 'Walk more');
+      expect(created.data.snapshotOf, isNull, reason: 'a goal is not a snapshot');
+      verify(() => mockPersistence.createDbEntity(any())).called(1);
+      verifyNever(() => mockPersistence.updateDbEntity(any()));
+    });
+
+    test('updates in place rather than duplicating an existing goal', () async {
+      // The backfill runs on every device, every launch. A second run must
+      // refresh the row it already wrote, never append another goal.
+      final existingId = 'derived:${goalEntryUuidV5Input('agent-1')}';
+      when(
+        () => mockDb.journalEntityById(existingId),
+      ).thenAnswer((_) async => goalEntry(id: existingId, title: 'Old title'));
+      when(
+        () => mockPersistence.updateMetadata(any()),
+      ).thenAnswer((_) async => meta(existingId));
+      when(() => mockPersistence.updateDbEntity(any())).thenAnswer(
+        (_) async => true,
+      );
+
+      final updated = await repository.upsertGoal(
+        agentId: 'agent-1',
+        title: 'New title',
+        statement: 'Walk on five days a week.',
+        criteria: criteria,
+        specVersion: 2,
+        specVersionId: 'agent-1:spec-v2',
+      );
+
+      expect(updated!.meta.id, existingId, reason: 'identity must not move');
+      expect(updated.data.title, 'New title');
+      expect(updated.data.specVersion, 2);
+      verify(() => mockPersistence.updateDbEntity(any())).called(1);
+      // Creating metadata reserves AND commits a vector-clock counter, so the
+      // refresh path must never touch it.
+      verifyNever(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      );
+    });
+
+    test('returns null when the write fails', () async {
+      when(() => mockDb.journalEntityById(any())).thenAnswer((_) async => null);
+      when(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((_) async => meta('new-goal'));
+      when(
+        () => mockPersistence.createDbEntity(any()),
+      ).thenAnswer((_) async => false);
+
+      expect(
+        await repository.upsertGoal(
+          agentId: 'agent-1',
+          title: 'Walk more',
+          statement: 'Walk on five days a week.',
+          criteria: criteria,
+          specVersion: 1,
+          specVersionId: 'agent-1:spec-v1',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('ensureSpecSnapshot', () {
+    test('never rewrites a snapshot that already exists', () async {
+      // A spec version is immutable, and registers and reflections are pinned
+      // to it. Refreshing one would rewrite history they point at.
+      final snapshotId =
+          'derived:${goalSpecSnapshotUuidV5Input('agent-1:spec-v1')}';
+      final existing = goalEntry(id: snapshotId, snapshotOf: 'goal-1');
+      when(
+        () => mockDb.journalEntityById(snapshotId),
+      ).thenAnswer((_) async => existing);
+
+      final result = await repository.ensureSpecSnapshot(
+        goalId: 'goal-1',
+        specVersionId: 'agent-1:spec-v1',
+        title: 'Rewritten title',
+        statement: 'Rewritten statement.',
+        criteria: criteria,
+        specVersion: 1,
+        createdAt: testDate,
+      );
+
+      expect(result, existing);
+      verifyNever(() => mockPersistence.updateDbEntity(any()));
+      verifyNever(() => mockPersistence.createDbEntity(any()));
+    });
+
+    test('writes a snapshot that names its goal', () async {
+      when(() => mockDb.journalEntityById(any())).thenAnswer((_) async => null);
+      when(
+        () => mockPersistence.createMetadata(
+          uuidV5Input: any(named: 'uuidV5Input'),
+          categoryId: any(named: 'categoryId'),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((_) async => meta('snapshot-1'));
+      when(() => mockPersistence.createDbEntity(any())).thenAnswer(
+        (_) async => true,
+      );
+
+      final snapshot = await repository.ensureSpecSnapshot(
+        goalId: 'goal-1',
+        specVersionId: 'agent-1:spec-v1',
+        title: 'Walk more',
+        statement: 'Walk on five days a week.',
+        criteria: criteria,
+        specVersion: 1,
+        createdAt: testDate,
+      );
+
+      // `snapshotOf` is what the subtype column carries, which is what makes
+      // version history an indexed lookup and keeps snapshots out of the goal
+      // list.
+      expect(snapshot!.data.snapshotOf, 'goal-1');
+      expect(snapshot.data.isSpecSnapshot, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Stacked PR **3 of 3** · base: `feat/goal-agent-link`

Journal-side persistence for goals and their spec snapshots.

## What

- `database_goal_queries.dart` — a `part of 'database.dart'` mixin (the
  `_JournalDbRelationshipQueries` pattern): `getGoals()` excludes snapshots by
  requiring an empty `subtype`; `getSpecSnapshotsForGoal(goalId)` selects them by
  it. Both ride `idx_journal_type_subtype`, both respect the private filter.
- `GoalRepository` — `upsertGoal`, `ensureSpecSnapshot`, `getGoalForAgent`,
  `getGoals`, `getSpecSnapshots`.
- `goal_entry_ids.dart` — the identity inputs.

## Idempotent by construction

Both write paths are reached from places that legitimately run more than once:
the startup backfill runs on **every device that syncs a goal**, and goal
creation can be retried after a deferred outbox flush fails. Random ids would
have each device create its own row for the same goal and sync would faithfully
replicate all of them.

So ids are **derived**, seeded from something the devices already agree on — the
agent id for a goal, the immutable `goalSpecVersion` id for a snapshot — and fed
to the repository's existing dedup mechanism,
`MetadataService.generateId(uuidV5Input:)`. Not a second id scheme.

This composes with the revision path rather than fighting it: revision version
ids already carry a random suffix precisely so two disconnected replicas minting
a v2 don't collide and lose history. Seeding snapshot ids from the version id
inherits that — v1 stays deterministic, concurrent revisions each keep their own
snapshot.

`ensureSpecSnapshot` never rewrites an existing snapshot: a version is immutable,
and "refreshing" one would rewrite history that registers and reflections are
pinned to.

## One subtlety worth flagging for review

Ids are resolved through the **pure** `MetadataService.generateId`, never by
building metadata. `createMetadata` reserves *and commits* a vector-clock
counter, so computing an id through it — only to find the row already present —
would burn a counter on every startup, on every device.

Refs `lotti3-aa4`.
