### PR TITLE
fix(goals): reconcile check-in summaries, and stop reading them twice

### DIFF
--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -176,8 +176,7 @@ flowchart TD
     ROUTE -- yes --> PB[GoalAgentWorkflow — Phase B\nsame derivation as Phase A]
     USERWAKE --> PB
     REFREG --> PB
-    CHECKIN[check-in linked to the goal\nJournalAudio / JournalEntry] --> STALE[mark report stale\nGoalCheckInNotifier — never a wake]
-    STALE --> ROUTE
+    CHECKIN[check-in linked to the goal\nJournalAudio / JournalEntry] --> CHECKINSTALE[mark report stale\nGoalCheckInNotifier — never a wake,\nconsumed by the next cadence tick]
     PB --> COMPACT[compact pending check-ins\nwake's own model, ≤500 tokens,\nkeyed by agentId+entryId, non-fatal]
     COMPACT --> FACTS[GoalFactsRenderer\nJSON fence: goal, evaluation,\nreporting, ads, personaTone,\nuserVoice — token-bounded, never transcripts]
     FACTS --> CONV[one bounded conversation\nglm-5.2 default, profile override,\ntemperature 0, 8-tool contract]

--- a/lib/features/goals/logic/goal_user_voice.dart
+++ b/lib/features/goals/logic/goal_user_voice.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:lotti/features/agents/projection/compaction_plan.dart';
 import 'package:lotti/features/ai/service/text_chunker.dart';
 import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
@@ -68,11 +70,11 @@ Map<String, Object?> _json(GoalCheckInSummary summary) => <String, Object?>{
   if (summary.asks != null) 'asks': summary.asks,
 };
 
-String _renderForBudget(GoalCheckInSummary summary) => [
-  summary.recordedAt.toIso8601String(),
-  summary.whatHappened,
-  ?summary.committedTo,
-  ?summary.blockers,
-  ?summary.mood,
-  ?summary.asks,
-].join(' ');
+/// Estimates against the JSON actually emitted, keys and all.
+///
+/// Estimating from the values alone under-counted every key and the entry id —
+/// an opaque string longer than several of the values — so the selected set
+/// could exceed the budget it was chosen to fit, by more the more entries were
+/// retained.
+String _renderForBudget(GoalCheckInSummary summary) =>
+    jsonEncode(_json(summary));

--- a/lib/features/goals/model/goal_checkin_summary.dart
+++ b/lib/features/goals/model/goal_checkin_summary.dart
@@ -22,6 +22,7 @@ class GoalCheckInSummary {
     this.blockers,
     this.mood,
     this.asks,
+    this.sourceDigest,
   });
 
   final String id;
