### PR TITLE
feat: capture the Play Store listing screen

### DIFF
--- a/.github/workflows/store-screenshots-android.yml
+++ b/.github/workflows/store-screenshots-android.yml
@@ -1,0 +1,96 @@
+name: Store screenshots (Android)
+
+# Captures the Play Store listing screenshots on an Android emulator and
+# publishes them as a workflow artifact. Manual, or on a pull request that
+# touches the capture itself; the listing changes rarely enough that a run per
+# push would be noise, and the emulator makes this the slowest lane we have.
+
+on:
+  workflow_dispatch:
+    inputs:
+      locale:
+        description: Fixture locale (see MANUAL_LOCALES in the Makefile)
+        default: en
+      themes:
+        description: Space-separated themes to capture
+        default: dark light
+  pull_request:
+    paths:
+      - integration_test/store_screenshots_test.dart
+      - integration_test/tutorial/tutorial_harness.dart
+      - tool/store_screenshots/**
+      - .github/workflows/store-screenshots-android.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    name: Capture on emulator
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+
+      # The emulator needs hardware acceleration; GitHub's Linux runners
+      # expose /dev/kvm but only to root until the node is made world-usable.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Install Android NDK 28
+        run: |
+          echo "y" | sudo "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" "ndk;28.2.13676358"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-linux-android
+
+      - uses: kuhnroyal/flutter-fvm-config-action@v2
+        id: fvm-config-action
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Capture
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: >-
+            FLUTTER=flutter
+            LOTTI_ANDROID_DEVICE=emulator-5554
+            LOTTI_MANUAL_LOCALE="${{ inputs.locale || 'en' }}"
+            LOTTI_STORE_THEMES="${{ inputs.themes || 'dark light' }}"
+            LOTTI_SCREENSHOT_DIR="$GITHUB_WORKSPACE/build/store_screenshots/android"
+            ./tool/store_screenshots/android.sh
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: store-screenshots-android-${{ inputs.locale || 'en' }}
+          path: build/store_screenshots/android/*.png
+          if-no-files-found: error

--- a/.github/workflows/store-screenshots-android.yml
+++ b/.github/workflows/store-screenshots-android.yml
@@ -42,7 +42,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '17'
@@ -70,6 +70,24 @@ jobs:
       - name: Flutter pub get
         run: flutter pub get
 
+      # AGP writes the debug keystore under $XDG_CONFIG_HOME/.android, which
+      # on this runner is not writable ("Unable to create debug keystore in
+      # /home/runner/.config/.android"). Point AGP at a home it owns.
+      - name: Give AGP a writable Android home
+        run: |
+          mkdir -p "$HOME/.android"
+          echo "ANDROID_USER_HOME=$HOME/.android" >> "$GITHUB_ENV"
+
+      # Build before the emulator boots: the Rust crates and Gradle take
+      # longer than the capture itself, a build failure then fails the job
+      # without an emulator log to wade through, and `flutter drive` reuses
+      # the warm caches. x64 only — that is the emulator's ABI.
+      - name: Build the test APK
+        run: >-
+          flutter build apk --debug
+          --target-platform android-x64
+          --target integration_test/store_screenshots_test.dart
+
       - name: Capture
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -89,7 +107,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: store-screenshots-android-${{ inputs.locale || 'en' }}
           path: build/store_screenshots/android/*.png

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ junit_upload:
 
 .PHONY: integration_test
 integration_test:
-	 $(FLUTTER_CMD) test integration_test --exclude-tags tutorial-video
+	 $(FLUTTER_CMD) test integration_test --exclude-tags tutorial-video --exclude-tags store-screenshots
 
 .PHONY: clean
 clean:
@@ -187,6 +187,14 @@ fluttium_production:
 .PHONY: fluttium_docs
 fluttium_docs: manual_screenshots
 	@echo "fluttium_docs is deprecated; generated manual media is ready in $(MANUAL_MEDIA_DIR)."
+
+# Play Store listing screenshots, captured on an Android emulator through
+# `flutter drive` so they are what a phone actually renders. Boots $(LOTTI_AVD)
+# when no device is attached; see tool/store_screenshots/android.sh for the
+# knobs. Output lands in build/store_screenshots/android (gitignored).
+.PHONY: store_screenshots_android
+store_screenshots_android:
+	FLUTTER="$(FLUTTER_CMD)" ./tool/store_screenshots/android.sh
 
 .PHONY: manual_deps
 manual_deps: docs-site/node_modules

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -78,7 +78,33 @@ Basic UI smoke test that creates a journal entry through the UI.
 - Navigation failures
 - Basic widget rendering issues
 
-### 4. Manual Screenshots (`manual_screenshots_test.dart`)
+### 4. Store listing screenshots (`store_screenshots_test.dart`)
+
+Captures the Play Store listing screenshots on a real Android device or emulator.
+Not a verification suite and excluded from `make integration_test` by its
+`store-screenshots` tag.
+
+It boots the production app shell on the tutorial harness — in-memory databases, a
+temp documents directory, the Intergalactic Penguin Logistics world seeded with its
+habits, time records and notes (`seedHistory: true`), and no demo-mode banner — then
+walks the task list, one task, habits, time analysis and the logbook, handing each
+screen to the driver as a PNG. Configuration is passed as dart-defines
+(`LOTTI_STORE_THEME`, `LOTTI_MANUAL_LOCALE`) because the test runs on the device,
+whose environment is not the host's.
+
+Run it through the script, which also pins the emulator window to a ratio Play
+accepts (see [knowledge/conventions/screenshots.md](../knowledge/conventions/screenshots.md)):
+
+```bash
+make store_screenshots_android                 # attached emulator-5554, dark + light
+make store_screenshots_android LOTTI_AVD=Medium_Phone_API_36.0 LOTTI_STORE_THEMES=dark
+```
+
+Output lands in `build/store_screenshots/android/`. CI runs the same script on an
+emulator in `store-screenshots-android.yml` (manual dispatch, or a pull request that
+touches the capture) and uploads the PNGs as a workflow artifact.
+
+### 5. Manual Screenshots (`manual_screenshots_test.dart`)
 
 A legacy full-shell screenshot-capture tool rather than a CI verification suite. It runs the full app shell
 with an in-memory harness and a single `testWidgets` case (`captures AI provider onboarding states

--- a/integration_test/store_screenshots_test.dart
+++ b/integration_test/store_screenshots_test.dart
@@ -1,0 +1,170 @@
+/// Play Store listing screenshots, captured on a real Android device or
+/// emulator.
+///
+/// Boots the production app shell on the tutorial harness — in-memory
+/// databases, a temp documents directory, the Intergalactic Penguin
+/// Logistics world with its habits, time records and notes, and no demo-mode
+/// banner — then walks the screens that say what Lotti is and hands each one
+/// to the driver as a PNG. Run through `tool/store_screenshots/android.sh`
+/// (`make store_screenshots_android`), which pins the emulator window to a
+/// ratio Play accepts and runs this once per theme:
+///
+///   flutter drive --driver=test_driver/manual_screenshots_driver.dart \
+///     --target=integration_test/store_screenshots_test.dart -d emulator-5554 \
+///     --dart-define=LOTTI_STORE_THEME=dark --dart-define=LOTTI_MANUAL_LOCALE=en
+///
+/// Configuration arrives as dart-defines, not environment variables: the
+/// test runs on the device, whose environment is not the host's.
+///
+/// Like the tutorial harness this waits on the wall clock — the app is the
+/// real thing on real hardware, with real image decoding and real database
+/// notifications — and is exempt from the fake-time policy in
+/// `test/README.md`. It is not a verification suite and is not run by
+/// `make integration_test`.
+@Tags(['store-screenshots'])
+library;
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:integration_test/integration_test.dart';
+import 'package:lotti/beamer/beamer_app.dart';
+import 'package:lotti/features/demo/seed/demo_seed_text.dart';
+import 'package:lotti/features/habits/ui/habits_page.dart';
+import 'package:lotti/features/insights/ui/time_analysis_page.dart';
+import 'package:lotti/features/journal/ui/pages/infinite_journal_page.dart';
+import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
+import 'package:lotti/utils/consts.dart';
+
+import '../test/helpers/manual_demo_world.dart';
+import 'manual_screenshot_utils.dart';
+import 'tutorial/tutorial_harness.dart';
+
+const _theme = String.fromEnvironment(
+  'LOTTI_STORE_THEME',
+  defaultValue: 'dark',
+);
+const _localeTag = String.fromEnvironment(
+  'LOTTI_MANUAL_LOCALE',
+  defaultValue: 'en',
+);
+
+/// One frame every 16ms for up to [timeout], stopping early once [finder]
+/// resolves. The app renders on real hardware here, so a fixed pump count
+/// would be either wasteful or flaky depending on the emulator's mood.
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (finder.evaluate().isEmpty) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TestFailure(
+        'Timed out waiting for ${finder.describeMatch(Plurality.one)}',
+      );
+    }
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+}
+
+/// Lets images decode and entrance animations finish before a capture.
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 45; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+  }
+}
+
+Future<Uint8List> _download(Uri uri) => http.readBytes(uri);
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final locale = demoSeedLocaleFromEnvironment({
+    'LOTTI_MANUAL_LOCALE': _localeTag,
+  });
+  const themeMode = _theme == 'light' ? ThemeMode.light : ThemeMode.dark;
+
+  testWidgets('captures the Play Store listing screens', (tester) async {
+    tester.platformDispatcher.localeTestValue = locale;
+    addTearDown(tester.platformDispatcher.clearLocaleTestValue);
+
+    final harness = await TutorialAppHarness.setUp(
+      aiConfigs: manualDemoAiProviders,
+      languageCode: locale.languageCode,
+      // Varies with --dart-define=LOTTI_STORE_THEME; the analyzer only sees
+      // the default.
+      // ignore: avoid_redundant_argument_values
+      themeMode: themeMode,
+      seedHistory: true,
+      configFlags: const {
+        enableHabitsPageFlag: true,
+        enableDailyOsPageFlag: true,
+      },
+      downloadMedia: (Platform.isAndroid || Platform.isIOS) ? _download : null,
+      now: DateTime.now(),
+    );
+    addTearDown(harness.dispose);
+
+    await tester.pumpWidget(
+      manualScreenshotBoundary(
+        child: ProviderScope(
+          overrides: harness.providerOverrides(),
+          child: MyBeamerApp(
+            navService: harness.navService,
+            userActivityService: harness.userActivityService,
+          ),
+        ),
+      ),
+    );
+    await _pumpUntilFound(tester, find.byType(TasksTabPage));
+    await _settle(tester);
+
+    // Android renders Flutter into a SurfaceView, which a screenshot cannot
+    // read; this swaps in an ImageView for the rest of the run.
+    if (Platform.isAndroid) {
+      await binding.convertFlutterSurfaceToImage();
+      await tester.pump();
+    }
+
+    final nav = harness.navService;
+    var index = 0;
+    Future<void> capture(String screen, Finder ready) async {
+      await _pumpUntilFound(tester, ready);
+      await _settle(tester);
+      index += 1;
+      final number = index.toString().padLeft(2, '0');
+      await captureManualScreenshot(
+        binding: binding,
+        tester: tester,
+        name: 'store_${locale.languageCode}_${_theme}_${number}_$screen',
+      );
+    }
+
+    // 1. The task list — what you meant to do.
+    await capture('tasks', find.byType(TasksTabPage));
+
+    // 2. One task with its cover art, checklist and logged time — what
+    //    actually happened, attached to the intent.
+    final task = harness.world.orbitalHabitatTask;
+    nav.beamToNamed('/tasks/${task.meta.id}');
+    await capture('task_detail', find.text(task.data.title));
+
+    // 3. Habits, with four imperfect weeks behind them.
+    nav.setIndex(nav.beamerDelegates.indexOf(nav.habitsDelegate));
+    await capture('habits', find.byType(HabitsTabPage));
+
+    // 4. Time analysis — where the tracked hours went.
+    nav
+      ..setIndex(nav.beamerDelegates.indexOf(nav.calendarDelegate))
+      ..beamToNamed('/calendar/time');
+    await capture('time_analysis', find.byType(TimeAnalysisPage));
+
+    // 5. The logbook — notes, photos and time records in one stream.
+    nav.setIndex(nav.beamerDelegates.indexOf(nav.journalDelegate));
+    await capture('journal', find.byType(InfiniteJournalPage));
+  });
+}

--- a/integration_test/tutorial/tutorial_harness.dart
+++ b/integration_test/tutorial/tutorial_harness.dart
@@ -31,6 +31,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/fts5_db.dart';
@@ -451,10 +452,28 @@ class TutorialAppHarness {
   final ManualDemoWorld world;
   final List<Object> _closeables;
 
+  /// Boots the harness.
+  ///
+  /// The tutorial scenarios take the defaults: dark theme, the penguin
+  /// category with its labels, cover art and tasks, and the config flags as
+  /// a fresh install has them. The store-listing capture asks for more —
+  /// [seedHistory] also writes every category, the habits with their four
+  /// weeks of completions, the checklists, time records and notes, and the
+  /// links between them, so the screens look lived-in; [configFlags] switches
+  /// tabs on before [NavService] reads them; [downloadMedia] replaces the
+  /// `curl` downloader on a device that has none; [now] anchors the world's
+  /// relative dates (due today, logged last Tuesday) — the tutorials keep the
+  /// fixture's fixed clock for determinism, a store capture passes the real
+  /// one so the tracked time lands in this month and nothing reads overdue.
   static Future<TutorialAppHarness> setUp({
     required List<AiConfig> aiConfigs,
     required String languageCode,
     CategoryDefinition Function(CategoryDefinition category)? categoryTransform,
+    ThemeMode themeMode = ThemeMode.dark,
+    bool seedHistory = false,
+    Map<String, bool> configFlags = const {},
+    Future<Uint8List> Function(Uri uri)? downloadMedia,
+    DateTime? now,
   }) async {
     _ignoreBenignOverlayRebuildRace();
     await getIt.reset();
@@ -490,7 +509,7 @@ class TutorialAppHarness {
     final outboxService = _outboxServiceMock();
 
     await Future.wait([
-      settingsDb.saveSettingsItem(themeModeKey, ThemeMode.dark.name),
+      settingsDb.saveSettingsItem(themeModeKey, themeMode.name),
       // The app shell resolves its UI language from this settings override
       // (ManualLanguageController) — platformDispatcher test locales are not
       // enough for the real desktop shell.
@@ -533,6 +552,13 @@ class TutorialAppHarness {
       );
 
     await initConfigFlags(journalDb, inMemoryDatabase: true);
+    for (final flag in configFlags.entries) {
+      final existing = await journalDb.getConfigFlagByName(flag.key);
+      if (existing == null) {
+        throw StateError('Config flag ${flag.key} missing after init');
+      }
+      await journalDb.upsertConfigFlag(existing.copyWith(status: flag.value));
+    }
 
     final vectorClockService = VectorClockService();
     getIt.registerSingleton<VectorClockService>(vectorClockService);
@@ -564,7 +590,7 @@ class TutorialAppHarness {
       ..registerSingleton<NotificationService>(NotificationService());
 
     final persistenceLogic = getIt<PersistenceLogic>();
-    final world = ManualDemoWorld.penguinLogistics();
+    final world = ManualDemoWorld.penguinLogistics(now: now);
     final category = categoryTransform == null
         ? world.category
         : categoryTransform(world.category);
@@ -572,7 +598,10 @@ class TutorialAppHarness {
       world,
       category,
       persistenceLogic,
+      journalDb,
       documentsDirectory,
+      seedHistory: seedHistory,
+      downloadMedia: downloadMedia,
     );
     for (final config in aiConfigs) {
       await aiConfigRepository.saveConfig(config, fromSync: true);
@@ -622,26 +651,54 @@ class TutorialAppHarness {
     ManualDemoWorld world,
     CategoryDefinition category,
     PersistenceLogic persistenceLogic,
-    Directory documentsDirectory,
-  ) async {
+    JournalDb journalDb,
+    Directory documentsDirectory, {
+    required bool seedHistory,
+    required Future<Uint8List> Function(Uri uri)? downloadMedia,
+  }) async {
     await persistenceLogic.upsertEntityDefinition(category);
+    if (seedHistory) {
+      for (final other in world.categories) {
+        if (other.id == category.id) continue;
+        await persistenceLogic.upsertEntityDefinition(other);
+      }
+    }
     for (final label in world.labels) {
       await persistenceLogic.upsertEntityDefinition(label);
     }
-    await installManualDemoMedia(world, documentsDirectory);
-    for (final image in world.coverImages) {
+    if (seedHistory) {
+      // Definitions before the completion entries that reference them.
+      for (final habit in world.habits) {
+        await persistenceLogic.upsertEntityDefinition(habit);
+      }
+    }
+
+    final images = seedHistory ? world.images : world.coverImages;
+    await installManualDemoMedia(
+      world,
+      documentsDirectory,
+      images: images,
+      download: downloadMedia ?? downloadManualDemoMedia,
+    );
+
+    // Same reference order as the production DemoSeeder: images, checklist
+    // items, the checklists that list them, the tasks that own them, then the
+    // history that hangs off the tasks.
+    final entities = seedHistory
+        ? world.journalEntities
+        : <JournalEntity>[...world.coverImages, ...world.tasks];
+    for (final entity in entities) {
       await persistenceLogic.createDbEntity(
-        image,
+        entity,
         shouldAddGeolocation: false,
         enqueueSync: false,
       );
     }
-    for (final task in world.tasks) {
-      await persistenceLogic.createDbEntity(
-        task,
-        shouldAddGeolocation: false,
-        enqueueSync: false,
-      );
+    if (seedHistory) {
+      // Links last: both endpoints must exist first.
+      for (final link in world.links) {
+        await journalDb.upsertEntryLink(link);
+      }
     }
   }
 

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -24,6 +24,14 @@ sources:
     resource: ../../tool/pr_screenshot_publish.py
     title: Immutable PR screenshot publisher
     last_modified: 2026-08-05
+  - id: store-capture
+    resource: ../../tool/store_screenshots/android.sh
+    title: Play Store listing capture on an Android emulator
+    last_modified: 2026-08-26
+  - id: store-test
+    resource: ../../integration_test/store_screenshots_test.dart
+    title: The screens the store listing shows, driven on the device
+    last_modified: 2026-08-26
 ---
 
 # Images do not live in this repository
@@ -93,6 +101,41 @@ does when iterating on one language:
 ```bash
 make manual_screenshots_shard MANUAL_LOCALE=de
 ```
+
+# Store listing screenshots come from a phone
+
+The Play Store listing is the one place a screenshot must come from the
+platform it advertises: a widget-test capture at a phone size is the right
+shape but not the real thing — no device fonts, no device image decoding, no
+platform text input. `integration_test/store_screenshots_test.dart` therefore
+runs on an Android emulator under `flutter drive`, booting the production app
+shell on the tutorial harness with the penguin world seeded in full (habits,
+time records, notes, links) and *no demo-mode banner*, then walks the screens
+that say what the app is. `tool/store_screenshots/android.sh` — `make
+store_screenshots_android` — boots the emulator if needed, runs the test once
+per theme, and collects the PNGs the driver writes; CI runs the same script in
+`store-screenshots-android.yml` on manual dispatch and uploads an artifact.
+
+Two device facts shape the script:
+
+- **Play rejects a screenshot whose long side is more than twice its short
+  side**, and the stock Pixel profiles are 20:9. The script pins the emulator
+  window to 1080×1920 (9:16, which Play also asks for when it features a
+  listing) with `adb shell wm size` and resets it afterwards.
+- **The test runs on the device, whose environment is not the host's.** Theme
+  and locale arrive as `--dart-define`s, not environment variables; the
+  driver, which does run on the host, still writes to `LOTTI_SCREENSHOT_DIR`.
+  And there is no `curl` on a phone, so the fixture media comes down through
+  `package:http` instead of the widget-test downloader.
+- **The emulator's DNS fails silently under Private DNS.** Android's
+  opportunistic DNS-over-TLS "validates" against the emulator's virtual
+  resolver at 10.0.2.3 and then answers nothing: ICMP works, no hostname
+  resolves, and the fixture media never arrives. The script turns
+  `private_dns_mode` off on the guest before driving; plain DNS through the
+  same resolver is fine.
+
+The output is a listing asset, not review evidence: it is uploaded to the
+Play Console by hand and does not go to R2.
 
 # A UI pull request shows before *and* after
 

--- a/lib/features/demo/seed/demo_world.dart
+++ b/lib/features/demo/seed/demo_world.dart
@@ -2786,15 +2786,29 @@ class ManualDemoWorld {
     required Future<Uint8List> Function(Uri uri) download,
     required List<DemoMediaAsset> catalog,
   }) async {
+    // The hydrator reports per-asset failures through a callback and
+    // returns a count; without the first cause in the message, a screenshot
+    // suite failing on a device only says "incomplete" and nothing about the
+    // DNS, TLS or checksum problem behind it.
+    Object? firstError;
+    DemoMediaAsset? firstFailed;
     final hydrator = DemoMediaHydrator(
       root: documentsDirectory,
       assets: catalog,
       download: download,
+      onError: (asset, error, _) {
+        firstError ??= error;
+        firstFailed ??= asset;
+      },
     );
     try {
       final result = await hydrator.hydrate();
       if (!result.isComplete) {
-        throw StateError('Unable to hydrate every manual demo cover');
+        throw StateError(
+          'Unable to hydrate every manual demo cover '
+          '(${result.failed} failed, ${result.cancelled} cancelled)'
+          '${firstFailed == null ? '' : ': ${firstFailed!.fileName}: $firstError'}',
+        );
       }
     } finally {
       hydrator.dispose();

--- a/test/features/demo/seed/demo_world_test.dart
+++ b/test/features/demo/seed/demo_world_test.dart
@@ -747,7 +747,14 @@ void main() {
           isA<StateError>().having(
             (error) => error.message,
             'message',
-            'Unable to hydrate every manual demo cover',
+            // The count and the first cause are what make a device-suite
+            // failure diagnosable from its log alone.
+            allOf(
+              contains('Unable to hydrate every manual demo cover'),
+              contains('1 failed, 0 cancelled'),
+              contains('bad-manual-test.webp'),
+              contains('Checksum mismatch'),
+            ),
           ),
         ),
       );

--- a/test/helpers/manual_demo_world.dart
+++ b/test/helpers/manual_demo_world.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/demo/seed/demo_seed_text.dart';
@@ -99,17 +100,29 @@ Future<Uint8List> downloadManualDemoMedia(Uri uri) =>
     _manualDemoMediaDownloader(uri);
 
 /// Materializes the manual fixture from R2 for a widget screenshot suite.
+///
+/// Installs the cover art by default; pass [images] to install a wider slice
+/// of the catalog, e.g. `world.images` for a task detail page whose attached
+/// photos must resolve too. [download] defaults to the `curl` downloader,
+/// which a widget test needs because the test binding answers every Dart
+/// `HttpClient` request with HTTP 400 — a device harness under
+/// `flutter drive` has no such override and no `curl`, so it passes an
+/// in-process downloader instead.
 Future<List<File>> installManualDemoMedia(
   ManualDemoWorld world,
-  Directory documentsDirectory,
-) {
-  final coverIds = world.coverImages.map((image) => image.meta.id).toSet();
+  Directory documentsDirectory, {
+  Iterable<JournalImage>? images,
+  Future<Uint8List> Function(Uri uri) download = downloadManualDemoMedia,
+}) {
+  final imageIds = (images ?? world.coverImages)
+      .map((image) => image.meta.id)
+      .toSet();
   final catalog = demoMediaAssets
-      .where((asset) => coverIds.contains(asset.id))
+      .where((asset) => imageIds.contains(asset.id))
       .toList();
   return world.installMedia(
     documentsDirectory,
-    download: downloadManualDemoMedia,
+    download: download,
     catalog: catalog,
   );
 }

--- a/tool/store_screenshots/android.sh
+++ b/tool/store_screenshots/android.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Captures the Play Store listing screenshots on an Android emulator.
+#
+# Drives integration_test/store_screenshots_test.dart with `flutter drive`
+# against a booted emulator (or boots one from $LOTTI_AVD), once per theme,
+# and collects the PNGs the driver writes into $LOTTI_SCREENSHOT_DIR.
+#
+# The emulator window is pinned to $LOTTI_STORE_WINDOW for the run and reset
+# afterwards: Play rejects a screenshot whose long side is more than twice
+# its short side, and the stock Pixel profiles are 20:9. 1080x1920 is 9:16,
+# the ratio Play also asks for when it features a listing.
+#
+#   FLUTTER            flutter command (default: fvm flutter)
+#   LOTTI_AVD          AVD to boot when no device is attached
+#   LOTTI_ANDROID_DEVICE  adb serial (default: emulator-5554)
+#   LOTTI_SCREENSHOT_DIR  output directory (default: build/store_screenshots/android)
+#   LOTTI_STORE_THEMES    space-separated themes (default: "dark light")
+#   LOTTI_MANUAL_LOCALE   fixture locale (default: en)
+#   LOTTI_STORE_WINDOW    WxH forced on the emulator (default: 1080x1920)
+set -euo pipefail
+
+FLUTTER=${FLUTTER:-fvm flutter}
+DEVICE=${LOTTI_ANDROID_DEVICE:-emulator-5554}
+OUT=${LOTTI_SCREENSHOT_DIR:-build/store_screenshots/android}
+THEMES=${LOTTI_STORE_THEMES:-dark light}
+LOCALE=${LOTTI_MANUAL_LOCALE:-en}
+WINDOW=${LOTTI_STORE_WINDOW:-1080x1920}
+SDK=${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}
+ADB=${ADB:-$SDK/platform-tools/adb}
+EMULATOR=${EMULATOR:-$SDK/emulator/emulator}
+
+booted_here=0
+if ! "$ADB" -s "$DEVICE" get-state >/dev/null 2>&1; then
+  if [ -z "${LOTTI_AVD:-}" ]; then
+    echo "No device '$DEVICE' attached and LOTTI_AVD is unset." >&2
+    echo "Boot an emulator first, or set LOTTI_AVD to one of:" >&2
+    "$EMULATOR" -list-avds >&2 || true
+    exit 1
+  fi
+  echo "Booting AVD $LOTTI_AVD as $DEVICE"
+  "$EMULATOR" -avd "$LOTTI_AVD" -no-snapshot-load -no-boot-anim -no-audio \
+    -gpu "${LOTTI_EMULATOR_GPU:-swiftshader_indirect}" >/dev/null 2>&1 &
+  booted_here=1
+  "$ADB" -s "$DEVICE" wait-for-device
+  until [ "$("$ADB" -s "$DEVICE" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+    sleep 2
+  done
+fi
+
+cleanup() {
+  "$ADB" -s "$DEVICE" shell wm size reset >/dev/null 2>&1 || true
+  if [ "$booted_here" = 1 ]; then
+    "$ADB" -s "$DEVICE" emu kill >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# Android's opportunistic Private DNS (DNS-over-TLS) "validates" against the
+# emulator's virtual resolver at 10.0.2.3 and then fails every real lookup
+# over it, silently: ICMP works, no hostname resolves, and the fixture media
+# on R2 never arrives. Plain DNS through the same resolver is fine.
+"$ADB" -s "$DEVICE" shell settings put global private_dns_mode off
+"$ADB" -s "$DEVICE" shell wm size "$WINDOW"
+mkdir -p "$OUT"
+
+for theme in $THEMES; do
+  echo "== store screenshots: locale=$LOCALE theme=$theme =="
+  LOTTI_SCREENSHOT_DIR="$OUT" $FLUTTER drive \
+    --driver=test_driver/manual_screenshots_driver.dart \
+    --target=integration_test/store_screenshots_test.dart \
+    -d "$DEVICE" \
+    --dart-define=LOTTI_MANUAL_LOCALE="$LOCALE" \
+    --dart-define=LOTTI_STORE_THEME="$theme"
+done
+
+echo "Store screenshots written to $OUT:"
+ls -1 "$OUT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated Android Play Store screenshot capture for multiple locales and themes.
  - Captures representative task, habit, time analysis, and journal screens.
  - Produces upload-ready PNG artifacts with consistent emulator sizing.
  - Added a command for running Android screenshot generation locally.

- **Documentation**
  - Documented setup, execution, output, emulator requirements, and Play Console submission guidance.

- **Bug Fixes**
  - Improved media installation errors with clearer failure details.
  - Restored Android Health Connect permission and Health import functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->