### PR TITLE
feat: relationships UI transformation

### DIFF
--- a/docs/adr/0041-relationship-contact-linking.md
+++ b/docs/adr/0041-relationship-contact-linking.md
@@ -23,8 +23,9 @@ would create hundreds of dormant relationship entities and destroy the
 signal the reminders and briefings depend on. Second, platform reality:
 OS contact pickers are well supported on iOS and Android, weakly on macOS,
 and effectively unavailable on Linux/Windows; contact identifiers are
-platform-local, so a contact reference cannot resolve on a synced peer
-device. `url_launcher` (already a dependency) covers `tel:`, `sms:`, and
+device-local — every address book assigns its own, so even two phones on
+the same OS hold unrelated ids — and a contact reference therefore cannot
+resolve on any synced peer device. `url_launcher` (already a dependency) covers `tel:`, `sms:`, and
 `mailto:` launching; no contacts plugin is currently in the dependency set.
 
 ## Decision
@@ -39,8 +40,11 @@ device. `url_launcher` (already a dependency) covers `tel:`, `sms:`, and
    `RelationshipData` gains `contactChannels`
    (`List<ContactChannel>` — `type` enum `phone`/`mobile`/`email`/
    `messaging`, optional `label`, `value`) and `contactRefs`
-   (per-platform map of contact identifiers, used only for an explicit
-   "Update from contact" refresh on the device that owns the contact).
+   (per-device map of contact identifiers, keyed by platform plus the
+   device's sync host id, used only for an explicit "Update from contact"
+   refresh on the device that owns the contact — a key scoped merely
+   per-platform would let two same-OS devices overwrite each other's ref
+   and resolve a peer's id against the wrong address book).
    Channels are manually editable on every platform, so Linux/Windows get
    full feature parity through manual entry; the picker is a convenience,
    not a requirement. Snapshot data syncs and cascades like everything else
@@ -69,8 +73,8 @@ device. `url_launcher` (already a dependency) covers `tel:`, `sms:`, and
 - The curated-relationship model survives contact integration: the address
   book never drives entity creation, only enriches entities the user
   already chose to create.
-- Per-platform `contactRefs` mean "Update from contact" works only on a
-  device that has the contact — synced peers still see the channel values,
+- Per-device `contactRefs` mean "Update from contact" works only on the
+  device that wrote the ref — synced peers still see the channel values,
   which is what the quick actions need.
 - The post-interaction prompt is a resume heuristic, not call detection: it
   can fire when no conversation happened (unanswered call) and misses

--- a/knowledge/features/notifications.md
+++ b/knowledge/features/notifications.md
@@ -11,15 +11,15 @@ sources:
   - id: src
     resource: ../../lib/features/notifications
     title: Synced notifications source
-    last_modified: 2026-08-02
+    last_modified: 2026-08-18
   - id: os-boundary
     resource: ../../lib/services/notification_service.dart
     title: NotificationService — the OS delivery boundary
     last_modified: 2026-08-17
   - id: scheduler
     resource: ../../lib/features/notifications/scheduler/notification_scheduler.dart
-    title: NotificationScheduler — rows to OS alarms, and startup reconcile
-    last_modified: 2026-08-17
+    title: NotificationScheduler — rows to OS alarms, and reconcile
+    last_modified: 2026-08-18
   - id: adr-0039
     resource: ../../docs/adr/0039-relationship-check-in-reminders.md
     title: ADR 0039 — Relationship check-in reminders
@@ -222,10 +222,14 @@ count on the icon until the user happened to write something.
 `setConfigFlagImpl` therefore refreshes the badge when
 `enable_notifications` actually changes, next to the `private` hook it already
 carries. That is also what makes the permission prompt land at the moment the
-user switches notifications on, rather than at some later write. A failure
-there is logged and swallowed: the setting the user asked for is already
-saved, and a badge refresh that cannot reach the platform is not a reason to
-report it as unsaved.
+user switches notifications on, rather than at some later write. Switching
+the flag *on* additionally runs the scheduler's reconcile (below): rows
+written while the flag was off never armed an OS alarm — the platform calls
+are gated on the flag — and the repository's idempotent creates skip existing
+rows on every later tick, so without this only the next app start would arm
+them. A failure in either hook is logged and swallowed: the setting the user
+asked for is already saved, and a badge refresh or re-arm that cannot reach
+the platform is not a reason to report it as unsaved.
 
 Cancelling is the one thing that stays ungated: removing an alert must keep
 working after notifications are switched off.
@@ -281,7 +285,9 @@ app update, a reinstall or an Android reboot, while the row describing it sits
 untouched in `notifications.sqlite`. Nothing reconciled the two, so a reminder
 armed weeks ahead silently stopped existing at the OS level.
 
-`NotificationScheduler.reconcile()` closes that at startup, and the query
+`NotificationScheduler.reconcile()` closes that at startup — and again when
+`enable_notifications` is switched on, which re-arms rows written while the
+flag was off (see the badge section above). The query
 already filters to unseen/unacted/undeleted rows — so a row dealt with on any
 device is never revived. It is called fire-and-forget through
 `reconcileScheduledNotifications`, which swallows and logs: a notification

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/relationships
     title: Relationships feature source
-    last_modified: 2026-08-14
+    last_modified: 2026-08-18
   - id: queries
     resource: ../../lib/database/database_relationship_queries.dart
     title: Relationship and check-in queries
@@ -75,7 +75,7 @@ sources:
   - id: adr-0041
     resource: ../../docs/adr/0041-relationship-contact-linking.md
     title: ADR 0041 — Relationship contact linking
-    last_modified: 2026-08-13
+    last_modified: 2026-08-18
 ---
 
 A person the user deliberately tracks is a `JournalEntity.relationship`; each
@@ -692,10 +692,13 @@ Phase 7 (ADR 0041), Android and iOS only. Three invariants carry it:
   permission and neither reads in the background, but user-facing copy must
   say "reads your address book while the import screen is open" rather than
   "reads only the contacts you choose", which is true of the picker alone.
-- **`contactRefs` are per-platform and per-device.** The same person carries a
-  different id in each address book, so a ref written on a phone reads as
-  *unlinked* on a tablet rather than resolving to a stranger. Both the link
-  action and `refreshFromContact` key on `contactRefPlatformKey()`.
+- **`contactRefs` are per-device.** The same person carries a different id in
+  each address book — even on two phones running the same OS — so a ref
+  written on one device reads as *unlinked* everywhere else rather than
+  resolving to a stranger. The key is the platform plus this device's sync
+  host id (`contactRefKeyForHost`), resolved via `contactRefKeyProvider`;
+  the link action, the import and `refreshFromContact` all go through it,
+  and a device whose host id is not yet provisioned stores no ref at all.
 
 **The import screen is pushed above the shell, not into the tab.** It docks
 its Import action in a `bottomNavigationBar`, and the mobile shell paints the

--- a/lib/features/notifications/scheduler/notification_scheduler.dart
+++ b/lib/features/notifications/scheduler/notification_scheduler.dart
@@ -73,9 +73,11 @@ class NotificationScheduler {
   ///
   /// An alarm set before an app update, a reinstall, or (on Android) a reboot
   /// is gone, while the durable row describing it still sits in
-  /// `notifications.sqlite`. Nothing else re-arms it, because [schedule] is
-  /// only ever called on a write — so without this a reminder armed weeks
-  /// ahead silently stops existing at the OS level.
+  /// `notifications.sqlite`. [schedule] is only ever called on a write — so
+  /// without this a reminder armed weeks ahead silently stops existing at the
+  /// OS level. The same gap exists for rows written while the
+  /// `enable_notifications` flag was off (the platform calls are gated on it),
+  /// which is why flipping that flag on also runs this.
   ///
   /// **Only future rows.** A row that is already due needs no alarm: it is by
   /// definition sitting in the inbox, on the device the user is holding.

--- a/lib/features/notifications/scheduler/notification_startup_reconcile.dart
+++ b/lib/features/notifications/scheduler/notification_startup_reconcile.dart
@@ -1,7 +1,12 @@
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/services/domain_logging.dart';
 
-/// Re-arms OS alerts for still-schedulable notification rows during startup.
+/// Re-arms OS alerts for still-schedulable notification rows.
+///
+/// Called at startup (alarms the OS lost across an update, reinstall or
+/// reboot) and when the `enable_notifications` flag is switched on (rows
+/// written while the flag was off were never armed, and the repository's
+/// idempotent creates do not re-schedule an existing row).
 ///
 /// Extracted from the composition root rather than inlined there so the
 /// swallow-and-log contract below is testable: `registerSingletons` cannot be

--- a/lib/features/relationships/model/imported_contact.dart
+++ b/lib/features/relationships/model/imported_contact.dart
@@ -28,13 +28,15 @@ typedef ImportedContact = ({
 /// marked important by default and no agent is created behind the user's back
 /// (ADR 0041: dormant entities destroy the nudge signal).
 ///
-/// The OS id is recorded under [platformKey] ('ios' / 'android'), matching the
-/// per-platform shape of `contactRefs`: the same person's contact has
-/// different identifiers on different devices, so a ref is only meaningful on
-/// the device that wrote it.
+/// The OS id is recorded under [refKey] — this device's slot in the
+/// per-device `contactRefs` map (see `contactRefKeyForHost`): the same
+/// person's contact has different identifiers in every address book, so a
+/// ref is only meaningful on the device that wrote it. A `null` key (host id
+/// not yet provisioned) imports the person without a ref rather than parking
+/// the id under a key another device could collide with.
 RelationshipData relationshipDataFromContact(
   ImportedContact contact, {
-  required String platformKey,
+  required String? refKey,
   required RelationshipStatus status,
   bool important = false,
   int? checkInCadenceDays,
@@ -45,7 +47,7 @@ RelationshipData relationshipDataFromContact(
     important: important,
     checkInCadenceDays: checkInCadenceDays,
     contactChannels: contact.channels,
-    contactRefs: {platformKey: contact.id},
+    contactRefs: {?refKey: contact.id},
   );
 }
 

--- a/lib/features/relationships/state/contact_import_controller.dart
+++ b/lib/features/relationships/state/contact_import_controller.dart
@@ -7,6 +7,8 @@ import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/features/relationships/model/imported_contact.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 
 /// Where the import flow currently stands.
@@ -210,12 +212,13 @@ class ContactImportController extends Notifier<ContactImportState> {
   /// five are missing, and the ones that did land are real.
   Future<List<String>> importSelected() async {
     final repository = ref.read(relationshipRepositoryProvider);
+    final refKey = await ref.read(contactRefKeyProvider.future);
     final created = <String>[];
 
     for (final draft in state.drafts.values) {
       final data = relationshipDataFromContact(
         draft.contact,
-        platformKey: contactRefPlatformKey(),
+        refKey: refKey,
         status: RelationshipStatus.active(
           id: uuid.v1(),
           createdAt: clock.now(),
@@ -243,12 +246,31 @@ class ContactImportController extends Notifier<ContactImportState> {
   }
 }
 
-/// The key a contact ref is stored under.
+/// The key [host]'s contact ref is stored under in
+/// `RelationshipData.contactRefs`.
 ///
-/// Refs are per-platform because the same person carries a different
-/// identifier in each device's address book, so a ref written on Android is
-/// meaningless on iOS (ADR 0041 §2).
-String contactRefPlatformKey() => Platform.isIOS ? 'ios' : 'android';
+/// Refs are per-device, not merely per-platform: every address book assigns
+/// its own identifiers, so two phones on the same OS still hold unrelated
+/// ids for the same person. Scoping the key by the sync host id gives each
+/// device its own slot — a link written on one device can never overwrite,
+/// or be resolved against, another device's address book (ADR 0041 §2). The
+/// platform prefix adds no uniqueness beyond the host; it makes the stored
+/// map read as "which kind of device wrote this".
+String contactRefKeyForHost(String host) =>
+    '${Platform.isIOS ? 'ios' : 'android'}:$host';
+
+/// This device's contact-ref key, or `null` while the sync host id is still
+/// unknown (it is provisioned during startup, before any contact UI runs).
+///
+/// Callers treat `null` as "this device has no ref and cannot store one":
+/// linking still copies channels, refreshing reports the contact missing,
+/// and nothing is written under a key another device could collide with.
+final contactRefKeyProvider = FutureProvider<String?>((ref) async {
+  final vectorClockService = getIt<VectorClockService>();
+  await vectorClockService.initialized;
+  final host = await vectorClockService.getHost();
+  return host == null ? null : contactRefKeyForHost(host);
+}, name: 'contactRefKeyProvider');
 
 final contactImportControllerProvider =
     NotifierProvider<ContactImportController, ContactImportState>(

--- a/lib/features/relationships/state/contact_link_controller.dart
+++ b/lib/features/relationships/state/contact_link_controller.dart
@@ -56,15 +56,17 @@ class ContactLinkController {
   /// Re-reads the contact this person is already linked to and copies over
   /// anything new. Returns [ContactLinkOutcome.contactMissing] when the ref
   /// resolves to nothing, which is the normal case on a second device: refs
-  /// are per-platform and per-device, so a person linked on a phone carries
-  /// a ref that means nothing on a tablet.
+  /// are per-device, so a person linked on one phone carries a ref that
+  /// means nothing anywhere else — including on a second phone running the
+  /// same OS.
   Future<ContactLinkOutcome> refreshFromContact(
     RelationshipEntry relationship,
   ) async {
     final service = _ref.read(contactsServiceProvider);
     if (!service.isSupported) return ContactLinkOutcome.unsupported;
 
-    final ref = relationship.data.contactRefs[contactRefPlatformKey()];
+    final refKey = await _ref.read(contactRefKeyProvider.future);
+    final ref = refKey == null ? null : relationship.data.contactRefs[refKey];
     if (ref == null || ref.isEmpty) return ContactLinkOutcome.contactMissing;
 
     final contact = await service.readById(ref);
@@ -78,7 +80,8 @@ class ContactLinkController {
   /// The person's own title is deliberately left alone: they may have been
   /// renamed here on purpose ("Mum" rather than "Margaret Schmidt"), and a
   /// contact refresh silently overwriting that would be a bad surprise.
-  /// Only channels and the ref are copied.
+  /// Only channels and the ref are copied — and the ref only into this
+  /// device's slot, leaving every other device's entry untouched.
   Future<ContactLinkOutcome> _applyContact(
     RelationshipEntry relationship,
     ImportedContact contact,
@@ -89,9 +92,9 @@ class ContactLinkController {
     );
 
     final refs = Map<String, String>.from(relationship.data.contactRefs);
-    final refKey = contactRefPlatformKey();
-    final refUnchanged = refs[refKey] == contact.id;
-    refs[refKey] = contact.id;
+    final refKey = await _ref.read(contactRefKeyProvider.future);
+    final refUnchanged = refKey == null || refs[refKey] == contact.id;
+    if (refKey != null) refs[refKey] = contact.id;
 
     final channelsUnchanged =
         merged.length == relationship.data.contactChannels.length;

--- a/lib/features/relationships/ui/pages/relationships_page.dart
+++ b/lib/features/relationships/ui/pages/relationships_page.dart
@@ -2,20 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
 import 'package:lotti/features/relationships/state/relationships_providers.dart';
 import 'package:lotti/features/relationships/ui/pages/contact_import_page.dart';
+import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
 import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/nav_bar/bottom_nav_safe_navigator.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
-/// The People tab: every tracked relationship, most recently interacted-with
-/// first (people without a check-in sort by tracking start), with an
-/// add-person FAB. Tapping a row beams to `/people/<id>`.
+/// The People tab (design plan §1): a left-aligned display header with one
+/// add affordance (a 34px teal circle `＋`), and one row per person — persona
+/// avatar, name with an inline star when favorited, a status line (the last
+/// meaningful event or a quiet-streak) with a cadence-state dot, and a
+/// trailing cadence pill. Rows sort due-first then by recency; favorites
+/// are a marker, not a section.
 class RelationshipsPage extends ConsumerWidget {
   const RelationshipsPage({super.key});
 
@@ -29,28 +33,15 @@ class RelationshipsPage extends ConsumerWidget {
     final failedFirstLoad = items == null && itemsAsync.hasError;
 
     return Scaffold(
-      floatingActionButton: DesignSystemBottomNavigationFabPadding(
-        child: FloatingActionButton.extended(
-          onPressed: () => showRelationshipCreateModal(context: context),
-          label: Text(context.messages.relationshipCreateTitle),
-          icon: const Icon(LottiIcons.personAdd),
-        ),
-      ),
       body: SafeArea(
         child: CustomScrollView(
           slivers: [
-            SliverAppBar(
-              pinned: true,
-              title: Text(context.messages.relationshipsPageTitle),
-              actions: const [_ImportContactsAction()],
-            ),
+            SliverToBoxAdapter(child: _PeopleHeader(itemCount: items?.length)),
             SliverPadding(
-              // The last row must clear the overlaid bottom navigation plus
-              // the lifted FAB's footprint (the projects-list clearance
-              // idiom).
+              // The last row must clear the overlaid bottom navigation.
               padding: EdgeInsets.fromLTRB(
                 tokens.spacing.step5,
-                tokens.spacing.step5,
+                tokens.spacing.step3,
                 tokens.spacing.step5,
                 tokens.spacing.step5 +
                     DesignSystemBottomNavigationBar.occupiedHeight(context) +
@@ -70,8 +61,7 @@ class RelationshipsPage extends ConsumerWidget {
                   ),
                 ),
                 // First load only — a background reload never reaches this
-                // arm because the previous value is retained above. The
-                // detail page and the projects list share this shape.
+                // arm because the previous value is retained above.
                 null => SliverToBoxAdapter(
                   child: Padding(
                     padding: EdgeInsets.only(top: tokens.spacing.sectionGap),
@@ -80,14 +70,20 @@ class RelationshipsPage extends ConsumerWidget {
                     ),
                   ),
                 ),
-                [] => const SliverToBoxAdapter(child: _EmptyState()),
-                final list => SliverList.separated(
-                  itemCount: list.length,
-                  separatorBuilder: (_, _) =>
-                      SizedBox(height: tokens.spacing.cardItemSpacing),
-                  itemBuilder: (context, index) =>
-                      _RelationshipRow(item: list[index]),
-                ),
+                [] => SliverToBoxAdapter(child: _EmptyState()),
+                final list => () {
+                  final sorted = sortPeopleForList(list);
+                  return SliverList.separated(
+                    itemCount: sorted.length,
+                    separatorBuilder: (_, _) => Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: tokens.colors.decorative.level01,
+                    ),
+                    itemBuilder: (context, index) =>
+                        _RelationshipRow(item: sorted[index]),
+                  );
+                }(),
               },
             ),
           ],
@@ -97,28 +93,60 @@ class RelationshipsPage extends ConsumerWidget {
   }
 }
 
-class _EmptyState extends StatelessWidget {
-  const _EmptyState();
+/// The left-aligned `People` title with a count caption and the single add
+/// affordance (design plan §0.3 / §1). Not a Material `AppBar` — the title is
+/// left-aligned display type, and the import-from-contacts door sits beside
+/// the add circle (a distinct action, not a second add affordance).
+class _PeopleHeader extends ConsumerWidget {
+  const _PeopleHeader({required this.itemCount});
+
+  final int? itemCount;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
+    final messages = context.messages;
+
     return Padding(
-      padding: EdgeInsets.only(top: tokens.spacing.sectionGap),
-      child: Column(
+      padding: EdgeInsets.fromLTRB(
+        tokens.spacing.step5,
+        tokens.spacing.step5,
+        tokens.spacing.step5,
+        tokens.spacing.step3,
+      ),
+      child: Row(
         children: [
-          Icon(
-            LottiIcons.people,
-            size: tokens.spacing.step12,
-            color: tokens.colors.text.lowEmphasis,
-          ),
-          SizedBox(height: tokens.spacing.step5),
           Text(
-            context.messages.relationshipsEmptyState,
-            textAlign: TextAlign.center,
-            style: tokens.typography.styles.body.bodyMedium.copyWith(
-              color: tokens.colors.text.mediumEmphasis,
+            messages.relationshipsPageTitle,
+            style: tokens.typography.styles.heading.heading2.copyWith(
+              color: tokens.colors.text.highEmphasis,
             ),
+          ),
+          if (itemCount != null) ...[
+            SizedBox(width: tokens.spacing.step2),
+            Text(
+              '· $itemCount',
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: tokens.colors.text.lowEmphasis,
+              ),
+            ),
+          ],
+          const Spacer(),
+          // Import is a distinct door, not a second add affordance; hidden on
+          // desktop where there is no address book (ADR 0041 §2).
+          if (ref.read(contactsServiceProvider).isSupported)
+            _IconButton(
+              icon: LottiIcons.contactImport,
+              tooltip: messages.relationshipImportAction,
+              onTap: () => bottomNavSafeNavigatorOf(context).push(
+                MaterialPageRoute<int>(
+                  builder: (_) => const ContactImportPage(),
+                ),
+              ),
+            ),
+          SizedBox(width: tokens.spacing.step2),
+          _AddPersonButton(
+            onTap: () => showRelationshipCreateModal(context: context),
           ),
         ],
       ),
@@ -126,6 +154,96 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
+class _AddPersonButton extends StatelessWidget {
+  const _AddPersonButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Material(
+      color: tokens.colors.interactive.enabled,
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        customBorder: const CircleBorder(),
+        child: SizedBox(
+          width: 34,
+          height: 34,
+          child: Icon(
+            LottiIcons.add,
+            size: 20,
+            color: tokens.colors.background.level01,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IconButton extends StatelessWidget {
+  const _IconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onTap,
+        customBorder: const CircleBorder(),
+        child: Padding(
+          padding: EdgeInsets.all(tokens.spacing.step2),
+          child: Icon(
+            icon,
+            size: 22,
+            color: tokens.colors.text.mediumEmphasis,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    return Padding(
+      padding: EdgeInsets.only(top: tokens.spacing.sectionGap),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            messages.relationshipsEmptyState,
+            textAlign: TextAlign.center,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step5),
+          _AddPersonButton(
+            onTap: () => showRelationshipCreateModal(context: context),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One person row (design plan §1): 40px persona avatar, name + inline star,
+/// a cadence-state dot + status line, and a trailing cadence pill.
 class _RelationshipRow extends StatelessWidget {
   const _RelationshipRow({required this.item});
 
@@ -136,73 +254,235 @@ class _RelationshipRow extends StatelessWidget {
     final tokens = context.designTokens;
     final relationship = item.relationship;
     final data = relationship.data;
+    final cadenceDays = data.checkInCadenceDays;
 
-    return ListTile(
-      contentPadding: EdgeInsets.symmetric(horizontal: tokens.spacing.step4),
-      leading: Icon(
-        LottiIcons.person,
-        color: tokens.colors.text.mediumEmphasis,
-      ),
-      title: Text(
-        data.title,
-        style: tokens.typography.styles.body.bodyLarge.copyWith(
-          color: tokens.colors.text.highEmphasis,
-        ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-      // Last-check-in recency (plan v2 phase 2); tracking start until the
-      // first check-in exists. The two dates mean opposite things on a
-      // recency screen — a person added today has NOT been contacted today —
-      // so each branch names itself.
-      subtitle: Text(
-        item.lastCheckInAt != null
-            ? context.messages.relationshipLastCheckInLabel(
-                entryDateLabel(context, item.lastCheckInAt!),
-              )
-            : context.messages.relationshipTrackingSinceLabel(
-                entryDateLabel(context, relationship.meta.dateFrom),
-              ),
-        style: tokens.typography.styles.body.bodySmall.copyWith(
-          color: tokens.colors.text.lowEmphasis,
-        ),
-      ),
-      trailing: data.important
-          ? Icon(
-              LottiIcons.star,
-              color: tokens.colors.interactive.enabled,
-            )
-          : null,
+    return InkWell(
       onTap: () => beamToNamed('/people/${relationship.id}'),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step4,
+          vertical: tokens.spacing.step3,
+        ),
+        child: Row(
+          children: [
+            PersonaAvatar(
+              initial: personaInitial(data.title),
+              id: relationship.id,
+            ),
+            SizedBox(width: tokens.spacing.step4),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          data.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tokens.typography.styles.body.bodyLarge
+                              .copyWith(
+                                fontWeight: tokens.typography.weight.semiBold,
+                                color: tokens.colors.text.highEmphasis,
+                              ),
+                        ),
+                      ),
+                      if (data.important) ...[
+                        SizedBox(width: tokens.spacing.step2),
+                        Icon(
+                          LottiIconsFilled.star,
+                          size: 11,
+                          color: tokens.colors.interactive.enabled,
+                        ),
+                      ],
+                    ],
+                  ),
+                  SizedBox(height: tokens.spacing.step1),
+                  Row(
+                    children: [
+                      _CadenceStateDot(
+                        cadenceDays: cadenceDays,
+                        lastCheckInAt: item.lastCheckInAt,
+                        trackingStartedAt: relationship.meta.dateFrom,
+                      ),
+                      SizedBox(width: tokens.spacing.step2),
+                      Flexible(
+                        child: Text(
+                          _statusLine(
+                            context,
+                            item,
+                            cadenceDays,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tokens.typography.styles.others.caption
+                              .copyWith(
+                                color: tokens.colors.text.mediumEmphasis,
+                              ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            _CadencePill(
+              cadenceDays: cadenceDays,
+              lastCheckInAt: item.lastCheckInAt,
+              trackingStartedAt: relationship.meta.dateFrom,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The status line: the last meaningful event (with its mono timestamp),
+  /// or the quiet-streak caption. "Tracking since …" is dropped entirely
+  /// (design plan §0.8) — a person added today has not been contacted today.
+  String _statusLine(
+    BuildContext context,
+    RelationshipListItem item,
+    int? cadenceDays,
+  ) {
+    final messages = context.messages;
+    final last = item.lastCheckInAt;
+    if (last != null) {
+      return messages.relationshipCheckedInLabel(
+        relationshipTimestampLabel(last),
+      );
+    }
+    final streak = quietStreakDays(
+      lastCheckInAt: null,
+      trackingStartedAt: item.relationship.meta.dateFrom,
+    );
+    if (streak == 0) return messages.relationshipJustAdded;
+    return messages.relationshipQuietForDays(streak);
+  }
+}
+
+/// The 7px cadence-state dot: teal when on track, warning when due, neutral
+/// when there is no cadence (design plan §0.6 / §1).
+class _CadenceStateDot extends StatelessWidget {
+  const _CadenceStateDot({
+    required this.cadenceDays,
+    required this.lastCheckInAt,
+    required this.trackingStartedAt,
+  });
+
+  final int? cadenceDays;
+  final DateTime? lastCheckInAt;
+  final DateTime trackingStartedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final overdue = cadenceOverdueDays(
+      lastCheckInAt: lastCheckInAt,
+      trackingStartedAt: trackingStartedAt,
+      cadenceDays: cadenceDays,
+    );
+    final color = switch (overdue) {
+      null => tokens.colors.text.highEmphasis.withValues(alpha: 0.38),
+      <= 0 => tokens.colors.interactive.enabled,
+      _ => tokens.colors.alert.warning.defaultColor,
+    };
+    return Container(
+      width: 7,
+      height: 7,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
     );
   }
 }
 
-/// Opens the multi-select contact import (plan v2 phase 7 item 3).
-///
-/// Absent on desktop, where there is no address book to import from and
-/// contact details are entered by hand (ADR 0041 §2). Nothing is read until
-/// the import screen itself asks — this is only the door.
-class _ImportContactsAction extends ConsumerWidget {
-  const _ImportContactsAction();
+/// The trailing cadence pill: quiet/on-track when not due, warning-tinted
+/// `Due {day}` when overdue (design plan §1).
+class _CadencePill extends StatelessWidget {
+  const _CadencePill({
+    required this.cadenceDays,
+    required this.lastCheckInAt,
+    required this.trackingStartedAt,
+  });
+
+  final int? cadenceDays;
+  final DateTime? lastCheckInAt;
+  final DateTime trackingStartedAt;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    if (!ref.read(contactsServiceProvider).isSupported) {
-      return const SizedBox.shrink();
-    }
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
 
-    return IconButton(
-      tooltip: context.messages.relationshipImportAction,
-      icon: const Icon(LottiIcons.contactImport),
-      // Pushed above the shell on mobile, not onto the tab's own navigator:
-      // the import screen docks its Import action in a `bottomNavigationBar`,
-      // and the floating nav pill is painted over each tab's page stack — so
-      // a nested push would leave the screen's primary action sitting behind
-      // it. See `bottom_nav_safe_navigator.dart`.
-      onPressed: () => bottomNavSafeNavigatorOf(context).push(
-        MaterialPageRoute<int>(builder: (_) => const ContactImportPage()),
+    if (cadenceDays == null) return const SizedBox.shrink();
+
+    final due = cadenceDueDate(
+      lastCheckInAt: lastCheckInAt,
+      trackingStartedAt: trackingStartedAt,
+      cadenceDays: cadenceDays,
+    );
+    final overdue = cadenceOverdueDays(
+      lastCheckInAt: lastCheckInAt,
+      trackingStartedAt: trackingStartedAt,
+      cadenceDays: cadenceDays,
+    );
+
+    final dueOverdue = (overdue ?? 0) > 0;
+    final label = dueOverdue
+        ? messages.relationshipDueDay(relationshipWeekdayLabel(due!))
+        : messages.relationshipCadenceOnTrack;
+    final fg = dueOverdue
+        ? tokens.colors.alert.warning.defaultColor
+        : tokens.colors.text.mediumEmphasis;
+    final bg = dueOverdue
+        ? tokens.colors.alert.warning.defaultColor.withValues(alpha: 0.16)
+        : tokens.colors.surface.enabled;
+
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.step3,
+        vertical: tokens.spacing.step1,
+      ),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: tokens.typography.styles.others.caption.copyWith(
+          color: fg,
+          fontWeight: tokens.typography.weight.semiBold,
+          height: 1,
+        ),
       ),
     );
   }
+}
+
+/// Sort the list due-first, then by last-contact recency (design plan §1).
+/// Favorites do NOT get a separate section; the star is a marker.
+List<RelationshipListItem> sortPeopleForList(List<RelationshipListItem> items) {
+  final due = <RelationshipListItem>[];
+  final rest = <RelationshipListItem>[];
+  for (final item in items) {
+    final overdue = cadenceOverdueDays(
+      lastCheckInAt: item.lastCheckInAt,
+      trackingStartedAt: item.relationship.meta.dateFrom,
+      cadenceDays: item.relationship.data.checkInCadenceDays,
+    );
+    if ((overdue ?? 0) > 0) {
+      due.add(item);
+    } else {
+      rest.add(item);
+    }
+  }
+  DateTime recency(RelationshipListItem i) =>
+      i.lastCheckInAt ?? i.relationship.meta.dateFrom;
+  due.sort((a, b) => recency(b).compareTo(recency(a)));
+  rest.sort((a, b) => recency(b).compareTo(recency(a)));
+  return [...due, ...rest];
 }

--- a/lib/features/relationships/ui/shared/ds_choice_pills.dart
+++ b/lib/features/relationships/ui/shared/ds_choice_pills.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// A single-select row of pill chips (design plan §0.2 / §6 — kill the
+/// default `ChoiceChip` wrap grid; one horizontal row, scroll if needed,
+/// selected = `surface.active` + teal text).
+///
+/// The row never wraps into a ragged grid. When the chips would overflow
+/// the available width it scrolls horizontally instead, so the choices
+/// stay on one line and the selection affordance stays consistent.
+class DsChoicePills<T> extends StatelessWidget {
+  const DsChoicePills({
+    required this.value,
+    required this.values,
+    required this.labelFor,
+    required this.onSelected,
+    this.leading,
+    super.key,
+  });
+
+  /// The currently selected value, or `null` when nothing is selected.
+  final T? value;
+
+  /// The full set of choices, in display order.
+  final List<T> values;
+
+  /// The localized label for a choice.
+  final String Function(T value) labelFor;
+
+  /// Called when the user taps a choice with that choice. Single-select: the
+  /// already-selected choice is a no-op (a cadence or interaction type is
+  /// always set, never cleared from here).
+  final ValueChanged<T> onSelected;
+
+  /// Optional leading widget rendered before the chips (e.g. a section
+  /// label that should travel with the row when it scrolls).
+  final Widget? leading;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final gap = tokens.spacing.step2;
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          if (leading != null) ...[leading!, SizedBox(width: gap)],
+          for (var i = 0; i < values.length; i++) ...[
+            if (i != 0) SizedBox(width: gap),
+            DsPill(
+              variant: DsPillVariant.filled,
+              label: labelFor(values[i]),
+              selected: values[i] == value,
+              onTap: () => onSelected(values[i]),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/relationships/ui/shared/persona_avatar.dart
+++ b/lib/features/relationships/ui/shared/persona_avatar.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// One accent per person, stable per id (design plan §0.7). The palette is
+/// the same family the goal agents draw from: the design system's semantic
+/// accents plus the two hand-authored goal hues. Assignment is a
+/// deterministic hash of the id, so the same person lands on the same
+/// accent on every device and across reloads — the avatar does not
+/// reshuffle when the list reorders.
+///
+/// Every entry comes from the exported token sets — the brightness picks
+/// which set, nothing here holds a color literal of its own. The alert
+/// accents use the `ink` variant because the accent is rendered as text
+/// (the initial), and ink is the text-weight resolution of each hue.
+Color personaAccentForId(String id, Brightness brightness) {
+  // A stable, well-mixed 32-bit hash of the id. String.hashCode is not
+  // guaranteed stable across Dart versions, so fold the bytes by hand.
+  var hash = 0x811C9DC5; // FNV-1a 32-bit offset basis.
+  for (final byte in id.codeUnits) {
+    hash ^= byte;
+    hash = (hash * 0x01000193) & 0xFFFFFFFF; // FNV-1a prime.
+  }
+  final tokens = brightness == Brightness.dark ? dsTokensDark : dsTokensLight;
+  final palette = <Color>[
+    tokens.colors.interactive.enabled,
+    GoalAccentHues.neon(brightness),
+    GoalAccentHues.aurora(brightness),
+    tokens.colors.alert.warning.ink,
+    tokens.colors.alert.info.ink,
+    tokens.colors.alert.success.ink,
+  ];
+  return palette[hash % palette.length];
+}
+
+/// A persona-tinted circle avatar: `color-mix(accent 20%, transparent)`
+/// fill with an accent-colored initial (design plan §0.7).
+///
+/// The accent is derived from [id] when supplied; callers that already
+/// hold an accent (e.g. a beat rail reusing the person's accent) pass it
+/// directly via [accent].
+class PersonaAvatar extends StatelessWidget {
+  const PersonaAvatar({
+    required this.initial,
+    this.id,
+    this.accent,
+    this.size = 40,
+    super.key,
+  }) : assert(
+         id != null || accent != null,
+         'PersonaAvatar needs either an id (to derive the accent) or an '
+         'explicit accent.',
+       );
+
+  /// The single character shown (usually the first letter of the name).
+  final String initial;
+
+  /// The person's entity id — used to derive a stable accent. Ignored when
+  /// [accent] is supplied.
+  final String? id;
+
+  /// An explicit accent, overriding the id-derived one.
+  final Color? accent;
+
+  /// The avatar diameter in logical pixels.
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final accent =
+        this.accent ?? personaAccentForId(id!, Theme.of(context).brightness);
+    final fontSize = size * 0.42;
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.20),
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        initial.isEmpty ? '·' : initial,
+        style: tokens.typography.styles.subtitle.subtitle1.copyWith(
+          color: accent,
+          fontSize: fontSize,
+          fontWeight: tokens.typography.weight.semiBold,
+          height: 1,
+        ),
+      ),
+    );
+  }
+}
+
+/// Convenience: the first letter of [name], uppercased, falling back to "·"
+/// for the empty/null name (the import list can carry a contact whose
+/// display name is blank).
+String personaInitial(String? name) {
+  final trimmed = name?.trim() ?? '';
+  if (trimmed.isEmpty) return '·';
+  return trimmed[0].toUpperCase();
+}

--- a/lib/features/relationships/ui/shared/relationship_timestamps.dart
+++ b/lib/features/relationships/ui/shared/relationship_timestamps.dart
@@ -1,0 +1,141 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/design_system/theme/typography_helpers.dart';
+
+/// 24h, mono date-time formatting for the relationships surface (design
+/// plan §0.5 — "All date/time strings render in `--ff-mono` (Inconsolata)
+/// at caption sizes: `Today 14:20`, `Fri 15 Aug 19:05`. Never `Aug 18, 2026
+/// 12:44 PM` in body type").
+///
+/// All formatters here are pure functions of a [DateTime] (and the clock),
+/// so they are unit-testable without a widget pump.
+
+/// The mono [TextStyle] for a relationship timestamp, derived from the
+/// design-system caption token with the Inconsolata override.
+TextStyle relationshipTimestampStyle(DsTokens tokens, {Color? color}) =>
+    monoMetaStyle(tokens, tokens.colors, color: color);
+
+/// `HH:mm` in 24h, mono — the time component shared by every relationship
+/// timestamp.
+String _hhMm(DateTime t) =>
+    '${t.hour.toString().padLeft(2, '0')}:'
+    '${t.minute.toString().padLeft(2, '0')}';
+
+/// The short weekday + day + month used when the timestamp is not today
+/// (e.g. `Fri 15 Aug`). English abbreviations are intentional: the mono
+/// timestamp is a system-level affordance, not localized prose, matching
+/// the existing `monoMetaStyle` usage across the app.
+String _shortDayMonth(DateTime t) {
+  const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${weekdays[t.weekday - 1]} ${t.day} ${months[t.month - 1]}';
+}
+
+/// A mono timestamp label for a single point in time, anchored to [now].
+///
+/// Same day → `Today 14:20`. The day before → `Yesterday 19:05`. Otherwise →
+/// `Fri 15 Aug 19:05`.
+///
+/// "Yesterday" earns its own case because it is the single most common
+/// non-today value on this surface — a check-in logged the previous evening
+/// reads as `Yesterday 18:00` rather than making the reader decode
+/// `Wed 12 Aug 18:00` against today's date.
+String relationshipTimestampLabel(DateTime at, {DateTime? now}) {
+  final anchor = now ?? clock.now();
+  if (_isSameDay(at, anchor)) return 'Today ${_hhMm(at)}';
+  if (_isSameDay(at, _dayBefore(anchor))) return 'Yesterday ${_hhMm(at)}';
+  return '${_shortDayMonth(at)} ${_hhMm(at)}';
+}
+
+/// The calendar day before [anchor]. Built from components rather than by
+/// subtracting a `Duration`, so the 23- and 25-hour days either side of a DST
+/// change still resolve to the previous date.
+DateTime _dayBefore(DateTime anchor) =>
+    DateTime(anchor.year, anchor.month, anchor.day - 1);
+
+/// A mono time-only label (`14:20`), used in the detail beat header where
+/// the date is already implied by the beat's position.
+String relationshipTimeLabel(DateTime at) => _hhMm(at);
+
+/// A mono weekday-only label (`Thu`), used by the cadence due pill.
+String relationshipWeekdayLabel(DateTime at) {
+  const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  return weekdays[at.weekday - 1];
+}
+
+bool _isSameDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
+
+/// The cadence due date: the next date by which a check-in should land,
+/// given the [lastCheckInAt] (or [trackingStartedAt] when none exists yet)
+/// and the [cadenceDays]. `null` when the person has no cadence.
+DateTime? cadenceDueDate({
+  required DateTime? lastCheckInAt,
+  required DateTime? trackingStartedAt,
+  required int? cadenceDays,
+  DateTime? now,
+}) {
+  if (cadenceDays == null || cadenceDays <= 0) return null;
+  final anchor = now ?? clock.now();
+  final base = lastCheckInAt ?? trackingStartedAt ?? anchor;
+  return base.add(Duration(days: cadenceDays));
+}
+
+/// Whole days between the cadence due date and [now]. Positive when the
+/// cadence is overdue (due in the past), negative when it is still ahead.
+/// `null` when there is no cadence.
+int? cadenceOverdueDays({
+  required DateTime? lastCheckInAt,
+  required DateTime? trackingStartedAt,
+  required int? cadenceDays,
+  DateTime? now,
+}) {
+  final due = cadenceDueDate(
+    lastCheckInAt: lastCheckInAt,
+    trackingStartedAt: trackingStartedAt,
+    cadenceDays: cadenceDays,
+    now: now,
+  );
+  if (due == null) return null;
+  final anchor = now ?? clock.now();
+  // Positive when the cadence is overdue (the due date is in the past): the
+  // days from the due date up to now.
+  return _wholeDaysBetween(due, anchor);
+}
+
+/// The number of whole days since the last check-in, or since tracking
+/// started when no check-in exists yet. Used for the "Quiet for N days"
+/// quiet-streak caption (design plan §0.8).
+int quietStreakDays({
+  required DateTime? lastCheckInAt,
+  required DateTime? trackingStartedAt,
+  DateTime? now,
+}) {
+  final anchor = now ?? clock.now();
+  final base = lastCheckInAt ?? trackingStartedAt;
+  if (base == null) return 0;
+  final days = _wholeDaysBetween(base, anchor);
+  return days < 0 ? 0 : days;
+}
+
+/// Whole days from [from] to [to], floored (a check-in 6 hours ago is 0
+/// days ago, not "today = 1"). Never negative when [from] is before [to].
+int _wholeDaysBetween(DateTime from, DateTime to) {
+  final fromMidnight = DateTime(from.year, from.month, from.day);
+  final toMidnight = DateTime(to.year, to.month, to.day);
+  return toMidnight.difference(fromMidnight).inDays;
+}

--- a/lib/features/relationships/ui/shared/sentiment.dart
+++ b/lib/features/relationships/ui/shared/sentiment.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// The single sentiment → color mapping for the relationships surface
+/// (design plan §0.6). One helper, used by the list rows, the detail beats
+/// and the composer — no per-screen color tables, no literal hexes at the
+/// call sites.
+///
+/// The mapping is fixed by the design plan:
+///   delightful → `interactive.enabled` (teal `#5ED4B7`)
+///   good       → `alert.success.defaultColor` (`#7AB889`)
+///   neutral    → foreground at 38% alpha (recedes; "nothing to report")
+///   strained   → `alert.warning.defaultColor`
+///   difficult  → `alert.error.defaultColor`
+Color sentimentColor(DsTokens tokens, CheckInSentiment sentiment) {
+  final colors = tokens.colors;
+  return switch (sentiment) {
+    CheckInSentiment.delightful => colors.interactive.enabled,
+    CheckInSentiment.good => colors.alert.success.defaultColor,
+    CheckInSentiment.neutral => sentimentNeutralColor(tokens),
+    CheckInSentiment.strained => colors.alert.warning.defaultColor,
+    CheckInSentiment.difficult => colors.alert.error.defaultColor,
+  };
+}
+
+/// The neutral sentiment's recede tone — foreground at 38% alpha. Exposed on
+/// its own because the unset/null sentiment bead reuses it.
+Color sentimentNeutralColor(DsTokens tokens) =>
+    tokens.colors.text.highEmphasis.withValues(alpha: 0.38);
+
+/// The tint used for the 16%-tint sentiment pills (design plan §0.6). Same
+/// hue as [sentimentColor], at the canonical 16% wash.
+Color sentimentPillFill(DsTokens tokens, CheckInSentiment sentiment) =>
+    sentimentColor(tokens, sentiment).withValues(alpha: 0.16);
+
+/// The sentiment dot/bead paint color for a nullable sentiment. `null`
+/// renders as the neutral tone so an unset sentiment still reads as a
+/// quiet bead rather than disappearing (the detail beat rail uses this).
+Color sentimentDotColor(DsTokens tokens, CheckInSentiment? sentiment) =>
+    sentiment == null
+    ? sentimentNeutralColor(tokens)
+    : sentimentColor(tokens, sentiment);
+
+/// The accent ring drawn around the selected sentiment dot in the composer
+/// (design plan §3.4: "selected dot gets a 2px gap ring in its own color").
+Color sentimentRingColor(DsTokens tokens, CheckInSentiment sentiment) =>
+    sentimentColor(tokens, sentiment);

--- a/lib/features/relationships/ui/widgets/contact_link_action.dart
+++ b/lib/features/relationships/ui/widgets/contact_link_action.dart
@@ -28,8 +28,13 @@ class ContactLinkAction extends ConsumerWidget {
 
   final RelationshipEntry relationship;
 
-  bool get _isLinked {
-    final ref = relationship.data.contactRefs[contactRefPlatformKey()];
+  /// Whether *this device* holds a ref for the person. Refs written by other
+  /// devices live under their own keys and deliberately do not count: a
+  /// menu offering "update from contact" for an address book this device
+  /// does not have would resolve to nothing — or to the wrong person.
+  bool _isLinked(String? refKey) {
+    if (refKey == null) return false;
+    final ref = relationship.data.contactRefs[refKey];
     return ref != null && ref.isNotEmpty;
   }
 
@@ -82,7 +87,11 @@ class ContactLinkAction extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    if (!_isLinked) {
+    // While the key is still resolving (one frame at most — the host id is
+    // read from memory) the person renders as unlinked, which offers the
+    // link action; both of that frame's states are safe to act on.
+    final refKey = ref.watch(contactRefKeyProvider).value;
+    if (!_isLinked(refKey)) {
       return IconButton(
         tooltip: context.messages.relationshipLinkContact,
         icon: const Icon(LottiIcons.findPerson),

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1398,9 +1398,21 @@
   "checkInAvoidLabel": "Raději se vyhnout",
   "checkInDateLabel": "Kdy?",
   "checkInDeleteConfirmMessage": "Smazat tento záznam? Tohle nelze vrátit zpět.",
+  "checkInDone": "Hotovo",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Upravit záznam",
   "checkInErrorCreateFailed": "Záznam se nepodařilo uložit. Zkus to prosím znovu.",
   "checkInErrorDeleteFailed": "Záznam se nepodařilo smazat. Zkus to prosím znovu.",
+  "checkInHowDidItFeel": "Jaké to bylo?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Jak proběhl kontakt?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Hovor",
   "checkInInteractionInPerson": "Osobně",
   "checkInInteractionLabel": "Jak jste se spojili?",
@@ -1409,6 +1421,7 @@
   "checkInInteractionVideoCall": "Videohovor",
   "checkInNarrativeLabel": "O čem jste mluvili?",
   "checkInPayAttentionLabel": "Příště se zaměřit na",
+  "checkInPreparedOverline": "✦ LOTTI · PŘIPRAVENO DNES RÁNO",
   "checkInSentimentDelightful": "Skvělé",
   "checkInSentimentDifficult": "Těžké",
   "checkInSentimentGood": "Dobré",
@@ -1421,6 +1434,10 @@
   "checkInTranscribingLabel": "Přepisuje se…",
   "checkInTranscriptFailed": "Přepis nedorazil. Můžeš text napsat sám.",
   "checkInTranscriptUnavailable": "Přepis pro tuto osobu není nastavený. Přidej zvukový model a zapni automatické odvozování pro její kategorii, nebo napiš záznam ručně.",
+  "checkInWriteInstead": "Spíše psát",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Přidat novou položku",
   "checklistAiConfidenceLabel": "Jistota: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4020,6 +4037,10 @@
   "relationshipActionFailed": "Nic v tomto zařízení to nedokáže otevřít",
   "relationshipActionMessage": "Zpráva",
   "relationshipAddChannelButton": "Přidat kontakt",
+  "relationshipAsk": "Zeptat",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Banner vztahu s {personName}",
   "relationshipBriefingDisclosureBody": "Briefing běží na {provider}. Poznámky o této osobě tam budou odeslány ke zpracování.",
   "relationshipBriefingDisclosureConfirm": "Pokračovat",
@@ -4028,16 +4049,36 @@
   "relationshipBriefingRequested": "Briefing vyžádán — za chvíli se tu objeví.",
   "relationshipBriefingRequestFailed": "Briefing se nepodařilo vyžádat.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Shrnout znovu",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Shrň mi to",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Každý den} few{Každé {days} dny} other{Každých {days} dní}}",
   "relationshipCadenceFortnightly": "Každé dva týdny",
   "relationshipCadenceLabel": "Frekvence kontaktu",
   "relationshipCadenceMonthly": "Každý měsíc",
   "relationshipCadenceNone": "Bez frekvence",
+  "relationshipCadenceNudgeNote": "Nastavení rytmu zapne připomínky záznamů.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "v rytmu",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Každé čtvrtletí",
   "relationshipCadenceWeekly": "Každý týden",
   "relationshipChatTooltip": "Chatovat o této osobě",
   "relationshipChatUnavailable": "Zatím žádný agent — nejprve označ tuto osobu jako důležitou.",
+  "relationshipCheckedInLabel": "Záznam {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Dobrá chvíle se ozvat.",
   "relationshipCheckInReminderTitle": "Ozvat se: {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4048,6 +4089,18 @@
     }
   },
   "relationshipCheckInsLabel": "Záznamy kontaktů",
+  "relationshipCheckInTitle": "Záznam · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Vizitka",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Kontaktní údaje",
   "relationshipContactLinked": "Kontaktní údaje zkopírovány",
   "relationshipContactLinkFailed": "Kontaktní údaje se nepodařilo uložit",
@@ -4056,6 +4109,14 @@
   "relationshipCreateTitle": "Přidat osobu",
   "relationshipDeleteConfirmMessage": "Smažou se i všechny záznamy kontaktů. Tohle nelze vrátit zpět.",
   "relationshipDeleteConfirmTitle": "Smazat {name}?",
+  "relationshipDueDay": "Do {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Upravit osobu",
   "relationshipErrorCreateFailed": "Osobu se nepodařilo uložit. Zkus to prosím znovu.",
   "relationshipErrorDeleteFailed": "Osobu se nepodařilo smazat. Zkus to prosím znovu.",
@@ -4083,17 +4144,45 @@
   "relationshipImportSettingsBody": "Přístup ke kontaktům je vypnutý. Zapni ho v nastavení systému, abys mohl lidi importovat.",
   "relationshipImportTitle": "Přidat lidi",
   "relationshipImportUnsupported": "Import kontaktů je dostupný na telefonech a tabletech. Kontaktní údaje sem zadej ručně.",
+  "relationshipJustAdded": "Právě přidáno",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Poslední záznam {date}",
   "relationshipLinkContact": "Propojit kontakt",
   "relationshipLinkedTasksLabel": "Úkoly",
   "relationshipLinkTaskButton": "Propojit úkol",
   "relationshipLogCheckIn": "Zaznamenat kontakt",
+  "relationshipLottisRead": "Lottiho odhad",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "k {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Jméno",
   "relationshipNameRequired": "Jméno je povinné",
+  "relationshipNextByDay": "příští do {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Přezdívka",
   "relationshipNoCheckIns": "Zatím žádné záznamy — přidej první po dalším rozhovoru.",
   "relationshipNoLinkedTasks": "Zatím žádné propojené úkoly.",
   "relationshipNotFound": "Tahle osoba už není sledovaná.",
+  "relationshipNudgesOn": "připomínky zapnuty",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Právě jsi se ozval. Chceš si zapsat check-in, dokud je to čerstvé?",
   "relationshipPostCallConfirm": "Zapsat check-in",
   "relationshipPostCallDismiss": "Teď ne",
@@ -4106,13 +4195,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "{count, plural, =1{1 den} few{{count} dny} other{{count} dní}} bez kontaktu",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Propojit jiný kontakt",
+  "relationshipSeeAllCheckIns": "Zobrazit všechny záznamy",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Přidej lidi, se kterými chceš zůstat v kontaktu.",
   "relationshipsPageTitle": "Lidé",
   "relationshipStatusActive": "Aktivní",
   "relationshipStatusArchived": "Archivované",
   "relationshipStatusDormant": "Spící",
   "relationshipStatusFieldLabel": "Stav",
+  "relationshipStayingInTouch": "Udržovat kontakt",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Udržovat kontakt",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Sledováno od {date}",
   "relationshipUpdateFromContact": "Aktualizovat z kontaktu",
   "saveButton": "Uložit",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1569,9 +1569,21 @@
   "checkInAvoidLabel": "Bedst at undgå",
   "checkInDateLabel": "Hvornår?",
   "checkInDeleteConfirmMessage": "Slet dette check-in? Det kan ikke fortrydes.",
+  "checkInDone": "Færdig",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Redigér check-in",
   "checkInErrorCreateFailed": "Check-in kunne ikke gemmes. Prøv igen.",
   "checkInErrorDeleteFailed": "Check-in kunne ikke slettes. Prøv igen.",
+  "checkInHowDidItFeel": "Hvordan føltes det?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Hvordan havde I kontakt?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Opkald",
   "checkInInteractionInPerson": "Personligt",
   "checkInInteractionLabel": "Hvordan talte I sammen?",
@@ -1580,6 +1592,7 @@
   "checkInInteractionVideoCall": "Videoopkald",
   "checkInNarrativeLabel": "Hvad talte I om?",
   "checkInPayAttentionLabel": "Næste gang: vær opmærksom på",
+  "checkInPreparedOverline": "✦ LOTTI · FORBEREDT I MORGES",
   "checkInSentimentDelightful": "Skønt",
   "checkInSentimentDifficult": "Svært",
   "checkInSentimentGood": "Godt",
@@ -1592,6 +1605,10 @@
   "checkInTranscribingLabel": "Transskriberer…",
   "checkInTranscriptFailed": "Der kom ingen udskrift. Du kan skrive den selv.",
   "checkInTranscriptUnavailable": "Transskription er ikke sat op for denne person. Tilføj en lydmodel og slå automatisk inferens til for deres kategori, eller skriv check-in selv.",
+  "checkInWriteInstead": "Skriv i stedet",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Tilføj en ny genstand",
   "checklistAiConfidenceLabel": "Selvtillid: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4526,6 +4543,10 @@
   "relationshipActionFailed": "Intet på denne enhed kan åbne det",
   "relationshipActionMessage": "Besked",
   "relationshipAddChannelButton": "Tilføj kontaktoplysning",
+  "relationshipAsk": "Spørg",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Relationsbanner for {personName}",
   "relationshipBriefingDisclosureBody": "Briefingen kører på {provider}. Noter om denne person sendes dertil til behandling.",
   "relationshipBriefingDisclosureConfirm": "Fortsæt",
@@ -4534,16 +4555,36 @@
   "relationshipBriefingRequested": "Briefing bestilt — den vises her om lidt.",
   "relationshipBriefingRequestFailed": "Kunne ikke bestille briefingen.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Brief igen",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Opdater mig",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Hver dag} other{Hver {days}. dag}}",
   "relationshipCadenceFortnightly": "Hver anden uge",
   "relationshipCadenceLabel": "Kontaktrytme",
   "relationshipCadenceMonthly": "Månedligt",
   "relationshipCadenceNone": "Ingen rytme",
+  "relationshipCadenceNudgeNote": "At vælge et tempo slår check-in-påmindelser til.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "på sporet",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Hvert kvartal",
   "relationshipCadenceWeekly": "Ugentligt",
   "relationshipChatTooltip": "Chat om denne person",
   "relationshipChatUnavailable": "Ingen agent endnu — markér først personen som vigtig.",
+  "relationshipCheckedInLabel": "Check-in {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Et godt tidspunkt at tage kontakt.",
   "relationshipCheckInReminderTitle": "Tag kontakt til {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4554,6 +4595,18 @@
     }
   },
   "relationshipCheckInsLabel": "Check-ins",
+  "relationshipCheckInTitle": "Check-in · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Kontaktkort",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Kontaktoplysninger",
   "relationshipContactLinked": "Kontaktoplysninger kopieret",
   "relationshipContactLinkFailed": "Kunne ikke gemme kontaktoplysningerne",
@@ -4562,6 +4615,14 @@
   "relationshipCreateTitle": "Tilføj person",
   "relationshipDeleteConfirmMessage": "Deres check-ins slettes også. Det kan ikke fortrydes.",
   "relationshipDeleteConfirmTitle": "Slet {name}?",
+  "relationshipDueDay": "Senest {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Redigér person",
   "relationshipErrorCreateFailed": "Personen kunne ikke gemmes. Prøv igen.",
   "relationshipErrorDeleteFailed": "Personen kunne ikke slettes. Prøv igen.",
@@ -4589,17 +4650,45 @@
   "relationshipImportSettingsBody": "Adgang til kontakter er slået fra. Slå den til i systemindstillingerne for at importere personer.",
   "relationshipImportTitle": "Tilføj personer",
   "relationshipImportUnsupported": "Kontaktimport findes på telefoner og tablets. Tilføj kontaktoplysninger i hånden her.",
+  "relationshipJustAdded": "Netop tilføjet",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Seneste check-in {date}",
   "relationshipLinkContact": "Tilknyt kontakt",
   "relationshipLinkedTasksLabel": "Opgaver",
   "relationshipLinkTaskButton": "Link opgave",
   "relationshipLogCheckIn": "Registrér check-in",
+  "relationshipLottisRead": "Lottis vurdering",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "kl. {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Navn",
   "relationshipNameRequired": "Navn er påkrævet",
+  "relationshipNextByDay": "næste senest {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Kaldenavn",
   "relationshipNoCheckIns": "Ingen check-ins endnu — registrér et efter jeres næste snak.",
   "relationshipNoLinkedTasks": "Ingen opgaver linket endnu.",
   "relationshipNotFound": "Denne person følges ikke længere.",
+  "relationshipNudgesOn": "påmindelser til",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Du tog lige kontakt. Vil du logge et tjek-ind, mens det er friskt?",
   "relationshipPostCallConfirm": "Log tjek-ind",
   "relationshipPostCallDismiss": "Ikke nu",
@@ -4612,13 +4701,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Ingen kontakt {count, plural, =1{i 1 dag} other{i {count} dage}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Tilknyt en anden kontakt",
+  "relationshipSeeAllCheckIns": "Se alle check-ins",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Tilføj de mennesker, du vil holde kontakten med.",
   "relationshipsPageTitle": "Personer",
   "relationshipStatusActive": "Aktiv",
   "relationshipStatusArchived": "Arkiveret",
   "relationshipStatusDormant": "Hvilende",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStayingInTouch": "Holde kontakten",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Hold kontakten",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Fulgt siden {date}",
   "relationshipUpdateFromContact": "Opdater fra kontakt",
   "saveButton": "Gem",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1391,9 +1391,21 @@
   "checkInAvoidLabel": "Besser vermeiden",
   "checkInDateLabel": "Wann?",
   "checkInDeleteConfirmMessage": "Diesen Check-in löschen? Das lässt sich nicht rückgängig machen.",
+  "checkInDone": "Fertig",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Check-in bearbeiten",
   "checkInErrorCreateFailed": "Check-in konnte nicht gespeichert werden. Bitte versuch es erneut.",
   "checkInErrorDeleteFailed": "Check-in konnte nicht gelöscht werden. Bitte versuch es erneut.",
+  "checkInHowDidItFeel": "Wie hat es sich angefühlt?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Wie habt ihr Kontakt gehabt?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Anruf",
   "checkInInteractionInPerson": "Persönlich",
   "checkInInteractionLabel": "Wie habt ihr gesprochen?",
@@ -1402,6 +1414,7 @@
   "checkInInteractionVideoCall": "Videoanruf",
   "checkInNarrativeLabel": "Worüber habt ihr gesprochen?",
   "checkInPayAttentionLabel": "Nächstes Mal achten auf",
+  "checkInPreparedOverline": "✦ LOTTI · HEUTE MORGEN VORBEREITET",
   "checkInSentimentDelightful": "Wunderbar",
   "checkInSentimentDifficult": "Schwierig",
   "checkInSentimentGood": "Gut",
@@ -1414,6 +1427,10 @@
   "checkInTranscribingLabel": "Wird transkribiert…",
   "checkInTranscriptFailed": "Es kam keine Transkription zurück. Du kannst es auch tippen.",
   "checkInTranscriptUnavailable": "Transkription ist für diese Person nicht eingerichtet. Füge ein Audiomodell hinzu und aktiviere die automatische Inferenz für ihre Kategorie, oder tippe das Check-in.",
+  "checkInWriteInstead": "Lieber schreiben",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Neues Element hinzufügen",
   "checklistAiConfidenceLabel": "Konfidenz: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4013,6 +4030,10 @@
   "relationshipActionFailed": "Auf diesem Gerät kann das nichts öffnen",
   "relationshipActionMessage": "Nachricht",
   "relationshipAddChannelButton": "Kontaktweg hinzufügen",
+  "relationshipAsk": "Fragen",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Beziehungs-Banner für {personName}",
   "relationshipBriefingDisclosureBody": "Das Briefing läuft über {provider}. Notizen zu dieser Person werden dorthin zur Verarbeitung gesendet.",
   "relationshipBriefingDisclosureConfirm": "Weiter",
@@ -4021,16 +4042,36 @@
   "relationshipBriefingRequested": "Briefing angefragt — es erscheint gleich hier.",
   "relationshipBriefingRequestFailed": "Briefing konnte nicht angefragt werden.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Erneut briefen",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Brief mich",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Jeden Tag} other{Alle {days} Tage}}",
   "relationshipCadenceFortnightly": "Alle zwei Wochen",
   "relationshipCadenceLabel": "Check-in-Rhythmus",
   "relationshipCadenceMonthly": "Monatlich",
   "relationshipCadenceNone": "Kein Rhythmus",
+  "relationshipCadenceNudgeNote": "Ein Rhythmus aktiviert Check-in-Erinnerungen.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "im Rhythmus",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Vierteljährlich",
   "relationshipCadenceWeekly": "Wöchentlich",
   "relationshipChatTooltip": "Über diese Person chatten",
   "relationshipChatUnavailable": "Noch kein Agent — markiere diese Person zuerst als wichtig.",
+  "relationshipCheckedInLabel": "Check-in {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Ein guter Moment, dich zu melden.",
   "relationshipCheckInReminderTitle": "Bei {name} melden?",
   "@relationshipCheckInReminderTitle": {
@@ -4041,6 +4082,18 @@
     }
   },
   "relationshipCheckInsLabel": "Check-ins",
+  "relationshipCheckInTitle": "Check-in · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Visitenkarte",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Kontaktdaten",
   "relationshipContactLinked": "Kontaktdaten übernommen",
   "relationshipContactLinkFailed": "Kontaktdaten konnten nicht gespeichert werden",
@@ -4049,6 +4102,14 @@
   "relationshipCreateTitle": "Person hinzufügen",
   "relationshipDeleteConfirmMessage": "Auch alle Check-ins werden gelöscht. Das lässt sich nicht rückgängig machen.",
   "relationshipDeleteConfirmTitle": "{name} löschen?",
+  "relationshipDueDay": "Fällig {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Person bearbeiten",
   "relationshipErrorCreateFailed": "Person konnte nicht gespeichert werden. Bitte versuch es erneut.",
   "relationshipErrorDeleteFailed": "Person konnte nicht gelöscht werden. Bitte versuch es erneut.",
@@ -4076,17 +4137,45 @@
   "relationshipImportSettingsBody": "Der Kontaktzugriff ist deaktiviert. Aktiviere ihn in den Systemeinstellungen, um Personen zu importieren.",
   "relationshipImportTitle": "Personen hinzufügen",
   "relationshipImportUnsupported": "Der Kontaktimport ist auf Smartphones und Tablets verfügbar. Trag die Kontaktdaten hier von Hand ein.",
+  "relationshipJustAdded": "Gerade hinzugefügt",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Letzter Check-in {date}",
   "relationshipLinkContact": "Kontakt verknüpfen",
   "relationshipLinkedTasksLabel": "Aufgaben",
   "relationshipLinkTaskButton": "Aufgabe verknüpfen",
   "relationshipLogCheckIn": "Check-in erfassen",
+  "relationshipLottisRead": "Lottis Einschätzung",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "Stand {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Name",
   "relationshipNameRequired": "Ein Name ist erforderlich",
+  "relationshipNextByDay": "nächstens bis {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Spitzname",
   "relationshipNoCheckIns": "Noch keine Check-ins — erfasse einen nach eurem nächsten Gespräch.",
   "relationshipNoLinkedTasks": "Noch keine Aufgaben verknüpft.",
   "relationshipNotFound": "Diese Person ist nicht mehr in deiner Liste.",
+  "relationshipNudgesOn": "Erinnerungen an",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Du hast dich gerade gemeldet. Willst du gleich einen Check-in festhalten?",
   "relationshipPostCallConfirm": "Check-in festhalten",
   "relationshipPostCallDismiss": "Jetzt nicht",
@@ -4099,13 +4188,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Seit {count, plural, =1{einem Tag} other{{count} Tagen}} keine Nachricht",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Anderen Kontakt verknüpfen",
+  "relationshipSeeAllCheckIns": "Alle Check-ins ansehen",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Füge die Menschen hinzu, denen du nah bleiben willst.",
   "relationshipsPageTitle": "Menschen",
   "relationshipStatusActive": "Aktiv",
   "relationshipStatusArchived": "Archiviert",
   "relationshipStatusDormant": "Ruhend",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStayingInTouch": "Kontakt halten",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Kontakt halten",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Erfasst seit {date}",
   "relationshipUpdateFromContact": "Aus Kontakt aktualisieren",
   "saveButton": "Speichern",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1907,9 +1907,21 @@
   "checkInAvoidLabel": "Better to avoid",
   "checkInDateLabel": "When?",
   "checkInDeleteConfirmMessage": "Delete this check-in? This cannot be undone.",
+  "checkInDone": "Done",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Edit check-in",
   "checkInErrorCreateFailed": "Could not save the check-in. Please try again.",
   "checkInErrorDeleteFailed": "Could not delete the check-in. Please try again.",
+  "checkInHowDidItFeel": "How did it feel?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "How did you connect?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Call",
   "checkInInteractionInPerson": "In person",
   "checkInInteractionLabel": "How did you connect?",
@@ -1918,6 +1930,7 @@
   "checkInInteractionVideoCall": "Video call",
   "checkInNarrativeLabel": "What did you talk about?",
   "checkInPayAttentionLabel": "Next time, pay attention to",
+  "checkInPreparedOverline": "✦ LOTTI · PREPARED THIS MORNING",
   "checkInSentimentDelightful": "Delightful",
   "checkInSentimentDifficult": "Difficult",
   "checkInSentimentGood": "Good",
@@ -1941,6 +1954,10 @@
   "checkInTranscriptUnavailable": "Transcription is not set up for this person. Add an audio model and turn on automatic inference for their category, or type the check-in.",
   "@checkInTranscriptUnavailable": {
     "description": "Shown when a spoken check-in cannot run at all because no transcription is configured for the person or their category."
+  },
+  "checkInWriteInstead": "Write instead",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
   },
   "checklistAddItem": "Add a new item",
   "checklistAiConfidenceLabel": "Confidence: {level}",
@@ -3741,9 +3758,6 @@
   },
   "goalDimensionNeedsAttentionStatus": "Needs attention",
   "goalDimensionNoDataNote": "There is not enough data to judge this dimension yet.",
-  "@goalDimensionOnTargetTodayNote": {
-    "description": "Positive health-dimension note when the latest reading recorded today meets its target even if the rolling aggregate does not."
-  },
   "goalDimensionOnTargetTodayStatus": "On target today",
   "@goalDimensionOnTargetTodayStatus": {
     "description": "Positive health-dimension status when the latest reading recorded today meets its target."
@@ -5859,6 +5873,10 @@
     "description": "Tooltip on the button that opens a message composer"
   },
   "relationshipAddChannelButton": "Add channel",
+  "relationshipAsk": "Ask",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Relationship banner for {personName}",
   "@relationshipBannerSemanticLabel": {
     "description": "Accessibility label of one relationship nudge banner; personName is the person's name.",
@@ -5891,6 +5909,10 @@
   "relationshipBriefingRequested": "Briefing requested — it will appear here shortly.",
   "relationshipBriefingRequestFailed": "Could not request the briefing.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Brief me again",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Brief me",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Every day} other{Every {days} days}}",
   "@relationshipCadenceEveryNDays": {
@@ -5904,10 +5926,26 @@
   "relationshipCadenceLabel": "Check-in cadence",
   "relationshipCadenceMonthly": "Monthly",
   "relationshipCadenceNone": "No cadence",
+  "relationshipCadenceNudgeNote": "Choosing a cadence turns on check-in nudges.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "On track",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Quarterly",
   "relationshipCadenceWeekly": "Weekly",
   "relationshipChatTooltip": "Chat about this person",
   "relationshipChatUnavailable": "No agent yet — mark this person as important first.",
+  "relationshipCheckedInLabel": "Checked in {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "A good moment to reach out.",
   "relationshipCheckInReminderTitle": "Check in with {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -5918,6 +5956,18 @@
     }
   },
   "relationshipCheckInsLabel": "Check-ins",
+  "relationshipCheckInTitle": "Check in · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Contact card",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Contact channels",
   "relationshipContactLinked": "Contact details copied",
   "@relationshipContactLinked": {
@@ -5941,6 +5991,14 @@
   "@relationshipDeleteConfirmTitle": {
     "placeholders": {
       "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDueDay": "Due {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
         "type": "String"
       }
     }
@@ -6035,6 +6093,10 @@
   "@relationshipImportUnsupported": {
     "description": "Shown on desktop, where there is no address book to import from"
   },
+  "relationshipJustAdded": "Just added",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Last check-in {date}",
   "@relationshipLastCheckInLabel": {
     "placeholders": {
@@ -6050,12 +6112,36 @@
   "relationshipLinkedTasksLabel": "Tasks",
   "relationshipLinkTaskButton": "Link task",
   "relationshipLogCheckIn": "Log check-in",
+  "relationshipLottisRead": "Lotti's read",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "as of {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Name",
   "relationshipNameRequired": "A name is required",
+  "relationshipNextByDay": "next by {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Nickname",
   "relationshipNoCheckIns": "No check-ins yet — log one after you next talk.",
   "relationshipNoLinkedTasks": "No tasks linked yet.",
   "relationshipNotFound": "This person is no longer tracked.",
+  "relationshipNudgesOn": "nudges on",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "You reached out a moment ago. Log a check-in while it is fresh?",
   "@relationshipPostCallBody": {
     "description": "Body of the prompt offered after returning from a call or message"
@@ -6078,9 +6164,21 @@
       }
     }
   },
+  "relationshipQuietForDays": "Quiet for {count, plural, =1{1 day} other{{count} days}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Link a different contact",
   "@relationshipRelinkContact": {
     "description": "Menu action that replaces the OS contact a person is linked to"
+  },
+  "relationshipSeeAllCheckIns": "See all check-ins",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Add the people you want to stay close to.",
   "relationshipsPageTitle": "People",
@@ -6088,6 +6186,14 @@
   "relationshipStatusArchived": "Archived",
   "relationshipStatusDormant": "Dormant",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStayingInTouch": "Staying in touch",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Stay in touch",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Tracking since {date}",
   "@relationshipTrackingSinceLabel": {
     "placeholders": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -9,6 +9,23 @@
   "categoryCreationError": "Failed to create category. Please try again.",
   "categoryDeleteConfirmation": "This action cannot be undone. All entries in this category will remain but will no longer be categorised.",
   "categoryFavoriteDescription": "Mark this category as a favourite",
+  "checkInDone": "Done",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidItFeel": "How did it feel?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "How did you connect?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
+  "checkInPreparedOverline": "✦ LOTTI · PREPARED THIS MORNING",
+  "checkInWriteInstead": "Write instead",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "colorLabel": "Colour",
   "configFlagEnableAiStreaming": "Enable AI streaming for task actions",
   "configFlagEnableAiStreamingDescription": "Stream AI responses for task-related actions. Turn off to buffer responses and keep the UI smoother.",
@@ -143,6 +160,98 @@
   "outboxMonitorNoAttachment": "no attachment",
   "outboxMonitorRetries": "retries",
   "outboxMonitorRetry": "retry",
+  "relationshipAsk": "Ask",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipBriefMeAgain": "Brief me again",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceNudgeNote": "Choosing a cadence turns on check-in nudges.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "On track",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCheckedInLabel": "Checked in {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipCheckInTitle": "Check in · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Contact card",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipDueDay": "Due {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipJustAdded": "Just added",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisRead": "Lotti's read",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "as of {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextByDay": "next by {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNudgesOn": "nudges on",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipQuietForDays": "Quiet for {count, plural, =1{1 day} other{{count} days}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipSeeAllCheckIns": "See all check-ins",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayingInTouch": "Staying in touch",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Stay in touch",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "saveLabel": "Save",
   "searchHint": "Search…",
   "selectColor": "Select a colour",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1391,9 +1391,21 @@
   "checkInAvoidLabel": "Mejor evitar",
   "checkInDateLabel": "¿Cuándo?",
   "checkInDeleteConfirmMessage": "¿Eliminar este registro? Esta acción no se puede deshacer.",
+  "checkInDone": "Listo",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Editar registro",
   "checkInErrorCreateFailed": "No se pudo guardar el registro. Inténtalo de nuevo.",
   "checkInErrorDeleteFailed": "No se pudo eliminar el registro. Inténtalo de nuevo.",
+  "checkInHowDidItFeel": "¿Cómo te sentiste?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "¿Cómo fue el contacto?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Llamada",
   "checkInInteractionInPerson": "En persona",
   "checkInInteractionLabel": "¿Cómo hablasteis?",
@@ -1402,6 +1414,7 @@
   "checkInInteractionVideoCall": "Videollamada",
   "checkInNarrativeLabel": "¿De qué hablasteis?",
   "checkInPayAttentionLabel": "La próxima vez, presta atención a",
+  "checkInPreparedOverline": "✦ LOTTI · PREPARADO ESTA MAÑANA",
   "checkInSentimentDelightful": "Genial",
   "checkInSentimentDifficult": "Difícil",
   "checkInSentimentGood": "Bien",
@@ -1414,6 +1427,10 @@
   "checkInTranscribingLabel": "Transcribiendo…",
   "checkInTranscriptFailed": "No llegó ninguna transcripción. Puedes escribirlo tú.",
   "checkInTranscriptUnavailable": "La transcripción no está configurada para esta persona. Añade un modelo de audio y activa la inferencia automática en su categoría, o escribe el registro.",
+  "checkInWriteInstead": "Mejor escribir",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Agregar un nuevo elemento",
   "checklistAiConfidenceLabel": "Confianza: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4013,6 +4030,10 @@
   "relationshipActionFailed": "Nada en este dispositivo puede abrir eso",
   "relationshipActionMessage": "Mensaje",
   "relationshipAddChannelButton": "Añadir medio de contacto",
+  "relationshipAsk": "Preguntar",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Banner de relación para {personName}",
   "relationshipBriefingDisclosureBody": "El informe se genera en {provider}. Las notas sobre esta persona se enviarán allí para su procesamiento.",
   "relationshipBriefingDisclosureConfirm": "Continuar",
@@ -4021,16 +4042,36 @@
   "relationshipBriefingRequested": "Informe solicitado: aparecerá aquí en breve.",
   "relationshipBriefingRequestFailed": "No se pudo solicitar el informe.",
   "relationshipBriefingTitle": "Informe",
+  "relationshipBriefMeAgain": "Actualízame otra vez",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Ponme al día",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Cada día} other{Cada {days} días}}",
   "relationshipCadenceFortnightly": "Cada dos semanas",
   "relationshipCadenceLabel": "Frecuencia de contacto",
   "relationshipCadenceMonthly": "Mensual",
   "relationshipCadenceNone": "Sin frecuencia",
+  "relationshipCadenceNudgeNote": "Elegir un ritmo activa los avisos de registro.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "al día",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Trimestral",
   "relationshipCadenceWeekly": "Semanal",
   "relationshipChatTooltip": "Chatear sobre esta persona",
   "relationshipChatUnavailable": "Aún no hay agente: marca primero a esta persona como importante.",
+  "relationshipCheckedInLabel": "Registro {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Un buen momento para retomar el contacto.",
   "relationshipCheckInReminderTitle": "¿Hablas con {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4041,6 +4082,18 @@
     }
   },
   "relationshipCheckInsLabel": "Registros",
+  "relationshipCheckInTitle": "Registrar · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Tarjeta de contacto",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Datos de contacto",
   "relationshipContactLinked": "Datos de contacto copiados",
   "relationshipContactLinkFailed": "No se pudieron guardar los datos de contacto",
@@ -4049,6 +4102,14 @@
   "relationshipCreateTitle": "Añadir persona",
   "relationshipDeleteConfirmMessage": "También se eliminarán todos sus registros. Esta acción no se puede deshacer.",
   "relationshipDeleteConfirmTitle": "¿Eliminar a {name}?",
+  "relationshipDueDay": "Tope {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Editar persona",
   "relationshipErrorCreateFailed": "No se pudo guardar la persona. Inténtalo de nuevo.",
   "relationshipErrorDeleteFailed": "No se pudo eliminar la persona. Inténtalo de nuevo.",
@@ -4076,17 +4137,45 @@
   "relationshipImportSettingsBody": "El acceso a los contactos está desactivado. Actívalo en los ajustes del sistema para importar personas.",
   "relationshipImportTitle": "Añadir personas",
   "relationshipImportUnsupported": "La importación de contactos está disponible en teléfonos y tabletas. Añade aquí los datos a mano.",
+  "relationshipJustAdded": "Añadido ahora",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Último registro {date}",
   "relationshipLinkContact": "Vincular contacto",
   "relationshipLinkedTasksLabel": "Tareas",
   "relationshipLinkTaskButton": "Vincular tarea",
   "relationshipLogCheckIn": "Registrar contacto",
+  "relationshipLottisRead": "Lotti opina",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "a las {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Nombre",
   "relationshipNameRequired": "El nombre es obligatorio",
+  "relationshipNextByDay": "próximo antes de {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Apodo",
   "relationshipNoCheckIns": "Aún no hay registros: añade uno tras vuestra próxima conversación.",
   "relationshipNoLinkedTasks": "Aún no hay tareas vinculadas.",
   "relationshipNotFound": "Esta persona ya no está en tu lista.",
+  "relationshipNudgesOn": "avisos activos",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Acabas de contactar. ¿Anotas un check-in mientras lo recuerdas?",
   "relationshipPostCallConfirm": "Anotar check-in",
   "relationshipPostCallDismiss": "Ahora no",
@@ -4099,13 +4188,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Sin contacto {count, plural, =1{desde hace 1 día} other{desde hace {count} días}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Vincular otro contacto",
+  "relationshipSeeAllCheckIns": "Ver todos los registros",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Añade a las personas de las que quieres estar cerca.",
   "relationshipsPageTitle": "Personas",
   "relationshipStatusActive": "Activa",
   "relationshipStatusArchived": "Archivada",
   "relationshipStatusDormant": "En reposo",
   "relationshipStatusFieldLabel": "Estado",
+  "relationshipStayingInTouch": "Mantener el contacto",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Mantener el contacto",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Seguimiento desde {date}",
   "relationshipUpdateFromContact": "Actualizar desde el contacto",
   "saveButton": "Guardar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1391,9 +1391,21 @@
   "checkInAvoidLabel": "À éviter",
   "checkInDateLabel": "Quand ?",
   "checkInDeleteConfirmMessage": "Supprimer cet échange ? Cette action est irréversible.",
+  "checkInDone": "Terminé",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Modifier l'échange",
   "checkInErrorCreateFailed": "Impossible d'enregistrer l'échange. Réessaie.",
   "checkInErrorDeleteFailed": "Impossible de supprimer l'échange. Réessaie.",
+  "checkInHowDidItFeel": "Comment ça s’est passé ?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Comment avez-vous échangé ?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Appel",
   "checkInInteractionInPerson": "En personne",
   "checkInInteractionLabel": "Comment avez-vous échangé ?",
@@ -1402,6 +1414,7 @@
   "checkInInteractionVideoCall": "Visio",
   "checkInNarrativeLabel": "De quoi avez-vous parlé ?",
   "checkInPayAttentionLabel": "La prochaine fois, fais attention à",
+  "checkInPreparedOverline": "✦ LOTTI · PRÉPARÉ CE MATIN",
   "checkInSentimentDelightful": "Merveilleux",
   "checkInSentimentDifficult": "Difficile",
   "checkInSentimentGood": "Bien",
@@ -1414,6 +1427,10 @@
   "checkInTranscribingLabel": "Transcription en cours…",
   "checkInTranscriptFailed": "Aucune transcription n'est revenue. Tu peux l'écrire toi-même.",
   "checkInTranscriptUnavailable": "La transcription n'est pas configurée pour cette personne. Ajoute un modèle audio et active l'inférence automatique pour sa catégorie, ou écris l'échange.",
+  "checkInWriteInstead": "Écrire plutôt",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Ajouter un nouvel élément",
   "checklistAiConfidenceLabel": "Confiance : {level}",
   "@checklistAiConfidenceLabel": {
@@ -4013,6 +4030,10 @@
   "relationshipActionFailed": "Rien sur cet appareil ne peut ouvrir ça",
   "relationshipActionMessage": "Message",
   "relationshipAddChannelButton": "Ajouter un moyen de contact",
+  "relationshipAsk": "Demander",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Bannière de relation pour {personName}",
   "relationshipBriefingDisclosureBody": "Le briefing est généré par {provider}. Les notes sur cette personne y seront envoyées pour traitement.",
   "relationshipBriefingDisclosureConfirm": "Continuer",
@@ -4021,16 +4042,36 @@
   "relationshipBriefingRequested": "Briefing demandé — il apparaîtra ici sous peu.",
   "relationshipBriefingRequestFailed": "Impossible de demander le briefing.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Briefe-moi à nouveau",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Briefe-moi",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Chaque jour} other{Tous les {days} jours}}",
   "relationshipCadenceFortnightly": "Toutes les deux semaines",
   "relationshipCadenceLabel": "Rythme de contact",
   "relationshipCadenceMonthly": "Chaque mois",
   "relationshipCadenceNone": "Aucun rythme",
+  "relationshipCadenceNudgeNote": "Choisir un rythme active les rappels d’échange.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "à jour",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Chaque trimestre",
   "relationshipCadenceWeekly": "Chaque semaine",
   "relationshipChatTooltip": "Discuter de cette personne",
   "relationshipChatUnavailable": "Pas encore d'agent — marque d'abord cette personne comme importante.",
+  "relationshipCheckedInLabel": "Échange {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Un bon moment pour reprendre contact.",
   "relationshipCheckInReminderTitle": "Prendre des nouvelles de {name} ?",
   "@relationshipCheckInReminderTitle": {
@@ -4041,6 +4082,18 @@
     }
   },
   "relationshipCheckInsLabel": "Échanges",
+  "relationshipCheckInTitle": "Échange · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Carte de contact",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Coordonnées",
   "relationshipContactLinked": "Coordonnées copiées",
   "relationshipContactLinkFailed": "Impossible d’enregistrer les coordonnées",
@@ -4049,6 +4102,14 @@
   "relationshipCreateTitle": "Ajouter une personne",
   "relationshipDeleteConfirmMessage": "Tous ses échanges seront aussi supprimés. Cette action est irréversible.",
   "relationshipDeleteConfirmTitle": "Supprimer {name} ?",
+  "relationshipDueDay": "À relancer {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Modifier la personne",
   "relationshipErrorCreateFailed": "Impossible d'enregistrer la personne. Réessaie.",
   "relationshipErrorDeleteFailed": "Impossible de supprimer la personne. Réessaie.",
@@ -4076,17 +4137,45 @@
   "relationshipImportSettingsBody": "L’accès aux contacts est désactivé. Active-le dans les réglages du système pour importer des personnes.",
   "relationshipImportTitle": "Ajouter des personnes",
   "relationshipImportUnsupported": "L’import de contacts est disponible sur téléphone et tablette. Saisis les coordonnées à la main ici.",
+  "relationshipJustAdded": "Vient d'être ajouté",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Dernier échange {date}",
   "relationshipLinkContact": "Associer un contact",
   "relationshipLinkedTasksLabel": "Tâches",
   "relationshipLinkTaskButton": "Lier une tâche",
   "relationshipLogCheckIn": "Noter un échange",
+  "relationshipLottisRead": "Lotti dit",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "à {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Nom",
   "relationshipNameRequired": "Le nom est obligatoire",
+  "relationshipNextByDay": "prochain avant {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Surnom",
   "relationshipNoCheckIns": "Aucun échange noté — ajoute le premier après votre prochaine conversation.",
   "relationshipNoLinkedTasks": "Aucune tâche liée pour l'instant.",
   "relationshipNotFound": "Cette personne n'est plus dans ta liste.",
+  "relationshipNudgesOn": "rappels activés",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Tu viens de le/la contacter. Tu notes un point tant que c’est frais ?",
   "relationshipPostCallConfirm": "Noter un point",
   "relationshipPostCallDismiss": "Pas maintenant",
@@ -4099,13 +4188,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Aucun échange {count, plural, =1{depuis 1 jour} other{depuis {count} jours}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Associer un autre contact",
+  "relationshipSeeAllCheckIns": "Voir tous les échanges",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Ajoute les personnes dont tu veux rester proche.",
   "relationshipsPageTitle": "Proches",
   "relationshipStatusActive": "Active",
   "relationshipStatusArchived": "Archivée",
   "relationshipStatusDormant": "En veille",
   "relationshipStatusFieldLabel": "Statut",
+  "relationshipStayingInTouch": "Rester en contact",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Rester en contact",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Suivi depuis {date}",
   "relationshipUpdateFromContact": "Mettre à jour depuis le contact",
   "saveButton": "Enregistrer",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1569,9 +1569,21 @@
   "checkInAvoidLabel": "Meglio evitare",
   "checkInDateLabel": "Quando?",
   "checkInDeleteConfirmMessage": "Eliminare questo contatto? L'azione non si può annullare.",
+  "checkInDone": "Fatto",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Modifica contatto",
   "checkInErrorCreateFailed": "Impossibile salvare il contatto. Riprova.",
   "checkInErrorDeleteFailed": "Impossibile eliminare il contatto. Riprova.",
+  "checkInHowDidItFeel": "Com’è andata?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Come vi siete sentiti?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Chiamata",
   "checkInInteractionInPerson": "Di persona",
   "checkInInteractionLabel": "Come avete parlato?",
@@ -1580,6 +1592,7 @@
   "checkInInteractionVideoCall": "Videochiamata",
   "checkInNarrativeLabel": "Di cosa avete parlato?",
   "checkInPayAttentionLabel": "La prossima volta fai attenzione a",
+  "checkInPreparedOverline": "✦ LOTTI · PREPARATO STAMATTINA",
   "checkInSentimentDelightful": "Splendido",
   "checkInSentimentDifficult": "Difficile",
   "checkInSentimentGood": "Bene",
@@ -1592,6 +1605,10 @@
   "checkInTranscribingLabel": "Trascrizione in corso…",
   "checkInTranscriptFailed": "Non è arrivata nessuna trascrizione. Puoi scriverlo tu.",
   "checkInTranscriptUnavailable": "La trascrizione non è configurata per questa persona. Aggiungi un modello audio e attiva l'inferenza automatica per la sua categoria, oppure scrivi il contatto.",
+  "checkInWriteInstead": "Scrivi invece",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Aggiungi un nuovo articolo",
   "checklistAiConfidenceLabel": "Confidenza: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4526,6 +4543,10 @@
   "relationshipActionFailed": "Niente su questo dispositivo può aprirlo",
   "relationshipActionMessage": "Messaggio",
   "relationshipAddChannelButton": "Aggiungi recapito",
+  "relationshipAsk": "Chiedi",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Banner della relazione con {personName}",
   "relationshipBriefingDisclosureBody": "Il briefing viene generato su {provider}. Le note su questa persona verranno inviate lì per l’elaborazione.",
   "relationshipBriefingDisclosureConfirm": "Continua",
@@ -4534,16 +4555,36 @@
   "relationshipBriefingRequested": "Briefing richiesto: apparirà qui a breve.",
   "relationshipBriefingRequestFailed": "Impossibile richiedere il briefing.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Aggiornami di nuovo",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Aggiornami",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Ogni giorno} other{Ogni {days} giorni}}",
   "relationshipCadenceFortnightly": "Ogni due settimane",
   "relationshipCadenceLabel": "Ritmo dei contatti",
   "relationshipCadenceMonthly": "Ogni mese",
   "relationshipCadenceNone": "Nessun ritmo",
+  "relationshipCadenceNudgeNote": "Scegliere un ritmo attiva i promemoria dei contatti.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "in regola",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Ogni trimestre",
   "relationshipCadenceWeekly": "Ogni settimana",
   "relationshipChatTooltip": "Chatta su questa persona",
   "relationshipChatUnavailable": "Nessun agente ancora: prima segna questa persona come importante.",
+  "relationshipCheckedInLabel": "Contatto {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Un buon momento per farsi sentire.",
   "relationshipCheckInReminderTitle": "Ti fai sentire con {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4554,6 +4595,18 @@
     }
   },
   "relationshipCheckInsLabel": "Contatti registrati",
+  "relationshipCheckInTitle": "Contatto · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Scheda contatto",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Recapiti",
   "relationshipContactLinked": "Recapiti copiati",
   "relationshipContactLinkFailed": "Impossibile salvare i recapiti",
@@ -4562,6 +4615,14 @@
   "relationshipCreateTitle": "Aggiungi persona",
   "relationshipDeleteConfirmMessage": "Verranno eliminati anche tutti i contatti registrati. L'azione non si può annullare.",
   "relationshipDeleteConfirmTitle": "Eliminare {name}?",
+  "relationshipDueDay": "Entro {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Modifica persona",
   "relationshipErrorCreateFailed": "Impossibile salvare la persona. Riprova.",
   "relationshipErrorDeleteFailed": "Impossibile eliminare la persona. Riprova.",
@@ -4589,17 +4650,45 @@
   "relationshipImportSettingsBody": "L’accesso ai contatti è disattivato. Attivalo nelle impostazioni di sistema per importare persone.",
   "relationshipImportTitle": "Aggiungi persone",
   "relationshipImportUnsupported": "L’importazione dei contatti è disponibile su telefoni e tablet. Inserisci qui i recapiti a mano.",
+  "relationshipJustAdded": "Appena aggiunto",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Ultimo contatto {date}",
   "relationshipLinkContact": "Collega contatto",
   "relationshipLinkedTasksLabel": "Attività",
   "relationshipLinkTaskButton": "Collega attività",
   "relationshipLogCheckIn": "Registra un contatto",
+  "relationshipLottisRead": "Lotti dice",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "alle {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Nome",
   "relationshipNameRequired": "Il nome è obbligatorio",
+  "relationshipNextByDay": "prossimo entro {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Soprannome",
   "relationshipNoCheckIns": "Nessun contatto registrato — aggiungine uno dopo la prossima conversazione.",
   "relationshipNoLinkedTasks": "Nessuna attività collegata.",
   "relationshipNotFound": "Questa persona non è più nella tua lista.",
+  "relationshipNudgesOn": "promemoria attivi",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Hai appena scritto o chiamato. Vuoi annotare un check-in finché è fresco?",
   "relationshipPostCallConfirm": "Annota check-in",
   "relationshipPostCallDismiss": "Non ora",
@@ -4612,13 +4701,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Nessun contatto {count, plural, =1{da 1 giorno} other{da {count} giorni}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Collega un altro contatto",
+  "relationshipSeeAllCheckIns": "Vedi tutti i contatti",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Aggiungi le persone a cui vuoi restare vicino.",
   "relationshipsPageTitle": "Persone",
   "relationshipStatusActive": "Attiva",
   "relationshipStatusArchived": "Archiviata",
   "relationshipStatusDormant": "In pausa",
   "relationshipStatusFieldLabel": "Stato",
+  "relationshipStayingInTouch": "Restare in contatto",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Restare in contatto",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Monitoraggio dal {date}",
   "relationshipUpdateFromContact": "Aggiorna dal contatto",
   "saveButton": "Salva",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5292,6 +5292,12 @@ abstract class AppLocalizations {
   /// **'Delete this check-in? This cannot be undone.'**
   String get checkInDeleteConfirmMessage;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get checkInDone;
+
   /// No description provided for @checkInEditTitle.
   ///
   /// In en, this message translates to:
@@ -5309,6 +5315,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not delete the check-in. Please try again.'**
   String get checkInErrorDeleteFailed;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'How did it feel?'**
+  String get checkInHowDidItFeel;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'How did you connect?'**
+  String get checkInHowDidYouConnect;
 
   /// No description provided for @checkInInteractionCall.
   ///
@@ -5357,6 +5375,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Next time, pay attention to'**
   String get checkInPayAttentionLabel;
+
+  /// No description provided for @checkInPreparedOverline.
+  ///
+  /// In en, this message translates to:
+  /// **'✦ LOTTI · PREPARED THIS MORNING'**
+  String get checkInPreparedOverline;
 
   /// No description provided for @checkInSentimentDelightful.
   ///
@@ -5429,6 +5453,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Transcription is not set up for this person. Add an audio model and turn on automatic inference for their category, or type the check-in.'**
   String get checkInTranscriptUnavailable;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Write instead'**
+  String get checkInWriteInstead;
 
   /// No description provided for @checklistAddItem.
   ///
@@ -17299,6 +17329,12 @@ abstract class AppLocalizations {
   /// **'Add channel'**
   String get relationshipAddChannelButton;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Ask'**
+  String get relationshipAsk;
+
   /// Accessibility label of one relationship nudge banner; personName is the person's name.
   ///
   /// In en, this message translates to:
@@ -17347,6 +17383,12 @@ abstract class AppLocalizations {
   /// **'Briefing'**
   String get relationshipBriefingTitle;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Brief me again'**
+  String get relationshipBriefMeAgain;
+
   /// No description provided for @relationshipBriefMeButton.
   ///
   /// In en, this message translates to:
@@ -17383,6 +17425,18 @@ abstract class AppLocalizations {
   /// **'No cadence'**
   String get relationshipCadenceNone;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Choosing a cadence turns on check-in nudges.'**
+  String get relationshipCadenceNudgeNote;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'On track'**
+  String get relationshipCadenceOnTrack;
+
   /// No description provided for @relationshipCadenceQuarterly.
   ///
   /// In en, this message translates to:
@@ -17407,6 +17461,12 @@ abstract class AppLocalizations {
   /// **'No agent yet — mark this person as important first.'**
   String get relationshipChatUnavailable;
 
+  /// No description provided for @relationshipCheckedInLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Checked in {date}'**
+  String relationshipCheckedInLabel(String date);
+
   /// No description provided for @relationshipCheckInReminderBody.
   ///
   /// In en, this message translates to:
@@ -17424,6 +17484,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Check-ins'**
   String get relationshipCheckInsLabel;
+
+  /// No description provided for @relationshipCheckInTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Check in · {name}'**
+  String relationshipCheckInTitle(String name);
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Contact card'**
+  String get relationshipContactCardAction;
 
   /// No description provided for @relationshipContactChannelsLabel.
   ///
@@ -17472,6 +17544,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Delete {name}?'**
   String relationshipDeleteConfirmTitle(String name);
+
+  /// No description provided for @relationshipDueDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Due {day}'**
+  String relationshipDueDay(String day);
 
   /// No description provided for @relationshipEditTitle.
   ///
@@ -17635,6 +17713,12 @@ abstract class AppLocalizations {
   /// **'Contact import is available on phones and tablets. Add contact details by hand here.'**
   String get relationshipImportUnsupported;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Just added'**
+  String get relationshipJustAdded;
+
   /// No description provided for @relationshipLastCheckInLabel.
   ///
   /// In en, this message translates to:
@@ -17665,6 +17749,18 @@ abstract class AppLocalizations {
   /// **'Log check-in'**
   String get relationshipLogCheckIn;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Lotti\'s read'**
+  String get relationshipLottisRead;
+
+  /// No description provided for @relationshipLottisReadAsOf.
+  ///
+  /// In en, this message translates to:
+  /// **'as of {time}'**
+  String relationshipLottisReadAsOf(String time);
+
   /// No description provided for @relationshipNameLabel.
   ///
   /// In en, this message translates to:
@@ -17676,6 +17772,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'A name is required'**
   String get relationshipNameRequired;
+
+  /// No description provided for @relationshipNextByDay.
+  ///
+  /// In en, this message translates to:
+  /// **'next by {day}'**
+  String relationshipNextByDay(String day);
 
   /// No description provided for @relationshipNicknameLabel.
   ///
@@ -17701,6 +17803,12 @@ abstract class AppLocalizations {
   /// **'This person is no longer tracked.'**
   String get relationshipNotFound;
 
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'nudges on'**
+  String get relationshipNudgesOn;
+
   /// Body of the prompt offered after returning from a call or message
   ///
   /// In en, this message translates to:
@@ -17725,11 +17833,23 @@ abstract class AppLocalizations {
   /// **'How did it go with {name}?'**
   String relationshipPostCallTitle(String name);
 
+  /// No description provided for @relationshipQuietForDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Quiet for {count, plural, =1{1 day} other{{count} days}}'**
+  String relationshipQuietForDays(int count);
+
   /// Menu action that replaces the OS contact a person is linked to
   ///
   /// In en, this message translates to:
   /// **'Link a different contact'**
   String get relationshipRelinkContact;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'See all check-ins'**
+  String get relationshipSeeAllCheckIns;
 
   /// No description provided for @relationshipsEmptyState.
   ///
@@ -17766,6 +17886,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Status'**
   String get relationshipStatusFieldLabel;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Staying in touch'**
+  String get relationshipStayingInTouch;
+
+  /// Relationships redesign label.
+  ///
+  /// In en, this message translates to:
+  /// **'Stay in touch'**
+  String get relationshipStayInTouch;
 
   /// No description provided for @relationshipTrackingSinceLabel.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Smazat tento záznam? Tohle nelze vrátit zpět.';
 
   @override
+  String get checkInDone => 'Hotovo';
+
+  @override
   String get checkInEditTitle => 'Upravit záznam';
 
   @override
@@ -3175,6 +3178,12 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Záznam se nepodařilo smazat. Zkus to prosím znovu.';
+
+  @override
+  String get checkInHowDidItFeel => 'Jaké to bylo?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Jak proběhl kontakt?';
 
   @override
   String get checkInInteractionCall => 'Hovor';
@@ -3199,6 +3208,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Příště se zaměřit na';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PŘIPRAVENO DNES RÁNO';
 
   @override
   String get checkInSentimentDelightful => 'Skvělé';
@@ -3237,6 +3249,9 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Přepis pro tuto osobu není nastavený. Přidej zvukový model a zapni automatické odvozování pro její kategorii, nebo napiš záznam ručně.';
+
+  @override
+  String get checkInWriteInstead => 'Spíše psát';
 
   @override
   String get checklistAddItem => 'Přidat novou položku';
@@ -10423,6 +10438,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipAddChannelButton => 'Přidat kontakt';
 
   @override
+  String get relationshipAsk => 'Zeptat';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Banner vztahu s $personName';
   }
@@ -10456,6 +10474,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Shrnout znovu';
+
+  @override
   String get relationshipBriefMeButton => 'Shrň mi to';
 
   @override
@@ -10483,6 +10504,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipCadenceNone => 'Bez frekvence';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Nastavení rytmu zapne připomínky záznamů.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'v rytmu';
+
+  @override
   String get relationshipCadenceQuarterly => 'Každé čtvrtletí';
 
   @override
@@ -10496,6 +10524,11 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zatím žádný agent — nejprve označ tuto osobu jako důležitou.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Záznam $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody => 'Dobrá chvíle se ozvat.';
 
   @override
@@ -10505,6 +10538,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Záznamy kontaktů';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Záznam · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Vizitka';
 
   @override
   String get relationshipContactChannelsLabel => 'Kontaktní údaje';
@@ -10533,6 +10574,11 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Smazat $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Do $day';
   }
 
   @override
@@ -10653,6 +10699,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Import kontaktů je dostupný na telefonech a tabletech. Kontaktní údaje sem zadej ručně.';
 
   @override
+  String get relationshipJustAdded => 'Právě přidáno';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Poslední záznam $date';
   }
@@ -10670,10 +10719,23 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipLogCheckIn => 'Zaznamenat kontakt';
 
   @override
+  String get relationshipLottisRead => 'Lottiho odhad';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'k $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Jméno';
 
   @override
   String get relationshipNameRequired => 'Jméno je povinné';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'příští do $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Přezdívka';
@@ -10687,6 +10749,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'Tahle osoba už není sledovaná.';
+
+  @override
+  String get relationshipNudgesOn => 'připomínky zapnuty';
 
   @override
   String get relationshipPostCallBody =>
@@ -10704,7 +10769,22 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dní',
+      few: '$count dny',
+      one: '1 den',
+    );
+    return '$_temp0 bez kontaktu';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Propojit jiný kontakt';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Zobrazit všechny záznamy';
 
   @override
   String get relationshipsEmptyState =>
@@ -10724,6 +10804,12 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Stav';
+
+  @override
+  String get relationshipStayingInTouch => 'Udržovat kontakt';
+
+  @override
+  String get relationshipStayInTouch => 'Udržovat kontakt';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3125,6 +3125,9 @@ class AppLocalizationsDa extends AppLocalizations {
       'Slet dette check-in? Det kan ikke fortrydes.';
 
   @override
+  String get checkInDone => 'Færdig';
+
+  @override
   String get checkInEditTitle => 'Redigér check-in';
 
   @override
@@ -3134,6 +3137,12 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Check-in kunne ikke slettes. Prøv igen.';
+
+  @override
+  String get checkInHowDidItFeel => 'Hvordan føltes det?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Hvordan havde I kontakt?';
 
   @override
   String get checkInInteractionCall => 'Opkald';
@@ -3158,6 +3167,9 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Næste gang: vær opmærksom på';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · FORBEREDT I MORGES';
 
   @override
   String get checkInSentimentDelightful => 'Skønt';
@@ -3196,6 +3208,9 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Transskription er ikke sat op for denne person. Tilføj en lydmodel og slå automatisk inferens til for deres kategori, eller skriv check-in selv.';
+
+  @override
+  String get checkInWriteInstead => 'Skriv i stedet';
 
   @override
   String get checklistAddItem => 'Tilføj en ny genstand';
@@ -10277,6 +10292,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipAddChannelButton => 'Tilføj kontaktoplysning';
 
   @override
+  String get relationshipAsk => 'Spørg';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Relationsbanner for $personName';
   }
@@ -10310,6 +10328,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Brief igen';
+
+  @override
   String get relationshipBriefMeButton => 'Opdater mig';
 
   @override
@@ -10336,6 +10357,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipCadenceNone => 'Ingen rytme';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'At vælge et tempo slår check-in-påmindelser til.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'på sporet';
+
+  @override
   String get relationshipCadenceQuarterly => 'Hvert kvartal';
 
   @override
@@ -10349,6 +10377,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Ingen agent endnu — markér først personen som vigtig.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Check-in $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Et godt tidspunkt at tage kontakt.';
 
@@ -10359,6 +10392,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Check-ins';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Check-in · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Kontaktkort';
 
   @override
   String get relationshipContactChannelsLabel => 'Kontaktoplysninger';
@@ -10387,6 +10428,11 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Slet $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Senest $day';
   }
 
   @override
@@ -10504,6 +10550,9 @@ class AppLocalizationsDa extends AppLocalizations {
       'Kontaktimport findes på telefoner og tablets. Tilføj kontaktoplysninger i hånden her.';
 
   @override
+  String get relationshipJustAdded => 'Netop tilføjet';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Seneste check-in $date';
   }
@@ -10521,10 +10570,23 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipLogCheckIn => 'Registrér check-in';
 
   @override
+  String get relationshipLottisRead => 'Lottis vurdering';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'kl. $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Navn';
 
   @override
   String get relationshipNameRequired => 'Navn er påkrævet';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'næste senest $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Kaldenavn';
@@ -10538,6 +10600,9 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'Denne person følges ikke længere.';
+
+  @override
+  String get relationshipNudgesOn => 'påmindelser til';
 
   @override
   String get relationshipPostCallBody =>
@@ -10555,7 +10620,21 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'i $count dage',
+      one: 'i 1 dag',
+    );
+    return 'Ingen kontakt $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Tilknyt en anden kontakt';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Se alle check-ins';
 
   @override
   String get relationshipsEmptyState =>
@@ -10575,6 +10654,12 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String get relationshipStayingInTouch => 'Holde kontakten';
+
+  @override
+  String get relationshipStayInTouch => 'Hold kontakten';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3151,6 +3151,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Diesen Check-in löschen? Das lässt sich nicht rückgängig machen.';
 
   @override
+  String get checkInDone => 'Fertig';
+
+  @override
   String get checkInEditTitle => 'Check-in bearbeiten';
 
   @override
@@ -3160,6 +3163,12 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Check-in konnte nicht gelöscht werden. Bitte versuch es erneut.';
+
+  @override
+  String get checkInHowDidItFeel => 'Wie hat es sich angefühlt?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Wie habt ihr Kontakt gehabt?';
 
   @override
   String get checkInInteractionCall => 'Anruf';
@@ -3184,6 +3193,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Nächstes Mal achten auf';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · HEUTE MORGEN VORBEREITET';
 
   @override
   String get checkInSentimentDelightful => 'Wunderbar';
@@ -3222,6 +3234,9 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Transkription ist für diese Person nicht eingerichtet. Füge ein Audiomodell hinzu und aktiviere die automatische Inferenz für ihre Kategorie, oder tippe das Check-in.';
+
+  @override
+  String get checkInWriteInstead => 'Lieber schreiben';
 
   @override
   String get checklistAddItem => 'Neues Element hinzufügen';
@@ -10340,6 +10355,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipAddChannelButton => 'Kontaktweg hinzufügen';
 
   @override
+  String get relationshipAsk => 'Fragen';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Beziehungs-Banner für $personName';
   }
@@ -10373,6 +10391,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Erneut briefen';
+
+  @override
   String get relationshipBriefMeButton => 'Brief mich';
 
   @override
@@ -10399,6 +10420,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipCadenceNone => 'Kein Rhythmus';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Ein Rhythmus aktiviert Check-in-Erinnerungen.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'im Rhythmus';
+
+  @override
   String get relationshipCadenceQuarterly => 'Vierteljährlich';
 
   @override
@@ -10412,6 +10440,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Noch kein Agent — markiere diese Person zuerst als wichtig.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Check-in $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Ein guter Moment, dich zu melden.';
 
@@ -10422,6 +10455,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Check-ins';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Check-in · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Visitenkarte';
 
   @override
   String get relationshipContactChannelsLabel => 'Kontaktdaten';
@@ -10450,6 +10491,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return '$name löschen?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Fällig $day';
   }
 
   @override
@@ -10567,6 +10613,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Der Kontaktimport ist auf Smartphones und Tablets verfügbar. Trag die Kontaktdaten hier von Hand ein.';
 
   @override
+  String get relationshipJustAdded => 'Gerade hinzugefügt';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Letzter Check-in $date';
   }
@@ -10584,10 +10633,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipLogCheckIn => 'Check-in erfassen';
 
   @override
+  String get relationshipLottisRead => 'Lottis Einschätzung';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'Stand $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Name';
 
   @override
   String get relationshipNameRequired => 'Ein Name ist erforderlich';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'nächstens bis $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Spitzname';
@@ -10602,6 +10664,9 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get relationshipNotFound =>
       'Diese Person ist nicht mehr in deiner Liste.';
+
+  @override
+  String get relationshipNudgesOn => 'Erinnerungen an';
 
   @override
   String get relationshipPostCallBody =>
@@ -10619,7 +10684,21 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Tagen',
+      one: 'einem Tag',
+    );
+    return 'Seit $_temp0 keine Nachricht';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Anderen Kontakt verknüpfen';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Alle Check-ins ansehen';
 
   @override
   String get relationshipsEmptyState =>
@@ -10639,6 +10718,12 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String get relationshipStayingInTouch => 'Kontakt halten';
+
+  @override
+  String get relationshipStayInTouch => 'Kontakt halten';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3110,6 +3110,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Delete this check-in? This cannot be undone.';
 
   @override
+  String get checkInDone => 'Done';
+
+  @override
   String get checkInEditTitle => 'Edit check-in';
 
   @override
@@ -3119,6 +3122,12 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Could not delete the check-in. Please try again.';
+
+  @override
+  String get checkInHowDidItFeel => 'How did it feel?';
+
+  @override
+  String get checkInHowDidYouConnect => 'How did you connect?';
 
   @override
   String get checkInInteractionCall => 'Call';
@@ -3143,6 +3152,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Next time, pay attention to';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PREPARED THIS MORNING';
 
   @override
   String get checkInSentimentDelightful => 'Delightful';
@@ -3181,6 +3193,9 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Transcription is not set up for this person. Add an audio model and turn on automatic inference for their category, or type the check-in.';
+
+  @override
+  String get checkInWriteInstead => 'Write instead';
 
   @override
   String get checklistAddItem => 'Add a new item';
@@ -10225,6 +10240,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipAddChannelButton => 'Add channel';
 
   @override
+  String get relationshipAsk => 'Ask';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Relationship banner for $personName';
   }
@@ -10258,6 +10276,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Brief me again';
+
+  @override
   String get relationshipBriefMeButton => 'Brief me';
 
   @override
@@ -10284,6 +10305,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipCadenceNone => 'No cadence';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Choosing a cadence turns on check-in nudges.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'On track';
+
+  @override
   String get relationshipCadenceQuarterly => 'Quarterly';
 
   @override
@@ -10297,6 +10325,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'No agent yet — mark this person as important first.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Checked in $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody => 'A good moment to reach out.';
 
   @override
@@ -10306,6 +10339,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Check-ins';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Check in · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Contact card';
 
   @override
   String get relationshipContactChannelsLabel => 'Contact channels';
@@ -10333,6 +10374,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Delete $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Due $day';
   }
 
   @override
@@ -10448,6 +10494,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Contact import is available on phones and tablets. Add contact details by hand here.';
 
   @override
+  String get relationshipJustAdded => 'Just added';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Last check-in $date';
   }
@@ -10465,10 +10514,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipLogCheckIn => 'Log check-in';
 
   @override
+  String get relationshipLottisRead => 'Lotti\'s read';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'as of $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Name';
 
   @override
   String get relationshipNameRequired => 'A name is required';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'next by $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Nickname';
@@ -10482,6 +10544,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'This person is no longer tracked.';
+
+  @override
+  String get relationshipNudgesOn => 'nudges on';
 
   @override
   String get relationshipPostCallBody =>
@@ -10499,7 +10564,21 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days',
+      one: '1 day',
+    );
+    return 'Quiet for $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Link a different contact';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'See all check-ins';
 
   @override
   String get relationshipsEmptyState =>
@@ -10519,6 +10598,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String get relationshipStayingInTouch => 'Staying in touch';
+
+  @override
+  String get relationshipStayInTouch => 'Stay in touch';
 
   @override
   String relationshipTrackingSinceLabel(String date) {
@@ -13626,6 +13711,21 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get categoryFavoriteDescription => 'Mark this category as a favourite';
 
   @override
+  String get checkInDone => 'Done';
+
+  @override
+  String get checkInHowDidItFeel => 'How did it feel?';
+
+  @override
+  String get checkInHowDidYouConnect => 'How did you connect?';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PREPARED THIS MORNING';
+
+  @override
+  String get checkInWriteInstead => 'Write instead';
+
+  @override
   String get colorLabel => 'Colour';
 
   @override
@@ -14040,6 +14140,76 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get outboxMonitorRetry => 'retry';
+
+  @override
+  String get relationshipAsk => 'Ask';
+
+  @override
+  String get relationshipBriefMeAgain => 'Brief me again';
+
+  @override
+  String get relationshipCadenceNudgeNote =>
+      'Choosing a cadence turns on check-in nudges.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'On track';
+
+  @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Checked in $date';
+  }
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Check in · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Contact card';
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Due $day';
+  }
+
+  @override
+  String get relationshipJustAdded => 'Just added';
+
+  @override
+  String get relationshipLottisRead => 'Lotti\'s read';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'as of $time';
+  }
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'next by $day';
+  }
+
+  @override
+  String get relationshipNudgesOn => 'nudges on';
+
+  @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days',
+      one: '1 day',
+    );
+    return 'Quiet for $_temp0';
+  }
+
+  @override
+  String get relationshipSeeAllCheckIns => 'See all check-ins';
+
+  @override
+  String get relationshipStayingInTouch => 'Staying in touch';
+
+  @override
+  String get relationshipStayInTouch => 'Stay in touch';
 
   @override
   String get saveLabel => 'Save';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsEs extends AppLocalizations {
       '¿Eliminar este registro? Esta acción no se puede deshacer.';
 
   @override
+  String get checkInDone => 'Listo';
+
+  @override
   String get checkInEditTitle => 'Editar registro';
 
   @override
@@ -3175,6 +3178,12 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'No se pudo eliminar el registro. Inténtalo de nuevo.';
+
+  @override
+  String get checkInHowDidItFeel => '¿Cómo te sentiste?';
+
+  @override
+  String get checkInHowDidYouConnect => '¿Cómo fue el contacto?';
 
   @override
   String get checkInInteractionCall => 'Llamada';
@@ -3199,6 +3208,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'La próxima vez, presta atención a';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PREPARADO ESTA MAÑANA';
 
   @override
   String get checkInSentimentDelightful => 'Genial';
@@ -3237,6 +3249,9 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'La transcripción no está configurada para esta persona. Añade un modelo de audio y activa la inferencia automática en su categoría, o escribe el registro.';
+
+  @override
+  String get checkInWriteInstead => 'Mejor escribir';
 
   @override
   String get checklistAddItem => 'Agregar un nuevo elemento';
@@ -10437,6 +10452,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipAddChannelButton => 'Añadir medio de contacto';
 
   @override
+  String get relationshipAsk => 'Preguntar';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Banner de relación para $personName';
   }
@@ -10470,6 +10488,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipBriefingTitle => 'Informe';
 
   @override
+  String get relationshipBriefMeAgain => 'Actualízame otra vez';
+
+  @override
   String get relationshipBriefMeButton => 'Ponme al día';
 
   @override
@@ -10496,6 +10517,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipCadenceNone => 'Sin frecuencia';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Elegir un ritmo activa los avisos de registro.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'al día';
+
+  @override
   String get relationshipCadenceQuarterly => 'Trimestral';
 
   @override
@@ -10509,6 +10537,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Aún no hay agente: marca primero a esta persona como importante.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Registro $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Un buen momento para retomar el contacto.';
 
@@ -10519,6 +10552,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Registros';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Registrar · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Tarjeta de contacto';
 
   @override
   String get relationshipContactChannelsLabel => 'Datos de contacto';
@@ -10547,6 +10588,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return '¿Eliminar a $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Tope $day';
   }
 
   @override
@@ -10664,6 +10710,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'La importación de contactos está disponible en teléfonos y tabletas. Añade aquí los datos a mano.';
 
   @override
+  String get relationshipJustAdded => 'Añadido ahora';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Último registro $date';
   }
@@ -10681,10 +10730,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipLogCheckIn => 'Registrar contacto';
 
   @override
+  String get relationshipLottisRead => 'Lotti opina';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'a las $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Nombre';
 
   @override
   String get relationshipNameRequired => 'El nombre es obligatorio';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'próximo antes de $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Apodo';
@@ -10698,6 +10760,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'Esta persona ya no está en tu lista.';
+
+  @override
+  String get relationshipNudgesOn => 'avisos activos';
 
   @override
   String get relationshipPostCallBody =>
@@ -10715,7 +10780,21 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'desde hace $count días',
+      one: 'desde hace 1 día',
+    );
+    return 'Sin contacto $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Vincular otro contacto';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Ver todos los registros';
 
   @override
   String get relationshipsEmptyState =>
@@ -10735,6 +10814,12 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Estado';
+
+  @override
+  String get relationshipStayingInTouch => 'Mantener el contacto';
+
+  @override
+  String get relationshipStayInTouch => 'Mantener el contacto';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3171,6 +3171,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Supprimer cet échange ? Cette action est irréversible.';
 
   @override
+  String get checkInDone => 'Terminé';
+
+  @override
   String get checkInEditTitle => 'Modifier l\'échange';
 
   @override
@@ -3180,6 +3183,12 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Impossible de supprimer l\'échange. Réessaie.';
+
+  @override
+  String get checkInHowDidItFeel => 'Comment ça s’est passé ?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Comment avez-vous échangé ?';
 
   @override
   String get checkInInteractionCall => 'Appel';
@@ -3204,6 +3213,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'La prochaine fois, fais attention à';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PRÉPARÉ CE MATIN';
 
   @override
   String get checkInSentimentDelightful => 'Merveilleux';
@@ -3243,6 +3255,9 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'La transcription n\'est pas configurée pour cette personne. Ajoute un modèle audio et active l\'inférence automatique pour sa catégorie, ou écris l\'échange.';
+
+  @override
+  String get checkInWriteInstead => 'Écrire plutôt';
 
   @override
   String get checklistAddItem => 'Ajouter un nouvel élément';
@@ -10467,6 +10482,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipAddChannelButton => 'Ajouter un moyen de contact';
 
   @override
+  String get relationshipAsk => 'Demander';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Bannière de relation pour $personName';
   }
@@ -10500,6 +10518,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Briefe-moi à nouveau';
+
+  @override
   String get relationshipBriefMeButton => 'Briefe-moi';
 
   @override
@@ -10526,6 +10547,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipCadenceNone => 'Aucun rythme';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Choisir un rythme active les rappels d’échange.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'à jour';
+
+  @override
   String get relationshipCadenceQuarterly => 'Chaque trimestre';
 
   @override
@@ -10539,6 +10567,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Pas encore d\'agent — marque d\'abord cette personne comme importante.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Échange $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Un bon moment pour reprendre contact.';
 
@@ -10549,6 +10582,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Échanges';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Échange · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Carte de contact';
 
   @override
   String get relationshipContactChannelsLabel => 'Coordonnées';
@@ -10577,6 +10618,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Supprimer $name ?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'À relancer $day';
   }
 
   @override
@@ -10694,6 +10740,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'L’import de contacts est disponible sur téléphone et tablette. Saisis les coordonnées à la main ici.';
 
   @override
+  String get relationshipJustAdded => 'Vient d\'être ajouté';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Dernier échange $date';
   }
@@ -10711,10 +10760,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipLogCheckIn => 'Noter un échange';
 
   @override
+  String get relationshipLottisRead => 'Lotti dit';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'à $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Nom';
 
   @override
   String get relationshipNameRequired => 'Le nom est obligatoire';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'prochain avant $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Surnom';
@@ -10729,6 +10791,9 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get relationshipNotFound =>
       'Cette personne n\'est plus dans ta liste.';
+
+  @override
+  String get relationshipNudgesOn => 'rappels activés';
 
   @override
   String get relationshipPostCallBody =>
@@ -10746,7 +10811,21 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'depuis $count jours',
+      one: 'depuis 1 jour',
+    );
+    return 'Aucun échange $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Associer un autre contact';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Voir tous les échanges';
 
   @override
   String get relationshipsEmptyState =>
@@ -10766,6 +10845,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Statut';
+
+  @override
+  String get relationshipStayingInTouch => 'Rester en contact';
+
+  @override
+  String get relationshipStayInTouch => 'Rester en contact';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Eliminare questo contatto? L\'azione non si può annullare.';
 
   @override
+  String get checkInDone => 'Fatto';
+
+  @override
   String get checkInEditTitle => 'Modifica contatto';
 
   @override
@@ -3175,6 +3178,12 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Impossibile eliminare il contatto. Riprova.';
+
+  @override
+  String get checkInHowDidItFeel => 'Com’è andata?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Come vi siete sentiti?';
 
   @override
   String get checkInInteractionCall => 'Chiamata';
@@ -3199,6 +3208,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'La prossima volta fai attenzione a';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PREPARATO STAMATTINA';
 
   @override
   String get checkInSentimentDelightful => 'Splendido';
@@ -3237,6 +3249,9 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'La trascrizione non è configurata per questa persona. Aggiungi un modello audio e attiva l\'inferenza automatica per la sua categoria, oppure scrivi il contatto.';
+
+  @override
+  String get checkInWriteInstead => 'Scrivi invece';
 
   @override
   String get checklistAddItem => 'Aggiungi un nuovo articolo';
@@ -10417,6 +10432,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipAddChannelButton => 'Aggiungi recapito';
 
   @override
+  String get relationshipAsk => 'Chiedi';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Banner della relazione con $personName';
   }
@@ -10450,6 +10468,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Aggiornami di nuovo';
+
+  @override
   String get relationshipBriefMeButton => 'Aggiornami';
 
   @override
@@ -10476,6 +10497,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipCadenceNone => 'Nessun ritmo';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Scegliere un ritmo attiva i promemoria dei contatti.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'in regola';
+
+  @override
   String get relationshipCadenceQuarterly => 'Ogni trimestre';
 
   @override
@@ -10489,6 +10517,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessun agente ancora: prima segna questa persona come importante.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Contatto $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Un buon momento per farsi sentire.';
 
@@ -10499,6 +10532,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Contatti registrati';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Contatto · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Scheda contatto';
 
   @override
   String get relationshipContactChannelsLabel => 'Recapiti';
@@ -10526,6 +10567,11 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Eliminare $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Entro $day';
   }
 
   @override
@@ -10644,6 +10690,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'L’importazione dei contatti è disponibile su telefoni e tablet. Inserisci qui i recapiti a mano.';
 
   @override
+  String get relationshipJustAdded => 'Appena aggiunto';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Ultimo contatto $date';
   }
@@ -10661,10 +10710,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipLogCheckIn => 'Registra un contatto';
 
   @override
+  String get relationshipLottisRead => 'Lotti dice';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'alle $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Nome';
 
   @override
   String get relationshipNameRequired => 'Il nome è obbligatorio';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'prossimo entro $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Soprannome';
@@ -10679,6 +10741,9 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get relationshipNotFound =>
       'Questa persona non è più nella tua lista.';
+
+  @override
+  String get relationshipNudgesOn => 'promemoria attivi';
 
   @override
   String get relationshipPostCallBody =>
@@ -10696,7 +10761,21 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'da $count giorni',
+      one: 'da 1 giorno',
+    );
+    return 'Nessun contatto $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Collega un altro contatto';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Vedi tutti i contatti';
 
   @override
   String get relationshipsEmptyState =>
@@ -10716,6 +10795,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Stato';
+
+  @override
+  String get relationshipStayingInTouch => 'Restare in contatto';
+
+  @override
+  String get relationshipStayInTouch => 'Restare in contatto';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3135,6 +3135,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Deze check-in verwijderen? Dit kan niet ongedaan worden gemaakt.';
 
   @override
+  String get checkInDone => 'Klaar';
+
+  @override
   String get checkInEditTitle => 'Check-in bewerken';
 
   @override
@@ -3144,6 +3147,12 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Kon de check-in niet verwijderen. Probeer het opnieuw.';
+
+  @override
+  String get checkInHowDidItFeel => 'Hoe voelde het?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Hoe was het contact?';
 
   @override
   String get checkInInteractionCall => 'Telefoontje';
@@ -3168,6 +3177,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Let de volgende keer op';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · VANOCHTEND VOORBEREID';
 
   @override
   String get checkInSentimentDelightful => 'Heerlijk';
@@ -3206,6 +3218,9 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Transcriptie is niet ingesteld voor deze persoon. Voeg een audiomodel toe en zet automatische inferentie aan voor hun categorie, of typ de check-in.';
+
+  @override
+  String get checkInWriteInstead => 'Liever schrijven';
 
   @override
   String get checklistAddItem => 'Een nieuw item toevoegen';
@@ -10294,6 +10309,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipAddChannelButton => 'Contactgegeven toevoegen';
 
   @override
+  String get relationshipAsk => 'Vraag';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Relatiebanner voor $personName';
   }
@@ -10327,6 +10345,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Opnieuw vatten';
+
+  @override
   String get relationshipBriefMeButton => 'Praat me bij';
 
   @override
@@ -10353,6 +10374,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipCadenceNone => 'Geen ritme';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Een cadans zet check-in-herinneringen aan.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'op schema';
+
+  @override
   String get relationshipCadenceQuarterly => 'Elk kwartaal';
 
   @override
@@ -10366,6 +10394,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Nog geen agent — markeer deze persoon eerst als belangrijk.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Check-in $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Een goed moment om contact op te nemen.';
 
@@ -10376,6 +10409,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Check-ins';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Check-in · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Contactkaart';
 
   @override
   String get relationshipContactChannelsLabel => 'Contactgegevens';
@@ -10404,6 +10445,11 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return '$name verwijderen?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Voor $day';
   }
 
   @override
@@ -10521,6 +10567,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Contacten importeren kan op telefoons en tablets. Voer de contactgegevens hier met de hand in.';
 
   @override
+  String get relationshipJustAdded => 'Net toegevoegd';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Laatste check-in $date';
   }
@@ -10538,10 +10587,23 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipLogCheckIn => 'Check-in vastleggen';
 
   @override
+  String get relationshipLottisRead => 'Lotti\'s inschatting';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'van $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Naam';
 
   @override
   String get relationshipNameRequired => 'Een naam is verplicht';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'volgende voor $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Bijnaam';
@@ -10556,6 +10618,9 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get relationshipNotFound =>
       'Deze persoon staat niet meer in je lijst.';
+
+  @override
+  String get relationshipNudgesOn => 'herinneringen aan';
 
   @override
   String get relationshipPostCallBody =>
@@ -10573,7 +10638,21 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagen',
+      one: '1 dag',
+    );
+    return '$_temp0 geen contact';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Ander contact koppelen';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Alle check-ins bekijken';
 
   @override
   String get relationshipsEmptyState =>
@@ -10593,6 +10672,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String get relationshipStayingInTouch => 'Contact houden';
+
+  @override
+  String get relationshipStayInTouch => 'Contact houden';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3155,6 +3155,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Excluir este registro? Isso não pode ser desfeito.';
 
   @override
+  String get checkInDone => 'Pronto';
+
+  @override
   String get checkInEditTitle => 'Editar registro';
 
   @override
@@ -3164,6 +3167,12 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Não foi possível excluir o registro. Tente novamente.';
+
+  @override
+  String get checkInHowDidItFeel => 'Como você se sentiu?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Como foi o contato?';
 
   @override
   String get checkInInteractionCall => 'Ligação';
@@ -3188,6 +3197,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Na próxima vez, preste atenção em';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PREPARADO ESTA MANHÃ';
 
   @override
   String get checkInSentimentDelightful => 'Maravilhoso';
@@ -3227,6 +3239,9 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'A transcrição não está configurada para esta pessoa. Adicione um modelo de áudio e ative a inferência automática na categoria dela, ou escreva o registro.';
+
+  @override
+  String get checkInWriteInstead => 'Escrever antes';
 
   @override
   String get checklistAddItem => 'Adicionar um novo item';
@@ -10378,6 +10393,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipAddChannelButton => 'Adicionar meio de contato';
 
   @override
+  String get relationshipAsk => 'Perguntar';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Banner de relacionamento com $personName';
   }
@@ -10411,6 +10429,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Atualiza-me de novo';
+
+  @override
   String get relationshipBriefMeButton => 'Atualiza-me';
 
   @override
@@ -10437,6 +10458,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipCadenceNone => 'Sem ritmo';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Escolher um ritmo ativa os lembretes de registro.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'em dia';
+
+  @override
   String get relationshipCadenceQuarterly => 'Trimestral';
 
   @override
@@ -10450,6 +10478,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Ainda sem agente — marca primeiro esta pessoa como importante.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Registro $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Um bom momento para dar notícias.';
 
@@ -10460,6 +10493,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Registros';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Registrar · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Cartão de contato';
 
   @override
   String get relationshipContactChannelsLabel => 'Dados de contato';
@@ -10488,6 +10529,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Excluir $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Até $day';
   }
 
   @override
@@ -10604,6 +10650,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'A importação de contactos está disponível em telemóveis e tablets. Adiciona aqui os dados à mão.';
 
   @override
+  String get relationshipJustAdded => 'Recém-adicionado';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Último registro $date';
   }
@@ -10621,10 +10670,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipLogCheckIn => 'Registrar contato';
 
   @override
+  String get relationshipLottisRead => 'Leitura do Lotti';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'às $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Nome';
 
   @override
   String get relationshipNameRequired => 'O nome é obrigatório';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'próximo até $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Apelido';
@@ -10638,6 +10700,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'Esta pessoa não está mais na sua lista.';
+
+  @override
+  String get relationshipNudgesOn => 'lembretes ativos';
 
   @override
   String get relationshipPostCallBody =>
@@ -10655,7 +10720,21 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'há $count dias',
+      one: 'há 1 dia',
+    );
+    return 'Sem contato $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Associar outro contacto';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Ver todos os registros';
 
   @override
   String get relationshipsEmptyState =>
@@ -10675,6 +10754,12 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String get relationshipStayingInTouch => 'Manter contato';
+
+  @override
+  String get relationshipStayInTouch => 'Manter contato';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3177,6 +3177,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Ștergeți această înregistrare? Acțiunea nu poate fi anulată.';
 
   @override
+  String get checkInDone => 'Gata';
+
+  @override
   String get checkInEditTitle => 'Editați înregistrarea';
 
   @override
@@ -3186,6 +3189,12 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Înregistrarea nu a putut fi ștearsă. Încercați din nou.';
+
+  @override
+  String get checkInHowDidItFeel => 'Cum a fost?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Cum a fost contactul?';
 
   @override
   String get checkInInteractionCall => 'Apel';
@@ -3210,6 +3219,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Data viitoare, acordați atenție la';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · PREGĂTIT AZI-DIMINEAȚĂ';
 
   @override
   String get checkInSentimentDelightful => 'Minunat';
@@ -3249,6 +3261,9 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Transcrierea nu este configurată pentru această persoană. Adăugați un model audio și activați inferența automată pentru categoria sa, sau scrieți contactul.';
+
+  @override
+  String get checkInWriteInstead => 'Scrie în schimb';
 
   @override
   String get checklistAddItem => 'Adăugați un element nou';
@@ -10490,6 +10505,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipAddChannelButton => 'Adăugați o modalitate de contact';
 
   @override
+  String get relationshipAsk => 'Întreabă';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Banner de relație pentru $personName';
   }
@@ -10523,6 +10541,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipBriefingTitle => 'Rezumat';
 
   @override
+  String get relationshipBriefMeAgain => 'Pune-mă la curent din nou';
+
+  @override
   String get relationshipBriefMeButton => 'Pune-mă la curent';
 
   @override
@@ -10550,6 +10571,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipCadenceNone => 'Fără ritm';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Alegerea unui ritm activează memento-urile de înregistrare.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'la zi';
+
+  @override
   String get relationshipCadenceQuarterly => 'Trimestrial';
 
   @override
@@ -10563,6 +10591,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Niciun agent încă — marcați mai întâi această persoană ca importantă.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Înregistrare $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Un moment bun pentru a lua legătura.';
 
@@ -10573,6 +10606,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Înregistrări';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Înregistrare · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Card de contact';
 
   @override
   String get relationshipContactChannelsLabel => 'Date de contact';
@@ -10601,6 +10642,11 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Ștergeți $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Până $day';
   }
 
   @override
@@ -10722,6 +10768,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Importul de contacte este disponibil pe telefoane și tablete. Adăugați aici datele de contact manual.';
 
   @override
+  String get relationshipJustAdded => 'Adăugat recent';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Ultima înregistrare $date';
   }
@@ -10739,10 +10788,23 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipLogCheckIn => 'Înregistrați un contact';
 
   @override
+  String get relationshipLottisRead => 'Părerea Lotti';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'la $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Nume';
 
   @override
   String get relationshipNameRequired => 'Numele este obligatoriu';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'următorul până $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Poreclă';
@@ -10756,6 +10818,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'Această persoană nu mai este urmărită.';
+
+  @override
+  String get relationshipNudgesOn => 'memento-uri active';
 
   @override
   String get relationshipPostCallBody =>
@@ -10773,7 +10838,21 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'de $count zile',
+      one: 'de 1 zi',
+    );
+    return 'Fără contact $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Asociați alt contact';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Vezi toate înregistrările';
 
   @override
   String get relationshipsEmptyState =>
@@ -10793,6 +10872,12 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Stare';
+
+  @override
+  String get relationshipStayingInTouch => 'Menținerea contactului';
+
+  @override
+  String get relationshipStayInTouch => 'Menține contactul';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3134,6 +3134,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ta bort den här avstämningen? Det går inte att ångra.';
 
   @override
+  String get checkInDone => 'Klart';
+
+  @override
   String get checkInEditTitle => 'Redigera avstämning';
 
   @override
@@ -3143,6 +3146,12 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get checkInErrorDeleteFailed =>
       'Avstämningen kunde inte tas bort. Försök igen.';
+
+  @override
+  String get checkInHowDidItFeel => 'Hur kändes det?';
+
+  @override
+  String get checkInHowDidYouConnect => 'Hur hade ni kontakt?';
 
   @override
   String get checkInInteractionCall => 'Samtal';
@@ -3167,6 +3176,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get checkInPayAttentionLabel => 'Nästa gång: var uppmärksam på';
+
+  @override
+  String get checkInPreparedOverline => '✦ LOTTI · FÖRBEREDD I MORSE';
 
   @override
   String get checkInSentimentDelightful => 'Underbart';
@@ -3205,6 +3217,9 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get checkInTranscriptUnavailable =>
       'Transkription är inte uppsatt för den här personen. Lägg till en ljudmodell och slå på automatisk inferens för deras kategori, eller skriv avstämningen.';
+
+  @override
+  String get checkInWriteInstead => 'Skriv istället';
 
   @override
   String get checklistAddItem => 'Lägg till ett nytt föremål';
@@ -10287,6 +10302,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipAddChannelButton => 'Lägg till kontaktuppgift';
 
   @override
+  String get relationshipAsk => 'Fråga';
+
+  @override
   String relationshipBannerSemanticLabel(String personName) {
     return 'Relationsbanner för $personName';
   }
@@ -10320,6 +10338,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipBriefingTitle => 'Briefing';
 
   @override
+  String get relationshipBriefMeAgain => 'Briefa igen';
+
+  @override
   String get relationshipBriefMeButton => 'Uppdatera mig';
 
   @override
@@ -10346,6 +10367,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipCadenceNone => 'Ingen rytm';
 
   @override
+  String get relationshipCadenceNudgeNote =>
+      'Att välja en rytm slår på avstämningspåminnelser.';
+
+  @override
+  String get relationshipCadenceOnTrack => 'i fas';
+
+  @override
   String get relationshipCadenceQuarterly => 'Varje kvartal';
 
   @override
@@ -10359,6 +10387,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ingen agent än — markera personen som viktig först.';
 
   @override
+  String relationshipCheckedInLabel(String date) {
+    return 'Avstämning $date';
+  }
+
+  @override
   String get relationshipCheckInReminderBody =>
       'Ett bra tillfälle att höra av dig.';
 
@@ -10369,6 +10402,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get relationshipCheckInsLabel => 'Avstämningar';
+
+  @override
+  String relationshipCheckInTitle(String name) {
+    return 'Avstämning · $name';
+  }
+
+  @override
+  String get relationshipContactCardAction => 'Kontaktkort';
 
   @override
   String get relationshipContactChannelsLabel => 'Kontaktuppgifter';
@@ -10397,6 +10438,11 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String relationshipDeleteConfirmTitle(String name) {
     return 'Ta bort $name?';
+  }
+
+  @override
+  String relationshipDueDay(String day) {
+    return 'Senast $day';
   }
 
   @override
@@ -10514,6 +10560,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Kontaktimport finns på telefoner och surfplattor. Lägg till kontaktuppgifter för hand här.';
 
   @override
+  String get relationshipJustAdded => 'Nyss tillagd';
+
+  @override
   String relationshipLastCheckInLabel(String date) {
     return 'Senaste avstämning $date';
   }
@@ -10531,10 +10580,23 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipLogCheckIn => 'Logga avstämning';
 
   @override
+  String get relationshipLottisRead => 'Lottis bedömning';
+
+  @override
+  String relationshipLottisReadAsOf(String time) {
+    return 'kl. $time';
+  }
+
+  @override
   String get relationshipNameLabel => 'Namn';
 
   @override
   String get relationshipNameRequired => 'Namn krävs';
+
+  @override
+  String relationshipNextByDay(String day) {
+    return 'nästa senast $day';
+  }
 
   @override
   String get relationshipNicknameLabel => 'Smeknamn';
@@ -10548,6 +10610,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get relationshipNotFound => 'Den här personen följs inte längre.';
+
+  @override
+  String get relationshipNudgesOn => 'påminnelser på';
 
   @override
   String get relationshipPostCallBody =>
@@ -10565,7 +10630,21 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String relationshipQuietForDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'på $count dagar',
+      one: 'på 1 dag',
+    );
+    return 'Ingen kontakt $_temp0';
+  }
+
+  @override
   String get relationshipRelinkContact => 'Länka en annan kontakt';
+
+  @override
+  String get relationshipSeeAllCheckIns => 'Se alla avstämningar';
 
   @override
   String get relationshipsEmptyState =>
@@ -10585,6 +10664,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String get relationshipStayingInTouch => 'Hålla kontakten';
+
+  @override
+  String get relationshipStayInTouch => 'Håll kontakten';
 
   @override
   String relationshipTrackingSinceLabel(String date) {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1568,9 +1568,21 @@
   "checkInAvoidLabel": "Beter vermijden",
   "checkInDateLabel": "Wanneer?",
   "checkInDeleteConfirmMessage": "Deze check-in verwijderen? Dit kan niet ongedaan worden gemaakt.",
+  "checkInDone": "Klaar",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Check-in bewerken",
   "checkInErrorCreateFailed": "Kon de check-in niet opslaan. Probeer het opnieuw.",
   "checkInErrorDeleteFailed": "Kon de check-in niet verwijderen. Probeer het opnieuw.",
+  "checkInHowDidItFeel": "Hoe voelde het?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Hoe was het contact?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Telefoontje",
   "checkInInteractionInPerson": "In persoon",
   "checkInInteractionLabel": "Hoe hadden jullie contact?",
@@ -1579,6 +1591,7 @@
   "checkInInteractionVideoCall": "Videogesprek",
   "checkInNarrativeLabel": "Waar hebben jullie het over gehad?",
   "checkInPayAttentionLabel": "Let de volgende keer op",
+  "checkInPreparedOverline": "✦ LOTTI · VANOCHTEND VOORBEREID",
   "checkInSentimentDelightful": "Heerlijk",
   "checkInSentimentDifficult": "Moeilijk",
   "checkInSentimentGood": "Goed",
@@ -1591,6 +1604,10 @@
   "checkInTranscribingLabel": "Bezig met transcriberen…",
   "checkInTranscriptFailed": "Er kwam geen transcriptie terug. Je kunt het zelf typen.",
   "checkInTranscriptUnavailable": "Transcriptie is niet ingesteld voor deze persoon. Voeg een audiomodel toe en zet automatische inferentie aan voor hun categorie, of typ de check-in.",
+  "checkInWriteInstead": "Liever schrijven",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Een nieuw item toevoegen",
   "checklistAiConfidenceLabel": "Vertrouwen: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4525,6 +4542,10 @@
   "relationshipActionFailed": "Niets op dit apparaat kan dat openen",
   "relationshipActionMessage": "Bericht",
   "relationshipAddChannelButton": "Contactgegeven toevoegen",
+  "relationshipAsk": "Vraag",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Relatiebanner voor {personName}",
   "relationshipBriefingDisclosureBody": "De briefing draait op {provider}. Notities over deze persoon worden daarheen gestuurd voor verwerking.",
   "relationshipBriefingDisclosureConfirm": "Doorgaan",
@@ -4533,16 +4554,36 @@
   "relationshipBriefingRequested": "Briefing aangevraagd — verschijnt hier zo.",
   "relationshipBriefingRequestFailed": "Kon de briefing niet aanvragen.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Opnieuw vatten",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Praat me bij",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Elke dag} other{Elke {days} dagen}}",
   "relationshipCadenceFortnightly": "Om de twee weken",
   "relationshipCadenceLabel": "Contactritme",
   "relationshipCadenceMonthly": "Maandelijks",
   "relationshipCadenceNone": "Geen ritme",
+  "relationshipCadenceNudgeNote": "Een cadans zet check-in-herinneringen aan.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "op schema",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Elk kwartaal",
   "relationshipCadenceWeekly": "Wekelijks",
   "relationshipChatTooltip": "Chat over deze persoon",
   "relationshipChatUnavailable": "Nog geen agent — markeer deze persoon eerst als belangrijk.",
+  "relationshipCheckedInLabel": "Check-in {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Een goed moment om contact op te nemen.",
   "relationshipCheckInReminderTitle": "Even contact met {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4553,6 +4594,18 @@
     }
   },
   "relationshipCheckInsLabel": "Check-ins",
