### PR TITLE
fix(tasks): hold the page below the AI card while suggestions are accepted

### DIFF
--- a/changelog.d/2026-08-28-accept-all-scroll-stability.md
+++ b/changelog.d/2026-08-28-accept-all-scroll-stability.md
@@ -1,0 +1,13 @@
+### Fixed
+- **Accepting all of an agent's suggestions no longer sends the task page
+  racing up the screen.** The page held the *top* of the proposal list still
+  while its rows collapsed, so the "Confirm all" button, the checklist and the
+  history below it all slid upwards by the height of every row that left — over
+  half a phone screen for a handful of suggestions — while new checklist items
+  pushed them back down. It now holds everything below the AI card in place:
+  the rows are worked through where they are, and the summary above eases down
+  into the space they leave. The smaller snaps that made the sweep feel jumpy
+  are gone too: rows no longer lose a line of text the moment they are
+  confirmed, the pending count fades out instead of shortening the header, and
+  the "Confirm all" button and the proposal section itself collapse smoothly
+  rather than vanishing in a single frame.

--- a/knowledge/features/agents/ui-surfaces.md
+++ b/knowledge/features/agents/ui-surfaces.md
@@ -15,7 +15,7 @@ sources:
   - id: card
     resource: ../../../lib/features/agents/ui/ai_summary_card.dart
     title: AiSummaryCard
-    last_modified: 2026-07-25
+    last_modified: 2026-08-28
   - id: automation-row
     resource: ../../../lib/features/agents/ui/agent_automation_row.dart
     title: Shared agent report automation controls
@@ -291,6 +291,26 @@ Invariants:
   reflow (`SizeTransition`, `alignment: topCenter`), so neighbours slide up on
   the same tween with no snap. The inter-row gap lives inside the collapse so
   nothing snaps on prune.
+- **Nothing in the section changes height in a single frame.** The task page
+  pins the card's bottom edge while a proposal resolves, so any instant change
+  inside the section would snap the content above it. Four things that used to
+  unmount now ease out instead: the row's trailing slot keeps
+  `RowActions.footprintWidth` while resolving (a narrower placeholder let the
+  text rewrap and the row lose a line before its collapse); the pending pill
+  fades in place at zero rather than leaving the header line; the Confirm-all
+  rail is always mounted inside a `SizeFadeCollapse` and collapses when a
+  confirm leaves one row — and stays for the whole of a Confirm-all sweep via
+  `_confirmAllSweeping`, rather than dropping while the last row is still
+  leaving; and the section itself is retained (`_lastProposalsSection`) inside a
+  `SizeFadeCollapse` so it collapses as a unit after the last row, then is
+  dropped from `onCollapsed` at zero height. A section that returns afterwards
+  gets a fresh wrapper (`_proposalsGeneration`) so it stands at full height at
+  once and only its new rows reveal themselves.
+- **The history band waits for the sweep.** The first confirm already writes a
+  ledger entry, and a report with nothing behind Read more shows history
+  unconditionally — so the band is latched (`_showHistory`) while any row is
+  still collapsing and reveals afterwards through a `SizeFadeEntrance`, animated
+  only when it appears after the initial load.
 - **The shell, not the provider, removes the row.** `_AiSummaryShellState` keeps
   a `Set<String> _exitingFingerprints`; `onResolveStart` records a fingerprint so
   the visible list re-inserts it even after the provider drops it, and
@@ -328,28 +348,25 @@ Invariants:
   travel, instant prune, instant pill swap, instant entrance — but the haptic
   still fires, because it is feedback rather than motion.
 
-### The off-screen card anchor
+### The card anchors
 
-While the card has scrolled **fully above** the viewport, `TaskDetailsPage` pins
-the seam just below it — a second `ScrollAnchor` keyed on the linked-entries
-sliver — instead of pinning the proposals, so neither a new proposal growing the
-card nor a resolved row collapsing it moves the visible area.
+The task page pins one edge per resolve. While the card is in view it pins the
+**card's bottom edge**, so a row collapsing inside the card — every accepted or
+dismissed proposal, and the whole staggered Confirm-all sweep — leaves the rows
+still to come, the rail and everything below the card exactly where they were,
+and the summary above slides down into the vacated space. While the card has
+scrolled **fully above** the viewport it pins the seam just below the work bands
+instead, so neither a new proposal growing the card nor a resolved row collapsing
+it moves the visible area.
 
 The collapse side matters for *every* tool and *both* verdicts: `_confirm` and
 `_reject` share the choreography, so a dismissed proposal shrinks the card
-exactly as an accepted one does. `_suggestionsAnchor` cannot cover it — it
-locates `ProposalsSection`'s own top, and a row collapsing *inside* that section
-never moves it, so the anchor measures zero drift and does nothing.
-`set_task_language` was the clearest reproducer: nothing above the card renders
-the language, so the card's collapse is that tool's entire page-layout effect.
-
-While off-screen the band also reports its own height delta
-(`ViewportStableSizeReporter(offscreenOnly: true)`), so the correction lands
-pre-paint rather than one frame late per frame of the collapse. The two anchors
-are mutually exclusive — they sit either side of the card, so the correction that
-holds one moves the other by exactly the card's height change.
-`TaskDetailsPage` evaluates the off-screen predicate once per resolve and arms
-exactly one.
+exactly as an accepted one does. The card band reports its own height delta
+(`ViewportStableSizeReporter`) whenever a hold is armed, so the correction lands
+pre-paint rather than one frame late per frame of the collapse; the anchor is
+the fallback. Which edge is pinned, and why the two anchors are mutually
+exclusive, is the page's concern — see
+[task detail composition](../tasks/detail-composition.md#which-edge-holds).
 
 ## Holding the list steady during a wake
 

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -19,7 +19,7 @@ sources:
   - id: pages
     resource: ../../../lib/features/tasks/ui/pages
     title: TaskDetailsPage, TasksRootPage and TaskForm
-    last_modified: 2026-08-20
+    last_modified: 2026-08-28
   - id: first-run
     resource: ../../../lib/features/tasks/ui/widgets/task_first_run_actions.dart
     title: First-run actions block
@@ -47,7 +47,7 @@ sources:
   - id: scroll-stability
     resource: ../../../lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
     title: TaskScrollStabilityScope and ViewportStableScrollController
-    last_modified: 2026-08-12
+    last_modified: 2026-08-28
 ---
 
 # Band order
@@ -449,13 +449,49 @@ three region-adapter modes over one `ViewportStableScrollController`:
 | Adapter | Behaviour |
 |---------|-----------|
 | `ViewportStableAnimatedSize` | Animates generated entry text and nested AI-response height, arming only when the region is fully above the viewport |
-| `ViewportStableSizeReporter` | No motion — used by the header band (the only band above the proposals) while a suggestion-resolution hold is armed, because its content already owns its own animations |
-| `ViewportStableSizeReporter(offscreenOnly: true)` | Wraps the AI card, checklist and linked-tasks bands, reporting only while the page armed the hold with `includeOffscreenRegions` — i.e. while the card is fully above the viewport and `_belowCardAnchor` pins the linked-entries seam. While the card is visible, a checklist or linked-task growing *below* the proposals is the visible reflow; compensating it would drag the proposals out from under the pointer |
+| `ViewportStableSizeReporter` | No motion — used by the header band and the AI card band while a suggestion-resolution hold is armed, because their content already owns its own animations. Whichever edge the page pins lies *below* both bands, so their deltas are absorbed unconditionally |
+| `ViewportStableSizeReporter(offscreenOnly: true)` | Wraps the checklist and linked-tasks bands, reporting only while the page armed the hold with `includeOffscreenRegions` — i.e. while the card is fully above the viewport and `_belowCardAnchor` pins the linked-entries seam. While the card is visible, a checklist or linked task growing *below* it is the visible reflow — new content appearing, only what lies under it moving |
 
 The offscreen-only reporters **deliberately do not compute the offscreen
 predicate themselves**: the page has to pick a matching `ScrollAnchor` from the
 same answer, and two mechanisms deciding independently would disagree over the
 padding between their reference points and then fight each frame.
+
+## Which edge holds
+
+The page arms exactly one post-frame `ScrollAnchor` per resolve, chosen by
+whether the AI card band has scrolled fully above the viewport:
+
+```mermaid
+flowchart TD
+  resolve["proposal resolves\n(tap, swipe or Confirm all)"] --> q{"card band bottom\nabove viewport top?"}
+  q -- no --> visible["_cardBottomAnchor\npins the card band's bottom edge"]
+  q -- yes --> off["_belowCardAnchor\npins the linked-entries seam"]
+  visible --> h["header + card report\ndeltas pre-paint"]
+  off --> h2["header + card + checklist +\nlinked tasks report pre-paint"]
+```
+
+**Card visible — the card's bottom edge.** Every resolved row collapses *inside*
+the card, and on a Confirm-all the rows collapse one after another from the top.
+Pinning the card's bottom keeps the rows still to come, the Confirm-all rail and
+everything below the card exactly where they were; the collapse is paid for above
+them, by the summary sliding down into the space the rows leave. The previous
+design pinned the proposals section's *top*, which sent the whole visible page
+racing upwards by the collapsed height — five rows is well over half a phone
+screen — because the collapsing rows sit between that edge and everything the
+user is looking at. Both the off-screen predicate and this anchor read the same
+edge (`_cardRegionBottomGlobal`), so the decision and the point held can never
+disagree.
+
+**Card fully above the viewport — the seam below the work bands.** The user is
+reading the linked entries; the card, the checklist and the linked-tasks bands
+all report so the correction lands pre-paint, and `_belowCardAnchor` catches
+whatever slips past.
+
+The two anchors are never armed together: they sit either side of the work
+bands, so the correction that holds one moves the other by exactly those bands'
+height change, which the other then reads as drift and undoes on the next
+post-frame.
 
 Each band carries a distinct, task-scoped `ValueKey`. `StaggeredEntrance` maps its
 children through `flutter_animate`, **which does not forward their keys**, so the
@@ -469,7 +505,12 @@ position**. The scroll position also retains a temporary trailing extent when a
 simultaneous shrink below the anchor would otherwise clamp the viewport; that
 extent disappears once the user scrolls inside the real range. User scrolling
 cancels the hold immediately, and the standalone journal-entry detail page stays
-outside the scope.
+outside the scope. At the scroll origin the correction clamps: what a collapse
+cannot give back above the viewport, the content below it moves up by.
+
+What the card itself does to stay collapse-only — no unmount in a single frame
+anywhere in the section — is the card's contract, in
+[agent UI surfaces](../agents/ui-surfaces.md#proposal-acceptreject-motion).
 
 ## Known gap: insertions inside the below-card sliver
 

--- a/lib/features/agents/ui/ai_summary_card.dart
+++ b/lib/features/agents/ui/ai_summary_card.dart
@@ -23,6 +23,8 @@ import 'package:lotti/features/agents/ui/ai_summary_card/tldr_section_part.dart'
 import 'package:lotti/features/agents/ui/task_agent_controls_footer.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/agents/ui/widgets/ai_card_chrome.dart';
+import 'package:lotti/features/design_system/components/motion/size_fade_collapse.dart';
+import 'package:lotti/features/design_system/components/motion/size_fade_entrance.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -156,6 +158,46 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
   /// from under the finger. The dual of [_mergeUnresolvedOpenSuggestions].
   final Set<String> _exitingFingerprints = {};
 
+  /// True from a Confirm-all tap until the last row of that batch has left.
+  /// Keeps the rail on screen for the whole sweep: the rows prune one by one,
+  /// and the rail would otherwise collapse the moment a single row remained,
+  /// while that row was still leaving.
+  bool _confirmAllSweeping = false;
+
+  /// Whether the resolved-history band is showing. Latched while rows are
+  /// collapsing: the first confirm of a sweep already puts an entry in the
+  /// ledger, and letting the band appear mid-sweep would shove the rows still
+  /// leaving — the ones the user is watching — by its own height. It reveals
+  /// once the sweep has settled, easing open instead of snapping.
+  bool _showHistory = false;
+
+  /// Whether the history band's next appearance should ease open. False when
+  /// the band is part of the initial load, whose bands the `StaggeredEntrance`
+  /// above already choreographs; true for a band that appears later.
+  bool _historyRevealAnimates = false;
+
+  /// Whether the history decision has been taken against a real list at
+  /// least once. Distinguishes a band present on the initial load (no reveal)
+  /// from one appearing after it.
+  bool _historyDecidedWithList = false;
+
+  /// The proposals section most recently built with rows in it, kept so the
+  /// section can collapse away as a unit once the last row has left. Without
+  /// it the residual — the section header, its paddings and the rail — would
+  /// unmount in one frame.
+  ProposalsSection? _lastProposalsSection;
+
+  /// Bumped each time the section comes back after having been absent, so
+  /// the collapse wrapper is rebuilt fresh and the returning rows play their
+  /// own entrance reveal rather than the whole section scaling back open.
+  int _proposalsGeneration = 0;
+
+  /// Whether the previous build had a section with rows in it. Read against
+  /// the *previous build* rather than [_lastProposalsSection], which is only
+  /// dropped a frame after the collapse ends — a section returning inside
+  /// that frame would otherwise keep the collapsed wrapper and scale open.
+  bool _hadProposalsSection = false;
+
   ProviderSubscription<AsyncValue<UnifiedSuggestionList>>?
   _suggestionsSubscription;
   ProviderSubscription<AsyncValue<bool>>? _runningSubscription;
@@ -175,6 +217,12 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
       // previous task must not carry into the next one (it would keep
       // `settling` on or skew the pending-count filter).
       _exitingFingerprints.clear();
+      _confirmAllSweeping = false;
+      _lastProposalsSection = null;
+      _hadProposalsSection = false;
+      _showHistory = false;
+      _historyRevealAnimates = false;
+      _historyDecidedWithList = false;
       _lastVisibleSuggestions = null;
       _seenFingerprints.clear();
       _hasSeededFingerprints = false;
@@ -228,6 +276,7 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
   /// stays.
   void _onRowResolveEnd(PendingSuggestion suggestion, {required bool removed}) {
     if (!_exitingFingerprints.remove(suggestion.fingerprint)) return;
+    if (_exitingFingerprints.isEmpty) _confirmAllSweeping = false;
     // The exiting set changed, and both `settling` and the pending count derive
     // from it — always rebuild so neither can stick in a stale state, even on
     // the paths where the visible list itself doesn't change.
@@ -371,6 +420,7 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
     );
     setState(() {
       _exitingFingerprints.addAll(pending.map((s) => s.fingerprint));
+      _confirmAllSweeping = true;
       _confirmAllBusy = true;
       _confirmAllPulse++;
     });
@@ -608,8 +658,9 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
     );
     // Nothing to propose, no section: an empty "Proposed changes" band cost a
     // divider and two paddings to say what the missing rows already said. A
-    // row committed by the user stays in `open` until its collapse finishes,
-    // so the section fades out with the last row rather than snapping.
+    // row committed by the user stays in `open` until its collapse finishes;
+    // then the section — header, paddings, rail — collapses away as a unit
+    // on the row's own clock, rather than unmounting in one frame.
     final proposalsSection = list == null || list.open.isEmpty
         ? null
         : ProposalsSection(
@@ -624,9 +675,17 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
                   (s) => !_exitingFingerprints.contains(s.fingerprint),
                 )
                 .length,
-            confirmAllBusy: _confirmAllBusy,
+            // Loading for the whole sweep, not just the writes: fast writes
+            // return before the rows have left, and a rail that re-enables
+            // then would re-run the batch — a second haptic, a second
+            // announcement, a redundant service round-trip.
+            confirmAllBusy: _confirmAllBusy || _confirmAllSweeping,
             confirmAllPulse: _confirmAllPulse,
-            onConfirmAll: list.open.length > 1
+            // The rail earns its place with more than one row to act on, and
+            // keeps it for the whole of a Confirm-all sweep: the rows prune
+            // one at a time, and it must not drop out while the last is
+            // still leaving.
+            onConfirmAll: list.open.length > 1 || _confirmAllSweeping
                 ? () => _confirmAll(list.open)
                 : null,
             onResolveStart: _onRowResolveStart,
@@ -635,6 +694,36 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
             // up — guard them so a fast second tap can't land on a row
             // that just moved under the pointer.
             settling: _exitingFingerprints.isNotEmpty,
+          );
+    // Latches, updated in build rather than in a listener: each is a pure
+    // function of state the build already holds (`_expanded`, the report,
+    // the exiting set), so the frame that reads them is the frame that can
+    // decide them, with no setState behind it. The same applies to the
+    // history latch below.
+    if (proposalsSection != null && !_hadProposalsSection) {
+      _proposalsGeneration++;
+    }
+    _hadProposalsSection = proposalsSection != null;
+    if (proposalsSection != null) _lastProposalsSection = proposalsSection;
+    // Mounted whenever there has been a section to show: the current one, or
+    // the last one collapsing away. A section that returns after collapsing
+    // gets a fresh wrapper (the generation key) so it stands at full height
+    // at once and only its new rows reveal themselves.
+    final retainedSection = _lastProposalsSection;
+    final proposalsBand = retainedSection == null
+        ? null
+        : SizeFadeCollapse(
+            key: ValueKey('proposals-band-$_proposalsGeneration'),
+            collapsed: proposalsSection == null,
+            duration: ProposalMotion.collapse,
+            // Fully gone: drop the departed section, at zero height, where
+            // unmounting it moves nothing.
+            onCollapsed: () {
+              if (mounted && (_lastVisibleSuggestions?.open.isEmpty ?? true)) {
+                setState(() => _lastProposalsSection = null);
+              }
+            },
+            child: retainedSection,
           );
     // History rides with the full report, not with the summary: while the
     // card is collapsed the reader wants the TL;DR and the decisions still
