### PR TITLE
fix(health): let a re-imported day replace its stale step count

### DIFF
--- a/changelog.d/2026-08-27-health-steps-late-sync.md
+++ b/changelog.d/2026-08-27-health-steps-late-sync.md
@@ -1,0 +1,11 @@
+### Fixed
+- **Step counts stayed stuck on the phone's bedtime figure after a wearable
+  synced its day overnight.** A band that uploads its step count once a day
+  lands yesterday's final total after Lotti has already stored the phone's own
+  count, and the dashboards never re-read yesterday — only a manual import did,
+  and even that put a second row next to the stale one instead of replacing the
+  day. Each day's steps, distance and flights are now stored as one entry that
+  is updated in place whenever Apple Health or Health Connect reports a new
+  total, and the background refresh re-reads the previous day as well, so the
+  count on the dashboard and the daily step goal follow the latest figure in
+  the health store.

--- a/knowledge/features/health_import.md
+++ b/knowledge/features/health_import.md
@@ -11,7 +11,15 @@ sources:
   - id: import
     resource: ../../lib/logic/health_import.dart
     title: HealthImport — the queue, the gate and the per-type fetchers
-    last_modified: 2026-08-05
+    last_modified: 2026-08-27
+  - id: daily-steps
+    resource: ../../lib/logic/health_daily_steps.dart
+    title: resolveDailySteps — the merged total versus the best single source
+    last_modified: 2026-08-27
+  - id: create-ops
+    resource: ../../lib/logic/persistence_create_ops.dart
+    title: PersistenceCreateOps — where a cumulative day is rewritten in place
+    last_modified: 2026-08-27
   - id: result
     resource: ../../lib/logic/health_import_result.dart
     title: HealthImportResult — the outcome type every request returns
