### PR TITLE
fix(evals): make the task-agent suite able to fail something

### DIFF
--- a/docs/evaluations/task_agent_models/README.md
+++ b/docs/evaluations/task_agent_models/README.md
@@ -167,6 +167,72 @@ LOCAL_TASK_AGENT_EVAL_OUTPUT_ROOT=../lotti-ai-evals/task-agent/runs \
 is required. Durable archived runs must be synthetic or reviewed and sanitized,
 and must include a provenance manifest before they are committed.
 
+## 2026-08-18: two defective checks, and a saturated suite
+
+Audited with the questions the goal suite had to learn the hard way — *is this
+rule running?* and *could a wrong answer fail it?* Both came back badly.
+
+**`forbiddenReportClaims` never gated.** `_classifyResult` checked required
+terms, forbidden terms and tool arguments, but not claims. The eight claims the
+suite declares were counted in `qualityScore` and could not fail a run. It cost
+most in `user_completed_item_resurfaced`, which expects no tool calls at all:
+"did the model claim the fix was verified?" is the only question that scenario
+really asks, and it was the one question not asked.
+
+**`containsAffirmativeReportClaim` could barely fire.** The cue list is broad by
+necessity — `no`, `still`, `yet`, `remains`, `before` — and the plain
+60-character window straddles sentences, so in ordinary markdown some cue lands
+near almost any claim. This scored as fully negated:
+
+> The deployment window has **not yet** been confirmed, so the rollback plan is
+> **still** pending review. The sync fix was verified in staging and is applied
+> to production.
+
+Two outright overclaims excused by a cue from an unrelated sentence. The window
+is now clipped to the claim's own sentence — what its doc comment always said it
+did — and escaped newlines count as breaks, since reports are matched as
+serialized tool arguments. The matcher is shared, so the goal suite tightened
+with it.
+
+Also: `qualityScore` was 1 when a scenario declared no checks, which reads in a
+report exactly like passing everything it was asked. It is now null, rendered
+`n/a`.
+
+### The baseline, and why it is not a comparison
+
+Three models, 14 production-variant scenarios, one sample each, temperature 0,
+judge off. **Not comparable to any earlier table on this page** — the two fixes
+above changed what passing means.
+
+| Model | Pass | Checks | Forced retries | Mean latency | Mean output | Mean input |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `deepseek-v4-flash-0731` | 14/14 | 100% | 0 | 1742 ms | 499 | 18746 |
+| `glm-5.2` | 14/14 | 100% | 0 | 1750 ms | 484 | 17971 |
+| `qwen3.5-122b-a10b` | 14/14 | 100% | 0 | 6669 ms | 882 | 14076 |
+
+**42/42 is a finding about the suite, not about the models.** Every check
+passes for every model on every scenario, with no forced report retry anywhere.
+These fourteen scenarios cannot separate this tier; the caveat about scenarios
+all models pass applies to the whole suite now, not to a row of it.
+
+The claim gate was genuinely exercised rather than passing by default — five of
+nine claim-carrying cases put a claim token in the report and negated it
+correctly: glm-5.2 wrote "fix not yet validated" and "should not be considered
+validated", qwen3.5 wrote "before the fix can be validated", each with its cue
+inside the claim's own sentence. So the tightened matcher discriminates without
+firing on correct deferrals — which is the property that had to hold before the
+gate could be trusted.
+
+What the run does discriminate is cost: deepseek and glm are indistinguishable
+in quality and ~3.8x faster than qwen3.5-122b-a10b, which also spends ~1.8x the
+output tokens.
+
+**What this asks for next.** Harder scenarios, not more models — the suite needs
+cases where a strong model can still be wrong: conflicting evidence across
+sources, an instruction the context contradicts, a report that must decline to
+conclude. Until then a pass here means "not obviously broken", and a model
+choice should rest on latency and cost, which is all the table above measures.
+
 ## Findings from 2026-07-10
 
 The corrected production-prompt run contains one sample per scenario at

--- a/docs/evaluations/task_agent_models/README.md
+++ b/docs/evaluations/task_agent_models/README.md
@@ -233,6 +233,61 @@ sources, an instruction the context contradicts, a report that must decline to
 conclude. Until then a pass here means "not obviously broken", and a model
 choice should rest on latency and cost, which is all the table above measures.
 
+## 2026-08-18: three scenarios summarising cannot pass
+
+The saturated baseline above measured extraction. Every required term in the
+original fourteen appears somewhere in its own context, so a model that
+summarises well scores 100% without deciding anything. Three scenarios were
+added where echoing produces the WRONG answer:
+
+| Scenario | The question | Why echoing fails |
+| --- | --- | --- |
+| `derived_estimate` | 3 x 45 + 60 = 195 | Every copyable number is wrong: 90 is the estimate the log retires, 45 and 60 are the parts, 135 drops the write-up |
+| `contradicted_instruction` | Two items requested, one already done and ticked | Literal obedience duplicates finished work; blanket caution drops the item that is genuinely new |
+| `undecided_evidence` | Two candidate dates, an option to drop it, "nothing decided" | Any mutation invents a decision the user withheld |
+
+All three models pass all three. **The scenarios do not discriminate at this
+tier** — they are regression protection, not a ranking instrument, and their
+value is in qualifying cheaper candidates (the oMLX profiles) and in catching a
+future model that answers by summarising.
+
+### Six of the first nine failures were the scenarios
+
+The first live run scored 3/9, and verifying each failure against the captured
+report text found the harness at fault six times:
+
+- `derived_estimate` failed all three for calling `add_multiple_checklist_items`
+  alongside the estimate — while every one of them computed 195 correctly.
+  Capturing the scoped work is the agent doing its job; the scenario was
+  grading tool minimalism instead of the arithmetic it exists to measure.
+- `undecided_evidence` forbade the claims `march`, `june` and `submit`. A
+  correct report must name both options to say the choice is open, and all
+  three wrote exactly that — "undecided on March vs. June", "weighing whether
+  to submit to March or hold for June". The scenario failed the sentences it
+  was asking for.
+
+Regraded, the same three models score 9/9 with no change to any model output.
+
+### The method that actually works
+
+Three separate checks written on the same day failed correct answers: a German
+stem (`fertig`) matching the infinitive "fertigstellen", month names a correct
+report has to weigh, and tool minimalism standing in for arithmetic. Each was
+written carefully and each was wrong, which says the fix is not more care.
+
+**Draft a check, then read what models actually write before trusting it.** A
+captured report from one cheap run settles in seconds what imagination gets
+wrong, and every false positive above is now a test carrying the verbatim
+sentence that exposed it, paired with a guard proving the genuine violation
+still fires. The negation matcher gained two whole cue classes this way —
+scope-deferral ("out of scope", "descoped") and open-question ("undecided",
+"whether", "weighing") — neither of which was imaginable in advance and both of
+which were obvious in the output.
+
+A tightened check also converts its own blind spots into visible failures, so
+**the first run after tightening measures the checks, not the models.** Budget
+for it.
+
 ## Findings from 2026-07-10
 
 The corrected production-prompt run contains one sample per scenario at

