### PR TITLE
fix(nav): make nav-state storage failures non-fatal, correct the nav docs

### DIFF
--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -1,7 +1,7 @@
 ---
 type: Architecture
 title: Navigation and app shell
-description: Eight independent Beamer stacks behind one IndexedStack, the rules that decide which chrome each route gets, and the one footer in that chrome that leaves the app entirely.
+description: Ten independent Beamer stacks behind one IndexedStack, how the active tab and every tab's route are persisted and restored, the rules that decide which chrome each route gets, and the one footer in that chrome that leaves the app entirely.
 resource: ../../lib/beamer
 tags: [architecture, navigation, beamer, routing, app-shell]
 status: stable
@@ -56,7 +56,7 @@ sources:
 
 # One stack per tab
 
-Lotti does not have a single navigation stack. It has **nine**, one per
+Lotti does not have a single navigation stack. It has **ten**, one per
 top-level destination, each a `BeamerDelegate` with its own history:
 
 | Destination | Root path | Enabled |
@@ -67,6 +67,7 @@ top-level destination, each a `BeamerDelegate` with its own history:
 | Goals (unified) | `/goals` | `enable_unified_goals` |
 | Habits | `/habits` | flag |
 | Dashboards | `/dashboards` | flag |
+| People | `/people` | `enable_relationships` |
 | Journal | `/journal` | always |
 | Events | `/events` | flag |
 | Settings | `/settings` | always |
@@ -94,6 +95,8 @@ flowchart TD
   Stack --> P["Beamer(projectsDelegate)"]
   Stack --> H["Beamer(habitsDelegate)"]
   Stack --> D["Beamer(dashboardsDelegate)"]
+  Stack --> G["Beamer(goalsDelegate)"]
+  Stack --> R["Beamer(relationshipsDelegate)"]
   Stack --> J["Beamer(journalDelegate)"]
   Stack --> E["Beamer(eventsDelegate)"]
   Stack --> S["Beamer(settingsDelegate)"]
@@ -156,8 +159,12 @@ active. It exposes:
 
 - `beamerDelegates` — the ordered list of *enabled* delegates, cached and
   invalidated when navigation feature flags change.
-- `index` plus `indexStreamController`, the broadcast stream the shell listens
-  to.
+- `index` plus `indexStreamController`, a `BehaviorSubject` the shell and the
+  per-tab controllers listen to. It **replays** the current index to every new
+  subscriber: nav state is restored before `runApp`, so the emission that
+  selects the restored tab happens before any of them has subscribed, and a
+  plain broadcast stream would drop it and leave them all believing the app is
+  on Tasks.
 - `setPath(path)`, which resolves a path to its owning delegate and switches the
   index to match.
 

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -7,6 +7,7 @@ import 'package:lotti/beamer/beamer_delegates.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -356,6 +357,13 @@ class NavService {
     _restoreInFlight = true;
     try {
       await _restoreNavigationState();
+    } catch (error, stackTrace) {
+      // `registerSingletons` awaits this before `runApp`, so an unreadable
+      // settings row must not take the whole app down with it. Degrade to
+      // what the constructor already set up — Tasks, every tab at its root —
+      // which is the same place an install with nothing saved starts.
+      _pendingActiveRootPath = null;
+      _logNavigationError('restoreNavigationState', error, stackTrace);
     } finally {
       _restoreInFlight = false;
     }
