### PR TITLE
fix(android): raise AGP and Kotlin to Flutter's required minimums

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '2.2.0'
+        kotlin_version = '2.2.20'
         compileSdkVersion = 36
     }
     repositories {
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4096M -Djava.net.preferIPv4Stack=true
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -21,8 +21,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 dependencyResolutionManagement {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.11+4346
+version: 1.0.11+4347
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
The Android release build has been failing outright, so `1.0.11+4345` shipped no Android artifact:

```
Your project's Android Gradle Plugin version (Android Gradle Plugin version 8.9.1)
is lower than Flutter's minimum supported version of Android Gradle Plugin version 8.11.1.
```

## There were two gates, not one

Raising AGP only uncovers the next check, which the release log never reached because the build died first:

```
Your project's Kotlin version (2.2.0) is lower than
Flutter's minimum supported version of 2.2.20.
```

I found this by configuring the build locally rather than bumping AGP and pushing — a bump of AGP alone would have failed CI a second time in the same place.

Both versions are declared twice, in `settings.gradle` (plugin resolution) and `build.gradle` (buildscript classpath). Both copies are raised so they cannot drift apart.

| | before | after |
|---|---|---|
| AGP | 8.9.1 | 8.11.1 |
| Kotlin | 2.2.0 | 2.2.20 |

Existing toolchain already satisfies these: the workflow sets JDK 17 (AGP 8.11 requires 17) and the wrapper is Gradle 8.14.3 (AGP 8.11 requires 8.13+). Both are set to Flutter's stated minimum rather than the newest release, to keep the change to what the failure demands.

`android/gradle.properties` picks up two flags the Flutter migrator writes itself on first configure under the new AGP. Committing them keeps CI from rewriting the tree mid-build, and both opt *out* of new behaviour (`android.builtInKotlin=false`, `android.newDsl=false`), so the existing KGP setup is preserved rather than swapped.

## How far this was verified

- `./gradlew :app:tasks` configures cleanly. Both validation gates that failed CI now pass, and every plugin configures — including the vendored `third_party/flutter_onnxruntime`, which declares its own AGP 8.7.0 / Kotlin 2.1.0 buildscript and does not conflict.
- `flutter build appbundle --debug` proceeds through dependency resolution into resource compilation — well past where CI died.

**It does not complete locally, and that is an environment limit rather than a result.** This machine is `aarch64`, and Google ships `aapt2` for `linux` as an x86-64 binary:

```
aapt2-8.11.1-...-linux/aapt2: ELF 64-bit LSB pie executable, x86-64
```

so it cannot start here at any AGP version. `flutter-android-release.yml` runs on `ubuntu-latest` (x86-64), where this is not an issue. **The signed release path — `flutter build appbundle --release` with the upload keystore — is only exercisable in CI**, so that step is genuinely unverified until this runs there.

No CHANGELOG entry: a build fix with no runtime behaviour change, which the conventions exclude explicitly.

## Note on CI here

Two test shards will fail on this branch for a reason unrelated to it: `relationship_reminder_service_test` and `notification_service_test` both carry hard-coded dates that expired on 2026-08-21, and reproduce identically on pristine `main`. They are fixed in #4025.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android build tooling and Kotlin support.
  * Added configuration for compatibility with the latest Flutter Android project setup.
  * Incremented the application build number to 1.0.11+4347.
  * No user-facing features or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->