--- a/test/features/ai/eval/eval_text_matchers_test.dart
+++ b/test/features/ai/eval/eval_text_matchers_test.dart
@@ -158,4 +158,35 @@ void main() {
       );
     });
   });
+
+  group('open-question markers', () {
+    // Verbatim from a live run: all three models wrote sentences of this shape
+    // and the scenario failed them for naming the options it asked them to
+    // weigh.
+    test('naming options under an open question is not asserting one', () {
+      for (final text in [
+        'undecided on march vs. june conference; pending ines talk next week',
+        'weighing march vs june conference submission, gated on the rewrite',
+        "you're weighing whether to submit a talk to the march conference "
+            'or hold for june.',
+      ]) {
+        expect(
+          containsAffirmativeReportClaim(text, 'march'),
+          isFalse,
+          reason: text,
+        );
+      }
+    });
+
+    test('committing to one of the options still fires', () {
+      // The guard: the cues above must not excuse an actual decision.
+      expect(
+        containsAffirmativeReportClaim(
+          'the talk is scheduled for the march conference.',
+          'scheduled',
+        ),
+        isTrue,
+      );
+    });
+  });
 }

--- a/test/features/ai/eval/eval_text_matchers_test.dart
+++ b/test/features/ai/eval/eval_text_matchers_test.dart
@@ -164,11 +164,13 @@ void main() {
     // and the scenario failed them for naming the options it asked them to
     // weigh.
     test('naming options under an open question is not asserting one', () {
+      const weighingSubmission =
+          "you're weighing whether to submit a talk to the march conference "
+          'or hold for june.';
       for (final text in [
         'undecided on march vs. june conference; pending ines talk next week',
         'weighing march vs june conference submission, gated on the rewrite',
-        "you're weighing whether to submit a talk to the march conference "
-            'or hold for june.',
+        weighingSubmission,
       ]) {
         expect(
           containsAffirmativeReportClaim(text, 'march'),

--- a/test/features/ai/eval/eval_text_matchers_test.dart
+++ b/test/features/ai/eval/eval_text_matchers_test.dart
@@ -115,4 +115,47 @@ void main() {
       );
     });
   });
+
+  group('phrase-level deferral cues', () {
+    // Each of these came from a live run that failed a model for reporting
+    // correctly. A single-word cue list could not see any of them.
+    test('"out of scope" reads as a deferral', () {
+      expect(
+        containsAffirmativeReportClaim(
+          'the administrator analytics dashboard idea was mentioned but is '
+              'out of scope for this task.',
+          'dashboard',
+        ),
+        isFalse,
+      );
+      expect(
+        containsAffirmativeReportClaim(
+          'the analytics work is descoped for now.',
+          'analytics',
+        ),
+        isFalse,
+      );
+    });
+
+    test('a genuine assertion in the same shape still fires', () {
+      // The guard against fixing a false positive by disabling the check.
+      expect(
+        containsAffirmativeReportClaim(
+          'the administrator analytics dashboard was delivered this sprint.',
+          'dashboard',
+        ),
+        isTrue,
+      );
+    });
+
+    test('describing an existing artefact is not claiming to have made it', () {
+      expect(
+        containsAffirmativeReportClaim(
+          'the fix as implemented does not fully resolve the problem.',
+          'implemented',
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/features/ai/eval/eval_text_matchers_test.dart
+++ b/test/features/ai/eval/eval_text_matchers_test.dart
@@ -53,4 +53,66 @@ void main() {
       expect(containsAffirmativeReportClaim(text, 'delivered'), isFalse);
     });
   });
+
+  group('negation is clipped to the claim sentence', () {
+    // The window alone let a cue from a DIFFERENT statement excuse an
+    // overclaim. Report bodies are several sentences of markdown and the cue
+    // list is necessarily broad — `no`, `still`, `yet`, `remains`, `before` —
+    // so in ordinary prose some cue lands within 60 characters of almost any
+    // claim. Both claims below are asserted outright.
+    const report =
+        'the deployment window has not yet been confirmed, so the rollback '
+        'plan is still pending review. the sync fix was verified in staging '
+        'and is applied to production.';
+
+    test('a cue in a neighbouring sentence does not excuse a claim', () {
+      expect(containsAffirmativeReportClaim(report, 'verified'), isTrue);
+      expect(containsAffirmativeReportClaim(report, 'applied'), isTrue);
+    });
+
+    test('a cue in the claim own sentence still negates it', () {
+      expect(
+        containsAffirmativeReportClaim(
+          'the rollback plan is still pending. the fix is not verified.',
+          'verified',
+        ),
+        isFalse,
+      );
+    });
+
+    test('escaped newlines in serialized tool arguments break sentences', () {
+      // Reports are matched as the JSON of the tool call, where a markdown
+      // list is one string with literal backslash-n between items. Without
+      // treating that as a break, the "not needed" item below excuses the
+      // claim two items away.
+      const json =
+          r'{"content":"- release notes are not needed yet\n- the migration '
+          r'was applied to production\n"}';
+      expect(containsAffirmativeReportClaim(json, 'applied'), isTrue);
+    });
+
+    test('a deferral still reads as deferred, in every suite language', () {
+      expect(
+        containsAffirmativeReportClaim(
+          'the newsletter idea was explicitly deferred.',
+          'newsletter',
+        ),
+        isFalse,
+      );
+      expect(
+        containsAffirmativeReportClaim(
+          'die newsletter-idee wurde zurückgestellt.',
+          'newsletter',
+        ),
+        isFalse,
+      );
+      expect(
+        containsAffirmativeReportClaim(
+          'el panel sigue pendiente, sin cambios.',
+          'panel',
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/features/ai/eval/local_task_agent_inference_eval_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_test.dart
@@ -410,14 +410,16 @@ void main() {
       'deepseek-v4-flash-candidate',
       'glm-5.2-reference',
     ]);
-    expect(defaultScenarios, hasLength(14));
+    // 17: the twelve core scenarios, two held-out ones, and the three added
+    // to give the suite cases that summarising well cannot pass.
+    expect(defaultScenarios, hasLength(17));
     expect(
       defaultScenarios.map((scenario) => scenario.promptVariant).toSet(),
       {LocalTaskAgentEvalPromptVariant.production},
     );
     expect(
       scenarios,
-      hasLength(14 * LocalTaskAgentEvalPromptVariant.values.length),
+      hasLength(17 * LocalTaskAgentEvalPromptVariant.values.length),
     );
     expect(
       scenarios.map((scenario) => scenario.promptVariant).toSet(),

--- a/test/features/ai/eval/local_task_agent_inference_eval_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_test.dart
@@ -702,11 +702,11 @@ void main() {
       failureCategory: LocalTaskAgentEvalFailureCategory.none,
     );
 
-    // 15, not 11: the scenario gained four premature-completion claims, and
+    // 14, not 11: the scenario gained three premature-completion claims, and
     // this report earns all of them — it says the steps are CAPTURED, never
     // that the work is done.
-    expect(result.qualityCheckCount, 15);
-    expect(result.passedQualityCheckCount, 15);
+    expect(result.qualityCheckCount, 14);
+    expect(result.passedQualityCheckCount, 14);
     expect(result.qualityScore, 1);
     expect(result.reportToolCall?.name, TaskAgentToolNames.updateReport);
   });

--- a/test/features/ai/eval/local_task_agent_inference_eval_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_test.dart
@@ -702,8 +702,11 @@ void main() {
       failureCategory: LocalTaskAgentEvalFailureCategory.none,
     );
 
-    expect(result.qualityCheckCount, 11);
-    expect(result.passedQualityCheckCount, 11);
+    // 15, not 11: the scenario gained four premature-completion claims, and
+    // this report earns all of them — it says the steps are CAPTURED, never
+    // that the work is done.
+    expect(result.qualityCheckCount, 15);
+    expect(result.passedQualityCheckCount, 15);
     expect(result.qualityScore, 1);
     expect(result.reportToolCall?.name, TaskAgentToolNames.updateReport);
   });

--- a/test/features/ai/eval/local_task_agent_inference_eval_test.dart
+++ b/test/features/ai/eval/local_task_agent_inference_eval_test.dart
@@ -1644,6 +1644,87 @@ void main() {
     );
   });
 
+  test('runner fails a report asserting work that did not happen', () async {
+    // `user_completed_item_resurfaced` expects NO tool calls, so "did the
+    // model claim the fix was verified?" is the only question it really asks.
+    // Those claims were counted in `qualityScore` and never gated, which made
+    // the scenario pass on the strength of its incidental checks alone.
+    final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+      (scenario) => scenario.id.startsWith('user_completed_item_resurfaced'),
+    );
+    final runner = _createRunner(
+      provider: provider,
+      inferenceRepository: _QueuedInferenceRepository([
+        [
+          _toolCalls([
+            (
+              name: TaskAgentToolNames.updateReport,
+              argumentsJson: jsonEncode({
+                'oneLiner': 'Sync issue reappeared',
+                'tldr': 'The sync item resurfaced and needs investigation.',
+                // Every other check is satisfied: the required terms are all
+                // present, no internal id leaks, no forbidden tool. The only
+                // thing wrong is the claim — and it sits in its own sentence,
+                // after one carrying an unrelated negation cue.
+                'content':
+                    'The root cause is not yet known. The sync fix was '
+                    'verified in staging and is applied to production.',
+              }),
+            ),
+          ]),
+        ],
+      ]),
+    );
+
+    final report = await runner.run(
+      profiles: const [profile],
+      scenarios: [scenario],
+    );
+
+    expect(
+      report.results.single.failureCategory,
+      LocalTaskAgentEvalFailureCategory.forbiddenReportClaim,
+    );
+  });
+
+  test('runner accepts the same report when the claim is negated', () async {
+    // The other half of the rule, and the reason the matcher is negation-aware
+    // at all: naming unfinished work in order to rule it out is exactly what
+    // this scenario wants, and must not be scored as an overclaim.
+    final scenario = defaultMeliousTaskAgentEvalScenarios().firstWhere(
+      (scenario) => scenario.id.startsWith('user_completed_item_resurfaced'),
+    );
+    final runner = _createRunner(
+      provider: provider,
+      inferenceRepository: _QueuedInferenceRepository([
+        [
+          _toolCalls([
+            (
+              name: TaskAgentToolNames.updateReport,
+              argumentsJson: jsonEncode({
+                'oneLiner': 'Sync issue reappeared',
+                'tldr': 'The sync item resurfaced and needs investigation.',
+                'content':
+                    'The fix has not been verified and is not yet applied; '
+                    'the root cause is still under investigation.',
+              }),
+            ),
+          ]),
+        ],
+      ]),
+    );
+
+    final report = await runner.run(
+      profiles: const [profile],
+      scenarios: [scenario],
+    );
+
+    expect(
+      report.results.single.failureCategory,
+      LocalTaskAgentEvalFailureCategory.none,
+    );
+  });
+
   test(
     'runner rewards a no-op note and rejects unnecessary report churn',
     () async {

--- a/test/features/ai/eval/support/eval_text_matchers.dart
+++ b/test/features/ai/eval/support/eval_text_matchers.dart
@@ -54,9 +54,43 @@ final RegExp _claimNegationPattern = RegExp(
 /// The cue can land on either side: English tends to precede the claim ("the
 /// fix cannot be considered validated") while German routinely follows it
 /// ("die Newsletter-Idee wurde explizit zurückgestellt"). Wide enough for a
-/// clause, narrow enough that a negation in a neighbouring sentence does not
-/// excuse a genuine overclaim.
+/// clause, and clipped to the claim's own sentence by [_sentenceBounds] so a
+/// negation belonging to a different statement cannot excuse an overclaim.
 const _claimNegationWindow = 60;
+
+/// Sentence and list-item terminators, including the escaped newlines a
+/// report carries once its tool arguments are serialized to JSON.
+final RegExp _sentenceBreakPattern = RegExp(r'[.!?;\n\r]|\\n|\\r');
+
+/// The claim's own sentence, as an offset pair clipped to [_claimNegationWindow].
+///
+/// The character window alone was not enough. Report bodies are several
+/// sentences of markdown, and the cue list is broad by necessity — `no`,
+/// `still`, `yet`, `remains`, `before` — so in ordinary prose SOME cue lands
+/// within 60 characters of almost any claim. "The deployment window has not
+/// yet been confirmed … The sync fix was verified in staging and is applied
+/// to production" scored as fully negated: two genuine overclaims excused by
+/// a cue belonging to an unrelated sentence two clauses away.
+///
+/// Sentence clipping is what the window was always documented to do. It
+/// tightens both suites that share this matcher.
+(int, int) _sentenceBounds(String text, int claimStart, int claimEnd) {
+  var start = claimStart < _claimNegationWindow
+      ? 0
+      : claimStart - _claimNegationWindow;
+  var stop = claimEnd + _claimNegationWindow >= text.length
+      ? text.length
+      : claimEnd + _claimNegationWindow;
+  // The LAST break before the claim, applied once. Adding each match's end in
+  // turn compounds the offsets and walks `start` past the claim itself.
+  final leading = _sentenceBreakPattern
+      .allMatches(text.substring(start, claimStart))
+      .lastOrNull;
+  if (leading != null) start += leading.end;
+  final tail = _sentenceBreakPattern.firstMatch(text.substring(claimEnd, stop));
+  if (tail != null) stop = claimEnd + tail.start;
+  return (start, stop);
+}
 
 /// Whether [claim] is asserted in [text], ignoring occurrences that are
 /// negated.
@@ -71,10 +105,7 @@ bool containsAffirmativeReportClaim(String text, String claim) {
   var index = normalizedText.indexOf(needle);
   while (index != -1) {
     final end = index + needle.length;
-    var start = index < _claimNegationWindow ? 0 : index - _claimNegationWindow;
-    var stop = end + _claimNegationWindow >= normalizedText.length
-        ? normalizedText.length
-        : end + _claimNegationWindow;
+    var (start, stop) = _sentenceBounds(normalizedText, index, end);
     // A cut mid-word would fabricate a cue: "casino" truncated at the
     // window edge leaves "no", which the whole-word pattern then matches
     // (the lookbehind sees the string start, not the severed letters).

--- a/test/features/ai/eval/support/eval_text_matchers.dart
+++ b/test/features/ai/eval/support/eval_text_matchers.dart
@@ -24,10 +24,15 @@ bool containsAnyEvalTerm(String text, List<String> terms) {
 /// correct behaviour as a violation. Every candidate model failed such a
 /// scenario for this reason alone before negation awareness was added.
 const _claimNegationCues = [
-  // English negation and deferral.
+  // English negation and deferral. The multi-word entries are matched as
+  // phrases: "the analytics dashboard idea is out of scope" is a textbook
+  // correct deferral that every single-word cue missed, and it only surfaced
+  // once the window was clipped to the sentence — before that an unrelated
+  // cue nearby happened to excuse it.
   'not', 'no', 'never', 'cannot', "can't", "won't", "isn't", "doesn't",
   "didn't", 'without', 'before', 'until', 'unless', 'pending', 'remains',
   'remain', 'still', 'yet', 'future', 'later', 'deferred', 'excluded',
+  'out of scope', 'outside the scope', 'descoped', 'not in scope',
   // German.
   'nicht', 'kein', 'keine', 'keinen', 'ohne', 'bevor', 'noch', 'erst',
   'zurückgestellt', 'zurückgestellte', 'ausstehend', 'offen', 'später',

--- a/test/features/ai/eval/support/eval_text_matchers.dart
+++ b/test/features/ai/eval/support/eval_text_matchers.dart
@@ -33,6 +33,10 @@ const _claimNegationCues = [
   "didn't", 'without', 'before', 'until', 'unless', 'pending', 'remains',
   'remain', 'still', 'yet', 'future', 'later', 'deferred', 'excluded',
   'out of scope', 'outside the scope', 'descoped', 'not in scope',
+  // Open-question markers. A report can be entirely correct while naming a
+  // thing it has NOT committed to — "undecided on March vs. June", "weighing
+  // whether to submit" — and none of the negation cues above see that.
+  'undecided', 'whether', 'weighing', 'either', 'options', 'open question',
   // German.
   'nicht', 'kein', 'keine', 'keinen', 'ohne', 'bevor', 'noch', 'erst',
   'zurückgestellt', 'zurückgestellte', 'ausstehend', 'offen', 'später',

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -807,12 +807,13 @@ LocalTaskAgentEvalScenario _germanPlanningScenario(
     // nicht abgeschlossen" is a correct sentence, and a bare substring
     // blacklist would fail it for containing the word. The claim matcher is
     // negation-aware and reads `noch`/`nicht` as the deferral it is.
-    forbiddenReportClaims: const [
-      'erledigt',
-      'abgeschlossen',
-      'umgesetzt',
-      'fertig',
-    ],
+    //
+    // NOT `fertig`: it is a stem, and the live run tripped all three models on
+    // "Figma-Prototyp fertigstellen" and "soll bis 30. September fertig sein"
+    // — an infinitive TODO and a future deadline, neither of them a claim that
+    // anything is done. The remaining three are past participles, which cannot
+    // be read as forward-looking the same way.
+    forbiddenReportClaims: const ['erledigt', 'abgeschlossen', 'umgesetzt'],
   );
 }
 
@@ -1057,10 +1058,21 @@ LocalTaskAgentEvalScenario _userCompletedItemScenario(
       ['reappeared', 'resurfaced', 'again', 'recurrence', 'recurred'],
       ['blocked', 'blocker', 'risk', 'root cause', 'investigat'],
     ],
-    forbiddenReportTerms: ['item-sync-fix', 'deployed', 'implemented'],
+    // Only the internal id is a bare term. "the fix as implemented does not
+    // fully resolve the problem" is correct prose about the EXISTING fix, and
+    // a substring blacklist fails it for containing the word — so the two
+    // English participles move to the negation-aware list below.
+    forbiddenReportTerms: ['item-sync-fix'],
     // A correct report says the fix is *not* validated, so these may appear
     // under negation but must never be asserted.
-    forbiddenReportClaims: ['verified', 'validated', 'applied', 'underway'],
+    forbiddenReportClaims: [
+      'verified',
+      'validated',
+      'applied',
+      'underway',
+      'deployed',
+      'implemented',
+    ],
   );
 }
 

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -307,6 +307,9 @@ List<LocalTaskAgentEvalScenario> defaultMeliousTaskAgentEvalScenarios({
       _spanishMixedContextScenario(variant),
       _externalLinkScenario(variant),
       _latestDeadlineWinsScenario(variant),
+      _derivedEstimateScenario(variant),
+      _contradictedInstructionScenario(variant),
+      _undecidedEvidenceScenario(variant),
     ],
   ];
 }
@@ -1140,6 +1143,103 @@ LocalTaskAgentEvalScenario _externalLinkScenario(
   );
 }
 
+/// The estimate exists nowhere in the context: 3 x 45 + 60 = 195.
+///
+/// Every number a model could copy is wrong. 90 is the stale estimate the log
+/// explicitly retires, 45 and 60 are the parts, and 135 is what dropping the
+/// write-up gives. Only arithmetic over the scoped work produces 195, so
+/// summarising well cannot pass this — which is the property the rest of the
+/// suite's required terms lack.
+LocalTaskAgentEvalScenario _derivedEstimateScenario(
+  LocalTaskAgentEvalPromptVariant variant,
+) {
+  return LocalTaskAgentEvalScenario(
+    id: 'derived_estimate_${variant.name}',
+    systemPrompt: _buildEvalSystemPrompt(variant),
+    userMessage: _derivedEstimateUserMessage,
+    currentEstimateMinutes: 90,
+    expectedToolCalls: const [
+      LocalTaskAgentExpectedToolCall(
+        name: TaskAgentToolNames.updateTaskEstimate,
+        expectedArgumentsSubset: {'minutes': 195},
+      ),
+    ],
+    promptVariant: variant,
+    requiredReportTermGroups: const [
+      ['interview'],
+      ['nadia'],
+    ],
+    // The audit is done and its estimate retired; a report that still carries
+    // 90 minutes forward is reporting a number the log withdrew.
+    forbiddenReportClaims: const ['90 minutes', '90 minute'],
+  );
+}
+
+/// An instruction the state contradicts: one of the two requested items is
+/// already on the checklist AND already ticked.
+///
+/// Following the request literally produces a duplicate of completed work,
+/// which is the failure. The credential rotation is genuinely new and must
+/// still be added, so refusing wholesale fails too — the scenario cannot be
+/// passed by either blanket obedience or blanket caution.
+LocalTaskAgentEvalScenario _contradictedInstructionScenario(
+  LocalTaskAgentEvalPromptVariant variant,
+) {
+  return LocalTaskAgentEvalScenario(
+    id: 'contradicted_instruction_${variant.name}',
+    systemPrompt: _buildEvalSystemPrompt(variant),
+    userMessage: _contradictedInstructionUserMessage,
+    expectedToolCalls: const [
+      LocalTaskAgentExpectedToolCall(
+        name: TaskAgentToolNames.addMultipleChecklistItems,
+      ),
+    ],
+    promptVariant: variant,
+    requiredToolArgumentTermGroups: const {
+      TaskAgentToolNames.addMultipleChecklistItems: [
+        ['credential', 'api key', 'rotate'],
+      ],
+    },
+    // The duplicate, caught where it would actually be created.
+    forbiddenToolArgumentTerms: const {
+      TaskAgentToolNames.addMultipleChecklistItems: ['sandbox'],
+    },
+    requiredReportTermGroups: const [
+      ['credential', 'rotat'],
+    ],
+  );
+}
+
+/// Evidence that supports no conclusion.
+///
+/// The log offers two dates and the possibility of dropping the task, and
+/// closes with "nothing decided". Any mutation here is the model inventing a
+/// decision the user explicitly withheld, so the correct wake changes nothing
+/// and says so — restraint under maximum temptation to be helpful.
+LocalTaskAgentEvalScenario _undecidedEvidenceScenario(
+  LocalTaskAgentEvalPromptVariant variant,
+) {
+  return LocalTaskAgentEvalScenario(
+    id: 'undecided_evidence_${variant.name}',
+    systemPrompt: _buildEvalSystemPrompt(variant),
+    userMessage: _undecidedEvidenceUserMessage,
+    expectedToolCalls: const [],
+    forbiddenToolNames: const {
+      TaskAgentToolNames.updateTaskDueDate,
+      TaskAgentToolNames.updateTaskPriority,
+      TaskAgentToolNames.addMultipleChecklistItems,
+    },
+    promptVariant: variant,
+    requiredReportTermGroups: const [
+      ['ines'],
+      ['decid', 'decision', 'undecided'],
+    ],
+    // Naming a date to say it is undecided is correct; asserting either as the
+    // plan is the failure, which is why these are claims and not terms.
+    forbiddenReportClaims: const ['march', 'june', 'scheduled', 'submit'],
+  );
+}
+
 LocalTaskAgentEvalScenario _latestDeadlineWinsScenario(
   LocalTaskAgentEvalPromptVariant variant,
 ) {
@@ -1685,6 +1785,78 @@ const _externalLinkUserMessage = '''
 
 Apply the explicit completion, preserve deployment as pending, and include the
 real pull-request URL in the report without exposing internal IDs.
+''';
+
+const _derivedEstimateUserMessage = '''
+## Current Task Context
+```json
+{
+  "id": "task-onboarding-revamp",
+  "title": "Revamp partner onboarding",
+  "status": "IN PROGRESS",
+  "estimate": 90,
+  "dueDate": "2026-09-18",
+  "languageCode": "en",
+  "checklist": [
+    {"id": "onb-audit", "title": "Audit the current flow", "isChecked": true}
+  ],
+  "log": [
+    {"timestamp": "2026-08-01T09:00:00Z", "text": "The old 90 minute estimate was for the audit alone, which is done."},
+    {"timestamp": "2026-08-14T10:00:00Z", "text": "Scoped the rest with Nadia: three partner interviews at 45 minutes each, then one hour to write the findings up. Nothing else is left."}
+  ]
+}
+```
+
+## First Wake - No prior report exists. Produce an initial report.
+
+Re-estimate the task from the scoped remaining work and publish a report.
+''';
+
+const _contradictedInstructionUserMessage = '''
+## Current Task Context
+```json
+{
+  "id": "task-billing-migration",
+  "title": "Migrate billing to the new provider",
+  "status": "IN PROGRESS",
+  "dueDate": "2026-10-02",
+  "languageCode": "en",
+  "checklist": [
+    {"id": "bill-sandbox", "title": "Verify sandbox charges settle", "isChecked": true},
+    {"id": "bill-webhooks", "title": "Point webhooks at the new endpoint", "isChecked": false}
+  ],
+  "log": [
+    {"timestamp": "2026-08-02T09:00:00Z", "text": "Sandbox charges settled cleanly last week, ticked that off."},
+    {"timestamp": "2026-08-16T15:30:00Z", "text": "Please add checklist items for verifying sandbox charges settle, and for rotating the API credentials before cutover."}
+  ]
+}
+```
+
+## First Wake - No prior report exists. Produce an initial report.
+
+Act on the request and publish a report.
+''';
+
+const _undecidedEvidenceUserMessage = '''
+## Current Task Context
+```json
+{
+  "id": "task-conference-talk",
+  "title": "Conference talk",
+  "status": "OPEN",
+  "priority": null,
+  "dueDate": null,
+  "languageCode": "en",
+  "checklist": [],
+  "log": [
+    {"timestamp": "2026-08-15T17:40:00Z", "text": "Thinking out loud here. Could submit to the March conference, or hold for the June one, depends whether the platform rewrite lands. Might not be worth doing at all if we are still firefighting. Nothing decided, I want to sleep on it and talk to Ines next week."}
+  ]
+}
+```
+
+## First Wake - No prior report exists. Produce an initial report.
+
+Record where this stands and publish a report.
 ''';
 
 const _latestDeadlineWinsUserMessage = '''

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -797,6 +797,22 @@ LocalTaskAgentEvalScenario _germanPlanningScenario(
         ['security', 'sicherheit'],
       ],
     },
+    // Everything above is extraction: the names and nouns are all in the
+    // transcript, so a model that summarises well passes without deciding
+    // anything. The transcript is a PLAN, and reporting a plan as work already
+    // delivered is the failure this scenario should catch — the German form of
+    // the check `implicit_workflow_plan` makes in English.
+    //
+    // Claims rather than forbidden terms, deliberately: "der Prototyp ist noch
+    // nicht abgeschlossen" is a correct sentence, and a bare substring
+    // blacklist would fail it for containing the word. The claim matcher is
+    // negation-aware and reads `noch`/`nicht` as the deferral it is.
+    forbiddenReportClaims: const [
+      'erledigt',
+      'abgeschlossen',
+      'umgesetzt',
+      'fertig',
+    ],
   );
 }
 

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -1164,6 +1164,15 @@ LocalTaskAgentEvalScenario _derivedEstimateScenario(
         expectedArgumentsSubset: {'minutes': 195},
       ),
     ],
+    // The scoped work is three interviews and a write-up, and turning that
+    // into checklist items is the agent doing its job. All three models did
+    // it on the first live run and the scenario failed them for it, which
+    // graded tool minimalism instead of the arithmetic it exists to measure.
+    allowedExtraToolNames: const {
+      TaskAgentToolNames.updateReport,
+      TaskAgentToolNames.recordObservations,
+      TaskAgentToolNames.addMultipleChecklistItems,
+    },
     promptVariant: variant,
     requiredReportTermGroups: const [
       ['interview'],
@@ -1234,9 +1243,12 @@ LocalTaskAgentEvalScenario _undecidedEvidenceScenario(
       ['ines'],
       ['decid', 'decision', 'undecided'],
     ],
-    // Naming a date to say it is undecided is correct; asserting either as the
-    // plan is the failure, which is why these are claims and not terms.
-    forbiddenReportClaims: const ['march', 'june', 'scheduled', 'submit'],
+    // NOT the month names, and not 'submit'. A correct report has to name both
+    // options in order to say the choice is open — "undecided on March vs.
+    // June", "weighing whether to submit to March or hold for June" — and the
+    // first live run failed all three models for writing exactly that. What
+    // must never appear is language asserting the choice was MADE.
+    forbiddenReportClaims: const ['scheduled', 'confirmed'],
   );
 }
 

--- a/test/features/ai/eval/support/local_task_agent_inference_eval.dart
+++ b/test/features/ai/eval/support/local_task_agent_inference_eval.dart
@@ -1770,6 +1770,7 @@ enum LocalTaskAgentEvalFailureCategory {
   missingReport,
   missingRequiredContent,
   forbiddenReportContent,
+  forbiddenReportClaim,
   missingReportRevision,
   invalidReportRevision,
   inferenceFailed,
@@ -1968,8 +1969,16 @@ class LocalTaskAgentEvalCaseResult {
     return passed;
   }
 
-  double get qualityScore =>
-      qualityCheckCount == 0 ? 1 : passedQualityCheckCount / qualityCheckCount;
+  /// Null when the scenario declares no quality checks at all.
+  ///
+  /// This used to be 1, which reads in a report exactly like a scenario that
+  /// passed everything it was asked — the vacuous pass the goal suite's
+  /// inflated first table was made of. A scenario with nothing to check has
+  /// no quality score, and the aggregate must skip it rather than average a
+  /// free 1.0 into the total.
+  double? get qualityScore => qualityCheckCount == 0
+      ? null
+      : passedQualityCheckCount / qualityCheckCount;
 
   Map<String, Object?> toJson() {
     return {
@@ -2084,7 +2093,7 @@ class LocalTaskAgentEvalReport {
         '| ${result.profile.name} | `${result.profile.providerModelId}` | '
         '${result.scenario.id} | ${result.scenario.promptVariant.name} | '
         '${result.passed ? 'yes' : 'no'} | '
-        '${(result.qualityScore * 100).round()}% | '
+        '${result.qualityScore == null ? 'n/a' : '${(result.qualityScore! * 100).round()}%'} | '
         '${result.usedForcedReportRetry ? 'yes' : 'no'} | '
         '${result.latencyMs} ms | ${toolNames.isEmpty ? '-' : toolNames} | '
         '${result.failureCategory.name} |',
@@ -2713,6 +2722,18 @@ LocalTaskAgentEvalFailureCategory _classifyResult({
     (term) => reportText.contains(term.toLowerCase()),
   )) {
     return LocalTaskAgentEvalFailureCategory.forbiddenReportContent;
+  }
+  // Separate from the term blacklist above, and separately named, because it
+  // fails for a different reason: the term list catches leaked internal ids,
+  // while this catches a report ASSERTING work that did not happen. It is the
+  // whole point of the scenarios that declare it — `user_completed_item_
+  // resurfaced` expects no tool calls at all, so "did the model claim the fix
+  // was verified?" is the only question it really asks. Until this was gated,
+  // those claims were counted in `qualityScore` and could not fail a run.
+  if (scenario.forbiddenReportClaims.any(
+    (claim) => containsAffirmativeReportClaim(reportText, claim),
+  )) {
+    return LocalTaskAgentEvalFailureCategory.forbiddenReportClaim;
   }
   for (final entry in scenario.requiredToolArgumentTermGroups.entries) {
     final arguments = toolCalls

--- a/test/features/ai/eval/task_agent_eval_fixture_honesty_test.dart
+++ b/test/features/ai/eval/task_agent_eval_fixture_honesty_test.dart
@@ -47,6 +47,13 @@ List<String> _discriminatingChecks(LocalTaskAgentEvalScenario scenario) {
     for (final claim in scenario.forbiddenReportClaims)
       'must not assert "$claim"',
     for (final name in scenario.forbiddenToolNames) 'must not call $name',
+    // Restraint expressed at the argument level rather than the tool level:
+    // "add the credential item but NOT a duplicate of the finished sandbox
+    // one" cannot be said by forbidding the tool, since the tool must be
+    // called. Missing this made the guard reject a scenario whose whole
+    // question was a forbidden argument.
+    for (final entry in scenario.forbiddenToolArgumentTerms.entries)
+      for (final term in entry.value) 'must keep "$term" out of ${entry.key}',
     for (final expected in scenario.expectedToolCalls)
       for (final entry in expected.expectedArgumentsSubset.entries)
         if (!_isEchoable(context, entry.value))

--- a/test/features/ai/eval/task_agent_eval_fixture_honesty_test.dart
+++ b/test/features/ai/eval/task_agent_eval_fixture_honesty_test.dart
@@ -1,0 +1,99 @@
+/// Fixture-honesty tests: every scenario must actually ASK its question.
+///
+/// A scenario whose every check is satisfied by copying salient nouns out of
+/// its own context measures summarisation, which every candidate model does
+/// for free. It then reports 100% forever and reads in a matrix exactly like
+/// a scenario that was hard and passed — the vacuous pass the goal suite's
+/// first tier-2 table was made of.
+///
+/// These tests are cheap, offline, and run in CI. They cannot judge whether a
+/// question is INTERESTING; they can only prove one was asked.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/local_task_agent_inference_eval.dart';
+
+/// Whether [value] can be produced by lifting text straight out of [context].
+bool _isEchoable(String context, Object? value) {
+  if (value == null) return true;
+  if (value is String) return context.contains(value.toLowerCase());
+  if (value is num || value is bool) {
+    return context.contains(value.toString().toLowerCase());
+  }
+  if (value is List) return value.every((item) => _isEchoable(context, item));
+  if (value is Map) {
+    return value.values.every((item) => _isEchoable(context, item));
+  }
+  return false;
+}
+
+/// The checks in [scenario] that copying its context cannot satisfy.
+///
+/// Three kinds count. A required term no phrasing of which appears in the
+/// context has to be DERIVED. Any forbidden term, claim or tool is restraint,
+/// which echoing actively works against. An expected tool argument whose value
+/// is absent from the context is the derivation the report prose is
+/// deliberately not asked for — "two and a half hours" becoming `minutes: 150`
+/// is asserted here and nowhere else, because requiring the prose to narrate
+/// metadata contradicts the shipped report directive.
+List<String> _discriminatingChecks(LocalTaskAgentEvalScenario scenario) {
+  final context = scenario.userMessage.toLowerCase();
+  return [
+    for (final group in scenario.requiredReportTermGroups)
+      if (!group.any((term) => context.contains(term.toLowerCase())))
+        'requires deriving "${group.first}"',
+    for (final term in scenario.forbiddenReportTerms) 'must not write "$term"',
+    for (final claim in scenario.forbiddenReportClaims)
+      'must not assert "$claim"',
+    for (final name in scenario.forbiddenToolNames) 'must not call $name',
+    for (final expected in scenario.expectedToolCalls)
+      for (final entry in expected.expectedArgumentsSubset.entries)
+        if (!_isEchoable(context, entry.value))
+          'must derive ${expected.name}.${entry.key}=${entry.value}',
+  ];
+}
+
+void main() {
+  final scenarios = defaultMeliousTaskAgentEvalScenarios(
+    variants: LocalTaskAgentEvalPromptVariant.values,
+  );
+
+  test('the suite has scenarios to check at all', () {
+    expect(scenarios, isNotEmpty);
+  });
+
+  group('every scenario asks something echoing cannot answer', () {
+    for (final scenario in scenarios) {
+      test(scenario.id, () {
+        expect(
+          _discriminatingChecks(scenario),
+          isNotEmpty,
+          reason:
+              'Every check in ${scenario.id} is satisfied by copying its own '
+              'context. Add a derived value, a restraint check, or a tool '
+              'argument the context does not already spell out.',
+        );
+      });
+    }
+  });
+
+  group('a scenario that requires a report also constrains it', () {
+    // Expecting a report and then checking nothing about it is the same
+    // vacuum one level up: the wake passes for emitting the call, whatever
+    // the call said.
+    for (final scenario in scenarios.where((s) => s.requiresReport)) {
+      test(scenario.id, () {
+        expect(
+          scenario.requiredReportTermGroups.length +
+              scenario.forbiddenReportTerms.length +
+              scenario.forbiddenReportClaims.length,
+          greaterThan(0),
+          reason:
+              '${scenario.id} requires a report but asserts nothing about its '
+              'content.',
+        );
+      });
+    }
+  });
+}

--- a/tool/task_agent_model_eval_judge.py
+++ b/tool/task_agent_model_eval_judge.py
@@ -325,9 +325,16 @@ def _write_markdown(path: Path, judged: dict) -> None:
     ]
     for case in judged["results"]:
         score = case["judge"].get("overall", 0)
+        # None when the scenario declares no deterministic checks. Rendering it
+        # as 0% would read as a total failure and as 100% as a clean sweep;
+        # both are claims the run never made.
+        deterministic = case["deterministicScore"]
+        deterministic_cell = (
+            "n/a" if deterministic is None else f"{deterministic * 100:.0f}%"
+        )
         lines.append(
             f"| {case['profileName']} | {case['scenarioId']} | {case['promptVariant']} | "
-            f"{case['deterministicScore'] * 100:.0f}% | {score:.1f}/4 | "
+            f"{deterministic_cell} | {score:.1f}/4 | "
             f"{case['judge'].get('verdict', 'parse_error')} |"
         )
     lines += ["", "## Findings"]


### PR DESCRIPTION
The task suite passed every model on every scenario. This makes it capable of
failing, then verifies the failures are real.

## Two checks that could not fire

**`forbiddenReportClaims` never gated.** `_classifyResult` checked required
terms, forbidden terms and tool arguments, but not claims. The eight claims the
suite declares were counted in `qualityScore` and could not fail a run. It cost
most in `user_completed_item_resurfaced`, which expects no tool calls at all —
"did the model claim the fix was verified?" is the only question that scenario
really asks, and it was the one question not asked.

**`containsAffirmativeReportClaim` could barely fire.** The cue list is broad by
necessity (`no`, `still`, `yet`, `remains`, `before`) and the ±60-character
window straddles sentences, so in ordinary markdown some cue lands near almost
any claim. This scored as fully negated:

> The deployment window has **not yet** been confirmed, so the rollback plan is
> **still** pending review. The sync fix was verified in staging and is applied
> to production.

The window is now clipped to the claim's own sentence — what its doc comment
always said it did — with escaped newlines counting as breaks, since reports are
matched as serialized tool arguments. The matcher is shared, so the goal suite
tightens with it.

Also: `qualityScore` is null rather than 1 when a scenario declares no checks.
1.0 reads exactly like a scenario that passed everything it was asked.

## A guard against vacuous scenarios

`task_agent_eval_fixture_honesty_test.dart` requires every scenario to carry at
least one check echoing cannot answer — a required term absent from its context,
any restraint check, or an expected tool argument the context does not spell
out. Offline, in CI.

It found one genuinely vacuous scenario (`german_voice_plan`, whose entire
question was whether Ben, Figma and Lea got mentioned), and then rejected one of
the new scenarios below and was right to: it had never counted
`forbiddenToolArgumentTerms`, which is where "call the tool, but not with this
argument" lives.

## Three scenarios summarising cannot pass

| Scenario | Question | Why echoing fails |
| --- | --- | --- |
| `derived_estimate` | 3 × 45 + 60 = 195 | Every copyable number is wrong — 90 is the retired estimate, 45 and 60 are the parts, 135 drops the write-up |
| `contradicted_instruction` | Two items requested, one already done and ticked | Literal obedience duplicates finished work; blanket caution drops the item that is new |
| `undecided_evidence` | Two dates, an option to drop it, "nothing decided" | Any mutation invents a decision the user withheld |

## Every failure was verified against the captured text

Two live runs produced eleven failures. **Nine were the harness, not the
models** — and each is now a test carrying the verbatim sentence that exposed
it, paired with a guard proving the genuine violation still fires:

- `fertig` is a stem: it matched "Figma-Prototyp **fertigstellen**" and "soll
  bis 30. September **fertig sein**" — an infinitive TODO and a future deadline.
- `implemented`/`deployed` were bare substring terms, so "the fix **as
  implemented** does not fully resolve the problem" failed for containing the
  word. Moved to the negation-aware list.
- "the analytics dashboard idea **is out of scope**" scored as an assertion —
  the cue list had no phrase entries.
- `undecided_evidence` forbade `march`, `june` and `submit`, the words a correct
  report must use to say the choice is open.
- `derived_estimate` failed all three models for capturing the scoped work as
  checklist items, while every one of them computed 195 correctly.

The matcher gained two cue classes this way — scope-deferral and open-question —
neither of which was imaginable in advance and both obvious in the output.

## Results

Regraded, the three models score 9/9 on the hard scenarios and 41/42 overall,
the single real failure being qwen3.5-122b-a10b writing a report without ever
calling `add_multiple_checklist_items`.

**The new scenarios do not discriminate at this tier.** They are regression
protection and a gate for cheaper candidates (the oMLX profiles), not a ranking
instrument, and the eval log says so rather than presenting 9/9 as a result.

376 offline tests green across both eval suites; analyzer clean. Test-only and
docs — no production code, no CHANGELOG entry.