@@ -46,6 +47,15 @@ class GoalCheckInSummary {
   /// Anything the user asked of the agent.
   final String? asks;
 
+  /// Fingerprint of the words this was distilled from.
+  ///
+  /// A transcript is not final when it first lands: it can be re-transcribed
+  /// with a better model, or the user can edit it. Without this the first
+  /// summary stood forever and the agent coached from words that had since
+  /// changed. Null on summaries written before the field existed, which are
+  /// recompacted once and then carry it.
+  final String? sourceDigest;
+
   Map<String, Object?> toContent() => <String, Object?>{
     'sourceEntryId': sourceEntryId,
     'recordedAt': recordedAt.toIso8601String(),
@@ -54,6 +64,7 @@ class GoalCheckInSummary {
     'blockers': blockers,
     'mood': mood,
     'asks': asks,
+    'sourceDigest': sourceDigest,
   };
 
   static GoalCheckInSummary? fromContent(
@@ -73,10 +84,20 @@ class GoalCheckInSummary {
       sourceEntryId: source,
       recordedAt: recordedAt,
       whatHappened: happened,
-      committedTo: content['committedTo'] as String?,
-      blockers: content['blockers'] as String?,
-      mood: content['mood'] as String?,
-      asks: content['asks'] as String?,
+      committedTo: _slot(content['committedTo']),
+      blockers: _slot(content['blockers']),
+      mood: _slot(content['mood']),
+      asks: _slot(content['asks']),
+      sourceDigest: _slot(content['sourceDigest']),
     );
   }
 }
+
+/// Reads an optional slot, tolerating a value that is not a string.
+///
+/// These arrive over sync from a peer that may be running a different build. A
+/// direct cast threw on one malformed field, and because the workflow reads
+/// every summary in one pass that single bad value cost the wake ALL of its
+/// user voice — and abandoned pending compaction with it. A slot that cannot
+/// be read is simply absent.
+String? _slot(Object? value) => value is String ? value : null;

--- a/lib/features/goals/runtime/goal_runtime_maintenance.dart
+++ b/lib/features/goals/runtime/goal_runtime_maintenance.dart
@@ -172,16 +172,18 @@ class GoalRuntimeMaintenance implements AgentRuntimeMaintenance {
         _checkInNotifier?.unwatch(identity.agentId);
         return;
       }
+      // Before the criteria gate: a synced identity can arrive ahead of its
+      // spec head, and returning for want of criteria left the goal unwatched
+      // until a restart — reintroducing the startup-snapshot bug by placement
+      // rather than by logic. Watching needs only the agent id.
+      _checkInNotifier?.watch(identity.agentId);
+
       final criteria = await _headCriteria(identity.agentId);
       if (criteria == null) return;
       _goalAgentService.registerSignalSubscription(
         identity.agentId,
         criteria,
       );
-      // The check-in watch is not a startup snapshot: a goal created or
-      // synced while the app stays open must mark its report stale from its
-      // first check-in, not from the next launch.
-      _checkInNotifier?.watch(identity.agentId);
     } catch (error, stackTrace) {
       _log('onIdentityReceived', identity.agentId, error, stackTrace);
     }

--- a/lib/features/goals/service/goal_checkin_compactor.dart
+++ b/lib/features/goals/service/goal_checkin_compactor.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:crypto/crypto.dart';
+
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -16,6 +18,14 @@ import 'package:openai_dart/openai_dart.dart';
 
 /// Tool name marking a stored check-in summary in the agent log.
 const goalCheckInSummaryToolName = 'goal_compact_check_in';
+
+/// Fingerprint of the words a summary was distilled from.
+///
+/// Cheap and stable: it only has to change when the text does, so a
+/// re-transcription or an edit is recognised as new words rather than as the
+/// same check-in already handled.
+String goalCheckInSourceDigest(String text) =>
+    sha256.convert(utf8.encode(text.trim())).toString();
 
 /// Deterministic id for the summary of one check-in.
 ///
@@ -101,6 +111,7 @@ class GoalCheckInCompactor {
         blockers: decoded.blockers,
         mood: decoded.mood,
         asks: decoded.asks,
+        sourceDigest: goalCheckInSourceDigest(text),
       );
       await _persist(agentId: agentId, summary: summary);
       return summary;

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -139,9 +139,14 @@ final goalChatServiceProvider = Provider<GoalChatService>(
   name: 'goalChatServiceProvider',
 );
 
