### PR TITLE
One treatment rule for both directions of the task list toggle

### DIFF
--- a/knowledge/features/tasks/overview.md
+++ b/knowledge/features/tasks/overview.md
@@ -119,12 +119,19 @@ controls — the back arrow (only while a linked task is stacked) and
 `TaskDetailShowListButton` takes the same corner, so the toggle is one control
 in one place rather than two affordances a pane apart.
 
-The toggle takes the shape of the row it joins, because **glass is for a
-photograph behind the glyph, not for app bars in general**: a bare glyph at
-medium emphasis on the compact bar, matching its trailing actions, and the
-glass treatment only on the cover-art bar, where those actions are glass too.
-A tinted circle beside two bare icons in the same row read as a different
-species of control.
+Both directions share one rule, because **glass is for a photograph behind the
+glyph, not for app bars in general**: a bare glyph at medium emphasis by
+default — matching the compact bar's trailing actions — and the glass
+treatment only where cover art actually sits behind that corner. A tinted
+circle beside two bare icons in the same row read as a different species of
+control.
+
+The two halves learn that from different places, since they render in
+different layers. `TaskDetailHideListButton` is told by the app bar that hosts
+it (the cover-art bar passes `glass: true`); `TaskDetailShowListButton` floats
+over the task instead, so it resolves the question itself from the task under
+it — `taskHasCoverArt(ref, taskId)`, with no task and no answer meaning no
+glass.
 
 The Hide action used to sit next to the *task list's* own title, where selecting
 a task made it appear and shoved that title sideways. The Show action is owned

--- a/lib/features/tasks/ui/pages/tasks_root_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_root_page.dart
@@ -128,6 +128,7 @@ class _TasksRootPageState extends ConsumerState<TasksRootPage> {
               ),
               detailPane: _TasksDetailPane(
                 stackDepth: stack.length,
+                selectedTaskId: selectedTaskId,
                 // The details column is the collapsed-list layout: once the
                 // reader has hidden the list to focus one task, the pane is
                 // wide enough to carry the task's metadata beside it instead
@@ -170,10 +171,16 @@ class _TasksDetailPane extends StatelessWidget {
     required this.stackDepth,
     required this.detail,
     required this.metaColumnTaskId,
+    required this.selectedTaskId,
   });
 
   final int stackDepth;
   final Widget detail;
+
+  /// The task on show, whatever the layout — unlike [metaColumnTaskId], which
+  /// is null in every state that has no metadata column. The "show list"
+  /// affordance reads it to tell whether cover art sits behind it.
+  final String? selectedTaskId;
 
   /// The task whose metadata the column shows, or null when this layout has
   /// no column (list pane visible, or no task selected).