@@ -568,17 +576,42 @@ class NavService {
 
   /// Writes the active tab and every tab's route to [navStateKey].
   ///
-  /// Fire-and-forget from the navigation call sites; failures are non-fatal
-  /// (the next navigation writes again, and a missing row just means the next
-  /// cold start lands on Tasks).
+  /// Fire-and-forget from the navigation call sites, so a failure has to be
+  /// caught here to be non-fatal at all: uncaught, it would surface as an
+  /// unhandled async error on EVERY navigation for as long as the storage
+  /// problem lasts. Losing a write costs nothing more than the next cold
+  /// start landing on Tasks, and the next navigation writes again.
   Future<void> _persistState() async {
     if (_disposed || _restoreInFlight) return;
-    await _settingsDb.saveSettingsItem(
-      navStateKey,
-      NavStateSnapshot(
-        activeRootPath: _activeRootPath,
-        routes: _routesByTabFromDelegates(),
-      ).encode(),
+    try {
+      await _settingsDb.saveSettingsItem(
+        navStateKey,
+        NavStateSnapshot(
+          activeRootPath: _activeRootPath,
+          routes: _routesByTabFromDelegates(),
+        ).encode(),
+      );
+    } catch (error, stackTrace) {
+      _logNavigationError('persistState', error, stackTrace);
+    }
+  }
+
+  /// Reports a swallowed navigation-persistence failure.
+  ///
+  /// Guarded on registration: NavService is built in unit harnesses that wire
+  /// nothing but the two databases, and a logger lookup must not turn a
+  /// degraded path into a crash.
+  void _logNavigationError(
+    String subDomain,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    if (!getIt.isRegistered<DomainLogger>()) return;
+    getIt<DomainLogger>().error(
+      LogDomain.navigation,
+      error,
+      stackTrace: stackTrace,
+      subDomain: subDomain,
     );
   }
 

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
@@ -1267,6 +1268,83 @@ void main() {
         expect(bench.navService.index, 0);
         expect(bench.navService.currentPath, '/tasks');
       });
+    });
+
+    group('storage failures are non-fatal', () {
+      test('an unreadable settings row does not abort bootstrap', () async {
+        final settingsDb = MockSettingsDb();
+        when(() => settingsDb.itemByKey(any())).thenThrow(
+          Exception('settings db unavailable'),
+        );
+        when(
+          () => settingsDb.saveSettingsItem(any(), any()),
+        ).thenAnswer((_) async => 1);
+
+        final bench = _NavFlagBench(settingsDb: settingsDb);
+
+        // `registerSingletons` awaits this before `runApp`; letting the read
+        // throw would take the whole app down instead of landing on Tasks.
+        await expectLater(
+          bench.navService.restoreNavigationState(),
+          completes,
+        );
+        bench.emitAll(enabled: true);
+
+        expect(bench.navService.index, 0);
+        expect(bench.navService.currentPath, '/tasks');
+      });
+
+      test(
+        'a failing write does not escape as an unhandled async error',
+        () async {
+          final settingsDb = MockSettingsDb();
+          when(() => settingsDb.itemByKey(any())).thenAnswer((_) async => null);
+          when(
+            () => settingsDb.saveSettingsItem(any(), any()),
+          ).thenThrow(Exception('disk full'));
+
+          // Swallowed, but not silently — a storage problem the user can do
+          // nothing about still has to be diagnosable.
+          final logger = MockDomainLogger();
+          when(
+            () => logger.error(
+              any<LogDomain>(),
+              any<Object>(),
+              stackTrace: any<StackTrace>(named: 'stackTrace'),
+              subDomain: any<String>(named: 'subDomain'),
+            ),
+          ).thenReturn(null);
+          getIt.registerSingleton<DomainLogger>(logger);
+          addTearDown(() => getIt.unregister<DomainLogger>());
+
+          final bench = _NavFlagBench(settingsDb: settingsDb)
+            ..emitAll(enabled: true);
+
+          // Every persist is fire-and-forget, so an uncaught failure would
+          // surface as an unhandled async error on EVERY navigation for as long
+          // as the storage problem lasts.
+          final errors = <Object>[];
+          await runZonedGuarded(() async {
+            bench.navService.beamToNamed('/journal');
+            await pumpEventQueue();
+          }, (error, stack) => errors.add(error));
+
+          expect(errors, isEmpty);
+          expect(
+            bench.navService.index,
+            bench.navService.journalIndex,
+            reason: 'navigation itself still succeeds',
+          );
+          verify(
+            () => logger.error(
+              LogDomain.navigation,
+              any<Object>(),
+              stackTrace: any<StackTrace>(named: 'stackTrace'),
+              subDomain: 'persistState',
+            ),
+          ).called(greaterThan(0));
+        },
+      );
     });
 
     group('stale index', () {


### PR DESCRIPTION
Follow-up to #4005. CodeRabbit's review landed after that PR merged (it had hit its OSS rate limit on the first two runs and posted a limit notice instead of a review). All three findings were valid; this is the fix.

## Startup could be aborted by an unreadable settings row — Major

`registerSingletons` awaits `restoreNavigationState()` before `runApp`. Only `NavStateSnapshot.decode` was defensive: a database or I/O failure in `_settingsDb.itemByKey` propagated straight out, so a corrupt settings DB would take the whole app down instead of degrading to the Tasks landing the method's own doc comment promised.

It now catches, clears the parked tab and lets the constructor's `resetTabsToRoots` result stand — the same place an install with nothing saved starts.

## A failing write became an unhandled error on every navigation — Major

`_persistState` documented its failures as non-fatal but caught nothing, and every caller invokes it through `unawaited`. One persistent storage problem would therefore surface as an unhandled async error on *every* navigation for as long as it lasted.

The regression test makes that concrete: with the fix reverted, a single `beamToNamed` produces **two** `disk full` errors in the guarded zone.

Both paths now report through `DomainLogger` under the existing `LogDomain.navigation` rather than swallowing silently — a storage problem the user can do nothing about still has to be diagnosable. The lookup is guarded on `getIt.isRegistered<DomainLogger>()`, following `vector_clock_service`, so the unit harnesses that wire only the two databases keep working.

## The navigation concept was stale — Minor

Pre-existing, not introduced by #4005, but this is the file that PR touched and AGENTS.md asks for docs to match the codebase *in their entirety*:

- It claimed **nine** stacks; `_tabSpecs` yields **ten**. The flag-gated People tab (`/people`, `enable_relationships`) was missing from the table.
- The Mermaid diagram was missing both People **and** Goals.
- The frontmatter description still said "Eight independent Beamer stacks".
- The `indexStreamController` bullet still described the broadcast stream that #4005 replaced with a `BehaviorSubject` — the very change that makes the restored tab visible.

## Tests

Two new cases in `test/services/nav_service_test.dart`, group `storage failures are non-fatal`:

- `an unreadable settings row does not abort bootstrap` — `itemByKey` throws; assert `restoreNavigationState()` completes and the app lands on Tasks.
- `a failing write does not escape as an unhandled async error` — `saveSettingsItem` throws; navigate inside `runZonedGuarded` and assert nothing reaches the zone handler, navigation still succeeds, and the failure *is* reported to `DomainLogger` with `subDomain: 'persistState'`.

Both re-run with their fixes reverted and fail correctly. Patch coverage 11/11 on changed lines; analyzer clean; `make knowledge_check` green including Mermaid; 359 tests pass across `nav_service`, `beamer/` and `journal_root_page`.

## Still open from #4005

The manual resize pass across the 960px breakpoint is not automated — this machine has no `wmctrl`/`xdotool`. Open a task from the desktop split, narrow below 960, confirm the same task's detail page shows on the **Tasks** tab, then widen and confirm it returns to the right pane. #4005's P1 (the shell rendering Tasks while the service was correctly restored) is a good reminder that DB-level checks cannot stand in for looking at the screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation recovery when saved navigation state cannot be read or restored.
  * Navigation now falls back to the default destination when restoration fails.
  * Storage and navigation errors are logged without interrupting navigation or causing unhandled failures.

* **Documentation**
  * Updated navigation architecture documentation to include ten tab stacks, People and Goals destinations, and navigation index replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->