### PR TITLE
chore(release): move release notes into changelog.d/ fragments

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: release
+description: Cut a Lotti release — assemble the changelog.d/ fragments into CHANGELOG.md and the Flathub metainfo, bump the version, open the release PR, then tag. Use when asked to cut or prepare a release, assemble the changelog, publish a new version, or work out what is unreleased.
+argument-hint: "[optional: version, e.g. 1.0.14]"
+---
+
+# Cut a release
+
+Release notes are written per change as **fragments** in `changelog.d/`, one new
+file per pull request, and assembled once per release. A release is therefore a
+small, boring, self-contained pull request: it turns the fragments into prose in
+two files, moves the version, and deletes what it consumed.
+
+**This is the only change allowed to touch `CHANGELOG.md`,
+`flatpak/com.matthiasn.lotti.metainfo.xml`, or the `version:` line in
+`pubspec.yaml`.** That rule is the whole point — those three files are written at
+the top by everything, so as long as exactly one pull request per release writes
+them, nothing can conflict. If you are here for any other reason, you are in the
+wrong skill; write a fragment instead (`changelog.d/README.md`).
+
+## Before you start
+
+```bash
+git checkout main && git pull
+ls changelog.d/[0-9]*.md       # the work queue; README.md is not a fragment
+fvm dart run tool/changelog/validate.dart --strict
+```
+
+`--strict` rather than `make changelog_check`: the house-style warnings the
+author-facing check only prints — an entry with no bold headline, a paragraph
+pasted as one long line — are about to become published prose, so here they
+block.
+
+- Work from an up-to-date `main`. A release assembled on a stale branch drops
+  whatever merged in the meantime.
+- If `changelog.d/` holds nothing but its README, there is nothing to release.
+  Say so and stop.
+- Fix any malformed fragment here, in the release branch. It is cheaper than
+  sending the author back.
+- A fragment describing something that was reverted before it shipped gets
+  deleted, not published.
+
+**Ask before committing, pushing or tagging.** Every step below writes files;
+the git operations are the user's call, always.
+
+## 1. Read every fragment
+
+Read them all before writing anything. You are producing one coherent set of
+release notes, not a concatenation: two fragments may describe two halves of the
+same user-visible change and should be merged into one entry, and a later
+fragment may supersede an earlier one.
+
+## 2. Choose the version
+
+```bash
+grep -m1 '^version:' pubspec.yaml     # e.g. version: 1.0.13+4352
+```
+
+- **Patch** (`1.0.13` → `1.0.14`) for fixes and ordinary improvements. This is
+  the usual one.
+- **Minor** (`1.0.13` → `1.1.0`) when the release leads with a genuinely new
+  capability.
+- **Build number**: previous + 1. It only has to be unique and increasing per
+  tag — every release lane triggers on tag push, not on merges to `main` — so it
+  moves once per release, not once per pull request.
+
+If the user named a version, use it. Otherwise propose one from what the
+fragments contain and confirm it.
+
+## 3. Assemble the CHANGELOG section
+
+Insert one new section at the top of `CHANGELOG.md`, directly under the
+Keep a Changelog preamble and above the previous version:
+
+```markdown
+## [1.0.14]
+### Added
+- **...**
+
+### Changed
+- **...**
+
+### Fixed
+- **...**
+```
+
+- **One section per type, in this order**: Added, Changed, Deprecated, Removed,
+  Fixed, Security. Skip the ones with no entries. Never repeat a heading inside
+  a version — older sections do, because entries used to be appended one PR at a
+  time; assembling from fragments is what fixes that.
+- **The version heading carries no date.** That is the file's existing shape.
+- Keep each entry's wording as the fragment wrote it, minus edits for
+  duplication, house voice, or an entry that reads oddly next to its neighbours.
+- Wrap at about 78 columns, continuation lines indented two spaces.
+
+## 4. Write the Flathub release block
+
+Add one `<release>` to `flatpak/com.matthiasn.lotti.metainfo.xml`, as the
+**first** child of `<releases>` — newest first:
+
+```xml
+<release version="1.0.14" date="2026-08-25">
+  <description>
+    <p>Fixed: ...</p>
+  </description>
+</release>
+```
+
+This is the same prose, mechanically transformed. AppStream renders `<p>` as
+plain text: markdown does not survive it, and an unescaped `&` breaks the build.
+
+| In `CHANGELOG.md` | In the metainfo |
+|---|---|
+| one `- ` bullet | one `<p>`, same order as the section |
+| the `### Fixed` heading above it | the prefix `Fixed: ` on every paragraph in that section |
+| `- **Bold headline.** Detail…` | `Fixed: bold headline. Detail…` — bold markers dropped, first letter lowercased unless it is a proper noun (`Settings`, `Flathub`) |
+| hard-wrapped over several lines | one long line |
+| `—` or `–` | ` - ` |
+| `` `code` `` or a glyph like `•••` | plain words a user recognises — `"..."`, `the "Location with the name CEST doesn't exist" error` |
+| `&`, `<`, `>` | `&amp;`, `&lt;`, `&gt;` |
+
+Worked example, from 1.0.13:
+
+```markdown
+- **Daily habit reminders arrived hours late on iPhone, iPad and Android.** The
+  app could not work out which timezone the device was in, quietly settled for
+  UTC, and then built the reminder's time of day in UTC — so an 08:00 habit
+  reminder rang at 10:00 in Central European Summer Time.
+```
+
+```xml
+<p>Fixed: daily habit reminders arrived hours late on iPhone, iPad and Android. The app could not work out which timezone the device was in, quietly settled for UTC, and then built the reminder's time of day in UTC - so an 08:00 habit reminder rang at 10:00 in Central European Summer Time.</p>
+```
+
+The `date` is the day the release is cut, `YYYY-MM-DD`.
+
+## 5. Bump the version
+
+One line in `pubspec.yaml`:
+
+```yaml
+version: 1.0.14+4353
+```
+
+## 6. Delete the fragments you consumed
+
+```bash
+git rm changelog.d/[0-9]*.md       # fragments start with their date; README.md does not
+```
+
+Everything you just published goes. `changelog.d/` holding only its README is
+what "nothing unreleased" looks like; git history keeps the originals.
+
+## 7. Verify
+
+```bash
+make changelog_check                                     # versions now agree
+xmllint --noout flatpak/com.matthiasn.lotti.metainfo.xml # if available
+git status --short
+```
+
+`git status` must show exactly four kinds of change and nothing else:
+`CHANGELOG.md`, the metainfo, `pubspec.yaml`, and deleted fragments. A release
+PR that also carries code is a release PR that can conflict.
+
+Re-read the assembled section once as a user would. It is the text that reaches
+Flathub, the GitHub release and the app's What's New — it is read far more often
+than it is written.
+
+## 8. Open the release pull request
+
+```
+chore(release): 1.0.14
+```
+
+Body: the assembled `## [1.0.14]` section, so review reads the notes rather than
+the diff. No screenshots — nothing visual changed.
+
+## 9. Tag, after it merges
+
+```bash
+git checkout main && git pull
+make tag_push        # tags 1.0.14+4353 from pubspec.yaml and pushes it
+```
+
+`make tag_push` reads the version with `yq`; install it (`brew install yq`) or tag
+by hand with the exact `version+build` string if the target reports it missing.
+
+The tag is what ships. Pushing it triggers, in parallel: macOS and iOS
+TestFlight, the Android release, the Linux GitHub release, the macOS signed
+`.dmg`, and the Flathub submission PR against `flathub/com.matthiasn.lotti` —
+which is why the metainfo has to be right *before* the tag, not after.
+
+Confirm with the user before tagging. Watch the lanes; `docs/macos-release.md`
+and `docs/flatpak-flathub-recovery.md` cover the two that fail in interesting
+ways.
+
+## 10. Downstream, and out of scope here
+
+The app's **What's New** modal reads from the separate `matthiasn/lotti-docs`
+repository (`whats-new/`), not from this one. Publishing there is an editorial
+step in that repo — mention it once the release is tagged; do not attempt it
+from here.
+
+## Gotchas
+
+- **The metainfo lagging a version behind is invisible until Flathub ships it.**
+  `make changelog_check` fails on exactly that, which is why it runs in CI on
+  every push rather than only at release time.
+- **Tags carry the build number** (`1.0.14+4353`), and every release lane keys
+  on tag push. Re-tagging the same build number to fix a mistake will not give
+  you a fresh TestFlight build; bump the build number and cut again.
+- **Do not fold anything else into the release PR** — not a "quick fix", not a
+  dependency bump. The moment it carries code it can conflict, and the reason
+  this flow exists is gone.