@@ -201,7 +208,11 @@ class _TasksDetailPane extends StatelessWidget {
             Expanded(
               child: TaskMetaColumnScope(
                 visible: showColumn,
-                child: _TaskPaneBody(stackDepth: stackDepth, detail: detail),
+                child: _TaskPaneBody(
+                  stackDepth: stackDepth,
+                  detail: detail,
+                  selectedTaskId: selectedTaskId,
+                ),
               ),
             ),
             if (showColumn)
@@ -217,10 +228,15 @@ class _TasksDetailPane extends StatelessWidget {
 }
 
 class _TaskPaneBody extends StatelessWidget {
-  const _TaskPaneBody({required this.stackDepth, required this.detail});
+  const _TaskPaneBody({
+    required this.stackDepth,
+    required this.detail,
+    required this.selectedTaskId,
+  });
 
   final int stackDepth;
   final Widget detail;
+  final String? selectedTaskId;
 
   @override
   Widget build(BuildContext context) {
@@ -244,6 +260,7 @@ class _TaskPaneBody extends StatelessWidget {
                 ),
                 child: TaskDetailShowListButton(
                   key: const ValueKey('tasks-show-list-pane'),
+                  taskId: selectedTaskId,
                   onPressed: splitController!.showListPane,
                 ),
               ),

--- a/lib/features/tasks/ui/widgets/task_detail_back_leading.dart
+++ b/lib/features/tasks/ui/widgets/task_detail_back_leading.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -100,39 +103,111 @@ class TaskDetailDesktopLeading extends StatelessWidget {
   }
 }
 
-/// Glass action used by the desktop task split to restore its hidden list.
-class TaskDetailShowListButton extends StatelessWidget {
-  const TaskDetailShowListButton({required this.onPressed, super.key});
+/// The list-pane toggle's glyph, in whichever treatment the surface behind it
+/// calls for.
+///
+/// Glass is for a photograph behind the glyph — nothing else. Over cover art
+/// it is a tinted circle with a white glyph, matching the cover-art bar's own
+/// actions; everywhere else it is the plain toolbar action treatment, so the
+/// toggle reads as a sibling of the icons at the other end of the row rather
+/// than as a different species of control.
+class _ListPaneToggleGlyph extends StatelessWidget {
+  const _ListPaneToggleGlyph({
+    required this.onPressed,
+    required this.tooltip,
+    required this.glass,
+    required this.buttonKey,
+  });
 
   final VoidCallback onPressed;
+  final String tooltip;
+  final bool glass;
+  final Key buttonKey;
 
   @override
   Widget build(BuildContext context) {
-    final label = context.messages.listPaneShowTooltip;
+    if (glass) {
+      return GlassActionButton(
+        key: buttonKey,
+        onTap: onPressed,
+        semanticLabel: tooltip,
+        tooltip: tooltip,
+        child: const Icon(
+          LottiIcons.sidebar,
+          // White over a photograph regardless of theme, like every other
+          // glass action on the cover-art bar.
+          size: IconSizes.l,
+          color: Colors.white,
+        ),
+      );
+    }
 
-    return GlassActionButton(
-      onTap: onPressed,
-      semanticLabel: label,
-      tooltip: label,
-      child: Icon(
+    return IconButton(
+      key: buttonKey,
+      onPressed: onPressed,
+      tooltip: tooltip,
+      // The glyph carries the name, not just the hover tooltip: this is an
+      // icon-only control, and the glass variant announces itself through
+      // `GlassActionButton`'s own semantics label. Both directions of the
+      // toggle should read the same to assistive tech.
+      icon: Icon(
         LottiIcons.sidebar,
-        size: IconSizes.m,
-        color: dsTokensDark.colors.text.highEmphasis,
+        semanticLabel: tooltip,
+        color: context.designTokens.colors.text.mediumEmphasis,
       ),
     );
   }
 }
 
+/// Restores the desktop task split's hidden list.
+///
+/// Sits in the same corner as [TaskDetailHideListButton] and wears the same
+/// treatment, so the toggle is one control that happens to point both ways.
+/// It floats over the task rather than living in the app bar, because
+/// `TasksRootPage` owns it: with the list hidden it has to stay reachable even
+/// when the task itself never loads and the bar has no actions of its own.
+///
+/// [taskId] decides the treatment: a task with cover art puts an image
+/// directly behind this corner, which is the one place glass belongs.
+class TaskDetailShowListButton extends ConsumerWidget {
+  const TaskDetailShowListButton({
+    required this.onPressed,
+    this.taskId,
+    super.key,
+  });
+
+  final VoidCallback onPressed;
+
+  /// The task under this button, or null while none is resolved — in which
+  /// case there is no cover art behind it either.
+  final String? taskId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return _ListPaneToggleGlyph(
+      buttonKey: const ValueKey('tasks-show-list-pane-button'),
+      onPressed: onPressed,
+      tooltip: context.messages.listPaneShowTooltip,
+      glass: taskHasCoverArt(ref, taskId),
+    );
+  }
+}
+
+/// Whether [taskId] resolves to a task carrying cover art, i.e. whether an
+/// image sits behind the detail pane's top-left corner.
+bool taskHasCoverArt(WidgetRef ref, String? taskId) {
+  if (taskId == null) return false;
+  final entry = ref.watch(entryControllerProvider(taskId)).value?.entry;
+  return entry is Task && entry.data.coverArtId != null;
+}
+
 /// Hides the desktop task split's list pane.
 ///
-/// The counterpart of [TaskDetailShowListButton], in the same corner, so one
-/// glyph in one place moves the split both ways. Rendered by
-/// [TaskDetailDesktopLeading], which owns the "is this offered at all"
-/// decision and the width the bar reserves for it.
-///
-/// Takes the shape of the row it joins: a bare glyph beside the compact bar's
-/// bare trailing actions, and the glass treatment only where there is cover
-/// art behind it. Either way the ink is centred on the glyph.
+/// The counterpart of [TaskDetailShowListButton], in the same corner and the
+/// same treatment, so one glyph in one place moves the split both ways.
+/// Rendered by [TaskDetailDesktopLeading], which owns the "is this offered at
+/// all" decision, the width the bar reserves for it, and — since it is the app
+/// bar that knows whether the task has cover art behind it — [glass].
 class TaskDetailHideListButton extends StatelessWidget {
   const TaskDetailHideListButton({this.glass = false, super.key});
 
@@ -144,35 +219,12 @@ class TaskDetailHideListButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final splitController = ListDetailFocusTraversal.maybeOf(context);
     if (splitController == null) return const SizedBox.shrink();
-    final label = context.messages.listPaneHideTooltip;
 
-    if (glass) {
-      return GlassActionButton(
-        key: const ValueKey('tasks-hide-list-pane'),
-        onTap: splitController.hideListPane,
-        semanticLabel: label,
-        tooltip: label,
-        child: const Icon(
-          LottiIcons.sidebar,
-          // Matches the glass actions at the other end of the same bar: the
-          // glyph is white over a photograph regardless of theme.
-          size: IconSizes.l,
-          color: Colors.white,
-        ),
-      );
-    }
-
-    // The compact bar's own action treatment, verbatim — same glyph size,
-    // same medium emphasis, same stock ripple — so the row reads as one set
-    // of controls from end to end.
-    return IconButton(
-      key: const ValueKey('tasks-hide-list-pane'),
+    return _ListPaneToggleGlyph(
+      buttonKey: const ValueKey('tasks-hide-list-pane'),
       onPressed: splitController.hideListPane,
-      tooltip: label,
-      icon: Icon(
-        LottiIcons.sidebar,
-        color: context.designTokens.colors.text.mediumEmphasis,
-      ),
+      tooltip: context.messages.listPaneHideTooltip,
+      glass: glass,
     );
   }
 }

--- a/test/features/tasks/ui/widgets/task_detail_back_leading_test.dart
+++ b/test/features/tasks/ui/widgets/task_detail_back_leading_test.dart
@@ -1,19 +1,41 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/journal/model/entry_state.dart';
+import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_detail_back_leading.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/app_bar/glass_action_button.dart';
 import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
 import '../../../../widget_test_utils.dart';
+
+/// Serves a fixed task so the cover-art question has an answer without a
+/// database behind it.
+class _FixedEntryController extends EntryController {
+  _FixedEntryController(this._entry);
+
+  final JournalEntity _entry;
+
+  @override
+  Future<EntryState?> build() async => EntryState.saved(
+    entryId: id,
+    entry: _entry,
+    showMap: false,
+    isFocused: false,
+    shouldShowEditorToolBar: false,
+  );
+}
 
 void main() {
   late MockNavService mockNavService;
@@ -26,7 +48,12 @@ void main() {
 
     await setUpTestGetIt(
       additionalSetup: () {
-        getIt.registerSingleton<NavService>(mockNavService);
+        // `EntryController`'s own field initializers resolve this from getIt
+        // even when the controller is overridden, and the show button reads
+        // that provider to find out whether cover art sits behind it.
+        getIt
+          ..registerSingleton<NavService>(mockNavService)
+          ..registerSingleton<EditorStateService>(MockEditorStateService());
       },
     );
   });
@@ -81,42 +108,92 @@ void main() {
     });
   });
 
