### PR TITLE
fix(goals): fit the auto span from the pane width, plus review follow-ups

### DIFF
--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -567,7 +567,8 @@ String goalAssessmentRatingLabel(
 ///
 /// Ink follows the fill so the letter stays readable on both states: the
 /// on-alert ink over a saturated fill, medium emphasis over the neutral and
-/// washed fills. Returns a [Positioned]; the cell hosts it in a [Stack].
+/// washed fills. Returns a [PositionedDirectional]; the cell hosts it in a
+/// [Stack].
 Widget? goalDayCellLetter(
   DsTokens tokens, {
   required String? letter,

--- a/lib/features/goals/ui/pages/goal_agent_detail_page.dart
+++ b/lib/features/goals/ui/pages/goal_agent_detail_page.dart
@@ -62,7 +62,8 @@ import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 /// trend), the hero stack (the timestamped Agent's-read card above the
 /// deterministic Goal-days card, each at the full content width), active
 /// banners and pending proposals, then the Habits and Signals evidence
-/// sections and the About-this-agent expander (cost pills + automation).
+/// sections — with the cost pills and automation controls riding the read
+/// card itself.
 /// Daily reflections live in the check-ins rail rather than the main
 /// column, and the retired-banner timeline is gone — the rail is the one
 /// place "what I've said about this goal" is read. Desktop hosts the
@@ -100,23 +101,41 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
   /// write per computed value rather than one per rebuild.
   int? _autoSpanRequestedFor;
 
-  /// How many day columns fit the content column at the authored pitch.
+  /// AUTO span: drives the shared range to the number of day columns that
+  /// fit the content column at the authored pitch, from the PANE's measured
+  /// width (the body [LayoutBuilder]'s constraint — the window width lied
+  /// whenever a navigation sidebar or the check-in rail narrowed the pane).
   ///
-  /// The width is an estimate from the window (the pane behind a desktop
-  /// sidebar is narrower), deliberately on the generous side: a span a few
-  /// days too wide goes through the tracks' own fit-before-scroll policy and
-  /// shrinks the columns slightly, which still fills the card edge to edge.
-  int _fitSpanDays(BuildContext context) {
+  /// Called from layout, so the controller write is deferred past the frame;
+  /// idempotent per computed value, and a no-op once the user has picked a
+  /// preset.
+  void _scheduleAutoSpan(
+    BuildContext context, {
+    required double paneWidth,
+    required bool railShown,
+  }) {
+    if (_rangePicked) return;
     final tokens = context.designTokens;
     final pitch = goalDayTrackMetrics(context, dayCount: 1).pitch;
     final contentWidth =
         math.min(
           kUnifiedGoalsContentMaxWidth,
-          MediaQuery.sizeOf(context).width - tokens.spacing.step6 * 2,
+          paneWidth -
+              (railShown ? kGoalTimelineRailWidth : 0) -
+              tokens.spacing.step6 * 2,
         ) -
         tokens.spacing.cardPadding * 2;
-    if (pitch <= 0 || contentWidth <= pitch) return 7;
-    return (contentWidth / pitch).floor().clamp(7, 90);
+    final fit = pitch <= 0 || contentWidth <= pitch
+        ? 7
+        : (contentWidth / pitch).floor().clamp(7, 90);
+    if (_autoSpanRequestedFor == fit) return;
+    _autoSpanRequestedFor = fit;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _rangePicked) return;
+      if (ref.read(habitsControllerProvider).timeSpanDays != fit) {
+        ref.read(habitsControllerProvider.notifier).setTimeSpan(fit);
+      }
+    });
   }
 
   /// Whether the desktop chat drawer is open. The drawer stays MOUNTED
@@ -362,22 +381,12 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
     final timeSpanDays = ref.watch(
       habitsControllerProvider.select((state) => state.timeSpanDays),
     );
-    // AUTO span: until the user picks a range here, drive the shared span to
-    // the day count that fits the content width — the completion chart, the
-    // heatmap data and every day track then follow the same fitted span, so
-    // the page keeps its one-range contract in auto mode too.
-    final fitSpanDays = _fitSpanDays(context);
-    if (!_rangePicked &&
-        timeSpanDays != fitSpanDays &&
-        _autoSpanRequestedFor != fitSpanDays) {
-      _autoSpanRequestedFor = fitSpanDays;
-      // Post-frame: a controller write mid-build would rebuild the page
-      // while it is already building.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || _rangePicked) return;
-        ref.read(habitsControllerProvider.notifier).setTimeSpan(fitSpanDays);
-      });
-    }
+    // AUTO span: until the user picks a range here, [_scheduleAutoSpan]
+    // (called from the body's LayoutBuilders, where the PANE width is known)
+    // drives the shared span to the day count that fits the content width —
+    // the completion chart, the heatmap data and every day track then follow
+    // the same fitted span, so the page keeps its one-range contract in auto
+    // mode too.
     final progressAsync = spec == null
         ? null
         : ref.watch(
@@ -908,30 +917,36 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
               // wide desktop still earns the rail, and a narrow pane behind a
               // wide sidebar still must not get one.
               ? LayoutBuilder(
-                  builder: (context, constraints) =>
-                      railFits(constraints.maxWidth)
-                      ? Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Expanded(
-                              child: detailList(
-                                showChatAction: false,
-                                contentMaxWidth: kUnifiedGoalsContentMaxWidth,
-                                showRail: true,
+                  builder: (context, constraints) {
+                    _scheduleAutoSpan(
+                      context,
+                      paneWidth: constraints.maxWidth,
+                      railShown: railFits(constraints.maxWidth),
+                    );
+                    return railFits(constraints.maxWidth)
+                        ? Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(
+                                child: detailList(
+                                  showChatAction: false,
+                                  contentMaxWidth: kUnifiedGoalsContentMaxWidth,
+                                  showRail: true,
+                                ),
                               ),
-                            ),
-                            SizedBox(
-                              width: kGoalTimelineRailWidth,
-                              child: _CheckInRail(card: checkInsCard()),
-                            ),
-                          ],
-                        )
-                      : detailList(
-                          showChatAction: !desktop && chatAvailable,
-                          contentMaxWidth: desktop
-                              ? kUnifiedGoalsContentMaxWidth
-                              : null,
-                        ),
+                              SizedBox(
+                                width: kGoalTimelineRailWidth,
+                                child: _CheckInRail(card: checkInsCard()),
+                              ),
+                            ],
+                          )
+                        : detailList(
+                            showChatAction: !desktop && chatAvailable,
+                            contentMaxWidth: desktop
+                                ? kUnifiedGoalsContentMaxWidth
+                                : null,
+                          );
+                  },
                 )
               : CallbackShortcuts(
                   bindings: {
@@ -945,102 +960,116 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
                   // draft survives, and it takes no pointer/focus traffic
                   // off-screen.
                   child: LayoutBuilder(
-                    builder: (context, constraints) => Stack(
-                      children: [
-                        // The drawer overlays without reflowing the cards, but
-                        // the COLUMN glides: closed, it centers in the window
-                        // (a fixed left-aligned measure left the right half of
-                        // wide windows dead); open, it centers in what the
-                        // drawer leaves free. Clamped to the PANE's real
-                        // constraints: with a wide navigation sidebar the pane
-                        // can be barely wider than the drawer, and always
-                        // subtracting the drawer span would squeeze the
-                        // dashboard into an unusable sliver — below the fold
-                        // width the drawer stays a true overlay instead.
-                        AnimatedPadding(
-                          duration: MotionDurations.medium2,
-                          curve: MotionCurves.emphasizedDecelerate,
-                          padding: EdgeInsetsDirectional.only(
-                            end:
-                                _chatOpen &&
-                                    constraints.maxWidth -
-                                            kGoalChatDrawerWidth >=
-                                        kPageHeaderFoldWidth
-                                ? kGoalChatDrawerWidth
-                                : 0,
+                    builder: (context, constraints) {
+                      _scheduleAutoSpan(
+                        context,
+                        paneWidth: constraints.maxWidth,
+                        railShown: railFits(constraints.maxWidth),
+                      );
+                      return Stack(
+                        children: [
+                          // The drawer overlays without reflowing the cards, but
+                          // the COLUMN glides: closed, it centers in the window
+                          // (a fixed left-aligned measure left the right half of
+                          // wide windows dead); open, it centers in what the
+                          // drawer leaves free. Clamped to the PANE's real
+                          // constraints: with a wide navigation sidebar the pane
+                          // can be barely wider than the drawer, and always
+                          // subtracting the drawer span would squeeze the
+                          // dashboard into an unusable sliver — below the fold
+                          // width the drawer stays a true overlay instead.
+                          AnimatedPadding(
+                            duration: MotionDurations.medium2,
+                            curve: MotionCurves.emphasizedDecelerate,
+                            padding: EdgeInsetsDirectional.only(
+                              end:
+                                  _chatOpen &&
+                                      constraints.maxWidth -
+                                              kGoalChatDrawerWidth >=
+                                          kPageHeaderFoldWidth
+                                  ? kGoalChatDrawerWidth
+                                  : 0,
+                            ),
+                            // Two columns, and the drawer still overlays rather
+                            // than becoming a third: a conversation is transient
+                            // and already owns correct focus, escape and
+                            // semantics behaviour as an overlay. The glide moves
+                            // BOTH columns.
+                            child: railFits(constraints.maxWidth)
+                                ? Row(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Expanded(
+                                        child: detailList(
+                                          showChatAction: false,
+                                          contentMaxWidth:
+                                              kUnifiedGoalsContentMaxWidth,
+                                          showRail: true,
+                                        ),
+                                      ),
+                                      SizedBox(
+                                        width: kGoalTimelineRailWidth,
+                                        child: _CheckInRail(
+                                          card: checkInsCard(),
+                                        ),
+                                      ),
+                                    ],
+                                  )
+                                : detailList(
+                                    showChatAction: false,
+                                    contentMaxWidth:
+                                        kUnifiedGoalsContentMaxWidth,
+                                  ),
                           ),
-                          // Two columns, and the drawer still overlays rather
-                          // than becoming a third: a conversation is transient
-                          // and already owns correct focus, escape and
-                          // semantics behaviour as an overlay. The glide moves
-                          // BOTH columns.
-                          child: railFits(constraints.maxWidth)
-                              ? Row(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Expanded(
-                                      child: detailList(
-                                        showChatAction: false,
-                                        contentMaxWidth:
-                                            kUnifiedGoalsContentMaxWidth,
-                                        showRail: true,
-                                      ),
-                                    ),
-                                    SizedBox(
-                                      width: kGoalTimelineRailWidth,
-                                      child: _CheckInRail(
-                                        card: checkInsCard(),
-                                      ),
-                                    ),
-                                  ],
-                                )
-                              : detailList(
-                                  showChatAction: false,
-                                  contentMaxWidth: kUnifiedGoalsContentMaxWidth,
-                                ),
-                        ),
-                        PositionedDirectional(
-                          top: 0,
-                          bottom: 0,
-                          end: 0,
-                          child: TapRegion(
-                            groupId: _chatRegionGroup,
-                            onTapOutside: (_) {
-                              if (_chatOpen) setState(() => _chatOpen = false);
-                            },
-                            child: AnimatedSlide(
-                              offset: _chatOpen
-                                  ? Offset.zero
-                                  : const Offset(1, 0),
-                              duration: MotionDurations.medium2,
-                              curve: MotionCurves.emphasizedDecelerate,
-                              child: IgnorePointer(
-                                ignoring: !_chatOpen,
-                                // Off-screen means out of the semantics tree
-                                // too: without this a screen reader traverses
-                                // the slid-away drawer's composer and close
-                                // button.
-                                child: ExcludeSemantics(
-                                  excluding: !_chatOpen,
-                                  child: ExcludeFocus(
+                          PositionedDirectional(
+                            top: 0,
+                            bottom: 0,
+                            end: 0,
+                            child: TapRegion(
+                              groupId: _chatRegionGroup,
+                              onTapOutside: (_) {
+                                if (_chatOpen) {
+                                  setState(() => _chatOpen = false);
+                                }
+                              },
+                              child: AnimatedSlide(
+                                offset: _chatOpen
+                                    ? Offset.zero
+                                    : const Offset(1, 0),
+                                duration: MotionDurations.medium2,
+                                curve: MotionCurves.emphasizedDecelerate,
+                                child: IgnorePointer(
+                                  ignoring: !_chatOpen,
+                                  // Off-screen means out of the semantics tree
+                                  // too: without this a screen reader traverses
+                                  // the slid-away drawer's composer and close
+                                  // button.
+                                  child: ExcludeSemantics(
                                     excluding: !_chatOpen,
-                                    child: Focus(
-                                      focusNode: _drawerFocusNode,
-                                      child: _GoalChatDrawer(
-                                        agentId: agentId,
-                                        identity: goalIdentity,
-                                        status: unifiedStatus,
-                                        hasStandingAssessment:
-                                            hasStandingAssessment,
-                                        recoveryHint: switch (health?.deficit) {
-                                          final int deficit when deficit > 0 =>
-                                            context.messages.goalDaysToRecover(
-                                              deficit,
-                                            ),
-                                          _ => null,
-                                        },
-                                        onClose: () =>
-                                            setState(() => _chatOpen = false),
+                                    child: ExcludeFocus(
+                                      excluding: !_chatOpen,
+                                      child: Focus(
+                                        focusNode: _drawerFocusNode,
+                                        child: _GoalChatDrawer(
+                                          agentId: agentId,
+                                          identity: goalIdentity,
+                                          status: unifiedStatus,
+                                          hasStandingAssessment:
+                                              hasStandingAssessment,
+                                          recoveryHint:
+                                              switch (health?.deficit) {
+                                                final int deficit
+                                                    when deficit > 0 =>
+                                                  context.messages
+                                                      .goalDaysToRecover(
+                                                        deficit,
+                                                      ),
+                                                _ => null,
+                                              },
+                                          onClose: () =>
+                                              setState(() => _chatOpen = false),
+                                        ),
                                       ),
                                     ),
                                   ),
@@ -1048,9 +1077,9 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
                               ),
                             ),
                           ),
-                        ),
-                      ],
-                    ),
+                        ],
+                      );
+                    },
                   ),
                 ),
         ),

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2685,7 +2685,7 @@
   "goalDimensionHabitReading": "{currentCount} de {targetCount} cette fenêtre",
   "goalDimensionHabitReadingOverTarget": "{currentCount} cette fenêtre · objectif {targetCount}",
   "goalDimensionHabitReadingOverTargetWindowed": "{currentCount} · objectif {targetCount} · {window}",
-  "goalDimensionHabitReadingWindowed": "{currentCount} de {targetCount} · {window}",
+  "goalDimensionHabitReadingWindowed": "{currentCount} sur {targetCount} · {window}",
   "goalDimensionHabitSource": "Achèvements d'habitudes",
   "goalDimensionHealthSource": "Données de santé",
   "goalDimensionImprovingNote": "Pas encore, mais la dernière mesure s'est rapprochée de la cible.",

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6622,7 +6622,7 @@ class AppLocalizationsFr extends AppLocalizations {
     int targetCount,
     String window,
   ) {
-    return '$currentCount de $targetCount · $window';
+    return '$currentCount sur $targetCount · $window';
   }
 
   @override

--- a/lib/widgets/timeline/timeline_view.dart
+++ b/lib/widgets/timeline/timeline_view.dart
@@ -30,9 +30,11 @@ class TimelineView extends StatelessWidget {
 
   final List<TimelineGroup> groups;
 
-  /// Opens a beat's source entry. When null — or when a beat carries no
-  /// `entryId` — the row renders as static and drops its chevron, so the
-  /// affordance always matches the behaviour.
+  /// Opens a beat's source entry. A beat's own [TimelineBeat.onTap] always
+  /// outranks this fallback. When neither applies — this is null or the beat
+  /// carries no `entryId`, and the beat has no `onTap` — the row renders as
+  /// static and drops its chevron, so the affordance always matches the
+  /// behaviour.
   final ValueChanged<String>? onOpenBeat;
 
   /// Renders the paging tail. Null means the caller is showing everything it

--- a/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
+++ b/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
@@ -2342,13 +2342,23 @@ void main() {
   });
 
   testWidgets('the page opens in AUTO span mode: the shared range is driven '
-      'to the day count that fits the content width', (tester) async {
+      'to the day count that fits the PANE width', (tester) async {
+    // The pane is deliberately narrower than the window: a navigation
+    // sidebar or the check-in rail shrinks the pane, and fitting from the
+    // window width would select too many days and defeat the no-scroll
+    // contract.
+    const paneWidth = 520.0;
     final habitsController = FakeHabitsController(
       HabitsState.initial(now: DateTime(2026, 8, 11)),
     );
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        const GoalAgentDetailPage(agentId: 'goal-1'),
+        const Center(
+          child: SizedBox(
+            width: paneWidth,
+            child: GoalAgentDetailPage(agentId: 'goal-1'),
+          ),
+        ),
         overrides: [
           habitsControllerProvider.overrideWith(() => habitsController),
           agentIdentityProvider(
@@ -2380,20 +2390,16 @@ void main() {
 
     // The fitted span: as many authored-pitch day columns as the content
     // column holds — computed here from the same tokens the page reads, so
-    // the test tracks the density rather than a magic number.
+    // the test tracks the density rather than a magic number. From the PANE
+    // width, never the (wider) MediaQuery width.
     final tokens = tester
         .element(find.byType(GoalAgentDetailPage))
         .designTokens;
     final pitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
-    // The same width source the page estimates from (the harness's
-    // MediaQuery, not the render box).
-    final surfaceWidth = MediaQuery.sizeOf(
-      tester.element(find.byType(GoalAgentDetailPage)),
-    ).width;
     final contentWidth =
         math.min(
           kUnifiedGoalsContentMaxWidth,
-          surfaceWidth - tokens.spacing.step6 * 2,
+          paneWidth - tokens.spacing.step6 * 2,
         ) -
         tokens.spacing.cardPadding * 2;
     final expectedFit = (contentWidth / pitch).floor().clamp(7, 90);

--- a/test/widgets/timeline/timeline_view_test.dart
+++ b/test/widgets/timeline/timeline_view_test.dart
@@ -94,7 +94,9 @@ void main() {
         TimelineView(
           groups: [
             TimelineGroup(
-              beats: [beat(onTap: () => opened++)],
+              // entryId present ON PURPOSE: the fallback path is live, so
+              // this test fails if onTap ever stops outranking it.
+              beats: [beat(entryId: 'entry-9', onTap: () => opened++)],
             ),
           ],
           onOpenBeat: (_) => fail('the beat tap outranks entry navigation'),


### PR DESCRIPTION
Follow-up to #3998 (merged before this last review round landed), addressing the remaining CodeRabbit findings there:

- **Fit the automatic span from the pane width** (Major): the auto-fit day count is now computed from the body `LayoutBuilder`'s measured pane width — minus the check-in rail when it is shown — instead of `MediaQuery`'s window width, which over-counted days whenever a navigation sidebar or the rail narrowed the pane and pushed the tracks into their shrink fallback. The regression test runs the page in a pane deliberately narrower than its window.
- **French count ratio** uses `sur`: "6 sur 7 · 7 jours glissants".
- **Doc fixes**: `goalDayCellLetter` references `PositionedDirectional` (its actual return type); the detail page's class doc drops the retired "About-this-agent expander" phrasing; `TimelineView.onOpenBeat` documents that `TimelineBeat.onTap` outranks it.
- **Test hardening**: the timeline `onTap` test now carries an `entryId`, so it fails if `onTap` ever stops taking precedence over the entry navigation.

Not changed, deliberately: reopening a reflection recorded under a superseded spec still opens the sheet under the **active** spec. Old-spec criteria no longer exist to be re-judged; the sheet records a new verdict under the current criteria while the old record stays readable in the rail — this is documented on `showGoalDayAssessmentSheet`.

No user-visible behavior beyond the auto-span correction on narrow panes, so no screenshots.

## Verification

- `dart analyze lib test` — no issues
- All goals + timeline suites pass locally (1080 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Goal progress automatically fits the available content area, including layouts with the check-in rail and chat drawer.
  * Closed chat drawers are excluded from keyboard focus and accessibility navigation.
  * Timeline beats now prioritize their own tap action over fallback navigation.

* **Localization**
  * Improved French wording for habit-dimension readings.

* **Documentation**
  * Clarified weekday and timeline interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->