### PR TITLE
fix: a failing habit reminder no longer reports a failed save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.12]
+### Fixed
+- **Picking a date in a settings editor on a phone no longer throws the edit
+  away.** In the habit editor, tapping Start date (or Show from, or the alert
+  time) and then Done closed the page underneath the picker instead of the
+  picker itself: the editor dropped back to the habits list, and the new date
+  along with anything else typed in the form went with it. The Health import
+  page's date fields did the same. The picker now dismisses itself and hands
+  the chosen date back to the form, which keeps it until you save.
+- **A habit that fails to save now says so.** If writing the definition failed,
+  the editor simply did nothing — no message, no clue whether the change had
+  landed. It now shows an error and keeps you on the page with your edit
+  intact.
+
 ### Changed
 - **The task page's two menus are now one design.** The `•••` menu and the
   action bar's Add sheet were built separately and had drifted apart: one
@@ -32,17 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.11]
 ### Fixed
-- **Picking a date in a settings editor on a phone no longer throws the edit
-  away.** In the habit editor, tapping Start date (or Show from, or the alert
-  time) and then Done closed the page underneath the picker instead of the
-  picker itself: the editor dropped back to the habits list, and the new date
-  along with anything else typed in the form went with it. The Health import
-  page's date fields did the same. The picker now dismisses itself and hands
-  the chosen date back to the form, which keeps it until you save.
-- **A habit that fails to save now says so.** If writing the definition failed,
-  the editor simply did nothing — no message, no clue whether the change had
-  landed. It now shows an error and keeps you on the page with your edit
-  intact.
 - **Habit day squares on a goal page stop at today.** A habit measured over a
   calendar week or month drew the whole period, so on a Friday its track ran on
   through Sunday: two empty "No entry" squares for days that have not happened

--- a/lib/features/habits/state/habit_settings_controller.dart
+++ b/lib/features/habits/state/habit_settings_controller.dart
@@ -10,6 +10,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/habits/repository/habits_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/notification_service.dart';
 
 part 'habit_settings_controller.freezed.dart';
@@ -246,7 +247,24 @@ class HabitSettingsController extends Notifier<HabitSettingsState> {
     await getIt<PersistenceLogic>().upsertEntityDefinition(dataType);
     state = state.copyWith(dirty: false);
 
-    await getIt<NotificationService>().scheduleHabitNotification(dataType);
+    // Scheduling the reminder is a side effect of a definition that has
+    // already been written. Letting it throw here would report a failed save
+    // for a habit that IS in the database — the editor would stay open behind
+    // an error toast with Save greyed out, and the user would have no way to
+    // tell the change had landed. This is a live failure mode, not a
+    // hypothetical: on macOS `getLocation` rejects the "CEST" abbreviation.
+    // `createHabitCompletionEntryImpl` guards the same call for the same
+    // reason.
+    try {
+      await getIt<NotificationService>().scheduleHabitNotification(dataType);
+    } catch (exception, stackTrace) {
+      getIt<DomainLogger>().error(
+        LogDomain.habits,
+        exception,
+        stackTrace: stackTrace,
+        subDomain: 'onSavePressed.scheduleHabitNotification',
+      );
+    }
 
     return true;
   }

--- a/test/features/settings/ui/pages/habits/habit_details_page_test.dart
+++ b/test/features/settings/ui/pages/habits/habit_details_page_test.dart
@@ -462,6 +462,12 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         expect(capturedUpsert().name, 'Flossing updated');
+        // Without this the test would pass vacuously if the controller ever
+        // stopped scheduling reminders: nothing would throw, so the absent
+        // toast would prove nothing about the guard.
+        verify(
+          () => mockNotificationService.scheduleHabitNotification(any()),
+        ).called(1);
         expect(find.text("Couldn't save your changes"), findsNothing);
         expect(beamedTo, '/settings/habits');
       },

--- a/test/features/settings/ui/pages/habits/habit_details_page_test.dart
+++ b/test/features/settings/ui/pages/habits/habit_details_page_test.dart
@@ -435,6 +435,39 @@ void main() {
     );
 
     testWidgets(
+      'a failing reminder does not make a saved habit look unsaved',
+      (tester) async {
+        // Regression: the definition commits, then scheduleHabitNotification
+        // throws (on macOS getLocation rejects the "CEST" abbreviation). The
+        // exception used to escape onSavePressed into the page's catch, which
+        // showed "Couldn't save your changes" and stayed put — for a habit
+        // that IS in the database, with Save now greyed out because the form
+        // is no longer dirty.
+        when(
+          () => mockNotificationService.scheduleHabitNotification(any()),
+        ).thenThrow(
+          ArgumentError('Location with the name "CEST" doesn\'t exist'),
+        );
+
+        await pumpPage(tester, EditHabitPage(habitId: habitFlossing.id));
+
+        await tester.enterText(
+          find.byKey(const Key('habit_name_field')),
+          'Flossing updated',
+        );
+        await tester.pump();
+
+        await tester.tap(find.widgetWithText(DsGlassPill, 'Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(capturedUpsert().name, 'Flossing updated');
+        expect(find.text("Couldn't save your changes"), findsNothing);
+        expect(beamedTo, '/settings/habits');
+      },
+    );
+
+    testWidgets(
       'a failing write shows an error toast and keeps the editor open',
       (tester) async {
         when(


### PR DESCRIPTION
Follow-up to #4033, which merged at `1b7f861` — one commit before these two review fixes landed on the branch. Both were raised by Codex on that PR and were valid; this carries them onto main.

## 1. A failing reminder reported a failed save (the P2)

`HabitSettingsController.onSavePressed` commits the definition and clears `dirty`, **then** awaits `scheduleHabitNotification`. #4033 added an error toast around the save call, and that turned a previously silent problem into a lying one: a throwing reminder now surfaced "Couldn't save your changes" for a habit that **is** in the database, left the editor open, and greyed out Save because the form was no longer dirty — so the user had no way to tell the change had landed, and no way to retry.

Not hypothetical: on macOS `getLocation` rejects the `"CEST"` abbreviation and throws. `createHabitCompletionEntryImpl` already guards the identical call for the identical reason (`lib/logic/persistence_create_ops.dart:196-216`), with a regression test documenting the failure shape (`test/logic/persistence_create_ops_test.dart:239`).

The scheduling call is now guarded and logged to `LogDomain.habits`, and the save reports success once the database write commits.

New regression test uses that same `ArgumentError('Location with the name "CEST" doesn\'t exist')` shape and asserts the definition persisted, no error toast appeared, and the page beamed to the list. Verified failing with the guard removed — the toast appears.

## 2. CHANGELOG entries were filed under the wrong version

#4033's two entries went in ahead of the habit-day-squares entry, which sits under the already-released `## [1.0.11]` heading. `pubspec.yaml` declares 1.0.12 and the metainfo entries were correctly under 1.0.12, so the changelog was the odd one out — 1.0.12 omitted the fixes and 1.0.11 was retroactively inaccurate. Both moved into a new `### Fixed` section under `## [1.0.12]`.

## Checks

`make analyze` clean; the habit editor and habit settings controller suites pass (24 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving a habit now succeeds even if reminder scheduling encounters an error.
  * Mobile date-picker dismissal preserves unsaved form edits.
  * Save errors are displayed without unexpectedly leaving the habit editor.
* **Documentation**
  * Updated the changelog with these fixes in version 1.0.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->