+  "relationshipCheckInTitle": "Check-in · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Contactkaart",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Contactgegevens",
   "relationshipContactLinked": "Contactgegevens gekopieerd",
   "relationshipContactLinkFailed": "Kon de contactgegevens niet opslaan",
@@ -4561,6 +4614,14 @@
   "relationshipCreateTitle": "Persoon toevoegen",
   "relationshipDeleteConfirmMessage": "Ook alle check-ins worden verwijderd. Dit kan niet ongedaan worden gemaakt.",
   "relationshipDeleteConfirmTitle": "{name} verwijderen?",
+  "relationshipDueDay": "Voor {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Persoon bewerken",
   "relationshipErrorCreateFailed": "Kon de persoon niet opslaan. Probeer het opnieuw.",
   "relationshipErrorDeleteFailed": "Kon de persoon niet verwijderen. Probeer het opnieuw.",
@@ -4588,17 +4649,45 @@
   "relationshipImportSettingsBody": "Toegang tot contacten staat uit. Zet het aan in de systeeminstellingen om personen te importeren.",
   "relationshipImportTitle": "Personen toevoegen",
   "relationshipImportUnsupported": "Contacten importeren kan op telefoons en tablets. Voer de contactgegevens hier met de hand in.",
+  "relationshipJustAdded": "Net toegevoegd",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Laatste check-in {date}",
   "relationshipLinkContact": "Contact koppelen",
   "relationshipLinkedTasksLabel": "Taken",
   "relationshipLinkTaskButton": "Taak koppelen",
   "relationshipLogCheckIn": "Check-in vastleggen",
