### PR TITLE
test(evals): grow the real-wake catalog, and record two rejected prompt fixes

### DIFF
--- a/docs/evaluations/task_agent_models/README.md
+++ b/docs/evaluations/task_agent_models/README.md
@@ -233,6 +233,62 @@ sources, an instruction the context contradicts, a report that must decline to
 conclude. Until then a pass here means "not obviously broken", and a model
 choice should rest on latency and cost, which is all the table above measures.
 
+## 2026-08-19: two prompt fixes for no-op churn, both rejected
+
+`noOp` fails on every model, every sample, every run — 0/48 across four models
+from three vendors. The contract states the rule twice: wake-protocol step 4
+("Otherwise end with a brief plain-text note and do not republish") and the
+live report directive ("finish with a brief plain-text note and do not
+republish unchanged content"). Nobody follows it.
+
+Two edits were measured against a 48-wake baseline, both sides, with the
+`materialChange` guard in place to catch over-correction.
+
+**Attempt 1 — promote the restraint clause to its own numbered step.** The
+narrow, structural-only change: same words, moved out of a subordinate clause
+on a step about *doing* something. Predicted `REPUBLISHED` would fall and
+`INVENTED WORK` would hold.
+
+Neither happened. `noOp` was unchanged in count *and* failure mode. The suite
+total rose 15/36 to 18/36 — entirely inside `pendingProposal`, a scenario the
+edit never touched. **Re-running with the edit reverted produced 18/36 again,
+model for model.** The gain was not the edit; it was variance, and without the
+control it would have shipped.
+
+**Attempt 2 — a materiality gate as the first protocol step.** A genuine
+addition rather than a move: decide whether anything material changed before
+any action step, and if not, call no tools at all. Worded as a general
+principle, deliberately saying nothing about the fixture's own note.
+
+It made things worse. Models proposing data changes on a no-op wake went from
+7/12 to **11/12**: qwen went from proposing nothing in 3 of 3 runs to inventing
+work in 2 of 3, and glm from 2 of 3 clean to 0 of 3. `noOp` stayed 0/12 and the
+total fell 30/48 to 29/48. `materialChange` held 12/12, so this is not
+over-correction — it is the opposite.
+
+The mechanism is legible afterwards: asking a model to *decide whether*
+anything changed hands it a reasoning step whose natural output is finding
+something to do. Two models that had been quietly idle started acting.
+
+### The lever that is not being pulled
+
+Both attempts confirm what this log already recorded on 2026-08-18: prompt
+edits redistribute attention rather than add a rule, while the structural fixes
+had no such tail. The goal agent does not ask for restraint — it **withholds**
+the ad tools its deterministic tier has ruled out.
+
+The task agent has the same deterministic knowledge and does not use it.
+`TaskAgentContextBuilder` computes "Changed Since Last Wake" and knows exactly
+which entity ids moved; the workflow then offers the full mutation surface
+regardless. Withholding mutation tools when nothing changed would make the
+failure unreachable instead of discouraged, which is the one intervention shape
+that has worked in either suite.
+
+Noise floor, from four identical runs: `requalification` and `materialChange`
+are stable at 12/12, `noOp` at 0/12, and `pendingProposal` swings +/-2 of 3 per
+model for deepseek and glm while kimi (3/3) and qwen (0/3) never move. Any
+`pendingProposal` claim inside that band is noise.
+
 ## 2026-08-18: the matrix had been running one scenario
 
 The real-wake suite has three scenarios. `scripts/penguin_wake_eval_matrix.sh`

--- a/scripts/penguin_wake_eval_matrix.sh
+++ b/scripts/penguin_wake_eval_matrix.sh
@@ -34,7 +34,21 @@ MODELS="${PENGUIN_WAKE_EVAL_MODELS:-glm-5.2 kimi-k3 qwen3.5-397b-a17b qwen3.6-27
 # `pendingProposal`, so the matrix reported 6/6 for a suite that was really
 # 2/6. A restraint scenario that never runs cannot catch churn, which is the
 # failure these scenarios exist for.
-SCENARIOS="${PENGUIN_WAKE_EVAL_SCENARIOS:-requalification noOp pendingProposal}"
+#
+# Derived from the enum, not listed here. A hand-kept copy went stale within
+# the hour: `materialChange` was added and the first matrix run after it
+# silently measured three scenarios while reporting totals out of 9, which is
+# the same failure this script was just fixed for at the scenario level.
+SCENARIO_NAMES=$(
+  sed -n '/^enum PenguinWakeScenarioId {/,/^}/p' \
+    test/features/ai/eval/support/penguin_wake_scenarios.dart |
+    grep -oE '^  [a-z][a-zA-Z]*,' | tr -d ' ,'
+)
+SCENARIOS="${PENGUIN_WAKE_EVAL_SCENARIOS:-$SCENARIO_NAMES}"
+if [[ -z "${SCENARIOS// /}" ]]; then
+  echo "Could not derive the scenario list from PenguinWakeScenarioId." >&2
+  exit 2
+fi
 
 if [[ -z "${PENGUIN_WAKE_EVAL_API_KEY:-}" ]]; then
   echo "PENGUIN_WAKE_EVAL_API_KEY is not set." >&2
@@ -79,7 +93,11 @@ run_one() {
   fi
 }
 
-echo "Running $SAMPLES sample(s) per model, up to $MAX_PARALLEL at a time."
+# Printed because the silent version fooled the person who wrote this fix: a
+# run covering one scenario looks exactly like a run covering all of them.
+echo "Models:    $(echo $MODELS | tr '\n' ' ')"
+echo "Scenarios: $(echo $SCENARIOS | tr '\n' ' ')"
+echo "Running $SAMPLES sample(s) per model per scenario, up to $MAX_PARALLEL at a time."
 start=$(date +%s)
 for model in $MODELS; do
   for scenario in $SCENARIOS; do

--- a/test/features/ai/eval/penguin_wake_workflow_eval_live_test.dart
+++ b/test/features/ai/eval/penguin_wake_workflow_eval_live_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/ai/constants/provider_config.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
@@ -277,13 +278,36 @@ void main() {
       // whole set rather than on individual traps is what makes it a real
       // test — "found something to do" is the failure, whatever it was.
       if (!scenario.expectsProposals) {
+        // Minus what the scenario explicitly permits. The no-op wake allows the
+        // `waiting-on` label: its note says the task is still waiting on an
+        // external party, so the label restates the evidence rather than
+        // inventing progress, and every evaluated model proposed it.
+        final unexpected = proposedTools
+            .where((tool) => !scenario.allowedProposalTools.contains(tool))
+            .toList();
         expect(
-          proposedTools,
+          unexpected,
           isEmpty,
           reason:
               'INVENTED WORK: ${scenario.summary} Proposed anyway: '
-              '$proposedTools with ${jsonEncode(proposedArgs)}. $where',
+              '$unexpected with ${jsonEncode(proposedArgs)}. $where',
         );
+        // Permission to add the supported label is not permission to invent
+        // one, so an allowed tool still has to carry the right argument —
+        // otherwise the allowance would pass any label at all.
+        if (scenario.id == PenguinWakeScenarioId.noOp) {
+          for (final args in proposedArgs) {
+            final labelId = args['id'];
+            if (labelId == null) continue;
+            expect(
+              labelId,
+              demoWaitingLabelId,
+              reason:
+                  'FABRICATION: the only label the note supports is '
+                  'waiting-on. $where',
+            );
+          }
+        }
       }
       if (scenario.id == PenguinWakeScenarioId.noOp) {
         // The live contract is TaskAgentEvidenceSynthesis.reportDirective,

--- a/test/features/ai/eval/penguin_wake_workflow_eval_live_test.dart
+++ b/test/features/ai/eval/penguin_wake_workflow_eval_live_test.dart
@@ -315,6 +315,34 @@ void main() {
           reason: 'the report should still describe the standing blocker',
         );
       }
+      // ---- The report the scenario expects ------------------------------
+      // Declared by every scenario since the suite was written and checked by
+      // nothing, which left "the report must change" stated and untested. It
+      // matters most for the case below: every fix for no-op churn pushes a
+      // model toward doing less, and without this a model that has gone silent
+      // on real news reads exactly like one that is correctly restrained.
+      if (scenario.expectsReport) {
+        expect(
+          agentReport,
+          isNotNull,
+          reason:
+              'MISSED: the wake published no report at all. '
+              '${scenario.summary} $where',
+        );
+        if (scenario.id != PenguinWakeScenarioId.requalification) {
+          // A follow-up wake starts from the seeded prior report, so leaving
+          // the standing one byte-identical means the news never reached the
+          // user.
+          expect(
+            agentReport?.oneLiner,
+            isNot(penguinWakePriorReportOneLiner),
+            reason:
+                'MISSED: the situation changed and the standing report was '
+                'left untouched. ${scenario.summary} $where',
+          );
+        }
+      }
+
       // ---- Proposals already awaiting the user --------------------------
       // Re-proposing a queued change puts the same decision in front of the
       // user twice. The pending list is in the context precisely so the agent

--- a/test/features/ai/eval/support/penguin_wake_scenarios.dart
+++ b/test/features/ai/eval/support/penguin_wake_scenarios.dart
@@ -70,6 +70,7 @@ class PenguinWakeScenario {
     required this.expectsProposals,
     required this.expectsReport,
     this.forbiddenToolNames = const {},
+    this.allowedProposalTools = const {},
   });
 
   final PenguinWakeScenarioId id;
@@ -88,6 +89,20 @@ class PenguinWakeScenario {
   /// checked by nothing until 2026-08-18, which made "the report must change"
   /// an expectation the suite stated and never tested.
   final bool expectsReport;
+
+  /// Tools a wake may propose even when it should otherwise propose nothing.
+  ///
+  /// The no-op wake is the case. Its note reports no movement — "still no date
+  /// from the parts store" — and every evaluated model responded by proposing
+  /// the `waiting-on` label. That is supported by the evidence, is not a
+  /// duplicate (the task carries `blocked`, not `waiting-on`), and is not
+  /// speculative, so the contract's "skip no-ops, duplicates, speculative
+  /// changes" does not forbid it. Asserting against it made four models from
+  /// three vendors fail for doing something reasonable.
+  ///
+  /// Everything else stays forbidden, and the label itself is still checked:
+  /// permission to add `waiting-on` is not permission to invent a label.
+  final Set<String> allowedProposalTools;
 
   /// Tools a correct wake must not call, even though it may call others.
   ///
@@ -109,10 +124,11 @@ class PenguinWakeScenario {
     PenguinWakeScenarioId.noOp: PenguinWakeScenario(
       id: PenguinWakeScenarioId.noOp,
       summary:
-          'Nothing materially changed: propose no data changes, do not '
-          'republish the report, and do not invent progress.',
+          'The note reports no movement: do not republish the report and do '
+          'not invent progress. Labelling what the note describes is fine.',
       expectsProposals: false,
       expectsReport: false,
+      allowedProposalTools: {TaskAgentToolNames.assignTaskLabel},
     ),
     PenguinWakeScenarioId.materialChange: PenguinWakeScenario(
       id: PenguinWakeScenarioId.materialChange,

--- a/test/features/ai/eval/support/penguin_wake_scenarios.dart
+++ b/test/features/ai/eval/support/penguin_wake_scenarios.dart
@@ -44,6 +44,16 @@ enum PenguinWakeScenarioId {
   /// progress it cannot support.
   noOp,
 
+  /// A follow-up wake where something genuinely DID change.
+  ///
+  /// The counterweight to the no-op scenario, and the reason it has to exist:
+  /// every fix for no-op churn pushes a model toward doing less, and nothing
+  /// in this catalog could tell "correctly restrained" from "too timid to
+  /// report real news". The prior report says Bay C is blocked on the sensor
+  /// swap; the closing note says the swap is done, the seam was walked and the
+  /// leak was found. Standing pat here is a failure, not restraint.
+  materialChange,
+
   /// A proposal for the very change the model is about to suggest is already
   /// queued and awaiting the user.
   ///
@@ -71,6 +81,12 @@ class PenguinWakeScenario {
   final bool expectsProposals;
 
   /// Whether a correct wake writes or revises a report.
+  ///
+  /// Asserted by the live test, in both directions: a scenario that expects a
+  /// report fails if the standing one is left untouched, and the no-op case
+  /// fails if it is rewritten. The field was declared on every scenario and
+  /// checked by nothing until 2026-08-18, which made "the report must change"
+  /// an expectation the suite stated and never tested.
   final bool expectsReport;
 
   /// Tools a correct wake must not call, even though it may call others.
@@ -97,6 +113,14 @@ class PenguinWakeScenario {
           'republish the report, and do not invent progress.',
       expectsProposals: false,
       expectsReport: false,
+    ),
+    PenguinWakeScenarioId.materialChange: PenguinWakeScenario(
+      id: PenguinWakeScenarioId.materialChange,
+      summary:
+          'The blocker cleared and the leak was found since the last report: '
+          'publish the change and propose the work the note supports.',
+      expectsProposals: true,
+      expectsReport: true,
     ),
     PenguinWakeScenarioId.pendingProposal: PenguinWakeScenario(
       id: PenguinWakeScenarioId.pendingProposal,


### PR DESCRIPTION
Follow-on from #3985. The real-wake tier is the one that can catch things —
it runs the production `TaskAgentWorkflow` against seeded databases and scores
what was persisted — and it had three scenarios. This adds the missing guard,
gives a dead expectation teeth, and records two prompt experiments that failed.

## `materialChange` — the over-correction guard

`noOp` was the only follow-up-report scenario, so **any** edit pushing models
toward doing less read as pure improvement and nothing could detect timidity.

`materialChange` is its counterweight: same follow-up shape, prior report says
Bay C is blocked on the sensor swap, but the closing note reports the swap done,
the seam walked and the leak found. Standing pat is a failure here. It needs no
harness wiring — the prior report already seeds for non-`requalification`
scenarios and the default note is the unblocking news.

It passes 12/12 at baseline, which is the point: a guard, not a discriminator.

## `expectsReport` now asserts something

Declared on every scenario since the suite was written and checked **nowhere** —
the same dead-expectation shape as `forbiddenReportClaims` in the inference
suite (#3980). It now fails both ways: no report published, or a follow-up that
left the standing report byte-identical.

## The no-op wake may label what its note describes

Four models from three vendors failed `noOp` for the same action: adding
`waiting-on` to a task whose newest note says "still no date from the parts
store". That is supported by the evidence, is not a duplicate (the task carries
`blocked`), and is not speculative — so the contract's "skip no-ops, duplicates,
speculative changes" does not forbid it. Unanimity across vendors is a poor sign
that the models are wrong.

`allowedProposalTools` carves out that one tool. Everything else still fails,
**and the label argument is still checked** — permission to add `waiting-on` is
not permission to invent a label.

This sharpened the scenario rather than weakening it. `noOp` now isolates one
defect (11 of 12 failures are `REPUBLISHED`), and the argument check immediately
caught kimi-k3 proposing `manual-project-waddle` alongside the supported label —
which the blanket assertion had been masking behind a generic `INVENTED WORK`.

## Two prompt fixes for no-op churn, both rejected

`noOp` failed 0/48 across four models with the rule stated twice in the
contract. Both edits were measured against a 48-wake baseline, both sides.

**Promoting the restraint clause to its own step** changed nothing: same count,
same failure mode. The suite total rose 15/36 → 18/36, entirely inside
`pendingProposal`, which the edit never touched — and **re-running with the edit
reverted produced 18/36 again, model for model.** Without that control it would
have shipped.

**A materiality gate as the first protocol step** made it worse: models
proposing data changes on a no-op wake went 7/12 → **11/12**. Asking a model to
*decide whether* anything changed hands it a reasoning step whose natural output
is finding something to do. Two models that had been quietly idle started acting.

Both confirm what the log already recorded: prompt edits redistribute attention;
the structural fixes had no such tail. Written up in the eval README, along with
the noise floor from four identical runs — `requalification` and
`materialChange` stable at 12/12, `noOp` at 0/12, `pendingProposal` swinging ±2
of 3 per model for deepseek and glm while kimi (3/3) and qwen (0/3) never move.

## Script drift, twice

`materialChange` was added and the very next matrix run silently measured three
scenarios while reporting totals out of 9 — the same hand-kept-list drift #3985
fixed for traps, repeated one line down within the hour. The scenario list now
derives from `PenguinWakeScenarioId`, the run aborts if derivation yields
nothing, and the script prints the models and scenarios it is about to run,
because a silent narrowed scope fooled the person who wrote the fix for it.

Test and docs only — no production code, no CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a material-change evaluation scenario covering resolved blockers and newly discovered issues.
  * Added support for explicitly permitted proposals in no-change scenarios.
  * Added report validation for scenarios requiring updated summaries.

* **Improvements**
  * Evaluation runs now discover available scenarios automatically while supporting manual selection.
  * Startup output clearly lists models, scenarios, and sampling details.
  * Runs now fail early when no scenarios are available.

* **Documentation**
  * Recorded evaluation results for prompt changes affecting no-op behavior, including observed limitations and scenario stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->