### PR TITLE
fix(android): run in a FlutterFragmentActivity so the health plugin loads

### DIFF
--- a/android/app/src/main/kotlin/com/matthiasn/lotti/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/matthiasn/lotti/MainActivity.kt
@@ -1,9 +1,15 @@
 package com.matthiasn.lotti
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 
-class MainActivity: FlutterActivity() {
+// FlutterFragmentActivity, not FlutterActivity: the health plugin's
+// onAttachedToActivity casts the activity to ComponentActivity for the
+// Health Connect permission launcher, and a plain FlutterActivity is not one.
+// It failed to register on every start — "MainActivity cannot be cast to
+// androidx.activity.ComponentActivity" in logcat — so health import on
+// Android never had a working platform side.
+class MainActivity: FlutterFragmentActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         flutterEngine.plugins.add(FlutterHealthFitPlugin())

--- a/changelog.d/2026-08-26-android-health-plugin-activity.md
+++ b/changelog.d/2026-08-26-android-health-plugin-activity.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Health import on Android never connected to Health Connect.** The plugin
+  that talks to Health Connect refused to load on every app start — the
+  Android activity Lotti ran in was not the kind it needs — so the Health
+  import page had no working platform side beneath it on Android. It loads
+  now, and the import works the way it does on iOS.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored Android Health Connect permissions handling.
  - Fixed Health Connect plugin loading and Health data import functionality.

- **Documentation**
  - Added a changelog entry covering the Android Health Connect fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->