### PR TITLE
feat(goals): carry years of check-ins into the wake as layered digests

### DIFF
--- a/changelog.d/2026-08-27-goal-checkin-digests.md
+++ b/changelog.d/2026-08-27-goal-checkin-digests.md
@@ -1,0 +1,11 @@
+### Changed
+- **Goal coaching now remembers years of check-ins, not just the last few
+  months.** A goal agent's wake used to carry only the newest check-in
+  summaries that fit its budget — roughly the last three months — so the
+  reason a goal was redefined, an injury a year ago, or the routine that
+  worked before a stall had quietly dropped out of view. Older check-ins are
+  now folded into short digests by month, then by quarter, then by year, and
+  the recent ones stay verbatim, so the agent's report and advice rest on the
+  whole history at a fraction of the token cost. Digests are written on the
+  same automatic wakes that summarise check-ins, a few spans at a time, and
+  are shared across devices like the summaries.

--- a/docs/evaluations/goal_agent_models/README.md
+++ b/docs/evaluations/goal_agent_models/README.md
@@ -16,6 +16,10 @@ and keeps the policy matrix the scenarios are derived from.
 
 ## Two tiers
 
+(A third, orthogonal eval — does compacting years of check-ins change the
+agent's conclusions? — has its own run book: [compaction.md](compaction.md).
+Its numbers are not comparable with either tier below.)
+
 There are two evals here, and they answer different questions. Their numbers
 are **not comparable** — do not put them in one table.
 