-/// Distills check-ins for the agent. Null where the AI stack is unavailable.
-final Provider<GoalCheckInCompactor?> goalCheckInCompactorProvider =
-    Provider<GoalCheckInCompactor?>(
+/// Distills check-ins for the agent.
+///
+/// Non-null unlike its journal-side siblings: it needs only the inference
+/// repository and the agent sync service, both of which are always available
+/// where the agent runtime is. Declaring it nullable made every consumer carry
+/// an unreachable branch.
+final Provider<GoalCheckInCompactor> goalCheckInCompactorProvider =
+    Provider<GoalCheckInCompactor>(
       (ref) => GoalCheckInCompactor(
         inferenceRepository: ref.watch(cloudInferenceRepositoryProvider),
         syncService: ref.watch(agentSyncServiceProvider),

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -380,11 +380,12 @@ class GoalAgentWorkflow with AgentErrorLogging {
       );
     }
 
-    // Compact any check-in whose words have arrived but which the agent has
-    // not seen yet, using the wake's OWN model — the agent reads its user in
-    // the same voice it thinks in. Non-fatal: a check-in that fails to compact
-    // simply is not in this wake's context, and the next wake retries.
-    await _compactPendingCheckIns(
+    // Compact any check-in whose words are new or have changed, using the
+    // wake's OWN model — the agent reads its user in the same voice it thinks
+    // in — and return the summaries whose sources are still live. Non-fatal: a
+    // check-in that fails to compact simply is not in this wake's context, and
+    // the next wake retries.
+    final checkInSummaries = await _reconcileCheckIns(
       agentId: agentId,
       goalStatement: version.statement,
       model: resolved.modelId,
@@ -400,16 +401,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
     // this wake its check-ins, never the wake itself — the deterministic FACTS
     // are what the agent is actually accountable to, and they are already
     // assembled.
-    var userVoice = const <Map<String, Object?>>[];
-    try {
-      userVoice = goalUserVoiceEntries(await _checkInSummaries(agentId));
-    } catch (error, stackTrace) {
-      logError(
-        'reading compacted check-ins failed; the wake continues without them',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    }
+    final userVoice = goalUserVoiceEntries(checkInSummaries);
 
     final renderedFacts = _factsRenderer.render(
       version: version,
@@ -1083,7 +1075,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
   /// retried compaction overwrites rather than appends. Individually
   /// contained — one unreadable recording must not cost the wake the rest of
   /// what the user said.
-  Future<void> _compactPendingCheckIns({
+  Future<List<GoalCheckInSummary>> _reconcileCheckIns({
     required String agentId,
     required String goalStatement,
     required String model,
@@ -1091,21 +1083,34 @@ class GoalAgentWorkflow with AgentErrorLogging {
   }) async {
     final compactor = _checkInCompactor;
     final reader = _checkInSourceReader;
-    if (compactor == null || reader == null) return;
+    if (compactor == null || reader == null) return const [];
 
-    final List<GoalCheckInSource> pending;
+    final List<GoalCheckInSource> sources;
+    List<GoalCheckInSummary> stored;
     try {
-      final existing = (await _checkInSummaries(
-        agentId,
-      )).map((summary) => summary.sourceEntryId).toSet();
-      pending = (await reader(
-        agentId,
-      )).where((source) => !existing.contains(source.entryId)).toList();
+      // ONE read of each side per wake. Reading the summaries again to render
+      // user voice doubled an already-unbounded scan, which is exactly what
+      // ADR 0057's bounded-read invariant forbids.
+      stored = await _checkInSummaries(agentId);
+      sources = await reader(agentId);
     } on Object {
-      return;
+      return const [];
     }
 
-    for (final source in pending) {
+    final byEntryId = {
+      for (final summary in stored) summary.sourceEntryId: summary,
+    };
+    final live = {for (final source in sources) source.entryId: source};
+
+    for (final source in sources) {
+      final existing = byEntryId[source.entryId];
+      // Recompact when the words changed. A transcript is not final when it
+      // first lands — it can be re-transcribed with a better model or edited —
+      // and without this the first summary stood forever while the agent
+      // coached from words that no longer existed. A summary predating the
+      // digest has none, so it is refreshed once and then carries one.
+      final digest = goalCheckInSourceDigest(source.text);
+      if (existing != null && existing.sourceDigest == digest) continue;
       await compactor.compact(
         agentId: agentId,
         entryId: source.entryId,
@@ -1116,6 +1121,21 @@ class GoalAgentWorkflow with AgentErrorLogging {
         provider: provider,
       );
     }
+
+    if (live.isEmpty && stored.isEmpty) return const [];
+    try {
+      stored = await _checkInSummaries(agentId);
+    } on Object {
+      return const [];
+    }
+    // Only summaries whose source is still linked and live. A deleted or
+    // unlinked check-in leaves its summary behind, and without this the agent
+    // kept quoting words the user had removed — the timeline already hides
+    // them, and the agent's view must not disagree with what the user sees.
+    return [
+      for (final summary in stored)
+        if (live.containsKey(summary.sourceEntryId)) summary,
+    ];
   }
 
   /// The compacted check-ins stored for this goal.

--- a/test/features/goals/logic/goal_user_voice_test.dart
+++ b/test/features/goals/logic/goal_user_voice_test.dart
@@ -40,9 +40,13 @@ void main() {
       summary('a', base, committed: 'walk after lunch'),
     ]);
 
-    // "You said on Tuesday you would walk after lunch" is only sayable if
-    // both of these survive compaction.
-    expect(entries.single['recordedAtLocal'], isNotNull);
+    // "You said on Tuesday you would walk after lunch" is only sayable if both
+    // of these survive compaction — and `isNotNull` would pass for a wrong
+    // field or a changed format, which is exactly what would break the quote.
+    expect(
+      entries.single['recordedAtLocal'],
+      base.toLocal().toIso8601String(),
+    );
     expect(entries.single['committedTo'], 'walk after lunch');
   });
 

--- a/test/features/goals/model/goal_checkin_summary_test.dart
+++ b/test/features/goals/model/goal_checkin_summary_test.dart
@@ -1,6 +1,20 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
 
+extension on GoalCheckInSummary {
+  GoalCheckInSummary copyWithDigest(String digest) => GoalCheckInSummary(
+    id: id,
+    sourceEntryId: sourceEntryId,
+    recordedAt: recordedAt,
+    whatHappened: whatHappened,
+    committedTo: committedTo,
+    blockers: blockers,
+    mood: mood,
+    asks: asks,
+    sourceDigest: digest,
+  );
+}
+
 void main() {
   final recordedAt = DateTime.utc(2026, 8, 18, 14, 20);
 
@@ -93,8 +107,33 @@ void main() {
       expect(GoalCheckInSummary.fromContent('id', content(at: null)), isNull);
     });
 
+    test('a malformed optional slot is ignored, not thrown', () {
+      // These arrive over sync from a peer on a different build. A direct cast
+      // threw, and because the workflow reads every summary in one pass that
+      // single bad value cost the wake ALL of its user voice.
+      final restored = GoalCheckInSummary.fromContent('id', {
+        ...content(),
+        'committedTo': 42,
+        'blockers': <String, Object?>{'unexpected': 'shape'},
+      });
+
+      expect(restored, isNotNull);
+      expect(restored!.whatHappened, 'Walked.');
+      expect(restored.committedTo, isNull);
+      expect(restored.blockers, isNull);
+    });
+
     test('a well-formed payload decodes', () {
       expect(GoalCheckInSummary.fromContent('id', content()), isNotNull);
+    });
+
+    test('the source fingerprint round-trips', () {
+      // It is what tells a re-transcription from a check-in already handled.
+      final restored = GoalCheckInSummary.fromContent(
+        'id',
+        summary().copyWithDigest('abc123').toContent(),
+      );
+      expect(restored!.sourceDigest, 'abc123');
     });
   });
 }

--- a/test/features/goals/runtime/goal_runtime_maintenance_test.dart
+++ b/test/features/goals/runtime/goal_runtime_maintenance_test.dart
@@ -62,6 +62,7 @@ void main() {
   late MockWakeOrchestrator orchestrator;
   late GoalRuntimeMaintenance maintenance;
   late MockGoalMirrorService mirror;
+  late MockGoalCheckInNotifier notifier;
   late List<AgentDomainEntity> upserts;
 
   void stubSpec(String agentId) {
@@ -96,6 +97,10 @@ void main() {
     syncService = MockAgentSyncService();
     orchestrator = MockWakeOrchestrator();
     mirror = MockGoalMirrorService();
+    notifier = MockGoalCheckInNotifier();
+    when(() => notifier.watch(any())).thenReturn(null);
+    when(() => notifier.unwatch(any())).thenReturn(null);
+    when(() => notifier.start(any())).thenReturn(null);
     when(
       () => mirror.mirrorHead(any(), categoryId: any(named: 'categoryId')),
     ).thenAnswer((_) async => null);
@@ -110,6 +115,7 @@ void main() {
         orchestrator: orchestrator,
       ),
       goalMirrorService: mirror,
+      checkInNotifier: notifier,
     );
     upserts = [];
     when(() => repository.getEntity(any())).thenAnswer((_) async => null);
@@ -195,6 +201,24 @@ void main() {
           ).called(1);
         },
       );
+
+      test('a goal that syncs in before its spec head is still watched', () async {
+        // Identity and spec head arrive as separate synced entities in no
+        // guaranteed order. Watching behind the criteria gate meant an identity
+        // that landed first left the goal unwatched until a restart — the
+        // startup-snapshot bug reintroduced by placement rather than by logic.
+        when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+
+        await maintenance.onIdentityReceived(
+          goal('head-not-here-yet', AgentLifecycle.active),
+        );
+
+        verify(() => mirror.mirrorHead('head-not-here-yet')).called(1);
+        verify(() => notifier.watch('head-not-here-yet')).called(1);
+        // No criteria, so no signal subscription — only the watch survives the
+        // missing head.
+        verifyNever(() => orchestrator.addSubscription(any()));
+      });
 
       test('a non-goal identity is ignored entirely', () async {
         await maintenance.onIdentityReceived(

--- a/test/features/goals/service/goal_checkin_compactor_test.dart
+++ b/test/features/goals/service/goal_checkin_compactor_test.dart
@@ -130,15 +130,28 @@ void main() {
   });
 
   test('is keyed by (agent, entry) so a retry converges', () async {
-    scripted = ['{"whatHappened":"Walked."}'];
-    final summary = await compact();
+    // Actually retry: comparing the id helper with itself held for any
+    // implementation and proved nothing, while the name promised convergence.
+    scripted = ['{"whatHappened":"Walked."}', '{"whatHappened":"Walked."}'];
+    final first = await compact();
+    final second = await compact();
 
-    expect(summary!.id, goalCheckInSummaryId('goal-1', 'audio-1'));
-    // Two devices reacting to the same synced recording must write one row.
+    expect(first!.id, goalCheckInSummaryId('goal-1', 'audio-1'));
+    expect(second!.id, first.id);
+
+    // Both runs wrote the SAME row, so a regression that appended a second
+    // summary of the same words fails here.
+    final messageIds = written
+        .whereType<AgentMessageEntity>()
+        .map((message) => message.id)
+        .toSet();
+    expect(messageIds, hasLength(1));
     expect(
-      goalCheckInSummaryId('goal-1', 'audio-1'),
-      goalCheckInSummaryId('goal-1', 'audio-1'),
+      written.whereType<AgentMessagePayloadEntity>().map((p) => p.id).toSet(),
+      hasLength(1),
     );
+
+    // A different recording is a different row.
     expect(
       goalCheckInSummaryId('goal-1', 'audio-2'),
       isNot(goalCheckInSummaryId('goal-1', 'audio-1')),

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -856,6 +856,9 @@ void main() {
           'recordedAt': '2026-08-10T09:00:00.000Z',
           'whatHappened': 'Walked the long way home.',
           'committedTo': 'walk after lunch tomorrow',
+          // Matching digest: the words have not changed, so this summary is
+          // reused rather than paid for again.
+          'sourceDigest': goalCheckInSourceDigest('Walked the long way home.'),
         },
       ),
     );
@@ -910,8 +913,8 @@ void main() {
       threadId: 'thread-compaction',
     );
 
-    // Only the un-summarised entry is compacted: the keyed summary makes a
-    // re-run converge rather than pay for the same words twice.
+    // Only the un-summarised entry is compacted: an unchanged check-in whose
+    // digest still matches is reused rather than paid for again.
     expect(compacted, ['audio-1']);
     expect(sentFacts, isNotNull);
     // The transcript itself never reaches the prompt; the compacted record
@@ -919,6 +922,136 @@ void main() {
     expect(sentFacts, isNot(contains('Skipped the lunch walk.')));
     expect(sentFacts, contains('userVoice'));
     expect(sentFacts, contains('walk after lunch tomorrow'));
+  });
+
+  test('a check-in whose words changed is recompacted, and a deleted one '
+      'stops reaching the agent', () async {
+    stubSpec();
+    stubGlmResolution();
+    _stubBadPrior(repository, agentId, now);
+
+    final compactor = MockGoalCheckInCompactor();
+    final compacted = <String>[];
+    when(
+      () => compactor.compact(
+        agentId: any(named: 'agentId'),
+        entryId: any(named: 'entryId'),
+        recordedAt: any(named: 'recordedAt'),
+        transcript: any(named: 'transcript'),
+        goalStatement: any(named: 'goalStatement'),
+        model: any(named: 'model'),
+        provider: any(named: 'provider'),
+      ),
+    ).thenAnswer((invocation) async {
+      compacted.add(invocation.namedArguments[#entryId] as String);
+      return null;
+    });
+
+    AgentDomainEntity summaryMessage(String id, String entryId) =>
+        AgentDomainEntity.agentMessage(
+          id: id,
+          agentId: agentId,
+          threadId: id,
+          kind: AgentMessageKind.action,
+          createdAt: DateTime.utc(2026, 8, 10, 9),
+          vectorClock: null,
+          metadata: const AgentMessageMetadata(
+            toolName: goalCheckInSummaryToolName,
+          ),
+          contentEntryId: '$id:payload',
+        );
+
+    when(
+      () => repository.getEntitiesByAgentIdAndSubtype(
+        agentId,
+        type: any(named: 'type'),
+        subtype: any(named: 'subtype'),
+      ),
+    ).thenAnswer(
+      (_) async => [
+        summaryMessage('summary-edited', 'audio-edited'),
+        summaryMessage('summary-gone', 'audio-gone'),
+      ],
+    );
+    Future<AgentDomainEntity?> payload(
+      String id,
+      String entryId,
+      String text,
+    ) async => AgentDomainEntity.agentMessagePayload(
+      id: '$id:payload',
+      agentId: agentId,
+      createdAt: DateTime.utc(2026, 8, 10, 9),
+      vectorClock: null,
+      content: <String, Object?>{
+        'sourceEntryId': entryId,
+        'recordedAt': '2026-08-10T09:00:00.000Z',
+        'whatHappened': 'Old reading of $entryId.',
+        'sourceDigest': goalCheckInSourceDigest(text),
+        // A malformed optional slot from a peer on another build: it must
+        // be ignored, not throw away every summary in this wake.
+        'committedTo': 42,
+      },
+    );
+    when(
+      () => repository.getEntity('summary-edited:payload'),
+    ).thenAnswer(
+      (_) => payload('summary-edited', 'audio-edited', 'the OLD words'),
+    );
+    when(
+      () => repository.getEntity('summary-gone:payload'),
+    ).thenAnswer((_) => payload('summary-gone', 'audio-gone', 'deleted words'));
+
+    workflow = GoalAgentWorkflow(
+      repository: repository,
+      syncService: syncService,
+      phaseA: GoalAgentPhaseA(
+        repository: repository,
+        syncService: syncService,
+        signalReader: _FakeReader(),
+      ),
+      conversationRepository: conversationRepository,
+      cloudInferenceRepository: cloudInferenceRepository,
+      aiConfigRepository: aiConfigRepository,
+      checkInCompactor: compactor,
+      // `audio-gone` is no longer linked — deleted or unlinked by the user.
+      checkInSourceReader: (agentId) async => [
+        GoalCheckInSource(
+          entryId: 'audio-edited',
+          recordedAt: DateTime.utc(2026, 8, 10, 9),
+          text: 'the NEW words after a re-transcription',
+        ),
+      ],
+    );
+
+    String? sentFacts;
+    conversationRepository.sendMessageDelegate =
+        ({
+          required conversationId,
+          required message,
+          required model,
+          required provider,
+          required inferenceRepo,
+          tools,
+          toolChoice,
+          temperature = 0.7,
+          strategy,
+        }) async {
+          sentFacts ??= message;
+          return const InferenceUsage(inputTokens: 10, outputTokens: 5);
+        };
+
+    await workflow.execute(
+      agentIdentity: identity,
+      runKey: 'run-reconcile',
+      triggerTokens: const {'goal-escalation:2026-08-11'},
+      threadId: 'thread-reconcile',
+    );
+
+    // Changed words are distilled again rather than left standing.
+    expect(compacted, ['audio-edited']);
+    // And the summary of a check-in the user removed no longer reaches the
+    // agent — the timeline already hides it, and the two must not disagree.
+    expect(sentFacts, isNot(contains('Old reading of audio-gone.')));
   });
 
   test('a full wake persists FACTS, report + head, the new ad, and token '

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -111,6 +111,7 @@ import 'package:lotti/features/demo/state/demo_mode_gateway.dart';
 import 'package:lotti/features/goals/repository/goal_repository.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:lotti/features/goals/service/goal_checkin_compactor.dart';
+import 'package:lotti/features/goals/service/goal_checkin_notifier.dart';
 import 'package:lotti/features/goals/service/goal_habit_completion_service.dart';
 import 'package:lotti/features/goals/service/goal_mirror_service.dart';
 import 'package:lotti/features/habits/repository/habits_repository.dart';
@@ -982,6 +983,9 @@ class FakeJournalImage extends Fake implements JournalImage {}
 class MockGoalRepository extends Mock implements GoalRepository {}
 
 class MockGoalMirrorService extends Mock implements GoalMirrorService {}
+
+class MockGoalCheckInNotifier extends Mock
+    implements GoalCheckInNotifier {}
 
 class MockGoalCheckInCompactor extends Mock
     implements GoalCheckInCompactor {}


### PR DESCRIPTION
Follow-up to #3975 · base: `main`

Two review rounds arrived after #3975 merged — CodeRabbit's seven and a
separate four-finding review. Ten of the eleven are addressed here; the
eleventh is declined with a reason below.

## The agent could coach from words that no longer exist

Compaction treated any existing `sourceEntryId` as permanently current, so:

- a check-in **re-transcribed or edited** kept its first summary forever;
- one the user **deleted or unlinked** kept reaching the agent indefinitely.

The timeline already hid deleted check-ins, so the agent's view and the user's
disagreed — the worse half of the two. Summaries now carry a fingerprint of the
words they were distilled from and are recompacted when it changes, and only
summaries whose source is still linked and live are rendered.

## Reads were doubled and unbounded

`_checkInSummaries` loaded every action message and then issued one payload
query per summary — **twice per wake**, once to find pending sources and again
to render. For a daily goal that grows without bound, which is what ADR 0057's
bounded-read invariant exists to prevent. One read per side now serves both.

## One malformed synced field cost a wake all of its user voice

Optional slots were cast directly, so a `committedTo: 42` from a peer on a
different build threw — abandoning pending compaction and omitting every
summary from that wake. Slots that cannot be read are now simply absent.

## The budget under-counted what it was budgeting

The estimate joined the values and omitted every JSON key, the entry id and the
wrapper, so the selected set could exceed the budget it was chosen to fit — by
more the more entries were retained. It now estimates the encoded shape, as the
agent-log compactor does.

## A goal that synced in before its spec head went unwatched

The watch call sat behind the criteria gate, so an identity arriving ahead of
its head returned early and the goal marked nothing stale until a restart —
the startup-snapshot bug reintroduced by placement rather than by logic.

## The new diagram made the concept contradict itself

Its stale-marking node reused an existing id, so mermaid kept the first label
and attached the new edge to the tracked-time node — rendering a claim that
tracked-time mutations reach the escalation router, which the invariants a few
hundred lines below explicitly deny.

## Two of my own tests asserted nothing

One compared the id helper **with itself**, under a name promising that a retry
converges, while never retrying; it now compacts twice and asserts a single row
is written. The other checked a timestamp was merely present when the whole
point was the format the agent quotes back.

## Declined, with a reason

**An idle timeout on the compaction stream.** A stalled provider is already
bounded by `wakeRunMaxDuration` (10 minutes), and `AgentLogLlmSummarizer`
shares the same property — giving one of the two a private timeout would be
inconsistent rather than safer. Worth doing for both, in its own change.

## Verification

`dart analyze lib test` clean, `make knowledge_check` passes, 1387 tests green
across goals, the goal eval suite and beamer. Patch coverage 100%.

Refs `lotti3-7zm`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Check-in summaries now track source changes, enabling updated transcripts to be recompacted automatically.
  * Deleted or unlinked check-ins are excluded from goal context.
  * Summary data handles optional and malformed fields more safely.

* **Bug Fixes**
  * Active goals continue to be monitored while criteria are temporarily unavailable.
  * Failed check-in reconciliation no longer prevents the rest of the wake process from continuing.

* **Tests**
  * Expanded coverage for digest reuse, edited and deleted check-ins, malformed data, and notifier monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->