--- a/.claude/skills/design-review-panel/SKILL.md
+++ b/.claude/skills/design-review-panel/SKILL.md
@@ -26,7 +26,7 @@ stateDiagram-v2
     Rescreenshot --> Rerate: regenerate the SAME shots
     Rerate --> Implement: either panel average < target
     Rerate --> Harden: both panel averages ≥ target
-    Harden --> [*]: tests, l10n, README, CHANGELOG+flatpak, analyzer clean, PR
+    Harden --> [*]: tests, l10n, README, changelog.d fragment, analyzer clean, PR
 ```
 
 1. **Baseline screenshot first.** Use the `app-screenshots` skill / the
@@ -45,9 +45,10 @@ stateDiagram-v2
 4. **Adjudicate genuine tradeoffs with the user** (`AskUserQuestion`) instead
    of silently picking a side — before declaring a conflict irreducible, hunt
    for a both-sides fix (one change that serves two opposed reviewers).
-5. **Harden to PR-ready** once converged: tests, l10n, feature README,
-   CHANGELOG + flatpak metainfo, analyzer zero-warning, formatter, PR on latest
-   main.
+5. **Harden to PR-ready** once converged: tests, l10n, feature README, a
+   `changelog.d/` fragment (never `CHANGELOG.md` or the flatpak metainfo
+   directly — those belong to the release), analyzer zero-warning, formatter,
+   PR on latest main.
 
 ## The two panels
 

--- a/.claude/skills/skeptical-review/SKILL.md
+++ b/.claude/skills/skeptical-review/SKILL.md
@@ -97,9 +97,10 @@ nitpick. Verify against `AGENTS.md` (authoritative) — highlights:
 - **UI stability**: async providers must not flash loading/empty shells on
   background refresh (`skipLoadingOnReload` or equivalent).
 - **Docs & release hygiene**: feature READMEs updated when behavior
-  changed; CHANGELOG entry under the current `pubspec.yaml` version (only
-  for user-visible changes, and paired with
-  `flatpak/com.matthiasn.lotti.metainfo.xml`).
+  changed; a release note as a new `changelog.d/YYYY-MM-DD-slug.md` fragment
+  (only for user-visible changes). A PR that edits `CHANGELOG.md`, the flatpak
+  metainfo, or the `version:` line in `pubspec.yaml` is a finding, not a
+  courtesy — those three belong to the release alone.
 - **Conventions**: Conventional Commits; no dependencies from new code onto
   old code being replaced; no hoarded/unused code.
 

--- a/.github/workflows/flutter-analyze.yml
+++ b/.github/workflows/flutter-analyze.yml
@@ -36,3 +36,10 @@ jobs:
       # Ratcheted — a file's legacy-icon count may fall, never rise.
       - name: Check icon-token discipline
         run: dart run tool/icons/validate.dart
+      # Release notes live in changelog.d/ as one file per pull request, so the
+      # three files every change used to edit at the top — CHANGELOG.md, the
+      # Flathub metainfo, pubspec.yaml — are written only by a release. This
+      # catches a malformed fragment while its author is still in context, and
+      # a released version that landed in some of those files but not all.
+      - name: Check release-note fragments
+        run: dart run tool/changelog/validate.dart

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,15 +162,20 @@ and what is enforced at construction rather than by review.
 - Aim for full coverage of every code path.
 - Every widget we touch should get as close to full test coverage as is reasonable, with meaningful
   tests.
-- Add CHANGELOG entry under the current version from `pubspec.yaml` (not under [Unreleased]).
-- Update `flatpak/com.matthiasn.lotti.metainfo.xml` alongside CHANGELOG — these two files go hand in hand.
-- Do not mention bugfixes in CHANGELOG for bugs that were never released. E.g. when working on a 
-  feature that comprises many commits, and the bug was fixed before being merged, then there is 
-  no reason to mention that bug in the CHANGELOG.
-- CHANGELOG entries are only required for things a user would actually notice. Skip them for
-  invisible work: dependency bumps with no behavior change, internal refactors, test-only
-  changes, build/CI tweaks, doc updates. If in doubt, ask — but default to "no entry" when the
-  user wouldn't see a difference at runtime.
+- **Release notes go in `changelog.d/`, never straight into `CHANGELOG.md`.** Add one new file
+  per pull request — `changelog.d/YYYY-MM-DD-slug.md`, holding the `### Fixed` (or `### Added`,
+  `### Changed`, …) section your change deserves, worded as it should read to a user. **Never
+  edit `CHANGELOG.md`, `flatpak/com.matthiasn.lotti.metainfo.xml` or the `version:` line in
+  `pubspec.yaml`.** Those three are written at the top by everything, so they are written once
+  per release, by the release — which is what stops concurrent pull requests conflicting over
+  prose they do not share. The format, the naming and what deserves an entry at all are in
+  [changelog.d/README.md](changelog.d/README.md); `make changelog_check` validates it.
+- Fragments are only for what a user would actually notice — not dependency bumps, refactors,
+  test-only changes, CI tweaks, docs, or a bug introduced and fixed before it ever shipped. If
+  in doubt, ask, but default to no fragment when nothing changes at runtime.
+- Assembling a release — fragments into `CHANGELOG.md` and the Flathub metainfo, version bump,
+  tag — is [.agents/skills/release/SKILL.md](.agents/skills/release/SKILL.md). It is the only
+  change permitted to touch those three files.
 - Update the documentation we touch such that it matches reality in the codebase, not only
   for what we touch but in its entirety. See "Documentation" below for which file gets what.
 - In most cases we prefer one test file for one implementation file.

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,16 @@ analyze:
 icon_check:
 	$(DART_CMD) run tool/icons/validate.dart
 
