### PR TITLE
Token the secondary-glyph alphas, drop unreachable agenda state arms

### DIFF
--- a/lib/features/daily_os_next/ui/widgets/agenda_card.dart
+++ b/lib/features/daily_os_next/ui/widgets/agenda_card.dart
@@ -565,45 +565,40 @@ class _StateMeta extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Only two states ever reach this row. `open` is filtered out by
+    // `_AgendaMetaRow`, and a `done` item never gets here at all — AgendaCard
+    // returns its own compact receipt layout before the meta row is built. The
+    // switch that used to cover all four carried three unreachable arms.
+    assert(
+      state == AgendaItemState.inProgress || state == AgendaItemState.overdue,
+      'AgendaCard renders open and done rows without a _StateMeta; reaching '
+      'here with $state means one of those paths changed.',
+    );
     final tokens = context.designTokens;
-    final (color, label) = switch (state) {
-      AgendaItemState.open => (
-        tokens.colors.text.lowEmphasis,
-        context.messages.dailyOsNextAgendaStateOpen,
-      ),
-      // Neutral: in-progress is the normal mid-day condition, not a
-      // warning — amber is reserved for overdue.
-      AgendaItemState.inProgress => (
-        tokens.colors.text.mediumEmphasis,
-        context.messages.dailyOsNextAgendaStateInProgress,
-      ),
-      AgendaItemState.overdue => (
-        tokens.colors.alert.error.defaultColor,
-        context.messages.dailyOsNextAgendaStateOverdue,
-      ),
-      AgendaItemState.done => (
-        tokens.colors.alert.success.defaultColor,
-        context.messages.dailyOsNextAgendaStateDone,
-      ),
-    };
-    // Done is a glyph, in-progress a quiet colored caption; only the
-    // overdue alarm earns a tinted container.
-    return switch (state) {
-      AgendaItemState.done => Semantics(
-        label: label,
-        child: Icon(LottiIcons.confirm, size: 14, color: color),
-      ),
-      AgendaItemState.overdue => DsPill(
-        variant: DsPillVariant.tinted,
-        color: color,
-        label: label,
-        labelColor: color,
-      ),
-      _ => Text(
-        label,
-        style: tokens.typography.styles.others.caption.copyWith(color: color),
-      ),
-    };
+    final isOverdue = state == AgendaItemState.overdue;
+    // Neutral for in-progress: it is the normal mid-day condition, not a
+    // warning — the alert colour is reserved for overdue.
+    final color = isOverdue
+        ? tokens.colors.alert.error.defaultColor
+        : tokens.colors.text.mediumEmphasis;
+    final label = isOverdue
+        ? context.messages.dailyOsNextAgendaStateOverdue
+        : context.messages.dailyOsNextAgendaStateInProgress;
+    // Only the overdue alarm earns a tinted container; in-progress stays a
+    // quiet coloured caption.
+    return isOverdue
+        ? DsPill(
+            variant: DsPillVariant.tinted,
+            color: color,
+            label: label,
+            labelColor: color,
+          )
+        : Text(
+            label,
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: color,
+            ),
+          );
   }
 }
 

--- a/lib/features/design_system/theme/alpha_tokens.dart
+++ b/lib/features/design_system/theme/alpha_tokens.dart
@@ -8,11 +8,15 @@
 ///
 /// **This group is deliberately small, and should stay small.** An alpha is
 /// the right answer only when a call site needs *the same hue at reduced
-/// strength* and no colour token expresses it. Text emphasis is not such a
-/// case: `colors.text.{high,medium,low}Emphasis` is already the fade ramp for
-/// type, and fading one of those further just re-derives a step that exists.
-/// An error-toned container fill is not such a case either — the theme's
-/// `colorScheme.errorContainer` is the design system's own error wash.
+/// strength* and no colour token expresses it. An error-toned container fill
+/// is not such a case — the theme's `colorScheme.errorContainer` is the design
+/// system's own error wash.
+///
+/// Text emphasis is *usually* not such a case either:
+/// `colors.text.{high,medium,low}Emphasis` is already the fade ramp for type,
+/// and fading one of those further normally just re-derives a step that
+/// exists. [SecondaryGlyphAlpha] is the one sanctioned exception, and it is
+/// there because the ramp genuinely stops short — see its doc.
 library;
 
 /// Alphas applied to a surface or accent colour that must stay recognisably
