### PR TITLE
fix(settings): a back tap out of a branch leaf stops at its hub

### DIFF
--- a/changelog.d/2026-08-26-settings-branch-back-navigation.md
+++ b/changelog.d/2026-08-26-settings-branch-back-navigation.md
@@ -1,0 +1,10 @@
+### Fixed
+- **Back out of a definitions list and you stay in Definitions.** On a phone,
+  leaving Categories — or Labels, Habits, Dashboards or Measurables — showed the
+  Definitions menu for a moment and then dropped you at the top of Settings on
+  its own, so reaching a second definition meant walking back down. One back tap
+  is now one level, and getting to Settings takes the second tap you make
+  yourself. Preferences and Advanced Settings had the same bug on their own
+  entries (Theming, Animations, Recording style, Speech, Keyboard shortcuts,
+  Feature flags, Health import) and are fixed with it — including Animations,
+  which used to land on Advanced Settings although it lives under Preferences.

--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -5,7 +5,7 @@ description: Ten independent Beamer stacks behind one IndexedStack, how the acti
 resource: ../../lib/beamer
 tags: [architecture, navigation, beamer, routing, app-shell]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-05T20:23:15Z }
+generated: { by: codex/gpt-5, at: 2026-08-25T14:10:00Z }
 stale_after: 2027-02-05
 sources:
   - id: beamer-app
@@ -321,15 +321,50 @@ one level and the pop plays as a pop:
 | AI provider detail | `/settings/ai/provider/:providerId` | `/settings/ai` |
 | AI model edit | `/settings/ai/model/:modelId` | `/settings/ai` |
 | AI profile edit | `/settings/ai/profile/:profileId` | `/settings/ai` |
+| Every definition leaf | `/settings/categories`, `/settings/labels`, `/settings/habits`, `/settings/dashboards`, `/settings/measurables` | `/settings/definitions` |
+| Every preference leaf | `/settings/theming`, `/settings/recording-style`, `/settings/speech`, `/settings/keyboard-shortcuts`, `/settings/advanced/animations` | `/settings/preferences` |
+| Advanced's two flat leaves | `/settings/flags`, `/settings/health_import` | `/settings/advanced` |
 
 The AI rows all use `aiSettingsParentRoute`, the same constant the detail pages'
 own back affordance beams to (`popAiSettingsDetail`), so the gesture and the
-chevron cannot drift apart.
+chevron cannot drift apart. The three branch rows are derived rather than
+written out, by
+[`settingsBranchHubOf`](../../lib/beamer/locations/settings_location.dart) —
+the same predicates that decide whether a hub is *in* the stack decide where
+its leaves pop to, so the two cannot disagree. The hub URLs themselves sit
+beside `aiSettingsParentRoute` in
+[`settings_tree_index.dart`](../../lib/features/settings_v2/domain/settings_tree_index.dart)
+and are read out of `settingsNodeUrls`, for the reason that constant documents:
+the tree tap, the hub page and the leaf's `popToNamed` all have to name one
+string, and the tree is where a settings URL is decided.
 
 A one-segment leaf like `/settings/daily-os` needs no `popToNamed`: the default