+# Checks the unreleased release notes in changelog.d/ — one new file per pull
+# request instead of an edit to the top of CHANGELOG.md, which is what used to
+# leave every open PR conflicted the moment one of them merged. Also fails when
+# pubspec.yaml, CHANGELOG.md and the Flathub metainfo disagree about the
+# released version: a metainfo left a version behind is invisible here and very
+# visible to everyone on Flathub.
+.PHONY: changelog_check
+changelog_check:
+	$(DART_CMD) run tool/changelog/validate.dart
+
 .PHONY: okf_check
 okf_check:
 	$(DART_CMD) run tool/okf/validate.dart knowledge

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,70 @@
+# Unreleased notes
+
+**One pull request, one new file in this folder. Nothing else.**
+
+`CHANGELOG.md`, `flatpak/com.matthiasn.lotti.metainfo.xml` and the `version:`
+line in `pubspec.yaml` are all written at the top, in the same few lines, by
+every change that lands. Git merges edits made in different places; it cannot
+merge two rewrites of the same lines. So the first PR to merge left every other
+open PR conflicted — over release prose, not over code.
+
+A fragment is a file that did not exist before, named after your change. Two of
+those cannot conflict. The three shared files are written exactly once per
+release, by the release, which is the only change allowed to touch them.
+
+## Write one
+
+Name it `YYYY-MM-DD-short-slug.md` — today's date, then a lower-kebab slug of
+the change:
+
+```
+changelog.d/2026-08-25-habit-reminder-timezone.md
+```
+
+Inside, write the entry exactly as it should read in `CHANGELOG.md`:
+
+```markdown
+### Fixed
+- **Daily habit reminders arrived hours late on iPhone and Android.** The app
+  could not work out which timezone the device was in, quietly settled for UTC,
+  and then built the reminder's time of day in UTC — so an 08:00 habit reminder
+  rang at 10:00 in Central European Summer Time. Reminders now use the zone the
+  device is actually in.
+```
+
+That is the whole file. The release pastes it in as it stands.
+
+- **Sections** are `### Added`, `### Changed`, `### Deprecated`, `### Removed`,
+  `### Fixed` and `### Security`. Use as many as your change needs, in one file.
+- **Every entry opens with a bold headline sentence**, then the detail: what was
+  wrong or missing, what it does now, and what a user will notice. Written for
+  someone who does not know the code and will read it in the app's What's New.
+- **Wrap prose at about 78 columns**, the way `CHANGELOG.md` does. Continuation
+  lines are indented by two spaces.
+- **No version heading.** `## [1.0.14]` is the release's job, not yours.
+
+## Skip one
+
+Fragments are for what a user would actually notice. No fragment for dependency
+bumps with no behaviour change, internal refactors, test-only changes, build and
+CI tweaks, or documentation. Nor for a bug that was introduced and fixed inside
+the same unreleased feature — it never reached anyone.
+
+## Check it
+
+```bash
+make changelog_check
+```
+
+It runs in CI on every push. It also fails when the released version disagrees
+across the three shared files, which is how a release that half-landed gets
+caught before Flathub ships notes for the wrong version.
+
+## What happens next
+
+At release time the fragments here are assembled into one `## [version]` section
+in `CHANGELOG.md` and one `<release>` block in the Flathub metainfo, the version
+is bumped, and these files are deleted — in a single release pull request. The
+runbook for that is [`.agents/skills/release/SKILL.md`](../.agents/skills/release/SKILL.md).
+
+Whatever is sitting in this folder is, by definition, what has not shipped yet.

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -5,17 +5,21 @@ description: Five platform targets from one codebase, the checks every branch ru
 resource: ../..
 tags: [architecture, ci, release, platforms, build]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-01T12:10:00Z }
