### PR TITLE
fix(goals): check a report the parser refused instead of only calling it incomplete

### DIFF
--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -766,6 +766,48 @@ per-series fields the app renders, instead of prose the model must echo and a
 regex must recover — which would delete this whole class of defect rather than
 repair it. Tracked as `lotti3-lf68`; see "Known gaps".
 
+## The guard stopped applying when the parse failed — 2026-08-18
+
+The last gap of the report-loss story, and the same shape as the matcher bug:
+a rule that could not be satisfied, this time because it was not being asked.
+
+`GoalStructuredReport.tryParse` is all-or-nothing. One absent slot and every
+field is unavailable — including `latestChange` and `coverage`, which may be
+empty but must be *present*, so a model with nothing to report that simply
+omits the key fails the parse. `_handleUpdateReport` then had nothing to read:
+the status-token scan lost the structured slots and the aggregate rule was
+skipped outright behind its `structured != null` guard. The rejection said
+"needs … a complete structured report" and nothing else.
+
+So the model fixed the shape, and met the aggregate rule for the first time on
+the one forced retry a wake gets — ending with no standing report at all. That
+is exactly the sequential-rejection failure batching was built to remove, still
+reachable through the parse path, which is why batching's measured effect was
+smaller than the mechanism suggested it should be.
+
+**The fix** separates what persists from what is checked.
+`GoalStructuredReport.lenient` recovers whatever text is present — missing
+slots read as empty, malformed action entries are dropped — and the two rules
+read that view instead. Completeness is still judged strictly from `tryParse`,
+so nothing lenient can make an incomplete report acceptable, and the lenient
+value is never persisted. One `isNotEmpty` guard keeps an absent standing from
+being reported twice, once as incomplete and once as missing its aggregate.
+
+**Not measured on the matrix.** After the matcher fix the tier-2 baseline sits
+at 53–54/54, so there is no headroom in which to observe this: the residual
+failures are single-digit and the parse path is a fraction of them. It is
+argued from the mechanism and pinned by tests — a report missing `latestChange`
+now collects three rules in one rejection where it previously collected one,
+and reverting the fix turns that test red. Quoting a suite delta here would be
+quoting noise.
+
+**The pattern, third time.** Every defect in this section of the log has been a
+check that was wrong rather than a model that was weak: a rule that punished
+correct prose, a rule reported one at a time, a rule that quietly stopped
+applying. "Would a correct answer pass this?" caught the first. "Is this rule
+even running?" is the same question one level up, and the rejection log is
+where both are cheap to ask.
+
 ## Cost and latency
 
 Cost and wall-clock latency are first-class outputs, captured per case:
@@ -917,20 +959,10 @@ anyway.
 What the runs surfaced and did not close. Where there is a tracker id the
 reasoning still lives here — the id is the task, this is why it matters.
 
-**A report the parser rejects skips most of the guard** (`lotti3-ozt0`, P1).
-`GoalStructuredReport.tryParse` is all-or-nothing over roughly ten shape
-conditions — a missing `rollingWindow`, a `nextActions.later` arriving as a
-string rather than a list, one malformed action item — and returns `null` for
-any of them. `_handleUpdateReport` then adds only the generic "needs … a complete
-structured report" problem: the status-token check no longer sees the
-structured fields (`tldr` is empty and the sections are excluded), and the
-rolling-aggregate check is skipped entirely behind its `structured != null`
-guard. So a model that gets the shape wrong is told about the shape and
-nothing else, fixes it, and meets the aggregate rule for the *first* time on
-the one forced retry it has left. That is precisely the sequential-rules
-failure the batched rejection was written to remove, still reachable through
-the parse path. Automated review raised it on the batching PR; it merged
-without a ruling.
+**A report the parser rejects skips most of the guard** — **closed**
+(`lotti3-ozt0`, P1), by "The guard stopped applying when the parse failed"
+above. Listed rather than deleted so the entry that sent someone here does not
+turn into a dead end.
 
 **The aggregate check proves appearance, not binding** (`lotti3-lf68`, P2).
 Stated in full under "The report loss was a matcher bug" → Still open, where it

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -437,7 +437,12 @@ flowchart TD
   latest change, coverage, and actions as separate required slots; the strategy
   parses the same complete shape used by the eval classifier and assembles the
   localized model-authored sentences without injecting English headings.