+  "relationshipLottisRead": "Lotti's inschatting",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "van {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Naam",
   "relationshipNameRequired": "Een naam is verplicht",
+  "relationshipNextByDay": "volgende voor {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Bijnaam",
   "relationshipNoCheckIns": "Nog geen check-ins — leg er een vast na jullie volgende gesprek.",
   "relationshipNoLinkedTasks": "Nog geen gekoppelde taken.",
   "relationshipNotFound": "Deze persoon staat niet meer in je lijst.",
+  "relationshipNudgesOn": "herinneringen aan",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Je hebt net contact gehad. Wil je een check-in vastleggen nu het nog vers is?",
   "relationshipPostCallConfirm": "Check-in vastleggen",
   "relationshipPostCallDismiss": "Niet nu",
@@ -4611,13 +4700,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "{count, plural, =1{1 dag} other{{count} dagen}} geen contact",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Ander contact koppelen",
+  "relationshipSeeAllCheckIns": "Alle check-ins bekijken",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Voeg de mensen toe met wie je dichtbij wilt blijven.",
   "relationshipsPageTitle": "Mensen",
   "relationshipStatusActive": "Actief",
   "relationshipStatusArchived": "Gearchiveerd",
   "relationshipStatusDormant": "Sluimerend",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStayingInTouch": "Contact houden",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Contact houden",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Gevolgd sinds {date}",
   "relationshipUpdateFromContact": "Bijwerken vanuit contact",
   "saveButton": "Opslaan",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1568,9 +1568,21 @@
   "checkInAvoidLabel": "Melhor evitar",
   "checkInDateLabel": "Quando?",
   "checkInDeleteConfirmMessage": "Excluir este registro? Isso não pode ser desfeito.",