+generated: { by: claude-code/opus-5, at: 2026-08-25T12:00:00Z }
 stale_after: 2027-02-01
 sources:
   - id: workflows
     resource: ../../.github/workflows
     title: GitHub Actions workflows
-    last_modified: 2026-07-31
+    last_modified: 2026-08-25
   - id: makefile
     resource: ../../Makefile
     title: Developer and build entry points
-    last_modified: 2026-07-26
+    last_modified: 2026-08-25
+  - id: changelog-fragments
+    resource: ../../tool/changelog/fragment_guard.dart
+    title: Release-note fragment guard
+    last_modified: 2026-08-25
   - id: pubspec
     resource: ../../pubspec.yaml
     title: Version, SDK constraints, dependencies
@@ -158,7 +162,8 @@ fans out from the same tag on a different provider:
 
 ```mermaid
 flowchart TD
-  Bump["Bump version in pubspec.yaml + CHANGELOG.md + flatpak metainfo"] --> Tag["git tag <version> && git push origin <version>"]
+  Assemble["Release PR: changelog.d fragments into CHANGELOG.md + flatpak metainfo, version bumped"] --> Merge["Merge to main"]
+  Merge --> Tag["git tag version && git push origin version"]
   Tag --> A["flutter-macos-testflight.yml"]
   Tag --> B["flutter-macos-release.yml"]
   Tag --> C["flutter-ios-testflight.yml"]
@@ -180,16 +185,20 @@ build-notification email, never on a pull request.
 commit SHA and version override, for re-cutting a Flathub PR without moving the
 tag.
 
-Two files must move together with every user-visible change, and the repo treats
-them as a pair:
+**No ordinary change writes the release files.** `CHANGELOG.md`,
+`flatpak/com.matthiasn.lotti.metainfo.xml` and the `version:` line in
+`pubspec.yaml` are all written at their top, so every pull request that edited
+them conflicted with every other one still open. Instead each change drops a
+note in [`changelog.d/`](../../changelog.d/README.md) — one new file, which
+cannot conflict — and a release pull request assembles them into the three
+files, once, and deletes what it consumed. `make changelog_check` gates both
+halves: the fragments' shape, and that the three files agree on the released
+version. Assembling a release is
+[`.agents/skills/release/SKILL.md`](../../.agents/skills/release/SKILL.md).
 
-- `CHANGELOG.md` — an entry under the **current** `pubspec.yaml` version, not
-  under `[Unreleased]`.
-- `flatpak/com.matthiasn.lotti.metainfo.xml` — the same release, in AppStream
-  form, which is what Flathub renders.
-
-Entries are only for things a user would notice. Dependency bumps, refactors,
-test-only changes and CI tweaks get none.
+Because the tag carries the build number and every lane above triggers on tag
+push rather than on merges to `main`, the build number moves once per release
+too — not once per pull request.
 
 # Local commands
 
@@ -202,6 +211,7 @@ test-only changes and CI tweaks get none.
 | Localization | `make l10n`, `make sort_arb_files` |
 | Integration tests | `make integration_test` |
 | Knowledge bundle check | `make knowledge_check` (validator + mermaid) |
+| Release-note fragments | `make changelog_check` |
 | Run the app | `fvm flutter run -d <device>` |
 
 Generated files — `*.g.dart`, `*.freezed.dart` — are checked in and must never

--- a/test/tool/changelog/fragment_guard_test.dart
+++ b/test/tool/changelog/fragment_guard_test.dart
@@ -1,0 +1,321 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// Relative import: the guard is a repo tool, not part of the `lotti` package,
+// so it has no `package:` URI.
+import '../../../tool/changelog/fragment_guard.dart';
+
+const _pubspec = '''
+name: lotti
+version: 1.0.13+4352
+''';
+
+const _changelog = '''
+# Changelog
+
+## [1.0.13]
+### Fixed
+- **A released thing.** Detail.
+
+## [1.0.12]
+### Fixed
+- **An older thing.** Detail.
+''';
+
+const _metainfo = '''
+<component type="desktop-application">
+  <releases>
+    <release version="1.0.13" date="2026-08-24">
+      <description>
+        <p>Fixed: a released thing. Detail.</p>
+      </description>
+    </release>
+  </releases>
+</component>
+''';
+
+/// A well-formed fragment, used wherever the body is not what is under test.
+const _validFragment = '''
+### Fixed
+- **A habit reminder no longer rings in UTC.** It now uses the zone the device
+  is actually in.
+''';
+
+/// Lays out a throwaway repository and scans it.
+///
+/// Each test gets its own directory so a stray file cannot leak between them.
+GuardResult scanFixture(
+  Map<String, String> fragments, {
+  String pubspec = _pubspec,
+  String changelog = _changelog,
+  String metainfo = _metainfo,
+  bool withFragmentDir = true,
+}) {
+  final root = Directory.systemTemp.createTempSync('changelog_guard_test');
+  addTearDown(() => root.deleteSync(recursive: true));
+
+  void write(String relative, String content) {
+    File('${root.path}/$relative')
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(content);
+  }
+
+  write(pubspecPath, pubspec);
+  write(changelogPath, changelog);
+  write(metainfoPath, metainfo);
+  if (withFragmentDir) {
+    Directory('${root.path}/$fragmentDirPath').createSync(recursive: true);
+  }
+  fragments.forEach(
+    (name, content) => write('$fragmentDirPath/$name', content),
+  );
+
+  return scan(root: root);
+}
+
+List<String> messages(Iterable<Issue> issues) =>
+    issues.map((i) => i.message).toList();
+
+Matcher hasMessage(String needle) => predicate<Issue>(
+  (i) => i.message.contains(needle),
+  'an issue mentioning "$needle"',
+);
+
+void main() {
+  group('fragment body', () {
+    test('a well-formed fragment produces nothing at all', () {
+      final result = scanFixture({
+        '2026-08-25-habit-reminder.md': _validFragment,
+      });
+
+      expect(result.issues, isEmpty);
+      expect(result.fragmentCount, 1);
+    });
+
+    test('one file may carry several sections', () {
+      final result = scanFixture({
+        '2026-08-25-two-sided.md': '''
+### Added
+- **A new thing.** Detail.
+
+### Fixed
+- **An old thing.** Detail.
+''',
+      });
+
+      expect(result.issues, isEmpty);
+    });
+
+    test('an unknown section type is rejected, and names the valid ones', () {
+      final result = scanFixture({
+        '2026-08-25-typo.md': '### Improved\n- **A thing.** Detail.\n',
+      });
+
+      expect(result.errors, [hasMessage('unknown section `### Improved`')]);
+      expect(result.errors.single.message, contains('Fixed'));
+    });
+
+    test('prose before the first heading is rejected', () {
+      final result = scanFixture({
+        '2026-08-25-loose.md':
+            'This PR fixes a thing.\n\n'
+            '### Fixed\n- **A thing.** Detail.\n',
+      });
+
+      expect(result.errors, [hasMessage('content before the first')]);
+    });
+
+    test('a section with no entries is rejected, named by its type', () {
+      final result = scanFixture({
+        '2026-08-25-hollow.md': '### Fixed\n\n### Added\n- **A thing.** X.\n',
+      });
+
+      expect(result.errors, [hasMessage('`### Fixed` has no entries')]);
+    });
+
+    test('the last section is checked for entries too', () {
+      final result = scanFixture({
+        '2026-08-25-trailing.md': '### Added\n- **A thing.** X.\n\n### Fixed\n',
+      });
+
+      expect(result.errors, [hasMessage('`### Fixed` has no entries')]);
+    });
+
+    test('a version heading belongs to the release, not to a fragment', () {
+      final result = scanFixture({
+        '2026-08-25-versioned.md':
+            '## [1.0.14]\n### Fixed\n- **A thing.** Detail.\n',
+      });
+
+      expect(result.errors, [hasMessage('version heading')]);
+    });
+
+    test('an unindented continuation line is rejected', () {
+      final result = scanFixture({
+        '2026-08-25-unindented.md':
+            '### Fixed\n- **A thing.** Detail that\nwrapped to column zero.\n',
+      });
+
+      expect(result.errors, [hasMessage('stray line')]);
+    });
+
+    test('indented continuations and nested bullets are fine', () {
+      final result = scanFixture({
+        '2026-08-25-nested.md': '''
+### Changed
+- **A thing has parts.** Namely:
+  - one part
+  - another part
+
+  and a closing thought.
+''',
+      });
+
+      expect(result.issues, isEmpty);
+    });
+
+    test('an empty fragment is rejected', () {
+      final result = scanFixture({'2026-08-25-blank.md': '\n\n'});
+
+      expect(result.errors, [hasMessage('empty')]);
+    });
+
+    test('an entry without a bold headline warns but does not fail', () {
+      final result = scanFixture({
+        '2026-08-25-plain.md': '### Fixed\n- Fixed the thing.\n',
+      });
+
+      expect(result.errors, isEmpty);
+      expect(result.warnings, [hasMessage('bold headline')]);
+    });
+
+    test('a paragraph pasted as one long line warns', () {
+      final result = scanFixture({
+        '2026-08-25-unwrapped.md':
+            '### Fixed\n- **A thing.** ${'detail ' * 30}\n',
+      });
+
+      expect(result.errors, isEmpty);
+      expect(result.warnings, [hasMessage('characters')]);
+    });
+
+    test('a repeated section type warns, so the release need not merge it', () {
+      final result = scanFixture({
+        '2026-08-25-repeated.md':
+            '### Fixed\n- **One.** X.\n\n### Fixed\n- **Two.** Y.\n',
+      });
+
+      expect(result.errors, isEmpty);
+      expect(result.warnings, [hasMessage('appears twice')]);
+    });
+  });
+
+  group('fragment names', () {
+    test('README.md is documentation, not an unreleased note', () {
+      final result = scanFixture({
+        'README.md': '# Unreleased notes\n\nProse.\n',
+      });
+
+      expect(result.issues, isEmpty);
+      expect(result.fragmentCount, 0);
+    });
+
+    test('a name without the date prefix is rejected', () {
+      final result = scanFixture({'habit-reminder.md': _validFragment});
+
+      expect(result.errors, [hasMessage('YYYY-MM-DD')]);
+      expect(result.fragmentCount, 0);
+    });
+
+    test('a name that is not kebab-case is rejected', () {
+      final result = scanFixture({
+        '2026-08-25-Habit_Reminder.md': _validFragment,
+      });
+
+      expect(result.errors, [hasMessage('YYYY-MM-DD')]);
+    });
+
+    test('a badly named file is not then read for body errors', () {
+      final result = scanFixture({'notes.txt': 'whatever this is'});
+
+      expect(result.errors, hasLength(1));
+      expect(result.errors.single.where, endsWith('notes.txt'));
+    });
+
+    test('a fragment hidden in a subdirectory is reported, not ignored', () {
+      final result = scanFixture({
+        'nested/2026-08-25-buried.md': _validFragment,
+      });
+
+      expect(result.errors, [hasMessage('subdirectory')]);
+      expect(result.fragmentCount, 0);
+    });
+
+    test('several fragments are all counted and all checked', () {
+      final result = scanFixture({
+        '2026-08-24-first.md': _validFragment,
+        '2026-08-25-second.md': _validFragment,
+      });
+
+      expect(result.fragmentCount, 2);
+      expect(result.issues, isEmpty);
+    });
+  });
+
+  group('released version', () {
+    test('agreement across the three shared files passes', () {
+      expect(scanFixture(const {}).issues, isEmpty);
+    });
+
+    test('the build number is not part of the comparison', () {
+      final result = scanFixture(
+        const {},
+        pubspec: 'name: lotti\nversion: 1.0.13+9999\n',
+      );
+
+      expect(result.issues, isEmpty);
+    });
+
+    test('a metainfo left a version behind fails, and says why it matters', () {
+      final result = scanFixture(
+        const {},
+        pubspec: 'name: lotti\nversion: 1.0.14+4353\n',
+        changelog: '# Changelog\n\n## [1.0.14]\n### Fixed\n- **A.** B.\n',
+      );
+
+      expect(result.errors, [hasMessage('newest release is 1.0.13')]);
+      expect(result.errors.single.message, contains('Flathub'));
+    });
+
+    test('a CHANGELOG left behind fails', () {
+      final result = scanFixture(
+        const {},
+        pubspec: 'name: lotti\nversion: 1.0.14+4353\n',
+        metainfo: _metainfo.replaceAll('1.0.13', '1.0.14'),
+      );
+
+      expect(messages(result.errors), [
+        contains('newest section is `## [1.0.13]`'),
+      ]);
+    });
+
+    test('a release date that is not YYYY-MM-DD fails', () {
+      final result = scanFixture(
+        const {},
+        metainfo: _metainfo.replaceAll('2026-08-24', '24.08.2026'),
+      );
+
+      expect(result.errors, [hasMessage('not YYYY-MM-DD')]);
+    });
+
+    test(
+      'a missing changelog.d directory fails — it must exist when empty',
+      () {
+        final result = scanFixture(const {}, withFragmentDir: false);
+
+        expect(result.errors, [hasMessage('directory is missing')]);
+      },
+    );
+  });
+}