-pop already lands on its parent. (One-segment URLs that hang off a branch in the
-tree — `/settings/theming` under `preferences`, `/settings/habits` under
-`definitions` — are the case the next paragraph covers, not this one.)
+pop already lands on its parent, the Settings root, which is where that leaf
+belongs.
+
+# A branch leaf pops to its hub, not to its URL's parent
+
+The rule above is about *depth*. The branch hubs add a second, independent way
+to strand a back tap: the leaf's URL is not under its hub's.
+
+Definitions, Preferences and Advanced are pure-navigation hubs that
+`buildPages` keeps beneath their leaves. Whether a hub stays there is decided
+by a path predicate (`_inDefinitionsBranch` and friends) evaluated against
+whatever URL the pop produces — and most branch leaves kept the flat URLs they
+shipped with. `/settings/categories` does not nest under
+`/settings/definitions`; `/settings/theming` does not nest under
+`/settings/preferences`; and `/settings/advanced/animations` nests under the
+*wrong* branch's hub, since Animations belongs to Preferences.
+
+So the single-segment pop lands on `/settings`, the hub predicate stops
+matching, and `buildPages` drops the hub along with the leaf: **one back tap
+left the branch entirely**. It read as a page bouncing back on its own, because
+the Navigator still uncovered the hub for the length of the pop animation
+before the route rebuild replaced it with the Settings root.
+
+Depth and branch membership are separate questions, and a page can need
+`popToNamed` for either. A nested leaf like `/settings/advanced/maintenance`
+needs none: it is one segment deep *and* its URL sits under its own hub's.
 
 But landing on the right URL is only half of it. The page the leaf pops *onto*
 must already be in the stack beneath it, on a stable key, or Navigator swaps