+  "checkInDone": "Pronto",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Editar registro",
   "checkInErrorCreateFailed": "Não foi possível salvar o registro. Tente novamente.",
   "checkInErrorDeleteFailed": "Não foi possível excluir o registro. Tente novamente.",
+  "checkInHowDidItFeel": "Como você se sentiu?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Como foi o contato?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Ligação",
   "checkInInteractionInPerson": "Pessoalmente",
   "checkInInteractionLabel": "Como vocês conversaram?",
@@ -1579,6 +1591,7 @@
   "checkInInteractionVideoCall": "Videochamada",
   "checkInNarrativeLabel": "Sobre o que vocês conversaram?",
   "checkInPayAttentionLabel": "Na próxima vez, preste atenção em",
+  "checkInPreparedOverline": "✦ LOTTI · PREPARADO ESTA MANHÃ",
   "checkInSentimentDelightful": "Maravilhoso",
   "checkInSentimentDifficult": "Difícil",
   "checkInSentimentGood": "Bom",
@@ -1591,6 +1604,10 @@
   "checkInTranscribingLabel": "Transcrevendo…",
   "checkInTranscriptFailed": "Nenhuma transcrição voltou. Você pode escrever você mesmo.",
   "checkInTranscriptUnavailable": "A transcrição não está configurada para esta pessoa. Adicione um modelo de áudio e ative a inferência automática na categoria dela, ou escreva o registro.",
