### PR TITLE
fix: localize the relationship timestamps and name the add circle

### DIFF
--- a/lib/features/relationships/ui/pages/relationships_page.dart
+++ b/lib/features/relationships/ui/pages/relationships_page.dart
@@ -162,20 +162,33 @@ class _AddPersonButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    return Material(
-      color: tokens.colors.interactive.enabled,
-      shape: const CircleBorder(),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        customBorder: const CircleBorder(),
-        child: SizedBox(
-          width: 34,
-          height: 34,
-          child: Icon(
-            LottiIcons.add,
-            size: 20,
-            color: tokens.colors.background.level01,
+    // The control is a bare glyph, so the name has to come from somewhere:
+    // `Semantics` states it for a screen reader, the tooltip shows the same
+    // words to a pointer, and `excludeFromSemantics` keeps the tooltip from
+    // announcing it a second time.
+    final label = context.messages.relationshipCreateTitle;
+    return Semantics(
+      button: true,
+      label: label,
+      child: Tooltip(
+        message: label,
+        excludeFromSemantics: true,
+        child: Material(
+          color: tokens.colors.interactive.enabled,
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: onTap,
+            customBorder: const CircleBorder(),
+            child: SizedBox(
+              width: 34,
+              height: 34,
+              child: Icon(
+                LottiIcons.add,
+                size: 20,
+                color: tokens.colors.background.level01,
+              ),
+            ),
           ),
         ),
       ),
@@ -352,7 +365,7 @@ class _RelationshipRow extends StatelessWidget {
     final last = item.lastCheckInAt;
     if (last != null) {
       return messages.relationshipCheckedInLabel(
-        relationshipTimestampLabel(last),
+        relationshipTimestampLabelOf(context, last),
       );
     }
     final streak = quietStreakDays(
@@ -431,7 +444,7 @@ class _CadencePill extends StatelessWidget {
 
     final dueOverdue = (overdue ?? 0) > 0;
     final label = dueOverdue
-        ? messages.relationshipDueDay(relationshipWeekdayLabel(due!))
+        ? messages.relationshipDueDay(relationshipWeekdayLabelOf(context, due!))
         : messages.relationshipCadenceOnTrack;
     final fg = dueOverdue
         ? tokens.colors.alert.warning.defaultColor

--- a/lib/features/relationships/ui/shared/relationship_timestamps.dart
+++ b/lib/features/relationships/ui/shared/relationship_timestamps.dart
@@ -1,7 +1,9 @@
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/typography_helpers.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 
 /// 24h, mono date-time formatting for the relationships surface (design
 /// plan §0.5 — "All date/time strings render in `--ff-mono` (Inconsolata)
@@ -23,27 +25,14 @@ String _hhMm(DateTime t) =>
     '${t.minute.toString().padLeft(2, '0')}';
 
 /// The short weekday + day + month used when the timestamp is not today
-/// (e.g. `Fri 15 Aug`). English abbreviations are intentional: the mono
-/// timestamp is a system-level affordance, not localized prose, matching
-/// the existing `monoMetaStyle` usage across the app.
-String _shortDayMonth(DateTime t) {
-  const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-  const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-  return '${weekdays[t.weekday - 1]} ${t.day} ${months[t.month - 1]}';
-}
+/// (e.g. `Fri 15 Aug`, `Fr. 15 Aug.` in German).
+///
+/// The abbreviations come from the locale's own date symbols rather than a
+/// hard-coded English table: a German reader gets `Fr.`, not `Fri`. The
+/// order stays weekday-day-month in every locale, because the design's mono
+/// column has to line up.
+String _shortDayMonth(DateTime t, String? locale) =>
+    DateFormat('E d MMM', locale).format(t);
 
 /// A mono timestamp label for a single point in time, anchored to [now].
 ///
@@ -54,12 +43,39 @@ String _shortDayMonth(DateTime t) {
 /// non-today value on this surface — a check-in logged the previous evening
 /// reads as `Yesterday 18:00` rather than making the reader decode
 /// `Wed 12 Aug 18:00` against today's date.
-String relationshipTimestampLabel(DateTime at, {DateTime? now}) {
+///
+/// The two relative words arrive as [todayLabel] and [yesterdayLabel] and
+/// the date symbols follow [locale], so the function stays a pure function
+/// of its inputs — [relationshipTimestampLabelOf] is the widget-side
+/// convenience that reads both off a [BuildContext].
+String relationshipTimestampLabel(
+  DateTime at, {
+  required String todayLabel,
+  required String yesterdayLabel,
+  String? locale,
+  DateTime? now,
+}) {
   final anchor = now ?? clock.now();
-  if (_isSameDay(at, anchor)) return 'Today ${_hhMm(at)}';
-  if (_isSameDay(at, _dayBefore(anchor))) return 'Yesterday ${_hhMm(at)}';
-  return '${_shortDayMonth(at)} ${_hhMm(at)}';
+  if (_isSameDay(at, anchor)) return '$todayLabel ${_hhMm(at)}';
+  if (_isSameDay(at, _dayBefore(anchor))) {
+    return '$yesterdayLabel ${_hhMm(at)}';
+  }
+  return '${_shortDayMonth(at, locale)} ${_hhMm(at)}';
 }
+
+/// [relationshipTimestampLabel] with the relative words and the date symbols
+/// resolved against the widget tree's locale.
+String relationshipTimestampLabelOf(
+  BuildContext context,
+  DateTime at, {
+  DateTime? now,
+}) => relationshipTimestampLabel(
+  at,
+  todayLabel: context.messages.relationshipTimestampToday,
+  yesterdayLabel: context.messages.relationshipTimestampYesterday,
+  locale: Localizations.localeOf(context).toString(),
+  now: now,
+);
 
 /// The calendar day before [anchor]. Built from components rather than by
 /// subtracting a `Duration`, so the 23- and 25-hour days either side of a DST
@@ -71,11 +87,17 @@ DateTime _dayBefore(DateTime anchor) =>
 /// the date is already implied by the beat's position.
 String relationshipTimeLabel(DateTime at) => _hhMm(at);
 
-/// A mono weekday-only label (`Thu`), used by the cadence due pill.
-String relationshipWeekdayLabel(DateTime at) {
-  const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-  return weekdays[at.weekday - 1];
-}
+/// A mono weekday-only label (`Thu`), used by the cadence due pill, in the
+/// locale's own abbreviation.
+String relationshipWeekdayLabel(DateTime at, {String? locale}) =>
+    DateFormat.E(locale).format(at);
+
+/// [relationshipWeekdayLabel] resolved against the widget tree's locale.
+String relationshipWeekdayLabelOf(BuildContext context, DateTime at) =>
+    relationshipWeekdayLabel(
+      at,
+      locale: Localizations.localeOf(context).toString(),
+    );
 
 bool _isSameDay(DateTime a, DateTime b) =>
     a.year == b.year && a.month == b.month && a.day == b.day;

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4222,6 +4222,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Dnes",
+  "relationshipTimestampYesterday": "Včera",
   "relationshipTrackingSinceLabel": "Sledováno od {date}",
   "relationshipUpdateFromContact": "Aktualizovat z kontaktu",
   "saveButton": "Uložit",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4728,6 +4728,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "I dag",
+  "relationshipTimestampYesterday": "I går",
   "relationshipTrackingSinceLabel": "Fulgt siden {date}",
   "relationshipUpdateFromContact": "Opdater fra kontakt",
   "saveButton": "Gem",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4215,6 +4215,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Heute",
+  "relationshipTimestampYesterday": "Gestern",
   "relationshipTrackingSinceLabel": "Erfasst seit {date}",
   "relationshipUpdateFromContact": "Aus Kontakt aktualisieren",
   "saveButton": "Speichern",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6194,6 +6194,14 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Today",
+  "@relationshipTimestampToday": {
+    "description": "The relative day word in a relationship timestamp, e.g. \"Today 14:20\"."
+  },
+  "relationshipTimestampYesterday": "Yesterday",
+  "@relationshipTimestampYesterday": {
+    "description": "The relative day word in a relationship timestamp, e.g. \"Yesterday 19:05\"."
+  },
   "relationshipTrackingSinceLabel": "Tracking since {date}",
   "@relationshipTrackingSinceLabel": {
     "placeholders": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -252,8 +252,6 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
-  "relationshipTimestampToday": "Today",
-  "relationshipTimestampYesterday": "Yesterday",
   "saveLabel": "Save",
   "searchHint": "Search…",
   "selectColor": "Select a colour",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -252,6 +252,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Today",
+  "relationshipTimestampYesterday": "Yesterday",
   "saveLabel": "Save",
   "searchHint": "Search…",
   "selectColor": "Select a colour",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4215,6 +4215,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Hoy",
+  "relationshipTimestampYesterday": "Ayer",
   "relationshipTrackingSinceLabel": "Seguimiento desde {date}",
   "relationshipUpdateFromContact": "Actualizar desde el contacto",
   "saveButton": "Guardar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4215,6 +4215,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Aujourd'hui",
+  "relationshipTimestampYesterday": "Hier",
   "relationshipTrackingSinceLabel": "Suivi depuis {date}",
   "relationshipUpdateFromContact": "Mettre à jour depuis le contact",
   "saveButton": "Enregistrer",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4728,6 +4728,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Oggi",
+  "relationshipTimestampYesterday": "Ieri",
   "relationshipTrackingSinceLabel": "Monitoraggio dal {date}",
   "relationshipUpdateFromContact": "Aggiorna dal contatto",
   "saveButton": "Salva",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17899,6 +17899,18 @@ abstract class AppLocalizations {
   /// **'Stay in touch'**
   String get relationshipStayInTouch;
 
+  /// The relative day word in a relationship timestamp, e.g. "Today 14:20".
+  ///
+  /// In en, this message translates to:
+  /// **'Today'**
+  String get relationshipTimestampToday;
+
+  /// The relative day word in a relationship timestamp, e.g. "Yesterday 19:05".
+  ///
+  /// In en, this message translates to:
+  /// **'Yesterday'**
+  String get relationshipTimestampYesterday;
+
   /// No description provided for @relationshipTrackingSinceLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10812,6 +10812,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipStayInTouch => 'Udržovat kontakt';
 
   @override
+  String get relationshipTimestampToday => 'Dnes';
+
+  @override
+  String get relationshipTimestampYesterday => 'Včera';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Sledováno od $date';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10662,6 +10662,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipStayInTouch => 'Hold kontakten';
 
   @override
+  String get relationshipTimestampToday => 'I dag';
+
+  @override
+  String get relationshipTimestampYesterday => 'I går';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Fulgt siden $date';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10726,6 +10726,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipStayInTouch => 'Kontakt halten';
 
   @override
+  String get relationshipTimestampToday => 'Heute';
+
+  @override
+  String get relationshipTimestampYesterday => 'Gestern';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Erfasst seit $date';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -14218,12 +14218,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get relationshipStayInTouch => 'Stay in touch';
 
   @override
-  String get relationshipTimestampToday => 'Today';
-
-  @override
-  String get relationshipTimestampYesterday => 'Yesterday';
-
-  @override
   String get saveLabel => 'Save';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10606,6 +10606,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipStayInTouch => 'Stay in touch';
 
   @override
+  String get relationshipTimestampToday => 'Today';
+
+  @override
+  String get relationshipTimestampYesterday => 'Yesterday';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Tracking since $date';
   }
@@ -14210,6 +14216,12 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get relationshipStayInTouch => 'Stay in touch';
+
+  @override
+  String get relationshipTimestampToday => 'Today';
+
+  @override
+  String get relationshipTimestampYesterday => 'Yesterday';
 
   @override
   String get saveLabel => 'Save';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10822,6 +10822,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipStayInTouch => 'Mantener el contacto';
 
   @override
+  String get relationshipTimestampToday => 'Hoy';
+
+  @override
+  String get relationshipTimestampYesterday => 'Ayer';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Seguimiento desde $date';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10853,6 +10853,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipStayInTouch => 'Rester en contact';
 
   @override
+  String get relationshipTimestampToday => 'Aujourd\'hui';
+
+  @override
+  String get relationshipTimestampYesterday => 'Hier';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Suivi depuis $date';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10803,6 +10803,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipStayInTouch => 'Restare in contatto';
 
   @override
+  String get relationshipTimestampToday => 'Oggi';
+
+  @override
+  String get relationshipTimestampYesterday => 'Ieri';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Monitoraggio dal $date';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10680,6 +10680,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipStayInTouch => 'Contact houden';
 
   @override
+  String get relationshipTimestampToday => 'Vandaag';
+
+  @override
+  String get relationshipTimestampYesterday => 'Gisteren';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Gevolgd sinds $date';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10762,6 +10762,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipStayInTouch => 'Manter contato';
 
   @override
+  String get relationshipTimestampToday => 'Hoje';
+
+  @override
+  String get relationshipTimestampYesterday => 'Ontem';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Acompanhando desde $date';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10880,6 +10880,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipStayInTouch => 'Menține contactul';
 
   @override
+  String get relationshipTimestampToday => 'Azi';
+
+  @override
+  String get relationshipTimestampYesterday => 'Ieri';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Urmărire din $date';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10672,6 +10672,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipStayInTouch => 'Håll kontakten';
 
   @override
+  String get relationshipTimestampToday => 'Idag';
+
+  @override
+  String get relationshipTimestampYesterday => 'Igår';
+
+  @override
   String relationshipTrackingSinceLabel(String date) {
     return 'Följs sedan $date';
   }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4727,6 +4727,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Vandaag",
+  "relationshipTimestampYesterday": "Gisteren",
   "relationshipTrackingSinceLabel": "Gevolgd sinds {date}",
   "relationshipUpdateFromContact": "Bijwerken vanuit contact",
   "saveButton": "Opslaan",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4727,6 +4727,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Hoje",
+  "relationshipTimestampYesterday": "Ontem",
   "relationshipTrackingSinceLabel": "Acompanhando desde {date}",
   "relationshipUpdateFromContact": "Atualizar a partir do contacto",
   "saveButton": "Salvar",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4215,6 +4215,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Azi",
+  "relationshipTimestampYesterday": "Ieri",
   "relationshipTrackingSinceLabel": "Urmărire din {date}",
   "relationshipUpdateFromContact": "Actualizați din contact",
   "saveButton": "Salvați",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4728,6 +4728,8 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
+  "relationshipTimestampToday": "Idag",
+  "relationshipTimestampYesterday": "Igår",
   "relationshipTrackingSinceLabel": "Följs sedan {date}",
   "relationshipUpdateFromContact": "Uppdatera från kontakt",
   "saveButton": "Spara",

--- a/test/features/relationships/ui/pages/relationships_page_test.dart
+++ b/test/features/relationships/ui/pages/relationships_page_test.dart
@@ -235,6 +235,39 @@ void main() {
     expect(find.text('Status'), findsNothing);
   });
 
+  testWidgets('the add circle names itself for a screen reader and a pointer', (
+    tester,
+  ) async {
+    when(
+      () => mockRepository.getRelationshipsByRecency(),
+    ).thenAnswer((_) async => []);
+
+    await tester.pumpWidget(buildPage());
+    await tester.pumpAndSettle();
+
+    final context = tester.element(find.byType(RelationshipsPage));
+    final label = context.messages.relationshipCreateTitle;
+
+    // Both add circles — the header one and the empty state's inline CTA —
+    // are the same bare glyph, which tells assistive tech nothing on its
+    // own. Each carries the localized name in both channels, and states it
+    // once rather than twice.
+    final labelled = find.byTooltip(label);
+    expect(labelled, findsNWidgets(2));
+    for (var i = 0; i < 2; i++) {
+      expect(
+        tester.getSemantics(labelled.at(i)),
+        matchesSemantics(
+          label: label,
+          isButton: true,
+          isFocusable: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+    }
+  });
+
   testWidgets(
     'renders one row per relationship, with persona avatars and inline stars '
     'only for important people',

--- a/test/features/relationships/ui/shared/relationship_timestamps_test.dart
+++ b/test/features/relationships/ui/shared/relationship_timestamps_test.dart
@@ -4,17 +4,34 @@
 // ignore_for_file: avoid_redundant_argument_values
 
 import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/l10n/app_localizations.dart';
 
 void main() {
   final now = DateTime(2026, 8, 18, 14, 20);
+
+  setUpAll(initializeDateFormatting);
+
+  // The relative words are the caller's to supply — every case below reads
+  // them in English so the assertions stay legible; the locale-specific
+  // behaviour has its own cases at the end.
+  String label(DateTime at, {DateTime? now, String? locale}) =>
+      relationshipTimestampLabel(
+        at,
+        todayLabel: 'Today',
+        yesterdayLabel: 'Yesterday',
+        locale: locale,
+        now: now,
+      );
 
   group('relationshipTimestampLabel', () {
     test('same day reads "Today HH:MM"', () {
       withClock(Clock.fixed(now), () {
         final earlier = DateTime(2026, 8, 18, 9, 5);
-        expect(relationshipTimestampLabel(earlier), 'Today 09:05');
+        expect(label(earlier), 'Today 09:05');
       });
     });
 
@@ -24,7 +41,7 @@ void main() {
     test('the previous calendar day reads "Yesterday HH:MM"', () {
       withClock(Clock.fixed(now), () {
         expect(
-          relationshipTimestampLabel(DateTime(2026, 8, 17, 18)),
+          label(DateTime(2026, 8, 17, 18)),
           'Yesterday 18:00',
         );
       });
@@ -35,11 +52,11 @@ void main() {
     test('yesterday holds across the whole calendar day', () {
       withClock(Clock.fixed(now), () {
         expect(
-          relationshipTimestampLabel(DateTime(2026, 8, 17, 0, 1)),
+          label(DateTime(2026, 8, 17, 0, 1)),
           'Yesterday 00:01',
         );
         expect(
-          relationshipTimestampLabel(DateTime(2026, 8, 17, 23, 59)),
+          label(DateTime(2026, 8, 17, 23, 59)),
           'Yesterday 23:59',
         );
       });
@@ -50,7 +67,7 @@ void main() {
     // can land back on the same date.
     test('yesterday crosses a month boundary', () {
       expect(
-        relationshipTimestampLabel(
+        label(
           DateTime(2026, 8, 31, 21, 30),
           now: DateTime(2026, 9, 1, 8),
         ),
@@ -62,7 +79,7 @@ void main() {
       withClock(Clock.fixed(now), () {
         // 2026-08-16 is a Sunday — two days before the fixed now.
         expect(
-          relationshipTimestampLabel(DateTime(2026, 8, 16, 19, 5)),
+          label(DateTime(2026, 8, 16, 19, 5)),
           'Sun 16 Aug 19:05',
         );
       });
@@ -72,7 +89,7 @@ void main() {
       withClock(Clock.fixed(now), () {
         // 2026-08-21 is a Friday.
         final fri = DateTime(2026, 8, 21, 19, 5);
-        expect(relationshipTimestampLabel(fri), 'Fri 21 Aug 19:05');
+        expect(label(fri), 'Fri 21 Aug 19:05');
       });
     });
 
@@ -82,17 +99,17 @@ void main() {
         final at = DateTime(2026, 8, 15, 19, 5);
         // A now on the next day is exactly the "Yesterday" case.
         expect(
-          relationshipTimestampLabel(at, now: DateTime(2026, 8, 16, 8)),
+          label(at, now: DateTime(2026, 8, 16, 8)),
           'Yesterday 19:05',
         );
         // Two days on, the date comes back.
         expect(
-          relationshipTimestampLabel(at, now: DateTime(2026, 8, 17, 8)),
+          label(at, now: DateTime(2026, 8, 17, 8)),
           'Sat 15 Aug 19:05',
         );
         // A now on the same day collapses to "Today".
         expect(
-          relationshipTimestampLabel(at, now: DateTime(2026, 8, 15, 20)),
+          label(at, now: DateTime(2026, 8, 15, 20)),
           'Today 19:05',
         );
       });
@@ -279,6 +296,103 @@ void main() {
           0,
         );
       });
+    });
+  });
+
+  group('locale', () {
+    // The abbreviations used to be a hard-coded English table, which read as
+    // "Fri 21 Aug" to a German reader looking at an otherwise German screen.
+    test('the weekday and month abbreviations follow the locale', () {
+      final at = DateTime(2026, 8, 21, 19, 5);
+
+      expect(label(at, now: DateTime(2026, 8, 24, 9)), 'Fri 21 Aug 19:05');
+      expect(
+        label(at, now: DateTime(2026, 8, 24, 9), locale: 'de'),
+        'Fr. 21 Aug. 19:05',
+      );
+      expect(
+        label(at, now: DateTime(2026, 8, 24, 9), locale: 'fr'),
+        'ven. 21 août 19:05',
+      );
+    });
+
+    test('the cadence pill weekday follows the locale too', () {
+      expect(relationshipWeekdayLabel(DateTime(2026, 8, 20)), 'Thu');
+      expect(
+        relationshipWeekdayLabel(DateTime(2026, 8, 20), locale: 'de'),
+        'Do',
+      );
+    });
+
+    // The time stays 24h in every locale: a mono column that switches to
+    // "7:05 PM" in one language stops lining up (design plan §0.5).
+    test('the time component stays 24h regardless of locale', () {
+      final at = DateTime(2026, 8, 21, 19, 5);
+
+      for (final locale in ['en', 'de', 'fr', 'sv']) {
+        expect(
+          label(at, now: DateTime(2026, 8, 24, 9), locale: locale),
+          endsWith('19:05'),
+          reason: '$locale must not fall back to a 12h clock',
+        );
+      }
+    });
+  });
+
+  group('the context-resolved wrappers', () {
+    Future<String> labelIn(WidgetTester tester, Locale locale) async {
+      late String rendered;
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              rendered = relationshipTimestampLabelOf(
+                context,
+                DateTime(2026, 8, 17, 18),
+                now: now,
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return rendered;
+    }
+
+    testWidgets('read the relative day word off the widget tree', (
+      tester,
+    ) async {
+      expect(await labelIn(tester, const Locale('en')), 'Yesterday 18:00');
+      expect(await labelIn(tester, const Locale('de')), 'Gestern 18:00');
+    });
+
+    testWidgets('the weekday wrapper resolves the locale as well', (
+      tester,
+    ) async {
+      late String rendered;
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('de'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              rendered = relationshipWeekdayLabelOf(
+                context,
+                DateTime(2026, 8, 20),
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(rendered, 'Do');
     });
   });
 }


### PR DESCRIPTION
Follow-up to #3981, which merged while these two review findings were still
open.

**The relationship timestamps were English in every locale.** The mono
timestamp helpers returned `Today`, `Yesterday` and a hard-coded table of
English weekday and month abbreviations, so a German reader saw
`Fri 15 Aug 19:05` on an otherwise German screen. The two relative words now
come from the catalogs (added to every language), and the abbreviations come
from the locale's own date symbols. The time component stays 24h in every
locale on purpose: the design's mono column stops lining up the moment one
language switches to a 12h clock, and there is a test pinning that.

The formatters stay pure functions — the localized words and the locale name
are parameters — with thin `…Of(context)` wrappers for the widget side, so
the existing unit tests keep working without a pump.

**The add circle was a bare glyph.** It now carries the localized
"Add person" name as a `Semantics` label and as a tooltip, with
`excludeFromSemantics` so it is announced once rather than twice.

Analyzer clean; the touched test files pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relationship timestamps now display localized Today/Yesterday labels, weekday names, month names, and time formats.
  * Added localized timestamp support across multiple languages.
  * The add-person control now includes clearer accessibility labels, focus behavior, and pointer tooltips.

* **Bug Fixes**
  * Prevented duplicate tooltip announcements for screen readers.

* **Tests**
  * Added coverage for accessibility semantics, tooltips, localization, and locale-specific date formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->