### PR TITLE
fix: resolve the Mac's IANA timezone, not its seasonal abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13]
+### Fixed
+- **Daily habit reminders arrived hours late on iPhone, iPad and Android.** The
+  app could not work out which timezone the device was in, quietly settled for
+  UTC, and then built the reminder's time of day in UTC — so an 08:00 habit
+  reminder rang at 10:00 in Central European Summer Time, and further off the
+  further you live from Greenwich. Reminders now use the zone the device is
+  actually in. Notifications scheduled for a specific moment — task suggestions,
+  overdue alerts and relationship check-ins — were unaffected and kept their
+  timing.
+- **The log no longer fills with `Location with the name "CEST" doesn't
+  exist`.** macOS stores its timezone data in a folder named after the current
+  tzdata release, and looking through it for a zone name failed on every Mac
+  that had taken a data update, leaving the app with the seasonal abbreviation
+  it could not use.
+- **New entries record the timezone they were made in.** Entries written on a
+  Mac stored a seasonal abbreviation such as "CEST" instead of the zone's real
+  name, which is ambiguous — "CST" alone belongs to three different zones — and
+  changes twice a year. They now store the full name, e.g. `Europe/Berlin`.
+
 ## [1.0.12]
 ### Fixed
 - **Picking a date in a settings editor on a phone no longer throws the edit

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,13 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.13" date="2026-08-24">
+      <description>
+        <p>Fixed: daily habit reminders arrived hours late on iPhone, iPad and Android. The app could not work out which timezone the device was in, quietly settled for UTC, and then built the reminder's time of day in UTC - so an 08:00 habit reminder rang at 10:00 in Central European Summer Time, and further off the further you live from Greenwich. Reminders now use the zone the device is actually in. Notifications scheduled for a specific moment - task suggestions, overdue alerts and relationship check-ins - were unaffected and kept their timing.</p>
+        <p>Fixed: a "Location with the name CEST doesn't exist" error no longer fills the log. macOS stores its timezone data in a folder named after the current tzdata release, and looking through it for a zone name failed on every Mac that had taken a data update, leaving the app with the seasonal abbreviation it could not use.</p>
+        <p>Fixed: new entries record the timezone they were made in. Entries written on a Mac stored a seasonal abbreviation such as CEST instead of the zone's real name, which is ambiguous - CST alone belongs to three different zones - and changes twice a year. They now store the full name, e.g. Europe/Berlin.</p>
+      </description>
+    </release>
     <release version="1.0.12" date="2026-08-22">
       <description>
         <p>Changed: the task page's two menus are now one design. The "..." menu and the action bar's Add sheet were built separately and had drifted apart: one centred its title over a hairline bar and stacked full-width rules between plain rows, the other ran teal glyphs and two-line rows with no rules at all. Both now read the same way - the title on the sheet's own left edge with a quiet close beside it, and rows that lead with a washed icon tile, highlight as a rounded block under the pointer, and separate by space instead of hairlines. The Add sheet's rows keep their teal tiles; the entry actions wear neutral ones, so which menu you are in is still obvious at a glance.</p>

--- a/knowledge/domain/journal-entity.md
+++ b/knowledge/domain/journal-entity.md
@@ -110,7 +110,7 @@ concerns live:
 | `dateFrom`, `dateTo` | **The entry's own time span** — what timelines, day plans and recorded-time queries read |
 | `categoryId` | Ownership, and the scope for AI consent and agent allow-lists |
 | `labelIds` | Label assignments — **not** stored in per-variant data |
-| `utcOffset`, `timezone` | Preserved so a time reads correctly where it was recorded |
+| `utcOffset`, `timezone` | Preserved so a time reads correctly where it was recorded. `timezone` is an IANA location name (`Europe/Berlin`), not the ambiguous, DST-dependent abbreviation `DateTime.timeZoneName` returns — see [`getLocalTimezone`](../../lib/utils/timezone.dart) |
 | `vectorClock` | Causal ordering for [sync](../features/sync/vector-clocks-and-conflicts.md) |
 | `deletedAt` | **Soft delete** — the row is the tombstone, which is what lets deletion replicate |
 | `flag` | `EntryFlag`, e.g. `import` |

--- a/lib/utils/timezone.dart
+++ b/lib/utils/timezone.dart
@@ -1,15 +1,68 @@
 import 'dart:io';
 
 import 'package:lotti/utils/platform.dart';
+import 'package:meta/meta.dart';
 import 'package:timezone/timezone.dart';
 
-/// Path segments that precede the IANA name in `/etc/localtime`'s symlink
-/// target. macOS and Linux ship the zoneinfo tree in different places.
-const _zoneinfoPrefixes = <String>[
-  '/usr/share/zoneinfo/',
-  '/var/db/timezone/zoneinfo/',
-  '/usr/lib/zoneinfo/',
-];
+/// The directory that separates a zoneinfo tree's root from the IANA name
+/// inside it.
+///
+/// Matched as a whole path *segment* rather than as part of a fixed list of
+/// absolute prefixes. The prefix list this replaced (`/usr/share/zoneinfo/`,
+/// `/var/db/timezone/zoneinfo/`, `/usr/lib/zoneinfo/`) could only ever
+/// enumerate layouts someone had already seen, and it missed the one macOS
+/// actually ships — see [ianaNameFromZoneinfoPath].
+const _zoneinfoDirectory = 'zoneinfo';
+
+/// Parallel sub-trees that mirror the entire zone set under a different
+/// leap-second convention. `/etc/localtime` may point into one, and the IANA
+/// name is whatever follows.
+const _zoneinfoFlavours = <String>['posix', 'right'];
+
+/// Extracts the IANA location name from a path into a zoneinfo tree, or null
+/// when [path] does not run through one.
+///
+/// The name is everything after the last `zoneinfo` segment, minus a leading
+/// [_zoneinfoFlavours] directory:
+///
+/// ```text
+/// /usr/share/zoneinfo/Europe/Berlin                     -> Europe/Berlin
+/// /var/db/timezone/tz/2026c.1.0/zoneinfo/Europe/Berlin  -> Europe/Berlin
+/// /usr/share/zoneinfo/right/Asia/Tokyo                  -> Asia/Tokyo
+/// ```
+///
+/// **Why a segment scan rather than a prefix list.** macOS resolves
+/// `/etc/localtime` to a *version-stamped* real path — on a machine carrying
+/// tzdata 2026c that is
+/// `/private/var/db/timezone/tz/2026c.1.0/zoneinfo/Europe/Berlin`, because
+/// `/var/db/timezone/zoneinfo` is itself a symlink into `tz/<version>/`. No
+/// fixed prefix survives a tzdata update, so matching one meant returning null
+/// on every up-to-date Mac, falling through to `DateTime.timeZoneName`, and
+/// handing `getLocation` the abbreviation `CEST` — which it rejects.
+///
+/// The scan takes the **last** occurrence so that a zoneinfo tree nested under
+/// an unrelated root (flatpak and snap sandboxes, test fixtures) resolves to
+/// the name inside it rather than to a path segment of the root.
+@visibleForTesting
+String? ianaNameFromZoneinfoPath(String path) {
+  final segments = path.split('/');
+  final zoneinfoIndex = segments.lastIndexOf(_zoneinfoDirectory);
+  if (zoneinfoIndex == -1) return null;
+
+  var nameSegments = segments.sublist(zoneinfoIndex + 1);
+  if (nameSegments.isNotEmpty &&
+      _zoneinfoFlavours.contains(nameSegments.first)) {
+    nameSegments = nameSegments.sublist(1);
+  }
+
+  // A trailing separator ("…/zoneinfo/") splits into a final empty segment,
+  // and an empty segment anywhere means the path was malformed rather than
+  // that a zone is named "".
+  if (nameSegments.isEmpty || nameSegments.any((segment) => segment.isEmpty)) {
+    return null;
+  }
+  return nameSegments.join('/');
+}
 
 /// Returns the local timezone as an **IANA location name** (`Europe/Berlin`),
 /// falling back to the platform's zone abbreviation (`CEST`) only when no