-  Evaluated-period and rolling-standing slots must be non-empty. Structured
+  Evaluated-period and rolling-standing slots must be non-empty. Completeness
+  is judged strictly, but the *rules* read a lenient view
+  (`GoalStructuredReport.lenient`) so a report the parser refused is still
+  checked for status tokens in prose and for quoting the deterministic
+  aggregates — a wake gets one forced report retry, and a rejection naming
+  only the shape would let those rules ambush it. Structured
   current actions carry a criterion id and survive only when deterministic
   `healthLoggingNeededCriterionIds` authorizes that id, so a lagging rolling
   habit cannot create a current action item; delayed overdue evaluations expose

--- a/lib/features/goals/workflow/goal_agent_contract.dart
+++ b/lib/features/goals/workflow/goal_agent_contract.dart
@@ -184,6 +184,57 @@ class GoalStructuredReport {
     );
   }
 
+  /// A best-effort view of a report [tryParse] refused, for the guard only.
+  ///
+  /// [tryParse] is all-or-nothing: one absent slot — including `latestChange`
+  /// or `coverage`, which may be empty but must be *present* — makes every
+  /// other field unavailable. The rules that read those fields then stop
+  /// applying silently, so the model is told its report was incomplete and
+  /// nothing else, fixes the shape, and meets those rules for the first time
+  /// on the single forced retry a wake gets. That is the sequential-rejection
+  /// failure batching was meant to end, reached through the parse path.
+  ///
+  /// This recovers whatever text is actually there so one rejection can carry
+  /// the shape error and the rule violations together. Missing slots come back
+  /// empty, which is precisely what the strict parser exists to refuse — so
+  /// never persist the result, and never let it decide completeness.
+  static GoalStructuredReport? lenient(Object? value) {
+    if (value is! Map<String, dynamic>) return null;
+    final actions = value[GoalReportSectionKeys.nextActions];
+    final rawNow = actions is Map<String, dynamic>
+        ? actions[GoalReportActionKeys.now]
+        : null;
+    final rawLater = actions is Map<String, dynamic>
+        ? actions[GoalReportActionKeys.later]
+        : null;
+    return GoalStructuredReport(
+      tldr: _optionalReportString(value[GoalReportSectionKeys.tldr]) ?? '',
+      currentPeriod:
+          _optionalReportString(value[GoalReportSectionKeys.currentPeriod]) ??
+          '',
+      rollingWindow:
+          _optionalReportString(value[GoalReportSectionKeys.rollingWindow]) ??
+          '',
+      latestChange:
+          _optionalReportString(value[GoalReportSectionKeys.latestChange]) ??
+          '',
+      coverage:
+          _optionalReportString(value[GoalReportSectionKeys.coverage]) ?? '',
+      now: [
+        for (final item in rawNow is List<dynamic> ? rawNow : const [])
+          if (item is Map<String, dynamic>)
+            GoalReportCurrentAction(
+              criterionId: _optionalReportString(item['criterionId']) ?? '',
+              action: _optionalReportString(item['action']) ?? '',
+            ),
+      ],
+      later: [
+        for (final item in rawLater is List<dynamic> ? rawLater : const [])
+          ?_optionalReportString(item),
+      ],
+    );
+  }
+
   /// Composes the **expanded** report body from model-authored localized
   /// sentences, without injecting English headings. [tldr] is deliberately
   /// absent: it is the collapsed view shown above this, and repeating it as

--- a/lib/features/goals/workflow/goal_agent_strategy.dart
+++ b/lib/features/goals/workflow/goal_agent_strategy.dart
@@ -227,6 +227,14 @@ class GoalAgentStrategy extends ConversationStrategy
     final content = _trimmed(args['content']);
     final hasStructuredReport = args.containsKey('report');
     final structured = GoalStructuredReport.tryParse(args['report']);