+  "checkInWriteInstead": "Escrever antes",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Adicionar um novo item",
   "checklistAiConfidenceLabel": "Confiança: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4525,6 +4542,10 @@
   "relationshipActionFailed": "Nada neste dispositivo consegue abrir isso",
   "relationshipActionMessage": "Mensagem",
   "relationshipAddChannelButton": "Adicionar meio de contato",
+  "relationshipAsk": "Perguntar",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Banner de relacionamento com {personName}",
   "relationshipBriefingDisclosureBody": "O briefing corre em {provider}. As notas sobre esta pessoa serão enviadas para lá para processamento.",
   "relationshipBriefingDisclosureConfirm": "Continuar",
@@ -4533,16 +4554,36 @@
   "relationshipBriefingRequested": "Briefing pedido — vai aparecer aqui em breve.",
   "relationshipBriefingRequestFailed": "Não foi possível pedir o briefing.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Atualiza-me de novo",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Atualiza-me",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Todos os dias} other{A cada {days} dias}}",
   "relationshipCadenceFortnightly": "A cada duas semanas",
   "relationshipCadenceLabel": "Ritmo de contato",
   "relationshipCadenceMonthly": "Mensal",
   "relationshipCadenceNone": "Sem ritmo",
+  "relationshipCadenceNudgeNote": "Escolher um ritmo ativa os lembretes de registro.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "em dia",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Trimestral",
   "relationshipCadenceWeekly": "Semanal",
   "relationshipChatTooltip": "Conversar sobre esta pessoa",
   "relationshipChatUnavailable": "Ainda sem agente — marca primeiro esta pessoa como importante.",
