### PR TITLE
feat(measurables): record a choice instead of a number

### DIFF
--- a/changelog.d/2026-08-28-measurable-choices.md
+++ b/changelog.d/2026-08-28-measurable-choices.md
@@ -1,0 +1,20 @@
+### Added
+- **Measurables can now record a choice instead of a number.** Not everything
+  worth tracking is a quantity: how hydrated you are reads off a colour, how
+  rested you feel is a word, not a value. A measurable's *Recorded as* switch
+  now offers *Choice* next to *Number*, and a choice measurable carries its
+  own list of choices — clear, pale, dark; very rested, somewhat, not at all;
+  emojis if you like — which you can rename and reorder at any time without
+  touching what you already recorded, because each choice keeps its identity
+  behind the name. Retiring a choice archives it: it leaves the picker but
+  every entry that recorded it still shows its name, and it can be restored.
+  Recording picks a chip instead of typing a number, in the measurement sheet
+  and in a habit's completion sheet alike; the journal shows the choice by
+  name; searching for a choice's name finds its entries; and on a dashboard a
+  choice measurable draws a day strip — one cell per day, shaded by the
+  choice you ended the day on, with a legend — instead of a bar chart.
+
+### Changed
+- **The journal list formats a measurement's value exactly like the entry's
+  own summary.** A percentage measurement showed as `55 %` in the list and
+  `55%` on the entry; both now read `55%`.

--- a/knowledge/architecture/signals.md
+++ b/knowledge/architecture/signals.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/logic/signals
     title: Signals package source
-    last_modified: 2026-08-27
+    last_modified: 2026-08-28
   - id: goal-reader
     resource: ../../lib/features/goals/evaluation/goal_signal_reader.dart
     title: GoalSignalReader — the first delegating consumer
@@ -71,7 +71,9 @@ Per-series semantics, all inherited from the surfaces the user already sees:
   whole percentages.
 - **Measurables** are summed per day. A recorded zero is *present*; a day
   with no entry is absent from the map. That distinction is the whole meaning
-  of an "any entry" rule.
+  of an "any entry" rule. A choice measurable records `value: 1` per entry,
+  so its day total is an occurrence count — enough for "any entry", and the
+  reason the habit editor offers no threshold for one.
 - **Workouts** keep the `WorkoutData` list per day so thresholds can be applied
   later; `workoutSignalValue` reports minutes, kilometres (stored metres ÷
   1000) or kcal — the units the workout chart labels. They are loaded through

--- a/knowledge/domain/entity-definitions.md
+++ b/knowledge/domain/entity-definitions.md
@@ -1,9 +1,9 @@
 ---
 type: Domain Model
 title: Entity definitions
-description: The five configuration entities — categories, labels, habits, dashboards, measurables — and why the category flag is a consent switch rather than a preference.
+description: The five configuration entities — categories, labels, habits, dashboards, measurables — why the category flag is a consent switch rather than a preference, and how a measurable records a number or one of its own choices.
 resource: ../../lib/classes/entity_definitions.dart
-tags: [domain, categories, labels, habits, dashboards]
+tags: [domain, categories, labels, habits, dashboards, measurables]
 status: stable
 generated: { by: claude-code/opus-5, at: 2026-07-26T02:30:00Z }
 stale_after: 2027-07-12
@@ -11,7 +11,7 @@ sources:
   - id: definitions
     resource: ../../lib/classes/entity_definitions.dart
     title: EntityDefinition union
-    last_modified: 2026-07-26
+    last_modified: 2026-08-28
 ---
 
 `EntityDefinition` is a union of five configuration entities:
@@ -72,6 +72,45 @@ so a later category edit does not reach back into existing agents. See
 
 The category model deliberately does **not** contain prompt allowlists, and the
 old `automaticPrompts` concept is not part of it.
+
+# `MeasurableDataType` records a number or a choice
+
+A measurable's `valueKind` decides what a `MeasurementData` for it carries:
+
+| `valueKind` | Recorded as | `MeasurementData` |
+|-------------|-------------|-------------------|
+| `number` (or absent) | a `num` with the definition's `unitName` | `value` |
+| `choice` | one of the definition's `choices` | `choiceId`, with `value: 1` |
+
+**Absent means `number`.** Every measurable that predates the choice kind has
+no `valueKind` key, and `@JsonKey(unknownEnumValue: number)` makes a kind this
+build does not know read the same way, so an older client sees a newer
+definition as a numeric measurable rather than failing to decode it.
+
+**A choice is an id with a title, never a Dart enum.** `MeasurableChoice` is
+`{id, title, archived?}`: the id is what a measurement stores and stays
+constant for the choice's lifetime; the title is presentation and may be
+renamed at will without touching recorded history. That split is the whole
+point — a serialized enum value cannot be relabelled, and a user's own
+vocabulary ("clear", "pale", "dark") changes. `archived` retires a choice from
+the recording surfaces while entries that recorded it keep resolving to its
+title; an archived choice can be restored. The list order is the user's
+display order, and the only structure the set has.
+
+**The data decides, not the definition.** `measurementValueLabel`
+(`lib/features/journal/util/entry_tools.dart`) reads a measurement as a choice
+recording iff `choiceId` is set: a number recorded before the measurable was
+switched to choices still reads as its number, and a choice id still resolves
+after a switch back. A choice the definition no longer lists reads as a
+localized "removed choice" label.
+
+**`value` is `1` for a choice recording — one occurrence.** That is what lets
+every consumer that sums measurements per day — the signal window behind
+habits and goals, the numeric aggregators — count recordings instead of
+breaking on a missing number, and it is why a habit rule on a choice
+measurable can only be "any entry today": the sum is a count, not a quantity.
+`MeasurableDataTypeChoices` (`isChoice`, `activeChoices`, `archivedChoices`,
+`choiceById`) is the extension the surfaces read the kind through.
 
 # Related
 

--- a/knowledge/domain/entity-definitions.md
+++ b/knowledge/domain/entity-definitions.md
@@ -97,6 +97,11 @@ the recording surfaces while entries that recorded it keep resolving to its
 title; an archived choice can be restored. The list order is the user's
 display order, and the only structure the set has.
 
+Measurement full-text rows are derived from the current measurable name, unit,
+and choice title. Applying a local or synced definition reindexes its
+historical measurements when any of those searchable labels change; archive
+state and choice ordering alone do not rewrite the index.
+
 **The data decides, not the definition.** `measurementValueLabel`
 (`lib/features/journal/util/entry_tools.dart`) reads a measurement as a choice
 recording iff `choiceId` is set: a number recorded before the measurable was

--- a/knowledge/features/dashboards.md
+++ b/knowledge/features/dashboards.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/dashboards
     title: Dashboards feature source
-    last_modified: 2026-07-26
+    last_modified: 2026-08-28
   - id: aggregation
     resource: ../../lib/features/dashboards/state/health_data.dart
     title: Health aggregations — and which day a sample belongs to
@@ -51,7 +51,7 @@ flowchart LR
   Def["DashboardDefinition<br/>an EntityDefinition variant"] --> Items["ordered List of DashboardItem"]
   Items --> Sw{"DashboardWidget<br/>switch on the sealed variant"}
 
-  Sw -->|DashboardMeasurementItem| M["MeasurablesBarChart<br/>key: measurement:id:aggregationType<br/>enableCreate — opens capture"]
+  Sw -->|DashboardMeasurementItem| M["MeasurablesBarChart<br/>key: measurement:id:aggregationType<br/>enableCreate — opens capture<br/>choice kind → day strip + legend"]
   Sw -->|DashboardSurveyItem| S["DashboardSurveyChart<br/>key: survey:surveyType<br/>runs CFQ-11 / PANAS / GHQ-12"]
   Sw -->|DashboardHealthItem| H["DashboardHealthChart<br/>key: health:healthType"]
   Sw -->|DashboardWorkoutItem| W["DashboardWorkoutChart<br/>key: workout:workoutType:valueType"]
@@ -69,6 +69,28 @@ data across a range change, so the `State` has to follow the item; without
 identity keys, replacing an item with another of the same type at the same index
 would reuse the old `State` and show the previous item's cached data under the new
 header.
+
+**A choice measurable is the one item whose chart is not a series of
+numbers.** `MeasurablesBarChart` branches on `MeasurableDataType.isChoice`
+before any aggregation is resolved: its raw entries for the range are reduced
+by `choiceDaySeries` (`state/measurable_choice_series.dart`) to one choice per
+calendar day — the day's **latest** recording, by time then entry id, so two
+replicas agree — and drawn by `MeasurableChoiceStrip` as one cell per day under
+the same `kChartLeftAxisWidth` inset every other card uses, so the shared date
+axis reads across it. The cells are **painted** (`ChoiceStripPainter`), not
+laid out: a range runs to a year, and a row of flex children with fixed gaps
+would be wider than a phone long before that. The painter fits the range to
+its width, drops the gaps once a cell would be narrower than one and then
+merges neighbouring days of one choice into a single run; one tooltip, worded
+for the day under the pointer, replaces a tooltip per cell. Cell colours come from `choiceColorsFor`: the accent
+token stepped from `background.level03` to `interactive.enabled` across the
+definition's choice list in the user's order (archived choices keep their
+step, an unknown id draws in `decorative.level02`), which reads the list as
+the ordinal scale it is without a categorical palette the token set does not
+have. A recorded day names its date and choice in a tooltip; the footer is a
+`MeasurableChoiceLegend` of the active choices plus any archived one still
+colouring a day. The dashboard editor neither names nor edits an aggregation
+for such an item, and the measurable picker adds it with `AggregationType.none`.
 
 **Two of those keys carry a second discriminator**, and it is load-bearing:
 `measurement:id:aggregationType` and `workout:workoutType:valueType`. Changing

--- a/knowledge/features/dashboards.md
+++ b/knowledge/features/dashboards.md
@@ -74,7 +74,8 @@ header.
 numbers.** `MeasurablesBarChart` branches on `MeasurableDataType.isChoice`
 before any aggregation is resolved: its raw entries for the range are reduced
 by `choiceDaySeries` (`state/measurable_choice_series.dart`) to one choice per
-calendar day — the day's **latest** recording, by time then entry id, so two
+calendar day, including both calendar dates touched by a partial-day range —
+the day's **latest** recording, by time then entry id, so two
 replicas agree — and drawn by `MeasurableChoiceStrip` as one cell per day under
 the same `kChartLeftAxisWidth` inset every other card uses, so the shared date
 axis reads across it. The cells are **painted** (`ChoiceStripPainter`), not
@@ -87,7 +88,8 @@ token stepped from `background.level03` to `interactive.enabled` across the
 definition's choice list in the user's order (archived choices keep their
 step, an unknown id draws in `decorative.level02`), which reads the list as
 the ordinal scale it is without a categorical palette the token set does not
-have. A recorded day names its date and choice in a tooltip; the footer is a
+have. A recorded day names its date and choice in a tooltip; leaving the strip
+clears the hover tooltip. The footer is a
 `MeasurableChoiceLegend` of the active choices plus any archived one still
 colouring a day. The dashboard editor neither names nor edits an aggregation
 for such an item, and the measurable picker adds it with `AggregationType.none`.

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -653,9 +653,10 @@ flowchart TD
   the memory and restores its default target. The same rule already governs
   category- and label-time matches, so no back-edit of the statement can silently
   resurrect a signal the user removed.
-  When an edited goal references a measurable that is now choice-based, the
-  editor removes that obsolete numeric leaf and target before saving; the
-  measurable is also excluded from numeric record offers.
+  When an edited goal references a measurable that is now choice-based, save
+  waits for the current measurable definitions and removes that obsolete
+  numeric leaf and target before rebuilding criteria; the measurable is also
+  excluded from numeric record offers.
   Signals added through the picker likewise stay on the card as unchecked rows
   once unticked, until the step is re-entered and the row order is re-frozen —
   deselecting is never a deletion the user has to undo through the picker. Saving validates

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -303,6 +303,9 @@ flowchart TD
   follow the habits UI's latest-completion-per-day collapse with
   success-only counting, measurable leaves reuse their authored data-type ids,
   and category time reuses the same category-attributed timer rows as Insights.
+  Choice occurrence markers are excluded from numeric measurable evidence, so
+  changing a measurable to choices cannot accidentally satisfy an older numeric
+  goal with the stored marker value of one.
   A category-time leaf can enforce an `atLeast` or `atMost` number of hours and
   can clip every local day to an optional time band; a crossing band such as
   `21:30 → 07:00` spans midnight. Evaluation clips the current day at the
@@ -650,6 +653,9 @@ flowchart TD
   the memory and restores its default target. The same rule already governs
   category- and label-time matches, so no back-edit of the statement can silently
   resurrect a signal the user removed.
+  When an edited goal references a measurable that is now choice-based, the
+  editor removes that obsolete numeric leaf and target before saving; the
+  measurable is also excluded from numeric record offers.
   Signals added through the picker likewise stay on the card as unchecked rows
   once unticked, until the step is re-entered and the row order is re-frozen —
   deselecting is never a deletion the user has to undo through the picker. Saving validates

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/habits
     title: Habits feature source
-    last_modified: 2026-08-16
+    last_modified: 2026-08-28
   - id: definitions
     resource: ../../lib/classes/entity_definitions.dart
     title: HabitDefinition
@@ -247,7 +247,9 @@ the current instant.
 The `autoCompleteReason` stored on the entry names the satisfied leaves —
 `Water · 750`, `Steps · 7412`, `running` — resolving measurable names through
 `EntitiesCacheService` and health types through the dashboard health config,
-so the habit row can say what checked it off without another read.
+so the habit row can say what checked it off without another read. A choice
+measurable is named without its value: its day total is an occurrence count,
+not something the user recorded.
 
 Consumers: the `completions` stream and `autoCompletedToday`, which
 `HabitsSummaryCard` consults so a day the engine finished does not play the
@@ -299,7 +301,12 @@ the old dialog that embedded a whole linked dashboard. It renders **one
 measurable (its three most-logged values, from the same ranking the
 measurement dialog uses, plus *Other* for the full capture), and a two-week
 `SignalSparkline` — above the unchanged form (date, comment, Success / Skip /
-Missed, Record).
+Missed, Record). A **choice measurable** offers every active choice as a chip
+instead of suggestions — the set is the vocabulary, not a ranking — records
+one occurrence of the tapped choice (`MeasurableQuickValue`, the number-or-
+choice shape the chips, row and sheet pass around), reports today as *logged*
+rather than as a count, and in the editor its only rule is *any entry*: the
+threshold modes are numeric and are not shown for it.
 
 ```mermaid
 flowchart LR

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -172,7 +172,11 @@ Each row's rule is a segmented mode — *Any entry / Total ≥ / Total ≤* for 
 measurable, *Any reading / Daily ≥ / Daily ≤* for a health type, *Any
 workout / Duration ≥ / Distance ≥ / Energy ≥* for a workout — with a
 threshold in the signal's unit. Steps default to *Daily ≥ 6,000*; everything
-else defaults to the record-based "any" mode.
+else defaults to the record-based "any" mode. If a measurable definition is
+later changed from numeric to choice, evaluation normalizes any older stored
+minimum or maximum away recursively before reading the signal. The choice's
+occurrence marker therefore keeps the same "any entry" semantics immediately,
+even before the habit is opened and saved again.
 
 # The data model is more ambitious than the schedule surface
 

--- a/knowledge/features/settings.md
+++ b/knowledge/features/settings.md
@@ -221,6 +221,10 @@ state and flip the same `dirty` flag; a save with the choice kind refuses a
 blank title or an empty list and calls the rows out instead. What a choice is,
 and why it is an id with a title rather than an enum, is in
 [entity definitions](../domain/entity-definitions.md#measurabledatatype-records-a-number-or-a-choice).
+Changing a numeric measurable to choices also changes the valid downstream
+contract: habit evaluation treats any stored numeric bounds as obsolete, and
+the goal editor drops a stored numeric criterion for that measurable when the
+goal is next edited.
 
 Dashboards and measurables save through `PersistenceLogic`; habits save through
 `habit_settings_controller.dart`, **which also schedules notifications**.

--- a/knowledge/features/settings.md
+++ b/knowledge/features/settings.md
@@ -11,7 +11,7 @@ sources:
   - id: settings
     resource: ../../lib/features/settings
     title: Settings feature source
-    last_modified: 2026-07-26
+    last_modified: 2026-08-28
   - id: tree
     resource: ../../lib/features/settings_v2/domain/settings_tree_data.dart
     title: buildSettingsTree — the single source of truth
@@ -178,8 +178,8 @@ reuse one pattern:
    button), and the create affordance — a bottom-nav-cleared FAB on mobile, a
    header button on desktop.
 3. Rows lead with one shared 36 px rounded-square chip and keep a **stable
-   subtitle semantic per page** — counts for categories and labels, unit for
-   measurables, description for habits and dashboards.
+   subtitle semantic per page** — counts for categories and labels,
+   description for measurables, habits and dashboards.
 4. Tapping a row beams to the detail editor; the desktop split pane dispatches
    the same URLs inline.
 5. Saving or deleting goes through shared persistence or a feature-specific
@@ -210,6 +210,17 @@ subtitles. Aggregation types always render **localized names, never raw enum
 identifiers**.
 
 ## The persistence split
+
+The measurable editor carries one field the kit has no widget for: a
+*Recorded as* switch (number / choice) that decides whether the unit and
+aggregation fields are shown at all, and for the choice kind a
+`MeasurableChoicesEditor` — a reorderable list of the definition's choices,
+each renamed in place and archived rather than deleted, with an archived
+section to restore from. Both live beside the `FormBuilder` as plain widget
+state and flip the same `dirty` flag; a save with the choice kind refuses a
+blank title or an empty list and calls the rows out instead. What a choice is,
+and why it is an id with a title rather than an enum, is in
+[entity definitions](../domain/entity-definitions.md#measurabledatatype-records-a-number-or-a-choice).
 
 Dashboards and measurables save through `PersistenceLogic`; habits save through
 `habit_settings_controller.dart`, **which also schedules notifications**.

--- a/lib/classes/entity_definitions.dart
+++ b/lib/classes/entity_definitions.dart
@@ -74,7 +74,7 @@ abstract class MeasurableChoice with _$MeasurableChoice {
   const factory MeasurableChoice({
     required String id,
     required String title,
-    bool? archived,
+    @JsonKey(includeIfNull: false) bool? archived,
   }) = _MeasurableChoice;
 
   factory MeasurableChoice.fromJson(Map<String, dynamic> json) =>

--- a/lib/classes/entity_definitions.dart
+++ b/lib/classes/entity_definitions.dart
@@ -43,6 +43,44 @@ class CategoryIconConverter implements JsonConverter<CategoryIcon?, String?> {
 
 enum AggregationType { none, dailySum, dailyMax, dailyAvg, hourlySum }
 
+/// How a [MeasurableDataType] records a value.
+///
+/// Absent from JSON on every measurable that predates the choice kind, so
+/// `null` reads as [number] everywhere — the original numeric measurable is
+/// the default, never a migration.
+enum MeasurableValueKind {
+  /// A number, optionally carrying a unit ("750 ml", "7.5").
+  number,
+
+  /// One of the measurable's own [MeasurableChoice]s — a user-defined set of
+  /// named values ("clear", "pale", "dark") rather than a quantity.
+  choice,
+}
+
+/// One selectable value of a [MeasurableValueKind.choice] measurable.
+///
+/// The [id] is what a measurement stores and what stays constant for the
+/// lifetime of the choice; the [title] is presentation and may be renamed at
+/// any time without touching recorded history. That split is the whole point
+/// of not using a Dart enum: a serialized enum value cannot be relabelled,
+/// and a user's own vocabulary changes.
+///
+/// [archived] retires a choice from the recording surfaces without deleting
+/// it, so entries that recorded it keep resolving to their title. `null` and
+/// `false` both mean active; the field is nullable so older definitions
+/// deserialize unchanged.
+@freezed
+abstract class MeasurableChoice with _$MeasurableChoice {
+  const factory MeasurableChoice({
+    required String id,
+    required String title,
+    bool? archived,
+  }) = _MeasurableChoice;
+
+  factory MeasurableChoice.fromJson(Map<String, dynamic> json) =>
+      _$MeasurableChoiceFromJson(json);
+}
+
 enum HabitCompletionType { success, skip, fail, open }
 
 /// Origin of a habit completion entry.
@@ -144,6 +182,16 @@ sealed class EntityDefinition with _$EntityDefinition {
     bool? favorite,
     String? categoryId,
     AggregationType? aggregationType,
+
+    /// [MeasurableValueKind.number] when absent. A kind this build does not
+    /// know reads as `number` rather than failing the whole definition.
+    @JsonKey(unknownEnumValue: MeasurableValueKind.number)
+    MeasurableValueKind? valueKind,
+
+    /// The selectable values of a [MeasurableValueKind.choice] measurable, in
+    /// the order the user arranged them. Kept (harmlessly) when the kind is
+    /// switched back to `number`, so a round trip loses nothing.
+    List<MeasurableChoice>? choices,
   }) = MeasurableDataType;
 
   const factory EntityDefinition.categoryDefinition({
@@ -293,6 +341,12 @@ abstract class MeasurementData with _$MeasurementData {
     required DateTime dateTo,
     required num value,
     required String dataTypeId,
+
+    /// The [MeasurableChoice.id] recorded for a choice measurable. Set only
+    /// for [MeasurableValueKind.choice]; [value] is then `1` — one occurrence
+    /// — so every consumer that sums measurements per day counts recordings
+    /// instead of breaking on a missing number.
+    String? choiceId,
   }) = _MeasurementData;
 
   factory MeasurementData.fromJson(Map<String, dynamic> json) =>
@@ -421,4 +475,35 @@ sealed class DashboardItem with _$DashboardItem {
 
   factory DashboardItem.fromJson(Map<String, dynamic> json) =>
       _$DashboardItemFromJson(json);
+}
+
+/// Choice-kind helpers on a [MeasurableDataType].
+extension MeasurableDataTypeChoices on MeasurableDataType {
+  /// Whether values are recorded as one of [choices] rather than a number.
+  bool get isChoice => valueKind == MeasurableValueKind.choice;
+
+  /// The choices still offered for recording, in the user's order. Archived
+  /// choices are excluded; a definition with no list yields an empty list.
+  List<MeasurableChoice> get activeChoices => [
+    for (final choice in choices ?? const <MeasurableChoice>[])
+      if (choice.archived != true) choice,
+  ];
+
+  /// The retired choices, in the user's order, so history stays legible and
+  /// an editor can restore one.
+  List<MeasurableChoice> get archivedChoices => [
+    for (final choice in choices ?? const <MeasurableChoice>[])
+      if (choice.archived == true) choice,
+  ];
+
+  /// The choice with [id], archived or not — history that recorded an
+  /// archived choice still has to resolve its title. `null` when [id] is
+  /// `null` or names no choice of this measurable.
+  MeasurableChoice? choiceById(String? id) {
+    if (id == null) return null;
+    for (final choice in choices ?? const <MeasurableChoice>[]) {
+      if (choice.id == id) return choice;
+    }
+    return null;
+  }
 }

--- a/lib/classes/entity_definitions.dart
+++ b/lib/classes/entity_definitions.dart
@@ -346,7 +346,7 @@ abstract class MeasurementData with _$MeasurementData {
     /// for [MeasurableValueKind.choice]; [value] is then `1` — one occurrence
     /// — so every consumer that sums measurements per day counts recordings
     /// instead of breaking on a missing number.
-    String? choiceId,
+    @JsonKey(includeIfNull: false) String? choiceId,
   }) = _MeasurementData;
 
   factory MeasurementData.fromJson(Map<String, dynamic> json) =>

--- a/lib/classes/entity_definitions.freezed.dart
+++ b/lib/classes/entity_definitions.freezed.dart
@@ -286,6 +286,275 @@ as DateTime?,
 
 }
 
+
+/// @nodoc
+mixin _$MeasurableChoice {
+
+ String get id; String get title; bool? get archived;
+/// Create a copy of MeasurableChoice
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MeasurableChoiceCopyWith<MeasurableChoice> get copyWith => _$MeasurableChoiceCopyWithImpl<MeasurableChoice>(this as MeasurableChoice, _$identity);
+
+  /// Serializes this MeasurableChoice to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MeasurableChoice&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.archived, archived) || other.archived == archived));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,archived);
+
+@override
+String toString() {
+  return 'MeasurableChoice(id: $id, title: $title, archived: $archived)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MeasurableChoiceCopyWith<$Res>  {
+  factory $MeasurableChoiceCopyWith(MeasurableChoice value, $Res Function(MeasurableChoice) _then) = _$MeasurableChoiceCopyWithImpl;
+@useResult
+$Res call({
+ String id, String title, bool? archived
+});
+
+
+
+
+}
+/// @nodoc
+class _$MeasurableChoiceCopyWithImpl<$Res>
+    implements $MeasurableChoiceCopyWith<$Res> {
+  _$MeasurableChoiceCopyWithImpl(this._self, this._then);
+
+  final MeasurableChoice _self;
+  final $Res Function(MeasurableChoice) _then;
+
+/// Create a copy of MeasurableChoice
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? archived = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,archived: freezed == archived ? _self.archived : archived // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [MeasurableChoice].
+extension MeasurableChoicePatterns on MeasurableChoice {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MeasurableChoice value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MeasurableChoice() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MeasurableChoice value)  $default,){
+final _that = this;
+switch (_that) {
+case _MeasurableChoice():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MeasurableChoice value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MeasurableChoice() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String title,  bool? archived)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MeasurableChoice() when $default != null:
+return $default(_that.id,_that.title,_that.archived);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String title,  bool? archived)  $default,) {final _that = this;
+switch (_that) {
+case _MeasurableChoice():
+return $default(_that.id,_that.title,_that.archived);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String title,  bool? archived)?  $default,) {final _that = this;
+switch (_that) {
+case _MeasurableChoice() when $default != null:
+return $default(_that.id,_that.title,_that.archived);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _MeasurableChoice implements MeasurableChoice {
+  const _MeasurableChoice({required this.id, required this.title, this.archived});
+  factory _MeasurableChoice.fromJson(Map<String, dynamic> json) => _$MeasurableChoiceFromJson(json);
+
+@override final  String id;
+@override final  String title;
+@override final  bool? archived;
+
+/// Create a copy of MeasurableChoice
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MeasurableChoiceCopyWith<_MeasurableChoice> get copyWith => __$MeasurableChoiceCopyWithImpl<_MeasurableChoice>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$MeasurableChoiceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MeasurableChoice&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.archived, archived) || other.archived == archived));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,archived);
+
+@override
+String toString() {
+  return 'MeasurableChoice(id: $id, title: $title, archived: $archived)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MeasurableChoiceCopyWith<$Res> implements $MeasurableChoiceCopyWith<$Res> {
+  factory _$MeasurableChoiceCopyWith(_MeasurableChoice value, $Res Function(_MeasurableChoice) _then) = __$MeasurableChoiceCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String title, bool? archived
+});
+
+
+
+
+}
+/// @nodoc
+class __$MeasurableChoiceCopyWithImpl<$Res>
+    implements _$MeasurableChoiceCopyWith<$Res> {
+  __$MeasurableChoiceCopyWithImpl(this._self, this._then);
+
+  final _MeasurableChoice _self;
+  final $Res Function(_MeasurableChoice) _then;
+
+/// Create a copy of MeasurableChoice
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? archived = freezed,}) {
+  return _then(_MeasurableChoice(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,archived: freezed == archived ? _self.archived : archived // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
 HabitSchedule _$HabitScheduleFromJson(
   Map<String, dynamic> json
 ) {
@@ -1753,10 +2022,10 @@ return dashboard(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String displayName,  String description,  String unitName,  int version,  VectorClock? vectorClock,  DateTime? deletedAt,  bool? private,  bool? favorite,  String? categoryId,  AggregationType? aggregationType)?  measurableDataType,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  VectorClock? vectorClock,  bool private,  bool active,  bool? favorite,  String? color,  String? categoryId,  DateTime? deletedAt,  String? defaultLanguageCode, @CategoryIconConverter()  CategoryIcon? icon,  List<String>? speechDictionary,  List<ChecklistCorrectionExample>? correctionExamples,  String? defaultProfileId,  bool? automaticInferenceEnabled,  String? defaultTemplateId,  bool? automaticAgentWakesEnabled,  String? defaultEventTemplateId,  bool? isAvailableForDayPlan)?  categoryDefinition,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String color,  VectorClock? vectorClock,  String? description,  int? sortOrder,  List<String>? applicableCategoryIds,  DateTime? deletedAt,  bool? private)?  labelDefinition,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String description,  HabitSchedule habitSchedule,  VectorClock? vectorClock,  bool active,  bool private,  AutoCompleteRule? autoCompleteRule,  String? version,  DateTime? activeFrom,  DateTime? activeUntil,  DateTime? deletedAt, @Deprecated('Tags concept removed — kept for JSON backward compatibility')  String? defaultStoryId,  String? categoryId,  bool? priority,  bool autoCompleteNotify)?  habit,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  DateTime lastReviewed,  String name,  String description,  List<DashboardItem> items,  String version,  VectorClock? vectorClock,  bool active,  bool private,  DateTime? reviewAt,  int days,  DateTime? deletedAt,  String? categoryId)?  dashboard,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String displayName,  String description,  String unitName,  int version,  VectorClock? vectorClock,  DateTime? deletedAt,  bool? private,  bool? favorite,  String? categoryId,  AggregationType? aggregationType, @JsonKey(unknownEnumValue: MeasurableValueKind.number)  MeasurableValueKind? valueKind,  List<MeasurableChoice>? choices)?  measurableDataType,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  VectorClock? vectorClock,  bool private,  bool active,  bool? favorite,  String? color,  String? categoryId,  DateTime? deletedAt,  String? defaultLanguageCode, @CategoryIconConverter()  CategoryIcon? icon,  List<String>? speechDictionary,  List<ChecklistCorrectionExample>? correctionExamples,  String? defaultProfileId,  bool? automaticInferenceEnabled,  String? defaultTemplateId,  bool? automaticAgentWakesEnabled,  String? defaultEventTemplateId,  bool? isAvailableForDayPlan)?  categoryDefinition,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String color,  VectorClock? vectorClock,  String? description,  int? sortOrder,  List<String>? applicableCategoryIds,  DateTime? deletedAt,  bool? private)?  labelDefinition,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String description,  HabitSchedule habitSchedule,  VectorClock? vectorClock,  bool active,  bool private,  AutoCompleteRule? autoCompleteRule,  String? version,  DateTime? activeFrom,  DateTime? activeUntil,  DateTime? deletedAt, @Deprecated('Tags concept removed — kept for JSON backward compatibility')  String? defaultStoryId,  String? categoryId,  bool? priority,  bool autoCompleteNotify)?  habit,TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  DateTime lastReviewed,  String name,  String description,  List<DashboardItem> items,  String version,  VectorClock? vectorClock,  bool active,  bool private,  DateTime? reviewAt,  int days,  DateTime? deletedAt,  String? categoryId)?  dashboard,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case MeasurableDataType() when measurableDataType != null:
-return measurableDataType(_that.id,_that.createdAt,_that.updatedAt,_that.displayName,_that.description,_that.unitName,_that.version,_that.vectorClock,_that.deletedAt,_that.private,_that.favorite,_that.categoryId,_that.aggregationType);case CategoryDefinition() when categoryDefinition != null:
+return measurableDataType(_that.id,_that.createdAt,_that.updatedAt,_that.displayName,_that.description,_that.unitName,_that.version,_that.vectorClock,_that.deletedAt,_that.private,_that.favorite,_that.categoryId,_that.aggregationType,_that.valueKind,_that.choices);case CategoryDefinition() when categoryDefinition != null:
 return categoryDefinition(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.vectorClock,_that.private,_that.active,_that.favorite,_that.color,_that.categoryId,_that.deletedAt,_that.defaultLanguageCode,_that.icon,_that.speechDictionary,_that.correctionExamples,_that.defaultProfileId,_that.automaticInferenceEnabled,_that.defaultTemplateId,_that.automaticAgentWakesEnabled,_that.defaultEventTemplateId,_that.isAvailableForDayPlan);case LabelDefinition() when labelDefinition != null:
 return labelDefinition(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.color,_that.vectorClock,_that.description,_that.sortOrder,_that.applicableCategoryIds,_that.deletedAt,_that.private);case HabitDefinition() when habit != null:
 return habit(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.description,_that.habitSchedule,_that.vectorClock,_that.active,_that.private,_that.autoCompleteRule,_that.version,_that.activeFrom,_that.activeUntil,_that.deletedAt,_that.defaultStoryId,_that.categoryId,_that.priority,_that.autoCompleteNotify);case DashboardDefinition() when dashboard != null:
@@ -1778,10 +2047,10 @@ return dashboard(_that.id,_that.createdAt,_that.updatedAt,_that.lastReviewed,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String displayName,  String description,  String unitName,  int version,  VectorClock? vectorClock,  DateTime? deletedAt,  bool? private,  bool? favorite,  String? categoryId,  AggregationType? aggregationType)  measurableDataType,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  VectorClock? vectorClock,  bool private,  bool active,  bool? favorite,  String? color,  String? categoryId,  DateTime? deletedAt,  String? defaultLanguageCode, @CategoryIconConverter()  CategoryIcon? icon,  List<String>? speechDictionary,  List<ChecklistCorrectionExample>? correctionExamples,  String? defaultProfileId,  bool? automaticInferenceEnabled,  String? defaultTemplateId,  bool? automaticAgentWakesEnabled,  String? defaultEventTemplateId,  bool? isAvailableForDayPlan)  categoryDefinition,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String color,  VectorClock? vectorClock,  String? description,  int? sortOrder,  List<String>? applicableCategoryIds,  DateTime? deletedAt,  bool? private)  labelDefinition,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String description,  HabitSchedule habitSchedule,  VectorClock? vectorClock,  bool active,  bool private,  AutoCompleteRule? autoCompleteRule,  String? version,  DateTime? activeFrom,  DateTime? activeUntil,  DateTime? deletedAt, @Deprecated('Tags concept removed — kept for JSON backward compatibility')  String? defaultStoryId,  String? categoryId,  bool? priority,  bool autoCompleteNotify)  habit,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  DateTime lastReviewed,  String name,  String description,  List<DashboardItem> items,  String version,  VectorClock? vectorClock,  bool active,  bool private,  DateTime? reviewAt,  int days,  DateTime? deletedAt,  String? categoryId)  dashboard,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String displayName,  String description,  String unitName,  int version,  VectorClock? vectorClock,  DateTime? deletedAt,  bool? private,  bool? favorite,  String? categoryId,  AggregationType? aggregationType, @JsonKey(unknownEnumValue: MeasurableValueKind.number)  MeasurableValueKind? valueKind,  List<MeasurableChoice>? choices)  measurableDataType,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  VectorClock? vectorClock,  bool private,  bool active,  bool? favorite,  String? color,  String? categoryId,  DateTime? deletedAt,  String? defaultLanguageCode, @CategoryIconConverter()  CategoryIcon? icon,  List<String>? speechDictionary,  List<ChecklistCorrectionExample>? correctionExamples,  String? defaultProfileId,  bool? automaticInferenceEnabled,  String? defaultTemplateId,  bool? automaticAgentWakesEnabled,  String? defaultEventTemplateId,  bool? isAvailableForDayPlan)  categoryDefinition,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String color,  VectorClock? vectorClock,  String? description,  int? sortOrder,  List<String>? applicableCategoryIds,  DateTime? deletedAt,  bool? private)  labelDefinition,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String description,  HabitSchedule habitSchedule,  VectorClock? vectorClock,  bool active,  bool private,  AutoCompleteRule? autoCompleteRule,  String? version,  DateTime? activeFrom,  DateTime? activeUntil,  DateTime? deletedAt, @Deprecated('Tags concept removed — kept for JSON backward compatibility')  String? defaultStoryId,  String? categoryId,  bool? priority,  bool autoCompleteNotify)  habit,required TResult Function( String id,  DateTime createdAt,  DateTime updatedAt,  DateTime lastReviewed,  String name,  String description,  List<DashboardItem> items,  String version,  VectorClock? vectorClock,  bool active,  bool private,  DateTime? reviewAt,  int days,  DateTime? deletedAt,  String? categoryId)  dashboard,}) {final _that = this;
 switch (_that) {
 case MeasurableDataType():
-return measurableDataType(_that.id,_that.createdAt,_that.updatedAt,_that.displayName,_that.description,_that.unitName,_that.version,_that.vectorClock,_that.deletedAt,_that.private,_that.favorite,_that.categoryId,_that.aggregationType);case CategoryDefinition():
+return measurableDataType(_that.id,_that.createdAt,_that.updatedAt,_that.displayName,_that.description,_that.unitName,_that.version,_that.vectorClock,_that.deletedAt,_that.private,_that.favorite,_that.categoryId,_that.aggregationType,_that.valueKind,_that.choices);case CategoryDefinition():
 return categoryDefinition(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.vectorClock,_that.private,_that.active,_that.favorite,_that.color,_that.categoryId,_that.deletedAt,_that.defaultLanguageCode,_that.icon,_that.speechDictionary,_that.correctionExamples,_that.defaultProfileId,_that.automaticInferenceEnabled,_that.defaultTemplateId,_that.automaticAgentWakesEnabled,_that.defaultEventTemplateId,_that.isAvailableForDayPlan);case LabelDefinition():
 return labelDefinition(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.color,_that.vectorClock,_that.description,_that.sortOrder,_that.applicableCategoryIds,_that.deletedAt,_that.private);case HabitDefinition():
 return habit(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.description,_that.habitSchedule,_that.vectorClock,_that.active,_that.private,_that.autoCompleteRule,_that.version,_that.activeFrom,_that.activeUntil,_that.deletedAt,_that.defaultStoryId,_that.categoryId,_that.priority,_that.autoCompleteNotify);case DashboardDefinition():
@@ -1799,10 +2068,10 @@ return dashboard(_that.id,_that.createdAt,_that.updatedAt,_that.lastReviewed,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String displayName,  String description,  String unitName,  int version,  VectorClock? vectorClock,  DateTime? deletedAt,  bool? private,  bool? favorite,  String? categoryId,  AggregationType? aggregationType)?  measurableDataType,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  VectorClock? vectorClock,  bool private,  bool active,  bool? favorite,  String? color,  String? categoryId,  DateTime? deletedAt,  String? defaultLanguageCode, @CategoryIconConverter()  CategoryIcon? icon,  List<String>? speechDictionary,  List<ChecklistCorrectionExample>? correctionExamples,  String? defaultProfileId,  bool? automaticInferenceEnabled,  String? defaultTemplateId,  bool? automaticAgentWakesEnabled,  String? defaultEventTemplateId,  bool? isAvailableForDayPlan)?  categoryDefinition,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String color,  VectorClock? vectorClock,  String? description,  int? sortOrder,  List<String>? applicableCategoryIds,  DateTime? deletedAt,  bool? private)?  labelDefinition,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String description,  HabitSchedule habitSchedule,  VectorClock? vectorClock,  bool active,  bool private,  AutoCompleteRule? autoCompleteRule,  String? version,  DateTime? activeFrom,  DateTime? activeUntil,  DateTime? deletedAt, @Deprecated('Tags concept removed — kept for JSON backward compatibility')  String? defaultStoryId,  String? categoryId,  bool? priority,  bool autoCompleteNotify)?  habit,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  DateTime lastReviewed,  String name,  String description,  List<DashboardItem> items,  String version,  VectorClock? vectorClock,  bool active,  bool private,  DateTime? reviewAt,  int days,  DateTime? deletedAt,  String? categoryId)?  dashboard,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String displayName,  String description,  String unitName,  int version,  VectorClock? vectorClock,  DateTime? deletedAt,  bool? private,  bool? favorite,  String? categoryId,  AggregationType? aggregationType, @JsonKey(unknownEnumValue: MeasurableValueKind.number)  MeasurableValueKind? valueKind,  List<MeasurableChoice>? choices)?  measurableDataType,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  VectorClock? vectorClock,  bool private,  bool active,  bool? favorite,  String? color,  String? categoryId,  DateTime? deletedAt,  String? defaultLanguageCode, @CategoryIconConverter()  CategoryIcon? icon,  List<String>? speechDictionary,  List<ChecklistCorrectionExample>? correctionExamples,  String? defaultProfileId,  bool? automaticInferenceEnabled,  String? defaultTemplateId,  bool? automaticAgentWakesEnabled,  String? defaultEventTemplateId,  bool? isAvailableForDayPlan)?  categoryDefinition,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String color,  VectorClock? vectorClock,  String? description,  int? sortOrder,  List<String>? applicableCategoryIds,  DateTime? deletedAt,  bool? private)?  labelDefinition,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  String name,  String description,  HabitSchedule habitSchedule,  VectorClock? vectorClock,  bool active,  bool private,  AutoCompleteRule? autoCompleteRule,  String? version,  DateTime? activeFrom,  DateTime? activeUntil,  DateTime? deletedAt, @Deprecated('Tags concept removed — kept for JSON backward compatibility')  String? defaultStoryId,  String? categoryId,  bool? priority,  bool autoCompleteNotify)?  habit,TResult? Function( String id,  DateTime createdAt,  DateTime updatedAt,  DateTime lastReviewed,  String name,  String description,  List<DashboardItem> items,  String version,  VectorClock? vectorClock,  bool active,  bool private,  DateTime? reviewAt,  int days,  DateTime? deletedAt,  String? categoryId)?  dashboard,}) {final _that = this;
 switch (_that) {
 case MeasurableDataType() when measurableDataType != null:
-return measurableDataType(_that.id,_that.createdAt,_that.updatedAt,_that.displayName,_that.description,_that.unitName,_that.version,_that.vectorClock,_that.deletedAt,_that.private,_that.favorite,_that.categoryId,_that.aggregationType);case CategoryDefinition() when categoryDefinition != null:
+return measurableDataType(_that.id,_that.createdAt,_that.updatedAt,_that.displayName,_that.description,_that.unitName,_that.version,_that.vectorClock,_that.deletedAt,_that.private,_that.favorite,_that.categoryId,_that.aggregationType,_that.valueKind,_that.choices);case CategoryDefinition() when categoryDefinition != null:
 return categoryDefinition(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.vectorClock,_that.private,_that.active,_that.favorite,_that.color,_that.categoryId,_that.deletedAt,_that.defaultLanguageCode,_that.icon,_that.speechDictionary,_that.correctionExamples,_that.defaultProfileId,_that.automaticInferenceEnabled,_that.defaultTemplateId,_that.automaticAgentWakesEnabled,_that.defaultEventTemplateId,_that.isAvailableForDayPlan);case LabelDefinition() when labelDefinition != null:
 return labelDefinition(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.color,_that.vectorClock,_that.description,_that.sortOrder,_that.applicableCategoryIds,_that.deletedAt,_that.private);case HabitDefinition() when habit != null:
 return habit(_that.id,_that.createdAt,_that.updatedAt,_that.name,_that.description,_that.habitSchedule,_that.vectorClock,_that.active,_that.private,_that.autoCompleteRule,_that.version,_that.activeFrom,_that.activeUntil,_that.deletedAt,_that.defaultStoryId,_that.categoryId,_that.priority,_that.autoCompleteNotify);case DashboardDefinition() when dashboard != null:
@@ -1818,7 +2087,7 @@ return dashboard(_that.id,_that.createdAt,_that.updatedAt,_that.lastReviewed,_th
 @JsonSerializable()
 
 class MeasurableDataType implements EntityDefinition {
-  const MeasurableDataType({required this.id, required this.createdAt, required this.updatedAt, required this.displayName, required this.description, required this.unitName, required this.version, required this.vectorClock, this.deletedAt, this.private, this.favorite, this.categoryId, this.aggregationType, final  String? $type}): $type = $type ?? 'measurableDataType';
+  const MeasurableDataType({required this.id, required this.createdAt, required this.updatedAt, required this.displayName, required this.description, required this.unitName, required this.version, required this.vectorClock, this.deletedAt, this.private, this.favorite, this.categoryId, this.aggregationType, @JsonKey(unknownEnumValue: MeasurableValueKind.number) this.valueKind, final  List<MeasurableChoice>? choices, final  String? $type}): _choices = choices,$type = $type ?? 'measurableDataType';
   factory MeasurableDataType.fromJson(Map<String, dynamic> json) => _$MeasurableDataTypeFromJson(json);
 
 @override final  String id;
@@ -1834,6 +2103,24 @@ class MeasurableDataType implements EntityDefinition {
  final  bool? favorite;
  final  String? categoryId;
  final  AggregationType? aggregationType;
+/// [MeasurableValueKind.number] when absent. A kind this build does not
+/// know reads as `number` rather than failing the whole definition.
+@JsonKey(unknownEnumValue: MeasurableValueKind.number) final  MeasurableValueKind? valueKind;
+/// The selectable values of a [MeasurableValueKind.choice] measurable, in
+/// the order the user arranged them. Kept (harmlessly) when the kind is
+/// switched back to `number`, so a round trip loses nothing.
+ final  List<MeasurableChoice>? _choices;
+/// The selectable values of a [MeasurableValueKind.choice] measurable, in
+/// the order the user arranged them. Kept (harmlessly) when the kind is
+/// switched back to `number`, so a round trip loses nothing.
+ List<MeasurableChoice>? get choices {
+  final value = _choices;
+  if (value == null) return null;
+  if (_choices is EqualUnmodifiableListView) return _choices;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
 
 @JsonKey(name: 'runtimeType')
 final String $type;
@@ -1852,16 +2139,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MeasurableDataType&&(identical(other.id, id) || other.id == id)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.description, description) || other.description == description)&&(identical(other.unitName, unitName) || other.unitName == unitName)&&(identical(other.version, version) || other.version == version)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.private, private) || other.private == private)&&(identical(other.favorite, favorite) || other.favorite == favorite)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.aggregationType, aggregationType) || other.aggregationType == aggregationType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MeasurableDataType&&(identical(other.id, id) || other.id == id)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.description, description) || other.description == description)&&(identical(other.unitName, unitName) || other.unitName == unitName)&&(identical(other.version, version) || other.version == version)&&(identical(other.vectorClock, vectorClock) || other.vectorClock == vectorClock)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.private, private) || other.private == private)&&(identical(other.favorite, favorite) || other.favorite == favorite)&&(identical(other.categoryId, categoryId) || other.categoryId == categoryId)&&(identical(other.aggregationType, aggregationType) || other.aggregationType == aggregationType)&&(identical(other.valueKind, valueKind) || other.valueKind == valueKind)&&const DeepCollectionEquality().equals(other._choices, _choices));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,createdAt,updatedAt,displayName,description,unitName,version,vectorClock,deletedAt,private,favorite,categoryId,aggregationType);
+int get hashCode => Object.hash(runtimeType,id,createdAt,updatedAt,displayName,description,unitName,version,vectorClock,deletedAt,private,favorite,categoryId,aggregationType,valueKind,const DeepCollectionEquality().hash(_choices));
 
 @override
 String toString() {
-  return 'EntityDefinition.measurableDataType(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, displayName: $displayName, description: $description, unitName: $unitName, version: $version, vectorClock: $vectorClock, deletedAt: $deletedAt, private: $private, favorite: $favorite, categoryId: $categoryId, aggregationType: $aggregationType)';
+  return 'EntityDefinition.measurableDataType(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, displayName: $displayName, description: $description, unitName: $unitName, version: $version, vectorClock: $vectorClock, deletedAt: $deletedAt, private: $private, favorite: $favorite, categoryId: $categoryId, aggregationType: $aggregationType, valueKind: $valueKind, choices: $choices)';
 }
 
 
@@ -1872,7 +2159,7 @@ abstract mixin class $MeasurableDataTypeCopyWith<$Res> implements $EntityDefinit
   factory $MeasurableDataTypeCopyWith(MeasurableDataType value, $Res Function(MeasurableDataType) _then) = _$MeasurableDataTypeCopyWithImpl;
 @override @useResult
 $Res call({
- String id, DateTime createdAt, DateTime updatedAt, String displayName, String description, String unitName, int version, VectorClock? vectorClock, DateTime? deletedAt, bool? private, bool? favorite, String? categoryId, AggregationType? aggregationType
+ String id, DateTime createdAt, DateTime updatedAt, String displayName, String description, String unitName, int version, VectorClock? vectorClock, DateTime? deletedAt, bool? private, bool? favorite, String? categoryId, AggregationType? aggregationType,@JsonKey(unknownEnumValue: MeasurableValueKind.number) MeasurableValueKind? valueKind, List<MeasurableChoice>? choices
 });
 
 
@@ -1889,7 +2176,7 @@ class _$MeasurableDataTypeCopyWithImpl<$Res>
 
 /// Create a copy of EntityDefinition
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? createdAt = null,Object? updatedAt = null,Object? displayName = null,Object? description = null,Object? unitName = null,Object? version = null,Object? vectorClock = freezed,Object? deletedAt = freezed,Object? private = freezed,Object? favorite = freezed,Object? categoryId = freezed,Object? aggregationType = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? createdAt = null,Object? updatedAt = null,Object? displayName = null,Object? description = null,Object? unitName = null,Object? version = null,Object? vectorClock = freezed,Object? deletedAt = freezed,Object? private = freezed,Object? favorite = freezed,Object? categoryId = freezed,Object? aggregationType = freezed,Object? valueKind = freezed,Object? choices = freezed,}) {
   return _then(MeasurableDataType(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
@@ -1904,7 +2191,9 @@ as DateTime?,private: freezed == private ? _self.private : private // ignore: ca
 as bool?,favorite: freezed == favorite ? _self.favorite : favorite // ignore: cast_nullable_to_non_nullable
 as bool?,categoryId: freezed == categoryId ? _self.categoryId : categoryId // ignore: cast_nullable_to_non_nullable
 as String?,aggregationType: freezed == aggregationType ? _self.aggregationType : aggregationType // ignore: cast_nullable_to_non_nullable
-as AggregationType?,
+as AggregationType?,valueKind: freezed == valueKind ? _self.valueKind : valueKind // ignore: cast_nullable_to_non_nullable
+as MeasurableValueKind?,choices: freezed == choices ? _self._choices : choices // ignore: cast_nullable_to_non_nullable
+as List<MeasurableChoice>?,
   ));
 }
 
@@ -2416,7 +2705,11 @@ as String?,
 /// @nodoc
 mixin _$MeasurementData {
 
- DateTime get dateFrom; DateTime get dateTo; num get value; String get dataTypeId;
+ DateTime get dateFrom; DateTime get dateTo; num get value; String get dataTypeId;/// The [MeasurableChoice.id] recorded for a choice measurable. Set only
+/// for [MeasurableValueKind.choice]; [value] is then `1` — one occurrence
+/// — so every consumer that sums measurements per day counts recordings
+/// instead of breaking on a missing number.
+ String? get choiceId;
 /// Create a copy of MeasurementData
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2429,16 +2722,16 @@ $MeasurementDataCopyWith<MeasurementData> get copyWith => _$MeasurementDataCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MeasurementData&&(identical(other.dateFrom, dateFrom) || other.dateFrom == dateFrom)&&(identical(other.dateTo, dateTo) || other.dateTo == dateTo)&&(identical(other.value, value) || other.value == value)&&(identical(other.dataTypeId, dataTypeId) || other.dataTypeId == dataTypeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MeasurementData&&(identical(other.dateFrom, dateFrom) || other.dateFrom == dateFrom)&&(identical(other.dateTo, dateTo) || other.dateTo == dateTo)&&(identical(other.value, value) || other.value == value)&&(identical(other.dataTypeId, dataTypeId) || other.dataTypeId == dataTypeId)&&(identical(other.choiceId, choiceId) || other.choiceId == choiceId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,dateFrom,dateTo,value,dataTypeId);
+int get hashCode => Object.hash(runtimeType,dateFrom,dateTo,value,dataTypeId,choiceId);
 
 @override
 String toString() {
-  return 'MeasurementData(dateFrom: $dateFrom, dateTo: $dateTo, value: $value, dataTypeId: $dataTypeId)';
+  return 'MeasurementData(dateFrom: $dateFrom, dateTo: $dateTo, value: $value, dataTypeId: $dataTypeId, choiceId: $choiceId)';
 }
 
 
@@ -2449,7 +2742,7 @@ abstract mixin class $MeasurementDataCopyWith<$Res>  {
   factory $MeasurementDataCopyWith(MeasurementData value, $Res Function(MeasurementData) _then) = _$MeasurementDataCopyWithImpl;
 @useResult
 $Res call({
- DateTime dateFrom, DateTime dateTo, num value, String dataTypeId
+ DateTime dateFrom, DateTime dateTo, num value, String dataTypeId, String? choiceId
 });
 
 
@@ -2466,13 +2759,14 @@ class _$MeasurementDataCopyWithImpl<$Res>
 
 /// Create a copy of MeasurementData
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? dateFrom = null,Object? dateTo = null,Object? value = null,Object? dataTypeId = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? dateFrom = null,Object? dateTo = null,Object? value = null,Object? dataTypeId = null,Object? choiceId = freezed,}) {
   return _then(_self.copyWith(
 dateFrom: null == dateFrom ? _self.dateFrom : dateFrom // ignore: cast_nullable_to_non_nullable
 as DateTime,dateTo: null == dateTo ? _self.dateTo : dateTo // ignore: cast_nullable_to_non_nullable
 as DateTime,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
 as num,dataTypeId: null == dataTypeId ? _self.dataTypeId : dataTypeId // ignore: cast_nullable_to_non_nullable
-as String,
+as String,choiceId: freezed == choiceId ? _self.choiceId : choiceId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -2557,10 +2851,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId,  String? choiceId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MeasurementData() when $default != null:
-return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId);case _:
+return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.choiceId);case _:
   return orElse();
 
 }
@@ -2578,10 +2872,10 @@ return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId);case _
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId,  String? choiceId)  $default,) {final _that = this;
 switch (_that) {
 case _MeasurementData():
-return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId);case _:
+return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.choiceId);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -2598,10 +2892,10 @@ return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId);case _
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId,  String? choiceId)?  $default,) {final _that = this;
 switch (_that) {
 case _MeasurementData() when $default != null:
-return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId);case _:
+return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.choiceId);case _:
   return null;
 
 }
@@ -2613,13 +2907,18 @@ return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId);case _
 @JsonSerializable()
 
 class _MeasurementData implements MeasurementData {
-  const _MeasurementData({required this.dateFrom, required this.dateTo, required this.value, required this.dataTypeId});
+  const _MeasurementData({required this.dateFrom, required this.dateTo, required this.value, required this.dataTypeId, this.choiceId});
   factory _MeasurementData.fromJson(Map<String, dynamic> json) => _$MeasurementDataFromJson(json);
 
 @override final  DateTime dateFrom;
 @override final  DateTime dateTo;
 @override final  num value;
 @override final  String dataTypeId;
+/// The [MeasurableChoice.id] recorded for a choice measurable. Set only
+/// for [MeasurableValueKind.choice]; [value] is then `1` — one occurrence
+/// — so every consumer that sums measurements per day counts recordings
+/// instead of breaking on a missing number.
+@override final  String? choiceId;
 
 /// Create a copy of MeasurementData
 /// with the given fields replaced by the non-null parameter values.
@@ -2634,16 +2933,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MeasurementData&&(identical(other.dateFrom, dateFrom) || other.dateFrom == dateFrom)&&(identical(other.dateTo, dateTo) || other.dateTo == dateTo)&&(identical(other.value, value) || other.value == value)&&(identical(other.dataTypeId, dataTypeId) || other.dataTypeId == dataTypeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MeasurementData&&(identical(other.dateFrom, dateFrom) || other.dateFrom == dateFrom)&&(identical(other.dateTo, dateTo) || other.dateTo == dateTo)&&(identical(other.value, value) || other.value == value)&&(identical(other.dataTypeId, dataTypeId) || other.dataTypeId == dataTypeId)&&(identical(other.choiceId, choiceId) || other.choiceId == choiceId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,dateFrom,dateTo,value,dataTypeId);
+int get hashCode => Object.hash(runtimeType,dateFrom,dateTo,value,dataTypeId,choiceId);
 
 @override
 String toString() {
-  return 'MeasurementData(dateFrom: $dateFrom, dateTo: $dateTo, value: $value, dataTypeId: $dataTypeId)';
+  return 'MeasurementData(dateFrom: $dateFrom, dateTo: $dateTo, value: $value, dataTypeId: $dataTypeId, choiceId: $choiceId)';
 }
 
 
@@ -2654,7 +2953,7 @@ abstract mixin class _$MeasurementDataCopyWith<$Res> implements $MeasurementData
   factory _$MeasurementDataCopyWith(_MeasurementData value, $Res Function(_MeasurementData) _then) = __$MeasurementDataCopyWithImpl;
 @override @useResult
 $Res call({
- DateTime dateFrom, DateTime dateTo, num value, String dataTypeId
+ DateTime dateFrom, DateTime dateTo, num value, String dataTypeId, String? choiceId
 });
 
 
@@ -2671,13 +2970,14 @@ class __$MeasurementDataCopyWithImpl<$Res>
 
 /// Create a copy of MeasurementData
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? dateFrom = null,Object? dateTo = null,Object? value = null,Object? dataTypeId = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? dateFrom = null,Object? dateTo = null,Object? value = null,Object? dataTypeId = null,Object? choiceId = freezed,}) {
   return _then(_MeasurementData(
 dateFrom: null == dateFrom ? _self.dateFrom : dateFrom // ignore: cast_nullable_to_non_nullable
 as DateTime,dateTo: null == dateTo ? _self.dateTo : dateTo // ignore: cast_nullable_to_non_nullable
 as DateTime,value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
 as num,dataTypeId: null == dataTypeId ? _self.dataTypeId : dataTypeId // ignore: cast_nullable_to_non_nullable
-as String,
+as String,choiceId: freezed == choiceId ? _self.choiceId : choiceId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/classes/entity_definitions.freezed.dart
+++ b/lib/classes/entity_definitions.freezed.dart
@@ -2709,7 +2709,7 @@ mixin _$MeasurementData {
 /// for [MeasurableValueKind.choice]; [value] is then `1` — one occurrence
 /// — so every consumer that sums measurements per day counts recordings
 /// instead of breaking on a missing number.
- String? get choiceId;
+@JsonKey(includeIfNull: false) String? get choiceId;
 /// Create a copy of MeasurementData
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2742,7 +2742,7 @@ abstract mixin class $MeasurementDataCopyWith<$Res>  {
   factory $MeasurementDataCopyWith(MeasurementData value, $Res Function(MeasurementData) _then) = _$MeasurementDataCopyWithImpl;
 @useResult
 $Res call({
- DateTime dateFrom, DateTime dateTo, num value, String dataTypeId, String? choiceId
+ DateTime dateFrom, DateTime dateTo, num value, String dataTypeId,@JsonKey(includeIfNull: false) String? choiceId
 });
 
 
@@ -2851,7 +2851,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId,  String? choiceId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId, @JsonKey(includeIfNull: false)  String? choiceId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MeasurementData() when $default != null:
 return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.choiceId);case _:
@@ -2872,7 +2872,7 @@ return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId,  String? choiceId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId, @JsonKey(includeIfNull: false)  String? choiceId)  $default,) {final _that = this;
 switch (_that) {
 case _MeasurementData():
 return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.choiceId);case _:
@@ -2892,7 +2892,7 @@ return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId,  String? choiceId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime dateFrom,  DateTime dateTo,  num value,  String dataTypeId, @JsonKey(includeIfNull: false)  String? choiceId)?  $default,) {final _that = this;
 switch (_that) {
 case _MeasurementData() when $default != null:
 return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.choiceId);case _:
@@ -2907,7 +2907,7 @@ return $default(_that.dateFrom,_that.dateTo,_that.value,_that.dataTypeId,_that.c
 @JsonSerializable()
 
 class _MeasurementData implements MeasurementData {
-  const _MeasurementData({required this.dateFrom, required this.dateTo, required this.value, required this.dataTypeId, this.choiceId});
+  const _MeasurementData({required this.dateFrom, required this.dateTo, required this.value, required this.dataTypeId, @JsonKey(includeIfNull: false) this.choiceId});
   factory _MeasurementData.fromJson(Map<String, dynamic> json) => _$MeasurementDataFromJson(json);
 
 @override final  DateTime dateFrom;
@@ -2918,7 +2918,7 @@ class _MeasurementData implements MeasurementData {
 /// for [MeasurableValueKind.choice]; [value] is then `1` — one occurrence
 /// — so every consumer that sums measurements per day counts recordings
 /// instead of breaking on a missing number.
-@override final  String? choiceId;
+@override@JsonKey(includeIfNull: false) final  String? choiceId;
 
 /// Create a copy of MeasurementData
 /// with the given fields replaced by the non-null parameter values.
@@ -2953,7 +2953,7 @@ abstract mixin class _$MeasurementDataCopyWith<$Res> implements $MeasurementData
   factory _$MeasurementDataCopyWith(_MeasurementData value, $Res Function(_MeasurementData) _then) = __$MeasurementDataCopyWithImpl;
 @override @useResult
 $Res call({
- DateTime dateFrom, DateTime dateTo, num value, String dataTypeId, String? choiceId
+ DateTime dateFrom, DateTime dateTo, num value, String dataTypeId,@JsonKey(includeIfNull: false) String? choiceId
 });
 
 

--- a/lib/classes/entity_definitions.freezed.dart
+++ b/lib/classes/entity_definitions.freezed.dart
@@ -290,7 +290,7 @@ as DateTime?,
 /// @nodoc
 mixin _$MeasurableChoice {
 
- String get id; String get title; bool? get archived;
+ String get id; String get title;@JsonKey(includeIfNull: false) bool? get archived;
 /// Create a copy of MeasurableChoice
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -323,7 +323,7 @@ abstract mixin class $MeasurableChoiceCopyWith<$Res>  {
   factory $MeasurableChoiceCopyWith(MeasurableChoice value, $Res Function(MeasurableChoice) _then) = _$MeasurableChoiceCopyWithImpl;
 @useResult
 $Res call({
- String id, String title, bool? archived
+ String id, String title,@JsonKey(includeIfNull: false) bool? archived
 });
 
 
@@ -430,7 +430,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String title,  bool? archived)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String title, @JsonKey(includeIfNull: false)  bool? archived)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MeasurableChoice() when $default != null:
 return $default(_that.id,_that.title,_that.archived);case _:
@@ -451,7 +451,7 @@ return $default(_that.id,_that.title,_that.archived);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String title,  bool? archived)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String title, @JsonKey(includeIfNull: false)  bool? archived)  $default,) {final _that = this;
 switch (_that) {
 case _MeasurableChoice():
 return $default(_that.id,_that.title,_that.archived);case _:
@@ -471,7 +471,7 @@ return $default(_that.id,_that.title,_that.archived);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String title,  bool? archived)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String title, @JsonKey(includeIfNull: false)  bool? archived)?  $default,) {final _that = this;
 switch (_that) {
 case _MeasurableChoice() when $default != null:
 return $default(_that.id,_that.title,_that.archived);case _:
@@ -486,12 +486,12 @@ return $default(_that.id,_that.title,_that.archived);case _:
 @JsonSerializable()
 
 class _MeasurableChoice implements MeasurableChoice {
-  const _MeasurableChoice({required this.id, required this.title, this.archived});
+  const _MeasurableChoice({required this.id, required this.title, @JsonKey(includeIfNull: false) this.archived});
   factory _MeasurableChoice.fromJson(Map<String, dynamic> json) => _$MeasurableChoiceFromJson(json);
 
 @override final  String id;
 @override final  String title;
-@override final  bool? archived;
+@override@JsonKey(includeIfNull: false) final  bool? archived;
 
 /// Create a copy of MeasurableChoice
 /// with the given fields replaced by the non-null parameter values.
@@ -526,7 +526,7 @@ abstract mixin class _$MeasurableChoiceCopyWith<$Res> implements $MeasurableChoi
   factory _$MeasurableChoiceCopyWith(_MeasurableChoice value, $Res Function(_MeasurableChoice) _then) = __$MeasurableChoiceCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String title, bool? archived
+ String id, String title,@JsonKey(includeIfNull: false) bool? archived
 });
 
 

--- a/lib/classes/entity_definitions.g.dart
+++ b/lib/classes/entity_definitions.g.dart
@@ -35,7 +35,7 @@ Map<String, dynamic> _$MeasurableChoiceToJson(_MeasurableChoice instance) =>
     <String, dynamic>{
       'id': instance.id,
       'title': instance.title,
-      'archived': instance.archived,
+      'archived': ?instance.archived,
     };
 
 DailyHabitSchedule _$DailyHabitScheduleFromJson(Map<String, dynamic> json) =>

--- a/lib/classes/entity_definitions.g.dart
+++ b/lib/classes/entity_definitions.g.dart
@@ -24,6 +24,20 @@ Map<String, dynamic> _$ChecklistCorrectionExampleToJson(
   'capturedAt': instance.capturedAt?.toIso8601String(),
 };
 
+_MeasurableChoice _$MeasurableChoiceFromJson(Map<String, dynamic> json) =>
+    _MeasurableChoice(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      archived: json['archived'] as bool?,
+    );
+
+Map<String, dynamic> _$MeasurableChoiceToJson(_MeasurableChoice instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'archived': instance.archived,
+    };
+
 DailyHabitSchedule _$DailyHabitScheduleFromJson(Map<String, dynamic> json) =>
     DailyHabitSchedule(
       requiredCompletions: (json['requiredCompletions'] as num).toInt(),
@@ -234,6 +248,14 @@ MeasurableDataType _$MeasurableDataTypeFromJson(Map<String, dynamic> json) =>
         _$AggregationTypeEnumMap,
         json['aggregationType'],
       ),
+      valueKind: $enumDecodeNullable(
+        _$MeasurableValueKindEnumMap,
+        json['valueKind'],
+        unknownValue: MeasurableValueKind.number,
+      ),
+      choices: (json['choices'] as List<dynamic>?)
+          ?.map((e) => MeasurableChoice.fromJson(e as Map<String, dynamic>))
+          .toList(),
       $type: json['runtimeType'] as String?,
     );
 
@@ -252,6 +274,8 @@ Map<String, dynamic> _$MeasurableDataTypeToJson(MeasurableDataType instance) =>
       'favorite': instance.favorite,
       'categoryId': instance.categoryId,
       'aggregationType': _$AggregationTypeEnumMap[instance.aggregationType],
+      'valueKind': _$MeasurableValueKindEnumMap[instance.valueKind],
+      'choices': instance.choices,
       'runtimeType': instance.$type,
     };
 
@@ -261,6 +285,11 @@ const _$AggregationTypeEnumMap = {
   AggregationType.dailyMax: 'dailyMax',
   AggregationType.dailyAvg: 'dailyAvg',
   AggregationType.hourlySum: 'hourlySum',
+};
+
+const _$MeasurableValueKindEnumMap = {
+  MeasurableValueKind.number: 'number',
+  MeasurableValueKind.choice: 'choice',
 };
 
 CategoryDefinition _$CategoryDefinitionFromJson(Map<String, dynamic> json) =>
@@ -479,6 +508,7 @@ _MeasurementData _$MeasurementDataFromJson(Map<String, dynamic> json) =>
       dateTo: DateTime.parse(json['dateTo'] as String),
       value: json['value'] as num,
       dataTypeId: json['dataTypeId'] as String,
+      choiceId: json['choiceId'] as String?,
     );
 
 Map<String, dynamic> _$MeasurementDataToJson(_MeasurementData instance) =>
@@ -487,6 +517,7 @@ Map<String, dynamic> _$MeasurementDataToJson(_MeasurementData instance) =>
       'dateTo': instance.dateTo.toIso8601String(),
       'value': instance.value,
       'dataTypeId': instance.dataTypeId,
+      'choiceId': instance.choiceId,
     };
 
 _AiResponseData _$AiResponseDataFromJson(Map<String, dynamic> json) =>

--- a/lib/classes/entity_definitions.g.dart
+++ b/lib/classes/entity_definitions.g.dart
@@ -517,7 +517,7 @@ Map<String, dynamic> _$MeasurementDataToJson(_MeasurementData instance) =>
       'dateTo': instance.dateTo.toIso8601String(),
       'value': instance.value,
       'dataTypeId': instance.dataTypeId,
-      'choiceId': instance.choiceId,
+      'choiceId': ?instance.choiceId,
     };
 
 _AiResponseData _$AiResponseDataFromJson(Map<String, dynamic> json) =>

--- a/lib/database/fts5_db.dart
+++ b/lib/database/fts5_db.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:drift/drift.dart';
+import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/features/dashboards/config/dashboard_health_config.dart';
@@ -11,6 +12,27 @@ import 'package:lotti/services/entities_cache_service.dart';
 part 'fts5_db.g.dart';
 
 const fts5DbFileName = 'fts5_db.sqlite';
+
+/// Whether replacing [previous] with [next] changes measurement search text.
+bool measurementDefinitionAffectsFts(
+  MeasurableDataType? previous,
+  MeasurableDataType next,
+) {
+  if (previous == null ||
+      previous.displayName != next.displayName ||
+      previous.unitName != next.unitName) {
+    return true;
+  }
+  return _choiceTitleSignature(previous) != _choiceTitleSignature(next);
+}
+
+String _choiceTitleSignature(MeasurableDataType dataType) {
+  final titles = [
+    for (final choice in dataType.choices ?? const <MeasurableChoice>[])
+      '${choice.id}\u0000${choice.title}',
+  ]..sort();
+  return titles.join('\u0001');
+}
 
 @DriftDatabase(include: {'fts5_db.drift'})
 class Fts5Db extends _$Fts5Db {
@@ -39,6 +61,7 @@ class Fts5Db extends _$Fts5Db {
   Future<void> insertText(
     JournalEntity entry, {
     bool removePrevious = false,
+    MeasurableDataType? measurementDataType,
   }) async {
     final uuid = entry.meta.id;
 
@@ -58,9 +81,9 @@ class Fts5Db extends _$Fts5Db {
         // Resolved lazily so non-measurement indexing (incl. seeding a
         // non-active world through WorldHandle) never touches the active
         // generation's cache.
-        final dataType = getIt<EntitiesCacheService>().getDataTypeById(
-          m.data.dataTypeId,
-        );
+        final dataType =
+            measurementDataType ??
+            getIt<EntitiesCacheService>().getDataTypeById(m.data.dataTypeId);
         // A choice recording indexes the choice's title, so searching for
         // "clear" finds the hydration entry; a number keeps value and unit.
         final value = dataType == null
@@ -93,6 +116,29 @@ class Fts5Db extends _$Fts5Db {
         summary,
         '',
         uuid,
+      );
+    }
+  }
+
+  /// Rebuilds the derived FTS rows for every measurement of [dataType].
+  ///
+  /// Choice titles, measurable names, and numeric units live on the
+  /// definition rather than the journal entry. When one changes, historical
+  /// entries need to be indexed again so search reflects what the journal
+  /// currently displays. Passing [dataType] directly avoids racing the
+  /// asynchronously refreshed definition cache.
+  Future<void> reindexMeasurements(
+    MeasurableDataType dataType,
+    Iterable<JournalEntity> entries,
+  ) async {
+    for (final entry in entries) {
+      if (entry is! MeasurementEntry || entry.data.dataTypeId != dataType.id) {
+        continue;
+      }
+      await insertText(
+        entry,
+        removePrevious: true,
+        measurementDataType: dataType,
       );
     }
   }

--- a/lib/database/fts5_db.dart
+++ b/lib/database/fts5_db.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/features/dashboards/config/dashboard_health_config.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 
@@ -60,8 +61,12 @@ class Fts5Db extends _$Fts5Db {
         final dataType = getIt<EntitiesCacheService>().getDataTypeById(
           m.data.dataTypeId,
         );
-        final value = m.data.value;
-        return '${dataType?.displayName} $value ${dataType?.unitName}';
+        // A choice recording indexes the choice's title, so searching for
+        // "clear" finds the hydration entry; a number keeps value and unit.
+        final value = dataType == null
+            ? '${m.data.value}'
+            : measurementValueLabel(m.data, dataType);
+        return '${dataType?.displayName} $value';
       },
       survey: (survey) {
         final scores = survey.data.calculatedScores.entries.map(

--- a/lib/features/dashboards/README.md
+++ b/lib/features/dashboards/README.md
@@ -6,7 +6,9 @@ chosen and ordered by the user, grouped on one page.
 ## What it does for the user
 
 - **Builds a view per interest.** A dashboard is a named, ordered set of charts —
-  measurements, health data, workouts, habits, survey results, time.
+  measurements, health data, workouts, habits, survey results, time. A
+  measurable recorded as a choice draws a day strip shaded by the day's choice,
+  with a legend, rather than a bar chart.
 - **Groups by area.** The dashboard list can be filtered by category.
 - **Picks a time range.** One control re-slices every chart on the page.
 - **Records from the chart.** A measurement chart can open its capture flow

--- a/lib/features/dashboards/state/measurable_choice_series.dart
+++ b/lib/features/dashboards/state/measurable_choice_series.dart
@@ -1,0 +1,51 @@
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
+import 'package:lotti/widgets/charts/utils.dart';
+
+/// One calendar day of a choice measurable: the choice recorded last that
+/// day, or `null` when nothing was recorded.
+typedef ChoiceDay = ({DateTime day, String? choiceId});
+
+/// Reduces a choice measurable's entries to one [ChoiceDay] per calendar day
+/// of the range, in order — the shape the day strip renders.
+///
+/// A day keeps its **latest** recording (by `meta.dateFrom`, then entry id
+/// so two replicas agree on equal timestamps): the strip answers "how did
+/// the day end up", the way a hydration check is read. Entries without a
+/// choice id — numbers recorded before the measurable was switched — do
+/// not count as a choice and leave the day empty. The range walk mirrors the
+/// numeric aggregators, so a strip and a bar chart of the same window line
+/// up cell for bar under the shared date axis.
+List<ChoiceDay> choiceDaySeries(
+  List<JournalEntity> entities, {
+  required DateTime rangeStart,
+  required DateTime rangeEnd,
+}) {
+  final latestByDay = <String, MeasurementEntry>{};
+  for (final entity in entities) {
+    if (entity is! MeasurementEntry || entity.data.choiceId == null) continue;
+    final key = entity.meta.dateFrom.ymd;
+    final current = latestByDay[key];
+    if (current == null || _isLater(entity, current)) {
+      latestByDay[key] = entity;
+    }
+  }
+
+  final dayStrings = getDayStrings(
+    rangeEnd.difference(rangeStart).inDays,
+    rangeStart,
+  );
+  return [
+    for (final dayString in dayStrings)
+      (
+        day: DateTime.parse(dayString),
+        choiceId: latestByDay[dayString]?.data.choiceId,
+      ),
+  ];
+}
+
+bool _isLater(MeasurementEntry a, MeasurementEntry b) {
+  final byTime = a.meta.dateFrom.compareTo(b.meta.dateFrom);
+  if (byTime != 0) return byTime > 0;
+  return a.meta.id.compareTo(b.meta.id) > 0;
+}

--- a/lib/features/dashboards/state/measurable_choice_series.dart
+++ b/lib/features/dashboards/state/measurable_choice_series.dart
@@ -31,9 +31,9 @@ List<ChoiceDay> choiceDaySeries(
     }
   }
 
-  final dayStrings = getDayStrings(
-    rangeEnd.difference(rangeStart).inDays,
-    rangeStart,
+  final dayStrings = daysInRange(
+    rangeStart: rangeStart,
+    rangeEnd: rangeEnd,
   );
   return [
     for (final dayString in dayStrings)

--- a/lib/features/dashboards/ui/widgets/charts/dashboard_measurables_chart.dart
+++ b/lib/features/dashboards/ui/widgets/charts/dashboard_measurables_chart.dart
@@ -3,9 +3,12 @@ import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/dashboards/state/measurable_choice_series.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_chart.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_info.dart';
+import 'package:lotti/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/stale_async_value.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/time_series_bar_chart.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/time_series_line_chart.dart';
@@ -16,7 +19,10 @@ import 'package:lotti/widgets/charts/utils.dart';
 
 /// Chart card for one measurable on a dashboard. The name is historical: this
 /// renders a *bar* chart only when an aggregation is applied; with
-/// `AggregationType.none` it renders a line chart of individual readings.
+/// `AggregationType.none` it renders a line chart of individual readings, and
+/// a choice measurable gets a day strip — one cell per day coloured by the
+/// day's latest choice, with a legend — since its numbers are occurrence
+/// counts and no aggregation of those is a picture of the data.
 ///
 /// Resolves the measurable definition and the effective aggregation (dashboard
 /// override → type default → daily sum) via providers, then watches
@@ -48,6 +54,15 @@ class MeasurablesBarChart extends ConsumerWidget {
 
     if (measurableDataType == null) {
       return const SizedBox.shrink();
+    }
+
+    if (measurableDataType.isChoice) {
+      return _ChoiceChart(
+        dataType: measurableDataType,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+        enableCreate: enableCreate,
+      );
     }
 
     final chartAggregationType =
@@ -103,6 +118,63 @@ class MeasurablesBarChart extends ConsumerWidget {
           isEmpty: observations.isEmpty,
           emptyMessage: context.messages.dashboardChartNoData,
           height: 180,
+        );
+      },
+    );
+  }
+}
+
+/// The choice measurable's card: the raw entries of the range reduced to one
+/// choice per day, rendered as a strip under the shared date axis.
+class _ChoiceChart extends ConsumerWidget {
+  const _ChoiceChart({
+    required this.dataType,
+    required this.rangeStart,
+    required this.rangeEnd,
+    required this.enableCreate,
+  });
+
+  final MeasurableDataType dataType;
+  final DateTime rangeStart;
+  final DateTime rangeEnd;
+  final bool enableCreate;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    return StaleAsyncValue<List<JournalEntity>>(
+      async: ref.watch(
+        measurableChartDataControllerProvider((
+          measurableDataTypeId: dataType.id,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        )),
+      ),
+      builder: (context, data, isInitialLoading) {
+        final entries = data ?? const <JournalEntity>[];
+        final days = choiceDaySeries(
+          entries,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        );
+        return DashboardChart(
+          chart: MeasurableChoiceStrip(days: days, dataType: dataType),
+          dateAxis: DashboardChartDateAxis(
+            rangeStart: rangeStart,
+            rangeEnd: rangeEnd,
+          ),
+          footer: MeasurableChoiceLegend(days: days, dataType: dataType),
+          chartHeader: MeasurablesChartInfoWidget(
+            dataType,
+            enableCreate: enableCreate,
+            aggregationType: AggregationType.none,
+          ),
+          isLoading: isInitialLoading,
+          // Numeric entries from before the switch to choices are in range
+          // but colour nothing; a strip of empty cells is not data.
+          isEmpty: days.every((day) => day.choiceId == null),
+          emptyMessage: context.messages.dashboardChartNoData,
+          height: tokens.spacing.step10,
         );
       },
     );

--- a/lib/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_info.dart
+++ b/lib/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_info.dart
@@ -36,9 +36,14 @@ class MeasurablesChartInfoWidget extends StatelessWidget {
     // like the health/workout cards' "bpm"/"kcal"). Only when a measurable has
     // no unit (e.g. a 1-10 rating) do we fall back to its description, then to
     // the humanized aggregation. Never an "[agg] · [description]" stack.
-    final unit = measurableDataType.unitName;
+    // A choice measurable has neither a unit nor an aggregation to speak of
+    // (a leftover unit from before the switch must not caption its strip),
+    // so its only caption is the description.
+    final unit = measurableDataType.isChoice ? '' : measurableDataType.unitName;
     final description = measurableDataType.description;
-    final aggregation = aggregationDisplayLabel(context, aggregationType);
+    final aggregation = measurableDataType.isChoice
+        ? ''
+        : aggregationDisplayLabel(context, aggregationType);
     final subtitle = unit.isNotEmpty
         ? unit
         : (description.isNotEmpty

--- a/lib/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart
+++ b/lib/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart
@@ -1,0 +1,258 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/dashboards/state/measurable_choice_series.dart';
+import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/utils.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// The colour of each choice of [dataType], keyed by choice id.
+///
+/// The user's own order is the only structure a choice set has, so it is
+/// read as an ordinal scale: one hue — the accent — stepped from faint to
+/// full across the list (index over **every** choice, archived ones
+/// included, so a retired choice keeps the colour its history was drawn
+/// in). Both ends are existing tokens; the steps between are computed, not
+/// authored, which is what keeps a five-choice ramp from needing five new
+/// colour tokens. A choice the definition no longer knows draws in the
+/// neutral decorative step.
+Map<String, Color> choiceColorsFor(
+  MeasurableDataType dataType,
+  DsTokens tokens,
+) {
+  final choices = dataType.choices ?? const <MeasurableChoice>[];
+  final faint = tokens.colors.background.level03;
+  final full = tokens.colors.interactive.enabled;
+  return {
+    for (final (index, choice) in choices.indexed)
+      choice.id: Color.lerp(faint, full, (index + 1) / choices.length)!,
+  };
+}
+
+/// One cell per day of the range, coloured by the day's latest choice, under
+/// the same left inset as the bar and line charts so the shared date axis
+/// reads across it. Hovering or long-pressing a recorded day names the date
+/// and the choice.
+///
+/// The cells are painted, not laid out: a dashboard range runs to a year,
+/// and a row of one flex child per day with fixed gaps between them is wider
+/// than a phone long before that. [ChoiceStripPainter] fits the range to
+/// whatever width it gets and drops the gaps once a cell would be narrower
+/// than one, at which point neighbouring days of the same choice merge into
+/// one run — the strip stays a picture of the range at every width.
+class MeasurableChoiceStrip extends StatefulWidget {
+  const MeasurableChoiceStrip({
+    required this.days,
+    required this.dataType,
+    super.key,
+  });
+
+  final List<ChoiceDay> days;
+  final MeasurableDataType dataType;
+
+  @override
+  State<MeasurableChoiceStrip> createState() => _MeasurableChoiceStripState();
+}
+
+class _MeasurableChoiceStripState extends State<MeasurableChoiceStrip> {
+  /// The day under the pointer, for the tooltip; `null` off the strip.
+  int? _pointerIndex;
+
+  void _trackPointer(Offset local, double width) {
+    final days = widget.days;
+    if (days.isEmpty || width <= 0) return;
+    final index = (local.dx / width * days.length).floor().clamp(
+      0,
+      days.length - 1,
+    );
+    if (index != _pointerIndex) setState(() => _pointerIndex = index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final colors = choiceColorsFor(widget.dataType, tokens);
+    final days = widget.days;
+    final index = _pointerIndex;
+    final hovered = index != null && index < days.length ? days[index] : null;
+    final String? message;
+    if (hovered?.choiceId case final choiceId?) {
+      final locale = Localizations.localeOf(context).toLanguageTag();
+      final title =
+          widget.dataType.choiceById(choiceId)?.title ??
+          messages.measurableChoiceNotFound;
+      message = '${DateFormat.yMMMd(locale).format(hovered!.day)} · $title';
+    } else {
+      message = null;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(left: kChartLeftAxisWidth),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          final strip = Listener(
+            onPointerHover: (event) =>
+                _trackPointer(event.localPosition, width),
+            onPointerDown: (event) => _trackPointer(event.localPosition, width),
+            child: CustomPaint(
+              key: const ValueKey('measurable-choice-strip'),
+              painter: ChoiceStripPainter(
+                colors: [
+                  for (final day in days)
+                    if (day.choiceId case final choiceId?)
+                      colors[choiceId] ?? tokens.colors.decorative.level02
+                    else
+                      tokens.colors.background.level03,
+                ],
+                gap: tokens.spacing.step1,
+                radius: tokens.radii.xs,
+              ),
+              child: const SizedBox.expand(),
+            ),
+          );
+          // One tooltip for the whole strip, worded for the day under the
+          // pointer; an empty day has nothing to say, so no tooltip at all.
+          if (message == null) return strip;
+          return Tooltip(
+            key: const ValueKey('measurable-choice-strip-tooltip'),
+            message: message,
+            child: strip,
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Paints [colors] as equal-width cells across the canvas: [gap] between
+/// cells while a cell is at least that wide, otherwise contiguous, with
+/// same-coloured neighbours drawn as one run so no seams appear.
+class ChoiceStripPainter extends CustomPainter {
+  const ChoiceStripPainter({
+    required this.colors,
+    required this.gap,
+    required this.radius,
+  });
+
+  final List<Color> colors;
+  final double gap;
+  final double radius;
+
+  /// The gap actually drawn at [width]: [gap], or none when a cell would be
+  /// narrower than it.
+  double gapFor(double width) {
+    final n = colors.length;
+    if (n < 2) return 0;
+    final cell = (width - gap * (n - 1)) / n;
+    return cell >= gap ? gap : 0;
+  }
+
+  /// The width of one cell at [width] (never negative).
+  double cellWidthFor(double width) {
+    final n = colors.length;
+    if (n == 0) return 0;
+    return math.max(0, (width - gapFor(width) * (n - 1)) / n);
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final n = colors.length;
+    if (n == 0 || size.isEmpty) return;
+    final drawnGap = gapFor(size.width);
+    final cell = cellWidthFor(size.width);
+    final stride = cell + drawnGap;
+    final paint = Paint();
+    var start = 0;
+    while (start < n) {
+      // With gaps every cell is its own rect; without, a run of one colour
+      // is one rect so anti-aliasing draws no hairlines between its days.
+      var end = start + 1;
+      if (drawnGap == 0) {
+        while (end < n && colors[end] == colors[start]) {
+          end++;
+        }
+      }
+      final left = start * stride;
+      final right = (end - 1) * stride + cell;
+      final rect = Rect.fromLTRB(left, 0, right, size.height);
+      final corner = Radius.circular(math.min(radius, rect.width / 2));
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(rect, corner),
+        paint..color = colors[start],
+      );
+      start = end;
+    }
+  }
+
+  @override
+  bool shouldRepaint(ChoiceStripPainter old) =>
+      old.gap != gap || old.radius != radius || !_sameColors(old.colors);
+
+  bool _sameColors(List<Color> other) {
+    if (other.length != colors.length) return false;
+    for (var i = 0; i < colors.length; i++) {
+      if (other[i] != colors[i]) return false;
+    }
+    return true;
+  }
+}
+
+/// The strip's key: every active choice in order, plus any retired choice
+/// that still colours a day in [days], each as a swatch and its title.
+class MeasurableChoiceLegend extends StatelessWidget {
+  const MeasurableChoiceLegend({
+    required this.days,
+    required this.dataType,
+    super.key,
+  });
+
+  final List<ChoiceDay> days;
+  final MeasurableDataType dataType;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final colors = choiceColorsFor(dataType, tokens);
+    final shown = {for (final day in days) day.choiceId};
+    final entries = [
+      for (final choice in dataType.choices ?? const <MeasurableChoice>[])
+        if (choice.archived != true || shown.contains(choice.id)) choice,
+    ];
+    final captionStyle = tokens.typography.styles.others.caption.copyWith(
+      color: tokens.colors.text.mediumEmphasis,
+    );
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: kChartLeftAxisWidth,
+        top: tokens.spacing.step2,
+      ),
+      child: Wrap(
+        spacing: tokens.spacing.step3,
+        runSpacing: tokens.spacing.step1,
+        children: [
+          for (final choice in entries)
+            Row(
+              key: ValueKey('choice-legend-${choice.id}'),
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: colors[choice.id],
+                    borderRadius: BorderRadius.circular(tokens.radii.xs),
+                  ),
+                  child: SizedBox.square(dimension: tokens.spacing.step3),
+                ),
+                SizedBox(width: tokens.spacing.step1),
+                Text(choice.title, style: captionStyle),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart
+++ b/lib/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart
@@ -94,24 +94,28 @@ class _MeasurableChoiceStripState extends State<MeasurableChoiceStrip> {
       child: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final strip = Listener(
-            onPointerHover: (event) =>
-                _trackPointer(event.localPosition, width),
-            onPointerDown: (event) => _trackPointer(event.localPosition, width),
-            child: CustomPaint(
-              key: const ValueKey('measurable-choice-strip'),
-              painter: ChoiceStripPainter(
-                colors: [
-                  for (final day in days)
-                    if (day.choiceId case final choiceId?)
-                      colors[choiceId] ?? tokens.colors.decorative.level02
-                    else
-                      tokens.colors.background.level03,
-                ],
-                gap: tokens.spacing.step1,
-                radius: tokens.radii.xs,
+          final strip = MouseRegion(
+            onExit: (_) => setState(() => _pointerIndex = null),
+            child: Listener(
+              onPointerHover: (event) =>
+                  _trackPointer(event.localPosition, width),
+              onPointerDown: (event) =>
+                  _trackPointer(event.localPosition, width),
+              child: CustomPaint(
+                key: const ValueKey('measurable-choice-strip'),
+                painter: ChoiceStripPainter(
+                  colors: [
+                    for (final day in days)
+                      if (day.choiceId case final choiceId?)
+                        colors[choiceId] ?? tokens.colors.decorative.level02
+                      else
+                        tokens.colors.background.level03,
+                  ],
+                  gap: tokens.spacing.step1,
+                  radius: tokens.radii.xs,
+                ),
+                child: const SizedBox.expand(),
               ),
-              child: const SizedBox.expand(),
             ),
           );
           // One tooltip for the whole strip, worded for the day under the

--- a/lib/features/goals/evaluation/goal_signal_reader.dart
+++ b/lib/features/goals/evaluation/goal_signal_reader.dart
@@ -139,6 +139,7 @@ class GoalSignalReader {
       for (final entity in entities) {
         entity.maybeMap(
           measurement: (measurement) {
+            if (measurement.data.choiceId != null) return;
             measurableEntryDaysById[measurement.meta.id] = GoalWindow.dayUtc(
               measurement.data.dateFrom,
             );
@@ -146,7 +147,16 @@ class GoalSignalReader {
           orElse: () {},
         );
       }
-      measurables[dataTypeId] = bucketMeasurableTotalsByDay(entities);
+      measurables[dataTypeId] = bucketMeasurableTotalsByDay(
+        entities
+            .where(
+              (entity) => entity.maybeMap(
+                measurement: (measurement) => measurement.data.choiceId == null,
+                orElse: () => false,
+              ),
+            )
+            .toList(),
+      );
     }
 
     final categoryTime = <String, Map<DateTime, num>>{};

--- a/lib/features/goals/model/goal_measurable_record_offer.dart
+++ b/lib/features/goals/model/goal_measurable_record_offer.dart
@@ -75,7 +75,7 @@ GoalMeasurableRecordOffer? parseGoalMeasurableRecordOffer({
   final text = message.text.toLowerCase();
   final candidates = <({MeasurableDataType measurable, RegExpMatch match})>[];
   for (final measurable in measurables) {
-    if (!linkedIds.contains(measurable.id)) continue;
+    if (!linkedIds.contains(measurable.id) || measurable.isChoice) continue;
     final unit = measurable.unitName.trim();
     if (unit.isEmpty) continue;
     final unitPattern = _unitPattern(unit);

--- a/lib/features/goals/ui/pages/create_goal_agent_page.dart
+++ b/lib/features/goals/ui/pages/create_goal_agent_page.dart
@@ -81,8 +81,10 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
   final _suppressedHealthTypes = <String>{};
   List<HabitDefinition> _knownHabits = const [];
   List<MeasurableDataType> _knownMeasurables = const [];
+  final _knownChoiceMeasurableIds = <String>{};
   List<CategoryDefinition> _knownCategories = const [];
   List<LabelDefinition> _knownLabels = const [];
+  var _measurableDefinitionsLoaded = false;
   var _watchesSteps = false;
   GoalFormCompositeRule _compositeRule = GoalFormCompositeRule.all;
   var _requiredSuccesses = 1;
@@ -187,6 +189,25 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       _chosenSignalOrder.remove('measurable:$id');
       _suggestedSignalOrder.remove('measurable:$id');
     }
+  }
+
+  void _rememberMeasurableDefinitions(
+    List<MeasurableDataType> measurables,
+  ) {
+    _knownMeasurables = [
+      for (final measurable in measurables)
+        if (!measurable.isChoice) measurable,
+    ];
+    _knownChoiceMeasurableIds
+      ..clear()
+      ..addAll(
+        measurables
+            .where((measurable) => measurable.isChoice)
+            .map(
+              (measurable) => measurable.id,
+            ),
+      );
+    _measurableDefinitionsLoaded = true;
   }
 
   num? _parseLocalizedTarget(String raw) {
@@ -689,6 +710,16 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
     return confirmedHabits;
   }
 
+  Future<void> _reconcileMeasurableTargetsForSave() async {
+    if (_measurableTargets.isEmpty) return;
+    if (!_measurableDefinitionsLoaded) {
+      _rememberMeasurableDefinitions(
+        await ref.read(measurableDataTypesStreamProvider.future),
+      );
+    }
+    _removeChoiceMeasurableTargets(_knownChoiceMeasurableIds);
+  }
+
   void _invalidateGoalViews(ProviderContainer container, String agentId) {
     container
       ..invalidate(agentIdentityProvider(agentId))
@@ -802,6 +833,8 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       confirmedHabits = await _reconcileHabitTargetsForSave();
       if (!mounted) return;
       confirmedCategories = await _reconcileCategoryTimeTargetsForSave();
+      if (!mounted) return;
+      await _reconcileMeasurableTargetsForSave();
     } on Object {
       if (mounted) {
         setState(() {
@@ -1010,18 +1043,10 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       _knownHabits = loaded;
     }
     final habits = habitsAsync.value ?? _knownHabits;
-    var choiceMeasurableIds = const <String>{};
     if (measurablesAsync.value case final loaded?) {
       // A goal criterion on a measurable is a numeric target; a choice
       // measurable has no quantity to target, so it is not on offer here.
-      choiceMeasurableIds = {
-        for (final measurable in loaded)
-          if (measurable.isChoice) measurable.id,
-      };
-      _knownMeasurables = [
-        for (final measurable in loaded)
-          if (!measurable.isChoice) measurable,
-      ];
+      _rememberMeasurableDefinitions(loaded);
     }
     final measurables = _knownMeasurables;
     if (categoriesAsync.value case final loaded?) {
@@ -1082,7 +1107,7 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       }
     }
 
-    _removeChoiceMeasurableTargets(choiceMeasurableIds);
+    _removeChoiceMeasurableTargets(_knownChoiceMeasurableIds);
 
     final pageTitle = _editing
         ? messages.goalFormEditTitle

--- a/lib/features/goals/ui/pages/create_goal_agent_page.dart
+++ b/lib/features/goals/ui/pages/create_goal_agent_page.dart
@@ -998,9 +998,14 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
     }
     final habits = habitsAsync.value ?? _knownHabits;
     if (measurablesAsync.value case final loaded?) {
-      _knownMeasurables = loaded;
+      // A goal criterion on a measurable is a numeric target; a choice
+      // measurable has no quantity to target, so it is not on offer here.
+      _knownMeasurables = [
+        for (final measurable in loaded)
+          if (!measurable.isChoice) measurable,
+      ];
     }
-    final measurables = measurablesAsync.value ?? _knownMeasurables;
+    final measurables = _knownMeasurables;
     if (categoriesAsync.value case final loaded?) {
       _knownCategories = [
         for (final category in loaded)

--- a/lib/features/goals/ui/pages/create_goal_agent_page.dart
+++ b/lib/features/goals/ui/pages/create_goal_agent_page.dart
@@ -176,6 +176,19 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
     _snapshotSignalGroups();
   }
 
+  /// Drops numeric goal targets whose measurable has since been converted to
+  /// choices. Keeping one would compare the choice occurrence marker (`1`)
+  /// with an old quantity, and filtering the definition alone would leave an
+  /// invisible target that the edit silently saved again.
+  void _removeChoiceMeasurableTargets(Set<String> choiceIds) {
+    for (final id in choiceIds) {
+      _measurableTargets.remove(id);
+      _targetErrors.remove('measurable:$id');
+      _chosenSignalOrder.remove('measurable:$id');
+      _suggestedSignalOrder.remove('measurable:$id');
+    }
+  }
+
   num? _parseLocalizedTarget(String raw) {
     final text = raw.trim();
     if (text.isEmpty) return null;
@@ -997,9 +1010,14 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
       _knownHabits = loaded;
     }
     final habits = habitsAsync.value ?? _knownHabits;
+    var choiceMeasurableIds = const <String>{};
     if (measurablesAsync.value case final loaded?) {
       // A goal criterion on a measurable is a numeric target; a choice
       // measurable has no quantity to target, so it is not on offer here.
+      choiceMeasurableIds = {
+        for (final measurable in loaded)
+          if (measurable.isChoice) measurable.id,
+      };
       _knownMeasurables = [
         for (final measurable in loaded)
           if (!measurable.isChoice) measurable,
@@ -1063,6 +1081,8 @@ class _CreateGoalAgentPageState extends ConsumerState<CreateGoalAgentPage> {
         );
       }
     }
+
+    _removeChoiceMeasurableTargets(choiceMeasurableIds);
 
     final pageTitle = _editing
         ? messages.goalFormEditTitle

--- a/lib/features/habits/model/habit_form_mapping.dart
+++ b/lib/features/habits/model/habit_form_mapping.dart
@@ -117,6 +117,36 @@ class HabitSignalsForm {
     requiredCount: requiredCount ?? this.requiredCount,
   );
 
+  /// The form with every signal on a choice measurable reduced to *any
+  /// entry*, or this very instance when none needed it.
+  ///
+  /// A choice measurable's day value is an occurrence count, so a bound set
+  /// while it was numeric — or on a device that has not yet learnt the kind —
+  /// would compare that count against a quantity and never fire, while the
+  /// editor, which offers no threshold for such a signal, says "any entry".
+  /// The saved rule must be the one on screen.
+  HabitSignalsForm unboundedForChoices(
+    Map<String, MeasurableDataType> measurablesById,
+  ) {
+    var changed = false;
+    final unbounded = [
+      for (final signal in signals)
+        if (signal.kind == HabitSignalKind.measurable &&
+            signal.mode != HabitSignalMode.any &&
+            (measurablesById[signal.id]?.isChoice ?? false))
+          () {
+            changed = true;
+            return signal.copyWith(
+              mode: HabitSignalMode.any,
+              clearThreshold: true,
+            );
+          }()
+        else
+          signal,
+    ];
+    return changed ? copyWith(signals: unbounded) : this;
+  }
+
   /// The form as the rule tree would give it back: a single signal has no
   /// composite, and an at-least count is clamped to what exists.
   HabitSignalsForm normalized() {

--- a/lib/features/habits/service/habit_auto_completion_service.dart
+++ b/lib/features/habits/service/habit_auto_completion_service.dart
@@ -275,11 +275,18 @@ class HabitAutoCompletionService {
   String describeReason(HabitRuleVerdict verdict) {
     final parts = <String>[];
     for (final leaf in verdict.satisfiedLeaves) {
+      final measurable = switch (leaf.rule) {
+        AutoCompleteRuleMeasurable(:final dataTypeId) =>
+          _entitiesCache.getDataTypeById(dataTypeId),
+        _ => null,
+      };
+      // A choice measurable's day value is an occurrence count, not something
+      // the user would recognise as "what checked it off"; its name alone is
+      // the reason.
+      final showValue = !(measurable?.isChoice ?? false);
       final name = switch (leaf.rule) {
         AutoCompleteRuleMeasurable(:final dataTypeId, :final title) =>
-          title ??
-              _entitiesCache.getDataTypeById(dataTypeId)?.displayName ??
-              dataTypeId,
+          title ?? measurable?.displayName ?? dataTypeId,
         AutoCompleteRuleHealth(:final dataType, :final title) =>
           title ?? healthTypes[dataType]?.displayName ?? dataType,
         AutoCompleteRuleWorkout(:final dataType, :final title) =>
@@ -292,7 +299,9 @@ class HabitAutoCompletionService {
       };
       if (name == null) continue;
       final value = leaf.value;
-      parts.add(value == null ? name : '$name · ${_formatValue(value)}');
+      parts.add(
+        value == null || !showValue ? name : '$name · ${_formatValue(value)}',
+      );
     }
     return parts.join(' · ');
   }

--- a/lib/features/habits/service/habit_auto_completion_service.dart
+++ b/lib/features/habits/service/habit_auto_completion_service.dart
@@ -212,7 +212,11 @@ class HabitAutoCompletionService {
     DateTime day,
     DateTime now,
   ) async {
-    final rule = habit.autoCompleteRule!;
+    final rule = normalizeChoiceMeasurableBounds(
+      habit.autoCompleteRule!,
+      isChoice: (dataTypeId) =>
+          _entitiesCache.getDataTypeById(dataTypeId)?.isChoice ?? false,
+    );
     final dayStart = DateTime(day.year, day.month, day.day);
     final dayEnd = DateTime(day.year, day.month, day.day + 1);
     // Anything already recorded for the day — manual, skip, or an earlier

--- a/lib/features/habits/state/habit_signal_status_controller.dart
+++ b/lib/features/habits/state/habit_signal_status_controller.dart
@@ -99,15 +99,21 @@ class HabitSignalStatusController extends AsyncNotifier<HabitSignalStatus?> {
 
   Future<HabitSignalStatus> _load(AutoCompleteRule rule) async {
     final now = clock.now();
+    final cache = getIt<EntitiesCacheService>();
+    final normalizedRule = normalizeChoiceMeasurableBounds(
+      rule,
+      isChoice: (dataTypeId) =>
+          cache.getDataTypeById(dataTypeId)?.isChoice ?? false,
+    );
     final reader = SignalReader(journalDb: getIt<JournalDb>());
-    final window = await reader.read(rule: rule, reference: now);
+    final window = await reader.read(rule: normalizedRule, reference: now);
     final verdict = const HabitRuleEvaluator().evaluate(
-      rule: rule,
+      rule: normalizedRule,
       window: window,
       day: now,
     );
     return HabitSignalStatus(
-      rule: rule,
+      rule: normalizedRule,
       window: window,
       verdict: verdict,
       today: signalDayKey(now),

--- a/lib/features/habits/ui/pages/habit_editor_page.dart
+++ b/lib/features/habits/ui/pages/habit_editor_page.dart
@@ -253,6 +253,16 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
 
     final state = ref.watch(habitSettingsControllerProvider(habitId));
     final signals = _formFrom(state);
+    // A bound on a choice measurable cannot be shown or satisfied; drop it
+    // once the definitions are known, after this frame, so the controller's
+    // rule matches the card. Returns the same instance when nothing changed,
+    // so this settles after one pass.
+    final unbounded = signals.unboundedForChoices(measurablesById);
+    if (!identical(unbounded, signals)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _setSignals(unbounded);
+      });
+    }
     final item = state.habitDefinition;
     final showFrom = item.habitSchedule.mapOrNull(daily: (d) => d.showFrom);
     final alertAtTime = item.habitSchedule.mapOrNull(

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/habits/state/habit_signal_status_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_signal_row.dart';
+import 'package:lotti/features/habits/ui/widgets/measurable_quick_record_chips.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
 import 'package:lotti/features/keyboard/ui/app_command_scope.dart';
@@ -97,7 +98,7 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
   bool _autoSatisfied = false;
 
   /// Values recorded from chips during this sheet, by measurable id.
-  final _recorded = <String, num>{};
+  final _recorded = <String, MeasurableQuickValue>{};
 
   /// Whether the completion being recorded is for the current day — from
   /// the date actually selected, so picking a past day in the field hides
@@ -138,13 +139,17 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
     );
   }
 
-  Future<void> _recordMeasurable(MeasurableDataType dataType, num value) async {
+  Future<void> _recordMeasurable(
+    MeasurableDataType dataType,
+    MeasurableQuickValue value,
+  ) async {
     final now = clock.now();
     final saved = await getIt<PersistenceLogic>().createMeasurementEntry(
       data: MeasurementData(
         dateFrom: now,
         dateTo: now,
-        value: value,
+        value: value.value,
+        choiceId: value.choiceId,
         dataTypeId: dataType.id,
       ),
       private: dataType.private ?? false,
@@ -252,10 +257,11 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
     );
   }
 
-  num? _recordedFor(HabitLeafVerdict leaf) => switch (leaf.rule) {
-    AutoCompleteRuleMeasurable(:final dataTypeId) => _recorded[dataTypeId],
-    _ => null,
-  };
+  MeasurableQuickValue? _recordedFor(HabitLeafVerdict leaf) =>
+      switch (leaf.rule) {
+        AutoCompleteRuleMeasurable(:final dataTypeId) => _recorded[dataTypeId],
+        _ => null,
+      };
 }
 
 /// The completion-capture card: habit name, optional description, the

--- a/lib/features/habits/ui/widgets/editor/habit_signal_card.dart
+++ b/lib/features/habits/ui/widgets/editor/habit_signal_card.dart
@@ -89,6 +89,9 @@ class HabitSignalCard extends StatelessWidget {
                 child: _RuleEditor(
                   signal: signal,
                   unit: habitSignalUnit(messages, signal, measurablesById),
+                  choiceOnly:
+                      signal.kind == HabitSignalKind.measurable &&
+                      (measurablesById[signal.id]?.isChoice ?? false),
                   onChanged: (updated) => _replace(index, updated),
                 ),
               ),
@@ -313,11 +316,17 @@ class _RuleEditor extends StatefulWidget {
     required this.signal,
     required this.unit,
     required this.onChanged,
+    this.choiceOnly = false,
   });
 
   final HabitSignalForm signal;
   final String unit;
   final ValueChanged<HabitSignalForm> onChanged;
+
+  /// A choice measurable has no quantity to bound: the only rule it can
+  /// satisfy is "any entry today", so the mode toggle and threshold give
+  /// way to that one line.
+  final bool choiceOnly;
 
   @override
   State<_RuleEditor> createState() => _RuleEditorState();
@@ -381,6 +390,16 @@ class _RuleEditorState extends State<_RuleEditor> {
     final messages = context.messages;
     final signal = widget.signal;
     final bounded = signal.mode != HabitSignalMode.any;
+
+    if (widget.choiceOnly) {
+      return Text(
+        messages.habitEditorRuleAnyEntry,
+        key: ValueKey('habit-signal-choice-any-${signal.id}'),
+        style: tokens.typography.styles.body.bodySmall.copyWith(
+          color: tokens.colors.text.mediumEmphasis,
+        ),
+      );
+    }
 
     final Widget toggle = switch (signal.kind) {
       HabitSignalKind.workout => DsSegmentedToggle<_WorkoutRule>(

--- a/lib/features/habits/ui/widgets/editor/habit_signal_picker.dart
+++ b/lib/features/habits/ui/widgets/editor/habit_signal_picker.dart
@@ -57,8 +57,13 @@ class _HabitSignalPickerState extends State<HabitSignalPicker> {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
+    // A choice measurable is found by any of its choices' titles, the way a
+    // numeric one is found by its unit.
     final measurables = widget.measurables.where(
-      (m) => _matches(m.displayName) || _matches(m.unitName),
+      (m) =>
+          _matches(m.displayName) ||
+          _matches(m.unitName) ||
+          m.activeChoices.any((choice) => _matches(choice.title)),
     );
     final health = [
       for (final key in evaluableHealthDataTypes)
@@ -133,7 +138,7 @@ class _HabitSignalPickerState extends State<HabitSignalPicker> {
                       HabitSignalKind.measurable,
                       m.id,
                       m.displayName,
-                      m.unitName.isEmpty ? null : m.unitName,
+                      habitMeasurableSubtitle(m),
                     ),
                   if (health.isNotEmpty)
                     section(messages.habitEditorPickerHealth),

--- a/lib/features/habits/ui/widgets/editor/habit_signal_presentation.dart
+++ b/lib/features/habits/ui/widgets/editor/habit_signal_presentation.dart
@@ -77,13 +77,29 @@ String habitWorkoutUnit(AppLocalizations messages, WorkoutValueType type) =>
       WorkoutValueType.energy => messages.habitUnitKilocalories,
     };
 
-/// The unit a threshold is entered in.
+/// The picker row's second line for a measurable: its unit, or for a choice
+/// measurable its active choices — "Clear · Pale · Dark" — since those are
+/// what a rule on it would be about. `null` when there is nothing to say.
+String? habitMeasurableSubtitle(MeasurableDataType measurable) {
+  if (measurable.isChoice) {
+    final titles = measurable.activeChoices.map((choice) => choice.title);
+    return titles.isEmpty ? null : titles.join(' · ');
+  }
+  return measurable.unitName.isEmpty ? null : measurable.unitName;
+}
+
+/// The unit a threshold is entered in. A choice measurable has none — its
+/// unit field is a leftover from before it was switched — so it reads as
+/// empty rather than labelling a threshold that does not exist.
 String habitSignalUnit(
   AppLocalizations messages,
   HabitSignalForm signal,
   Map<String, MeasurableDataType> measurablesById,
 ) => switch (signal.kind) {
-  HabitSignalKind.measurable => measurablesById[signal.id]?.unitName ?? '',
+  HabitSignalKind.measurable => switch (measurablesById[signal.id]) {
+    null => '',
+    final measurable => measurable.isChoice ? '' : measurable.unitName,
+  },
   HabitSignalKind.health => healthTypes[signal.id]?.unit ?? '',
   HabitSignalKind.workout => switch (signal.workoutValueType) {
     null => '',

--- a/lib/features/habits/ui/widgets/habit_signal_row.dart
+++ b/lib/features/habits/ui/widgets/habit_signal_row.dart
@@ -30,10 +30,10 @@ class HabitSignalRow extends StatelessWidget {
 
   final HabitLeafVerdict leaf;
   final HabitSignalStatus status;
-  final void Function(MeasurableDataType dataType, num value)
+  final void Function(MeasurableDataType dataType, MeasurableQuickValue value)
   onRecordMeasurable;
   final ValueChanged<MeasurableDataType> onMoreMeasurable;
-  final num? recordedValue;
+  final MeasurableQuickValue? recordedValue;
 
   @override
   Widget build(BuildContext context) {
@@ -57,8 +57,10 @@ class HabitSignalRow extends StatelessWidget {
         title ?? cache.getHabitById(habitId)?.name ?? habitId,
       _ => '',
     };
+    final isChoice = measurable?.isChoice ?? false;
     final unit = switch (rule) {
-      AutoCompleteRuleMeasurable() => measurable?.unitName ?? '',
+      AutoCompleteRuleMeasurable() =>
+        isChoice ? '' : measurable?.unitName ?? '',
       AutoCompleteRuleHealth(:final dataType) =>
         healthTypes[dataType]?.unit ?? '',
       AutoCompleteRuleWorkout(:final valueType?) => habitWorkoutUnit(
@@ -74,9 +76,13 @@ class HabitSignalRow extends StatelessWidget {
     final captionStyle = tokens.typography.styles.others.caption.copyWith(
       color: tokens.colors.text.mediumEmphasis,
     );
+    // A choice measurable's day value is an occurrence count, which is not
+    // what the user recorded; the row says only that something was logged.
     final todayValue = leaf.value;
     final todayText = todayValue == null
         ? messages.habitSignalTodayNone
+        : isChoice
+        ? messages.habitSignalTodayLogged
         : messages.habitSignalToday(
             '${_format(todayValue, locale)} $unit'.trim(),
           );

--- a/lib/features/habits/ui/widgets/measurable_quick_record_chips.dart
+++ b/lib/features/habits/ui/widgets/measurable_quick_record_chips.dart
@@ -6,13 +6,20 @@ import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
+/// What a quick chip records: a number for a numeric measurable, or one
+/// occurrence (`value: 1`) of `choiceId` for a choice measurable — the same
+/// two shapes `MeasurementData` takes.
+typedef MeasurableQuickValue = ({num value, String? choiceId});
+
 /// The measurable's most-logged values as one-tap chips, plus a "+" that
 /// opens the full measurement capture.
 ///
-/// Three chips at most — the completion sheet is compact — drawn from the
-/// same ranking the measurement dialog's quick-add uses, so the values a
-/// user sees here are the ones they already log. The chip whose value was
-/// just recorded reads as selected.
+/// Three chips at most for a numeric measurable — the completion sheet is
+/// compact — drawn from the same ranking the measurement dialog's quick-add
+/// uses, so the values a user sees here are the ones they already log. A
+/// choice measurable offers every active choice instead, in the user's own
+/// order: the set is the vocabulary, not a suggestion. The chip whose value
+/// was just recorded reads as selected.
 class MeasurableQuickRecordChips extends ConsumerWidget {
   const MeasurableQuickRecordChips({
     required this.dataType,
@@ -23,11 +30,11 @@ class MeasurableQuickRecordChips extends ConsumerWidget {
   });
 
   final MeasurableDataType dataType;
-  final ValueChanged<num> onRecord;
+  final ValueChanged<MeasurableQuickValue> onRecord;
   final VoidCallback onMore;
 
   /// The value recorded from this row during this sheet, if any.
-  final num? recordedValue;
+  final MeasurableQuickValue? recordedValue;
 
   static const maxChips = 3;
 
@@ -35,23 +42,45 @@ class MeasurableQuickRecordChips extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final suggestions =
-        ref.watch(measurableSuggestionsControllerProvider(dataType.id)).value ??
-        const <num>[];
     final accent = tokens.colors.interactive.enabled;
-    return Wrap(
-      spacing: tokens.spacing.step2,
-      runSpacing: tokens.spacing.step2,
-      children: [
+    final List<Widget> valueChips;
+    if (dataType.isChoice) {
+      valueChips = [
+        for (final choice in dataType.activeChoices)
+          DsPill(
+            key: ValueKey('habit-quick-record-${dataType.id}-${choice.id}'),
+            variant: DsPillVariant.outline,
+            color: accent,
+            selected: choice.id == recordedValue?.choiceId,
+            label: choice.title,
+            onTap: () => onRecord((value: 1, choiceId: choice.id)),
+          ),
+      ];
+    } else {
+      final suggestions =
+          ref
+              .watch(measurableSuggestionsControllerProvider(dataType.id))
+              .value ??
+          const <num>[];
+      valueChips = [
         for (final value in suggestions.take(maxChips))
           DsPill(
             key: ValueKey('habit-quick-record-${dataType.id}-$value'),
             variant: DsPillVariant.outline,
             color: accent,
-            selected: value == recordedValue,
+            selected:
+                recordedValue?.choiceId == null &&
+                value == recordedValue?.value,
             label: '$value ${dataType.unitName}'.trim(),
-            onTap: () => onRecord(value),
+            onTap: () => onRecord((value: value, choiceId: null)),
           ),
+      ];
+    }
+    return Wrap(
+      spacing: tokens.spacing.step2,
+      runSpacing: tokens.spacing.step2,
+      children: [
+        ...valueChips,
         DsPill(
           key: ValueKey('habit-quick-record-more-${dataType.id}'),
           variant: DsPillVariant.outline,

--- a/lib/features/journal/ui/widgets/entry_details/measurement_summary.dart
+++ b/lib/features/journal/ui/widgets/entry_details/measurement_summary.dart
@@ -3,11 +3,13 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/ui/widgets/helpers.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 
 /// Detail-view summary for a measurement entry: the entry's note text (if any)
-/// plus the formatted `name: value unit` line. Renders nothing when the
-/// measurement's data type is no longer in the cache.
+/// plus the formatted `name: value unit` line — `name: choice` for a choice
+/// recording. Renders nothing when the measurement's data type is no longer
+/// in the cache.
 class MeasurementSummary extends StatelessWidget {
   const MeasurementSummary(
     this.measurementEntry, {
@@ -31,7 +33,11 @@ class MeasurementSummary extends StatelessWidget {
     // The entry's note is rendered once by the card's editor above this
     // summary, so the summary shows only the value line (no duplicate note).
     return EntryTextWidget(
-      entryTextForMeasurable(data, dataType),
+      entryTextForMeasurable(
+        data,
+        dataType,
+        removedChoiceLabel: context.messages.measurableChoiceNotFound,
+      ),
       padding: EdgeInsets.zero,
     );
   }

--- a/lib/features/journal/ui/widgets/list_cards/journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/journal_card.dart
@@ -460,20 +460,22 @@ class _EntryCardContent extends StatelessWidget {
       m.data.dataTypeId,
     );
     final name = dataType?.displayName ?? context.messages.measurableNotFound;
-    final unit = dataType?.unitName ?? '';
-    final value = nf.format(m.data.value);
+    // Without its definition the value can only be the raw number; with it,
+    // the shared formatter reads a choice recording as the choice's title.
+    final value = dataType == null
+        ? nf.format(m.data.value)
+        : measurementValueLabel(
+            m.data,
+            dataType,
+            removedChoiceLabel: context.messages.measurableChoiceNotFound,
+          );
 
     return _scaffold(
       context,
       icon: LottiIcons.measure,
       iconColor: _categoryColor(context, item),
       title: _titleText(context, name),
-      metaChips: [
-        _metricChip(
-          context,
-          label: unit.isEmpty ? value : '$value $unit',
-        ),
-      ],
+      metaChips: [_metricChip(context, label: value)],
       secondary: _notePreview(context, m.entryText),
     );
   }

--- a/lib/features/journal/util/entry_tools.dart
+++ b/lib/features/journal/util/entry_tools.dart
@@ -185,13 +185,46 @@ String entryTextForWorkout(
 
 /// Renders a measurement as `name: value unit` using the measurable type's
 /// display name and unit.
+/// "Weight: 94.49 kg", or "Hydration: Clear" for a choice recording.
+///
+/// [removedChoiceLabel] stands in for a choice the definition no longer
+/// lists; see [measurementValueLabel].
 String entryTextForMeasurable(
   MeasurementData data,
-  MeasurableDataType dataType,
-) {
+  MeasurableDataType dataType, {
+  String? removedChoiceLabel,
+}) {
+  final value = measurementValueLabel(
+    data,
+    dataType,
+    removedChoiceLabel: removedChoiceLabel,
+  );
+  return '${dataType.displayName}: $value';
+}
+
+/// The recorded value as a user reads it.
+///
+/// A measurement that carries a [MeasurementData.choiceId] is a choice
+/// recording and reads as that choice's current title — the data, not the
+/// definition's kind, decides, so a numeric entry recorded before a
+/// measurable was switched to choices still reads as its number. A choice
+/// the definition no longer lists at all reads as [removedChoiceLabel], or
+/// nothing when none is given (the search index has no words to spare for
+/// it).
+///
+/// Numbers keep conventional formatting: no space before a percent sign
+/// ("55%"), a space before word units ("94.49 kg"), the bare number without
+/// a unit.
+String measurementValueLabel(
+  MeasurementData data,
+  MeasurableDataType dataType, {
+  String? removedChoiceLabel,
+}) {
+  final choiceId = data.choiceId;
+  if (choiceId != null) {
+    return dataType.choiceById(choiceId)?.title ?? removedChoiceLabel ?? '';
+  }
   final unit = dataType.unitName;
-  // No space before a percent sign ("55%"), a thin space before word units
-  // ("94.49 kg") — matches conventional numeric formatting.
-  final separator = unit == '%' ? '' : ' ';
-  return '${dataType.displayName}: ${nf.format(data.value)}$separator$unit';
+  final separator = unit == '%' || unit.isEmpty ? '' : ' ';
+  return '${nf.format(data.value)}$separator$unit';
 }

--- a/lib/features/settings/ui/pages/dashboards/chart_multi_select.dart
+++ b/lib/features/settings/ui/pages/dashboards/chart_multi_select.dart
@@ -366,9 +366,10 @@ class _MeasurementSelectListState extends State<_MeasurementSelectList> {
                           onSelectedChanged: (checked) {
                             setState(() {
                               if (checked ?? false) {
-                                _selected[item.id] =
-                                    item.aggregationType ??
-                                    AggregationType.dailySum;
+                                _selected[item.id] = item.isChoice
+                                    ? AggregationType.none
+                                    : item.aggregationType ??
+                                          AggregationType.dailySum;
                               } else {
                                 _selected.remove(item.id);
                               }
@@ -430,11 +431,13 @@ class _MeasurementSelectRow extends StatelessWidget {
     final aggregation = selectedAggregation;
     final selected = aggregation != null;
 
+    // A choice measurable is charted as a day strip; there is no
+    // aggregation to pick for it.
     return _PickerSelectRow(
       label: item.displayName,
       selected: selected,
       onChanged: onSelectedChanged,
-      trailing: aggregation != null
+      trailing: aggregation != null && !item.isChoice
           ? _ChartModeSelector(
               label: context.messages.dashboardMeasurementAggregationFor(
                 item.displayName,

--- a/lib/features/settings/ui/pages/dashboards/dashboard_item_card.dart
+++ b/lib/features/settings/ui/pages/dashboards/dashboard_item_card.dart
@@ -120,9 +120,12 @@ class MeasurableItemCard extends StatelessWidget {
             // Fall back to the id when the referenced measurable type is
             // missing (e.g. deleted) so the row isn't visually blank.
             var title = measurement.id;
+            // A choice measurable is charted as a day strip: there is no
+            // aggregation to name or to edit.
+            final isChoice = matches.isNotEmpty && matches.first.isChoice;
             if (matches.isNotEmpty) {
               final aggregationType = measurement.aggregationType;
-              final aggregationSuffix = aggregationType != null
+              final aggregationSuffix = aggregationType != null && !isChoice
                   ? ' — ${aggregationTypeLabel(context.messages, aggregationType)}'
                   : '';
               title = '${matches.first.displayName}$aggregationSuffix';
@@ -132,25 +135,28 @@ class MeasurableItemCard extends StatelessWidget {
               title: title,
               reorderIndex: index,
               onRemove: onRemove,
-              editSemanticsLabel:
-                  context.messages.dashboardEditAggregationLabel,
-              onTap: () {
-                ModalUtils.showSinglePageModal<void>(
-                  context: context,
-                  title: context.messages.dashboardAggregationTitle,
-                  padding: EdgeInsets.all(
-                    context.designTokens.spacing.cardPadding,
-                  ),
-                  builder: (BuildContext context) {
-                    return DashboardItemModal(
-                      item: measurement,
-                      updateItemFn: updateItemFn,
-                      index: index,
-                      chartTitle: title,
-                    );
-                  },
-                );
-              },
+              editSemanticsLabel: isChoice
+                  ? null
+                  : context.messages.dashboardEditAggregationLabel,
+              onTap: isChoice
+                  ? null
+                  : () {
+                      ModalUtils.showSinglePageModal<void>(
+                        context: context,
+                        title: context.messages.dashboardAggregationTitle,
+                        padding: EdgeInsets.all(
+                          context.designTokens.spacing.cardPadding,
+                        ),
+                        builder: (BuildContext context) {
+                          return DashboardItemModal(
+                            item: measurement,
+                            updateItemFn: updateItemFn,
+                            index: index,
+                            chartTitle: title,
+                          );
+                        },
+                      );
+                    },
             );
           },
     );

--- a/lib/features/settings/ui/pages/measurables/measurable_choices_editor.dart
+++ b/lib/features/settings/ui/pages/measurables/measurable_choices_editor.dart
@@ -1,0 +1,354 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/inputs/design_system_text_input.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/file_utils.dart';
+import 'package:lotti/widgets/settings/settings_form_section.dart';
+
+/// Edits the [MeasurableChoice] list of a choice-kind measurable.
+///
+/// The list is the user's vocabulary, so every operation keeps a choice's
+/// id: renaming edits the title in place, reordering moves the row, and
+/// "removing" archives it — an archived choice leaves the recording surfaces
+/// but keeps resolving the entries that already recorded it, and can be
+/// restored from the archived section below the list.
+///
+/// The widget owns nothing but the text controllers (one per choice id, so a
+/// rebuild from the parent never resets a caret). The list itself is the
+/// parent's state, handed back through [onChanged] after every edit,
+/// **normalised** so active choices come first in display order and archived
+/// ones trail — the reorderable list only shows the active ones, and that
+/// invariant is what lets its indices address the full list directly.
+class MeasurableChoicesEditor extends StatefulWidget {
+  const MeasurableChoicesEditor({
+    required this.choices,
+    required this.onChanged,
+    this.showErrors = false,
+    this.newChoiceId = _newUuid,
+    super.key,
+  });
+
+  /// Every choice, archived ones included.
+  final List<MeasurableChoice> choices;
+
+  /// Receives the whole list after each edit, active choices first.
+  final ValueChanged<List<MeasurableChoice>> onChanged;
+
+  /// Whether a blank title is called out as an error. Off while the user is
+  /// still typing; the form turns it on after a save attempt failed.
+  final bool showErrors;
+
+  /// Mints the id of an added choice. Injectable so tests can predict it.
+  final String Function() newChoiceId;
+
+  /// Active choices in display order followed by the archived ones — the
+  /// shape [onChanged] always reports, and what a caller should persist.
+  static List<MeasurableChoice> normalize(List<MeasurableChoice> choices) => [
+    for (final choice in choices)
+      if (choice.archived != true) choice,
+    for (final choice in choices)
+      if (choice.archived == true) choice,
+  ];
+
+  static String _newUuid() => uuid.v4();
+
+  @override
+  State<MeasurableChoicesEditor> createState() =>
+      _MeasurableChoicesEditorState();
+}
+
+class _MeasurableChoicesEditorState extends State<MeasurableChoicesEditor> {
+  final _controllers = <String, TextEditingController>{};
+
+  List<MeasurableChoice> get _active => [
+    for (final choice in widget.choices)
+      if (choice.archived != true) choice,
+  ];
+
+  List<MeasurableChoice> get _archived => [
+    for (final choice in widget.choices)
+      if (choice.archived == true) choice,
+  ];
+
+  TextEditingController _controllerFor(MeasurableChoice choice) =>
+      _controllers.putIfAbsent(
+        choice.id,
+        () => TextEditingController(text: choice.title),
+      );
+
+  @override
+  void didUpdateWidget(MeasurableChoicesEditor old) {
+    super.didUpdateWidget(old);
+    // A choice the parent dropped altogether (never the case for archive,
+    // which keeps the row) must not leak its controller.
+    final ids = {for (final choice in widget.choices) choice.id};
+    for (final id in _controllers.keys.toList()) {
+      if (!ids.contains(id)) _controllers.remove(id)!.dispose();
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _emit(List<MeasurableChoice> choices) =>
+      widget.onChanged(MeasurableChoicesEditor.normalize(choices));
+
+  void _add() {
+    _emit([
+      ...widget.choices,
+      MeasurableChoice(id: widget.newChoiceId(), title: ''),
+    ]);
+  }
+
+  void _rename(MeasurableChoice choice, String title) {
+    _emit([
+      for (final existing in widget.choices)
+        if (existing.id == choice.id)
+          existing.copyWith(title: title)
+        else
+          existing,
+    ]);
+  }
+
+  /// Archiving keeps the row where it was (it moves to the tail through
+  /// normalisation); restoring appends the choice after the active ones, so
+  /// a choice that comes back reads as newly added rather than silently
+  /// reclaiming a slot in the middle of the order.
+  void _setArchived(MeasurableChoice choice, {required bool archived}) {
+    final updated = choice.copyWith(archived: archived);
+    if (archived) {
+      _emit([
+        for (final existing in widget.choices)
+          if (existing.id == choice.id) updated else existing,
+      ]);
+      return;
+    }
+    _emit([
+      for (final existing in widget.choices)
+        if (existing.id != choice.id) existing,
+      updated,
+    ]);
+  }
+
+  /// [newIndex] arrives already adjusted for the removed row, so the move
+  /// is a plain remove-then-insert within the active prefix of the list.
+  void _reorder(int oldIndex, int newIndex) {
+    final active = _active;
+    final moved = active.removeAt(oldIndex);
+    active.insert(newIndex, moved);
+    _emit([...active, ..._archived]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final active = _active;
+    final archived = _archived;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SettingsFormSection(
+          title: messages.settingsMeasurableChoicesTitle,
+          description: messages.settingsMeasurableChoicesDescription,
+          children: [
+            if (active.isEmpty)
+              Text(
+                messages.settingsMeasurableChoicesRequired,
+                key: const ValueKey('measurable-choices-empty'),
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: widget.showErrors
+                      ? tokens.colors.alert.error.ink
+                      : tokens.colors.text.mediumEmphasis,
+                ),
+              )
+            else
+              ReorderableListView(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                buildDefaultDragHandles: false,
+                proxyDecorator: (child, _, _) =>
+                    Material(type: MaterialType.transparency, child: child),
+                onReorderItem: _reorder,
+                children: [
+                  for (final (index, choice) in active.indexed)
+                    Padding(
+                      key: ValueKey('measurable-choice-row-${choice.id}'),
+                      padding: EdgeInsets.only(
+                        bottom: index == active.length - 1
+                            ? 0
+                            : tokens.spacing.cardItemSpacing,
+                      ),
+                      child: _ActiveChoiceRow(
+                        index: index,
+                        choice: choice,
+                        controller: _controllerFor(choice),
+                        showErrors: widget.showErrors,
+                        onChanged: (title) => _rename(choice, title),
+                        onArchive: () => _setArchived(choice, archived: true),
+                      ),
+                    ),
+                ],
+              ),
+            InkWell(
+              key: const ValueKey('measurable-choice-add'),
+              onTap: _add,
+              borderRadius: BorderRadius.circular(tokens.radii.m),
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: tokens.spacing.step2),
+                child: Row(
+                  children: [
+                    Icon(
+                      LottiIcons.add,
+                      size: IconSizes.m,
+                      color: tokens.colors.interactive.enabled,
+                    ),
+                    SizedBox(width: tokens.spacing.step3),
+                    Text(
+                      messages.settingsMeasurableChoiceAdd,
+                      style: tokens.typography.styles.subtitle.subtitle2
+                          .copyWith(color: tokens.colors.interactive.enabled),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+        if (archived.isNotEmpty)
+          SettingsFormSection(
+            title: messages.settingsMeasurableChoicesArchivedTitle,
+            description: messages.settingsMeasurableChoicesArchivedDescription,
+            children: [
+              for (final choice in archived)
+                _ArchivedChoiceRow(
+                  key: ValueKey('measurable-choice-archived-${choice.id}'),
+                  choice: choice,
+                  onRestore: () => _setArchived(choice, archived: false),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+/// A drag handle, the editable title, and the archive action.
+class _ActiveChoiceRow extends StatelessWidget {
+  const _ActiveChoiceRow({
+    required this.index,
+    required this.choice,
+    required this.controller,
+    required this.showErrors,
+    required this.onChanged,
+    required this.onArchive,
+  });
+
+  final int index;
+  final MeasurableChoice choice;
+  final TextEditingController controller;
+  final bool showErrors;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onArchive;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final title = choice.title.trim();
+    final name = title.isEmpty
+        ? messages.settingsMeasurableChoiceNameHint
+        : title;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // The list merges each row into one accessibility node (its own
+        // "move up / move down" actions are the reorder affordance there), so
+        // the handle carries a tooltip — the hover text a pointer user gets —
+        // rather than a label nothing would read.
+        Tooltip(
+          message: messages.settingsMeasurableChoiceReorder(name),
+          child: ReorderableDragStartListener(
+            index: index,
+            child: MouseRegion(
+              cursor: SystemMouseCursors.grab,
+              child: SizedBox(
+                key: ValueKey('measurable-choice-drag-${choice.id}'),
+                width: TapTargets.minimum,
+                height: TapTargets.minimum,
+                child: Icon(
+                  LottiIcons.drag,
+                  size: IconSizes.m,
+                  color: tokens.colors.text.mediumEmphasis,
+                ),
+              ),
+            ),
+          ),
+        ),
+        SizedBox(width: tokens.spacing.step2),
+        Expanded(
+          child: DesignSystemTextInput(
+            key: ValueKey('measurable-choice-title-${choice.id}'),
+            controller: controller,
+            hintText: messages.settingsMeasurableChoiceNameHint,
+            semanticsLabel: messages.settingsMeasurableChoiceNameHint,
+            textCapitalization: TextCapitalization.sentences,
+            errorText: showErrors && title.isEmpty
+                ? messages.settingsMeasurableChoiceNameRequired
+                : null,
+            onChanged: onChanged,
+            trailingIcon: LottiIcons.archive,
+            trailingIconTooltip: messages.settingsMeasurableChoiceArchive(name),
+            trailingIconKey: ValueKey('measurable-choice-archive-${choice.id}'),
+            onTrailingIconTap: onArchive,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A retired choice: its title, dimmed, and a restore action.
+class _ArchivedChoiceRow extends StatelessWidget {
+  const _ArchivedChoiceRow({
+    required this.choice,
+    required this.onRestore,
+    super.key,
+  });
+
+  final MeasurableChoice choice;
+  final VoidCallback onRestore;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            choice.title,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ),
+        DesignSystemIconAction(
+          key: ValueKey('measurable-choice-restore-${choice.id}'),
+          icon: LottiIcons.unarchive,
+          tooltip: messages.settingsMeasurableChoiceRestore(choice.title),
+          onPressed: onRestore,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/ui/pages/measurables/measurable_details_page.dart
+++ b/lib/features/settings/ui/pages/measurables/measurable_details_page.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/aggregation_label.dart';
+import 'package:lotti/features/settings/ui/pages/measurables/measurable_choices_editor.dart';
 import 'package:lotti/features/settings/ui/widgets/form/form_switch.dart';
 import 'package:lotti/features/settings/ui/widgets/form/settings_form_text_field.dart';
 import 'package:lotti/features/settings/ui/widgets/settings_card.dart';
@@ -26,7 +28,11 @@ import 'package:lotti/widgets/settings/settings_picker_field.dart';
 ///
 /// The form mechanics are unchanged: a local `FormBuilder` key plus a
 /// `dirty` flag gate the save action, and save reads the form values into
-/// a `copyWith` on the edited [MeasurableDataType]. Navigation (back,
+/// a `copyWith` on the edited [MeasurableDataType]. The value kind and the
+/// choice list live beside the form as plain widget state — the kind
+/// decides which fields the form shows (unit and aggregation are numeric
+/// affairs), and the choices are a list the form kit has no field for —
+/// and flip the same `dirty` flag. Navigation (back,
 /// cancel, after save/delete) beams to `/settings/measurables` rather
 /// than popping — V2's desktop detail surface mounts the page inline (no
 /// Navigator route to pop); on mobile the URL change still pops the page
@@ -54,6 +60,43 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   final _formKey = GlobalKey<FormBuilderState>();
   bool dirty = false;
+
+  late MeasurableValueKind _valueKind =
+      widget.dataType.valueKind ?? MeasurableValueKind.number;
+  late List<MeasurableChoice> _choices = MeasurableChoicesEditor.normalize(
+    widget.dataType.choices ?? const [],
+  );
+
+  /// Set by a save attempt that a blank or missing choice blocked, so the
+  /// editor calls those rows out until the user fixes them.
+  bool _showChoiceErrors = false;
+
+  bool get _isChoice => _valueKind == MeasurableValueKind.choice;
+
+  void _setValueKind(MeasurableValueKind kind) {
+    setState(() {
+      _valueKind = kind;
+      dirty = true;
+    });
+  }
+
+  void _setChoices(List<MeasurableChoice> choices) {
+    setState(() {
+      _choices = choices;
+      dirty = true;
+    });
+  }
+
+  /// A choice measurable needs at least one active choice, and every active
+  /// choice needs a name — an unnamed choice would record as a blank chip.
+  bool get _choicesValid {
+    final active = [
+      for (final choice in _choices)
+        if (choice.archived != true) choice,
+    ];
+    return active.isNotEmpty &&
+        active.every((choice) => choice.title.trim().isNotEmpty);
+  }
 
   /// Opens a single-page modal listing every [AggregationType] under its
   /// localized name; picking one writes it into the form [field].
@@ -105,17 +148,37 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
 
     Future<void> onSavePressed() async {
       _formKey.currentState!.save();
-      if (_formKey.currentState!.validate()) {
+      final formValid = _formKey.currentState!.validate();
+      if (_isChoice && !_choicesValid) {
+        setState(() => _showChoiceErrors = true);
+        return;
+      }
+      if (formValid) {
         final formData = _formKey.currentState?.value;
         final private = formData?['private'] as bool? ?? false;
         final favorite = formData?['favorite'] as bool? ?? false;
         final dataType = item.copyWith(
           description: '${formData!['description']}'.trim(),
-          unitName: '${formData['unitName']}'.trim(),
+          // Unit and aggregation are numeric fields the choice form does not
+          // show; a choice measurable keeps whatever it had.
+          unitName: _isChoice
+              ? item.unitName
+              : '${formData['unitName']}'.trim(),
           displayName: '${formData['displayName']}'.trim(),
           private: private,
           favorite: favorite,
-          aggregationType: formData['aggregationType'] as AggregationType?,
+          aggregationType: _isChoice
+              ? item.aggregationType
+              : formData['aggregationType'] as AggregationType?,
+          valueKind: _valueKind,
+          // A numeric measurable that never had choices stays without the
+          // key rather than gaining an empty list on every save.
+          choices: _choices.isEmpty
+              ? null
+              : [
+                  for (final choice in _choices)
+                    choice.copyWith(title: choice.title.trim()),
+                ],
         );
 
         await persistenceLogic.upsertEntityDefinition(dataType);
@@ -203,35 +266,47 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
                     name: 'description',
                     semanticsLabel: messages.settingsMeasurableDescriptionLabel,
                   ),
-                  SettingsFormTextField(
-                    initialValue: item.unitName,
-                    labelText: messages.settingsMeasurableUnitLabel,
-                    fieldRequired: false,
-                    name: 'unitName',
-                    semanticsLabel: messages.settingsMeasurableUnitLabel,
+                  _ValueKindField(
+                    valueKind: _valueKind,
+                    onChanged: _setValueKind,
                   ),
-                  FormBuilderField<AggregationType>(
-                    name: 'aggregationType',
-                    initialValue: item.aggregationType,
-                    builder: (field) {
-                      final value = field.value;
-                      return SettingsPickerField(
-                        key: const Key('measurable_aggregation_field'),
-                        label: messages.settingsMeasurableAggregationLabel,
-                        valueText: value != null
-                            ? aggregationTypeLabel(messages, value)
-                            : null,
-                        hintText: messages.aggregationNone,
-                        helperText:
-                            messages.settingsMeasurableAggregationHelper,
-                        semanticsLabel:
-                            messages.settingsMeasurableAggregationLabel,
-                        onTap: () => _pickAggregationType(field),
-                      );
-                    },
-                  ),
+                  if (!_isChoice) ...[
+                    SettingsFormTextField(
+                      initialValue: item.unitName,
+                      labelText: messages.settingsMeasurableUnitLabel,
+                      fieldRequired: false,
+                      name: 'unitName',
+                      semanticsLabel: messages.settingsMeasurableUnitLabel,
+                    ),
+                    FormBuilderField<AggregationType>(
+                      name: 'aggregationType',
+                      initialValue: item.aggregationType,
+                      builder: (field) {
+                        final value = field.value;
+                        return SettingsPickerField(
+                          key: const Key('measurable_aggregation_field'),
+                          label: messages.settingsMeasurableAggregationLabel,
+                          valueText: value != null
+                              ? aggregationTypeLabel(messages, value)
+                              : null,
+                          hintText: messages.aggregationNone,
+                          helperText:
+                              messages.settingsMeasurableAggregationHelper,
+                          semanticsLabel:
+                              messages.settingsMeasurableAggregationLabel,
+                          onTap: () => _pickAggregationType(field),
+                        );
+                      },
+                    ),
+                  ],
                 ],
               ),
+              if (_isChoice)
+                MeasurableChoicesEditor(
+                  choices: _choices,
+                  showErrors: _showChoiceErrors,
+                  onChanged: _setChoices,
+                ),
               SettingsFormSection(
                 title: messages.habitSectionOptionsTitle,
                 children: [
@@ -251,6 +326,56 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
                 ],
               ),
             ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// "Recorded as": the number / choice switch with its helper line, styled
+/// like the kit's labelled fields so it sits naturally between them.
+class _ValueKindField extends StatelessWidget {
+  const _ValueKindField({required this.valueKind, required this.onChanged});
+
+  final MeasurableValueKind valueKind;
+  final ValueChanged<MeasurableValueKind> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          messages.settingsMeasurableValueKindLabel,
+          style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+            color: tokens.colors.text.highEmphasis,
+          ),
+        ),
+        SizedBox(height: tokens.spacing.step2),
+        DsSegmentedToggle<MeasurableValueKind>(
+          key: const Key('measurable_value_kind_field'),
+          expand: true,
+          selected: valueKind,
+          onChanged: onChanged,
+          segments: [
+            DsSegment(
+              MeasurableValueKind.number,
+              messages.settingsMeasurableValueKindNumber,
+            ),
+            DsSegment(
+              MeasurableValueKind.choice,
+              messages.settingsMeasurableValueKindChoice,
+            ),
+          ],
+        ),
+        SizedBox(height: tokens.spacing.step2),
+        Text(
+          messages.settingsMeasurableValueKindHelper,
+          style: tokens.typography.styles.others.caption.copyWith(
+            color: tokens.colors.text.mediumEmphasis,
           ),
         ),
       ],

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -15,6 +15,7 @@ import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/notification_entity.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/journal_update_result.dart';
 import 'package:lotti/database/notifications_db.dart';
 import 'package:lotti/database/settings_db.dart';
@@ -132,6 +133,7 @@ class SyncEventProcessor {
     this._notificationsDb,
     this._notificationScheduler,
     this._syncNodeProfileRepository,
+    this._fts5Db,
   }) : _documentsDirectory =
            journalEntityLoader?.documentsDirectory ?? documentsDirectory,
        _journalEntityLoader =
@@ -171,6 +173,7 @@ class SyncEventProcessor {
   // `SyncSyncNodeProfile` messages are still acknowledged but the directory
   // upsert is skipped.
   final SyncNodeProfileRepository? _syncNodeProfileRepository;
+  final Fts5Db? _fts5Db;
 
   // Cached local host id. Resolved lazily on the first event that carries
   // an `originatingHostId`. Vector-clock host ids are stable for the life

--- a/lib/features/sync/matrix/sync_event_processor_apply.dart
+++ b/lib/features/sync/matrix/sync_event_processor_apply.dart
@@ -44,7 +44,35 @@ extension SyncEventProcessorApply on SyncEventProcessor {
           journalDb: journalDb,
         );
       case SyncEntityDefinition(:final entityDefinition):
+        final measurable = entityDefinition is MeasurableDataType
+            ? entityDefinition
+            : null;
+        final fts5Db = _fts5Db;
+        final previousMeasurable = measurable != null && fts5Db != null
+            ? await journalDb.getMeasurableDataTypeById(measurable.id)
+            : null;
         await journalDb.upsertEntityDefinition(entityDefinition);
+        if (measurable != null &&
+            fts5Db != null &&
+            measurementDefinitionAffectsFts(previousMeasurable, measurable)) {
+          try {
+            final entries = await journalDb.getMeasurementsByType(
+              type: measurable.id,
+              rangeStart: DateTime(1),
+              rangeEnd: DateTime(9999, 12, 31, 23, 59, 59, 999),
+            );
+            await fts5Db.reindexMeasurements(measurable, entries);
+          } catch (exception, stackTrace) {
+            // Search rows are derived. Keep the synced definition even if its
+            // local index cannot be refreshed right now.
+            _loggingService.error(
+              LogDomain.sync,
+              exception,
+              stackTrace: stackTrace,
+              subDomain: 'processor.apply.entityDefinition.reindex',
+            );
+          }
+        }
         final typeNotification = switch (entityDefinition) {
           CategoryDefinition() => categoriesNotification,
           HabitDefinition() => habitsNotification,

--- a/lib/get_it_sync.dart
+++ b/lib/get_it_sync.dart
@@ -74,6 +74,7 @@ Future<String? Function()> _registerMatrixSyncStack({
     notificationsDb: notificationsDb,
     notificationScheduler: notificationScheduler,
     syncNodeProfileRepository: syncNodeProfileRepository,
+    fts5Db: getIt<Fts5Db>(),
   )..consumptionRepository = consumptionRepository;
 
   final collectSyncMetrics = await journalDb.getConfigFlag(enableLoggingFlag);

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2978,6 +2978,7 @@
   "habitSignalStatusNotYet": "{target} · zatím ne",
   "habitSignalStatusSoFar": "{target} · zatím {value}",
   "habitSignalToday": "dnes: {value}",
+  "habitSignalTodayLogged": "dnes: zaznamenáno",
   "habitSignalTodayNone": "dnes: —",
   "habitsLaggardHint": "{habit} — splněno {kept} z {active}",
   "habitsOpenHeader": "K splnění",
@@ -3558,9 +3559,19 @@
   "matrixStatsSignals": "Signály",
   "matrixStatsSignalsConnectivity": "Signály (připojení)",
   "matrixStatsTopKpis": "Hlavní ukazatele",
+  "measurableChoiceNotFound": "Odstraněná volba",
   "measurableDeleteConfirm": "Ano, smazat tuto měřitelnou veličinu",
   "measurableDeleteQuestion": "Chcete tento měřitelný datový typ smazat?",
   "measurableNotFound": "Měřitelný typ nenalezen",
+  "measurementChoicePrompt": "Vyber jednu",
+  "measurementChoiceSelectSemantic": "Vybrat {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Přidat poznámku (volitelné)",
   "measurementCommentSemantic": "Poznámka, volitelná",
   "measurementObservedAtChangeSemantic": "Naměřeno {dateTime}. Změnit datum a čas.",
@@ -4652,6 +4663,38 @@
   "settingsMatrixVerifyLabel": "Ověřit",
   "settingsMeasurableAggregationHelper": "Jak se záznamy jednoho dne kombinují v grafech",
   "settingsMeasurableAggregationLabel": "Výchozí agregace",
+  "settingsMeasurableChoiceAdd": "Přidat volbu",
+  "settingsMeasurableChoiceArchive": "Archivovat {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Název volby",
+  "settingsMeasurableChoiceNameRequired": "Pojmenuj tuto volbu",
+  "settingsMeasurableChoiceReorder": "Přesunout {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Obnovit {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Při zaznamenávání skryté; položky, které je použily, dál ukazují jejich název.",
+  "settingsMeasurableChoicesArchivedTitle": "Archivované volby",
+  "settingsMeasurableChoicesDescription": "Při zaznamenávání si jednu vybereš. Kdykoli je můžeš přejmenovat nebo přeuspořádat – už zaznamenané položky si svou volbu ponechají.",
+  "settingsMeasurableChoicesRequired": "Přidej alespoň jednu volbu",
+  "settingsMeasurableChoicesTitle": "Volby",
   "settingsMeasurableDeleteTooltip": "Smazat měřitelný typ",
   "settingsMeasurableDescriptionLabel": "Popis (volitelné)",
   "settingsMeasurableDetailsLabel": "Upravit měřitelný typ",
@@ -4660,7 +4703,7 @@
   "settingsMeasurableSaveLabel": "Uložit",
   "settingsMeasurablesCreateTitle": "Vytvořit měřitelný typ",
   "settingsMeasurablesEmptyState": "Zatím žádné měřitelné typy",
-  "settingsMeasurablesEmptyStateHint": "Měřitelné typy jsou čísla sledovaná v čase — váha, voda, kroky.",
+  "settingsMeasurablesEmptyStateHint": "Měřitelné typy jsou hodnoty sledované v čase — váha, voda, kroky nebo volba jako to, jak odpočatě se cítíš.",
   "settingsMeasurablesErrorLoading": "Chyba při načítání měřitelných typů",
   "settingsMeasurablesNoMatchQuery": "Žádný měřitelný typ neodpovídá \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -4674,6 +4717,10 @@
   "settingsMeasurablesSubtitle": "Konfigurace měřitelných datových typů",
   "settingsMeasurablesTitle": "Měřitelné typy",
   "settingsMeasurableUnitLabel": "Zkratka jednotky (volitelné)",
+  "settingsMeasurableValueKindChoice": "Volba",
+  "settingsMeasurableValueKindHelper": "Číslo s jednotkou, nebo jedna z voleb, které si nastavíš",
+  "settingsMeasurableValueKindLabel": "Zaznamenává se jako",
+  "settingsMeasurableValueKindNumber": "Číslo",
   "settingsOnboardingActionSubtitle": "Znovu otevři uvítací postup — připoj svou AI a vytvoř úkol",
   "settingsOnboardingMetricsSubtitle": "FTUE trychtýř — instalace, aktivace, retence (ladění)",
   "settingsOnboardingMetricsTitle": "Metriky onboardingu",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -3286,6 +3286,7 @@
   "habitSignalStatusNotYet": "{target} · ikke endnu",
   "habitSignalStatusSoFar": "{target} · {value} indtil videre",
   "habitSignalToday": "i dag: {value}",
+  "habitSignalTodayLogged": "i dag: registreret",
   "habitSignalTodayNone": "i dag: —",
   "habitsLaggardHint": "{habit} — beholdt {kept} af {active}",
   "@habitsLaggardHint": {
@@ -3944,9 +3945,19 @@
   "matrixStatsSignals": "Signaler",
   "matrixStatsSignalsConnectivity": "Signaler (forbindelse)",
   "matrixStatsTopKpis": "Top KPI'er",
+  "measurableChoiceNotFound": "Fjernet valg",
   "measurableDeleteConfirm": "Ja, slet denne målbare værdi",
   "measurableDeleteQuestion": "Vil du slette denne målbare datatype?",
   "measurableNotFound": "Målbar ikke fundet",
+  "measurementChoicePrompt": "Vælg ét",
+  "measurementChoiceSelectSemantic": "Vælg {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Tilføj en note (valgfrit)",
   "measurementCommentSemantic": "Kommentar, valgfrit",
   "measurementObservedAtChangeSemantic": "Observeret ved {dateTime}. Skift dato og tidspunkt.",
@@ -5191,6 +5202,38 @@
   "settingsMatrixVerifyLabel": "Bekræft",
   "settingsMeasurableAggregationHelper": "Hvordan dagens indgange kombineres på diagrammer",
   "settingsMeasurableAggregationLabel": "Standard aggregeringstype",
+  "settingsMeasurableChoiceAdd": "Tilføj valg",
+  "settingsMeasurableChoiceArchive": "Arkivér {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Navn på valg",
+  "settingsMeasurableChoiceNameRequired": "Giv dette valg et navn",
+  "settingsMeasurableChoiceReorder": "Flyt {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Gendan {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Skjult ved registrering; poster, der brugte dem, viser stadig deres navn.",
+  "settingsMeasurableChoicesArchivedTitle": "Arkiverede valg",
+  "settingsMeasurableChoicesDescription": "Når du registrerer, vælger du ét af dem. Omdøb eller omarranger dem når som helst – allerede registrerede poster beholder deres valg.",
+  "settingsMeasurableChoicesRequired": "Tilføj mindst ét valg",
+  "settingsMeasurableChoicesTitle": "Valgmuligheder",
   "settingsMeasurableDeleteTooltip": "Slet målbar type",
   "settingsMeasurableDescriptionLabel": "Beskrivelse (valgfrit)",
   "settingsMeasurableDetailsLabel": "Redigeret målbar",
@@ -5199,7 +5242,7 @@
   "settingsMeasurableSaveLabel": "Gem",
   "settingsMeasurablesCreateTitle": "Skab målbar",
   "settingsMeasurablesEmptyState": "Ingen målbare ting endnu",
-  "settingsMeasurablesEmptyStateHint": "Målbare tal er tal, du følger over tid — vægt, vand, skridt.",
+  "settingsMeasurablesEmptyStateHint": "Målbare er værdier, du følger over tid — vægt, vand, skridt eller et valg som hvor udhvilet du føler dig.",
   "settingsMeasurablesErrorLoading": "Fejlindlæsning af målbare",
   "settingsMeasurablesNoMatchQuery": "Ingen målbare størrelser matcher \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -5213,6 +5256,10 @@
   "settingsMeasurablesSubtitle": "Konfigurér målbare datatyper",
   "settingsMeasurablesTitle": "Målbare ting",
   "settingsMeasurableUnitLabel": "Enhedsforkortelse (valgfrit)",
+  "settingsMeasurableValueKindChoice": "Valg",
+  "settingsMeasurableValueKindHelper": "Et tal med enhed, eller et af de valg, du selv definerer",
+  "settingsMeasurableValueKindLabel": "Registreres som",
+  "settingsMeasurableValueKindNumber": "Tal",
   "settingsOnboardingActionSubtitle": "Genopblæs velkomstflowet — forbind din AI-hjerne og skab en opgave",
   "settingsOnboardingMetricsSubtitle": "FTUE-tragt — installation, aktivering, fastholdelse (fejlsøgning)",
   "settingsOnboardingMetricsTitle": "Onboarding-målinger",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2971,6 +2971,7 @@
   "habitSignalStatusNotYet": "{target} · noch nicht",
   "habitSignalStatusSoFar": "{target} · bisher {value}",
   "habitSignalToday": "heute: {value}",
+  "habitSignalTodayLogged": "heute: erfasst",
   "habitSignalTodayNone": "heute: —",
   "habitsLaggardHint": "{habit} — {kept} von {active} geschafft",
   "habitsOpenHeader": "Jetzt fällig",
@@ -3551,9 +3552,19 @@
   "matrixStatsSignals": "Signale",
   "matrixStatsSignalsConnectivity": "Signale (Verbindung)",
   "matrixStatsTopKpis": "Wichtigste KPIs",
+  "measurableChoiceNotFound": "Entfernte Auswahl",
   "measurableDeleteConfirm": "Ja, diese Messgröße löschen",
   "measurableDeleteQuestion": "Möchtest du diesen Messgrößen-Datentyp löschen?",
   "measurableNotFound": "Messgröße nicht gefunden",
+  "measurementChoicePrompt": "Wähle eine",
+  "measurementChoiceSelectSemantic": "{title} auswählen",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Notiz hinzufügen (optional)",
   "measurementCommentSemantic": "Kommentar, optional",
   "measurementObservedAtChangeSemantic": "Erfasst am {dateTime}. Datum und Uhrzeit ändern.",
@@ -4645,6 +4656,38 @@
   "settingsMatrixVerifyLabel": "Verifizieren",
   "settingsMeasurableAggregationHelper": "Wie die Einträge eines Tages in Diagrammen zusammengefasst werden",
   "settingsMeasurableAggregationLabel": "Standard-Aggregation",
+  "settingsMeasurableChoiceAdd": "Auswahl hinzufügen",
+  "settingsMeasurableChoiceArchive": "{title} archivieren",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Name der Auswahl",
+  "settingsMeasurableChoiceNameRequired": "Gib dieser Auswahl einen Namen",
+  "settingsMeasurableChoiceReorder": "{title} verschieben",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "{title} wiederherstellen",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Beim Erfassen ausgeblendet; Einträge, die sie verwendet haben, zeigen weiterhin ihren Namen.",
+  "settingsMeasurableChoicesArchivedTitle": "Archivierte Auswahlmöglichkeiten",
+  "settingsMeasurableChoicesDescription": "Beim Erfassen wählst du eine davon. Du kannst sie jederzeit umbenennen oder neu anordnen – bereits erfasste Einträge behalten ihre Auswahl.",
+  "settingsMeasurableChoicesRequired": "Füge mindestens eine Auswahl hinzu",
+  "settingsMeasurableChoicesTitle": "Auswahlmöglichkeiten",
   "settingsMeasurableDeleteTooltip": "Messgröße löschen",
   "settingsMeasurableDescriptionLabel": "Beschreibung (optional)",
   "settingsMeasurableDetailsLabel": "Messgröße bearbeiten",
@@ -4653,7 +4696,7 @@
   "settingsMeasurableSaveLabel": "Speichern",
   "settingsMeasurablesCreateTitle": "Messgröße erstellen",
   "settingsMeasurablesEmptyState": "Noch keine Messgrößen",
-  "settingsMeasurablesEmptyStateHint": "Messgrößen sind Zahlen, die du über die Zeit verfolgst — Gewicht, Wasser, Schritte.",
+  "settingsMeasurablesEmptyStateHint": "Messgrößen sind Werte, die du über die Zeit verfolgst — Gewicht, Wasser, Schritte oder eine Auswahl wie „wie ausgeruht du bist“.",
   "settingsMeasurablesErrorLoading": "Fehler beim Laden der Messgrößen",
   "settingsMeasurablesNoMatchQuery": "Keine Messgrößen passend zu \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -4667,6 +4710,10 @@
   "settingsMeasurablesSubtitle": "Messbare Datentypen konfigurieren",
   "settingsMeasurablesTitle": "Messgrößen",
   "settingsMeasurableUnitLabel": "Einheitenabkürzung (optional)",
+  "settingsMeasurableValueKindChoice": "Auswahl",
+  "settingsMeasurableValueKindHelper": "Eine Zahl mit Einheit oder eine der Auswahlmöglichkeiten, die du festlegst",
+  "settingsMeasurableValueKindLabel": "Erfasst als",
+  "settingsMeasurableValueKindNumber": "Zahl",
   "settingsOnboardingActionSubtitle": "Öffne den Willkommens-Ablauf erneut – verbinde dein KI-Gehirn und erstelle eine Aufgabe",
   "settingsOnboardingMetricsSubtitle": "FTUE-Funnel – Installation, Aktivierung, Bindung (Debug)",
   "settingsOnboardingMetricsTitle": "Onboarding-Metriken",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4520,6 +4520,7 @@
       }
     }
   },
+  "habitSignalTodayLogged": "today: logged",
   "habitSignalTodayNone": "today: —",
   "habitsLaggardHint": "{habit} — kept {kept} of {active}",
   "@habitsLaggardHint": {
@@ -5332,9 +5333,19 @@
   "matrixStatsSignals": "Signals",
   "matrixStatsSignalsConnectivity": "Signals (connectivity)",
   "matrixStatsTopKpis": "Top KPIs",
+  "measurableChoiceNotFound": "Removed choice",
   "measurableDeleteConfirm": "Yes, delete this measurable",
   "measurableDeleteQuestion": "Do you want to delete this measurable data type?",
   "measurableNotFound": "Measurable not found",
+  "measurementChoicePrompt": "Pick one",
+  "measurementChoiceSelectSemantic": "Select {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Add a note (optional)",
   "measurementCommentSemantic": "Comment, optional",
   "measurementObservedAtChangeSemantic": "Observed at {dateTime}. Change date and time.",
@@ -6765,6 +6776,38 @@
   "settingsMatrixVerifyLabel": "Verify",
   "settingsMeasurableAggregationHelper": "How a day's entries combine on charts",
   "settingsMeasurableAggregationLabel": "Default aggregation type",
+  "settingsMeasurableChoiceAdd": "Add choice",
+  "settingsMeasurableChoiceArchive": "Archive {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Choice name",
+  "settingsMeasurableChoiceNameRequired": "Give this choice a name",
+  "settingsMeasurableChoiceReorder": "Reorder {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Restore {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Hidden when recording; entries that used them still show their name.",
+  "settingsMeasurableChoicesArchivedTitle": "Archived choices",
+  "settingsMeasurableChoicesDescription": "Recording picks one of these. Rename or reorder them any time — entries you already recorded keep their choice.",
+  "settingsMeasurableChoicesRequired": "Add at least one choice",
+  "settingsMeasurableChoicesTitle": "Choices",
   "settingsMeasurableDeleteTooltip": "Delete measurable type",
   "settingsMeasurableDescriptionLabel": "Description (optional)",
   "settingsMeasurableDetailsLabel": "Edit measurable",
@@ -6773,7 +6816,7 @@
   "settingsMeasurableSaveLabel": "Save",
   "settingsMeasurablesCreateTitle": "Create measurable",
   "settingsMeasurablesEmptyState": "No measurables yet",
-  "settingsMeasurablesEmptyStateHint": "Measurables are numbers you track over time — weight, water, steps.",
+  "settingsMeasurablesEmptyStateHint": "Measurables are values you track over time — weight, water, steps, or a choice like how rested you feel.",
   "settingsMeasurablesErrorLoading": "Error loading measurables",
   "settingsMeasurablesNoMatchQuery": "No measurables match \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -6787,6 +6830,10 @@
   "settingsMeasurablesSubtitle": "Configure measurable data types",
   "settingsMeasurablesTitle": "Measurables",
   "settingsMeasurableUnitLabel": "Unit abbreviation (optional)",
+  "settingsMeasurableValueKindChoice": "Choice",
+  "settingsMeasurableValueKindHelper": "A number with a unit, or one of the choices you define",
+  "settingsMeasurableValueKindLabel": "Recorded as",
+  "settingsMeasurableValueKindNumber": "Number",
   "settingsOnboardingActionSubtitle": "Reopen the welcome flow — connect your AI brain and create a task",
   "settingsOnboardingMetricsSubtitle": "FTUE funnel — install, activation, retention (debug)",
   "settingsOnboardingMetricsTitle": "Onboarding Metrics",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4696,7 +4696,7 @@
   "settingsMeasurableSaveLabel": "Guardar",
   "settingsMeasurablesCreateTitle": "Crear valor medible",
   "settingsMeasurablesEmptyState": "Aún no hay valores medibles",
-  "settingsMeasurablesEmptyStateHint": "Los valores medibles son valores que sigues a lo largo del tiempo: peso, agua, pasos o una opción como lo descansado que te sientes.",
+  "settingsMeasurablesEmptyStateHint": "Los valores medibles son datos que sigues a lo largo del tiempo: peso, agua, pasos o una opción como lo descansado que te sientes.",
   "settingsMeasurablesErrorLoading": "Error al cargar valores medibles",
   "settingsMeasurablesNoMatchQuery": "Ningún valor medible coincide con \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2971,6 +2971,7 @@
   "habitSignalStatusNotYet": "{target} · aún no",
   "habitSignalStatusSoFar": "{target} · {value} por ahora",
   "habitSignalToday": "hoy: {value}",
+  "habitSignalTodayLogged": "hoy: registrado",
   "habitSignalTodayNone": "hoy: —",
   "habitsLaggardHint": "{habit} — {kept} de {active} cumplidos",
   "habitsOpenHeader": "Vencido ahora",
@@ -3551,9 +3552,19 @@
   "matrixStatsSignals": "Señales",
   "matrixStatsSignalsConnectivity": "Señales (conectividad)",
   "matrixStatsTopKpis": "Indicadores principales",
+  "measurableChoiceNotFound": "Opción eliminada",
   "measurableDeleteConfirm": "Sí, eliminar este valor medible",
   "measurableDeleteQuestion": "¿Quieres eliminar esta definición de valor medible?",
   "measurableNotFound": "Valor medible no encontrado",
+  "measurementChoicePrompt": "Elige una",
+  "measurementChoiceSelectSemantic": "Seleccionar {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Añade una nota (opcional)",
   "measurementCommentSemantic": "Comentario, opcional",
   "measurementObservedAtChangeSemantic": "Observado el {dateTime}. Cambiar la fecha y la hora.",
@@ -4645,6 +4656,38 @@
   "settingsMatrixVerifyLabel": "Verificar",
   "settingsMeasurableAggregationHelper": "Cómo se combinan las entradas de un día en los gráficos",
   "settingsMeasurableAggregationLabel": "Agregación predeterminada",
+  "settingsMeasurableChoiceAdd": "Añadir opción",
+  "settingsMeasurableChoiceArchive": "Archivar {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Nombre de la opción",
+  "settingsMeasurableChoiceNameRequired": "Ponle un nombre a esta opción",
+  "settingsMeasurableChoiceReorder": "Mover {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Restaurar {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Ocultas al registrar; las entradas que las usaron siguen mostrando su nombre.",
+  "settingsMeasurableChoicesArchivedTitle": "Opciones archivadas",
+  "settingsMeasurableChoicesDescription": "Al registrar eliges una de ellas. Puedes renombrarlas o reordenarlas cuando quieras: las entradas ya registradas conservan su opción.",
+  "settingsMeasurableChoicesRequired": "Añade al menos una opción",
+  "settingsMeasurableChoicesTitle": "Opciones",
   "settingsMeasurableDeleteTooltip": "Eliminar tipo de medición",
   "settingsMeasurableDescriptionLabel": "Descripción (opcional)",
   "settingsMeasurableDetailsLabel": "Editar valor medible",
@@ -4653,7 +4696,7 @@
   "settingsMeasurableSaveLabel": "Guardar",
   "settingsMeasurablesCreateTitle": "Crear valor medible",
   "settingsMeasurablesEmptyState": "Aún no hay valores medibles",
-  "settingsMeasurablesEmptyStateHint": "Los valores medibles son números que sigues a lo largo del tiempo: peso, agua o pasos.",
+  "settingsMeasurablesEmptyStateHint": "Los valores medibles son valores que sigues a lo largo del tiempo: peso, agua, pasos o una opción como lo descansado que te sientes.",
   "settingsMeasurablesErrorLoading": "Error al cargar valores medibles",
   "settingsMeasurablesNoMatchQuery": "Ningún valor medible coincide con \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -4667,6 +4710,10 @@
   "settingsMeasurablesSubtitle": "Configurar los valores que mides",
   "settingsMeasurablesTitle": "Valores medibles",
   "settingsMeasurableUnitLabel": "Abreviatura de la unidad (opcional)",
+  "settingsMeasurableValueKindChoice": "Opción",
+  "settingsMeasurableValueKindHelper": "Un número con unidad, o una de las opciones que definas",
+  "settingsMeasurableValueKindLabel": "Se registra como",
+  "settingsMeasurableValueKindNumber": "Número",
   "settingsOnboardingActionSubtitle": "Vuelve a abrir el flujo de bienvenida: conecta tu cerebro de IA y crea una tarea",
   "settingsOnboardingMetricsSubtitle": "Embudo FTUE: instalación, activación, retención (depuración)",
   "settingsOnboardingMetricsTitle": "Métricas de onboarding",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2971,6 +2971,7 @@
   "habitSignalStatusNotYet": "{target} · pas encore",
   "habitSignalStatusSoFar": "{target} · {value} pour l’instant",
   "habitSignalToday": "aujourd’hui : {value}",
+  "habitSignalTodayLogged": "aujourd'hui : enregistré",
   "habitSignalTodayNone": "aujourd’hui : —",
   "habitsLaggardHint": "{habit} — {kept} sur {active} réussis",
   "habitsOpenHeader": "Dues maintenant",
@@ -3551,9 +3552,19 @@
   "matrixStatsSignals": "Signaux",
   "matrixStatsSignalsConnectivity": "Signaux (connectivité)",
   "matrixStatsTopKpis": "Indicateurs clés",
+  "measurableChoiceNotFound": "Choix supprimé",
   "measurableDeleteConfirm": "Oui, supprimer cet élément mesurable",
   "measurableDeleteQuestion": "Veux-tu supprimer ce type de données mesurables ?",
   "measurableNotFound": "Élément mesurable introuvable",
+  "measurementChoicePrompt": "Choisis-en un",
+  "measurementChoiceSelectSemantic": "Sélectionner {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Ajoute une note (facultatif)",
   "measurementCommentSemantic": "Commentaire, facultatif",
   "measurementObservedAtChangeSemantic": "Observé le {dateTime}. Modifier la date et l’heure.",
@@ -4645,6 +4656,38 @@
   "settingsMatrixVerifyLabel": "Vérifier",
   "settingsMeasurableAggregationHelper": "Comment les entrées d'une journée sont combinées dans les graphiques",
   "settingsMeasurableAggregationLabel": "Agrégation par défaut",
+  "settingsMeasurableChoiceAdd": "Ajouter un choix",
+  "settingsMeasurableChoiceArchive": "Archiver {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Nom du choix",
+  "settingsMeasurableChoiceNameRequired": "Donne un nom à ce choix",
+  "settingsMeasurableChoiceReorder": "Déplacer {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Restaurer {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Masqués à l'enregistrement ; les entrées qui les ont utilisés affichent toujours leur nom.",
+  "settingsMeasurableChoicesArchivedTitle": "Choix archivés",
+  "settingsMeasurableChoicesDescription": "Tu en choisis un à chaque enregistrement. Renomme-les ou réordonne-les quand tu veux : les entrées déjà enregistrées gardent leur choix.",
+  "settingsMeasurableChoicesRequired": "Ajoute au moins un choix",
+  "settingsMeasurableChoicesTitle": "Choix",
   "settingsMeasurableDeleteTooltip": "Supprimer type mesurable",
   "settingsMeasurableDescriptionLabel": "Description",
   "settingsMeasurableDetailsLabel": "Modifier l'élément mesurable",
@@ -4653,7 +4696,7 @@
   "settingsMeasurableSaveLabel": "Enregistrer",
   "settingsMeasurablesCreateTitle": "Créer un élément mesurable",
   "settingsMeasurablesEmptyState": "Aucun élément mesurable pour le moment",
-  "settingsMeasurablesEmptyStateHint": "Les éléments mesurables sont des chiffres que tu suis dans le temps — poids, eau, pas.",
+  "settingsMeasurablesEmptyStateHint": "Les éléments mesurables sont des valeurs que tu suis dans le temps — poids, eau, pas, ou un choix comme ton niveau de repos.",
   "settingsMeasurablesErrorLoading": "Erreur lors du chargement des éléments mesurables",
   "settingsMeasurablesNoMatchQuery": "Aucun élément mesurable ne correspond à \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -4667,6 +4710,10 @@
   "settingsMeasurablesSubtitle": "Configurer les types de données mesurables",
   "settingsMeasurablesTitle": "Éléments mesurables",
   "settingsMeasurableUnitLabel": "Abréviation d'unité",
+  "settingsMeasurableValueKindChoice": "Choix",
+  "settingsMeasurableValueKindHelper": "Un nombre avec une unité, ou l'un des choix que tu définis",
+  "settingsMeasurableValueKindLabel": "Enregistré comme",
+  "settingsMeasurableValueKindNumber": "Nombre",
   "settingsOnboardingActionSubtitle": "Rouvre le parcours de bienvenue — connecte ton cerveau IA et crée une tâche",
   "settingsOnboardingMetricsSubtitle": "Entonnoir FTUE — installation, activation, rétention (débogage)",
   "settingsOnboardingMetricsTitle": "Métriques d'intégration",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3286,6 +3286,7 @@
   "habitSignalStatusNotYet": "{target} · non ancora",
   "habitSignalStatusSoFar": "{target} · {value} finora",
   "habitSignalToday": "oggi: {value}",
+  "habitSignalTodayLogged": "oggi: registrato",
   "habitSignalTodayNone": "oggi: —",
   "habitsLaggardHint": "{habit} — tenuto {kept} di {active}",
   "@habitsLaggardHint": {
@@ -3944,9 +3945,19 @@
   "matrixStatsSignals": "Segnali",
   "matrixStatsSignalsConnectivity": "Segnali (connettività)",
   "matrixStatsTopKpis": "I migliori KPI",
+  "measurableChoiceNotFound": "Scelta rimossa",
   "measurableDeleteConfirm": "Sì, elimina questo misurabile",
   "measurableDeleteQuestion": "Vuoi eliminare questo tipo di dati misurabile?",
   "measurableNotFound": "Misurazione non trovata",
+  "measurementChoicePrompt": "Scegline una",
+  "measurementChoiceSelectSemantic": "Seleziona {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Aggiungi una nota (opzionale)",
   "measurementCommentSemantic": "Commento, opzionale",
   "measurementObservedAtChangeSemantic": "Osservato a {dateTime}. Cambia la data e l'ora.",
@@ -5191,6 +5202,38 @@
   "settingsMatrixVerifyLabel": "Verifica",
   "settingsMeasurableAggregationHelper": "Come le voci di un giorno si combinano sui grafici",
   "settingsMeasurableAggregationLabel": "Tipo di aggregazione predefinito",
+  "settingsMeasurableChoiceAdd": "Aggiungi scelta",
+  "settingsMeasurableChoiceArchive": "Archivia {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Nome della scelta",
+  "settingsMeasurableChoiceNameRequired": "Dai un nome a questa scelta",
+  "settingsMeasurableChoiceReorder": "Sposta {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Ripristina {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Nascoste durante la registrazione; le voci che le hanno usate mostrano ancora il loro nome.",
+  "settingsMeasurableChoicesArchivedTitle": "Scelte archiviate",
+  "settingsMeasurableChoicesDescription": "Quando registri ne scegli una. Puoi rinominarle o riordinarle quando vuoi: le voci già registrate mantengono la loro scelta.",
+  "settingsMeasurableChoicesRequired": "Aggiungi almeno una scelta",
+  "settingsMeasurableChoicesTitle": "Scelte",
   "settingsMeasurableDeleteTooltip": "Eliminare il tipo misurabile",
   "settingsMeasurableDescriptionLabel": "Descrizione (opzionale)",
   "settingsMeasurableDetailsLabel": "Modificare misurabile",
@@ -5199,7 +5242,7 @@
   "settingsMeasurableSaveLabel": "Salva",
   "settingsMeasurablesCreateTitle": "Creare misurabili",
   "settingsMeasurablesEmptyState": "Non ancora misurabili",
-  "settingsMeasurablesEmptyStateHint": "Misurabili sono numeri che si traccia nel tempo — peso, acqua, passi.",
+  "settingsMeasurablesEmptyStateHint": "I misurabili sono valori di cui tieni traccia nel tempo — peso, acqua, passi, oppure una scelta come quanto ti senti riposato.",
   "settingsMeasurablesErrorLoading": "Caricamento errori misurabili",
   "settingsMeasurablesNoMatchQuery": "Nessuna corrispondenza misurabile \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -5213,6 +5256,10 @@
   "settingsMeasurablesSubtitle": "Configurare tipi di dati misurabili",
   "settingsMeasurablesTitle": "Misurabili",
   "settingsMeasurableUnitLabel": "Abbreviazione unità (opzionale)",
+  "settingsMeasurableValueKindChoice": "Scelta",
+  "settingsMeasurableValueKindHelper": "Un numero con unità, oppure una delle scelte che definisci",
+  "settingsMeasurableValueKindLabel": "Registrato come",
+  "settingsMeasurableValueKindNumber": "Numero",
   "settingsOnboardingActionSubtitle": "Riaprire il flusso di benvenuto — collegare il cervello AI e creare un compito",
   "settingsOnboardingMetricsSubtitle": "Imbuto FTUE — installazione, attivazione, ritenzione (debug)",
   "settingsOnboardingMetricsTitle": "Metriche di bordo",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12804,6 +12804,12 @@ abstract class AppLocalizations {
   /// **'today: {value}'**
   String habitSignalToday(String value);
 
+  /// No description provided for @habitSignalTodayLogged.
+  ///
+  /// In en, this message translates to:
+  /// **'today: logged'**
+  String get habitSignalTodayLogged;
+
   /// No description provided for @habitSignalTodayNone.
   ///
   /// In en, this message translates to:
@@ -15637,6 +15643,12 @@ abstract class AppLocalizations {
   /// **'Top KPIs'**
   String get matrixStatsTopKpis;
 
+  /// No description provided for @measurableChoiceNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Removed choice'**
+  String get measurableChoiceNotFound;
+
   /// No description provided for @measurableDeleteConfirm.
   ///
   /// In en, this message translates to:
@@ -15654,6 +15666,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Measurable not found'**
   String get measurableNotFound;
+
+  /// No description provided for @measurementChoicePrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick one'**
+  String get measurementChoicePrompt;
+
+  /// No description provided for @measurementChoiceSelectSemantic.
+  ///
+  /// In en, this message translates to:
+  /// **'Select {title}'**
+  String measurementChoiceSelectSemantic(String title);
 
   /// No description provided for @measurementCommentHint.
   ///
@@ -20185,6 +20209,72 @@ abstract class AppLocalizations {
   /// **'Default aggregation type'**
   String get settingsMeasurableAggregationLabel;
 
+  /// No description provided for @settingsMeasurableChoiceAdd.
+  ///
+  /// In en, this message translates to:
+  /// **'Add choice'**
+  String get settingsMeasurableChoiceAdd;
+
+  /// No description provided for @settingsMeasurableChoiceArchive.
+  ///
+  /// In en, this message translates to:
+  /// **'Archive {title}'**
+  String settingsMeasurableChoiceArchive(String title);
+
+  /// No description provided for @settingsMeasurableChoiceNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Choice name'**
+  String get settingsMeasurableChoiceNameHint;
+
+  /// No description provided for @settingsMeasurableChoiceNameRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Give this choice a name'**
+  String get settingsMeasurableChoiceNameRequired;
+
+  /// No description provided for @settingsMeasurableChoiceReorder.
+  ///
+  /// In en, this message translates to:
+  /// **'Reorder {title}'**
+  String settingsMeasurableChoiceReorder(String title);
+
+  /// No description provided for @settingsMeasurableChoiceRestore.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore {title}'**
+  String settingsMeasurableChoiceRestore(String title);
+
+  /// No description provided for @settingsMeasurableChoicesArchivedDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Hidden when recording; entries that used them still show their name.'**
+  String get settingsMeasurableChoicesArchivedDescription;
+
+  /// No description provided for @settingsMeasurableChoicesArchivedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Archived choices'**
+  String get settingsMeasurableChoicesArchivedTitle;
+
+  /// No description provided for @settingsMeasurableChoicesDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording picks one of these. Rename or reorder them any time — entries you already recorded keep their choice.'**
+  String get settingsMeasurableChoicesDescription;
+
+  /// No description provided for @settingsMeasurableChoicesRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Add at least one choice'**
+  String get settingsMeasurableChoicesRequired;
+
+  /// No description provided for @settingsMeasurableChoicesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choices'**
+  String get settingsMeasurableChoicesTitle;
+
   /// No description provided for @settingsMeasurableDeleteTooltip.
   ///
   /// In en, this message translates to:
@@ -20236,7 +20326,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsMeasurablesEmptyStateHint.
   ///
   /// In en, this message translates to:
-  /// **'Measurables are numbers you track over time — weight, water, steps.'**
+  /// **'Measurables are values you track over time — weight, water, steps, or a choice like how rested you feel.'**
   String get settingsMeasurablesEmptyStateHint;
 
   /// No description provided for @settingsMeasurablesErrorLoading.
@@ -20274,6 +20364,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Unit abbreviation (optional)'**
   String get settingsMeasurableUnitLabel;
+
+  /// No description provided for @settingsMeasurableValueKindChoice.
+  ///
+  /// In en, this message translates to:
+  /// **'Choice'**
+  String get settingsMeasurableValueKindChoice;
+
+  /// No description provided for @settingsMeasurableValueKindHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'A number with a unit, or one of the choices you define'**
+  String get settingsMeasurableValueKindHelper;
+
+  /// No description provided for @settingsMeasurableValueKindLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Recorded as'**
+  String get settingsMeasurableValueKindLabel;
+
+  /// No description provided for @settingsMeasurableValueKindNumber.
+  ///
+  /// In en, this message translates to:
+  /// **'Number'**
+  String get settingsMeasurableValueKindNumber;
 
   /// No description provided for @settingsOnboardingActionSubtitle.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7632,6 +7632,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'dnes: zaznamenáno';
+
+  @override
   String get habitSignalTodayNone => 'dnes: —';
 
   @override
@@ -9317,6 +9320,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get matrixStatsTopKpis => 'Hlavní ukazatele';
 
   @override
+  String get measurableChoiceNotFound => 'Odstraněná volba';
+
+  @override
   String get measurableDeleteConfirm => 'Ano, smazat tuto měřitelnou veličinu';
 
   @override
@@ -9325,6 +9331,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Měřitelný typ nenalezen';
+
+  @override
+  String get measurementChoicePrompt => 'Vyber jednu';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Vybrat $title';
+  }
 
   @override
   String get measurementCommentHint => 'Přidat poznámku (volitelné)';
@@ -12108,6 +12122,47 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Výchozí agregace';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Přidat volbu';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Archivovat $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Název volby';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired => 'Pojmenuj tuto volbu';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Přesunout $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Obnovit $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Při zaznamenávání skryté; položky, které je použily, dál ukazují jejich název.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Archivované volby';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Při zaznamenávání si jednu vybereš. Kdykoli je můžeš přejmenovat nebo přeuspořádat – už zaznamenané položky si svou volbu ponechají.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Přidej alespoň jednu volbu';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Volby';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Smazat měřitelný typ';
 
   @override
@@ -12133,7 +12188,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Měřitelné typy jsou čísla sledovaná v čase — váha, voda, kroky.';
+      'Měřitelné typy jsou hodnoty sledované v čase — váha, voda, kroky nebo volba jako to, jak odpočatě se cítíš.';
 
   @override
   String get settingsMeasurablesErrorLoading =>
@@ -12156,6 +12211,19 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Zkratka jednotky (volitelné)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Volba';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Číslo s jednotkou, nebo jedna z voleb, které si nastavíš';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Zaznamenává se jako';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Číslo';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7551,6 +7551,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'i dag: registreret';
+
+  @override
   String get habitSignalTodayNone => 'i dag: —';
 
   @override
@@ -9195,6 +9198,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get matrixStatsTopKpis => 'Top KPI\'er';
 
   @override
+  String get measurableChoiceNotFound => 'Fjernet valg';
+
+  @override
   String get measurableDeleteConfirm => 'Ja, slet denne målbare værdi';
 
   @override
@@ -9203,6 +9209,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Målbar ikke fundet';
+
+  @override
+  String get measurementChoicePrompt => 'Vælg ét';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Vælg $title';
+  }
 
   @override
   String get measurementCommentHint => 'Tilføj en note (valgfrit)';
@@ -11962,6 +11976,47 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Standard aggregeringstype';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Tilføj valg';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Arkivér $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Navn på valg';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired => 'Giv dette valg et navn';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Flyt $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Gendan $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Skjult ved registrering; poster, der brugte dem, viser stadig deres navn.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Arkiverede valg';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Når du registrerer, vælger du ét af dem. Omdøb eller omarranger dem når som helst – allerede registrerede poster beholder deres valg.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Tilføj mindst ét valg';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Valgmuligheder';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Slet målbar type';
 
   @override
@@ -11987,7 +12042,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Målbare tal er tal, du følger over tid — vægt, vand, skridt.';
+      'Målbare er værdier, du følger over tid — vægt, vand, skridt eller et valg som hvor udhvilet du føler dig.';
 
   @override
   String get settingsMeasurablesErrorLoading => 'Fejlindlæsning af målbare';
@@ -12008,6 +12063,19 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Enhedsforkortelse (valgfrit)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Valg';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Et tal med enhed, eller et af de valg, du selv definerer';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Registreres som';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Tal';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7606,6 +7606,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'heute: erfasst';
+
+  @override
   String get habitSignalTodayNone => 'heute: —';
 
   @override
@@ -9259,6 +9262,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get matrixStatsTopKpis => 'Wichtigste KPIs';
 
   @override
+  String get measurableChoiceNotFound => 'Entfernte Auswahl';
+
+  @override
   String get measurableDeleteConfirm => 'Ja, diese Messgröße löschen';
 
   @override
@@ -9267,6 +9273,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Messgröße nicht gefunden';
+
+  @override
+  String get measurementChoicePrompt => 'Wähle eine';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return '$title auswählen';
+  }
 
   @override
   String get measurementCommentHint => 'Notiz hinzufügen (optional)';
@@ -12038,6 +12052,50 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Standard-Aggregation';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Auswahl hinzufügen';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return '$title archivieren';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Name der Auswahl';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired =>
+      'Gib dieser Auswahl einen Namen';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return '$title verschieben';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return '$title wiederherstellen';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Beim Erfassen ausgeblendet; Einträge, die sie verwendet haben, zeigen weiterhin ihren Namen.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle =>
+      'Archivierte Auswahlmöglichkeiten';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Beim Erfassen wählst du eine davon. Du kannst sie jederzeit umbenennen oder neu anordnen – bereits erfasste Einträge behalten ihre Auswahl.';
+
+  @override
+  String get settingsMeasurableChoicesRequired =>
+      'Füge mindestens eine Auswahl hinzu';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Auswahlmöglichkeiten';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Messgröße löschen';
 
   @override
@@ -12063,7 +12121,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Messgrößen sind Zahlen, die du über die Zeit verfolgst — Gewicht, Wasser, Schritte.';
+      'Messgrößen sind Werte, die du über die Zeit verfolgst — Gewicht, Wasser, Schritte oder eine Auswahl wie „wie ausgeruht du bist“.';
 
   @override
   String get settingsMeasurablesErrorLoading =>
@@ -12085,6 +12143,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Einheitenabkürzung (optional)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Auswahl';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Eine Zahl mit Einheit oder eine der Auswahlmöglichkeiten, die du festlegst';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Erfasst als';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Zahl';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7527,6 +7527,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'today: logged';
+
+  @override
   String get habitSignalTodayNone => 'today: —';
 
   @override
@@ -9157,6 +9160,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get matrixStatsTopKpis => 'Top KPIs';
 
   @override
+  String get measurableChoiceNotFound => 'Removed choice';
+
+  @override
   String get measurableDeleteConfirm => 'Yes, delete this measurable';
 
   @override
@@ -9165,6 +9171,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Measurable not found';
+
+  @override
+  String get measurementChoicePrompt => 'Pick one';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Select $title';
+  }
 
   @override
   String get measurementCommentHint => 'Add a note (optional)';
@@ -11896,6 +11910,47 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Default aggregation type';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Add choice';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Archive $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Choice name';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired => 'Give this choice a name';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Reorder $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Restore $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Hidden when recording; entries that used them still show their name.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Archived choices';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Recording picks one of these. Rename or reorder them any time — entries you already recorded keep their choice.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Add at least one choice';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Choices';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Delete measurable type';
 
   @override
@@ -11921,7 +11976,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Measurables are numbers you track over time — weight, water, steps.';
+      'Measurables are values you track over time — weight, water, steps, or a choice like how rested you feel.';
 
   @override
   String get settingsMeasurablesErrorLoading => 'Error loading measurables';
@@ -11942,6 +11997,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Unit abbreviation (optional)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Choice';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'A number with a unit, or one of the choices you define';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Recorded as';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Number';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12208,7 +12208,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Los valores medibles son valores que sigues a lo largo del tiempo: peso, agua, pasos o una opción como lo descansado que te sientes.';
+      'Los valores medibles son datos que sigues a lo largo del tiempo: peso, agua, pasos o una opción como lo descansado que te sientes.';
 
   @override
   String get settingsMeasurablesErrorLoading =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7658,6 +7658,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'hoy: registrado';
+
+  @override
   String get habitSignalTodayNone => 'hoy: —';
 
   @override
@@ -9331,6 +9334,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get matrixStatsTopKpis => 'Indicadores principales';
 
   @override
+  String get measurableChoiceNotFound => 'Opción eliminada';
+
+  @override
   String get measurableDeleteConfirm => 'Sí, eliminar este valor medible';
 
   @override
@@ -9339,6 +9345,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Valor medible no encontrado';
+
+  @override
+  String get measurementChoicePrompt => 'Elige una';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Seleccionar $title';
+  }
 
   @override
   String get measurementCommentHint => 'Añade una nota (opcional)';
@@ -12127,6 +12141,48 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Agregación predeterminada';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Añadir opción';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Archivar $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Nombre de la opción';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired =>
+      'Ponle un nombre a esta opción';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Mover $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Restaurar $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Ocultas al registrar; las entradas que las usaron siguen mostrando su nombre.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Opciones archivadas';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Al registrar eliges una de ellas. Puedes renombrarlas o reordenarlas cuando quieras: las entradas ya registradas conservan su opción.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Añade al menos una opción';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Opciones';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Eliminar tipo de medición';
 
   @override
@@ -12152,7 +12208,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Los valores medibles son números que sigues a lo largo del tiempo: peso, agua o pasos.';
+      'Los valores medibles son valores que sigues a lo largo del tiempo: peso, agua, pasos o una opción como lo descansado que te sientes.';
 
   @override
   String get settingsMeasurablesErrorLoading =>
@@ -12175,6 +12231,19 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settingsMeasurableUnitLabel =>
       'Abreviatura de la unidad (opcional)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Opción';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Un número con unidad, o una de las opciones que definas';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Se registra como';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Número';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7675,6 +7675,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'aujourd\'hui : enregistré';
+
+  @override
   String get habitSignalTodayNone => 'aujourd’hui : —';
 
   @override
@@ -9358,6 +9361,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get matrixStatsTopKpis => 'Indicateurs clés';
 
   @override
+  String get measurableChoiceNotFound => 'Choix supprimé';
+
+  @override
   String get measurableDeleteConfirm => 'Oui, supprimer cet élément mesurable';
 
   @override
@@ -9366,6 +9372,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Élément mesurable introuvable';
+
+  @override
+  String get measurementChoicePrompt => 'Choisis-en un';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Sélectionner $title';
+  }
 
   @override
   String get measurementCommentHint => 'Ajoute une note (facultatif)';
@@ -12171,6 +12185,47 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Agrégation par défaut';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Ajouter un choix';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Archiver $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Nom du choix';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired => 'Donne un nom à ce choix';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Déplacer $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Restaurer $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Masqués à l\'enregistrement ; les entrées qui les ont utilisés affichent toujours leur nom.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Choix archivés';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Tu en choisis un à chaque enregistrement. Renomme-les ou réordonne-les quand tu veux : les entrées déjà enregistrées gardent leur choix.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Ajoute au moins un choix';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Choix';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Supprimer type mesurable';
 
   @override
@@ -12197,7 +12252,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Les éléments mesurables sont des chiffres que tu suis dans le temps — poids, eau, pas.';
+      'Les éléments mesurables sont des valeurs que tu suis dans le temps — poids, eau, pas, ou un choix comme ton niveau de repos.';
 
   @override
   String get settingsMeasurablesErrorLoading =>
@@ -12221,6 +12276,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Abréviation d\'unité';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Choix';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Un nombre avec une unité, ou l\'un des choix que tu définis';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Enregistré comme';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Nombre';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7644,6 +7644,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'oggi: registrato';
+
+  @override
   String get habitSignalTodayNone => 'oggi: —';
 
   @override
@@ -9315,6 +9318,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get matrixStatsTopKpis => 'I migliori KPI';
 
   @override
+  String get measurableChoiceNotFound => 'Scelta rimossa';
+
+  @override
   String get measurableDeleteConfirm => 'Sì, elimina questo misurabile';
 
   @override
@@ -9323,6 +9329,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Misurazione non trovata';
+
+  @override
+  String get measurementChoicePrompt => 'Scegline una';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Seleziona $title';
+  }
 
   @override
   String get measurementCommentHint => 'Aggiungi una nota (opzionale)';
@@ -12122,6 +12136,48 @@ class AppLocalizationsIt extends AppLocalizations {
       'Tipo di aggregazione predefinito';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Aggiungi scelta';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Archivia $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Nome della scelta';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired =>
+      'Dai un nome a questa scelta';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Sposta $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Ripristina $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Nascoste durante la registrazione; le voci che le hanno usate mostrano ancora il loro nome.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Scelte archiviate';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Quando registri ne scegli una. Puoi rinominarle o riordinarle quando vuoi: le voci già registrate mantengono la loro scelta.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Aggiungi almeno una scelta';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Scelte';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Eliminare il tipo misurabile';
 
   @override
@@ -12147,7 +12203,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Misurabili sono numeri che si traccia nel tempo — peso, acqua, passi.';
+      'I misurabili sono valori di cui tieni traccia nel tempo — peso, acqua, passi, oppure una scelta come quanto ti senti riposato.';
 
   @override
   String get settingsMeasurablesErrorLoading => 'Caricamento errori misurabili';
@@ -12169,6 +12225,19 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Abbreviazione unità (opzionale)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Scelta';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Un numero con unità, oppure una delle scelte che definisci';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Registrato come';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Numero';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7567,6 +7567,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'vandaag: vastgelegd';
+
+  @override
   String get habitSignalTodayNone => 'vandaag: —';
 
   @override
@@ -9214,6 +9217,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get matrixStatsTopKpis => 'Top KPI\'s';
 
   @override
+  String get measurableChoiceNotFound => 'Verwijderde keuze';
+
+  @override
   String get measurableDeleteConfirm =>
       'Ja, verwijder dit meetbare gegevenstype';
 
@@ -9223,6 +9229,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Maattabel niet gevonden';
+
+  @override
+  String get measurementChoicePrompt => 'Kies er een';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return '$title selecteren';
+  }
 
   @override
   String get measurementCommentHint => 'Nota toevoegen (facultatief)';
@@ -11982,6 +11996,47 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Standaard aggregatietype';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Keuze toevoegen';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return '$title archiveren';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Naam van de keuze';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired => 'Geef deze keuze een naam';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return '$title verplaatsen';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return '$title terugzetten';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Verborgen bij het vastleggen; items die ze gebruikten tonen nog steeds hun naam.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Gearchiveerde keuzes';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Bij het vastleggen kies je er een. Je kunt ze altijd hernoemen of herschikken – al vastgelegde items houden hun keuze.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Voeg minstens één keuze toe';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Keuzes';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Meetbaar type verwijderen';
 
   @override
@@ -12007,7 +12062,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Measurables zijn nummers die je volgt in de tijd .. gewicht, water, stappen.';
+      'Meetwaarden zijn waarden die je in de tijd volgt — gewicht, water, stappen, of een keuze zoals hoe uitgerust je je voelt.';
 
   @override
   String get settingsMeasurablesErrorLoading =>
@@ -12030,6 +12085,19 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Eenheidsafkorting (facultatief)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Keuze';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Een getal met eenheid, of een van de keuzes die je zelf bepaalt';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Vastgelegd als';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Getal';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7626,6 +7626,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'hoje: registrado';
+
+  @override
   String get habitSignalTodayNone => 'hoje: —';
 
   @override
@@ -9285,6 +9288,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get matrixStatsTopKpis => 'Principais KPIs';
 
   @override
+  String get measurableChoiceNotFound => 'Opção removida';
+
+  @override
   String get measurableDeleteConfirm => 'Sim, excluir este mensurável';
 
   @override
@@ -9293,6 +9299,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Mensurável não encontrado';
+
+  @override
+  String get measurementChoicePrompt => 'Escolha uma';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Selecionar $title';
+  }
 
   @override
   String get measurementCommentHint => 'Adicione uma nota (opcional)';
@@ -12071,6 +12085,48 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Tipo de agregação padrão';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Adicionar opção';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Arquivar $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Nome da opção';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired => 'Dê um nome a esta opção';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Mover $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Restaurar $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Ocultas ao registrar; as entradas que as usaram continuam mostrando o nome.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Opções arquivadas';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'Ao registrar, você escolhe uma delas. Renomeie ou reordene quando quiser – as entradas já registradas mantêm a opção.';
+
+  @override
+  String get settingsMeasurableChoicesRequired =>
+      'Adicione pelo menos uma opção';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Opções';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Excluir tipo mensurável';
 
   @override
@@ -12096,7 +12152,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Mensuráveis são números que você acompanha ao longo do tempo – peso, água, passos.';
+      'Mensuráveis são valores que você acompanha ao longo do tempo – peso, água, passos ou uma opção como o quanto você se sente descansado.';
 
   @override
   String get settingsMeasurablesErrorLoading => 'Erro ao carregar mensuráveis';
@@ -12118,6 +12174,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Abreviatura da unidade (opcional)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Opção';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Um número com unidade, ou uma das opções que você define';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Registrado como';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Número';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7692,6 +7692,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'azi: înregistrat';
+
+  @override
   String get habitSignalTodayNone => 'azi: —';
 
   @override
@@ -9383,6 +9386,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get matrixStatsTopKpis => 'Indicatori principali';
 
   @override
+  String get measurableChoiceNotFound => 'Opțiune eliminată';
+
+  @override
   String get measurableDeleteConfirm => 'Da, ștergeți acest tip de măsurătoare';
 
   @override
@@ -9391,6 +9397,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Masuratoarea nu a fost gasita';
+
+  @override
+  String get measurementChoicePrompt => 'Alegeți una';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Selectați $title';
+  }
 
   @override
   String get measurementCommentHint => 'Adăugați o notă (opțional)';
@@ -12190,6 +12204,49 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Agregare implicită';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Adăugați o opțiune';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Arhivați $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Numele opțiunii';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired =>
+      'Dați un nume acestei opțiuni';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Mutați $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Restaurați $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Ascunse la înregistrare; intrările care le-au folosit își afișează în continuare numele.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Opțiuni arhivate';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'La înregistrare alegeți una dintre ele. Le puteți redenumi sau reordona oricând – intrările deja înregistrate își păstrează opțiunea.';
+
+  @override
+  String get settingsMeasurableChoicesRequired =>
+      'Adăugați cel puțin o opțiune';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Opțiuni';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Ștergeți tipul măsurătorii';
 
   @override
@@ -12215,7 +12272,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Măsurătorile sunt valori urmărite în timp — greutate, apă, pași.';
+      'Măsurătorile sunt valori urmărite în timp — greutate, apă, pași sau o opțiune precum cât de odihnit vă simțiți.';
 
   @override
   String get settingsMeasurablesErrorLoading =>
@@ -12238,6 +12295,19 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Unitatea abrevierii';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Opțiune';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Un număr cu unitate sau una dintre opțiunile pe care le definiți';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Se înregistrează ca';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Număr';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7562,6 +7562,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get habitSignalTodayLogged => 'idag: registrerat';
+
+  @override
   String get habitSignalTodayNone => 'idag: —';
 
   @override
@@ -9206,6 +9209,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get matrixStatsTopKpis => 'Topp-KPI:er';
 
   @override
+  String get measurableChoiceNotFound => 'Borttaget val';
+
+  @override
   String get measurableDeleteConfirm => 'Ja, radera detta mätvärde';
 
   @override
@@ -9214,6 +9220,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get measurableNotFound => 'Mätbar inte hittad';
+
+  @override
+  String get measurementChoicePrompt => 'Välj ett';
+
+  @override
+  String measurementChoiceSelectSemantic(String title) {
+    return 'Välj $title';
+  }
 
   @override
   String get measurementCommentHint => 'Lägg till en anteckning (valfritt)';
@@ -11974,6 +11988,48 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsMeasurableAggregationLabel => 'Standardaggregeringstyp';
 
   @override
+  String get settingsMeasurableChoiceAdd => 'Lägg till val';
+
+  @override
+  String settingsMeasurableChoiceArchive(String title) {
+    return 'Arkivera $title';
+  }
+
+  @override
+  String get settingsMeasurableChoiceNameHint => 'Namn på valet';
+
+  @override
+  String get settingsMeasurableChoiceNameRequired =>
+      'Ge det här valet ett namn';
+
+  @override
+  String settingsMeasurableChoiceReorder(String title) {
+    return 'Flytta $title';
+  }
+
+  @override
+  String settingsMeasurableChoiceRestore(String title) {
+    return 'Återställ $title';
+  }
+
+  @override
+  String get settingsMeasurableChoicesArchivedDescription =>
+      'Dolda vid registrering; poster som använde dem visar fortfarande sitt namn.';
+
+  @override
+  String get settingsMeasurableChoicesArchivedTitle => 'Arkiverade val';
+
+  @override
+  String get settingsMeasurableChoicesDescription =>
+      'När du registrerar väljer du ett av dem. Byt namn eller ordning när som helst – redan registrerade poster behåller sitt val.';
+
+  @override
+  String get settingsMeasurableChoicesRequired => 'Lägg till minst ett val';
+
+  @override
+  String get settingsMeasurableChoicesTitle => 'Valmöjligheter';
+
+  @override
   String get settingsMeasurableDeleteTooltip => 'Ta bort mätbar typ';
 
   @override
@@ -11999,7 +12055,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Mätbara är siffror du följer över tid — vikt, vatten, steg.';
+      'Mätbara är värden du följer över tid — vikt, vatten, steg eller ett val som hur utvilad du känner dig.';
 
   @override
   String get settingsMeasurablesErrorLoading => 'Fellastningsmätbara';
@@ -12020,6 +12076,19 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get settingsMeasurableUnitLabel => 'Enhetsförkortning (valfritt)';
+
+  @override
+  String get settingsMeasurableValueKindChoice => 'Val';
+
+  @override
+  String get settingsMeasurableValueKindHelper =>
+      'Ett tal med enhet, eller ett av de val du själv definierar';
+
+  @override
+  String get settingsMeasurableValueKindLabel => 'Registreras som';
+
+  @override
+  String get settingsMeasurableValueKindNumber => 'Tal';
 
   @override
   String get settingsOnboardingActionSubtitle =>

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -12055,7 +12055,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get settingsMeasurablesEmptyStateHint =>
-      'Mätbara är värden du följer över tid — vikt, vatten, steg eller ett val som hur utvilad du känner dig.';
+      'Mätvärden är sådant du följer över tid — vikt, vatten, steg eller ett val för hur utvilad du känner dig.';
 
   @override
   String get settingsMeasurablesErrorLoading => 'Fellastningsmätbara';

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3285,6 +3285,7 @@
   "habitSignalStatusNotYet": "{target} · nog niet",
   "habitSignalStatusSoFar": "{target} · {value} tot nu toe",
   "habitSignalToday": "vandaag: {value}",
+  "habitSignalTodayLogged": "vandaag: vastgelegd",
   "habitSignalTodayNone": "vandaag: —",
   "habitsLaggardHint": "{habit}  — kept  {kept} van {active}",
   "@habitsLaggardHint": {
@@ -3943,9 +3944,19 @@
   "matrixStatsSignals": "Signalen",
   "matrixStatsSignalsConnectivity": "Signalen (connectiviteit)",
   "matrixStatsTopKpis": "Top KPI's",
+  "measurableChoiceNotFound": "Verwijderde keuze",
   "measurableDeleteConfirm": "Ja, verwijder dit meetbare gegevenstype",
   "measurableDeleteQuestion": "Wilt u dit meetbare gegevenstype verwijderen?",
   "measurableNotFound": "Maattabel niet gevonden",
+  "measurementChoicePrompt": "Kies er een",
+  "measurementChoiceSelectSemantic": "{title} selecteren",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Nota toevoegen (facultatief)",
   "measurementCommentSemantic": "Opmerking, facultatief",
   "measurementObservedAtChangeSemantic": "Waargenomen bij {dateTime}. Wijziging datum en tijd.",
@@ -5190,6 +5201,38 @@
   "settingsMatrixVerifyLabel": "Verifiëren",
   "settingsMeasurableAggregationHelper": "Hoe een dag inzendingen combineren op grafieken",
   "settingsMeasurableAggregationLabel": "Standaard aggregatietype",
+  "settingsMeasurableChoiceAdd": "Keuze toevoegen",
+  "settingsMeasurableChoiceArchive": "{title} archiveren",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Naam van de keuze",
+  "settingsMeasurableChoiceNameRequired": "Geef deze keuze een naam",
+  "settingsMeasurableChoiceReorder": "{title} verplaatsen",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "{title} terugzetten",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Verborgen bij het vastleggen; items die ze gebruikten tonen nog steeds hun naam.",
+  "settingsMeasurableChoicesArchivedTitle": "Gearchiveerde keuzes",
+  "settingsMeasurableChoicesDescription": "Bij het vastleggen kies je er een. Je kunt ze altijd hernoemen of herschikken – al vastgelegde items houden hun keuze.",
+  "settingsMeasurableChoicesRequired": "Voeg minstens één keuze toe",
+  "settingsMeasurableChoicesTitle": "Keuzes",
   "settingsMeasurableDeleteTooltip": "Meetbaar type verwijderen",
   "settingsMeasurableDescriptionLabel": "Beschrijving (facultatief)",
   "settingsMeasurableDetailsLabel": "Meetbaar bewerken",
@@ -5198,7 +5241,7 @@
   "settingsMeasurableSaveLabel": "Opslaan",
   "settingsMeasurablesCreateTitle": "Meetbaar maken",
   "settingsMeasurablesEmptyState": "Nog geen meetbare waarden",
-  "settingsMeasurablesEmptyStateHint": "Measurables zijn nummers die je volgt in de tijd .. gewicht, water, stappen.",
+  "settingsMeasurablesEmptyStateHint": "Meetwaarden zijn waarden die je in de tijd volgt — gewicht, water, stappen, of een keuze zoals hoe uitgerust je je voelt.",
   "settingsMeasurablesErrorLoading": "Fout bij laden van meetbare gegevens",
   "settingsMeasurablesNoMatchQuery": "Geen meetbare overeenkomst \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -5212,6 +5255,10 @@
   "settingsMeasurablesSubtitle": "Meetbare gegevenstypen configureren",
   "settingsMeasurablesTitle": "Meetbare",
   "settingsMeasurableUnitLabel": "Eenheidsafkorting (facultatief)",
+  "settingsMeasurableValueKindChoice": "Keuze",
+  "settingsMeasurableValueKindHelper": "Een getal met eenheid, of een van de keuzes die je zelf bepaalt",
+  "settingsMeasurableValueKindLabel": "Vastgelegd als",
+  "settingsMeasurableValueKindNumber": "Getal",
   "settingsOnboardingActionSubtitle": "Open de welkomststroom . . Sluit uw AI-hersenen en maak een taak",
   "settingsOnboardingMetricsSubtitle": "FTUE trechter",
   "settingsOnboardingMetricsTitle": "Metrics aan boord",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3285,6 +3285,7 @@
   "habitSignalStatusNotYet": "{target} · ainda não",
   "habitSignalStatusSoFar": "{target} · {value} até agora",
   "habitSignalToday": "hoje: {value}",
+  "habitSignalTodayLogged": "hoje: registrado",
   "habitSignalTodayNone": "hoje: —",
   "habitsLaggardHint": "{habit} — mantido {kept} de {active}",
   "@habitsLaggardHint": {
@@ -3943,9 +3944,19 @@
   "matrixStatsSignals": "Sinais",
   "matrixStatsSignalsConnectivity": "Sinais (conectividade)",
   "matrixStatsTopKpis": "Principais KPIs",
+  "measurableChoiceNotFound": "Opção removida",
   "measurableDeleteConfirm": "Sim, excluir este mensurável",
   "measurableDeleteQuestion": "Deseja excluir este tipo de dados mensuráveis?",
   "measurableNotFound": "Mensurável não encontrado",
+  "measurementChoicePrompt": "Escolha uma",
+  "measurementChoiceSelectSemantic": "Selecionar {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Adicione uma nota (opcional)",
   "measurementCommentSemantic": "Comentário, opcional",
   "measurementObservedAtChangeSemantic": "Observado em {dateTime}. Alterar data e hora.",
@@ -5190,6 +5201,38 @@
   "settingsMatrixVerifyLabel": "Verifique",
   "settingsMeasurableAggregationHelper": "Como as entradas de um dia se combinam nos gráficos",
   "settingsMeasurableAggregationLabel": "Tipo de agregação padrão",
+  "settingsMeasurableChoiceAdd": "Adicionar opção",
+  "settingsMeasurableChoiceArchive": "Arquivar {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Nome da opção",
+  "settingsMeasurableChoiceNameRequired": "Dê um nome a esta opção",
+  "settingsMeasurableChoiceReorder": "Mover {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Restaurar {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Ocultas ao registrar; as entradas que as usaram continuam mostrando o nome.",
+  "settingsMeasurableChoicesArchivedTitle": "Opções arquivadas",
+  "settingsMeasurableChoicesDescription": "Ao registrar, você escolhe uma delas. Renomeie ou reordene quando quiser – as entradas já registradas mantêm a opção.",
+  "settingsMeasurableChoicesRequired": "Adicione pelo menos uma opção",
+  "settingsMeasurableChoicesTitle": "Opções",
   "settingsMeasurableDeleteTooltip": "Excluir tipo mensurável",
   "settingsMeasurableDescriptionLabel": "Descrição (opcional)",
   "settingsMeasurableDetailsLabel": "Editar mensurável",
@@ -5198,7 +5241,7 @@
   "settingsMeasurableSaveLabel": "Salvar",
   "settingsMeasurablesCreateTitle": "Crie mensuráveis",
   "settingsMeasurablesEmptyState": "Ainda não há mensuráveis",
-  "settingsMeasurablesEmptyStateHint": "Mensuráveis são números que você acompanha ao longo do tempo – peso, água, passos.",
+  "settingsMeasurablesEmptyStateHint": "Mensuráveis são valores que você acompanha ao longo do tempo – peso, água, passos ou uma opção como o quanto você se sente descansado.",
   "settingsMeasurablesErrorLoading": "Erro ao carregar mensuráveis",
   "settingsMeasurablesNoMatchQuery": "Nenhum mensurável corresponde a \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -5212,6 +5255,10 @@
   "settingsMeasurablesSubtitle": "Configurar tipos de dados mensuráveis",
   "settingsMeasurablesTitle": "Mensuráveis",
   "settingsMeasurableUnitLabel": "Abreviatura da unidade (opcional)",
+  "settingsMeasurableValueKindChoice": "Opção",
+  "settingsMeasurableValueKindHelper": "Um número com unidade, ou uma das opções que você define",
+  "settingsMeasurableValueKindLabel": "Registrado como",
+  "settingsMeasurableValueKindNumber": "Número",
   "settingsOnboardingActionSubtitle": "Reabra o fluxo de boas-vindas – conecte seu cérebro de IA e crie uma tarefa",
   "settingsOnboardingMetricsSubtitle": "Funil FTUE – instalação, ativação, retenção (depuração)",
   "settingsOnboardingMetricsTitle": "Métricas de integração",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2971,6 +2971,7 @@
   "habitSignalStatusNotYet": "{target} · încă nu",
   "habitSignalStatusSoFar": "{target} · {value} până acum",
   "habitSignalToday": "azi: {value}",
+  "habitSignalTodayLogged": "azi: înregistrat",
   "habitSignalTodayNone": "azi: —",
   "habitsLaggardHint": "{habit} — {kept} din {active} realizate",
   "habitsOpenHeader": "Scadente acum",
@@ -3551,9 +3552,19 @@
   "matrixStatsSignals": "Semnale",
   "matrixStatsSignalsConnectivity": "Semnale (conectivitate)",
   "matrixStatsTopKpis": "Indicatori principali",
+  "measurableChoiceNotFound": "Opțiune eliminată",
   "measurableDeleteConfirm": "Da, ștergeți acest tip de măsurătoare",
   "measurableDeleteQuestion": "Sigur doriți să ștergeți acest tip de măsurătoare?",
   "measurableNotFound": "Masuratoarea nu a fost gasita",
+  "measurementChoicePrompt": "Alegeți una",
+  "measurementChoiceSelectSemantic": "Selectați {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Adăugați o notă (opțional)",
   "measurementCommentSemantic": "Comentariu, opțional",
   "measurementObservedAtChangeSemantic": "Înregistrat la {dateTime}. Modificați data și ora.",
@@ -4645,6 +4656,38 @@
   "settingsMatrixVerifyLabel": "Verificați",
   "settingsMeasurableAggregationHelper": "Cum se combină intrările unei zile în grafice",
   "settingsMeasurableAggregationLabel": "Agregare implicită",
+  "settingsMeasurableChoiceAdd": "Adăugați o opțiune",
+  "settingsMeasurableChoiceArchive": "Arhivați {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Numele opțiunii",
+  "settingsMeasurableChoiceNameRequired": "Dați un nume acestei opțiuni",
+  "settingsMeasurableChoiceReorder": "Mutați {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Restaurați {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Ascunse la înregistrare; intrările care le-au folosit își afișează în continuare numele.",
+  "settingsMeasurableChoicesArchivedTitle": "Opțiuni arhivate",
+  "settingsMeasurableChoicesDescription": "La înregistrare alegeți una dintre ele. Le puteți redenumi sau reordona oricând – intrările deja înregistrate își păstrează opțiunea.",
+  "settingsMeasurableChoicesRequired": "Adăugați cel puțin o opțiune",
+  "settingsMeasurableChoicesTitle": "Opțiuni",
   "settingsMeasurableDeleteTooltip": "Ștergeți tipul măsurătorii",
   "settingsMeasurableDescriptionLabel": "Descriere",
   "settingsMeasurableDetailsLabel": "Editare măsurătoare",
@@ -4653,7 +4696,7 @@
   "settingsMeasurableSaveLabel": "Salvare",
   "settingsMeasurablesCreateTitle": "Creare măsurătoare",
   "settingsMeasurablesEmptyState": "Nicio măsurătoare încă",
-  "settingsMeasurablesEmptyStateHint": "Măsurătorile sunt valori urmărite în timp — greutate, apă, pași.",
+  "settingsMeasurablesEmptyStateHint": "Măsurătorile sunt valori urmărite în timp — greutate, apă, pași sau o opțiune precum cât de odihnit vă simțiți.",
   "settingsMeasurablesErrorLoading": "Eroare la încărcarea măsurătorilor",
   "settingsMeasurablesNoMatchQuery": "Nicio măsurătoare nu corespunde cu \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -4667,6 +4710,10 @@
   "settingsMeasurablesSubtitle": "Configurați tipurile de date măsurabile",
   "settingsMeasurablesTitle": "Măsurători",
   "settingsMeasurableUnitLabel": "Unitatea abrevierii",
+  "settingsMeasurableValueKindChoice": "Opțiune",
+  "settingsMeasurableValueKindHelper": "Un număr cu unitate sau una dintre opțiunile pe care le definiți",
+  "settingsMeasurableValueKindLabel": "Se înregistrează ca",
+  "settingsMeasurableValueKindNumber": "Număr",
   "settingsOnboardingActionSubtitle": "Redeschideți fluxul de bun venit — conectați-vă creierul AI și creați o sarcină",
   "settingsOnboardingMetricsSubtitle": "Pâlnie FTUE — instalare, activare, retenție (depanare)",
   "settingsOnboardingMetricsTitle": "Valori de onboarding",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -3286,6 +3286,7 @@
   "habitSignalStatusNotYet": "{target} · inte än",
   "habitSignalStatusSoFar": "{target} · {value} hittills",
   "habitSignalToday": "idag: {value}",
+  "habitSignalTodayLogged": "idag: registrerat",
   "habitSignalTodayNone": "idag: —",
   "habitsLaggardHint": "{habit} — behöll {kept} av {active}",
   "@habitsLaggardHint": {
@@ -3944,9 +3945,19 @@
   "matrixStatsSignals": "Signaler",
   "matrixStatsSignalsConnectivity": "Signaler (anslutning)",
   "matrixStatsTopKpis": "Topp-KPI:er",
+  "measurableChoiceNotFound": "Borttaget val",
   "measurableDeleteConfirm": "Ja, radera detta mätvärde",
   "measurableDeleteQuestion": "Vill du ta bort denna mätbara datatyp?",
   "measurableNotFound": "Mätbar inte hittad",
+  "measurementChoicePrompt": "Välj ett",
+  "measurementChoiceSelectSemantic": "Välj {title}",
+  "@measurementChoiceSelectSemantic": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "measurementCommentHint": "Lägg till en anteckning (valfritt)",
   "measurementCommentSemantic": "Kommentar, valfritt",
   "measurementObservedAtChangeSemantic": "Observerad vid {dateTime}. Ändra datum och tid.",
@@ -5191,6 +5202,38 @@
   "settingsMatrixVerifyLabel": "Verifiera",
   "settingsMeasurableAggregationHelper": "Hur dagens poster kombineras på diagram",
   "settingsMeasurableAggregationLabel": "Standardaggregeringstyp",
+  "settingsMeasurableChoiceAdd": "Lägg till val",
+  "settingsMeasurableChoiceArchive": "Arkivera {title}",
+  "@settingsMeasurableChoiceArchive": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceNameHint": "Namn på valet",
+  "settingsMeasurableChoiceNameRequired": "Ge det här valet ett namn",
+  "settingsMeasurableChoiceReorder": "Flytta {title}",
+  "@settingsMeasurableChoiceReorder": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoiceRestore": "Återställ {title}",
+  "@settingsMeasurableChoiceRestore": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsMeasurableChoicesArchivedDescription": "Dolda vid registrering; poster som använde dem visar fortfarande sitt namn.",
+  "settingsMeasurableChoicesArchivedTitle": "Arkiverade val",
+  "settingsMeasurableChoicesDescription": "När du registrerar väljer du ett av dem. Byt namn eller ordning när som helst – redan registrerade poster behåller sitt val.",
+  "settingsMeasurableChoicesRequired": "Lägg till minst ett val",
+  "settingsMeasurableChoicesTitle": "Valmöjligheter",
   "settingsMeasurableDeleteTooltip": "Ta bort mätbar typ",
   "settingsMeasurableDescriptionLabel": "Beskrivning (valfritt)",
   "settingsMeasurableDetailsLabel": "Redigering mätbar",
@@ -5199,7 +5242,7 @@
   "settingsMeasurableSaveLabel": "Spara",
   "settingsMeasurablesCreateTitle": "Skapa mätbart",
   "settingsMeasurablesEmptyState": "Inga mätbara faktorer än",
-  "settingsMeasurablesEmptyStateHint": "Mätbara är siffror du följer över tid — vikt, vatten, steg.",
+  "settingsMeasurablesEmptyStateHint": "Mätbara är värden du följer över tid — vikt, vatten, steg eller ett val som hur utvilad du känner dig.",
   "settingsMeasurablesErrorLoading": "Fellastningsmätbara",
   "settingsMeasurablesNoMatchQuery": "Inga mätbara värden matchar \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {
@@ -5213,6 +5256,10 @@
   "settingsMeasurablesSubtitle": "Konfigurera mätbara datatyper",
   "settingsMeasurablesTitle": "Mätbara egenskaper",
   "settingsMeasurableUnitLabel": "Enhetsförkortning (valfritt)",
+  "settingsMeasurableValueKindChoice": "Val",
+  "settingsMeasurableValueKindHelper": "Ett tal med enhet, eller ett av de val du själv definierar",
+  "settingsMeasurableValueKindLabel": "Registreras som",
+  "settingsMeasurableValueKindNumber": "Tal",
   "settingsOnboardingActionSubtitle": "Öppna välkomstflödet igen – koppla upp din AI-hjärna och skapa en uppgift",
   "settingsOnboardingMetricsSubtitle": "FTUE-tratten — installation, aktivering, retention (felsökning)",
   "settingsOnboardingMetricsTitle": "Onboarding-mått",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5242,7 +5242,7 @@
   "settingsMeasurableSaveLabel": "Spara",
   "settingsMeasurablesCreateTitle": "Skapa mätbart",
   "settingsMeasurablesEmptyState": "Inga mätbara faktorer än",
-  "settingsMeasurablesEmptyStateHint": "Mätbara är värden du följer över tid — vikt, vatten, steg eller ett val som hur utvilad du känner dig.",
+  "settingsMeasurablesEmptyStateHint": "Mätvärden är sådant du följer över tid — vikt, vatten, steg eller ett val för hur utvilad du känner dig.",
   "settingsMeasurablesErrorLoading": "Fellastningsmätbara",
   "settingsMeasurablesNoMatchQuery": "Inga mätbara värden matchar \"{query}\"",
   "@settingsMeasurablesNoMatchQuery": {

--- a/lib/logic/persistence_definition_ops.dart
+++ b/lib/logic/persistence_definition_ops.dart
@@ -1,5 +1,6 @@
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/features/notifications/scheduler/notification_startup_reconcile.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
@@ -19,6 +20,9 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
   Future<int> upsertEntityDefinitionImpl(
     EntityDefinition entityDefinition,
   ) async {
+    final previousMeasurable = entityDefinition is MeasurableDataType
+        ? await journalDb.getMeasurableDataTypeById(entityDefinition.id)
+        : null;
     final linesAffected = await journalDb.upsertEntityDefinition(
       entityDefinition,
     );
@@ -30,6 +34,13 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
       LabelDefinition() => labelsNotification,
     };
     updateNotifications.notify({entityDefinition.id, typeNotification});
+    if (entityDefinition is MeasurableDataType &&
+        measurementDefinitionAffectsFts(
+          previousMeasurable,
+          entityDefinition,
+        )) {
+      await _reindexMeasurements(entityDefinition);
+    }
     await outboxService.enqueueMessage(
       SyncMessage.entityDefinition(
         entityDefinition: entityDefinition,
@@ -37,6 +48,27 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
       ),
     );
     return linesAffected;
+  }
+
+  Future<void> _reindexMeasurements(MeasurableDataType dataType) async {
+    try {
+      final entries = await journalDb.getMeasurementsByType(
+        type: dataType.id,
+        rangeStart: DateTime(1),
+        rangeEnd: DateTime(9999, 12, 31, 23, 59, 59, 999),
+      );
+      await getIt<Fts5Db>().reindexMeasurements(dataType, entries);
+    } catch (exception, stackTrace) {
+      // FTS is derived and can be rebuilt from the journal. A failed reindex
+      // must not turn an already-persisted definition edit into a failed save
+      // or prevent it from syncing.
+      loggingService.error(
+        LogDomain.persistence,
+        exception,
+        stackTrace: stackTrace,
+        subDomain: 'upsertEntityDefinition.reindexMeasurements',
+      );
+    }
   }
 
   Future<int> upsertDashboardDefinitionImpl(

--- a/lib/logic/signals/habit_rule_evaluator.dart
+++ b/lib/logic/signals/habit_rule_evaluator.dart
@@ -3,6 +3,69 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/logic/signals/signal_day_buckets.dart';
 import 'package:lotti/logic/signals/signal_window.dart';
 
+/// Clears numeric bounds from measurable leaves whose definitions now record
+/// choices.
+///
+/// A choice measurement stores `value: 1` as an occurrence marker. Applying a
+/// bound authored while the measurable was numeric would compare that marker
+/// with the old quantity and make the runtime disagree with the editor's
+/// choice-only "any entry" rule. The tree shape, titles, and every other leaf
+/// remain unchanged.
+AutoCompleteRule normalizeChoiceMeasurableBounds(
+  AutoCompleteRule rule, {
+  required bool Function(String dataTypeId) isChoice,
+}) {
+  switch (rule) {
+    case final AutoCompleteRuleMeasurable measurable:
+      if (!isChoice(measurable.dataTypeId) ||
+          (measurable.minimum == null && measurable.maximum == null)) {
+        return rule;
+      }
+      return measurable.copyWith(minimum: null, maximum: null);
+    case final AutoCompleteRuleAnd composite:
+      final originalRules = composite.rules;
+      final rules = _normalizeChoiceChildren(originalRules, isChoice);
+      return identical(rules, originalRules)
+          ? rule
+          : composite.copyWith(rules: rules);
+    case final AutoCompleteRuleOr composite:
+      final originalRules = composite.rules;
+      final rules = _normalizeChoiceChildren(originalRules, isChoice);
+      return identical(rules, originalRules)
+          ? rule
+          : composite.copyWith(rules: rules);
+    case final AutoCompleteRuleMultiple composite:
+      final originalRules = composite.rules;
+      final rules = _normalizeChoiceChildren(originalRules, isChoice);
+      return identical(rules, originalRules)
+          ? rule
+          : composite.copyWith(rules: rules);
+    case AutoCompleteRuleHealth() ||
+        AutoCompleteRuleWorkout() ||
+        AutoCompleteRuleHabit():
+      return rule;
+  }
+}
+
+List<AutoCompleteRule> _normalizeChoiceChildren(
+  List<AutoCompleteRule> rules,
+  bool Function(String dataTypeId) isChoice,
+) {
+  var changed = false;
+  final normalized = [
+    for (final rule in rules)
+      () {
+        final next = normalizeChoiceMeasurableBounds(
+          rule,
+          isChoice: isChoice,
+        );
+        changed = changed || !identical(next, rule);
+        return next;
+      }(),
+  ];
+  return changed ? normalized : rules;
+}
+
 /// What one leaf of an [AutoCompleteRule] tree saw on the evaluated day.
 ///
 /// [value] is the day's aggregate the thresholds were compared against — a

--- a/lib/pages/create/create_measurement_dialog.dart
+++ b/lib/pages/create/create_measurement_dialog.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
+import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
 import 'package:lotti/features/design_system/components/glass_strip.dart';
 import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -24,6 +25,10 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 /// draft-bearing objects live for the route lifetime because Wolt disposes an
 /// inactive page after pagination; returning from the picker therefore keeps
 /// the entered value and comment without reopening the keyboard.
+///
+/// A choice measurable swaps the number field and quick-value chips for one
+/// chip per active choice; the rest of the sheet — observed-at, comment,
+/// save — is the same route.
 abstract final class MeasurementCaptureModal {
   static Future<void> show({
     required BuildContext context,
@@ -140,6 +145,10 @@ class _MeasurementCaptureDraft {
   );
   final ValueNotifier<DateTime> measurementDateTime;
   final ValueNotifier<DateTime> pickerDateTime;
+
+  /// The choice picked so far on a choice measurable; always null on a
+  /// numeric one.
+  final ValueNotifier<String?> selectedChoiceId = ValueNotifier(null);
   final ValueNotifier<int> pageIndexNotifier = ValueNotifier(0);
   final ValueNotifier<_MeasurementSaveState> saveState = ValueNotifier(
     (isSaving: false, error: null),
@@ -170,8 +179,12 @@ class _MeasurementCaptureDraft {
     return num.tryParse(normalized);
   }
 
-  bool get canSave =>
-      parseValue() != null && !saveState.value.isSaving && !_disposed;
+  bool get isChoice => dataType.isChoice;
+
+  bool get _hasValue =>
+      isChoice ? selectedChoiceId.value != null : parseValue() != null;
+
+  bool get canSave => _hasValue && !saveState.value.isSaving && !_disposed;
 
   DateTime now() => routeClock.now();
 
@@ -196,21 +209,39 @@ class _MeasurementCaptureDraft {
     pageIndexNotifier.value = 0;
   }
 
+  /// Persists the draft. A numeric measurable saves [value] or the typed
+  /// value; a choice measurable saves the selected choice as one occurrence
+  /// (`value: 1`, see [MeasurementData.choiceId]).
   Future<void> save(BuildContext modalContext, {num? value}) async {
-    final resolved = value ?? parseValue();
-    if (resolved == null || saveState.value.isSaving || _disposed) return;
+    if (saveState.value.isSaving || _disposed) return;
+    final MeasurementData Function(DateTime observedAt) buildData;
+    if (isChoice) {
+      final choiceId = selectedChoiceId.value;
+      if (choiceId == null) return;
+      buildData = (observedAt) => MeasurementData(
+        dataTypeId: dataType.id,
+        dateTo: observedAt,
+        dateFrom: observedAt,
+        value: 1,
+        choiceId: choiceId,
+      );
+    } else {
+      final resolved = value ?? parseValue();
+      if (resolved == null) return;
+      buildData = (observedAt) => MeasurementData(
+        dataTypeId: dataType.id,
+        dateTo: observedAt,
+        dateFrom: observedAt,
+        value: resolved,
+      );
+    }
 
     final errorMessage = modalContext.messages.measurementSaveError;
     saveState.value = (isSaving: true, error: null);
     final observedAt = measurementDateTime.value;
     try {
       final savedEntry = await getIt<PersistenceLogic>().createMeasurementEntry(
-        data: MeasurementData(
-          dataTypeId: dataType.id,
-          dateTo: observedAt,
-          dateFrom: observedAt,
-          value: resolved,
-        ),
+        data: buildData(observedAt),
         comment: commentController.text,
         private: dataType.private ?? false,
       );
@@ -248,6 +279,7 @@ class _MeasurementCaptureDraft {
     observedAtFocusNode.dispose();
     measurementDateTime.dispose();
     pickerDateTime.dispose();
+    selectedChoiceId.dispose();
     pageIndexNotifier.dispose();
     saveState.dispose();
   }
@@ -374,6 +406,7 @@ class _MeasurementEditorPageState extends State<_MeasurementEditorPage> {
       .takeObservedAtFocusRestore();
   late final Listenable _editorState = Listenable.merge([
     widget.draft.valueController,
+    widget.draft.selectedChoiceId,
     widget.draft.measurementDateTime,
     widget.draft.saveState,
   ]);
@@ -411,21 +444,30 @@ class _MeasurementEditorPageState extends State<_MeasurementEditorPage> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _ValueHeroField(
-              controller: draft.valueController,
-              focusNode: draft.valueFocusNode,
-              unit: unit,
-              autofocus: _autofocusValue,
-              semanticsLabel: context.messages.measurementValueSemantic(
-                measurableLabel,
+            if (draft.isChoice)
+              _ChoiceField(
+                choices: dataType.activeChoices,
+                selectedId: draft.selectedChoiceId.value,
+                enabled: !saveState.isSaving,
+                onSelect: (id) => draft.selectedChoiceId.value = id,
+              )
+            else ...[
+              _ValueHeroField(
+                controller: draft.valueController,
+                focusNode: draft.valueFocusNode,
+                unit: unit,
+                autofocus: _autofocusValue,
+                semanticsLabel: context.messages.measurementValueSemantic(
+                  measurableLabel,
+                ),
+                onSubmitted: () => unawaited(draft.save(context)),
               ),
-              onSubmitted: () => unawaited(draft.save(context)),
-            ),
-            MeasurementSuggestions(
-              measurableDataType: dataType,
-              enabled: !saveState.isSaving,
-              onSelect: (value) => draft.save(context, value: value),
-            ),
+              MeasurementSuggestions(
+                measurableDataType: dataType,
+                enabled: !saveState.isSaving,
+                onSelect: (value) => draft.save(context, value: value),
+              ),
+            ],
             SizedBox(height: tokens.spacing.sectionGap),
             _LabeledField(
               label: context.messages.addMeasurementDateLabel,
@@ -493,7 +535,11 @@ class _MeasurementSaveFooter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-      listenable: Listenable.merge([draft.valueController, draft.saveState]),
+      listenable: Listenable.merge([
+        draft.valueController,
+        draft.selectedChoiceId,
+        draft.saveState,
+      ]),
       builder: (context, _) {
         final state = draft.saveState.value;
         return DesignSystemGlassActionFooter(
@@ -922,6 +968,51 @@ class _ValueHeroField extends StatelessWidget {
               ),
             ),
           ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The choice measurable's hero: one touch-size chip per active choice under
+/// a "Pick one" label. Tapping selects — the sheet still has a date and a
+/// comment to offer, so the save stays with the footer button rather than
+/// firing on the tap.
+class _ChoiceField extends StatelessWidget {
+  const _ChoiceField({
+    required this.choices,
+    required this.selectedId,
+    required this.enabled,
+    required this.onSelect,
+  });
+
+  final List<MeasurableChoice> choices;
+  final String? selectedId;
+  final bool enabled;
+  final ValueChanged<String> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    return _LabeledField(
+      label: messages.measurementChoicePrompt,
+      child: Wrap(
+        key: const Key('measurement_choice_field'),
+        spacing: tokens.spacing.step2,
+        runSpacing: tokens.spacing.step2,
+        children: [
+          for (final choice in choices)
+            DesignSystemChip(
+              key: ValueKey('measurement-choice-${choice.id}'),
+              label: choice.title,
+              size: DesignSystemChipSize.touch,
+              selected: choice.id == selectedId,
+              semanticsLabel: messages.measurementChoiceSelectSemantic(
+                choice.title,
+              ),
+              onPressed: enabled ? () => onSelect(choice.id) : null,
+            ),
         ],
       ),
     );

--- a/test/README.md
+++ b/test/README.md
@@ -842,3 +842,22 @@ This codebase is in the process of migrating all tests to fake time. See:
 - [fake_async package](https://pub.dev/packages/fake_async)
 - [Flutter testing guide](https://docs.flutter.dev/cookbook/testing)
 - Migration plan: `docs/implementation_plans/2025-11-01_tests_fake_async_migration.md`
+
+## Rows inside a `ReorderableListView` merge their semantics
+
+`ReorderableListView` wraps every item in `MergeSemantics` (that is how its
+"move up / move down" custom actions work), so a `Semantics(label:)` on a
+drag handle or a per-row button is folded into one node whose label is not
+what you wrote — `find.bySemanticsLabel` will not find it. Give the handle a
+`Tooltip` and assert with `find.byTooltip` instead (that is also the hover
+text a pointer user gets). Example: `measurable_choices_editor.dart` and its
+test.
+
+## Re-pumping the same host widget keeps its `State`
+
+A test helper that pumps `_Host(initial: …)` twice with different data gets
+the *first* list both times: the same widget type in the same slot reuses its
+`State`, and a `late` field seeded from `widget.initial` is not re-run. Give
+the host a fresh `key: UniqueKey()` per pump (see
+`measurable_choices_editor_test.dart`), or drive the change through the
+host's own state.

--- a/test/classes/entity_definitions_test.dart
+++ b/test/classes/entity_definitions_test.dart
@@ -540,7 +540,7 @@ void main() {
         dataTypeId: 'water',
       );
       final json = data.toJson();
-      expect(json['choiceId'], isNull);
+      expect(json, isNot(contains('choiceId')));
       expect(MeasurementData.fromJson(json).choiceId, isNull);
     });
 

--- a/test/classes/entity_definitions_test.dart
+++ b/test/classes/entity_definitions_test.dart
@@ -429,7 +429,7 @@ void main() {
     test('archived is absent from JSON when unset and reads back null', () {
       const choice = MeasurableChoice(id: 'choice-1', title: 'Clear');
       final json = choice.toJson();
-      expect(json['archived'], isNull);
+      expect(json, isNot(contains('archived')));
       expect(MeasurableChoice.fromJson(json).archived, isNull);
     });
   });
@@ -500,8 +500,14 @@ void main() {
     });
 
     test('isChoice is true only for the choice kind', () {
-      expect(measurable(valueKind: MeasurableValueKind.choice).isChoice, isTrue);
-      expect(measurable(valueKind: MeasurableValueKind.number).isChoice, isFalse);
+      expect(
+        measurable(valueKind: MeasurableValueKind.choice).isChoice,
+        isTrue,
+      );
+      expect(
+        measurable(valueKind: MeasurableValueKind.number).isChoice,
+        isFalse,
+      );
     });
 
     test('activeChoices keeps order and drops only archived == true', () {

--- a/test/classes/entity_definitions_test.dart
+++ b/test/classes/entity_definitions_test.dart
@@ -412,4 +412,146 @@ void main() {
   // -------------------------------------------------------------------------
   // EntityDefinition — all 5 variants
   // -------------------------------------------------------------------------
+
+  group('MeasurableChoice', () {
+    test('round-trips id, title and archived through JSON', () {
+      const choice = MeasurableChoice(
+        id: 'choice-1',
+        title: 'Clear',
+        archived: true,
+      );
+      final decoded = MeasurableChoice.fromJson(
+        jsonDecode(jsonEncode(choice.toJson())) as Map<String, dynamic>,
+      );
+      expect(decoded, choice);
+    });
+
+    test('archived is absent from JSON when unset and reads back null', () {
+      const choice = MeasurableChoice(id: 'choice-1', title: 'Clear');
+      final json = choice.toJson();
+      expect(json['archived'], isNull);
+      expect(MeasurableChoice.fromJson(json).archived, isNull);
+    });
+  });
+
+  group('MeasurableDataType value kind', () {
+    MeasurableDataType measurable({
+      MeasurableValueKind? valueKind,
+      List<MeasurableChoice>? choices,
+    }) => MeasurableDataType(
+      id: 'hydration',
+      displayName: 'Hydration',
+      description: '',
+      unitName: '',
+      version: 1,
+      createdAt: DateTime(2026, 8, 28),
+      updatedAt: DateTime(2026, 8, 28),
+      vectorClock: null,
+      valueKind: valueKind,
+      choices: choices,
+    );
+
+    const clear = MeasurableChoice(id: 'c-clear', title: 'Clear');
+    const pale = MeasurableChoice(id: 'c-pale', title: 'Pale');
+    const dark = MeasurableChoice(id: 'c-dark', title: 'Dark', archived: true);
+    const brown = MeasurableChoice(
+      id: 'c-brown',
+      title: 'Brown',
+      archived: false,
+    );
+
+    test('a definition without valueKind is a number measurable', () {
+      // Every measurable persisted before the choice kind existed has no
+      // valueKind key at all; that must keep reading as the numeric kind.
+      final legacyJson = measurable().toJson()
+        ..remove('valueKind')
+        ..remove('choices');
+      final decoded = EntityDefinition.fromJson(legacyJson);
+      expect(decoded, isA<MeasurableDataType>());
+      final dataType = decoded as MeasurableDataType;
+      expect(dataType.valueKind, isNull);
+      expect(dataType.isChoice, isFalse);
+      expect(dataType.activeChoices, isEmpty);
+      expect(dataType.archivedChoices, isEmpty);
+      expect(dataType.choiceById('c-clear'), isNull);
+    });
+
+    test('a valueKind this build does not know reads as number', () {
+      final json = measurable().toJson()..['valueKind'] = 'colourWheel';
+      final decoded = EntityDefinition.fromJson(json) as MeasurableDataType;
+      expect(decoded.valueKind, MeasurableValueKind.number);
+      expect(decoded.isChoice, isFalse);
+    });
+
+    test('valueKind and choices survive a JSON round trip in order', () {
+      final original = measurable(
+        valueKind: MeasurableValueKind.choice,
+        choices: const [clear, dark, pale],
+      );
+      final decoded =
+          EntityDefinition.fromJson(
+                jsonDecode(jsonEncode(original.toJson()))
+                    as Map<String, dynamic>,
+              )
+              as MeasurableDataType;
+      expect(decoded.valueKind, MeasurableValueKind.choice);
+      expect(decoded.choices, const [clear, dark, pale]);
+      expect(decoded, original);
+    });
+
+    test('isChoice is true only for the choice kind', () {
+      expect(measurable(valueKind: MeasurableValueKind.choice).isChoice, isTrue);
+      expect(measurable(valueKind: MeasurableValueKind.number).isChoice, isFalse);
+    });
+
+    test('activeChoices keeps order and drops only archived == true', () {
+      final dataType = measurable(
+        valueKind: MeasurableValueKind.choice,
+        choices: const [pale, dark, clear, brown],
+      );
+      expect(dataType.activeChoices, const [pale, clear, brown]);
+      expect(dataType.archivedChoices, const [dark]);
+    });
+
+    test('choiceById resolves archived choices too, and null for a miss', () {
+      final dataType = measurable(
+        valueKind: MeasurableValueKind.choice,
+        choices: const [clear, dark],
+      );
+      expect(dataType.choiceById('c-dark'), dark);
+      expect(dataType.choiceById('c-clear'), clear);
+      expect(dataType.choiceById('c-missing'), isNull);
+      expect(dataType.choiceById(null), isNull);
+    });
+  });
+
+  group('MeasurementData choiceId', () {
+    test('is absent for a numeric measurement and reads back null', () {
+      final data = MeasurementData(
+        dateFrom: DateTime(2026, 8, 28, 9),
+        dateTo: DateTime(2026, 8, 28, 9),
+        value: 750,
+        dataTypeId: 'water',
+      );
+      final json = data.toJson();
+      expect(json['choiceId'], isNull);
+      expect(MeasurementData.fromJson(json).choiceId, isNull);
+    });
+
+    test('round-trips alongside the occurrence value', () {
+      final data = MeasurementData(
+        dateFrom: DateTime(2026, 8, 28, 9),
+        dateTo: DateTime(2026, 8, 28, 9),
+        value: 1,
+        dataTypeId: 'hydration',
+        choiceId: 'c-clear',
+      );
+      final decoded = MeasurementData.fromJson(
+        jsonDecode(jsonEncode(data.toJson())) as Map<String, dynamic>,
+      );
+      expect(decoded.choiceId, 'c-clear');
+      expect(decoded.value, 1);
+      expect(decoded, data);
+    });
+  });
 }

--- a/test/database/fts5_db_test.dart
+++ b/test/database/fts5_db_test.dart
@@ -192,6 +192,43 @@ void main() {
         },
       );
 
+      test(
+        'insertText with a choice recording indexes the choice title, not '
+        'the occurrence count',
+        () async {
+          when(
+            () => entitiesCacheService.getDataTypeById(measurableHydration.id),
+          ).thenReturn(measurableHydration);
+
+          await db.insertText(testMeasurementHydrationEntry);
+
+          final byTitle = await db
+              .watchFullTextMatches('"Hydration Clear"')
+              .first;
+          expect(byTitle, contains(testMeasurementHydrationEntry.meta.id));
+
+          final byCount = await db.watchFullTextMatches('"Hydration 1"').first;
+          expect(
+            byCount,
+            isNot(contains(testMeasurementHydrationEntry.meta.id)),
+          );
+        },
+      );
+
+      test(
+        'a measurement whose definition is gone still indexes its number',
+        () async {
+          when(
+            () => entitiesCacheService.getDataTypeById(measurableChocolate.id),
+          ).thenReturn(null);
+
+          await db.insertText(testMeasurementChocolateEntry);
+
+          final matches = await db.watchFullTextMatches('100').first;
+          expect(matches, contains(testMeasurementChocolateEntry.meta.id));
+        },
+      );
+
       test('insertText with quantitative entry indexes health data', () async {
         await db.insertText(testWeightEntry);
 

--- a/test/database/fts5_db_test.dart
+++ b/test/database/fts5_db_test.dart
@@ -216,6 +216,41 @@ void main() {
       );
 
       test(
+        'reindexing replaces an old choice title with its current one',
+        () async {
+          when(
+            () => entitiesCacheService.getDataTypeById(measurableHydration.id),
+          ).thenReturn(measurableHydration);
+          await db.insertText(testMeasurementHydrationEntry);
+          final renamed = measurableHydration.copyWith(
+            choices: [
+              for (final choice in measurableHydration.choices!)
+                if (choice.id == hydrationClear.id)
+                  choice.copyWith(title: 'Transparent')
+                else
+                  choice,
+            ],
+          );
+
+          await db.reindexMeasurements(renamed, [
+            testMeasurementHydrationEntry,
+          ]);
+
+          final byNewTitle = await db
+              .watchFullTextMatches('"Hydration Transparent"')
+              .first;
+          expect(byNewTitle, contains(testMeasurementHydrationEntry.meta.id));
+          final byOldTitle = await db
+              .watchFullTextMatches('"Hydration Clear"')
+              .first;
+          expect(
+            byOldTitle,
+            isNot(contains(testMeasurementHydrationEntry.meta.id)),
+          );
+        },
+      );
+
+      test(
         'a measurement whose definition is gone still indexes its number',
         () async {
           when(

--- a/test/features/dashboards/state/measurable_choice_series_test.dart
+++ b/test/features/dashboards/state/measurable_choice_series_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/dashboards/state/measurable_choice_series.dart';
+
+import '../../../test_data/test_data.dart';
+
+void main() {
+  final rangeStart = DateTime(2022, 7, 5);
+  // Half-open like the numeric aggregators: four days, Jul 5 – Jul 8.
+  final rangeEnd = DateTime(2022, 7, 9);
+
+  MeasurementEntry recording(
+    String id,
+    DateTime at, {
+    String? choiceId,
+    num value = 1,
+  }) => testMeasurementHydrationEntry.copyWith(
+    meta: testMeasurementHydrationEntry.meta.copyWith(
+      id: id,
+      dateFrom: at,
+      dateTo: at,
+    ),
+    data: testMeasurementHydrationEntry.data.copyWith(
+      dateFrom: at,
+      dateTo: at,
+      value: value,
+      choiceId: choiceId,
+    ),
+  );
+
+  test('yields one day per day of the range, in order, empty by default', () {
+    final days = choiceDaySeries(
+      const [],
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+    expect(days.map((d) => d.day), [
+      DateTime(2022, 7, 5),
+      DateTime(2022, 7, 6),
+      DateTime(2022, 7, 7),
+      DateTime(2022, 7, 8),
+    ]);
+    expect(days.every((d) => d.choiceId == null), isTrue);
+  });
+
+  test('a day keeps its latest recording, by time then by id', () {
+    final days = choiceDaySeries(
+      [
+        recording('a', DateTime(2022, 7, 6, 8), choiceId: hydrationClear.id),
+        recording('b', DateTime(2022, 7, 6, 18), choiceId: hydrationDark.id),
+        // Same instant: the greater id wins, so replicas agree.
+        recording('c', DateTime(2022, 7, 7, 9), choiceId: hydrationPale.id),
+        recording('d', DateTime(2022, 7, 7, 9), choiceId: hydrationClear.id),
+        // Listed out of order: order of arrival must not matter.
+        recording('e', DateTime(2022, 7, 7, 9), choiceId: hydrationDark.id),
+      ],
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+    expect(days[1].choiceId, hydrationDark.id);
+    expect(days[2].choiceId, hydrationDark.id);
+  });
+
+  test('numeric entries and other entry types never colour a day', () {
+    final days = choiceDaySeries(
+      [
+        recording('n', DateTime(2022, 7, 5, 8), value: 3),
+        testTextEntry,
+      ],
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+    expect(days.every((d) => d.choiceId == null), isTrue);
+  });
+
+  test('a recording outside the range does not appear', () {
+    final days = choiceDaySeries(
+      [recording('x', DateTime(2022, 7, 9, 8), choiceId: hydrationClear.id)],
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+    expect(days.every((d) => d.choiceId == null), isTrue);
+  });
+
+  test('an inverted range is empty rather than an error', () {
+    expect(
+      choiceDaySeries(const [], rangeStart: rangeEnd, rangeEnd: rangeStart),
+      isEmpty,
+    );
+  });
+}

--- a/test/features/dashboards/state/measurable_choice_series_test.dart
+++ b/test/features/dashboards/state/measurable_choice_series_test.dart
@@ -6,8 +6,8 @@ import '../../../test_data/test_data.dart';
 
 void main() {
   final rangeStart = DateTime(2022, 7, 5);
-  // Half-open like the numeric aggregators: four days, Jul 5 – Jul 8.
-  final rangeEnd = DateTime(2022, 7, 9);
+  // The dashboard range ends late on the final calendar day.
+  final rangeEnd = DateTime(2022, 7, 8, 23, 59, 59);
 
   MeasurementEntry recording(
     String id,
@@ -59,6 +59,23 @@ void main() {
     );
     expect(days[1].choiceId, hydrationDark.id);
     expect(days[2].choiceId, hydrationDark.id);
+  });
+
+  test('includes a recording on the partial final calendar day', () {
+    final days = choiceDaySeries(
+      [
+        recording(
+          'today',
+          DateTime(2022, 7, 8, 18),
+          choiceId: hydrationClear.id,
+        ),
+      ],
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+
+    expect(days.last.day, DateTime(2022, 7, 8));
+    expect(days.last.choiceId, hydrationClear.id);
   });
 
   test('numeric entries and other entry types never colour a day', () {

--- a/test/features/dashboards/ui/dashboard_charts_screenshots_test.dart
+++ b/test/features/dashboards/ui/dashboard_charts_screenshots_test.dart
@@ -24,6 +24,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/dashboards/state/health_chart_controller.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
 import 'package:lotti/features/dashboards/state/workout_chart_controller.dart';
@@ -54,6 +55,52 @@ final DateTime _rangeEnd = DateTime(2026, 5, 31);
 
 const _measureBarId = 'screenshot-water';
 const _measureLineId = 'screenshot-mood';
+const _measureChoiceId = 'screenshot-hydration';
+
+final MeasurableDataType _hydrationCheck = MeasurableDataType(
+  id: _measureChoiceId,
+  displayName: 'Hydration check',
+  description: 'Urine colour, first thing',
+  unitName: '',
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+  vectorClock: const VectorClock({}),
+  version: 1,
+  valueKind: MeasurableValueKind.choice,
+  choices: const [
+    MeasurableChoice(id: 'hyd-clear', title: 'Clear'),
+    MeasurableChoice(id: 'hyd-pale', title: 'Pale yellow'),
+    MeasurableChoice(id: 'hyd-dark', title: 'Dark yellow'),
+  ],
+);
+
+/// A recording most days of the range, cycling through the choices.
+List<JournalEntity> _hydrationRecordings() {
+  final days = _rangeEnd.difference(_rangeStart).inDays;
+  const cycle = ['hyd-clear', 'hyd-pale', 'hyd-clear', 'hyd-clear', 'hyd-dark'];
+  return [
+    for (var i = 0; i < days; i++)
+      if (i % 9 != 4)
+        JournalEntity.measurement(
+          meta: Metadata(
+            id: 'hydration-$i',
+            createdAt: _rangeStart.add(Duration(days: i, hours: 8)),
+            updatedAt: _rangeStart.add(Duration(days: i, hours: 8)),
+            dateFrom: _rangeStart.add(Duration(days: i, hours: 8)),
+            dateTo: _rangeStart.add(Duration(days: i, hours: 8)),
+            starred: false,
+            private: false,
+          ),
+          data: MeasurementData(
+            value: 1,
+            dataTypeId: _measureChoiceId,
+            choiceId: cycle[i % cycle.length],
+            dateFrom: _rangeStart.add(Duration(days: i, hours: 8)),
+            dateTo: _rangeStart.add(Duration(days: i, hours: 8)),
+          ),
+        ),
+  ];
+}
 
 const _workoutConfig =
     DashboardItem.workoutChart(
@@ -204,6 +251,16 @@ List<Override> _overrides() {
       rangeEnd: _rangeEnd,
     )).overrideWithBuild((ref, notifier) => _series(78, 6, everyNthDay: 3)),
 
+    // Measurement (choice strip).
+    measurableDataTypeControllerProvider(_measureChoiceId).overrideWithBuild(
+      (ref, notifier) => _hydrationCheck,
+    ),
+    measurableChartDataControllerProvider((
+      measurableDataTypeId: _measureChoiceId,
+      rangeStart: _rangeStart,
+      rangeEnd: _rangeEnd,
+    )).overrideWithBuild((ref, notifier) => _hydrationRecordings()),
+
     // BMI / weight.
     healthObservationsControllerProvider((
       healthDataType: 'HealthDataType.WEIGHT',
@@ -223,6 +280,12 @@ Widget _cards() {
     ),
     MeasurablesBarChart(
       measurableDataTypeId: _measureLineId,
+      rangeStart: _rangeStart,
+      rangeEnd: _rangeEnd,
+      enableCreate: true,
+    ),
+    MeasurablesBarChart(
+      measurableDataTypeId: _measureChoiceId,
       rangeStart: _rangeStart,
       rangeEnd: _rangeEnd,
       enableCreate: true,
@@ -384,7 +447,7 @@ void main() {
   testWidgets('dashboard charts — dark', (tester) async {
     await _pump(tester, brightness: Brightness.dark);
     expect(find.textContaining('Water'), findsOneWidget);
-    expect(find.byIcon(LottiIcons.add), findsNWidgets(2));
+    expect(find.byIcon(LottiIcons.add), findsNWidgets(3));
     await _capture(tester, '01_dashboard_charts_dark');
   });
 
@@ -404,7 +467,7 @@ void main() {
       brightness: Brightness.dark,
       contentWidth: 480,
     );
-    expect(find.byIcon(LottiIcons.add), findsNWidgets(2));
+    expect(find.byIcon(LottiIcons.add), findsNWidgets(3));
     await _capture(tester, '03_dashboard_charts_narrow_pane_dark');
   });
 }

--- a/test/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_info_test.dart
+++ b/test/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_info_test.dart
@@ -155,6 +155,43 @@ void main() {
     );
 
     testWidgets(
+      'a choice measurable captions with its description only — a leftover '
+      'unit and the aggregation are ignored',
+      (tester) async {
+        final withUnit = _makeDataType(
+          displayName: 'Hydration',
+          unitName: 'ml',
+          description: 'Urine colour check',
+          aggregationType: AggregationType.dailySum,
+        ).copyWith(valueKind: MeasurableValueKind.choice);
+
+        await _pumpWidget(
+          tester,
+          MeasurablesChartInfoWidget(
+            withUnit,
+            aggregationType: AggregationType.dailySum,
+            enableCreate: false,
+          ),
+        );
+        expect(find.text('Hydration'), findsOneWidget);
+        expect(find.text('Urine colour check'), findsOneWidget);
+        expect(find.text('ml'), findsNothing);
+        expect(find.text('Daily total'), findsNothing);
+
+        await _pumpWidget(
+          tester,
+          MeasurablesChartInfoWidget(
+            withUnit.copyWith(description: ''),
+            aggregationType: AggregationType.dailySum,
+            enableCreate: false,
+          ),
+        );
+        expect(find.text('ml'), findsNothing);
+        expect(find.text('Daily total'), findsNothing);
+      },
+    );
+
+    testWidgets(
       'humanized aggregation appears in the subtitle, not the title',
       (tester) async {
         const expected = {

--- a/test/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_test.dart
+++ b/test/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_test.dart
@@ -1,13 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_chart.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_measurables_chart.dart';
+import 'package:lotti/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/time_series_bar_chart.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/time_series_line_chart.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 
 import '../../../../../helpers/fallbacks.dart';
+import '../../../../../test_data/test_data.dart';
 import '../../../../../widget_test_utils.dart';
 
 void main() {
@@ -156,5 +159,105 @@ void main() {
       // The header still renders so the chart stays identifiable.
       expect(find.text('Water'), findsOneWidget);
     });
+  });
+
+  group('choice measurable', () {
+    final hydration = measurableHydration.copyWith(id: typeId);
+
+    Future<void> pumpChoiceChart(
+      WidgetTester tester, {
+      required List<JournalEntity> entries,
+    }) async {
+      await tester.pumpWidget(
+        makeTestableWidget(
+          MeasurablesBarChart(
+            measurableDataTypeId: typeId,
+            rangeStart: rangeStart,
+            rangeEnd: rangeEnd,
+          ),
+          overrides: [
+            measurableDataTypeControllerProvider(
+              typeId,
+            ).overrideWithBuild((ref, notifier) => hydration),
+            measurableChartDataControllerProvider((
+              measurableDataTypeId: typeId,
+              rangeStart: rangeStart,
+              rangeEnd: rangeEnd,
+            )).overrideWithBuild((ref, notifier) => entries),
+          ],
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets(
+      'renders the day strip and legend under the header — never a bar or '
+      'line chart — and shows the description, not the unit',
+      (tester) async {
+        final recordedAt = rangeStart.add(const Duration(days: 2, hours: 9));
+        await pumpChoiceChart(
+          tester,
+          entries: [
+            testMeasurementHydrationEntry.copyWith(
+              meta: testMeasurementHydrationEntry.meta.copyWith(
+                dateFrom: recordedAt,
+                dateTo: recordedAt,
+              ),
+              data: testMeasurementHydrationEntry.data.copyWith(
+                dataTypeId: typeId,
+                dateFrom: recordedAt,
+                dateTo: recordedAt,
+              ),
+            ),
+          ],
+        );
+
+        expect(find.byType(DashboardChart), findsOneWidget);
+        expect(find.byType(MeasurableChoiceStrip), findsOneWidget);
+        expect(find.byType(MeasurableChoiceLegend), findsOneWidget);
+        expect(find.byType(TimeSeriesBarChart), findsNothing);
+        expect(find.byType(TimeSeriesLineChart), findsNothing);
+        expect(find.text('Hydration'), findsOneWidget);
+        expect(find.text('Urine colour check'), findsOneWidget);
+
+        final strip = tester.widget<MeasurableChoiceStrip>(
+          find.byType(MeasurableChoiceStrip),
+        );
+        expect(strip.days, hasLength(30));
+        expect(strip.days[2].choiceId, hydrationClear.id);
+        expect(strip.days.where((d) => d.choiceId != null), hasLength(1));
+      },
+    );
+
+    testWidgets('with no entries in range the card says so', (tester) async {
+      await pumpChoiceChart(tester, entries: const []);
+      expect(find.text('No data in this range'), findsOneWidget);
+      expect(find.byType(MeasurableChoiceStrip), findsNothing);
+    });
+
+    testWidgets(
+      'numeric entries from before the switch are not data for the strip',
+      (tester) async {
+        final recordedAt = rangeStart.add(const Duration(days: 1, hours: 9));
+        await pumpChoiceChart(
+          tester,
+          entries: [
+            testMeasurementChocolateEntry.copyWith(
+              meta: testMeasurementChocolateEntry.meta.copyWith(
+                dateFrom: recordedAt,
+                dateTo: recordedAt,
+              ),
+              data: testMeasurementChocolateEntry.data.copyWith(
+                dataTypeId: typeId,
+                dateFrom: recordedAt,
+                dateTo: recordedAt,
+              ),
+            ),
+          ],
+        );
+        expect(find.text('No data in this range'), findsOneWidget);
+        expect(find.byType(MeasurableChoiceStrip), findsNothing);
+      },
+    );
   });
 }

--- a/test/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_test.dart
+++ b/test/features/dashboards/ui/widgets/charts/dashboard_measurables_chart_test.dart
@@ -223,7 +223,7 @@ void main() {
         final strip = tester.widget<MeasurableChoiceStrip>(
           find.byType(MeasurableChoiceStrip),
         );
-        expect(strip.days, hasLength(30));
+        expect(strip.days, hasLength(31));
         expect(strip.days[2].choiceId, hydrationClear.id);
         expect(strip.days.where((d) => d.choiceId != null), hasLength(1));
       },

--- a/test/features/dashboards/ui/widgets/charts/measurable_choice_strip_test.dart
+++ b/test/features/dashboards/ui/widgets/charts/measurable_choice_strip_test.dart
@@ -160,6 +160,20 @@ void main() {
       },
     );
 
+    testWidgets('moving the pointer off the strip removes its tooltip', (
+      tester,
+    ) async {
+      await pumpStrip(tester);
+      final gesture = await hoverDay(tester, index: 0, n: days.length);
+      expect(find.byKey(tooltipKey), findsOneWidget);
+
+      final box = tester.getRect(find.byKey(stripKey));
+      await gesture.moveTo(box.bottomRight + const Offset(20, 20));
+      await tester.pump();
+
+      expect(find.byKey(tooltipKey), findsNothing);
+    });
+
     testWidgets('a touch on a day words the tooltip for that day too', (
       tester,
     ) async {

--- a/test/features/dashboards/ui/widgets/charts/measurable_choice_strip_test.dart
+++ b/test/features/dashboards/ui/widgets/charts/measurable_choice_strip_test.dart
@@ -1,0 +1,360 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/dashboards/state/measurable_choice_series.dart';
+import 'package:lotti/features/dashboards/ui/widgets/charts/measurable_choice_strip.dart';
+import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/utils.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
+
+void main() {
+  final days = <ChoiceDay>[
+    (day: DateTime(2022, 7, 5), choiceId: hydrationClear.id),
+    (day: DateTime(2022, 7, 6), choiceId: null),
+    (day: DateTime(2022, 7, 7), choiceId: hydrationDark.id),
+    (day: DateTime(2022, 7, 8), choiceId: 'gone'),
+  ];
+
+  const stripKey = ValueKey('measurable-choice-strip');
+  const tooltipKey = ValueKey('measurable-choice-strip-tooltip');
+
+  ChoiceStripPainter painter(WidgetTester tester) =>
+      tester.widget<CustomPaint>(find.byKey(stripKey)).painter!
+          as ChoiceStripPainter;
+
+  Future<DsTokens> pumpStrip(
+    WidgetTester tester, {
+    List<ChoiceDay>? strip,
+    MeasurableDataType? dataType,
+    double width = 400,
+  }) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: width,
+            height: 40,
+            child: MeasurableChoiceStrip(
+              days: strip ?? days,
+              dataType: dataType ?? measurableHydration,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return tester.element(find.byType(MeasurableChoiceStrip)).designTokens;
+  }
+
+  /// A mouse pointer over the [index]th day of a strip [n] days long.
+  Future<TestGesture> hoverDay(
+    WidgetTester tester, {
+    required int index,
+    required int n,
+  }) async {
+    final box = tester.getRect(find.byKey(stripKey));
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(
+      Offset(box.left + box.width * (index + 0.5) / n, box.center.dy),
+    );
+    await tester.pump();
+    return gesture;
+  }
+
+  group('choiceColorsFor', () {
+    testWidgets(
+      'steps the accent from faint to full across every choice, archived '
+      'ones included, in the definition order',
+      (tester) async {
+        final tokens = await pumpStrip(tester);
+        final colors = choiceColorsFor(measurableHydration, tokens);
+        final faint = tokens.colors.background.level03;
+        final full = tokens.colors.interactive.enabled;
+
+        expect(colors.keys, [
+          hydrationClear.id,
+          hydrationPale.id,
+          hydrationDark.id,
+          hydrationBrown.id,
+        ]);
+        expect(colors[hydrationClear.id], Color.lerp(faint, full, 0.25));
+        expect(colors[hydrationPale.id], Color.lerp(faint, full, 0.5));
+        expect(colors[hydrationDark.id], Color.lerp(faint, full, 0.75));
+        // The last choice is the full accent; an archived choice keeps the
+        // step its history was drawn in.
+        expect(colors[hydrationBrown.id], full);
+      },
+    );
+
+    testWidgets('a single choice is the full accent; none is empty', (
+      tester,
+    ) async {
+      final tokens = await pumpStrip(tester);
+      expect(
+        choiceColorsFor(
+          measurableHydration.copyWith(choices: const [hydrationClear]),
+          tokens,
+        ),
+        {hydrationClear.id: tokens.colors.interactive.enabled},
+      );
+      expect(
+        choiceColorsFor(measurableHydration.copyWith(choices: null), tokens),
+        isEmpty,
+      );
+    });
+  });
+
+  group('MeasurableChoiceStrip', () {
+    testWidgets(
+      'hands the painter one colour per day: the choice ramp, the track '
+      'colour for an empty day, the neutral step for an unknown choice',
+      (tester) async {
+        final tokens = await pumpStrip(tester);
+        final colors = choiceColorsFor(measurableHydration, tokens);
+        expect(painter(tester).colors, [
+          colors[hydrationClear.id],
+          tokens.colors.background.level03,
+          colors[hydrationDark.id],
+          tokens.colors.decorative.level02,
+        ]);
+        expect(painter(tester).gap, tokens.spacing.step1);
+        expect(painter(tester).radius, tokens.radii.xs);
+      },
+    );
+
+    testWidgets('sits under the shared left axis inset', (tester) async {
+      await pumpStrip(tester);
+      final outer = tester.getTopLeft(find.byType(MeasurableChoiceStrip));
+      final canvas = tester.getTopLeft(find.byKey(stripKey));
+      expect(canvas.dx - outer.dx, kChartLeftAxisWidth);
+    });
+
+    testWidgets(
+      'hovering a recorded day names its date and choice; a removed choice '
+      'is named as such; an empty day has no tooltip',
+      (tester) async {
+        await pumpStrip(tester);
+        expect(find.byKey(tooltipKey), findsNothing);
+
+        final gesture = await hoverDay(tester, index: 0, n: days.length);
+        expect(find.byTooltip('Jul 5, 2022 · Clear'), findsOneWidget);
+
+        final box = tester.getRect(find.byKey(stripKey));
+        await gesture.moveTo(
+          Offset(box.left + box.width * 1.5 / days.length, box.center.dy),
+        );
+        await tester.pump();
+        expect(find.byKey(tooltipKey), findsNothing);
+
+        await gesture.moveTo(
+          Offset(box.left + box.width * 3.5 / days.length, box.center.dy),
+        );
+        await tester.pump();
+        expect(find.byTooltip('Jul 8, 2022 · Removed choice'), findsOneWidget);
+      },
+    );
+
+    testWidgets('a touch on a day words the tooltip for that day too', (
+      tester,
+    ) async {
+      await pumpStrip(tester);
+      final box = tester.getRect(find.byKey(stripKey));
+      final gesture = await tester.startGesture(
+        Offset(box.left + box.width * 2.5 / days.length, box.center.dy),
+      );
+      await tester.pump();
+      expect(find.byTooltip('Jul 7, 2022 · Dark'), findsOneWidget);
+      await gesture.up();
+    });
+
+    testWidgets(
+      'a year at phone width paints without overflowing: gaps dropped, '
+      'every day still has width',
+      (tester) async {
+        final year = [
+          for (var i = 0; i < 365; i++)
+            (
+              day: DateTime(2022).add(Duration(days: i)),
+              choiceId: i % 3 == 0 ? hydrationClear.id : hydrationDark.id,
+            ),
+        ];
+        await pumpStrip(tester, strip: year, width: 300);
+        expect(tester.takeException(), isNull);
+
+        final p = painter(tester);
+        final width = tester.getSize(find.byKey(stripKey)).width;
+        expect(p.colors, hasLength(365));
+        expect(p.gapFor(width), 0);
+        expect(p.cellWidthFor(width), greaterThan(0));
+        expect(p.cellWidthFor(width) * 365, closeTo(width, 0.001));
+      },
+    );
+
+    testWidgets('a short range keeps its gaps', (tester) async {
+      await pumpStrip(tester);
+      final p = painter(tester);
+      final width = tester.getSize(find.byKey(stripKey)).width;
+      expect(p.gapFor(width), p.gap);
+      expect(
+        p.cellWidthFor(width) * days.length + p.gap * (days.length - 1),
+        closeTo(width, 0.001),
+      );
+    });
+  });
+
+  group('ChoiceStripPainter', () {
+    const a = Color(0xFF111111);
+    const b = Color(0xFF222222);
+
+    test('a single cell or none needs no gap', () {
+      expect(
+        const ChoiceStripPainter(colors: [a], gap: 2, radius: 4).gapFor(100),
+        0,
+      );
+      const empty = ChoiceStripPainter(colors: [], gap: 2, radius: 4);
+      expect(empty.gapFor(100), 0);
+      expect(empty.cellWidthFor(100), 0);
+    });
+
+    test('repaints only when colours, gap or radius change', () {
+      const base = ChoiceStripPainter(colors: [a, b], gap: 2, radius: 4);
+      expect(
+        base.shouldRepaint(
+          const ChoiceStripPainter(colors: [a, b], gap: 2, radius: 4),
+        ),
+        isFalse,
+      );
+      expect(
+        base.shouldRepaint(
+          const ChoiceStripPainter(colors: [b, a], gap: 2, radius: 4),
+        ),
+        isTrue,
+      );
+      expect(
+        base.shouldRepaint(
+          const ChoiceStripPainter(colors: [a], gap: 2, radius: 4),
+        ),
+        isTrue,
+      );
+      expect(
+        base.shouldRepaint(
+          const ChoiceStripPainter(colors: [a, b], gap: 1, radius: 4),
+        ),
+        isTrue,
+      );
+    });
+
+    test('paints one rect per cell with gaps, one per run without', () {
+      final recorder = _RecordingCanvas();
+      const gapped = ChoiceStripPainter(
+        colors: [a, a, b],
+        gap: 2,
+        radius: 4,
+      );
+      gapped.paint(recorder, const Size(304, 10));
+      expect(recorder.rects, hasLength(3));
+      expect(recorder.rects[0].left, 0);
+      expect(recorder.rects[1].left, closeTo(102, 0.001));
+
+      final merged = _RecordingCanvas();
+      const tight = ChoiceStripPainter(
+        colors: [a, a, b],
+        gap: 200,
+        radius: 4,
+      );
+      tight.paint(merged, const Size(30, 10));
+      // Two cells of `a` become one run; the corner radius shrinks to fit.
+      expect(merged.rects, hasLength(2));
+      expect(merged.rects[0].width, closeTo(20, 0.001));
+      expect(merged.rects[1].left, closeTo(20, 0.001));
+      expect(merged.corners.every((r) => r.x <= 4), isTrue);
+
+      // Nothing to paint paints nothing.
+      final none = _RecordingCanvas();
+      const ChoiceStripPainter(
+        colors: [],
+        gap: 2,
+        radius: 4,
+      ).paint(none, const Size(30, 10));
+      expect(none.rects, isEmpty);
+    });
+  });
+
+  group('MeasurableChoiceLegend', () {
+    Future<DsTokens> pumpLegend(
+      WidgetTester tester,
+      List<ChoiceDay> strip,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          MeasurableChoiceLegend(days: strip, dataType: measurableHydration),
+        ),
+      );
+      await tester.pump();
+      return tester.element(find.byType(MeasurableChoiceLegend)).designTokens;
+    }
+
+    Finder entry(MeasurableChoice choice) =>
+        find.byKey(ValueKey('choice-legend-${choice.id}'));
+
+    testWidgets('lists the active choices in order with their swatches', (
+      tester,
+    ) async {
+      final tokens = await pumpLegend(tester, days);
+      final colors = choiceColorsFor(measurableHydration, tokens);
+
+      expect(entry(hydrationClear), findsOneWidget);
+      expect(entry(hydrationPale), findsOneWidget);
+      expect(entry(hydrationDark), findsOneWidget);
+      expect(entry(hydrationBrown), findsNothing);
+      expect(find.text('Brown'), findsNothing);
+
+      final swatch =
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(
+                      of: entry(hydrationPale),
+                      matching: find.byType(DecoratedBox),
+                    ),
+                  )
+                  .decoration
+              as BoxDecoration;
+      expect(swatch.color, colors[hydrationPale.id]);
+      expect(
+        find.descendant(of: entry(hydrationPale), matching: find.text('Pale')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('an archived choice appears only while a day still shows it', (
+      tester,
+    ) async {
+      await pumpLegend(tester, [
+        (day: DateTime(2022, 7, 5), choiceId: hydrationBrown.id),
+      ]);
+      expect(entry(hydrationBrown), findsOneWidget);
+      expect(find.text('Brown'), findsOneWidget);
+    });
+  });
+}
+
+/// Records the rounded rects a painter draws, ignoring everything else.
+class _RecordingCanvas implements Canvas {
+  final rects = <Rect>[];
+  final corners = <Radius>[];
+
+  @override
+  void drawRRect(RRect rrect, Paint paint) {
+    rects.add(rrect.outerRect);
+    corners.add(rrect.tlRadius);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/test/features/goals/evaluation/goal_signal_reader_test.dart
+++ b/test/features/goals/evaluation/goal_signal_reader_test.dart
@@ -51,7 +51,7 @@ void main() {
         ),
       );
 
-  JournalEntity measurement(DateTime at, num value) =>
+  JournalEntity measurement(DateTime at, num value, {String? choiceId}) =>
       JournalEntity.measurement(
         meta: meta(at),
         data: MeasurementData(
@@ -59,6 +59,7 @@ void main() {
           dateTo: at,
           value: value,
           dataTypeId: 'water-id',
+          choiceId: choiceId,
         ),
       );
 
@@ -428,6 +429,43 @@ void main() {
       1200,
     );
   });
+
+  test(
+    'choice occurrence markers do not satisfy an old numeric goal',
+    () async {
+      const water = GoalCriterion.measurable(
+        criterionId: 'water',
+        dataTypeId: 'water-id',
+        window: GoalWindow.day(),
+        aggregation: GoalAggregation.sum,
+        target: 2000,
+      );
+      when(
+        () => journalDb.getMeasurementsByType(
+          type: 'water-id',
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          measurement(DateTime(2026, 8, 8, 9), 500),
+          measurement(
+            DateTime(2026, 8, 8, 13),
+            1,
+            choiceId: 'clear',
+          ),
+        ],
+      );
+
+      final window = await reader.read(criteria: water, reference: reference);
+
+      expect(
+        window.measurableDailySums['water-id']![DateTime.utc(2026, 8, 8)],
+        500,
+      );
+      expect(window.measurableEntryDaysById, hasLength(1));
+    },
+  );
 
   test(
     'the query range covers the widest window plus a prior period',

--- a/test/features/goals/model/goal_measurable_record_offer_test.dart
+++ b/test/features/goals/model/goal_measurable_record_offer_test.dart
@@ -114,6 +114,31 @@ void main() {
     );
   });
 
+  test(
+    'does not offer numeric capture after the measurable became a choice',
+    () {
+      final offer = parseGoalMeasurableRecordOffer(
+        message: AgentChatMessage(
+          id: 'message-choice',
+          role: AgentChatRole.user,
+          text: 'I read 20 pages today.',
+          createdAt: now,
+        ),
+        criteria: linked,
+        measurables: [
+          pages.copyWith(
+            valueKind: MeasurableValueKind.choice,
+            choices: const [MeasurableChoice(id: 'some', title: 'Some')],
+          ),
+        ],
+        reference: now,
+        recentDayLabels: const {},
+      );
+
+      expect(offer, isNull);
+    },
+  );
+
   test('declines two quantities for the same measurable', () {
     final offer = parseGoalMeasurableRecordOffer(
       message: AgentChatMessage(

--- a/test/features/goals/ui/pages/create_goal_agent_page_test.dart
+++ b/test/features/goals/ui/pages/create_goal_agent_page_test.dart
@@ -35,6 +35,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../../helpers/fallbacks.dart';
 import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
 import '../../../../widget_test_utils.dart';
 
 class _MockGoalSpecRevisionService extends Mock
@@ -2179,6 +2180,53 @@ void main() {
     await tester.tap(find.text('Create measurable'));
     await tester.pumpAndSettle();
     expect(navigated, ['/settings/measurables/create']);
+  });
+
+  testWidgets('a choice measurable is not offered as a goal signal', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 1800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final doses = MeasurableDataType(
+      id: 'meds',
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+      displayName: 'Medication doses',
+      description: '',
+      unitName: 'doses',
+      version: 1,
+      vectorClock: null,
+    );
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        const CreateGoalAgentPage(),
+        overrides: [
+          ...overrides(),
+          measurableDataTypesStreamProvider.overrideWith(
+            (ref) => Stream.value([doses, measurableHydration]),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('goal-form-intention')),
+      'Take my meds',
+    );
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('goal-form-add-signal')),
+    );
+    await tester.tap(find.byKey(const ValueKey('goal-form-add-signal')));
+    await tester.pumpAndSettle();
+
+    // The numeric measurable can carry a target; the choice one cannot, so
+    // it is simply not there to pick.
+    expect(find.text('Medication doses'), findsOneWidget);
+    expect(find.text('Hydration'), findsNothing);
   });
 
   testWidgets('clearing a selected measurable target blocks confirmation', (

--- a/test/features/goals/ui/pages/create_goal_agent_page_test.dart
+++ b/test/features/goals/ui/pages/create_goal_agent_page_test.dart
@@ -122,6 +122,23 @@ GoalSpecVersionEntity _spec({
         )
         as GoalSpecVersionEntity;
 
+Iterable<GoalCriterion> _criterionLeaves(GoalCriterion criterion) sync* {
+  switch (criterion) {
+    case GoalCriterionMetric() ||
+        GoalCriterionHabit() ||
+        GoalCriterionMeasurable() ||
+        GoalCriterionCategoryTime() ||
+        GoalCriterionLabelTime():
+      yield criterion;
+    case GoalCriterionAllOf(criteria: final children) ||
+        GoalCriterionAnyOf(criteria: final children) ||
+        GoalCriterionAtLeastCount(criteria: final children):
+      for (final child in children) {
+        yield* _criterionLeaves(child);
+      }
+  }
+}
+
 final _identity =
     AgentDomainEntity.agent(
           id: 'goal-1',
@@ -2228,6 +2245,107 @@ void main() {
     expect(find.text('Medication doses'), findsOneWidget);
     expect(find.text('Hydration'), findsNothing);
   });
+
+  testWidgets(
+    'editing removes a numeric target whose measurable became a choice',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 2200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      const criteria = GoalCriterion.allOf(
+        criterionId: 'routine',
+        criteria: [
+          GoalCriterion.habit(
+            criterionId: 'habit-gym',
+            habitId: 'gym',
+            window: GoalWindow.rollingDays(count: 7),
+            targetCount: 2,
+          ),
+          GoalCriterion.measurable(
+            criterionId: 'measurable-hydration',
+            dataTypeId: 'hydration',
+            window: GoalWindow.rollingDays(count: 7),
+            aggregation: GoalAggregation.sum,
+            target: 3,
+          ),
+        ],
+      );
+      final current = _spec(criteria: criteria);
+      final revised = _spec(
+        version: 4,
+        criteria: const GoalCriterion.habit(
+          criterionId: 'habit-gym',
+          habitId: 'gym',
+          window: GoalWindow.rollingDays(count: 7),
+          targetCount: 2,
+        ),
+      );
+      when(
+        () => revisionService.reviseFromOwner(
+          agentId: 'goal-1',
+          baseVersionId: any(named: 'baseVersionId'),
+          displayName: any(named: 'displayName'),
+          title: any(named: 'title'),
+          statement: any(named: 'statement'),
+          criteria: any(named: 'criteria'),
+        ),
+      ).thenAnswer(
+        (_) async => GoalSpecRevisionMinted(
+          version: revised,
+          changeSummaries: const ['removed obsolete measurable target'],
+        ),
+      );
+      when(
+        () => agentService.refreshAfterRevision(
+          agentId: 'goal-1',
+          criteria: any(named: 'criteria'),
+        ),
+      ).thenReturn(null);
+
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const CreateGoalAgentPage(agentId: 'goal-1'),
+          overrides: [
+            ...overrides(editSpec: current),
+            measurableDataTypesStreamProvider.overrideWith(
+              (ref) => Stream.value([
+                measurableHydration.copyWith(id: 'hydration'),
+              ]),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(
+          const ValueKey('goal-form-measurable-card-hydration'),
+        ),
+        findsNothing,
+      );
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save new version'));
+      await tester.pump();
+
+      final saved = verify(
+        () => revisionService.reviseFromOwner(
+          agentId: 'goal-1',
+          baseVersionId: current.id,
+          displayName: any(named: 'displayName'),
+          title: any(named: 'title'),
+          statement: any(named: 'statement'),
+          criteria: captureAny(named: 'criteria'),
+        ),
+      ).captured.single;
+      final leaves = _criterionLeaves(saved as GoalCriterion).toList();
+      expect(leaves.whereType<GoalCriterionMeasurable>(), isEmpty);
+      expect(
+        leaves.whereType<GoalCriterionHabit>().map((leaf) => leaf.habitId),
+        ['gym'],
+      );
+    },
+  );
 
   testWidgets('clearing a selected measurable target blocks confirmation', (
     tester,

--- a/test/features/goals/ui/pages/create_goal_agent_page_test.dart
+++ b/test/features/goals/ui/pages/create_goal_agent_page_test.dart
@@ -2247,7 +2247,8 @@ void main() {
   });
 
   testWidgets(
-    'editing removes a numeric target whose measurable became a choice',
+    'editing waits for measurable definitions before removing a numeric '
+    'target that became a choice',
     (tester) async {
       tester.view.physicalSize = const Size(900, 2200);
       tester.view.devicePixelRatio = 1;
@@ -2301,6 +2302,8 @@ void main() {
           criteria: any(named: 'criteria'),
         ),
       ).thenReturn(null);
+      final measurables = StreamController<List<MeasurableDataType>>();
+      addTearDown(measurables.close);
 
       await tester.pumpWidget(
         makeTestableWidgetNoScroll(
@@ -2308,9 +2311,7 @@ void main() {
           overrides: [
             ...overrides(editSpec: current),
             measurableDataTypesStreamProvider.overrideWith(
-              (ref) => Stream.value([
-                measurableHydration.copyWith(id: 'hydration'),
-              ]),
+              (ref) => measurables.stream,
             ),
           ],
         ),
@@ -2327,6 +2328,21 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text('Save new version'));
       await tester.pump();
+      verifyNever(
+        () => revisionService.reviseFromOwner(
+          agentId: any(named: 'agentId'),
+          baseVersionId: any(named: 'baseVersionId'),
+          displayName: any(named: 'displayName'),
+          title: any(named: 'title'),
+          statement: any(named: 'statement'),
+          criteria: any(named: 'criteria'),
+        ),
+      );
+
+      measurables.add([
+        measurableHydration.copyWith(id: 'hydration'),
+      ]);
+      await tester.pumpAndSettle();
 
       final saved = verify(
         () => revisionService.reviseFromOwner(

--- a/test/features/habits/model/habit_form_mapping_test.dart
+++ b/test/features/habits/model/habit_form_mapping_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/habits/model/habit_form_mapping.dart';
+import '../../../test_data/test_data.dart';
 
 void main() {
   const water = HabitSignalForm(
@@ -274,6 +275,48 @@ void main() {
       expect(cleared, anyRun);
       expect(cleared.toString(), contains('running'));
       expect(cleared.hashCode, anyRun.hashCode);
+    });
+  });
+  group('unboundedForChoices', () {
+    final hydration = measurableHydration.copyWith(id: 'hydration');
+    final byId = {'hydration': hydration, 'water': measurableWater};
+    const boundedChoice = HabitSignalForm(
+      kind: HabitSignalKind.measurable,
+      id: 'hydration',
+      mode: HabitSignalMode.atLeast,
+      threshold: 500,
+    );
+    const boundedWater = HabitSignalForm(
+      kind: HabitSignalKind.measurable,
+      id: 'water',
+      mode: HabitSignalMode.atMost,
+      threshold: 2,
+    );
+
+    test('drops a bound on a choice measurable and keeps every other', () {
+      const form = HabitSignalsForm(
+        signals: [boundedChoice, boundedWater],
+        composite: HabitCompositeRule.all,
+      );
+      final result = form.unboundedForChoices(byId);
+      expect(result.signals, const [
+        HabitSignalForm(kind: HabitSignalKind.measurable, id: 'hydration'),
+        boundedWater,
+      ]);
+      expect(result.composite, HabitCompositeRule.all);
+    });
+
+    test('returns the same instance when nothing needs changing', () {
+      const form = HabitSignalsForm(
+        signals: [
+          HabitSignalForm(kind: HabitSignalKind.measurable, id: 'hydration'),
+          boundedWater,
+        ],
+      );
+      expect(identical(form.unboundedForChoices(byId), form), isTrue);
+      // An unknown measurable is left alone: its kind is not known either.
+      const unknown = HabitSignalsForm(signals: [boundedChoice]);
+      expect(identical(unknown.unboundedForChoices(const {}), unknown), isTrue);
     });
   });
 }

--- a/test/features/habits/service/habit_auto_completion_service_test.dart
+++ b/test/features/habits/service/habit_auto_completion_service_test.dart
@@ -408,6 +408,29 @@ void main() {
       expect(service.describeReason(verdict), 'Floss · habit-gone');
     });
 
+    test('a choice measurable is named without its occurrence count', () {
+      when(
+        () => entitiesCache.getDataTypeById('hydration'),
+      ).thenReturn(measurableHydration.copyWith(id: 'hydration'));
+      final verdict = HabitRuleVerdict(
+        satisfied: true,
+        leaves: [
+          leaf(
+            const AutoCompleteRule.measurable(dataTypeId: 'hydration'),
+            value: 1,
+          ),
+          leaf(
+            const AutoCompleteRule.measurable(
+              dataTypeId: 'hydration',
+              title: 'Pee check',
+            ),
+            value: 2,
+          ),
+        ],
+      );
+      expect(service.describeReason(verdict), 'Hydration · Pee check');
+    });
+
     test('an authored title wins over the resolved name', () {
       final verdict = HabitRuleVerdict(
         satisfied: true,

--- a/test/features/habits/service/habit_auto_completion_service_test.dart
+++ b/test/features/habits/service/habit_auto_completion_service_test.dart
@@ -182,6 +182,25 @@ void main() {
       expect(emitted, isEmpty);
     });
 
+    test('a converted choice measurable ignores its stale numeric bound', () {
+      when(() => entitiesCache.getDataTypeById('water')).thenReturn(
+        measurableHydration.copyWith(id: 'water'),
+      );
+      stubHabits([waterHabit]);
+      final entry =
+          measurementEntity(DateTime(2026, 8, 8, 9), 1) as MeasurementEntry;
+      stubMeasurements([
+        entry.copyWith(
+          data: entry.data.copyWith(choiceId: hydrationClear.id),
+        ),
+      ]);
+
+      run((async) => service.start());
+
+      expect(written, hasLength(1));
+      expect(written.single.autoCompleteReason, 'Hydration');
+    });
+
     test('inactive habits and habits without a rule are not candidates', () {
       stubHabits([
         waterHabit.copyWith(active: false),

--- a/test/features/habits/state/habit_signal_status_controller_test.dart
+++ b/test/features/habits/state/habit_signal_status_controller_test.dart
@@ -92,6 +92,26 @@ void main() {
     expect(status.verdict.leaves.single.value, 250);
   });
 
+  test(
+    'a converted choice measurable ignores its stale numeric bound',
+    () async {
+      when(() => cache.getDataTypeById('water')).thenReturn(
+        measurableHydration.copyWith(id: 'water'),
+      );
+      measurements = {DateTime(2026, 8, 8, 9): 1};
+
+      final status = await withClock(
+        Clock.fixed(now),
+        () => container.read(habitSignalStatusProvider(habit.id).future),
+      );
+
+      final rule = status!.rule as AutoCompleteRuleMeasurable;
+      expect(rule.minimum, isNull);
+      expect(rule.maximum, isNull);
+      expect(status.verdict.satisfied, isTrue);
+    },
+  );
+
   test('a write to the measurable refreshes in place, never via loading', () {
     withClock(Clock.fixed(now), () {
       fakeAsync((async) {

--- a/test/features/habits/ui/habits_manual_screenshots_test.dart
+++ b/test/features/habits/ui/habits_manual_screenshots_test.dart
@@ -96,6 +96,23 @@ final _krillRations = MeasurableDataType(
   aggregationType: AggregationType.dailySum,
 );
 
+final _hydrationCheck = MeasurableDataType(
+  id: 'hydration-check',
+  displayName: _t('Hydration check', 'Hydrationscheck'),
+  description: '',
+  unitName: '',
+  version: 1,
+  createdAt: DateTime(2026),
+  updatedAt: _today,
+  vectorClock: null,
+  valueKind: MeasurableValueKind.choice,
+  choices: [
+    MeasurableChoice(id: 'hyd-clear', title: _t('Clear', 'Klar')),
+    MeasurableChoice(id: 'hyd-pale', title: _t('Pale yellow', 'Hellgelb')),
+    MeasurableChoice(id: 'hyd-dark', title: _t('Dark yellow', 'Dunkelgelb')),
+  ],
+);
+
 final HabitDefinition _inspectHabitatSeals =
     _habit(
       id: 'inspect-habitat-seals',
@@ -108,6 +125,7 @@ final HabitDefinition _inspectHabitatSeals =
       autoCompleteRule: AutoCompleteRule.and(
         rules: [
           AutoCompleteRule.measurable(dataTypeId: _krillRations.id, minimum: 3),
+          AutoCompleteRule.measurable(dataTypeId: _hydrationCheck.id),
           const AutoCompleteRule.health(
             dataType: 'cumulative_step_count',
             minimum: 6000,
@@ -130,6 +148,7 @@ class _FixedSignalStatus extends HabitSignalStatusController {
   Future<HabitSignalStatus?> build() async {
     final rule = _inspectHabitatSeals.autoCompleteRule!;
     final krill = <DateTime, num>{};
+    final hydration = <DateTime, num>{};
     final steps = <DateTime, num>{};
     const krillByOffset = [2, 4, 3, null, 5, 3, 4, 2, null, 4, 3, 5, 4, 2];
     const stepsByOffset = [
@@ -151,12 +170,17 @@ class _FixedSignalStatus extends HabitSignalStatusController {
     for (var i = 0; i < 14; i++) {
       final day = _todayKey.subtract(Duration(days: 13 - i));
       if (krillByOffset[i] != null) krill[day] = krillByOffset[i]!;
+      // Checked most mornings, not yet today.
+      if (i % 5 != 2 && i != 13) hydration[day] = 1;
       steps[day] = stepsByOffset[i];
     }
     final window = SignalWindow(
       start: _todayKey.subtract(const Duration(days: 13)),
       end: _todayKey,
-      measurableTotalsByDay: {_krillRations.id: krill},
+      measurableTotalsByDay: {
+        _krillRations.id: krill,
+        _hydrationCheck.id: hydration,
+      },
       quantitativeByDay: {'cumulative_step_count': steps},
     );
     return HabitSignalStatus(
@@ -240,6 +264,7 @@ void main() {
           )
           ..categoriesById[_penguinOps.id] = _penguinOps
           ..dataTypesById[_krillRations.id] = _krillRations
+          ..dataTypesById[_hydrationCheck.id] = _hydrationCheck
           ..habitsById.addEntries(
             _habits.map((habit) => MapEntry(habit.id, habit)),
           );
@@ -343,7 +368,7 @@ void main() {
           findsNWidgets(2),
         );
         expect(find.byKey(const Key('habit_save')), findsOneWidget);
-        expect(find.byType(HabitSignalRow), findsNWidgets(2));
+        expect(find.byType(HabitSignalRow), findsNWidgets(3));
         await captureScreenshot(
           tester,
           'habits_record_${viewport}_$theme',
@@ -548,7 +573,7 @@ Future<void> _pumpHabitEditor(
     ProviderScope(
       overrides: [
         measurableDataTypesStreamProvider.overrideWith(
-          (ref) => Stream.value([_krillRations]),
+          (ref) => Stream.value([_krillRations, _hydrationCheck]),
         ),
         workoutTypesProvider.overrideWith(
           (ref) async => ['functionalStrengthTraining', 'running'],

--- a/test/features/habits/ui/pages/habit_editor_page_test.dart
+++ b/test/features/habits/ui/pages/habit_editor_page_test.dart
@@ -98,6 +98,7 @@ void main() {
     WidgetTester tester, {
     String? habitId,
     String returnPath = '/habits',
+    List<MeasurableDataType>? measurables,
   }) async {
     tester.view.physicalSize = const Size(1200, 1800);
     tester.view.devicePixelRatio = 1.0;
@@ -113,7 +114,7 @@ void main() {
         mediaQueryData: const MediaQueryData(size: Size(1200, 1800)),
         overrides: [
           measurableDataTypesStreamProvider.overrideWith(
-            (ref) => Stream.value([water]),
+            (ref) => Stream.value(measurables ?? [water]),
           ),
           workoutTypesProvider.overrideWith((ref) async => ['running']),
         ],
@@ -235,6 +236,52 @@ void main() {
             rules: [
               AutoCompleteRule.measurable(dataTypeId: 'water'),
               AutoCompleteRule.workout(dataType: 'running'),
+            ],
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'a bound persisted on a choice measurable is dropped on load and '
+      'saved as any entry',
+      (tester) async {
+        final hydration = measurableHydration.copyWith(id: 'hydration');
+        final stale = ruledHabit.copyWith(
+          id: 'stale',
+          autoCompleteRule: const AutoCompleteRule.and(
+            rules: [
+              AutoCompleteRule.measurable(
+                dataTypeId: 'hydration',
+                minimum: 500,
+              ),
+              AutoCompleteRule.measurable(dataTypeId: 'water', minimum: 1000),
+            ],
+          ),
+        );
+        when(
+          () => mocks.journalDb.getHabitById(stale.id),
+        ).thenAnswer((_) async => stale);
+        await pumpEditor(
+          tester,
+          habitId: stale.id,
+          measurables: [water, hydration],
+        );
+        // The card already shows the choice signal as "any entry"…
+        expect(
+          find.byKey(const ValueKey('habit-signal-choice-any-hydration')),
+          findsOneWidget,
+        );
+        await tester.tap(find.byKey(const ValueKey('habit-editor-primary')));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        // …and the saved rule is the one on screen, the water bound intact.
+        expect(
+          savedHabit().autoCompleteRule,
+          const AutoCompleteRule.and(
+            rules: [
+              AutoCompleteRule.measurable(dataTypeId: 'hydration'),
+              AutoCompleteRule.measurable(dataTypeId: 'water', minimum: 1000),
             ],
           ),
         );

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/habits/state/habit_signal_status_controller.dart';
 import 'package:lotti/features/habits/ui/sheets/habit_completion_sheet.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_signal_row.dart';
@@ -67,6 +68,34 @@ class _FakeStatus extends HabitSignalStatusController {
   Future<void> refresh() async => state = AsyncData(_status());
 }
 
+/// Like [_FakeStatus], for the hydration habit's any-entry choice rule.
+class _ChoiceStatus extends HabitSignalStatusController {
+  _ChoiceStatus(super.habitId, this.windowOf);
+  final SignalWindow Function() windowOf;
+
+  static const rule = AutoCompleteRule.measurable(dataTypeId: 'hydration');
+
+  HabitSignalStatus _status() {
+    final window = windowOf();
+    return HabitSignalStatus(
+      rule: rule,
+      window: window,
+      verdict: const HabitRuleEvaluator().evaluate(
+        rule: rule,
+        window: window,
+        day: window.end,
+      ),
+      today: window.end,
+    );
+  }
+
+  @override
+  Future<HabitSignalStatus?> build() async => _status();
+
+  @override
+  Future<void> refresh() async => state = AsyncData(_status());
+}
+
 /// [testWidgets] under the fixed sheet clock.
 void clockedWidgets(
   String description,
@@ -95,12 +124,22 @@ void main() {
     name: 'Drink water',
     autoCompleteRule: _FakeStatus.rule,
   );
+  final hydration = measurableHydration.copyWith(id: 'hydration');
+  final hydrationHabit = habitFlossing.copyWith(
+    id: 'hydration-habit',
+    name: 'Check hydration',
+    autoCompleteRule: _ChoiceStatus.rule,
+  );
   var waterToday = <DateTime, num>{};
+  var hydrationToday = <DateTime, num>{};
 
   SignalWindow window() => SignalWindow(
     start: todayKey.subtract(const Duration(days: 13)),
     end: todayKey,
-    measurableTotalsByDay: {'water': Map.of(waterToday)},
+    measurableTotalsByDay: {
+      'water': Map.of(waterToday),
+      'hydration': Map.of(hydrationToday),
+    },
   );
 
   setUpAll(registerAllFallbackValues);
@@ -109,8 +148,13 @@ void main() {
     persistence = MockPersistenceLogic();
     cache = MockEntitiesCacheService();
     waterToday = {};
+    hydrationToday = {};
     when(() => cache.getHabitById(habitFlossing.id)).thenReturn(habitFlossing);
     when(() => cache.getHabitById(waterHabit.id)).thenReturn(waterHabit);
+    when(
+      () => cache.getHabitById(hydrationHabit.id),
+    ).thenReturn(hydrationHabit);
+    when(() => cache.getDataTypeById('hydration')).thenReturn(hydration);
     when(() => cache.getHabitById('missing')).thenReturn(null);
     when(() => cache.getDataTypeById('water')).thenReturn(water);
     when(
@@ -196,6 +240,9 @@ void main() {
           habitSignalStatusProvider(
             waterHabit.id,
           ).overrideWith(() => _FakeStatus(waterHabit.id, window)),
+          habitSignalStatusProvider(
+            hydrationHabit.id,
+          ).overrideWith(() => _ChoiceStatus(hydrationHabit.id, window)),
         ],
       ),
     );
@@ -458,6 +505,45 @@ void main() {
         await tester.tap(find.byKey(const Key('habit_save')));
         await tester.pump(const Duration(milliseconds: 300));
         expect(captured().completionType, HabitCompletionType.success);
+      },
+    );
+
+    clockedWidgets(
+      'a choice chip records one occurrence of the choice, marks the row '
+      'done and the chip selected',
+      (tester) async {
+        MeasurementData? saved;
+        when(
+          () => persistence.createMeasurementEntry(
+            data: any(named: 'data'),
+            private: any(named: 'private'),
+          ),
+        ).thenAnswer((invocation) async {
+          saved = invocation.namedArguments[#data] as MeasurementData;
+          hydrationToday[todayKey] = (hydrationToday[todayKey] ?? 0) + 1;
+          return testMeasurementHydrationEntry;
+        });
+
+        await pumpSheet(tester, habitId: hydrationHabit.id);
+        expect(find.text('any entry · not yet'), findsOneWidget);
+        expect(find.text('Pale'), findsOneWidget);
+        expect(find.text('Brown'), findsNothing);
+
+        await tester.tap(find.text('Pale'));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(saved, isNotNull);
+        expect(saved!.dataTypeId, 'hydration');
+        expect(saved!.choiceId, hydrationPale.id);
+        expect(saved!.value, 1);
+        expect(find.text('any entry · done'), findsOneWidget);
+        expect(find.text('today: logged'), findsOneWidget);
+        final paleChip = tester.widget<DsPill>(
+          find.byKey(
+            const ValueKey('habit-quick-record-hydration-hydration-pale'),
+          ),
+        );
+        expect(paleChip.selected, isTrue);
       },
     );
 

--- a/test/features/habits/ui/widgets/editor/habit_signal_card_test.dart
+++ b/test/features/habits/ui/widgets/editor/habit_signal_card_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/habits/model/habit_form_mapping.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_signal_card.dart';
 
@@ -16,6 +17,11 @@ void main() {
   const waterAny = HabitSignalForm(
     kind: HabitSignalKind.measurable,
     id: 'water',
+  );
+  final hydration = measurableHydration.copyWith(id: 'hydration');
+  const hydrationAny = HabitSignalForm(
+    kind: HabitSignalKind.measurable,
+    id: 'hydration',
   );
   const steps = HabitSignalForm(
     kind: HabitSignalKind.health,
@@ -41,7 +47,7 @@ void main() {
       makeTestableWidgetWithScaffold(
         HabitSignalCard(
           form: form,
-          measurablesById: {'water': water},
+          measurablesById: {'water': water, 'hydration': hydration},
           onChanged: changes.add,
           onAddSignal: () => adds++,
           onChangeComposite: () => composites++,
@@ -103,6 +109,28 @@ void main() {
       await tester.tap(find.text('Any entry').first);
       await tester.pump();
       expect(changes.last.signals.single, waterAny);
+    },
+  );
+
+  testWidgets(
+    'a choice measurable row offers only "any entry" — no mode toggle, no '
+    'threshold — while a numeric row keeps both',
+    (tester) async {
+      await pump(
+        tester,
+        const HabitSignalsForm(signals: [hydrationAny, waterAny]),
+      );
+      expect(find.text('Hydration'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('habit-signal-choice-any-hydration')),
+        findsOneWidget,
+      );
+      // Exactly one toggle on the page: the water row's.
+      expect(find.byType(DsSegmentedToggle<HabitSignalMode>), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('habit-signal-choice-any-water')),
+        findsNothing,
+      );
     },
   );
 
@@ -241,7 +269,7 @@ void main() {
       makeTestableWidgetWithScaffold(
         HabitSignalCard(
           form: HabitSignalsForm(signals: [bounded.copyWith(threshold: 250)]),
-          measurablesById: {'water': water},
+          measurablesById: {'water': water, 'hydration': hydration},
           onChanged: changes.add,
           onAddSignal: () {},
           onChangeComposite: () {},

--- a/test/features/habits/ui/widgets/editor/habit_signal_picker_test.dart
+++ b/test/features/habits/ui/widgets/editor/habit_signal_picker_test.dart
@@ -26,7 +26,10 @@ void main() {
     await tester.pumpWidget(
       makeTestableWidgetWithScaffold(
         HabitSignalPicker(
-          measurables: [water],
+          measurables: [
+            water,
+            measurableHydration.copyWith(id: 'hydration'),
+          ],
           workoutTypes: const ['running', 'swimming'],
           selected: selected,
           onToggle: (kind, id, {required selected}) =>
@@ -97,6 +100,21 @@ void main() {
     await tester.pump();
     expect(find.text('Nothing matches'), findsOneWidget);
   });
+
+  testWidgets(
+    'a choice measurable lists its active choices as its subtitle and is '
+    'found by any of them',
+    (tester) async {
+      await pump(tester);
+      expect(find.text('Clear · Pale · Dark'), findsOneWidget);
+      expect(find.textContaining('Brown'), findsNothing);
+
+      await tester.enterText(find.byType(TextField), 'pale');
+      await tester.pump();
+      expect(find.text('Hydration'), findsOneWidget);
+      expect(find.text('Water'), findsNothing);
+    },
+  );
 
   testWidgets('dashboard-only health keys are not offered', (tester) async {
     await pump(tester);

--- a/test/features/habits/ui/widgets/editor/habit_signal_presentation_test.dart
+++ b/test/features/habits/ui/widgets/editor/habit_signal_presentation_test.dart
@@ -13,7 +13,13 @@ void main() {
     displayName: 'Water',
     unitName: 'ml',
   );
-  final byId = {'water': water};
+  final hydration = measurableHydration.copyWith(
+    id: 'hydration',
+    // A leftover unit from before the switch to choices must not label a
+    // threshold that no longer exists.
+    unitName: 'ml',
+  );
+  final byId = {'water': water, 'hydration': hydration};
   final messages = AppLocalizationsEn();
 
   test('each kind has its own icon', () {
@@ -118,6 +124,40 @@ void main() {
         byId,
       ),
       '',
+    );
+  });
+
+  test('a choice measurable has no threshold unit, whatever it stores', () {
+    expect(
+      habitSignalUnit(
+        messages,
+        const HabitSignalForm(
+          kind: HabitSignalKind.measurable,
+          id: 'hydration',
+        ),
+        byId,
+      ),
+      '',
+    );
+    expect(
+      habitSignalUnit(
+        messages,
+        const HabitSignalForm(kind: HabitSignalKind.measurable, id: 'gone'),
+        byId,
+      ),
+      '',
+    );
+  });
+
+  test('the picker subtitle is the unit, or the active choices', () {
+    expect(habitMeasurableSubtitle(water), 'ml');
+    expect(habitMeasurableSubtitle(water.copyWith(unitName: '')), isNull);
+    expect(habitMeasurableSubtitle(hydration), 'Clear · Pale · Dark');
+    expect(
+      habitMeasurableSubtitle(
+        hydration.copyWith(choices: const [hydrationBrown]),
+      ),
+      isNull,
     );
   });
 

--- a/test/features/habits/ui/widgets/habit_signal_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_signal_row_test.dart
@@ -36,6 +36,9 @@ void main() {
   setUp(() async {
     cache = MockEntitiesCacheService();
     when(() => cache.getDataTypeById('water')).thenReturn(water);
+    when(
+      () => cache.getDataTypeById('hydration'),
+    ).thenReturn(measurableHydration.copyWith(id: 'hydration'));
     when(() => cache.getHabitById(any())).thenReturn(null);
     await setUpTestGetIt(
       additionalSetup: () =>
@@ -68,14 +71,14 @@ void main() {
     workoutsByDay: workouts,
   );
 
-  final recorded = <(String, num)>[];
+  final recorded = <(String, MeasurableQuickValue)>[];
   final more = <String>[];
 
   Future<void> pump(
     WidgetTester tester,
     AutoCompleteRule rule,
     SignalWindow w, {
-    num? recordedValue,
+    MeasurableQuickValue? recordedValue,
   }) {
     recorded.clear();
     more.clear();
@@ -145,12 +148,56 @@ void main() {
     });
 
     testWidgets('chips record through the row callbacks', (tester) async {
-      await pump(tester, anyEntry, window(), recordedValue: 500);
+      await pump(
+        tester,
+        anyEntry,
+        window(),
+        recordedValue: (value: 500, choiceId: null),
+      );
       await tester.pump();
       await tester.tap(find.text('250 ml'));
-      expect(recorded, [('water', 250)]);
+      expect(recorded, [('water', (value: 250, choiceId: null))]);
       await tester.tap(find.text('Other'));
       expect(more, ['water']);
+    });
+
+    testWidgets(
+      'a choice measurable shows no unit, says "logged" for today, and '
+      'records the tapped choice',
+      (tester) async {
+        const rule = AutoCompleteRule.measurable(dataTypeId: 'hydration');
+        await pump(
+          tester,
+          rule,
+          window(
+            measurables: {
+              'hydration': {todayKey: 1},
+            },
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Hydration'), findsOneWidget);
+        expect(find.text('any entry · done'), findsOneWidget);
+        // Never the occurrence count that backs the day value.
+        expect(find.text('today: logged'), findsOneWidget);
+        expect(find.textContaining('today: 1'), findsNothing);
+
+        await tester.tap(find.text('Pale'));
+        expect(recorded, [
+          ('hydration', (value: 1, choiceId: hydrationPale.id)),
+        ]);
+      },
+    );
+
+    testWidgets('a choice measurable with nothing today says so', (
+      tester,
+    ) async {
+      const rule = AutoCompleteRule.measurable(dataTypeId: 'hydration');
+      await pump(tester, rule, window());
+      await tester.pump();
+      expect(find.text('any entry · not yet'), findsOneWidget);
+      expect(find.text('today: —'), findsOneWidget);
     });
 
     testWidgets('the sparkline carries one value per window day', (

--- a/test/features/habits/ui/widgets/measurable_quick_record_chips_test.dart
+++ b/test/features/habits/ui/widgets/measurable_quick_record_chips_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/habits/ui/widgets/measurable_quick_record_chips.dart';
 
 import '../../../../test_data/test_data.dart';
@@ -14,16 +16,21 @@ class _FixedSuggestions extends MeasurableSuggestionsController {
 }
 
 void main() {
-  final recorded = <num>[];
+  final recorded = <MeasurableQuickValue>[];
   var more = 0;
 
-  Future<void> pump(WidgetTester tester, List<num>? values, {num? selected}) {
+  Future<void> pump(
+    WidgetTester tester,
+    List<num>? values, {
+    MeasurableQuickValue? selected,
+    MeasurableDataType? dataType,
+  }) {
     recorded.clear();
     more = 0;
     return tester.pumpWidget(
       makeTestableWidgetWithScaffold(
         MeasurableQuickRecordChips(
-          dataType: measurableWater,
+          dataType: dataType ?? measurableWater,
           recordedValue: selected,
           onRecord: recorded.add,
           onMore: () => more++,
@@ -59,7 +66,7 @@ void main() {
     await pump(tester, [250, 500]);
     await tester.pump();
     await tester.tap(find.text('500 ${measurableWater.unitName}'));
-    expect(recorded, [500]);
+    expect(recorded, [(value: 500, choiceId: null)]);
     await tester.tap(find.text('Other'));
     expect(more, 1);
   });
@@ -68,5 +75,61 @@ void main() {
     await pump(tester, null);
     await tester.pump();
     expect(find.text('Other'), findsOneWidget);
+  });
+
+  testWidgets('the recorded numeric value reads as selected', (tester) async {
+    await pump(tester, [250, 500], selected: (value: 500, choiceId: null));
+    await tester.pump();
+    DsPill pill(num value) => tester.widget<DsPill>(
+      find.byKey(ValueKey('habit-quick-record-${measurableWater.id}-$value')),
+    );
+    expect(pill(500).selected, isTrue);
+    expect(pill(250).selected, isFalse);
+  });
+
+  group('choice measurable', () {
+    Finder chip(MeasurableChoice choice) => find.byKey(
+      ValueKey('habit-quick-record-${measurableHydration.id}-${choice.id}'),
+    );
+
+    testWidgets(
+      'offers every active choice in order — never a suggestion — plus Other',
+      (tester) async {
+        // No suggestion override for the hydration id: a choice measurable
+        // must not consult the popularity ranking at all.
+        await pump(tester, null, dataType: measurableHydration);
+        await tester.pump();
+
+        final labels = tester
+            .widgetList<DsPill>(find.byType(DsPill))
+            .map((pill) => pill.label)
+            .toList();
+        expect(labels, ['Clear', 'Pale', 'Dark', 'Other']);
+        expect(chip(hydrationBrown), findsNothing);
+      },
+    );
+
+    testWidgets('tapping a choice records one occurrence of it', (
+      tester,
+    ) async {
+      await pump(tester, null, dataType: measurableHydration);
+      await tester.pump();
+      await tester.tap(chip(hydrationPale));
+      expect(recorded, [(value: 1, choiceId: hydrationPale.id)]);
+      await tester.tap(find.text('Other'));
+      expect(more, 1);
+    });
+
+    testWidgets('the recorded choice reads as selected', (tester) async {
+      await pump(
+        tester,
+        null,
+        dataType: measurableHydration,
+        selected: (value: 1, choiceId: hydrationDark.id),
+      );
+      await tester.pump();
+      expect(tester.widget<DsPill>(chip(hydrationDark)).selected, isTrue);
+      expect(tester.widget<DsPill>(chip(hydrationClear)).selected, isFalse);
+    });
   });
 }

--- a/test/features/journal/ui/pages/infinite_journal_page_test.dart
+++ b/test/features/journal/ui/pages/infinite_journal_page_test.dart
@@ -350,12 +350,15 @@ void main() {
         findsOneWidget,
       );
 
-      // measurement entry displays its name (title) and value chip
+      // measurement entry displays its name (title) and value chip, worded
+      // by the same formatter as the entry summary ("55%", no space).
       expect(find.text(measurableCoverage.displayName), findsOneWidget);
       expect(
         find.text(
-          '${nf.format(testMeasuredCoverageEntry.data.value)} '
-          '${measurableCoverage.unitName}',
+          measurementValueLabel(
+            testMeasuredCoverageEntry.data,
+            measurableCoverage,
+          ),
         ),
         findsOneWidget,
       );

--- a/test/features/journal/ui/widgets/entry_details/measurement_summary_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/measurement_summary_test.dart
@@ -49,6 +49,43 @@ void main() {
       expect(find.textContaining('Coverage: 55%'), findsOneWidget);
     });
 
+    testWidgets('a choice recording reads as name: choice title', (
+      tester,
+    ) async {
+      when(
+        () => mockEntitiesCacheService.getDataTypeById(measurableHydration.id),
+      ).thenAnswer((_) => measurableHydration);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          MeasurementSummary(testMeasurementHydrationEntry),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Hydration: Clear'), findsOneWidget);
+      // Never the occurrence count that backs the value.
+      expect(find.textContaining('Hydration: 1'), findsNothing);
+    });
+
+    testWidgets('a choice no longer on the definition reads as removed', (
+      tester,
+    ) async {
+      when(
+        () => mockEntitiesCacheService.getDataTypeById(measurableHydration.id),
+      ).thenAnswer((_) => measurableHydration);
+      final orphan = testMeasurementHydrationEntry.copyWith(
+        data: testMeasurementHydrationEntry.data.copyWith(choiceId: 'gone'),
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(MeasurementSummary(orphan)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Hydration: Removed choice'), findsOneWidget);
+    });
+
     testWidgets('does not duplicate the note — summary shows only the value', (
       tester,
     ) async {

--- a/test/features/journal/ui/widgets/list_cards/journal_card_test.dart
+++ b/test/features/journal/ui/widgets/list_cards/journal_card_test.dart
@@ -519,6 +519,48 @@ void main() {
       expect(find.text('100 g'), findsOneWidget);
     });
 
+    testWidgets('a choice recording shows the choice title as its chip', (
+      tester,
+    ) async {
+      when(
+        () => mockEntitiesCacheService.getDataTypeById(measurableHydration.id),
+      ).thenReturn(measurableHydration);
+
+      await tester.pumpWidget(
+        makeTestableWidget(
+          ModernJournalCard(item: testMeasurementHydrationEntry),
+        ),
+      );
+
+      expect(find.text('Hydration'), findsOneWidget);
+      expect(find.text('Clear'), findsOneWidget);
+      // The occurrence count backing the value never surfaces.
+      expect(find.text('1'), findsNothing);
+    });
+
+    testWidgets('a choice the definition dropped shows the removed label', (
+      tester,
+    ) async {
+      when(
+        () => mockEntitiesCacheService.getDataTypeById(measurableHydration.id),
+      ).thenReturn(measurableHydration);
+      final orphan = testMeasurementHydrationEntry.copyWith(
+        data: testMeasurementHydrationEntry.data.copyWith(choiceId: 'gone'),
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidget(ModernJournalCard(item: orphan)),
+      );
+
+      final BuildContext context = tester.element(
+        find.byType(ModernJournalCard),
+      );
+      expect(
+        find.text(context.messages.measurableChoiceNotFound),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('measurement falls back to not-found when type is unknown', (
       tester,
     ) async {
@@ -572,7 +614,8 @@ void main() {
       expect(find.byIcon(LottiIcons.measure), findsOneWidget);
       expect(find.text(measurableCoverage.displayName), findsOneWidget);
       // value 55 + unit '%' -> '55 %'.
-      expect(find.text('55 %'), findsOneWidget);
+      // Same rule as the entry summary: no space before a percent sign.
+      expect(find.text('55%'), findsOneWidget);
     });
 
     testWidgets('shows starred icon when entry is starred', (tester) async {

--- a/test/features/journal/util/entry_tools_test.dart
+++ b/test/features/journal/util/entry_tools_test.dart
@@ -5,6 +5,8 @@ import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 
+import '../../../test_data/test_data.dart';
+
 /// Glados generators for entry-tools property tests.
 extension _AnyDuration on glados.Any {
   /// Generates non-negative durations up to 99 hours 59 minutes 59 seconds,
@@ -452,5 +454,92 @@ void main() {
         'Body Fat: 55%',
       );
     });
+
+    test('a unit-less number is the bare number', () {
+      expect(
+        entryTextForMeasurable(
+          measurement(7.5),
+          dataType(displayName: 'Mood', unitName: ''),
+        ),
+        'Mood: 7.5',
+      );
+    });
+
+    test('a choice recording reads as the choice title', () {
+      expect(
+        entryTextForMeasurable(
+          testMeasurementHydrationEntry.data,
+          measurableHydration,
+        ),
+        'Hydration: Clear',
+      );
+    });
+
+    test('a choice the definition no longer lists reads as the fallback', () {
+      final orphan = testMeasurementHydrationEntry.data.copyWith(
+        choiceId: 'gone',
+      );
+      expect(
+        entryTextForMeasurable(
+          orphan,
+          measurableHydration,
+          removedChoiceLabel: 'Removed choice',
+        ),
+        'Hydration: Removed choice',
+      );
+    });
+  });
+
+  group('measurementValueLabel', () {
+    test('formats a number with its unit', () {
+      expect(
+        measurementValueLabel(
+          testMeasurementChocolateEntry.data,
+          measurableChocolate,
+        ),
+        '100 g',
+      );
+    });
+
+    test('an archived choice still resolves to its title', () {
+      final brown = testMeasurementHydrationEntry.data.copyWith(
+        choiceId: hydrationBrown.id,
+      );
+      expect(measurementValueLabel(brown, measurableHydration), 'Brown');
+    });
+
+    test('a missing choice is empty without a fallback', () {
+      final orphan = testMeasurementHydrationEntry.data.copyWith(
+        choiceId: 'gone',
+      );
+      expect(measurementValueLabel(orphan, measurableHydration), '');
+    });
+
+    test(
+      'the data decides: a numeric entry on a choice measurable is a number',
+      () {
+        // Recorded before the measurable was switched to choices.
+        final legacy = MeasurementData(
+          value: 3,
+          dateFrom: DateTime(2024, 3, 15),
+          dateTo: DateTime(2024, 3, 15),
+          dataTypeId: measurableHydration.id,
+        );
+        expect(measurementValueLabel(legacy, measurableHydration), '3');
+      },
+    );
+
+    test(
+      'and a choice id resolves even after the measurable went numeric',
+      () {
+        final numeric = measurableHydration.copyWith(
+          valueKind: MeasurableValueKind.number,
+        );
+        expect(
+          measurementValueLabel(testMeasurementHydrationEntry.data, numeric),
+          'Clear',
+        );
+      },
+    );
   });
 }

--- a/test/features/settings/ui/pages/dashboards/chart_multi_select_test.dart
+++ b/test/features/settings/ui/pages/dashboards/chart_multi_select_test.dart
@@ -386,6 +386,53 @@ void main() {
     });
 
     testWidgets(
+      'a choice measurable is added without an aggregation picker',
+      (tester) async {
+        List<DashboardMeasurementItem>? confirmedItems;
+        await tester.pumpWidget(
+          WidgetTestBench(
+            child: MeasurementChartMultiSelect(
+              items: [measurableWater, measurableHydration],
+              onConfirm: (items) => confirmedItems = items,
+              title: 'Measurement Charts',
+              buttonText: 'Measurement Charts',
+              semanticsLabel: 'Measurement Charts',
+              iconData: LottiIcons.insights,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Measurement Charts'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(measurableHydration.displayName));
+        await tester.pumpAndSettle();
+        // No chart-mode control appears for it…
+        expect(find.text('Daily sum'), findsNothing);
+        expect(find.text('None'), findsNothing);
+
+        // …while a numeric measurable still gets one.
+        await tester.tap(find.text(measurableWater.displayName));
+        await tester.pumpAndSettle();
+        expect(find.text('Daily sum'), findsOneWidget);
+
+        final addButton = find.widgetWithText(
+          DesignSystemButton,
+          'Add 2 charts',
+        );
+        await tester.ensureVisible(addButton);
+        await tester.pumpAndSettle();
+        await tester.tap(addButton);
+        await tester.pumpAndSettle();
+
+        final hydrationItem = confirmedItems!.singleWhere(
+          (item) => item.id == measurableHydration.id,
+        );
+        expect(hydrationItem.aggregationType, AggregationType.none);
+      },
+    );
+
+    testWidgets(
       'search shows the measurement empty state when no item matches',
       (
         tester,

--- a/test/features/settings/ui/pages/dashboards/dashboard_item_card_test.dart
+++ b/test/features/settings/ui/pages/dashboards/dashboard_item_card_test.dart
@@ -6,9 +6,11 @@ import 'package:lotti/features/settings/ui/pages/dashboards/dashboard_item_card.
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/widgets/charts/dashboard_item_modal.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
 import '../../../../../test_helper.dart';
 
 void main() {
@@ -104,6 +106,74 @@ void main() {
         expect(updatedItem, isNull);
         expect(updatedIndex, isNull);
       });
+
+      testWidgets(
+        'tapping a numeric measurement card opens the aggregation editor '
+        'for that chart',
+        (tester) async {
+          const measurementItem = DashboardItem.measurement(
+            id: 'water-id',
+            aggregationType: AggregationType.dailySum,
+          );
+          when(() => mockJournalDb.getAllMeasurableDataTypes()).thenAnswer(
+            (_) async => [measurableWater.copyWith(id: 'water-id')],
+          );
+
+          await tester.pumpWidget(
+            WidgetTestBench(
+              child: DashboardItemCard(
+                index: 0,
+                item: measurementItem,
+                updateItemFn: (item, index) {},
+              ),
+            ),
+          );
+          await tester.pump();
+
+          tester.widget<ItemCard>(find.byType(ItemCard)).onTap!();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+
+          expect(find.text('Aggregation type'), findsOneWidget);
+          final modal = tester.widget<DashboardItemModal>(
+            find.byType(DashboardItemModal),
+          );
+          expect(modal.item, measurementItem);
+          expect(modal.index, 0);
+          expect(modal.chartTitle, 'Water — Daily sum');
+        },
+      );
+
+      testWidgets(
+        'a choice measurable names itself without an aggregation and opens '
+        'no aggregation editor',
+        (tester) async {
+          const measurementItem = DashboardItem.measurement(
+            id: 'hydration-id',
+            aggregationType: AggregationType.dailySum,
+          );
+          when(() => mockJournalDb.getAllMeasurableDataTypes()).thenAnswer(
+            (_) async => [measurableHydration.copyWith(id: 'hydration-id')],
+          );
+
+          await tester.pumpWidget(
+            WidgetTestBench(
+              child: DashboardItemCard(
+                index: 0,
+                item: measurementItem,
+                updateItemFn: (item, index) {},
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.text('Hydration'), findsOneWidget);
+          expect(find.textContaining('Daily sum'), findsNothing);
+          final itemCard = tester.widget<ItemCard>(find.byType(ItemCard));
+          expect(itemCard.onTap, isNull);
+          expect(itemCard.editSemanticsLabel, isNull);
+        },
+      );
 
       testWidgets('should handle measurement item without aggregation type', (
         tester,

--- a/test/features/settings/ui/pages/measurables/measurable_choices_editor_test.dart
+++ b/test/features/settings/ui/pages/measurables/measurable_choices_editor_test.dart
@@ -1,0 +1,368 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/settings/ui/pages/measurables/measurable_choices_editor.dart';
+
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
+
+/// Plays the editor's parent: holds the list, hands every emitted list back
+/// in, and records what was emitted so a test can assert on the contract
+/// rather than on rendering alone.
+class _Host extends StatefulWidget {
+  const _Host({
+    required this.initial,
+    required this.emitted,
+    this.showErrors = false,
+    this.newChoiceId,
+    super.key,
+  });
+
+  final List<MeasurableChoice> initial;
+  final List<List<MeasurableChoice>> emitted;
+  final bool showErrors;
+  final String Function()? newChoiceId;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  late List<MeasurableChoice> choices = widget.initial;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: MeasurableChoicesEditor(
+        choices: choices,
+        showErrors: widget.showErrors,
+        newChoiceId: widget.newChoiceId ?? () => 'new-id',
+        onChanged: (next) {
+          widget.emitted.add(next);
+          setState(() => choices = next);
+        },
+      ),
+    );
+  }
+}
+
+void main() {
+  Future<List<List<MeasurableChoice>>> pump(
+    WidgetTester tester, {
+    required List<MeasurableChoice> initial,
+    bool showErrors = false,
+    String Function()? newChoiceId,
+  }) async {
+    final emitted = <List<MeasurableChoice>>[];
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        _Host(
+          // A fresh host per pump: the same widget type in the same slot
+          // would keep its State — and the previous list — otherwise.
+          key: UniqueKey(),
+          initial: initial,
+          emitted: emitted,
+          showErrors: showErrors,
+          newChoiceId: newChoiceId,
+        ),
+      ),
+    );
+    await tester.pump();
+    return emitted;
+  }
+
+  Finder titleField(String id) =>
+      find.byKey(ValueKey('measurable-choice-title-$id'));
+  Finder archiveAction(String id) =>
+      find.byKey(ValueKey('measurable-choice-archive-$id'));
+  Finder restoreAction(String id) =>
+      find.byKey(ValueKey('measurable-choice-restore-$id'));
+  Finder dragHandle(String id) =>
+      find.byKey(ValueKey('measurable-choice-drag-$id'));
+  Finder row(String id) => find.byKey(ValueKey('measurable-choice-row-$id'));
+
+  String fieldText(WidgetTester tester, String id) => tester
+      .widget<TextField>(
+        find.descendant(of: titleField(id), matching: find.byType(TextField)),
+      )
+      .controller!
+      .text;
+
+  group('normalize', () {
+    test('keeps active choices in order and trails the archived ones', () {
+      expect(
+        MeasurableChoicesEditor.normalize(const [
+          hydrationBrown,
+          hydrationDark,
+          hydrationClear,
+        ]),
+        const [hydrationDark, hydrationClear, hydrationBrown],
+      );
+    });
+
+    test('is a no-op on an already normalised list', () {
+      const list = [hydrationClear, hydrationPale, hydrationBrown];
+      expect(MeasurableChoicesEditor.normalize(list), list);
+    });
+  });
+
+  group('MeasurableChoicesEditor rendering', () {
+    testWidgets(
+      'lists active choices as editable rows with drag handles and archived '
+      'ones under their own section',
+      (tester) async {
+        await pump(
+          tester,
+          initial: const [hydrationClear, hydrationPale, hydrationBrown],
+        );
+
+        expect(fieldText(tester, hydrationClear.id), 'Clear');
+        expect(fieldText(tester, hydrationPale.id), 'Pale');
+        expect(dragHandle(hydrationClear.id), findsOneWidget);
+        expect(dragHandle(hydrationPale.id), findsOneWidget);
+        expect(archiveAction(hydrationClear.id), findsOneWidget);
+
+        // The archived choice is not an editable row.
+        expect(titleField(hydrationBrown.id), findsNothing);
+        expect(dragHandle(hydrationBrown.id), findsNothing);
+        expect(find.text('Archived choices'), findsOneWidget);
+        expect(find.text('Brown'), findsOneWidget);
+        expect(restoreAction(hydrationBrown.id), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('measurable-choices-empty')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('without archived choices the archived section is absent', (
+      tester,
+    ) async {
+      await pump(tester, initial: const [hydrationClear]);
+      expect(find.text('Archived choices'), findsNothing);
+      expect(find.text('Choices'), findsOneWidget);
+    });
+
+    testWidgets(
+      'an empty list shows the at-least-one hint quietly, and in error ink '
+      'once errors are shown',
+      (tester) async {
+        await pump(tester, initial: const []);
+        final quiet = tester.widget<Text>(
+          find.byKey(const ValueKey('measurable-choices-empty')),
+        );
+        final tokens = tester
+            .element(find.byType(MeasurableChoicesEditor))
+            .designTokens;
+        expect(quiet.data, 'Add at least one choice');
+        expect(quiet.style?.color, tokens.colors.text.mediumEmphasis);
+        expect(find.byType(ReorderableListView), findsNothing);
+
+        await pump(tester, initial: const [], showErrors: true);
+        final loud = tester.widget<Text>(
+          find.byKey(const ValueKey('measurable-choices-empty')),
+        );
+        expect(loud.style?.color, tokens.colors.alert.error.ink);
+      },
+    );
+
+    testWidgets(
+      'a blank title is only called out as an error when errors are shown',
+      (tester) async {
+        const blank = MeasurableChoice(id: 'blank', title: '   ');
+        await pump(tester, initial: const [blank, hydrationClear]);
+        expect(find.text('Give this choice a name'), findsNothing);
+
+        await pump(
+          tester,
+          initial: const [blank, hydrationClear],
+          showErrors: true,
+        );
+        // Only the blank row carries the error.
+        expect(find.text('Give this choice a name'), findsOneWidget);
+        expect(
+          find.descendant(
+            of: titleField('blank'),
+            matching: find.text('Give this choice a name'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('a blank row names itself by the hint in its actions', (
+      tester,
+    ) async {
+      const blank = MeasurableChoice(id: 'blank', title: '');
+      await pump(tester, initial: const [blank]);
+      expect(find.byTooltip('Reorder Choice name'), findsOneWidget);
+      expect(find.byTooltip('Archive Choice name'), findsOneWidget);
+
+      await pump(tester, initial: const [hydrationClear]);
+      expect(find.byTooltip('Reorder Clear'), findsOneWidget);
+      expect(find.byTooltip('Archive Clear'), findsOneWidget);
+    });
+  });
+
+  group('MeasurableChoicesEditor edits', () {
+    testWidgets('Add choice appends a blank choice with the minted id', (
+      tester,
+    ) async {
+      final emitted = await pump(
+        tester,
+        initial: const [hydrationClear, hydrationBrown],
+        newChoiceId: () => 'minted',
+      );
+
+      await tester.tap(find.byKey(const ValueKey('measurable-choice-add')));
+      await tester.pump();
+
+      // Appended after the active choices, ahead of the archived tail.
+      expect(emitted.single, const [
+        hydrationClear,
+        MeasurableChoice(id: 'minted', title: ''),
+        hydrationBrown,
+      ]);
+      expect(titleField('minted'), findsOneWidget);
+      expect(fieldText(tester, 'minted'), '');
+    });
+
+    testWidgets('typing renames the choice in place, id untouched', (
+      tester,
+    ) async {
+      final emitted = await pump(
+        tester,
+        initial: const [hydrationClear, hydrationPale],
+      );
+
+      await tester.enterText(titleField(hydrationPale.id), 'Pale yellow');
+      await tester.pump();
+
+      expect(emitted.last, [
+        hydrationClear,
+        const MeasurableChoice(id: 'hydration-pale', title: 'Pale yellow'),
+      ]);
+      // The field keeps what was typed through the parent's rebuild.
+      expect(fieldText(tester, hydrationPale.id), 'Pale yellow');
+      expect(fieldText(tester, hydrationClear.id), 'Clear');
+    });
+
+    testWidgets('the archive action retires the choice to the tail', (
+      tester,
+    ) async {
+      final emitted = await pump(
+        tester,
+        initial: const [hydrationClear, hydrationPale, hydrationDark],
+      );
+
+      await tester.tap(archiveAction(hydrationClear.id));
+      await tester.pump();
+
+      expect(emitted.single, const [
+        hydrationPale,
+        hydrationDark,
+        MeasurableChoice(id: 'hydration-clear', title: 'Clear', archived: true),
+      ]);
+      expect(titleField(hydrationClear.id), findsNothing);
+      expect(find.text('Archived choices'), findsOneWidget);
+      expect(restoreAction(hydrationClear.id), findsOneWidget);
+    });
+
+    testWidgets('restore reactivates the choice after the active ones', (
+      tester,
+    ) async {
+      final emitted = await pump(
+        tester,
+        initial: const [hydrationClear, hydrationBrown, hydrationPale],
+      );
+
+      await tester.tap(restoreAction(hydrationBrown.id));
+      await tester.pump();
+
+      expect(emitted.single, const [
+        hydrationClear,
+        hydrationPale,
+        MeasurableChoice(
+          id: 'hydration-brown',
+          title: 'Brown',
+          archived: false,
+        ),
+      ]);
+      expect(titleField(hydrationBrown.id), findsOneWidget);
+      expect(fieldText(tester, hydrationBrown.id), 'Brown');
+      expect(find.text('Archived choices'), findsNothing);
+    });
+
+    testWidgets('dragging a handle reorders the active choices only', (
+      tester,
+    ) async {
+      final emitted = await pump(
+        tester,
+        initial: const [
+          hydrationClear,
+          hydrationPale,
+          hydrationDark,
+          hydrationBrown,
+        ],
+      );
+
+      final from = tester.getCenter(dragHandle(hydrationClear.id));
+      final to = tester.getCenter(row(hydrationDark.id));
+      final gesture = await tester.startGesture(from);
+      await tester.pump();
+      // Walk the pointer down in steps so the list animates the gap along.
+      const steps = 8;
+      final step = (to - from) / steps.toDouble();
+      for (var i = 0; i < steps; i++) {
+        await gesture.moveBy(step + const Offset(0, 4));
+        await tester.pump(const Duration(milliseconds: 32));
+      }
+      await gesture.up();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(emitted.single, const [
+        hydrationPale,
+        hydrationDark,
+        hydrationClear,
+        hydrationBrown,
+      ]);
+    });
+  });
+
+  group('MeasurableChoicesEditor controllers', () {
+    testWidgets(
+      'a choice the parent drops loses its controller, so re-adding the id '
+      'starts from the new title',
+      (tester) async {
+        final emitted = <List<MeasurableChoice>>[];
+        Widget host(List<MeasurableChoice> choices) =>
+            makeTestableWidgetWithScaffold(
+              SingleChildScrollView(
+                child: MeasurableChoicesEditor(
+                  choices: choices,
+                  onChanged: emitted.add,
+                ),
+              ),
+            );
+
+        await tester.pumpWidget(host(const [hydrationClear]));
+        await tester.pump();
+        expect(fieldText(tester, hydrationClear.id), 'Clear');
+
+        await tester.pumpWidget(host(const [hydrationPale]));
+        await tester.pump();
+        expect(titleField(hydrationClear.id), findsNothing);
+
+        await tester.pumpWidget(
+          host(const [MeasurableChoice(id: 'hydration-clear', title: 'Fresh')]),
+        );
+        await tester.pump();
+        // A retained controller would still say "Clear".
+        expect(fieldText(tester, hydrationClear.id), 'Fresh');
+        expect(emitted, isEmpty);
+      },
+    );
+  });
+}

--- a/test/features/settings/ui/pages/measurables/measurable_details_page_test.dart
+++ b/test/features/settings/ui/pages/measurables/measurable_details_page_test.dart
@@ -3,11 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/components/glass_action_bar.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
+import 'package:lotti/features/settings/ui/pages/measurables/measurable_choices_editor.dart';
 import 'package:lotti/features/settings/ui/pages/measurables/measurable_details_page.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -135,6 +137,9 @@ void main() {
         expect(saved.description, 'H₂O, with or without bubbles');
         expect(saved.unitName, 'ml');
         expect(saved.aggregationType, AggregationType.dailySum);
+        // A numeric measurable does not gain an empty choices list.
+        expect(saved.valueKind, MeasurableValueKind.number);
+        expect(saved.choices, isNull);
         expect(beamedTo, '/settings/measurables');
       },
     );
@@ -396,6 +401,179 @@ void main() {
 
         expect(find.text('Measurable not found'), findsOneWidget);
         expect(find.byType(DsGlassPill), findsNothing);
+      },
+    );
+  });
+
+  group('MeasurableDetailsPage value kind', () {
+    MeasurableValueKind selectedKind(WidgetTester tester) => tester
+        .widget<DsSegmentedToggle<MeasurableValueKind>>(
+          find.byKey(const Key('measurable_value_kind_field')),
+        )
+        .selected;
+
+    Finder titleField(String id) =>
+        find.byKey(ValueKey('measurable-choice-title-$id'));
+
+    testWidgets(
+      'a numeric measurable seeds Number, shows unit and aggregation, and '
+      'no choices editor',
+      (tester) async {
+        await pumpPage(
+          tester,
+          MeasurableDetailsPage(dataType: measurableWater),
+        );
+
+        expect(selectedKind(tester), MeasurableValueKind.number);
+        expect(find.text('ml'), findsOneWidget);
+        expect(
+          find.byKey(const Key('measurable_aggregation_field')),
+          findsOneWidget,
+        );
+        expect(find.byType(MeasurableChoicesEditor), findsNothing);
+        expect(saveAction(tester).enabled, isFalse);
+      },
+    );
+
+    testWidgets(
+      'switching to Choice hides the numeric fields, shows the editor and '
+      'dirties the form; Save without a choice is refused with the hint in '
+      'error ink',
+      (tester) async {
+        await pumpPage(
+          tester,
+          MeasurableDetailsPage(dataType: measurableWater),
+        );
+
+        await tester.tap(find.text('Choice').last);
+        await tester.pump();
+
+        expect(selectedKind(tester), MeasurableValueKind.choice);
+        expect(find.text('ml'), findsNothing);
+        expect(
+          find.byKey(const Key('measurable_aggregation_field')),
+          findsNothing,
+        );
+        expect(find.byType(MeasurableChoicesEditor), findsOneWidget);
+        expect(saveAction(tester).enabled, isTrue);
+
+        await tester.tap(find.widgetWithText(DsGlassPill, 'Save'));
+        await tester.pump();
+
+        verifyNever(() => mockPersistenceLogic.upsertEntityDefinition(any()));
+        expect(beamedTo, isNull);
+        final hint = tester.widget<Text>(
+          find.byKey(const ValueKey('measurable-choices-empty')),
+        );
+        final tokens = tester
+            .element(find.byType(MeasurableDetailsPage))
+            .designTokens;
+        expect(hint.style?.color, tokens.colors.alert.error.ink);
+      },
+    );
+
+    testWidgets(
+      'a converted measurable saves the choice kind and its choices while '
+      'keeping the unit and aggregation it had',
+      (tester) async {
+        await pumpPage(
+          tester,
+          MeasurableDetailsPage(dataType: measurableWater),
+        );
+
+        await tester.tap(find.text('Choice').last);
+        await tester.pump();
+        await tester.tap(find.byKey(const ValueKey('measurable-choice-add')));
+        await tester.pump();
+
+        final field = find.byType(MeasurableChoicesEditor);
+        final newId = tester
+            .widget<MeasurableChoicesEditor>(field)
+            .choices
+            .single
+            .id;
+        await tester.enterText(titleField(newId), '  Sparkling  ');
+        await tester.pump();
+
+        await tester.tap(find.widgetWithText(DsGlassPill, 'Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final saved = capturedUpsert();
+        expect(saved.valueKind, MeasurableValueKind.choice);
+        expect(saved.choices, [
+          MeasurableChoice(id: newId, title: 'Sparkling'),
+        ]);
+        expect(saved.unitName, 'ml');
+        expect(saved.aggregationType, AggregationType.dailySum);
+        expect(beamedTo, '/settings/measurables');
+      },
+    );
+
+    testWidgets(
+      'a choice measurable seeds Choice with its choices, refuses a blank '
+      'title on save, then persists trimmed titles with the archived tail',
+      (tester) async {
+        await pumpPage(
+          tester,
+          MeasurableDetailsPage(dataType: measurableHydration),
+        );
+
+        expect(selectedKind(tester), MeasurableValueKind.choice);
+        expect(find.text('Unit abbreviation (optional)'), findsNothing);
+        expect(titleField(hydrationClear.id), findsOneWidget);
+        expect(titleField(hydrationPale.id), findsOneWidget);
+        expect(titleField(hydrationDark.id), findsOneWidget);
+        expect(find.text('Brown'), findsOneWidget);
+
+        await tester.enterText(titleField(hydrationPale.id), '   ');
+        await tester.pump();
+        await tester.tap(find.widgetWithText(DsGlassPill, 'Save'));
+        await tester.pump();
+
+        verifyNever(() => mockPersistenceLogic.upsertEntityDefinition(any()));
+        expect(find.text('Give this choice a name'), findsOneWidget);
+
+        await tester.enterText(titleField(hydrationPale.id), ' Pale yellow ');
+        await tester.pump();
+        await tester.tap(find.widgetWithText(DsGlassPill, 'Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final saved = capturedUpsert();
+        expect(saved.valueKind, MeasurableValueKind.choice);
+        expect(saved.choices, const [
+          hydrationClear,
+          MeasurableChoice(id: 'hydration-pale', title: 'Pale yellow'),
+          hydrationDark,
+          hydrationBrown,
+        ]);
+        expect(saved.unitName, '');
+      },
+    );
+
+    testWidgets(
+      'switching a choice measurable back to Number saves the number kind '
+      'and keeps the choices for a later switch back',
+      (tester) async {
+        await pumpPage(
+          tester,
+          MeasurableDetailsPage(dataType: measurableHydration),
+        );
+
+        await tester.tap(find.text('Number').last);
+        await tester.pump();
+
+        expect(find.byType(MeasurableChoicesEditor), findsNothing);
+        expect(find.text('Unit abbreviation (optional)'), findsOneWidget);
+
+        await tester.tap(find.widgetWithText(DsGlassPill, 'Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final saved = capturedUpsert();
+        expect(saved.valueKind, MeasurableValueKind.number);
+        expect(saved.choices, measurableHydration.choices);
       },
     );
   });

--- a/test/features/settings/ui/pages/measurables/measurables_page_test.dart
+++ b/test/features/settings/ui/pages/measurables/measurables_page_test.dart
@@ -247,8 +247,8 @@ void main() {
         expect(find.text('No measurables yet'), findsOneWidget);
         expect(
           find.text(
-            'Measurables are numbers you track over time — weight, water, '
-            'steps.',
+            'Measurables are values you track over time — weight, water, '
+            'steps, or a choice like how rested you feel.',
           ),
           findsOneWidget,
         );

--- a/test/features/settings/ui/settings_definitions_screenshots_test.dart
+++ b/test/features/settings/ui/settings_definitions_screenshots_test.dart
@@ -325,10 +325,37 @@ final MeasurableDataType _penguinsAccountedFor = _measurable(
   favorite: true,
 );
 
+final MeasurableDataType _hydrationCheck =
+    _measurable(
+      id: 'meas-hydration-check',
+      displayName: _t('Hydration check', 'Hydrationscheck'),
+      unitName: '',
+      description: _t(
+        'Urine colour, first thing.',
+        'Urinfarbe, gleich morgens.',
+      ),
+    ).copyWith(
+      valueKind: MeasurableValueKind.choice,
+      choices: [
+        MeasurableChoice(id: 'hyd-clear', title: _t('Clear', 'Klar')),
+        MeasurableChoice(id: 'hyd-pale', title: _t('Pale yellow', 'Hellgelb')),
+        MeasurableChoice(
+          id: 'hyd-dark',
+          title: _t('Dark yellow', 'Dunkelgelb'),
+        ),
+        MeasurableChoice(
+          id: 'hyd-amber',
+          title: _t('Amber', 'Bernstein'),
+          archived: true,
+        ),
+      ],
+    );
+
 final List<MeasurableDataType> _allMeasurables = [
   _habitatPressure,
   _sardinesConsumed,
   _penguinsAccountedFor,
+  _hydrationCheck,
 ];
 
 DashboardDefinition _dashboard({
@@ -1158,6 +1185,31 @@ void main() {
         await captureScreenshot(
           tester,
           'measurables_settings_detail_${viewport}_$theme',
+          subdir: _subdir,
+        );
+      });
+
+      testWidgets('$viewport measurables settings detail (choice) — $theme', (
+        tester,
+      ) async {
+        await _pumpScreen(
+          tester,
+          device: device,
+          brightness: brightness,
+          home: MeasurableDetailsPage(dataType: _hydrationCheck),
+        );
+        expect(
+          find.text(_t('Hydration check', 'Hydrationscheck')),
+          findsOneWidget,
+        );
+        expect(
+          find.text(_messages(tester).settingsMeasurableChoicesTitle),
+          findsOneWidget,
+        );
+        expect(find.text(_t('Amber', 'Bernstein')), findsOneWidget);
+        await captureScreenshot(
+          tester,
+          'measurables_settings_detail_choice_${viewport}_$theme',
           subdir: _subdir,
         );
       });

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -566,6 +566,51 @@ void main() {
     verify(() => journalDb.upsertEntityDefinition(measurableWater)).called(1);
   });
 
+  test('a synced choice rename reindexes historical measurements', () async {
+    final fts5Db = MockFts5Db();
+    final renamed = measurableHydration.copyWith(
+      choices: [
+        for (final choice in measurableHydration.choices!)
+          if (choice.id == hydrationClear.id)
+            choice.copyWith(title: 'Transparent')
+          else
+            choice,
+      ],
+    );
+    final entries = [testMeasurementHydrationEntry];
+    processor = SyncEventProcessor(
+      loggingService: loggingService,
+      updateNotifications: updateNotifications,
+      aiConfigRepository: aiConfigRepository,
+      savedTaskFiltersRepository: savedTaskFiltersRepository,
+      settingsDb: settingsDb,
+      journalEntityLoader: journalEntityLoader,
+      fts5Db: fts5Db,
+    );
+    when(
+      () => journalDb.getMeasurableDataTypeById(renamed.id),
+    ).thenAnswer((_) async => measurableHydration);
+    when(
+      () => journalDb.getMeasurementsByType(
+        type: renamed.id,
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => entries);
+    when(
+      () => fts5Db.reindexMeasurements(renamed, entries),
+    ).thenAnswer((_) async {});
+    final message = SyncMessage.entityDefinition(
+      entityDefinition: renamed,
+      status: SyncEntryStatus.update,
+    );
+    when(() => event.text).thenReturn(encodeMessage(message));
+
+    await processor.process(event: event, journalDb: journalDb);
+
+    verify(() => fts5Db.reindexMeasurements(renamed, entries)).called(1);
+  });
+
   test('processes ai config messages', () async {
     final message = SyncMessage.aiConfig(
       aiConfig: fallbackAiConfig,

--- a/test/logic/persistence_definition_ops_test.dart
+++ b/test/logic/persistence_definition_ops_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -13,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../helpers/fallbacks.dart';
 import '../mocks/mocks.dart';
+import '../test_data/test_data.dart';
 import '../widget_test_utils.dart';
 
 /// Mirror test for [PersistenceDefinitionOps].
@@ -26,6 +28,7 @@ void main() {
   late MockNotificationService notificationService;
   late MockNotificationScheduler notificationScheduler;
   late MockOutboxService outboxService;
+  late MockFts5Db fts5Db;
   late PersistenceDefinitionOps ops;
   late TestGetItMocks mocks;
 
@@ -50,10 +53,12 @@ void main() {
     notificationService = MockNotificationService();
     notificationScheduler = MockNotificationScheduler();
     outboxService = MockOutboxService();
+    fts5Db = MockFts5Db();
     mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt
           ..registerSingleton<OutboxService>(outboxService)
+          ..registerSingleton<Fts5Db>(fts5Db)
           ..registerSingleton<NotificationService>(notificationService)
           ..registerSingleton<NotificationScheduler>(notificationScheduler);
       },
@@ -72,6 +77,80 @@ void main() {
   });
 
   tearDown(tearDownTestGetIt);
+
+  test('renaming a choice reindexes historical measurements', () async {
+    final previous = measurableHydration;
+    final renamed = previous.copyWith(
+      choices: [
+        for (final choice in previous.choices!)
+          if (choice.id == hydrationClear.id)
+            choice.copyWith(title: 'Transparent')
+          else
+            choice,
+      ],
+    );
+    final entries = [testMeasurementHydrationEntry];
+    when(
+      () => mocks.journalDb.getMeasurableDataTypeById(previous.id),
+    ).thenAnswer((_) async => previous);
+    when(
+      () => mocks.journalDb.upsertEntityDefinition(renamed),
+    ).thenAnswer((_) async => 1);
+    when(
+      () => mocks.journalDb.getMeasurementsByType(
+        type: previous.id,
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => entries);
+    when(
+      () => fts5Db.reindexMeasurements(renamed, entries),
+    ).thenAnswer((_) async {});
+
+    final affected = await ops.upsertEntityDefinitionImpl(renamed);
+
+    expect(affected, 1);
+    verify(() => fts5Db.reindexMeasurements(renamed, entries)).called(1);
+    verify(
+      () => mocks.updateNotifications.notify({
+        renamed.id,
+        measurablesNotification,
+      }),
+    ).called(1);
+    verify(() => outboxService.enqueueMessage(any())).called(1);
+  });
+
+  test(
+    'archiving or reordering choices does not rebuild unchanged text',
+    () async {
+      final previous = measurableHydration;
+      final reordered = previous.copyWith(
+        choices: [
+          ...previous.choices!.reversed.map(
+            (choice) =>
+                choice.copyWith(archived: choice.id == hydrationClear.id),
+          ),
+        ],
+      );
+      when(
+        () => mocks.journalDb.getMeasurableDataTypeById(previous.id),
+      ).thenAnswer((_) async => previous);
+      when(
+        () => mocks.journalDb.upsertEntityDefinition(reordered),
+      ).thenAnswer((_) async => 1);
+
+      await ops.upsertEntityDefinitionImpl(reordered);
+
+      verifyNoMoreInteractions(fts5Db);
+      verifyNever(
+        () => mocks.journalDb.getMeasurementsByType(
+          type: any(named: 'type'),
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      );
+    },
+  );
 
   test(
     'upsertDashboardDefinitionImpl notifies and enqueues a sync update',

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -2535,6 +2535,11 @@ void main() {
       test(
         'upsertEntityDefinition emits $expectedNotification for $description',
         () async {
+          if (definition case final MeasurableDataType measurable) {
+            when(
+              () => journalDb.getMeasurableDataTypeById(measurable.id),
+            ).thenAnswer((_) async => measurable);
+          }
           when(
             () => journalDb.upsertEntityDefinition(any<EntityDefinition>()),
           ).thenAnswer((_) async => 1);

--- a/test/logic/signals/habit_rule_evaluator_test.dart
+++ b/test/logic/signals/habit_rule_evaluator_test.dart
@@ -30,6 +30,70 @@ void main() {
   HabitRuleVerdict eval(AutoCompleteRule rule, SignalWindow w) =>
       evaluator.evaluate(rule: rule, window: w, day: today);
 
+  group('choice measurable normalization', () {
+    test('clears stale bounds recursively and preserves every other rule', () {
+      const numeric = AutoCompleteRule.measurable(
+        dataTypeId: 'water',
+        minimum: 500,
+        title: 'Water',
+      );
+      const choice = AutoCompleteRule.measurable(
+        dataTypeId: 'hydration',
+        minimum: 2,
+        maximum: 4,
+        title: 'Hydration',
+      );
+      const rule = AutoCompleteRule.and(
+        rules: [
+          numeric,
+          AutoCompleteRule.or(
+            rules: [
+              choice,
+              AutoCompleteRule.health(
+                dataType: 'cumulative_step_count',
+                minimum: 5000,
+              ),
+            ],
+          ),
+        ],
+      );
+      final originalNested =
+          (rule as AutoCompleteRuleAnd).rules.last as AutoCompleteRuleOr;
+
+      final normalized =
+          normalizeChoiceMeasurableBounds(
+                rule,
+                isChoice: (id) => id == 'hydration',
+              )
+              as AutoCompleteRuleAnd;
+      expect(normalized.rules.first, same(numeric));
+      final nested = normalized.rules.last as AutoCompleteRuleOr;
+      expect(
+        nested.rules.first,
+        const AutoCompleteRule.measurable(
+          dataTypeId: 'hydration',
+          title: 'Hydration',
+        ),
+      );
+      expect(
+        nested.rules.last,
+        same(originalNested.rules.last),
+      );
+    });
+
+    test('returns the original tree when no choice bound needs changing', () {
+      const rule = AutoCompleteRule.multiple(
+        rules: [AutoCompleteRule.measurable(dataTypeId: 'water')],
+        successes: 1,
+      );
+
+      expect(
+        normalizeChoiceMeasurableBounds(rule, isChoice: (_) => true),
+        same(rule),
+      );
+    });
+  });
+
   group('measurable leaf', () {
     const anyEntry = AutoCompleteRule.measurable(dataTypeId: 'water');
     const atLeast = AutoCompleteRule.measurable(

--- a/test/pages/create/create_measurement_dialog_screenshots_test.dart
+++ b/test/pages/create/create_measurement_dialog_screenshots_test.dart
@@ -57,6 +57,49 @@ final MeasurableDataType _sardinesConsumed = MeasurableDataType(
   favorite: true,
 );
 
+const _hydrationId = 'manual-hydration-check';
+
+final MeasurableDataType _hydrationCheck = MeasurableDataType(
+  id: _hydrationId,
+  displayName: _t('Hydration check', 'Hydrationscheck'),
+  description: _t('Urine colour, first thing.', 'Urinfarbe, gleich morgens.'),
+  unitName: '',
+  createdAt: manualDemoNow.subtract(const Duration(days: 60)),
+  updatedAt: manualDemoNow,
+  vectorClock: null,
+  version: 1,
+  valueKind: MeasurableValueKind.choice,
+  choices: [
+    MeasurableChoice(id: 'hyd-clear', title: _t('Clear', 'Klar')),
+    MeasurableChoice(id: 'hyd-pale', title: _t('Pale yellow', 'Hellgelb')),
+    MeasurableChoice(id: 'hyd-dark', title: _t('Dark yellow', 'Dunkelgelb')),
+  ],
+);
+
+/// A recording most days of the range, cycling through the choices.
+List<MeasurementEntry> _hydrationRecordings() => [
+  for (var day = 0; day < 30; day++)
+    if (day % 7 != 3)
+      MeasurementEntry(
+        meta: Metadata(
+          id: 'hydration-$day',
+          createdAt: _rangeStart.add(Duration(days: day, hours: 8)),
+          dateFrom: _rangeStart.add(Duration(days: day, hours: 8)),
+          dateTo: _rangeStart.add(Duration(days: day, hours: 8)),
+          updatedAt: _rangeStart.add(Duration(days: day, hours: 8)),
+          starred: false,
+          private: false,
+        ),
+        data: MeasurementData(
+          value: 1,
+          dataTypeId: _hydrationId,
+          choiceId: ['hyd-clear', 'hyd-pale', 'hyd-clear', 'hyd-dark'][day % 4],
+          dateFrom: _rangeStart.add(Duration(days: day, hours: 8)),
+          dateTo: _rangeStart.add(Duration(days: day, hours: 8)),
+        ),
+      ),
+];
+
 List<Observation> _dashboardObservations() => [
   for (var day = 0; day < 30; day++)
     Observation(
@@ -106,12 +149,21 @@ List<Override> _chartOverrides() => [
     rangeEnd: _rangeEnd,
     dashboardDefinedAggregationType: AggregationType.dailySum,
   )).overrideWithBuild((ref, notifier) => _dashboardObservations()),
+  measurableDataTypeControllerProvider(_hydrationId).overrideWithBuild(
+    (ref, notifier) => _hydrationCheck,
+  ),
+  measurableChartDataControllerProvider((
+    measurableDataTypeId: _hydrationId,
+    rangeStart: _rangeStart,
+    rangeEnd: _rangeEnd,
+  )).overrideWithBuild((ref, notifier) => _hydrationRecordings()),
 ];
 
 Future<void> _pumpDashboard(
   WidgetTester tester, {
   required ScreenshotDevice device,
   required Brightness brightness,
+  String measurableId = _measurableId,
 }) async {
   applyScreenshotDevice(tester, device);
   await tester.pumpWidget(
@@ -141,7 +193,7 @@ Future<void> _pumpDashboard(
                   child: SingleChildScrollView(
                     padding: EdgeInsets.all(tokens.spacing.step5),
                     child: MeasurablesBarChart(
-                      measurableDataTypeId: _measurableId,
+                      measurableDataTypeId: measurableId,
                       rangeStart: _rangeStart,
                       rangeEnd: _rangeEnd,
                       enableCreate: true,
@@ -171,7 +223,10 @@ void main() {
   setUpAll(loadScreenshotFonts);
 
   setUp(() async {
-    final journalDb = mockJournalDbWithMeasurableTypes([_sardinesConsumed]);
+    final journalDb = mockJournalDbWithMeasurableTypes([
+      _sardinesConsumed,
+      _hydrationCheck,
+    ]);
     await setUpTestGetIt(
       additionalSetup: () {
         getIt
@@ -272,6 +327,61 @@ void main() {
         await captureScreenshot(
           tester,
           'measurement_capture_time_${viewport}_$theme',
+          subdir: 'manual',
+        );
+      });
+    }
+  }
+  for (final device in [miniDevice, desktopDevice]) {
+    final viewport = device.isPhone ? 'mobile' : 'desktop';
+    for (final brightness in [Brightness.light, Brightness.dark]) {
+      final theme = brightness.name;
+      testWidgets('$viewport choice measurement capture — $theme', (
+        tester,
+      ) async {
+        await _pumpDashboard(
+          tester,
+          device: device,
+          brightness: brightness,
+          measurableId: _hydrationId,
+        );
+        expect(
+          find.text(_t('Hydration check', 'Hydrationscheck')),
+          findsOneWidget,
+        );
+        await captureScreenshot(
+          tester,
+          'dashboard_choice_strip_${viewport}_$theme',
+          subdir: 'manual',
+        );
+
+        await withClock(Clock.fixed(manualDemoNow), () async {
+          await tester.tap(find.byIcon(LottiIcons.add));
+          await settleFrames(tester, 10);
+        });
+        expect(
+          find.text(_messages(tester).measurementChoicePrompt),
+          findsOneWidget,
+        );
+
+        await tester.tap(
+          find.byKey(const ValueKey('measurement-choice-hyd-pale')),
+        );
+        await settleFrames(tester, 4);
+        final comment = _t(
+          'Before the morning briefing',
+          'Vor dem Morgenbriefing',
+        );
+        await tester.enterText(
+          find.byKey(const Key('measurement_comment_field')),
+          comment,
+        );
+        FocusManager.instance.primaryFocus?.unfocus();
+        await settleFrames(tester, 4);
+        expect(find.text(comment), findsOneWidget);
+        await captureScreenshot(
+          tester,
+          'measurement_capture_choice_${viewport}_$theme',
           subdir: 'manual',
         );
       });

--- a/test/pages/create/create_measurement_dialog_test.dart
+++ b/test/pages/create/create_measurement_dialog_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
+import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
 import 'package:lotti/features/design_system/components/glass_strip.dart';
 import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -1026,5 +1027,170 @@ void main() {
         private: any(named: 'private'),
       ),
     );
+  });
+
+  group('choice measurable', () {
+    const choiceFieldKey = Key('measurement_choice_field');
+    Finder chip(MeasurableChoice choice) =>
+        find.byKey(ValueKey('measurement-choice-${choice.id}'));
+    bool chipSelected(WidgetTester tester, MeasurableChoice choice) =>
+        tester.widget<DesignSystemChip>(chip(choice)).selected;
+
+    Future<void> openChoiceCapture(WidgetTester tester) async {
+      await tester.tap(find.byKey(_openKey));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 450));
+      expect(find.byKey(choiceFieldKey), findsOneWidget);
+    }
+
+    testWidgets(
+      'offers one chip per active choice instead of a number field, with '
+      'Save held until a choice is picked',
+      (tester) async {
+        await pumpLauncher(tester, dataType: measurableHydration);
+        await openChoiceCapture(tester);
+
+        expect(find.byKey(_valueKey), findsNothing);
+        expect(find.text('Quick log'), findsNothing);
+        expect(find.text('Pick one'), findsOneWidget);
+        expect(chip(hydrationClear), findsOneWidget);
+        expect(chip(hydrationPale), findsOneWidget);
+        expect(chip(hydrationDark), findsOneWidget);
+        // Archived choices are not on offer.
+        expect(chip(hydrationBrown), findsNothing);
+        expect(find.text('Brown'), findsNothing);
+        expect(
+          tester.widget<DesignSystemChip>(chip(hydrationClear)).semanticsLabel,
+          'Select Clear',
+        );
+
+        final save = tester.widget<DesignSystemButton>(find.byKey(_saveKey));
+        expect(save.onPressed, isNull);
+        for (final choice in [hydrationClear, hydrationPale, hydrationDark]) {
+          expect(chipSelected(tester, choice), isFalse);
+        }
+      },
+    );
+
+    testWidgets('picking a chip selects it exclusively and arms Save', (
+      tester,
+    ) async {
+      await pumpLauncher(tester, dataType: measurableHydration);
+      await openChoiceCapture(tester);
+
+      await tester.tap(chip(hydrationPale));
+      await tester.pump();
+      expect(chipSelected(tester, hydrationPale), isTrue);
+      expect(chipSelected(tester, hydrationClear), isFalse);
+      expect(
+        tester.widget<DesignSystemButton>(find.byKey(_saveKey)).onPressed,
+        isNotNull,
+      );
+
+      await tester.tap(chip(hydrationDark));
+      await tester.pump();
+      expect(chipSelected(tester, hydrationDark), isTrue);
+      expect(chipSelected(tester, hydrationPale), isFalse);
+    });
+
+    testWidgets(
+      'Save persists the choice as one occurrence at the observed time, '
+      'with the comment, and closes the sheet',
+      (tester) async {
+        MeasurementData? saved;
+        String? savedComment;
+        bool? savedPrivate;
+        when(
+          () => mockPersistenceLogic.createMeasurementEntry(
+            data: any(named: 'data'),
+            comment: any(named: 'comment'),
+            private: any(named: 'private'),
+          ),
+        ).thenAnswer((invocation) async {
+          saved = capturedData(invocation);
+          savedComment =
+              invocation.namedArguments[const Symbol('comment')] as String?;
+          savedPrivate =
+              invocation.namedArguments[const Symbol('private')] as bool?;
+          return testMeasurementHydrationEntry;
+        });
+
+        await pumpLauncher(
+          tester,
+          dataType: measurableHydration.copyWith(private: true),
+        );
+        await openChoiceCapture(tester);
+
+        await tester.tap(chip(hydrationPale));
+        await tester.pump();
+        await tester.enterText(find.byKey(_commentKey), 'After the run');
+        await tester.pump();
+
+        await tester.tap(find.byKey(_saveKey));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 450));
+
+        expect(saved, isNotNull);
+        expect(saved!.dataTypeId, measurableHydration.id);
+        expect(saved!.choiceId, hydrationPale.id);
+        expect(saved!.value, 1);
+        expect(saved!.dateFrom, _fixedNow);
+        expect(saved!.dateTo, _fixedNow);
+        expect(savedComment, 'After the run');
+        expect(savedPrivate, isTrue);
+        expect(find.byKey(choiceFieldKey), findsNothing);
+      },
+    );
+
+    testWidgets('the picked choice survives the observed-at round trip', (
+      tester,
+    ) async {
+      await pumpLauncher(tester, dataType: measurableHydration);
+      await openChoiceCapture(tester);
+
+      await tester.tap(chip(hydrationDark));
+      await tester.pump();
+
+      await openObservedAt(tester);
+      await tapDone(tester);
+
+      expect(chipSelected(tester, hydrationDark), isTrue);
+      expect(
+        tester.widget<DesignSystemButton>(find.byKey(_saveKey)).onPressed,
+        isNotNull,
+      );
+    });
+
+    testWidgets('chips go inert while the save is in flight', (tester) async {
+      final pending = Completer<MeasurementEntry?>();
+      when(
+        () => mockPersistenceLogic.createMeasurementEntry(
+          data: any(named: 'data'),
+          comment: any(named: 'comment'),
+          private: any(named: 'private'),
+        ),
+      ).thenAnswer((_) => pending.future);
+
+      await pumpLauncher(tester, dataType: measurableHydration);
+      await openChoiceCapture(tester);
+      await tester.tap(chip(hydrationClear));
+      await tester.pump();
+      await tester.tap(find.byKey(_saveKey));
+      await tester.pump();
+
+      expect(
+        tester.widget<DesignSystemChip>(chip(hydrationPale)).onPressed,
+        isNull,
+      );
+      expect(
+        tester.widget<DesignSystemButton>(find.byKey(_saveKey)).isLoading,
+        isTrue,
+      );
+
+      pending.complete(testMeasurementHydrationEntry);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 450));
+      expect(find.byKey(choiceFieldKey), findsNothing);
+    });
   });
 }

--- a/test/test_data/test_data.dart
+++ b/test/test_data/test_data.dart
@@ -94,6 +94,30 @@ final measurablePullUps = MeasurableDataType(
   aggregationType: AggregationType.dailyMax,
 );
 
+/// The choices of [measurableHydration]; [hydrationBrown] is archived.
+const hydrationClear = MeasurableChoice(id: 'hydration-clear', title: 'Clear');
+const hydrationPale = MeasurableChoice(id: 'hydration-pale', title: 'Pale');
+const hydrationDark = MeasurableChoice(id: 'hydration-dark', title: 'Dark');
+const hydrationBrown = MeasurableChoice(
+  id: 'hydration-brown',
+  title: 'Brown',
+  archived: true,
+);
+
+/// A choice-kind measurable: recorded as one of its choices, not a number.
+final measurableHydration = MeasurableDataType(
+  id: '0c1c2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d',
+  displayName: 'Hydration',
+  description: 'Urine colour check',
+  unitName: '',
+  createdAt: testEpochDateTime,
+  updatedAt: testEpochDateTime,
+  vectorClock: null,
+  version: 1,
+  valueKind: MeasurableValueKind.choice,
+  choices: const [hydrationClear, hydrationPale, hydrationDark, hydrationBrown],
+);
+
 final measurableChocolate = MeasurableDataType(
   id: 'f8f55c10-e30b-4bf5-990d-d569ce4867fb',
   displayName: 'Chocolate',
@@ -408,6 +432,26 @@ final testMeasurementChocolateEntry = MeasurementEntry(
     dataTypeId: measurableChocolate.id,
     dateTo: DateTime(2022, 7, 7, 17),
     dateFrom: DateTime(2022, 7, 7, 17),
+  ),
+);
+
+/// A choice recording of [measurableHydration]: "Clear", one occurrence.
+final testMeasurementHydrationEntry = MeasurementEntry(
+  meta: Metadata(
+    id: 'a7b1c2d3-e4f5-4a6b-9c8d-0e1f2a3b4c5d',
+    createdAt: DateTime(2022, 7, 7, 8),
+    dateFrom: DateTime(2022, 7, 7, 8),
+    dateTo: DateTime(2022, 7, 7, 8),
+    updatedAt: DateTime(2022, 7, 7, 8),
+    starred: false,
+    private: false,
+  ),
+  data: MeasurementData(
+    value: 1,
+    dataTypeId: measurableHydration.id,
+    choiceId: hydrationClear.id,
+    dateTo: DateTime(2022, 7, 7, 8),
+    dateFrom: DateTime(2022, 7, 7, 8),
   ),
 );
 


### PR DESCRIPTION
## Summary

A measurable can now be recorded as **one of its own choices** instead of a number — hydration by urine colour (clear / pale / dark), how rested you feel, emojis, anything with a small named set. A choice is an **id with a renamable title**, never an enum: rename or reorder freely and every past entry keeps pointing at the same choice; retire one and it is archived (history stays legible, and it can be restored).

## What changed

- **Model** — `MeasurableDataType.valueKind` (`number` | `choice`, absent = number, unknown → number) and `choices: [MeasurableChoice {id, title, archived?}]`; `MeasurementData.choiceId`, with `value: 1` per choice recording so every per-day sum (signals, aggregators) counts occurrences instead of breaking.
- **Measurable editor** — a *Recorded as* switch; the choice kind hides unit/aggregation and shows a reorderable choices list (rename in place, archive, add, restore from an *Archived choices* section). Save refuses a blank title or an empty list.
- **Measurement capture sheet** — *Pick one* chips replace the number field and quick-log values; Save persists the choice.
- **Habit completion sheet** — every active choice as a one-tap chip; the row says *today: logged*; the habit editor offers only *any entry* for a choice measurable; the picker lists the choices as the row's subtitle and finds a measurable by any of them; the auto-completion reason names the measurable without a count.
- **Journal / search** — entries read `Hydration: Clear` (never the occurrence count); the full-text index carries the choice title; the journal card and entry summary share one value formatter (a percentage now reads `55%` in both).
- **Dashboard** — a choice measurable draws a **day strip** (one cell per day, shaded by the day's latest choice on an accent ramp in the user's order, with tooltips and a legend) under the shared date axis; the dashboard editor and picker offer no aggregation for it.
- **Goals** — choice measurables are not offered as goal signals (a criterion is a numeric target); a proper choice criterion is a follow-up.
- **Docs & catalog** — concept updates (entity definitions, dashboards, habits, signals, settings), 19 new labels in all 11 catalogs, changelog fragment, and the manual-screenshot scenarios extended with the choice states.

## Screenshots

_Before/after pairs for every surface (measurable editor, capture sheet, dashboard strip, habit completion sheet; mobile + desktop, light + dark) are captured; the table is added once the images are uploaded._

## Testing

- Every touched source file is at 100 % line coverage on its changed lines (measured with a scoped `--coverage-path` run over the 28 touched test files); analyzer clean, `make knowledge_check` and `make changelog_check` green.
- New test files: `measurable_choices_editor_test`, `measurable_choice_series_test`, `measurable_choice_strip_test`; choice cases added to the editor page, capture sheet, journal card/summary/FTS, habit chips/row/sheet/card/picker/presentation/auto-completion, dashboard chart/header/item card/multi-select, and the goal form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LTSxnu8BkgWDtFDMQHSLS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Measurables can use named choices instead of numbers.
  * Manage choices in settings by adding, renaming, reordering, archiving, or restoring them.
  * Record choices with quick-select chips in measurements and habits.
  * View choice measurables as day strips with legends on dashboards.
  * Search journal entries by choice names.
* **Bug Fixes**
  * Journal values now use consistent formatting, including percentages without extra spaces.
  * Choice values display their names instead of occurrence counts.
  * Choice measurables now use “any entry” habit rules and are excluded from numeric goals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
