### PR TITLE
fix(nav): keep a way out of a restored detail route

### DIFF
--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -225,6 +225,19 @@ stateDiagram-v2
 A corrupt or unknown-version row degrades to "nothing saved" — the Tasks
 landing — rather than throwing during bootstrap.
 
+**A restored route is stacked on its tab root, never substituted for it.**
+Restore beams each tab with `beamToNamed` on top of the root the constructor's
+`resetTabsToRoots` just set, so the tab's beaming history is two entries long
+and `canBeamBack` is true. Replacing the root instead (`beamToReplacementNamed`)
+left a one-entry history: `BeamerDelegate.beamBack` then does nothing, and since
+the mobile shell *removes* the bottom bar on `/tasks/<id>`, a cold start
+restored onto a task detail had no exit at all — no bar, a dead back chevron,
+and a blank page when the task had since been deleted.
+
+`NavService.beamBack` is the second half of that guarantee: when the delegate
+reports it cannot beam back, it beams to the active tab's root rather than
+doing nothing, so no route reached by any means is a dead end.
+
 ## Background tabs must not steal the foreground
 
 Every tab is mounted at once, so a tab the user is not looking at still builds

--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -236,7 +236,11 @@ and a blank page when the task had since been deleted.
 
 `NavService.beamBack` is the second half of that guarantee: when the delegate
 reports it cannot beam back, it beams to the active tab's root rather than
-doing nothing, so no route reached by any means is a dead end.
+doing nothing, so no route reached by any means is a dead end. That fallback
+**replaces** the dead route (`beamToReplacementNamed`) instead of stacking the
+root above it — a push would leave the detail underneath, and the next back
+would drop the user straight back into the page they just escaped. The tab root
+is therefore terminal: `canBeamBack` stays false and further backs are no-ops.
 
 ## Background tabs must not steal the foreground
 

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -380,7 +380,14 @@ class NavService {
       final route = snapshot.routes[spec.rootPath];
       if (route == null || route == spec.rootPath) continue;
       if (!_matchesRootPath(route, spec.rootPath)) continue;
-      spec.delegate.beamToReplacementNamed(route);
+      // Stacked on top of the root [resetTabsToRoots] just beamed to, NOT
+      // replacing it: a replacement leaves the tab's beaming history one
+      // entry long, `canBeamBack` false, and the restored detail page's back
+      // button dead. On mobile the shell also hides the bottom bar on a task
+      // detail route, so a replaced history restored the user straight into a
+      // screen with no way out at all — worse still when the entity had since
+      // been deleted and the page rendered empty.
+      spec.delegate.beamToNamed(route);
     }
 
     _pendingActiveRootPath = snapshot.activeRootPath;
@@ -867,8 +874,21 @@ class NavService {
     return snapshot?.activeRoute;
   }
 
+  /// Pops the active tab one step back, guaranteeing an escape.
+  ///
+  /// When the tab has no beaming history to pop (a cold start restored
+  /// straight onto a detail route), it falls back to that tab's root instead
+  /// of doing nothing.
   void beamBack({Object? data}) {
-    delegateByIndex(index).beamBack(data: data);
+    final delegate = delegateByIndex(index);
+    if (delegate.beamBack(data: data)) return;
+    // Nothing to go back to. That must never mean "stay here": a detail route
+    // can hide the mobile bottom bar (task details) and render nothing at all
+    // (a deleted entity), so a dead back button is a full lockout. Fall back
+    // to the tab's own root, which is always a real screen.
+    final rootPath = _activeRootPath;
+    if (routeForTab(rootPath) == rootPath) return;
+    delegate.beamToNamed(rootPath);
   }
 
   Future<void> dispose() async {

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -886,9 +886,15 @@ class NavService {
     // can hide the mobile bottom bar (task details) and render nothing at all
     // (a deleted entity), so a dead back button is a full lockout. Fall back
     // to the tab's own root, which is always a real screen.
+    //
+    // REPLACING the dead route rather than stacking on top of it: a push would
+    // leave the detail underneath, and the next back would drop the user right
+    // back into the page they just escaped. The root is the terminal state of
+    // this tab's history, so `canBeamBack` stays false and further backs are
+    // no-ops.
     final rootPath = _activeRootPath;
     if (routeForTab(rootPath) == rootPath) return;
-    delegate.beamToNamed(rootPath);
+    delegate.beamToReplacementNamed(rootPath);
   }
 
   Future<void> dispose() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.11+4340
+version: 1.0.11+4341
 
 msix_config:
   display_name: LottiApp

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -855,6 +855,22 @@ void main() {
         // Should not throw even if there is no history to go back to.
         expect(navService.beamBack, returnsNormally);
       });