+    // What the RULES read, which is not what gets persisted. A report the
+    // strict parser refused still has text in it, and the rules below are the
+    // model's only warning about that text — skipping them because a slot was
+    // missing spends the one forced retry on the shape and lets the aggregate
+    // rule ambush the retry. Completeness is still judged strictly, from
+    // `structured`, so nothing here can make an incomplete report acceptable.
+    final checkable =
+        structured ?? GoalStructuredReport.lenient(args['report']);
     final tldr = hasStructuredReport
         ? structured?.tldr ?? ''
         : _trimmed(args['tldr']);
@@ -262,13 +270,14 @@ class GoalAgentStrategy extends ConversationStrategy
     final tokenInProse = _statusTokenIn([
       oneLiner,
       tldr,
-      if (structured != null) ...[
-        structured.currentPeriod,
-        structured.rollingWindow,
-        structured.latestChange,
-        structured.coverage,
-        for (final item in structured.now) item.action,
-        ...structured.later,
+      if (checkable != null) ...[
+        checkable.tldr,
+        checkable.currentPeriod,
+        checkable.rollingWindow,
+        checkable.latestChange,
+        checkable.coverage,
+        for (final item in checkable.now) item.action,
+        ...checkable.later,
       ],
       content,
     ]);
@@ -293,9 +302,14 @@ class GoalAgentStrategy extends ConversationStrategy
     // ("127.85" where FACTS carry 127). Both put a wrong number in front of
     // the user, and every evaluated model does it, so it is enforced here
     // rather than asked for in prose. Same authority as trackStatus above.
-    if (structured != null && expectedRollingAggregates.isNotEmpty) {
+    // `isNotEmpty` is free on the strict path — the slot is required there —
+    // and on the lenient one it keeps an absent standing from being reported
+    // twice, once as incomplete and once as missing its aggregate.
+    if (checkable != null &&
+        checkable.rollingWindow.isNotEmpty &&
+        expectedRollingAggregates.isNotEmpty) {
       final missing = expectedRollingAggregates
-          .where((value) => !_quotesNumber(structured.rollingWindow, value))
+          .where((value) => !_quotesNumber(checkable.rollingWindow, value))
           .toList();
       if (missing.isNotEmpty) {
         problems.add(

--- a/test/features/goals/workflow/goal_agent_contract_test.dart
+++ b/test/features/goals/workflow/goal_agent_contract_test.dart
@@ -260,5 +260,77 @@ void main() {
         expect(GoalStructuredReport.tryParse(value), isNull, reason: '$value');
       }
     });
+
+    group('lenient', () {
+      test('reads the same fields as tryParse on a complete report', () {
+        // The guard runs the same rules whichever view it gets, so a valid
+        // report has to look identical through both.
+        final strict = GoalStructuredReport.tryParse(validReport())!;
+        final loose = GoalStructuredReport.lenient(validReport())!;
+        expect(loose.tldr, strict.tldr);
+        expect(loose.currentPeriod, strict.currentPeriod);
+        expect(loose.rollingWindow, strict.rollingWindow);
+        expect(loose.latestChange, strict.latestChange);
+        expect(loose.coverage, strict.coverage);
+        expect(
+          loose.now.map((a) => '${a.criterionId}:${a.action}'),
+          strict.now.map((a) => '${a.criterionId}:${a.action}'),
+        );
+        expect(loose.later, strict.later);
+      });
+
+      test('recovers the text present in a report tryParse refused', () {
+        // The point of the whole method: `latestChange` is gone, so strict
+        // parsing yields nothing at all, while the standing the aggregate
+        // rule has to read is sitting right there.
+        final value = validReport()..remove('latestChange');
+        expect(GoalStructuredReport.tryParse(value), isNull);
+
+        final loose = GoalStructuredReport.lenient(value)!;
+        expect(loose.rollingWindow, isNotEmpty);
+        expect(loose.rollingWindow, validReport()['rollingWindow']);
+        expect(loose.latestChange, isEmpty);
+      });
+
+      test('degrades every malformed slot to empty rather than failing', () {
+        final loose = GoalStructuredReport.lenient({
+          'tldr': 7,
+          'rollingWindow': '  Averaging 6000 steps.  ',
+          'nextActions': {
+            'now': [
+              {'criterionId': 'steps'},
+              'not an action map',
+            ],
+            'later': ['Keep walking.', 12],
+          },
+        })!;
+        // Mistyped and absent slots read the same: empty, never a throw.
+        expect(loose.tldr, isEmpty);
+        expect(loose.currentPeriod, isEmpty);
+        expect(loose.coverage, isEmpty);
+        // Trimmed exactly as the strict reader trims.
+        expect(loose.rollingWindow, 'Averaging 6000 steps.');
+        // A map missing `action` survives with an empty one; a non-map is
+        // dropped, since there is no field to recover from it.
+        expect(loose.now, hasLength(1));
+        expect(loose.now.single.criterionId, 'steps');
+        expect(loose.now.single.action, isEmpty);
+        // Non-strings in `later` are dropped for the same reason.
+        expect(loose.later, ['Keep walking.']);
+      });
+
+      test('returns null only when there is no report map at all', () {
+        for (final value in <Object?>[null, 'report', 7, <Object?>[]]) {
+          expect(GoalStructuredReport.lenient(value), isNull, reason: '$value');
+        }
+        // `nextActions` of the wrong type costs the actions, not the report.
+        final loose = GoalStructuredReport.lenient(
+          validReport()..['nextActions'] = 'later',
+        )!;
+        expect(loose.now, isEmpty);
+        expect(loose.later, isEmpty);
+        expect(loose.rollingWindow, isNotEmpty);
+      });
+    });
   });
 }

