### PR TITLE
fix(goals): name the day-letter geometry, gate the shallow card foot

### DIFF
--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -471,6 +471,30 @@ String formatGoalAggregate(NumberFormat number, num value, {num? against}) {
 /// `radii.s`. Same instrument, same week, two shapes.
 double goalDayCellRadius(DsTokens tokens) => tokens.radii.s;
 
+/// Where the weekday initial sits inside a day cell, and how big it gets.
+///
+/// Proportions of the cell rather than absolute lengths: the cell itself is
+/// sized by [goalDayTrackMetrics] from the available width, so a fixed inset
+/// that looked right on a fortnight track would crowd the corner on a
+/// ninety-day one. They are geometry, not spacing — there is no
+/// design-system token for "a fraction of a cell" — so they live here, named
+/// and in ONE place, rather than as bare numbers inside the widget.
+///
+/// [letterScaleBox] is a ceiling, not a size: the rendered letter is
+/// `min(fontSize, cellSize * letterScaleBox)`, because the glyph is fitted
+/// with [BoxFit.scaleDown] and that never scales UP. The box therefore
+/// governs small cells while the style's own size caps large ones.
+extension GoalDayCellLetterMetrics on DsTokens {
+  /// Inset from the cell's leading edge.
+  double get letterInsetStart => 0.18;
+
+  /// Inset from the cell's bottom edge.
+  double get letterInsetBottom => 0.14;
+
+  /// Ceiling on the letter's height, as a fraction of the cell.
+  double get letterScaleBox => 0.38;
+}
+
 /// Shared fill for a day cell: the full-strength success hue when the goal
 /// requirement held as of that day, a lighter wash of the same hue for a
 /// partial success (routine kept, target still building), neutral otherwise.
@@ -594,8 +618,8 @@ Widget? goalDayCellLetter(
     // under and behind it than pinned to the rounded rect's inner angle —
     // but it stays an annotation, so it moves TOWARD the center rather than
     // to it.
-    start: cellSize * 0.18,
-    bottom: cellSize * 0.14,
+    start: cellSize * tokens.letterInsetStart,
+    bottom: cellSize * tokens.letterInsetBottom,
     child: SizedBox(
       // The scale bound: the glyph shrinks into this box, so the letter
       // stays a small corner annotation at every cell size instead of
@@ -603,7 +627,7 @@ Widget? goalDayCellLetter(
       // `min(fontSize, this height)` — `scaleDown` never scales UP — so
       // raising the letter one step means raising BOTH: the box governs the
       // small cells, the style's own size caps the large ones.
-      height: cellSize * 0.38,
+      height: cellSize * tokens.letterScaleBox,
       child: FittedBox(
         fit: BoxFit.scaleDown,
         child: Text(
@@ -1056,6 +1080,15 @@ class _HabitDimensionCard extends StatelessWidget {
         habit.window == const GoalWindow.rollingDays(count: 7)
         ? habit.successfulWeeks
         : null;
+    // The shallow foot pays for the centering slack an interactive day track
+    // leaves under its squares — so it is only right on a card that actually
+    // ENDS on that track. The legend closes some cards; a check-off callout
+    // closes others, and it is a bordered surface that would sit crowded
+    // against the card edge with the slack stranded above it instead.
+    final endsOnDayTrack =
+        !showLegend &&
+        !(onHabitOutcomeSelected != null &&
+            habit.suggestedFromDimensionName != null);
     return DesignSystemSectionCard(
       // An interactive day row is already a touch-floor-tall track around a
       // cell half its height, so the card gets ~10px of centering slack under
@@ -1067,7 +1100,7 @@ class _HabitDimensionCard extends StatelessWidget {
         tokens.spacing.step5,
         tokens.spacing.step5,
         tokens.spacing.step5,
-        showLegend ? tokens.spacing.step5 : tokens.spacing.step2,
+        endsOnDayTrack ? tokens.spacing.step2 : tokens.spacing.step5,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -687,22 +687,36 @@ void main() {
     expect(find.text('Improving'), findsOneWidget);
   });
 
-  testWidgets('the today ring is drawn in one ink and one stroke everywhere '
-      'it appears, including the key that explains it', (tester) async {
+  testWidgets('the today ring is drawn in one ink and one stroke on every '
+      'surface that draws one, including the key that explains it', (
+    tester,
+  ) async {
+    // Each ring-producing surface has to be MOUNTED, or the test grades an
+    // empty set: the whole-goal strip lives on GoalThisWeekCard, not on
+    // GoalProgressCard, and the strip's cell only draws its ring on a day
+    // with no recorded verdict of its own.
+    final habit = GoalHabitProgressView(
+      habitId: 'gym',
+      name: 'Gym',
+      targetCount: 3,
+      days: [for (var offset = 6; offset >= 0; offset--) day(offset, 0)],
+      successfulWeeks: 0,
+    );
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        GoalProgressCard(
-          progress: GoalProgressView(
-            today: today,
-            habits: [
-              GoalHabitProgressView(
-                habitId: 'gym',
-                name: 'Gym',
-                targetCount: 3,
-                days: [
-                  for (var offset = 6; offset >= 0; offset--) day(offset, 0),
-                ],
-                successfulWeeks: 0,
+        SingleChildScrollView(
+          child: Column(
+            children: [
+              GoalThisWeekCard(
+                progress: GoalProgressView(
+                  today: today,
+                  compositeRule: GoalCompositeRuleKind.all,
+                  habits: [habit],
+                ),
+                onReflectDay: (_) {},
+              ),
+              GoalProgressCard(
+                progress: GoalProgressView(today: today, habits: [habit]),
               ),
             ],
           ),
@@ -711,18 +725,31 @@ void main() {
     );
 
     final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
-    final rings = tester
-        .widgetList<DsDashedBorder>(find.byType(DsDashedBorder))
-        .toList();
-    expect(rings, isNotEmpty);
-    // A hairline in the low-emphasis ink is a rumour on a dark screen. Every
-    // ring — the cell's and the legend swatch that keys it — lifts a step
-    // and takes the emphasis stroke, and they must not diverge: a key drawn
-    // differently from the mark is a key to nothing.
-    for (final ring in rings) {
-      expect(ring.color, tokens.colors.text.mediumEmphasis);
+    Iterable<DsDashedBorder> ringsIn(Finder host) =>
+        tester.widgetList<DsDashedBorder>(
+          find.descendant(of: host, matching: find.byType(DsDashedBorder)),
+        );
+
+    // Named per surface rather than swept as one bag: a bare
+    // `byType(DsDashedBorder)` passed while the strip was never mounted at
+    // all, and would keep passing if it stopped being mounted again.
+    final stripRings = ringsIn(find.byType(GoalCompactWindowStrip));
+    final cardRings = ringsIn(find.byType(GoalProgressCard));
+    expect(stripRings, hasLength(1), reason: 'the strip marks today once');
+    expect(
+      cardRings.length,
+      greaterThanOrEqualTo(2),
+      reason: "the habit card's today cell plus the legend swatch keying it",
+    );
+
+    // A hairline in the low-emphasis ink is a rumour on a dark screen. Mark
+    // and key must not diverge either: a key drawn differently from the mark
+    // is a key to nothing.
+    for (final ring in [...stripRings, ...cardRings]) {
+      expect(ring.color, goalTodayRingInk(tokens));
       expect(ring.strokeWidth, BorderWidths.emphasis);
     }
+    expect(goalTodayRingInk(tokens), tokens.colors.text.mediumEmphasis);
   });
 
   testWidgets('a habit card that ends on its squares gets a shallower foot '
@@ -769,6 +796,63 @@ void main() {
     expect(footOf('Gym').bottom, tokens.spacing.step5);
     expect(footOf('Read').bottom, tokens.spacing.step2);
     expect(footOf('Read').top, tokens.spacing.step5);
+  });
+
+  testWidgets('a card closing on a check-off callout keeps its full foot, '
+      'legend or not', (tester) async {
+    // The shallow foot pays for the centering slack an interactive day track
+    // leaves UNDER its squares. A callout after the track strands that slack
+    // above itself, so the callout — a bordered surface — would sit crowded
+    // against the card edge.
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        SingleChildScrollView(
+          child: GoalProgressCard(
+            progress: GoalProgressView(
+              today: today,
+              habits: [
+                for (final name in ['Gym', 'Read'])
+                  GoalHabitProgressView(
+                    habitId: name,
+                    name: name,
+                    targetCount: 3,
+                    days: [
+                      for (var offset = 6; offset >= 0; offset--)
+                        day(offset, 0),
+                    ],
+                    successfulWeeks: 0,
+                    suggestedFromDimensionName: name == 'Read'
+                        ? 'Weight'
+                        : null,
+                  ),
+              ],
+            ),
+            onHabitOutcomeSelected:
+                ({required day, required habitId, required outcome}) async =>
+                    true,
+          ),
+        ),
+      ),
+    );
+
+    final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
+    expect(
+      find.byKey(const ValueKey('goal-habit-checkoff-callout-Read')),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<DesignSystemSectionCard>(
+            find.ancestor(
+              of: find.text('Read'),
+              matching: find.byType(DesignSystemSectionCard),
+            ),
+          )
+          .padding!
+          .bottom,
+      tokens.spacing.step5,
+      reason: 'the callout closes this card, so it keeps the full foot',
+    );
   });
 
   testWidgets('the day-cell legend rides inside the first habit card', (


### PR DESCRIPTION
Addresses the four review comments left on #4021, which merged before they
were handled. All three code findings confirmed against the source; the
fourth was about my own test, and it was right.

## The ring regression test was vacuous (CodeRabbit)

The worst of the four. It swept `find.byType(DsDashedBorder)` over a
fixture that mounts only `GoalProgressCard` — but the whole-goal strip
lives on `GoalThisWeekCard`, so it was never rendered. Instrumenting it
showed **2 rings**, not the full set: it graded the habit cell and the
legend swatch while claiming to cover every surface that draws one.

It now mounts both cards and asserts **per surface** rather than sweeping
one bag, so a surface that stops being mounted fails the test instead of
silently leaving it. Verified by reverting each ring independently —
strip and habit cell — each of which fails it.

## The shallow foot was gated on the wrong thing (Codex, P2)

`endsOnDayTrack` replaces `!showLegend`. The shallow foot pays for the
centering slack an interactive day track leaves *under* its squares, so
it is only right on a card that genuinely ends there. A habit with a
same-day check-off suggestion closes on a bordered callout instead, which
strands that slack above itself and would leave the callout crowded
against the card edge. Covered by a new test.

## The letter geometry is named and centralized (Codex P1 / CodeRabbit)

The `0.18` / `0.14` / `0.38` ratios move out of the widget into named,
documented members beside the other day-cell metrics.

I have **not** turned them into design-system tokens, and want a decision
before doing so. They are geometry rather than spacing: fractions of a
cell whose own size is computed from the available width by
`goalDayTrackMetrics`. There is no "fraction of a cell" token to reach
for, and inventing one is exactly what `AGENTS.md` says to ask about
first. Centralizing them under one name is what the rule is really
protecting against — the drift and the widget-level duplication — so that
part is done; promoting them to exported tokens is a design call.

## Testing

99 tests green in the progress-card suite. Analyzer clean on `lib` and
`test`. Patch coverage measured locally against the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal and habit card spacing when cards end with a check-off callout or legend.
  * Standardized weekday lettering and scaling across goal progress cards.
  * Corrected today-ring rendering and styling across weekly goal and habit views.

* **Tests**
  * Added coverage for today-ring appearance and check-off callout spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->