+  "relationshipCheckedInLabel": "Registro {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Um bom momento para dar notícias.",
   "relationshipCheckInReminderTitle": "Falar com {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4553,6 +4594,18 @@
     }
   },
   "relationshipCheckInsLabel": "Registros",
+  "relationshipCheckInTitle": "Registrar · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Cartão de contato",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Dados de contato",
   "relationshipContactLinked": "Dados de contacto copiados",
   "relationshipContactLinkFailed": "Não foi possível guardar os dados de contacto",
@@ -4561,6 +4614,14 @@
   "relationshipCreateTitle": "Adicionar pessoa",
   "relationshipDeleteConfirmMessage": "Todos os registros dessa pessoa também serão excluídos. Isso não pode ser desfeito.",
   "relationshipDeleteConfirmTitle": "Excluir {name}?",
+  "relationshipDueDay": "Até {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Editar pessoa",
   "relationshipErrorCreateFailed": "Não foi possível salvar a pessoa. Tente novamente.",
   "relationshipErrorDeleteFailed": "Não foi possível excluir a pessoa. Tente novamente.",
@@ -4588,17 +4649,45 @@
   "relationshipImportSettingsBody": "O acesso aos contactos está desligado. Liga-o nas definições do sistema para importar pessoas.",
   "relationshipImportTitle": "Adicionar pessoas",
   "relationshipImportUnsupported": "A importação de contactos está disponível em telemóveis e tablets. Adiciona aqui os dados à mão.",
+  "relationshipJustAdded": "Recém-adicionado",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Último registro {date}",
   "relationshipLinkContact": "Associar contacto",
   "relationshipLinkedTasksLabel": "Tarefas",
   "relationshipLinkTaskButton": "Vincular tarefa",
   "relationshipLogCheckIn": "Registrar contato",
+  "relationshipLottisRead": "Leitura do Lotti",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "às {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Nome",
   "relationshipNameRequired": "O nome é obrigatório",
+  "relationshipNextByDay": "próximo até {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Apelido",
   "relationshipNoCheckIns": "Nenhum registro ainda — adicione um após a próxima conversa.",
   "relationshipNoLinkedTasks": "Nenhuma tarefa vinculada ainda.",
   "relationshipNotFound": "Esta pessoa não está mais na sua lista.",
+  "relationshipNudgesOn": "lembretes ativos",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Acabaste de entrar em contacto. Queres registar um check-in enquanto está fresco?",
   "relationshipPostCallConfirm": "Registar check-in",
   "relationshipPostCallDismiss": "Agora não",
@@ -4611,13 +4700,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Sem contato {count, plural, =1{há 1 dia} other{há {count} dias}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Associar outro contacto",
+  "relationshipSeeAllCheckIns": "Ver todos os registros",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Adicione as pessoas de quem você quer ficar perto.",
   "relationshipsPageTitle": "Pessoas",
   "relationshipStatusActive": "Ativo",
   "relationshipStatusArchived": "Arquivado",
   "relationshipStatusDormant": "Adormecido",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStayingInTouch": "Manter contato",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Manter contato",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Acompanhando desde {date}",
   "relationshipUpdateFromContact": "Atualizar a partir do contacto",
   "saveButton": "Salvar",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1391,9 +1391,21 @@
   "checkInAvoidLabel": "De evitat",
   "checkInDateLabel": "Când?",
   "checkInDeleteConfirmMessage": "Ștergeți această înregistrare? Acțiunea nu poate fi anulată.",
+  "checkInDone": "Gata",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Editați înregistrarea",
   "checkInErrorCreateFailed": "Înregistrarea nu a putut fi salvată. Încercați din nou.",
   "checkInErrorDeleteFailed": "Înregistrarea nu a putut fi ștearsă. Încercați din nou.",
+  "checkInHowDidItFeel": "Cum a fost?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Cum a fost contactul?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Apel",
   "checkInInteractionInPerson": "În persoană",
   "checkInInteractionLabel": "Cum ați vorbit?",
@@ -1402,6 +1414,7 @@
   "checkInInteractionVideoCall": "Apel video",
   "checkInNarrativeLabel": "Despre ce ați vorbit?",
   "checkInPayAttentionLabel": "Data viitoare, acordați atenție la",
+  "checkInPreparedOverline": "✦ LOTTI · PREGĂTIT AZI-DIMINEAȚĂ",
   "checkInSentimentDelightful": "Minunat",
   "checkInSentimentDifficult": "Dificil",
   "checkInSentimentGood": "Bine",
@@ -1414,6 +1427,10 @@
   "checkInTranscribingLabel": "Se transcrie…",
   "checkInTranscriptFailed": "Nu a venit nicio transcriere. O puteți scrie dvs.",
   "checkInTranscriptUnavailable": "Transcrierea nu este configurată pentru această persoană. Adăugați un model audio și activați inferența automată pentru categoria sa, sau scrieți contactul.",
+  "checkInWriteInstead": "Scrie în schimb",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Adăugați un element nou",
   "checklistAiConfidenceLabel": "Încredere: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4013,6 +4030,10 @@
   "relationshipActionFailed": "Nimic de pe acest dispozitiv nu poate deschide acest lucru",
   "relationshipActionMessage": "Mesaj",
   "relationshipAddChannelButton": "Adăugați o modalitate de contact",
+  "relationshipAsk": "Întreabă",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Banner de relație pentru {personName}",
   "relationshipBriefingDisclosureBody": "Rezumatul rulează pe {provider}. Notițele despre această persoană vor fi trimise acolo pentru procesare.",
   "relationshipBriefingDisclosureConfirm": "Continuați",
@@ -4021,16 +4042,36 @@
   "relationshipBriefingRequested": "Rezumat solicitat — va apărea aici în curând.",
   "relationshipBriefingRequestFailed": "Rezumatul nu a putut fi solicitat.",
   "relationshipBriefingTitle": "Rezumat",
+  "relationshipBriefMeAgain": "Pune-mă la curent din nou",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Pune-mă la curent",
   "relationshipCadenceEveryNDays": "{days, plural, =1{În fiecare zi} few{La fiecare {days} zile} other{La fiecare {days} de zile}}",
   "relationshipCadenceFortnightly": "La două săptămâni",
   "relationshipCadenceLabel": "Ritmul contactului",
   "relationshipCadenceMonthly": "Lunar",
   "relationshipCadenceNone": "Fără ritm",
+  "relationshipCadenceNudgeNote": "Alegerea unui ritm activează memento-urile de înregistrare.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "la zi",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Trimestrial",
   "relationshipCadenceWeekly": "Săptămânal",
   "relationshipChatTooltip": "Discutați despre această persoană",
   "relationshipChatUnavailable": "Niciun agent încă — marcați mai întâi această persoană ca importantă.",
+  "relationshipCheckedInLabel": "Înregistrare {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Un moment bun pentru a lua legătura.",
   "relationshipCheckInReminderTitle": "Luați legătura cu {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4041,6 +4082,18 @@
     }
   },
   "relationshipCheckInsLabel": "Înregistrări",
+  "relationshipCheckInTitle": "Înregistrare · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Card de contact",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Date de contact",
   "relationshipContactLinked": "Datele de contact au fost copiate",
   "relationshipContactLinkFailed": "Datele de contact nu au putut fi salvate",
@@ -4049,6 +4102,14 @@
   "relationshipCreateTitle": "Adăugați o persoană",
   "relationshipDeleteConfirmMessage": "Se vor șterge și toate înregistrările asociate. Acțiunea nu poate fi anulată.",
   "relationshipDeleteConfirmTitle": "Ștergeți {name}?",
+  "relationshipDueDay": "Până {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Editați persoana",
   "relationshipErrorCreateFailed": "Persoana nu a putut fi salvată. Încercați din nou.",
   "relationshipErrorDeleteFailed": "Persoana nu a putut fi ștearsă. Încercați din nou.",
@@ -4076,17 +4137,45 @@
   "relationshipImportSettingsBody": "Accesul la contacte este dezactivat. Activați-l din setările sistemului pentru a importa persoane.",
   "relationshipImportTitle": "Adăugați persoane",
   "relationshipImportUnsupported": "Importul de contacte este disponibil pe telefoane și tablete. Adăugați aici datele de contact manual.",
+  "relationshipJustAdded": "Adăugat recent",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Ultima înregistrare {date}",
   "relationshipLinkContact": "Asociați un contact",
   "relationshipLinkedTasksLabel": "Sarcini",
   "relationshipLinkTaskButton": "Asociați o sarcină",
   "relationshipLogCheckIn": "Înregistrați un contact",
+  "relationshipLottisRead": "Părerea Lotti",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "la {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Nume",
   "relationshipNameRequired": "Numele este obligatoriu",
+  "relationshipNextByDay": "următorul până {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Poreclă",
   "relationshipNoCheckIns": "Nicio înregistrare încă — adăugați una după următoarea conversație.",
   "relationshipNoLinkedTasks": "Nicio sarcină asociată încă.",
   "relationshipNotFound": "Această persoană nu mai este urmărită.",
+  "relationshipNudgesOn": "memento-uri active",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Tocmai ați luat legătura. Doriți să notați un check-in cât este proaspăt?",
   "relationshipPostCallConfirm": "Notați check-in",
   "relationshipPostCallDismiss": "Nu acum",
@@ -4099,13 +4188,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Fără contact {count, plural, =1{de 1 zi} other{de {count} zile}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Asociați alt contact",
+  "relationshipSeeAllCheckIns": "Vezi toate înregistrările",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Adăugați persoanele de care doriți să rămâneți aproape.",
   "relationshipsPageTitle": "Persoane",
   "relationshipStatusActive": "Activă",
   "relationshipStatusArchived": "Arhivată",
   "relationshipStatusDormant": "Inactivă",
   "relationshipStatusFieldLabel": "Stare",
+  "relationshipStayingInTouch": "Menținerea contactului",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Menține contactul",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Urmărire din {date}",
   "relationshipUpdateFromContact": "Actualizați din contact",
   "saveButton": "Salvați",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1569,9 +1569,21 @@
   "checkInAvoidLabel": "Bäst att undvika",
   "checkInDateLabel": "När?",
   "checkInDeleteConfirmMessage": "Ta bort den här avstämningen? Det går inte att ångra.",
+  "checkInDone": "Klart",
+  "@checkInDone": {
+    "description": "Relationships redesign label."
+  },
   "checkInEditTitle": "Redigera avstämning",
   "checkInErrorCreateFailed": "Avstämningen kunde inte sparas. Försök igen.",
   "checkInErrorDeleteFailed": "Avstämningen kunde inte tas bort. Försök igen.",
+  "checkInHowDidItFeel": "Hur kändes det?",
+  "@checkInHowDidItFeel": {
+    "description": "Relationships redesign label."
+  },
+  "checkInHowDidYouConnect": "Hur hade ni kontakt?",
+  "@checkInHowDidYouConnect": {
+    "description": "Relationships redesign label."
+  },
   "checkInInteractionCall": "Samtal",
   "checkInInteractionInPerson": "Personligen",
   "checkInInteractionLabel": "Hur pratade ni?",
@@ -1580,6 +1592,7 @@
   "checkInInteractionVideoCall": "Videosamtal",
   "checkInNarrativeLabel": "Vad pratade ni om?",
   "checkInPayAttentionLabel": "Nästa gång: var uppmärksam på",
+  "checkInPreparedOverline": "✦ LOTTI · FÖRBEREDD I MORSE",
   "checkInSentimentDelightful": "Underbart",
   "checkInSentimentDifficult": "Svårt",
   "checkInSentimentGood": "Bra",
@@ -1592,6 +1605,10 @@
   "checkInTranscribingLabel": "Transkriberar…",
   "checkInTranscriptFailed": "Ingen transkription kom tillbaka. Du kan skriva den själv.",
   "checkInTranscriptUnavailable": "Transkription är inte uppsatt för den här personen. Lägg till en ljudmodell och slå på automatisk inferens för deras kategori, eller skriv avstämningen.",
+  "checkInWriteInstead": "Skriv istället",
+  "@checkInWriteInstead": {
+    "description": "Relationships redesign label."
+  },
   "checklistAddItem": "Lägg till ett nytt föremål",
   "checklistAiConfidenceLabel": "Självförtroende: {level}",
   "@checklistAiConfidenceLabel": {
@@ -4526,6 +4543,10 @@
   "relationshipActionFailed": "Inget på den här enheten kan öppna det",
   "relationshipActionMessage": "Meddelande",
   "relationshipAddChannelButton": "Lägg till kontaktuppgift",
+  "relationshipAsk": "Fråga",
+  "@relationshipAsk": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBannerSemanticLabel": "Relationsbanner för {personName}",
   "relationshipBriefingDisclosureBody": "Briefingen körs på {provider}. Anteckningar om personen skickas dit för bearbetning.",
   "relationshipBriefingDisclosureConfirm": "Fortsätt",
@@ -4534,16 +4555,36 @@
   "relationshipBriefingRequested": "Briefing begärd — den visas här strax.",
   "relationshipBriefingRequestFailed": "Det gick inte att begära briefingen.",
   "relationshipBriefingTitle": "Briefing",
+  "relationshipBriefMeAgain": "Briefa igen",
+  "@relationshipBriefMeAgain": {
+    "description": "Relationships redesign label."
+  },
   "relationshipBriefMeButton": "Uppdatera mig",
   "relationshipCadenceEveryNDays": "{days, plural, =1{Varje dag} other{Var {days}:e dag}}",
   "relationshipCadenceFortnightly": "Varannan vecka",
   "relationshipCadenceLabel": "Kontaktrytm",
   "relationshipCadenceMonthly": "Varje månad",
   "relationshipCadenceNone": "Ingen rytm",
+  "relationshipCadenceNudgeNote": "Att välja en rytm slår på avstämningspåminnelser.",
+  "@relationshipCadenceNudgeNote": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipCadenceOnTrack": "i fas",
+  "@relationshipCadenceOnTrack": {
+    "description": "Relationships redesign label."
+  },
   "relationshipCadenceQuarterly": "Varje kvartal",
   "relationshipCadenceWeekly": "Varje vecka",
   "relationshipChatTooltip": "Chatta om den här personen",
   "relationshipChatUnavailable": "Ingen agent än — markera personen som viktig först.",
+  "relationshipCheckedInLabel": "Avstämning {date}",
+  "@relationshipCheckedInLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipCheckInReminderBody": "Ett bra tillfälle att höra av dig.",
   "relationshipCheckInReminderTitle": "Hör av dig till {name}?",
   "@relationshipCheckInReminderTitle": {
@@ -4554,6 +4595,18 @@
     }
   },
   "relationshipCheckInsLabel": "Avstämningar",
+  "relationshipCheckInTitle": "Avstämning · {name}",
+  "@relationshipCheckInTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipContactCardAction": "Kontaktkort",
+  "@relationshipContactCardAction": {
+    "description": "Relationships redesign label."
+  },
   "relationshipContactChannelsLabel": "Kontaktuppgifter",
   "relationshipContactLinked": "Kontaktuppgifter kopierade",
   "relationshipContactLinkFailed": "Kunde inte spara kontaktuppgifterna",
@@ -4562,6 +4615,14 @@
   "relationshipCreateTitle": "Lägg till person",
   "relationshipDeleteConfirmMessage": "Alla avstämningar tas också bort. Det går inte att ångra.",
   "relationshipDeleteConfirmTitle": "Ta bort {name}?",
+  "relationshipDueDay": "Senast {day}",
+  "@relationshipDueDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipEditTitle": "Redigera person",
   "relationshipErrorCreateFailed": "Personen kunde inte sparas. Försök igen.",
   "relationshipErrorDeleteFailed": "Personen kunde inte tas bort. Försök igen.",
@@ -4589,17 +4650,45 @@
   "relationshipImportSettingsBody": "Åtkomst till kontakter är avstängd. Slå på den i systeminställningarna för att importera personer.",
   "relationshipImportTitle": "Lägg till personer",
   "relationshipImportUnsupported": "Kontaktimport finns på telefoner och surfplattor. Lägg till kontaktuppgifter för hand här.",
+  "relationshipJustAdded": "Nyss tillagd",
+  "@relationshipJustAdded": {
+    "description": "Relationships redesign label."
+  },
   "relationshipLastCheckInLabel": "Senaste avstämning {date}",
   "relationshipLinkContact": "Länka kontakt",
   "relationshipLinkedTasksLabel": "Uppgifter",
   "relationshipLinkTaskButton": "Länka uppgift",
   "relationshipLogCheckIn": "Logga avstämning",
+  "relationshipLottisRead": "Lottis bedömning",
+  "@relationshipLottisRead": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipLottisReadAsOf": "kl. {time}",
+  "@relationshipLottisReadAsOf": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNameLabel": "Namn",
   "relationshipNameRequired": "Namn krävs",
+  "relationshipNextByDay": "nästa senast {day}",
+  "@relationshipNextByDay": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipNicknameLabel": "Smeknamn",
   "relationshipNoCheckIns": "Inga avstämningar än — logga en efter ert nästa samtal.",
   "relationshipNoLinkedTasks": "Inga uppgifter länkade än.",
   "relationshipNotFound": "Den här personen följs inte längre.",
+  "relationshipNudgesOn": "påminnelser på",
+  "@relationshipNudgesOn": {
+    "description": "Relationships redesign label."
+  },
   "relationshipPostCallBody": "Du hörde precis av dig. Vill du logga en avstämning medan det är färskt?",
   "relationshipPostCallConfirm": "Logga avstämning",
   "relationshipPostCallDismiss": "Inte nu",
@@ -4612,13 +4701,33 @@
       }
     }
   },
+  "relationshipQuietForDays": "Ingen kontakt {count, plural, =1{på 1 dag} other{på {count} dagar}}",
+  "@relationshipQuietForDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipRelinkContact": "Länka en annan kontakt",
+  "relationshipSeeAllCheckIns": "Se alla avstämningar",
+  "@relationshipSeeAllCheckIns": {
+    "description": "Relationships redesign label."
+  },
   "relationshipsEmptyState": "Lägg till människorna du vill hålla kontakten med.",
   "relationshipsPageTitle": "Personer",
   "relationshipStatusActive": "Aktiv",
   "relationshipStatusArchived": "Arkiverad",
   "relationshipStatusDormant": "Vilande",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStayingInTouch": "Hålla kontakten",
+  "@relationshipStayingInTouch": {
+    "description": "Relationships redesign label."
+  },
+  "relationshipStayInTouch": "Håll kontakten",
+  "@relationshipStayInTouch": {
+    "description": "Relationships redesign label."
+  },
   "relationshipTrackingSinceLabel": "Följs sedan {date}",
   "relationshipUpdateFromContact": "Uppdatera från kontakt",
   "saveButton": "Spara",

