### PR TITLE
Give the language flag room to breathe

### DIFF
--- a/lib/features/design_system/components/action_modal/ds_action_row.dart
+++ b/lib/features/design_system/components/action_modal/ds_action_row.dart
@@ -229,8 +229,11 @@ class _DsActionRowState extends State<DsActionRow> {
                         children: [
                           if (widget.trailingValueLeading case final leading?)
                             Padding(
+                              // step3, not step2: at 4pt the flag crowded the
+                              // name it marks and the pair read as one smudge
+                              // rather than a mark and a word.
                               padding: EdgeInsets.only(
-                                right: tokens.spacing.step2,
+                                right: tokens.spacing.step3,
                               ),
                               child: leading,
                             ),

--- a/test/features/design_system/components/action_modal/ds_action_row_test.dart
+++ b/test/features/design_system/components/action_modal/ds_action_row_test.dart
@@ -562,10 +562,11 @@ void main() {
       );
 
       // It decorates the reading, so it sits between the title and the value
-      // rather than anywhere else on the row.
+      // rather than anywhere else on the row, one step off the word it marks.
       expect(
-        tester.getRect(find.byKey(flagKey)).right,
-        lessThanOrEqualTo(tester.getRect(find.text('German')).left),
+        tester.getRect(find.text('German')).left -
+            tester.getRect(find.byKey(flagKey)).right,
+        _tokens(tester).spacing.step3,
       );
       expect(
         tester.getRect(find.text('Set language')).right,


### PR DESCRIPTION
Follow-up to #4030.

The gap between the language flag and the name beside it was `spacing.step2`.
At 4pt the mark crowded the word it marks and the pair read as one smudge on
the row's trailing edge rather than as a flag and a name. It is now
`spacing.step3` — the same 8pt that separates every other pair of things on a
`DsActionRow`.

One line of production code. The adornment-placement test in
`ds_action_row_test.dart` now asserts the exact gap rather than a bare
left-of/right-of ordering, so the value cannot drift back unnoticed.

No CHANGELOG entry: 1.0.12 has not shipped, so this is polish on an unreleased
surface rather than a fix a user could have seen.

## Screenshots

### Entry actions, language set — desktop dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/action-row-flag-gap/a4696c1ee038227342bc1000174d3cf4eddf412d/before/entry_actions_language_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/action-row-flag-gap/a4696c1ee038227342bc1000174d3cf4eddf412d/after/entry_actions_language_desktop_dark.png) |

### Entry actions, language set — desktop light
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/action-row-flag-gap/a4696c1ee038227342bc1000174d3cf4eddf412d/before/entry_actions_language_desktop_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/action-row-flag-gap/a4696c1ee038227342bc1000174d3cf4eddf412d/after/entry_actions_language_desktop_light.png) |

## Testing

`test/features/design_system/components/action_modal/` and the entry-header
suites — 211 tests green. `dart analyze lib test` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing between action-row adornments and their displayed values for a more consistent layout.

* **Tests**
  * Updated layout validation to confirm the revised spacing and preserve the expected title-and-adornment order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->