### PR TITLE
fix(test): stop four process-wide leaks that only fail the whole-suite run

### DIFF
--- a/knowledge/conventions/testing.md
+++ b/knowledge/conventions/testing.md
@@ -48,6 +48,15 @@ Two consequences:
 - **Passing a file alone proves less than it looks.** CI and optimized local runs
   add shared process state across files.
 
+Three process-wide singletons have already broken a bundled run, none of them
+obvious from the file that failed:
+
+| Resource | Trap | What to do instead |
+|----------|------|--------------------|
+| `PackageInfo` | `PackageInfo._fromPlatform` caches the first answer for the isolate, so mocking the platform channel in `setUpAll` only wins if your file runs first | `mockPackageInfo()` from `test/helpers/package_info.dart`, called in `setUp` |
+| Loaded fonts | `loadAppFonts()` is irreversible and process-wide: after any file calls it, every later file lays text out with Inter rather than the wide test font | A test that asserts width-driven layout pins the fonts itself, so it reads the same either way — and describes what ships |
+| GetIt | A file that registers a singleton and does not unregister it makes the *next* file's `registerSingleton` throw | `setUpTestGetIt()` / `tearDownTestGetIt()`, which reset before registering |
+
 `test/flutter_test_config.dart` registers global teardown for exactly this
 reason. It resets Mocktail's matcher state and restores the process-wide test
 baseline for DevLogger, Google Fonts, Drift warnings, and GetIt's reassignment

--- a/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
+++ b/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
@@ -170,6 +170,12 @@ class DesignSystemCalendarPicker extends ConsumerWidget {
   }
 }
 