@@ -646,15 +735,25 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
     // — there the card is already showing everything it has, and hiding the
     // record behind a control that does not exist would strand it.
     final reportIsExpandable = additionalReport?.trim().isNotEmpty ?? false;
-    final showHistory =
+    final wantHistory =
         list != null &&
         list.activity.isNotEmpty &&
         (_expanded || !reportIsExpandable);
-    final historySection = showHistory
-        ? ProposalHistorySection(
-            resolved: list.activity,
-            open: _historyOpen,
-            onToggle: () => setState(() => _historyOpen = !_historyOpen),
+    // Latched while rows are collapsing — see [_showHistory].
+    if (_exitingFingerprints.isEmpty && wantHistory != _showHistory) {
+      _showHistory = wantHistory;
+      _historyRevealAnimates = wantHistory && _historyDecidedWithList;
+    }
+    if (list != null) _historyDecidedWithList = true;
+    final historySection = _showHistory && list != null
+        ? SizeFadeEntrance(
+            key: const ValueKey('proposalHistoryBand'),
+            animate: _historyRevealAnimates,
+            child: ProposalHistorySection(
+              resolved: list.activity,
+              open: _historyOpen,
+              onToggle: () => setState(() => _historyOpen = !_historyOpen),
+            ),
           )
         : null;
 
@@ -686,7 +785,7 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
                 child: reportBody,
               ),
             // Both hidden until the first value to avoid flashing empty state.
