### PR TITLE
Point PR screenshots at R2, not lotti-docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 ## Commit & Pull Request Guidelines
 - Use Conventional Commits (e.g., `feat:`, `fix:`, `chore:`, `ci:`). Keep subjects concise and imperative.
 - PRs must pass `make analyze` and `make test`; include a clear description and linked issues.
-- **UI changes need a before/after screenshot pair per surface**, captured with the harness (see the `app-screenshots` skill). Capture `before/` from the base commit *first* — it cannot be reconstructed once the change is in. **Never commit images to this repo**; they go to the sibling `lotti-docs` repo under `pr-screenshots/<topic-slug>/{before,after}/` and are linked by raw URL. The layout, the three destinations in `lotti-docs`, and the naming rules are in [knowledge/conventions/screenshots.md](knowledge/conventions/screenshots.md).
+- **UI changes need a before/after screenshot pair per surface**, captured with the harness (see the `app-screenshots` skill). Capture `before/` from the base commit *first* — it cannot be reconstructed once the change is in. **Never commit images to this repo**; publish the pair to Cloudflare R2 with `make pr_screenshots_publish` and link the printed URLs from the PR body. The key layout, the naming rules and the credentials the target needs are in [knowledge/conventions/screenshots.md](knowledge/conventions/screenshots.md).
 - Update docs and localization as needed (run `make l10n`).
 
 ## Security & Configuration Tips

--- a/test/features/agents/ui/agents_manual_screenshots_test.dart
+++ b/test/features/agents/ui/agents_manual_screenshots_test.dart
@@ -7,8 +7,8 @@
 /// settings page. Editors, ritual reviews, and instance details are the real
 /// routed pages at both sizes.
 ///
-/// Generated PNGs are staging inputs for `lotti-docs` and are never committed
-/// to this repository.
+/// Generated PNGs are staging inputs for the manual catalog published to R2
+/// and are never committed to this repository.
 ///
 /// Opt in with:
 /// `LOTTI_SCREENSHOT_DIR=/tmp/lotti_agents_manual fvm flutter test \

--- a/test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart
+++ b/test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart
@@ -6,7 +6,8 @@
 ///
 /// Desktop captures render the production Settings V2 tree/detail shell.
 /// Mobile captures render the production full-screen pages. Generated PNGs
-/// are staging inputs for `lotti-docs` and are never committed to this repo.
+/// are staging inputs for the manual catalog published to R2 and are never
+/// committed to this repo.
 ///
 /// Opt in with:
 /// `LOTTI_SCREENSHOT_DIR=/tmp/lotti_ai_manual fvm flutter test \

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -5,8 +5,8 @@
 /// data follows the Project Waddle world used by the task and Daily OS manual
 /// so operational states remain recognizable across chapters.
 ///
-/// Generated PNGs are staging inputs for `lotti-docs` and are never committed
-/// to this repository.
+/// Generated PNGs are staging inputs for the manual catalog published to R2
+/// and are never committed to this repository.
 ///
 /// Opt in with:
 /// `LOTTI_SCREENSHOT_DIR=/tmp/lotti_sync_manual fvm flutter test \


### PR DESCRIPTION
`AGENTS.md` still told every agent session and every new contributor to put
pull-request screenshots in the sibling `lotti-docs` repo, and referred to
"the three destinations in `lotti-docs`". PR #3816 moved review evidence to
immutable, commit-addressed R2 keys published by `make pr_screenshots_publish`,
and rewrote `knowledge/conventions/screenshots.md` accordingly — but the
AGENTS.md bullet was missed.

That is worse than an ordinary stale line: AGENTS.md loads as project
instructions for every agent session and is the first thing a contributor
reads, so it was actively overriding the correct convention it links to.

The bullet now describes the R2 flow and still defers the key layout and naming
rules to the convention doc rather than restating them — no fact written twice.

Three manual-screenshot test docstrings carried the same staleness, describing
their PNGs as "staging inputs for `lotti-docs`" when the manual catalog also
publishes to R2. The Makefile comment above `MANUAL_CAPTURE_DIR` already says
so; the docstrings just never caught up.

Deliberately left alone: the dated research records under `docs/research/` that
reference `lotti-docs` pr-screenshots paths. Those are history, not
instructions. `GETTING_STARTED.md` also still embeds from `lotti-docs/images/`,
which remains correct — the convention keeps that tree as the legacy archive
for existing release imagery.

Closes lotti3-85o.4.

## Testing

Documentation and comments only; no runtime code touched. `fvm flutter analyze`
clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UI screenshot guidance to use published before-and-after image pairs.
  * Clarified that generated screenshots are temporary staging files for the manual catalog and should remain uncommitted.
  * Updated related documentation links and references to reflect the current publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->