-  testWidgets('TaskDetailShowListButton exposes its action and label', (
-    tester,
-  ) async {
-    var presses = 0;
-    await tester.pumpWidget(
-      makeTestableWidgetWithScaffold(
-        TaskDetailShowListButton(onPressed: () => presses++),
+  group('TaskDetailShowListButton', () {
+    /// A task whose cover art puts an image behind the pane's top-left
+    /// corner, wired through the entry controller the button reads.
+    List<Override> withCoverArt({required bool coverArt}) => [
+      entryControllerProvider(testTask.meta.id).overrideWith(
+        () => _FixedEntryController(
+          coverArt
+              ? testTask.copyWith(
+                  data: testTask.data.copyWith(coverArtId: 'cover-1'),
+                )
+              : testTask,
+        ),
       ),
+    ];
+
+    testWidgets('exposes its action and label', (tester) async {
+      var presses = 0;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          TaskDetailShowListButton(onPressed: () => presses++),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byTooltip('Show list'), findsOneWidget);
+      final semanticsFinder = find.bySemanticsLabel('Show list');
+      expect(semanticsFinder, findsOneWidget);
+      final semantics = tester.getSemantics(semanticsFinder);
+      expect(
+        semantics.getSemanticsData().hasAction(ui.SemanticsAction.tap),
+        isTrue,
+      );
+
+      await tester.tap(find.byIcon(LottiIcons.sidebar));
+      expect(presses, 1);
+    });
+
+    testWidgets(
+      'takes the plain toolbar treatment over an ordinary task — the corner '
+      'it restores from is the same corner the hide toggle sat in',
+      (tester) async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            TaskDetailShowListButton(
+              onPressed: () {},
+              taskId: testTask.meta.id,
+            ),
+            overrides: withCoverArt(coverArt: false),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(GlassActionButton), findsNothing);
+        expect(
+          tester.widget<Icon>(find.byIcon(LottiIcons.sidebar)).color,
+          tester
+              .element(find.byIcon(LottiIcons.sidebar))
+              .designTokens
+              .colors
+              .text
+              .mediumEmphasis,
+        );
+      },
     );
 
-    expect(find.byTooltip('Show list'), findsOneWidget);
-    final semanticsFinder = find.bySemanticsLabel('Show list');
-    expect(semanticsFinder, findsOneWidget);
-    final semantics = tester.getSemantics(semanticsFinder);
-    expect(semantics.label, 'Show list');
-    expect(
-      semantics.getSemanticsData().hasAction(ui.SemanticsAction.tap),
-      isTrue,
-    );
-    await tester.tap(find.byType(GlassActionButton));
-    expect(presses, 1);
-  });
-
-  testWidgets('TaskDetailShowListButton keeps light ink in the dark theme', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      makeTestableWidgetWithScaffold(
-        TaskDetailShowListButton(onPressed: () {}),
-        theme: DesignSystemTheme.dark(),
-      ),
-    );
-
-    expect(
-      tester.widget<Icon>(find.byIcon(LottiIcons.sidebar)).color,
-      dsTokensDark.colors.text.highEmphasis,
+    testWidgets(
+      'wears glass only where cover art is actually behind it, in white so it '
+      'survives whatever the photograph is',
+      (tester) async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            TaskDetailShowListButton(
+              onPressed: () {},
+              taskId: testTask.meta.id,
+            ),
+            overrides: withCoverArt(coverArt: true),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(GlassActionButton), findsOneWidget);
+        expect(
+          tester.widget<Icon>(find.byIcon(LottiIcons.sidebar)).color,
+          Colors.white,
+        );
+      },
     );
   });
 