-            ?proposalsSection,
+            ?proposalsBand,
             ?historySection,
             controlsFooter,
           ],

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
@@ -942,12 +942,18 @@ class ProposalRowContent extends StatelessWidget {
   final Future<void> Function() onReject;
   final Future<void> Function() onConfirm;
 
-  /// The trailing slot: a resolved-status tag for history rows, an empty
-  /// 48×48 slot while resolving (the badge overlays it), else the action
-  /// buttons. The fixed slot keeps the text from reflowing on resolve.
-  Widget _trailing() {
+  /// The trailing slot: a resolved-status tag for history rows, an empty slot
+  /// the width of the action rail while resolving (the badge overlays it),
+  /// else the action buttons. The slot keeps [RowActions.footprintWidth] in
+  /// every pending state so the text beside it never rewraps on resolve.
+  Widget _trailing(BuildContext context) {
     if (isResolved) return ResolvedTag(status: resolvedStatus);
-    if (resolving) return const SizedBox(width: 48, height: 48);
+    if (resolving) {
+      return SizedBox(
+        width: RowActions.footprintWidth(context),
+        height: RowActions.buttonSize,
+      );
+    }
     return RowActions(busy: busy, onReject: onReject, onConfirm: onConfirm);
   }
 
@@ -984,7 +990,7 @@ class ProposalRowContent extends StatelessWidget {
       children: [
         Expanded(child: textWidget),
         SizedBox(width: tokens.spacing.step2),
-        _trailing(),
+        _trailing(context),
       ],
     );
   }

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart
@@ -16,14 +16,24 @@ class RowActions extends StatelessWidget {
   final Future<void> Function() onReject;
   final Future<void> Function() onConfirm;
 
+  /// The hit target of one action: 48×48, the visible disc centred inside.
+  static const double buttonSize = 48;
+
+  /// The width of the two-button rail, gap included. Every other state of the
+  /// trailing slot — the busy spinner, the resolve badge's placeholder — keeps
+  /// this exact width so the summary text beside it never rewraps: a narrower
+  /// slot widened the text column mid-resolve, and a two-line proposal
+  /// snapping to one line dropped the row's height a beat *before* its
+  /// collapse began.
+  static double footprintWidth(BuildContext context) =>
+      buttonSize * 2 + context.designTokens.spacing.step2;
+
   @override
   Widget build(BuildContext context) {
     if (busy) {
-      // Match the 48×48 footprint of a single non-busy
-      // [_SquareIconButton] so the row doesn't reflow when toggling.
       return SizedBox(
-        width: 48,
-        height: 48,
+        width: footprintWidth(context),
+        height: buttonSize,
         child: Center(
           child: SizedBox(
             width: 14,
@@ -107,8 +117,8 @@ class _SquareIconButton extends StatelessWidget {
             onTap: onPressed.call,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             builder: (context, highlighted) => SizedBox(
-              width: 48,
-              height: 48,
+              width: RowActions.buttonSize,
+              height: RowActions.buttonSize,
               child: Center(
                 child: Container(
                   width: tokens.spacing.step7,

--- a/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart'
 import 'package:lotti/features/agents/ui/ai_summary_card/tldr_section_part.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
+import 'package:lotti/features/design_system/components/motion/size_fade_collapse.dart';
 import 'package:lotti/features/design_system/components/motion/size_fade_entrance.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -41,6 +42,10 @@ class ProposalsSection extends StatelessWidget {
   /// Falls back to `open.length` when not supplied.
   final int? pendingCount;
   final bool confirmAllBusy;
+
+  /// Confirms every open row. Null when the rail has nothing to offer — one
+  /// pending row, or none — which collapses the rail rather than unmounting
+  /// it; see the rail's own note in [build].
   final Future<void> Function()? onConfirmAll;
 
   /// Bumped by the shell on each "Confirm all" press; forwarded to the rows so
@@ -107,11 +112,12 @@ class ProposalsSection extends StatelessWidget {
                   ),
                   // At zero the pill is furniture — the absence of rows
                   // already says it, so the count earns its ink only when
-                  // there is something to act on.
-                  if ((pendingCount ?? open.length) > 0) ...[
-                    SizedBox(width: tokens.spacing.step3),
-                    _PendingPill(count: pendingCount ?? open.length),
-                  ],
+                  // there is something to act on. It fades rather than
+                  // unmounts: it is the tallest thing on this line, and
+                  // zero is only ever reached mid-sweep, when dropping it
+                  // stepped the whole header up by the difference.
+                  SizedBox(width: tokens.spacing.step3),
+                  _PendingPill(count: pendingCount ?? open.length),
                 ],
               ),
               SizedBox(height: tokens.spacing.step3),
@@ -151,19 +157,29 @@ class ProposalsSection extends StatelessWidget {
                 ),
               // Bottom rail: the one list-level operation, trailing-aligned.
               // Open rows already end with their own trailing gap, so the
-              // rail needs none of its own.
-              if (onConfirmAll != null)
-                Align(
-                  key: const ValueKey('proposalBottomRail'),
+              // rail needs none of its own. Always mounted and collapsed
+              // away rather than conditionally built: when a confirm leaves
+              // a single row behind, the rail eases out on the same clock as
+              // the row that just left instead of vanishing in one frame and
+              // snapping the last row up by its height. A section that never
+              // needed the rail starts collapsed, without animation.
+              SizeFadeCollapse(
+                key: const ValueKey('proposalBottomRail'),
+                collapsed: onConfirmAll == null,
+                duration: ProposalMotion.collapse,
+                child: Align(
                   alignment: Alignment.centerRight,
                   child: DesignSystemButton(
                     label: messages.changeSetConfirmAll,
                     leadingIcon: LottiIcons.confirmAll,
                     variant: DesignSystemButtonVariant.outlined,
                     isLoading: confirmAllBusy,
-                    onPressed: () => unawaited(onConfirmAll!()),
+                    onPressed: onConfirmAll == null
+                        ? null
+                        : () => unawaited(onConfirmAll!()),
                   ),
                 ),
+              ),
             ],
           ),
         ),
@@ -267,24 +283,35 @@ class _PendingPill extends StatelessWidget {
     // Instant under reduced motion. Keyed by count so the switcher
     // cross-fades only when it changes.
     final reduceMotion = MediaQuery.disableAnimationsOf(context);
-    return Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: tokens.spacing.step3,
-        vertical: tokens.spacing.step1,
-      ),
-      decoration: BoxDecoration(
-        color: ai.subtleWashStrong,
-        borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
-      ),
-      child: AnimatedSwitcher(
-        duration: reduceMotion ? Duration.zero : MotionDurations.medium1,
-        switchInCurve: MotionCurves.standard,
-        switchOutCurve: MotionCurves.standard,
-        child: Text(
-          context.messages.changeSetPendingCount(count),
-          key: ValueKey(count),
-          style: tokens.typography.styles.others.caption.copyWith(
-            color: ai.metaText,
+    final duration = reduceMotion ? Duration.zero : MotionDurations.medium1;
+    // Zero fades the pill out in place — see the header row in
+    // [ProposalsSection.build] for why it keeps its footprint.
+    return ExcludeSemantics(
+      excluding: count == 0,
+      child: AnimatedOpacity(
+        opacity: count > 0 ? 1 : 0,
+        duration: duration,
+        curve: MotionCurves.standard,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: tokens.spacing.step3,
+            vertical: tokens.spacing.step1,
+          ),
+          decoration: BoxDecoration(
+            color: ai.subtleWashStrong,
+            borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
+          ),
+          child: AnimatedSwitcher(
+            duration: duration,
+            switchInCurve: MotionCurves.standard,
+            switchOutCurve: MotionCurves.standard,
+            child: Text(
+              context.messages.changeSetPendingCount(count),
+              key: ValueKey(count),
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: ai.metaText,
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/features/design_system/components/motion/size_fade_collapse.dart
+++ b/lib/features/design_system/components/motion/size_fade_collapse.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:lotti/features/design_system/theme/motion_tokens.dart';
 
 /// Collapses content away — and brings it back — as a single unit.
@@ -27,6 +28,7 @@ class SizeFadeCollapse extends StatefulWidget {
     required this.collapsed,
     required this.duration,
     required this.child,
+    this.onCollapsed,
     super.key,
   });
 
@@ -41,6 +43,13 @@ class SizeFadeCollapse extends StatefulWidget {
   final Duration duration;
 
   final Widget child;
+
+  /// Called once the content has fully collapsed away — after the animation,
+  /// or at once under reduced motion. Lets an owner that keeps a departed
+  /// subtree mounted only for the sake of this exit drop it afterwards, at
+  /// zero height where unmounting moves nothing. Not called for content that
+  /// starts out collapsed.
+  final VoidCallback? onCollapsed;
 
   @override
   State<SizeFadeCollapse> createState() => _SizeFadeCollapseState();
@@ -68,6 +77,24 @@ class _SizeFadeCollapseState extends State<SizeFadeCollapse>
       .animate(
         CurvedAnimation(parent: _controller, curve: MotionCurves.standard),
       );
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addStatusListener(_onStatus);
+  }
+
+  /// Reports a collapse that ran to the end. A status listener rather than
+  /// the `forward()` future, so the reduced-motion snap — a plain value
+  /// assignment — reports the same way. Delivered after the frame: the snap
+  /// fires from [didUpdateWidget], mid-build, where an owner's `setState`
+  /// would be illegal, and at zero height one frame's delay is invisible.
+  void _onStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onCollapsed?.call();
+    });
+  }
 
   @override
   void didUpdateWidget(SizeFadeCollapse oldWidget) {

--- a/lib/features/tasks/ui/pages/task_details_page.dart
+++ b/lib/features/tasks/ui/pages/task_details_page.dart
@@ -87,16 +87,19 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
   );
   Timer? _suggestionsRetryTimer;
 
-  /// Fallback anchor for above-card changes that do not report their own size
-  /// delta to [_scrollController]. With the AI card sitting right below the
-  /// header, the header band is the only content above the proposals; this
-  /// anchor covers proposal-driven header mutations (title, tagline,
-  /// metadata) that slip past the pre-paint correction path.
-  late final ScrollAnchor _suggestionsAnchor;
+  /// Pins the AI card's bottom edge while a proposal resolves with the card
+  /// in view. Every resolved row collapses *inside* the card, so holding this
+  /// edge keeps the rows still to come, the Confirm-all rail and everything
+  /// below the card where they were; the collapse is paid for above, by the
+  /// summary sliding down into the space the rows leave. It is also the
+  /// fallback for above-card changes that slip past the pre-paint path (the
+  /// header and the card both report their deltas to [_scrollController]).
+  late final ScrollAnchor _cardBottomAnchor;
 
-  /// Holds the content below the AI card fixed while the card grows off-screen
-  /// above the viewport (a new suggestion landing), so the visible area never
-  /// jumps. The dual of [_suggestionsAnchor], which guards shrink-above-card.
+  /// Holds the content below the work bands fixed while the card changes
+  /// height off-screen above the viewport (a new suggestion landing, a row
+  /// collapsing), so the visible area never jumps. The off-screen counterpart
+  /// of [_cardBottomAnchor].
   late final ScrollAnchor _belowCardAnchor;
 
   /// Spans the card's `EnterTransition` reveal (`MotionDurations.medium2`) plus
@@ -147,15 +150,13 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
       ..addListener(_listener)
       ..addListener(_updateOffsetListener);
 
-    _suggestionsAnchor = ScrollAnchor(
+    _cardBottomAnchor = ScrollAnchor(
       controller: _scrollController,
-      locate: _suggestionsViewportTop,
-      // Cover a checked-off item's *delayed* row collapse: confirming a
-      // "check off" proposal leaves the checklist row in place, then collapses
-      // it (hold + cross-fade) ~a second later. The checklist sits below the
-      // card now, so that shrink no longer displaces the proposals — but the
-      // window still has to span header-band mutations from the same batch.
-      // The hold bows out early if the user scrolls in the meantime.
+      locate: _cardRegionBottomGlobal,
+      // Spans a confirm-all sweep: the staggered row exits, the rail and the
+      // section collapsing after the last row, and header-band mutations from
+      // the same batch. The hold bows out early if the user scrolls in the
+      // meantime.
       holdDuration: _suggestionResolveHold,
     );
 
@@ -172,7 +173,7 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
   void dispose() {
     disposeHighlight();
     _suggestionsRetryTimer?.cancel();
-    _suggestionsAnchor.dispose();
+    _cardBottomAnchor.dispose();
     _belowCardAnchor.dispose();
     _scrollController
       ..removeListener(_listener)
@@ -181,40 +182,39 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
     super.dispose();
   }
 
-  /// Global-Y of the AI proposals section, or null when it isn't laid out.
-  double? _suggestionsViewportTop() {
-    final renderObject = _suggestionsKey.currentContext?.findRenderObject();
-    if (renderObject is! RenderBox || !renderObject.attached) return null;
-    return renderObject.localToGlobal(Offset.zero).dy;
-  }
-
   /// Arms exactly one stabilization geometry before proposal persistence
   /// begins.
   ///
-  /// The header — the only band above the card — always reports its height
-  /// deltas to [_scrollController], which corrects during viewport layout so
-  /// no displaced frame is painted. The checklist and linked-tasks bands sit
-  /// below the card and report only while the below-card hold is armed. What
-  /// changes is *which point* has to stay still, and that flips when the card
-  /// leaves the screen:
+  /// The header — the only band above the card — and the card band itself
+  /// report their height deltas to [_scrollController], which corrects during
+  /// viewport layout so no displaced frame is painted. The checklist and
+  /// linked-tasks bands sit below the card and report only while the
+  /// below-card hold is armed. What changes is *which edge* has to stay still,
+  /// and that flips when the card leaves the screen:
   ///
-  /// * **Card visible** — the proposals under the user's pointer must not move,
-  ///   so [_suggestionsAnchor] holds. The card's own collapse is the reflow the
-  ///   user is watching, so the card band stays silent.
+  /// * **Card visible** — the user is watching the proposals being worked
+  ///   through, and every resolved row collapses *inside* the card. So the
+  ///   card's bottom edge holds ([_cardBottomAnchor]): the rows still to come,
+  ///   the Confirm-all rail and everything below the card stay exactly where
+  ///   they were, and the collapse is absorbed above them by the summary
+  ///   sliding down. Pinning the proposals' *top* instead — the previous
+  ///   design — sent the whole visible page racing upwards by the collapsed
+  ///   height on a confirm-all, because the collapsing rows sit between that
+  ///   edge and everything the user is looking at. A checklist item landing
+  ///   below the card is left as the visible reflow it is: new content
+  ///   appears, and only the content beneath it moves.
   /// * **Card fully above the viewport** — the user is reading the content
   ///   below it, and every resolved proposal — confirmed or dismissed
-  ///   alike — collapses a row and shrinks
-  ///   the card, dragging that content up. [_suggestionsAnchor] is structurally
-  ///   blind to it, because a row collapsing *inside* the proposals section does
-  ///   not move the section's top. So the card band reports its own shrink for a
-  ///   pre-paint correction — as do the checklist and linked-tasks bands, which
-  ///   sit between the card and the seam — and [_belowCardAnchor] pins the
-  ///   linked-entries seam.
+  ///   alike — collapses a row and shrinks the card, dragging that content up.
+  ///   The card band's own shrink is corrected pre-paint — as are the
+  ///   checklist and linked-tasks bands, which sit between the card and the
+  ///   seam — and [_belowCardAnchor] pins the linked-entries seam.
   ///
   /// The two anchors are never armed together. They sit either side of the
-  /// change, so the correction that holds one still moves the other by exactly
-  /// that height change — which the other then reads as drift and undoes on the
-  /// next post-frame. Both holding means both jumping, every frame.
+  /// work bands, so the correction that holds one still moves the other by
+  /// exactly those bands' height change — which the other then reads as drift
+  /// and undoes on the next post-frame. Both holding means both jumping, every
+  /// frame.
   ///
   /// The layers cooperate via [CooperativeScrollStabilizer] so neither mistakes
   /// the other's correction for a user scroll and disarms mid-batch.
@@ -225,11 +225,11 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
       includeOffscreenRegions: cardOffscreen,
     );
     if (cardOffscreen) {
-      _suggestionsAnchor.release();
+      _cardBottomAnchor.release();
       _belowCardAnchor.hold(duration: _suggestionResolveHold);
     } else {
       _belowCardAnchor.release();
-      _suggestionsAnchor.hold();
+      _cardBottomAnchor.hold();
     }
   }
 
@@ -253,8 +253,8 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
   }
 
   /// When the open-proposal count drops (a proposal was confirmed/dismissed),
-  /// pin the proposals' position so the relayout above them doesn't yank the
-  /// page down under the user's eyes.
+  /// re-arm the hold so the row collapsing inside the card, and any header
+  /// mutation from the same batch, cannot move what the user is looking at.
   void _onSuggestionsChanged(
     AsyncValue<UnifiedSuggestionList>? previous,
     AsyncValue<UnifiedSuggestionList> next,
@@ -293,7 +293,9 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
 
   /// Global-Y of the bottom of the AI card band, or null when it isn't laid
   /// out. `SliverToBoxAdapter` lays its child out at any scroll offset, so this
-  /// stays valid however far the card has scrolled away.
+  /// stays valid however far the card has scrolled away. Both the off-screen
+  /// predicate and [_cardBottomAnchor] read this same edge, so the decision
+  /// which anchor to arm and the point it then holds can never disagree.
   double? _cardRegionBottomGlobal() {
     final renderObject = _cardRegionKey.currentContext?.findRenderObject();
     if (renderObject is! RenderBox ||
@@ -346,7 +348,7 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
       _belowCardGrowthHold,
       includeOffscreenRegions: true,
     );
-    _suggestionsAnchor.release();
+    _cardBottomAnchor.release();
     _belowCardAnchor.hold();
   }
 
@@ -384,7 +386,7 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
   /// band that is visible or above stays worth arming for, because the
   /// linked entries below it would otherwise shift. (While the card is
   /// visible the armed hold ignores this band's delta anyway — the band sits
-  /// below the proposals, so its growth is the visible reflow.)
+  /// below the card's pinned edge, so its growth is the visible reflow.)
   ///
   /// The baseline falls back to the listener's own [previous] value, because
   /// `taskLinkGroupsControllerProvider` is cached for `entryCacheDuration`: a
@@ -483,8 +485,9 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
         focusProvider,
         (previous, next) => handleFocus(next, isInitialLoad: previous == null),
       )
-      // Hold the AI proposals in place when one is confirmed (which can grow
-      // the header above them) so the page doesn't jump under the user.
+      // Hold the content below the AI card in place when a proposal is
+      // confirmed (its row collapses inside the card, and the header above
+      // can grow) so the page doesn't jump under the user.
       ..listen<AsyncValue<UnifiedSuggestionList>>(
         unifiedSuggestionListProvider(widget.taskId),
         _onSuggestionsChanged,

--- a/lib/features/tasks/ui/task_form.dart
+++ b/lib/features/tasks/ui/task_form.dart
@@ -29,18 +29,19 @@ import 'package:lotti/features/tasks/ui/widgets/viewport_stable_animated_size.da
 /// * **header** — title, tagline and metadata; the only band above the AI
 ///   card, so its growth is compensated unconditionally to keep the proposals
 ///   still under the user's pointer
-/// * **AI card**, off-screen only — every resolved proposal collapses its row
-///   and so shrinks the card, whether it was confirmed or dismissed (both
-///   gestures run the same resolve-then-collapse path). While the card is
-///   visible that collapse is the
-///   reflow the user is watching and must not move the page; once the card has
-///   scrolled above the viewport the same shrink drags the content the
-///   user *is* reading upwards, so the page arms
-///   [ViewportStableScrollController.hold]'s `includeOffscreenRegions` and this
-///   band's delta is absorbed instead.
+/// * **AI card** — every resolved proposal collapses its row and so shrinks
+///   the card, whether it was confirmed or dismissed (both gestures run the
+///   same resolve-then-collapse path), and the Confirm-all rail and the
+///   section itself collapse after the last row. Whichever edge the page has
+///   pinned — the card's own bottom while it is visible, the seam below the
+///   work bands once it has scrolled above the viewport — sits *below* this
+///   band, so its delta is absorbed unconditionally: the content under that
+///   edge never moves, and the collapse is paid for by the summary above
+///   sliding down into the space the rows leave.
 /// * **checklist**, off-screen only — items added, checked off, archived or
-///   migrated. Below the card, so while the card is visible its growth is the
-///   visible reflow under the proposals; only the below-card hold absorbs it.
+///   migrated. Below the card's pinned edge, so while the card is visible its
+///   growth is the visible reflow under the proposals — new content appears
+///   and only what is beneath it moves; only the below-card hold absorbs it.
 /// * **linked tasks**, off-screen only — `create_follow_up_task` links a new
 ///   task here, and the first link is a large step: two tall empty-state
 ///   actions plus a divider give way to one compact row while the card header
@@ -143,7 +144,6 @@ class TaskForm extends ConsumerWidget {
           ),
         ViewportStableSizeReporter(
           key: ValueKey('ai-card-size-reporter-$taskId'),
-          offscreenOnly: true,
           child: Padding(
             key: cardRegionKey,
             // A step4 top bonds the card to the identity header above it, the
@@ -165,11 +165,11 @@ class TaskForm extends ConsumerWidget {
             ),
           ),
         ),
-        // Both work bands sit BELOW the AI card now, so their deltas are
+        // Both work bands sit BELOW the AI card, so their deltas are
         // consumed only while the page armed the below-card hold (card fully
         // above the viewport, `_belowCardAnchor` pinning the linked-entries
-        // seam). While the card is visible the proposals are the anchor, and
-        // a checklist or linked-task growing underneath them is the visible
+        // seam). While the card is visible its bottom edge is the anchor, and
+        // a checklist or linked-task growing underneath it is the visible
         // reflow — compensating it would drag the proposals out from under
         // the user's pointer.
         ViewportStableSizeReporter(

--- a/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
+++ b/lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
@@ -55,11 +55,13 @@ class ViewportStableScrollController extends ScrollController
   /// [includeOffscreenRegions] additionally admits deltas from regions built as
   /// `ViewportStableSizeReporter(offscreenOnly: true)` — regions whose own
   /// height change must be compensated only while they are out of sight. The
-  /// AI card is the case this exists for: a proposal row collapsing inside it
-  /// drags everything below the card up, which matters only when the card
-  /// itself cannot be seen. While it is visible that reflow is the animation
-  /// the user is watching, and compensating it would slide the card out from
-  /// under their next tap.
+  /// task page's checklist and linked-tasks bands are the case this exists
+  /// for: a checklist item landing there pushes everything below it down,
+  /// which matters only once the AI card above has scrolled out of view and
+  /// the page is pinning the seam below the bands. While the card is visible
+  /// the page pins the card's own bottom edge instead, and the band growing
+  /// beneath it is the reflow the user is watching — new content appearing,
+  /// only what lies under it moving.
   ///
   /// The caller owns that predicate rather than the region, because the caller
   /// must pick a matching post-frame [ScrollAnchor] in the same breath: the
@@ -376,11 +378,11 @@ class ViewportStableSizeReporter extends StatelessWidget {
   /// only while the page has determined that this region is scrolled fully
   /// above the viewport.
   ///
-  /// Regions the user can see must never be compensated this way: a proposal
-  /// row collapsing inside a *visible* AI card is the reflow the user is
-  /// watching, and correcting it would scroll the page under their pointer.
-  /// The predicate lives with the page rather than here because the page must
-  /// pick the matching anchor from the same answer — see
+  /// Regions the user can see must never be compensated this way: a checklist
+  /// item landing in a *visible* checklist band is new content appearing, and
+  /// correcting it would scroll the page under their pointer. The predicate
+  /// lives with the page rather than here because the page must pick the
+  /// matching anchor from the same answer — see
   /// [ViewportStableScrollController.hold].
   final bool offscreenOnly;
 

--- a/test/README.md
+++ b/test/README.md
@@ -39,6 +39,17 @@ The authoritative metric contract, thresholds, corpus design, and diagnostic
 interpretation are documented in
 [Daily OS evaluation](../knowledge/features/daily_os_next/evaluation.md).
 
+## An animation ends strictly *after* its duration
+
+`AnimationController` reports `completed` only once the elapsed time is
+*greater than* the duration, and the first tick after `forward()` lands on the
+next pumped frame with zero elapsed. So `pump(duration)` right after the trigger
+leaves the value at its end but the status still `forward`: `onEnd`-style
+callbacks, `whenComplete` futures and status listeners have not fired, and a
+`SizeFadeCollapse(onCollapsed:)` owner has not dropped its subtree. Pump the
+start frame, then the duration, then a little past it — or sample in small steps
+until the state you are waiting for appears, and assert you saw it.
+
 ## Platform-channel calls in widgets (e.g. HapticFeedback)
 
 A widget action that `await`s a `SystemChannels.platform` call — `HapticFeedback.lightImpact()`, clipboard, etc. — never resolves under the test binding unless a mock handler is installed, so any follow-up work after the await (a DB write, a `setState`, a navigation) silently never runs and the test fails in a confusing way. Install a handler in `setUp` **and reset it in `tearDown`**, or it leaks into every later test in the same isolate under the batched (`very_good`) runner:

--- a/test/features/agents/ui/ai_summary_card/lifecycle_test.dart
+++ b/test/features/agents/ui/ai_summary_card/lifecycle_test.dart
@@ -7,11 +7,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposals_section_part.dart';
+import 'package:lotti/features/design_system/components/motion/size_fade_entrance.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
@@ -31,6 +34,7 @@ Widget _buildShell({
   AgentDomainEntity? Function(Ref ref)? agentState,
   UnifiedSuggestionList Function(Ref ref)? suggestionsSync,
   MockTaskAgentService? taskAgentService,
+  AgentReportEntity? report,
   bool enableSummaryTts = false,
   MediaQueryData mediaQueryData = desktopMediaQueryData,
 }) {
@@ -47,7 +51,7 @@ Widget _buildShell({
         (ref, id) async => defaultResolvedSetup,
       ),
       agentReportProvider.overrideWith(
-        (ref, agentId) async => makeTestReport(tldr: 'Tldr line.'),
+        (ref, agentId) async => report ?? makeTestReport(tldr: 'Tldr line.'),
       ),
       templateForAgentProvider.overrideWith((ref, agentId) async => null),
       agentIsRunningProvider.overrideWith(
@@ -222,6 +226,70 @@ void main() {
 
         firstUpdate.complete();
         await tester.pump();
+      },
+    );
+  });
+
+  group('AiSummaryCard – didUpdateWidget resets the history latch', () {
+    testWidgets(
+      "history present on the next task's first list appears at once, "
+      'not with a reveal',
+      (tester) async {
+        // The reveal flag distinguishes a band on the initial load from one
+        // appearing later. When the shell is reused for another agent, the
+        // new agent's first list is an initial load again — a stale flag
+        // from the previous one would ease the band open.
+        final first = makeTestIdentity(
+          id: 'agent-A',
+          agentId: 'agent-A',
+          displayName: 'Agent Alpha',
+        );
+        final second = makeTestIdentity(
+          id: 'agent-B',
+          agentId: 'agent-B',
+          displayName: 'Agent Beta',
+        );
+        var current = first;
+
+        await tester.pumpWidget(
+          _buildShell(
+            identity: (ref) => current,
+            // Nothing behind Read more, so history shows unconditionally.
+            report: makeTestReport(content: 'Same text', tldr: 'Same text'),
+            suggestionsSync: (ref) => current.agentId == 'agent-A'
+                ? const UnifiedSuggestionList.empty()
+                : UnifiedSuggestionList(
+                    open: const [],
+                    activity: [
+                      makeLedgerEntry(
+                        id: 'b-0',
+                        status: ChangeItemStatus.confirmed,
+                      ),
+                    ],
+                  ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(ProposalHistorySection), findsNothing);
+
+        final element = tester.element(find.byType(AiSummaryCard));
+        final container = ProviderScope.containerOf(element);
+        current = second;
+        container
+          ..invalidate(taskAgentProvider(AgentTestBench.taskId))
+          ..invalidate(unifiedSuggestionListProvider(AgentTestBench.taskId));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Agent Beta'), findsOneWidget);
+        expect(find.byType(ProposalHistorySection), findsOneWidget);
+        expect(
+          tester
+              .widget<SizeFadeEntrance>(
+                find.byKey(const ValueKey('proposalHistoryBand')),
+              )
+              .animate,
+          isFalse,
+        );
       },
     );
   });

--- a/test/features/agents/ui/ai_summary_card/proposal_row_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposal_row_part_test.dart
@@ -153,8 +153,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         await tester.tap(find.byIcon(LottiIcons.confirm));
-        // A couple of frames is enough — no resolve/collapse animation runs
-        // under reduced motion, so the row is pruned without a timed window.
+        // A few frames is enough — no resolve/collapse animation runs under
+        // reduced motion, so the row is pruned without a timed window, the
+        // section snaps shut, and the frame after that it is dropped.
+        await tester.pump();
         await tester.pump();
         await tester.pump();
         expect(find.byType(ProposalRow), findsNothing);
@@ -613,7 +615,11 @@ void main() {
         await tester.pump(ProposalMotion.resolveHold);
         await tester.pump(ProposalMotion.collapse);
         await tester.pump(ProposalMotion.collapse);
-        await tester.pump();
+        // Then the section itself collapses away and is dropped: the first
+        // pump is the ticker's zero-elapsed start frame, the second runs it.
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
         expect(find.byType(ProposalRow), findsNothing);
         expect(find.byIcon(LottiIcons.confirm), findsNothing);
       },

--- a/test/features/agents/ui/ai_summary_card/proposal_row_widgets_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposal_row_widgets_part_test.dart
@@ -1,12 +1,19 @@
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
 import 'package:lotti/features/agents/ui/localized_change_summary.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_en.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
+import '../../../../widget_test_utils.dart';
 import '../../test_data/change_set_factories.dart';
 import 'test_bench.dart';
 
@@ -184,6 +191,101 @@ void main() {
           inkWell.overlayColor?.resolve({WidgetState.hovered}),
           Colors.transparent,
         );
+      },
+    );
+  });
+
+  group('AiSummaryCard – RowActions footprint', () {
+    // The summary text beside the slot must never rewrap: a narrower slot
+    // widened the text column mid-resolve, and a two-line proposal snapping
+    // to one line dropped the row's height a beat before its collapse.
+    testWidgets(
+      'the busy spinner keeps the two-button footprint',
+      (tester) async {
+        late double expected;
+        await tester.pumpWidget(
+          makeTestableWidget(
+            Builder(
+              builder: (context) {
+                expected = RowActions.footprintWidth(context);
+                return Center(
+                  child: RowActions(
+                    busy: true,
+                    onReject: () async {},
+                    onConfirm: () async {},
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+        final tokens = tester.element(find.byType(RowActions)).designTokens;
+        expect(expected, RowActions.buttonSize * 2 + tokens.spacing.step2);
+        expect(
+          tester.getSize(find.byType(RowActions)),
+          Size(expected, RowActions.buttonSize),
+        );
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'a resolving row keeps its text at the same width as a pending one',
+      (tester) async {
+        final completer = Completer<ToolExecutionResult>();
+        final service = MockChangeSetConfirmationService();
+        when(
+          () => service.confirmItem(any(), any()),
+        ).thenAnswer((_) => completer.future);
+        final bench = AgentTestBench(
+          confirmationService: service,
+          updateNotifications: MockUpdateNotifications(),
+          suggestions: UnifiedSuggestionList(
+            open: [_pending('set_task_status')],
+            activity: const [],
+          ),
+        );
+        await tester.pumpWidget(bench.build());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        Finder body() => find.byWidgetPredicate(
+          (w) => w is Text && w.textSpan != null,
+        );
+        final pendingWidth = tester.getSize(body()).width;
+        final buttonsWidth = tester.getSize(find.byType(RowActions)).width;
+        // The rendered two-button rail is what the footprint stands for.
+        expect(
+          buttonsWidth,
+          RowActions.footprintWidth(tester.element(find.byType(RowActions))),
+        );
+
+        await tester.tap(find.byIcon(LottiIcons.confirm));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(find.text('Confirmed'), findsOneWidget);
+        expect(find.byType(RowActions), findsNothing);
+        expect(tester.getSize(body()).width, pendingWidth);
+        // And the placeholder that replaced the buttons is exactly their size.
+        expect(
+          tester.getSize(
+            find.descendant(
+              of: find.byType(ProposalRowContent),
+              matching: find.byWidgetPredicate(
+                (w) =>
+                    w is SizedBox &&
+                    w.width == buttonsWidth &&
+                    w.height == RowActions.buttonSize,
+              ),
+            ),
+          ),
+          Size(buttonsWidth, RowActions.buttonSize),
+        );
+        completer.complete(
+          const ToolExecutionResult(success: true, output: 'ok'),
+        );
+        await tester.pump();
       },
     );
   });

--- a/test/features/agents/ui/ai_summary_card/proposals_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposals_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
@@ -15,6 +16,7 @@ import 'package:lotti/features/agents/ui/ai_summary_card.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposals_section_part.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/motion/size_fade_collapse.dart';
 import 'package:lotti/features/design_system/components/motion/size_fade_entrance.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/utils/consts.dart';
@@ -144,7 +146,28 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.text('Confirm all'), findsNothing);
+      // Mounted but collapsed away from the start — no reveal, no height,
+      // no tap target — so a later confirm that leaves one row can ease it
+      // out rather than unmount it in one frame.
+      final rail = tester.widget<SizeFadeCollapse>(
+        find.byKey(const ValueKey('proposalBottomRail')),
+      );
+      expect(rail.collapsed, isTrue);
+      expect(
+        tester.getSize(find.byKey(const ValueKey('proposalBottomRail'))).height,
+        0,
+      );
+      expect(
+        tester
+            .widget<DesignSystemButton>(
+              find.descendant(
+                of: find.byKey(const ValueKey('proposalBottomRail')),
+                matching: find.byType(DesignSystemButton),
+              ),
+            )
+            .onPressed,
+        isNull,
+      );
     });
 
     testWidgets('Confirm-all batches confirmAll over distinct change sets', (
@@ -311,6 +334,24 @@ void main() {
         await tester.pump();
         await tester.pump();
 
+        // The section collapses away on the row's own clock rather than
+        // unmounting in one frame; once fully gone it is dropped.
+        expect(
+          tester
+              .widget<SizeFadeCollapse>(
+                find.ancestor(
+                  of: find.byType(ProposalsSection),
+                  matching: find.byType(SizeFadeCollapse),
+                ),
+              )
+              .collapsed,
+          isTrue,
+        );
+        // Two collapse-length pumps: the first is the ticker's zero-elapsed
+        // start frame, the second runs it; then the drop lands.
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
         expect(find.textContaining('Set status to Groomed'), findsNothing);
         expect(find.text('0 pending'), findsNothing);
         expect(find.text('1 pending'), findsNothing);
@@ -1482,7 +1523,12 @@ void main() {
         );
         await tester.pump(ProposalMotion.collapse);
         await tester.pump(ProposalMotion.staggerStep * 8);
-        await tester.pump();
+        // Then the section itself collapses away and is dropped — past the
+        // end, not exactly at it: the simulation reports done only strictly
+        // after its duration, and the drop lands post-frame.
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
         expect(find.byType(ProposalRow), findsNothing);
       },
     );
@@ -1675,10 +1721,423 @@ void main() {
         );
         await tester.pump(ProposalMotion.collapse);
         await tester.pump(ProposalMotion.staggerStep * 8);
-        await tester.pump();
+        // Then the section itself collapses away and is dropped — past the
+        // end, not exactly at it: the simulation reports done only strictly
+        // after its duration, and the drop lands post-frame.
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
         expect(find.byType(ProposalRow), findsNothing);
       },
     );
+  });
+
+  // Everything below the card is what a confirm-all must not move (the task
+  // page pins the card's bottom edge), so nothing inside the section may
+  // change height in a single frame: each change that used to unmount now
+  // eases out on the row's own collapse clock.
+  group('AiSummaryCard – sweep geometry', () {
+    PendingSuggestion pendingAt(String id, ChangeSetEntity cs, int index) =>
+        PendingSuggestion(
+          changeSet: cs,
+          itemIndex: index,
+          item: cs.items[index],
+          fingerprint: 'fp-$id-$index',
+        );
+
+    ChangeSetEntity twoItems(String id) => makeTestChangeSet(
+      id: id,
+      items: const [
+        ChangeItem(
+          toolName: 'set_task_status',
+          args: {'status': 'GROOMED'},
+          humanSummary: 'Set status to GROOMED',
+        ),
+        ChangeItem(
+          toolName: 'update_task_priority',
+          args: {'priority': 'P1'},
+          humanSummary: 'Raise priority to P1',
+        ),
+      ],
+    );
+
+    Finder rail() => find.byKey(const ValueKey('proposalBottomRail'));
+    SizeFadeCollapse railCollapse(WidgetTester tester) =>
+        tester.widget<SizeFadeCollapse>(rail());
+    Finder sectionBand() => find.ancestor(
+      of: find.byType(ProposalsSection),
+      matching: find.byType(SizeFadeCollapse),
+    );
+
+    testWidgets(
+      'the rail stays for the whole of a Confirm-all sweep, and the section '
+      'then collapses as a unit and is dropped',
+      (tester) async {
+        final cs = twoItems('cs-sweep');
+        final completer = Completer<List<ToolExecutionResult>>();
+        final service = MockChangeSetConfirmationService();
+        when(
+          () => service.confirmAll(any()),
+        ).thenAnswer((_) => completer.future);
+        await tester.pumpWidget(
+          AgentTestBench(
+            confirmationService: service,
+            updateNotifications: MockUpdateNotifications(),
+            suggestions: UnifiedSuggestionList(
+              open: [pendingAt('sweep', cs, 0), pendingAt('sweep', cs, 1)],
+              activity: const [],
+            ),
+          ).build(),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(railCollapse(tester).collapsed, isFalse);
+
+        await tester.tap(find.text('Confirm all'));
+        await tester.pump();
+        completer.complete(const []);
+
+        // Sample the sweep: the rows prune one after another (55 ms apart),
+        // and at no point while any row is still leaving may the rail drop —
+        // including the stretch where a single row remains. The section's
+        // own collapse flag marks the end of the sweep: the last row stays
+        // mounted inside the retained section while that collapses, so the
+        // row count alone cannot tell the two apart.
+        var sawSingleRowLeaving = false;
+        for (var step = 0; step < 40; step++) {
+          await tester.pump(const Duration(milliseconds: 50));
+          if (tester.widget<SizeFadeCollapse>(sectionBand()).collapsed) break;
+          if (find.byType(ProposalRow).evaluate().length == 1) {
+            sawSingleRowLeaving = true;
+          }
+          expect(
+            railCollapse(tester).collapsed,
+            isFalse,
+            reason: 'the rail dropped at step $step with rows still leaving',
+          );
+          expect(tester.getSize(rail()).height, greaterThan(0));
+          // And it stays in its loading state for the whole sweep — the
+          // writes returned long ago, and a re-enabled rail would re-run
+          // the batch.
+          expect(
+            tester
+                .widget<DesignSystemButton>(
+                  find.descendant(
+                    of: rail(),
+                    matching: find.byType(DesignSystemButton),
+                  ),
+                )
+                .isLoading,
+            isTrue,
+            reason: 'the rail re-enabled at step $step mid-sweep',
+          );
+        }
+        expect(
+          sawSingleRowLeaving,
+          isTrue,
+          reason: 'the sweep was never observed with one row left',
+        );
+
+        // The last row has left: the whole section collapses on the same clock
+        // rather than unmounting, then is dropped once fully gone.
+        expect(
+          tester.widget<SizeFadeCollapse>(sectionBand()).collapsed,
+          isTrue,
+        );
+        final heightAtStart = tester.getSize(sectionBand()).height;
+        expect(heightAtStart, greaterThan(0));
+        await tester.pump(const Duration(milliseconds: 100));
+        final midHeight = tester.getSize(sectionBand()).height;
+        expect(midHeight, greaterThan(0));
+        expect(midHeight, lessThan(heightAtStart));
+        // Past the end, not exactly at it: the simulation reports done only
+        // strictly after its duration, and the drop lands post-frame.
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(find.byType(ProposalsSection), findsNothing);
+        expect(find.byType(SizeFadeCollapse), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'a confirm that leaves a single row eases the rail out instead of '
+      'unmounting it',
+      (tester) async {
+        final cs = twoItems('cs-single');
+        final service = MockChangeSetConfirmationService();
+        when(() => service.confirmItem(any(), any())).thenAnswer(
+          (_) async => const ToolExecutionResult(success: true, output: 'ok'),
+        );
+        await tester.pumpWidget(
+          AgentTestBench(
+            confirmationService: service,
+            updateNotifications: MockUpdateNotifications(),
+            suggestions: UnifiedSuggestionList(
+              open: [pendingAt('single', cs, 0), pendingAt('single', cs, 1)],
+              activity: const [],
+            ),
+          ).build(),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        final railHeight = tester.getSize(rail()).height;
+        expect(railHeight, greaterThan(0));
+
+        await tester.tap(find.byIcon(LottiIcons.confirm).first);
+        await tester.pump();
+        // Through the row's resolve beat and collapse the rail is untouched —
+        // two rows are still listed, one of them leaving.
+        await tester.pump(ProposalMotion.resolveHold);
+        expect(railCollapse(tester).collapsed, isFalse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump();
+        expect(find.byType(ProposalRow), findsOneWidget);
+
+        // Pruned to one row: the rail collapses, and it is still there to be
+        // seen doing so.
+        expect(railCollapse(tester).collapsed, isTrue);
+        // The ticker's zero-elapsed start frame, then a partial run.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        final mid = tester.getSize(rail()).height;
+        expect(mid, greaterThan(0));
+        expect(mid, lessThan(railHeight));
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(tester.getSize(rail()).height, 0);
+        expect(find.byType(ProposalsSection), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'the pending pill fades in place at zero, keeping the header line its '
+      'height',
+      (tester) async {
+        final cs = twoItems('cs-pill');
+        final completer = Completer<List<ToolExecutionResult>>();
+        final service = MockChangeSetConfirmationService();
+        when(
+          () => service.confirmAll(any()),
+        ).thenAnswer((_) => completer.future);
+        await tester.pumpWidget(
+          AgentTestBench(
+            confirmationService: service,
+            updateNotifications: MockUpdateNotifications(),
+            suggestions: UnifiedSuggestionList(
+              open: [pendingAt('pill', cs, 0), pendingAt('pill', cs, 1)],
+              activity: const [],
+            ),
+          ).build(),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        Finder headerLine() => find
+            .ancestor(
+              of: find.text('Proposed changes'),
+              matching: find.byType(Row),
+            )
+            .first;
+        AnimatedOpacity pillOpacity(String text) =>
+            tester.widget<AnimatedOpacity>(
+              find
+                  .ancestor(
+                    of: find.text(text),
+                    matching: find.byType(AnimatedOpacity),
+                  )
+                  .first,
+            );
+        final lineHeight = tester.getSize(headerLine()).height;
+        expect(pillOpacity('2 pending').opacity, 1);
+
+        await tester.tap(find.text('Confirm all'));
+        await tester.pump();
+        await tester.pump(MotionDurations.medium1);
+
+        // Every row is committed, so nothing is pending — the pill is faded
+        // out, still occupying its line, and no longer announced.
+        expect(pillOpacity('0 pending').opacity, 0);
+        expect(tester.getSize(headerLine()).height, lineHeight);
+        expect(
+          find.ancestor(
+            of: find.text('0 pending'),
+            matching: find.byWidgetPredicate(
+              (w) => w is ExcludeSemantics && w.excluding,
+            ),
+          ),
+          findsOneWidget,
+        );
+        completer.complete(const []);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'a section returning after it collapsed away stands at full height at '
+      'once — only its rows reveal themselves',
+      (tester) async {
+        final cs = twoItems('cs-return');
+        var current = UnifiedSuggestionList(
+          open: [pendingAt('return', cs, 0)],
+          activity: const [],
+        );
+        await tester.pumpWidget(
+          AgentTestBench(
+            suggestionListOverride: (ref, taskId) => current,
+          ).build(),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        final firstBand = tester.widget<SizeFadeCollapse>(sectionBand());
+
+        // The provider drops the row (a retraction): collapse, then gone.
+        current = const UnifiedSuggestionList.empty();
+        ProviderScope.containerOf(
+          tester.element(find.byType(AiSummaryCard)),
+        ).invalidate(unifiedSuggestionListProvider(AgentTestBench.taskId));
+        await tester.pump();
+        await tester.pump();
+        expect(
+          tester.widget<SizeFadeCollapse>(sectionBand()).collapsed,
+          isTrue,
+        );
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(find.byType(ProposalsSection), findsNothing);
+
+        // A new proposal arrives: a fresh wrapper, open from its first frame.
+        current = UnifiedSuggestionList(
+          open: [pendingAt('return', cs, 1)],
+          activity: const [],
+        );
+        ProviderScope.containerOf(
+          tester.element(find.byType(AiSummaryCard)),
+        ).invalidate(unifiedSuggestionListProvider(AgentTestBench.taskId));
+        await tester.pump();
+        await tester.pump();
+        final secondBand = tester.widget<SizeFadeCollapse>(sectionBand());
+        expect(secondBand.key, isNot(firstBand.key));
+        expect(secondBand.collapsed, isFalse);
+        expect(
+          tester
+              .widget<FadeTransition>(
+                find
+                    .descendant(
+                      of: sectionBand(),
+                      matching: find.byType(FadeTransition),
+                    )
+                    .first,
+              )
+              .opacity
+              .value,
+          1,
+        );
+        expect(find.byType(ProposalRow), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'the history band waits for the sweep to settle, then eases open',
+      (tester) async {
+        // A report with nothing behind Read more shows history unconditionally,
+        // so the first confirmed entry would otherwise put the band on screen
+        // while the rows above it are still leaving.
+        final cs = twoItems('cs-history');
+        var current = UnifiedSuggestionList(
+          open: [pendingAt('history', cs, 0), pendingAt('history', cs, 1)],
+          activity: const [],
+        );
+        final completer = Completer<List<ToolExecutionResult>>();
+        final service = MockChangeSetConfirmationService();
+        when(
+          () => service.confirmAll(any()),
+        ).thenAnswer((_) => completer.future);
+        await tester.pumpWidget(
+          AgentTestBench(
+            report: makeTestReport(content: 'Same text', tldr: 'Same text'),
+            confirmationService: service,
+            updateNotifications: MockUpdateNotifications(),
+            suggestionListOverride: (ref, taskId) => current,
+          ).build(),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(find.byType(ProposalHistorySection), findsNothing);
+
+        await tester.tap(find.text('Confirm all'));
+        await tester.pump();
+        // The writes land while the rows are still collapsing.
+        current = UnifiedSuggestionList(
+          open: const [],
+          activity: [
+            makeLedgerEntry(
+              id: 'history-0',
+              status: ChangeItemStatus.confirmed,
+            ),
+          ],
+        );
+        ProviderScope.containerOf(
+          tester.element(find.byType(AiSummaryCard)),
+        ).invalidate(unifiedSuggestionListProvider(AgentTestBench.taskId));
+        await tester.pump();
+        await tester.pump(ProposalMotion.resolveHold);
+        expect(find.byType(ProposalRow), findsNWidgets(2));
+        expect(
+          find.byType(ProposalHistorySection),
+          findsNothing,
+          reason: 'the band must not appear under rows still leaving',
+        );
+
+        completer.complete(const []);
+        // Let the sweep run out: every row gone, the section collapsed away.
+        for (var step = 0; step < 40; step++) {
+          await tester.pump(const Duration(milliseconds: 50));
+          if (find.byType(ProposalRow).evaluate().isEmpty) break;
+        }
+        expect(find.byType(ProposalRow), findsNothing);
+        expect(find.byType(ProposalHistorySection), findsOneWidget);
+        expect(
+          tester
+              .widget<SizeFadeEntrance>(
+                find.byKey(const ValueKey('proposalHistoryBand')),
+              )
+              .animate,
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets('history present on the initial load does not reveal itself', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        AgentTestBench(
+          report: makeTestReport(content: 'Same text', tldr: 'Same text'),
+          suggestions: UnifiedSuggestionList(
+            open: const [],
+            activity: [
+              makeLedgerEntry(
+                id: 'initial-0',
+                status: ChangeItemStatus.confirmed,
+              ),
+            ],
+          ),
+        ).build(),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.byType(ProposalHistorySection), findsOneWidget);
+      expect(
+        tester
+            .widget<SizeFadeEntrance>(
+              find.byKey(const ValueKey('proposalHistoryBand')),
+            )
+            .animate,
+        isFalse,
+      );
+    });
   });
 
   // The card wraps each section that lands while the agent runs in an

--- a/test/features/design_system/components/motion/size_fade_collapse_test.dart
+++ b/test/features/design_system/components/motion/size_fade_collapse_test.dart
@@ -30,6 +30,7 @@ Future<void> _pump(
   required bool collapsed,
   bool reduceMotion = false,
   VoidCallback? onTap,
+  VoidCallback? onCollapsed,
   Duration duration = const Duration(milliseconds: 300),
 }) => tester.pumpWidget(
   makeTestableWidgetNoScroll(
@@ -42,6 +43,7 @@ Future<void> _pump(
         child: SizeFadeCollapse(
           collapsed: collapsed,
           duration: duration,
+          onCollapsed: onCollapsed,
           child: _content(onTap: onTap),
         ),
       ),
@@ -217,6 +219,67 @@ void main() {
 
       semantics.dispose();
     });
+
+    testWidgets(
+      'onCollapsed fires once the collapse has run to the end, not before',
+      (tester) async {
+        var calls = 0;
+        await _pump(tester, collapsed: false, onCollapsed: () => calls++);
+        await _pump(tester, collapsed: true, onCollapsed: () => calls++);
+        // The ticker's zero-elapsed start frame, then half the collapse.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 150));
+        // Mid-collapse the content is still partly there — the owner must
+        // not drop it yet.
+        final mid = _measure(tester).reserved.height;
+        expect(mid, greaterThan(0));
+        expect(mid, lessThan(_contentSize.height));
+        expect(calls, 0);
+
+        // Past the end, not exactly at it: the simulation reports done only
+        // strictly after its duration, and the callback lands post-frame.
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(_measure(tester).reserved.height, 0);
+        expect(calls, 1);
+      },
+    );
+
+    testWidgets(
+      'onCollapsed fires for the reduced-motion snap too',
+      (tester) async {
+        var calls = 0;
+        await _pump(
+          tester,
+          collapsed: false,
+          reduceMotion: true,
+          onCollapsed: () => calls++,
+        );
+        await _pump(
+          tester,
+          collapsed: true,
+          reduceMotion: true,
+          onCollapsed: () => calls++,
+        );
+        expect(_measure(tester).reserved.height, 0);
+        expect(calls, 1);
+      },
+    );
+
+    testWidgets(
+      'onCollapsed does not fire for content that starts out collapsed, nor '
+      'on a reveal',
+      (tester) async {
+        var calls = 0;
+        await _pump(tester, collapsed: true, onCollapsed: () => calls++);
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(calls, 0);
+
+        await _pump(tester, collapsed: false, onCollapsed: () => calls++);
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(_measure(tester).reserved.height, _contentSize.height);
+        expect(calls, 0);
+      },
+    );
 
     testWidgets('a changed duration retimes the next collapse', (tester) async {
       const slow = Duration(milliseconds: 800);

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/state/change_set_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
@@ -172,6 +173,7 @@ void main() {
     ).thenAnswer(
       (_) => Stream<bool>.fromIterable([false]),
     );
+    when(() => mockEditorStateService.entryIsUnsaved(any())).thenReturn(false);
 
     when(
       mockTimeService.getStream,
@@ -826,14 +828,97 @@ void main() {
     setUp(registerTaskDetailsServices);
     tearDown(getIt.reset);
 
-    testWidgets(
-      'Accept all keeps the proposals position stable at a nonzero scroll '
-      'offset while its rows collapse',
-      (tester) async {
-        tester.view.physicalSize = const Size(800, 500);
-        tester.view.devicePixelRatio = 1;
-        addTearDown(tester.view.reset);
+    /// Four proposals, so the section is tall enough to scroll the rail well
+    /// down the page — and long enough a sweep to observe.
+    const fourItems = [
+      ChangeItem(
+        toolName: 'update_task_estimate',
+        args: {'minutes': 30},
+        humanSummary: 'Set estimate to 30 minutes',
+      ),
+      ChangeItem(
+        toolName: 'add_checklist_item',
+        args: {'title': 'Add a checklist item'},
+        humanSummary: 'Add a checklist item',
+      ),
+      ChangeItem(
+        toolName: 'set_task_language',
+        args: {'languageCode': 'de', 'confidence': 'high'},
+        humanSummary: 'Set language to "de"',
+      ),
+      ChangeItem(
+        toolName: 'update_task_priority',
+        args: {'priority': 'P1'},
+        humanSummary: 'Raise priority to P1',
+      ),
+    ];
 
+    /// Pumps the page with the AI card in view and the Confirm-all rail at
+    /// the viewport's centre, far enough down the page that the correction
+    /// has room to run: the collapse of the whole section has to fit above
+    /// the scroll origin, or the clamp at zero would move the content below
+    /// the card for a reason these tests are not about. A short viewport and
+    /// a four-row section put the rail that far down.
+    Future<ScrollPosition> pumpWithRailCentred(
+      WidgetTester tester,
+      ProviderContainer container,
+    ) async {
+      tester.view.physicalSize = const Size(800, 400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      container
+          .read(controllableOpenSuggestionCountProvider.notifier)
+          .set(fourItems.length);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: makeTestableWidget2(
+            TaskDetailsPage(taskId: testTask.id),
+          ),
+        ),
+      );
+      // Explicit pumps (not pumpAndSettle, which would hang on the AI
+      // card's long-lived wake timers) to let the async providers resolve.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final confirmAll = find.text('Confirm all');
+      expect(find.byType(ProposalsSection), findsOneWidget);
+      expect(confirmAll, findsOneWidget);
+      await Scrollable.ensureVisible(
+        tester.element(confirmAll),
+        alignment: 0.5,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      final position = tester
+          .state<ScrollableState>(
+            find
+                .descendant(
+                  of: find.byType(CustomScrollView),
+                  matching: find.byType(Scrollable),
+                )
+                .first,
+          )
+          .position;
+      final sectionHeight = tester
+          .getSize(find.byType(ProposalsSection, skipOffstage: false))
+          .height;
+      expect(
+        position.pixels,
+        greaterThan(sectionHeight + 20),
+        reason:
+            'the rail must sit further down the page than the section '
+            'is tall, or the correction has no room',
+      );
+      return position;
+    }
+
+    testWidgets(
+      'Accept all keeps everything below the AI card fixed while its rows '
+      'collapse — the summary above slides down into the space they leave',
+      (tester) async {
         final confirmationService = MockChangeSetConfirmationService();
         late final ProviderContainer container;
         when(() => confirmationService.confirmAll(any())).thenAnswer((_) async {
@@ -846,56 +931,47 @@ void main() {
         container = ProviderContainer(
           overrides: [
             ...hTaskDetailsPageOverrides(),
-            ...hControllableSuggestionOverrides(),
+            ...hLinkedEntriesOverrides(),
+            ...hControllableSuggestionOverrides(items: fourItems),
             changeSetConfirmationServiceProvider.overrideWith(
               (ref) => confirmationService,
             ),
           ],
         );
+        final position = await pumpWithRailCentred(tester, container);
 
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: makeTestableWidget2(
-              TaskDetailsPage(taskId: testTask.id),
-            ),
-          ),
-        );
-        // Explicit pumps (not pumpAndSettle, which would hang on the AI
-        // card's long-lived wake timers) to let the async providers resolve.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.pump(const Duration(milliseconds: 300));
-
-        final proposals = find.byType(ProposalsSection);
-        final confirmAll = find.text('Confirm all');
-        expect(proposals, findsOneWidget);
-        expect(confirmAll, findsOneWidget);
-
-        await tester.ensureVisible(confirmAll);
-        await tester.pump();
-        final position = tester
-            .state<ScrollableState>(
-              find
-                  .descendant(
-                    of: find.byType(CustomScrollView),
-                    matching: find.byType(Scrollable),
-                  )
-                  .first,
-            )
-            .position;
-        expect(position.pixels, greaterThan(0));
+        // The band directly under the card: the first thing the user is not
+        // meant to see move. Offstage-tolerant, because the correction
+        // decides where it ends up.
+        final belowCard = find.byType(LinkedTasksWidget, skipOffstage: false);
+        final proposals = find.byType(ProposalsSection, skipOffstage: false);
+        final belowCardTop = tester.getTopLeft(belowCard).dy;
         final proposalsTop = tester.getTopLeft(proposals).dy;
+        final offsetBefore = position.pixels;
 
-        await tester.tap(confirmAll);
-        for (var frame = 0; frame < 6; frame++) {
+        await tester.tap(find.text('Confirm all'));
+        var proposalsDescended = false;
+        for (var frame = 0; frame < 12; frame++) {
           await tester.pump(const Duration(milliseconds: 100));
           expect(
-            tester.getTopLeft(proposals).dy,
-            closeTo(proposalsTop, 1),
-            reason: 'proposals moved during Accept-all frame $frame',
+            tester.getTopLeft(belowCard).dy,
+            closeTo(belowCardTop, 1),
+            reason:
+                'the band below the card moved during Accept-all '
+                'frame $frame',
           );
+          if (proposals.evaluate().isNotEmpty &&
+              tester.getTopLeft(proposals).dy > proposalsTop + 1) {
+            proposalsDescended = true;
+          }
         }
+
+        // The rows really collapsed above the pinned edge: the section's top
+        // came down to meet the rows still leaving, the offset gave back the
+        // collapsed height, and the section is gone once the sweep settled.
+        expect(proposalsDescended, isTrue);
+        expect(position.pixels, lessThan(offsetBefore - 100));
+        expect(proposals, findsNothing);
 
         verify(() => confirmationService.confirmAll(any())).called(1);
         expect(
@@ -903,9 +979,84 @@ void main() {
           isZero,
         );
         expect(tester.takeException(), isNull);
+        container.dispose();
+      },
+    );
 
-        // Dispose the container (cancels the entry-controller cache timer)
-        // before the framework's pending-timer check.
+    testWidgets(
+      'a header growing while the rows collapse composes with the same '
+      'correction — the band below the card still does not move',
+      (tester) async {
+        // A title proposal lands in the header band while the sweep is still
+        // running. The header reports its delta pre-paint like the card does,
+        // so the two corrections sum and the pinned edge stays put.
+        final updates = StreamController<Set<String>>.broadcast();
+        addTearDown(updates.close);
+        var currentTask = testTask;
+        when(
+          () => mockUpdateNotifications.updateStream,
+        ).thenAnswer((_) => updates.stream);
+        when(
+          () => mockJournalDb.journalEntityById(testTask.meta.id),
+        ).thenAnswer((_) async => currentTask);
+
+        // The test releases the write itself, a few frames into the sweep,
+        // so the title lands while rows are still collapsing.
+        final release = Completer<void>();
+        final confirmationService = MockChangeSetConfirmationService();
+        late final ProviderContainer container;
+        when(() => confirmationService.confirmAll(any())).thenAnswer((_) async {
+          await release.future;
+          currentTask = testTask.copyWith(
+            data: testTask.data.copyWith(
+              title: List.filled(
+                6,
+                'A title long enough to wrap onto several lines',
+              ).join(' '),
+            ),
+          );
+          updates.add({testTask.meta.id});
+          container
+              .read(controllableOpenSuggestionCountProvider.notifier)
+              .set(0);
+          return const [ToolExecutionResult(success: true, output: 'ok')];
+        });
+
+        container = ProviderContainer(
+          overrides: [
+            ...hTaskDetailsPageOverrides(),
+            ...hLinkedEntriesOverrides(),
+            ...hControllableSuggestionOverrides(items: fourItems),
+            changeSetConfirmationServiceProvider.overrideWith(
+              (ref) => confirmationService,
+            ),
+          ],
+        );
+        await pumpWithRailCentred(tester, container);
+
+        final belowCard = find.byType(LinkedTasksWidget, skipOffstage: false);
+        final header = find.byType(
+          DesktopTaskHeaderConnector,
+          skipOffstage: false,
+        );
+        final belowCardTop = tester.getTopLeft(belowCard).dy;
+        final headerHeight = tester.getSize(header).height;
+
+        await tester.tap(find.text('Confirm all'));
+        for (var frame = 0; frame < 12; frame++) {
+          if (frame == 2) release.complete();
+          await tester.pump(const Duration(milliseconds: 100));
+          expect(
+            tester.getTopLeft(belowCard).dy,
+            closeTo(belowCardTop, 1),
+            reason: 'the band below the card moved on frame $frame',
+          );
+        }
+
+        // The header really did grow — otherwise the assertion above would
+        // hold trivially.
+        expect(tester.getSize(header).height, greaterThan(headerHeight + 10));
+        expect(tester.takeException(), isNull);
         container.dispose();
       },
     );

--- a/test/features/tasks/ui/task_form_test.dart
+++ b/test/features/tasks/ui/task_form_test.dart
@@ -336,29 +336,28 @@ void main() {
     );
 
     testWidgets(
-      'reports the header unconditionally, and every band from the AI card '
-      'down only while the below-card hold is armed',
+      'reports the header and the AI card unconditionally, and the work bands '
+      'below the card only while the below-card hold is armed',
       (tester) async {
         await tester.pumpWidget(buildSubject(task: testTask));
         await tester.pumpAndSettle();
 
-        // The header is the only band above the proposals: its growth moves
-        // them, so it is compensated unconditionally.
-        expect(
-          reporterFor(
-            tester,
-            find.byType(DesktopTaskHeaderConnector),
-          ).offscreenOnly,
-          isFalse,
-        );
-        // The card's own collapse must move the page only when the user
-        // cannot see it; a visible collapse is the reflow they are watching.
+        // Whichever edge the page pins — the card's bottom while it is
+        // visible, the seam below the work bands once it has scrolled away —
+        // lies below both the header and the card, so their height changes
+        // are compensated unconditionally: a proposal row collapsing inside
+        // the card must never move what sits under that edge.
+        for (final band in [
+          find.byType(DesktopTaskHeaderConnector),
+          find.byType(AiSummaryCard),
+        ]) {
+          expect(reporterFor(tester, band).offscreenOnly, isFalse);
+        }
         // The checklist and linked-tasks bands sit BELOW the card, so while
-        // the card is visible their growth is the visible reflow under the
-        // proposals — compensating it would drag the proposals out from
+        // the card is visible their growth is the visible reflow under its
+        // pinned edge — compensating it would drag the proposals out from
         // under the user's pointer.
         for (final band in [
-          find.byType(AiSummaryCard),
           find.byType(ChecklistsWidget),
           find.byType(LinkedTasksWidget),
         ]) {


### PR DESCRIPTION
Accepting all of an agent's suggestions jumped the task page. The stabilisation layers were working exactly as designed — the design pinned the wrong edge.

## The claim, confirmed

A scripted five-item accept-all (language, title, two checklist items, a label) on the task page, sampling every visible band each 50 ms (phone viewport, rail at the viewport's centre):

| what | at the tap | 550 ms later | moved by |
|---|---|---|---|
| proposals section top | −146 | −146 | **0** — the anchor did its job |
| "Confirm all" button top | 458 | **−58** | −516, off the top of the screen |
| checklist band top | 613 | **97** | −516 |
| history top | 621 | **266** | −355 (the checklist landing pushed it back down) |

`_suggestionsAnchor` held the **top of the proposals section** still, and the header's title growth at 300 ms was corrected pre-paint as intended. But the rows that collapse on a confirm-all sit *between* that edge and everything the user is looking at, so the button they just tapped, the checklist and the history all raced upwards by the full collapsed height — over half a phone screen for five rows, ~300 px even for the two-checklist-item case — while new checklist items pushed them back down. Three smaller snaps compounded it: a resolving row's trailing slot narrowed from two buttons to one 48 px box, so its text rewrapped and the row lost a line *before* collapsing (−20/−40 px steps in the first 250 ms); the pending pill unmounting at zero stepped the section header up 20 px; and the "Confirm all" rail (−39 px) and then the whole section (−45 px) unmounted in a single frame.

So the user's read was right: it "worked" when only checklist items were added because the checklist growing below roughly cancelled the rows collapsing above.

## The fix

**The page pins the AI card's bottom edge while the card is in view** (`_cardBottomAnchor`, replacing `_suggestionsAnchor`), and the card band reports its height deltas unconditionally rather than off-screen only. Every resolved row collapses *inside* the card, so the rows still to come, the rail and everything below the card stay exactly where they were; the collapse is paid for above them, by the summary sliding down into the space the rows leave. The same scripted run after the change: button 458 → 458, checklist 613 → 613 for the entire sweep, header growth still corrected pre-paint. The off-screen branch (card scrolled above the viewport → `_belowCardAnchor` on the seam below the work bands) is unchanged, and both the predicate and the anchor now read the same edge (`_cardRegionBottomGlobal`) so they can never disagree.

With the content below the card pinned, nothing inside the section may change height in a single frame any more, so the card side changes too:

- **Rows keep their width while resolving** — `RowActions.footprintWidth` for the busy spinner and the resolve placeholder, so the text never rewraps.
- **The pending pill fades in place at zero** instead of leaving the header line.
- **The rail is always mounted inside a `SizeFadeCollapse`** and eases out when a confirm leaves one row; during a Confirm-all sweep it stays until the section leaves (`_confirmAllSweeping`), instead of dropping while the last row is still collapsing.
- **The section collapses as a unit after the last row** (retained in `_lastProposalsSection`), then is dropped via the new `SizeFadeCollapse.onCollapsed` at zero height. A section that returns later gets a fresh wrapper so it stands at full height at once and only its new rows reveal themselves.
- **The history band waits for the sweep to settle**, then eases open (`SizeFadeEntrance`); on the initial load it does not animate.

What still moves, deliberately: a checklist item landing *below* the card pushes the history down (new content appearing), and at the scroll origin the correction clamps — what a collapse cannot give back above the viewport, the content below moves up by.

## Screenshots

> **Note:** the before/after pair is captured and staged, but not yet published to R2 (no credentials on the machine that ran this). The links below use the immutable commit-addressed scheme for `8705103e1cd6f56bc3b03b3c7d348b156910b38e` and will resolve once `make pr_screenshots_publish` has run for this commit.

Same scripted five-item accept-all, captured with the harness at the tap, 450 ms into the sweep, and settled. In the mid-sweep frame the "Confirm all" button and the History section are where they were at the tap on the right and have flown to the top on the left.

### Confirm all — at the tap — mobile dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_1_tap_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_1_tap_mobile_dark.png) |
### Confirm all — 450 ms in, mid-sweep — mobile dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_2_mid_sweep_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_2_mid_sweep_mobile_dark.png) |
### Confirm all — settled — mobile dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_3_settled_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_3_settled_mobile_dark.png) |
### Confirm all — at the tap — mobile light
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_1_tap_mobile_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_1_tap_mobile_light.png) |
### Confirm all — 450 ms in, mid-sweep — mobile light
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_2_mid_sweep_mobile_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_2_mid_sweep_mobile_light.png) |
### Confirm all — settled — mobile light
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_3_settled_mobile_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_3_settled_mobile_light.png) |
### Confirm all — at the tap — desktop dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_1_tap_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_1_tap_desktop_dark.png) |
### Confirm all — 450 ms in, mid-sweep — desktop dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_2_mid_sweep_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_2_mid_sweep_desktop_dark.png) |
### Confirm all — settled — desktop dark
| Before | After |
| --- | --- |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/before/task_accept_all_3_settled_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/accept-all-scroll-stability/8705103e1cd6f56bc3b03b3c7d348b156910b38e/after/task_accept_all_3_settled_desktop_dark.png) |

## Testing

- Every new test was run with the fix reverted and fails without it: the page-level accept-all test (below-card band fixed, section top descends, offset returned), the header-growth-during-sweep composition test, the rail retention and ease-out tests, the pill fade, the section drop and return, the history latch, the row footprint, and `onCollapsed`.
- Updated: `task_form_test` (the card band reports unconditionally), and the tests that observed the section unmounting now pump its collapse. A gotcha they surfaced — an animation completes strictly *after* its duration — is written down in `test/README.md`.
- Touched files pass; analyzer zero issues on the touched trees; `make knowledge_check` and `make changelog_check` pass.

## Docs

`knowledge/features/tasks/detail-composition.md` (which edge holds, with a diagram) and `knowledge/features/agents/ui-surfaces.md` (the collapse-only contract of the section) describe the new behaviour; a `changelog.d` fragment carries the user-facing note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDCKy8gTYShiLfa4qLvE8y


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the task page from jumping upward when accepting all AI suggestions.
  - Keeps content below the AI summary card anchored while suggestion rows collapse.
  - Added smooth transitions for collapsing proposals, the “Confirm all” button, and pending counts.
  - History now appears after the acceptance animation completes, avoiding visual jumps.
  - Preserved text layout during suggestion processing by maintaining consistent action-button spacing.
- **Documentation**
  - Updated guidance describing the improved scroll and animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->