### PR TITLE
fix(docs): list the People chat route in the surface inventory

### DIFF
--- a/docs-site/metadata/surface-inventory.json
+++ b/docs-site/metadata/surface-inventory.json
@@ -1276,7 +1276,8 @@
       "locator": "/people",
       "routes": [
         "/people",
-        "/people/:relationshipId"
+        "/people/:relationshipId",
+        "/people/:relationshipId/chat"
       ],
       "page": "organize-and-reflect/people",
       "status": "planned"


### PR DESCRIPTION
**Main is red, and this unblocks it.** One line.

## What broke

#3983 added `/people/:relationshipId/chat` to `lib/beamer/locations/relationships_location.dart` without a matching entry in `docs-site/metadata/surface-inventory.json`, so `validate-manual.mjs` fails:

```
Manual validation failed with 1 error(s):
- Beamer route /people/:relationshipId/chat from relationships_location.dart is missing from the surface inventory.
```

## Why nobody noticed

The **Manual** workflow is path-filtered, and #3983 touched no `docs-site/` path — so it never ran on main and main went red silently. The failure surfaces instead on every *pull request* that does trigger the workflow, because PR checks run against the merge with main rather than the branch alone.

It was first seen on #3989, a health-import PR that changed no relationships code whatsoever, which makes it fairly confusing to land on. Every PR touching `lib/` inherits it until this is in.

## The fix

The route is listed on the existing `people-relationships` entry. This matches the `goal-agents` entry directly above it, which already carries its own `/goals/details/:agentId/chat` — so the convention is to list chat sub-routes explicitly rather than to let a parent pattern cover them.

Verified locally on a clean checkout of main: fails before, and after the change

```
Manual validation passed: 37 features, 42 source pages across 11 locale(s),
134 screenshot case(s), 105 inventoried surface(s) (102 verified, 1 documented, 2 planned).
```

`npm run typecheck` and `npm run test` in `docs-site/` are also clean.

Marked `status: planned` is untouched — this only adds the route to the existing entry's `routes` list.