--- a/test/helpers/package_info_test.dart
+++ b/test/helpers/package_info_test.dart
@@ -8,7 +8,7 @@ void main() {
     'the last call wins, so a per-test seed survives an earlier one',
     () async {
       // ignore: avoid_redundant_argument_values
-    mockPackageInfo(version: '1.0.0', packageName: 'first.app');
+      mockPackageInfo(version: '1.0.0', packageName: 'first.app');
       expect((await PackageInfo.fromPlatform()).version, '1.0.0');
 
       // The point of the helper: `PackageInfo` caches the first platform answer


### PR DESCRIPTION
Follow-up to #4027, from review feedback: with the list hidden, the corner
switched back to a glass chip.

#4027 taught `TaskDetailHideListButton` to drop the glass treatment on a task
without cover art, so it reads as a sibling of the two bare glyphs at the other
end of the same toolbar row. Its counterpart did not learn the same thing:
`TaskDetailShowListButton` — the control that restores the list, in the very
same corner — was still a `GlassActionButton` unconditionally. Hiding the list
therefore swapped a bare glyph for a tinted circle in place.

Both halves now share one glyph widget and one rule: **glass is for a
photograph behind the glyph**, so it applies only where cover art actually sits
behind that corner, and the plain toolbar treatment applies everywhere else.

They learn it from different places because they render in different layers:

- `TaskDetailHideListButton` lives in the app bar's leading slot, so the bar
  hosting it passes `glass` (the cover-art bar passes `true`).
- `TaskDetailShowListButton` floats over the task — `TasksRootPage` owns it so
  it stays reachable even when the task never loads — so it resolves the
  question itself from the task under it, via `taskHasCoverArt(ref, taskId)`.
  No task, no answer, no glass.

The plain variant also carries a `semanticLabel` on its glyph rather than
relying on the hover tooltip alone, so both directions read to assistive tech
the way the glass variant already did.

## Verification

`fvm flutter analyze` clean, `make okf_check` and `make knowledge_check` clean.
74 tests green across the leading cluster, both task app bars, the root page
and the detail pane. New/reworked tests cover the plain variant (no
`GlassActionButton`, the bar's own action colour), the glass variant (white
glyph, 40 pt container) and the cover-art switch on the show button, driven
through the entry controller.

No changelog entry: the toggle's move has not shipped yet, so this corrects
unreleased work rather than something a user has seen.

Incidentally included: a one-line indentation fix in
`test/helpers/package_info_test.dart` that `dart format` produced — the file
landed slightly mis-indented in #4028.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Task detail list controls now adapt their appearance to the selected task’s cover art.
  * Glass styling is shown when cover art is available behind the control; otherwise, a standard style is used.
  * List controls without available task information remain usable with standard styling.

* **Documentation**
  * Updated task interface documentation to explain when glass styling appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->