@@ -62,4 +66,34 @@ abstract final class SurfaceAlphas {
   /// 0.20 — the resting fill of a pressable accent control (the banner's
   /// CTA pill): visibly a control, never louder than the copy above it.
   static const double washControl = 0.20;
+}
+
+/// The one approved step below `colors.text.lowEmphasis`.
+///
+/// The text ramp bottoms out at `lowEmphasis`, which is the right weight for a
+/// glyph that is *the* thing in its slot — a row's trailing chevron, a meta
+/// caption. It is too loud for a glyph that sits *beside* the row's real
+/// action and must not compete with it.
+///
+/// The checklist row is the case that forced this. Its primary action is
+/// checking the item off; the pencil is a secondary way into the editor,
+/// sitting next to a 44pt checkbox. At `lowEmphasis` the pencil carried ~2.5x
+/// the ink of the chevron it is meant to pair with and read as the loudest
+/// mark on the row. Nothing in `colors.text.*` expresses "quieter than
+/// lowEmphasis", so this is a real gap rather than a re-derivation of an
+/// existing step.
+///
+/// Maintainer-approved (2026-08-19). Reach for it only for a genuinely
+/// secondary affordance; if a glyph is the point of its slot, it belongs at a
+/// `colors.text.*` tier instead.
+abstract final class SecondaryGlyphAlpha {
+  /// 0.55 — a secondary affordance beside a row's primary action: clearly
+  /// present, never competing with it.
+  static const double affordance = 0.55;
+
+  /// 0.2 — a hint that only has to be findable once. The checklist row's drag
+  /// handle: a long-press anywhere on the row starts the drag, so the grip is
+  /// a reminder that the gesture exists, not the way to perform it. At any
+  /// higher alpha its repeating texture pulls the eye off the title.
+  static const double hint = 0.2;
 }

--- a/lib/features/tasks/ui/checklists/checklist_item_row_state.dart
+++ b/lib/features/tasks/ui/checklists/checklist_item_row_state.dart
@@ -413,7 +413,7 @@ class ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
                     LottiIcons.drag,
                     size: IconSizes.l,
                     color: tokens.colors.text.lowEmphasis.withValues(
-                      alpha: 0.2,
+                      alpha: SecondaryGlyphAlpha.hint,
                     ),
                   ),
                   SizedBox(width: tokens.spacing.step3),
@@ -596,7 +596,7 @@ class ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
                             // row whose primary action is checking it off.
                             size: IconSizes.xs,
                             color: tokens.colors.text.lowEmphasis.withValues(
-                              alpha: 0.55,
+                              alpha: SecondaryGlyphAlpha.affordance,
                             ),
                           ),
                         ),

--- a/test/features/daily_os_next/ui/widgets/agenda_card_test.dart
+++ b/test/features/daily_os_next/ui/widgets/agenda_card_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/agenda_card.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/editable_title.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/link_badge.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tasks/ui/cover_art_thumbnail.dart';
 