--- a/lib/beamer/locations/settings_location.dart
+++ b/lib/beamer/locations/settings_location.dart
@@ -123,6 +123,15 @@ class SettingsLocation extends BeamLocation<BeamState> {
     '/settings/theming',
     '/settings/keyboard-shortcuts',
     '/settings/speech',
+    // Spelled out, not `definitionsHubUrl` & co. `pathPatterns` doubles as
+    // this app's machine-readable route manifest: `validate-manual.mjs` in
+    // `docs-site/scripts` regex-scans this getter for quoted route literals
+    // and cross-checks them against the manual's surface inventory. A
+    // constant here is invisible to that scan, and the manual build fails
+    // claiming no location declares the route. (Its regex reads comments
+    // too, so do not write an example route in one.) The hub URL constants
+    // are still what the branch predicates and `settingsBranchHubOf` read —
+    // that is where a second spelling could actually diverge in behaviour.
     '/settings/definitions',
     '/settings/preferences',
     '/settings/advanced',
@@ -152,6 +161,9 @@ class SettingsLocation extends BeamLocation<BeamState> {
     bool pathContains(String s) => state.uri.path.contains(s);
     bool pathContainsKey(String s) => state.pathParameters.containsKey(s);
     final path = state.uri.path;
+    // The hub a branch leaf pops back to. Null outside the three branches and
+    // on the hubs themselves — see [settingsBranchHubOf].
+    final branchHub = settingsBranchHubOf(path);
     final navService = getIt<NavService>();
     final isDesktop = navService.isDesktopMode;
 
@@ -371,9 +383,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
         ),
 
       if (pathContains('labels'))
-        const BeamPage(
-          key: ValueKey('settings-labels'),
-          child: LabelsListPage(),
+        BeamPage(
+          key: const ValueKey('settings-labels'),
+          popToNamed: branchHub,
+          child: const LabelsListPage(),
         ),
 
       if (pathContains('labels/create'))
@@ -394,9 +407,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
 
       // New Categories Implementation (Riverpod)
       if (pathContains('categories'))
-        const BeamPage(
-          key: ValueKey('settings-categories'),
-          child: new_categories.CategoriesListPage(),
+        BeamPage(
+          key: const ValueKey('settings-categories'),
+          popToNamed: branchHub,
+          child: const new_categories.CategoriesListPage(),
         ),
 
       if (pathContains('categories/create'))
@@ -439,9 +453,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
 
       // Dashboards
       if (pathContains('dashboards'))
-        const BeamPage(
-          key: ValueKey('settings-dashboards'),
-          child: DashboardSettingsPage(),
+        BeamPage(
+          key: const ValueKey('settings-dashboards'),
+          popToNamed: branchHub,
+          child: const DashboardSettingsPage(),
         ),
 
       if (pathContains('dashboards') &&
@@ -464,9 +479,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
 
       // Measurables
       if (pathContains('measurables'))
-        const BeamPage(
-          key: ValueKey('settings-measurables'),
-          child: MeasurablesPage(),
+        BeamPage(
+          key: const ValueKey('settings-measurables'),
+          popToNamed: branchHub,
+          child: const MeasurablesPage(),
         ),
 
       if (pathContains('measurables') &&
@@ -489,9 +505,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
 
       // Habits
       if (pathContains('habits') && !pathContains('/search'))
-        const BeamPage(
-          key: ValueKey('settings-habits'),
-          child: HabitsPage(),
+        BeamPage(
+          key: const ValueKey('settings-habits'),
+          popToNamed: branchHub,
+          child: const HabitsPage(),
         ),
 
       // The habits sub-routes are two segments deep (`by_id/<id>`,
@@ -611,9 +628,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
 
       // Flags
       if (pathContains('flags'))
-        const BeamPage(
-          key: ValueKey('settings-flags'),
-          child: FlagsPage(),
+        BeamPage(
+          key: const ValueKey('settings-flags'),
+          popToNamed: branchHub,
+          child: const FlagsPage(),
         ),
 
       // Onboarding — top-level leaf, opens directly. Exact-path match
@@ -627,42 +645,48 @@ class SettingsLocation extends BeamLocation<BeamState> {
 
       // Recording style — top-level leaf, opens directly.
       if (pathContains('recording-style'))
-        const BeamPage(
-          key: ValueKey('settings-recording-style'),
-          child: RecordingStyleSettingsPage(),
+        BeamPage(
+          key: const ValueKey('settings-recording-style'),
+          popToNamed: branchHub,
+          child: const RecordingStyleSettingsPage(),
         ),
 
       // Theming
       if (pathContains('theming'))
-        const BeamPage(
-          key: ValueKey('settings-theming'),
-          child: ThemingPage(),
+        BeamPage(
+          key: const ValueKey('settings-theming'),
+          popToNamed: branchHub,
+          child: const ThemingPage(),
         ),
 
       if (pathContains('keyboard-shortcuts'))
-        const BeamPage(
-          key: ValueKey('settings-keyboard-shortcuts'),
-          child: KeyboardShortcutsPage(),
+        BeamPage(
+          key: const ValueKey('settings-keyboard-shortcuts'),
+          popToNamed: branchHub,
+          child: const KeyboardShortcutsPage(),
         ),
 
       // Speech (text-to-speech) — top-level leaf, opens directly.
       if (pathContains('speech'))
-        const BeamPage(
-          key: ValueKey('settings-speech'),
-          child: SpeechSettingsPage(),
+        BeamPage(
+          key: const ValueKey('settings-speech'),
+          popToNamed: branchHub,
+          child: const SpeechSettingsPage(),
         ),
 
       // Health Import
       if (pathContains('health_import'))
-        const BeamPage(
-          key: ValueKey('settings-health_import'),
-          child: HealthImportPage(),
+        BeamPage(
+          key: const ValueKey('settings-health_import'),
+          popToNamed: branchHub,
+          child: const HealthImportPage(),
         ),
 
       if (pathContains('advanced/animations'))
-        const BeamPage(
-          key: ValueKey('settings-animations'),
-          child: CelebrationSettingsPage(),
+        BeamPage(
+          key: const ValueKey('settings-animations'),
+          popToNamed: branchHub,
+          child: const CelebrationSettingsPage(),
         ),
 
       if (pathContains('advanced/manual-language'))
@@ -719,7 +743,7 @@ class SettingsLocation extends BeamLocation<BeamState> {
 /// the `definitions/` branch, but their URLs stay flat for deep-link
 /// compatibility (see `settingsNodeUrls`), so the Definitions hub is
 /// matched on the flat URL here.
-const List<String> _definitionsLeafPaths = [
+const List<String> definitionsLeafPaths = [
   '/settings/categories',
   '/settings/labels',
   '/settings/habits',
@@ -728,8 +752,8 @@ const List<String> _definitionsLeafPaths = [
 ];
 
 bool _inDefinitionsBranch(String path) =>
-    path == '/settings/definitions' ||
-    _definitionsLeafPaths.any((p) => path == p || path.startsWith('$p/'));
+    path == definitionsHubUrl ||
+    definitionsLeafPaths.any((p) => path == p || path.startsWith('$p/'));
 
 /// Animations moved into the `preferences` branch but kept the URL it
 /// shipped with, under `/settings/advanced/` (see `settingsNodeUrls`). That
@@ -742,7 +766,7 @@ const String _animationsPath = '/settings/advanced/animations';
 /// the `preferences/` branch while their URLs stay where they were, so the
 /// Preferences hub is matched on those URLs here — exactly as the
 /// Definitions hub is matched on the flat definition URLs.
-const List<String> _preferencesLeafPaths = [
+const List<String> preferencesLeafPaths = [
   '/settings/theming',
   _animationsPath,
   '/settings/recording-style',
@@ -751,15 +775,67 @@ const List<String> _preferencesLeafPaths = [
 ];
 
 bool _inPreferencesBranch(String path) =>
-    path == '/settings/preferences' ||
-    _preferencesLeafPaths.any((p) => path == p || path.startsWith('$p/'));
+    path == preferencesHubUrl ||
+    preferencesLeafPaths.any((p) => path == p || path.startsWith('$p/'));
+
+/// The hub of the branch [path] belongs to, or `null` when it belongs to
+/// none — and, on a branch's own leaf page, the destination that leaf must
+/// name with `popToNamed`.
+///
+/// **Only a leaf page may use this as its pop destination.** The answer is
+/// branch membership, which every URL inside a branch shares: a page stacked
+/// *above* a leaf gets the same hub back, though it must pop to the leaf
+/// beneath it instead. `/settings/advanced/conflicts/:conflictId` returns
+/// [advancedHubUrl] here and pops to `/settings/advanced/conflicts`; the
+/// habit editor returns [definitionsHubUrl] and pops to `/settings/habits`.
+/// Passing this to a detail page would skip a level.
+///
+/// Beamer's default pop ([BeamPage.pathSegmentPop]) strips exactly one URI
+/// segment. That is the right answer only when a leaf's URL nests under its
+/// hub's: popping `/settings/advanced/maintenance` lands on
+/// `/settings/advanced`, where [_inAdvancedBranch] still matches, so the hub
+/// stays in the stack and the back tap moves one level.
+///
+/// Most branch leaves do not nest. The definition and preference leaves keep
+/// the flat URLs they shipped with (`/settings/categories`,
+/// `/settings/theming`) for deep-link compatibility, `/settings/flags` and
+/// `/settings/health_import` do the same under Advanced, and Animations sits
+/// under `/settings/advanced/` while belonging to Preferences. For every one
+/// of them the single-segment pop lands where the leaf's own hub predicate
+/// does *not* match — so `buildPages` drops the hub as well, and one back tap
+/// left the branch entirely. The hub was still revealed by the Navigator's
+/// pop animation, then replaced by the Settings root when the rebuild landed,
+/// which is why it read as the page bouncing back on its own after a second.
+///
+/// Deriving the destination from the same predicates that decide whether the
+/// hub is *in* the stack is the point: hub presence and hub pop cannot
+/// disagree, and a leaf added to one of the `*LeafPaths` lists is routed here
+/// without a second edit.
+String? settingsBranchHubOf(String path) {
+  // A hub itself pops to the Settings root, which the default pop already
+  // does — naming a hub as its own destination would trap the back gesture.
+  if (path == definitionsHubUrl ||
+      path == preferencesHubUrl ||
+      path == advancedHubUrl) {
+    return null;
+  }
+  if (_inDefinitionsBranch(path)) return definitionsHubUrl;
+  if (_inPreferencesBranch(path)) return preferencesHubUrl;
+  if (_inAdvancedBranch(path)) return advancedHubUrl;
+  return null;
+}
+
+/// Advanced's leaves that kept a flat URL instead of nesting under
+/// [advancedHubUrl] — Health import's tree node lives under Advanced but its
+/// public URL never moved. Listed so the hub is matched on them, and so the
+/// tests can derive their coverage from the same list the routing reads.
+const List<String> advancedFlatLeafPaths = [
+  '/settings/flags',
+  '/settings/health_import',
+];
 
 bool _inAdvancedBranch(String path) =>
     !_inPreferencesBranch(path) &&
-    (path == '/settings/advanced' ||
-        path.startsWith('/settings/advanced/') ||
-        path == '/settings/flags' ||
-        // Health import's tree node lives under Advanced but keeps its
-        // flat legacy URL, so match it here to keep the hub in the back
-        // stack.
-        path == '/settings/health_import');
+    (path == advancedHubUrl ||
+        path.startsWith('$advancedHubUrl/') ||
+        advancedFlatLeafPaths.contains(path));

--- a/lib/features/settings_v2/domain/settings_tree_index.dart
+++ b/lib/features/settings_v2/domain/settings_tree_index.dart
@@ -111,6 +111,19 @@ const String settingsRootUrl = '/settings';
 /// the header chevron cannot drift onto different destinations.
 const String aiSettingsParentRoute = '/settings/ai';
 
+/// The three pure-navigation branch hubs, by the same rule as
+/// [aiSettingsParentRoute]: the tree tap that opens a hub, the hub page
+/// `SettingsLocation` keeps beneath that branch's leaves, and the
+/// `popToNamed` those leaves pop back to all have to name one string.
+///
+/// Read out of [settingsNodeUrls] rather than restated, so the tree stays the
+/// single place a settings URL is decided. A missing key here is a tree that
+/// no longer has the branch at all, which `SettingsTreeIndex` would fail on
+/// first.
+final String definitionsHubUrl = settingsNodeUrls['definitions']!;
+final String preferencesHubUrl = settingsNodeUrls['preferences']!;
+final String advancedHubUrl = settingsNodeUrls['advanced']!;
+
 /// Turns a tree path into a Beamer URL. The deepest node in the
 /// path wins — any ancestors are implicit in the URL structure.
 /// Returns [settingsRootUrl] for an empty path, for unknown ids

--- a/test/beamer/locations/settings_location_test.dart
+++ b/test/beamer/locations/settings_location_test.dart
@@ -42,6 +42,7 @@ import 'package:lotti/features/settings/ui/pages/measurables/measurables_page.da
 import 'package:lotti/features/settings/ui/pages/recording_style_settings_page.dart';
 import 'package:lotti/features/settings/ui/pages/settings_root_page.dart';
 import 'package:lotti/features/settings/ui/pages/theming_page.dart';
+import 'package:lotti/features/settings_v2/domain/settings_tree_index.dart';
 import 'package:lotti/features/settings_v2/ui/mobile/settings_mobile_branch_page.dart';
 import 'package:lotti/features/settings_v2/ui/mobile/settings_mobile_root_page.dart';
 import 'package:lotti/features/sync/ui/backfill_settings_page.dart';
@@ -60,6 +61,13 @@ import 'package:lotti/services/nav_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../mocks/mocks.dart';
+
+/// Page keys of the three settings branch hubs. The production location
+/// spells these inline; they are named here so the branch-navigation tables
+/// below can pair a leaf with the hub page it must uncover.
+const ValueKey<String> definitionsHubKey = ValueKey('settings-definitions');
+const ValueKey<String> preferencesHubKey = ValueKey('settings-preferences');
+const ValueKey<String> advancedHubKey = ValueKey('settings-advanced');
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -688,6 +696,334 @@ void main() {
           await tapBack(tester);
 
           expect(delegate.configuration.uri.toString(), '/settings/ai');
+        },
+      );
+    });
+
+    /// Back navigation out of a settings *branch* leaf.
+    ///
+    /// A branch hub (Definitions / Preferences / Advanced) is a pure
+    /// navigation page that `buildPages` keeps beneath its leaves so a back
+    /// tap returns to the hub rather than to the Settings root. Whether it
+    /// stays there is decided by the hub's own path predicate, evaluated
+    /// against whatever URL the pop produces.
+    ///
+    /// Beamer's default pop strips one URI segment, and most branch leaves
+    /// keep flat URLs that do not nest under their hub's — `/settings/
+    /// categories` under a hub at `/settings/definitions`. Stripping a
+    /// segment there lands on `/settings`, the hub predicate stops matching,
+    /// and the hub is dropped from the stack along with the leaf: one back
+    /// tap left the branch. The hub was still uncovered by the Navigator's
+    /// pop animation and only replaced once the route rebuild landed, which
+    /// is why it read as the Definitions page bouncing back to Settings by
+    /// itself a moment later.
+    ///
+    /// Each `(leaf URL, hub URL, hub page key)`, **derived from the same
+    /// lists the routing reads** — `definitionsLeafPaths`,
+    /// `preferencesLeafPaths` and `advancedFlatLeafPaths`. A leaf added to one
+    /// of those is added to every group below at once; a hand-written table
+    /// here would let a new leaf ship with the bug and no red test.
+    ///
+    /// Shared by all three groups so a leaf is provably covered at the
+    /// predicate, `buildPages` and real-navigator levels alike.
+    final branchLeaves = <(String, String, ValueKey<String>)>[
+      // Definitions — the reported bug.
+      for (final leaf in definitionsLeafPaths)
+        (leaf, definitionsHubUrl, definitionsHubKey),
+      // Preferences — the same flat-URL shape, so the same bug. Animations is
+      // in this list while its URL sits under `/settings/advanced/`, so its
+      // default pop reached the *wrong branch's* hub, not merely the root.
+      for (final leaf in preferencesLeafPaths)
+        (leaf, preferencesHubUrl, preferencesHubKey),
+      // Advanced's two flat leaves.
+      for (final leaf in advancedFlatLeafPaths)
+        (leaf, advancedHubUrl, advancedHubKey),
+    ];
+
+    test('every branch leaf is covered by the tables below', () {
+      // Guards the derivation itself: if a list is emptied or a branch is
+      // dropped, the loops below would silently generate no tests at all.
+      expect(definitionsLeafPaths, isNotEmpty);
+      expect(preferencesLeafPaths, isNotEmpty);
+      expect(advancedFlatLeafPaths, isNotEmpty);
+      expect(
+        branchLeaves.length,
+        definitionsLeafPaths.length +
+            preferencesLeafPaths.length +
+            advancedFlatLeafPaths.length,
+      );
+      // The hub URLs resolve out of the settings tree, so a branch renamed
+      // there fails here rather than at runtime on a null assertion.
+      expect(definitionsHubUrl, '/settings/definitions');
+      expect(preferencesHubUrl, '/settings/preferences');
+      expect(advancedHubUrl, '/settings/advanced');
+    });
+
+    group('settingsBranchHubOf names the hub a leaf returns to', () {
+      for (final (leaf, hub, _) in branchLeaves) {
+        test('$leaf -> $hub', () {
+          expect(settingsBranchHubOf(leaf), hub);
+        });
+      }
+
+      test(
+        'animations resolves to Preferences, not the Advanced hub its URL '
+        'sits under — the branch is a property of the leaf, not the path',
+        () {
+          expect(
+            settingsBranchHubOf('/settings/advanced/animations'),
+            preferencesHubUrl,
+          );
+          expect(
+            settingsBranchHubOf('/settings/advanced/maintenance'),
+            advancedHubUrl,
+          );
+        },
+      );
+
+      test(
+        'a detail URL under a leaf still names the hub, for the list page '
+        'sitting beneath it in the stack',
+        () {
+          expect(
+            settingsBranchHubOf('/settings/categories/cat-1'),
+            definitionsHubUrl,
+          );
+          expect(
+            settingsBranchHubOf('/settings/habits/by_id/h-1'),
+            definitionsHubUrl,
+          );
+        },
+      );
+
+      // A hub naming itself would make its own back tap a no-op, trapping
+      // the user on the hub.
+      for (final hub in [
+        definitionsHubUrl,
+        preferencesHubUrl,
+        advancedHubUrl,
+      ]) {
+        test('the $hub hub itself names no destination', () {
+          expect(settingsBranchHubOf(hub), isNull);
+        });
+      }
+
+      for (final outside in const [
+        '/settings',
+        '/settings/ai',
+        '/settings/ai/provider/gemini-1',
+        '/settings/sync/backfill',
+        '/settings/agents',
+        '/settings/onboarding',
+        '/settings/daily-os',
+      ]) {
+        test('$outside is not in a hub branch, so it names no destination', () {
+          expect(settingsBranchHubOf(outside), isNull);
+        });
+      }
+    });
+
+    group('branch leaf pages declare their hub as popToNamed', () {
+      List<BeamPage> buildFor(String uri) {
+        final routeInformation = RouteInformation(uri: Uri.parse(uri));
+        return SettingsLocation(routeInformation).buildPages(
+          mockBuildContext,
+          BeamState.fromRouteInformation(routeInformation),
+        );
+      }
+
+      for (final (leaf, hub, _) in branchLeaves) {
+        test('$leaf pops to $hub', () {
+          expect(buildFor(leaf).last.popToNamed, hub);
+        });
+      }
+
+      for (final hub in [
+        definitionsHubUrl,
+        preferencesHubUrl,
+        advancedHubUrl,
+      ]) {
+        test('the $hub hub sets none — its default pop reaches /settings', () {
+          expect(buildFor(hub).last.popToNamed, isNull);
+        });
+      }
+
+      test(
+        'a leaf detail page pops to its list, not past it to the hub — the '
+        'list page beneath is the one carrying the hub destination',
+        () {
+          final routeInformation = RouteInformation(
+            uri: Uri.parse('/settings/categories/cat-1'),
+          );
+          final pages = SettingsLocation(routeInformation).buildPages(
+            mockBuildContext,
+            BeamState.fromRouteInformation(
+              routeInformation,
+            ).copyWith(pathParameters: {'categoryId': 'cat-1'}),
+          );
+
+          expect(pages, hasLength(4));
+          expect(pages[2].key, const ValueKey('settings-categories'));
+          expect(pages[2].popToNamed, definitionsHubUrl);
+          // No destination of its own: the default single-segment pop from
+          // `/settings/categories/cat-1` already reaches the list.
+          expect(pages[3].popToNamed, isNull);
+        },
+      );
+    });
+
+    /// The same contract end to end, through a real [BeamerDelegate] and
+    /// [Navigator] — the layer that actually consumes `popToNamed`. Children
+    /// are placeholders ([_RoutingOnlySettingsLocation]); every routing input
+    /// Beamer reads still comes from the production location.
+    group('branch back navigation through a real Beamer navigator', () {
+      late BeamerDelegate delegate;
+      late _RouteRecordingObserver observer;
+
+      /// Walks the route sequence a user does — Settings, hub, leaf — rather
+      /// than deep-linking to the leaf, so Beamer has the real beaming
+      /// history its pop machinery consults.
+      Future<void> openLeaf(
+        WidgetTester tester,
+        String hub,
+        String leaf, {
+        List<String> then = const [],
+      }) async {
+        observer = _RouteRecordingObserver();
+        delegate = BeamerDelegate(
+          setBrowserTabTitle: false,
+          initialPath: '/settings',
+          navigatorObservers: [observer],
+          locationBuilder: (routeInformation, _) =>
+              _RoutingOnlySettingsLocation(routeInformation),
+        );
+        await delegate.setNewRoutePath(
+          RouteInformation(uri: Uri.parse('/settings')),
+        );
+        await tester.pumpWidget(
+          MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routeInformationParser: BeamerParser(),
+            routerDelegate: delegate,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        for (final url in [hub, leaf, ...then]) {
+          delegate.beamToNamed(url);
+          await tester.pumpAndSettle();
+        }
+      }
+
+      Future<void> tapBack(WidgetTester tester) async {
+        delegate.navigator.pop();
+        await tester.pumpAndSettle();
+      }
+
+      List<Object?> pageKeys() =>
+          delegate.currentPages.map((page) => page.key).toList();
+
+      tearDown(() => delegate.dispose());
+
+      for (final (leaf, hub, hubKey) in branchLeaves) {
+        testWidgets('one back tap from $leaf lands on $hub, not /settings', (
+          tester,
+        ) async {
+          await openLeaf(tester, hub, leaf);
+          expect(delegate.currentPages, hasLength(3));
+
+          await tapBack(tester);
+
+          expect(delegate.configuration.uri.path, hub);
+          expect(pageKeys(), [const ValueKey('settings'), hubKey]);
+        });
+      }
+
+      testWidgets(
+        'the hub is uncovered rather than swapped for a fresh copy, so the '
+        'back tap plays a pop and not a push',
+        (tester) async {
+          await openLeaf(tester, definitionsHubUrl, '/settings/categories');
+
+          observer.reset();
+          await tapBack(tester);
+
+          expect(observer.pushedKeys, isEmpty);
+          expect(observer.goneKeys, const [ValueKey('settings-categories')]);
+        },
+      );
+
+      testWidgets(
+        'a second back tap then leaves the branch for the Settings root — '
+        'the two levels the one tap used to collapse into one',
+        (tester) async {
+          await openLeaf(tester, definitionsHubUrl, '/settings/categories');
+
+          await tapBack(tester);
+          await tapBack(tester);
+
+          expect(delegate.configuration.uri.path, '/settings');
+          expect(pageKeys(), const [ValueKey('settings')]);
+        },
+      );
+
+      testWidgets(
+        'from a category detail the way out is detail, list, hub, root — one '
+        'level per tap, no level skipped',
+        (tester) async {
+          await openLeaf(
+            tester,
+            definitionsHubUrl,
+            '/settings/categories',
+            then: ['/settings/categories/cat-1'],
+          );
+          expect(delegate.currentPages, hasLength(4));
+
+          await tapBack(tester);
+          expect(delegate.configuration.uri.path, '/settings/categories');
+
+          await tapBack(tester);
+          expect(delegate.configuration.uri.path, definitionsHubUrl);
+
+          await tapBack(tester);
+          expect(delegate.configuration.uri.path, '/settings');
+        },
+      );
+
+      testWidgets(
+        'backing out of Animations reaches Preferences, not the Advanced hub '
+        'whose URL prefix it borrows',
+        (tester) async {
+          await openLeaf(
+            tester,
+            preferencesHubUrl,
+            '/settings/advanced/animations',
+          );
+
+          await tapBack(tester);
+
+          expect(delegate.configuration.uri.path, preferencesHubUrl);
+          expect(pageKeys(), const [
+            ValueKey('settings'),
+            preferencesHubKey,
+          ]);
+        },
+      );
+
+      testWidgets(
+        'a nested Advanced leaf was never broken and still pops to its hub',
+        (tester) async {
+          await openLeaf(
+            tester,
+            advancedHubUrl,
+            '/settings/advanced/maintenance',
+          );
+
+          await tapBack(tester);
+
+          expect(delegate.configuration.uri.path, advancedHubUrl);
+          expect(pageKeys(), const [ValueKey('settings'), advancedHubKey]);
         },
       );
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected mobile back navigation in Settings so Definition, Preference, and Advanced Settings pages return to their appropriate section.
  - Fixed back navigation for flat Settings pages, including Categories, Theming, and Animations.
  - Preserved expected list-and-detail navigation behavior.

- **Documentation**
  - Updated navigation documentation to clarify Settings back-navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->