### PR TITLE
test(goals): pin that the rail's grace timer dies with the rail

### DIFF
--- a/test/features/goals/ui/checkins/goal_checkin_timeline_test.dart
+++ b/test/features/goals/ui/checkins/goal_checkin_timeline_test.dart
@@ -193,6 +193,31 @@ void main() {
     expect(find.text('Transcribing…'), findsNothing);
   });
 
+  testWidgets('the rail takes its pending timer with it when it goes', (
+    tester,
+  ) async {
+    // Arms a timer for a recording five minutes short of its deadline.
+    await pump(tester, [
+      GoalAudioCheckIn(
+        audio('waiting', today.add(const Duration(hours: 2, minutes: 55))),
+      ),
+    ]);
+    expect(find.text('Transcribing…'), findsOneWidget);
+
+    // Navigating away mid-window is ordinary — the rail is a card on a page
+    // the user leaves — and the timer has to go with it.
+    await tester.pumpWidget(const SizedBox.shrink());
+    // Deliberately NOT past the deadline: a timer that is allowed to fire is
+    // caught by the `mounted` guard and leaves nothing pending, so advancing
+    // past it would prove the guard rather than the cancel. Stopping short
+    // leaves the timer live unless `dispose` cancelled it, and the binding's
+    // pending-timer check at teardown is then the assertion.
+    await tester.pump(const Duration(minutes: 1));
+
+    expect(find.byType(GoalCheckInTimeline), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('the rail wakes for the soonest beat, not the newest', (
     tester,
   ) async {


### PR DESCRIPTION
Follow-up to the last review comment on #3995, which claimed the re-armed grace timer leaks at test teardown. It does not — the `dispose` added in that PR cancels it, and the suite was green locally and across all 30 checks. But the finding named a real gap: **nothing asserted the cancel.**

A regression would still have been caught, because every other test in the file arms a timer too. It would just have failed as a pending-timer complaint from the binding, in tests about day dividers and paging, naming neither the timer nor the widget that leaked it. This makes it fail by name instead.

## The part worth reading

The obvious version of this test passes with the fix removed, and I nearly shipped it. Unmounting and then advancing *past* the deadline lets the timer fire, where the callback's `mounted` guard catches it and leaves nothing pending — so it proves the guard, not the cancel.

Stopping **short** of the deadline is what makes it an assertion: the timer stays live unless `dispose` cancelled it, and the binding's teardown check does the rest.

Verified in both directions — with the cancel removed, this test fails by name (alongside the three neighbours that were the only signal before).

No production change. `dart analyze lib test` clean, file green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring goal check-in timelines clean up pending transcription timers when removed, preventing exceptions and lingering timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->