+
+      test('falls back to the tab root when there is no history to pop', () {
+        final bench = _NavFlagBench()..emitAll(enabled: true);
+        final navService = bench.navService;
+
+        // A caller outside this service can replace the tab's only history
+        // entry with a detail route — restore used to do exactly that. The
+        // delegate then cannot beam back, and on mobile the detail route
+        // hides the bottom bar: without a fallback the user is locked in.
+        navService.tasksDelegate.beamToReplacementNamed('/tasks/task-3');
+        expect(navService.tasksDelegate.canBeamBack, isFalse);
+
+        navService.beamBack();
+
+        expect(navService.routeForTab('/tasks'), '/tasks');
+      });
     });
 
     group('resetDesktopTaskDetail selectedTaskId sync', () {
@@ -1158,6 +1174,36 @@ void main() {
         expect(bench.navService.index, 0);
         expect(bench.navService.currentPath, '/tasks');
       });
+
+      test(
+        'a restored detail route can be backed out of',
+        () async {
+          final settingsDb = SettingsDb(inMemoryDatabase: true);
+          await settingsDb.saveSettingsItem(
+            navStateKey,
+            const NavStateSnapshot(
+              activeRootPath: '/tasks',
+              routes: {'/tasks': '/tasks/task-7'},
+            ).encode(),
+          );
+
+          final bench = _NavFlagBench(settingsDb: settingsDb);
+          await bench.navService.restoreNavigationState();
+          bench.emitAll(enabled: true);
+          expect(bench.navService.routeForTab('/tasks'), '/tasks/task-7');
+
+          // Restoring must leave the tab root UNDER the detail route. The
+          // mobile shell hides the bottom bar on `/tasks/<id>`, so if the
+          // restored history were one entry long the back button would be
+          // dead and the user locked into the detail page — with nothing on
+          // it at all when the task has since been deleted.
+          expect(bench.navService.tasksDelegate.canBeamBack, isTrue);
+          bench.navService.beamBack();
+          await pumpEventQueue();
+
+          expect(bench.navService.routeForTab('/tasks'), '/tasks');
+        },
+      );
 
       test('a pre-JSON NAV_LAST_ROUTE row still restores its tab', () async {
         final settingsDb = SettingsDb(inMemoryDatabase: true);

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -870,6 +870,12 @@ void main() {
         navService.beamBack();
 
         expect(navService.routeForTab('/tasks'), '/tasks');
+        // The fallback REPLACES the dead route instead of stacking the root on
+        // top of it: leaving the detail underneath would make the very next
+        // back drop the user straight back into the page they just escaped.
+        expect(navService.tasksDelegate.canBeamBack, isFalse);
+        navService.beamBack();
+        expect(navService.routeForTab('/tasks'), '/tasks');
       });
     });
 


### PR DESCRIPTION
## The lockout

`restoreNavigationState` beamed each tab's saved route with
`beamToReplacementNamed`, which removes the last history entry before beaming.
The constructor's `resetTabsToRoots` had just put the tab root there, so restore
replaced it: the tab's beaming history ended up **one entry long**,
`canBeamBack` false, and `BeamerDelegate.beamBack()` a no-op.

On mobile the shell *removes* the bottom nav bar entirely on a `/tasks/<uuid>`
route (`_isTaskDetailRoute`, `beamer_app.dart`). So a cold start restored onto a
task detail had no nav bar and a dead back chevron — and when the task had since
been deleted, `TaskDetailsPage` renders `EmptyScaffoldWithTitle('')`, i.e. a
blank page. Empty screen, no way out, reported from a phone.

Introduced by #4005, which is itself unreleased (1.0.11), so no CHANGELOG entry.

## The fix

Two layers, in `lib/services/nav_service.dart`:

1. Restore uses `beamToNamed(route)`, stacking the saved route **on top of** the
   tab root rather than substituting for it. History is two deep, back works.
2. `NavService.beamBack()` falls back to the active tab's root when the delegate
   reports it cannot beam back — so no route reached by any means (including a
   direct external `beamToReplacementNamed`) is a dead end.

## Tests

Two regression tests in `test/services/nav_service_test.dart`; both were re-run
with the fix reverted and both fail there:

- a restored detail route leaves `canBeamBack` true and backs out to `/tasks`
- `beamBack` falls back to the tab root when there is no history to pop

`nav_service_test.dart` + `beamer/beamer_app_test.dart` green (171 tests),
analyzer clean, `make knowledge_check` passes with the invariant documented in
`knowledge/architecture/navigation.md`.

No UI change, so no screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored detail pages now retain working back navigation to their tab’s root.
  * Back navigation now safely returns to the active tab’s root when no navigation history is available.
  * Prevented users from becoming stuck on empty or detail screens after navigation restoration.

* **Documentation**
  * Documented restored-route behavior and root fallback navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->