@@ -24,21 +77,25 @@ const _zoneinfoPrefixes = <String>[
 /// Resolution order:
 ///
 /// 1. `/etc/timezone` — Linux ships the IANA name here as plain text.
-/// 2. The `/etc/localtime` symlink target — works on macOS *and* Linux, where
-///    it points into the zoneinfo tree, e.g.
-///    `/var/db/timezone/zoneinfo/Europe/Berlin`.
+/// 2. The `/etc/localtime` symlink, read both one level deep and fully
+///    resolved — see [_resolveLocaltimeLink] for why both are needed.
 /// 3. `DateTime.timeZoneName` — the abbreviation, as a last resort. Callers
-///    that hand this to `getLocation` must tolerate failure.
+///    that hand this to `getLocation` must tolerate failure;
+///    [configureLocalTimezone] does.
 ///
-/// [overrideIsTestEnv] is intended for tests only — it bypasses the
-/// `isTestEnv` early-return so the platform-specific branches can be
-/// exercised. [clock] is also test-only and lets callers inject a fixed
-/// [DateTime] so the result is deterministic. [linuxTimezoneFilePath] and
-/// [localtimeLinkPath] let tests point the two file lookups at fixtures.
+/// Every parameter is a test seam. [overrideIsTestEnv] bypasses the
+/// `isTestEnv` early-return so the platform-specific branches can be reached
+/// at all, and [overrideIsLinux] decides whether step 1 runs — without it the
+/// `/etc/timezone` branch would be dead code on a macOS developer machine and
+/// live only on CI, which is the worst of both worlds for a lookup this
+/// fiddly. [clock] injects a fixed [DateTime] so the result is deterministic,
+/// and [linuxTimezoneFilePath] and [localtimeLinkPath] point the two file
+/// lookups at fixtures.
 Future<String> getLocalTimezone({
   String? linuxTimezoneFilePath,
   String? localtimeLinkPath,
   bool? overrideIsTestEnv,
+  bool? overrideIsLinux,
   DateTime Function()? clock,
 }) async {
   final now = (clock ?? DateTime.now)();
@@ -48,7 +105,7 @@ Future<String> getLocalTimezone({
     return now.timeZoneName;
   }
 
-  if (Platform.isLinux) {
+  if (overrideIsLinux ?? Platform.isLinux) {
     final fromFile = await _readTimezoneFile(
       linuxTimezoneFilePath ?? '/etc/timezone',
     );
@@ -71,27 +128,174 @@ Future<String> getLocalTimezone({
 /// scheduling — would then place a 09:00 reminder at 09:00 UTC, an hour or
 /// more away from the 09:00 the user asked for.
 ///
-/// Called once at start-up, and deliberately total: a device whose zone cannot
-/// be resolved to an IANA name keeps the currently configured [local] location
-/// (the package's UTC default during normal startup). Start-up must not fail
+/// Called once at start-up, and deliberately total: start-up must not fail
 /// over a timezone.
+///
+/// **Two levels of degradation, because leaving [local] at UTC is not one.**
+/// The previous implementation swallowed a resolution failure and returned,
+/// which sounds harmless but silently kept the package's UTC default — the
+/// exact "reminder lands hours off" outcome this function exists to prevent.
+/// When [getLocalTimezone] can only produce an abbreviation, this now falls
+/// back to [locationForDeviceZone], which is wrong about the user's *city*
+/// but right about their *clock*.
 ///
 /// [resolve] is a test seam — [getLocalTimezone] short-circuits to the
 /// abbreviation under `isTestEnv`, so without it neither branch here could be
-/// exercised. [onError] surfaces resolution failures without coupling this
-/// utility to the application's logging service.
+/// exercised. [deviceZone] is the seam for the offset fallback: a process
+/// cannot change its own `TZ` mid-run, so the fallback's behaviour in a zone
+/// other than the host's is only reachable by injection. [onError] surfaces
+/// resolution failures without coupling this utility to the application's
+/// logging service. It fires for the *named* lookup even when the offset
+/// fallback then succeeds, because a device that cannot name its own zone is
+/// worth knowing about either way — and again if the fallback itself throws,
+/// which is reachable because [deviceZone] is caller-supplied.
 Future<void> configureLocalTimezone({
   Future<String> Function()? resolve,
   void Function(Object error, StackTrace stackTrace)? onError,
+  DeviceZone Function()? deviceZone,
 }) async {
+  // [onError] is caller-supplied, so reporting a failure is itself a call that
+  // can fail. Left bare it would escape the catch block it sits in, and a
+  // diagnostic that aborts start-up is worse than no diagnostic.
+  void report(Object error, StackTrace stackTrace) {
+    try {
+      onError?.call(error, stackTrace);
+    } on Object {
+      // Nothing left to report it to.
+    }
+  }
+
   try {
     setLocalLocation(getLocation(await (resolve ?? getLocalTimezone)()));
+    return;
   } on Object catch (error, stackTrace) {
-    onError?.call(error, stackTrace);
-    // Leave the existing location unchanged. [getLocalTimezone] can still hand
-    // back an abbreviation on a platform with no zoneinfo tree, and
-    // `getLocation` rejects those.
+    report(error, stackTrace);
   }
+
+  try {
+    final fallback = locationForDeviceZone((deviceZone ?? readDeviceZone)());
+    if (fallback != null) {
+      setLocalLocation(fallback);
+    }
+  } on Object catch (error, stackTrace) {
+    // Guarded for the same reason the first attempt is: this runs
+    // fire-and-forget during boot, and there is nothing left to degrade to.
+    report(error, stackTrace);
+  }
+}
+
+/// What `DateTime` can still say about the clock on a device that exposes no
+/// IANA zone name.
+///
+/// `offsetAt` is the load-bearing member: `DateTime` knows the device's UTC
+/// offset at *any* instant, not just now, which is what makes the device's
+/// own daylight-saving rules observable without a zone name.
+typedef DeviceZone = ({
+  DateTime at,
+  String abbreviation,
+  Duration Function(DateTime instant) offsetAt,
+});
+
+/// Reads the [DeviceZone] from the platform clock.
+///
+/// [clock] is a test seam: it pins `at` so a test does not have to assert the
+/// instant within a tolerance. `abbreviation` and `offsetAt` still come from
+/// the platform either way — this fixes *when* the reading is taken, not what
+/// the device says about that moment.
+DeviceZone readDeviceZone({DateTime Function()? clock}) {
+  final now = (clock ?? DateTime.now)();
+  return (at: now, abbreviation: now.timeZoneName, offsetAt: _platformOffsetAt);
+}
+
+/// The device's UTC offset at [instant], as the platform's own timezone rules
+/// see it.
+Duration _platformOffsetAt(DateTime instant) =>
+    DateTime.fromMillisecondsSinceEpoch(
+      instant.millisecondsSinceEpoch,
+    ).timeZoneOffset;
+
+/// How far ahead a candidate zone is compared against the device's own rules,
+/// and how finely.
+///
+/// Just over a year, so every seasonal transition the device observes falls
+/// inside the window at least once. A fortnightly step is far shorter than any
+/// daylight-saving period, so no transition can hide between two probes; it
+/// costs ~29 offset comparisons per candidate, once, on a path that only runs
+/// when the zone could not be named.
+const _ruleProbeHorizon = Duration(days: 400);
+const _ruleProbeStep = Duration(days: 14);
+
+/// A [Location] that keeps [zone]'s wall clock, or null when the timezone
+/// database holds none.
+///
+/// Picks a **rule set, not a city**. The name it lands on ("America/Menominee"
+/// for a device in Chicago) is not a claim about where the user is — only that
+/// the two keep the same clock.
+///
+/// Selection happens in two stages, and the second is not optional:
+///
+/// 1. **Instantaneous match.** Zones whose offset *and* abbreviation equal the
+///    device's at `zone.at`. Where the device reports an abbreviation the
+///    database does not use — Android is fond of `GMT-06:00` — offset alone
+///    stands in, because a slightly wrong zone beats no fallback at all.
+/// 2. **Agreement across upcoming transitions.** One instant is not a rule
+///    set. A device in Chicago starting the app in January reports
+///    `CST`/-06:00, which twenty-five zones also report — and the
+///    alphabetically first of them, `America/Bahia_Banderas`, stays on CST all
+///    year while Chicago springs forward in March. Choosing on the snapshot
+///    alone therefore put every reminder an hour late from spring onwards.
+///    Candidates are scored on how often their offset matches the device's own
+///    across [_ruleProbeHorizon], which separates the two.
+///
+/// Scored rather than filtered, so a device whose tzdata is a different
+/// vintage from the bundled database still gets its closest match instead of
+/// nothing. Candidates are walked in sorted order and ties keep the first, so
+/// the choice is stable across runs rather than dependent on map iteration
+/// order.
+@visibleForTesting
+Location? locationForDeviceZone(DeviceZone zone) {
+  final instant = zone.at.millisecondsSinceEpoch;
+  final offset = zone.offsetAt(zone.at);
+
+  final matchingAbbreviation = <String>[];
+  final matchingOffset = <String>[];
+  for (final entry in timeZoneDatabase.locations.entries) {
+    final timeZone = entry.value.timeZone(instant);
+    if (timeZone.offset != offset) continue;
+    matchingOffset.add(entry.key);
+    if (timeZone.abbreviation == zone.abbreviation) {
+      matchingAbbreviation.add(entry.key);
+    }
+  }
+
+  final candidates = matchingAbbreviation.isNotEmpty
+      ? matchingAbbreviation
+      : matchingOffset;
+  if (candidates.isEmpty) return null;
+  candidates.sort();
+
+  var bestName = candidates.first;
+  var bestScore = -1;
+  for (final name in candidates) {
+    final location = timeZoneDatabase.locations[name]!;
+    var score = 0;
+    for (
+      var ahead = _ruleProbeStep;
+      ahead <= _ruleProbeHorizon;
+      ahead += _ruleProbeStep
+    ) {
+      final probe = zone.at.add(ahead);
+      if (location.timeZone(probe.millisecondsSinceEpoch).offset ==
+          zone.offsetAt(probe)) {
+        score++;
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestName = name;
+    }
+  }
+  return timeZoneDatabase.locations[bestName];
 }
 
 /// Reads an IANA name from a plain-text file such as `/etc/timezone`.
@@ -107,34 +311,49 @@ Future<String?> _readTimezoneFile(String path) async {
   }
 }
 
-/// Extracts the IANA name from `/etc/localtime`'s symlink target.
+/// Extracts the IANA name from `/etc/localtime`, or null when none can be
+/// derived.
+///
+/// Two readings of the link are tried in turn, and **neither alone is
+/// sufficient**:
+///
+/// 1. `readlink` — the link's immediate target. macOS points `/etc/localtime`
+///    straight at `/var/db/timezone/zoneinfo/Europe/Berlin`, naming the zone
+///    without the tzdata version that fully resolving the path splices in. It
+///    is also the only reading that survives a **dangling** link (minimal
+///    containers ship one) or a sandbox that permits `readlink` on the link
+///    while denying traversal of the tree it points into — Lotti's own macOS
+///    build runs under `com.apple.security.app-sandbox`.
+/// 2. `realpath` — the fully resolved path. Distributions that chain
+///    `/etc/localtime` through an intermediate link, where the immediate
+///    target names no zone at all, need this instead.
+///
+/// Each reading is attempted independently: one throwing must not cost the
+/// other its turn, which is why this is a loop over thunks rather than a list
+/// of already-awaited paths.
 ///
 /// Returns null when the path is not a symlink (some systems copy the zoneinfo
-/// file instead of linking it) or when the target sits outside a recognised
-/// zoneinfo tree, since a name cannot be derived in that case.
+/// file instead of linking it) or when neither reading runs through a zoneinfo
+/// tree, since no name can be derived in that case.
 Future<String?> _resolveLocaltimeLink(String path) async {
+  final link = Link(path);
   try {
-    final link = Link(path);
     if (!link.existsSync()) return null;
-    final target = await link.resolveSymbolicLinks();
-    for (final prefix in _zoneinfoPrefixes) {
-      // Searched rather than anchored at the start: sandboxed runtimes
-      // (flatpak, snap) and test fixtures place the zoneinfo tree under a
-      // different root, and the IANA name is still whatever follows it.
-      final index = target.indexOf(prefix);
-      if (index != -1) {
-        var name = target.substring(index + prefix.length);
-        for (final variant in const ['posix/', 'right/']) {
-          if (name.startsWith(variant)) {
-            name = name.substring(variant.length);
-            break;
-          }
-        }
-        return name.isEmpty ? null : name;
-      }
-    }
-    return null;
   } on Object {
     return null;
   }
+
+  for (final read in <Future<String> Function()>[
+    link.target,
+    link.resolveSymbolicLinks,
+  ]) {
+    try {
+      final name = ianaNameFromZoneinfoPath(await read());
+      if (name != null) return name;
+    } on Object {
+      // This reading cannot see the path; the other one still may.
+      continue;
+    }
+  }
+  return null;
 }

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -866,6 +866,79 @@ void main() {
       expect(channel.countOf('cancel'), 1);
     });
 
+    test('builds the wall clock in the device zone, not in UTC', () async {
+      // The reported failure, at the point where it actually costs the user a
+      // reminder. Unlike `scheduleNotificationAt`, this path composes an
+      // *instant out of wall-clock components* in the resolved location, so
+      // the location is not cosmetic: build 07:45 in UTC for a device in
+      // Berlin and the habit reminder arrives at 09:45.
+      //
+      // `local` stood in for the device zone whenever `getLocalTimezone()`
+      // could only produce an abbreviation — and on macOS it always could,
+      // because the tzdata version directory in the resolved /etc/localtime
+      // path defeated the IANA lookup. `configureLocalTimezone()` then failed
+      // the same way and left `local` at the package's UTC default, so the
+      // fallback silently became the bug.
+      // Mirrors `scheduleHabitNotification`'s own call: mobile on, desktop
+      // off. `_alertDetails` hands a platform the caller did not opt into null
+      // details, so a habit reminder only ever presents on iOS and Android —
+      // which is where this mistiming was actually felt.
+      _usePlatform(TargetPlatform.iOS);
+      tz.setLocalLocation(tz.getLocation('Europe/Berlin'));
+      final service = await buildService();
+
+      await withClock(Clock.fixed(DateTime.utc(2000)), () async {
+        await service.scheduleNotification(
+          title: 'Meditate',
+          body: 'Daily meditation',
+          notifyAt: DateTime(2024, 3, 15, 7, 45),
+          notificationId: 42,
+          showOnMobile: true,
+          showOnDesktop: false,
+        );
+      });
+
+      final args = channel.argsOf('zonedSchedule');
+      final scheduled = DateTime.parse(
+        args['scheduledDateTimeISO8601']! as String,
+      );
+      final today = DateTime.now();
+
+      expect(
+        args['scheduledDateTime'],
+        endsWith('T07:45:00'),
+        reason: 'the wall clock the user set is what they must see',
+      );
+      final berlin = tz.getLocation('Europe/Berlin');
+      final expected = tz.TZDateTime(
+        berlin,
+        today.year,
+        today.month,
+        today.day,
+        7,
+        45,
+      );
+
+      // Compared as instants: TZDateTime and DateTime never test equal to each
+      // other, so `expect(a, b)` on the objects would fail even when the two
+      // name the same moment.
+      expect(
+        scheduled.toUtc().millisecondsSinceEpoch,
+        expected.millisecondsSinceEpoch,
+        reason:
+            '07:45 in Berlin, not 07:45 in UTC — the gap is the whole '
+            'offset the device is in, which is exactly how late the reminder '
+            'used to arrive',
+      );
+      expect(
+        expected.toUtc().hour,
+        isNot(7),
+        reason:
+            'guards the guard: if Berlin ever sat at UTC+0 this test would '
+            'pass without distinguishing the two',
+      );
+    });
+
     test('repeat asks the OS to match on time of day', () async {
       final service = await buildService();
 

--- a/test/utils/timezone_test.dart
+++ b/test/utils/timezone_test.dart
@@ -13,7 +13,178 @@ void main() {
   final fixedNow = DateTime(2024, 3, 15, 12);
   DateTime clock() => fixedNow;
 
-  group('getLocalTimezone', () {
+  // ---------------------------------------------------------------------------
+  // ianaNameFromZoneinfoPath
+  //
+  // The pure half of the resolution, tested without touching the filesystem.
+  // This is where the "CEST" bug lived: the parser matched a fixed list of
+  // absolute zoneinfo prefixes, and macOS's real path carries a tzdata version
+  // directory that no fixed prefix can contain.
+  // ---------------------------------------------------------------------------
+  group('ianaNameFromZoneinfoPath — layouts that must resolve', () {
+    test(
+      'the version-stamped path macOS actually resolves /etc/localtime to',
+      () {
+        // The regression. /var/db/timezone/zoneinfo is itself a symlink into
+        // tz/<tzdata-version>/, so realpath() returns this — and the prefix
+        // list this replaced contained '/var/db/timezone/zoneinfo/', which
+        // does not appear in it. Every up-to-date Mac therefore fell through
+        // to DateTime.timeZoneName and handed getLocation the abbreviation.
+        expect(
+          ianaNameFromZoneinfoPath(
+            '/private/var/db/timezone/tz/2026c.1.0/zoneinfo/Europe/Berlin',
+          ),
+          'Europe/Berlin',
+          reason:
+              'the tzdata version between the tree root and "zoneinfo" must '
+              'not defeat the match, or it breaks again on the next update',
+        );
+      },
+    );
+
+    test('the same path with a different tzdata version', () {
+      // Pins that the match is version-agnostic rather than accidentally
+      // tolerant of one particular string.
+      expect(
+        ianaNameFromZoneinfoPath(
+          '/private/var/db/timezone/tz/2031a.7.2/zoneinfo/Asia/Tokyo',
+        ),
+        'Asia/Tokyo',
+      );
+    });
+
+    test("macOS's unresolved link target", () {
+      expect(
+        ianaNameFromZoneinfoPath('/var/db/timezone/zoneinfo/Europe/Berlin'),
+        'Europe/Berlin',
+      );
+    });
+
+    test('the Linux system tree', () {
+      expect(
+        ianaNameFromZoneinfoPath('/usr/share/zoneinfo/America/New_York'),
+        'America/New_York',
+      );
+    });
+
+    test('the alternate Linux tree', () {
+      expect(
+        ianaNameFromZoneinfoPath('/usr/lib/zoneinfo/Asia/Tokyo'),
+        'Asia/Tokyo',
+      );
+    });
+
+    test('a relative link target', () {
+      // readlink() reports whatever the link literally holds, which need not
+      // be absolute.
+      expect(
+        ianaNameFromZoneinfoPath('../usr/share/zoneinfo/Europe/Paris'),
+        'Europe/Paris',
+      );
+    });
+
+    test('a tree nested under a sandbox root', () {
+      // flatpak and snap mount the host tree under a prefix of their own.
+      expect(
+        ianaNameFromZoneinfoPath(
+          '/run/host/usr/share/zoneinfo/America/Sao_Paulo',
+        ),
+        'America/Sao_Paulo',
+      );
+    });
+
+    test('a three-segment zone name stays intact', () {
+      expect(
+        ianaNameFromZoneinfoPath(
+          '/usr/share/zoneinfo/America/Argentina/Buenos_Aires',
+        ),
+        'America/Argentina/Buenos_Aires',
+      );
+    });
+
+    test('a single-segment zone name', () {
+      expect(ianaNameFromZoneinfoPath('/usr/share/zoneinfo/UTC'), 'UTC');
+    });
+
+    test('the last zoneinfo segment wins', () {
+      // A backup or staging copy of the tree placed inside another one would
+      // otherwise resolve to "usr/share/zoneinfo/Asia/Tokyo".
+      expect(
+        ianaNameFromZoneinfoPath(
+          '/opt/zoneinfo/usr/share/zoneinfo/Asia/Tokyo',
+        ),
+        'Asia/Tokyo',
+      );
+    });
+
+    for (final flavour in ['posix', 'right']) {
+      test('the $flavour/ leap-second subtree is stripped', () {
+        expect(
+          ianaNameFromZoneinfoPath(
+            '/usr/share/zoneinfo/$flavour/Australia/Sydney',
+          ),
+          'Australia/Sydney',
+        );
+      });
+    }
+
+    test('only the first flavour segment is stripped', () {
+      // "posix" is stripped as the subtree it names, not as a banned word, so
+      // a deeper occurrence is left alone.
+      expect(
+        ianaNameFromZoneinfoPath('/usr/share/zoneinfo/posix/posix/UTC'),
+        'posix/UTC',
+      );
+    });
+  });
+
+  group('ianaNameFromZoneinfoPath — paths that name no zone', () {
+    test('a path with no zoneinfo segment at all', () {
+      expect(ianaNameFromZoneinfoPath('/etc/localtime.backup'), isNull);
+    });
+
+    test('a segment that merely contains "zoneinfo"', () {
+      // Matching a substring rather than a whole segment would derive
+      // "Europe/Berlin" from a directory that is not a zoneinfo tree.
+      expect(
+        ianaNameFromZoneinfoPath('/home/u/zoneinfo-backup/Europe/Berlin'),
+        isNull,
+      );
+      expect(
+        ianaNameFromZoneinfoPath('/home/u/myzoneinfo/Europe/Berlin'),
+        isNull,
+      );
+    });
+
+    test('the tree root with nothing after it', () {
+      expect(ianaNameFromZoneinfoPath('/usr/share/zoneinfo'), isNull);
+    });
+
+    test('the tree root with a trailing separator', () {
+      expect(ianaNameFromZoneinfoPath('/usr/share/zoneinfo/'), isNull);
+    });
+
+    test('a flavour subtree with no zone inside it', () {
+      expect(ianaNameFromZoneinfoPath('/usr/share/zoneinfo/right'), isNull);
+    });
+
+    test('a doubled separator inside the name', () {
+      // An empty segment means a malformed path, not a zone named "".
+      expect(
+        ianaNameFromZoneinfoPath('/usr/share/zoneinfo//Europe/Berlin'),
+        isNull,
+      );
+    });
+
+    test('an empty path', () {
+      expect(ianaNameFromZoneinfoPath(''), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getLocalTimezone
+  // ---------------------------------------------------------------------------
+  group('getLocalTimezone — test-environment short circuit', () {
     test('returns system timezone name in test environment', () async {
       final tz = await getLocalTimezone(clock: clock);
       expect(tz, fixedNow.timeZoneName);
@@ -29,7 +200,9 @@ void main() {
         expect(tz, fixedNow.timeZoneName);
       },
     );
+  });
 
+  group('getLocalTimezone — fallback', () {
     test(
       'falls back to the platform abbreviation when nothing resolves',
       () async {
@@ -57,41 +230,98 @@ void main() {
         }
       },
     );
+  });
 
-    test('reads timezone from file on Linux when isTestEnv is false', () async {
-      if (!Platform.isLinux) return;
+  group('getLocalTimezone — /etc/timezone', () {
+    // Linux is the only platform that ships this file, but the branch is
+    // driven through `overrideIsLinux` rather than skipped off-Linux: a test
+    // that early-returns on the developer's machine and only really runs on CI
+    // is a test nobody is watching.
+    late Directory tempDir;
+    late File tzFile;
 
-      final tempDir = await Directory.systemTemp.createTemp('tz_test');
-      final tzFile = File('${tempDir.path}/timezone');
-      await tzFile.writeAsString('Europe/Berlin\n');
-
-      try {
-        final tz = await getLocalTimezone(
-          linuxTimezoneFilePath: tzFile.path,
-          overrideIsTestEnv: false,
-        );
-        expect(tz, 'Europe/Berlin');
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('tz_test');
+      tzFile = File('${tempDir.path}/timezone');
     });
 
-    test('trims whitespace from timezone file on Linux', () async {
-      if (!Platform.isLinux) return;
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
 
-      final tempDir = await Directory.systemTemp.createTemp('tz_test');
-      final tzFile = File('${tempDir.path}/timezone');
-      await tzFile.writeAsString('  America/New_York  \n');
+    test('reads the IANA name straight out of the file', () async {
+      await tzFile.writeAsString('Europe/Berlin\n');
 
-      try {
-        final tz = await getLocalTimezone(
+      expect(
+        await getLocalTimezone(
           linuxTimezoneFilePath: tzFile.path,
+          localtimeLinkPath: '${tempDir.path}/absent-link',
           overrideIsTestEnv: false,
-        );
-        expect(tz, 'America/New_York');
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
+          overrideIsLinux: true,
+        ),
+        'Europe/Berlin',
+      );
+    });
+
+    test('trims surrounding whitespace', () async {
+      await tzFile.writeAsString('  America/New_York  \n\n');
+
+      expect(
+        await getLocalTimezone(
+          linuxTimezoneFilePath: tzFile.path,
+          localtimeLinkPath: '${tempDir.path}/absent-link',
+          overrideIsTestEnv: false,
+          overrideIsLinux: true,
+        ),
+        'America/New_York',
+      );
+    });
+
+    test('a missing file falls through instead of throwing', () async {
+      expect(
+        await getLocalTimezone(
+          linuxTimezoneFilePath: '${tempDir.path}/absent',
+          localtimeLinkPath: '${tempDir.path}/absent-link',
+          overrideIsTestEnv: false,
+          overrideIsLinux: true,
+          clock: clock,
+        ),
+        fixedNow.timeZoneName,
+      );
+    });
+
+    test('an unreadable path falls through instead of throwing', () async {
+      // A directory where a file is expected: readAsString throws, and the
+      // caller must see the next source rather than the exception.
+      await Directory('${tempDir.path}/not-a-file').create();
+
+      expect(
+        await getLocalTimezone(
+          linuxTimezoneFilePath: '${tempDir.path}/not-a-file',
+          localtimeLinkPath: '${tempDir.path}/absent-link',
+          overrideIsTestEnv: false,
+          overrideIsLinux: true,
+          clock: clock,
+        ),
+        fixedNow.timeZoneName,
+      );
+    });
+
+    test('is not consulted off Linux, even when the file exists', () async {
+      // macOS has no /etc/timezone; reading whatever sits at that path anyway
+      // would be a guess, so the branch must stay shut.
+      await tzFile.writeAsString('Europe/Berlin\n');
+
+      expect(
+        await getLocalTimezone(
+          linuxTimezoneFilePath: tzFile.path,
+          localtimeLinkPath: '${tempDir.path}/absent-link',
+          overrideIsTestEnv: false,
+          overrideIsLinux: false,
+          clock: clock,
+        ),
+        fixedNow.timeZoneName,
+      );
     });
   });
 
@@ -153,6 +383,52 @@ void main() {
       });
 
       test(
+        'resolves the real macOS layout, where zoneinfo is a versioned link',
+        () async {
+          // The shape that produced the reported crash, end to end. macOS lays
+          // the tree out as
+          //   /var/db/timezone/zoneinfo -> /var/db/timezone/tz/<version>/zoneinfo
+          // so resolveSymbolicLinks() on /etc/localtime returns a path with the
+          // tzdata version spliced into the middle. Reproduced here with a real
+          // directory symlink rather than a hand-written string, so the test
+          // exercises the same filesystem behaviour the app hits.
+          final versioned = Directory(
+            '${tempDir.path}/var/db/timezone/tz/2026c.1.0/zoneinfo/Europe',
+          );
+          await versioned.create(recursive: true);
+          await File('${versioned.path}/Berlin').writeAsString('TZif');
+
+          await Link('${tempDir.path}/var/db/timezone/zoneinfo').create(
+            '${tempDir.path}/var/db/timezone/tz/2026c.1.0/zoneinfo',
+          );
+          final localtime = Link('${tempDir.path}/localtime');
+          await localtime.create(
+            '${tempDir.path}/var/db/timezone/zoneinfo/Europe/Berlin',
+          );
+
+          final tz = await getLocalTimezone(
+            linuxTimezoneFilePath: '${tempDir.path}/absent',
+            localtimeLinkPath: localtime.path,
+            overrideIsTestEnv: false,
+            clock: clock,
+          );
+
+          expect(
+            tz,
+            'Europe/Berlin',
+            reason:
+                'the tzdata version directory in the fully resolved path is '
+                'what made this return the "CEST" abbreviation instead',
+          );
+          expect(
+            tz,
+            isNot(fixedNow.timeZoneName),
+            reason: 'guards against the fallback quietly answering instead',
+          );
+        },
+      );
+
+      test(
         'resolves the real macOS layout, where /etc is itself a symlink',
         () async {
           // On macOS /etc -> /private/etc, so resolveSymbolicLinks() returns
@@ -189,6 +465,65 @@ void main() {
         },
       );
 
+      test('reads a dangling link, which realpath cannot follow', () async {
+        // A link into a tree that is not there — minimal containers ship one,
+        // and a sandbox that allows readlink() while denying traversal of the
+        // target tree looks the same from here. resolveSymbolicLinks() throws,
+        // so the name is only reachable from the link's immediate target.
+        final localtime = Link('${tempDir.path}/localtime');
+        // Deliberately inside the fixture directory: pointing at a real system
+        // path such as /usr/share/zoneinfo/... would not dangle on a host that
+        // ships one, and the test would prove nothing.
+        await localtime.create(
+          '${tempDir.path}/absent-tree/usr/share/zoneinfo/Pacific/Auckland',
+        );
+
+        expect(
+          localtime.existsSync(),
+          isTrue,
+          reason: 'the link itself is present; only its target is missing',
+        );
+        await expectLater(localtime.resolveSymbolicLinks(), throwsA(anything));
+
+        final tz = await getLocalTimezone(
+          linuxTimezoneFilePath: '${tempDir.path}/absent',
+          localtimeLinkPath: localtime.path,
+          overrideIsTestEnv: false,
+          clock: clock,
+        );
+
+        expect(
+          tz,
+          'Pacific/Auckland',
+          reason:
+              'one reading of the link throwing must not cost the other its '
+              'turn',
+        );
+      });
+
+      test('follows a chain whose immediate target names no zone', () async {
+        // The mirror case: readlink() answers with an intermediate path that
+        // carries no zoneinfo segment, and only the fully resolved path does.
+        final zoneFile = File(
+          '${tempDir.path}/usr/share/zoneinfo/America/Chicago',
+        );
+        await zoneFile.parent.create(recursive: true);
+        await zoneFile.writeAsString('TZif');
+
+        await Link('${tempDir.path}/current-zone').create(zoneFile.path);
+        final localtime = Link('${tempDir.path}/localtime');
+        await localtime.create('${tempDir.path}/current-zone');
+
+        final tz = await getLocalTimezone(
+          linuxTimezoneFilePath: '${tempDir.path}/absent',
+          localtimeLinkPath: localtime.path,
+          overrideIsTestEnv: false,
+          clock: clock,
+        );
+
+        expect(tz, 'America/Chicago');
+      });
+
       test('reads the IANA name from a Linux-style zoneinfo link', () async {
         final linkPath = await makeLocaltimeLink(
           zoneinfoPrefix: '/usr/share/zoneinfo/',
@@ -219,11 +554,11 @@ void main() {
         expect(tz, 'America/Argentina/Buenos_Aires');
       });
 
-      for (final variant in const ['posix', 'right']) {
+      for (final variant in const ['posix/', 'right/']) {
         test('strips the $variant zoneinfo subtree', () async {
           final linkPath = await makeLocaltimeLink(
-            zoneinfoPrefix: '/usr/share/zoneinfo/',
-            ianaName: '$variant/Europe/Berlin',
+            zoneinfoPrefix: '/usr/share/zoneinfo/$variant',
+            ianaName: 'Europe/Berlin',
           );
 
           final tz = await getLocalTimezone(
@@ -237,13 +572,11 @@ void main() {
       }
 
       test('falls back to the abbreviation when the link is missing', () async {
-        final fixedNow = DateTime(2024, 3, 15, 12);
-
         final tz = await getLocalTimezone(
           linuxTimezoneFilePath: '${tempDir.path}/absent',
           localtimeLinkPath: '${tempDir.path}/no-such-link',
           overrideIsTestEnv: false,
-          clock: () => fixedNow,
+          clock: clock,
         );
 
         expect(
@@ -253,20 +586,34 @@ void main() {
         );
       });
 
+      test('falls back when /etc/localtime is a copy, not a link', () async {
+        // Some systems copy the zoneinfo file into place. There is no link to
+        // read, so no name can be derived.
+        final copied = File('${tempDir.path}/localtime');
+        await copied.writeAsString('TZif');
+
+        final tz = await getLocalTimezone(
+          linuxTimezoneFilePath: '${tempDir.path}/absent',
+          localtimeLinkPath: copied.path,
+          overrideIsTestEnv: false,
+          clock: clock,
+        );
+
+        expect(tz, fixedNow.timeZoneName);
+      });
+
       test('falls back when the link points outside a zoneinfo tree', () async {
-        // Some systems copy the zoneinfo file rather than linking it, and a
-        // link into an unrecognised location yields no derivable name.
+        // A link into an unrecognised location yields no derivable name.
         final stray = File('${tempDir.path}/stray-tzfile');
         await stray.writeAsString('TZif');
         final link = Link('${tempDir.path}/localtime');
         await link.create(stray.path);
-        final fixedNow = DateTime(2024, 3, 15, 12);
 
         final tz = await getLocalTimezone(
           linuxTimezoneFilePath: '${tempDir.path}/absent',
           localtimeLinkPath: link.path,
           overrideIsTestEnv: false,
-          clock: () => fixedNow,
+          clock: clock,
         );
 
         expect(tz, fixedNow.timeZoneName);
@@ -285,6 +632,7 @@ void main() {
           linuxTimezoneFilePath: tzFile.path,
           localtimeLinkPath: linkPath,
           overrideIsTestEnv: false,
+          overrideIsLinux: true,
         );
 
         expect(tz, 'Asia/Tokyo');
@@ -300,7 +648,7 @@ void main() {
   // This property proves that `.trim()` is correct for any combination of
   // leading/trailing whitespace from the representative set.
   // ---------------------------------------------------------------------------
-  group('getLocalTimezone — properties (Linux only)', () {
+  group('getLocalTimezone — /etc/timezone properties', () {
     // Known valid timezone strings drawn from common real values.
     const knownTimezones = [
       'UTC',
@@ -336,12 +684,12 @@ void main() {
     ).test(
       'trims any leading/trailing whitespace from the timezone file',
       (timezone, leadingWs, trailingWs) async {
-        if (!Platform.isLinux) return;
-
         await tzFile0.writeAsString('$leadingWs$timezone$trailingWs');
         final result = await getLocalTimezone(
           linuxTimezoneFilePath: tzFile0.path,
+          localtimeLinkPath: '${tempDir0.path}/absent-link',
           overrideIsTestEnv: false,
+          overrideIsLinux: true,
         );
         expect(
           result,
@@ -355,11 +703,249 @@ void main() {
     );
   });
 
+  // ---------------------------------------------------------------------------
+  // The offset fallback
+  // ---------------------------------------------------------------------------
+  group('readDeviceZone', () {
+    test('reports what DateTime knows about the process clock', () {
+      // The instant is pinned rather than asserted within a tolerance, so the
+      // test cannot depend on how long the two readings are apart. The
+      // abbreviation and offset still come from the platform — the seam fixes
+      // *when* the reading is taken, not what the device says about it.
+      final zone = readDeviceZone(clock: () => fixedNow);
+
+      expect(zone.at, fixedNow);
+      expect(zone.abbreviation, fixedNow.timeZoneName);
+      expect(zone.offsetAt(fixedNow), fixedNow.timeZoneOffset);
+    });
+
+    test('answers for instants other than now', () {
+      // The member the rule-set scoring depends on: the platform's offset at a
+      // future instant, which is how the device's own daylight-saving
+      // behaviour becomes observable without a zone name.
+      final zone = readDeviceZone(clock: () => fixedNow);
+
+      for (final ahead in const [
+        Duration(days: 90),
+        Duration(days: 180),
+        Duration(days: 300),
+      ]) {
+        final instant = zone.at.add(ahead);
+        expect(
+          zone.offsetAt(instant),
+          DateTime.fromMillisecondsSinceEpoch(
+            instant.millisecondsSinceEpoch,
+          ).timeZoneOffset,
+        );
+      }
+    });
+  });
+
+  group('locationForDeviceZone', () {
+    // UTC instants, so the fixtures do not depend on the host's own zone.
+    final summer = DateTime.utc(2026, 7, 1, 12);
+    final winter = DateTime.utc(2026, 1, 15, 12);
+
+    setUpAll(tzdata.initializeTimeZones);
+
+    /// A device whose platform rules are exactly [zoneName]'s — the shape
+    /// `readDeviceZone` produces on a real device, without depending on the
+    /// zone the suite happens to run in.
+    DeviceZone deviceIn(String zoneName, DateTime at) {
+      final location = tz.getLocation(zoneName);
+      Duration offsetAt(DateTime instant) =>
+          location.timeZone(instant.millisecondsSinceEpoch).offset;
+      return (
+        at: at,
+        abbreviation: location.timeZone(at.millisecondsSinceEpoch).abbreviation,
+        offsetAt: offsetAt,
+      );
+    }
+
+    /// Whether [location] and [zoneName] keep the same clock at [at].
+    void expectSameClockAs(
+      String zoneName,
+      tz.Location? location,
+      DateTime at,
+    ) {
+      expect(location, isNotNull);
+      expect(
+        location!.timeZone(at.millisecondsSinceEpoch).offset,
+        tz.getLocation(zoneName).timeZone(at.millisecondsSinceEpoch).offset,
+      );
+    }
+
+    test('returns a zone that really keeps the requested wall clock', () {
+      final location = locationForDeviceZone(deviceIn('Europe/Berlin', summer));
+
+      expect(location, isNotNull);
+      final zone = location!.timeZone(summer.millisecondsSinceEpoch);
+      expect(zone.offset, const Duration(hours: 2));
+      expect(zone.abbreviation, 'CEST');
+    });
+
+    test('the returned zone builds the same wall clock as Berlin', () {
+      // The point of the fallback: a 09:00 reminder stays at 09:00 for the
+      // user, even though the zone chosen is not the one they live in.
+      final location = locationForDeviceZone(
+        deviceIn('Europe/Berlin', summer),
+      )!;
+
+      expect(
+        tz.TZDateTime(location, 2026, 7, 1, 9).toUtc(),
+        tz.TZDateTime(tz.getLocation('Europe/Berlin'), 2026, 7, 1, 9).toUtc(),
+      );
+    });
+
+    test(
+      "a winter CST device keeps Chicago's spring transition, not Bahia "
+      "Banderas' lack of one",
+      () {
+        // The regression. In January a device in Chicago reports CST/-06:00,
+        // and so do twenty-five database zones; the alphabetically first,
+        // America/Bahia_Banderas, abolished daylight saving and stays on CST
+        // all year. Choosing on that one instant alone therefore put every
+        // habit reminder an hour late from the March transition onward — the
+        // very failure this fallback exists to prevent.
+        final location = locationForDeviceZone(
+          deviceIn('America/Chicago', winter),
+        );
+
+        expect(
+          location?.name,
+          isNot('America/Bahia_Banderas'),
+          reason: 'the alphabetically first instantaneous match is the trap',
+        );
+        expectSameClockAs('America/Chicago', location, winter);
+        expectSameClockAs('America/Chicago', location, summer);
+      },
+    );
+
+    test('a CST device that never springs forward keeps that rule', () {
+      // The mirror: same abbreviation and offset in January, opposite summer
+      // behaviour. Proves the scoring follows the device rather than always
+      // preferring a DST-observing zone.
+      final location = locationForDeviceZone(
+        deviceIn('America/Bahia_Banderas', winter),
+      );
+
+      expectSameClockAs('America/Bahia_Banderas', location, winter);
+      expectSameClockAs('America/Bahia_Banderas', location, summer);
+      expect(
+        location!.timeZone(summer.millisecondsSinceEpoch).offset,
+        const Duration(hours: -6),
+        reason: 'still CST in July, unlike Chicago',
+      );
+    });
+
+    test('southern-hemisphere rules are followed too', () {
+      // Sydney's daylight saving runs opposite to the northern hemisphere, so
+      // a zone scored only on northern transitions would get this backwards.
+      final location = locationForDeviceZone(
+        deviceIn('Australia/Sydney', summer),
+      );
+
+      expectSameClockAs('Australia/Sydney', location, summer);
+      expectSameClockAs('Australia/Sydney', location, winter);
+    });
+
+    test('the abbreviation, not just the offset, narrows the field', () {
+      // CEST and SAST are both +02:00 in July, and neither observes the
+      // other's transitions.
+      final european = locationForDeviceZone(
+        deviceIn('Europe/Berlin', summer),
+      )!;
+      final southAfrican = locationForDeviceZone(
+        deviceIn('Africa/Johannesburg', summer),
+      )!;
+
+      expect(southAfrican.name, 'Africa/Johannesburg');
+      expect(european.name, isNot('Africa/Johannesburg'));
+      expect(
+        tz.TZDateTime(european, 2026, 1, 15, 9).toUtc().difference(
+          tz.TZDateTime(southAfrican, 2026, 1, 15, 9).toUtc(),
+        ),
+        const Duration(hours: 1),
+        reason: 'in January the two have diverged — different rule sets',
+      );
+    });
+
+    test('a zone with a unique abbreviation resolves to exactly it', () {
+      expect(
+        locationForDeviceZone(deviceIn('Asia/Tokyo', summer))?.name,
+        'Asia/Tokyo',
+      );
+    });
+
+    test('an unrecognised abbreviation falls back to offset alone', () {
+      // Android reports offsets such as "GMT+02:00" rather than an
+      // abbreviation the database uses. No fallback at all would be worse than
+      // a zone picked on offset and future rules.
+      final berlin = tz.getLocation('Europe/Berlin');
+      final location = locationForDeviceZone((
+        at: summer,
+        abbreviation: 'GMT+02:00',
+        offsetAt: (instant) =>
+            berlin.timeZone(instant.millisecondsSinceEpoch).offset,
+      ));
+
+      expectSameClockAs('Europe/Berlin', location, summer);
+      expectSameClockAs('Europe/Berlin', location, winter);
+    });
+
+    test('is stable across repeated calls', () {
+      expect(
+        locationForDeviceZone(deviceIn('America/Chicago', winter))?.name,
+        locationForDeviceZone(deviceIn('America/Chicago', winter))?.name,
+      );
+    });
+
+    test('the instant is honoured, not ignored', () {
+      // No zone is CEST in January — the abbreviation is CET then, so the
+      // abbreviation tier finds nothing and the offset tier answers instead.
+      final berlin = tz.getLocation('Europe/Berlin');
+      final location = locationForDeviceZone((
+        at: winter,
+        abbreviation: 'CEST',
+        offsetAt: (instant) =>
+            berlin.timeZone(instant.millisecondsSinceEpoch).offset,
+      ));
+
+      expect(
+        location?.timeZone(winter.millisecondsSinceEpoch).abbreviation,
+        'CET',
+      );
+    });
+
+    test('an offset no zone reports matches nothing', () {
+      expect(
+        locationForDeviceZone((
+          at: summer,
+          abbreviation: 'ZZZ',
+          offsetAt: (_) => const Duration(minutes: 7),
+        )),
+        isNull,
+      );
+    });
+  });
+
   group('configureLocalTimezone', () {
     // Without this the package's `local` is UTC — initializeTimeZones() loads
     // the database but chooses nothing — so anything building wall-clock
     // components against it schedules in the wrong zone.
     late tz.Location originalLocation;
+
+    /// A device that knows its clock but cannot name its zone — the state
+    /// every platform without a readable zoneinfo tree is in.
+    DeviceZone berlinInJuly() {
+      final berlin = tz.getLocation('Europe/Berlin');
+      return (
+        at: DateTime.utc(2026, 7, 1, 12),
+        abbreviation: 'CEST',
+        offsetAt: (instant) =>
+            berlin.timeZone(instant.millisecondsSinceEpoch).offset,
+      );
+    }
 
     setUp(() {
       tzdata.initializeTimeZones();
@@ -381,21 +967,76 @@ void main() {
       );
     });
 
-    test(
-      'keeps the existing location when the zone is an abbreviation',
-      () async {
-        await configureLocalTimezone(resolve: () async => 'Europe/Berlin');
-        // getLocation rejects abbreviations; start-up must survive that rather
-        // than throw out of main().
-        await configureLocalTimezone(resolve: () async => 'CEST');
+    test('does not consult the device zone when the name resolves', () async {
+      var consulted = false;
 
-        expect(tz.local.name, 'Europe/Berlin');
+      await configureLocalTimezone(
+        resolve: () async => 'Asia/Tokyo',
+        deviceZone: () {
+          consulted = true;
+          return berlinInJuly();
+        },
+      );
+
+      expect(tz.local.name, 'Asia/Tokyo');
+      expect(consulted, isFalse);
+    });
+
+    test(
+      'recovers the device wall clock when the zone is an abbreviation',
+      () async {
+        // getLocation rejects abbreviations. Start-up must survive that — but
+        // surviving by leaving `local` at the package's UTC default is what
+        // put a 09:00 reminder at 11:00 for a user in Berlin, so the offset
+        // the device *does* know is used instead.
+        tz.setLocalLocation(tz.UTC);
+
+        await configureLocalTimezone(
+          resolve: () async => 'CEST',
+          deviceZone: berlinInJuly,
+        );
+
+        expect(tz.local.name, isNot('UTC'));
+        expect(
+          tz.TZDateTime(tz.local, 2026, 7, 1, 9).toUtc().hour,
+          7,
+          reason:
+              'the whole point of the fallback: 09:00 stays 09:00 for the '
+              'user instead of sliding to 11:00 via UTC',
+        );
       },
     );
 
+    test('reports the naming failure even when the fallback works', () async {
+      tz.setLocalLocation(tz.UTC);
+      Object? capturedError;
+      StackTrace? capturedStackTrace;
+
+      await configureLocalTimezone(
+        resolve: () async => 'CEST',
+        deviceZone: berlinInJuly,
+        onError: (error, stackTrace) {
+          capturedError = error;
+          capturedStackTrace = stackTrace;
+        },
+      );
+
+      expect(
+        capturedError,
+        isNotNull,
+        reason:
+            'a device that cannot name its own zone is worth a diagnostic '
+            'even though the reminder is now scheduled correctly',
+      );
+      expect(capturedStackTrace, isNotNull);
+      expect(
+        tz.TZDateTime(tz.local, 2026, 7, 1, 9).toUtc().hour,
+        7,
+        reason: 'the diagnostic is in addition to the recovery, not instead',
+      );
+    });
+
     test('survives a resolver that throws', () async {
-      await configureLocalTimezone(resolve: () async => 'Europe/Berlin');
-      final previousLocation = tz.local;
       final error = StateError('no tz');
       Object? capturedError;
       StackTrace? capturedStackTrace;
@@ -403,6 +1044,7 @@ void main() {
       await expectLater(
         configureLocalTimezone(
           resolve: () async => throw error,
+          deviceZone: berlinInJuly,
           onError: (exception, stackTrace) {
             capturedError = exception;
             capturedStackTrace = stackTrace;
@@ -411,9 +1053,105 @@ void main() {
         completes,
       );
 
-      expect(tz.local, same(previousLocation));
       expect(capturedError, same(error));
       expect(capturedStackTrace, isNotNull);
+      expect(
+        tz.TZDateTime(tz.local, 2026, 7, 1, 9).toUtc().hour,
+        7,
+        reason: 'a thrown resolver is still a device with a known offset',
+      );
+    });
+
+    test('survives an onError that throws', () async {
+      // Reporting a failure is itself a caller-supplied call that can fail.
+      // Left bare it would escape the catch block it sits in, turning a
+      // diagnostic into an aborted start-up.
+      tz.setLocalLocation(tz.UTC);
+
+      await expectLater(
+        configureLocalTimezone(
+          resolve: () async => 'CEST',
+          deviceZone: berlinInJuly,
+          onError: (_, _) => throw StateError('logger unavailable'),
+        ),
+        completes,
+      );
+
+      expect(
+        tz.TZDateTime(tz.local, 2026, 7, 1, 9).toUtc().hour,
+        7,
+        reason:
+            'the fallback still ran — a broken logger must not cost the user '
+            'a correctly scheduled reminder',
+      );
+    });
+
+    test('survives a device-zone reader that throws', () async {
+      // The fallback is the last line of defence, and `deviceZone` is supplied
+      // by the caller — so it can throw. Start-up calls this fire-and-forget,
+      // where an escaping error surfaces as an unhandled async error during
+      // boot rather than as a missed reminder.
+      await configureLocalTimezone(resolve: () async => 'Europe/Berlin');
+      final previousLocation = tz.local;
+      final failure = StateError('no device clock');
+      final errors = <Object>[];
+
+      await expectLater(
+        configureLocalTimezone(
+          resolve: () async => 'CEST',
+          deviceZone: () => throw failure,
+          onError: (error, _) => errors.add(error),
+        ),
+        completes,
+      );
+
+      expect(tz.local, same(previousLocation));
+      expect(
+        errors,
+        [isA<Object>(), same(failure)],
+        reason:
+            'both the naming failure and the fallback failure are reported, '
+            'in that order',
+      );
+    });
+
+    test(
+      'leaves the location alone when the device zone matches nothing',
+      () async {
+        await configureLocalTimezone(resolve: () async => 'Europe/Berlin');
+        final previousLocation = tz.local;
+
+        await configureLocalTimezone(
+          resolve: () async => 'CEST',
+          deviceZone: () => (
+            at: DateTime.utc(2026, 7, 1, 12),
+            abbreviation: 'ZZZ',
+            offsetAt: (_) => const Duration(minutes: 7),
+          ),
+        );
+
+        expect(
+          tz.local,
+          same(previousLocation),
+          reason:
+              'with nothing better to offer, keeping the current location '
+              'beats replacing it with a guess',
+        );
+      },
+    );
+
+    test('reads the real device zone when none is injected', () async {
+      // The production path: no seams at all beyond the resolver. Whatever the
+      // host's zone is, the outcome must keep the host's wall clock.
+      tz.setLocalLocation(tz.UTC);
+
+      await configureLocalTimezone(resolve: () async => 'CEST');
+
+      final now = DateTime.now();
+      expect(
+        tz.local.timeZone(now.millisecondsSinceEpoch).offset,
+        now.timeZoneOffset,
+      );
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Habit reminders now follow the device’s actual timezone on iPhone, iPad, Android, and macOS.
  * Point-in-time notifications retain their existing timing.
  * macOS timezone detection is more reliable across versioned and seasonal timezone data.
  * New entries now save standardized IANA timezone names, preventing ambiguity.

* **Documentation**
  * Updated release and metadata documentation to clarify timezone handling and the 1.0.13 changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->