--- a/test/features/goals/workflow/goal_agent_strategy_test.dart
+++ b/test/features/goals/workflow/goal_agent_strategy_test.dart
@@ -455,6 +455,126 @@ void main() {
     expect(gated.reportStatus, GoalTrackStatus.offTrack);
   });
 
+  test(
+    'a report the parser refused is still checked against the rules',
+    () async {
+      // `latestChange` is simply absent — a slot a model with nothing to report
+      // omits, and one `tryParse` requires to be PRESENT even when empty. The
+      // parse therefore fails, and every field it would have exposed used to
+      // become unreadable: the status-token scan lost the structured slots and
+      // the aggregate rule stopped applying altogether. The model was told only
+      // that its report was incomplete, fixed the shape, and met those rules for
+      // the first time on the one forced retry a wake gets — the sequential
+      // rejection batching exists to prevent, reached through the parse path.
+      final gated = GoalAgentStrategy(
+        syncService: syncService,
+        agentId: 'goal-1',
+        threadId: 'thread-1',
+        runKey: 'run-1',
+        knownAdIds: const {},
+        expectedStatus: GoalTrackStatus.offTrack,
+        expectedRollingAggregates: const ['6000'],
+      );
+      await gated.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              // Status agrees with FACTS and `oneLiner` is clean, so the two
+              // violations below can only be found inside the structured slots
+              // the failed parse used to hide.
+              'status': 'offTrack',
+              'oneLiner': 'Well under the daily target.',
+              'report': {
+                'tldr': 'Behind on steps.',
+                'currentPeriod': 'The current period reads offTrack.',
+                'rollingWindow': 'Averaging about 6.5k steps a day.',
+                'coverage': '7 days.',
+                'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+              },
+            },
+          ),
+        ],
+        manager: manager,
+      );
+
+      expect(gated.hasReport, isFalse);
+      final refusal = rejection();
+      expect(refusal, contains('broke 3 rules'));
+      expect(refusal, contains('a complete structured report'));
+      // Both of these were unreachable while the parse failure hid the slots.
+      expect(
+        refusal,
+        contains('"offTrack" is a status field value, not prose'),
+      );
+      expect(refusal, contains('6000 is missing'));
+
+      // One retry, every rule honoured, and the report lands.
+      await gated.processToolCalls(
+        toolCalls: [
+          _call(
+            name: GoalAgentToolNames.updateGoalReport,
+            args: {
+              'status': 'offTrack',
+              'oneLiner': 'Well under the daily target.',
+              'report': {
+                'tldr': 'Behind on steps.',
+                'currentPeriod': 'Around 6.4k yesterday.',
+                'rollingWindow': 'Averaging 6000 steps a day against 10000.',
+                'latestChange': 'Down from last week.',
+                'coverage': '7 days.',
+                'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+              },
+            },
+          ),
+        ],
+        manager: manager,
+      );
+      expect(gated.reportStatus, GoalTrackStatus.offTrack);
+    },
+  );
+
+  test('an absent rolling standing is reported once, not twice', () async {
+    // The lenient view reads a missing slot as empty, and an empty standing
+    // trivially fails "quote 6000". Reporting that alongside "incomplete"
+    // would tell the model twice that a section it never wrote is wrong.
+    final gated = GoalAgentStrategy(
+      syncService: syncService,
+      agentId: 'goal-1',
+      threadId: 'thread-1',
+      runKey: 'run-1',
+      knownAdIds: const {},
+      expectedStatus: GoalTrackStatus.offTrack,
+      expectedRollingAggregates: const ['6000'],
+    );
+    await gated.processToolCalls(
+      toolCalls: [
+        _call(
+          name: GoalAgentToolNames.updateGoalReport,
+          args: {
+            'status': 'offTrack',
+            'oneLiner': 'Well under the daily target.',
+            'report': {
+              'tldr': 'Behind on steps.',
+              'currentPeriod': 'Around 6.4k yesterday.',
+              'latestChange': 'Down from last week.',
+              'coverage': '7 days.',
+              'nextActions': {'now': <Object?>[], 'later': <Object?>[]},
+            },
+          },
+        ),
+      ],
+      manager: manager,
+    );
+
+    expect(gated.hasReport, isFalse);
+    final refusal = rejection();
+    expect(refusal, contains('a complete structured report'));
+    expect(refusal, isNot(contains('6000 is missing')));
+    // A single problem keeps the plain wording — no "broke N rules" envelope.
+    expect(refusal, isNot(contains('broke')));
+  });
+
   test('a single broken rule reads exactly as it always did', () async {
     // The envelope is for the multiple case only: one problem must not gain
     // a "broke 1 rules" preamble.


### PR DESCRIPTION
Closes the P1 recorded in the goal-agent eval log (#3977), raised by automated
review on #3966 and merged without a ruling.

## The defect

`GoalStructuredReport.tryParse` is all-or-nothing, and two of the slots it
requires to be *present* may be empty — a model with no latest change that
simply omits `latestChange` fails the parse. `_handleUpdateReport` then had
nothing to read:

- the status-token scan lost the structured sections
- the rolling-aggregate rule was skipped outright behind `structured != null`

So the rejection said only "needs … a complete structured report". The model
fixed the shape and met the aggregate rule for the **first time** on the one
forced retry a wake gets, ending with no standing report at all — the
sequential rejection #3966 removed, still reachable through the parse path.

## The fix

Separates what persists from what is checked. `GoalStructuredReport.lenient`
recovers whatever text is present; the two rules read that view. Completeness
is still judged strictly from `tryParse`, so nothing lenient can make an
incomplete report acceptable, and the lenient value is never persisted. One
`isNotEmpty` guard keeps an absent rolling standing from being reported twice.

## Verification

- 149 tests green in `test/features/goals/workflow/`, 90 in the offline eval
  suite, analyzer clean.
- **Reverted the fix and re-ran the new test**: it fails with exactly the
  defect's signature — one generic message where three rules should appear.

Argued from the mechanism rather than the matrix, deliberately: after the
matcher fix (#3968) tier 2 sits at 53–54/54, leaving no headroom to observe a
parse-path change. Quoting a suite delta would be quoting noise, and the eval
log says so rather than implying a measurement happened.

Docs updated in the same change: a dated section in the eval log, the Known
gaps entry marked closed with a pointer, and the guard description in
`knowledge/features/goals.md`.

No CHANGELOG entry — the feature is flag-gated and unreleased, matching #3966
and #3968.