@@ -55,7 +63,7 @@ load-bearing rather than incidental. See [One request at a time](#one-request-at
 
 | Caller | Entry point | Range | Awaited? |
 |--------|-------------|-------|----------|
-| A dashboard chart | `fetchHealthDataDelta(type)` / `getWorkoutsHealthDataDelta()` | newest stored sample → now | No — returns as soon as the type is queued |
+| A dashboard chart | `fetchHealthDataDelta(type)` / `getWorkoutsHealthDataDelta()` | newest stored sample → now (cumulative types: the day **before** the newest stored day → now) | No — returns as soon as the type is queued |
 | Settings → Health Import | `getActivityHealthData` / `fetchHealthData` / `getWorkoutsHealthData` | user-chosen | Yes — the page renders the outcome |
 
 `HealthObservationsController`'s constructor schedules a delta fetch for its
@@ -237,12 +245,45 @@ follow, and both are deliberate:
 
 - A staged sleep sample stored twice (see below) counts once — it is one
   measurement, not two.
-- Re-importing a range that is already stored counts **zero**. Health entries
-  carry deterministic `uuidV5` ids and `createDbEntity` writes with
-  `overwrite: false`, so each duplicate row is rejected;
-  `createQuantitativeEntryImpl` returns `null` for a rejected write and the
-  counters honour it. Counting attempts instead would tell the user it had
-  imported samples it had not.
+- Re-importing a range that is already stored counts **zero**. Discrete
+  samples carry deterministic `uuidV5` ids over their payload and
+  `createDbEntity` writes with `overwrite: false`, so each duplicate row is
+  rejected; `createQuantitativeEntryImpl` returns `null` for a rejected write
+  and the counters honour it. Counting attempts instead would tell the user it
+  had imported samples it had not.
+- A cumulative day whose total **changed** counts as one. Those rows are keyed
+  by type, local date and importing device (`cumulativeQuantityEntryId`), and
+  `createQuantitativeEntryImpl` rewrites the stored day in place when the total
+  differs and returns `null` when it does not. See [Late-syncing
+  sources](#late-syncing-sources) for why.
+
+# Late-syncing sources
+
+A wearable that uploads its day once, overnight, lands yesterday's final step
+count *after* yesterday already has a row — the phone's own count at bedtime,
+written by the last background delta. Two things used to keep that stale figure
+on screen:
+
+- **Nothing replaced the day.** The day's row was keyed by its payload, so a
+  new total became a second row beside the old one. The readers' per-day
+  maximum hid that most of the time, but the journal accumulated a row per
+  refresh of the day in progress, and a day whose store-side total went
+  *down* could never be corrected. `addActivityEntries` now writes each day
+  under `cumulativeQuantityEntryId` — type, local date, device — and the
+  create op updates that row in place when the total differs. The device is
+  part of the key so two phones importing the same day do not race for one
+  row through sync; their rows still merge through the readers' maximum, as
+  the payload-keyed rows did.
+- **The delta never looked back.** A cumulative delta started at the newest
+  stored day, which is today, so yesterday was only ever re-read by a manual
+  import. It now starts one day earlier.
+
+`fetchAndProcessActivityDataForDay` also reads the raw `STEPS` samples next to
+the store's merged total and takes the larger of the merged figure and the best
+single source (`resolveDailySteps`). HealthKit's merged sum resolves
+overlapping samples by the *Data Sources & Access* priority, which can drop a
+wearable ranked below the phone; the guard cannot lower a figure, only restore
+one that priority discarded, and never sums across sources.
 
 # Type strings, and the composites
 

--- a/knowledge/features/health_import.md
+++ b/knowledge/features/health_import.md
@@ -252,9 +252,11 @@ follow, and both are deliberate:
   and the counters honour it. Counting attempts instead would tell the user it
   had imported samples it had not.
 - A cumulative day whose total **changed** counts as one. Those rows are keyed
-  by type, local date and importing device (`cumulativeQuantityEntryId`), and
-  `createQuantitativeEntryImpl` rewrites the stored day in place when the total
-  differs and returns `null` when it does not. See [Late-syncing
+  by type, local date and the importing installation's sync host
+  (`cumulativeQuantityEntryId`), and `createQuantitativeEntryImpl` rewrites the
+  stored day in place when the total differs and returns `null` when it does
+  not — the value alone decides, so the in-progress day's advancing end time
+  is not a rewrite. See [Late-syncing
   sources](#late-syncing-sources) for why.
 
 # Late-syncing sources
@@ -269,21 +271,27 @@ on screen:
   maximum hid that most of the time, but the journal accumulated a row per
   refresh of the day in progress, and a day whose store-side total went
   *down* could never be corrected. `addActivityEntries` now writes each day
-  under `cumulativeQuantityEntryId` — type, local date, device — and the
-  create op updates that row in place when the total differs. The device is
-  part of the key so two phones importing the same day do not race for one
-  row through sync; their rows still merge through the readers' maximum, as
-  the payload-keyed rows did.
+  under `cumulativeQuantityEntryId` — type, local date, sync host — and the
+  create op updates that row in place when the total differs. The host is
+  part of the key so two installations importing the same day do not race
+  for one row through sync; their rows still merge through the readers'
+  maximum, as the payload-keyed rows did. Rows written before this scheme
+  keep their payload-derived ids and are not migrated: they still merge
+  through the same maximum, which is right for a total that rose, and a
+  legacy row above a corrected-downward total is a known limit.
 - **The delta never looked back.** A cumulative delta started at the newest
   stored day, which is today, so yesterday was only ever re-read by a manual
-  import. It now starts one day earlier.
+  import. It now starts one calendar day earlier (date arithmetic, not a
+  24-hour duration, which lands a date short across a spring-forward).
 
 `fetchAndProcessActivityDataForDay` also reads the raw `STEPS` samples next to
 the store's merged total and takes the larger of the merged figure and the best
 single source (`resolveDailySteps`). HealthKit's merged sum resolves
 overlapping samples by the *Data Sources & Access* priority, which can drop a
 wearable ranked below the phone; the guard cannot lower a figure, only restore
-one that priority discarded, and never sums across sources.
+one that priority discarded, and never sums across sources. A source is its
+`sourceId`, falling back to `sourceName` — Health Connect hands over step
+records with an empty id and the provider's package name.
 
 # Type strings, and the composites
 

--- a/lib/logic/health_daily_steps.dart
+++ b/lib/logic/health_daily_steps.dart
@@ -1,0 +1,41 @@
+import 'package:health/health.dart';
+
+/// Resolves one day's step total from what the health store hands back.
+///
+/// [mergedTotal] is the store's own de-duplicated sum over every source
+/// (`getTotalStepsInInterval`). HealthKit builds that figure by resolving
+/// overlapping samples in favour of the source ranked highest under *Data
+/// Sources & Access*, which is what quietly discards a wearable's count: an
+/// iPhone that sat on a desk still writes samples whenever it moved, and every
+/// wearable sample those overlap loses to it. A band that syncs its day once,
+/// overnight, is the worst case — its one sample overlaps everything.
+///
+/// [samples] are the raw `STEPS` samples for the same day, which the store
+/// hands over unmerged and stamped with their source. Every source counts the
+/// same person's steps over the same day, so the largest single-source total
+/// is the best complete count on record — and the merged figure can only be
+/// less than or equal to the best source when priority dropped that source's
+/// samples. The answer is therefore the larger of the two, never a sum across
+/// sources, which would double-count.
+///
+/// Samples without a numeric value are ignored; a `null` [mergedTotal] (no
+/// answer from the store) counts as zero.
+int resolveDailySteps(int? mergedTotal, List<HealthDataPoint> samples) {
+  final bySource = <String, double>{};
+  for (final sample in samples) {
+    final value = sample.value;
+    if (value is NumericHealthValue) {
+      bySource.update(
+        sample.sourceId,
+        (total) => total + value.numericValue,
+        ifAbsent: () => value.numericValue.toDouble(),
+      );
+    }
+  }
+  final bestSource = bySource.values.fold<double>(
+    0,
+    (best, total) => total > best ? total : best,
+  );
+  final merged = mergedTotal ?? 0;
+  return bestSource > merged ? bestSource.round() : merged;
+}

--- a/lib/logic/health_daily_steps.dart
+++ b/lib/logic/health_daily_steps.dart
@@ -1,46 +1,38 @@
+import 'dart:math';
+
+import 'package:collection/collection.dart';
 import 'package:health/health.dart';
 
-/// Resolves one day's step total from what the health store hands back.
+/// Sums the numeric values in [dataPoints], ignoring any other value kind.
+num sumNumericHealthValues(List<HealthDataPoint> dataPoints) => dataPoints
+    .map((point) => point.value)
+    .whereType<NumericHealthValue>()
+    .map((value) => value.numericValue)
+    .sum;
+
+/// Resolves one day's step total: the larger of the store's own merged sum
+/// ([mergedTotal], `getTotalStepsInInterval`) and the best single source's sum
+/// over the raw [samples] for the same day.
 ///
-/// [mergedTotal] is the store's own de-duplicated sum over every source
-/// (`getTotalStepsInInterval`). HealthKit builds that figure by resolving
-/// overlapping samples in favour of the source ranked highest under *Data
-/// Sources & Access*, which is what quietly discards a wearable's count: an
-/// iPhone that sat on a desk still writes samples whenever it moved, and every
-/// wearable sample those overlap loses to it. A band that syncs its day once,
-/// overnight, is the worst case — its one sample overlaps everything.
+/// HealthKit builds the merged figure by resolving overlapping samples in
+/// favour of the source ranked highest under *Data Sources & Access*, which
+/// discards a wearable ranked below the phone wherever the two overlap. Every
+/// source counts the same person's day, so the largest single-source total is
+/// the best complete count on record; taking the larger of the two restores a
+/// dropped source and never sums across sources, which would double-count.
+/// Background in `knowledge/features/health_import.md`.
 ///
-/// [samples] are the raw `STEPS` samples for the same day, which the store
-/// hands over unmerged and stamped with their source. Every source counts the
-/// same person's steps over the same day, so the largest single-source total
-/// is the best complete count on record — and the merged figure can only be
-/// less than or equal to the best source when priority dropped that source's
-/// samples. The answer is therefore the larger of the two, never a sum across
-/// sources, which would double-count.
-///
-/// Samples without a numeric value are ignored; a `null` [mergedTotal] (no
-/// answer from the store) counts as zero.
-///
-/// A source is identified by `sourceId`, falling back to `sourceName`: Health
-/// Connect hands over step records with an empty id and the provider's package
-/// name, and keying on the empty id alone would pool every provider into one
-/// "source" and sum them.
+/// A source is its `sourceId`, falling back to `sourceName` — Health Connect
+/// hands over step records with an empty id and the provider's package name.
+/// A `null` [mergedTotal] counts as zero.
 int resolveDailySteps(int? mergedTotal, List<HealthDataPoint> samples) {
-  final bySource = <String, double>{};
-  for (final sample in samples) {
-    final value = sample.value;
-    if (value is NumericHealthValue) {
-      bySource.update(
-        sample.sourceId.isNotEmpty ? sample.sourceId : sample.sourceName,
-        (total) => total + value.numericValue,
-        ifAbsent: () => value.numericValue.toDouble(),
-      );
-    }
-  }
-  final bestSource = bySource.values.fold<double>(
-    0,
-    (best, total) => total > best ? total : best,
-  );
-  final merged = mergedTotal ?? 0;
-  return bestSource > merged ? bestSource.round() : merged;
+  final bestSource = samples
+      .groupListsBy(
+        (sample) =>
+            sample.sourceId.isNotEmpty ? sample.sourceId : sample.sourceName,
+      )
+      .values
+      .map(sumNumericHealthValues)
+      .fold<num>(0, max);
+  return max(bestSource.round(), mergedTotal ?? 0);
 }

--- a/lib/logic/health_daily_steps.dart
+++ b/lib/logic/health_daily_steps.dart
@@ -20,13 +20,18 @@ import 'package:health/health.dart';
 ///
 /// Samples without a numeric value are ignored; a `null` [mergedTotal] (no
 /// answer from the store) counts as zero.
+///
+/// A source is identified by `sourceId`, falling back to `sourceName`: Health
+/// Connect hands over step records with an empty id and the provider's package
+/// name, and keying on the empty id alone would pool every provider into one
+/// "source" and sum them.
 int resolveDailySteps(int? mergedTotal, List<HealthDataPoint> samples) {
   final bySource = <String, double>{};
   for (final sample in samples) {
     final value = sample.value;
     if (value is NumericHealthValue) {
       bySource.update(
-        sample.sourceId,
+        sample.sourceId.isNotEmpty ? sample.sourceId : sample.sourceName,
         (total) => total + value.numericValue,
         ifAbsent: () => value.numericValue.toDouble(),
       );

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -649,9 +649,13 @@ class HealthImport {
       // total after that day already has a row, and a delta that only looks
       // from the newest day forward would never see it: the dashboards kept
       // showing the phone's own count at bedtime until a manual import.
-      final dayBeforeLatest = latest == null
+      // Calendar arithmetic, not a 24-hour duration: across a spring-forward
+      // transition the duration lands at 23:00 two dates back, and `getDays`
+      // would then skip the intended day.
+      final latestDay = latest?.meta.dateFrom;
+      final dayBeforeLatest = latestDay == null
           ? dateFrom
-          : latest.meta.dateFrom.subtract(const Duration(days: 1));
+          : DateTime(latestDay.year, latestDay.month, latestDay.day - 1);
       return _getActivityHealthData(
         dateFrom: dayBeforeLatest,
         dateTo: now,

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -11,13 +11,16 @@ import 'package:lotti/classes/health.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/health_daily_steps.dart';
+import 'package:lotti/logic/health_daily_steps.dart'
+    as health_daily_steps
+    show resolveDailySteps, sumNumericHealthValues;
 import 'package:lotti/logic/health_data_types.dart';
 import 'package:lotti/logic/health_import_result.dart';
 import 'package:lotti/logic/health_permission_gate.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/health_service.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:permission_handler/permission_handler.dart';
 
@@ -83,6 +86,12 @@ class HealthImport {
   }
 
   Duration defaultFetchDuration = const Duration(days: 90);
+
+  /// How many calendar days before the newest stored day a cumulative delta
+  /// re-reads. A source that syncs its day late — a band that uploads
+  /// overnight — lands its final total after that day already has a row, and
+  /// a delta that only looked forward would never see it.
+  static const cumulativeDeltaLookBackDays = 1;
 
   final queue = Queue<String>();
   bool running = false;
@@ -193,34 +202,26 @@ class HealthImport {
         999,
       );
 
-      // The merged total alone is not enough: HealthKit resolves overlapping
-      // samples by source priority, so a wearable ranked below the phone
-      // loses its count wherever the phone also recorded steps. The raw
-      // samples come back per source, and the best single source wins — see
-      // [resolveDailySteps].
       final mergedSteps = await health.getTotalStepsInInterval(
         dateFrom,
         dateTo,
       );
-      final stepSamples = await health.getHealthDataFromTypes(
-        types: [HealthDataType.STEPS],
+      final samplesByType = (await health.getHealthDataFromTypes(
+        types: activityTypes,
         startTime: dateFrom,
         endTime: dateTo,
-      );
-      stepsByDay[dateFrom] = resolveDailySteps(mergedSteps, stepSamples);
+      )).groupListsBy((point) => point.type);
+      final flightsClimbedDataPoints =
+          samplesByType[HealthDataType.FLIGHTS_CLIMBED] ?? const [];
+      final distanceDataPoints =
+          samplesByType[HealthDataType.DISTANCE_WALKING_RUNNING] ?? const [];
 
-      final flightsClimbedDataPoints = await health.getHealthDataFromTypes(
-        types: [HealthDataType.FLIGHTS_CLIMBED],
-        startTime: dateFrom,
-        endTime: dateTo,
+      // Steps go through the raw samples as well — see [resolveDailySteps].
+      // Flights and distance keep their plain sum, as they always have.
+      stepsByDay[dateFrom] = health_daily_steps.resolveDailySteps(
+        mergedSteps,
+        samplesByType[HealthDataType.STEPS] ?? const [],
       );
-
-      final distanceDataPoints = await health.getHealthDataFromTypes(
-        types: [HealthDataType.DISTANCE_WALKING_RUNNING],
-        startTime: dateFrom,
-        endTime: dateTo,
-      );
-
       flightsByDay[dateFrom] = sumNumericHealthValues(flightsClimbedDataPoints);
       distanceByDay[dateFrom] = sumNumericHealthValues(distanceDataPoints);
     }
@@ -390,13 +391,8 @@ class HealthImport {
     }
   }
 
-  num sumNumericHealthValues(List<HealthDataPoint> dataPoints) {
-    return dataPoints
-        .map((HealthDataPoint e) => e.value)
-        .whereType<NumericHealthValue>()
-        .map((NumericHealthValue e) => e.numericValue)
-        .sum;
-  }
+  num sumNumericHealthValues(List<HealthDataPoint> dataPoints) =>
+      health_daily_steps.sumNumericHealthValues(dataPoints);
 
   /// Authorizes [types] and everything in their permission families.
   ///
@@ -644,20 +640,11 @@ class HealthImport {
         latest?.meta.dateFrom ?? now.subtract(defaultFetchDuration);
 
     if (type.contains('cumulative')) {
-      // Re-read the day before the newest stored one as well. A source that
-      // syncs its day late — a band that uploads overnight — lands its final
-      // total after that day already has a row, and a delta that only looks
-      // from the newest day forward would never see it: the dashboards kept
-      // showing the phone's own count at bedtime until a manual import.
-      // Calendar arithmetic, not a 24-hour duration: across a spring-forward
-      // transition the duration lands at 23:00 two dates back, and `getDays`
-      // would then skip the intended day.
-      final latestDay = latest?.meta.dateFrom;
-      final dayBeforeLatest = latestDay == null
-          ? dateFrom
-          : DateTime(latestDay.year, latestDay.month, latestDay.day - 1);
+      // See [cumulativeDeltaLookBackDays].
       return _getActivityHealthData(
-        dateFrom: dayBeforeLatest,
+        dateFrom: latest == null
+            ? dateFrom
+            : dateFrom.dateOnly.addCalendarDays(-cumulativeDeltaLookBackDays),
         dateTo: now,
         // Nobody asked for this — a chart scheduled it on open. Re-raising an
         // authorization sheet the user has already answered would put a modal

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -11,6 +11,7 @@ import 'package:lotti/classes/health.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_daily_steps.dart';
 import 'package:lotti/logic/health_data_types.dart';
 import 'package:lotti/logic/health_import_result.dart';
 import 'package:lotti/logic/health_permission_gate.dart';
@@ -192,8 +193,21 @@ class HealthImport {
         999,
       );
 
-      final steps = await health.getTotalStepsInInterval(dateFrom, dateTo);
-      stepsByDay[dateFrom] = steps ?? 0;
+      // The merged total alone is not enough: HealthKit resolves overlapping
+      // samples by source priority, so a wearable ranked below the phone
+      // loses its count wherever the phone also recorded steps. The raw
+      // samples come back per source, and the best single source wins — see
+      // [resolveDailySteps].
+      final mergedSteps = await health.getTotalStepsInInterval(
+        dateFrom,
+        dateTo,
+      );
+      final stepSamples = await health.getHealthDataFromTypes(
+        types: [HealthDataType.STEPS],
+        startTime: dateFrom,
+        endTime: dateTo,
+      );
+      stepsByDay[dateFrom] = resolveDailySteps(mergedSteps, stepSamples);
 
       final flightsClimbedDataPoints = await health.getHealthDataFromTypes(
         types: [HealthDataType.FLIGHTS_CLIMBED],
@@ -218,6 +232,12 @@ class HealthImport {
   /// Each entry spans its whole calendar day, except the day in progress, whose
   /// end is capped at the current instant so a chart never plots a total into
   /// the future.
+  ///
+  /// A day is keyed by its type and date, not by its value:
+  /// `createQuantitativeEntry` updates the stored day in place when the total
+  /// has changed and leaves it alone when it has not, so re-importing after a
+  /// late-syncing source has landed replaces the stale figure rather than
+  /// sitting a second row next to it (see `createQuantitativeEntryImpl`).
   Future<int> addActivityEntries(
     Map<DateTime, num> data,
     String type,
@@ -624,8 +644,16 @@ class HealthImport {
         latest?.meta.dateFrom ?? now.subtract(defaultFetchDuration);
 
     if (type.contains('cumulative')) {
+      // Re-read the day before the newest stored one as well. A source that
+      // syncs its day late — a band that uploads overnight — lands its final
+      // total after that day already has a row, and a delta that only looks
+      // from the newest day forward would never see it: the dashboards kept
+      // showing the phone's own count at bedtime until a manual import.
+      final dayBeforeLatest = latest == null
+          ? dateFrom
+          : latest.meta.dateFrom.subtract(const Duration(days: 1));
       return _getActivityHealthData(
-        dateFrom: dateFrom,
+        dateFrom: dayBeforeLatest,
         dateTo: now,
         // Nobody asked for this — a chart scheduled it on open. Re-raising an
         // authorization sheet the user has already answered would put a modal

--- a/lib/logic/persistence_create_ops.dart
+++ b/lib/logic/persistence_create_ops.dart
@@ -13,6 +13,7 @@ import 'package:lotti/logic/persistence_logic.dart' show PersistenceLogic;
 import 'package:lotti/logic/persistence_logic_contract.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/notification_service.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/utils/entry_utils.dart';
 
 /// Entry-creation operations of [PersistenceLogic].
@@ -40,26 +41,9 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
     QuantitativeData data,
   ) async {
     try {
-      if (data is CumulativeQuantityData) {
-        return await _upsertCumulativeDay(data);
-      }
-      final journalEntity = QuantitativeEntry(
-        data: data,
-        meta: await logic.createMetadata(
-          dateFrom: data.dateFrom,
-          dateTo: data.dateTo,
-          uuidV5Input: json.encode(data),
-        ),
-      );
-      // Honour the write verdict. Returning the entity regardless made every
-      // caller unable to tell a fresh sample from a duplicate — the health
-      // import counted both and told the user it had imported samples it had
-      // not.
-      final applied = await logic.createDbEntity(
-        journalEntity,
-        shouldAddGeolocation: false,
-      );
-      return (applied ?? false) ? journalEntity : null;
+      return data is CumulativeQuantityData
+          ? await _upsertCumulativeDay(data)
+          : await _createQuantitativeEntry(data, json.encode(data));
     } catch (exception, stackTrace) {
       loggingService.error(
         LogDomain.persistence,
@@ -70,6 +54,27 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
     }
 
     return null;
+  }
+
+  /// Writes a fresh row under the id derived from [uuidV5Input], honouring the
+  /// write verdict: `null` when the database rejected it as a duplicate.
+  Future<QuantitativeEntry?> _createQuantitativeEntry(
+    QuantitativeData data,
+    String uuidV5Input,
+  ) async {
+    final entry = QuantitativeEntry(
+      data: data,
+      meta: await logic.createMetadata(
+        dateFrom: data.dateFrom,
+        dateTo: data.dateTo,
+        uuidV5Input: uuidV5Input,
+      ),
+    );
+    final applied = await logic.createDbEntity(
+      entry,
+      shouldAddGeolocation: false,
+    );
+    return (applied ?? false) ? entry : null;
   }
 
   /// The deterministic uuidV5 input for one cumulative day: its type, its
@@ -87,12 +92,7 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
     CumulativeQuantityData data, {
     required String? host,
   }) {
-    final day = data.dateFrom;
-    final date =
-        '${day.year.toString().padLeft(4, '0')}-'
-        '${day.month.toString().padLeft(2, '0')}-'
-        '${day.day.toString().padLeft(2, '0')}';
-    return 'cumulative:${data.dataType}:$date:$host';
+    return 'cumulative:${data.dataType}:${data.dateFrom.ymd}:$host';
   }
 
   /// Creates the day's row, or rewrites it when the stored total differs.
@@ -129,19 +129,7 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
       return (applied ?? false) ? updated : null;
     }
 
-    final created = QuantitativeEntry(
-      data: data,
-      meta: await logic.createMetadata(
-        dateFrom: data.dateFrom,
-        dateTo: data.dateTo,
-        uuidV5Input: uuidV5Input,
-      ),
-    );
-    final applied = await logic.createDbEntity(
-      created,
-      shouldAddGeolocation: false,
-    );
-    return (applied ?? false) ? created : null;
+    return _createQuantitativeEntry(data, uuidV5Input);
   }
 
   Future<WorkoutEntry?> createWorkoutEntryImpl(WorkoutData data) async {

--- a/lib/logic/persistence_create_ops.dart
+++ b/lib/logic/persistence_create_ops.dart
@@ -23,10 +23,26 @@ import 'package:lotti/utils/entry_utils.dart';
 class PersistenceCreateOps extends PersistenceCollaboratorBase {
   PersistenceCreateOps(super.logic);
 
+  /// Stores a health sample, returning the entity when the database accepted a
+  /// change and `null` when nothing was written.
+  ///
+  /// Discrete samples are keyed by their whole payload: a re-imported sample
+  /// hashes to the id it already has, `createDbEntity` writes with
+  /// `overwrite: false`, and the duplicate is rejected row by row.
+  ///
+  /// Cumulative days ([CumulativeQuantityData]) are keyed by type and day
+  /// instead, and **updated in place** when the total differs — see
+  /// [cumulativeQuantityEntryId]. Keyed by payload, a day whose total rose after
+  /// import (a wearable that syncs overnight, a phone that caught up) became a
+  /// second row beside the stale one, and a day whose total was unchanged was
+  /// "rejected" indistinguishably from one that never reached the database.
   Future<QuantitativeEntry?> createQuantitativeEntryImpl(
     QuantitativeData data,
   ) async {
     try {
+      if (data is CumulativeQuantityData) {
+        return await _upsertCumulativeDay(data);
+      }
       final journalEntity = QuantitativeEntry(
         data: data,
         meta: await logic.createMetadata(
@@ -35,12 +51,10 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
           uuidV5Input: json.encode(data),
         ),
       );
-      // Honour the write verdict. Health entries carry deterministic uuidV5
-      // ids and `createDbEntity` writes with `overwrite: false`, so
-      // re-importing a range that is already stored is rejected row by row.
-      // Returning the entity regardless made every caller unable to tell a
-      // fresh sample from a duplicate — the health import counted both and
-      // told the user it had imported samples it had not.
+      // Honour the write verdict. Returning the entity regardless made every
+      // caller unable to tell a fresh sample from a duplicate — the health
+      // import counted both and told the user it had imported samples it had
+      // not.
       final applied = await logic.createDbEntity(
         journalEntity,
         shouldAddGeolocation: false,
@@ -56,6 +70,66 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
     }
 
     return null;
+  }
+
+  /// The deterministic uuidV5 input for one cumulative day: its type, its
+  /// local calendar date and the importing device, so every import of that day
+  /// on that device addresses the same row whatever total it read.
+  ///
+  /// The device is part of the key on purpose. Two devices importing the same
+  /// day would otherwise race for one row through sync and land as a conflict;
+  /// kept apart, each writes its own row and the readers' per-day maximum
+  /// merges them, exactly as it merged the payload-keyed rows before.
+  static String cumulativeQuantityEntryId(CumulativeQuantityData data) {
+    final day = data.dateFrom;
+    final date =
+        '${day.year.toString().padLeft(4, '0')}-'
+        '${day.month.toString().padLeft(2, '0')}-'
+        '${day.day.toString().padLeft(2, '0')}';
+    return 'cumulative:${data.dataType}:$date:${data.deviceType}';
+  }
+
+  /// Creates the day's row, or rewrites it when the stored total differs.
+  ///
+  /// Returns `null` when the stored day already carries exactly [data], so an
+  /// import over an unchanged range still reports nothing new.
+  Future<QuantitativeEntry?> _upsertCumulativeDay(
+    CumulativeQuantityData data,
+  ) async {
+    final uuidV5Input = cumulativeQuantityEntryId(data);
+    final existing = await journalDb.journalEntityById(
+      metadataService.generateId(uuidV5Input: uuidV5Input),
+    );
+
+    if (existing is QuantitativeEntry) {
+      if (existing.data == data) {
+        return null;
+      }
+      final updated = existing.copyWith(
+        data: data,
+        meta: await logic.updateMetadata(
+          existing.meta,
+          dateFrom: data.dateFrom,
+          dateTo: data.dateTo,
+        ),
+      );
+      final applied = await logic.updateDbEntity(updated);
+      return (applied ?? false) ? updated : null;
+    }
+
+    final created = QuantitativeEntry(
+      data: data,
+      meta: await logic.createMetadata(
+        dateFrom: data.dateFrom,
+        dateTo: data.dateTo,
+        uuidV5Input: uuidV5Input,
+      ),
+    );
+    final applied = await logic.createDbEntity(
+      created,
+      shouldAddGeolocation: false,
+    );
+    return (applied ?? false) ? created : null;
   }
 
   Future<WorkoutEntry?> createWorkoutEntryImpl(WorkoutData data) async {

--- a/lib/logic/persistence_create_ops.dart
+++ b/lib/logic/persistence_create_ops.dart
@@ -73,36 +73,48 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
   }
 
   /// The deterministic uuidV5 input for one cumulative day: its type, its
-  /// local calendar date and the importing device, so every import of that day
-  /// on that device addresses the same row whatever total it read.
+  /// local calendar date and the importing installation's sync [host], so
+  /// every import of that day on that installation addresses the same row
+  /// whatever total it read.
   ///
-  /// The device is part of the key on purpose. Two devices importing the same
+  /// The host is part of the key on purpose. Two devices importing the same
   /// day would otherwise race for one row through sync and land as a conflict;
   /// kept apart, each writes its own row and the readers' per-day maximum
-  /// merges them, exactly as it merged the payload-keyed rows before.
-  static String cumulativeQuantityEntryId(CumulativeQuantityData data) {
+  /// merges them, exactly as it merged the payload-keyed rows before. The
+  /// hardware model would not do: two phones of the same model, or two whose
+  /// device-info lookup failed, share one.
+  static String cumulativeQuantityEntryId(
+    CumulativeQuantityData data, {
+    required String? host,
+  }) {
     final day = data.dateFrom;
     final date =
         '${day.year.toString().padLeft(4, '0')}-'
         '${day.month.toString().padLeft(2, '0')}-'
         '${day.day.toString().padLeft(2, '0')}';
-    return 'cumulative:${data.dataType}:$date:${data.deviceType}';
+    return 'cumulative:${data.dataType}:$date:$host';
   }
 
   /// Creates the day's row, or rewrites it when the stored total differs.
   ///
-  /// Returns `null` when the stored day already carries exactly [data], so an
-  /// import over an unchanged range still reports nothing new.
+  /// Returns `null` when the stored day already carries the same total, so an
+  /// import over an unchanged range still reports nothing new. Only the value
+  /// decides: the day in progress carries "now" as its end, which advances on
+  /// every background refresh, and rewriting (and syncing) three rows every ten
+  /// minutes to move an end time nobody reads is not a change worth a write.
   Future<QuantitativeEntry?> _upsertCumulativeDay(
     CumulativeQuantityData data,
   ) async {
-    final uuidV5Input = cumulativeQuantityEntryId(data);
+    final uuidV5Input = cumulativeQuantityEntryId(
+      data,
+      host: await vectorClockService.getHost(),
+    );
     final existing = await journalDb.journalEntityById(
       metadataService.generateId(uuidV5Input: uuidV5Input),
     );
 
     if (existing is QuantitativeEntry) {
-      if (existing.data == data) {
+      if (existing.data.value == data.value) {
         return null;
       }
       final updated = existing.copyWith(

--- a/test/logic/health_daily_steps_test.dart
+++ b/test/logic/health_daily_steps_test.dart
@@ -6,19 +6,22 @@ import 'package:lotti/logic/health_daily_steps.dart';
 void main() {
   final day = DateTime(2026, 8, 26);
 
-  HealthDataPoint steps(num value, {required String sourceId}) =>
-      HealthDataPoint(
-        uuid: '$sourceId-$value',
-        value: NumericHealthValue(numericValue: value),
-        type: HealthDataType.STEPS,
-        unit: HealthDataUnit.COUNT,
-        dateFrom: day,
-        dateTo: day.add(const Duration(hours: 1)),
-        sourcePlatform: HealthPlatformType.appleHealth,
-        sourceDeviceId: sourceId,
-        sourceId: sourceId,
-        sourceName: sourceId,
-      );
+  HealthDataPoint steps(
+    num value, {
+    required String sourceId,
+    String? sourceName,
+  }) => HealthDataPoint(
+    uuid: '$sourceId-${sourceName ?? ''}-$value',
+    value: NumericHealthValue(numericValue: value),
+    type: HealthDataType.STEPS,
+    unit: HealthDataUnit.COUNT,
+    dateFrom: day,
+    dateTo: day.add(const Duration(hours: 1)),
+    sourcePlatform: HealthPlatformType.appleHealth,
+    sourceDeviceId: sourceId,
+    sourceId: sourceId,
+    sourceName: sourceName ?? sourceId,
+  );
 
   group('resolveDailySteps', () {
     // The reported scenario: the phone under-counts a day spent without it,
@@ -56,6 +59,22 @@ void main() {
         ]),
         6000,
       );
+    });
+
+    // Health Connect step records arrive with an empty `sourceId` and the
+    // provider's package name as `sourceName`. Keyed on the id alone, every
+    // provider pooled into one "source" and their counts were summed.
+    test('falls back to the source name when the source id is empty', () {
+      final result = resolveDailySteps(7000, [
+        steps(
+          6000,
+          sourceId: '',
+          sourceName: 'com.google.android.apps.fitness',
+        ),
+        steps(7000, sourceId: '', sourceName: 'com.whoop.android'),
+      ]);
+
+      expect(result, 7000);
     });
 
     test('a missing merged total counts as zero', () {

--- a/test/logic/health_daily_steps_test.dart
+++ b/test/logic/health_daily_steps_test.dart
@@ -141,24 +141,5 @@ void main() {
         reason: 'merged=$merged values=$values',
       );
     }, tags: 'glados');
-
-    glados.Glados2<int, List<int>>(
-      mergedAny,
-      samplesAny,
-      glados.ExploreConfig(numRuns: 150),
-    ).test('is never below the merged total and never above the sum of all', (
-      merged,
-      values,
-    ) {
-      final samples = [
-        for (var i = 0; i < values.length; i++)
-          steps(values[i], sourceId: 'source-${i % 3}'),
-      ];
-      final total = values.fold<int>(0, (a, b) => a + b);
-      final result = resolveDailySteps(merged, samples);
-
-      expect(result, greaterThanOrEqualTo(merged));
-      expect(result, lessThanOrEqualTo(total > merged ? total : merged));
-    }, tags: 'glados');
   });
 }

--- a/test/logic/health_daily_steps_test.dart
+++ b/test/logic/health_daily_steps_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:health/health.dart';
+import 'package:lotti/logic/health_daily_steps.dart';
+
+void main() {
+  final day = DateTime(2026, 8, 26);
+
+  HealthDataPoint steps(num value, {required String sourceId}) =>
+      HealthDataPoint(
+        uuid: '$sourceId-$value',
+        value: NumericHealthValue(numericValue: value),
+        type: HealthDataType.STEPS,
+        unit: HealthDataUnit.COUNT,
+        dateFrom: day,
+        dateTo: day.add(const Duration(hours: 1)),
+        sourcePlatform: HealthPlatformType.appleHealth,
+        sourceDeviceId: sourceId,
+        sourceId: sourceId,
+        sourceName: sourceId,
+      );
+
+  group('resolveDailySteps', () {
+    // The reported scenario: the phone under-counts a day spent without it,
+    // the band synced its full day overnight, and HealthKit's merged sum sided
+    // with the phone wherever the two overlapped.
+    test(
+      'takes the wearable count when the merged total sided with the phone',
+      () {
+        final result = resolveDailySteps(9800, [
+          steps(4000, sourceId: 'phone'),
+          steps(5800, sourceId: 'phone'),
+          steps(11600, sourceId: 'whoop'),
+        ]);
+
+        expect(result, 11600);
+      },
+    );
+
+    test('keeps the merged total when no single source beats it', () {
+      // Two sources that genuinely cover different hours: the store merged
+      // them correctly, and neither alone tells the whole day.
+      final result = resolveDailySteps(9000, [
+        steps(4000, sourceId: 'phone'),
+        steps(5000, sourceId: 'watch'),
+      ]);
+
+      expect(result, 9000);
+    });
+
+    test('never sums across sources', () {
+      expect(
+        resolveDailySteps(null, [
+          steps(6000, sourceId: 'phone'),
+          steps(6000, sourceId: 'whoop'),
+        ]),
+        6000,
+      );
+    });
+
+    test('a missing merged total counts as zero', () {
+      expect(resolveDailySteps(null, const []), 0);
+      expect(resolveDailySteps(null, [steps(12, sourceId: 'a')]), 12);
+    });
+
+    test('ignores samples without a numeric value', () {
+      final result = resolveDailySteps(100, [
+        HealthDataPoint(
+          uuid: 'audiogram',
+          value: AudiogramHealthValue(
+            frequencies: [1],
+            leftEarSensitivities: [1],
+            rightEarSensitivities: [1],
+          ),
+          type: HealthDataType.AUDIOGRAM,
+          unit: HealthDataUnit.DECIBEL_HEARING_LEVEL,
+          dateFrom: day,
+          dateTo: day,
+          sourcePlatform: HealthPlatformType.appleHealth,
+          sourceDeviceId: 'a',
+          sourceId: 'a',
+          sourceName: 'a',
+        ),
+      ]);
+
+      expect(result, 100);
+    });
+  });
+
+  group('resolveDailySteps — Glados properties', () {
+    final samplesAny = glados.ListAnys(glados.any).listWithLengthInRange(
+      0,
+      12,
+      glados.IntAnys(glados.any).intInRange(0, 5000),
+    );
+    final mergedAny = glados.IntAnys(glados.any).intInRange(0, 30000);
+
+    glados.Glados2<int, List<int>>(
+      mergedAny,
+      samplesAny,
+      glados.ExploreConfig(numRuns: 150),
+    ).test('equals max(merged, best single-source total)', (merged, values) {
+      // Alternate two sources so both per-source sums are non-trivial.
+      final samples = [
+        for (var i = 0; i < values.length; i++)
+          steps(values[i], sourceId: i.isEven ? 'phone' : 'band'),
+      ];
+      var phone = 0;
+      var band = 0;
+      for (var i = 0; i < values.length; i++) {
+        if (i.isEven) {
+          phone += values[i];
+        } else {
+          band += values[i];
+        }
+      }
+      final best = phone > band ? phone : band;
+
+      expect(
+        resolveDailySteps(merged, samples),
+        best > merged ? best : merged,
+        reason: 'merged=$merged values=$values',
+      );
+    }, tags: 'glados');
+
+    glados.Glados2<int, List<int>>(
+      mergedAny,
+      samplesAny,
+      glados.ExploreConfig(numRuns: 150),
+    ).test('is never below the merged total and never above the sum of all', (
+      merged,
+      values,
+    ) {
+      final samples = [
+        for (var i = 0; i < values.length; i++)
+          steps(values[i], sourceId: 'source-${i % 3}'),
+      ];
+      final total = values.fold<int>(0, (a, b) => a + b);
+      final result = resolveDailySteps(merged, samples);
+
+      expect(result, greaterThanOrEqualTo(merged));
+      expect(result, lessThanOrEqualTo(total > merged ? total : merged));
+    }, tags: 'glados');
+  });
+}

--- a/test/logic/health_import_test.dart
+++ b/test/logic/health_import_test.dart
@@ -415,39 +415,29 @@ void main() {
           startTime: any(named: 'startTime'),
           endTime: any(named: 'endTime'),
         ),
-      ).thenAnswer((invocation) async {
-        final types =
-            invocation.namedArguments[const Symbol('types')]
-                as List<HealthDataType>;
-
-        if (types.contains(HealthDataType.FLIGHTS_CLIMBED)) {
-          return [
-            makeNumericDataPoint(
-              type: HealthDataType.FLIGHTS_CLIMBED,
-              value: 15,
-              dateFrom: testDate,
-              dateTo: testDate.add(const Duration(hours: 1)),
-            ),
-            makeNumericDataPoint(
-              type: HealthDataType.FLIGHTS_CLIMBED,
-              value: 10,
-              dateFrom: testDate.add(const Duration(hours: 2)),
-              dateTo: testDate.add(const Duration(hours: 3)),
-            ),
-          ];
-        } else if (types.contains(HealthDataType.DISTANCE_WALKING_RUNNING)) {
-          return [
-            makeNumericDataPoint(
-              type: HealthDataType.DISTANCE_WALKING_RUNNING,
-              value: 5000,
-              dateFrom: testDate,
-              dateTo: testDate.add(const Duration(hours: 1)),
-              unit: HealthDataUnit.METER,
-            ),
-          ];
-        }
-        return [];
-      });
+      ).thenAnswer(
+        (_) async => [
+          makeNumericDataPoint(
+            type: HealthDataType.FLIGHTS_CLIMBED,
+            value: 15,
+            dateFrom: testDate,
+            dateTo: testDate.add(const Duration(hours: 1)),
+          ),
+          makeNumericDataPoint(
+            type: HealthDataType.FLIGHTS_CLIMBED,
+            value: 10,
+            dateFrom: testDate.add(const Duration(hours: 2)),
+            dateTo: testDate.add(const Duration(hours: 3)),
+          ),
+          makeNumericDataPoint(
+            type: HealthDataType.DISTANCE_WALKING_RUNNING,
+            value: 5000,
+            dateFrom: testDate,
+            dateTo: testDate.add(const Duration(hours: 1)),
+            unit: HealthDataUnit.METER,
+          ),
+        ],
+      );
 
       await healthImport.fetchAndProcessActivityDataForDay(
         testDate,
@@ -469,27 +459,7 @@ void main() {
           startTime: any(named: 'startTime'),
           endTime: any(named: 'endTime'),
         ),
-      ).called(3); // Steps samples, flights, distance
-    });
-
-    test('reads the raw step samples over the same whole day', () async {
-      final testDate = DateTime(2024);
-      stubHealthStore();
-
-      await healthImport.fetchAndProcessActivityDataForDay(
-        testDate,
-        <DateTime, num>{},
-        <DateTime, num>{},
-        <DateTime, num>{},
-      );
-
-      verify(
-        () => mockHealthService.getHealthDataFromTypes(
-          types: [HealthDataType.STEPS],
-          startTime: testDate,
-          endTime: DateTime(2024, 1, 1, 23, 59, 59, 999),
-        ),
-      ).called(1);
+      ).called(1); // One batched read for steps, flights and distance
     });
 
     // The reported bug: a band that syncs its whole day once overnight is
@@ -546,6 +516,13 @@ void main() {
         );
 
         expect(stepsByDay[testDate], 11600);
+        verify(
+          () => mockHealthService.getHealthDataFromTypes(
+            types: activityTypes,
+            startTime: testDate,
+            endTime: DateTime(2024, 1, 1, 23, 59, 59, 999),
+          ),
+        ).called(1);
       },
     );
 
@@ -1860,37 +1837,39 @@ void main() {
     // yesterday already has a row. A delta that only looked from the newest
     // stored day forward never re-read it, so the dashboards kept the phone's
     // bedtime count until a manual import.
-    test(
-      'a cumulative delta re-reads the day before the newest stored one',
-      () {
+    group('cumulative delta look-back', () {
+      void stubLatestCumulativeDay(DateTime day) {
+        final dateTo = day.add(const Duration(hours: 8));
+        when(
+          () => mockJournalDb.latestQuantitativeByType(any()),
+        ).thenAnswer(
+          (_) async => QuantitativeEntry(
+            data: QuantitativeData.cumulativeQuantityData(
+              dateFrom: day,
+              dateTo: dateTo,
+              value: 1200,
+              dataType: 'cumulative_step_count',
+              unit: 'count',
+            ),
+            meta: Metadata(
+              id: 'latest',
+              createdAt: day,
+              updatedAt: day,
+              dateFrom: day,
+              dateTo: dateTo,
+            ),
+          ),
+        );
+      }
+
+      test('re-reads the day before the newest stored one', () {
         fakeAsync((async) {
           final mobileImport = createMobileHealthImport();
-          final now = DateTime(2024, 1, 10, 9);
           final latestDay = DateTime(2024, 1, 10);
-
-          when(
-            () => mockJournalDb.latestQuantitativeByType(any()),
-          ).thenAnswer(
-            (_) async => QuantitativeEntry(
-              data: QuantitativeData.cumulativeQuantityData(
-                dateFrom: latestDay,
-                dateTo: DateTime(2024, 1, 10, 8),
-                value: 1200,
-                dataType: 'cumulative_step_count',
-                unit: 'count',
-              ),
-              meta: Metadata(
-                id: 'latest',
-                createdAt: latestDay,
-                updatedAt: latestDay,
-                dateFrom: latestDay,
-                dateTo: DateTime(2024, 1, 10, 8),
-              ),
-            ),
-          );
+          stubLatestCumulativeDay(latestDay);
           stubHealthStore();
 
-          withClock(Clock.fixed(now), () {
+          withClock(Clock.fixed(DateTime(2024, 1, 10, 9)), () {
             mobileImport.fetchHealthDataDelta('cumulative_step_count');
             async.flushMicrotasks();
           });
@@ -1914,50 +1893,29 @@ void main() {
             ),
           );
         });
-      },
-    );
+      });
 
-    test('the look-back is a calendar day, not 24 hours', () {
-      fakeAsync((async) {
-        final mobileImport = createMobileHealthImport();
-        final latestDay = DateTime(2024, 3, 31);
+      // The previous calendar date at local midnight — the same value the
+      // day-keyed row for that date carries — whatever the clock offset
+      // between the two midnights happens to be across a DST transition.
+      test('steps back a calendar day, not 24 hours', () {
+        fakeAsync((async) {
+          final mobileImport = createMobileHealthImport();
+          stubLatestCumulativeDay(DateTime(2024, 3, 31));
+          stubHealthStore();
 
-        when(
-          () => mockJournalDb.latestQuantitativeByType(any()),
-        ).thenAnswer(
-          (_) async => QuantitativeEntry(
-            data: QuantitativeData.cumulativeQuantityData(
-              dateFrom: latestDay,
-              dateTo: DateTime(2024, 3, 31, 8),
-              value: 1,
-              dataType: 'cumulative_step_count',
-              unit: 'count',
+          withClock(Clock.fixed(DateTime(2024, 3, 31, 9)), () {
+            mobileImport.fetchHealthDataDelta('cumulative_step_count');
+            async.flushMicrotasks();
+          });
+
+          verify(
+            () => mockHealthService.getTotalStepsInInterval(
+              DateTime(2024, 3, 30),
+              any(),
             ),
-            meta: Metadata(
-              id: 'latest',
-              createdAt: latestDay,
-              updatedAt: latestDay,
-              dateFrom: latestDay,
-              dateTo: DateTime(2024, 3, 31, 8),
-            ),
-          ),
-        );
-        stubHealthStore();
-
-        withClock(Clock.fixed(DateTime(2024, 3, 31, 9)), () {
-          mobileImport.fetchHealthDataDelta('cumulative_step_count');
-          async.flushMicrotasks();
+          ).called(1);
         });
-
-        // The previous calendar date at local midnight — the same value the
-        // day-keyed row for that date carries — whatever the clock offset
-        // between the two midnights happens to be.
-        verify(
-          () => mockHealthService.getTotalStepsInInterval(
-            DateTime(2024, 3, 30),
-            any(),
-          ),
-        ).called(1);
       });
     });
 

--- a/test/logic/health_import_test.dart
+++ b/test/logic/health_import_test.dart
@@ -1917,6 +1917,50 @@ void main() {
       },
     );
 
+    test('the look-back is a calendar day, not 24 hours', () {
+      fakeAsync((async) {
+        final mobileImport = createMobileHealthImport();
+        final latestDay = DateTime(2024, 3, 31);
+
+        when(
+          () => mockJournalDb.latestQuantitativeByType(any()),
+        ).thenAnswer(
+          (_) async => QuantitativeEntry(
+            data: QuantitativeData.cumulativeQuantityData(
+              dateFrom: latestDay,
+              dateTo: DateTime(2024, 3, 31, 8),
+              value: 1,
+              dataType: 'cumulative_step_count',
+              unit: 'count',
+            ),
+            meta: Metadata(
+              id: 'latest',
+              createdAt: latestDay,
+              updatedAt: latestDay,
+              dateFrom: latestDay,
+              dateTo: DateTime(2024, 3, 31, 8),
+            ),
+          ),
+        );
+        stubHealthStore();
+
+        withClock(Clock.fixed(DateTime(2024, 3, 31, 9)), () {
+          mobileImport.fetchHealthDataDelta('cumulative_step_count');
+          async.flushMicrotasks();
+        });
+
+        // The previous calendar date at local midnight — the same value the
+        // day-keyed row for that date carries — whatever the clock offset
+        // between the two midnights happens to be.
+        verify(
+          () => mockHealthService.getTotalStepsInInterval(
+            DateTime(2024, 3, 30),
+            any(),
+          ),
+        ).called(1);
+      });
+    });
+
     // Silently importing nothing is what made a dashboard configured for a
     // retired type look like a broken import rather than stale configuration.
     test('an unresolvable type is reported, not silently skipped', () {

--- a/test/logic/health_import_test.dart
+++ b/test/logic/health_import_test.dart
@@ -469,8 +469,85 @@ void main() {
           startTime: any(named: 'startTime'),
           endTime: any(named: 'endTime'),
         ),
-      ).called(2); // Once for flights, once for distance
+      ).called(3); // Steps samples, flights, distance
     });
+
+    test('reads the raw step samples over the same whole day', () async {
+      final testDate = DateTime(2024);
+      stubHealthStore();
+
+      await healthImport.fetchAndProcessActivityDataForDay(
+        testDate,
+        <DateTime, num>{},
+        <DateTime, num>{},
+        <DateTime, num>{},
+      );
+
+      verify(
+        () => mockHealthService.getHealthDataFromTypes(
+          types: [HealthDataType.STEPS],
+          startTime: testDate,
+          endTime: DateTime(2024, 1, 1, 23, 59, 59, 999),
+        ),
+      ).called(1);
+    });
+
+    // The reported bug: a band that syncs its whole day once overnight is
+    // ranked below the phone in Health's source priority, so HealthKit's merged
+    // total kept the phone's under-count. The per-source samples still carry
+    // the band's figure, and the best single source wins.
+    test(
+      'prefers the best single source over a merged total that dropped it',
+      () async {
+        final testDate = DateTime(2024);
+        final stepsByDay = <DateTime, num>{};
+
+        when(
+          () => mockHealthService.getTotalStepsInInterval(any(), any()),
+        ).thenAnswer((_) async => 9800);
+        when(
+          () => mockHealthService.getHealthDataFromTypes(
+            types: any(named: 'types'),
+            startTime: any(named: 'startTime'),
+            endTime: any(named: 'endTime'),
+          ),
+        ).thenAnswer((invocation) async {
+          final types =
+              invocation.namedArguments[const Symbol('types')]
+                  as List<HealthDataType>;
+          if (!types.contains(HealthDataType.STEPS)) {
+            return [];
+          }
+          return [
+            makeNumericDataPoint(
+              type: HealthDataType.STEPS,
+              value: 9800,
+              dateFrom: testDate,
+              dateTo: testDate.add(const Duration(hours: 23)),
+              sourceId: 'com.apple.health.iphone',
+              sourceName: 'iPhone',
+            ),
+            makeNumericDataPoint(
+              type: HealthDataType.STEPS,
+              value: 11600,
+              dateFrom: testDate,
+              dateTo: testDate.add(const Duration(hours: 24)),
+              sourceId: 'com.whoop.app',
+              sourceName: 'WHOOP',
+            ),
+          ];
+        });
+
+        await healthImport.fetchAndProcessActivityDataForDay(
+          testDate,
+          stepsByDay,
+          <DateTime, num>{},
+          <DateTime, num>{},
+        );
+
+        expect(stepsByDay[testDate], 11600);
+      },
+    );
 
     test('should handle zero values correctly', () async {
       final testDate = DateTime(2024);
@@ -1778,6 +1855,67 @@ void main() {
         ).called(1);
       });
     });
+
+    // A band that syncs its day overnight lands yesterday's final total after
+    // yesterday already has a row. A delta that only looked from the newest
+    // stored day forward never re-read it, so the dashboards kept the phone's
+    // bedtime count until a manual import.
+    test(
+      'a cumulative delta re-reads the day before the newest stored one',
+      () {
+        fakeAsync((async) {
+          final mobileImport = createMobileHealthImport();
+          final now = DateTime(2024, 1, 10, 9);
+          final latestDay = DateTime(2024, 1, 10);
+
+          when(
+            () => mockJournalDb.latestQuantitativeByType(any()),
+          ).thenAnswer(
+            (_) async => QuantitativeEntry(
+              data: QuantitativeData.cumulativeQuantityData(
+                dateFrom: latestDay,
+                dateTo: DateTime(2024, 1, 10, 8),
+                value: 1200,
+                dataType: 'cumulative_step_count',
+                unit: 'count',
+              ),
+              meta: Metadata(
+                id: 'latest',
+                createdAt: latestDay,
+                updatedAt: latestDay,
+                dateFrom: latestDay,
+                dateTo: DateTime(2024, 1, 10, 8),
+              ),
+            ),
+          );
+          stubHealthStore();
+
+          withClock(Clock.fixed(now), () {
+            mobileImport.fetchHealthDataDelta('cumulative_step_count');
+            async.flushMicrotasks();
+          });
+
+          verify(
+            () => mockHealthService.getTotalStepsInInterval(
+              DateTime(2024, 1, 9),
+              DateTime(2024, 1, 9, 23, 59, 59, 999),
+            ),
+          ).called(1);
+          verify(
+            () => mockHealthService.getTotalStepsInInterval(
+              latestDay,
+              DateTime(2024, 1, 10, 23, 59, 59, 999),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockHealthService.getTotalStepsInInterval(
+              DateTime(2024, 1, 8),
+              any(),
+            ),
+          );
+        });
+      },
+    );
 
     // Silently importing nothing is what made a dashboard configured for a
     // retired type look like a broken import rather than stale configuration.

--- a/test/logic/persistence_create_ops_test.dart
+++ b/test/logic/persistence_create_ops_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/logic/persistence_create_ops.dart';
 import 'package:lotti/logic/services/metadata_service.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/notification_service.dart';
+import 'package:lotti/services/vector_clock_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../helpers/fallbacks.dart';
@@ -29,6 +30,7 @@ void main() {
   late MockDomainLogger domainLogger;
   late MockJournalDb journalDb;
   late MockMetadataService metadataService;
+  late MockVectorClockService vectorClockService;
   late PersistenceCreateOps ops;
 
   Metadata metaFor(String id) => Metadata(
@@ -43,12 +45,15 @@ void main() {
     registerAllFallbackValues();
     domainLogger = MockDomainLogger();
     metadataService = MockMetadataService();
+    vectorClockService = MockVectorClockService();
+    when(() => vectorClockService.getHost()).thenAnswer((_) async => 'host-a');
     final mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt
           ..unregister<DomainLogger>()
           ..registerSingleton<DomainLogger>(domainLogger)
           ..registerSingleton<MetadataService>(metadataService)
+          ..registerSingleton<VectorClockService>(vectorClockService)
           ..registerSingleton<NotificationService>(MockNotificationService());
       },
     );
@@ -156,7 +161,7 @@ void main() {
           deviceType: 'iPhone17,1',
           platformType: 'IOS',
         );
-    const dayId = 'id:cumulative:cumulative_step_count:2026-08-26:iPhone17,1';
+    const dayId = 'id:cumulative:cumulative_step_count:2026-08-26:host-a';
 
     QuantitativeEntry stored(num value) => QuantitativeEntry(
       data: steps(value),
@@ -176,34 +181,29 @@ void main() {
       when(() => logic.updateDbEntity(any())).thenAnswer((_) async => true);
     });
 
-    test('the id is keyed by type and local calendar day, not by value', () {
+    test('the id is keyed by type, local calendar day and sync host', () {
+      String idOf(CumulativeQuantityData data, {String? host = 'host-a'}) =>
+          PersistenceCreateOps.cumulativeQuantityEntryId(data, host: host);
+
+      expect(idOf(steps(9800)), idOf(steps(11600)));
       expect(
-        PersistenceCreateOps.cumulativeQuantityEntryId(steps(9800)),
-        PersistenceCreateOps.cumulativeQuantityEntryId(steps(11600)),
+        idOf(steps(1)),
+        'cumulative:cumulative_step_count:2026-08-26:host-a',
       );
       expect(
-        PersistenceCreateOps.cumulativeQuantityEntryId(steps(1)),
-        'cumulative:cumulative_step_count:2026-08-26:iPhone17,1',
+        idOf(steps(1).copyWith(dateFrom: DateTime(2026, 8, 27))),
+        isNot(idOf(steps(1))),
       );
       expect(
-        PersistenceCreateOps.cumulativeQuantityEntryId(
-          steps(1).copyWith(dateFrom: DateTime(2026, 8, 27)),
-        ),
-        isNot(PersistenceCreateOps.cumulativeQuantityEntryId(steps(1))),
+        idOf(steps(1).copyWith(dataType: 'cumulative_distance')),
+        isNot(idOf(steps(1))),
       );
-      // Two devices importing the same day keep separate rows rather than
-      // racing for one through sync.
+      // Two installations importing the same day keep separate rows rather
+      // than racing for one through sync — even on the same hardware model.
+      expect(idOf(steps(1), host: 'host-b'), isNot(idOf(steps(1))));
       expect(
-        PersistenceCreateOps.cumulativeQuantityEntryId(
-          steps(1).copyWith(deviceType: 'iPad16,3'),
-        ),
-        isNot(PersistenceCreateOps.cumulativeQuantityEntryId(steps(1))),
-      );
-      expect(
-        PersistenceCreateOps.cumulativeQuantityEntryId(
-          steps(1).copyWith(dataType: 'cumulative_distance'),
-        ),
-        isNot(PersistenceCreateOps.cumulativeQuantityEntryId(steps(1))),
+        idOf(steps(1).copyWith(deviceType: 'iPad16,3')),
+        idOf(steps(1)),
       );
     });
 
@@ -218,8 +218,7 @@ void main() {
           () => logic.createMetadata(
             dateFrom: day,
             dateTo: DateTime(2026, 8, 26, 23, 59, 59, 999),
-            uuidV5Input:
-                'cumulative:cumulative_step_count:2026-08-26:iPhone17,1',
+            uuidV5Input: 'cumulative:cumulative_step_count:2026-08-26:host-a',
           ),
         ).called(1);
         verifyNever(() => logic.updateDbEntity(any()));
@@ -284,6 +283,25 @@ void main() {
           linkedId: any(named: 'linkedId'),
         ),
       );
+    });
+
+    // The day in progress carries "now" as its end, which moves on every
+    // background refresh. Only the total decides whether to rewrite.
+    test('an advanced end time with the same total is not a rewrite', () async {
+      when(
+        () => journalDb.journalEntityById(dayId),
+      ).thenAnswer(
+        (_) async => stored(9800).copyWith(
+          data: steps(9800, dateTo: DateTime(2026, 8, 26, 10)),
+        ),
+      );
+
+      final result = await ops.createQuantitativeEntryImpl(
+        steps(9800, dateTo: DateTime(2026, 8, 26, 10, 10)),
+      );
+
+      expect(result, isNull);
+      verifyNever(() => logic.updateDbEntity(any()));
     });
 
     test('returns null when the database rejects the rewrite', () async {

--- a/test/logic/persistence_create_ops_test.dart
+++ b/test/logic/persistence_create_ops_test.dart
@@ -242,6 +242,14 @@ void main() {
               as QuantitativeEntry;
       expect(updated.data.value, 11600);
       expect(updated.meta.id, dayId);
+
+      // The store is the authority in both directions: a lower re-read
+      // overwrites too.
+      when(
+        () => journalDb.journalEntityById(dayId),
+      ).thenAnswer((_) async => stored(11600));
+      final lowered = await ops.createQuantitativeEntryImpl(steps(9800));
+      expect(lowered?.data.value, 9800);
       verifyNever(
         () => logic.createDbEntity(
           any(),
@@ -251,20 +259,6 @@ void main() {
         ),
       );
     });
-
-    test(
-      'a lower re-read also overwrites — the store is the authority',
-      () async {
-        when(
-          () => journalDb.journalEntityById(dayId),
-        ).thenAnswer((_) async => stored(11600));
-
-        final result = await ops.createQuantitativeEntryImpl(steps(9800));
-
-        expect(result?.data.value, 9800);
-        verify(() => logic.updateDbEntity(any())).called(1);
-      },
-    );
 
     test('leaves an unchanged day alone and reports nothing written', () async {
       when(

--- a/test/logic/persistence_create_ops_test.dart
+++ b/test/logic/persistence_create_ops_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_create_ops.dart';
+import 'package:lotti/logic/services/metadata_service.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:mocktail/mocktail.dart';
@@ -26,6 +27,8 @@ import '../widget_test_utils.dart';
 void main() {
   late MockPersistenceLogic logic;
   late MockDomainLogger domainLogger;
+  late MockJournalDb journalDb;
+  late MockMetadataService metadataService;
   late PersistenceCreateOps ops;
 
   Metadata metaFor(String id) => Metadata(
@@ -39,13 +42,22 @@ void main() {
   setUp(() async {
     registerAllFallbackValues();
     domainLogger = MockDomainLogger();
-    await setUpTestGetIt(
+    metadataService = MockMetadataService();
+    final mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt
           ..unregister<DomainLogger>()
           ..registerSingleton<DomainLogger>(domainLogger)
+          ..registerSingleton<MetadataService>(metadataService)
           ..registerSingleton<NotificationService>(MockNotificationService());
       },
+    );
+    journalDb = mocks.journalDb;
+    when(
+      () => metadataService.generateId(uuidV5Input: any(named: 'uuidV5Input')),
+    ).thenAnswer(
+      (invocation) =>
+          'id:${invocation.namedArguments[const Symbol('uuidV5Input')]}',
     );
     logic = MockPersistenceLogic();
     ops = PersistenceCreateOps(logic);
@@ -131,6 +143,205 @@ void main() {
       expect(result, isNull);
     },
   );
+
+  group('createQuantitativeEntryImpl — cumulative days', () {
+    final day = DateTime(2026, 8, 26);
+    CumulativeQuantityData steps(num value, {DateTime? dateTo}) =>
+        CumulativeQuantityData(
+          dateFrom: day,
+          dateTo: dateTo ?? DateTime(2026, 8, 26, 23, 59, 59, 999),
+          value: value,
+          dataType: 'cumulative_step_count',
+          unit: 'count',
+          deviceType: 'iPhone17,1',
+          platformType: 'IOS',
+        );
+    const dayId = 'id:cumulative:cumulative_step_count:2026-08-26:iPhone17,1';
+
+    QuantitativeEntry stored(num value) => QuantitativeEntry(
+      data: steps(value),
+      meta: metaFor(dayId).copyWith(dateFrom: day),
+    );
+
+    setUp(() {
+      when(
+        () => logic.updateMetadata(
+          any(),
+          dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer(
+        (invocation) async => invocation.positionalArguments.first as Metadata,
+      );
+      when(() => logic.updateDbEntity(any())).thenAnswer((_) async => true);
+    });
+
+    test('the id is keyed by type and local calendar day, not by value', () {
+      expect(
+        PersistenceCreateOps.cumulativeQuantityEntryId(steps(9800)),
+        PersistenceCreateOps.cumulativeQuantityEntryId(steps(11600)),
+      );
+      expect(
+        PersistenceCreateOps.cumulativeQuantityEntryId(steps(1)),
+        'cumulative:cumulative_step_count:2026-08-26:iPhone17,1',
+      );
+      expect(
+        PersistenceCreateOps.cumulativeQuantityEntryId(
+          steps(1).copyWith(dateFrom: DateTime(2026, 8, 27)),
+        ),
+        isNot(PersistenceCreateOps.cumulativeQuantityEntryId(steps(1))),
+      );
+      // Two devices importing the same day keep separate rows rather than
+      // racing for one through sync.
+      expect(
+        PersistenceCreateOps.cumulativeQuantityEntryId(
+          steps(1).copyWith(deviceType: 'iPad16,3'),
+        ),
+        isNot(PersistenceCreateOps.cumulativeQuantityEntryId(steps(1))),
+      );
+      expect(
+        PersistenceCreateOps.cumulativeQuantityEntryId(
+          steps(1).copyWith(dataType: 'cumulative_distance'),
+        ),
+        isNot(PersistenceCreateOps.cumulativeQuantityEntryId(steps(1))),
+      );
+    });
+
+    test(
+      'creates the day under its day-keyed id when none is stored',
+      () async {
+        final result = await ops.createQuantitativeEntryImpl(steps(9800));
+
+        expect(result, isA<QuantitativeEntry>());
+        verify(() => journalDb.journalEntityById(dayId)).called(1);
+        verify(
+          () => logic.createMetadata(
+            dateFrom: day,
+            dateTo: DateTime(2026, 8, 26, 23, 59, 59, 999),
+            uuidV5Input:
+                'cumulative:cumulative_step_count:2026-08-26:iPhone17,1',
+          ),
+        ).called(1);
+        verifyNever(() => logic.updateDbEntity(any()));
+      },
+    );
+
+    // The stale-steps bug: the phone's count was stored before the band
+    // synced its (higher) day overnight. Re-importing must replace the day.
+    test('overwrites the stored day when the total changed', () async {
+      when(
+        () => journalDb.journalEntityById(dayId),
+      ).thenAnswer((_) async => stored(9800));
+
+      final result = await ops.createQuantitativeEntryImpl(steps(11600));
+
+      expect(result, isA<QuantitativeEntry>());
+      expect(result!.data.value, 11600);
+      expect(result.meta.id, dayId);
+      final updated =
+          verify(() => logic.updateDbEntity(captureAny())).captured.single
+              as QuantitativeEntry;
+      expect(updated.data.value, 11600);
+      expect(updated.meta.id, dayId);
+      verifyNever(
+        () => logic.createDbEntity(
+          any(),
+          shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+          enqueueSync: any(named: 'enqueueSync'),
+          linkedId: any(named: 'linkedId'),
+        ),
+      );
+    });
+
+    test(
+      'a lower re-read also overwrites — the store is the authority',
+      () async {
+        when(
+          () => journalDb.journalEntityById(dayId),
+        ).thenAnswer((_) async => stored(11600));
+
+        final result = await ops.createQuantitativeEntryImpl(steps(9800));
+
+        expect(result?.data.value, 9800);
+        verify(() => logic.updateDbEntity(any())).called(1);
+      },
+    );
+
+    test('leaves an unchanged day alone and reports nothing written', () async {
+      when(
+        () => journalDb.journalEntityById(dayId),
+      ).thenAnswer((_) async => stored(9800));
+
+      final result = await ops.createQuantitativeEntryImpl(steps(9800));
+
+      expect(result, isNull);
+      verifyNever(() => logic.updateDbEntity(any()));
+      verifyNever(
+        () => logic.createDbEntity(
+          any(),
+          shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+          enqueueSync: any(named: 'enqueueSync'),
+          linkedId: any(named: 'linkedId'),
+        ),
+      );
+    });
+
+    test('returns null when the database rejects the rewrite', () async {
+      when(
+        () => journalDb.journalEntityById(dayId),
+      ).thenAnswer((_) async => stored(9800));
+      when(() => logic.updateDbEntity(any())).thenAnswer((_) async => false);
+
+      expect(await ops.createQuantitativeEntryImpl(steps(11600)), isNull);
+    });
+
+    test(
+      'a row under the day id that is not quantitative is not touched',
+      () async {
+        when(() => journalDb.journalEntityById(dayId)).thenAnswer(
+          (_) async => JournalEntity.journalEntry(meta: metaFor(dayId)),
+        );
+
+        // Falls through to a create, which the DB will reject as a duplicate —
+        // never an update that would clobber a foreign row.
+        await ops.createQuantitativeEntryImpl(steps(9800));
+
+        verifyNever(() => logic.updateDbEntity(any()));
+        verify(
+          () => logic.createDbEntity(
+            any(),
+            shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+            enqueueSync: any(named: 'enqueueSync'),
+            linkedId: any(named: 'linkedId'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test('discrete samples keep the payload-keyed id', () async {
+      await ops.createQuantitativeEntryImpl(
+        QuantitativeData.discreteQuantityData(
+          dateFrom: day,
+          dateTo: day,
+          value: 72,
+          dataType: 'HealthDataType.HEART_RATE',
+          unit: 'BEATS_PER_MINUTE',
+        ),
+      );
+
+      verifyNever(() => journalDb.journalEntityById(any()));
+      final input =
+          verify(
+                () => logic.createMetadata(
+                  dateFrom: any(named: 'dateFrom'),
+                  dateTo: any(named: 'dateTo'),
+                  uuidV5Input: captureAny(named: 'uuidV5Input'),
+                ),
+              ).captured.single
+              as String;
+      expect(input, contains('"value":72'));
+    });
+  });
 
   test('createWorkoutEntryImpl returns null on a rejected write', () async {
     when(


### PR DESCRIPTION
## Problem

After a wearable (WHOOP) syncs its step count to Apple Health overnight, Lotti kept showing the phone's own count from just before midnight, so the daily step goal read as missed even though Apple Health showed 11–12k.

## Diagnosis

Two defects on the app side, independent of what HealthKit returns:

1. **A day was never replaced.** `createQuantitativeEntryImpl` derived the row id from the whole payload (`json.encode(data)`), so a changed total became a *second* row beside the stale one. Readers only looked right because they take the day's maximum; the journal accumulated one row per background refresh of the day in progress, and a corrected-downwards total could never win.
2. **The background delta never looked back.** `_fetchHealthDataDelta` for cumulative types started at the newest stored day — today — so yesterday was only ever re-read by a manual import.

## Fix

- Cumulative day rows are keyed by `(type, local date, device)` via `PersistenceCreateOps.cumulativeQuantityEntryId` and **updated in place** when the stored total differs; an unchanged day returns `null` so the import still reports nothing written. The device stays in the key so two phones importing the same day do not race for one row through sync — their rows merge through the readers' per-day maximum as before.
- The cumulative delta re-reads the day before the newest stored one.
- `fetchAndProcessActivityDataForDay` reads the raw `STEPS` samples alongside the merged total and takes the larger of the merged figure and the best single source (`resolveDailySteps`). HealthKit's merged sum resolves overlapping samples by *Data Sources & Access* priority; the guard can only restore a figure priority discarded, never lower one, and never sums across sources.

## Tests

- `health_daily_steps_test.dart` (new, incl. Glados properties): best-source-wins, never sums across sources, bounds.
- `persistence_create_ops_test.dart`: day-keyed id, (a) re-import overwrites a day with a newer value, (b) no duplicate row for the same day, (c) unchanged day is left alone and reports nothing written, rejected rewrite, foreign row under the id is not clobbered, discrete samples keep the payload id.
- `health_import_test.dart`: the delta re-reads the previous day; per-source read over the whole day; best source over merged.

All new regression tests were re-run with the fix reverted and fail there.

No UI change. Closes lotti3-zkhw (private tracker).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Daily step, distance, and flight totals now update existing daily records when late wearable data arrives.
  - Health imports reread the previous calendar day to capture delayed synchronization, including across daylight-saving changes.
  - Step totals use the most reliable available source without double-counting across devices.

- **Bug Fixes**
  - Corrected undercounted daily step totals caused by delayed or incomplete health-source synchronization.
  - Prevented unchanged daily totals from being rewritten unnecessarily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->