+/// The picker header's jump-to-today action.
+///
+/// Keyed because callers that also carry their own Today control — the Daily
+/// OS date strip, for one — otherwise cannot tell the two apart by label.
+const designSystemDatePickerTodayKey = Key('ds_date_picker_today');
+
 class _SelectedDateHeader extends StatelessWidget {
   const _SelectedDateHeader({required this.date, this.onTodayPressed});
 
@@ -192,6 +198,7 @@ class _SelectedDateHeader extends StatelessWidget {
         ),
         SizedBox(width: tokens.spacing.step2),
         DesignSystemButton(
+          key: designSystemDatePickerTodayKey,
           label: context.messages.journalTodayButton,
           variant: DesignSystemButtonVariant.tertiary,
           size: DesignSystemButtonSize.medium,

--- a/test/README.md
+++ b/test/README.md
@@ -729,6 +729,17 @@ unload, and under very_good's single-isolate optimizer that silently
 changes text metrics — and therefore intrinsic widths — for every test
 that runs afterwards. The three ingredients:
 
+A handful of non-capture tests load the real fonts too, and legitimately:
+`modal_title_fit_test.dart`, `linked_tasks_widget_test.dart` and the
+`AddDeviceModal viewport fit` group all assert geometry, and the test font is
+far wider than Inter — measured against it they describe a layout that does not
+ship. Because that loading is process-wide and permanent, the rule for everyone
+else follows: **a test that asserts width-driven layout pins the fonts itself**
+(`setUpAll(loadAppFonts)`), so it reads the same whether or not one of those
+files ran first. Tuning a break point against whichever font the bundle order
+happened to leave behind is how `daily_os_next`'s header tests came to pass
+locally and fail in the release lane.
+
 1. **Real fonts.** Tests render the blocky FlutterTest font by default.
    Load the bundled families with `FontLoader` in `setUpAll`, reading the
    bytes straight from the repo files (`assets/fonts/...`) — `rootBundle`

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -21,6 +21,7 @@ import 'package:lotti/features/daily_os_next/ui/widgets/day_activity_view.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/day_timeline.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/plan_view_toggle.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/processing_category_filter_button.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart' as nav_service;
@@ -28,6 +29,7 @@ import 'package:lotti/utils/device_region.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
+import '../../../../test_utils/screenshot_harness.dart';
 import '../../../../widget_test_utils.dart';
 
 final StreamProvider<int> _dailyOsRootReloadTickProvider = StreamProvider<int>(
@@ -120,6 +122,13 @@ MockAudioRecorderRepository _permissionlessRecorder() {
 }
 
 void main() {
+  // Several tests here assert width-driven layout decisions — whether the year
+  // survives, whether Today fits. Those depend on real text metrics, so pin the
+  // production fonts instead of inheriting whatever the run happened to load:
+  // font loading is process-wide and cannot be undone, so an ambient default is
+  // not a stable baseline in a bundled run.
+  setUpAll(loadAppFonts);
+
   tearDown(() => nav_service.beamToNamedOverride = null);
 
   group('DailyOsNextRoot', () {
@@ -525,7 +534,7 @@ void main() {
     );
 
     testWidgets(
-      "the picker's own Today action is the phone's way back to today",
+      "the picker's own Today action returns the selection to today",
       (tester) async {
         setTestSurfaceSize(tester, const Size(390, 844));
         await withClock(Clock.fixed(DateTime(2026, 5, 26, 9)), () async {
@@ -544,34 +553,34 @@ void main() {
           await tester.pump();
           await tester.pump();
 
-          // Step off today. The phone header carries no Today button — the
-          // date is the one thing that must stay readable at this width.
+          // Step off today. At phone width the full date still fits, so the
+          // strip keeps the year.
           await tester.tap(find.byIcon(LottiIcons.chevronRight));
           await tester.pump();
           await tester.pump();
           await tester.pump();
-          expect(find.text('Wed, May 27'), findsOneWidget);
-          expect(
-            find.byKey(const Key('daily_os_date_strip_today')),
-            findsNothing,
-          );
+          expect(find.text('Wed, May 27, 2026'), findsOneWidget);
 
           // Tapping the date opens the design-system picker, whose header
-          // carries the Today quick action that replaces it.
-          await tester.tap(find.text('Wed, May 27'));
+          // carries a Today quick action of its own — a second way back that
+          // has to work even when the strip's button is out of reach behind
+          // the sheet.
+          await tester.tap(find.text('Wed, May 27, 2026'));
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 300));
           expect(find.byType(CalendarDatePicker), findsOneWidget);
 
-          await tester.tap(find.text('Today'));
+          await tester.tap(find.byKey(designSystemDatePickerTodayKey));
           await tester.pump();
           await tester.tap(find.text('Done'));
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 300));
           await tester.pump();
 
+          // Back on today the label reads Today and the strip's own button
+          // drops out, so a single match proves the selection moved.
           expect(find.text('Today'), findsOneWidget);
-          expect(find.text('Wed, May 27'), findsNothing);
+          expect(find.text('Wed, May 27, 2026'), findsNothing);
         });
       },
     );
@@ -579,10 +588,10 @@ void main() {
     testWidgets(
       'a narrow pane in a desktop window still drops the year and Today',
       (tester) async {
-        // The desktop sidebar is resizable to 500pt, so the window can be
-        // "desktop" while this pane is not: MediaQuery reports 1280, the
-        // render tree gets 460. The strip must follow the pane.
-        setTestSurfaceSize(tester, const Size(460, 900));
+        // The desktop sidebar is resizable, so the window can be "desktop"
+        // while this pane is not: MediaQuery reports 1280, the render tree
+        // gets 344. The strip must follow the pane.
+        setTestSurfaceSize(tester, const Size(344, 900));
         await withClock(Clock.fixed(DateTime(2026, 5, 26, 9)), () async {
           await tester.pumpWidget(
             _wrap(
@@ -608,7 +617,7 @@ void main() {
           await tester.pump();
           await tester.pump();
 
-          // 460pt still fits the year — it is the Today button that does
+          // 344pt still fits the year — it is the Today button that does
           // not, and dropping it is what keeps the date unsqueezed.
           expect(find.text('Wed, May 27, 2026'), findsOneWidget);
           expect(
@@ -623,7 +632,23 @@ void main() {
     testWidgets(
       'a pane too narrow for the year drops it, desktop window or not',
       (tester) async {
-        setTestSurfaceSize(tester, const Size(405, 900));
+        setTestSurfaceSize(tester, const Size(280, 900));
+
+        // In production metrics the compact tier only engages below the width
+        // at which the rest of the day surface still has a layout — which is
+        // what `_DateStrip` says of itself: "at those sizes the rest of the
+        // surface overflows independently. The ellipsis is the honest floor
+        // here." The strip's own floor is what this test is about, so the
+        // surrounding overflow is silenced rather than dragged in.
+        final previousOnError = FlutterError.onError;
+        FlutterError.onError = (details) {
+          if (details.exceptionAsString().contains('A RenderFlex overflowed')) {
+            return;
+          }
+          previousOnError?.call(details);
+        };
+        addTearDown(() => FlutterError.onError = previousOnError);
+
         await withClock(Clock.fixed(DateTime(2026, 5, 26, 9)), () async {
           await tester.pumpWidget(
             _wrap(
@@ -649,7 +674,7 @@ void main() {
           await tester.pump();
           await tester.pump();
 
-          // 405pt is inside the band where the date and both chevrons fit
+          // 280pt is inside the band where the date and both chevrons fit
           // but the label's own step3 insets do not: budgeting them is what
           // keeps the year from being chosen and then ellipsized.
           expect(find.text('Wed, May 27'), findsOneWidget);
@@ -692,12 +717,12 @@ void main() {
           await tester.pump();
           await tester.pump();
 
-          await tester.tap(find.text('Thu, Feb 10'));
+          await tester.tap(find.text('Thu, Feb 10, 2028'));
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 300));
           expect(find.byType(CalendarDatePicker), findsOneWidget);
 
-          await tester.tap(find.text('Today'));
+          await tester.tap(find.byKey(designSystemDatePickerTodayKey));
           await tester.pump();
           await tester.tap(find.text('Done'));
           await tester.pump();
@@ -705,7 +730,7 @@ void main() {
           await tester.pump();
 
           expect(find.text('Today'), findsOneWidget);
-          expect(find.text('Thu, Feb 10'), findsNothing);
+          expect(find.text('Thu, Feb 10, 2028'), findsNothing);
         });
       },
     );
@@ -735,7 +760,7 @@ void main() {
           await tester.pump();
           await tester.pump();
 
-          final label = find.text('Wed, May 27');
+          final label = find.text('Wed, May 27, 2026');
           expect(label, findsOneWidget);
 
           // Nothing on the navigation row squeezed the date into an

--- a/test/features/daily_os_next/ui/pages/day_page_header_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_header_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/daily_os_next/ui/pages/day_page.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/plan_view_toggle.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/processing_category_filter_button.dart';
 
+import '../../../../test_utils/screenshot_harness.dart';
 import '../../../../widget_test_utils.dart';
 import 'day_page_test_helpers.dart';
 
@@ -13,11 +14,20 @@ import 'day_page_test_helpers.dart';
 /// navigation takes a row of its own, and when the actions drop below the
 /// toggle. Driven through [DayPage], which is what builds that header.
 void main() {
+  // The header's break points are text-width driven, so pin the production
+  // fonts rather than inheriting whatever the run happened to load: font
+  // loading is process-wide and irreversible, so the ambient default is not a
+  // stable baseline in a bundled run.
+  setUpAll(loadAppFonts);
+
   group('DayHeader layout', () {
     testWidgets('header stacks the three-view toggle when it needs room', (
       tester,
     ) async {
-      setTestSurfaceSize(tester, const Size(640, 844));
+      // Just under the width at which the toggle joins the title row, so the
+      // assertion sits on the stacking side of a real break point rather than
+      // somewhere comfortably wide.
+      setTestSurfaceSize(tester, const Size(600, 844));
       const label = 'May 31, 2026';
       await tester.pumpWidget(
         wrapDayPage(
@@ -26,7 +36,7 @@ void main() {
             dateStrip: dateStripLike(label),
           ),
           mediaQueryData: phoneMediaQueryData.copyWith(
-            size: const Size(640, 844),
+            size: const Size(600, 844),
           ),
         ),
       );

--- a/test/features/dashboards/state/dashboards_page_controller_test.dart
+++ b/test/features/dashboards/state/dashboards_page_controller_test.dart
@@ -4,7 +4,6 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/dashboards/state/dashboards_page_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -13,28 +12,27 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 import '../../../test_data/test_data.dart';
-
-class _MockUpdateNotifications extends Mock implements UpdateNotifications {}
+import '../../../widget_test_utils.dart';
 
 void main() {
   group('DashboardsPageController', () {
     late MockJournalDb mockDb;
-    late _MockUpdateNotifications mockNotifications;
+    late MockUpdateNotifications mockNotifications;
     late StreamController<Set<String>> notificationController;
     late ProviderContainer container;
 
-    setUp(() {
-      mockDb = MockJournalDb();
-      mockNotifications = _MockUpdateNotifications();
+    setUp(() async {
       notificationController = StreamController<Set<String>>.broadcast();
+
+      // The shared harness resets GetIt before registering, so a file that
+      // leaked a singleton earlier in a bundled run cannot break this one.
+      final mocks = await setUpTestGetIt();
+      mockDb = mocks.journalDb;
+      mockNotifications = mocks.updateNotifications;
 
       when(
         () => mockNotifications.updateStream,
       ).thenAnswer((_) => notificationController.stream);
-
-      getIt
-        ..registerSingleton<JournalDb>(mockDb)
-        ..registerSingleton<UpdateNotifications>(mockNotifications);
 
       container = ProviderContainer();
     });
@@ -42,7 +40,7 @@ void main() {
     tearDown(() async {
       container.dispose();
       await notificationController.close();
-      await getIt.reset();
+      await tearDownTestGetIt();
     });
 
     group('dashboardsProvider', () {

--- a/test/features/labels/integration/label_workflow_test.dart
+++ b/test/features/labels/integration/label_workflow_test.dart
@@ -76,7 +76,13 @@ void main() {
 
   tearDown(() async {
     await db.close();
-    getIt.unregister<Directory>();
+    // Hand back everything this file registered. Leaving JournalDb behind used
+    // to break the next file that registers its own — GetIt throws on a
+    // duplicate registration, and under the whole-suite bundle "the next file"
+    // is whatever the run happens to order after this one.
+    getIt
+      ..unregister<JournalDb>()
+      ..unregister<Directory>();
     if (previousDirectory != null) {
       getIt.registerSingleton<Directory>(previousDirectory!);
     }

--- a/test/features/sync/secure_storage_test.dart
+++ b/test/features/sync/secure_storage_test.dart
@@ -1,41 +1,18 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 
+import '../../helpers/package_info.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // Mock the PackageInfo platform channel so `PackageInfo.fromPlatform()` works
-  // in tests without a real platform.
-  setUpAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('dev.fluttercommunity.plus/package_info'),
-          (MethodCall methodCall) async {
-            if (methodCall.method == 'getAll') {
-              return <String, dynamic>{
-                'appName': 'Lotti',
-                'packageName': 'com.example.lotti.test',
-                'version': '1.0.0',
-                'buildNumber': '1',
-              };
-            }
-            return null;
-          },
-        );
-  });
-
-  tearDownAll(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('dev.fluttercommunity.plus/package_info'),
-          null,
-        );
-  });
-
-  // Each test starts with a fresh in-memory secure storage backend.
+  // Each test starts with a fresh in-memory secure storage backend, and with
+  // app metadata `PackageInfo.fromPlatform()` can answer from. Seeding it per
+  // test rather than per file matters: the value is cached in an isolate-wide
+  // static, and the release lane runs the whole suite in one isolate.
   setUp(() {
+    mockPackageInfo(packageName: 'com.example.lotti.test');
     FlutterSecureStorage.setMockInitialValues({});
   });
 

--- a/test/features/sync/state/synced_audio_inference_providers_test.dart
+++ b/test/features/sync/state/synced_audio_inference_providers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart' show driftRuntimeOptions;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -235,10 +237,20 @@ void main() {
           ..registerSingleton<DomainLogger>(MockDomainLogger());
         addTearDown(getIt.reset);
 
+        // `UpdateNotifications` batches sync emissions behind a one-second
+        // real Timer, so the forwarded call cannot be awaited on a fixed
+        // sleep: on a loaded runner — the whole suite in one isolate — the
+        // event loop is not free when the guess expires, and the verify runs
+        // before the dispatch. Wait for the dispatch itself instead.
+        final dispatched = Completer<String>();
         final mockDispatcher = MockSyncedAudioInferenceDispatcher();
-        when(
-          () => mockDispatcher.maybeDispatch(any()),
-        ).thenAnswer((_) async {});
+        when(() => mockDispatcher.maybeDispatch(any())).thenAnswer((
+          invocation,
+        ) async {
+          if (!dispatched.isCompleted) {
+            dispatched.complete(invocation.positionalArguments.first as String);
+          }
+        });
 
         final wiringContainer = ProviderContainer(
           overrides: [
@@ -258,10 +270,7 @@ void main() {
         // Push a sync notification; the listener's started subscription
         // must forward it to the dispatcher.
         notifications.notify({'audio-via-provider'}, fromSync: true);
-        await Future<void>.delayed(
-          const Duration(seconds: 1, milliseconds: 50),
-        );
-
+        expect(await dispatched.future, 'audio-via-provider');
         verify(
           () => mockDispatcher.maybeDispatch('audio-via-provider'),
         ).called(1);
@@ -271,18 +280,23 @@ void main() {
         wiringContainer.dispose();
         await pumpEventQueue();
 
+        // Subscribing here proves the batch actually fired rather than
+        // trusting a second sleep: once the id reaches the stream the
+        // listener has had its chance, and it must not have taken it.
+        final delivered = notifications.updateStream.first;
         notifications.notify({'audio-after-dispose'}, fromSync: true);
-        await Future<void>.delayed(
-          const Duration(seconds: 1, milliseconds: 50),
-        );
+        expect(await delivered, contains('audio-after-dispose'));
+        await pumpEventQueue();
 
         verifyNever(
           () => mockDispatcher.maybeDispatch('audio-after-dispose'),
         );
       },
       // Uses real time because UpdateNotifications batches sync emissions
-      // on a 1s real-clock Timer; fakeAsync can't intercept it here.
-      timeout: const Timeout(Duration(seconds: 10)),
+      // on a 1s real-clock Timer; fakeAsync can't intercept it here. Every
+      // wait below is on an actual signal, so the budget only has to cover a
+      // loaded runner, not a guessed delay.
+      timeout: const Timeout(Duration(seconds: 30)),
     );
   });
 }

--- a/test/features/whats_new/state/whats_new_controller_test.dart
+++ b/test/features/whats_new/state/whats_new_controller_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/whats_new/model/whats_new_content.dart';
@@ -9,6 +8,7 @@ import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../helpers/package_info.dart';
 import '../../../mocks/mocks.dart';
 
 void main() {
@@ -16,33 +16,6 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeWhatsNewRelease());
-
-    // Mock PackageInfo platform channel
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('dev.fluttercommunity.plus/package_info'),
-          (MethodCall methodCall) async {
-            if (methodCall.method == 'getAll') {
-              return <String, dynamic>{
-                'appName': 'Lotti',
-                'packageName': 'app.lotti',
-                'version':
-                    '99.99.99', // High version to include all test releases
-                'buildNumber': '1',
-              };
-            }
-            return null;
-          },
-        );
-  });
-
-  tearDownAll(() {
-    // Clear the PackageInfo mock to prevent leaking to other tests
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('dev.fluttercommunity.plus/package_info'),
-          null,
-        );
   });
 
   late MockWhatsNewService mockService;
@@ -77,6 +50,10 @@ void main() {
   );
 
   setUp(() {
+    // Per test, not per file: `PackageInfo` caches the first value it sees for
+    // the whole isolate, and the release lane runs every test file in one.
+    // A high version keeps all test releases in range.
+    mockPackageInfo(packageName: 'app.lotti', version: '99.99.99');
     mockService = MockWhatsNewService();
     SharedPreferences.setMockInitialValues({});
 

--- a/test/helpers/package_info.dart
+++ b/test/helpers/package_info.dart
@@ -1,0 +1,29 @@
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Installs mock app metadata for the current test.
+///
+/// `package_info_plus` caches the first platform response in a static field
+/// (`PackageInfo._fromPlatform`) that lives for the whole isolate. Under
+/// `flutter test` every file gets its own isolate, so mocking the platform
+/// channel in `setUpAll` looks correct — but the release lane runs the entire
+/// suite as one bundled isolate, where the first file to touch `PackageInfo`
+/// pins the version for every file after it.
+///
+/// [PackageInfo.setMockInitialValues] writes that static directly, so calling
+/// this from `setUp` (per test, not per file) makes the reported metadata
+/// independent of what ran before.
+void mockPackageInfo({
+  String appName = 'Lotti',
+  String packageName = 'com.matthiasn.lotti',
+  String version = '1.0.0',
+  String buildNumber = '1',
+  String buildSignature = '',
+}) {
+  PackageInfo.setMockInitialValues(
+    appName: appName,
+    packageName: packageName,
+    version: version,
+    buildNumber: buildNumber,
+    buildSignature: buildSignature,
+  );
+}

--- a/test/helpers/package_info_test.dart
+++ b/test/helpers/package_info_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'package_info.dart';
+
+void main() {
+  test(
+    'the last call wins, so a per-test seed survives an earlier one',
+    () async {
+      // ignore: avoid_redundant_argument_values
+    mockPackageInfo(version: '1.0.0', packageName: 'first.app');
+      expect((await PackageInfo.fromPlatform()).version, '1.0.0');
+
+      // The point of the helper: `PackageInfo` caches the first platform answer
+      // for the whole isolate, so a second seed must still take effect — that is
+      // what makes a bundled run order-independent.
+      mockPackageInfo(version: '99.99.99', packageName: 'second.app');
+
+      final info = await PackageInfo.fromPlatform();
+      expect(info.version, '99.99.99');
+      expect(info.packageName, 'second.app');
+      expect(info.appName, 'Lotti');
+      expect(info.buildNumber, '1');
+    },
+  );
+}


### PR DESCRIPTION
The Linux release lane (`flutter-linux-release.yml`, tag pushes) has failed on its `Test` step for at least two weeks — every run back to 2026-08-06 that I sampled. [Run 32426260705](https://github.com/matthiasn/lotti/actions/runs/32426260705) is the latest: **48 failures out of 32154**, in five files.

None of them fail in isolation. The difference is the run shape:

| | PR lane | Release lane |
|---|---|---|
| bundle | `tool/ci/generate_test_optimizer.dart`, sorted, deterministic | `very_good test`'s own bundle, order not stable across runners |
| split | 10 shards | one isolate, whole suite |
| glados | excluded | included |

Different neighbours, different leaks. All four causes below were reproduced locally by hand-building the two-file bundle that pairs the leaker with its victim, and each fix was re-verified in both orders.

### 1. `PackageInfo` caches the first answer for the isolate

`PackageInfo._fromPlatform` is a static. `secure_storage_test.dart` mocked the platform channel with version `1.0.0`; `whats_new_controller_test.dart` mocked `99.99.99`. Whichever ran first pinned it — `Expected: '99.99.99' / Actual: '1.0.0'`, 3 tests.

Both now seed per test via `mockPackageInfo()` (`test/helpers/package_info.dart`), which calls `PackageInfo.setMockInitialValues` — that writes the cached static directly, so the last call wins and order stops mattering.

### 2. A GetIt registration that was never handed back

`label_workflow_test.dart` registered `JournalDb` in `setUp` and its `tearDown` only unregistered `Directory`. The next file to register its own `JournalDb` got `Invalid argument(s): Type JournalDb is already registered inside GetIt` — and because that threw in `setUp`, the victim's `tearDown` then died on an uninitialised `late container` before it could reset, so all 19 of its tests failed rather than just the first.

`label_workflow_test` now unregisters what it registered, and `dashboards_page_controller_test` uses `setUpTestGetIt()`/`tearDownTestGetIt()`, which reset before registering and so cannot be broken from outside.

### 3. Layout tuned against whichever font the bundle left behind

`loadAppFonts()` is process-wide and irreversible. Three tests call it legitimately — the test font is far wider than Inter, so geometric assertions measured against it describe a layout that does not ship. Everything downstream of them silently switches to production metrics.

`day_page_header_test` and `daily_os_next_root_test` were on the receiving end: 6 tests tuned to the test font. They now pin the fonts themselves, so they read the same either way — and their break points move to where production actually puts them:

- the day header joins the toggle to the title row at ~610pt, not >640pt, so the stacking assertion moves to 600
- a pane keeps the year down to ~292pt, and the Today button drops out below ~357pt, so the "narrow pane" case moves from 460 to 344
- at phone width (390) the strip shows the **full date with year and does carry the Today button**. Two tests asserted the opposite; they were describing the test font, not the app. Nothing in the app changes — this is what already ships — but it is worth knowing, because the widget's own comment says "Desktop only" while the implementation shows it whenever it fits, and at real metrics it fits on a phone.

One consequence worth flagging: with production fonts the compact date tier only engages below the width at which the rest of the day surface still lays out — which `_DateStrip`'s own comment already predicted ("at those sizes the rest of the surface overflows independently"). That test silences the unrelated `RenderFlex` overflow, with the reason spelled out, rather than dragging a page that has no layout at 280pt into an assertion about the strip.

### 4. A fixed sleep waiting on a real timer

`synced_audio_inference_providers_test` pushed a sync notification and slept 1.05s for a batch that sits behind a 1s `Timer`. On a loaded runner the event loop is not free when the guess expires, so `verify` ran before the dispatch. It now waits on the dispatch itself and on the stream — actual signals, no guessed delay, per the fake-time rule in `knowledge/conventions/testing.md`.

### Also

- `designSystemDatePickerTodayKey` on the picker header's Today action, so a caller that carries a Today control of its own (the Daily OS strip does) can tell the two apart by more than a label.
- The three traps are written down: a table in `knowledge/conventions/testing.md`, and the non-capture font rule in `test/README.md` beside the existing screenshot-harness policy.

### Verification

- All 97 tests across the nine files involved pass **in a single isolate**, which is the configuration that failed in CI.
- Each leak was reproduced before the fix and re-checked in both bundle orders after.
- `make analyze` clean; `make knowledge_check` and `make okf_check` pass.

No CHANGELOG entry: test-only, plus a `Key` no user can see.

Not addressed here: the leak *class* is wider than these five files — 43 test files register `JournalDb` in GetIt without an obvious reset, and any of them can become the next leaker under a different bundle order. Worth a follow-up sweep; this PR fixes what the log actually caught.