--- a/docs/evaluations/goal_agent_models/compaction.md
+++ b/docs/evaluations/goal_agent_models/compaction.md
@@ -1,0 +1,373 @@
+# Goal check-in compaction evaluation
+
+Does the goal agent draw the same conclusions from a **compacted** check-in
+history as from the **full** one? A goal runs for years; three check-ins a
+week at ~100 tokens each is ~15k tokens a year of user voice, against a wake
+budgeted at ≤8k input tokens in total (ADR 0057). Something has to give, and
+this evaluation measures what.
+
+## Arms
+
+The seam is `GoalCheckInCompactionStrategy`
+(`lib/features/goals/logic/goal_checkin_compaction_strategy.dart`): every
+strategy reads the same `GoalCheckInSummary` list and fills the same
+`userVoice` slot of the FACTS block. Three arms:
+
+| Arm | What the agent sees | Role |
+| --- | --- | --- |
+| `full` | every check-in, verbatim, unbounded | the oracle: what a coach who read everything would conclude |
+| `truncate` | the newest check-ins that fit 1,200 tokens (`goalUserVoiceEntries`) | **what ships today** — about the last three months |
+| `hierarchical` | recent tail verbatim (same 1,200 tokens); folded history as calendar digests — monthly inside 6 months (≤120 words), quarterly inside 18 months (≤80), yearly beyond (≤80) | the candidate |
+
+The hierarchical arm's digests are written by `CachedLlmDigestWriter`
+(one call per span with the layer's word limit in the prompt, temperature 0,
+cached on disk by content). The yearly layer is what bounds the total: the
+first run below, without it, grew ~220 tokens per quarter for ever. The
+production implementation will persist digests as agent messages; the
+strategy interface is what it plugs into.
+
+## Fixtures
+
+Five synthetic goals in the Ross Station penguin universe, ~24 months, ~300
+check-ins each, generated from a seed
+(`test/features/agents/eval/goal/compaction/support/goal_compaction_fixtures.dart`).
+Each is a case where the present alone misleads:
+
+| Fixture | Shape | Status at reference | What the full history changes |
+| --- | --- | --- | --- |
+| `steady_then_stall` | eight good months, then a year of upbeat check-ins over falling numbers | offTrack | the routine that worked (a calendar block) and the moment it was deleted |
+| `regress_recover` | ankle sprain in month 9, medic step caps, slow rebuild | onTrack | why "on track" is an achievement, and the two-short-loops advice |
+| `redefined` | 10k steps → 8k + gym in month 6 on doctor's advice | onTrack | 10k is not the target, and why going back would be wrong |
+| `abandoned_revived` | five silent months on night shift, restart with a treadmill habit | atRisk | the user has reached the target before; the gap explains the trend |
+| `completed` | deadline met in month 18, maintenance since | achieved | the user has said, repeatedly, not to raise the target |
+
+Every fixture carries an answer key: the status the deterministic tier
+derives (asserted against the real evaluator and policy in
+`goal_compaction_fixtures_test.dart`), five to seven **fact-recall probes**
+whose answers live in dated check-ins (stratified by age: ≤1 month, 1–6
+months, >6 months), the recommendation a fully informed coach would make,
+and the recommendations the history rules out.
+
+Every evaluation wake is a status **transition** carrying a pending user
+message ("where does this goal stand and what should I focus on next?"), so
+`update_goal_report` and `reply_to_user` are both contract-mandated on every
+arm. A same-status wake is a no-op by contract and would compare nothing.
+
+## What is measured
+
+| Metric | Source | Judge needed |
+| --- | --- | --- |
+| Status accuracy — `update_goal_report.status` equals the derived status | packet | no |
+| Tool-set agreement — the wake's tool names equal the full arm's for the same fixture and sample | packet | no |
+| Wake input tokens (provider-reported) and `userVoice` tokens (estimated), per arm | packet | no |
+| Token growth curve — `userVoice` tokens at 3/6/12/18/24 months per arm | packet | no |
+| Digest cost, amortised per check-in | packet | no |
+| Fact recall by age — probe answers graded against the key | scores | **yes** |
+| Hallucination — a wrong answer given as history | scores + packet `basis` | **yes** |
+| Recommendation consistency with the full arm — same / compatible / contradictory, forbidden direction | scores | **yes** |
+
+### Pass bar (candidate vs `full`)
+
+- old-fact recall ≥ 90% of the full arm's
+- hallucination rate ≤ full's + 5 percentage points
+- recommendation same-or-compatible ≥ 90%, contradictory ≤ 10%
+- status accuracy ≥ full's
+- `userVoice` ≤ 2,500 tokens at 24 months. The growth curve is printed for
+  inspection; that the count of digest entries stops growing with the
+  goal's age is a structural property of the layering, asserted in the
+  strategy's unit test rather than measured on a 24-month fixture.
+
+`tool/goal_compaction_eval_report.dart` prints the verdict per arm.
+
+## Running it
+
+```sh
+MELIOUS_API_KEY=... scripts/goal_compaction_eval_matrix.sh [samples]
+```
+
+writes `eval_artifacts/goal_compaction_<stamp>/packet.json`, `run.log` and
+the deterministic `report.md`. Digests are cached under
+`eval_artifacts/goal_compaction_digests/<model>/`, so re-runs make no digest
+calls. Environment overrides: `GOAL_COMPACTION_EVAL_MODEL` (default
+`glm-5.2`), `_DIGEST_MODEL`, `_FIXTURES`, `_STRATEGIES`, `_SAMPLES`,
+`_TEMPERATURE`, `_PROVIDER_TYPE`, `_BASE_URL`.
+
+Offline checks that need no key:
+
+```sh
+fvm flutter test test/features/agents/eval/goal/compaction/ \
+  test/features/goals/logic/goal_checkin_compaction_strategy_test.dart \
+  test/tool/goal_compaction_eval_report_test.dart
+```
+
+## Judging
+
+Grading is deliberately separate from the run. The packet holds everything
+a judge needs per case: the FACTS the agent saw, its report and reply, its
+probe answers, and the answer key. The judge — a stronger model than the
+agent under test, in practice a Claude session working from the packet —
+writes `scores.json`:
+
+```json
+{
+  "kind": "lotti.goalCompactionEvalScores",
+  "judge": "<who graded>",
+  "cases": [
+    {
+      "fixtureId": "steady_then_stall",
+      "strategyId": "hierarchical",
+      "sample": 1,
+      "probes": [{"id": "stall_boots", "grade": "correct"}],
+      "recommendation": {
+        "agreement": "same",
+        "forbiddenHit": false,
+        "notes": "optional"
+      }
+    }
+  ]
+}
+```
+
+### Rubric
+
+**Probe grade**, against `referenceAnswer` only (never against the judge's
+own reading of the history):
+
+- `correct` — the substance of the reference answer, including any date or
+  number it names to within a month / rounding.
+- `partial` — the right event but a wrong or missing date, number or cause;
+  or only one of two facts the reference asks for.
+- `wrong` — a different event, date, number or cause, stated as fact. This
+  is a hallucination when the agent gave `basis: history`.
+- `honestUnknown` — the agent says the history it has does not cover it,
+  regardless of `basis`. Not penalised as a hallucination; counted as a
+  miss for recall.
+
+**Recommendation agreement**, comparing the arm's `reply` with the `full`
+arm's reply for the same fixture and sample, blind to which is which where
+possible:
+
+- `same` — the same next action or focus.
+- `compatible` — different emphasis, nothing the other rules out.
+- `contradictory` — one recommends what the other advises against, or one
+  rests on a reading of the history the other refutes.
+
+`forbiddenHit` is true when the reply does any of the fixture's
+`forbiddenRecommendations`, judged against the fixture's answer key, not
+against the full arm.
+
+Then:
+
+```sh
+fvm dart run tool/goal_compaction_eval_report.dart \
+  eval_artifacts/goal_compaction_<stamp>/packet.json \
+  eval_artifacts/goal_compaction_<stamp>/scores.json > report.md
+```
+
+## Results
+
+Dated sections, newest last; packets and scores stay under `eval_artifacts/`
+(git-ignored) and the report tables are quoted here.
+
+### First run — 2026-08-27
+
+Agent `glm-5.2`, temperature 0, one sample per (fixture × arm), digests by
+`glm-5.2` (67 spans, ~220 tokens each). Judge: Claude Fable 5 in-session,
+one blinded judge per fixture with the arms relabelled. Packet and scores
+under `eval_artifacts/goal_compaction_20260827-212039/` (git-ignored).
+
+| Arm | Cases | Errors | Status correct | Report | Reply | Tool set = full | Wake input tokens | userVoice tokens | Verbatim | Digests |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `full` | 5 | 0 | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | — | 33326 | 7722 | 300 | 0 |
+| `truncate` | 5 | 0 | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 4/5 (80%) | 8144 | 1192 | 49 | 0 |
+| `hierarchical` | 5 | 0 | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 11130 | 3064 | 49 | 10 |
+
+#### Token growth curve (userVoice, estimated, mean over fixtures)
+
+| Months | Check-ins | `full` | `truncate` | `hierarchical` |
+| ---: | ---: | ---: | ---: | ---: |
+| 3 | 39 | 955 | 955 | 955 |
+| 6 | 78 | 1901 | 1188 | 1535 |
+| 12 | 152 | 3888 | 1184 | 1901 |
+| 18 | 222 | 5752 | 1180 | 2260 |
+| 24 | 300 | 7722 | 1192 | 3064 |
+
+#### Fact recall (correct = 1, partial = ½) by fact age
+
+| Arm | recent | mid | old | All | Hallucination | Honest unknown |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `full` | 100% | 100% | 98% | 98% | 0/30 (0%) | 0/30 (0%) |
+| `truncate` | 100% | 10% | 8% | 23% | 1/30 (3%) | 20/30 (67%) |
+| `hierarchical` | 90% | 100% | 100% | 98% | 0/30 (0%) | 0/30 (0%) |
+
+#### Recommendation consistency with the full-context arm
+
+| Arm | Same | Compatible | Contradictory | Forbidden direction |
+| --- | ---: | ---: | ---: | ---: |
+| `full` | 5/5 (100%) | 0/5 (0%) | 0/5 (0%) | 0/5 (0%) |
+| `truncate` | 0/5 (0%) | 2/5 (40%) | 3/5 (60%) | 3/5 (60%) |
+| `hierarchical` | 3/5 (60%) | 2/5 (40%) | 0/5 (0%) | 0/5 (0%) |
+
+
+Pass bar:
+
+| Arm | Old recall | Hallucination | Agreement | Contradiction | Status | Tokens | Verdict |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `truncate` | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | **FAIL** |
+| `hierarchical` | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | **FAIL** |
+
+What it says:
+
+- **Truncation — what ships — fails on substance, not on tokens.** It
+  restates the status correctly every time (the deterministic FACTS carry
+  it), but recalls 8% of facts older than six months, contradicts the
+  full-context coach in 3 of 5 goals, and takes a forbidden direction in 3 of
+  5: proposing to *lower* the stalled goal's target, treating 10,000 steps as
+  headroom on the goal a doctor lowered, and reading the revived goal's trend
+  as if the night-shift gap were decline. One outright hallucination ("no
+  10k day ever" on a goal that averaged 12,600 before the winter).
+- **Hierarchical digests close the gap on substance.** 98% recall overall,
+  100% on old facts, zero hallucinations, zero contradictions, zero forbidden
+  directions, same or compatible recommendation in 5 of 5. Wake input drops
+  from 33k tokens (full) to 11k.
+- **Hierarchical fails only the token bound, and the growth curve says why.**
+  `userVoice` is 3,064 tokens at 24 months and still rising (1.9k → 2.3k →
+  3.1k from 12 to 24 months): each folded quarter adds a ~220-token digest and
+  nothing ever shrinks again. Two remedies to evaluate next, in this harness:
+  tighter digests (≤80 words for quarters), and a fourth, yearly layer so the
+  number of digest entries stops growing with age.
+- Status accuracy is not a discriminator (15/15): the contract tells the
+  model to copy the FACTS status, and it does. The eval earns its keep on
+  recall and recommendations.
+
+### Second run — 2026-08-27, yearly layer and per-layer word caps
+
+Same agent, judge and fixtures; the hierarchical arm now folds months
+inside 6 months (≤120 words), quarters inside 18 months (≤80), years beyond
+(≤80). One sample per (fixture × arm). Artifacts under
+`eval_artifacts/goal_compaction_20260827-213958/`.
+
+| Arm | Cases | Errors | Status correct | Report | Reply | Tool set = full | Wake input tokens | userVoice tokens | Verbatim | Digests |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `full` | 5 | 0 | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | — | 33326 | 7722 | 300 | 0 |
+| `truncate` | 5 | 0 | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 8144 | 1192 | 49 | 0 |
+| `hierarchical` | 5 | 0 | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 5/5 (100%) | 10433 | 2436 | 49 | 10 |
+
+#### Token growth curve (userVoice, estimated, mean over fixtures)
+
+| Months | Check-ins | `full` | `truncate` | `hierarchical` |
+| ---: | ---: | ---: | ---: | ---: |
+| 3 | 39 | 955 | 955 | 955 |
+| 6 | 78 | 1901 | 1188 | 1304 |
+| 12 | 152 | 3888 | 1184 | 1618 |
+| 18 | 222 | 5752 | 1180 | 1830 |
+| 24 | 300 | 7722 | 1192 | 2436 |
+
+Digest cost: 67 digest call(s), 89 cache hit(s); 82311 input + 33704 output tokens over 1498 check-ins ≈ 77 tokens per check-in, once.
+
+#### Fact recall (correct = 1, partial = ½) by fact age
+
+| Arm | recent | mid | old | All | Hallucination | Honest unknown |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `full` | 100% | 100% | 100% | 100% | 0/30 (0%) | 0/30 (0%) |
+| `truncate` | 100% | 20% | 13% | 28% | 1/30 (3%) | 19/30 (63%) |
+| `hierarchical` | 100% | 100% | 95% | 97% | 0/30 (0%) | 0/30 (0%) |
+
+#### Recommendation consistency with the full-context arm
+
+| Arm | Same | Compatible | Contradictory | Forbidden direction |
+| --- | ---: | ---: | ---: | ---: |
+| `full` | 5/5 (100%) | 0/5 (0%) | 0/5 (0%) | 0/5 (0%) |
+| `truncate` | 0/5 (0%) | 2/5 (40%) | 3/5 (60%) | 3/5 (60%) |
+| `hierarchical` | 3/5 (60%) | 1/5 (20%) | 1/5 (20%) | 1/5 (20%) |
+
+
+Pass bar:
+
+| Arm | Old recall | Hallucination | Agreement | Contradiction | Status | Tokens | Verdict |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `truncate` | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | **FAIL** |
+| `hierarchical` | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | **FAIL** |
+
+What changed, and what did not:
+
+- **The token bound is met and the curve bends.** 2,436 tokens at 24 months
+  (was 3,064), digest entries capped at ten, and the yearly layer makes the
+  count independent of the goal's age — a four-year history adds at most two
+  entries over a two-year one (asserted in the strategy's unit test). Digests
+  cost ≈77 tokens per check-in, once.
+- **Recall held**: 95% on facts older than six months, 100% otherwise, zero
+  hallucinations.
+- **Recommendation agreement slipped to 4/5 on two coaching-judgment calls**,
+  both made with full recall of the history: on the revived goal the
+  hierarchical arm advised finding the missing steps indoors rather than
+  waiting for calm days for the outdoor loops (the full arm's lever), and on
+  the completed goal it closed with "if you want a new challenge, you know
+  where to find me" against the user's repeated wish not to raise the target.
+  With one sample per fixture the 10% contradiction bar means zero misses,
+  and at temperature 0 a single divergence cannot be separated from the
+  model's own turn-to-turn variance. The third run below adds samples for
+  exactly that reason.
+- Truncation is unchanged: 13% old-fact recall, 3/5 contradictions, 3/5
+  forbidden directions, one hallucination.
+
+### Third run — 2026-08-27, three samples per arm
+
+Same strategy as the second run, three samples per (fixture × arm): 45
+wakes, n = 15 per arm for every rate. Fifteen blinded judges, one per
+(fixture, sample). Artifacts under
+`eval_artifacts/goal_compaction_20260827-214638/`.
+
+| Arm | Cases | Errors | Status correct | Report | Reply | Tool set = full | Wake input tokens | userVoice tokens | Verbatim | Digests |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `full` | 15 | 0 | 15/15 (100%) | 15/15 (100%) | 15/15 (100%) | — | 33326 | 7722 | 300 | 0 |
+| `truncate` | 15 | 0 | 15/15 (100%) | 15/15 (100%) | 15/15 (100%) | 12/15 (80%) | 8144 | 1192 | 49 | 0 |
+| `hierarchical` | 15 | 0 | 15/15 (100%) | 15/15 (100%) | 15/15 (100%) | 12/15 (80%) | 10433 | 2436 | 49 | 10 |
+
+#### Fact recall (correct = 1, partial = ½) by fact age
+
+| Arm | recent | mid | old | All | Hallucination | Honest unknown |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `full` | 97% | 100% | 100% | 99% | 0/90 (0%) | 0/90 (0%) |
+| `truncate` | 100% | 17% | 10% | 26% | 2/90 (2%) | 60/90 (67%) |
+| `hierarchical` | 100% | 100% | 97% | 98% | 0/90 (0%) | 0/90 (0%) |
+
+#### Recommendation consistency with the full-context arm
+
+| Arm | Same | Compatible | Contradictory | Forbidden direction |
+| --- | ---: | ---: | ---: | ---: |
+| `full` | 15/15 (100%) | 0/15 (0%) | 0/15 (0%) | 0/15 (0%) |
+| `truncate` | 1/15 (7%) | 3/15 (20%) | 11/15 (73%) | 12/15 (80%) |
+| `hierarchical` | 14/15 (93%) | 0/15 (0%) | 1/15 (7%) | 0/15 (0%) |
+
+
+Pass bar:
+
+| Arm | Old recall | Hallucination | Agreement | Contradiction | Status | Tokens | Verdict |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `truncate` | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | **FAIL** |
+| `hierarchical` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+
+**Verdict: the hierarchical candidate passes; the shipped truncation fails.**
+
+- Recall: 97% of facts older than six months (full: 100%), 98% overall, no
+  hallucination in 90 graded answers, no "I don't know" where the answer
+  existed.
+- Recommendations: same next action as the full-context coach in 14 of 15
+  wakes, one contradiction (the recovering goal: endorsing the switch back
+  to one long loop now rather than after more runway), no forbidden
+  direction. The second run's "new challenge" nudge did not recur in three
+  samples of the completed goal.
+- Tokens: 10.4k per wake against 33.3k for the full history; `userVoice`
+  2,436 at 24 months with the count of digest entries capped by the yearly
+  layer.
+- Truncation, at n = 15: 10% old-fact recall, contradicts the full-context
+  coach in 11 of 15 wakes and takes a forbidden direction in 12 — lowering
+  the stalled goal's target, offering 10,000 steps to the user whose doctor
+  lowered it, reading the revived goal as a beginner's, and reading the
+  recovering goal's dips as ordinary off-days. Two hallucinations.
+- Noise floor: the full arm agrees with itself in all fifteen wakes, so the
+  hierarchical arm's one contradiction is above the floor but inside the
+  bar. Tool-set agreement is 80% for both candidates because the full arm's
+  own samples vary on whether to file a `record_goal_observation` — a
+  model-level choice, not a compaction effect.

--- a/docs/evaluations/goal_agent_models/compaction.md
+++ b/docs/evaluations/goal_agent_models/compaction.md
@@ -17,12 +17,15 @@ strategy reads the same `GoalCheckInSummary` list and fills the same
 | --- | --- | --- |
 | `full` | every check-in, verbatim, unbounded | the oracle: what a coach who read everything would conclude |
 | `truncate` | the newest check-ins that fit 1,200 tokens (`goalUserVoiceEntries`) | **what ships today** — about the last three months |
-| `hierarchical` | recent tail verbatim (same 1,200 tokens); folded history as calendar digests — monthly inside 6 months (≤120 words), quarterly inside 18 months (≤80), yearly beyond (≤80) | the candidate |
+| `hierarchical` | recent tail verbatim (same 1,200 tokens); folded history as calendar digests — monthly inside 6 months (≤120 words), quarterly inside 18 months (≤80), yearly inside 36 months (≤80), one "earlier" span beyond (≤80) | the candidate |
 
 The hierarchical arm's digests are written by `CachedLlmDigestWriter`
 (one call per span with the layer's word limit in the prompt, temperature 0,
-cached on disk by content). The yearly layer is what bounds the total: the
-first run below, without it, grew ~220 tokens per quarter for ever. The
+cached on disk by content) — the eval-side twin of the production
+`GoalCheckInDigestService`, which persists digests as agent messages and
+runs the same prompt. The yearly layer is what bounds the total: the first
+run below, without it, grew ~220 tokens per quarter for ever. Since the
+third run met the pass bar, the wake uses the hierarchical strategy. The
 production implementation will persist digests as agent messages; the
 strategy interface is what it plugs into.
 

--- a/docs/evaluations/goal_agent_models/compaction.md
+++ b/docs/evaluations/goal_agent_models/compaction.md
@@ -295,9 +295,12 @@ Pass bar:
 What changed, and what did not:
 
 - **The token bound is met and the curve bends.** 2,436 tokens at 24 months
-  (was 3,064), digest entries capped at ten, and the yearly layer makes the
-  count independent of the goal's age — a four-year history adds at most two
-  entries over a two-year one (asserted in the strategy's unit test). Digests
+  (was 3,064), ten digest entries on this two-year fixture. At this point the
+  oldest layer was still one entry per calendar year — O(years), not a fixed
+  bound; the single "earlier" span beyond 36 months that makes the count
+  independent of the goal's age landed after review, and the strategy's unit
+  test now asserts a six-year history carries no more entries than a
+  four-year one. Digests
   cost ≈77 tokens per check-in, once.
 - **Recall held**: 95% on facts older than six months, 100% otherwise, zero
   hallucinations.
@@ -362,8 +365,9 @@ Pass bar:
   direction. The second run's "new challenge" nudge did not recur in three
   samples of the completed goal.
 - Tokens: 10.4k per wake against 33.3k for the full history; `userVoice`
-  2,436 at 24 months with the count of digest entries capped by the yearly
-  layer.
+  2,436 at 24 months. (On a two-year fixture the "earlier" span added later
+  changes nothing — it only applies beyond 36 months — so these numbers
+  stand for the shipped layering.)
 - Truncation, at n = 15: 10% old-fact recall, contradicts the full-context
   coach in 11 of 15 wakes and takes a forbidden direction in 12 — lowering
   the stalled goal's target, offering 10,000 steps to the user whose doctor

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -68,6 +68,14 @@ sources:
     resource: ../../lib/features/goals/service/goal_checkin_compactor.dart
     title: GoalCheckInCompactor — bounded user-voice distillation
     last_modified: 2026-08-18
+  - id: checkin-compaction-strategy
+    resource: ../../lib/features/goals/logic/goal_checkin_compaction_strategy.dart
+    title: GoalCheckInCompactionStrategy — the seam the compaction eval measures across
+    last_modified: 2026-08-27
+  - id: compaction-eval
+    resource: ../../docs/evaluations/goal_agent_models/compaction.md
+    title: Check-in compaction evaluation — full vs truncate vs hierarchical
+    last_modified: 2026-08-27
   - id: goal-agent-evals
     resource: ../../docs/evaluations/goal_agent_models/README.md
     title: Goal-agent model evaluation run book and results
@@ -1478,8 +1486,43 @@ Key pieces:
 - `lib/features/goals/logic/goal_user_voice.dart` — selection under a token
   budget via `planCompaction`; the oldest fall away first and the newest is
   always kept.
+- `lib/features/goals/logic/goal_checkin_compaction_strategy.dart` — the
+  seam above that selection: a `GoalCheckInCompactionStrategy` turns the
+  summary list into `userVoice` entries. `TruncatingCheckInCompaction` wraps
+  the shipped selection; `FullContextCheckInCompaction` is the unbounded
+  oracle; `HierarchicalCheckInCompaction` keeps the same verbatim tail and
+  folds older check-ins into calendar-aligned digests — monthly inside six
+  months, quarterly inside eighteen, yearly beyond — through a
+  `GoalCheckInDigestWriter`, with a per-layer word cap that falls as the
+  span ages, so the block is bounded by the number of live layers rather
+  than by the goal's age.
+  Only the truncating strategy is wired into the wake today; the others
+  exist for the evaluation below, and a persisted-digest implementation
+  slots in behind the same interface.
 - `lib/features/goals/service/goal_mirror_service.dart` — keeps the
   journal-side `GoalEntry` in step with the agent-side spec chain.
+
+### Compaction layers and their evaluation
+
+```mermaid
+flowchart LR
+  T["transcript"] -- "Layer 1: GoalCheckInCompactor<br/>≤500 tokens, per check-in" --> S["GoalCheckInSummary"]
+  S -- "verbatim tail<br/>1,200 tokens (today)" --> V["userVoice: recent"]
+  S -. "Layer 2: monthly digest<br/>inside 6 months, ≤120 words<br/>(eval-side today)" .-> M["userVoice: month"]
+  S -. "Layer 3: quarterly digest<br/>6–18 months, ≤80 words" .-> Q["userVoice: quarter"]
+  S -. "Layer 4: yearly digest<br/>beyond 18 months, ≤80 words" .-> Y["userVoice: year"]
+```
+
+Today's selection is truncation: the 1,200-token slice holds roughly the
+last three months, and a two-year goal's redefinition, injury or best-ever
+streak is invisible to the wake. Whether hierarchical digests close that gap
+without inventing history is a measured question, not an assumed one —
+[the compaction evaluation](../../docs/evaluations/goal_agent_models/compaction.md)
+runs five seeded two-year goals through all three strategies on the real
+renderer and contract, and scores status accuracy, dated fact recall by age,
+recommendation agreement with the full-context arm, and the token growth
+curve. The pass bar is written down there; the production digest layer is
+not to be wired in before it is met.
 
 Invariants worth not breaking:
 

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -1492,13 +1492,22 @@ Key pieces:
   the shipped selection; `FullContextCheckInCompaction` is the unbounded
   oracle; `HierarchicalCheckInCompaction` keeps the same verbatim tail and
   folds older check-ins into calendar-aligned digests — monthly inside six
-  months, quarterly inside eighteen, yearly beyond — through a
+  months, quarterly inside eighteen, yearly inside thirty-six, one
+  "earlier" span beyond — through a
   `GoalCheckInDigestWriter`, with a per-layer word cap that falls as the
   span ages, so the block is bounded by the number of live layers rather
-  than by the goal's age.
-  Only the truncating strategy is wired into the wake today; the others
-  exist for the evaluation below, and a persisted-digest implementation
-  slots in behind the same interface.
+  than by the goal's age. This is what the wake uses when a
+  `GoalCheckInDigestService` is wired (it is, via
+  `goalCheckInDigestServiceProvider`); without one, or when digesting fails,
+  the wake falls back to the truncating selection.
+- `lib/features/goals/service/goal_checkin_digest_service.dart` — writes
+  and stores one digest per calendar span as an agent action message keyed
+  `(agentId, periodLabel)`, with a source key over the span's members so a
+  late-synced or re-transcribed check-in rewrites its span. Inference runs
+  only on wakes that also compact check-ins (never interactive turns), at
+  most `goalCheckInDigestsPerWake` spans per wake; other spans read their
+  stored digest or a short placeholder naming what is not yet digested.
+  The full-context strategy exists for the evaluation only.
 - `lib/features/goals/service/goal_mirror_service.dart` — keeps the
   journal-side `GoalEntry` in step with the agent-side spec chain.
 
@@ -1508,21 +1517,24 @@ Key pieces:
 flowchart LR
   T["transcript"] -- "Layer 1: GoalCheckInCompactor<br/>≤500 tokens, per check-in" --> S["GoalCheckInSummary"]
   S -- "verbatim tail<br/>1,200 tokens (today)" --> V["userVoice: recent"]
-  S -. "Layer 2: monthly digest<br/>inside 6 months, ≤120 words<br/>(eval-side today)" .-> M["userVoice: month"]
+  S -. "Layer 2: monthly digest<br/>inside 6 months, ≤120 words" .-> M["userVoice: month"]
   S -. "Layer 3: quarterly digest<br/>6–18 months, ≤80 words" .-> Q["userVoice: quarter"]
-  S -. "Layer 4: yearly digest<br/>beyond 18 months, ≤80 words" .-> Y["userVoice: year"]
+  S -. "Layer 4: yearly digest<br/>18–36 months, ≤80 words" .-> Y["userVoice: year"]
+  S -. "Layer 5: one earlier span<br/>beyond 36 months, ≤80 words" .-> E["userVoice: earlier"]
 ```
 
-Today's selection is truncation: the 1,200-token slice holds roughly the
-last three months, and a two-year goal's redefinition, injury or best-ever
-streak is invisible to the wake. Whether hierarchical digests close that gap
-without inventing history is a measured question, not an assumed one —
+Before the digest layers, the selection was truncation: the 1,200-token
+slice holds roughly the last three months, and a two-year goal's
+redefinition, injury or best-ever streak was invisible to the wake. Whether
+hierarchical digests close that gap without inventing history was a measured
+question, not an assumed one —
 [the compaction evaluation](../../docs/evaluations/goal_agent_models/compaction.md)
 runs five seeded two-year goals through all three strategies on the real
 renderer and contract, and scores status accuracy, dated fact recall by age,
 recommendation agreement with the full-context arm, and the token growth
-curve. The pass bar is written down there; the production digest layer is
-not to be wired in before it is met.
+curve. The pass bar is written down there and was met before the digest
+layer was wired in (third run, 2026-08-27); re-run it as the gate for any
+change to the layering or the digest prompt.
 
 Invariants worth not breaking:
 

--- a/lib/features/goals/logic/goal_checkin_compaction_strategy.dart
+++ b/lib/features/goals/logic/goal_checkin_compaction_strategy.dart
@@ -1,0 +1,289 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:lotti/features/agents/projection/compaction_plan.dart';
+import 'package:lotti/features/ai/service/text_chunker.dart';
+import 'package:lotti/features/goals/logic/goal_user_voice.dart';
+import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
+
+/// Turns a goal's check-in history into the `userVoice` entries one wake
+/// carries.
+///
+/// The seam the compaction evaluation measures across: every strategy reads
+/// the same [GoalCheckInSummary] list and emits entries for the same FACTS
+/// slot, so swapping the mechanism changes nothing else about a wake. The
+/// production wake uses [TruncatingCheckInCompaction]; the other two exist so
+/// the evaluation can hold the uncompacted history up as the oracle and
+/// measure a hierarchical candidate against it.
+abstract interface class GoalCheckInCompactionStrategy {
+  /// Stable identifier, used as the arm name in evaluation reports.
+  String get id;
+
+  /// Builds the entries for [summaries] as seen from [reference].
+  Future<GoalUserVoiceContext> build(
+    List<GoalCheckInSummary> summaries, {
+    required DateTime reference,
+  });
+}
+
+/// What a strategy produced, with the counts a report needs.
+@immutable
+class GoalUserVoiceContext {
+  const GoalUserVoiceContext({
+    required this.entries,
+    required this.verbatimCount,
+    this.digestCount = 0,
+  });
+
+  static const empty = GoalUserVoiceContext(entries: [], verbatimCount: 0);
+
+  /// Oldest first, exactly as rendered into FACTS.
+  final List<Map<String, Object?>> entries;
+
+  /// Check-ins carried unchanged.
+  final int verbatimCount;
+
+  /// Digest entries standing in for older check-ins.
+  final int digestCount;
+
+  /// Token estimate of the entries as they are emitted, keys included —
+  /// the same estimator the wake budget uses.
+  int get estimatedTokens => entries.fold(
+    0,
+    (sum, e) => sum + TextChunker.estimateTokens(jsonEncode(e)),
+  );
+}
+
+/// Every check-in, verbatim, unbounded. The evaluation oracle; never a
+/// production choice, because it grows without limit.
+class FullContextCheckInCompaction implements GoalCheckInCompactionStrategy {
+  const FullContextCheckInCompaction();
+
+  @override
+  String get id => 'full';
+
+  @override
+  Future<GoalUserVoiceContext> build(
+    List<GoalCheckInSummary> summaries, {
+    required DateTime reference,
+  }) async {
+    final chronological = _chronological(summaries);
+    return GoalUserVoiceContext(
+      entries: [for (final s in chronological) goalUserVoiceEntry(s)],
+      verbatimCount: chronological.length,
+    );
+  }
+}
+
+/// What ships today: the most recent check-ins that fit [budget] tokens,
+/// everything older dropped.
+class TruncatingCheckInCompaction implements GoalCheckInCompactionStrategy {
+  const TruncatingCheckInCompaction({this.budget = goalUserVoiceTokenBudget});
+
+  final int budget;
+
+  @override
+  String get id => 'truncate';
+
+  @override
+  Future<GoalUserVoiceContext> build(
+    List<GoalCheckInSummary> summaries, {
+    required DateTime reference,
+  }) async {
+    final entries = goalUserVoiceEntries(summaries, budget: budget);
+    return GoalUserVoiceContext(
+      entries: entries,
+      verbatimCount: entries.length,
+    );
+  }
+}
+
+/// The granularity a folded span is digested at.
+enum GoalCheckInDigestLayer {
+  month(maxWords: 120),
+  quarter(maxWords: 80),
+  year(maxWords: 80);
+
+  const GoalCheckInDigestLayer({required this.maxWords});
+
+  /// Upper bound on the digest's length. Coarser layers cover more
+  /// check-ins in FEWER words: the point of ageing a span is that its token
+  /// cost falls, so the total stays bounded as years accumulate.
+  final int maxWords;
+}
+
+/// One folded span of history handed to a [GoalCheckInDigestWriter].
+@immutable
+class GoalCheckInDigestRequest {
+  const GoalCheckInDigestRequest({
+    required this.periodLabel,
+    required this.layer,
+    required this.from,
+    required this.to,
+    required this.checkIns,
+  });
+
+  /// Human-readable span, e.g. `2025-03`, `2024-Q4` or `2024`.
+  final String periodLabel;
+  final GoalCheckInDigestLayer layer;
+  final DateTime from;
+  final DateTime to;
+
+  /// Oldest first.
+  final List<GoalCheckInSummary> checkIns;
+
+  int get maxWords => layer.maxWords;
+}
+
+/// Writes the prose digest of one folded span.
+///
+/// Abstract so the strategy stays pure: production would back it with an
+/// inference call and persist the result; the evaluation backs it with a
+/// cached inference call; unit tests back it with a fake.
+// ignore: one_member_abstracts
+abstract interface class GoalCheckInDigestWriter {
+  Future<String> write(GoalCheckInDigestRequest request);
+}
+
+/// Recent check-ins verbatim, older months digested, then quarters, then
+/// years — each coarser layer shorter than the last.
+///
+/// Layer boundaries are calendar-aligned so a span's digest is stable as
+/// time moves on: a month that has been folded once reads the same on every
+/// later wake until it ages into a quarter, which is what makes the digests
+/// cacheable and, later, persistable. The yearly layer is what bounds the
+/// total: without it every quarter of a goal's life stays a separate entry
+/// and the block grows without limit.
+class HierarchicalCheckInCompaction implements GoalCheckInCompactionStrategy {
+  const HierarchicalCheckInCompaction({
+    required this.digestWriter,
+    this.verbatimBudget = goalUserVoiceTokenBudget,
+    this.monthlyHorizonMonths = 6,
+    this.quarterlyHorizonMonths = 18,
+  }) : assert(monthlyHorizonMonths > 0, 'monthlyHorizonMonths must be > 0'),
+       assert(
+         quarterlyHorizonMonths > monthlyHorizonMonths,
+         'quarterlyHorizonMonths must exceed monthlyHorizonMonths',
+       );
+
+  final GoalCheckInDigestWriter digestWriter;
+
+  /// Token budget for the verbatim tail, sized like the production slice so
+  /// the recent picture is exactly what truncation shows today.
+  final int verbatimBudget;
+
+  /// Folded months younger than this stay monthly; older ones merge into
+  /// quarters.
+  final int monthlyHorizonMonths;
+
+  /// Quarters younger than this stay quarterly; older ones merge into
+  /// calendar years.
+  final int quarterlyHorizonMonths;
+
+  @override
+  String get id => 'hierarchical';
+
+  @override
+  Future<GoalUserVoiceContext> build(
+    List<GoalCheckInSummary> summaries, {
+    required DateTime reference,
+  }) async {
+    final chronological = _chronological(summaries);
+    if (chronological.isEmpty) return GoalUserVoiceContext.empty;
+
+    final plan = planCompaction(
+      tail: [
+        for (final s in chronological)
+          TailEntry(
+            id: s.id,
+            tokens: TextChunker.estimateTokens(
+              jsonEncode(goalUserVoiceEntry(s)),
+            ),
+          ),
+      ],
+      budget: verbatimBudget,
+    );
+    final kept = plan.keepIds.toSet();
+    final folded = [
+      for (final s in chronological)
+        if (!kept.contains(s.id)) s,
+    ];
+    final verbatim = [
+      for (final s in chronological)
+        if (kept.contains(s.id)) s,
+    ];
+
+    final requests = _spans(folded, reference);
+    final digests = <Map<String, Object?>>[];
+    for (final request in requests) {
+      final text = await digestWriter.write(request);
+      digests.add(<String, Object?>{
+        'kind': 'digest',
+        'layer': request.layer.name,
+        'period': request.periodLabel,
+        'fromLocal': request.from.toLocal().toIso8601String(),
+        'toLocal': request.to.toLocal().toIso8601String(),
+        'checkIns': request.checkIns.length,
+        'digest': text,
+      });
+    }
+
+    return GoalUserVoiceContext(
+      entries: [...digests, for (final s in verbatim) goalUserVoiceEntry(s)],
+      verbatimCount: verbatim.length,
+      digestCount: digests.length,
+    );
+  }
+
+  /// Groups [folded] (oldest first) into calendar spans: monthly inside
+  /// [monthlyHorizonMonths] before [reference], quarterly inside
+  /// [quarterlyHorizonMonths], yearly beyond.
+  List<GoalCheckInDigestRequest> _spans(
+    List<GoalCheckInSummary> folded,
+    DateTime reference,
+  ) {
+    if (folded.isEmpty) return const [];
+    // Horizons and labels are both taken in local time: a UTC reference
+    // near a month boundary would otherwise place the boundary in one zone
+    // and the check-ins in another, moving a whole month between layers.
+    final local = reference.toLocal();
+    final monthlyHorizon = DateTime(
+      local.year,
+      local.month - monthlyHorizonMonths,
+    );
+    final quarterlyHorizon = DateTime(
+      local.year,
+      local.month - quarterlyHorizonMonths,
+    );
+    final groups =
+        <String, (GoalCheckInDigestLayer, List<GoalCheckInSummary>)>{};
+    for (final s in folded) {
+      final at = s.recordedAt.toLocal();
+      final (layer, label) = at.isBefore(quarterlyHorizon)
+          ? (GoalCheckInDigestLayer.year, '${at.year}')
+          : at.isBefore(monthlyHorizon)
+          ? (
+              GoalCheckInDigestLayer.quarter,
+              '${at.year}-Q${(at.month - 1) ~/ 3 + 1}',
+            )
+          : (
+              GoalCheckInDigestLayer.month,
+              '${at.year}-${at.month.toString().padLeft(2, '0')}',
+            );
+      groups.putIfAbsent(label, () => (layer, [])).$2.add(s);
+    }
+    return [
+      for (final entry in groups.entries)
+        GoalCheckInDigestRequest(
+          periodLabel: entry.key,
+          layer: entry.value.$1,
+          from: entry.value.$2.first.recordedAt,
+          to: entry.value.$2.last.recordedAt,
+          checkIns: entry.value.$2,
+        ),
+    ];
+  }
+}
+
+List<GoalCheckInSummary> _chronological(List<GoalCheckInSummary> summaries) =>
+    [...summaries]..sort((a, b) => a.recordedAt.compareTo(b.recordedAt));

--- a/lib/features/goals/logic/goal_checkin_compaction_strategy.dart
+++ b/lib/features/goals/logic/goal_checkin_compaction_strategy.dart
@@ -102,7 +102,12 @@ class TruncatingCheckInCompaction implements GoalCheckInCompactionStrategy {
 enum GoalCheckInDigestLayer {
   month(maxWords: 120),
   quarter(maxWords: 80),
-  year(maxWords: 80);
+  year(maxWords: 80),
+
+  /// Everything older than the yearly horizon, as ONE span. This is what
+  /// makes the block bounded: without it a goal adds an entry per year of
+  /// its life.
+  earlier(maxWords: 80);
 
   const GoalCheckInDigestLayer({required this.maxWords});
 
@@ -123,7 +128,8 @@ class GoalCheckInDigestRequest {
     required this.checkIns,
   });
 
-  /// Human-readable span, e.g. `2025-03`, `2024-Q4` or `2024`.
+  /// Human-readable span, e.g. `2025-03`, `2024-Q4`, `2024` or
+  /// `before-2023`.
   final String periodLabel;
   final GoalCheckInDigestLayer layer;
   final DateTime from;
@@ -146,24 +152,31 @@ abstract interface class GoalCheckInDigestWriter {
 }
 
 /// Recent check-ins verbatim, older months digested, then quarters, then
-/// years — each coarser layer shorter than the last.
+/// years, then one "earlier" span for everything beyond the yearly horizon —
+/// each coarser layer shorter than the last.
 ///
 /// Layer boundaries are calendar-aligned so a span's digest is stable as
 /// time moves on: a month that has been folded once reads the same on every
 /// later wake until it ages into a quarter, which is what makes the digests
-/// cacheable and, later, persistable. The yearly layer is what bounds the
-/// total: without it every quarter of a goal's life stays a separate entry
-/// and the block grows without limit.
+/// cacheable and persistable. The entry count is bounded by the horizons
+/// alone — at most the months inside the monthly horizon, the quarters
+/// inside the quarterly one, the years inside the yearly one, and one
+/// earlier span — never by the goal's age.
 class HierarchicalCheckInCompaction implements GoalCheckInCompactionStrategy {
   const HierarchicalCheckInCompaction({
     required this.digestWriter,
     this.verbatimBudget = goalUserVoiceTokenBudget,
     this.monthlyHorizonMonths = 6,
     this.quarterlyHorizonMonths = 18,
+    this.yearlyHorizonMonths = 36,
   }) : assert(monthlyHorizonMonths > 0, 'monthlyHorizonMonths must be > 0'),
        assert(
          quarterlyHorizonMonths > monthlyHorizonMonths,
          'quarterlyHorizonMonths must exceed monthlyHorizonMonths',
+       ),
+       assert(
+         yearlyHorizonMonths > quarterlyHorizonMonths,
+         'yearlyHorizonMonths must exceed quarterlyHorizonMonths',
        );
 
   final GoalCheckInDigestWriter digestWriter;
@@ -179,6 +192,9 @@ class HierarchicalCheckInCompaction implements GoalCheckInCompactionStrategy {
   /// Quarters younger than this stay quarterly; older ones merge into
   /// calendar years.
   final int quarterlyHorizonMonths;
+
+  /// Years younger than this stay yearly; everything older is one span.
+  final int yearlyHorizonMonths;
 
   @override
   String get id => 'hierarchical';
@@ -237,7 +253,8 @@ class HierarchicalCheckInCompaction implements GoalCheckInCompactionStrategy {
 
   /// Groups [folded] (oldest first) into calendar spans: monthly inside
   /// [monthlyHorizonMonths] before [reference], quarterly inside
-  /// [quarterlyHorizonMonths], yearly beyond.
+  /// [quarterlyHorizonMonths], yearly inside [yearlyHorizonMonths], and one
+  /// span for everything earlier.
   List<GoalCheckInDigestRequest> _spans(
     List<GoalCheckInSummary> folded,
     DateTime reference,
@@ -255,11 +272,17 @@ class HierarchicalCheckInCompaction implements GoalCheckInCompactionStrategy {
       local.year,
       local.month - quarterlyHorizonMonths,
     );
+    final yearlyHorizon = DateTime(
+      local.year,
+      local.month - yearlyHorizonMonths,
+    );
     final groups =
         <String, (GoalCheckInDigestLayer, List<GoalCheckInSummary>)>{};
     for (final s in folded) {
       final at = s.recordedAt.toLocal();
-      final (layer, label) = at.isBefore(quarterlyHorizon)
+      final (layer, label) = at.isBefore(yearlyHorizon)
+          ? (GoalCheckInDigestLayer.earlier, 'before-${yearlyHorizon.year}')
+          : at.isBefore(quarterlyHorizon)
           ? (GoalCheckInDigestLayer.year, '${at.year}')
           : at.isBefore(monthlyHorizon)
           ? (

--- a/lib/features/goals/logic/goal_user_voice.dart
+++ b/lib/features/goals/logic/goal_user_voice.dart
@@ -44,7 +44,7 @@ List<Map<String, Object?>> goalUserVoiceEntries(
   final kept = plan.keepIds.toSet();
   return [
     for (final summary in chronological)
-      if (kept.contains(summary.id)) _json(summary),
+      if (kept.contains(summary.id)) goalUserVoiceEntry(summary),
   ];
 }
 
@@ -58,17 +58,22 @@ const String goalUserVoiceInterpretationPolicy =
     "the user's own words inform coaching and record what they committed "
     'to; they never override deterministic criterion results';
 
-Map<String, Object?> _json(GoalCheckInSummary summary) => <String, Object?>{
-  // The date is load-bearing: "you said on Tuesday you would walk after
-  // lunch" is only sayable if it survives compaction.
-  'recordedAtLocal': summary.recordedAt.toLocal().toIso8601String(),
-  'sourceEntryId': summary.sourceEntryId,
-  'whatHappened': summary.whatHappened,
-  if (summary.committedTo != null) 'committedTo': summary.committedTo,
-  if (summary.blockers != null) 'blockers': summary.blockers,
-  if (summary.mood != null) 'mood': summary.mood,
-  if (summary.asks != null) 'asks': summary.asks,
-};
+/// The wire shape of one verbatim check-in inside the `userVoice` block.
+///
+/// Shared by every compaction strategy, so a strategy can only change WHICH
+/// check-ins the agent sees, never how a kept one reads.
+Map<String, Object?> goalUserVoiceEntry(GoalCheckInSummary summary) =>
+    <String, Object?>{
+      // The date is load-bearing: "you said on Tuesday you would walk after
+      // lunch" is only sayable if it survives compaction.
+      'recordedAtLocal': summary.recordedAt.toLocal().toIso8601String(),
+      'sourceEntryId': summary.sourceEntryId,
+      'whatHappened': summary.whatHappened,
+      if (summary.committedTo != null) 'committedTo': summary.committedTo,
+      if (summary.blockers != null) 'blockers': summary.blockers,
+      if (summary.mood != null) 'mood': summary.mood,
+      if (summary.asks != null) 'asks': summary.asks,
+    };
 
 /// Estimates against the JSON actually emitted, keys and all.
 ///
@@ -77,4 +82,4 @@ Map<String, Object?> _json(GoalCheckInSummary summary) => <String, Object?>{
 /// could exceed the budget it was chosen to fit, by more the more entries were
 /// retained.
 String _renderForBudget(GoalCheckInSummary summary) =>
-    jsonEncode(_json(summary));
+    jsonEncode(goalUserVoiceEntry(summary));

--- a/lib/features/goals/service/goal_checkin_digest_service.dart
+++ b/lib/features/goals/service/goal_checkin_digest_service.dart
@@ -1,0 +1,377 @@
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:crypto/crypto.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/ai/model/ai_call_impact.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
+import 'package:lotti/features/ai_consumption/model/ai_consumption_enums.dart';
+import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+/// Tool name marking a stored span digest in the agent log.
+const goalCheckInDigestToolName = 'goal_checkin_digest';
+
+/// How many spans one wake may digest. Bounds the wake: a goal whose two
+/// years of check-ins are digested for the first time pays for a few spans
+/// per wake and finishes over the following wakes, rather than turning one
+/// report refresh into a dozen inference calls.
+const goalCheckInDigestsPerWake = 4;
+
+/// Deterministic id for the digest of one span — the calendar period is the
+/// key, so a span digested on two devices converges on one row.
+String goalCheckInDigestId(String agentId, String periodLabel) =>
+    'goal_checkin_digest:$agentId:$periodLabel';
+
+/// Fingerprint of what a span digest was written from: its layer and every
+/// member summary's identity and words. A check-in that syncs in late, a
+/// re-transcription, or a span ageing from monthly to quarterly all change
+/// it, and the digest is rewritten instead of standing stale.
+String goalCheckInDigestSourceKey(GoalCheckInDigestRequest request) {
+  final buffer = StringBuffer(request.layer.name);
+  for (final c in request.checkIns) {
+    buffer
+      ..write('\n')
+      ..write(c.sourceEntryId)
+      ..write('|')
+      ..write(c.sourceDigest ?? c.whatHappened);
+  }
+  return sha256.convert(utf8.encode(buffer.toString())).toString();
+}
+
+/// A stored span digest.
+class GoalCheckInDigest {
+  const GoalCheckInDigest({
+    required this.periodLabel,
+    required this.layer,
+    required this.sourceKey,
+    required this.checkInCount,
+    required this.text,
+    required this.writtenAt,
+  });
+
+  final String periodLabel;
+  final String layer;
+  final String sourceKey;
+  final int checkInCount;
+  final String text;
+  final DateTime writtenAt;
+
+  Map<String, Object?> toContent() => {
+    'periodLabel': periodLabel,
+    'layer': layer,
+    'sourceKey': sourceKey,
+    'checkInCount': checkInCount,
+    'text': text,
+    'writtenAt': writtenAt.toUtc().toIso8601String(),
+  };
+
+  static GoalCheckInDigest? fromContent(Map<String, Object?> content) {
+    final periodLabel = content['periodLabel'];
+    final layer = content['layer'];
+    final sourceKey = content['sourceKey'];
+    final checkInCount = content['checkInCount'];
+    final text = content['text'];
+    final writtenAt = DateTime.tryParse(content['writtenAt'] as String? ?? '');
+    if (periodLabel is! String ||
+        layer is! String ||
+        sourceKey is! String ||
+        checkInCount is! int ||
+        text is! String ||
+        text.trim().isEmpty ||
+        writtenAt == null) {
+      return null;
+    }
+    return GoalCheckInDigest(
+      periodLabel: periodLabel,
+      layer: layer,
+      sourceKey: sourceKey,
+      checkInCount: checkInCount,
+      text: text,
+      writtenAt: writtenAt,
+    );
+  }
+}
+
+/// Writes and stores the span digests the hierarchical compaction reads.
+///
+/// One row per calendar span, keyed by `(agentId, periodLabel)`; the
+/// [goalCheckInDigestSourceKey] decides whether the stored text is still the
+/// digest of the span's current members. Inference runs only on wakes that
+/// allow it (automatic report wakes, like check-in compaction) and at most
+/// [goalCheckInDigestsPerWake] times per wake; every other span reads its
+/// stored digest, or a plain placeholder naming what is not yet digested.
+/// Never throws: the user's voice is additive context, and a digest that
+/// could not be written must not cost the wake.
+class GoalCheckInDigestService {
+  GoalCheckInDigestService({
+    required CloudInferenceRepository inferenceRepository,
+    required this._repository,
+    required this._syncService,
+    this.maxDigestTokens = 400,
+    this._domainLogger,
+  }) : _inference = inferenceRepository;
+
+  final CloudInferenceRepository _inference;
+  final AgentRepository _repository;
+  final AgentSyncService _syncService;
+  final DomainLogger? _domainLogger;
+
+  /// Output cap per digest. The layer's word limit is in the prompt; this is
+  /// the hard stop behind it.
+  final int maxDigestTokens;
+
+  static const double _temperature = 0.3;
+
+  static const String _systemMessage =
+      "You condense a span of a person's spoken check-ins about one personal "
+      'goal into a faithful digest that a coach will read months or years '
+      'later instead of the originals. Preserve, with dates where they were '
+      'given: what actually happened to the numbers over the span; every '
+      'commitment made and whether it was kept; setbacks, injuries, medical '
+      'advice, and life changes; anything that changed about the goal itself; '
+      "how the person's mood related to their results. Drop routine "
+      'repetition. Write in plain prose within the word limit given, in the '
+      'language the person spoke. Never infer, advise or judge — record.';
+
+  /// The writer for one wake of [agentId].
+  GoalCheckInDigestWriter forWake({
+    required String agentId,
+    required String goalStatement,
+    required String model,
+    required AiConfigInferenceProvider provider,
+    required bool allowInference,
+  }) => _WakeDigestWriter(
+    service: this,
+    agentId: agentId,
+    goalStatement: goalStatement,
+    model: model,
+    provider: provider,
+    allowInference: allowInference,
+  );
+
+  Future<GoalCheckInDigest?> _stored(String agentId, String periodLabel) async {
+    final message = await _repository.getEntity(
+      goalCheckInDigestId(agentId, periodLabel),
+    );
+    final payloadId = message is AgentMessageEntity
+        ? message.contentEntryId
+        : null;
+    if (payloadId == null) return null;
+    final payload = await _repository.getEntity(payloadId);
+    if (payload is! AgentMessagePayloadEntity) return null;
+    return GoalCheckInDigest.fromContent(payload.content);
+  }
+
+  Future<void> _persist(String agentId, GoalCheckInDigest digest) async {
+    final id = goalCheckInDigestId(agentId, digest.periodLabel);
+    final payloadId = '$id:payload';
+    await _syncService.runInTransaction(() async {
+      await _syncService.upsertEntity(
+        AgentDomainEntity.agentMessagePayload(
+          id: payloadId,
+          agentId: agentId,
+          createdAt: digest.writtenAt,
+          vectorClock: null,
+          content: digest.toContent(),
+        ),
+      );
+      await _syncService.upsertEntity(
+        AgentDomainEntity.agentMessage(
+          id: id,
+          agentId: agentId,
+          threadId: id,
+          // An action, like the check-in summaries: filed as observations
+          // these would push real coaching observations out of FACTS.
+          kind: AgentMessageKind.action,
+          createdAt: digest.writtenAt,
+          vectorClock: null,
+          metadata: const AgentMessageMetadata(
+            toolName: goalCheckInDigestToolName,
+          ),
+          contentEntryId: payloadId,
+        ),
+      );
+    });
+  }
+
+  Future<String> _write({
+    required String agentId,
+    required String goalStatement,
+    required String model,
+    required AiConfigInferenceProvider provider,
+    required GoalCheckInDigestRequest request,
+  }) async {
+    final prompt = _prompt(goalStatement, request);
+    final captureRegistered = getIt.isRegistered<AiInteractionCapture>();
+    final impactCollector = InferenceImpactCollector();
+    Stream<CreateChatCompletionStreamResponse> invoke() => _inference.generate(
+      prompt,
+      model: model,
+      temperature: _temperature,
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey,
+      systemMessage: _systemMessage,
+      maxCompletionTokens: maxDigestTokens,
+      geminiThinkingMode: GeminiThinkingMode.minimal,
+      reasoningEffort: ReasoningEffort.minimal,
+      provider: provider,
+      impactCollector: captureRegistered ? impactCollector : null,
+    );
+    final stream = captureRegistered
+        ? getIt<AiInteractionCapture>().captureStream(
+            workType: AiWorkType.internalInference,
+            interactionKind: AiInteractionKind.textGeneration,
+            responseType: AiConsumptionResponseType.textGeneration,
+            providerType: provider.inferenceProviderType,
+            modelId: model,
+            requestText: prompt,
+            invoke: invoke,
+            responseText: (chunk) =>
+                chunk.choices?.firstOrNull?.delta?.content ?? '',
+            usageForChunk: (chunk) {
+              final usage = chunk.usage;
+              if (usage == null) return null;
+              return AiCapturedUsage(
+                inputTokens: usage.promptTokens,
+                outputTokens: usage.completionTokens,
+                cachedInputTokens: usage.promptTokensDetails?.cachedTokens,
+                thoughtsTokens: usage.completionTokensDetails?.reasoningTokens,
+                totalTokens: usage.totalTokens,
+              );
+            },
+            impact: () => impactCollector.impact,
+            triggerType: AiTriggerType.automatic,
+            automationId: 'automation:goal-check-in-digest',
+            automationDisplayName: 'Goal check-in digest',
+            interactionContext: AiCapturedContext(agentId: agentId),
+          )
+        : invoke();
+
+    final buffer = StringBuffer();
+    await for (final response in stream) {
+      final content = response.choices?.firstOrNull?.delta?.content;
+      if (content != null) buffer.write(content);
+    }
+    return buffer.toString().trim();
+  }
+
+  String _prompt(String goalStatement, GoalCheckInDigestRequest request) {
+    final buffer = StringBuffer()
+      ..writeln('Goal: $goalStatement')
+      ..writeln()
+      ..writeln(
+        'Span: ${request.periodLabel} (${request.layer.name}; '
+        '${_day(request.from)} to ${_day(request.to)}), '
+        '${request.checkIns.length} check-ins, oldest first. '
+        'Word limit: ${request.maxWords}.',
+      )
+      ..writeln();
+    for (final c in request.checkIns) {
+      buffer.writeln('${_day(c.recordedAt)}: ${c.whatHappened}');
+      if (c.committedTo != null) {
+        buffer.writeln('  committed to: ${c.committedTo}');
+      }
+      if (c.blockers != null) buffer.writeln('  blockers: ${c.blockers}');
+      if (c.mood != null) buffer.writeln('  mood: ${c.mood}');
+    }
+    return buffer.toString();
+  }
+
+  static String _day(DateTime at) =>
+      at.toLocal().toIso8601String().substring(0, 10);
+}
+
+/// Placeholder for a span whose digest is not yet written. Honest and
+/// short: the agent learns that a stretch of history exists and is not yet
+/// readable, which beats silently omitting it.
+String goalCheckInDigestPlaceholder(GoalCheckInDigestRequest request) =>
+    '(${request.checkIns.length} check-ins from this span are not yet '
+    'digested)';
+
+class _WakeDigestWriter implements GoalCheckInDigestWriter {
+  _WakeDigestWriter({
+    required this.service,
+    required this.agentId,
+    required this.goalStatement,
+    required this.model,
+    required this.provider,
+    required this.allowInference,
+  });
+
+  final GoalCheckInDigestService service;
+  final String agentId;
+  final String goalStatement;
+  final String model;
+  final AiConfigInferenceProvider provider;
+  final bool allowInference;
+  int _written = 0;
+
+  @override
+  Future<String> write(GoalCheckInDigestRequest request) async {
+    final sourceKey = goalCheckInDigestSourceKey(request);
+    GoalCheckInDigest? stored;
+    try {
+      stored = await service._stored(agentId, request.periodLabel);
+    } catch (error, stackTrace) {
+      service._domainLogger?.error(
+        LogDomain.agentWorkflow,
+        error,
+        subDomain: 'goalCheckInDigest',
+        message: 'failed to read digest ${request.periodLabel}',
+        stackTrace: stackTrace,
+      );
+    }
+    if (stored != null && stored.sourceKey == sourceKey) return stored.text;
+
+    if (!allowInference || _written >= goalCheckInDigestsPerWake) {
+      // A stale digest still describes most of the span; better than a
+      // placeholder, and rewritten on the next wake that may infer.
+      return stored?.text ?? goalCheckInDigestPlaceholder(request);
+    }
+
+    _written++;
+    try {
+      final text = await service._write(
+        agentId: agentId,
+        goalStatement: goalStatement,
+        model: model,
+        provider: provider,
+        request: request,
+      );
+      if (text.isEmpty) {
+        throw const FormatException('check-in digest returned no text');
+      }
+      await service._persist(
+        agentId,
+        GoalCheckInDigest(
+          periodLabel: request.periodLabel,
+          layer: request.layer.name,
+          sourceKey: sourceKey,
+          checkInCount: request.checkIns.length,
+          text: text,
+          writtenAt: clock.now(),
+        ),
+      );
+      return text;
+    } catch (error, stackTrace) {
+      service._domainLogger?.error(
+        LogDomain.agentWorkflow,
+        error,
+        subDomain: 'goalCheckInDigest',
+        message: 'goal check-in digest failed for ${request.periodLabel}',
+        stackTrace: stackTrace,
+      );
+      return stored?.text ?? goalCheckInDigestPlaceholder(request);
+    }
+  }
+}

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -31,6 +31,7 @@ import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:lotti/features/goals/service/goal_chat_history_service.dart';
 import 'package:lotti/features/goals/service/goal_chat_service.dart';
 import 'package:lotti/features/goals/service/goal_checkin_compactor.dart';
+import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
 import 'package:lotti/features/goals/service/goal_checkin_notifier.dart';
 import 'package:lotti/features/goals/service/goal_mirror_service.dart';
 import 'package:lotti/features/goals/service/goal_spec_revision_service.dart';
@@ -163,6 +164,17 @@ final Provider<GoalCheckInCompactor> goalCheckInCompactorProvider =
       name: 'goalCheckInCompactorProvider',
     );
 
+final Provider<GoalCheckInDigestService> goalCheckInDigestServiceProvider =
+    Provider<GoalCheckInDigestService>(
+      (ref) => GoalCheckInDigestService(
+        inferenceRepository: ref.watch(cloudInferenceRepositoryProvider),
+        repository: ref.watch(agentRepositoryProvider),
+        syncService: ref.watch(agentSyncServiceProvider),
+        domainLogger: ref.watch(domainLoggerProvider),
+      ),
+      name: 'goalCheckInDigestServiceProvider',
+    );
+
 /// Reads a goal's check-ins out of the journal for the headless workflow.
 ///
 /// A function rather than a repository handle, so the agent tier depends on
@@ -185,6 +197,7 @@ final goalAgentWorkflowProvider = Provider<GoalAgentWorkflow>(
     chatHistoryService: ref.watch(goalChatHistoryServiceProvider),
     checkInCompactor: ref.watch(goalCheckInCompactorProvider),
     checkInSourceReader: ref.watch(goalCheckInSourceReaderProvider),
+    checkInDigestService: ref.watch(goalCheckInDigestServiceProvider),
     domainLogger: ref.watch(domainLoggerProvider),
   ),
   name: 'goalAgentWorkflowProvider',

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -33,6 +33,7 @@ import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
 import 'package:lotti/features/goals/evaluation/goal_evaluation.dart';
 import 'package:lotti/features/goals/logic/goal_aggregate_rounding.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
 import 'package:lotti/features/goals/logic/goal_user_voice.dart';
 import 'package:lotti/features/goals/model/goal_checkin_source.dart';
 import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
@@ -40,6 +41,7 @@ import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 import 'package:lotti/features/goals/service/goal_chat_history_service.dart';
 import 'package:lotti/features/goals/service/goal_checkin_compactor.dart';
+import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_strategy.dart';
 import 'package:lotti/features/goals/workflow/goal_facts_renderer.dart';
@@ -111,6 +113,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
     this._factsRenderer = const GoalFactsRenderer(),
     this._checkInCompactor,
     this._checkInSourceReader,
+    this._checkInDigestService,
     this._domainLogger,
   }) : _chatHistoryService =
            chatHistoryService ?? GoalChatHistoryService(_repository);
@@ -133,6 +136,10 @@ class GoalAgentWorkflow with AgentErrorLogging {
   /// imported so this headless workflow keeps no dependency on the journal
   /// stack.
   final GoalCheckInSourceReader? _checkInSourceReader;
+
+  /// Writes the span digests the hierarchical compaction reads. Null keeps
+  /// the truncating selection: the recent tail only.
+  final GoalCheckInDigestService? _checkInDigestService;
   final DomainLogger? _domainLogger;
 
   @override
@@ -428,7 +435,22 @@ class GoalAgentWorkflow with AgentErrorLogging {
     // this wake its check-ins, never the wake itself — the deterministic FACTS
     // are what the agent is actually accountable to, and they are already
     // assembled.
-    final userVoice = goalUserVoiceEntries(checkInSummaries);
+    //
+    // Hierarchical when a digest service is wired: the recent tail verbatim,
+    // older spans as stored digests, so a two-year goal's redefinition or
+    // injury stays in view (the compaction evaluation is the gate for this:
+    // docs/evaluations/goal_agent_models/compaction.md). Digests are written
+    // on the same wakes that compact check-ins — never on an interactive
+    // turn — and a failure anywhere falls back to the truncating selection.
+    final userVoice = await _userVoiceEntries(
+      agentId: agentId,
+      summaries: checkInSummaries,
+      goalStatement: version.statement,
+      model: resolved.modelId,
+      provider: resolved.provider,
+      allowInference: pendingUserMessage == null,
+      reference: reference,
+    );
 
     final renderedFacts = _factsRenderer.render(
       version: version,
@@ -1198,6 +1220,42 @@ class GoalAgentWorkflow with AgentErrorLogging {
       for (final summary in stored)
         if (live.containsKey(summary.sourceEntryId)) summary,
     ];
+  }
+
+  Future<List<Map<String, Object?>>> _userVoiceEntries({
+    required String agentId,
+    required List<GoalCheckInSummary> summaries,
+    required String goalStatement,
+    required String model,
+    required AiConfigInferenceProvider provider,
+    required bool allowInference,
+    required DateTime reference,
+  }) async {
+    final digestService = _checkInDigestService;
+    if (digestService == null || summaries.isEmpty) {
+      return goalUserVoiceEntries(summaries);
+    }
+    try {
+      final context = await HierarchicalCheckInCompaction(
+        digestWriter: digestService.forWake(
+          agentId: agentId,
+          goalStatement: goalStatement,
+          model: model,
+          provider: provider,
+          allowInference: allowInference,
+        ),
+      ).build(summaries, reference: reference);
+      return context.entries;
+    } catch (error, stackTrace) {
+      _domainLogger?.error(
+        LogDomain.agentWorkflow,
+        error,
+        subDomain: 'goalCheckInDigest',
+        message: 'hierarchical user voice failed; falling back to the tail',
+        stackTrace: stackTrace,
+      );
+      return goalUserVoiceEntries(summaries);
+    }
   }
 
   /// The compacted check-ins and retry failures stored for this goal.

--- a/scripts/goal_compaction_eval_matrix.sh
+++ b/scripts/goal_compaction_eval_matrix.sh
@@ -35,6 +35,7 @@ LOTTI_GOAL_COMPACTION_EVAL_LIVE=1 \
 GOAL_COMPACTION_EVAL_SAMPLES="$SAMPLES" \
 GOAL_COMPACTION_EVAL_PACKET="$OUT_DIR/packet.json" \
 fvm flutter test "$TEST_PATH" --tags eval-live 2>&1 | tee "$OUT_DIR/run.log" | grep -E '^\[compaction-eval\]|All tests passed|Some tests failed'
+TEST_STATUS=${PIPESTATUS[0]}
 
 if [[ ! -f "$OUT_DIR/packet.json" ]]; then
   echo "No packet written; see $OUT_DIR/run.log" >&2
@@ -45,4 +46,10 @@ if ! fvm dart run tool/goal_compaction_eval_report.dart "$OUT_DIR/packet.json" >
   exit 1
 fi
 echo "Deterministic report: $OUT_DIR/report.md"
+if (( TEST_STATUS != 0 )); then
+  # The packet is kept for diagnosis, but a run with errored cases is not a
+  # result: do not hand it to the judge as if it were.
+  echo "Live eval FAILED (exit $TEST_STATUS); see $OUT_DIR/run.log. Do not judge this packet." >&2
+  exit 1
+fi
 echo "Next: judge $OUT_DIR/packet.json into $OUT_DIR/scores.json, then re-run the report with both."

--- a/scripts/goal_compaction_eval_matrix.sh
+++ b/scripts/goal_compaction_eval_matrix.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Runs the goal check-in compaction eval and renders the deterministic
+# report. The judged metrics (fact recall, hallucination, recommendation
+# consistency) need a scores file from the judge — see
+# docs/evaluations/goal_agent_models/compaction.md — after which re-run
+# only the report step:
+#
+#   fvm dart run tool/goal_compaction_eval_report.dart \
+#     eval_artifacts/goal_compaction_<stamp>/packet.json \
+#     eval_artifacts/goal_compaction_<stamp>/scores.json
+#
+# Usage:
+#   scripts/goal_compaction_eval_matrix.sh [samples]
+#
+# Reads credentials from MELIOUS_API_KEY (or GOAL_COMPACTION_EVAL_API_KEY).
+# GOAL_COMPACTION_EVAL_MODEL, _DIGEST_MODEL, _FIXTURES and _STRATEGIES pass
+# through to the live test. The digest cache under eval_artifacts/ is shared
+# between runs, so re-running costs no digest calls.
+set -uo pipefail
+
+SAMPLES="${1:-1}"
+case "$SAMPLES" in (*[!0-9]*|0|'') echo "samples must be a positive integer, got '$SAMPLES'" >&2; exit 2;; esac
+TEST_PATH="test/features/agents/eval/goal/compaction/goal_compaction_eval_live_test.dart"
+RUN_STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="eval_artifacts/goal_compaction_${RUN_STAMP}"
+
+if [[ -z "${GOAL_COMPACTION_EVAL_API_KEY:-${MELIOUS_API_KEY:-}}" ]]; then
+  echo "Set MELIOUS_API_KEY (or GOAL_COMPACTION_EVAL_API_KEY)." >&2
+  exit 2
+fi
+mkdir -p "$OUT_DIR"
+
+echo "Running ${SAMPLES} sample(s) per (fixture × arm) → $OUT_DIR"
+LOTTI_GOAL_COMPACTION_EVAL_LIVE=1 \
+GOAL_COMPACTION_EVAL_SAMPLES="$SAMPLES" \
+GOAL_COMPACTION_EVAL_PACKET="$OUT_DIR/packet.json" \
+fvm flutter test "$TEST_PATH" --tags eval-live 2>&1 | tee "$OUT_DIR/run.log" | grep -E '^\[compaction-eval\]|All tests passed|Some tests failed'
+
+if [[ ! -f "$OUT_DIR/packet.json" ]]; then
+  echo "No packet written; see $OUT_DIR/run.log" >&2
+  exit 1
+fi
+if ! fvm dart run tool/goal_compaction_eval_report.dart "$OUT_DIR/packet.json" > "$OUT_DIR/report.md"; then
+  echo "Report failed; see $OUT_DIR/packet.json" >&2
+  exit 1
+fi
+echo "Deterministic report: $OUT_DIR/report.md"
+echo "Next: judge $OUT_DIR/packet.json into $OUT_DIR/scores.json, then re-run the report with both."

--- a/test/features/agents/eval/goal/compaction/goal_compaction_eval_live_test.dart
+++ b/test/features/agents/eval/goal/compaction/goal_compaction_eval_live_test.dart
@@ -1,0 +1,213 @@
+@Tags(['eval-live'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/constants/provider_config.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/get_it.dart';
+
+import '../../../../../helpers/fallbacks.dart';
+import '../../../../ai_consumption/test_utils.dart';
+import 'support/goal_compaction_eval.dart';
+import 'support/goal_compaction_fixtures.dart';
+
+/// Live check-in compaction eval: writes the judging packet.
+///
+/// Run book: `docs/evaluations/goal_agent_models/compaction.md`.
+///
+///     LOTTI_GOAL_COMPACTION_EVAL_LIVE=1 \
+///     MELIOUS_API_KEY=... \
+///     GOAL_COMPACTION_EVAL_MODEL=glm-5.2 \
+///     GOAL_COMPACTION_EVAL_SAMPLES=1 \
+///     fvm flutter test \
+///       test/features/agents/eval/goal/compaction/goal_compaction_eval_live_test.dart \
+///       --tags eval-live
+///
+/// Environment:
+/// - `GOAL_COMPACTION_EVAL_MODEL` — the agent model (default `glm-5.2`).
+/// - `GOAL_COMPACTION_EVAL_DIGEST_MODEL` — the digest writer (default: same).
+/// - `GOAL_COMPACTION_EVAL_FIXTURES` — comma-separated fixture ids.
+/// - `GOAL_COMPACTION_EVAL_STRATEGIES` — subset of `full,truncate,hierarchical`.
+/// - `GOAL_COMPACTION_EVAL_SAMPLES` — runs per (fixture × strategy), default 1.
+/// - `GOAL_COMPACTION_EVAL_PACKET` — where the packet JSON goes.
+/// - `GOAL_COMPACTION_EVAL_DIGEST_CACHE` — digest cache directory.
+/// - `GOAL_COMPACTION_EVAL_TEMPERATURE` — default 0.
+/// - `GOAL_COMPACTION_EVAL_PROVIDER_TYPE`, `_BASE_URL`, `_API_KEY` — provider
+///   overrides; the key falls back to `MELIOUS_API_KEY`.
+/// - `GOAL_COMPACTION_EVAL_TIMEOUT_MINUTES` — default 90.
+void main() {
+  test(
+    'writes a goal check-in compaction judging packet',
+    () async {
+      HttpOverrides.global = null;
+      registerAllFallbackValues();
+      final attribution = AiInteractionCaptureTestBench.create()..register();
+      addTearDown(attribution.unregister);
+      addTearDown(getIt.reset);
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final conversationSubscription = container.listen(
+        conversationRepositoryProvider,
+        (_, _) {},
+      );
+      addTearDown(conversationSubscription.close);
+      final cloudSubscription = container.listen(
+        cloudInferenceRepositoryProvider,
+        (_, _) {},
+      );
+      addTearDown(cloudSubscription.close);
+
+      final providerType = _providerType(
+        Platform.environment['GOAL_COMPACTION_EVAL_PROVIDER_TYPE'],
+      );
+      final provider = AiConfigInferenceProvider(
+        id: 'goal-compaction-eval-${providerType.name}',
+        name: 'Goal Compaction Eval (${providerType.name})',
+        baseUrl:
+            Platform.environment['GOAL_COMPACTION_EVAL_BASE_URL'] ??
+            ProviderConfig.defaultBaseUrls[providerType]!,
+        apiKey:
+            Platform.environment['GOAL_COMPACTION_EVAL_API_KEY'] ??
+            Platform.environment['MELIOUS_API_KEY'] ??
+            '',
+        inferenceProviderType: providerType,
+        createdAt: DateTime(2026, 8, 27),
+      );
+
+      final modelId =
+          Platform.environment['GOAL_COMPACTION_EVAL_MODEL'] ?? 'glm-5.2';
+      final digestModelId =
+          Platform.environment['GOAL_COMPACTION_EVAL_DIGEST_MODEL'] ?? modelId;
+      final conversationRepository = container.read(
+        conversationRepositoryProvider.notifier,
+      );
+      final inferenceRepository = CloudInferenceWrapper(
+        cloudRepository: container.read(cloudInferenceRepositoryProvider),
+      );
+
+      final digestWriter = CachedLlmDigestWriter(
+        provider: provider,
+        modelId: digestModelId,
+        conversationRepository: conversationRepository,
+        inferenceRepository: inferenceRepository,
+        cacheDirectory: Directory(
+          Platform.environment['GOAL_COMPACTION_EVAL_DIGEST_CACHE'] ??
+              'eval_artifacts/goal_compaction_digests/$digestModelId',
+        ),
+      );
+
+      final requestedFixtures = _envList('GOAL_COMPACTION_EVAL_FIXTURES');
+      final fixtures = requestedFixtures.isEmpty
+          ? goalCompactionFixtures
+          : goalCompactionFixtures
+                .where((f) => requestedFixtures.contains(f.id))
+                .toList(growable: false);
+      expect(fixtures, isNotEmpty, reason: 'no fixture matched');
+
+      final requestedStrategies = _envList('GOAL_COMPACTION_EVAL_STRATEGIES');
+      final strategies = goalCompactionEvalArms(digestWriter)
+          .where(
+            (s) =>
+                requestedStrategies.isEmpty ||
+                requestedStrategies.contains(s.id),
+          )
+          .toList(growable: false);
+      expect(strategies, isNotEmpty, reason: 'no strategy matched');
+      expect(
+        strategies.any((s) => s is FullContextCheckInCompaction),
+        isTrue,
+        reason: 'the full arm is the oracle every other arm is judged against',
+      );
+
+      final runner = GoalCompactionEvalRunner(
+        provider: provider,
+        modelId: modelId,
+        conversationRepository: conversationRepository,
+        inferenceRepository: inferenceRepository,
+        temperature:
+            double.tryParse(
+              Platform.environment['GOAL_COMPACTION_EVAL_TEMPERATURE'] ?? '',
+            ) ??
+            0,
+        log: (line) => stdout.writeln('[compaction-eval] $line'),
+      );
+
+      final packet = await runner.run(
+        fixtures: fixtures,
+        strategies: strategies,
+        samples:
+            int.tryParse(
+              Platform.environment['GOAL_COMPACTION_EVAL_SAMPLES'] ?? '',
+            ) ??
+            1,
+        digestUsage: () => digestWriter.usageJson,
+      );
+
+      final packetPath =
+          Platform.environment['GOAL_COMPACTION_EVAL_PACKET'] ??
+          '${Directory.systemTemp.path}/lotti-goal-compaction-packet.json';
+      File(packetPath)
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(packet.toPrettyJson());
+      stdout.writeln('[compaction-eval] packet: $packetPath');
+
+      expect(packet.cases, isNotEmpty);
+      final errors = packet.cases.where((c) => c.errorMessage != null);
+      expect(
+        errors,
+        isEmpty,
+        reason: errors
+            .map(
+              (c) =>
+                  '${c.fixture.id}/${c.strategyId}: '
+                  '${c.errorMessage}',
+            )
+            .join('\n'),
+      );
+    },
+    skip: Platform.environment['LOTTI_GOAL_COMPACTION_EVAL_LIVE'] == '1'
+        ? null
+        : 'Set LOTTI_GOAL_COMPACTION_EVAL_LIVE=1 (and MELIOUS_API_KEY) to run '
+              'the live compaction eval.',
+    timeout: Timeout(
+      Duration(
+        minutes:
+            int.tryParse(
+              Platform.environment['GOAL_COMPACTION_EVAL_TIMEOUT_MINUTES'] ??
+                  '',
+            ) ??
+            90,
+      ),
+    ),
+  );
+}
+
+InferenceProviderType _providerType(String? name) {
+  if (name == null || name.trim().isEmpty) {
+    return InferenceProviderType.melious;
+  }
+  return InferenceProviderType.values.firstWhere(
+    (value) => value.name == name.trim(),
+    orElse: () => throw FormatException(
+      'Unknown GOAL_COMPACTION_EVAL_PROVIDER_TYPE "$name".',
+    ),
+  );
+}
+
+List<String> _envList(String name) {
+  final value = Platform.environment[name];
+  if (value == null || value.trim().isEmpty) return const [];
+  return value
+      .split(',')
+      .map((part) => part.trim())
+      .where((part) => part.isNotEmpty)
+      .toList(growable: false);
+}

--- a/test/features/agents/eval/goal/compaction/goal_compaction_eval_test.dart
+++ b/test/features/agents/eval/goal/compaction/goal_compaction_eval_test.dart
@@ -1,0 +1,513 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_call_impact.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/gemini_tool_call.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import 'support/goal_compaction_eval.dart';
+import 'support/goal_compaction_fixtures.dart';
+
+/// A scripted model: answers the wake with a report and a reply, answers
+/// the probe turn with JSON, and answers a digest request with prose. The
+/// user turn's text decides which; a tool-result turn ends the exchange.
+class _ScriptedInference extends InferenceRepositoryInterface {
+  _ScriptedInference({
+    this.reportedStatus = 'offTrack',
+    this.failOn,
+    this.blankDigest = false,
+  });
+
+  final String reportedStatus;
+
+  /// A substring of a user message that makes the call throw.
+  final String? failOn;
+
+  /// Answer digest requests with whitespace only.
+  final bool blankDigest;
+
+  final prompts = <String>[];
+
+  @override
+  Stream<CreateChatCompletionStreamResponse> generateTextWithMessages({
+    required List<ChatCompletionMessage> messages,
+    required String model,
+    required double temperature,
+    required AiConfigInferenceProvider provider,
+    int? maxCompletionTokens,
+    List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
+    Map<String, String>? thoughtSignatures,
+    ThoughtSignatureCollector? signatureCollector,
+    int? turnIndex,
+    InferenceImpactCollector? impactCollector,
+  }) {
+    final last = messages.last;
+    if (last.role == ChatCompletionMessageRole.tool) {
+      return Stream.value(_text('done', promptTokens: 10));
+    }
+    final user = last.mapOrNull(user: (m) => m.content.value)?.toString() ?? '';
+    prompts.add(user);
+    if (failOn != null && user.contains(failOn!)) {
+      return Stream.error(Exception('scripted failure'));
+    }
+    if (user.startsWith('Span:')) {
+      if (blankDigest) return Stream.value(_text('  \n', promptTokens: 400));
+      return Stream.value(
+        _text(
+          'Digest of the span: numbers fell, loop block deleted.',
+          promptTokens: 400,
+        ),
+      );
+    }
+    if (user.startsWith('A few questions')) {
+      final ids = RegExp(
+        r'^- (\w+):',
+        multiLine: true,
+      ).allMatches(user).map((m) => m.group(1)!).toList();
+      final answers = [
+        for (final (i, id) in ids.indexed)
+          {
+            'id': id,
+            'answer': i.isEven ? 'Answer for $id.' : 'Not in what I was given.',
+            'basis': i.isEven ? 'history' : 'notInHistory',
+          },
+      ];
+      return Stream.value(
+        _tools([
+          (
+            GoalAgentToolNames.replyToUser,
+            jsonEncode({
+              'message': jsonEncode({'answers': answers}),
+            }),
+          ),
+        ], promptTokens: 700),
+      );
+    }
+    // The wake.
+    return Stream.value(
+      _tools([
+        (
+          GoalAgentToolNames.updateGoalReport,
+          jsonEncode({
+            'status': reportedStatus,
+            'oneLiner': 'Off track for a year.',
+            'report': {
+              'tldr': 'tldr',
+              'currentPeriod': 'c',
+              'rollingWindow': 'r',
+              'latestChange': 'l',
+              'coverage': 'cov',
+              'now': <Object>[],
+            },
+          }),
+        ),
+        (
+          GoalAgentToolNames.replyToUser,
+          jsonEncode({'message': 'Restore the calendar block.'}),
+        ),
+      ], promptTokens: 5000),
+    );
+  }
+
+  CreateChatCompletionStreamResponse _text(
+    String text, {
+    required int promptTokens,
+  }) => CreateChatCompletionStreamResponse(
+    id: 'r',
+    choices: [
+      ChatCompletionStreamResponseChoice(
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta(content: text),
+      ),
+    ],
+    object: 'chat.completion.chunk',
+    created: 1,
+    usage: CompletionUsage(
+      promptTokens: promptTokens,
+      completionTokens: 20,
+      totalTokens: promptTokens + 20,
+    ),
+  );
+
+  CreateChatCompletionStreamResponse _tools(
+    List<(String, String)> calls, {
+    required int promptTokens,
+  }) => CreateChatCompletionStreamResponse(
+    id: 'r',
+    choices: [
+      ChatCompletionStreamResponseChoice(
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta(
+          toolCalls: [
+            for (final (i, call) in calls.indexed)
+              ChatCompletionStreamMessageToolCallChunk(
+                index: i,
+                id: 'call-$i',
+                type: ChatCompletionStreamMessageToolCallChunkType.function,
+                function: ChatCompletionStreamMessageFunctionCall(
+                  name: call.$1,
+                  arguments: call.$2,
+                ),
+              ),
+          ],
+        ),
+      ),
+    ],
+    object: 'chat.completion.chunk',
+    created: 1,
+    usage: CompletionUsage(
+      promptTokens: promptTokens,
+      completionTokens: 40,
+      totalTokens: promptTokens + 40,
+    ),
+  );
+}
+
+class _FixedDigestWriter implements GoalCheckInDigestWriter {
+  int writes = 0;
+  @override
+  Future<String> write(GoalCheckInDigestRequest request) async {
+    writes++;
+    return 'digest ${request.periodLabel}';
+  }
+}
+
+void main() {
+  final provider = AiConfigInferenceProvider(
+    id: 'p',
+    name: 'p',
+    baseUrl: 'https://example.test',
+    apiKey: 'k',
+    inferenceProviderType: InferenceProviderType.genericOpenAi,
+    createdAt: DateTime(2026),
+  );
+  final fixture = goalCompactionFixtures.first;
+
+  late ProviderContainer container;
+  late ConversationRepository conversations;
+  setUp(() {
+    container = ProviderContainer();
+    conversations = container.read(conversationRepositoryProvider.notifier);
+  });
+  tearDown(() => container.dispose());
+
+  group('probe message and answer parsing', () {
+    test('the message lists every probe by id', () {
+      final message = goalCompactionProbeMessage(fixture.truth.probes);
+      for (final probe in fixture.truth.probes) {
+        expect(message, contains('- ${probe.id}: ${probe.question}'));
+      }
+      expect(message, contains('"notInHistory"'));
+    });
+
+    test('parses answers by id, tolerating surrounding prose', () {
+      final probes = fixture.truth.probes.take(2).toList();
+      final results = parseGoalCompactionProbeAnswers(
+        probes,
+        'Here you go:\n{"answers":[{"id":"${probes[1].id}","answer":"B.", '
+        '"basis":"notInHistory"},{"id":"${probes[0].id}","answer":"A.","basis":"history"}]}\nDone.',
+      );
+      expect(results.map((r) => r.answer), ['A.', 'B.']);
+      expect(results.map((r) => r.basis), ['history', 'notInHistory']);
+    });
+
+    test('garbage yields unanswered probes, never guesses', () {
+      final probes = fixture.truth.probes.take(3).toList();
+      for (final raw in [
+        '',
+        'no json here',
+        '{"answers": "nope"}',
+        '{broken',
+      ]) {
+        final results = parseGoalCompactionProbeAnswers(probes, raw);
+        expect(results.length, 3, reason: raw);
+        expect(
+          results.every((r) => r.answer == null && r.basis == null),
+          isTrue,
+          reason: raw,
+        );
+      }
+    });
+
+    test('a missing id is unanswered while the others parse', () {
+      final probes = fixture.truth.probes.take(2).toList();
+      final results = parseGoalCompactionProbeAnswers(
+        probes,
+        '{"answers":[{"id":"${probes[0].id}","answer":"A.","basis":"history"}]}',
+      );
+      expect(results[0].answer, 'A.');
+      expect(results[1].answer, isNull);
+    });
+  });
+
+  group('CachedLlmDigestWriter', () {
+    late Directory cache;
+    setUp(() {
+      cache = Directory.systemTemp.createTempSync('lotti-digest-cache');
+    });
+    tearDown(() => cache.deleteSync(recursive: true));
+
+    GoalCheckInDigestRequest request() => GoalCheckInDigestRequest(
+      periodLabel: '2025-Q1',
+      layer: GoalCheckInDigestLayer.quarter,
+      from: fixture.checkIns[10].recordedAt,
+      to: fixture.checkIns[30].recordedAt,
+      checkIns: fixture.checkIns.sublist(10, 31),
+    );
+
+    test(
+      'calls the model once and serves the second request from disk',
+      () async {
+        final inference = _ScriptedInference();
+        final writer = CachedLlmDigestWriter(
+          provider: provider,
+          modelId: 'm',
+          conversationRepository: conversations,
+          inferenceRepository: inference,
+          cacheDirectory: cache,
+        );
+
+        final first = await writer.write(request());
+        final second = await writer.write(request());
+
+        expect(first, 'Digest of the span: numbers fell, loop block deleted.');
+        expect(second, first);
+        expect(writer.calls, 1);
+        expect(writer.cacheHits, 1);
+        expect(inference.prompts.length, 1);
+        expect(inference.prompts.single, startsWith('Span: 2025-Q1 (quarter;'));
+        expect(inference.prompts.single, contains('Word limit: 80.'));
+        expect(
+          inference.prompts.single,
+          contains(fixture.checkIns[10].whatHappened),
+        );
+        expect(cache.listSync().whereType<File>().length, 1);
+        expect(writer.usageJson, {
+          'calls': 1,
+          'cacheHits': 1,
+          'inputTokens': 400,
+          'outputTokens': 20,
+        });
+      },
+    );
+
+    test('a different model is a different cache key', () async {
+      final inference = _ScriptedInference();
+      for (final model in ['m1', 'm2']) {
+        await CachedLlmDigestWriter(
+          provider: provider,
+          modelId: model,
+          conversationRepository: conversations,
+          inferenceRepository: inference,
+          cacheDirectory: cache,
+        ).write(request());
+      }
+      expect(inference.prompts.length, 2);
+      expect(cache.listSync().whereType<File>().length, 2);
+    });
+
+    test('an inference failure propagates and caches nothing', () async {
+      final writer = CachedLlmDigestWriter(
+        provider: provider,
+        modelId: 'm',
+        conversationRepository: conversations,
+        inferenceRepository: _ScriptedInference(failOn: 'Span:'),
+        cacheDirectory: cache,
+      );
+      await expectLater(writer.write(request()), throwsA(isA<Exception>()));
+      expect(cache.listSync(), isEmpty);
+      expect(writer.calls, 1);
+    });
+
+    test('a blank digest is an error, not a cached blank', () async {
+      final writer = CachedLlmDigestWriter(
+        provider: provider,
+        modelId: 'm',
+        conversationRepository: conversations,
+        inferenceRepository: _ScriptedInference(blankDigest: true),
+        cacheDirectory: cache,
+      );
+      await expectLater(
+        writer.write(request()),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('2025-Q1'),
+          ),
+        ),
+      );
+      expect(cache.listSync(), isEmpty);
+      // The call was made and billed even though nothing usable came back.
+      expect(writer.calls, 1);
+      expect(writer.usageJson['inputTokens'], 400);
+    });
+  });
+
+  group('GoalCompactionEvalRunner', () {
+    test(
+      'produces one case per fixture × arm × sample with the growth curve',
+      () async {
+        final inference = _ScriptedInference();
+        final writer = _FixedDigestWriter();
+        final runner = GoalCompactionEvalRunner(
+          provider: provider,
+          modelId: 'm',
+          conversationRepository: conversations,
+          inferenceRepository: inference,
+        );
+
+        final packet = await runner.run(
+          fixtures: [fixture],
+          strategies: goalCompactionEvalArms(writer),
+          samples: 2,
+          digestUsage: () => {'calls': writer.writes},
+        );
+
+        expect(packet.cases.length, 3 * 2);
+        expect(packet.strategyIds, ['full', 'truncate', 'hierarchical']);
+        expect(
+          packet.growthCurve.length,
+          3 * goalCompactionEvalHorizons.length,
+        );
+        final fullCurve = packet.growthCurve
+            .where((g) => g.strategyId == 'full')
+            .map((g) => g.context.estimatedTokens)
+            .toList();
+        expect(fullCurve, orderedEquals([...fullCurve]..sort()));
+        expect(fullCurve.last, greaterThan(fullCurve.first * 4));
+        final hierarchicalCurve = packet.growthCurve
+            .where((g) => g.strategyId == 'hierarchical')
+            .map((g) => g.context.estimatedTokens)
+            .toList();
+        expect(hierarchicalCurve.last, lessThan(fullCurve.last ~/ 4));
+        expect(writer.writes, greaterThan(0));
+      },
+    );
+
+    test(
+      'a case carries the FACTS it saw, the report status, the reply and the probes',
+      () async {
+        final runner = GoalCompactionEvalRunner(
+          provider: provider,
+          modelId: 'm',
+          conversationRepository: _repo(container),
+          inferenceRepository: _ScriptedInference(),
+        );
+
+        final packet = await runner.run(
+          fixtures: [fixture],
+          strategies: const [TruncatingCheckInCompaction()],
+          samples: 1,
+        );
+
+        final c = packet.cases.single;
+        expect(c.facts, contains('"userVoice"'));
+        expect(c.facts, contains(fixture.checkIns.last.whatHappened));
+        expect(c.facts, isNot(contains(fixture.checkIns.first.whatHappened)));
+        expect(c.reportedStatus, 'offTrack');
+        expect(c.reportOneLiner, 'Off track for a year.');
+        expect(c.wakeReply, 'Restore the calendar block.');
+        expect(c.wakeToolNames, ['reply_to_user', 'update_goal_report']);
+        // Provider-reported, accumulated over the exchange's turns.
+        expect(c.wakeUsage?.inputTokens, greaterThanOrEqualTo(5000));
+        expect(c.probeUsage?.inputTokens, greaterThanOrEqualTo(700));
+        expect(c.errorMessage, isNull);
+        expect(c.probes.length, fixture.truth.probes.length);
+        expect(c.probes[0].answer, 'Answer for ${fixture.truth.probes[0].id}.');
+        expect(c.probes[0].basis, 'history');
+        expect(c.probes[1].basis, 'notInHistory');
+
+        final json = c.toJson(goalCompactionEvalReference);
+        final wake = json['wake']! as Map<String, Object?>;
+        expect(wake['statusCorrect'], isTrue);
+        expect(wake['toolNames'], ['reply_to_user', 'update_goal_report']);
+        expect((json['probes']! as List).length, fixture.truth.probes.length);
+        expect((json['userVoice']! as Map)['verbatimCount'], greaterThan(0));
+      },
+    );
+
+    test('a wrong status is recorded as incorrect, not hidden', () async {
+      final runner = GoalCompactionEvalRunner(
+        provider: provider,
+        modelId: 'm',
+        conversationRepository: _repo(container),
+        inferenceRepository: _ScriptedInference(reportedStatus: 'onTrack'),
+      );
+      final packet = await runner.run(
+        fixtures: [fixture],
+        strategies: const [FullContextCheckInCompaction()],
+        samples: 1,
+      );
+      final wake =
+          packet.cases.single.toJson(goalCompactionEvalReference)['wake']!
+              as Map;
+      expect(wake['reportedStatus'], 'onTrack');
+      expect(wake['expectedStatus'], 'offTrack');
+      expect(wake['statusCorrect'], isFalse);
+    });
+
+    test(
+      'an inference failure lands as an errored case with unanswered probes',
+      () async {
+        final runner = GoalCompactionEvalRunner(
+          provider: provider,
+          modelId: 'm',
+          conversationRepository: _repo(container),
+          inferenceRepository: _ScriptedInference(failOn: 'A few questions'),
+        );
+        final packet = await runner.run(
+          fixtures: [fixture],
+          strategies: const [FullContextCheckInCompaction()],
+          samples: 1,
+        );
+        final c = packet.cases.single;
+        expect(c.errorMessage, contains('scripted failure'));
+        expect(
+          c.reportedStatus,
+          'offTrack',
+          reason: 'the wake itself succeeded',
+        );
+        expect(c.probes.every((p) => p.answer == null), isTrue);
+      },
+    );
+
+    test('the packet JSON is self-describing', () async {
+      final runner = GoalCompactionEvalRunner(
+        provider: provider,
+        modelId: 'm',
+        conversationRepository: _repo(container),
+        inferenceRepository: _ScriptedInference(),
+      );
+      final packet = await runner.run(
+        fixtures: [fixture],
+        strategies: const [FullContextCheckInCompaction()],
+        samples: 1,
+        digestUsage: () => const {'calls': 3},
+      );
+      final json = jsonDecode(packet.toPrettyJson()) as Map<String, dynamic>;
+      expect(json['kind'], goalCompactionEvalPacketKind);
+      expect(json['modelId'], 'm');
+      expect(json['digestUsage'], {'calls': 3});
+      final f = (json['fixtures']! as List).single as Map<String, dynamic>;
+      expect(f['id'], fixture.id);
+      expect(f['checkInCount'], fixture.checkIns.length);
+      expect((f['truth']! as Map)['expectedStatus'], 'offTrack');
+      expect(
+        ((f['truth'] as Map)['probes'] as List).length,
+        fixture.truth.probes.length,
+      );
+    });
+  });
+}
+
+ConversationRepository _repo(ProviderContainer container) =>
+    container.read(conversationRepositoryProvider.notifier);

--- a/test/features/agents/eval/goal/compaction/goal_compaction_fixtures_test.dart
+++ b/test/features/agents/eval/goal/compaction/goal_compaction_fixtures_test.dart
@@ -1,0 +1,232 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/features/goals/logic/goal_user_voice.dart';
+
+import 'support/goal_compaction_facts.dart';
+import 'support/goal_compaction_fixtures.dart';
+
+/// Offline self-test of the compaction fixtures: the answer key must be a
+/// key to the history that is actually generated, and the status it
+/// predicts must be the one production derives.
+void main() {
+  test('catalog covers the five archetypes exactly once', () {
+    expect(goalCompactionFixtures.map((f) => f.id), [
+      'steady_then_stall',
+      'regress_recover',
+      'redefined',
+      'abandoned_revived',
+      'completed',
+    ]);
+  });
+
+  test('generation is deterministic — a re-run reads the same history', () {
+    final again = buildGoalCompactionFixtures();
+    for (final (index, fixture) in goalCompactionFixtures.indexed) {
+      final other = again[index];
+      expect(other.checkIns.length, fixture.checkIns.length);
+      for (final (i, checkIn) in fixture.checkIns.indexed) {
+        expect(other.checkIns[i].id, checkIn.id);
+        expect(other.checkIns[i].recordedAt, checkIn.recordedAt);
+        expect(other.checkIns[i].whatHappened, checkIn.whatHappened);
+        expect(other.checkIns[i].committedTo, checkIn.committedTo);
+      }
+    }
+  });
+
+  for (final fixture in goalCompactionFixtures) {
+    group(fixture.id, () {
+      test('is a long-running goal: many check-ins over about two years', () {
+        expect(fixture.checkIns.length, greaterThanOrEqualTo(120));
+        final span = fixture.checkIns.last.recordedAt.difference(
+          fixture.checkIns.first.recordedAt,
+        );
+        expect(span.inDays, greaterThan(600));
+        expect(
+          fixture.checkIns.last.recordedAt.isBefore(
+            goalCompactionEvalReference,
+          ),
+          isTrue,
+        );
+      });
+
+      test('check-ins are chronological with unique ids and one per day', () {
+        final ids = fixture.checkIns.map((c) => c.id).toSet();
+        expect(ids.length, fixture.checkIns.length);
+        for (var i = 1; i < fixture.checkIns.length; i++) {
+          expect(
+            fixture.checkIns[i].recordedAt.isAfter(
+              fixture.checkIns[i - 1].recordedAt,
+            ),
+            isTrue,
+          );
+        }
+      });
+
+      test('every check-in has something to say', () {
+        for (final checkIn in fixture.checkIns) {
+          expect(checkIn.whatHappened.trim(), isNotEmpty);
+          expect(checkIn.whatHappened, isNot(contains('{steps}')));
+          expect(checkIn.committedTo ?? '', isNot(contains('{steps}')));
+        }
+      });
+
+      test('the deterministic tier derives the status the key predicts', () {
+        final derivation = deriveGoalCompactionFacts(fixture);
+        expect(derivation.status, fixture.truth.expectedStatus);
+        expect(derivation.facts.evaluation.dataCoverage, greaterThan(0.5));
+        // A same-status wake is a no-op by contract; every eval wake must
+        // owe a report.
+        expect(derivation.facts.previousStatus, fixture.transitionFrom);
+        expect(fixture.transitionFrom, isNot(fixture.truth.expectedStatus));
+        expect(derivation.facts.statusTransitioned, isTrue);
+      });
+
+      test('every probe points at a check-in that exists', () {
+        for (final probe in fixture.truth.probes) {
+          final near = fixture.checkIns.where(
+            (c) => c.recordedAt.difference(probe.factDate).inDays.abs() <= 7,
+          );
+          expect(
+            near,
+            isNotEmpty,
+            reason: '${probe.id} has no check-in within a week of its fact',
+          );
+          expect(probe.referenceAnswer.trim(), isNotEmpty);
+        }
+      });
+
+      test('probes span every age stratum', () {
+        final ages = fixture.truth.probes
+            .map((p) => p.age(goalCompactionEvalReference))
+            .toSet();
+        expect(ages, containsAll(GoalCompactionFactAge.values));
+      });
+
+      test('needle facts are recorded on their dates, not just templated', () {
+        // A needle is the one check-in on its day, so any probe whose fact
+        // date has a check-in that day should find its own words there.
+        final byDay = {
+          for (final c in fixture.checkIns)
+            c.recordedAt.toIso8601String().substring(0, 10): c,
+        };
+        final needleProbes = fixture.truth.probes.where((p) => !p.isPattern);
+        expect(needleProbes, isNotEmpty);
+        for (final probe in needleProbes) {
+          final checkIn =
+              byDay[probe.factDate.toIso8601String().substring(0, 10)];
+          expect(checkIn, isNotNull, reason: '${probe.id} has no needle');
+          // Needles are hand-written and long; templates are one line.
+          expect(
+            checkIn!.whatHappened.length,
+            greaterThan(90),
+            reason: '${probe.id}: ${checkIn.whatHappened}',
+          );
+        }
+      });
+
+      test('the shipped truncation drops all but the newest check-ins', () {
+        final kept = goalUserVoiceEntries(fixture.checkIns);
+        // Realistically sized summaries: the 1,200-token slice holds about
+        // three months of a two-year history.
+        expect(kept.length, lessThan(fixture.checkIns.length ~/ 4));
+        final oldestKept = DateTime.parse(
+          kept.first['recordedAtLocal']! as String,
+        );
+        expect(
+          goalCompactionEvalReference.difference(oldestKept).inDays,
+          lessThan(150),
+        );
+        expect(
+          kept.last['sourceEntryId'],
+          fixture.checkIns.last.sourceEntryId,
+        );
+        // Which is the whole problem: every old-stratum probe fact is gone.
+        final keptIds = kept.map((e) => e['sourceEntryId']).toSet();
+        for (final probe in fixture.truth.probes) {
+          if (probe.age(goalCompactionEvalReference) !=
+              GoalCompactionFactAge.old) {
+            continue;
+          }
+          final carriers = fixture.checkIns.where(
+            (c) => c.recordedAt.difference(probe.factDate).inDays.abs() <= 7,
+          );
+          expect(
+            carriers.any((c) => keptIds.contains(c.sourceEntryId)),
+            isFalse,
+            reason: '${probe.id} should be beyond the truncation slice',
+          );
+        }
+      });
+
+      test('growth-curve horizons are nested prefixes of the history', () {
+        var previous = 0;
+        for (final months in const [3, 6, 12, 18, 24]) {
+          final prefix = fixture.upTo(months);
+          expect(prefix.length, greaterThanOrEqualTo(previous));
+          expect(prefix, fixture.checkIns.sublist(0, prefix.length));
+          previous = prefix.length;
+        }
+        expect(fixture.upTo(24).length, greaterThan(fixture.upTo(12).length));
+      });
+
+      test('renders through the production FACTS renderer', () async {
+        final derivation = deriveGoalCompactionFacts(fixture);
+        final voice = await const FullContextCheckInCompaction().build(
+          fixture.checkIns,
+          reference: goalCompactionEvalReference,
+        );
+        final facts = renderGoalCompactionFacts(
+          fixture,
+          derivation,
+          userVoice: voice.entries,
+        );
+        expect(
+          facts,
+          contains('"trackStatus": "${fixture.truth.expectedStatus.name}"'),
+        );
+        expect(facts, contains('"userVoice"'));
+        expect(facts, contains(fixture.checkIns.first.whatHappened));
+        expect(facts, contains(fixture.checkIns.last.whatHappened));
+        expect(facts, contains(fixture.statement));
+        expect(facts, contains('"materialChangeSinceLastReport": true'));
+        expect(facts, contains(goalCompactionEvalUserMessage));
+      });
+    });
+  }
+
+  test('the abandoned goal has a five-month silence and nothing else does', () {
+    String month(DateTime d) => d.toIso8601String().substring(0, 7);
+    for (final fixture in goalCompactionFixtures) {
+      final months = fixture.checkIns.map((c) => month(c.recordedAt)).toSet();
+      final silent = [
+        for (var m = 0; m < 24; m++)
+          if (!months.contains(
+            month(
+              DateTime.utc(fixture.startDate.year, fixture.startDate.month + m),
+            ),
+          ))
+            month(
+              DateTime.utc(fixture.startDate.year, fixture.startDate.month + m),
+            ),
+      ];
+      if (fixture.id == 'abandoned_revived') {
+        expect(silent, ['2025-07', '2025-08', '2025-09', '2025-10', '2025-11']);
+      } else {
+        expect(silent, isEmpty, reason: fixture.id);
+      }
+    }
+  });
+
+  test('statuses are the non-trivial spread the evaluation needs', () {
+    expect(
+      goalCompactionFixtures.map((f) => f.truth.expectedStatus).toSet(),
+      {
+        GoalTrackStatus.offTrack,
+        GoalTrackStatus.onTrack,
+        GoalTrackStatus.atRisk,
+        GoalTrackStatus.achieved,
+      },
+    );
+  });
+}

--- a/test/features/agents/eval/goal/compaction/support/goal_compaction_eval.dart
+++ b/test/features/agents/eval/goal/compaction/support/goal_compaction_eval.dart
@@ -1,0 +1,654 @@
+/// Runner for the check-in compaction evaluation.
+///
+/// For every (fixture × strategy × sample) it renders the production FACTS
+/// block with that strategy's `userVoice`, runs one wake through the
+/// production prompt and tool contract, then asks the fact-recall probes as
+/// a follow-up turn. Everything the judge needs — the FACTS the agent saw,
+/// its report and reply, its probe answers, the answer key, and the
+/// provider-reported tokens — lands in one JSON **judging packet**.
+///
+/// The packet is deliberately the seam: grading is a separate step (a model
+/// reading the packet against `docs/evaluations/goal_agent_models/compaction.md`)
+/// that writes a scores file in the schema `tool/goal_compaction_eval_report.dart`
+/// merges. The deterministic metrics — status accuracy, tool-set agreement,
+/// tokens, the growth curve — need no judge and are computed from the packet
+/// alone.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:lotti/features/ai/conversation/conversation_manager.dart';
+import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/inference_usage.dart';
+import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import '../../../../../../../tool/goal_compaction_eval_report.dart';
+import '../../support/goal_agent_eval_runner.dart';
+import 'goal_compaction_facts.dart';
+import 'goal_compaction_fixtures.dart';
+
+/// The packet kind, shared with the report tool so the two cannot drift.
+const String goalCompactionEvalPacketKind = goalCompactionPacketKind;
+
+/// The horizons of the token growth curve, in months from the goal's start.
+const goalCompactionEvalHorizons = [3, 6, 12, 18, 24];
+
+// ── Digest writer ────────────────────────────────────────────────────────
+
+const _digestSystemMessage =
+    "You condense a span of a person's spoken check-ins about one personal "
+    'goal into a faithful digest that a coach will read months or years '
+    'later instead of the originals. Preserve, with dates where they were '
+    'given: what actually happened to the numbers over the span; every '
+    'commitment made and whether it was kept; setbacks, injuries, medical '
+    'advice, and life changes; anything that changed about the goal itself; '
+    "how the person's mood related to their results. Drop routine "
+    'repetition. Write in plain prose within the word limit given. Never '
+    'infer, advise or judge — record.';
+
+/// Writes span digests with one inference call each, cached on disk by
+/// content so a re-run of the evaluation (or a later horizon that folds
+/// the same span) costs nothing.
+class CachedLlmDigestWriter implements GoalCheckInDigestWriter {
+  CachedLlmDigestWriter({
+    required this.provider,
+    required this.modelId,
+    required this.conversationRepository,
+    required this.inferenceRepository,
+    required this.cacheDirectory,
+    this.temperature = 0,
+  });
+
+  final AiConfigInferenceProvider provider;
+  final String modelId;
+  final ConversationRepository conversationRepository;
+  final InferenceRepositoryInterface inferenceRepository;
+  final Directory cacheDirectory;
+  final double temperature;
+
+  int calls = 0;
+  int cacheHits = 0;
+  InferenceUsage? usage;
+
+  Map<String, Object?> get usageJson => {
+    'calls': calls,
+    'cacheHits': cacheHits,
+    'inputTokens': usage?.inputTokens,
+    'outputTokens': usage?.outputTokens,
+  };
+
+  @override
+  Future<String> write(GoalCheckInDigestRequest request) async {
+    final prompt = _prompt(request);
+    final key = sha256.convert(utf8.encode('$modelId\n$prompt')).toString();
+    final file = File('${cacheDirectory.path}/$key.json');
+    if (file.existsSync()) {
+      cacheHits++;
+      final cached =
+          jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      return cached['digest'] as String;
+    }
+
+    calls++;
+    final conversationId = conversationRepository.createConversation(
+      systemMessage: _digestSystemMessage,
+      maxTurns: 2,
+    );
+    try {
+      final turnUsage = await conversationRepository.sendMessage(
+        conversationId: conversationId,
+        message: prompt,
+        model: modelId,
+        provider: provider,
+        inferenceRepo: inferenceRepository,
+        temperature: temperature,
+        consumptionAgentId: 'goal_agent:compaction-eval-digest',
+        consumptionWakeRunKey: 'goal-compaction-digest:${request.periodLabel}',
+        rethrowInferenceErrors: true,
+      );
+      if (turnUsage != null) {
+        final current = usage;
+        usage = current == null ? turnUsage : current.merge(turnUsage);
+      }
+      final manager = conversationRepository.getConversation(conversationId);
+      final digest = assistantText(manager).trim();
+      if (digest.isEmpty) {
+        throw StateError('empty digest for ${request.periodLabel}');
+      }
+      cacheDirectory.createSync(recursive: true);
+      file.writeAsStringSync(
+        const JsonEncoder.withIndent('  ').convert({
+          'model': modelId,
+          'period': request.periodLabel,
+          'checkIns': request.checkIns.length,
+          'digest': digest,
+        }),
+      );
+      return digest;
+    } finally {
+      conversationRepository.deleteConversation(conversationId);
+    }
+  }
+
+  String _prompt(GoalCheckInDigestRequest request) {
+    final buffer = StringBuffer()
+      ..writeln(
+        'Span: ${request.periodLabel} (${request.layer.name}; '
+        '${goalCompactionDayKey(request.from)} to ${goalCompactionDayKey(request.to)}), '
+        '${request.checkIns.length} check-ins, oldest first. '
+        'Word limit: ${request.maxWords}.',
+      )
+      ..writeln();
+    for (final c in request.checkIns) {
+      buffer.writeln(
+        '${goalCompactionDayKey(c.recordedAt)}: ${c.whatHappened}',
+      );
+      if (c.committedTo != null) {
+        buffer.writeln('  committed to: ${c.committedTo}');
+      }
+      if (c.blockers != null) buffer.writeln('  blockers: ${c.blockers}');
+      if (c.mood != null) buffer.writeln('  mood: ${c.mood}');
+    }
+    return buffer.toString();
+  }
+}
+
+/// Plain assistant text across a conversation, newline-joined.
+String assistantText(ConversationManager? manager) {
+  if (manager == null) return '';
+  return manager.messages
+      .map((m) => m.mapOrNull(assistant: (a) => a.content) ?? '')
+      .where((c) => c.isNotEmpty)
+      .join('\n');
+}
+
+// ── Results ──────────────────────────────────────────────────────────────
+
+/// One probe with the agent's answer alongside the key.
+class GoalCompactionProbeResult {
+  const GoalCompactionProbeResult({
+    required this.probe,
+    required this.answer,
+    required this.basis,
+  });
+
+  final GoalCompactionProbe probe;
+
+  /// Null when the agent produced no parseable answer for this probe.
+  final String? answer;
+
+  /// `history`, `notInHistory`, or null when unparseable.
+  final String? basis;
+
+  Map<String, Object?> toJson(DateTime reference) => {
+    ...probe.toJson(reference),
+    'answer': answer,
+    'basis': basis,
+  };
+}
+
+/// One (fixture × strategy × sample) run.
+class GoalCompactionCaseResult {
+  const GoalCompactionCaseResult({
+    required this.fixture,
+    required this.strategyId,
+    required this.modelId,
+    required this.sample,
+    required this.facts,
+    required this.userVoice,
+    required this.toolCalls,
+    required this.assistantContent,
+    required this.probes,
+    required this.latencyMs,
+    this.wakeUsage,
+    this.probeUsage,
+    this.errorMessage,
+  });
+
+  final GoalCompactionFixture fixture;
+  final String strategyId;
+  final String modelId;
+  final int sample;
+  final String facts;
+  final GoalUserVoiceContext userVoice;
+  final List<GoalAgentEvalToolCall> toolCalls;
+  final String assistantContent;
+  final List<GoalCompactionProbeResult> probes;
+  final int latencyMs;
+  final InferenceUsage? wakeUsage;
+  final InferenceUsage? probeUsage;
+  final String? errorMessage;
+
+  /// The status the wake reported, from the last `update_goal_report`.
+  String? get reportedStatus {
+    for (final call in toolCalls.reversed) {
+      if (call.name == GoalAgentToolNames.updateGoalReport &&
+          call.exchangeIndex == 0) {
+        final status = call.jsonObjectArguments?['status'];
+        if (status is String) return status;
+      }
+    }
+    return null;
+  }
+
+  String? get reportOneLiner {
+    for (final call in toolCalls.reversed) {
+      if (call.name == GoalAgentToolNames.updateGoalReport) {
+        final oneLiner = call.jsonObjectArguments?['oneLiner'];
+        if (oneLiner is String) return oneLiner;
+      }
+    }
+    return null;
+  }
+
+  /// The wake's reply to the pending user message — the recommendation.
+  String? get wakeReply => _replyText(0);
+
+  /// Names of the tools called during the wake, sorted, for set agreement.
+  List<String> get wakeToolNames => ([
+    for (final call in toolCalls)
+      if (call.exchangeIndex == 0) call.name,
+  ]..sort());
+
+  String? _replyText(int exchange) {
+    final replies = [
+      for (final call in toolCalls)
+        if (call.name == GoalAgentToolNames.replyToUser &&
+            call.exchangeIndex == exchange)
+          if (call.jsonObjectArguments?['message'] case final String m)
+            if (m.trim().isNotEmpty) m,
+    ];
+    return replies.isEmpty ? null : replies.join('\n');
+  }
+
+  Map<String, Object?> toJson(DateTime reference) => {
+    'fixtureId': fixture.id,
+    'strategyId': strategyId,
+    'modelId': modelId,
+    'sample': sample,
+    'facts': facts,
+    'userVoice': {
+      'estimatedTokens': userVoice.estimatedTokens,
+      'verbatimCount': userVoice.verbatimCount,
+      'digestCount': userVoice.digestCount,
+      'entries': userVoice.entries,
+    },
+    'wake': {
+      'expectedStatus': fixture.truth.expectedStatus.name,
+      'reportedStatus': reportedStatus,
+      'statusCorrect': reportedStatus == fixture.truth.expectedStatus.name,
+      'oneLiner': reportOneLiner,
+      'reply': wakeReply,
+      'toolNames': wakeToolNames,
+      'toolCalls': [
+        for (final call in toolCalls)
+          if (call.exchangeIndex == 0) call.toJson(),
+      ],
+      'assistantContent': assistantContent,
+      'inputTokens': wakeUsage?.inputTokens,
+      'outputTokens': wakeUsage?.outputTokens,
+      'thoughtsTokens': wakeUsage?.thoughtsTokens,
+      'cachedInputTokens': wakeUsage?.cachedInputTokens,
+    },
+    'probes': [for (final p in probes) p.toJson(reference)],
+    'probeTurn': {
+      'inputTokens': probeUsage?.inputTokens,
+      'outputTokens': probeUsage?.outputTokens,
+      'raw': _replyText(1) ?? '',
+    },
+    'latencyMs': latencyMs,
+    'errorMessage': errorMessage,
+  };
+}
+
+/// One point on the token growth curve.
+class GoalCompactionGrowthPoint {
+  const GoalCompactionGrowthPoint({
+    required this.fixtureId,
+    required this.strategyId,
+    required this.months,
+    required this.checkIns,
+    required this.context,
+  });
+
+  final String fixtureId;
+  final String strategyId;
+  final int months;
+  final int checkIns;
+  final GoalUserVoiceContext context;
+
+  Map<String, Object?> toJson() => {
+    'fixtureId': fixtureId,
+    'strategyId': strategyId,
+    'months': months,
+    'checkIns': checkIns,
+    'estimatedTokens': context.estimatedTokens,
+    'verbatimCount': context.verbatimCount,
+    'digestCount': context.digestCount,
+  };
+}
+
+/// The judging packet.
+class GoalCompactionEvalPacket {
+  const GoalCompactionEvalPacket({
+    required this.provider,
+    required this.modelId,
+    required this.temperature,
+    required this.reference,
+    required this.strategyIds,
+    required this.fixtures,
+    required this.cases,
+    required this.growthCurve,
+    required this.digestUsage,
+  });
+
+  final AiConfigInferenceProvider provider;
+  final String modelId;
+  final double temperature;
+  final DateTime reference;
+  final List<String> strategyIds;
+  final List<GoalCompactionFixture> fixtures;
+  final List<GoalCompactionCaseResult> cases;
+  final List<GoalCompactionGrowthPoint> growthCurve;
+  final Map<String, Object?> digestUsage;
+
+  Map<String, Object?> toJson() => {
+    'kind': goalCompactionEvalPacketKind,
+    'provider': {
+      'id': provider.id,
+      'type': provider.inferenceProviderType.name,
+      'baseUrl': provider.baseUrl,
+    },
+    'modelId': modelId,
+    'temperature': temperature,
+    'reference': reference.toIso8601String(),
+    'strategyIds': strategyIds,
+    'fixtures': [
+      for (final f in fixtures)
+        {
+          'id': f.id,
+          'title': f.title,
+          'statement': f.statement,
+          'checkInCount': f.checkIns.length,
+          'startDate': f.startDate.toIso8601String(),
+          'transitionFrom': f.transitionFrom.name,
+          'truth': f.truth.toJson(reference),
+        },
+    ],
+    'cases': [for (final c in cases) c.toJson(reference)],
+    'growthCurve': [for (final g in growthCurve) g.toJson()],
+    'digestUsage': digestUsage,
+  };
+
+  String toPrettyJson() => const JsonEncoder.withIndent('  ').convert(toJson());
+}
+
+// ── Probe turn ───────────────────────────────────────────────────────────
+
+/// The follow-up message that asks the probes. Answers come back through
+/// `reply_to_user` as JSON so they can be matched to probe ids.
+String goalCompactionProbeMessage(List<GoalCompactionProbe> probes) {
+  final buffer = StringBuffer()
+    ..writeln(
+      'A few questions about the history of this goal. Answer each one '
+      'strictly from what you were given about my own check-ins; if the '
+      'history you have does not contain the answer, say so rather than '
+      'guessing. Reply by calling reply_to_user exactly once, with message '
+      'set to ONLY a JSON object of this shape: '
+      '{"answers":[{"id":"<question id>","answer":"<one or two sentences>", '
+      '"basis":"history" or "notInHistory"}]}',
+    )
+    ..writeln();
+  for (final probe in probes) {
+    buffer.writeln('- ${probe.id}: ${probe.question}');
+  }
+  return buffer.toString();
+}
+
+/// Parses the probe answers out of the agent's reply (or, failing that, its
+/// plain text). Unparseable answers are null, never guessed.
+List<GoalCompactionProbeResult> parseGoalCompactionProbeAnswers(
+  List<GoalCompactionProbe> probes,
+  String raw,
+) {
+  final answers = <String, Map<String, dynamic>>{};
+  final start = raw.indexOf('{');
+  final end = raw.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    try {
+      final decoded = jsonDecode(raw.substring(start, end + 1));
+      final list = decoded is Map ? decoded['answers'] : null;
+      if (list is List) {
+        for (final item in list) {
+          if (item is Map<String, dynamic> && item['id'] is String) {
+            answers[item['id'] as String] = item;
+          }
+        }
+      }
+    } on FormatException {
+      // Fall through: every probe reads as unanswered.
+    }
+  }
+  return [
+    for (final probe in probes)
+      GoalCompactionProbeResult(
+        probe: probe,
+        answer: answers[probe.id]?['answer'] is String
+            ? answers[probe.id]!['answer'] as String
+            : null,
+        basis: answers[probe.id]?['basis'] is String
+            ? answers[probe.id]!['basis'] as String
+            : null,
+      ),
+  ];
+}
+
+// ── Runner ───────────────────────────────────────────────────────────────
+
+class GoalCompactionEvalRunner {
+  GoalCompactionEvalRunner({
+    required this.provider,
+    required this.modelId,
+    required this.conversationRepository,
+    required this.inferenceRepository,
+    this.temperature = 0,
+    this.maxTurnsPerExchange = 6,
+    this.reference,
+    this.log,
+  });
+
+  final AiConfigInferenceProvider provider;
+  final String modelId;
+  final ConversationRepository conversationRepository;
+  final InferenceRepositoryInterface inferenceRepository;
+  final double temperature;
+  final int maxTurnsPerExchange;
+  final DateTime? reference;
+  final void Function(String)? log;
+
+  DateTime get _reference => reference ?? goalCompactionEvalReference;
+
+  Future<GoalCompactionEvalPacket> run({
+    required List<GoalCompactionFixture> fixtures,
+    required List<GoalCheckInCompactionStrategy> strategies,
+    required int samples,
+    // Read AFTER the run: the digest writer's counters only exist then.
+    Map<String, Object?> Function()? digestUsage,
+    List<int> horizons = goalCompactionEvalHorizons,
+  }) async {
+    final cases = <GoalCompactionCaseResult>[];
+    final growth = <GoalCompactionGrowthPoint>[];
+
+    for (final fixture in fixtures) {
+      final derivation = deriveGoalCompactionFacts(
+        fixture,
+        reference: _reference,
+      );
+      for (final strategy in strategies) {
+        // Growth curve first: it needs no agent call, and it warms the
+        // digest cache for the spans the full-horizon wake will fold.
+        for (final months in horizons) {
+          final prefix = fixture.upTo(months);
+          final context = await strategy.build(prefix, reference: _reference);
+          growth.add(
+            GoalCompactionGrowthPoint(
+              fixtureId: fixture.id,
+              strategyId: strategy.id,
+              months: months,
+              checkIns: prefix.length,
+              context: context,
+            ),
+          );
+        }
+
+        final context = await strategy.build(
+          fixture.checkIns,
+          reference: _reference,
+        );
+        final facts = renderGoalCompactionFacts(
+          fixture,
+          derivation,
+          userVoice: context.entries,
+          reference: _reference,
+        );
+        for (var sample = 1; sample <= samples; sample++) {
+          log?.call('${fixture.id} × ${strategy.id} × s$sample');
+          cases.add(
+            await _runCase(fixture, strategy.id, sample, facts, context),
+          );
+        }
+      }
+    }
+
+    return GoalCompactionEvalPacket(
+      provider: provider,
+      modelId: modelId,
+      temperature: temperature,
+      reference: _reference,
+      strategyIds: [for (final s in strategies) s.id],
+      fixtures: fixtures,
+      cases: cases,
+      growthCurve: growth,
+      digestUsage: digestUsage?.call() ?? const {},
+    );
+  }
+
+  Future<GoalCompactionCaseResult> _runCase(
+    GoalCompactionFixture fixture,
+    String strategyId,
+    int sample,
+    String facts,
+    GoalUserVoiceContext context,
+  ) async {
+    final stopwatch = Stopwatch()..start();
+    final strategy = GoalAgentEvalStrategy();
+    final conversationId = conversationRepository.createConversation(
+      systemMessage: goalAgentSystemPrompt,
+      maxTurns: maxTurnsPerExchange * 2,
+    );
+    final manager = conversationRepository.getConversation(conversationId);
+    final tools = [
+      for (final tool in goalAgentTools)
+        // Mirrors the runtime: a wake whose status rules out a banner is not
+        // offered the ad tools. Off-track is the only fixture status that
+        // would be; keeping the surface uniform across arms is what makes
+        // the tool-set comparison meaningful.
+        if (tool.name != GoalAgentToolNames.createGoalAd &&
+            tool.name != GoalAgentToolNames.rerunGoalAd)
+          ChatCompletionTool(
+            type: ChatCompletionToolType.function,
+            function: FunctionObject(
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.parameters,
+            ),
+          ),
+    ];
+
+    Future<InferenceUsage?> exchange(int index, String message) {
+      strategy.beginExchange(index);
+      return conversationRepository.sendMessage(
+        conversationId: conversationId,
+        message: message,
+        model: modelId,
+        provider: provider,
+        inferenceRepo: inferenceRepository,
+        tools: tools,
+        temperature: temperature,
+        strategy: strategy,
+        consumptionAgentId: 'goal_agent:compaction-eval',
+        consumptionWakeRunKey:
+            'goal-compaction:${fixture.id}:$strategyId:$sample',
+        consumptionThreadId: fixture.id,
+        rethrowInferenceErrors: true,
+      );
+    }
+
+    InferenceUsage? wakeUsage;
+    InferenceUsage? probeUsage;
+    try {
+      wakeUsage = await exchange(0, facts);
+      probeUsage = await exchange(
+        1,
+        goalCompactionProbeMessage(fixture.truth.probes),
+      );
+      final probeRaw = [
+        for (final call in strategy.toolCalls)
+          if (call.exchangeIndex == 1 &&
+              call.name == GoalAgentToolNames.replyToUser)
+            if (call.jsonObjectArguments?['message'] case final String m) m,
+      ].join('\n');
+      final content = assistantText(manager);
+      return GoalCompactionCaseResult(
+        fixture: fixture,
+        strategyId: strategyId,
+        modelId: modelId,
+        sample: sample,
+        facts: facts,
+        userVoice: context,
+        toolCalls: strategy.toolCalls,
+        assistantContent: content,
+        probes: parseGoalCompactionProbeAnswers(
+          fixture.truth.probes,
+          probeRaw.isEmpty ? content : probeRaw,
+        ),
+        latencyMs: stopwatch.elapsedMilliseconds,
+        wakeUsage: wakeUsage,
+        probeUsage: probeUsage,
+      );
+    } catch (error) {
+      return GoalCompactionCaseResult(
+        fixture: fixture,
+        strategyId: strategyId,
+        modelId: modelId,
+        sample: sample,
+        facts: facts,
+        userVoice: context,
+        toolCalls: strategy.toolCalls,
+        assistantContent: assistantText(manager),
+        probes: parseGoalCompactionProbeAnswers(fixture.truth.probes, ''),
+        latencyMs: stopwatch.elapsedMilliseconds,
+        wakeUsage: wakeUsage,
+        probeUsage: probeUsage,
+        errorMessage: error.toString(),
+      );
+    } finally {
+      conversationRepository.deleteConversation(conversationId);
+    }
+  }
+}
+
+/// Convenience for tests and the live driver: the three arms.
+List<GoalCheckInCompactionStrategy> goalCompactionEvalArms(
+  GoalCheckInDigestWriter digestWriter,
+) => [
+  const FullContextCheckInCompaction(),
+  const TruncatingCheckInCompaction(),
+  HierarchicalCheckInCompaction(digestWriter: digestWriter),
+];

--- a/test/features/agents/eval/goal/compaction/support/goal_compaction_eval.dart
+++ b/test/features/agents/eval/goal/compaction/support/goal_compaction_eval.dart
@@ -86,7 +86,16 @@ class CachedLlmDigestWriter implements GoalCheckInDigestWriter {
   @override
   Future<String> write(GoalCheckInDigestRequest request) async {
     final prompt = _prompt(request);
-    final key = sha256.convert(utf8.encode('$modelId\n$prompt')).toString();
+    // Every input that shapes the digest: a provider or prompt change must
+    // miss the cache rather than silently reuse another backend's output.
+    final key = sha256
+        .convert(
+          utf8.encode(
+            '${provider.inferenceProviderType.name}\n${provider.baseUrl}\n'
+            '$modelId\n$temperature\n$_digestSystemMessage\n$prompt',
+          ),
+        )
+        .toString();
     final file = File('${cacheDirectory.path}/$key.json');
     if (file.existsSync()) {
       cacheHits++;
@@ -495,7 +504,16 @@ class GoalCompactionEvalRunner {
         // digest cache for the spans the full-horizon wake will fold.
         for (final months in horizons) {
           final prefix = fixture.upTo(months);
-          final context = await strategy.build(prefix, reference: _reference);
+          // Dated at its own horizon: a six-month-old goal is compacted as
+          // seen from its sixth month, not from two years on, or the early
+          // history would be folded into layers it had not yet aged into.
+          final context = await strategy.build(
+            prefix,
+            reference: DateTime.utc(
+              fixture.startDate.year,
+              fixture.startDate.month + months,
+            ),
+          );
           growth.add(
             GoalCompactionGrowthPoint(
               fixtureId: fixture.id,

--- a/test/features/agents/eval/goal/compaction/support/goal_compaction_facts.dart
+++ b/test/features/agents/eval/goal/compaction/support/goal_compaction_facts.dart
@@ -1,0 +1,148 @@
+/// The production derivation for a compaction fixture: signal window →
+/// evaluator → policy → `GoalWakeFacts` → `GoalFactsRenderer`.
+///
+/// Every arm of the evaluation renders through this, so the only thing that
+/// differs between arms is the `userVoice` block. The status the agent is
+/// asked to restate comes from the real evaluator and the real policy; the
+/// fixture's answer key merely predicts it, and the offline self-test holds
+/// the two together.
+library;
+
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/goals/evaluation/goal_progress_evaluator.dart';
+import 'package:lotti/features/goals/evaluation/goal_track_policy.dart';
+import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
+import 'package:lotti/features/goals/workflow/goal_facts_renderer.dart';
+
+import 'goal_compaction_fixtures.dart';
+
+/// What the deterministic tier says about a fixture at the reference date.
+class GoalCompactionDerivation {
+  const GoalCompactionDerivation({
+    required this.version,
+    required this.facts,
+    required this.priorRegisters,
+  });
+
+  final GoalSpecVersionEntity version;
+  final GoalWakeFacts facts;
+  final List<GoalProgressEntity> priorRegisters;
+
+  GoalTrackStatus get status => facts.trackStatus;
+}
+
+/// Runs the fixture's window through the production evaluator and policy.
+GoalCompactionDerivation deriveGoalCompactionFacts(
+  GoalCompactionFixture fixture, {
+  DateTime? reference,
+}) {
+  final now = reference ?? goalCompactionEvalReference;
+  const evaluator = GoalProgressEvaluator();
+  const policy = GoalTrackPolicy();
+  final evaluation = evaluator.evaluate(fixture.criteria, fixture.window, now);
+  final shortTerm = evaluator.shortTermAttainment(
+    fixture.criteria,
+    fixture.window,
+    now,
+  );
+  final targetDate = fixture.targetDate;
+  final status = policy.derive(
+    evaluation: evaluation,
+    shortTermAttainment: shortTerm,
+    priorAttainments: fixture.priorAttainments,
+    targetDatePassed:
+        targetDate != null &&
+        GoalWindow.dayUtc(now).isAfter(GoalWindow.dayUtc(targetDate)),
+  );
+
+  final specVersionId = '${fixture.agentId}:spec-v1';
+  final version =
+      AgentDomainEntity.goalSpecVersion(
+            id: specVersionId,
+            agentId: fixture.agentId,
+            version: 1,
+            status: GoalSpecVersionStatus.active,
+            authoredBy: 'user',
+            title: fixture.title,
+            statement: fixture.statement,
+            criteria: fixture.criteria,
+            createdAt: fixture.startDate,
+            vectorClock: null,
+            startDate: fixture.startDate,
+            targetDate: fixture.targetDate,
+          )
+          as GoalSpecVersionEntity;
+
+  final priorRegisters = <GoalProgressEntity>[
+    for (final (index, attainment) in fixture.priorAttainments.indexed)
+      AgentDomainEntity.goalProgress(
+            id: goalProgressId(
+              fixture.agentId,
+              goalCompactionDayKey(now.subtract(Duration(days: index + 1))),
+            ),
+            agentId: fixture.agentId,
+            periodKey: goalCompactionDayKey(
+              now.subtract(Duration(days: index + 1)),
+            ),
+            trackStatus: fixture.priorStatus,
+            attainment: attainment,
+            dataCoverage: 1,
+            satisfied: attainment >= 1,
+            specVersionId: specVersionId,
+            createdAt: now.subtract(Duration(days: index + 1)),
+            updatedAt: now.subtract(Duration(days: index + 1)),
+            vectorClock: null,
+          )
+          as GoalProgressEntity,
+  ];
+
+  return GoalCompactionDerivation(
+    version: version,
+    facts: GoalWakeFacts(
+      trackStatus: status,
+      previousStatus: fixture.transitionFrom,
+      evaluation: evaluation,
+      shortTermAttainment: shortTerm,
+    ),
+    priorRegisters: priorRegisters,
+  );
+}
+
+/// The question every evaluation wake carries. It makes `reply_to_user`
+/// contract-mandated, so each arm produces a status assessment and a
+/// recommendation the judge can compare against the full-context arm.
+const goalCompactionEvalUserMessage =
+    'Quick check: where does this goal stand right now, and what would you '
+    'suggest I focus on next? Please take the whole history into account, '
+    'not just this week.';
+
+/// Renders the FACTS block the agent reads, with [userVoice] in the slot
+/// the compaction strategy fills and the evaluation question pending.
+String renderGoalCompactionFacts(
+  GoalCompactionFixture fixture,
+  GoalCompactionDerivation derivation, {
+  required List<Map<String, Object?>> userVoice,
+  DateTime? reference,
+}) {
+  final now = reference ?? goalCompactionEvalReference;
+  return withClock(
+    Clock.fixed(now),
+    () => const GoalFactsRenderer().render(
+      version: derivation.version,
+      facts: derivation.facts,
+      priorRegisters: derivation.priorRegisters,
+      nudges: const [],
+      evaluationReference: now,
+      unansweredUserMessages: const [goalCompactionEvalUserMessage],
+      userVoice: userVoice,
+    ),
+  );
+}
+
+/// A register's period key: the UTC calendar day.
+String goalCompactionDayKey(DateTime day) =>
+    day.toIso8601String().substring(0, 10);

--- a/test/features/agents/eval/goal/compaction/support/goal_compaction_fixtures.dart
+++ b/test/features/agents/eval/goal/compaction/support/goal_compaction_fixtures.dart
@@ -1,0 +1,1188 @@
+/// Synthetic long-running goals for the check-in compaction evaluation.
+///
+/// Each fixture is a goal that has been running for roughly two years with
+/// three check-ins a week, generated deterministically from a seed so a
+/// re-run reads the same history. The interesting part is not the volume but
+/// the shape: every archetype is a case where drawing the right conclusion
+/// from the present alone is wrong or incomplete — a stall that the user's
+/// own words paper over, a recovery whose cause is nine months old, a
+/// redefinition that retired the number the early check-ins keep quoting.
+///
+/// A fixture carries its own answer key: the status the deterministic tier
+/// derives at the reference date (asserted against the real evaluator in the
+/// offline self-test), a set of fact-recall probes whose answers live in
+/// specific dated check-ins, and the recommendation a well-informed coach
+/// would make. The Ross Station penguin universe keeps it obviously
+/// synthetic; nothing here resembles real user data.
+library;
+
+import 'dart:math';
+
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
+
+/// Every fixture shares this "today": a Thursday at noon, station time.
+final goalCompactionEvalReference = DateTime.utc(2026, 8, 27, 12);
+
+/// How far back a fact is from the reference — the strata the recall
+/// metric is reported over, because that is where each compaction layer
+/// starts losing.
+enum GoalCompactionFactAge {
+  /// Inside the last month: should survive even truncation.
+  recent,
+
+  /// One to six months: the monthly-digest layer.
+  mid,
+
+  /// Older than six months: the quarterly layer.
+  old;
+
+  static GoalCompactionFactAge of(DateTime factDate, DateTime reference) {
+    final days = reference.difference(factDate).inDays;
+    if (days <= 31) return recent;
+    if (days <= 183) return mid;
+    return old;
+  }
+}
+
+/// One fact-recall question with the answer the history supports.
+class GoalCompactionProbe {
+  const GoalCompactionProbe({
+    required this.id,
+    required this.question,
+    required this.referenceAnswer,
+    required this.factDate,
+    this.isPattern = false,
+  });
+
+  final String id;
+  final String question;
+
+  /// True when the answer is a pattern across many templated check-ins
+  /// rather than the words of one dated needle.
+  final bool isPattern;
+
+  /// What a correct answer must contain, in the judge's terms.
+  final String referenceAnswer;
+
+  /// When the check-in(s) carrying the answer were recorded.
+  final DateTime factDate;
+
+  GoalCompactionFactAge age(DateTime reference) =>
+      GoalCompactionFactAge.of(factDate, reference);
+
+  Map<String, Object?> toJson(DateTime reference) => {
+    'id': id,
+    'question': question,
+    'referenceAnswer': referenceAnswer,
+    'factDate': factDate.toIso8601String(),
+    'age': age(reference).name,
+    'isPattern': isPattern,
+  };
+}
+
+/// The answer key.
+class GoalCompactionGroundTruth {
+  const GoalCompactionGroundTruth({
+    required this.expectedStatus,
+    required this.probes,
+    required this.expectedRecommendation,
+    required this.forbiddenRecommendations,
+  });
+
+  /// What the deterministic tier derives; the report must restate it.
+  final GoalTrackStatus expectedStatus;
+  final List<GoalCompactionProbe> probes;
+
+  /// The coaching direction a coach who read everything would take.
+  final String expectedRecommendation;
+
+  /// Directions the full history rules out — the ones a truncated view is
+  /// prone to.
+  final List<String> forbiddenRecommendations;
+
+  Map<String, Object?> toJson(DateTime reference) => {
+    'expectedStatus': expectedStatus.name,
+    'probes': [for (final p in probes) p.toJson(reference)],
+    'expectedRecommendation': expectedRecommendation,
+    'forbiddenRecommendations': forbiddenRecommendations,
+  };
+}
+
+/// One synthetic goal: its spec, its two years of check-ins, the signal
+/// window at the reference date, and the answer key.
+class GoalCompactionFixture {
+  const GoalCompactionFixture({
+    required this.id,
+    required this.title,
+    required this.statement,
+    required this.criteria,
+    required this.startDate,
+    required this.checkIns,
+    required this.window,
+    required this.priorAttainments,
+    required this.priorStatus,
+    required this.transitionFrom,
+    required this.truth,
+    this.targetDate,
+  });
+
+  final String id;
+  final String title;
+  final String statement;
+  final GoalCriterion criteria;
+  final DateTime startDate;
+  final DateTime? targetDate;
+
+  /// Oldest first.
+  final List<GoalCheckInSummary> checkIns;
+
+  /// The seven days ending at the reference, as the signal reader would
+  /// return them.
+  final GoalSignalWindow window;
+
+  /// Prior period attainments, most recent first — the trend input.
+  final List<double> priorAttainments;
+  final GoalTrackStatus priorStatus;
+
+  /// The status the wake transitions FROM. A same-status wake is a
+  /// contract-mandated no-op, which would leave nothing to compare; every
+  /// evaluation wake is therefore a transition, so a report is owed.
+  final GoalTrackStatus transitionFrom;
+  final GoalCompactionGroundTruth truth;
+
+  String get agentId => 'goal-compaction-eval:$id';
+
+  /// The check-ins recorded within [months] of [startDate] — the growth
+  /// curve's horizons.
+  List<GoalCheckInSummary> upTo(int months) {
+    final cutoff = DateTime.utc(startDate.year, startDate.month + months);
+    return [
+      for (final c in checkIns)
+        if (c.recordedAt.isBefore(cutoff)) c,
+    ];
+  }
+}
+
+/// Uniform daily step sums over the seven days ending at the reference.
+GoalSignalWindow _stepsWindow(int perDay, {Map<DateTime, int>? gymDays}) =>
+    GoalSignalWindow(
+      quantitativeDailySums: {
+        'cumulative_step_count': {
+          for (var day = 21; day <= 27; day++)
+            DateTime.utc(2026, 8, day): perDay,
+        },
+      },
+      habitSuccessesByDay: gymDays == null ? const {} : {'gym': gymDays},
+    );
+
+const _steps10k = GoalCriterion.metric(
+  criterionId: 'steps',
+  dataType: 'cumulative_step_count',
+  window: GoalWindow.rollingDays(count: 7),
+  aggregation: GoalAggregation.dailySumThenAverage,
+  target: 10000,
+);
+
+// ── The generator ────────────────────────────────────────────────────────
+
+/// A stretch of months with one voice: what the check-ins say, what the
+/// user keeps promising, what is in the way.
+class _Phase {
+  const _Phase({
+    required this.fromMonth,
+    required this.toMonth,
+    required this.happened,
+    required this.committed,
+    required this.stepsRange,
+    this.blockers = const [],
+    this.moods = const ['steady'],
+  });
+
+  /// Month offsets from the start, inclusive/exclusive.
+  final int fromMonth;
+  final int toMonth;
+
+  /// Templates; `{steps}` is replaced with a number drawn from [stepsRange].
+  final List<String> happened;
+  final List<String?> committed;
+  final List<String?> blockers;
+  final List<String> moods;
+  final (int, int) stepsRange;
+}
+
+/// A specific check-in on a specific date — the fact a probe asks for.
+class _Needle {
+  const _Needle({
+    required this.date,
+    required this.happened,
+    this.committed,
+    this.blockers,
+    this.mood,
+  });
+
+  final DateTime date;
+  final String happened;
+  final String? committed;
+  final String? blockers;
+  final String? mood;
+}
+
+const _checkInsPerWeek = 3;
+
+List<GoalCheckInSummary> _generate({
+  required String fixtureId,
+  required DateTime start,
+  required DateTime end,
+  required List<_Phase> phases,
+  required List<_Needle> needles,
+  required int seed,
+}) {
+  final random = Random(seed);
+  final byDay = <DateTime, GoalCheckInSummary>{};
+  // The reference is "today at noon"; today's check-in has not happened.
+  final endDay = DateTime.utc(end.year, end.month, end.day);
+
+  GoalCheckInSummary make(
+    DateTime day, {
+    required String happened,
+    String? committed,
+    String? blockers,
+    String? mood,
+  }) {
+    final at = DateTime.utc(
+      day.year,
+      day.month,
+      day.day,
+      7 + random.nextInt(13),
+      random.nextInt(60),
+    );
+    final key = DateTime.utc(day.year, day.month, day.day);
+    final id = 'checkin:$fixtureId:${key.toIso8601String().substring(0, 10)}';
+    return GoalCheckInSummary(
+      id: id,
+      sourceEntryId: 'entry:$id',
+      recordedAt: at,
+      whatHappened: happened,
+      committedTo: committed,
+      blockers: blockers,
+      mood: mood,
+    );
+  }
+
+  for (final phase in phases) {
+    final phaseStart = DateTime.utc(start.year, start.month + phase.fromMonth);
+    final phaseEnd = DateTime.utc(start.year, start.month + phase.toMonth);
+    var weekStart = phaseStart;
+    while (weekStart.isBefore(phaseEnd) && weekStart.isBefore(endDay)) {
+      final offsets = <int>{};
+      while (offsets.length < _checkInsPerWeek) {
+        offsets.add(random.nextInt(7));
+      }
+      for (final offset in offsets.toList()..sort()) {
+        final day = weekStart.add(Duration(days: offset));
+        if (!day.isBefore(phaseEnd) || !day.isBefore(endDay)) continue;
+        final (low, high) = phase.stepsRange;
+        final steps = (low + random.nextInt(high - low + 1)) ~/ 100 * 100;
+        String fill(String s) => s.replaceAll('{steps}', _thousands(steps));
+        final key = DateTime.utc(day.year, day.month, day.day);
+        byDay[key] = make(
+          day,
+          happened: fill(phase.happened[random.nextInt(phase.happened.length)]),
+          committed: _pick(random, phase.committed)?.let(fill),
+          blockers: _pick(random, phase.blockers),
+          mood: phase.moods[random.nextInt(phase.moods.length)],
+        );
+      }
+      weekStart = weekStart.add(const Duration(days: 7));
+    }
+  }
+
+  for (final needle in needles) {
+    final key = DateTime.utc(
+      needle.date.year,
+      needle.date.month,
+      needle.date.day,
+    );
+    byDay[key] = make(
+      needle.date,
+      happened: needle.happened,
+      committed: needle.committed,
+      blockers: needle.blockers,
+      mood: needle.mood,
+    );
+  }
+
+  final days = byDay.keys.toList()..sort();
+  return [for (final day in days) byDay[day]!];
+}
+
+T? _pick<T>(Random random, List<T?> options) =>
+    options.isEmpty ? null : options[random.nextInt(options.length)];
+
+String _thousands(int value) {
+  final text = value.toString();
+  return text.length <= 3
+      ? text
+      : '${text.substring(0, text.length - 3)},${text.substring(text.length - 3)}';
+}
+
+extension<T> on T {
+  R let<R>(R Function(T) f) => f(this);
+}
+
+// Shared voices. Wording varies enough that a digest has to abstract rather
+// than pattern-match, and every template mentions concrete station life so
+// the digests have something to lose.
+const List<String> _steadyHappened = [
+  'Two perimeter loops today, one after lunch and one after the evening count. Tracker says {steps}.',
+  'Walked out to the weather mast and back before the shift, then the lunch loop. {steps} on the tracker.',
+  'Good day — {steps} steps. Did the long loop past the ice ramp while the light held.',
+  'Lunch loop plus pacing the corridor during the radio check. {steps}, comfortably over.',
+  'Went out with the survey team on foot instead of the skidoo. Ended on {steps}.',
+];
+const List<String?> _steadyCommitted = [
+  'Both loops again tomorrow.',
+  'Keep the lunch loop non-negotiable this week.',
+  null,
+  'Weather mast walk before the shift tomorrow.',
+];
+
+// ── Archetype 1: steady, then a stall the user talks over ───────────────
+
+final DateTime _stallStart = DateTime.utc(2024, 9, 2);
+
+List<GoalCheckInSummary> _stallCheckIns() => _generate(
+  fixtureId: 'steady_then_stall',
+  start: _stallStart,
+  end: goalCompactionEvalReference,
+  seed: 11,
+  phases: [
+    const _Phase(
+      fromMonth: 0,
+      toMonth: 2,
+      happened: [
+        'First weeks. Managed {steps} mostly by walking to the far hangar instead of taking the skidoo.',
+        'Getting the hang of it. {steps} today, mostly the hangar walk and the lunch loop.',
+        'Under target at {steps} — boots are rubbing and I cut the afternoon loop short.',
+      ],
+      committed: ['Hangar walk every day this week.', null],
+      blockers: ['Blisters from the old boots.', null],
+      moods: ['keen', 'a bit sore'],
+      stepsRange: (7500, 10500),
+    ),
+    const _Phase(
+      fromMonth: 2,
+      toMonth: 8,
+      happened: _steadyHappened,
+      committed: _steadyCommitted,
+      moods: ['steady', 'good', 'tired but fine'],
+      stepsRange: (9800, 12500),
+    ),
+    // The stall: numbers fall, the voice stays upbeat. Reading these as
+    // evidence of progress is exactly the mistake the interpretation policy
+    // warns about, and the compaction must preserve that the numbers fell.
+    const _Phase(
+      fromMonth: 8,
+      toMonth: 24,
+      happened: [
+        'Feeling really good about the goal this week. Only {steps} on the tracker but the intent is there.',
+        'Busy colony-survey day at the desk, {steps}. Still committed, honestly.',
+        'Solid mindset, {steps} steps. The survey deadlines are eating the loop time but I feel on top of it.',
+        'Quick one — {steps}. Long stretch of data entry, but I walked the corridor a lot.',
+        'Positive week overall I think. {steps} today.',
+      ],
+      committed: [
+        'Get the lunch loop back in once the survey batch is filed.',
+        null,
+        null,
+        'Try for one loop tomorrow.',
+      ],
+      blockers: [
+        'Colony survey season keeps me at the desk most of the day.',
+        'Survey data entry backlog.',
+        null,
+      ],
+      moods: ['upbeat', 'optimistic', 'cheerful'],
+      stepsRange: (5200, 7400),
+    ),
+  ],
+  needles: [
+    _Needle(
+      date: DateTime.utc(2024, 10, 14),
+      happened:
+          'Bought the new insulated boots from the station store — the old ones gave me blisters that were cutting every walk short. {steps} today, first full loop without limping.'
+              .replaceAll('{steps}', '9,400'),
+      committed: 'Break the new boots in on the short loop this week.',
+      mood: 'relieved',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 1, 20),
+      happened:
+          'Made the perimeter loop after lunch a fixed appointment in my shift calendar, every weekday. That is what got me from about 8,000 to consistently over 10,000 — the calendar block, not willpower.',
+      committed:
+          'Perimeter loop after lunch, every weekday, as a calendar block.',
+      mood: 'confident',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 5, 9),
+      happened:
+          'Colony survey season started this week. The survey lead moved me to data entry, which means most of the day at a desk. First day I dropped the lunch loop and only got 6,100.',
+      committed: 'Keep the lunch loop even during survey season.',
+      blockers: 'Colony survey data entry, all day.',
+      mood: 'a bit worried',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 5, 23),
+      happened:
+          'Deleted the perimeter-loop calendar block because it kept clashing with the survey stand-ups. Told myself I would fit the walk in anyway. 5,800 today.',
+      blockers: 'Survey stand-ups overlapped the loop slot.',
+      mood: 'fine',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 8, 20),
+      happened:
+          'Feeling great about where the goal is this week, honestly. 6,300 steps but the energy is good and I have been thinking about walking a lot.',
+      committed: 'Get a loop in over the weekend.',
+      mood: 'upbeat',
+    ),
+  ],
+);
+
+final _stallTruth = GoalCompactionGroundTruth(
+  expectedStatus: GoalTrackStatus.offTrack,
+  probes: [
+    GoalCompactionProbe(
+      id: 'stall_boots',
+      question:
+          'Early on, what did the user buy and why did it matter for the goal?',
+      referenceAnswer:
+          'New insulated boots from the station store, in October 2024, because the old boots caused blisters that were cutting walks short.',
+      factDate: DateTime.utc(2024, 10, 14),
+    ),
+    GoalCompactionProbe(
+      id: 'stall_routine',
+      question:
+          'What routine did the user credit for getting consistently over 10,000 steps, and roughly when did they establish it?',
+      referenceAnswer:
+          'A fixed calendar block for the perimeter loop after lunch every weekday, set up around January 2025. They credited the calendar block rather than willpower.',
+      factDate: DateTime.utc(2025, 1, 20),
+    ),
+    GoalCompactionProbe(
+      id: 'stall_cause',
+      question:
+          "When did the step counts start falling, and what changed in the user's life at that point?",
+      referenceAnswer:
+          'Around May 2025, when colony survey season started and the user was moved to all-day data entry at a desk.',
+      factDate: DateTime.utc(2025, 5, 9),
+    ),
+    GoalCompactionProbe(
+      id: 'stall_block_deleted',
+      question: 'What happened to the lunch-loop calendar block, and why?',
+      referenceAnswer:
+          'The user deleted it in late May 2025 because it clashed with survey stand-ups, telling themselves they would fit the walk in anyway.',
+      factDate: DateTime.utc(2025, 5, 23),
+    ),
+    GoalCompactionProbe(
+      id: 'stall_mood_vs_numbers',
+      isPattern: true,
+      question:
+          "How does the user's mood in the check-ins of the last year compare with their measured step counts?",
+      referenceAnswer:
+          'The mood has stayed upbeat, optimistic and confident while the measured steps have sat around 5,000–7,500, well under target, for over a year.',
+      factDate: DateTime.utc(2026, 3),
+    ),
+    GoalCompactionProbe(
+      id: 'stall_recent',
+      question: 'What did the user commit to in their most recent check-ins?',
+      referenceAnswer:
+          'Small, vague commitments — a loop over the weekend, "try for one loop tomorrow" — rather than restoring the routine.',
+      factDate: DateTime.utc(2026, 8, 20),
+    ),
+  ],
+  expectedRecommendation:
+      'Name the stall plainly (over a year under target, contradicting the upbeat check-ins) and propose restoring the specific thing that worked before — the fixed after-lunch perimeter-loop calendar block — adapted around survey stand-ups, rather than a generic "walk more".',
+  forbiddenRecommendations: [
+    'Congratulating the user on progress or momentum.',
+    'Treating the upbeat mood as evidence the goal is going well.',
+    'Suggesting a brand-new routine without reference to the calendar block that worked in 2025.',
+  ],
+);
+
+// ── Archetype 2: an injury, a long regression, a slow recovery ──────────
+
+final DateTime _recoverStart = DateTime.utc(2024, 9, 2);
+
+List<GoalCheckInSummary> _recoverCheckIns() => _generate(
+  fixtureId: 'regress_recover',
+  start: _recoverStart,
+  end: goalCompactionEvalReference,
+  seed: 23,
+  phases: [
+    const _Phase(
+      fromMonth: 0,
+      toMonth: 9,
+      happened: _steadyHappened,
+      committed: _steadyCommitted,
+      moods: ['steady', 'good'],
+      stepsRange: (9800, 12800),
+    ),
+    const _Phase(
+      fromMonth: 9,
+      toMonth: 13,
+      happened: [
+        'Physio day. Mostly the stationary bike and the ankle exercises; {steps} steps shuffling around the module.',
+        'Ankle still swells by the evening. {steps} and that felt like plenty.',
+        'Short corridor walks only, as the medic said. {steps}.',
+        'Tried the short loop with the brace. {steps}, ankle complained afterwards.',
+      ],
+      committed: [
+        'Ankle exercises twice a day, as prescribed.',
+        "Stay under the medic's step cap this week.",
+        null,
+      ],
+      blockers: ['Ankle sprain — medic step cap.', 'Swelling by the evening.'],
+      moods: ['frustrated', 'patient', 'low'],
+      stepsRange: (2800, 4600),
+    ),
+    const _Phase(
+      fromMonth: 13,
+      toMonth: 18,
+      happened: [
+        'Building back up. {steps} today, one loop at an easy pace, ankle fine afterwards.',
+        'Two short loops instead of one long one, the way the physio suggested. {steps}.',
+        'Best week since the sprain — {steps}. No swelling.',
+        'Careful day, {steps}. Kept off the ice ramp entirely.',
+      ],
+      committed: [
+        'Add about 500 steps a week, no more.',
+        'Two short loops rather than one long one.',
+        null,
+      ],
+      blockers: [null, 'Still avoiding the ice ramp.'],
+      moods: ['hopeful', 'careful', 'good'],
+      stepsRange: (6500, 9400),
+    ),
+    const _Phase(
+      fromMonth: 18,
+      toMonth: 24,
+      happened: _steadyHappened,
+      committed: _steadyCommitted,
+      moods: ['good', 'strong', 'steady'],
+      stepsRange: (9600, 12000),
+    ),
+  ],
+  needles: [
+    _Needle(
+      date: DateTime.utc(2025, 6, 3),
+      happened:
+          'Twisted my left ankle badly on the ice ramp behind the fuel depot this morning. The medic thinks it is a grade-two sprain, no fracture. I am on a step cap of 3,000 a day for at least six weeks.',
+      committed: "Follow the medic's step cap and do the ankle exercises.",
+      blockers: 'Grade-two ankle sprain, 3,000-step cap.',
+      mood: 'gutted',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 7, 15),
+      happened:
+          'Six-week review with the medic: healing is slower than hoped, cap stays at 4,000 and I am to add the stationary bike for cardio instead of walking. Also told to stay off the ice ramp until spring.',
+      committed: 'Stationary bike three times a week, stay off the ice ramp.',
+      blockers: 'Ankle still healing; ramp off limits.',
+      mood: 'patient',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 10, 6),
+      happened:
+          'Cleared by the medic today. No more step cap. The advice is to build back gradually — roughly five hundred more steps a week — and to split the walking into two shorter loops rather than one long one.',
+      committed: 'Add about 500 steps per week; two short loops.',
+      mood: 'relieved',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 3, 11),
+      happened:
+          'First 10,000-step day since the sprain — 10,200. Nine months. Took the long loop past the hangar, ankle absolutely fine.',
+      committed: 'Hold around 10,000 for a couple of weeks before pushing on.',
+      mood: 'proud',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 8, 24),
+      happened:
+          'Solid 11,400 today. Ankle has not complained in months. Thinking about going back to the one long loop instead of two short ones.',
+      committed: 'Decide about the long loop after this week.',
+      mood: 'strong',
+    ),
+  ],
+);
+
+final _recoverTruth = GoalCompactionGroundTruth(
+  expectedStatus: GoalTrackStatus.onTrack,
+  probes: [
+    GoalCompactionProbe(
+      id: 'recover_injury',
+      question:
+          'What injury did the user have, and when and where did it happen?',
+      referenceAnswer:
+          'A grade-two sprain of the left ankle, in early June 2025, on the ice ramp behind the fuel depot.',
+      factDate: DateTime.utc(2025, 6, 3),
+    ),
+    GoalCompactionProbe(
+      id: 'recover_cap',
+      question:
+          'What restrictions did the medic place on the user, and how did they change over the summer of 2025?',
+      referenceAnswer:
+          'A step cap of 3,000 a day for at least six weeks; at the six-week review it was set to 4,000, with the stationary bike added for cardio and the ice ramp off limits until spring.',
+      factDate: DateTime.utc(2025, 7, 15),
+    ),
+    GoalCompactionProbe(
+      id: 'recover_cleared',
+      question:
+          'When was the user cleared to walk without a cap, and what rebuild advice did they get?',
+      referenceAnswer:
+          'Early October 2025; add roughly 500 steps a week and split walking into two shorter loops rather than one long one.',
+      factDate: DateTime.utc(2025, 10, 6),
+    ),
+    GoalCompactionProbe(
+      id: 'recover_first_10k',
+      question:
+          'When did the user first reach 10,000 steps again after the injury?',
+      referenceAnswer:
+          'March 2026 (10,200 steps), about nine months after the sprain.',
+      factDate: DateTime.utc(2026, 3, 11),
+    ),
+    GoalCompactionProbe(
+      id: 'recover_before',
+      isPattern: true,
+      question:
+          "What was the user's step pattern like in the months before the injury?",
+      referenceAnswer:
+          'Consistently over target — roughly 10,000–12,800 a day, with two perimeter loops most days.',
+      factDate: DateTime.utc(2025, 3),
+    ),
+    GoalCompactionProbe(
+      id: 'recover_recent',
+      question:
+          'What is the user currently considering changing about their routine?',
+      referenceAnswer:
+          'Going back to one long loop instead of two short ones, now that the ankle has been fine for months.',
+      factDate: DateTime.utc(2026, 8, 24),
+    ),
+  ],
+  expectedRecommendation:
+      "Acknowledge the recovery as the achievement it is (on track again after a nine-month injury setback), and, on the question of returning to one long loop, refer back to the physio's two-short-loops advice and suggest a gradual change rather than an abrupt one.",
+  forbiddenRecommendations: [
+    'Treating the current on-track status as unremarkable, as if the goal had always been on track.',
+    'Encouraging a sharp increase in volume.',
+    'Suggesting the user has no injury history to consider.',
+  ],
+);
+
+// ── Archetype 3: the goal was redefined ──────────────────────────────────
+
+final DateTime _redefinedStart = DateTime.utc(2024, 9, 2);
+
+List<GoalCheckInSummary> _redefinedCheckIns() => _generate(
+  fixtureId: 'redefined',
+  start: _redefinedStart,
+  end: goalCompactionEvalReference,
+  seed: 37,
+  phases: [
+    const _Phase(
+      fromMonth: 0,
+      toMonth: 6,
+      happened: [
+        'Chasing the 10,000 again — {steps}. The long loop twice is the only way I get there.',
+        'Got to {steps}. Knees a bit grumbly after the second loop on the hard-packed snow.',
+        'Hit 10k target-ish, {steps}. Both knees stiff this evening.',
+        '{steps} today. The 10,000 needs two long loops and my knees are starting to object.',
+      ],
+      committed: ['Two long loops tomorrow for the 10k.', null],
+      blockers: ['Knees stiff after long loops.', null],
+      moods: ['determined', 'sore'],
+      stepsRange: (8800, 10800),
+    ),
+    const _Phase(
+      fromMonth: 6,
+      toMonth: 24,
+      happened: [
+        'One loop for {steps} steps and a gym session — squats and the leg press, as the doctor suggested.',
+        '{steps} steps and gym day two of three. Knees are fine on this plan.',
+        'Rest from the gym, {steps} steps on the short loop.',
+        'Gym three of three done this week, {steps} steps. No knee pain at all.',
+        '{steps} today plus the leg session. This version of the goal suits me much better.',
+      ],
+      committed: [
+        'Three gym sessions this week.',
+        'Short loop daily, gym on the usual days.',
+        null,
+      ],
+      moods: ['good', 'steady', 'pleased'],
+      stepsRange: (7800, 9400),
+    ),
+  ],
+  needles: [
+    _Needle(
+      date: DateTime.utc(2025, 2, 18),
+      happened:
+          'Saw the station doctor about the knees. Early patellar tendinopathy from the volume of walking on hard snow. The advice is to lower the daily steps and add strength work for the legs instead.',
+      committed: 'Book a follow-up and think about changing the goal.',
+      blockers: 'Knee pain — patellar tendinopathy.',
+      mood: 'concerned',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 3, 3),
+      happened:
+          'Changed the goal today: it is now 8,000 steps a day on the rolling week plus three station-gym strength sessions per calendar week, instead of 10,000 steps. The doctor was clear that 10,000 on this terrain was what hurt the knees.',
+      committed: 'Follow the new goal — 8,000 steps and three gym sessions.',
+      mood: 'settled',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 9, 9),
+      happened:
+          'Six months on the new definition. Knees have been pain-free since about May. 8,400 steps today and the third gym session of the week.',
+      committed: 'Keep exactly this.',
+      mood: 'pleased',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 5, 12),
+      happened:
+          'Follow-up with the station doctor: knees fully settled, no tenderness. Asked whether I could go back up to 10,000 and was told to stay at 8,000 plus the strength sessions — the strength work is what protects the knees.',
+      committed: 'Stay at 8,000 and the three gym sessions.',
+      mood: 'reassured',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 8, 25),
+      happened:
+          '8,700 steps and gym session two of the week. Someone in the mess suggested I go back to 10,000 now the knees are fine; I said I would think about it.',
+      committed: 'Third gym session on Thursday.',
+      mood: 'good',
+    ),
+  ],
+);
+
+final _redefinedTruth = GoalCompactionGroundTruth(
+  expectedStatus: GoalTrackStatus.onTrack,
+  probes: [
+    GoalCompactionProbe(
+      id: 'redefined_original',
+      isPattern: true,
+      question: 'What was the goal originally, before it was changed?',
+      referenceAnswer: 'An average of 10,000 steps a day over a rolling week.',
+      factDate: DateTime.utc(2024, 11),
+    ),
+    GoalCompactionProbe(
+      id: 'redefined_why',
+      question: 'Why was the goal changed, and who advised it?',
+      referenceAnswer:
+          'Knee pain — early patellar tendinopathy from walking volume on hard snow; the station doctor advised fewer steps plus leg strength work (February 2025).',
+      factDate: DateTime.utc(2025, 2, 18),
+    ),
+    GoalCompactionProbe(
+      id: 'redefined_when_what',
+      question:
+          'When was the goal redefined and what is the current definition?',
+      referenceAnswer:
+          'Early March 2025; 8,000 steps a day on a rolling week plus three station-gym strength sessions per calendar week.',
+      factDate: DateTime.utc(2025, 3, 3),
+    ),
+    GoalCompactionProbe(
+      id: 'redefined_is_10k_target',
+      question: 'Is 10,000 steps a day still the target?',
+      referenceAnswer:
+          'No — the target has been 8,000 steps plus gym sessions since March 2025.',
+      factDate: DateTime.utc(2025, 3, 3),
+    ),
+    GoalCompactionProbe(
+      id: 'redefined_knees_since',
+      question: "How have the user's knees been since the change?",
+      referenceAnswer:
+          'Pain-free since around May 2025; check-ins repeatedly say no knee pain on the new plan.',
+      factDate: DateTime.utc(2025, 9, 9),
+    ),
+    GoalCompactionProbe(
+      id: 'redefined_doctor_followup',
+      question:
+          'What did the station doctor say at the most recent follow-up about the step target?',
+      referenceAnswer:
+          'At the May 2026 follow-up the knees were fully settled, but the doctor said to stay at 8,000 steps plus the strength sessions rather than return to 10,000, because the strength work protects the knees.',
+      factDate: DateTime.utc(2026, 5, 12),
+    ),
+    GoalCompactionProbe(
+      id: 'redefined_recent',
+      question:
+          'What suggestion did the user receive recently, and how did they respond?',
+      referenceAnswer:
+          'Someone in the mess suggested going back to 10,000 steps now the knees are fine; the user said they would think about it.',
+      factDate: DateTime.utc(2026, 8, 25),
+    ),
+  ],
+  expectedRecommendation:
+      "Confirm the goal is on track under its current definition, and, if the 10,000-step suggestion comes up, remind the user why the goal was lowered (the doctor's knee advice) rather than endorsing a return to 10,000.",
+  forbiddenRecommendations: [
+    'Treating 10,000 steps as the current target or as a shortfall.',
+    'Encouraging a return to 10,000 steps without mentioning the knee history.',
+  ],
+);
+
+// ── Archetype 4: abandoned for five months, then revived ─────────────────
+
+final DateTime _revivedStart = DateTime.utc(2024, 9, 2);
+
+List<GoalCheckInSummary> _revivedCheckIns() => _generate(
+  fixtureId: 'abandoned_revived',
+  start: _revivedStart,
+  end: goalCompactionEvalReference,
+  seed: 41,
+  phases: [
+    const _Phase(
+      fromMonth: 0,
+      toMonth: 10,
+      happened: _steadyHappened,
+      committed: _steadyCommitted,
+      moods: ['steady', 'good'],
+      stepsRange: (9500, 12200),
+    ),
+    // Months 10–15: nothing. The goal was not paused; it was simply not
+    // spoken to, which is what a real abandonment looks like in the data.
+    const _Phase(
+      fromMonth: 15,
+      toMonth: 24,
+      happened: [
+        'Treadmill in the gym before the shift, {steps} by the end of the day. Not the loops I used to do but it is consistent.',
+        '{steps}. Treadmill session done, skipped the outdoor loop because of the wind.',
+        'Back on it — {steps}. Treadmill plus a short loop.',
+        'Missed the treadmill, {steps} from corridor walking only.',
+      ],
+      committed: [
+        'Treadmill before every shift this week.',
+        'Add the short loop on calm days.',
+        null,
+      ],
+      blockers: ['Wind too strong for the outdoor loop.', null],
+      moods: ['rebuilding', 'okay', 'determined'],
+      stepsRange: (6800, 9400),
+    ),
+  ],
+  needles: [
+    _Needle(
+      date: DateTime.utc(2025, 4, 28),
+      happened:
+          'Best week so far: averaged 12,600 over the seven days. Two loops every day plus the survey walks. Feels almost easy now.',
+      committed: 'Keep both loops daily.',
+      mood: 'great',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 6, 27),
+      happened:
+          'Last check-in for a while probably. I move to the overwinter night shift on Monday — twelve hours on the generator watch, sleeping through the daylight. Walking is going to fall apart and I would rather not pretend otherwise.',
+      blockers: 'Overwinter night shift starting Monday.',
+      mood: 'resigned',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 12),
+      happened:
+          'Back after five months. The night shift ended last week. I did essentially no deliberate walking the whole time — maybe 3,000 a day. Starting over, and this time I am going to use the gym treadmill before the shift so the weather cannot stop me.',
+      committed: 'Treadmill in the gym before every shift, starting tomorrow.',
+      mood: 'determined',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 4, 14),
+      happened:
+          'First 10,000-step day since before the winter: 10,100. Treadmill before the shift and then both outdoor loops because the wind finally dropped. Proof the treadmill base plus the loops gets me there.',
+      committed: 'Both loops whenever the wind allows.',
+      mood: 'pleased',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 8, 25),
+      happened:
+          'Treadmill done, then a short loop. 8,600 today. Slowly climbing back toward where I was before the winter.',
+      committed: 'Treadmill again tomorrow, loop if calm.',
+      mood: 'okay',
+    ),
+  ],
+);
+
+final _revivedTruth = GoalCompactionGroundTruth(
+  expectedStatus: GoalTrackStatus.atRisk,
+  probes: [
+    GoalCompactionProbe(
+      id: 'revived_gap_why',
+      question:
+          'There was a long gap in the check-ins. When was it, and what caused it?',
+      referenceAnswer:
+          'Roughly July to November 2025; the user moved to the overwinter night shift (twelve-hour generator watch) and stopped walking and checking in.',
+      factDate: DateTime.utc(2025, 6, 27),
+    ),
+    GoalCompactionProbe(
+      id: 'revived_best',
+      question: "What was the user's best week before the gap?",
+      referenceAnswer:
+          'Late April 2025, averaging about 12,600 steps a day with two loops daily.',
+      factDate: DateTime.utc(2025, 4, 28),
+    ),
+    GoalCompactionProbe(
+      id: 'revived_restart',
+      question:
+          'When did the user restart, and what new approach did they commit to?',
+      referenceAnswer:
+          'Early December 2025; using the gym treadmill before every shift so the weather cannot stop them.',
+      factDate: DateTime.utc(2025, 12),
+    ),
+    GoalCompactionProbe(
+      id: 'revived_during_gap',
+      question: 'Roughly how much did the user walk during the gap?',
+      referenceAnswer:
+          'Essentially no deliberate walking — about 3,000 steps a day.',
+      factDate: DateTime.utc(2025, 12),
+    ),
+    GoalCompactionProbe(
+      id: 'revived_first_10k_after',
+      question:
+          'Since restarting, when did the user first reach 10,000 steps in a day, and how?',
+      referenceAnswer:
+          'Mid-April 2026 (10,100 steps): treadmill before the shift plus both outdoor loops on a calm day.',
+      factDate: DateTime.utc(2026, 4, 14),
+    ),
+    GoalCompactionProbe(
+      id: 'revived_recent',
+      question: "What has the user's routine been in the last few weeks?",
+      referenceAnswer:
+          'Treadmill before the shift plus a short outdoor loop on calm days, landing around 7,000–9,400 steps.',
+      factDate: DateTime.utc(2026, 8, 25),
+    ),
+  ],
+  expectedRecommendation:
+      'Frame the current at-risk status as a rebuild in progress since the December restart — the treadmill habit is holding — and point at the gap between the current ~8,500 and the pre-winter level rather than at failure; the outdoor loops that produced the best weeks are the lever.',
+  forbiddenRecommendations: [
+    'Treating the user as a beginner with no history of reaching the target.',
+    'Ignoring the five-month night-shift gap when reading the long-term trend.',
+  ],
+);
+
+// ── Archetype 5: completed, now in maintenance ───────────────────────────
+
+final DateTime _completedStart = DateTime.utc(2024, 9, 2);
+final DateTime _completedTarget = DateTime.utc(2026, 3);
+
+List<GoalCheckInSummary> _completedCheckIns() => _generate(
+  fixtureId: 'completed',
+  start: _completedStart,
+  end: goalCompactionEvalReference,
+  seed: 53,
+  phases: [
+    const _Phase(
+      fromMonth: 0,
+      toMonth: 6,
+      happened: [
+        'Working up to it — {steps}. Long way from 10,000 but the hangar walk helps.',
+        '{steps} today. Added the weather-mast walk this week.',
+        'Not there yet, {steps}. Building the loops up slowly.',
+      ],
+      committed: ['Add one more short walk this week.', null],
+      moods: ['keen', 'steady'],
+      stepsRange: (6500, 8800),
+    ),
+    const _Phase(
+      fromMonth: 6,
+      toMonth: 18,
+      happened: _steadyHappened,
+      committed: _steadyCommitted,
+      moods: ['good', 'steady'],
+      stepsRange: (9400, 11600),
+    ),
+    const _Phase(
+      fromMonth: 18,
+      toMonth: 24,
+      happened: [
+        'Maintenance mode. {steps} without thinking about it much — the loops are just what the day looks like now.',
+        '{steps}. Nothing to report; the routine runs itself.',
+        'Easy {steps}. Skipped the evening loop for the film night and still cleared it.',
+      ],
+      committed: [null, 'Same again.'],
+      moods: ['content', 'relaxed'],
+      stepsRange: (9800, 11800),
+    ),
+  ],
+  needles: [
+    _Needle(
+      date: DateTime.utc(2024, 9, 4),
+      happened:
+          'Set the goal today with a deadline: average 10,000 steps a day by the first of March 2026, which is the end of my current posting. Starting from about 6,500.',
+      committed: 'Build up gradually over the posting.',
+      mood: 'keen',
+    ),
+    _Needle(
+      date: DateTime.utc(2025, 3, 10),
+      happened:
+          'First full week averaging over 10,000 — 10,300. Nearly a year early. The two-loop pattern did it.',
+      committed: 'Hold it there.',
+      mood: 'proud',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 3, 2),
+      happened:
+          'Deadline day was yesterday and the rolling average was 10,900. Goal done, properly. I am going to keep the loops but I do not want to push the target up — this is the level I want to live at.',
+      committed: 'Keep the routine, do not raise the target.',
+      mood: 'satisfied',
+    ),
+    _Needle(
+      date: DateTime.utc(2026, 8, 26),
+      happened:
+          'Quiet week, 10,400. Still not interested in raising the target; the posting extension was confirmed so I will be here another year at the same pace.',
+      mood: 'content',
+    ),
+  ],
+);
+
+final _completedTruth = GoalCompactionGroundTruth(
+  expectedStatus: GoalTrackStatus.achieved,
+  probes: [
+    GoalCompactionProbe(
+      id: 'completed_deadline',
+      question:
+          'What deadline did the user set for the goal, and why that date?',
+      referenceAnswer:
+          'The first of March 2026 — the end of their current posting (set in September 2024).',
+      factDate: DateTime.utc(2024, 9, 4),
+    ),
+    GoalCompactionProbe(
+      id: 'completed_first_hit',
+      question:
+          'When did the user first average over 10,000 steps for a full week?',
+      referenceAnswer:
+          'March 2025 (10,300), nearly a year before the deadline.',
+      factDate: DateTime.utc(2025, 3, 10),
+    ),
+    GoalCompactionProbe(
+      id: 'completed_at_deadline',
+      question:
+          'What was the situation at the deadline, and what did the user decide?',
+      referenceAnswer:
+          'Rolling average 10,900 at the deadline; the user decided to keep the routine but explicitly not raise the target.',
+      factDate: DateTime.utc(2026, 3, 2),
+    ),
+    GoalCompactionProbe(
+      id: 'completed_start_level',
+      question: 'Where did the user start from when the goal was set?',
+      referenceAnswer: 'About 6,500 steps a day.',
+      factDate: DateTime.utc(2024, 9, 4),
+    ),
+    GoalCompactionProbe(
+      id: 'completed_recent',
+      question: 'What did the user say recently about raising the target?',
+      referenceAnswer:
+          'Still not interested in raising it; their posting was extended a year and they want to stay at the same pace.',
+      factDate: DateTime.utc(2026, 8, 26),
+    ),
+  ],
+  expectedRecommendation:
+      "Treat the goal as achieved and in maintenance; if anything, offer to close or archive it or to keep a light-touch watch, and respect the user's explicit, repeated wish not to raise the target.",
+  forbiddenRecommendations: [
+    'Proposing a higher step target or a "next level".',
+    'Urging the user to push harder or "keep the momentum going" toward more.',
+  ],
+);
+
+// ── The catalog ──────────────────────────────────────────────────────────
+
+/// The catalog, built once. [buildGoalCompactionFixtures] exists so a test
+/// can prove that building it twice yields the same history.
+final List<GoalCompactionFixture> goalCompactionFixtures =
+    buildGoalCompactionFixtures();
+
+/// The five archetypes, freshly generated.
+List<GoalCompactionFixture> buildGoalCompactionFixtures() => [
+  GoalCompactionFixture(
+    id: 'steady_then_stall',
+    title: 'Steps',
+    statement: 'Average 10,000 steps per day over a rolling week.',
+    criteria: _steps10k,
+    startDate: _stallStart,
+    checkIns: _stallCheckIns(),
+    window: _stepsWindow(6400),
+    priorAttainments: const [0.78, 0.84],
+    priorStatus: GoalTrackStatus.atRisk,
+    transitionFrom: GoalTrackStatus.atRisk,
+    truth: _stallTruth,
+  ),
+  GoalCompactionFixture(
+    id: 'regress_recover',
+    title: 'Steps',
+    statement: 'Average 10,000 steps per day over a rolling week.',
+    criteria: _steps10k,
+    startDate: _recoverStart,
+    checkIns: _recoverCheckIns(),
+    window: _stepsWindow(11000),
+    priorAttainments: const [0.9, 0.86],
+    priorStatus: GoalTrackStatus.recovering,
+    transitionFrom: GoalTrackStatus.recovering,
+    truth: _recoverTruth,
+  ),
+  GoalCompactionFixture(
+    id: 'redefined',
+    title: 'Steps and strength',
+    statement:
+        'Average 8,000 steps per day over a rolling week and three station-gym strength sessions per calendar week.',
+    criteria: const GoalCriterion.allOf(
+      criterionId: 'steps_and_gym',
+      criteria: [
+        GoalCriterion.metric(
+          criterionId: 'steps',
+          dataType: 'cumulative_step_count',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          target: 8000,
+        ),
+        GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: 'gym',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+      ],
+    ),
+    startDate: _redefinedStart,
+    checkIns: _redefinedCheckIns(),
+    window: _stepsWindow(
+      8600,
+      gymDays: {
+        DateTime.utc(2026, 8, 24): 1,
+        DateTime.utc(2026, 8, 25): 1,
+        DateTime.utc(2026, 8, 27): 1,
+      },
+    ),
+    priorAttainments: const [0.92, 0.9],
+    priorStatus: GoalTrackStatus.recovering,
+    transitionFrom: GoalTrackStatus.recovering,
+    truth: _redefinedTruth,
+  ),
+  GoalCompactionFixture(
+    id: 'abandoned_revived',
+    title: 'Steps',
+    statement: 'Average 10,000 steps per day over a rolling week.',
+    criteria: _steps10k,
+    startDate: _revivedStart,
+    checkIns: _revivedCheckIns(),
+    window: _stepsWindow(8500),
+    priorAttainments: const [0.74, 0.7],
+    priorStatus: GoalTrackStatus.offTrack,
+    transitionFrom: GoalTrackStatus.offTrack,
+    truth: _revivedTruth,
+  ),
+  GoalCompactionFixture(
+    id: 'completed',
+    title: 'Steps',
+    statement:
+        'Average 10,000 steps per day over a rolling week by 1 March 2026.',
+    criteria: _steps10k,
+    startDate: _completedStart,
+    targetDate: _completedTarget,
+    checkIns: _completedCheckIns(),
+    window: _stepsWindow(10400),
+    priorAttainments: const [1.04, 1.09],
+    priorStatus: GoalTrackStatus.onTrack,
+    transitionFrom: GoalTrackStatus.onTrack,
+    truth: _completedTruth,
+  ),
+];

--- a/test/features/goals/logic/goal_checkin_compaction_strategy_test.dart
+++ b/test/features/goals/logic/goal_checkin_compaction_strategy_test.dart
@@ -195,16 +195,29 @@ void main() {
     });
 
     test('the number of digest entries stops growing with age', () async {
-      // Four years of history: the yearly layer holds the count to
-      // (months in horizon) + (quarters in horizon) + years.
+      // Beyond the yearly horizon everything is ONE span, so a six-year
+      // history carries exactly as many digest entries as a four-year one.
       final fourYears = history(DateTime.utc(2022, 9, 5), 207);
+      final sixYears = history(DateTime.utc(2020, 9, 7), 311);
       final writer = _RecordingDigestWriter();
       final strategy = HierarchicalCheckInCompaction(digestWriter: writer);
 
       final two = await strategy.build(twoYears, reference: reference);
       final four = await strategy.build(fourYears, reference: reference);
+      final six = await strategy.build(sixYears, reference: reference);
 
-      expect(four.digestCount - two.digestCount, lessThanOrEqualTo(2));
+      expect(four.digestCount, greaterThan(two.digestCount));
+      expect(six.digestCount, four.digestCount);
+      final earlier = writer.requests.where(
+        (r) => r.layer == GoalCheckInDigestLayer.earlier,
+      );
+      expect(earlier.map((r) => r.periodLabel).toSet(), {'before-2023'});
+      // The earlier span for six years holds everything from 2020 to the
+      // yearly horizon (2023-08), oldest first.
+      final sixEarlier = earlier.last;
+      expect(sixEarlier.checkIns.first.recordedAt.year, 2020);
+      expect(sixEarlier.to.isBefore(DateTime(2023, 8)), isTrue);
+      expect(six.estimatedTokens - four.estimatedTokens, lessThan(50));
     });
 
     test('a history that fits the verbatim budget needs no digest', () async {

--- a/test/features/goals/logic/goal_checkin_compaction_strategy_test.dart
+++ b/test/features/goals/logic/goal_checkin_compaction_strategy_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/features/goals/logic/goal_user_voice.dart';
+import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
+
+/// Records every span it was asked to digest and returns a legible stub.
+class _RecordingDigestWriter implements GoalCheckInDigestWriter {
+  final requests = <GoalCheckInDigestRequest>[];
+
+  @override
+  Future<String> write(GoalCheckInDigestRequest request) async {
+    requests.add(request);
+    return 'digest of ${request.periodLabel} '
+        '(${request.checkIns.length} check-ins)';
+  }
+}
+
+void main() {
+  // Sized like a real Layer-1 summary (~120 tokens), not a one-liner: the
+  // budgets under test are token budgets, and a toy history that fits in
+  // the verbatim slice would let every strategy look identical.
+  GoalCheckInSummary summary(String id, DateTime at) => GoalCheckInSummary(
+    id: id,
+    sourceEntryId: 'entry-$id',
+    recordedAt: at,
+    whatHappened:
+        'Walked the perimeter loop after lunch and again after the evening '
+        'colony count, about 9,800 steps by the tracker. The wind picked up '
+        'in the afternoon so the second loop was shorter than planned.',
+    committedTo:
+        'Do the full perimeter loop both times tomorrow, even if the wind '
+        'is up, and log it before the shift ends.',
+    blockers: 'Afternoon katabatic wind and a long desk block for the survey.',
+    mood: 'Steady, a little tired.',
+  );
+
+  /// Three check-ins a week from [start] for [weeks] weeks.
+  List<GoalCheckInSummary> history(DateTime start, int weeks) => [
+    for (var w = 0; w < weeks; w++)
+      for (final d in const [0, 2, 4])
+        summary('w$w-d$d', start.add(Duration(days: w * 7 + d, hours: 8))),
+  ];
+
+  final reference = DateTime.utc(2026, 8, 27, 12);
+  final start = DateTime.utc(2024, 9, 2);
+  final twoYears = history(start, 103);
+
+  group('full', () {
+    test(
+      'carries every check-in, oldest first, in the production shape',
+      () async {
+        final shuffled = [twoYears[5], twoYears[0], twoYears[2]];
+        final context = await const FullContextCheckInCompaction().build(
+          shuffled,
+          reference: reference,
+        );
+
+        expect(context.verbatimCount, 3);
+        expect(context.digestCount, 0);
+        expect(
+          context.entries.map((e) => e['sourceEntryId']),
+          ['entry-w0-d0', 'entry-w0-d4', 'entry-w1-d4'],
+        );
+        expect(context.entries.first, goalUserVoiceEntry(twoYears[0]));
+      },
+    );
+
+    test('is unbounded — the oracle grows with the history', () async {
+      final one = await const FullContextCheckInCompaction().build(
+        twoYears.take(30).toList(),
+        reference: reference,
+      );
+      final all = await const FullContextCheckInCompaction().build(
+        twoYears,
+        reference: reference,
+      );
+      expect(all.estimatedTokens, greaterThan(one.estimatedTokens * 5));
+    });
+  });
+
+  group('truncate', () {
+    test('matches the shipped goalUserVoiceEntries slice exactly', () async {
+      final context = await const TruncatingCheckInCompaction().build(
+        twoYears,
+        reference: reference,
+      );
+
+      expect(context.entries, goalUserVoiceEntries(twoYears));
+      expect(context.verbatimCount, context.entries.length);
+      expect(context.digestCount, 0);
+      expect(
+        context.estimatedTokens,
+        lessThanOrEqualTo(goalUserVoiceTokenBudget),
+      );
+      // The point of the whole evaluation: two years of history reduce to a
+      // handful of the newest check-ins.
+      expect(context.entries.length, lessThan(20));
+      expect(
+        context.entries.last['sourceEntryId'],
+        'entry-${twoYears.last.id}',
+      );
+    });
+  });
+
+  group('hierarchical', () {
+    test('keeps the recent tail verbatim and digests the rest', () async {
+      final writer = _RecordingDigestWriter();
+      final strategy = HierarchicalCheckInCompaction(digestWriter: writer);
+
+      final context = await strategy.build(twoYears, reference: reference);
+
+      final truncated = goalUserVoiceEntries(twoYears);
+      expect(context.verbatimCount, truncated.length);
+      expect(context.entries.sublist(context.digestCount), truncated);
+      expect(context.digestCount, writer.requests.length);
+      expect(context.digestCount, greaterThan(0));
+      final foldedCount = writer.requests.fold<int>(
+        0,
+        (sum, r) => sum + r.checkIns.length,
+      );
+      expect(foldedCount + context.verbatimCount, twoYears.length);
+    });
+
+    test('digests read oldest first and carry their span and count', () async {
+      final writer = _RecordingDigestWriter();
+      final strategy = HierarchicalCheckInCompaction(digestWriter: writer);
+
+      final context = await strategy.build(twoYears, reference: reference);
+
+      final digests = context.entries.take(context.digestCount).toList();
+      expect(digests.first['kind'], 'digest');
+      expect(digests.first['layer'], 'year');
+      expect(digests.first['period'], '2024');
+      expect(digests.first['checkIns'], writer.requests.first.checkIns.length);
+      expect(
+        digests.first['digest'],
+        'digest of 2024 (${writer.requests.first.checkIns.length} check-ins)',
+      );
+      final froms = writer.requests.map((r) => r.from).toList();
+      expect(froms, orderedEquals([...froms]..sort()));
+      for (var i = 1; i < writer.requests.length; i++) {
+        expect(
+          writer.requests[i].from.isAfter(writer.requests[i - 1].to),
+          isTrue,
+          reason: 'spans must not overlap',
+        );
+      }
+    });
+
+    test('months → quarters → years by age, each layer shorter', () async {
+      final writer = _RecordingDigestWriter();
+      final strategy = HierarchicalCheckInCompaction(
+        digestWriter: writer,
+        // ignore: avoid_redundant_argument_values
+        monthlyHorizonMonths: 6,
+        // ignore: avoid_redundant_argument_values
+        quarterlyHorizonMonths: 18,
+      );
+
+      await strategy.build(twoYears, reference: reference);
+
+      final byLabel = {for (final r in writer.requests) r.periodLabel: r};
+      // Six months before 2026-08-27 is 2026-02: February onwards is monthly.
+      expect(byLabel['2026-02']?.layer, GoalCheckInDigestLayer.month);
+      expect(byLabel['2026-07']?.layer, GoalCheckInDigestLayer.month);
+      // Between 18 and 6 months back: quarters. January 2026 sits alone in
+      // a one-month quarter rather than being promoted to monthly.
+      expect(byLabel['2025-Q4']?.layer, GoalCheckInDigestLayer.quarter);
+      expect(byLabel['2026-Q1']?.layer, GoalCheckInDigestLayer.quarter);
+      expect(byLabel.containsKey('2026-01'), isFalse);
+      expect(byLabel.containsKey('2025-10'), isFalse);
+      // Eighteen months back is 2025-02: everything before is yearly.
+      expect(byLabel['2024']?.layer, GoalCheckInDigestLayer.year);
+      expect(byLabel['2025']?.layer, GoalCheckInDigestLayer.year);
+      expect(byLabel['2025']!.checkIns.first.recordedAt.month, 1);
+      expect(byLabel['2025']!.checkIns.last.recordedAt.month, 1);
+      // February and March 2025 are still inside the quarterly window, so
+      // 2025-Q1 exists as a two-month quarter.
+      expect(byLabel['2025-Q1']!.checkIns.first.recordedAt.month, 2);
+      expect(byLabel.containsKey('2024-Q4'), isFalse);
+      // Coarser is shorter: the bound the layers exist for.
+      expect(
+        GoalCheckInDigestLayer.year.maxWords,
+        lessThan(GoalCheckInDigestLayer.month.maxWords),
+      );
+      expect(byLabel['2024']!.maxWords, 80);
+      expect(byLabel['2026-07']!.maxWords, 120);
+      for (final request in writer.requests) {
+        expect(request.from.isBefore(request.to), isTrue);
+        expect(
+          request.checkIns.map((c) => c.recordedAt),
+          orderedEquals([...request.checkIns.map((c) => c.recordedAt)]..sort()),
+        );
+      }
+    });
+
+    test('the number of digest entries stops growing with age', () async {
+      // Four years of history: the yearly layer holds the count to
+      // (months in horizon) + (quarters in horizon) + years.
+      final fourYears = history(DateTime.utc(2022, 9, 5), 207);
+      final writer = _RecordingDigestWriter();
+      final strategy = HierarchicalCheckInCompaction(digestWriter: writer);
+
+      final two = await strategy.build(twoYears, reference: reference);
+      final four = await strategy.build(fourYears, reference: reference);
+
+      expect(four.digestCount - two.digestCount, lessThanOrEqualTo(2));
+    });
+
+    test('a history that fits the verbatim budget needs no digest', () async {
+      final writer = _RecordingDigestWriter();
+      final strategy = HierarchicalCheckInCompaction(digestWriter: writer);
+
+      final context = await strategy.build(
+        twoYears.take(3).toList(),
+        reference: reference,
+      );
+
+      expect(context.digestCount, 0);
+      expect(writer.requests, isEmpty);
+      expect(context.entries, goalUserVoiceEntries(twoYears.take(3).toList()));
+    });
+
+    test('an empty history is empty', () async {
+      final writer = _RecordingDigestWriter();
+      final context = await HierarchicalCheckInCompaction(
+        digestWriter: writer,
+      ).build(const [], reference: reference);
+      expect(context, GoalUserVoiceContext.empty);
+      expect(writer.requests, isEmpty);
+    });
+
+    test(
+      'stays bounded: two years cost a small multiple of the tail',
+      () async {
+        final writer = _RecordingDigestWriter();
+        final strategy = HierarchicalCheckInCompaction(digestWriter: writer);
+        final full = await const FullContextCheckInCompaction().build(
+          twoYears,
+          reference: reference,
+        );
+
+        final context = await strategy.build(twoYears, reference: reference);
+
+        expect(context.estimatedTokens, lessThan(full.estimatedTokens ~/ 5));
+      },
+    );
+  });
+}

--- a/test/features/goals/service/goal_checkin_digest_service_test.dart
+++ b/test/features/goals/service/goal_checkin_digest_service_test.dart
@@ -4,6 +4,9 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
+import 'package:lotti/features/ai_consumption/model/ai_consumption_event.dart';
+import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dart';
 import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
 import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
 import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
@@ -14,6 +17,7 @@ import 'package:openai_dart/openai_dart.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../agents/test_data/ai_config_factories.dart';
+import '../../ai_consumption/test_utils.dart';
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -59,6 +63,23 @@ void main() {
               delta: ChatCompletionStreamResponseDelta(content: body),
             ),
           ],
+        ),
+        // A usage chunk, so the token accounting the cost pills read is
+        // exercised rather than assumed.
+        const CreateChatCompletionStreamResponse(
+          id: 'usage',
+          object: 'chat.completion.chunk',
+          created: 0,
+          choices: [],
+          usage: CompletionUsage(
+            promptTokens: 300,
+            completionTokens: 60,
+            totalTokens: 360,
+            promptTokensDetails: PromptTokensDetails(cachedTokens: 50),
+            completionTokensDetails: CompletionTokensDetails(
+              reasoningTokens: 4,
+            ),
+          ),
         ),
       ]);
 
@@ -364,6 +385,37 @@ void main() {
         stackTrace: any(named: 'stackTrace'),
       ),
     ).called(1);
+  });
+
+  test('a digest is attributed to the goal that paid for it', () async {
+    final attribution = AiInteractionCaptureTestBench.create()..register();
+    addTearDown(attribution.unregister);
+    scripted.add('Attributed digest.');
+
+    expect(await writer().write(request()), 'Attributed digest.');
+
+    final start =
+        verify(() => attribution.service.begin(captureAny())).captured.single
+            as AiAttributionStart;
+    expect(start.initiator.type, AiActorType.automation);
+    expect(start.initiator.id, 'automation:goal-check-in-digest');
+
+    final event =
+        verify(
+              () => attribution.service.recordInteraction(
+                attributionId: any(named: 'attributionId'),
+                event: captureAny(named: 'event'),
+              ),
+            ).captured.single
+            as AiConsumptionEvent;
+    // Totals by agent are what the goal's lifetime cost pills show; a
+    // digest without its agent id would be invisible spend.
+    expect(event.agentId, agentId);
+    expect(event.inputTokens, 300);
+    expect(event.outputTokens, 60);
+    expect(event.cachedInputTokens, 50);
+    expect(event.thoughtsTokens, 4);
+    expect(event.totalTokens, 360);
   });
 
   test('fromContent rejects malformed rows rather than guessing', () {

--- a/test/features/goals/service/goal_checkin_digest_service_test.dart
+++ b/test/features/goals/service/goal_checkin_digest_service_test.dart
@@ -1,0 +1,386 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
+import 'package:lotti/features/goals/model/goal_checkin_summary.dart';
+import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openai_dart/openai_dart.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../agents/test_data/ai_config_factories.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  late MockCloudInferenceRepository inference;
+  late MockAgentRepository repository;
+  late MockAgentSyncService sync;
+  late MockDomainLogger logger;
+  late List<String> prompts;
+  late List<String> scripted;
+  late List<AgentDomainEntity> written;
+
+  final provider = testInferenceProvider(apiKey: 'k-123');
+  const agentId = 'goal-agent-1';
+  final now = DateTime.utc(2026, 8, 27, 12);
+
+  GoalCheckInSummary summary(int day) => GoalCheckInSummary(
+    id: 'summary-$day',
+    sourceEntryId: 'entry-$day',
+    recordedAt: DateTime.utc(2025, 3, day, 9),
+    whatHappened: 'Walked the perimeter loop, day $day.',
+    committedTo: day.isEven ? 'Loop again tomorrow.' : null,
+    sourceDigest: 'digest-$day',
+  );
+
+  GoalCheckInDigestRequest request({int count = 5}) => GoalCheckInDigestRequest(
+    periodLabel: '2025-Q1',
+    layer: GoalCheckInDigestLayer.quarter,
+    from: DateTime.utc(2025, 3),
+    to: DateTime.utc(2025, 3, count),
+    checkIns: [for (var d = 1; d <= count; d++) summary(d)],
+  );
+
+  Stream<CreateChatCompletionStreamResponse> streamOf(String body) =>
+      Stream.fromIterable([
+        CreateChatCompletionStreamResponse(
+          id: 'chunk',
+          object: 'chat.completion.chunk',
+          created: 0,
+          choices: [
+            ChatCompletionStreamResponseChoice(
+              index: 0,
+              delta: ChatCompletionStreamResponseDelta(content: body),
+            ),
+          ],
+        ),
+      ]);
+
+  setUp(() {
+    inference = MockCloudInferenceRepository();
+    repository = MockAgentRepository();
+    sync = MockAgentSyncService();
+    logger = MockDomainLogger();
+    prompts = [];
+    scripted = [];
+    written = [];
+    when(
+      () => inference.generate(
+        any(),
+        model: any(named: 'model'),
+        temperature: any(named: 'temperature'),
+        baseUrl: any(named: 'baseUrl'),
+        apiKey: any(named: 'apiKey'),
+        systemMessage: any(named: 'systemMessage'),
+        maxCompletionTokens: any(named: 'maxCompletionTokens'),
+        provider: any(named: 'provider'),
+        geminiThinkingMode: GeminiThinkingMode.minimal,
+        reasoningEffort: ReasoningEffort.minimal,
+        impactCollector: any(named: 'impactCollector'),
+      ),
+    ).thenAnswer((invocation) {
+      prompts.add(invocation.positionalArguments.first as String);
+      return streamOf(scripted.removeAt(0));
+    });
+    when(() => sync.upsertEntity(any())).thenAnswer((invocation) async {
+      written.add(invocation.positionalArguments.first as AgentDomainEntity);
+    });
+    when(() => repository.getEntity(any())).thenAnswer((_) async => null);
+  });
+
+  GoalCheckInDigestService service() => GoalCheckInDigestService(
+    inferenceRepository: inference,
+    repository: repository,
+    syncService: sync,
+    domainLogger: logger,
+  );
+
+  GoalCheckInDigestWriter writer({bool allowInference = true}) =>
+      service().forWake(
+        agentId: agentId,
+        goalStatement: 'Average 10,000 steps a day.',
+        model: 'glm-5.2',
+        provider: provider,
+        allowInference: allowInference,
+      );
+
+  void stubStored(GoalCheckInDigest digest) {
+    final id = goalCheckInDigestId(agentId, digest.periodLabel);
+    when(() => repository.getEntity(id)).thenAnswer(
+      (_) async => AgentDomainEntity.agentMessage(
+        id: id,
+        agentId: agentId,
+        threadId: id,
+        kind: AgentMessageKind.action,
+        createdAt: digest.writtenAt,
+        vectorClock: null,
+        metadata: const AgentMessageMetadata(
+          toolName: goalCheckInDigestToolName,
+        ),
+        contentEntryId: '$id:payload',
+      ),
+    );
+    when(() => repository.getEntity('$id:payload')).thenAnswer(
+      (_) async => AgentDomainEntity.agentMessagePayload(
+        id: '$id:payload',
+        agentId: agentId,
+        createdAt: digest.writtenAt,
+        vectorClock: null,
+        content: digest.toContent(),
+      ),
+    );
+  }
+
+  test(
+    'writes, persists and returns a digest for a span it has not seen',
+    () async {
+      scripted.add('  March 2025: five loops, two promises kept.  ');
+
+      final text = await withClock(
+        Clock.fixed(now),
+        () => writer().write(request()),
+      );
+
+      expect(text, 'March 2025: five loops, two promises kept.');
+      // The prompt carries the goal, the span, the layer's word limit and
+      // every member with its date — the digest is written from the words,
+      // not from a count.
+      expect(prompts.single, contains('Goal: Average 10,000 steps a day.'));
+      expect(prompts.single, contains('Span: 2025-Q1 (quarter;'));
+      expect(prompts.single, contains('Word limit: 80.'));
+      expect(
+        prompts.single,
+        contains('2025-03-04: Walked the perimeter loop, day 4.'),
+      );
+      expect(prompts.single, contains('committed to: Loop again tomorrow.'));
+
+      expect(written, hasLength(2));
+      final payload = written.first as AgentMessagePayloadEntity;
+      final message = written.last as AgentMessageEntity;
+      expect(message.id, goalCheckInDigestId(agentId, '2025-Q1'));
+      expect(message.kind, AgentMessageKind.action);
+      expect(message.metadata.toolName, goalCheckInDigestToolName);
+      expect(message.contentEntryId, payload.id);
+      final stored = GoalCheckInDigest.fromContent(payload.content)!;
+      expect(stored.text, text);
+      expect(stored.layer, 'quarter');
+      expect(stored.checkInCount, 5);
+      expect(stored.sourceKey, goalCheckInDigestSourceKey(request()));
+      expect(stored.writtenAt, now);
+    },
+  );
+
+  test(
+    'a stored digest of the same members is reused without inference',
+    () async {
+      stubStored(
+        GoalCheckInDigest(
+          periodLabel: '2025-Q1',
+          layer: 'quarter',
+          sourceKey: goalCheckInDigestSourceKey(request()),
+          checkInCount: 5,
+          text: 'Already written.',
+          writtenAt: now.subtract(const Duration(days: 30)),
+        ),
+      );
+
+      final text = await writer().write(request());
+
+      expect(text, 'Already written.');
+      expect(prompts, isEmpty);
+      expect(written, isEmpty);
+    },
+  );
+
+  test('a span whose members changed is rewritten', () async {
+    stubStored(
+      GoalCheckInDigest(
+        periodLabel: '2025-Q1',
+        layer: 'quarter',
+        sourceKey: goalCheckInDigestSourceKey(request(count: 4)),
+        checkInCount: 4,
+        text: 'Four check-ins.',
+        writtenAt: now.subtract(const Duration(days: 30)),
+      ),
+    );
+    scripted.add('Five check-ins now.');
+
+    final text = await writer().write(request());
+
+    expect(text, 'Five check-ins now.');
+    expect(prompts, hasLength(1));
+    expect(written, hasLength(2));
+  });
+
+  test('the source key changes with words, membership and layer', () {
+    final base = goalCheckInDigestSourceKey(request());
+    expect(goalCheckInDigestSourceKey(request()), base);
+    expect(goalCheckInDigestSourceKey(request(count: 4)), isNot(base));
+    final reworded = GoalCheckInDigestRequest(
+      periodLabel: '2025-Q1',
+      layer: GoalCheckInDigestLayer.quarter,
+      from: DateTime.utc(2025, 3),
+      to: DateTime.utc(2025, 3, 5),
+      checkIns: [
+        for (var d = 1; d <= 5; d++)
+          if (d == 3)
+            GoalCheckInSummary(
+              id: 'summary-3',
+              sourceEntryId: 'entry-3',
+              recordedAt: DateTime.utc(2025, 3, 3, 9),
+              whatHappened: 'Re-transcribed.',
+              sourceDigest: 'digest-3-v2',
+            )
+          else
+            summary(d),
+      ],
+    );
+    expect(goalCheckInDigestSourceKey(reworded), isNot(base));
+    final aged = GoalCheckInDigestRequest(
+      periodLabel: '2025',
+      layer: GoalCheckInDigestLayer.year,
+      from: DateTime.utc(2025, 3),
+      to: DateTime.utc(2025, 3, 5),
+      checkIns: request().checkIns,
+    );
+    expect(goalCheckInDigestSourceKey(aged), isNot(base));
+  });
+
+  test(
+    'an interactive wake never infers: stored text or a placeholder',
+    () async {
+      final text = await writer(allowInference: false).write(request());
+
+      expect(text, '(5 check-ins from this span are not yet digested)');
+      expect(prompts, isEmpty);
+      expect(written, isEmpty);
+
+      stubStored(
+        GoalCheckInDigest(
+          periodLabel: '2025-Q1',
+          layer: 'quarter',
+          sourceKey: 'stale',
+          checkInCount: 4,
+          text: 'Stale but real.',
+          writtenAt: now.subtract(const Duration(days: 30)),
+        ),
+      );
+      expect(
+        await writer(allowInference: false).write(request()),
+        'Stale but real.',
+        reason: 'a stale digest beats a placeholder',
+      );
+      expect(prompts, isEmpty);
+    },
+  );
+
+  test(
+    'at most goalCheckInDigestsPerWake spans are written per wake',
+    () async {
+      final w = writer();
+      scripted.addAll(List.filled(goalCheckInDigestsPerWake, 'Written.'));
+
+      final texts = <String>[];
+      for (var i = 0; i <= goalCheckInDigestsPerWake; i++) {
+        texts.add(
+          await w.write(
+            GoalCheckInDigestRequest(
+              periodLabel: '2025-0${i + 1}',
+              layer: GoalCheckInDigestLayer.month,
+              from: DateTime.utc(2025, i + 1),
+              to: DateTime.utc(2025, i + 1, 20),
+              checkIns: [summary(i + 1)],
+            ),
+          ),
+        );
+      }
+
+      expect(prompts, hasLength(goalCheckInDigestsPerWake));
+      expect(texts.take(goalCheckInDigestsPerWake), everyElement('Written.'));
+      expect(texts.last, '(1 check-ins from this span are not yet digested)');
+    },
+  );
+
+  test('an inference failure is logged and yields the placeholder', () async {
+    when(
+      () => inference.generate(
+        any(),
+        model: any(named: 'model'),
+        temperature: any(named: 'temperature'),
+        baseUrl: any(named: 'baseUrl'),
+        apiKey: any(named: 'apiKey'),
+        systemMessage: any(named: 'systemMessage'),
+        maxCompletionTokens: any(named: 'maxCompletionTokens'),
+        provider: any(named: 'provider'),
+        geminiThinkingMode: GeminiThinkingMode.minimal,
+        reasoningEffort: ReasoningEffort.minimal,
+        impactCollector: any(named: 'impactCollector'),
+      ),
+    ).thenAnswer((_) => Stream.error(Exception('HTTP 500')));
+
+    final text = await writer().write(request());
+
+    expect(text, '(5 check-ins from this span are not yet digested)');
+    expect(written, isEmpty);
+    verify(
+      () => logger.error(
+        LogDomain.agentWorkflow,
+        any<Object>(),
+        subDomain: 'goalCheckInDigest',
+        message: 'goal check-in digest failed for 2025-Q1',
+        stackTrace: any(named: 'stackTrace'),
+      ),
+    ).called(1);
+  });
+
+  test('a blank response is a failure, never a stored blank', () async {
+    scripted.add('   ');
+
+    final text = await writer().write(request());
+
+    expect(text, '(5 check-ins from this span are not yet digested)');
+    expect(written, isEmpty);
+  });
+
+  test('a read failure is logged and does not stop the write', () async {
+    when(() => repository.getEntity(any())).thenThrow(Exception('db'));
+    scripted.add('Fresh.');
+
+    final text = await writer().write(request());
+
+    expect(text, 'Fresh.');
+    verify(
+      () => logger.error(
+        LogDomain.agentWorkflow,
+        any<Object>(),
+        subDomain: 'goalCheckInDigest',
+        message: 'failed to read digest 2025-Q1',
+        stackTrace: any(named: 'stackTrace'),
+      ),
+    ).called(1);
+  });
+
+  test('fromContent rejects malformed rows rather than guessing', () {
+    expect(
+      GoalCheckInDigest.fromContent({'periodLabel': '2025-Q1', 'text': ''}),
+      isNull,
+    );
+    expect(
+      GoalCheckInDigest.fromContent({
+        'periodLabel': '2025-Q1',
+        'layer': 'quarter',
+        'sourceKey': 'k',
+        'checkInCount': 'five',
+        'text': 'x',
+        'writtenAt': now.toIso8601String(),
+      }),
+      isNull,
+    );
+  });
+}

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -19,11 +19,13 @@ import 'package:lotti/features/ai_consumption/service/ai_attribution_service.dar
 import 'package:lotti/features/ai_consumption/service/ai_interaction_capture.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_reader.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/logic/goal_checkin_compaction_strategy.dart';
 import 'package:lotti/features/goals/model/goal_checkin_source.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/goals/runtime/goal_agent_phase_a.dart';
 import 'package:lotti/features/goals/runtime/goal_wake_facts.dart';
 import 'package:lotti/features/goals/service/goal_checkin_compactor.dart';
+import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_strategy.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
@@ -1114,6 +1116,216 @@ void main() {
     expect(sentFacts, isNot(contains('Skipped the lunch walk.')));
     expect(sentFacts, contains('userVoice'));
     expect(sentFacts, contains('walk after lunch tomorrow'));
+  });
+
+  group('hierarchical user voice', () {
+    /// Two years of stored summaries, three a week, all with live sources.
+    List<GoalCheckInSource> stubTwoYearsOfCheckIns() {
+      final sources = <GoalCheckInSource>[];
+      final messages = <AgentDomainEntity>[];
+      final start = DateTime.utc(2024, 8, 12, 9);
+      for (var i = 0; i < 300; i++) {
+        final at = start.add(Duration(days: (i ~/ 3) * 7 + (i % 3) * 2));
+        if (!at.isBefore(now)) break;
+        final id = 'summary-$i';
+        sources.add(
+          GoalCheckInSource(entryId: 'audio-$i', recordedAt: at, text: 'w $i'),
+        );
+        messages.add(
+          AgentDomainEntity.agentMessage(
+            id: id,
+            agentId: agentId,
+            threadId: id,
+            kind: AgentMessageKind.action,
+            createdAt: at,
+            vectorClock: null,
+            metadata: const AgentMessageMetadata(
+              toolName: goalCheckInSummaryToolName,
+            ),
+            contentEntryId: '$id:payload',
+          ),
+        );
+        when(() => repository.getEntity('$id:payload')).thenAnswer(
+          (_) async => AgentDomainEntity.agentMessagePayload(
+            id: '$id:payload',
+            agentId: agentId,
+            createdAt: at,
+            vectorClock: null,
+            content: <String, Object?>{
+              'sourceEntryId': 'audio-$i',
+              'recordedAt': at.toIso8601String(),
+              'whatHappened': 'Walked the perimeter loop, check-in $i.',
+              'committedTo': 'Loop again tomorrow, check-in $i.',
+              'sourceDigest': goalCheckInSourceDigest('w $i'),
+            },
+          ),
+        );
+      }
+      when(
+        () => repository.getEntitiesByAgentIdAndSubtype(
+          agentId,
+          type: any(named: 'type'),
+          subtype: any(named: 'subtype'),
+        ),
+      ).thenAnswer((_) async => messages);
+      return sources;
+    }
+
+    var liveCheckIns = 0;
+    Future<String?> runWake({
+      required GoalCheckInDigestService digestService,
+      String? pendingUserMessage,
+    }) async {
+      stubSpec();
+      stubGlmResolution();
+      _stubBadPrior(repository, agentId, now);
+      final compactor = MockGoalCheckInCompactor();
+      final sources = stubTwoYearsOfCheckIns();
+      liveCheckIns = sources.length;
+      workflow = GoalAgentWorkflow(
+        repository: repository,
+        syncService: syncService,
+        phaseA: GoalAgentPhaseA(
+          repository: repository,
+          syncService: syncService,
+          signalReader: _FakeReader(),
+        ),
+        conversationRepository: conversationRepository,
+        cloudInferenceRepository: cloudInferenceRepository,
+        aiConfigRepository: aiConfigRepository,
+        checkInCompactor: compactor,
+        checkInSourceReader: (agentId) async => sources,
+        checkInDigestService: digestService,
+      );
+      String? sentFacts;
+      conversationRepository.sendMessageDelegate =
+          ({
+            required conversationId,
+            required message,
+            required model,
+            required provider,
+            required inferenceRepo,
+            tools,
+            toolChoice,
+            temperature = 0.7,
+            strategy,
+          }) async {
+            sentFacts ??= message;
+            return const InferenceUsage(inputTokens: 10, outputTokens: 5);
+          };
+      await workflow.execute(
+        agentIdentity: identity,
+        runKey: 'run-hierarchical',
+        triggerTokens: pendingUserMessage == null
+            ? const {'goal-escalation:2026-08-11'}
+            : const {},
+        threadId: 'thread-hierarchical',
+        pendingUserMessage: pendingUserMessage,
+        chatMessageId: pendingUserMessage == null ? null : 'chat-source',
+      );
+      return sentFacts;
+    }
+
+    test('an automatic wake carries digests of the older spans and the '
+        'recent tail verbatim', () async {
+      final digestService = MockGoalCheckInDigestService();
+      final writer = _RecordingDigestWriter();
+      bool? allowInference;
+      when(
+        () => digestService.forWake(
+          agentId: any(named: 'agentId'),
+          goalStatement: any(named: 'goalStatement'),
+          model: any(named: 'model'),
+          provider: any(named: 'provider'),
+          allowInference: any(named: 'allowInference'),
+        ),
+      ).thenAnswer((invocation) {
+        allowInference = invocation.namedArguments[#allowInference] as bool;
+        return writer;
+      });
+
+      final facts = await runWake(digestService: digestService);
+
+      expect(facts, isNotNull);
+      // A scheduled wake may write digests, and it asks with the goal's own
+      // model — the same wake that compacts check-ins.
+      expect(allowInference, isTrue);
+      verify(
+        () => digestService.forWake(
+          agentId: agentId,
+          goalStatement: any(named: 'goalStatement'),
+          model: 'glm-5.2',
+          provider: any(named: 'provider'),
+          allowInference: true,
+        ),
+      ).called(1);
+      // Older spans reach FACTS as digests, oldest first, and the most
+      // recent check-in stays verbatim with its commitment.
+      expect(writer.requests, isNotEmpty);
+      expect(writer.requests.first.layer, GoalCheckInDigestLayer.year);
+      expect(facts, contains('"kind": "digest"'));
+      expect(facts, contains('digest of ${writer.requests.first.periodLabel}'));
+      final newest = 'check-in ${liveCheckIns - 1}.';
+      expect(facts, contains('Walked the perimeter loop, $newest'));
+      expect(facts, contains('Loop again tomorrow, $newest'));
+      expect(
+        facts,
+        isNot(contains('Walked the perimeter loop, check-in 0.')),
+        reason: 'the oldest check-in is digested, not verbatim',
+      );
+      // Every folded check-in is in exactly one span; nothing is dropped.
+      final folded = writer.requests.fold<int>(
+        0,
+        (n, r) => n + r.checkIns.length,
+      );
+      final verbatim = RegExp('"whatHappened"').allMatches(facts!).length;
+      expect(folded + verbatim, liveCheckIns);
+    });
+
+    test('an interactive turn reads digests but must not write them', () async {
+      final digestService = MockGoalCheckInDigestService();
+      bool? allowInference;
+      when(
+        () => digestService.forWake(
+          agentId: any(named: 'agentId'),
+          goalStatement: any(named: 'goalStatement'),
+          model: any(named: 'model'),
+          provider: any(named: 'provider'),
+          allowInference: any(named: 'allowInference'),
+        ),
+      ).thenAnswer((invocation) {
+        allowInference = invocation.namedArguments[#allowInference] as bool;
+        return _RecordingDigestWriter();
+      });
+      await runWake(
+        digestService: digestService,
+        pendingUserMessage: 'How am I doing?',
+      );
+
+      expect(allowInference, isFalse);
+    });
+
+    test('a failing digest layer falls back to the truncating tail', () async {
+      final digestService = MockGoalCheckInDigestService();
+      when(
+        () => digestService.forWake(
+          agentId: any(named: 'agentId'),
+          goalStatement: any(named: 'goalStatement'),
+          model: any(named: 'model'),
+          provider: any(named: 'provider'),
+          allowInference: any(named: 'allowInference'),
+        ),
+      ).thenReturn(_ThrowingDigestWriter());
+
+      final facts = await runWake(digestService: digestService);
+
+      expect(facts, isNotNull);
+      expect(facts, contains('userVoice'));
+      expect(facts, isNot(contains('"kind": "digest"')));
+      // The newest check-in is still there: the wake lost the digests, not
+      // its user voice.
+      expect(facts, contains('"whatHappened"'));
+    });
   });
 
   test(
@@ -5602,4 +5814,21 @@ void main() {
     ]);
     expect(sections['unexpected'], 7);
   });
+}
+
+/// Records digest requests and answers with a legible stub.
+class _RecordingDigestWriter implements GoalCheckInDigestWriter {
+  final requests = <GoalCheckInDigestRequest>[];
+
+  @override
+  Future<String> write(GoalCheckInDigestRequest request) async {
+    requests.add(request);
+    return 'digest of ${request.periodLabel}';
+  }
+}
+
+class _ThrowingDigestWriter implements GoalCheckInDigestWriter {
+  @override
+  Future<String> write(GoalCheckInDigestRequest request) =>
+      throw StateError('digest store unavailable');
 }

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -113,6 +113,7 @@ import 'package:lotti/features/goals/repository/goal_repository.dart';
 import 'package:lotti/features/goals/service/goal_agent_service.dart';
 import 'package:lotti/features/goals/service/goal_chat_service.dart';
 import 'package:lotti/features/goals/service/goal_checkin_compactor.dart';
+import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
 import 'package:lotti/features/goals/service/goal_checkin_notifier.dart';
 import 'package:lotti/features/goals/service/goal_habit_completion_service.dart';
 import 'package:lotti/features/goals/service/goal_mirror_service.dart';
@@ -995,6 +996,9 @@ class MockGoalMirrorService extends Mock implements GoalMirrorService {}
 class MockGoalCheckInNotifier extends Mock implements GoalCheckInNotifier {}
 
 class MockGoalCheckInCompactor extends Mock implements GoalCheckInCompactor {}
+
+class MockGoalCheckInDigestService extends Mock
+    implements GoalCheckInDigestService {}
 
 class MockAgentRepository extends Mock implements AgentRepository {
   @override

--- a/test/tool/goal_compaction_eval_report_test.dart
+++ b/test/tool/goal_compaction_eval_report_test.dart
@@ -297,6 +297,29 @@ void main() {
       },
     );
 
+    test('without a judged full arm there is no verdict', () {
+      final noFull = _packet(
+        [
+          for (final c in cases)
+            if (c['strategyId'] != 'full') c,
+        ],
+      )..['strategyIds'] = ['truncate', 'hierarchical'];
+      final partial = scores(
+        truncateGrades: ['correct', 'correct', 'correct', 'correct'],
+        hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+      );
+      (partial['cases'] as List).removeWhere(
+        (c) => (c as Map)['strategyId'] == 'full',
+      );
+      final report = buildGoalCompactionEvalReport(
+        packet: noFull,
+        scores: partial,
+      );
+      expect(report, contains('No judged `full` arm in this run: no verdict'));
+      expect(report, isNot(contains('**PASS**')));
+      expect(report, isNot(contains('**FAIL**')));
+    });
+
     test('a scores file missing a packet case is refused', () {
       final partial = scores(
         truncateGrades: ['correct', 'correct', 'correct', 'correct'],

--- a/test/tool/goal_compaction_eval_report_test.dart
+++ b/test/tool/goal_compaction_eval_report_test.dart
@@ -297,6 +297,55 @@ void main() {
       },
     );
 
+    test('a scores file missing a packet case is refused', () {
+      final partial = scores(
+        truncateGrades: ['correct', 'correct', 'correct', 'correct'],
+        hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+      );
+      (partial['cases'] as List).removeWhere(
+        (c) => (c as Map)['strategyId'] == 'hierarchical',
+      );
+      expect(
+        () => buildGoalCompactionEvalReport(
+          packet: _packet(cases),
+          scores: partial,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('stall|hierarchical|1 has no scores case'),
+          ),
+        ),
+      );
+    });
+
+    test('a scores case missing a probe grade is refused', () {
+      final partial = scores(
+        truncateGrades: ['correct', 'correct', 'correct', 'correct'],
+        hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+      );
+      final hier =
+          (partial['cases'] as List).firstWhere(
+                (c) => (c as Map)['strategyId'] == 'hierarchical',
+              )
+              as Map<String, dynamic>;
+      (hier['probes'] as List).removeWhere((p) => (p as Map)['id'] == 'b');
+      expect(
+        () => buildGoalCompactionEvalReport(
+          packet: _packet(cases),
+          scores: partial,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('missing probe(s): b'),
+          ),
+        ),
+      );
+    });
+
     test('a scores case with no packet counterpart is refused', () {
       final stray = scores(
         truncateGrades: ['correct', 'correct', 'correct', 'correct'],

--- a/test/tool/goal_compaction_eval_report_test.dart
+++ b/test/tool/goal_compaction_eval_report_test.dart
@@ -1,0 +1,422 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/goal_compaction_eval_report.dart';
+
+Map<String, dynamic> _case({
+  required String fixtureId,
+  required String strategyId,
+  int sample = 1,
+  String expectedStatus = 'offTrack',
+  String? reportedStatus = 'offTrack',
+  List<String> toolNames = const ['reply_to_user', 'update_goal_report'],
+  String? reply = 'Restore the after-lunch loop calendar block.',
+  int? inputTokens = 5000,
+  int voiceTokens = 1000,
+  int verbatim = 8,
+  int digests = 0,
+  List<Map<String, dynamic>> probes = const [],
+  String? errorMessage,
+}) => {
+  'fixtureId': fixtureId,
+  'strategyId': strategyId,
+  'sample': sample,
+  'wake': {
+    'expectedStatus': expectedStatus,
+    'reportedStatus': reportedStatus,
+    'statusCorrect': reportedStatus == expectedStatus,
+    'oneLiner': reportedStatus == null ? null : 'One-liner.',
+    'reply': reply,
+    'toolNames': toolNames,
+    'inputTokens': inputTokens,
+  },
+  'userVoice': {
+    'estimatedTokens': voiceTokens,
+    'verbatimCount': verbatim,
+    'digestCount': digests,
+  },
+  'probes': probes,
+  'errorMessage': errorMessage,
+};
+
+Map<String, dynamic> _probe(
+  String id,
+  String age, {
+  String? basis = 'history',
+}) => {'id': id, 'age': age, 'basis': basis};
+
+Map<String, dynamic> _packet(List<Map<String, dynamic>> cases) => {
+  'kind': goalCompactionPacketKind,
+  'provider': {'baseUrl': 'https://example.test'},
+  'modelId': 'glm-5.2',
+  'temperature': 0,
+  'reference': '2026-08-27T12:00:00.000Z',
+  'strategyIds': ['full', 'truncate', 'hierarchical'],
+  'fixtures': [
+    {'id': 'stall', 'checkInCount': 300},
+  ],
+  'cases': cases,
+  'growthCurve': [
+    for (final s in ['full', 'truncate', 'hierarchical'])
+      for (final (i, m) in [3, 24].indexed)
+        {
+          'fixtureId': 'stall',
+          'strategyId': s,
+          'months': m,
+          'checkIns': m * 12,
+          'estimatedTokens': s == 'full' ? m * 1000 : 1000 + i * 200,
+        },
+  ],
+  'digestUsage': {
+    'calls': 10,
+    'cacheHits': 5,
+    'inputTokens': 30000,
+    'outputTokens': 3000,
+  },
+};
+
+void main() {
+  final probes = [
+    _probe('a', 'old'),
+    _probe('b', 'old'),
+    _probe('c', 'mid'),
+    _probe('d', 'recent', basis: 'notInHistory'),
+  ];
+  final cases = [
+    _case(fixtureId: 'stall', strategyId: 'full', probes: probes),
+    _case(
+      fixtureId: 'stall',
+      strategyId: 'truncate',
+      toolNames: const ['reply_to_user'],
+      reportedStatus: null,
+      voiceTokens: 1100,
+      probes: probes,
+    ),
+    _case(
+      fixtureId: 'stall',
+      strategyId: 'hierarchical',
+      voiceTokens: 1900,
+      digests: 7,
+      probes: probes,
+    ),
+  ];
+
+  group('deterministic section', () {
+    test('reports per-arm status accuracy and tool-set agreement with full', () {
+      final report = buildGoalCompactionEvalReport(packet: _packet(cases));
+
+      expect(
+        report,
+        contains(
+          '| `full` | 1 | 0 | 1/1 (100%) | 1/1 (100%) | 1/1 (100%) | — | 5000 | 1000 | 8 | 0 |',
+        ),
+      );
+      // Truncate skipped the report and so disagrees on the tool set.
+      expect(
+        report,
+        contains(
+          '| `truncate` | 1 | 0 | 0/1 (0%) | 0/1 (0%) | 1/1 (100%) | 0/1 (0%) | 5000 | 1100 | 8 | 0 |',
+        ),
+      );
+      expect(
+        report,
+        contains(
+          '| `hierarchical` | 1 | 0 | 1/1 (100%) | 1/1 (100%) | 1/1 (100%) | 1/1 (100%) | 5000 | 1900 | 8 | 7 |',
+        ),
+      );
+    });
+
+    test('renders the growth curve with one column per arm', () {
+      final report = buildGoalCompactionEvalReport(packet: _packet(cases));
+
+      expect(
+        report,
+        contains(
+          '| Months | Check-ins | `full` | `truncate` | `hierarchical` |',
+        ),
+      );
+      expect(report, contains('| 3 | 36 | 3000 | 1000 | 1000 |'));
+      expect(report, contains('| 24 | 288 | 24000 | 1200 | 1200 |'));
+    });
+
+    test('amortises digest cost per check-in', () {
+      final report = buildGoalCompactionEvalReport(packet: _packet(cases));
+
+      expect(report, contains('10 digest call(s), 5 cache hit(s)'));
+      expect(report, contains('≈ 110 tokens per check-in, once'));
+    });
+
+    test('counts an errored case and shows the error in the appendix', () {
+      final report = buildGoalCompactionEvalReport(
+        packet: _packet([
+          ...cases,
+          _case(
+            fixtureId: 'stall',
+            strategyId: 'full',
+            sample: 2,
+            reportedStatus: null,
+            reply: null,
+            inputTokens: null,
+            errorMessage: 'HTTP 500',
+          ),
+        ]),
+      );
+
+      expect(report, contains('| `full` | 2 | 1 | 1/2 (50%)'));
+      expect(report, contains('Error: HTTP 500'));
+    });
+
+    test('says what is missing without a scores file', () {
+      final report = buildGoalCompactionEvalReport(packet: _packet(cases));
+      expect(report, contains('No scores file given'));
+      expect(report, isNot(contains('## Pass bar')));
+    });
+  });
+
+  group('judged section', () {
+    Map<String, dynamic> scores({
+      required List<String> truncateGrades,
+      required List<String> hierarchicalGrades,
+      String hierarchicalAgreement = 'same',
+      bool hierarchicalForbidden = false,
+    }) => {
+      'kind': goalCompactionScoresKind,
+      'judge': 'fable-5 (in session)',
+      'cases': [
+        {
+          'fixtureId': 'stall',
+          'strategyId': 'full',
+          'sample': 1,
+          'probes': [
+            for (final id in ['a', 'b', 'c', 'd'])
+              {'id': id, 'grade': 'correct'},
+          ],
+          'recommendation': {'agreement': 'same', 'forbiddenHit': false},
+        },
+        {
+          'fixtureId': 'stall',
+          'strategyId': 'truncate',
+          'sample': 1,
+          'probes': [
+            for (final (i, id) in ['a', 'b', 'c', 'd'].indexed)
+              {'id': id, 'grade': truncateGrades[i]},
+          ],
+          'recommendation': {
+            'agreement': 'contradictory',
+            'forbiddenHit': true,
+          },
+        },
+        {
+          'fixtureId': 'stall',
+          'strategyId': 'hierarchical',
+          'sample': 1,
+          'probes': [
+            for (final (i, id) in ['a', 'b', 'c', 'd'].indexed)
+              {'id': id, 'grade': hierarchicalGrades[i]},
+          ],
+          'recommendation': {
+            'agreement': hierarchicalAgreement,
+            'forbiddenHit': hierarchicalForbidden,
+          },
+        },
+      ],
+    };
+
+    test('scores recall by age, counting partial as half', () {
+      final report = buildGoalCompactionEvalReport(
+        packet: _packet(cases),
+        scores: scores(
+          truncateGrades: ['wrong', 'honestUnknown', 'correct', 'correct'],
+          hierarchicalGrades: ['correct', 'partial', 'correct', 'correct'],
+        ),
+      );
+
+      expect(
+        report,
+        contains(
+          '| `full` | 100% | 100% | 100% | 100% | 0/4 (0%) | 0/4 (0%) |',
+        ),
+      );
+      // Truncate: old = (0 + 0)/2, one wrong-as-history hallucination, one honest unknown.
+      expect(
+        report,
+        contains(
+          '| `truncate` | 100% | 100% | 0% | 50% | 1/4 (25%) | 1/4 (25%) |',
+        ),
+      );
+      expect(
+        report,
+        contains(
+          '| `hierarchical` | 100% | 100% | 75% | 88% | 0/4 (0%) | 0/4 (0%) |',
+        ),
+      );
+    });
+
+    test(
+      'a wrong answer flagged notInHistory is a miss, not a hallucination',
+      () {
+        final report = buildGoalCompactionEvalReport(
+          packet: _packet(cases),
+          scores: scores(
+            // Probe d carries basis notInHistory in the packet.
+            truncateGrades: ['correct', 'correct', 'correct', 'wrong'],
+            hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+          ),
+        );
+        expect(
+          report,
+          contains(
+            '| `truncate` | 0% | 100% | 100% | 75% | 0/4 (0%) | 0/4 (0%) |',
+          ),
+        );
+      },
+    );
+
+    test(
+      'a wrong answer with no parseable basis is a miss, not a hallucination',
+      () {
+        final unparseable = [
+          for (final c in cases)
+            {
+              ...c,
+              'probes': [
+                for (final p in probes) {...p, 'basis': null},
+              ],
+            },
+        ];
+        final report = buildGoalCompactionEvalReport(
+          packet: _packet(unparseable),
+          scores: scores(
+            truncateGrades: ['wrong', 'wrong', 'wrong', 'wrong'],
+            hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+          ),
+        );
+        expect(
+          report,
+          contains('| `truncate` | 0% | 0% | 0% | 0% | 0/4 (0%) | 0/4 (0%) |'),
+        );
+      },
+    );
+
+    test('a scores case with no packet counterpart is refused', () {
+      final stray = scores(
+        truncateGrades: ['correct', 'correct', 'correct', 'correct'],
+        hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+      );
+      (stray['cases'] as List).add({
+        'fixtureId': 'stall',
+        'strategyId': 'hierarchical',
+        'sample': 9,
+        'probes': [
+          {'id': 'a', 'grade': 'correct'},
+        ],
+      });
+      expect(
+        () => buildGoalCompactionEvalReport(
+          packet: _packet(cases),
+          scores: stray,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('stall|hierarchical|9'),
+          ),
+        ),
+      );
+    });
+
+    test('reports recommendation agreement and forbidden directions', () {
+      final report = buildGoalCompactionEvalReport(
+        packet: _packet(cases),
+        scores: scores(
+          truncateGrades: ['wrong', 'wrong', 'correct', 'correct'],
+          hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+          hierarchicalAgreement: 'compatible',
+        ),
+      );
+      expect(
+        report,
+        contains(
+          '| `truncate` | 0/1 (0%) | 0/1 (0%) | 1/1 (100%) | 1/1 (100%) |',
+        ),
+      );
+      expect(
+        report,
+        contains(
+          '| `hierarchical` | 0/1 (0%) | 1/1 (100%) | 0/1 (0%) | 0/1 (0%) |',
+        ),
+      );
+    });
+
+    test(
+      'pass bar: hierarchical passes, truncate fails, full is the reference',
+      () {
+        final report = buildGoalCompactionEvalReport(
+          packet: _packet(cases),
+          scores: scores(
+            truncateGrades: ['wrong', 'wrong', 'correct', 'correct'],
+            // A partial on a mid-age fact is fine; old recall stays at full's.
+            hierarchicalGrades: ['correct', 'correct', 'partial', 'correct'],
+          ),
+        );
+
+        expect(report, contains('## Pass bar'));
+        expect(
+          report,
+          contains('| `hierarchical` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |'),
+        );
+        // Truncate: old recall 0 (✗), hallucinated 2/4 (✗), contradictory (✗ ✗),
+        // status 0 < full's 1 (✗), tokens fine (✓).
+        expect(
+          report,
+          contains('| `truncate` | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | **FAIL** |'),
+        );
+        expect(report, isNot(contains('| `full` | ✓')));
+      },
+    );
+
+    test('pass bar: a bloated hierarchical context fails on tokens alone', () {
+      final bloated = [
+        for (final c in cases)
+          if (c['strategyId'] == 'hierarchical')
+            {
+              ...c,
+              'userVoice': {
+                'estimatedTokens': 6000,
+                'verbatimCount': 8,
+                'digestCount': 30,
+              },
+            }
+          else
+            c,
+      ];
+      final report = buildGoalCompactionEvalReport(
+        packet: _packet(bloated),
+        scores: scores(
+          truncateGrades: ['wrong', 'wrong', 'correct', 'correct'],
+          hierarchicalGrades: ['correct', 'correct', 'correct', 'correct'],
+        ),
+      );
+      expect(
+        report,
+        contains('| `hierarchical` | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | **FAIL** |'),
+      );
+    });
+
+    test('pass bar: recall below 90% of full fails', () {
+      final report = buildGoalCompactionEvalReport(
+        packet: _packet(cases),
+        scores: scores(
+          truncateGrades: ['wrong', 'wrong', 'correct', 'correct'],
+          hierarchicalGrades: ['correct', 'wrong', 'correct', 'correct'],
+        ),
+      );
+      // Old recall 50% vs full 100%: ✗ on recall, and the wrong-as-history
+      // answer is a hallucination above full's zero + 5pp: ✗.
+      expect(
+        report,
+        contains('| `hierarchical` | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | **FAIL** |'),
+      );
+    });
+  });
+}

--- a/tool/goal_compaction_eval_report.dart
+++ b/tool/goal_compaction_eval_report.dart
@@ -341,7 +341,17 @@ String buildGoalCompactionEvalReport({
     // ── Pass bar ────────────────────────────────────────────────────────
     final full = judged['full'];
     final fullDet = deterministic['full'];
-    if (full != null && fullDet != null) {
+    if (full == null || fullDet == null || full.all.total == 0) {
+      // A candidate is only ever judged AGAINST the oracle. Without judged
+      // full-arm probes the recall and hallucination gates would compare
+      // against zero and pass anything.
+      buffer
+        ..writeln()
+        ..writeln(
+          '## Pass bar\n\n_No judged `full` arm in this run: no verdict. '
+          'Run the full arm alongside every candidate._',
+        );
+    } else {
       buffer
         ..writeln()
         ..writeln('## Pass bar')

--- a/tool/goal_compaction_eval_report.dart
+++ b/tool/goal_compaction_eval_report.dart
@@ -226,6 +226,7 @@ String buildGoalCompactionEvalReport({
     final probesByCase = <String, Map<String, dynamic>>{
       for (final c in cases) _caseKey(c, withStrategy: true): c,
     };
+    _requireCompleteScores(cases, scoreCases);
     buffer
       ..writeln()
       ..writeln('## Judged metrics (judge: ${scores['judge']})')
@@ -445,6 +446,42 @@ String buildGoalCompactionEvalReport({
     }
   }
   return buffer.toString();
+}
+
+/// A verdict over a subset would be a verdict over the judge's selection.
+/// Every packet case must be scored, and every probe of every case graded,
+/// before any rate is computed.
+void _requireCompleteScores(
+  List<Map<String, dynamic>> cases,
+  List<Map<String, dynamic>> scoreCases,
+) {
+  final scored = <String, Map<String, dynamic>>{
+    for (final s in scoreCases) _caseKey(s, withStrategy: true): s,
+  };
+  for (final c in cases) {
+    final key = _caseKey(c, withStrategy: true);
+    final s = scored[key];
+    if (s == null) {
+      throw StateError('packet case $key has no scores case');
+    }
+    final expected = {
+      for (final p in (c['probes'] as List).cast<Map<String, dynamic>>())
+        p['id'] as String,
+    };
+    final graded = {
+      for (final p in (s['probes'] as List).cast<Map<String, dynamic>>())
+        p['id'] as String,
+    };
+    final missing = expected.difference(graded);
+    if (missing.isNotEmpty) {
+      throw StateError(
+        'scores case $key is missing probe(s): ${missing.join(', ')}',
+      );
+    }
+    if (s['recommendation'] == null) {
+      throw StateError('scores case $key has no recommendation verdict');
+    }
+  }
 }
 
 String _caseKey(Map<String, dynamic> c, {bool withStrategy = false}) =>

--- a/tool/goal_compaction_eval_report.dart
+++ b/tool/goal_compaction_eval_report.dart
@@ -1,0 +1,508 @@
+// Turns a goal check-in compaction judging packet (written by
+// test/features/agents/eval/goal/compaction/goal_compaction_eval_live_test.dart)
+// plus an optional scores file (written by the judge, in the schema described
+// in docs/evaluations/goal_agent_models/compaction.md) into one markdown
+// report.
+//
+// The deterministic metrics — status accuracy, tool-set agreement with the
+// full-context arm, provider-reported tokens, the growth curve, digest cost —
+// come from the packet alone. The judged metrics — fact recall by age,
+// hallucination, recommendation agreement — appear when a scores file is
+// given, and the pass bar is evaluated only then.
+//
+// Usage:
+//   fvm dart run tool/goal_compaction_eval_report.dart packet.json [scores.json]
+//
+// Pure Dart on purpose: runnable without a Flutter context, testable from
+// test/tool/goal_compaction_eval_report_test.dart.
+
+import 'dart:convert';
+import 'dart:io';
+
+const goalCompactionPacketKind = 'lotti.goalCompactionEvalPacket';
+const goalCompactionScoresKind = 'lotti.goalCompactionEvalScores';
+
+void main(List<String> args) {
+  final flags = args.where((arg) => arg.startsWith('--')).toList();
+  if (flags.isNotEmpty) {
+    stderr.writeln(
+      'Unknown flag(s): ${flags.join(' ')}. This tool takes only file paths.',
+    );
+    exitCode = 2;
+    return;
+  }
+  final paths = args.toList();
+  if (paths.isEmpty) {
+    stderr.writeln(
+      'Usage: dart run tool/goal_compaction_eval_report.dart '
+      '<packet.json> [scores.json]',
+    );
+    exitCode = 2;
+    return;
+  }
+  Map<String, dynamic>? packet;
+  Map<String, dynamic>? scores;
+  for (final path in paths) {
+    final file = File(path);
+    if (!file.existsSync()) {
+      stderr.writeln('No such file: $path');
+      exitCode = 2;
+      return;
+    }
+    final decoded = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    switch (decoded['kind']) {
+      case goalCompactionPacketKind:
+        packet = decoded;
+      case goalCompactionScoresKind:
+        scores = decoded;
+      default:
+        stderr.writeln('Unknown artifact kind in $path: ${decoded['kind']}');
+        exitCode = 2;
+        return;
+    }
+  }
+  if (packet == null) {
+    stderr.writeln('No packet given.');
+    exitCode = 2;
+    return;
+  }
+  stdout.write(buildGoalCompactionEvalReport(packet: packet, scores: scores));
+}
+
+/// The pass bar, evaluated against the full-context arm.
+///
+/// Numbers, not adjectives: a candidate arm passes when its old-fact recall
+/// is at least [minRecallRatioVsFull] of the full arm's, it hallucinates no
+/// more than the full arm (plus [hallucinationSlack]), its recommendations
+/// agree with the full arm at least [minRecommendationAgreement] of the
+/// time, it never contradicts the full arm more than
+/// [maxContradictionRate], it restates the status as accurately, and its
+/// context stays under [maxUserVoiceTokens] at the full horizon.
+class GoalCompactionPassBar {
+  const GoalCompactionPassBar({
+    this.minRecallRatioVsFull = 0.9,
+    this.hallucinationSlack = 0.05,
+    this.minRecommendationAgreement = 0.9,
+    this.maxContradictionRate = 0.1,
+    this.maxUserVoiceTokens = 2500,
+  });
+
+  final double minRecallRatioVsFull;
+  final double hallucinationSlack;
+  final double minRecommendationAgreement;
+  final double maxContradictionRate;
+  final int maxUserVoiceTokens;
+}
+
+String buildGoalCompactionEvalReport({
+  required Map<String, dynamic> packet,
+  Map<String, dynamic>? scores,
+  GoalCompactionPassBar passBar = const GoalCompactionPassBar(),
+}) {
+  final strategyIds = (packet['strategyIds'] as List).cast<String>();
+  final cases = (packet['cases'] as List).cast<Map<String, dynamic>>();
+  final fixtures = (packet['fixtures'] as List).cast<Map<String, dynamic>>();
+  final growth = ((packet['growthCurve'] as List?) ?? const [])
+      .cast<Map<String, dynamic>>();
+  final samples = cases.isEmpty
+      ? 0
+      : cases.map((c) => c['sample'] as int).reduce((a, b) => a > b ? a : b);
+
+  final buffer = StringBuffer()
+    ..writeln('# Goal check-in compaction eval')
+    ..writeln()
+    ..writeln(
+      'Agent model `${packet['modelId']}` on '
+      '`${(packet['provider'] as Map)['baseUrl']}`, temperature '
+      '${packet['temperature']}, reference ${packet['reference']}. '
+      '${fixtures.length} fixture(s) × ${strategyIds.length} arm(s) × '
+      '$samples sample(s) = ${cases.length} case(s).',
+    )
+    ..writeln()
+    // ── Deterministic ───────────────────────────────────────────────────
+    ..writeln('## Deterministic metrics')
+    ..writeln()
+    ..writeln(
+      '| Arm | Cases | Errors | Status correct | Report | Reply | '
+      'Tool set = full | Wake input tokens | userVoice tokens | '
+      'Verbatim | Digests |',
+    )
+    ..writeln(
+      '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    );
+  final fullByKey = <String, Map<String, dynamic>>{
+    for (final c in cases)
+      if (c['strategyId'] == 'full') _caseKey(c): c,
+  };
+  final deterministic = <String, _ArmStats>{};
+  for (final strategyId in strategyIds) {
+    final arm = cases.where((c) => c['strategyId'] == strategyId).toList();
+    final stats = _ArmStats();
+    for (final c in arm) {
+      final wake = c['wake'] as Map<String, dynamic>;
+      stats.cases++;
+      if (c['errorMessage'] != null) stats.errors++;
+      if (wake['statusCorrect'] == true) stats.statusCorrect++;
+      if (wake['reportedStatus'] != null) stats.reports++;
+      if (wake['reply'] != null) stats.replies++;
+      final full = fullByKey[_caseKey(c)];
+      if (full != null) {
+        stats.comparable++;
+        final mine = (wake['toolNames'] as List).join(',');
+        final theirs =
+            ((full['wake'] as Map<String, dynamic>)['toolNames'] as List).join(
+              ',',
+            );
+        if (mine == theirs) stats.toolSetAgree++;
+      }
+      stats.wakeInput.add(wake['inputTokens'] as int?);
+      final voice = c['userVoice'] as Map<String, dynamic>;
+      stats.voiceTokens.add(voice['estimatedTokens'] as int?);
+      stats.verbatim.add(voice['verbatimCount'] as int?);
+      stats.digests.add(voice['digestCount'] as int?);
+    }
+    deterministic[strategyId] = stats;
+    buffer.writeln(
+      '| `$strategyId` | ${stats.cases} | ${stats.errors} | '
+      '${_ratio(stats.statusCorrect, stats.cases)} | '
+      '${_ratio(stats.reports, stats.cases)} | '
+      '${_ratio(stats.replies, stats.cases)} | '
+      '${strategyId == 'full' ? '—' : _ratio(stats.toolSetAgree, stats.comparable)} | '
+      '${_mean(stats.wakeInput)} | ${_mean(stats.voiceTokens)} | '
+      '${_mean(stats.verbatim)} | ${_mean(stats.digests)} |',
+    );
+  }
+
+  // ── Growth curve ──────────────────────────────────────────────────────
+  if (growth.isNotEmpty) {
+    final months = growth.map((g) => g['months'] as int).toSet().toList()
+      ..sort();
+    buffer
+      ..writeln()
+      ..writeln(
+        '## Token growth curve (userVoice, estimated, mean over fixtures)',
+      )
+      ..writeln()
+      ..writeln(
+        '| Months | Check-ins | ${strategyIds.map((s) => '`$s`').join(' | ')} |',
+      )
+      ..writeln('| ---: | ---: |${' ---: |' * strategyIds.length}');
+    for (final m in months) {
+      final at = growth.where((g) => g['months'] == m).toList();
+      final checkIns = _mean([for (final g in at) g['checkIns'] as int?]);
+      final cells = strategyIds.map((s) {
+        final points = at.where((g) => g['strategyId'] == s);
+        return _mean([for (final g in points) g['estimatedTokens'] as int?]);
+      });
+      buffer.writeln('| $m | $checkIns | ${cells.join(' | ')} |');
+    }
+  }
+
+  // ── Digest cost ───────────────────────────────────────────────────────
+  final digestUsage = packet['digestUsage'] as Map<String, dynamic>?;
+  if (digestUsage != null && digestUsage.isNotEmpty) {
+    final totalCheckIns = fixtures.fold<int>(
+      0,
+      (sum, f) => sum + (f['checkInCount'] as int),
+    );
+    final inputTokens = digestUsage['inputTokens'] as int?;
+    final outputTokens = digestUsage['outputTokens'] as int?;
+    buffer
+      ..writeln()
+      ..writeln('## Digest cost (hierarchical arm, amortised)')
+      ..writeln()
+      ..writeln(
+        '${digestUsage['calls']} digest call(s), ${digestUsage['cacheHits']} '
+        'cache hit(s); ${inputTokens ?? '?'} input + ${outputTokens ?? '?'} '
+        'output tokens over $totalCheckIns check-ins'
+        '${inputTokens != null && outputTokens != null && totalCheckIns > 0 ? ' ≈ ${((inputTokens + outputTokens) / totalCheckIns).toStringAsFixed(0)} tokens per check-in, once' : ''}.',
+      );
+  }
+
+  // ── Judged ────────────────────────────────────────────────────────────
+  final judged = <String, _JudgedStats>{};
+  if (scores != null) {
+    final scoreCases = (scores['cases'] as List).cast<Map<String, dynamic>>();
+    final probesByCase = <String, Map<String, dynamic>>{
+      for (final c in cases) _caseKey(c, withStrategy: true): c,
+    };
+    buffer
+      ..writeln()
+      ..writeln('## Judged metrics (judge: ${scores['judge']})')
+      ..writeln();
+    for (final strategyId in strategyIds) {
+      final stats = _JudgedStats();
+      for (final s in scoreCases.where((s) => s['strategyId'] == strategyId)) {
+        final packetCase = probesByCase[_caseKey(s, withStrategy: true)];
+        if (packetCase == null) {
+          // A scores file from another run would silently distort every
+          // rate; refuse rather than fold unknown probes into the totals.
+          throw StateError(
+            'scores case ${_caseKey(s, withStrategy: true)} has no packet case',
+          );
+        }
+        final packetProbes = (packetCase['probes'] as List)
+            .cast<Map<String, dynamic>>();
+        final ageById = <String, String>{
+          for (final p in packetProbes) p['id'] as String: p['age'] as String,
+        };
+        final basisById = <String, String?>{
+          for (final p in packetProbes)
+            p['id'] as String: p['basis'] as String?,
+        };
+        for (final p in (s['probes'] as List).cast<Map<String, dynamic>>()) {
+          final age = ageById[p['id']] ?? 'unknown';
+          final grade = p['grade'] as String;
+          final bucket = stats.byAge.putIfAbsent(age, _AgeStats.new);
+          bucket.total++;
+          stats.all.total++;
+          switch (grade) {
+            case 'correct':
+              bucket.score += 1;
+              stats.all.score += 1;
+            case 'partial':
+              bucket.score += 0.5;
+              stats.all.score += 0.5;
+            case 'honestUnknown':
+              bucket.honestUnknown++;
+              stats.all.honestUnknown++;
+            case 'wrong':
+              // A wrong answer the agent presented AS history is a
+              // hallucination. Flagged notInHistory, or unparseable (null
+              // basis), it is merely a miss.
+              if (basisById[p['id']] == 'history') {
+                bucket.hallucinated++;
+                stats.all.hallucinated++;
+              }
+          }
+        }
+        final rec = s['recommendation'] as Map<String, dynamic>?;
+        if (rec != null) {
+          stats.recommendations++;
+          switch (rec['agreement']) {
+            case 'same':
+              stats.same++;
+            case 'compatible':
+              stats.compatible++;
+            case 'contradictory':
+              stats.contradictory++;
+          }
+          if (rec['forbiddenHit'] == true) stats.forbidden++;
+        }
+      }
+      judged[strategyId] = stats;
+    }
+
+    final ages = ['recent', 'mid', 'old'];
+    buffer
+      ..writeln('### Fact recall (correct = 1, partial = ½) by fact age')
+      ..writeln()
+      ..writeln(
+        '| Arm | ${ages.join(' | ')} | All | Hallucination | Honest unknown |',
+      )
+      ..writeln('| --- |${' ---: |' * (ages.length + 3)}');
+    for (final strategyId in strategyIds) {
+      final stats = judged[strategyId]!;
+      final cells = ages.map((age) {
+        final bucket = stats.byAge[age];
+        return bucket == null ? '—' : _score(bucket.score, bucket.total);
+      });
+      buffer.writeln(
+        '| `$strategyId` | ${cells.join(' | ')} | '
+        '${_score(stats.all.score, stats.all.total)} | '
+        '${_ratio(stats.all.hallucinated, stats.all.total)} | '
+        '${_ratio(stats.all.honestUnknown, stats.all.total)} |',
+      );
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('### Recommendation consistency with the full-context arm')
+      ..writeln()
+      ..writeln(
+        '| Arm | Same | Compatible | Contradictory | Forbidden direction |',
+      )
+      ..writeln('| --- | ---: | ---: | ---: | ---: |');
+    for (final strategyId in strategyIds) {
+      final stats = judged[strategyId]!;
+      if (stats.recommendations == 0) {
+        buffer.writeln('| `$strategyId` | — | — | — | — |');
+        continue;
+      }
+      buffer.writeln(
+        '| `$strategyId` | ${_ratio(stats.same, stats.recommendations)} | '
+        '${_ratio(stats.compatible, stats.recommendations)} | '
+        '${_ratio(stats.contradictory, stats.recommendations)} | '
+        '${_ratio(stats.forbidden, stats.recommendations)} |',
+      );
+    }
+
+    // ── Pass bar ────────────────────────────────────────────────────────
+    final full = judged['full'];
+    final fullDet = deterministic['full'];
+    if (full != null && fullDet != null) {
+      buffer
+        ..writeln()
+        ..writeln('## Pass bar')
+        ..writeln()
+        ..writeln(
+          'Old-fact recall ≥ ${(passBar.minRecallRatioVsFull * 100).round()}% '
+          'of full; hallucination ≤ full + ${(passBar.hallucinationSlack * 100).round()} pp; '
+          'recommendation same-or-compatible ≥ ${(passBar.minRecommendationAgreement * 100).round()}%; '
+          'contradictory ≤ ${(passBar.maxContradictionRate * 100).round()}%; '
+          'status accuracy ≥ full; userVoice ≤ ${passBar.maxUserVoiceTokens} tokens.',
+        )
+        ..writeln()
+        ..writeln(
+          '| Arm | Old recall | Hallucination | Agreement | Contradiction | Status | Tokens | Verdict |',
+        )
+        ..writeln('| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |');
+      final fullOld = full.byAge['old'];
+      final fullOldRecall = fullOld == null || fullOld.total == 0
+          ? 0.0
+          : fullOld.score / fullOld.total;
+      final fullHallucination = full.all.total == 0
+          ? 0.0
+          : full.all.hallucinated / full.all.total;
+      final fullStatus = fullDet.cases == 0
+          ? 0.0
+          : fullDet.statusCorrect / fullDet.cases;
+      for (final strategyId in strategyIds) {
+        if (strategyId == 'full') continue;
+        final stats = judged[strategyId]!;
+        final det = deterministic[strategyId]!;
+        final old = stats.byAge['old'];
+        final oldRecall = old == null || old.total == 0
+            ? 0.0
+            : old.score / old.total;
+        final hallucination = stats.all.total == 0
+            ? 0.0
+            : stats.all.hallucinated / stats.all.total;
+        final agreement = stats.recommendations == 0
+            ? 0.0
+            : (stats.same + stats.compatible) / stats.recommendations;
+        final contradiction = stats.recommendations == 0
+            ? 0.0
+            : stats.contradictory / stats.recommendations;
+        final status = det.cases == 0 ? 0.0 : det.statusCorrect / det.cases;
+        final tokens = _meanValue(det.voiceTokens);
+        final checks = [
+          oldRecall >= fullOldRecall * passBar.minRecallRatioVsFull,
+          hallucination <= fullHallucination + passBar.hallucinationSlack,
+          agreement >= passBar.minRecommendationAgreement,
+          contradiction <= passBar.maxContradictionRate,
+          status >= fullStatus,
+          tokens != null && tokens <= passBar.maxUserVoiceTokens,
+        ];
+        buffer.writeln(
+          '| `$strategyId` | ${checks.map(_mark).join(' | ')} | '
+          '**${checks.every((c) => c) ? 'PASS' : 'FAIL'}** |',
+        );
+      }
+    }
+  } else {
+    buffer
+      ..writeln()
+      ..writeln(
+        '_No scores file given: fact recall, hallucination and recommendation '
+        'consistency need the judge. See the run book for the scores schema._',
+      );
+  }
+
+  // ── Appendix ──────────────────────────────────────────────────────────
+  buffer
+    ..writeln()
+    ..writeln('## Cases')
+    ..writeln();
+  for (final c in cases) {
+    final wake = c['wake'] as Map<String, dynamic>;
+    buffer
+      ..writeln(
+        '### ${c['fixtureId']} × `${c['strategyId']}` × s${c['sample']}',
+      )
+      ..writeln()
+      ..writeln(
+        'Status expected `${wake['expectedStatus']}`, reported '
+        '`${wake['reportedStatus'] ?? '—'}`; tools: '
+        '${(wake['toolNames'] as List).isEmpty ? 'none' : (wake['toolNames'] as List).join(', ')}; '
+        'wake input ${wake['inputTokens'] ?? '?'} tokens.',
+      )
+      ..writeln();
+    if (c['errorMessage'] != null) {
+      buffer
+        ..writeln('Error: ${c['errorMessage']}')
+        ..writeln();
+    }
+    if (wake['oneLiner'] != null) {
+      buffer
+        ..writeln('> ${wake['oneLiner']}')
+        ..writeln();
+    }
+    if (wake['reply'] != null) {
+      buffer
+        ..writeln(_clip(wake['reply'] as String, 600))
+        ..writeln();
+    }
+  }
+  return buffer.toString();
+}
+
+String _caseKey(Map<String, dynamic> c, {bool withStrategy = false}) =>
+    withStrategy
+    ? '${c['fixtureId']}|${c['strategyId']}|${c['sample']}'
+    : '${c['fixtureId']}|${c['sample']}';
+
+class _ArmStats {
+  int cases = 0;
+  int errors = 0;
+  int statusCorrect = 0;
+  int reports = 0;
+  int replies = 0;
+  int comparable = 0;
+  int toolSetAgree = 0;
+  final wakeInput = <int?>[];
+  final voiceTokens = <int?>[];
+  final verbatim = <int?>[];
+  final digests = <int?>[];
+}
+
+class _AgeStats {
+  int total = 0;
+  double score = 0;
+  int hallucinated = 0;
+  int honestUnknown = 0;
+}
+
+class _JudgedStats {
+  final byAge = <String, _AgeStats>{};
+  final all = _AgeStats();
+  int recommendations = 0;
+  int same = 0;
+  int compatible = 0;
+  int contradictory = 0;
+  int forbidden = 0;
+}
+
+String _ratio(int part, int total) =>
+    total == 0 ? '—' : '$part/$total (${(100 * part / total).round()}%)';
+
+String _score(double score, int total) =>
+    total == 0 ? '—' : '${(100 * score / total).round()}%';
+
+double? _meanValue(List<int?> values) {
+  final present = values.whereType<int>().toList();
+  if (present.isEmpty) return null;
+  return present.reduce((a, b) => a + b) / present.length;
+}
+
+String _mean(List<int?> values) {
+  final mean = _meanValue(values);
+  return mean == null ? '—' : mean.round().toString();
+}
+
+String _mark(bool ok) => ok ? '✓' : '✗';
+
+String _clip(String text, int max) {
+  final flat = text.replaceAll('\n', ' ').trim();
+  return flat.length <= max ? flat : '${flat.substring(0, max)}…';
+}


### PR DESCRIPTION
## Why

Goals run for years and check-ins accumulate without bound, but a goal wake is budgeted at ~8k input tokens. Until now the wake kept the newest ~1,200 tokens of check-in summaries — about the last three months — and dropped the rest, so the reason a goal was redefined, an injury a year ago, or the routine that worked before a stall had quietly dropped out of the agent's view.

This PR does two things, in order: it builds the **evaluation** that answers "does the agent draw the same conclusions from a compacted history as from the full one?", and — because the candidate passed — it **ships** that compaction into the wake.

## The evaluation

- **Strategy seam** — `GoalCheckInCompactionStrategy` with three arms: `full` (unbounded oracle), `truncate` (the previous behaviour), `hierarchical` (verbatim tail, then digests by month inside 6 months (≤120 words), quarter inside 18 (≤80), year inside 36 (≤80), and one "earlier" span beyond, so the entry count is bounded by the horizons, not the goal's age).
- **Fixtures** — five seeded ~2-year goals (~300 check-ins each): a stall talked over by upbeat check-ins, an injury and recovery, a redefined goal, an abandoned-then-revived goal, a completed goal in maintenance. Each carries an answer key (derived status asserted against the real evaluator/policy, dated fact-recall probes stratified by age, expected and forbidden recommendations). Every wake renders through the production `GoalFactsRenderer` and prompt/tool contract.
- **Harness** — live runner writes a judging packet; `tool/goal_compaction_eval_report.dart` merges packet + judge scores into a report with a pass bar (and refuses incomplete score sets); `scripts/goal_compaction_eval_matrix.sh`; run book and rubric in `docs/evaluations/goal_agent_models/compaction.md`.

### Results (glm-5.2, 3 samples × 5 fixtures × 3 arms, blinded judging)

| Arm | Old-fact recall | Hallucinations | Same recommendation as full | Contradictory | Forbidden direction | Input tokens / wake | userVoice @ 24 mo |
|---|---|---|---|---|---|---|---|
| full (oracle) | 100% | 0/90 | 15/15 | 0 | 0 | 33.3k | 7,722 |
| truncate (previous) | **10%** | 2/90 | 1/15 | **11/15** | **12/15** | 8.1k | 1,192 |
| hierarchical | **97%** | 0/90 | **14/15** | 1/15 | 0/15 | **10.4k** | **2,436** |

Hierarchical passes every pass-bar criterion. Truncation fails on substance: with only three months visible it proposes lowering a stalled goal's target, offers 10,000 steps to a user whose doctor lowered the goal for knee pain, and reads a night-shift gap as decline. (The first run, without the yearly layer, failed the token bound at 3,064 and growing; the layering above fixed it.)

## The change to the wake

`GoalCheckInDigestService` writes one digest per calendar span and stores it as an agent action message keyed `(agentId, periodLabel)` with a source key over the span's members, so a late-synced or re-transcribed check-in rewrites its span and two devices converge on one row. Inference runs only on the wakes that also compact check-ins (never interactive turns), at most four spans per wake; other spans read their stored digest or a short placeholder naming what is not yet digested. Any failure falls back to the previous truncating tail — user voice is additive context and never costs the wake.

## Verification

- 100+ new tests: strategy (incl. the bounded-entry-count assertion over 2/4/6-year histories), digest service, workflow (automatic wake carries digests + verbatim tail; interactive turn never infers; failing digest layer falls back), fixture self-test through the real evaluator, runner with a scripted model, report tool. Analyzer clean; `make knowledge_check` and `make changelog_check` clean.
- Three live runs recorded in the run book; packets/scores under `eval_artifacts/` (git-ignored).
- Changelog fragment: `changelog.d/2026-08-27-goal-checkin-digests.md`. No UI.
