### PR TITLE
fix(android): drop the unused FOREGROUND_SERVICE_LOCATION permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.matthiasn.lotti">
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -7,6 +8,13 @@
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- The location plugin declares this for a background-tracking mode Lotti
+         never enables: location is read once, in the foreground, when an entry
+         is saved. Play requires a declared use for the permission, and there is
+         none, so it is removed from the merged manifest. -->
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_LOCATION"
+        tools:node="remove" />
     <!-- Notifications. POST_NOTIFICATIONS is the Android 13+ runtime
          permission, requested only after the in-app notifications flag is on.
          RECEIVE_BOOT_COMPLETED lets the receiver below restore reminders a

--- a/changelog.d/2026-08-26-android-foreground-service-location.md
+++ b/changelog.d/2026-08-26-android-foreground-service-location.md
@@ -1,0 +1,6 @@
+### Changed
+- **Lotti on Android no longer asks for the foreground location service
+  permission.** A location library declared it for a background-tracking mode
+  the app never uses; Lotti only reads your position once, when you save an
+  entry, and only if you switched that on. The permission is gone from the
+  app's manifest.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary Android location foreground-service permission.
  * Location access during entry saving remains available when enabled, without requiring ongoing background location service access.

* **Documentation**
  * Added a changelog entry describing the permission update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->