### PR TITLE
fix(evals): run every real-wake scenario, not just the default

### DIFF
--- a/docs/evaluations/task_agent_models/README.md
+++ b/docs/evaluations/task_agent_models/README.md
@@ -233,6 +233,57 @@ sources, an instruction the context contradicts, a report that must decline to
 conclude. Until then a pass here means "not obviously broken", and a model
 choice should rest on latency and cost, which is all the table above measures.
 
+## 2026-08-18: the matrix had been running one scenario
+
+The real-wake suite has three scenarios. `scripts/penguin_wake_eval_matrix.sh`
+never set `PENGUIN_WAKE_EVAL_SCENARIO`, so every model in every run of that
+matrix took the live test's default — `requalification` — and the other two
+never executed. The default is also the easy one, which is how the matrix
+reported a clean sweep for a suite that was failing two thirds of its cases.
+
+Fixed: the script now loops scenarios x models x samples, and the summary
+breaks down per scenario, because one weak restraint case is the entire finding
+and a single model total hides it behind the cases that pass. The
+failure-reason regex also missed `INVENTED WORK` and `DUPLICATE PROPOSAL` — the
+two traps that actually fire — so real failures printed "unknown, see log".
+
+Same model, before and after the fix:
+
+| | reported |
+| --- | --- |
+| before | `deepseek-v4-flash-0731  1/1` |
+| after | `deepseek-v4-flash-0731  1/3` — noOp INVENTED WORK, pendingProposal DUPLICATE PROPOSAL |
+
+### The realistic tier disagrees with the synthetic one
+
+Both models, all three scenarios, run 2026-08-18:
+
+| Scenario | deepseek-v4-flash-0731 | glm-5.2 |
+| --- | --- | --- |
+| `requalification` | pass | pass |
+| `noOp` | **INVENTED WORK** | **INVENTED WORK** |
+| `pendingProposal` | **DUPLICATE PROPOSAL** | **DUPLICATE PROPOSAL** |
+
+On the no-op wake deepseek proposed `assign_task_label` with
+`manual-label-waiting-on` at `confidence: high`, on a wake where the prior
+report already described the state — churn, the failure `gp_noop` exists to
+catch on the goal side. Verified against the captured tool calls rather than
+inferred from the category.
+
+**The same models score 41/42 on the inference tier**, and 17/17 on three
+identical runs. The tiers are measuring different things and only one of them
+can see this: the inference tier hand-writes its `userMessage`, so it never
+reaches `TaskAgentContextBuilder` (853 lines, owned by `TaskAgentWorkflow` and
+exercised only when the real workflow runs), and it scores attempted tool calls
+rather than what was persisted.
+
+**Where scenario work belongs.** The cheap tier has seventeen scenarios and
+cannot catch this; the realistic tier has three and can. New scenarios go to
+the real-wake catalog. The inference tier keeps its breadth of *situations* —
+a German transcript, Spanish mixed context, a contradicted instruction — which
+one demo task cannot express, and stays what it is: a cheap first filter that a
+pass in does not mean much.
+
 ## 2026-08-18: the suite finally reports a bill
 
 Every cost statement about this suite before now was inferred from token counts,

--- a/scripts/penguin_wake_eval_matrix.sh
+++ b/scripts/penguin_wake_eval_matrix.sh
@@ -50,7 +50,15 @@ LOTTI_PENGUIN_WAKE_EVAL_LIVE= fvm flutter test "$TEST_PATH" >/dev/null 2>&1
 
 # The named traps the scenarios assert, so a failure line says which one bit
 # rather than "a test failed".