--- a/tool/changelog/fragment_guard.dart
+++ b/tool/changelog/fragment_guard.dart
@@ -1,0 +1,376 @@
+/// Checks the release-note fragments in `changelog.d/`.
+///
+/// **Why fragments exist.** `CHANGELOG.md`, the Flathub metainfo and
+/// `pubspec.yaml` are all written at the top, in the same few lines, by every
+/// pull request that lands. Git merges edits in different places; it cannot
+/// merge two rewrites of the same lines. So the first PR to merge left every
+/// other open PR conflicted, over prose that had nothing to do with the code.
+///
+/// A fragment is one new file per pull request. Two files that did not exist
+/// before cannot conflict, so the shared files are written exactly once — by
+/// the release, which is the only change allowed to touch them.
+///
+/// **What this guard enforces.**
+///
+/// *Fragments*: a name that sorts and never collides (`YYYY-MM-DD-slug.md`),
+/// and a body that is nothing but `### <Type>` sections of bullets — the exact
+/// shape the release pastes into `CHANGELOG.md`. Anything the release would
+/// have to rewrite by hand (a version heading, prose loose at the top of the
+/// file, an unwrapped paragraph) is caught here instead, while the author who
+/// wrote it is still in context.
+///
+/// *The released version*: `pubspec.yaml`, the top section of `CHANGELOG.md`
+/// and the newest `<release>` in the metainfo must agree. Under the fragment
+/// flow the three move together in one release change and are identical the
+/// rest of the time, so any disagreement means a release went out half-written
+/// — the metainfo lagging a version behind is what Flathub ships to users.
+library;
+
+import 'dart:io';
+
+/// Directory holding the unreleased fragments, relative to the repository root.
+const fragmentDirPath = 'changelog.d';
+
+const changelogPath = 'CHANGELOG.md';
+const metainfoPath = 'flatpak/com.matthiasn.lotti.metainfo.xml';
+const pubspecPath = 'pubspec.yaml';
+
+/// Keep a Changelog section types, in the order a release assembles them.
+///
+/// The order is the spec's, not this repository's history: released sections
+/// used to come out in whatever order the entries were appended, and one
+/// version carries `### Fixed` three separate times. Assembling from fragments
+/// is the chance to fix that, so the list is ordered and the release follows it.
+const sectionTypes = <String>[
+  'Added',
+  'Changed',
+  'Deprecated',
+  'Removed',
+  'Fixed',
+  'Security',
+];
+
+/// `YYYY-MM-DD-some-slug.md`.
+///
+/// The date makes collisions between two branches unlikely and sorts the
+/// folder chronologically; the slug says which change it belongs to. A PR
+/// number would be better at both, but is not known until after the file has
+/// to be written.
+final RegExp fragmentNamePattern = RegExp(
+  r'^\d{4}-\d{2}-\d{2}-[a-z0-9]+(?:-[a-z0-9]+)*\.md$',
+);
+
+final RegExp _sectionHeading = RegExp(r'^###\s+(.*?)\s*$');
+final RegExp _pubspecVersion = RegExp(
+  r'^version:\s*(\S+)\s*$',
+  multiLine: true,
+);
+final RegExp _changelogVersion = RegExp(r'^##\s+\[([^\]]+)\]', multiLine: true);
+final RegExp _metainfoRelease = RegExp(
+  r'<release\s+version="([^"]*)"\s+date="([^"]*)"',
+);
+final RegExp _isoDate = RegExp(r'^\d{4}-\d{2}-\d{2}$');
+
+/// Prose in this repository wraps around 78 columns. The threshold sits well
+/// above that: the point is not to police the wrap, it is to catch a paragraph
+/// pasted as one long line, which reads as a 400-character diff for every later
+/// edit to it.
+const maxLineLength = 100;
+
+enum Severity { error, warning }
+
+/// One problem, phrased as something the author can act on.
+class Issue {
+  const Issue(this.severity, this.where, this.message);
+
+  final Severity severity;
+
+  /// `path` or `path:line`, so an editor can jump straight to it.
+  final String where;
+
+  final String message;
+
+  @override
+  String toString() =>
+      '${severity == Severity.error ? 'error' : 'warning'}: $where: $message';
+}
+
+/// Everything one run found.
+class GuardResult {
+  const GuardResult(this.issues, this.fragmentCount);
+
+  final List<Issue> issues;
+
+  /// How many valid-named fragments were seen — the release's work queue.
+  final int fragmentCount;
+
+  List<Issue> get errors =>
+      issues.where((i) => i.severity == Severity.error).toList();
+
+  List<Issue> get warnings =>
+      issues.where((i) => i.severity == Severity.warning).toList();
+}
+
+/// Checks one fragment's body.
+///
+/// [path] is used only for reporting. [content] is the file verbatim.
+List<Issue> validateFragmentBody({
+  required String path,
+  required String content,
+}) {
+  final issues = <Issue>[];
+  void err(int line, String message) =>
+      issues.add(Issue(Severity.error, '$path:$line', message));
+  void warn(int line, String message) =>
+      issues.add(Issue(Severity.warning, '$path:$line', message));
+
+  if (content.trim().isEmpty) {
+    return [Issue(Severity.error, path, 'the fragment is empty')];
+  }
+
+  final lines = content.split('\n');
+  final seenTypes = <String>{};
+  String? currentType;
+  var currentTypeLine = 0;
+  var bulletsInSection = 0;
+
+  void closeSection() {
+    if (currentType != null && bulletsInSection == 0) {
+      err(
+        currentTypeLine,
+        '`### $currentType` has no entries — every section needs at least one '
+        '`- ` bullet',
+      );
+    }
+  }
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    final lineNo = i + 1;
+    if (line.trim().isEmpty) continue;
+
+    if (line.length > maxLineLength) {
+      warn(
+        lineNo,
+        'line is ${line.length} characters — wrap prose at about 78 columns, '
+        'the way CHANGELOG.md does',
+      );
+    }
+
+    final heading = _sectionHeading.firstMatch(line);
+    if (heading != null) {
+      final type = heading.group(1)!;
+      if (!sectionTypes.contains(type)) {
+        err(
+          lineNo,
+          'unknown section `### $type` — use one of ${sectionTypes.join(', ')}',
+        );
+      } else if (!seenTypes.add(type)) {
+        warn(
+          lineNo,
+          '`### $type` appears twice in one fragment — fold the entries into '
+          'the first section',
+        );
+      }
+      closeSection();
+      currentType = type;
+      currentTypeLine = lineNo;
+      bulletsInSection = 0;
+      continue;
+    }
+
+    if (line.startsWith('#')) {
+      err(
+        lineNo,
+        'a fragment carries `### <Type>` sections only — the version heading '
+        'belongs to the release that assembles it',
+      );
+      continue;
+    }
+
+    if (currentType == null) {
+      err(
+        lineNo,
+        'content before the first `### <Type>` heading — a fragment opens with '
+        'its section',
+      );
+      continue;
+    }
+
+    if (line.startsWith('- ')) {
+      bulletsInSection++;
+      if (!line.startsWith('- **')) {
+        warn(
+          lineNo,
+          'entry does not open with a bold headline — the house style is '
+          '`- **What changed, in one sentence.** Then the detail.`',
+        );
+      }
+      continue;
+    }
+
+    // Continuation prose and nested bullets, both indented, both fine.
+    if (line.startsWith('  ')) continue;
+
+    err(
+      lineNo,
+      'stray line — an entry is a `- ` bullet and its continuation lines are '
+      'indented by two spaces',
+    );
+  }
+
+  closeSection();
+
+  return issues;
+}
+
+/// Checks that the released version agrees across the three shared files.
+List<Issue> validateReleasedVersion({
+  required String pubspec,
+  required String changelog,
+  required String metainfo,
+}) {
+  final issues = <Issue>[];
+
+  final pubspecMatch = _pubspecVersion.firstMatch(pubspec);
+  if (pubspecMatch == null) {
+    return [const Issue(Severity.error, pubspecPath, 'no `version:` line')];
+  }
+  // `1.0.13+4352` — the build number rides along on the tag, not on the notes.
+  final version = pubspecMatch.group(1)!.split('+').first;
+
+  final changelogMatch = _changelogVersion.firstMatch(changelog);
+  if (changelogMatch == null) {
+    issues.add(
+      const Issue(
+        Severity.error,
+        changelogPath,
+        'no `## [version]` section at all',
+      ),
+    );
+  } else if (changelogMatch.group(1) != version) {
+    issues.add(
+      Issue(
+        Severity.error,
+        changelogPath,
+        'newest section is `## [${changelogMatch.group(1)}]` but pubspec.yaml '
+        'says $version — the release left one of them behind',
+      ),
+    );
+  }
+
+  final metainfoMatch = _metainfoRelease.firstMatch(metainfo);
+  if (metainfoMatch == null) {
+    issues.add(
+      const Issue(
+        Severity.error,
+        metainfoPath,
+        'no `<release version="..." date="...">` entry',
+      ),
+    );
+    return issues;
+  }
+  if (metainfoMatch.group(1) != version) {
+    issues.add(
+      Issue(
+        Severity.error,
+        metainfoPath,
+        'newest release is ${metainfoMatch.group(1)} but pubspec.yaml says '
+        '$version — Flathub would ship notes for the wrong version',
+      ),
+    );
+  }
+  if (!_isoDate.hasMatch(metainfoMatch.group(2)!)) {
+    issues.add(
+      Issue(
+        Severity.error,
+        metainfoPath,
+        'release date "${metainfoMatch.group(2)}" is not YYYY-MM-DD',
+      ),
+    );
+  }
+
+  return issues;
+}
+
+/// Runs every check against the repository rooted at [root].
+GuardResult scan({required Directory root}) {
+  final issues = <Issue>[];
+  var fragmentCount = 0;
+
+  final dir = Directory('${root.path}/$fragmentDirPath');
+  if (!dir.existsSync()) {
+    issues.add(
+      const Issue(
+        Severity.error,
+        fragmentDirPath,
+        'directory is missing — it holds the unreleased notes and must exist '
+        'even when empty',
+      ),
+    );
+  } else {
+    final entries = dir.listSync()..sort((a, b) => a.path.compareTo(b.path));
+    for (final entry in entries) {
+      final name = entry.uri.pathSegments.where((s) => s.isNotEmpty).last;
+      final reportPath = '$fragmentDirPath/$name';
+      if (entry is! File) {
+        issues.add(
+          Issue(
+            Severity.error,
+            reportPath,
+            'only fragment files live here — a note inside a subdirectory is '
+            'read by nobody and would never ship',
+          ),
+        );
+        continue;
+      }
+      final file = entry;
+      if (name == 'README.md' || name == '.gitkeep') continue;
+      if (!fragmentNamePattern.hasMatch(name)) {
+        issues.add(
+          Issue(
+            Severity.error,
+            reportPath,
+            'name does not match YYYY-MM-DD-lower-kebab-slug.md',
+          ),
+        );
+        continue;
+      }
+      fragmentCount++;
+      issues.addAll(
+        validateFragmentBody(
+          path: reportPath,
+          content: file.readAsStringSync(),
+        ),
+      );
+    }
+  }
+
+  String? read(String relative) {
+    final file = File('${root.path}/$relative');
+    return file.existsSync() ? file.readAsStringSync() : null;
+  }
+
+  final pubspec = read(pubspecPath);
+  final changelog = read(changelogPath);
+  final metainfo = read(metainfoPath);
+  if (pubspec == null || changelog == null || metainfo == null) {
+    for (final missing in {
+      pubspecPath: pubspec,
+      changelogPath: changelog,
+      metainfoPath: metainfo,
+    }.entries.where((e) => e.value == null)) {
+      issues.add(Issue(Severity.error, missing.key, 'file not found'));
+    }
+  } else {
+    issues.addAll(
+      validateReleasedVersion(
+        pubspec: pubspec,
+        changelog: changelog,
+        metainfo: metainfo,
+      ),
+    );
+  }
+
+  return GuardResult(issues, fragmentCount);
+}

