### PR TITLE
fix(tasks): give the aligned FAB location value equality

### DIFF
--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -1061,11 +1061,29 @@ Future<void> _defaultCreateTaskPressed(
 /// Never closer to the edge than the system's own bottom inset allows — a
 /// tighter margin is a visual alignment, not a licence to sit under the home
 /// indicator.
+@immutable
 class _ActionBarAlignedFabLocation extends StandardFabLocation
     with FabEndOffsetX, FabFloatOffsetY {
   const _ActionBarAlignedFabLocation({required this.bottomMargin});
 
   final double bottomMargin;
+
+  // Value equality, not identity: `build` constructs a fresh instance every
+  // time, and `Scaffold.didUpdateWidget` reads a changed location as a move —
+  // restarting the FAB transition (and its setState) on every rebuild of a
+  // page that rebuilds on every journal query result.
+  // Value equality, not identity: `build` constructs a fresh instance every
+  // time, and `Scaffold.didUpdateWidget` reads a changed location as a move —
+  // restarting the FAB transition (and its setState) on every rebuild of a
+  // page that rebuilds on every journal query result.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _ActionBarAlignedFabLocation &&
+          other.bottomMargin == bottomMargin;
+
+  @override
+  int get hashCode => bottomMargin.hashCode;
 
   @override
   double getOffsetY(

--- a/test/features/tasks/ui/pages/tasks_tab_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_tab_page_test.dart
@@ -624,6 +624,39 @@ void main() {
     },
   );
 
+  testWidgets(
+    'rebuilding the page does not restart the FAB move transition',
+    (tester) async {
+      await tester.pumpWidget(
+        buildSubject(
+          state: state(),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(
+        tester.hasRunningAnimations,
+        isFalse,
+        reason: 'baseline: the page must be settled before the rebuild',
+      );
+
+      // Rebuild the page with an equivalent tree — the Scaffold element is
+      // reused, so `didUpdateWidget` compares the old and new FAB locations.
+      await tester.pumpWidget(
+        buildSubject(
+          state: state(),
+        ),
+      );
+      await tester.pump();
+
+      // The FAB location is rebuilt from tokens on every build. Without value
+      // equality Scaffold reads each fresh instance as a move to a new spot
+      // and restarts the transition — a setState and an animation per journal
+      // query result, for a FAB that never actually moves.
+      expect(tester.hasRunningAnimations, isFalse);
+    },
+  );
+
   testWidgets('desktop mode listens to desktopSelectedTaskId', (
     tester,
   ) async {


### PR DESCRIPTION
Follow-up to #4012, which merged while its CodeRabbit review was still running.
This addresses the one actionable comment from that review.

`_ActionBarAlignedFabLocation` — the location that puts the tasks list's worded
FAB on the task action bar's centreline — is rebuilt from tokens on every
`TasksTabPage.build`. `FloatingActionButtonLocation` uses identity equality, so
`Scaffold.didUpdateWidget` reads each fresh instance as a move to a new spot and
calls `_moveFloatingActionButton`: a `setState` plus a restarted move transition
on every rebuild of a page that rebuilds on every journal query result — for a
FAB that never actually moves.

Value equality on `bottomMargin` fixes it; the class is marked `@immutable`,
which is also what the analyzer wants next to `operator ==` / `hashCode`.

## Tests

One regression test: settle the page, rebuild it with an equivalent tree so the
Scaffold element is reused and `didUpdateWidget` runs, then assert no animation
is running. Re-run with the equality override removed, it fails with
`Expected: false / Actual: true` — the restarted transition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task page stability when rebuilding the interface, preventing unnecessary Floating Action Button movement animations.
  * Ensured equivalent layout configurations are recognized consistently, resulting in smoother transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->