### PR TITLE
fix(goals): stop the new header rails clipping at phone width

### DIFF
--- a/lib/features/agents/ui/ai_summary_card/tldr_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/tldr_section_part.dart
@@ -40,101 +40,116 @@ class TldrHeader extends StatelessWidget {
         tokens.spacing.cardPadding,
         tokens.spacing.step4,
       ),
-      child: Row(
-        children: [
-          // `Expanded` keeps the slot so the playback control stays pinned to
-          // the card's trailing edge, while `Align` hands the button loose
-          // constraints — without it the ink target stretches across the whole
-          // header instead of hugging the badge and the title.
-          Expanded(
-            child: Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: Semantics(
-                button: true,
-                label: hasName
-                    ? '${messages.aiCardTitle}. $displayName'
-                    : messages.aiCardTitle,
-                excludeSemantics: true,
-                // No hover fill: a rectangle washing over the badge + title
-                // block made the card's identity read as a phantom button.
-                // Hover/focus/press answers on the block's own ink — the
-                // badge border firms to the accent and the agent name
-                // brightens a step.
-                child: DsQuietInk(
-                  onTap: onAgentTap,
-                  borderRadius: BorderRadius.circular(tokens.radii.m),
-                  builder: (context, highlighted) => ConstrainedBox(
-                    constraints: const BoxConstraints(
-                      minHeight: kMinInteractiveDimension,
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Container(
-                          width: tokens.spacing.step8,
-                          height: tokens.spacing.step8,
-                          alignment: Alignment.center,
-                          decoration: BoxDecoration(
-                            color: ai.accentSoft,
-                            borderRadius: BorderRadius.circular(
-                              tokens.radii.m,
-                            ),
-                            border: Border.all(
-                              color: highlighted ? ai.accent : ai.border,
-                            ),
-                          ),
-                          child: Icon(
-                            LottiIcons.aiSpark,
-                            size: tokens.spacing.step6,
-                            color: ai.accent,
-                          ),
-                        ),
-                        SizedBox(width: tokens.spacing.step3),
-                        // `Flexible` + single-line text is what makes the
-                        // shrink-wrap real: text allowed to wrap would
-                        // report the full available width straight back and
-                        // re-inflate the row.
-                        Flexible(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              _HeaderTitle(
-                                text: messages.aiCardTitle,
-                                style: tokens
-                                    .typography
-                                    .styles
-                                    .subtitle
-                                    .subtitle1
-                                    .copyWith(color: ai.titleText),
+      child: LayoutBuilder(
+        builder: (context, constraints) => Row(
+          children: [
+            // `Expanded` keeps the slot so the playback control stays pinned to
+            // the card's trailing edge, while `Align` hands the button loose
+            // constraints — without it the ink target stretches across the whole
+            // header instead of hugging the badge and the title.
+            Expanded(
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: Semantics(
+                  button: true,
+                  label: hasName
+                      ? '${messages.aiCardTitle}. $displayName'
+                      : messages.aiCardTitle,
+                  excludeSemantics: true,
+                  // No hover fill: a rectangle washing over the badge + title
+                  // block made the card's identity read as a phantom button.
+                  // Hover/focus/press answers on the block's own ink — the
+                  // badge border firms to the accent and the agent name
+                  // brightens a step.
+                  child: DsQuietInk(
+                    onTap: onAgentTap,
+                    borderRadius: BorderRadius.circular(tokens.radii.m),
+                    builder: (context, highlighted) => ConstrainedBox(
+                      constraints: const BoxConstraints(
+                        minHeight: kMinInteractiveDimension,
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: tokens.spacing.step8,
+                            height: tokens.spacing.step8,
+                            alignment: Alignment.center,
+                            decoration: BoxDecoration(
+                              color: ai.accentSoft,
+                              borderRadius: BorderRadius.circular(
+                                tokens.radii.m,
                               ),
-                              if (hasName)
-                                Text(
-                                  displayName,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: tokens.typography.styles.others.caption
-                                      .copyWith(
-                                        color: highlighted
-                                            ? ai.bodyText
-                                            : ai.metaText,
-                                      ),
-                                ),
-                            ],
+                              border: Border.all(
+                                color: highlighted ? ai.accent : ai.border,
+                              ),
+                            ),
+                            child: Icon(
+                              LottiIcons.aiSpark,
+                              size: tokens.spacing.step6,
+                              color: ai.accent,
+                            ),
                           ),
-                        ),
-                      ],
+                          SizedBox(width: tokens.spacing.step3),
+                          // `Flexible` + single-line text is what makes the
+                          // shrink-wrap real: text allowed to wrap would
+                          // report the full available width straight back and
+                          // re-inflate the row.
+                          Flexible(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                _HeaderTitle(
+                                  text: messages.aiCardTitle,
+                                  style: tokens
+                                      .typography
+                                      .styles
+                                      .subtitle
+                                      .subtitle1
+                                      .copyWith(color: ai.titleText),
+                                ),
+                                if (hasName)
+                                  Text(
+                                    displayName,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: tokens
+                                        .typography
+                                        .styles
+                                        .others
+                                        .caption
+                                        .copyWith(
+                                          color: highlighted
+                                              ? ai.bodyText
+                                              : ai.metaText,
+                                        ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-          if (playbackControl != null) ...[
-            SizedBox(width: tokens.spacing.step3),
-            playbackControl!,
+            if (playbackControl case final control?) ...[
+              SizedBox(width: tokens.spacing.step3),
+              // Non-flex, so the identity block absorbs the slack and the
+              // control stays flush to the trailing edge — but BOUNDED, because
+              // a slot that carries text rather than a fixed-size button (a
+              // freshness caption, an impact pill) grows with the locale and
+              // the text scale, and an unbounded trailing child of a Row
+              // overflows instead of shrinking.
+              ConstrainedBox(
+                constraints: BoxConstraints(maxWidth: constraints.maxWidth / 2),
+                child: control,
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -808,30 +808,31 @@ class GoalThisWeekCard extends StatelessWidget {
           // under the strip the reflection cost the card a touch-target's
           // height plus two gaps to say what a corner button says in the
           // header's own line — and it left the header rail empty.
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  // Over the page's shared range the card is no longer a
-                  // week — it is the goal's day-by-day record over the same
-                  // span every other track shows.
-                  progress.compactWindow.length > 7
-                      ? context.messages.goalDetailGoalDaysTitle
-                      : context.messages.goalDetailThisWeekTitle,
-                  style: tokens.typography.styles.subtitle.subtitle2,
-                ),
-              ),
-              if (onReflectDay != null)
-                _ReflectTodayButton(
-                  recorded:
-                      ratingsByDay[DateTime.utc(
-                        progress.today.year,
-                        progress.today.month,
-                        progress.today.day,
-                      )],
-                  onReflect: () => onReflectDay!(progress.today),
-                ),
-            ],
+          //
+          // The pairing is CONDITIONAL on the action fitting. Its label is
+          // localized and user-scaled — German renders it "Über den heutigen
+          // Tag nachdenken" — so at phone width and a raised text scale the
+          // button alone can outgrow the card, and an inflexible trailing
+          // child in a Row does not shrink, it overflows. Measured rather
+          // than guessed at a breakpoint, for exactly that reason.
+          _GoalDaysHeader(
+            title: progress.compactWindow.length > 7
+                // Over the page's shared range the card is no longer a
+                // week — it is the goal's day-by-day record over the same
+                // span every other track shows.
+                ? context.messages.goalDetailGoalDaysTitle
+                : context.messages.goalDetailThisWeekTitle,
+            action: onReflectDay == null
+                ? null
+                : _ReflectTodayButton(
+                    recorded:
+                        ratingsByDay[DateTime.utc(
+                          progress.today.year,
+                          progress.today.month,
+                          progress.today.day,
+                        )],
+                    onReflect: () => onReflectDay!(progress.today),
+                  ),
           ),
           SizedBox(height: tokens.spacing.step2),
           // The strip counts DAYS; the caption below counts dimensions on
@@ -890,6 +891,76 @@ class GoalThisWeekCard extends StatelessWidget {
           ],
         ],
       ),
+    );
+  }
+}
+
+/// The Goal-days card header: the title with the day's action on its
+/// trailing edge, or — when the two cannot share the width — the title with
+/// the action on its own line beneath, still end-aligned.
+///
+/// The action is a button, so it has no ellipsis to fall back on: it either
+/// fits or it overflows its row. The decision is taken against the label's
+/// MEASURED width at the current locale and text scale, because no fixed
+/// breakpoint can tell whether "Über den heutigen Tag nachdenken" fits
+/// beside a title at 1.6x.
+class _GoalDaysHeader extends StatelessWidget {
+  const _GoalDaysHeader({required this.title, required this.action});
+
+  final String title;
+
+  /// The trailing action; null while the goal cannot be reflected on.
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final titleStyle = tokens.typography.styles.subtitle.subtitle2;
+    final action = this.action;
+    if (action == null) return Text(title, style: titleStyle);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textScaler = MediaQuery.textScalerOf(context);
+        double width(String text, TextStyle style) => (TextPainter(
+          text: TextSpan(text: text, style: style),
+          textDirection: Directionality.of(context),
+          textScaler: textScaler,
+          maxLines: 1,
+        )..layout()).width;
+        // The button's own ink: its dense label, plus the glyph and the
+        // gaps and insets the size spec puts around it.
+        final actionWidth =
+            width(
+              context.messages.goalAssessmentReflectToday,
+              tokens.typography.styles.others.caption,
+            ) +
+            IconSizes.s +
+            tokens.spacing.step6;
+        // The title keeps a readable measure of its own rather than being
+        // squeezed to a sliver beside a long action.
+        final fitsBeside =
+            actionWidth + width(title, titleStyle) + tokens.spacing.step4 <=
+            constraints.maxWidth;
+        if (fitsBeside) {
+          return Row(
+            children: [
+              Expanded(child: Text(title, style: titleStyle)),
+              SizedBox(width: tokens.spacing.step4),
+              action,
+            ],
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(title, style: titleStyle),
+            SizedBox(height: tokens.spacing.step2),
+            // Still the card's trailing rail, one line down: the action does
+            // not become a leading-aligned row again just because it moved.
+            Align(alignment: AlignmentDirectional.centerEnd, child: action),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -927,15 +927,19 @@ class _GoalDaysHeader extends StatelessWidget {
           textScaler: textScaler,
           maxLines: 1,
         )..layout()).width;
-        // The button's own ink: its dense label, plus the glyph and the
-        // gaps and insets the size spec puts around it.
+        // The button's own ink, from the SAME tokens its dense size spec
+        // reads: the caption label, a glyph at the caption's line height,
+        // and the gap plus the two horizontal insets around them. Reserving
+        // a hand-picked icon constant here would drift from the button the
+        // moment the spec changed, and a measurement that under-reserves
+        // puts the row back in the overflow it exists to prevent.
         final actionWidth =
             width(
               context.messages.goalAssessmentReflectToday,
               tokens.typography.styles.others.caption,
             ) +
-            IconSizes.s +
-            tokens.spacing.step6;
+            tokens.typography.lineHeight.caption +
+            tokens.spacing.step2 * 3;
         // The title keeps a readable measure of its own rather than being
         // squeezed to a sliver beside a long action.
         final fitsBeside =

--- a/lib/features/goals/ui/pages/goal_agent_detail_page.dart
+++ b/lib/features/goals/ui/pages/goal_agent_detail_page.dart
@@ -1544,12 +1544,21 @@ class _AgentReadCardState extends ConsumerState<_AgentReadCard> {
               // goal's agent has cost over its lifetime, and how old the
               // read below it is. Neither earns a row of the card's body —
               // the header rail was empty space beside them.
-              playbackControl: Row(
-                mainAxisSize: MainAxisSize.min,
+              // A Wrap, not a Row: the slot's cap bounds the RAIL, and a Row
+              // would still lay these two out at their intrinsic widths and
+              // clip past it. Both facts are money-and-time figures that a
+              // longer locale or a raised text scale lengthens, so when they
+              // stop fitting side by side the caption drops UNDER the pill —
+              // end-aligned, still the header's trailing rail — rather than
+              // either of them being truncated into a wrong number.
+              playbackControl: Wrap(
+                alignment: WrapAlignment.end,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: tokens.spacing.step3,
+                runSpacing: tokens.spacing.step1,
                 children: [
                   GoalAgentLifetimePills(agentId: widget.agentId, inline: true),
-                  if (freshness != null) ...[
-                    SizedBox(width: tokens.spacing.step3),
+                  if (freshness != null)
                     Text(
                       freshness,
                       style: tokens.typography.styles.others.caption.copyWith(
@@ -1558,7 +1567,6 @@ class _AgentReadCardState extends ConsumerState<_AgentReadCard> {
                             : tokens.colors.aiCard.metaText,
                       ),
                     ),
-                  ],
                 ],
               ),
             ),

--- a/lib/features/habits/ui/widgets/habits_chart_card.dart
+++ b/lib/features/habits/ui/widgets/habits_chart_card.dart
@@ -22,11 +22,22 @@ class HabitsChartCard extends ConsumerWidget {
     this.title,
     this.showTimeSpanPicker = true,
     super.key,
-  });
+  }) : assert(
+         habitIds == null || !showTimeSpanPicker,
+         'A scoped card puts its rate summary on the header rail, where the '
+         'range picker would also sit. The two do not fit a phone-width '
+         'header together, and the hosting page that scopes the card is '
+         'exactly the one that owns the page-wide range control — so pass '
+         'showTimeSpanPicker: false alongside habitIds.',
+       );
 
   /// Hidden when a hosting page provides its own page-wide range control
   /// (the goal detail dashboard) — two pickers for one shared span would
   /// fight over the same state.
+  ///
+  /// Asserted mutually exclusive with [habitIds]: the scoped card spends its
+  /// header rail on the rate summary, and a picker beside it clips the
+  /// header at phone width.
   final bool showTimeSpanPicker;
 
   /// When non-null, the card renders the §4b goal-scoped chart variant for
@@ -69,68 +80,81 @@ class HabitsChartCard extends ConsumerWidget {
       ),
       child: Padding(
         padding: EdgeInsets.all(tokens.spacing.cardPadding),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    title ?? messages.habitsCompletionRateTitle,
-                    style: tokens.typography.styles.subtitle.subtitle1.copyWith(
-                      color: tokens.colors.text.highEmphasis,
+        child: LayoutBuilder(
+          builder: (context, constraints) => Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title ?? messages.habitsCompletionRateTitle,
+                      style: tokens.typography.styles.subtitle.subtitle1
+                          .copyWith(
+                            color: tokens.colors.text.highEmphasis,
+                          ),
                     ),
                   ),
-                ),
-                if (habitIds == null && state.minY > 20)
-                  Semantics(
-                    label: state.zeroBased
-                        ? messages.habitsChartUseDynamicBaseline
-                        : messages.habitsChartUseZeroBaseline,
-                    button: true,
-                    toggled: state.zeroBased,
-                    excludeSemantics: true,
-                    onTap: controller.toggleZeroBased,
-                    child: IconButton(
-                      visualDensity: VisualDensity.compact,
-                      onPressed: controller.toggleZeroBased,
-                      tooltip: state.zeroBased
+                  if (habitIds == null && state.minY > 20)
+                    Semantics(
+                      label: state.zeroBased
                           ? messages.habitsChartUseDynamicBaseline
                           : messages.habitsChartUseZeroBaseline,
-                      isSelected: state.zeroBased,
-                      icon: Icon(
-                        state.zeroBased
-                            ? LottiIcons.expandBoth
-                            : LottiIcons.collapseBoth,
-                        size: tokens.spacing.step5,
-                        color: tokens.colors.text.mediumEmphasis,
+                      button: true,
+                      toggled: state.zeroBased,
+                      excludeSemantics: true,
+                      onTap: controller.toggleZeroBased,
+                      child: IconButton(
+                        visualDensity: VisualDensity.compact,
+                        onPressed: controller.toggleZeroBased,
+                        tooltip: state.zeroBased
+                            ? messages.habitsChartUseDynamicBaseline
+                            : messages.habitsChartUseZeroBaseline,
+                        isSelected: state.zeroBased,
+                        icon: Icon(
+                          state.zeroBased
+                              ? LottiIcons.expandBoth
+                              : LottiIcons.collapseBoth,
+                          size: tokens.spacing.step5,
+                          color: tokens.colors.text.mediumEmphasis,
+                        ),
                       ),
                     ),
-                  ),
-                if (showTimeSpanPicker) ...[
-                  SizedBox(width: tokens.spacing.step2),
-                  TimeSpanSegmentedControl(
-                    timeSpanDays: state.timeSpanDays,
-                    onValueChanged: controller.setTimeSpan,
-                    segments: timeSpans,
-                  ),
+                  if (showTimeSpanPicker) ...[
+                    SizedBox(width: tokens.spacing.step2),
+                    TimeSpanSegmentedControl(
+                      timeSpanDays: state.timeSpanDays,
+                      onValueChanged: controller.setTimeSpan,
+                      segments: timeSpans,
+                    ),
+                  ],
+                  // Scoped mode adopts the goal dashboard's card grammar: the
+                  // key reading pinned to the header's trailing edge with its
+                  // verdict underneath, instead of a display-tier number and a
+                  // pair of pills on a row of their own.
+                  if (scoped) ...[
+                    SizedBox(width: tokens.spacing.step3),
+                    // Bounded, not free-standing: the summary's figures are
+                    // localized and user-scaled, and an inflexible trailing
+                    // child of a Row does not shrink — it overflows. Half the
+                    // card is the same ceiling the signal cards' corner blocks
+                    // take, and the summary ellipsizes inside it.
+                    ConstrainedBox(
+                      constraints: BoxConstraints(
+                        maxWidth: constraints.maxWidth / 2,
+                      ),
+                      child: HabitCompletionRateSummary(habitIds: habitIds),
+                    ),
+                  ],
                 ],
-                // Scoped mode adopts the goal dashboard's card grammar: the
-                // key reading pinned to the header's trailing edge with its
-                // verdict underneath, instead of a display-tier number and a
-                // pair of pills on a row of their own.
-                if (scoped) ...[
-                  SizedBox(width: tokens.spacing.step3),
-                  HabitCompletionRateSummary(habitIds: habitIds),
-                ],
-              ],
-            ),
-            SizedBox(height: tokens.spacing.step4),
-            HabitCompletionRateChart(
-              habitIds: habitIds,
-              showsHeadline: !scoped,
-            ),
-          ],
+              ),
+              SizedBox(height: tokens.spacing.step4),
+              HabitCompletionRateChart(
+                habitIds: habitIds,
+                showsHeadline: !scoped,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -362,6 +362,8 @@ class HabitCompletionRateSummary extends ConsumerWidget {
     if (stats.windowDays == 0) return const SizedBox.shrink();
 
     if (state.selectedInfoYmd.isNotEmpty) {
+      // Scaled down rather than clipped: the split is four labels wide and
+      // the corner it now lives in is half a card.
       return FittedBox(
         fit: BoxFit.scaleDown,
         alignment: AlignmentDirectional.centerEnd,
@@ -412,15 +414,24 @@ class HabitCompletionRateSummary extends ConsumerWidget {
           ),
           textAlign: TextAlign.end,
           maxLines: 1,
+          // The host bounds this block to half the card, so a long locale or
+          // a raised text scale has to shorten the line rather than push it
+          // past the card's edge.
+          overflow: TextOverflow.ellipsis,
         ),
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              atGoal
-                  ? messages.habitsAboveGoal
-                  : messages.habitsPointsToGoal(stats.pointsToGoal),
-              style: caption.copyWith(color: goalColor),
+            Flexible(
+              child: Text(
+                atGoal
+                    ? messages.habitsAboveGoal
+                    : messages.habitsPointsToGoal(stats.pointsToGoal),
+                style: caption.copyWith(color: goalColor),
+                textAlign: TextAlign.end,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
             if (delta != null) _SummaryTrend(delta: delta),
           ],

--- a/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -75,6 +76,63 @@ void main() {
       expect(agentTaps, 1);
     });
 
+    testWidgets('a nameless agent gets the card title alone, in both the '
+        'header and its semantics', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidget(
+          TldrHeader(agentName: '   ', onAgentTap: () {}),
+        ),
+      );
+
+      // A blank name is no name: the caption row is omitted rather than
+      // rendered empty, and the tap target announces only what it opens.
+      expect(find.text('AI summary'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(TldrHeader),
+          matching: find.byType(Text),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('AI summary'),
+        findsOneWidget,
+        reason: 'the nameless header announces the card, nothing more',
+      );
+    });
+
+    testWidgets('the agent name rests in the meta ink and lifts to body ink '
+        'under the pointer', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidget(
+          TldrHeader(agentName: 'Task Laura', onAgentTap: () {}),
+        ),
+      );
+
+      final ai = tester
+          .element(find.byType(TldrHeader))
+          .designTokens
+          .colors
+          .aiCard;
+      Color nameColor() => tester
+          .renderObject<RenderParagraph>(find.text('Task Laura'))
+          .text
+          .style!
+          .color!;
+      expect(nameColor(), ai.metaText);
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer();
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(find.text('Task Laura')));
+      await tester.pump();
+      // The block answers on its own ink — there is no hover fill to answer
+      // with, by design.
+      expect(nameColor(), ai.bodyText);
+      await gesture.moveTo(Offset.zero);
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('the tap target hugs the badge and title, not the whole row', (
       tester,
     ) async {
@@ -142,11 +200,23 @@ void main() {
           TldrHeader(
             agentName: 'Task Laura',
             onAgentTap: () {},
-            playbackControl: const Text(
-              'EUR 0.33 - 179 Wh - 35 g - as of 1 hour ago',
+            // The PRODUCTION shape, not a single ellipsizing Text: the goal
+            // read card hands this slot a min-size Row of two facts. Capping
+            // the slot bounds the rail, not the children inside it — a Row
+            // still lays its non-flex children out at their intrinsic
+            // widths — so the fact that yields has to be flexible.
+            // The PRODUCTION shape, not a single ellipsizing Text: the goal
+            // read card hands this slot TWO facts. Each fits the cap alone;
+            // together they do not. A Row would lay both out at their
+            // intrinsic widths and clip past the cap — a Wrap drops the
+            // second onto its own line instead.
+            playbackControl: const Wrap(
               key: ValueKey('rail'),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+              alignment: WrapAlignment.end,
+              children: [
+                SizedBox(key: ValueKey('rail-pill'), width: 90, height: 16),
+                SizedBox(key: ValueKey('rail-age'), width: 90, height: 16),
+              ],
             ),
           ),
         ),
@@ -161,6 +231,12 @@ void main() {
         lessThanOrEqualTo(header.width / 2 + 1),
         reason: 'the identity block keeps at least half the header',
       );
+      // 90 + 90 cannot fit a 160px cap, so the second fact took its own
+      // line rather than the pair clipping past the header's edge.
+      final pill = tester.getRect(find.byKey(const ValueKey('rail-pill')));
+      final age = tester.getRect(find.byKey(const ValueKey('rail-age')));
+      expect(age.top, greaterThanOrEqualTo(pill.bottom));
+      expect(age.right, lessThanOrEqualTo(header.right));
     });
 
     testWidgets('a long agent name truncates instead of wrapping', (

--- a/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/tldr_section_part_test.dart
@@ -124,6 +124,45 @@ void main() {
       );
     });
 
+    testWidgets('a text-bearing trailing slot is bounded to half the header '
+        'instead of overflowing it', (tester) async {
+      // Regression: the slot was an unbounded, non-flex child of the header
+      // Row. A fixed-size playback button never noticed, but the goal read
+      // card puts TEXT there — an impact pill plus an "as of …" caption —
+      // which grows with the locale and the text scale, and an unbounded
+      // trailing child of a Row clips rather than shrinks.
+      tester.view
+        ..physicalSize = const Size(320, 400)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        makeTestableWidget(
+          TldrHeader(
+            agentName: 'Task Laura',
+            onAgentTap: () {},
+            playbackControl: const Text(
+              'EUR 0.33 - 179 Wh - 35 g - as of 1 hour ago',
+              key: ValueKey('rail'),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      final header = tester.getRect(find.byType(TldrHeader));
+      final rail = tester.getRect(find.byKey(const ValueKey('rail')));
+      expect(rail.right, lessThanOrEqualTo(header.right));
+      expect(
+        rail.width,
+        lessThanOrEqualTo(header.width / 2 + 1),
+        reason: 'the identity block keeps at least half the header',
+      );
+    });
+
     testWidgets('a long agent name truncates instead of wrapping', (
       tester,
     ) async {

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -3885,6 +3885,74 @@ void main() {
     );
   });
 
+  testWidgets('a reflect label too long to share the title row drops to its '
+      'own line rather than overflowing it', (tester) async {
+    addTearDown(tester.view.reset);
+
+    Future<void> pump(double scale, double width) async {
+      tester.view
+        ..physicalSize = Size(width, 900)
+        ..devicePixelRatio = 1.0;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+            child: GoalThisWeekCard(
+              progress: GoalProgressView(
+                today: today,
+                compositeRule: GoalCompositeRuleKind.all,
+                habits: [
+                  GoalHabitProgressView(
+                    habitId: 'gym',
+                    name: 'Gym',
+                    targetCount: 3,
+                    days: [
+                      for (var offset = 6; offset >= 0; offset--)
+                        day(offset, 0),
+                    ],
+                    successfulWeeks: 0,
+                  ),
+                ],
+              ),
+              onReflectDay: (_) {},
+            ),
+          ),
+          locale: const Locale('de'),
+        ),
+      );
+    }
+
+    // German renders the action as "Über den heutigen Tag nachdenken"; at a
+    // raised text scale it is wider than a phone card on its own, and an
+    // inflexible trailing child of a Row does not shrink — it overflows.
+    await pump(1.6, 358);
+    expect(tester.takeException(), isNull);
+    final action = find.byKey(const ValueKey('goal-reflect-today'));
+    final title = find.text('Zieltage').evaluate().isEmpty
+        ? find.textContaining('Woche')
+        : find.text('Zieltage');
+    expect(
+      tester.getTopLeft(action).dy,
+      greaterThanOrEqualTo(tester.getBottomLeft(title).dy),
+      reason: 'the action moved below the title it could not sit beside',
+    );
+    // ...and it stays inside the card rather than being clipped by it, which
+    // is what the overflow actually did.
+    final card = tester.getRect(find.byType(GoalThisWeekCard));
+    expect(tester.getTopRight(action).dx, lessThanOrEqualTo(card.right));
+    expect(tester.getTopLeft(action).dx, greaterThanOrEqualTo(card.left));
+
+    // Given the width for it, the pair still shares one row: the stack is a
+    // fallback, not the new layout. (Same locale, same scale — only the
+    // measurement changed, which is the point of measuring.)
+    await pump(1.6, 1200);
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.getCenter(action).dy,
+      closeTo(tester.getCenter(title).dy, 1),
+    );
+  });
+
   testWidgets('the reflect action is a quiet accent button that answers '
       'hover on its own ink', (tester) async {
     await tester.pumpWidget(

--- a/test/widgets/charts/habits/habit_completion_rate_chart_test.dart
+++ b/test/widgets/charts/habits/habit_completion_rate_chart_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/habits/state/habits_controller.dart';
 import 'package:lotti/features/habits/state/habits_state.dart';
+import 'package:lotti/features/habits/ui/widgets/habits_chart_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
@@ -157,6 +158,51 @@ void main() {
         tester.getTopLeft(verdict).dy,
         greaterThan(tester.getTopLeft(rate).dy),
         reason: 'the verdict is the caption UNDER the key figure',
+      );
+    });
+
+    testWidgets('the summary shrinks inside a bounded corner instead of '
+        'overflowing a phone-width header', (tester) async {
+      // Regression: as an inflexible trailing child of the card's header
+      // Row, the summary took its intrinsic width — so a long locale or a
+      // raised text scale pushed it straight past the card's edge.
+      tester.view
+        ..physicalSize = const Size(358, 1200)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(1.8)),
+            child: HabitsChartCard(
+              habitIds: {habitFlossing.id},
+              showTimeSpanPicker: false,
+            ),
+          ),
+          overrides: [
+            habitsControllerProvider.overrideWith(
+              () => _FixedStateController(_fourteenDayState()),
+            ),
+          ],
+          locale: const Locale('de'),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      final card = tester.getRect(find.byType(HabitsChartCard));
+      final summary = tester.getRect(
+        find.byType(HabitCompletionRateSummary),
+      );
+      expect(summary.right, lessThanOrEqualTo(card.right));
+      expect(
+        summary.width,
+        lessThanOrEqualTo(card.width / 2 + 1),
+        reason:
+            'the corner is capped at half the card, like the signal '
+            'cards it sits beneath',
       );
     });
 


### PR DESCRIPTION
Follow-up to #4018, which merged with three unaddressed P2 review
comments from Codex. All three are the same defect and all three are
real — reproduced before fixing.

The decluttering pass moved three blocks onto header rows as inflexible
trailing children of a `Row`. A `Row` does not shrink those; it clips
them. Every one of the three carries localized, user-scaled **text**, so
a long locale or a raised text scale pushes it past the card's edge.

Reproduction at 358 px, German, 1.6x text scale, before the fix:

```
A RenderFlex overflowed by 324 pixels on the right.
```

## Goal days header

The title and the reflection action now pair **only when they fit**. The
action is a button, so it has no ellipsis to fall back on — it either
fits or it overflows. The decision is measured against the label's actual
width at the current locale and text scale, because no fixed breakpoint
can tell whether "Über den heutigen Tag nachdenken" fits beside a title
at 1.6x. When it does not fit, the action takes its own line, still
end-aligned on the trailing rail.

## Read card header rail

`TldrHeader` bounds its trailing slot to half the header. The slot was
unbounded, which a fixed-size playback button never noticed — but the
goal read card puts an impact pill plus an "as of …" caption there, and
those grow. Fixed in the shared header, so every caller benefits.

## Completion rate summary

Bounded to half the card, with both of its lines ellipsizing and the
selected-day split scaling down inside the same bound.

While reproducing this I found the overflow was *not* reachable through
the goal page at all — it needed a scoped card **also** showing the range
picker. That combination is now an `assert` rather than a silent clip:
the page that scopes the card is exactly the one that owns the page-wide
range control, so the two were never meant to coexist. This follows the
design-system principle of enforcing at construction rather than by
review.

## Testing

Three regression tests, each pumped at 358 px with a raised text scale
and (where the label length matters) the German catalogue — every one of
them fails with a `RenderFlex overflowed` on the pre-fix code. The
Goal-days test also asserts the pair still shares one row when given the
width, so the stack is a fallback rather than the new layout.

`fvm dart analyze lib test` clean; 337 tests green across the touched
files and the AI-summary-card suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card and header layouts on narrow screens, with better support for localization and increased text sizes.
  * Prevented playback controls, reflection actions, and habit summaries from overflowing or being clipped.
  * Added flexible text handling with ellipses where space is limited.
  * Ensured scoped habit cards use compatible time-span controls.

* **Tests**
  * Added regression coverage for responsive layouts, localized text, and text scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->