### PR TITLE
fix: inventory the relationship chat route and run the manual check when routes change

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - '.github/workflows/manual.yml'
       - 'docs-site/**'
+      # The validator discovers routes and settings leaves from these
+      # sources, so a new one must re-run the check that inventories it.
+      - 'lib/beamer/locations/**'
+      - 'lib/features/settings_v2/domain/settings_tree_data.dart'
       - 'docs/implementation_plans/2026-07-17_automated_manual_system.md'
       - 'Makefile'
       - 'pubspec.yaml'
@@ -20,6 +24,10 @@ on:
     paths:
       - '.github/workflows/manual.yml'
       - 'docs-site/**'
+      # The validator discovers routes and settings leaves from these
+      # sources, so a new one must re-run the check that inventories it.
+      - 'lib/beamer/locations/**'
+      - 'lib/features/settings_v2/domain/settings_tree_data.dart'
       - 'docs/implementation_plans/2026-07-17_automated_manual_system.md'
       - 'Makefile'
       - 'pubspec.yaml'

--- a/docs-site/metadata/surface-inventory.json
+++ b/docs-site/metadata/surface-inventory.json
@@ -1276,7 +1276,8 @@
       "locator": "/people",
       "routes": [
         "/people",
-        "/people/:relationshipId"
+        "/people/:relationshipId",
+        "/people/:relationshipId/chat"
       ],
       "page": "organize-and-reflect/people",
       "status": "planned"


### PR DESCRIPTION
`main` currently fails the manual validator:

```
Manual validation failed with 1 error(s):
- Beamer route /people/:relationshipId/chat from relationships_location.dart
  is missing from the surface inventory.
```

Two commits: the missing inventory entry, and the trigger gap that let it through.

**Inventory the route.** The People chat route arrived with the relationship agent's LLM tier (#3983) but was never added to `surface-inventory.json`. It belongs to the existing `people-relationships` surface, so it is one line.

**Run the check when its inputs change.** `validate-manual.mjs` discovers Beamer routes from `lib/beamer/locations` and settings leaves from `settings_tree_data.dart`, but `manual.yml` was triggered by neither. A new route could land completely unchecked and then fail later on an unrelated branch that happened to touch one of the listed paths — which is exactly what happened: #3983 added the route and never ran the check, then #3959 tripped it via its `pubspec.yaml` bump and was merged with the check red.

Adding those two sources to the trigger means the branch that introduces a route is the branch that has to inventory it.

Verified locally against current `main`: failing before, and `Manual validation passed: 37 features, 42 source pages across 11 locale(s), 134 screenshot case(s), 105 inventoried surface(s)` after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the people relationships chat route to the surface inventory.

* **Chores**
  * Updated validation triggers so route and settings inventory checks run when relevant source files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->