-TRAPS='(INVENTED WORK|DUPLICATE PROPOSAL|UNSUPPORTED COMPLETION|NEGATION|RESTRAINT|CHURN|MISSED|HTTP [0-9]+)'
+#
+# Read out of the live test rather than listed here. A hand-kept copy has now
+# drifted twice — it was missing INVENTED WORK and DUPLICATE PROPOSAL, then
+# REPUBLISHED and FABRICATION — and each time the symptom was a real failure
+# printing "unknown, see log", which is worse than no diagnosis because it
+# reads like a harness problem. Deriving it means a trap added to the test
+# cannot go missing here.
+TRAP_NAMES=$(grep -oE "'[A-Z][A-Z ]{4,}:" "$TEST_PATH" | tr -d "':" | sort -u | paste -sd '|')
+TRAPS="(${TRAP_NAMES:-INVENTED WORK|DUPLICATE PROPOSAL}|HTTP [0-9]+)"
 
 run_one() {
   local model="$1" scenario="$2" sample="$3"

--- a/scripts/penguin_wake_eval_matrix.sh
+++ b/scripts/penguin_wake_eval_matrix.sh
@@ -9,6 +9,9 @@
 # Usage:
 #   scripts/penguin_wake_eval_matrix.sh [samples] [max_parallel]
 #
+# Runs every scenario in PENGUIN_WAKE_EVAL_SCENARIOS for every model, so the
+# matrix covers the restraint cases and not only the live test's default.
+#
 # Reads credentials from the environment:
 #   PENGUIN_WAKE_EVAL_BASE_URL, PENGUIN_WAKE_EVAL_API_KEY
 #
@@ -23,6 +26,16 @@ LOG_DIR="$OUT_DIR/logs"
 
 MODELS="${PENGUIN_WAKE_EVAL_MODELS:-glm-5.2 kimi-k3 qwen3.5-397b-a17b qwen3.6-27b qwen3.6-35b-a3b deepseek-v4-flash-0731}"
 
+# Every scenario, not just the live test's default.
+#
+# The default is `requalification`, and this script never set the variable, so
+# the whole matrix has only ever run that one case. It is also the easy one:
+# both models measured on 2026-08-18 passed it and failed `noOp` and
+# `pendingProposal`, so the matrix reported 6/6 for a suite that was really
+# 2/6. A restraint scenario that never runs cannot catch churn, which is the
+# failure these scenarios exist for.
+SCENARIOS="${PENGUIN_WAKE_EVAL_SCENARIOS:-requalification noOp pendingProposal}"
+
 if [[ -z "${PENGUIN_WAKE_EVAL_API_KEY:-}" ]]; then
   echo "PENGUIN_WAKE_EVAL_API_KEY is not set." >&2
   exit 2
@@ -35,12 +48,17 @@ mkdir -p "$LOG_DIR"
 echo "Warming the test build..."
 LOTTI_PENGUIN_WAKE_EVAL_LIVE= fvm flutter test "$TEST_PATH" >/dev/null 2>&1
 
+# The named traps the scenarios assert, so a failure line says which one bit
+# rather than "a test failed".
+TRAPS='(INVENTED WORK|DUPLICATE PROPOSAL|UNSUPPORTED COMPLETION|NEGATION|RESTRAINT|CHURN|MISSED|HTTP [0-9]+)'
+
 run_one() {
-  local model="$1" sample="$2"
-  local label="s${sample}"
+  local model="$1" scenario="$2" sample="$3"
+  local label="${scenario}_s${sample}"
   local log="$LOG_DIR/${model}_${label}.log"
   LOTTI_PENGUIN_WAKE_EVAL_LIVE=1 \
   PENGUIN_WAKE_EVAL_MODEL="$model" \
+  PENGUIN_WAKE_EVAL_SCENARIO="$scenario" \
   PENGUIN_WAKE_EVAL_RUN_LABEL="$label" \
   timeout 900 fvm flutter test "$TEST_PATH" >"$log" 2>&1
   if grep -q "All tests passed" "$log"; then
@@ -48,7 +66,7 @@ run_one() {
   else
     # Surface the named trap rather than a bare failure.
     local why
-    why=$(grep -oE '(UNSUPPORTED COMPLETION|NEGATION|RESTRAINT|CHURN|MISSED|HTTP [0-9]+)[^.]{0,120}' "$log" | head -1)
+    why=$(grep -oE "$TRAPS[^.]{0,120}" "$log" | head -1)
     echo "FAIL $model $label :: ${why:-see $log}"
   fi
 }
@@ -56,9 +74,11 @@ run_one() {
 echo "Running $SAMPLES sample(s) per model, up to $MAX_PARALLEL at a time."
 start=$(date +%s)
 for model in $MODELS; do
-  for sample in $(seq 1 "$SAMPLES"); do
-    while (( $(jobs -rp | wc -l) >= MAX_PARALLEL )); do wait -n; done
-    run_one "$model" "$sample" &
+  for scenario in $SCENARIOS; do
+    for sample in $(seq 1 "$SAMPLES"); do
+      while (( $(jobs -rp | wc -l) >= MAX_PARALLEL )); do wait -n; done
+      run_one "$model" "$scenario" "$sample" &
+    done
   done
 done
 wait
@@ -68,16 +88,23 @@ echo
 echo "===== SUMMARY ====="
 for model in $MODELS; do
   pass=0; total=0; reasons=""
-  for sample in $(seq 1 "$SAMPLES"); do
-    log="$LOG_DIR/${model}_s${sample}.log"
-    [[ -f "$log" ]] || continue
-    total=$((total+1))
-    if grep -q "All tests passed" "$log"; then
-      pass=$((pass+1))
-    else
-      why=$(grep -oE '(UNSUPPORTED COMPLETION|NEGATION|RESTRAINT|CHURN|MISSED|HTTP [0-9]+)[^.]{0,90}' "$log" | head -1)
-      reasons="$reasons\n      - ${why:-unknown, see $log}"
-    fi
+  for scenario in $SCENARIOS; do
+    spass=0; stotal=0
+    for sample in $(seq 1 "$SAMPLES"); do
+      log="$LOG_DIR/${model}_${scenario}_s${sample}.log"
+      [[ -f "$log" ]] || continue
+      total=$((total+1)); stotal=$((stotal+1))
+      if grep -q "All tests passed" "$log"; then
+        pass=$((pass+1)); spass=$((spass+1))
+      else
+        why=$(grep -oE "$TRAPS[^.]{0,90}" "$log" | head -1)
+        reasons="$reasons\n      - ${scenario}: ${why:-unknown, see $log}"
+      fi
+    done
+    # Per scenario as well as per model: one weak restraint case is the whole
+    # finding, and a single model total hides it behind the cases that pass.
+    [[ $stotal -gt 0 ]] &&
+      reasons="$reasons\n      = ${scenario}: ${spass}/${stotal}"
   done
   printf '%-26s %s/%s' "$model" "$pass" "$total"
   [[ -n "$reasons" ]] && printf '%b' "$reasons"


### PR DESCRIPTION
The real-wake suite has three scenarios. The matrix script has been running one.

`scripts/penguin_wake_eval_matrix.sh` never set `PENGUIN_WAKE_EVAL_SCENARIO`,
so every model in every run took the live test's default — `requalification` —
and `noOp` and `pendingProposal` never executed. The default is also the easy
one, which is how the matrix reported a clean sweep for a suite that was
failing two thirds of its cases. A restraint scenario that never runs cannot
catch churn, which is the failure those scenarios exist for.

Same model, before and after:

| | reported |
| --- | --- |
| before | `deepseek-v4-flash-0731  1/1` |
| after | `deepseek-v4-flash-0731  1/3` — noOp INVENTED WORK, pendingProposal DUPLICATE PROPOSAL |

## Changes

- The script loops scenarios x models x samples. Scenario list overridable via
  `PENGUIN_WAKE_EVAL_SCENARIOS`.
- The summary breaks down **per scenario**, not only per model: one weak
  restraint case is the entire finding, and a model total hides it behind the
  cases that pass.
- The failure-reason regex missed `INVENTED WORK` and `DUPLICATE PROPOSAL` —
  the two traps these scenarios actually assert — so real failures printed
  "unknown, see log". Both added, and the pattern is now shared between
  `run_one` and the summary rather than duplicated in two places that had
  already drifted.

## What it surfaced

Both models, all three scenarios:

| Scenario | deepseek-v4-flash-0731 | glm-5.2 |
| --- | --- | --- |
| `requalification` | pass | pass |
| `noOp` | **INVENTED WORK** | **INVENTED WORK** |
| `pendingProposal` | **DUPLICATE PROPOSAL** | **DUPLICATE PROPOSAL** |

On the no-op wake deepseek proposed `assign_task_label` with
`manual-label-waiting-on` at `confidence: high`, where the prior report already
described the state. Verified against the captured tool calls rather than
inferred from the failure category.

The same models score 41/42 on the inference tier and 17/17 on three identical
runs. Only the realistic tier can see this: the inference tier hand-writes its
`userMessage`, so it never reaches `TaskAgentContextBuilder` (853 lines, owned
by `TaskAgentWorkflow`), and it scores attempted tool calls rather than what
was persisted.

Documented in the eval README, including the conclusion that new scenario work
belongs in the real-wake catalog rather than the inference one.

Script and docs only — no production code, no CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Evaluation Improvements**
  - Evaluation runs now cover all configured scenarios, models, and samples instead of only the default scenario.
  - Results include scenario-specific labels, logs, pass totals, and failure reasons.
  - Additional failure conditions, including invented work and duplicate proposals, are now detected.

- **Documentation**
  - Added corrected before-and-after evaluation results.
  - Documented differences between realistic and synthetic inference evaluation tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->