--- a/lib/logic/persistence_definition_ops.dart
+++ b/lib/logic/persistence_definition_ops.dart
@@ -1,5 +1,7 @@
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
+import 'package:lotti/features/notifications/scheduler/notification_startup_reconcile.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_collaborator_base.dart';
@@ -76,6 +78,18 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
     if (configFlag.name == enableNotificationsFlag &&
         previous?.status != configFlag.status) {
       await _refreshBadgeForNotificationsFlag();
+      if (configFlag.status) {
+        // Rows written while the flag was off carry no OS alarm — the
+        // scheduler's platform calls are gated on the flag, and the
+        // repository's idempotent creates never re-schedule an existing row.
+        // Without this, only the next app start would arm them, so a user
+        // who turns notifications on and keeps the app running would miss
+        // every reminder already sitting in the database.
+        await reconcileScheduledNotifications(
+          scheduler: getIt<NotificationScheduler>(),
+          logger: getIt<DomainLogger>(),
+        );
+      }
     }
   }
 

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -86,10 +86,7 @@ void main() {
     ).thenAnswer((_) async => []);
     when(() => repository.getEntity(any())).thenAnswer((_) async => null);
     when(
-      () => repository.getEntitiesByAgentId(
-        any(),
-        type: any(named: 'type'),
-      ),
+      () => repository.getEntitiesByAgentId(any(), type: any(named: 'type')),
     ).thenAnswer((_) async => []);
     when(
       () => repository.getMessagesByKind(

--- a/test/features/relationships/model/imported_contact_test.dart
+++ b/test/features/relationships/model/imported_contact_test.dart
@@ -190,7 +190,7 @@ void main() {
         _contact(
           channels: [_channel(ContactChannelType.mobile, '+15550109999')],
         ),
-        platformKey: 'ios',
+        refKey: 'ios:host-a',
         status: _activeStatus(),
       );
 
@@ -198,19 +198,35 @@ void main() {
       expect(data.contactChannels.single.value, '+15550109999');
     });
 
-    test('records the OS id under the platform that owns it', () {
+    test('records the OS id under the device key that owns it', () {
       final data = relationshipDataFromContact(
         _contact(id: 'ABC-123'),
-        platformKey: 'android',
+        refKey: 'android:host-a',
         status: _activeStatus(),
       );
 
       expect(
         data.contactRefs,
-        {'android': 'ABC-123'},
+        {'android:host-a': 'ABC-123'},
         reason:
-            'the same person has different ids on different devices, so '
+            'the same person has different ids in every address book, so '
             'a ref is only meaningful on the device that wrote it',
+      );
+    });
+
+    test('stores no ref at all when the device key is unknown', () {
+      final data = relationshipDataFromContact(
+        _contact(id: 'ABC-123'),
+        refKey: null,
+        status: _activeStatus(),
+      );
+
+      expect(
+        data.contactRefs,
+        isEmpty,
+        reason:
+            'an id parked under a made-up key could collide with a key '
+            'another device legitimately owns',
       );
     });
 
@@ -218,7 +234,7 @@ void main() {
         'without being asked for', () {
       final data = relationshipDataFromContact(
         _contact(),
-        platformKey: 'ios',
+        refKey: 'ios:host-a',
         status: _activeStatus(),
       );
 
@@ -229,7 +245,7 @@ void main() {
     test('honors the importance and cadence chosen on the review screen', () {
       final data = relationshipDataFromContact(
         _contact(),
-        platformKey: 'ios',
+        refKey: 'ios:host-a',
         status: _activeStatus(),
         important: true,
         checkInCadenceDays: 14,
@@ -242,7 +258,7 @@ void main() {
     test('starts a person with no channels rather than refusing them', () {
       final data = relationshipDataFromContact(
         _contact(),
-        platformKey: 'ios',
+        refKey: 'ios:host-a',
         status: _activeStatus(),
       );
 

--- a/test/features/relationships/state/contact_import_controller_test.dart
+++ b/test/features/relationships/state/contact_import_controller_test.dart
@@ -6,6 +6,8 @@ import 'package:lotti/features/relationships/model/imported_contact.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
 import 'package:lotti/features/relationships/state/contact_import_controller.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/vector_clock_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -80,11 +82,14 @@ void main() {
     repository = MockRelationshipRepository();
   });
 
-  ({ProviderContainer container, ContactImportController controller}) build() {
+  ({ProviderContainer container, ContactImportController controller}) build({
+    String? refKey = 'android:host-a',
+  }) {
     final container = ProviderContainer(
       overrides: [
         contactsServiceProvider.overrideWithValue(service),
         relationshipRepositoryProvider.overrideWithValue(repository),
+        contactRefKeyProvider.overrideWith((ref) async => refKey),
       ],
     );
     addTearDown(container.dispose);
@@ -489,25 +494,52 @@ void main() {
       },
     );
 
-    test('records the OS id under a platform key so a ref written on one '
-        'device is not trusted on another', () async {
-      final controller = build().controller
-        ..toggleSelection(contact('os-99', 'Anna'));
+    test(
+      "records the OS id under this device's key so a ref written on one "
+      'device is never trusted on another — not even a same-platform one',
+      () async {
+        final controller = build().controller
+          ..toggleSelection(contact('os-99', 'Anna'));
 
-      await controller.importSelected();
+        await controller.importSelected();
 
-      final data =
-          verify(
-                () => repository.createRelationship(
-                  data: captureAny(named: 'data'),
-                  entryText: any(named: 'entryText'),
-                  categoryId: any(named: 'categoryId'),
-                ),
-              ).captured.single
-              as RelationshipData;
+        final data =
+            verify(
+                  () => repository.createRelationship(
+                    data: captureAny(named: 'data'),
+                    entryText: any(named: 'entryText'),
+                    categoryId: any(named: 'categoryId'),
+                  ),
+                ).captured.single
+                as RelationshipData;
 
-      expect(data.contactRefs, {contactRefPlatformKey(): 'os-99'});
-    });
+        expect(data.contactRefs, {'android:host-a': 'os-99'});
+      },
+    );
+
+    test(
+      'imports without a ref while the host id is unknown, rather than '
+      'parking the id under a key another device could collide with',
+      () async {
+        final controller = build(refKey: null).controller
+          ..toggleSelection(contact('os-99', 'Anna'));
+
+        final ids = await controller.importSelected();
+
+        final data =
+            verify(
+                  () => repository.createRelationship(
+                    data: captureAny(named: 'data'),
+                    entryText: any(named: 'entryText'),
+                    categoryId: any(named: 'categoryId'),
+                  ),
+                ).captured.single
+                as RelationshipData;
+
+        expect(ids, isNotEmpty);
+        expect(data.contactRefs, isEmpty);
+      },
+    );
 
     test('imports in the order the user selected', () async {
       final controller = build().controller
@@ -597,6 +629,45 @@ void main() {
           categoryId: any(named: 'categoryId'),
         ),
       );
+    });
+  });
+
+  group('contactRefKeyProvider', () {
+    late MockVectorClockService vectorClockService;
+
+    setUp(() {
+      vectorClockService = MockVectorClockService();
+      when(
+        () => vectorClockService.initialized,
+      ).thenAnswer((_) => Future.value());
+      getIt.registerSingleton<VectorClockService>(vectorClockService);
+    });
+
+    tearDown(() => getIt.unregister<VectorClockService>());
+
+    test('scopes the key to this device via the sync host id', () async {
+      when(vectorClockService.getHost).thenAnswer((_) async => 'host-a');
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final key = await container.read(contactRefKeyProvider.future);
+
+      expect(key, contactRefKeyForHost('host-a'));
+      expect(
+        key,
+        endsWith(':host-a'),
+        reason:
+            'two devices on the same platform must land on different keys, '
+            'so the host id has to be part of the key',
+      );
+    });
+
+    test('yields no key while the host id is unprovisioned', () async {
+      when(vectorClockService.getHost).thenAnswer((_) async => null);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(await container.read(contactRefKeyProvider.future), isNull);
     });
   });
 }

--- a/test/features/relationships/state/contact_link_controller_test.dart
+++ b/test/features/relationships/state/contact_link_controller_test.dart
@@ -42,7 +42,10 @@ class _FakeContactsService implements ContactsService {
 
 void main() {
   final testDate = DateTime(2026, 8, 17, 12);
-  final platformKey = contactRefPlatformKey();
+  // Refs are per-device: the key carries this device's sync host id, and a
+  // same-platform key with a different host belongs to another device.
+  const deviceKey = 'android:host-a';
+  const otherDeviceKey = 'android:host-b';
 
   late _FakeContactsService service;
   late MockRelationshipRepository repository;
@@ -93,11 +96,12 @@ void main() {
     ),
   );
 
-  ContactLinkController build() {
+  ContactLinkController build({String? refKey = deviceKey}) {
     final container = ProviderContainer(
       overrides: [
         contactsServiceProvider.overrideWithValue(service),
         relationshipRepositoryProvider.overrideWithValue(repository),
+        contactRefKeyProvider.overrideWith((ref) async => refKey),
       ],
     );
     addTearDown(container.dispose);
@@ -133,7 +137,7 @@ void main() {
 
         await build().linkContact(person());
 
-        expect(savedData().contactRefs, {platformKey: 'os-42'});
+        expect(savedData().contactRefs, {deviceKey: 'os-42'});
       },
     );
 
@@ -189,7 +193,7 @@ void main() {
       final outcome = await build().linkContact(
         person(
           channels: [channel(ContactChannelType.mobile, '+15550109999')],
-          refs: {platformKey: 'os-1'},
+          refs: {deviceKey: 'os-1'},
         ),
       );
 
@@ -207,12 +211,12 @@ void main() {
       final outcome = await build().linkContact(
         person(
           channels: [channel(ContactChannelType.mobile, '+15550109999')],
-          refs: {platformKey: 'os-1'},
+          refs: {deviceKey: 'os-1'},
         ),
       );
 
       expect(outcome, ContactLinkOutcome.linked);
-      expect(savedData().contactRefs[platformKey], 'os-99');
+      expect(savedData().contactRefs[deviceKey], 'os-99');
     });
 
     test('reports a cancelled picker without writing anything', () async {
@@ -253,8 +257,45 @@ void main() {
       final outcome = await build().linkContact(person());
 
       expect(outcome, ContactLinkOutcome.linked);
-      expect(savedData().contactRefs, {platformKey: 'os-7'});
+      expect(savedData().contactRefs, {deviceKey: 'os-7'});
     });
+
+    test(
+      "writes only into this device's slot, leaving a ref another device "
+      'wrote untouched',
+      () async {
+        service.picked = contact(
+          id: 'os-42',
+          channels: [channel(ContactChannelType.mobile, '+15550109999')],
+        );
+
+        await build().linkContact(
+          person(refs: {otherDeviceKey: 'their-os-id'}),
+        );
+
+        expect(savedData().contactRefs, {
+          otherDeviceKey: 'their-os-id',
+          deviceKey: 'os-42',
+        });
+      },
+    );
+
+    test(
+      'copies channels without storing a ref while the host id is unknown, '
+      'rather than parking the id under a key another device could collide '
+      'with',
+      () async {
+        service.picked = contact(
+          id: 'os-42',
+          channels: [channel(ContactChannelType.mobile, '+15550109999')],
+        );
+
+        final outcome = await build(refKey: null).linkContact(person());
+
+        expect(outcome, ContactLinkOutcome.linked);
+        expect(savedData().contactRefs, isEmpty);
+      },
+    );
   });
 
   group('refreshFromContact', () {
@@ -269,7 +310,7 @@ void main() {
       final outcome = await build().refreshFromContact(
         person(
           channels: [channel(ContactChannelType.mobile, '+15550109999')],
-          refs: {platformKey: 'os-1'},
+          refs: {deviceKey: 'os-1'},
         ),
       );
 
@@ -280,7 +321,7 @@ void main() {
     test('reads the contact the stored ref names', () async {
       service.byId = contact(id: 'os-5');
 
-      await build().refreshFromContact(person(refs: {platformKey: 'os-5'}));
+      await build().refreshFromContact(person(refs: {deviceKey: 'os-5'}));
 
       expect(service.readByIdArg, 'os-5');
     });
@@ -298,17 +339,51 @@ void main() {
 
     test('treats an empty ref as no ref', () async {
       final outcome = await build().refreshFromContact(
-        person(refs: {platformKey: ''}),
+        person(refs: {deviceKey: ''}),
       );
 
       expect(outcome, ContactLinkOutcome.contactMissing);
     });
 
     test(
+      "never resolves a ref another device wrote — a same-platform peer's "
+      'contact id would name an unrelated person in this address book',
+      () async {
+        service.byId = contact(
+          name: 'Wrong Person',
+          channels: [channel(ContactChannelType.mobile, '+15550100000')],
+        );
+
+        final outcome = await build().refreshFromContact(
+          person(refs: {otherDeviceKey: 'os-1'}),
+        );
+
+        expect(outcome, ContactLinkOutcome.contactMissing);
+        expect(
+          service.readByIdArg,
+          isNull,
+          reason:
+              "the other device's id must not even be looked up — ids are "
+              'only meaningful in the address book that assigned them',
+        );
+        verifyNever(() => repository.updateRelationship(any()));
+      },
+    );
+
+    test('reports the contact missing while the host id is unknown', () async {
+      final outcome = await build(refKey: null).refreshFromContact(
+        person(refs: {deviceKey: 'os-1'}),
+      );
+
+      expect(outcome, ContactLinkOutcome.contactMissing);
+      expect(service.readByIdArg, isNull);
+    });
+
+    test(
       'reports the contact missing when it was deleted from the device',
       () async {
         final outcome = await build().refreshFromContact(
-          person(refs: {platformKey: 'os-gone'}),
+          person(refs: {deviceKey: 'os-gone'}),
         );
 
         expect(outcome, ContactLinkOutcome.contactMissing);
@@ -324,7 +399,7 @@ void main() {
       final outcome = await build().refreshFromContact(
         person(
           channels: [channel(ContactChannelType.mobile, '+15550109999')],
-          refs: {platformKey: 'os-1'},
+          refs: {deviceKey: 'os-1'},
         ),
       );
 
@@ -335,7 +410,7 @@ void main() {
       service.supported = false;
 
       expect(
-        await build().refreshFromContact(person(refs: {platformKey: 'os-1'})),
+        await build().refreshFromContact(person(refs: {deviceKey: 'os-1'})),
         ContactLinkOutcome.unsupported,
       );
     });
@@ -349,7 +424,7 @@ void main() {
       );
 
       expect(
-        await build().refreshFromContact(person(refs: {platformKey: 'os-1'})),
+        await build().refreshFromContact(person(refs: {deviceKey: 'os-1'})),
         ContactLinkOutcome.saveFailed,
       );
     });

--- a/test/features/relationships/ui/pages/contact_import_page_test.dart
+++ b/test/features/relationships/ui/pages/contact_import_page_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/model/imported_contact.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
+import 'package:lotti/features/relationships/state/contact_import_controller.dart';
 import 'package:lotti/features/relationships/ui/pages/contact_import_page.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -93,6 +94,9 @@ void main() {
         overrides: [
           contactsServiceProvider.overrideWithValue(service),
           relationshipRepositoryProvider.overrideWithValue(repository),
+          // The import writes the OS id into this device's own ref slot, so
+          // the key has to resolve without a live sync host id behind it.
+          contactRefKeyProvider.overrideWith((ref) async => 'android:host-a'),
         ],
       ),
     );
@@ -328,6 +332,9 @@ void main() {
           overrides: [
             contactsServiceProvider.overrideWithValue(service),
             relationshipRepositoryProvider.overrideWithValue(repository),
+            contactRefKeyProvider.overrideWith(
+              (ref) async => 'android:host-a',
+            ),
           ],
         ),
       );

--- a/test/features/relationships/ui/pages/relationships_page_test.dart
+++ b/test/features/relationships/ui/pages/relationships_page_test.dart
@@ -1,15 +1,17 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/relationships/model/imported_contact.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
 import 'package:lotti/features/relationships/ui/pages/relationships_page.dart';
+import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -64,6 +66,7 @@ void main() {
     String id, {
     required String title,
     bool important = false,
+    int? cadenceDays,
     DateTime? lastCheckInAt,
   }) => (
     relationship: RelationshipEntry(
@@ -77,6 +80,7 @@ void main() {
       data: RelationshipData(
         title: title,
         important: important,
+        checkInCadenceDays: cadenceDays,
         status: RelationshipStatus.active(
           id: 'status-$id',
           createdAt: testDate,
@@ -103,16 +107,16 @@ void main() {
     await getIt.unregister<EntitiesCacheService>();
   });
 
-  Widget buildPage() => makeTestableWidgetNoScroll(
-    const RelationshipsPage(),
-    overrides: [
-      relationshipRepositoryProvider.overrideWithValue(mockRepository),
-    ],
-  );
+  Widget buildPage({List<Override> overrides = const []}) =>
+      makeTestableWidgetNoScroll(
+        const RelationshipsPage(),
+        overrides: [
+          relationshipRepositoryProvider.overrideWithValue(mockRepository),
+          ...overrides,
+        ],
+      );
 
-  testWidgets('renders the empty state when nothing is tracked', (
-    tester,
-  ) async {
+  testWidgets('renders the empty state with an add affordance', (tester) async {
     when(
       () => mockRepository.getRelationshipsByRecency(),
     ).thenAnswer((_) async => []);
@@ -123,6 +127,25 @@ void main() {
     expect(
       find.text('Add the people you want to stay close to.'),
       findsOneWidget,
+    );
+    // Two: the persistent header circle plus the empty state's own inline
+    // CTA (design plan §1). With people present only the header one remains
+    // — asserted by 'the import door sits beside the add circle' below.
+    expect(find.byIcon(LottiIcons.add), findsNWidgets(2));
+  });
+
+  testWidgets('shows the error text when the first load fails', (tester) async {
+    when(
+      () => mockRepository.getRelationshipsByRecency(),
+    ).thenThrow(Exception('db gone'));
+
+    await tester.pumpWidget(buildPage());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Error'), findsOneWidget);
+    expect(
+      find.text('Add the people you want to stay close to.'),
+      findsNothing,
     );
   });
 
@@ -169,25 +192,6 @@ void main() {
     },
   );
 
-  testWidgets('reports a failed first load instead of an empty tab', (
-    tester,
-  ) async {
-    when(
-      () => mockRepository.getRelationshipsByRecency(),
-    ).thenThrow(Exception('db gone'));
-
-    await tester.pumpWidget(buildPage());
-    await tester.pumpAndSettle();
-
-    expect(find.text('Error'), findsOneWidget);
-    // Never the "you have no people" copy — that would read as data loss.
-    expect(
-      find.text('Add the people you want to stay close to.'),
-      findsNothing,
-    );
-    expect(find.byType(CircularProgressIndicator), findsNothing);
-  });
-
   testWidgets('tapping a row beams to that person', (tester) async {
     when(() => mockRepository.getRelationshipsByRecency()).thenAnswer(
       (_) async => [item('rel-1', title: 'Anna')],
@@ -205,7 +209,9 @@ void main() {
     expect(beamedTo, ['/people/rel-1']);
   });
 
-  testWidgets('the FAB opens the add-person form', (tester) async {
+  testWidgets('the header add circle opens the add-person form', (
+    tester,
+  ) async {
     when(
       () => mockRepository.getRelationshipsByRecency(),
     ).thenAnswer((_) async => []);
@@ -213,17 +219,25 @@ void main() {
     await tester.pumpWidget(buildPage());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Add person'));
+    // The only add affordances are circles (design plan §0.3): no FAB, no
+    // app-bar person-add icon. With an empty list there are two — the header
+    // circle and the empty state's inline CTA — and the header is built
+    // first, so `.first` is the one this test is about.
+    final addIcons = find.byIcon(LottiIcons.add);
+    expect(addIcons, findsNWidgets(2));
+
+    await tester.tap(addIcons.first);
     await tester.pumpAndSettle();
 
-    // Create mode: the name field is up, and the edit-only status picker
-    // is not.
+    // Create mode: the name field is up, and the edit-only status picker is
+    // not.
     expect(find.text('Name'), findsOneWidget);
     expect(find.text('Status'), findsNothing);
   });
 
   testWidgets(
-    'renders one row per relationship and stars only important ones',
+    'renders one row per relationship, with persona avatars and inline stars '
+    'only for important people',
     (tester) async {
       when(() => mockRepository.getRelationshipsByRecency()).thenAnswer(
         (_) async => [
@@ -237,33 +251,30 @@ void main() {
         ],
       );
 
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
+      await withClock(Clock.fixed(testDate), () async {
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+      });
 
       expect(find.text('Anna'), findsOneWidget);
       expect(find.text('Ben'), findsOneWidget);
-      // Exactly one star: Anna is important, Ben is not.
-      expect(find.byIcon(LottiIcons.star), findsOneWidget);
-      // Anna's subtitle is her last check-in, Ben's his tracking start —
-      // and each names itself: on a recency screen a person added today
-      // must not read as recently contacted.
+      // Persona avatars replace the bare person icon.
+      expect(find.byType(PersonaAvatar), findsNWidgets(2));
+      // Exactly one star: Anna is important, Ben is not. The star is inline
+      // with the name (11px), not a trailing app-bar icon.
+      expect(find.byIcon(LottiIconsFilled.star), findsOneWidget);
+      // The status line is the last meaningful event, mono — "Checked in …",
+      // never "Tracking since …" (design plan §0.8).
       final context = tester.element(find.byType(RelationshipsPage));
       expect(
         find.text(
-          context.messages.relationshipLastCheckInLabel(
-            entryDateLabelForTest(tester, DateTime(2026, 8, 12, 18)),
-          ),
+          context.messages.relationshipCheckedInLabel('Yesterday 18:00'),
         ),
         findsOneWidget,
       );
-      expect(
-        find.text(
-          context.messages.relationshipTrackingSinceLabel(
-            entryDateLabelForTest(tester, testDate),
-          ),
-        ),
-        findsOneWidget,
-      );
+      // Ben has no check-in: the quiet-streak caption (here 0 days → "Just
+      // added"), never "Tracking since …".
+      expect(find.text(context.messages.relationshipJustAdded), findsOneWidget);
       expect(
         find.text('Add the people you want to stay close to.'),
         findsNothing,
@@ -288,43 +299,46 @@ void main() {
     expect(find.text('Anna'), findsOneWidget);
   });
 
-  testWidgets('a notification-triggered reload keeps the previous rows on '
-      'screen — the no-flash house rule, pinned', (tester) async {
-    final updates = StreamController<Set<String>>.broadcast();
-    addTearDown(updates.close);
-    when(
-      () => mockNotifications.updateStream,
-    ).thenAnswer((_) => updates.stream);
-    var calls = 0;
-    final second = Completer<List<RelationshipListItem>>();
-    when(() => mockRepository.getRelationshipsByRecency()).thenAnswer((_) {
-      calls++;
-      if (calls == 1) {
-        return Future.value([item('rel-1', title: 'Anna')]);
-      }
-      return second.future;
-    });
+  testWidgets(
+    'a notification-triggered reload keeps the previous rows on screen — '
+    'the no-flash house rule, pinned',
+    (tester) async {
+      final updates = StreamController<Set<String>>.broadcast();
+      addTearDown(updates.close);
+      when(
+        () => mockNotifications.updateStream,
+      ).thenAnswer((_) => updates.stream);
+      var calls = 0;
+      final second = Completer<List<RelationshipListItem>>();
+      when(() => mockRepository.getRelationshipsByRecency()).thenAnswer((_) {
+        calls++;
+        if (calls == 1) {
+          return Future.value([item('rel-1', title: 'Anna')]);
+        }
+        return second.future;
+      });
 
-    await tester.pumpWidget(buildPage());
-    await tester.pumpAndSettle();
-    expect(find.text('Anna'), findsOneWidget);
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+      expect(find.text('Anna'), findsOneWidget);
 
-    updates.add({relationshipNotification});
-    await tester.pump();
-    await tester.pump();
+      updates.add({relationshipNotification});
+      await tester.pump();
+      await tester.pump();
 
-    // Mid-refetch: the established list must stay, with no loading shell.
-    expect(calls, 2);
-    expect(find.text('Anna'), findsOneWidget);
-    expect(find.byType(CircularProgressIndicator), findsNothing);
+      // Mid-refetch: the established list must stay, with no loading shell.
+      expect(calls, 2);
+      expect(find.text('Anna'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
 
-    second.complete([
-      item('rel-1', title: 'Anna'),
-      item('rel-2', title: 'Ben'),
-    ]);
-    await tester.pumpAndSettle();
-    expect(find.text('Ben'), findsOneWidget);
-  });
+      second.complete([
+        item('rel-1', title: 'Anna'),
+        item('rel-2', title: 'Ben'),
+      ]);
+      await tester.pumpAndSettle();
+      expect(find.text('Ben'), findsOneWidget);
+    },
+  );
 
   // The import screen docks its Import action in a `bottomNavigationBar`, and
   // the mobile shell paints the nav pill over each tab's page stack — so a
@@ -365,11 +379,110 @@ void main() {
     expect(rootObserver.pushes, 1, reason: 'pushed above the shell');
     expect(nestedObserver.pushes, 0, reason: 'never onto the tab navigator');
   });
+
+  testWidgets('hides the import door on unsupported platforms (desktop)', (
+    tester,
+  ) async {
+    when(
+      () => mockRepository.getRelationshipsByRecency(),
+    ).thenAnswer((_) async => []);
+
+    await tester.pumpWidget(
+      buildPage(
+        overrides: [
+          contactsServiceProvider.overrideWithValue(
+            _UnsupportedContactsService(),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(LottiIcons.contactImport), findsNothing);
+    // Hiding the import door leaves the add circles untouched: the header's
+    // and, because this case has no people, the empty state's.
+    expect(find.byIcon(LottiIcons.add), findsNWidgets(2));
+  });
+
+  testWidgets('sorts due people ahead of on-track people', (tester) async {
+    // Anna: due (last check-in 10 days ago, weekly cadence).
+    // Ben:  on track (last check-in today, weekly cadence).
+    when(() => mockRepository.getRelationshipsByRecency()).thenAnswer(
+      (_) async => [
+        item(
+          'rel-ben',
+          title: 'Ben',
+          cadenceDays: 7,
+          lastCheckInAt: DateTime(2026, 8, 13, 9),
+        ),
+        item(
+          'rel-anna',
+          title: 'Anna',
+          cadenceDays: 7,
+          lastCheckInAt: DateTime(2026, 8, 3, 9),
+        ),
+      ],
+    );
+
+    await withClock(Clock.fixed(testDate), () async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+    });
+
+    // Anna (due) renders above Ben (on track).
+    expect(find.text('Anna'), findsOneWidget);
+    expect(find.text('Ben'), findsOneWidget);
+    // The due pill is the warning-tinted "Due {day}" label.
+    final context = tester.element(find.byType(RelationshipsPage));
+    // Anna's last check-in was 2026-08-03; +7 days of cadence is
+    // 2026-08-10, a Monday.
+    final dueLabel = find.text(
+      context.messages.relationshipDueDay('Mon'),
+    );
+    expect(dueLabel, findsOneWidget);
+    expect(
+      find.text(context.messages.relationshipCadenceOnTrack),
+      findsOneWidget,
+    );
+    // Anna's row sits above Ben's: her text is found first in the column.
+    final annaCenter = tester.getCenter(find.text('Anna'));
+    final benCenter = tester.getCenter(find.text('Ben'));
+    expect(annaCenter.dy, lessThan(benCenter.dy));
+  });
+
+  testWidgets('a person with no cadence shows no cadence pill', (tester) async {
+    when(() => mockRepository.getRelationshipsByRecency()).thenAnswer(
+      (_) async => [item('rel-1', title: 'Anna')],
+    );
+
+    await tester.pumpWidget(buildPage());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Anna'), findsOneWidget);
+    final context = tester.element(find.byType(RelationshipsPage));
+    expect(
+      find.text(context.messages.relationshipCadenceOnTrack),
+      findsNothing,
+    );
+  });
 }
 
-/// Resolves [entryDateLabel] against the pumped widget tree's locale, so the
-/// assertion tracks the production formatting instead of duplicating it.
-String entryDateLabelForTest(WidgetTester tester, DateTime date) {
-  final context = tester.element(find.byType(RelationshipsPage));
-  return entryDateLabel(context, date);
+class _UnsupportedContactsService implements ContactsService {
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<ContactsAccess> requestReadAccess() async => ContactsAccess.denied;
+
+  @override
+  Future<ImportedContact?> pickSingle() async => null;
+
+  @override
+  Future<List<ImportedContact>> readAll() async => const [];
+
+  @override
+  Future<ImportedContact?> readById(String id) async => null;
+
+  @override
+  Future<void> openSystemSettings() async {}
 }

--- a/test/features/relationships/ui/shared/ds_choice_pills_test.dart
+++ b/test/features/relationships/ui/shared/ds_choice_pills_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/relationships/ui/shared/ds_choice_pills.dart';
+
+import '../../../../widget_test_utils.dart';
+
+enum _Flavor { apple, banana, cherry }
+
+void main() {
+  group('DsChoicePills', () {
+    Widget build<T>({
+      required T? value,
+      required List<T> values,
+      required String Function(T) labelFor,
+      required void Function(T) onSelected,
+    }) {
+      return MaterialApp(
+        theme: resolveTestTheme(),
+        home: Scaffold(
+          body: DsChoicePills<T>(
+            value: value,
+            values: values,
+            labelFor: labelFor,
+            onSelected: onSelected,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders one pill per value with the label', (tester) async {
+      await tester.pumpWidget(
+        build<_Flavor>(
+          value: _Flavor.banana,
+          values: _Flavor.values,
+          labelFor: (_Flavor f) => f.name,
+          onSelected: (_) {},
+        ),
+      );
+      expect(find.text('apple'), findsOneWidget);
+      expect(find.text('banana'), findsOneWidget);
+      expect(find.text('cherry'), findsOneWidget);
+    });
+
+    testWidgets('marks only the selected value as selected', (tester) async {
+      await tester.pumpWidget(
+        build<_Flavor>(
+          value: _Flavor.cherry,
+          values: _Flavor.values,
+          labelFor: (_Flavor f) => f.name,
+          onSelected: (_) {},
+        ),
+      );
+      // The selected pill's text is bold (w700) per DsPill.
+      final banana = tester.widget<Text>(find.text('banana'));
+      final cherry = tester.widget<Text>(find.text('cherry'));
+      expect(banana.style?.fontWeight, isNot(FontWeight.w700));
+      expect(cherry.style?.fontWeight, FontWeight.w700);
+    });
+
+    testWidgets('taps call onSelected with the tapped value', (tester) async {
+      _Flavor? picked;
+      await tester.pumpWidget(
+        build<_Flavor>(
+          value: _Flavor.apple,
+          values: _Flavor.values,
+          labelFor: (_Flavor f) => f.name,
+          onSelected: (_Flavor f) => picked = f,
+        ),
+      );
+
+      await tester.tap(find.text('cherry'));
+      expect(picked, _Flavor.cherry);
+    });
+
+    testWidgets('renders nothing when values is empty', (tester) async {
+      await tester.pumpWidget(
+        build<_Flavor>(
+          value: null,
+          values: const [],
+          labelFor: (_Flavor f) => f.name,
+          onSelected: (_) {},
+        ),
+      );
+      expect(find.byType(DsChoicePills<_Flavor>), findsOneWidget);
+      expect(find.text('apple'), findsNothing);
+    });
+
+    testWidgets('scrolls horizontally (never wraps to a second row)', (
+      tester,
+    ) async {
+      // Many long labels would wrap a Row; the row is inside a horizontal
+      // SingleChildScrollView, so it never wraps.
+      await tester.pumpWidget(
+        build<String>(
+          value: null,
+          values: List.generate(20, (i) => 'option-$i-very-long-label'),
+          labelFor: (String s) => s,
+          onSelected: (_) {},
+        ),
+      );
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      expect(
+        tester
+            .widget<SingleChildScrollView>(find.byType(SingleChildScrollView))
+            .scrollDirection,
+        Axis.horizontal,
+      );
+    });
+  });
+}

--- a/test/features/relationships/ui/shared/persona_avatar_test.dart
+++ b/test/features/relationships/ui/shared/persona_avatar_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('personaAccentForId', () {
+    test('is stable for the same id across calls', () {
+      final a = personaAccentForId('rel-1', Brightness.dark);
+      final b = personaAccentForId('rel-1', Brightness.dark);
+      expect(a, b);
+    });
+
+    test('is stable across brightness only when the palette agrees', () {
+      // Different brightness can resolve to a different value; the contract
+      // is stability *per brightness*, not across brightness.
+      final dark = personaAccentForId('rel-1', Brightness.dark);
+      final light = personaAccentForId('rel-1', Brightness.light);
+      expect(dark, isA<Color>());
+      expect(light, isA<Color>());
+    });
+
+    test('distributes across ids (not every id maps to the same accent)', () {
+      final accents = {
+        for (final id in ['rel-1', 'rel-2', 'rel-3', 'rel-4', 'rel-5', 'rel-6'])
+          id: personaAccentForId(id, Brightness.dark),
+      };
+      expect(accents.values.toSet().length, greaterThan(1));
+    });
+
+    test('every accent comes from the exported token sets — no widget-local '
+        'color literals', () {
+      for (final brightness in Brightness.values) {
+        final tokens = brightness == Brightness.dark
+            ? dsTokensDark
+            : dsTokensLight;
+        final tokenAccents = {
+          tokens.colors.interactive.enabled,
+          GoalAccentHues.neon(brightness),
+          GoalAccentHues.aurora(brightness),
+          tokens.colors.alert.warning.ink,
+          tokens.colors.alert.info.ink,
+          tokens.colors.alert.success.ink,
+        };
+        for (var i = 0; i < 64; i++) {
+          expect(
+            tokenAccents,
+            contains(personaAccentForId('rel-$i', brightness)),
+            reason:
+                'persona accents must resolve to design-system tokens so '
+                'palette changes propagate from the token export',
+          );
+        }
+      }
+    });
+  });
+
+  group('personaInitial', () {
+    test('returns the uppercased first letter of a name', () {
+      expect(personaInitial('Anna'), 'A');
+      expect(personaInitial('ben'), 'B');
+      expect(personaInitial('  carla  '), 'C');
+    });
+
+    test('falls back to a middot for empty or null names', () {
+      expect(personaInitial(''), '·');
+      expect(personaInitial(null), '·');
+      expect(personaInitial('   '), '·');
+    });
+  });
+
+  group('PersonaAvatar', () {
+    testWidgets('renders the initial and derives the accent from id', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: const PersonaAvatar(initial: 'A', id: 'rel-1'),
+        ),
+      );
+
+      expect(find.text('A'), findsOneWidget);
+      // The avatar circle is a Container with a BoxShape.circle decoration.
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.shape, BoxShape.circle);
+    });
+
+    testWidgets('honours an explicit accent over the id', (tester) async {
+      const accent = Color(0xFF123456);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: const PersonaAvatar(initial: 'A', id: 'rel-1', accent: accent),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, accent.withValues(alpha: 0.20));
+    });
+
+    testWidgets('asserts when neither id nor accent is given', (tester) async {
+      // The constructor's `id != null || accent != null` assertion is a
+      // hard failure, so constructing it directly is the cleanest proof.
+      expect(
+        () => PersonaAvatar(initial: 'A'),
+        throwsA(isA<Object>()),
+      );
+    });
+
+    testWidgets('uses the middot for an empty initial', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: const PersonaAvatar(initial: '', id: 'rel-1'),
+        ),
+      );
+      expect(find.text('·'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/relationships/ui/shared/relationship_timestamps_test.dart
+++ b/test/features/relationships/ui/shared/relationship_timestamps_test.dart
@@ -1,0 +1,284 @@
+// Explicit date/time components are the point of a timestamp-formatting test:
+// `DateTime(2026, 8, 15, 9, 0)` reads as 09:00 on a specific day, while
+// trimming the defaults leaves a bare hour that has to be decoded.
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+
+void main() {
+  final now = DateTime(2026, 8, 18, 14, 20);
+
+  group('relationshipTimestampLabel', () {
+    test('same day reads "Today HH:MM"', () {
+      withClock(Clock.fixed(now), () {
+        final earlier = DateTime(2026, 8, 18, 9, 5);
+        expect(relationshipTimestampLabel(earlier), 'Today 09:05');
+      });
+    });
+
+    // The most common non-today value on this surface: a check-in logged the
+    // previous evening. Rendering it as a date makes the reader work out what
+    // yesterday's date was.
+    test('the previous calendar day reads "Yesterday HH:MM"', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          relationshipTimestampLabel(DateTime(2026, 8, 17, 18)),
+          'Yesterday 18:00',
+        );
+      });
+    });
+
+    // "Yesterday" is a calendar-day question, not a 24-hour one: 00:01 and
+    // 23:59 yesterday are both yesterday, however many hours ago they were.
+    test('yesterday holds across the whole calendar day', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          relationshipTimestampLabel(DateTime(2026, 8, 17, 0, 1)),
+          'Yesterday 00:01',
+        );
+        expect(
+          relationshipTimestampLabel(DateTime(2026, 8, 17, 23, 59)),
+          'Yesterday 23:59',
+        );
+      });
+    });
+
+    // The previous day is built from calendar components, so it crosses a
+    // month boundary — and survives a DST shift, where subtracting 24 hours
+    // can land back on the same date.
+    test('yesterday crosses a month boundary', () {
+      expect(
+        relationshipTimestampLabel(
+          DateTime(2026, 8, 31, 21, 30),
+          now: DateTime(2026, 9, 1, 8),
+        ),
+        'Yesterday 21:30',
+      );
+    });
+
+    test('two days back reads "Www D Mon HH:MM"', () {
+      withClock(Clock.fixed(now), () {
+        // 2026-08-16 is a Sunday — two days before the fixed now.
+        expect(
+          relationshipTimestampLabel(DateTime(2026, 8, 16, 19, 5)),
+          'Sun 16 Aug 19:05',
+        );
+      });
+    });
+
+    test('a different day reads "Www D Mon HH:MM"', () {
+      withClock(Clock.fixed(now), () {
+        // 2026-08-21 is a Friday.
+        final fri = DateTime(2026, 8, 21, 19, 5);
+        expect(relationshipTimestampLabel(fri), 'Fri 21 Aug 19:05');
+      });
+    });
+
+    test('honours an explicit now override', () {
+      withClock(Clock.fixed(DateTime(2020, 1, 1)), () {
+        // 2026-08-15 is a Saturday.
+        final at = DateTime(2026, 8, 15, 19, 5);
+        // A now on the next day is exactly the "Yesterday" case.
+        expect(
+          relationshipTimestampLabel(at, now: DateTime(2026, 8, 16, 8)),
+          'Yesterday 19:05',
+        );
+        // Two days on, the date comes back.
+        expect(
+          relationshipTimestampLabel(at, now: DateTime(2026, 8, 17, 8)),
+          'Sat 15 Aug 19:05',
+        );
+        // A now on the same day collapses to "Today".
+        expect(
+          relationshipTimestampLabel(at, now: DateTime(2026, 8, 15, 20)),
+          'Today 19:05',
+        );
+      });
+    });
+  });
+
+  group('relationshipTimeLabel', () {
+    test('renders HH:MM with leading zeros', () {
+      expect(relationshipTimeLabel(DateTime(2026, 8, 18, 7, 9)), '07:09');
+      expect(relationshipTimeLabel(DateTime(2026, 8, 18, 14, 20)), '14:20');
+    });
+  });
+
+  group('relationshipWeekdayLabel', () {
+    test('returns the 3-letter weekday abbreviation', () {
+      expect(relationshipWeekdayLabel(DateTime(2026, 8, 17)), 'Mon');
+      expect(relationshipWeekdayLabel(DateTime(2026, 8, 18)), 'Tue');
+      expect(relationshipWeekdayLabel(DateTime(2026, 8, 21)), 'Fri');
+    });
+  });
+
+  group('cadenceDueDate', () {
+    test('returns null when there is no cadence', () {
+      expect(
+        cadenceDueDate(
+          lastCheckInAt: now,
+          trackingStartedAt: now,
+          cadenceDays: null,
+        ),
+        isNull,
+      );
+      expect(
+        cadenceDueDate(
+          lastCheckInAt: now,
+          trackingStartedAt: now,
+          cadenceDays: 0,
+        ),
+        isNull,
+      );
+    });
+
+    test('is cadenceDays after the last check-in', () {
+      withClock(Clock.fixed(now), () {
+        final last = DateTime(2026, 8, 11, 10, 0);
+        expect(
+          cadenceDueDate(
+            lastCheckInAt: last,
+            trackingStartedAt: now,
+            cadenceDays: 7,
+          ),
+          DateTime(2026, 8, 18, 10, 0),
+        );
+      });
+    });
+
+    test('falls back to tracking start when no check-in exists yet', () {
+      withClock(Clock.fixed(now), () {
+        final started = DateTime(2026, 8, 1, 9, 0);
+        expect(
+          cadenceDueDate(
+            lastCheckInAt: null,
+            trackingStartedAt: started,
+            cadenceDays: 14,
+          ),
+          DateTime(2026, 8, 15, 9, 0),
+        );
+      });
+    });
+
+    test('falls back to now when neither date is known', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          cadenceDueDate(
+            lastCheckInAt: null,
+            trackingStartedAt: null,
+            cadenceDays: 7,
+          ),
+          now.add(const Duration(days: 7)),
+        );
+      });
+    });
+  });
+
+  group('cadenceOverdueDays', () {
+    test('null when there is no cadence', () {
+      expect(
+        cadenceOverdueDays(
+          lastCheckInAt: now,
+          trackingStartedAt: now,
+          cadenceDays: null,
+        ),
+        isNull,
+      );
+    });
+
+    test('positive when the cadence is overdue', () {
+      withClock(Clock.fixed(now), () {
+        // Last check-in 10 days ago with a weekly cadence → due 3 days ago.
+        final overdue = cadenceOverdueDays(
+          lastCheckInAt: DateTime(2026, 8, 8, 10, 0),
+          trackingStartedAt: now,
+          cadenceDays: 7,
+        );
+        expect(overdue, 3);
+      });
+    });
+
+    test('negative when the cadence is still ahead', () {
+      withClock(Clock.fixed(now), () {
+        final ahead = cadenceOverdueDays(
+          lastCheckInAt: DateTime(2026, 8, 16, 10, 0),
+          trackingStartedAt: now,
+          cadenceDays: 7,
+        );
+        expect(ahead, -5);
+      });
+    });
+
+    test('zero on the due day', () {
+      withClock(Clock.fixed(now), () {
+        final due = cadenceOverdueDays(
+          lastCheckInAt: DateTime(2026, 8, 11, 14, 20),
+          trackingStartedAt: now,
+          cadenceDays: 7,
+        );
+        expect(due, 0);
+      });
+    });
+  });
+
+  group('quietStreakDays', () {
+    test('whole days since the last check-in', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          quietStreakDays(
+            lastCheckInAt: DateTime(2026, 8, 9, 10, 0),
+            trackingStartedAt: now,
+          ),
+          9,
+        );
+      });
+    });
+
+    test('same-day check-in is 0, not 1', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          quietStreakDays(
+            lastCheckInAt: DateTime(2026, 8, 18, 6, 0),
+            trackingStartedAt: now,
+          ),
+          0,
+        );
+      });
+    });
+
+    test('falls back to tracking start when no check-in exists', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          quietStreakDays(
+            lastCheckInAt: null,
+            trackingStartedAt: DateTime(2026, 8, 9, 10, 0),
+          ),
+          9,
+        );
+      });
+    });
+
+    test('zero when neither date is known', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          quietStreakDays(lastCheckInAt: null, trackingStartedAt: null),
+          0,
+        );
+      });
+    });
+
+    test('never negative when the check-in is in the future', () {
+      withClock(Clock.fixed(now), () {
+        expect(
+          quietStreakDays(
+            lastCheckInAt: now.add(const Duration(days: 2)),
+            trackingStartedAt: now,
+          ),
+          0,
+        );
+      });
+    });
+  });
+}