--- a/tool/changelog/validate.dart
+++ b/tool/changelog/validate.dart
@@ -1,0 +1,72 @@
+// Checks the release-note fragments in `changelog.d/`, and that the released
+// version agrees across pubspec.yaml, CHANGELOG.md and the Flathub metainfo.
+//
+// Usage:
+//   dart run tool/changelog/validate.dart [--strict]
+//
+// Exits 0 when nothing is wrong, 1 on any error — or on any warning under
+// `--strict`. See `fragment_guard.dart` for the rules and why they exist, and
+// `changelog.d/README.md` for how to write a fragment.
+
+import 'dart:io';
+
+import 'fragment_guard.dart';
+
+const _usage = '''
+Checks the unreleased notes in changelog.d/.
+
+Usage: dart run tool/changelog/validate.dart [--strict]
+
+  --strict   Treat warnings as errors.
+''';
+
+void main(List<String> args) {
+  final unknown = args.where((a) => a != '--strict').toList();
+  if (unknown.isNotEmpty) {
+    stderr
+      ..writeln('error: unrecognised argument(s): ${unknown.join(', ')}')
+      ..writeln()
+      ..writeln(_usage);
+    exit(1);
+  }
+  final strict = args.contains('--strict');
+
+  final root = Directory.current;
+  if (!File('${root.path}/$pubspecPath').existsSync()) {
+    stderr.writeln(
+      'error: no `$pubspecPath` here — run from the repository root',
+    );
+    exit(1);
+  }
+
+  final result = scan(root: root);
+
+  // Everything goes to one stream: split across stdout and stderr, the two
+  // interleave unpredictably in a CI log and the issues stop being in file
+  // order, which is the only order that helps someone fixing them.
+  for (final issue in result.issues) {
+    stderr.writeln('  $issue');
+  }
+
+  final errors = result.errors.length;
+  final warnings = result.warnings.length;
+  final fragments = result.fragmentCount;
+
+  if (errors == 0 && warnings == 0) {
+    stdout.writeln(
+      fragments == 0
+          ? 'changelog.d/ is empty — nothing waiting for a release.'
+          : '$fragments unreleased '
+                '${fragments == 1 ? 'fragment' : 'fragments'}, all well formed.',
+    );
+  } else {
+    stderr.writeln(
+      '\n$errors ${errors == 1 ? 'error' : 'errors'}, '
+      '$warnings ${warnings == 1 ? 'warning' : 'warnings'} '
+      'across $fragments ${fragments == 1 ? 'fragment' : 'fragments'}. '
+      'See changelog.d/README.md.',
+    );
+  }
+
+  if (errors > 0 || (strict && warnings > 0)) exit(1);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured release-note fragment workflow for documenting pull-request changes.
  * Added validation for fragment names, formatting, supported sections, and release-version consistency.
  * Added a command-line check and Make target for validating release notes.

* **Documentation**
  * Documented release-note formatting, assembly, validation, and release procedures.
  * Updated contributor guidance to use release-note fragments instead of editing generated release files directly.

* **CI**
  * Added automatic release-note validation to the Flutter analysis workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->