@@ -555,6 +556,83 @@ void main() {
       expect(find.text('In progress'), findsNothing);
       expect(find.text('Overdue'), findsNothing);
       expect(find.text('Done'), findsNothing);
+    });
+
+    testWidgets('a done row collapses to a quiet receipt with a tick', (
+      tester,
+    ) async {
+      // A finished item does not render the normal card at all: AgendaCard
+      // returns a compact one-line receipt so in-progress and upcoming rows
+      // own the viewport. The tick is that row's only state marker — there is
+      // no "Done" caption anywhere — so it is what has to be right.
+      await tester.pumpWidget(
+        _wrap(
+          const Material(
+            child: AgendaCard(
+              index: 5,
+              item: AgendaItem(
+                id: 'a1',
+                title: 'Finished item',
+                category: _category,
+                linkedBlockIds: ['b1'],
+                state: AgendaItemState.done,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Done'), findsNothing, reason: 'a glyph, not a caption');
+      final tick = find.byIcon(LottiIcons.confirm);
+      expect(tick, findsOneWidget);
+      expect(
+        tester.widget<Icon>(tick).color,
+        dsTokensLight.colors.alert.success.defaultColor,
+      );
+      // It is the receipt layout, not the full card: no meta row, so none of
+      // the pills a normal card carries. If this starts finding one, the
+      // early return has been lost and finished items are competing for the
+      // viewport again.
+      expect(
+        find.byType(DsPill),
+        findsNothing,
+        reason: 'the receipt has no meta row',
+      );
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    });
+
+    testWidgets('an overdue row keeps its word — only done is a glyph', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const Material(
+            child: AgendaCard(
+              index: 6,
+              item: AgendaItem(
+                id: 'a1',
+                title: 'Late item',
+                category: _category,
+                linkedBlockIds: ['b1'],
+                state: AgendaItemState.overdue,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Overdue'), findsOneWidget);
+      expect(find.byIcon(LottiIcons.confirm), findsNothing);
+      // Overdue is the one state that earns a tinted container — asserting the
+      // label alone would pass just as happily for a plain caption, which is
+      // what in-progress gets.
+      final pill = tester.widget<DsPill>(
+        find.ancestor(of: find.text('Overdue'), matching: find.byType(DsPill)),
+      );
+      expect(pill.variant, DsPillVariant.tinted);
+      expect(pill.color, dsTokensLight.colors.alert.error.defaultColor);
     });
   });
 }

--- a/test/features/daily_os_next/ui/widgets/knowledge_nudge_test.dart
+++ b/test/features/daily_os_next/ui/widgets/knowledge_nudge_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
+import 'package:lotti/features/daily_os_next/state/planner_knowledge_provider.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/knowledge_nudge.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/knowledge_panel.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+import '../../../../mocks/mocks.dart';
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  PlannerKnowledgeEntity proposal(String id) {
+    return AgentDomainEntity.plannerKnowledge(
+          id: id,
+          agentId: 'daily_os_planner',
+          key: 'key-$id',
+          hook: 'hook',
+          statementText: 'You plan better before 10am',
+          source: KnowledgeSource.agentInferred,
+          status: KnowledgeStatus.proposed,
+          createdAt: DateTime(2026, 5, 20),
+          updatedAt: DateTime(2026, 5, 20),
+          vectorClock: null,
+        )
+        as PlannerKnowledgeEntity;
+  }
+
+  Widget nudge(PlannerKnowledgeView view) => makeTestableWidget(
+    const KnowledgeNudge(),
+    overrides: [
+      plannerKnowledgeProvider.overrideWith((ref) async => view),
+      // The panel the nudge opens resolves this; the nudge itself never does.
+      dayAgentKnowledgeServiceProvider.overrideWithValue(
+        MockDayAgentKnowledgeService(),
+      ),
+    ],
+  );
+
+  testWidgets('renders nothing while no proposal awaits confirmation', (
+    tester,
+  ) async {
+    // The Day page stays calm by default — this is the widget's whole reason
+    // for existing, so it is the first thing worth pinning.
+    await tester.pumpWidget(
+      nudge(
+        PlannerKnowledgeView(confirmed: [proposal('c1')], proposed: const []),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(KnowledgeNudge.nudgeKey), findsNothing);
+    expect(find.byType(Icon), findsNothing);
+  });
+
+  testWidgets('renders nothing while the provider is still loading', (
+    tester,
+  ) async {
+    // `?? 0` on an unresolved AsyncValue: the nudge must not flash in and out
+    // as the day loads.
+    await tester.pumpWidget(
+      nudge(
+        const PlannerKnowledgeView(
+          confirmed: [],
+          proposed: [],
+        ),
+      ),
+    );
+    // deliberately not settled
+
+    expect(find.byKey(KnowledgeNudge.nudgeKey), findsNothing);
+  });
+
+  testWidgets('surfaces proposals with the AI mark and an opening chevron', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      nudge(
+        PlannerKnowledgeView(
+          confirmed: const [],
+          proposed: [proposal('p1'), proposal('p2')],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(KnowledgeNudge.nudgeKey), findsOneWidget);
+    // The sparkle marks this as agent-authored, and the chevron says the row
+    // opens something — together they are what make a quiet line read as
+    // tappable without a button.
+    expect(find.byIcon(LottiIcons.aiSpark), findsOneWidget);
+    expect(find.byIcon(LottiIcons.chevronRight), findsOneWidget);
+  });
+
+  testWidgets('names how many proposals are waiting', (tester) async {
+    // The count is the entire payload of the line; a nudge that said only
+    // "review" would not be worth the row it costs.
+    await tester.pumpWidget(
+      nudge(
+        PlannerKnowledgeView(
+          confirmed: const [],
+          proposed: [proposal('p1'), proposal('p2'), proposal('p3')],
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final text = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(KnowledgeNudge.nudgeKey),
+        matching: find.byType(Text),
+      ),
+    );
+    expect(text.data, contains('3'));
+    expect(text.maxLines, 1, reason: 'the nudge is one quiet line, never two');
+    expect(text.overflow, TextOverflow.ellipsis);
+  });
+
+  testWidgets('the whole line is one tap target, not just the glyph', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      nudge(
+        PlannerKnowledgeView(confirmed: const [], proposed: [proposal('p1')]),
+      ),
+    );
+    await tester.pump();
+
+    // A 14pt sparkle is not a tap target. The InkWell has to span the chip, so
+    // this measures the actual hit area rather than asserting one exists.
+    final size = tester.getSize(find.byKey(KnowledgeNudge.nudgeKey));
+    expect(size.height, greaterThanOrEqualTo(44));
+  });
+
+  testWidgets('tapping it opens the knowledge panel', (tester) async {
+    await tester.pumpWidget(
+      nudge(
+        PlannerKnowledgeView(confirmed: const [], proposed: [proposal('p1')]),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(KnowledgeNudge.nudgeKey));
+    await tester.pumpAndSettle();
+
+    // The nudge's only job is to be the way in.
+    expect(find.byType(KnowledgePanel), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Two follow-ups to #4001, which merged before they landed.

## The pencil alpha (Codex P1)

The checklist pencil carried a raw `alpha: 0.55`. There was no token for it:
`colors.text` bottoms out at `lowEmphasis`, and `alpha_tokens.dart` explicitly
ruled out fading a text tier — "just re-derives a step that exists".

That rule is right in general and wrong here. `lowEmphasis` is the correct
weight for a glyph that *is* its slot (a row's trailing chevron, a meta
caption); it is too loud for one sitting *beside* the row's real action. On the
checklist row the primary action is checking the item off, and at `lowEmphasis`
the pencil carried ~2.5× the ink of the chevron it is meant to pair with.

So `SecondaryGlyphAlpha` adds two named values, and the token file's own doc is
amended to name this as the one sanctioned exception — otherwise the new token
reads as a violation of the file it lives in.

The drag handle in the same row adopts the other value, retiring a
**pre-existing** raw `0.2`.

## The two lines codecov flagged

`knowledge_nudge.dart` had **no test at all** — the icon migration touching two
of its lines is what surfaced that. Six now: renders nothing while nothing
awaits confirmation (the widget's whole reason for existing), nothing while
loading, the count, a ≥44pt hit area, and that tapping opens the panel.

`agenda_card.dart` turned out to be **dead code**. `_StateMeta` can only ever
receive `inProgress` or `overdue`: `open` is filtered by `_AgendaMetaRow`, and
a `done` item never reaches the meta row at all, because `AgendaCard`
early-returns a compact receipt layout. Three of its four switch arms were
unreachable. Removed, with an `assert` so the invariant fails loudly if either
upstream path changes — which also retires the flagged line rather than
inventing a test for something that cannot execute.

## Two of my own tests were wrong, and how that surfaced

Worth writing down, because both passed while proving nothing.

The first done-state test asserted on **the wrong widget**. `find.byIcon` was
matching the receipt row's tick, not `_StateMeta`'s — and even the colour
assertion matched, because both use `alert.success.defaultColor`. It looked
like a real test. Only `hits=0` on the line it claimed to cover exposed it.

Mutation testing then caught a second: rendering overdue as a plain caption
instead of a tinted pill failed **nothing**, because a `DsPill` renders its
label as `Text` too. Now asserted on the pill's variant and colour.

All three mutations (done row loses its tick, overdue loses its pill,
in-progress takes the alert colour) are caught by the final tests.

## Also found, not fixed here

`_StateMeta` wraps the done tick in `Semantics(label: 'Done')`, but that label
never reaches the semantics tree — `find.bySemanticsLabel('Done')` returns
zero. The why-chip at `agenda_card.dart:519` uses the identical idiom and is
likely affected too. It predates the icon work and is out of scope for this
change; recorded in `lotti3-9isr` and noted in the test rather than asserted.

## Verification

594 tests green across `daily_os_next/ui/widgets`, `tasks/ui/checklists` and
`design_system/theme`; `fvm flutter analyze` clean; `make icon_check` at 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated agenda cards to display clearer in-progress and overdue status indicators.
  * Completed agenda items now show only a success indicator.
  * Improved overdue styling with a tinted alert pill.
  * Refined secondary icon opacity for more consistent visual emphasis.

* **Bug Fixes**
  * Improved Knowledge Nudge behavior across empty, loading, and proposal states.
  * Ensured proposal text truncates cleanly and remains easy to tap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->