--- a/test/features/relationships/ui/shared/sentiment_test.dart
+++ b/test/features/relationships/ui/shared/sentiment_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/ui/shared/sentiment.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('sentimentColor', () {
+    testWidgets('maps each sentiment to the design-plan color', (tester) async {
+      late DsTokens tokens;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: Builder(
+            builder: (context) {
+              tokens = context.designTokens;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(
+        sentimentColor(tokens, CheckInSentiment.delightful),
+        tokens.colors.interactive.enabled,
+      );
+      expect(
+        sentimentColor(tokens, CheckInSentiment.good),
+        tokens.colors.alert.success.defaultColor,
+      );
+      expect(
+        sentimentColor(tokens, CheckInSentiment.strained),
+        tokens.colors.alert.warning.defaultColor,
+      );
+      expect(
+        sentimentColor(tokens, CheckInSentiment.difficult),
+        tokens.colors.alert.error.defaultColor,
+      );
+    });
+
+    testWidgets('neutral is foreground at 38% alpha', (tester) async {
+      late DsTokens tokens;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: Builder(
+            builder: (context) {
+              tokens = context.designTokens;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final neutral = sentimentColor(tokens, CheckInSentiment.neutral);
+      expect(neutral, tokens.colors.text.highEmphasis.withValues(alpha: 0.38));
+    });
+
+    testWidgets('sentimentPillFill is the sentiment hue at 16% alpha', (
+      tester,
+    ) async {
+      late DsTokens tokens;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: Builder(
+            builder: (context) {
+              tokens = context.designTokens;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(
+        sentimentPillFill(tokens, CheckInSentiment.delightful),
+        tokens.colors.interactive.enabled.withValues(alpha: 0.16),
+      );
+    });
+
+    testWidgets('sentimentDotColor falls back to the neutral tone for null', (
+      tester,
+    ) async {
+      late DsTokens tokens;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: Builder(
+            builder: (context) {
+              tokens = context.designTokens;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(
+        sentimentDotColor(tokens, null),
+        sentimentNeutralColor(tokens),
+      );
+      expect(
+        sentimentDotColor(tokens, CheckInSentiment.good),
+        sentimentColor(tokens, CheckInSentiment.good),
+      );
+    });
+
+    testWidgets('sentimentRingColor matches the dot color', (tester) async {
+      late DsTokens tokens;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: resolveTestTheme(),
+          home: Builder(
+            builder: (context) {
+              tokens = context.designTokens;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(
+        sentimentRingColor(tokens, CheckInSentiment.difficult),
+        sentimentColor(tokens, CheckInSentiment.difficult),
+      );
+    });
+  });
+}

--- a/test/features/relationships/ui/widgets/contact_link_action_test.dart
+++ b/test/features/relationships/ui/widgets/contact_link_action_test.dart
@@ -62,7 +62,8 @@ class _FakeContactLinkController implements ContactLinkController {
 
 void main() {
   final testDate = DateTime(2026, 8, 17, 12);
-  final platformKey = contactRefPlatformKey();
+  // Refs are per-device: the key carries this device's sync host id.
+  const deviceKey = 'android:host-a';
 
   RelationshipEntry person({Map<String, String> refs = const {}}) =>
       RelationshipEntry(
@@ -99,6 +100,7 @@ void main() {
             _FakeContactsService(supported: supported),
           ),
           contactLinkControllerProvider.overrideWithValue(controller),
+          contactRefKeyProvider.overrideWith((ref) async => deviceKey),
         ],
       ),
     );
@@ -115,25 +117,34 @@ void main() {
     });
 
     testWidgets('a linked person gets the menu instead', (tester) async {
-      await pump(tester, relationship: person(refs: {platformKey: 'os-1'}));
+      await pump(tester, relationship: person(refs: {deviceKey: 'os-1'}));
 
       expect(find.byIcon(LottiIcons.contactCard), findsOneWidget);
       expect(find.byIcon(LottiIcons.findPerson), findsNothing);
     });
 
     testWidgets('an empty ref counts as unlinked', (tester) async {
-      await pump(tester, relationship: person(refs: {platformKey: ''}));
+      await pump(tester, relationship: person(refs: {deviceKey: ''}));
 
       expect(find.byIcon(LottiIcons.findPerson), findsOneWidget);
     });
 
-    testWidgets('a ref belonging to another platform counts as unlinked — '
-        'refs do not travel between devices', (tester) async {
-      final otherPlatform = platformKey == 'ios' ? 'android' : 'ios';
+    testWidgets('a ref another device wrote counts as unlinked — even one '
+        'from a device on the same platform', (tester) async {
+      await pump(
+        tester,
+        relationship: person(
+          refs: {'android:host-b': 'os-1', 'ios:host-c': 'os-2'},
+        ),
+      );
 
-      await pump(tester, relationship: person(refs: {otherPlatform: 'os-1'}));
-
-      expect(find.byIcon(LottiIcons.findPerson), findsOneWidget);
+      expect(
+        find.byIcon(LottiIcons.findPerson),
+        findsOneWidget,
+        reason:
+            'offering "update from contact" here would resolve another '
+            "device's contact id against this device's address book",
+      );
     });
 
     testWidgets('renders nothing where there is no address book', (
@@ -150,7 +161,7 @@ void main() {
     testWidgets('offers refreshing and re-linking as separate intents', (
       tester,
     ) async {
-      await pump(tester, relationship: person(refs: {platformKey: 'os-1'}));
+      await pump(tester, relationship: person(refs: {deviceKey: 'os-1'}));
 
       await tester.tap(find.byIcon(LottiIcons.contactCard));
       await tester.pumpAndSettle();
@@ -162,7 +173,7 @@ void main() {
     testWidgets('refreshing re-reads the linked contact', (tester) async {
       final controller = await pump(
         tester,
-        relationship: person(refs: {platformKey: 'os-1'}),
+        relationship: person(refs: {deviceKey: 'os-1'}),
       );
 
       await tester.tap(find.byIcon(LottiIcons.contactCard));
@@ -176,7 +187,7 @@ void main() {
     testWidgets('re-linking opens the picker instead', (tester) async {
       final controller = await pump(
         tester,
-        relationship: person(refs: {platformKey: 'os-1'}),
+        relationship: person(refs: {deviceKey: 'os-1'}),
       );
 
       await tester.tap(find.byIcon(LottiIcons.contactCard));

--- a/test/logic/persistence_definition_ops_test.dart
+++ b/test/logic/persistence_definition_ops_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
@@ -23,6 +24,7 @@ import '../widget_test_utils.dart';
 void main() {
   late MockPersistenceLogic logic;
   late MockNotificationService notificationService;
+  late MockNotificationScheduler notificationScheduler;
   late MockOutboxService outboxService;
   late PersistenceDefinitionOps ops;
   late TestGetItMocks mocks;
@@ -46,14 +48,19 @@ void main() {
   setUp(() async {
     registerAllFallbackValues();
     notificationService = MockNotificationService();
+    notificationScheduler = MockNotificationScheduler();
     outboxService = MockOutboxService();
     mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt
           ..registerSingleton<OutboxService>(outboxService)
-          ..registerSingleton<NotificationService>(notificationService);
+          ..registerSingleton<NotificationService>(notificationService)
+          ..registerSingleton<NotificationScheduler>(notificationScheduler);
       },
     );
+    when(
+      () => notificationScheduler.reconcile(now: any(named: 'now')),
+    ).thenAnswer((_) async {});
     logic = MockPersistenceLogic();
     ops = PersistenceDefinitionOps(logic);
 
@@ -217,6 +224,56 @@ void main() {
       // the setting as unsaved.
       await expectLater(
         ops.setConfigFlagImpl(notificationsFlag(status: false)),
+        completes,
+      );
+    });
+
+    test(
+      'switching on re-arms reminders written while the flag was off',
+      () async {
+        withStoredStatus(status: false);
+
+        await ops.setConfigFlagImpl(notificationsFlag(status: true));
+
+        // Rows created while the flag was off never armed an OS alarm, and the
+        // repository's idempotent creates skip existing rows — without this
+        // reconcile, only the next app start would arm them.
+        verify(
+          () => notificationScheduler.reconcile(now: any(named: 'now')),
+        ).called(1);
+      },
+    );
+
+    test('switching off does not touch the armed alarms', () async {
+      withStoredStatus(status: true);
+
+      await ops.setConfigFlagImpl(notificationsFlag(status: false));
+
+      verifyNever(
+        () => notificationScheduler.reconcile(now: any(named: 'now')),
+      );
+    });
+
+    test('re-writing an already-on flag does not reconcile', () async {
+      withStoredStatus(status: true);
+
+      await ops.setConfigFlagImpl(notificationsFlag(status: true));
+
+      verifyNever(
+        () => notificationScheduler.reconcile(now: any(named: 'now')),
+      );
+    });
+
+    test('a reconcile failure does not fail the settings write', () async {
+      withStoredStatus(status: false);
+      when(
+        () => notificationScheduler.reconcile(now: any(named: 'now')),
+      ).thenThrow(StateError('db gone'));
+
+      // Same contract as the badge: the setting is saved, re-arming alarms is
+      // best-effort and logged.
+      await expectLater(
+        ops.setConfigFlagImpl(notificationsFlag(status: true)),
         completes,
       );
     });


### PR DESCRIPTION
## What this does

Rebuilds the People tab (behind `enable_relationships`) on top of what already
shipped, and tightens how a linked OS contact is recorded.

**The list.** A left-aligned display header with one add affordance and the
contact-import door beside it. Each person is one row: a persona avatar, the
name with an inline star when favorited, a status line stating the last
meaningful event (or a quiet streak) with a cadence-state dot, and a trailing
pill that reads on-track, or warning-tinted `Due <day>` when the desired
check-in interval has lapsed. The list sorts due-first, then by recency —
favorites are not a separate section; the star is a marker.

**Shared pieces.** `PersonaAvatar`, choice pills, sentiment tones and the
relationship timestamp helpers now live under `ui/shared/`, each with its own
tests, so the list, the detail page and the check-in sheet render the same
person the same way.

**Contact refs are per device, not per platform.** The same person carries a
different id in every address book — two phones on the same OS included — so
the ref key now carries this device's sync host id. A ref written on one
device reads as *unlinked* everywhere else instead of resolving to a stranger,
and a device whose host id is not yet provisioned stores no ref at all rather
than parking an id under a key another device could claim. ADR 0041 and the
relationships concept are updated to match.

**Also here:** scheduled alerts are re-armed when the notifications flag is
switched on, not only at startup, so reminders written while it was off are
not silently lost.

## Notes for review

- The branch was collapsed onto current `main`: phases 2–9 of this work had
  already merged separately, so the history replayed nothing but the genuinely
  new delta.
- New user-visible strings are added to every catalog; `make l10n` regenerated.
- Analyzer clean; the touched test files pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the People and relationships experience with clearer headers, add actions, avatars, favorites, check-in status, cadence indicators, and overdue-first sorting.
  * Added reusable choice pills, persona avatars, sentiment styling, and relationship timestamp displays.
  * Expanded check-in and relationship messaging across supported languages.

* **Bug Fixes**
  * Contact links are now isolated per device, preventing references from being mixed between devices.
  * Enabling notifications now restores eligible scheduled reminders automatically; reconciliation failures no longer block settings updates.

* **Documentation**
  * Updated relationship and notification guidance to reflect the latest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->